### PR TITLE
Add Sentry observability with distributed tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ apps/*/dist
 packages/*/dist
 .env
 .env.local
+.env.sentry-build-plugin
 build/
 .logs/
 release/

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,10 +15,10 @@
   ],
   "type": "module",
   "scripts": {
-    "dev": "node --watch src/bin.ts",
+    "dev": "node --import ./src/instrument.ts --watch src/bin.ts",
     "build": "node scripts/cli.ts build",
     "build:bundle": "tsdown",
-    "start": "node dist/bin.mjs",
+    "start": "node --import ./src/instrument.ts dist/bin.mjs",
     "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
@@ -31,6 +31,8 @@
     "@effect/sql-sqlite-bun": "catalog:",
     "@opencode-ai/sdk": "^1.3.15",
     "@pierre/diffs": "^1.1.0-beta.16",
+    "@sentry/node": "^10.50.0",
+    "@sentry/profiling-node": "^10.50.0",
     "effect": "catalog:",
     "node-pty": "^1.1.0",
     "open": "^10.1.0"

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -1,5 +1,7 @@
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Sentry from "@sentry/node";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Command } from "effect/unstable/cli";
@@ -11,6 +13,15 @@ import packageJson from "../package.json" with { type: "json" };
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
 Command.run(cli, { version: packageJson.version }).pipe(
+  // Effect's runMain reports fatal failures via its own logger and exits, which
+  // bypasses Sentry's uncaughtException/unhandledRejection integrations. Bridge
+  // the Cause into Sentry and flush before the process exits.
+  Effect.tapCause((cause) =>
+    Effect.promise(async () => {
+      Sentry.captureException(Cause.squash(cause));
+      await Sentry.flush(2000);
+    }),
+  ),
   Effect.scoped,
   Effect.provide(CliRuntimeLayer),
   NodeRuntime.runMain,

--- a/apps/server/src/instrument.ts
+++ b/apps/server/src/instrument.ts
@@ -7,12 +7,17 @@ Sentry.init({
   // Verbose SDK logs — prints every event/span dispatched and any transport
   // errors. Useful for confirming spans are being created and flushed. Remove
   // once gen_ai instrumentation is verified.
-  debug: true,
+  debug: false,
 
   sendDefaultPii: true,
   includeLocalVariables: true,
 
-  integrations: [nodeProfilingIntegration()],
+  integrations: [
+    nodeProfilingIntegration(),
+    Sentry.httpIntegration({
+      ignoreIncomingRequests: (url) => url.includes("/api/observability/"),
+    }),
+  ],
 
   // Performance Monitoring.
   // NODE_ENV isn't reliably passed through turbo to workspace dev scripts

--- a/apps/server/src/instrument.ts
+++ b/apps/server/src/instrument.ts
@@ -1,0 +1,31 @@
+import * as Sentry from "@sentry/node";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  dsn: "https://d9e62d21f585aa2c60b50e5f4023e07d@o4509446862274560.ingest.us.sentry.io/4511294368972800",
+
+  // Verbose SDK logs — prints every event/span dispatched and any transport
+  // errors. Useful for confirming spans are being created and flushed. Remove
+  // once gen_ai instrumentation is verified.
+  debug: true,
+
+  sendDefaultPii: true,
+  includeLocalVariables: true,
+
+  integrations: [nodeProfilingIntegration()],
+
+  // Performance Monitoring.
+  // NODE_ENV isn't reliably passed through turbo to workspace dev scripts
+  // (it's not in turbo.json's globalEnv), so the previous
+  // `NODE_ENV === "development" ? 1.0 : 0.1` conditional silently fell to 0.1
+  // and dropped ~90% of spans. Hardcoding 1.0 matches the local-only DSN
+  // setup in this file. Tighten if/when this app ships beyond local dev.
+  tracesSampleRate: 1.0,
+
+  // Profiling
+  profileSessionSampleRate: 1.0,
+  profileLifecycle: "trace",
+
+  // Logging
+  enableLogs: true,
+});

--- a/apps/server/src/observability/GenAiSpan.ts
+++ b/apps/server/src/observability/GenAiSpan.ts
@@ -1,0 +1,247 @@
+import * as Sentry from "@sentry/node";
+import type { Span } from "@sentry/node";
+
+export interface InvokeAgentSpanInit {
+  readonly agentName: string;
+  readonly system: string;
+  readonly model: string;
+  readonly conversationId?: string;
+  /** Stringified messages array sent to the model. Sentry caps attribute size. */
+  readonly messages?: string;
+  readonly availableTools?: ReadonlyArray<string>;
+  readonly extraAttributes?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export interface InvokeAgentSpanFinish {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly totalTokens?: number;
+  readonly cachedInputTokens?: number;
+  readonly cacheWriteInputTokens?: number;
+  readonly reasoningOutputTokens?: number;
+  readonly responseText?: string;
+  readonly toolCallsJson?: string;
+  readonly errorMessage?: string;
+}
+
+// OpenTelemetry SpanStatusCode.ERROR. Avoids importing @opentelemetry/api
+// just for the constant; Sentry's Span.setStatus accepts the numeric code.
+const SPAN_STATUS_ERROR = 2 as const;
+
+export function startInvokeAgentSpan(init: InvokeAgentSpanInit): Span {
+  if (init.conversationId !== undefined) {
+    // Per Sentry's docs (https://docs.sentry.io/platforms/javascript/guides/node/ai-agent-monitoring/#tracking-conversations),
+    // setConversationId tags the current scope so all subsequent AI spans
+    // (and Logs/errors) are linked to this conversation in the AI Agents view.
+    // Caveat: the scope is process-wide. For concurrent turns from different
+    // threads the most recent caller wins — acceptable for the local-first
+    // single-user model t3code targets, but a multi-tenant server would need
+    // per-turn isolation via Sentry.withIsolationScope.
+    Sentry.setConversationId(init.conversationId);
+  }
+  return Sentry.startInactiveSpan({
+    op: "gen_ai.invoke_agent",
+    name: `invoke_agent ${init.agentName}`,
+    attributes: {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.system": init.system,
+      "gen_ai.request.model": init.model,
+      "gen_ai.agent.name": init.agentName,
+      ...(init.conversationId !== undefined
+        ? { "gen_ai.conversation.id": init.conversationId }
+        : {}),
+      ...(init.messages !== undefined ? { "gen_ai.request.messages": init.messages } : {}),
+      ...(init.availableTools && init.availableTools.length > 0
+        ? { "gen_ai.request.available_tools": JSON.stringify(init.availableTools) }
+        : {}),
+      ...(init.extraAttributes ?? {}),
+    },
+  });
+}
+
+export function finishInvokeAgentSpan(span: Span | undefined, finish: InvokeAgentSpanFinish): void {
+  if (!span) return;
+  if (finish.inputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.input_tokens", finish.inputTokens);
+  }
+  if (finish.outputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.output_tokens", finish.outputTokens);
+  }
+  if (finish.totalTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.total_tokens", finish.totalTokens);
+  }
+  if (finish.cachedInputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.input_tokens.cached", finish.cachedInputTokens);
+  }
+  if (finish.cacheWriteInputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.input_tokens.cache_write", finish.cacheWriteInputTokens);
+  }
+  if (finish.reasoningOutputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.output_tokens.reasoning", finish.reasoningOutputTokens);
+  }
+  if (finish.responseText !== undefined) {
+    span.setAttribute("gen_ai.response.text", finish.responseText);
+  }
+  if (finish.toolCallsJson !== undefined) {
+    span.setAttribute("gen_ai.response.tool_calls", finish.toolCallsJson);
+  }
+  if (finish.errorMessage !== undefined) {
+    span.setStatus({ code: SPAN_STATUS_ERROR, message: finish.errorMessage });
+  }
+  span.end();
+}
+
+// ============================================================================
+// gen_ai.request — one per LLM HTTP request (i.e. per assistant turn)
+// ============================================================================
+
+export interface GenAiRequestSpanInit {
+  readonly model: string;
+  /** Stringified messages array sent to the model. Sentry caps attribute size. */
+  readonly messages?: string;
+  readonly system?: string;
+  readonly conversationId?: string;
+  readonly availableTools?: ReadonlyArray<string>;
+  readonly maxTokens?: number;
+  readonly temperature?: number;
+  readonly topP?: number;
+  readonly extraAttributes?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export interface GenAiRequestSpanFinish {
+  readonly responseText?: string;
+  readonly toolCallsJson?: string;
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly totalTokens?: number;
+  readonly cachedInputTokens?: number;
+  readonly cacheWriteInputTokens?: number;
+  readonly reasoningOutputTokens?: number;
+  /** e.g. Anthropic stop_reason: "end_turn" | "tool_use" | "max_tokens" | ... */
+  readonly finishReason?: string;
+  readonly errorMessage?: string;
+}
+
+/**
+ * Opens a `gen_ai.request` child span. Caller must pass the parent
+ * `gen_ai.invoke_agent` span explicitly so concurrent turns in a multi-session
+ * server cannot accidentally adopt the wrong active scope as parent.
+ */
+export function startGenAiRequestSpan(parent: Span, init: GenAiRequestSpanInit): Span {
+  return Sentry.withActiveSpan(parent, () =>
+    Sentry.startInactiveSpan({
+      op: "gen_ai.request",
+      name: `request ${init.model}`,
+      attributes: {
+        "gen_ai.operation.name": "request",
+        "gen_ai.request.model": init.model,
+        ...(init.system !== undefined ? { "gen_ai.system": init.system } : {}),
+        ...(init.messages !== undefined ? { "gen_ai.request.messages": init.messages } : {}),
+        ...(init.conversationId !== undefined
+          ? { "gen_ai.conversation.id": init.conversationId }
+          : {}),
+        ...(init.availableTools && init.availableTools.length > 0
+          ? { "gen_ai.request.available_tools": JSON.stringify(init.availableTools) }
+          : {}),
+        ...(init.maxTokens !== undefined ? { "gen_ai.request.max_tokens": init.maxTokens } : {}),
+        ...(init.temperature !== undefined
+          ? { "gen_ai.request.temperature": init.temperature }
+          : {}),
+        ...(init.topP !== undefined ? { "gen_ai.request.top_p": init.topP } : {}),
+        ...(init.extraAttributes ?? {}),
+      },
+    }),
+  );
+}
+
+export function finishGenAiRequestSpan(
+  span: Span | undefined,
+  finish: GenAiRequestSpanFinish,
+): void {
+  if (!span) return;
+  if (finish.inputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.input_tokens", finish.inputTokens);
+  }
+  if (finish.outputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.output_tokens", finish.outputTokens);
+  }
+  if (finish.totalTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.total_tokens", finish.totalTokens);
+  }
+  if (finish.cachedInputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.input_tokens.cached", finish.cachedInputTokens);
+  }
+  if (finish.cacheWriteInputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.input_tokens.cache_write", finish.cacheWriteInputTokens);
+  }
+  if (finish.reasoningOutputTokens !== undefined) {
+    span.setAttribute("gen_ai.usage.output_tokens.reasoning", finish.reasoningOutputTokens);
+  }
+  if (finish.responseText !== undefined) {
+    span.setAttribute("gen_ai.response.text", finish.responseText);
+  }
+  if (finish.toolCallsJson !== undefined) {
+    span.setAttribute("gen_ai.response.tool_calls", finish.toolCallsJson);
+  }
+  if (finish.finishReason !== undefined) {
+    span.setAttribute("gen_ai.response.finish_reasons", JSON.stringify([finish.finishReason]));
+  }
+  if (finish.errorMessage !== undefined) {
+    span.setStatus({ code: SPAN_STATUS_ERROR, message: finish.errorMessage });
+  }
+  span.end();
+}
+
+// ============================================================================
+// gen_ai.execute_tool — one per tool call requested by the model
+// ============================================================================
+
+export interface ExecuteToolSpanInit {
+  readonly toolName: string;
+  /** Stringified tool input payload. Sentry caps attribute size. */
+  readonly toolInput?: string;
+  /** "function" | "extension" | "datastore" | provider-specific (e.g. "mcp") */
+  readonly toolType?: string;
+  readonly toolDescription?: string;
+  readonly extraAttributes?: Readonly<Record<string, string | number | boolean>>;
+}
+
+export interface ExecuteToolSpanFinish {
+  /** Stringified tool output. Sentry caps attribute size. */
+  readonly toolOutput?: string;
+  readonly errorMessage?: string;
+}
+
+/**
+ * Opens a `gen_ai.execute_tool` child span. Caller must pass the parent
+ * `gen_ai.invoke_agent` span explicitly (see startGenAiRequestSpan).
+ */
+export function startExecuteToolSpan(parent: Span, init: ExecuteToolSpanInit): Span {
+  return Sentry.withActiveSpan(parent, () =>
+    Sentry.startInactiveSpan({
+      op: "gen_ai.execute_tool",
+      name: `execute_tool ${init.toolName}`,
+      attributes: {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": init.toolName,
+        ...(init.toolInput !== undefined ? { "gen_ai.tool.input": init.toolInput } : {}),
+        ...(init.toolType !== undefined ? { "gen_ai.tool.type": init.toolType } : {}),
+        ...(init.toolDescription !== undefined
+          ? { "gen_ai.tool.description": init.toolDescription }
+          : {}),
+        ...(init.extraAttributes ?? {}),
+      },
+    }),
+  );
+}
+
+export function finishExecuteToolSpan(span: Span | undefined, finish: ExecuteToolSpanFinish): void {
+  if (!span) return;
+  if (finish.toolOutput !== undefined) {
+    span.setAttribute("gen_ai.tool.output", finish.toolOutput);
+  }
+  if (finish.errorMessage !== undefined) {
+    span.setStatus({ code: SPAN_STATUS_ERROR, message: finish.errorMessage });
+  }
+  span.end();
+}

--- a/apps/server/src/observability/GenAiSpan.ts
+++ b/apps/server/src/observability/GenAiSpan.ts
@@ -5,8 +5,7 @@ export interface InvokeAgentSpanInit {
   readonly agentName: string;
   readonly system: string;
   readonly model: string;
-  readonly conversationId?: string;
-  /** Stringified messages array sent to the model. Sentry caps attribute size. */
+  readonly conversationId: string;
   readonly messages?: string;
   readonly availableTools?: ReadonlyArray<string>;
   readonly extraAttributes?: Readonly<Record<string, string | number | boolean>>;
@@ -24,21 +23,10 @@ export interface InvokeAgentSpanFinish {
   readonly errorMessage?: string;
 }
 
-// OpenTelemetry SpanStatusCode.ERROR. Avoids importing @opentelemetry/api
-// just for the constant; Sentry's Span.setStatus accepts the numeric code.
 const SPAN_STATUS_ERROR = 2 as const;
 
 export function startInvokeAgentSpan(init: InvokeAgentSpanInit): Span {
-  if (init.conversationId !== undefined) {
-    // Per Sentry's docs (https://docs.sentry.io/platforms/javascript/guides/node/ai-agent-monitoring/#tracking-conversations),
-    // setConversationId tags the current scope so all subsequent AI spans
-    // (and Logs/errors) are linked to this conversation in the AI Agents view.
-    // Caveat: the scope is process-wide. For concurrent turns from different
-    // threads the most recent caller wins — acceptable for the local-first
-    // single-user model t3code targets, but a multi-tenant server would need
-    // per-turn isolation via Sentry.withIsolationScope.
-    Sentry.setConversationId(init.conversationId);
-  }
+  Sentry.setConversationId(init.conversationId);
   return Sentry.startInactiveSpan({
     op: "gen_ai.invoke_agent",
     name: `invoke_agent ${init.agentName}`,
@@ -47,10 +35,8 @@ export function startInvokeAgentSpan(init: InvokeAgentSpanInit): Span {
       "gen_ai.system": init.system,
       "gen_ai.request.model": init.model,
       "gen_ai.agent.name": init.agentName,
-      ...(init.conversationId !== undefined
-        ? { "gen_ai.conversation.id": init.conversationId }
-        : {}),
-      ...(init.messages !== undefined ? { "gen_ai.request.messages": init.messages } : {}),
+      "gen_ai.conversation.id": init.conversationId,
+      ...(init.messages !== undefined ? { "gen_ai.input.messages": init.messages } : {}),
       ...(init.availableTools && init.availableTools.length > 0
         ? { "gen_ai.request.available_tools": JSON.stringify(init.availableTools) }
         : {}),
@@ -61,30 +47,16 @@ export function startInvokeAgentSpan(init: InvokeAgentSpanInit): Span {
 
 export function finishInvokeAgentSpan(span: Span | undefined, finish: InvokeAgentSpanFinish): void {
   if (!span) return;
-  if (finish.inputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.input_tokens", finish.inputTokens);
-  }
-  if (finish.outputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.output_tokens", finish.outputTokens);
-  }
-  if (finish.totalTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.total_tokens", finish.totalTokens);
-  }
-  if (finish.cachedInputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.input_tokens.cached", finish.cachedInputTokens);
-  }
-  if (finish.cacheWriteInputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.input_tokens.cache_write", finish.cacheWriteInputTokens);
-  }
-  if (finish.reasoningOutputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.output_tokens.reasoning", finish.reasoningOutputTokens);
-  }
-  if (finish.responseText !== undefined) {
-    span.setAttribute("gen_ai.response.text", finish.responseText);
-  }
-  if (finish.toolCallsJson !== undefined) {
-    span.setAttribute("gen_ai.response.tool_calls", finish.toolCallsJson);
-  }
+  const attrs: Record<string, string | number | boolean> = {};
+  if (finish.inputTokens !== undefined) attrs["gen_ai.usage.input_tokens"] = finish.inputTokens;
+  if (finish.outputTokens !== undefined) attrs["gen_ai.usage.output_tokens"] = finish.outputTokens;
+  if (finish.totalTokens !== undefined) attrs["gen_ai.usage.total_tokens"] = finish.totalTokens;
+  if (finish.cachedInputTokens !== undefined) attrs["gen_ai.usage.input_tokens.cached"] = finish.cachedInputTokens;
+  if (finish.cacheWriteInputTokens !== undefined) attrs["gen_ai.usage.input_tokens.cache_write"] = finish.cacheWriteInputTokens;
+  if (finish.reasoningOutputTokens !== undefined) attrs["gen_ai.usage.output_tokens.reasoning"] = finish.reasoningOutputTokens;
+  if (finish.responseText !== undefined) attrs["gen_ai.response.text"] = finish.responseText;
+  if (finish.toolCallsJson !== undefined) attrs["gen_ai.response.tool_calls"] = finish.toolCallsJson;
+  span.setAttributes(attrs);
   if (finish.errorMessage !== undefined) {
     span.setStatus({ code: SPAN_STATUS_ERROR, message: finish.errorMessage });
   }
@@ -92,15 +64,14 @@ export function finishInvokeAgentSpan(span: Span | undefined, finish: InvokeAgen
 }
 
 // ============================================================================
-// gen_ai.request — one per LLM HTTP request (i.e. per assistant turn)
+// gen_ai.request — one per LLM HTTP request
 // ============================================================================
 
 export interface GenAiRequestSpanInit {
   readonly model: string;
-  /** Stringified messages array sent to the model. Sentry caps attribute size. */
   readonly messages?: string;
   readonly system?: string;
-  readonly conversationId?: string;
+  readonly conversationId: string;
   readonly availableTools?: ReadonlyArray<string>;
   readonly maxTokens?: number;
   readonly temperature?: number;
@@ -117,16 +88,10 @@ export interface GenAiRequestSpanFinish {
   readonly cachedInputTokens?: number;
   readonly cacheWriteInputTokens?: number;
   readonly reasoningOutputTokens?: number;
-  /** e.g. Anthropic stop_reason: "end_turn" | "tool_use" | "max_tokens" | ... */
   readonly finishReason?: string;
   readonly errorMessage?: string;
 }
 
-/**
- * Opens a `gen_ai.request` child span. Caller must pass the parent
- * `gen_ai.invoke_agent` span explicitly so concurrent turns in a multi-session
- * server cannot accidentally adopt the wrong active scope as parent.
- */
 export function startGenAiRequestSpan(parent: Span, init: GenAiRequestSpanInit): Span {
   return Sentry.withActiveSpan(parent, () =>
     Sentry.startInactiveSpan({
@@ -135,18 +100,14 @@ export function startGenAiRequestSpan(parent: Span, init: GenAiRequestSpanInit):
       attributes: {
         "gen_ai.operation.name": "request",
         "gen_ai.request.model": init.model,
+        "gen_ai.conversation.id": init.conversationId,
         ...(init.system !== undefined ? { "gen_ai.system": init.system } : {}),
-        ...(init.messages !== undefined ? { "gen_ai.request.messages": init.messages } : {}),
-        ...(init.conversationId !== undefined
-          ? { "gen_ai.conversation.id": init.conversationId }
-          : {}),
+        ...(init.messages !== undefined ? { "gen_ai.input.messages": init.messages } : {}),
         ...(init.availableTools && init.availableTools.length > 0
           ? { "gen_ai.request.available_tools": JSON.stringify(init.availableTools) }
           : {}),
         ...(init.maxTokens !== undefined ? { "gen_ai.request.max_tokens": init.maxTokens } : {}),
-        ...(init.temperature !== undefined
-          ? { "gen_ai.request.temperature": init.temperature }
-          : {}),
+        ...(init.temperature !== undefined ? { "gen_ai.request.temperature": init.temperature } : {}),
         ...(init.topP !== undefined ? { "gen_ai.request.top_p": init.topP } : {}),
         ...(init.extraAttributes ?? {}),
       },
@@ -159,33 +120,17 @@ export function finishGenAiRequestSpan(
   finish: GenAiRequestSpanFinish,
 ): void {
   if (!span) return;
-  if (finish.inputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.input_tokens", finish.inputTokens);
-  }
-  if (finish.outputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.output_tokens", finish.outputTokens);
-  }
-  if (finish.totalTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.total_tokens", finish.totalTokens);
-  }
-  if (finish.cachedInputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.input_tokens.cached", finish.cachedInputTokens);
-  }
-  if (finish.cacheWriteInputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.input_tokens.cache_write", finish.cacheWriteInputTokens);
-  }
-  if (finish.reasoningOutputTokens !== undefined) {
-    span.setAttribute("gen_ai.usage.output_tokens.reasoning", finish.reasoningOutputTokens);
-  }
-  if (finish.responseText !== undefined) {
-    span.setAttribute("gen_ai.response.text", finish.responseText);
-  }
-  if (finish.toolCallsJson !== undefined) {
-    span.setAttribute("gen_ai.response.tool_calls", finish.toolCallsJson);
-  }
-  if (finish.finishReason !== undefined) {
-    span.setAttribute("gen_ai.response.finish_reasons", JSON.stringify([finish.finishReason]));
-  }
+  const attrs: Record<string, string | number | boolean> = {};
+  if (finish.inputTokens !== undefined) attrs["gen_ai.usage.input_tokens"] = finish.inputTokens;
+  if (finish.outputTokens !== undefined) attrs["gen_ai.usage.output_tokens"] = finish.outputTokens;
+  if (finish.totalTokens !== undefined) attrs["gen_ai.usage.total_tokens"] = finish.totalTokens;
+  if (finish.cachedInputTokens !== undefined) attrs["gen_ai.usage.input_tokens.cached"] = finish.cachedInputTokens;
+  if (finish.cacheWriteInputTokens !== undefined) attrs["gen_ai.usage.input_tokens.cache_write"] = finish.cacheWriteInputTokens;
+  if (finish.reasoningOutputTokens !== undefined) attrs["gen_ai.usage.output_tokens.reasoning"] = finish.reasoningOutputTokens;
+  if (finish.responseText !== undefined) attrs["gen_ai.response.text"] = finish.responseText;
+  if (finish.toolCallsJson !== undefined) attrs["gen_ai.response.tool_calls"] = finish.toolCallsJson;
+  if (finish.finishReason !== undefined) attrs["gen_ai.response.finish_reasons"] = JSON.stringify([finish.finishReason]);
+  span.setAttributes(attrs);
   if (finish.errorMessage !== undefined) {
     span.setStatus({ code: SPAN_STATUS_ERROR, message: finish.errorMessage });
   }
@@ -198,24 +143,17 @@ export function finishGenAiRequestSpan(
 
 export interface ExecuteToolSpanInit {
   readonly toolName: string;
-  /** Stringified tool input payload. Sentry caps attribute size. */
   readonly toolInput?: string;
-  /** "function" | "extension" | "datastore" | provider-specific (e.g. "mcp") */
   readonly toolType?: string;
   readonly toolDescription?: string;
   readonly extraAttributes?: Readonly<Record<string, string | number | boolean>>;
 }
 
 export interface ExecuteToolSpanFinish {
-  /** Stringified tool output. Sentry caps attribute size. */
   readonly toolOutput?: string;
   readonly errorMessage?: string;
 }
 
-/**
- * Opens a `gen_ai.execute_tool` child span. Caller must pass the parent
- * `gen_ai.invoke_agent` span explicitly (see startGenAiRequestSpan).
- */
 export function startExecuteToolSpan(parent: Span, init: ExecuteToolSpanInit): Span {
   return Sentry.withActiveSpan(parent, () =>
     Sentry.startInactiveSpan({

--- a/apps/server/src/observability/GenAiSpan.ts
+++ b/apps/server/src/observability/GenAiSpan.ts
@@ -25,9 +25,9 @@ export interface InvokeAgentSpanFinish {
 
 const SPAN_STATUS_ERROR = 2 as const;
 
-export function startInvokeAgentSpan(init: InvokeAgentSpanInit): Span {
+export function startInvokeAgentSpan(init: InvokeAgentSpanInit, parentSpan?: Span): Span {
   Sentry.setConversationId(init.conversationId);
-  return Sentry.startInactiveSpan({
+  const spanOptions = {
     op: "gen_ai.invoke_agent",
     name: `invoke_agent ${init.agentName}`,
     attributes: {
@@ -42,7 +42,11 @@ export function startInvokeAgentSpan(init: InvokeAgentSpanInit): Span {
         : {}),
       ...(init.extraAttributes ?? {}),
     },
-  });
+  } as const;
+  if (parentSpan) {
+    return Sentry.withActiveSpan(parentSpan, () => Sentry.startInactiveSpan(spanOptions));
+  }
+  return Sentry.startInactiveSpan(spanOptions);
 }
 
 export function finishInvokeAgentSpan(span: Span | undefined, finish: InvokeAgentSpanFinish): void {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -12,6 +12,7 @@ import {
   type TurnId,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
+import * as Sentry from "@sentry/node";
 import { Cache, Cause, Duration, Effect, Equal, Layer, Option, Schema, Stream } from "effect";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
@@ -763,9 +764,16 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    yield* providerService
-      .sendTurn(sendTurnRequest.value)
-      .pipe(Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
+    const sentryTrace = (event.payload as { sentryTrace?: string }).sentryTrace;
+    const sentryBaggage = (event.payload as { sentryBaggage?: string }).sentryBaggage;
+    const sendEffect = sentryTrace
+      ? Effect.sync(() =>
+          Sentry.continueTrace({ sentryTrace, baggage: sentryBaggage }, () => {
+            Sentry.getIsolationScope().setConversationId(event.payload.threadId);
+          }),
+        ).pipe(Effect.andThen(providerService.sendTurn(sendTurnRequest.value)))
+      : providerService.sendTurn(sendTurnRequest.value);
+    yield* sendEffect.pipe(Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -13,6 +13,7 @@ import {
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch, WORKTREE_BRANCH_PREFIX } from "@t3tools/shared/git";
 import * as Sentry from "@sentry/node";
+import { propagationContextFromHeaders } from "@sentry/core";
 import { Cache, Cause, Duration, Effect, Equal, Layer, Option, Schema, Stream } from "effect";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
@@ -766,14 +767,15 @@ const make = Effect.gen(function* () {
 
     const sentryTrace = (event.payload as { sentryTrace?: string }).sentryTrace;
     const sentryBaggage = (event.payload as { sentryBaggage?: string }).sentryBaggage;
-    const sendEffect = sentryTrace
-      ? Effect.sync(() =>
-          Sentry.continueTrace({ sentryTrace, baggage: sentryBaggage }, () => {
-            Sentry.getIsolationScope().setConversationId(event.payload.threadId);
-          }),
-        ).pipe(Effect.andThen(providerService.sendTurn(sendTurnRequest.value)))
-      : providerService.sendTurn(sendTurnRequest.value);
-    yield* sendEffect.pipe(Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
+    if (sentryTrace) {
+      Sentry.getIsolationScope().setPropagationContext(
+        propagationContextFromHeaders(sentryTrace, sentryBaggage),
+      );
+    }
+    Sentry.getIsolationScope().setConversationId(event.payload.threadId);
+    yield* providerService
+      .sendTurn(sendTurnRequest.value)
+      .pipe(Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -444,6 +444,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           interactionMode: targetThread.interactionMode,
           ...(sourceProposedPlan !== undefined ? { sourceProposedPlan } : {}),
           createdAt: command.createdAt,
+          ...(command.sentryTrace ? { sentryTrace: command.sentryTrace } : {}),
+          ...(command.sentryBaggage ? { sentryBaggage: command.sentryBaggage } : {}),
         },
       };
       return [userMessageEvent, turnStartRequestedEvent];

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3423,7 +3423,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
           "t3.turn.id": turnId,
           ...(context.session.cwd ? { "t3.workspace.cwd": context.session.cwd } : {}),
         },
-      }),
+      }, Sentry.getActiveSpan() ?? undefined),
       ...(userMessagesJson ? { genAiUserMessages: userMessagesJson } : {}),
     };
 

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -19,6 +19,7 @@ import {
   type SDKUserMessage,
   type ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
+import * as Sentry from "@sentry/node";
 import type { Span } from "@sentry/node";
 import * as path from "node:path";
 
@@ -141,6 +142,8 @@ interface ClaudeTurnState {
    * `undefined` when a request span closes (`exactOptionalPropertyTypes`).
    */
   currentRequestSpan?: Span | undefined;
+  /** Accumulated response text for the current request, for gen_ai.response.text */
+  currentResponseText: string;
 }
 
 interface AssistantTextBlockState {
@@ -418,11 +421,11 @@ function claudeGenAiSpanFinish(
   const failureMessage = errorMessage ?? (status === "failed" ? "Claude turn failed" : undefined);
 
   return {
-    ...(inputTokens > 0 ? { inputTokens } : {}),
-    ...(outputTokens !== undefined && outputTokens > 0 ? { outputTokens } : {}),
-    ...(totalTokens > 0 ? { totalTokens } : {}),
-    ...(cacheRead > 0 ? { cachedInputTokens: cacheRead } : {}),
-    ...(cacheWrite > 0 ? { cacheWriteInputTokens: cacheWrite } : {}),
+    inputTokens,
+    outputTokens: outputTokens ?? 0,
+    totalTokens,
+    cachedInputTokens: cacheRead,
+    cacheWriteInputTokens: cacheWrite,
     ...(failureMessage ? { errorMessage: failureMessage } : {}),
   };
 }
@@ -1627,22 +1630,51 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       providerRefs: nativeProviderRefs(context),
     });
 
-    // Defensively close any in-flight gen_ai child spans BEFORE the parent
-    // invoke_agent span ends, so they remain valid descendants of the trace.
+    // The `result` message often arrives before the final `assistant` message,
+    // so the request span is still open here. Close it with the result's usage
+    // data so token counts and response text appear on the span.
     if (turnState.currentRequestSpan) {
+      const usage = (result?.usage ?? undefined) as Record<string, unknown> | undefined;
+      const fresh = readFiniteNumber(usage?.input_tokens) ?? 0;
+      const cacheRead = readFiniteNumber(usage?.cache_read_input_tokens) ?? 0;
+      const cacheWrite = readFiniteNumber(usage?.cache_creation_input_tokens) ?? 0;
+      const inputTokens = fresh + cacheRead + cacheWrite;
+      const outputTokens = readFiniteNumber(usage?.output_tokens);
+      const totalTokens = readFiniteNumber(usage?.total_tokens) ?? inputTokens + (outputTokens ?? 0);
+      const stopReason = result?.stop_reason;
+
+      Sentry.logger.info("gen_ai.request span closing from result message", {
+        threadId: context.session.threadId,
+        turnId: turnState.turnId,
+        inputTokens,
+        outputTokens: outputTokens ?? 0,
+        totalTokens,
+        cachedInputTokens: cacheRead,
+        stopReason: typeof stopReason === "string" ? stopReason : "none",
+      });
       finishGenAiRequestSpan(turnState.currentRequestSpan, {
+        inputTokens,
+        outputTokens: outputTokens ?? 0,
+        totalTokens,
+        cachedInputTokens: cacheRead,
+        cacheWriteInputTokens: cacheWrite,
+        ...(turnState.currentResponseText.length > 0 ? { responseText: turnState.currentResponseText } : {}),
+        ...(typeof stopReason === "string" ? { finishReason: stopReason } : {}),
         ...(errorMessage ? { errorMessage } : {}),
       });
       turnState.currentRequestSpan = undefined;
+      turnState.currentResponseText = "";
     }
     for (const inFlightTool of context.inFlightTools.values()) {
       if (inFlightTool.genAiToolSpan) {
+        Sentry.logger.warn("gen_ai.execute_tool span force-closed at turn end", { threadId: context.session.threadId, tool: inFlightTool.toolName });
         finishExecuteToolSpan(inFlightTool.genAiToolSpan, {
           errorMessage: errorMessage ?? "tool did not complete before turn ended",
         });
       }
     }
 
+    Sentry.logger.info("gen_ai.invoke_agent span closing", { threadId: context.session.threadId, turnId: turnState.turnId, status });
     finishInvokeAgentSpan(turnState.genAiSpan, claudeGenAiSpanFinish(status, errorMessage, result));
 
     const updatedAt = yield* nowIso;
@@ -1680,6 +1712,9 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
               : "";
         if (deltaText.length === 0) {
           return;
+        }
+        if (event.delta.type === "text_delta") {
+          context.turnState.currentResponseText += deltaText;
         }
         const streamKind = streamKindFromDeltaType(event.delta.type);
         const assistantBlockEntry =
@@ -1832,11 +1867,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         context.turnState.currentRequestSpan = startGenAiRequestSpan(context.turnState.genAiSpan, {
           model: context.session.model ?? "unknown",
           system: "anthropic",
-          ...(context.session.threadId ? { conversationId: context.session.threadId } : {}),
+          conversationId: context.session.threadId,
           ...(context.turnState.genAiUserMessages
             ? { messages: context.turnState.genAiUserMessages }
             : {}),
         });
+        Sentry.logger.info("gen_ai.request span opened", { threadId: context.session.threadId, turnId: context.turnState.turnId, model: context.session.model ?? "unknown" });
       }
 
       const { index, content_block: block } = event;
@@ -2051,6 +2087,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       if (tool.genAiToolSpan) {
         const toolOutput =
           toolResult.text.length > 0 ? toolResult.text : JSON.stringify(toolResult.block);
+        Sentry.logger.info("gen_ai.execute_tool span closing", { threadId: context.session.threadId, tool: tool.toolName, isError: toolResult.isError });
         finishExecuteToolSpan(tool.genAiToolSpan, {
           toolOutput,
           ...(toolResult.isError
@@ -2084,6 +2121,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         assistantTextBlockOrder: [],
         capturedProposedPlanKeys: new Set(),
         nextSyntheticAssistantBlockIndex: -1,
+        currentResponseText: "",
         genAiSpan: startInvokeAgentSpan({
           agentName: genAiAgentName(context.session.cwd),
           system: "anthropic",
@@ -2170,6 +2208,26 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     // verified empirically against trace 75d8c8c3... where ungated closing
     // produced 1–3 duplicate spans per call, all stamped with the cumulative
     // running totals at their close moment.
+    // Retroactively open a gen_ai.request span for follow-up API calls where the
+    // SDK didn't emit stream_event content_block_start (e.g. second model call
+    // after tool use). Check early so the span is available for the close logic.
+    if (
+      context.turnState &&
+      context.turnState.genAiSpan &&
+      !context.turnState.currentRequestSpan
+    ) {
+      const peekStop = (message.message as { stop_reason?: unknown } | undefined)?.stop_reason;
+      const peekModel = (message.message as { model?: unknown } | undefined)?.model;
+      if (typeof peekStop === "string") {
+        Sentry.logger.warn("gen_ai.request span opened retroactively from assistant message", { threadId: context.session.threadId, turnId: context.turnState.turnId, stopReason: String(peekStop) });
+        context.turnState.currentRequestSpan = startGenAiRequestSpan(context.turnState.genAiSpan, {
+          model: (typeof peekModel === "string" ? peekModel : undefined) ?? context.session.model ?? "unknown",
+          system: "anthropic",
+          conversationId: context.session.threadId,
+        });
+      }
+    }
+
     if (context.turnState?.currentRequestSpan) {
       const sdkMessage = (message.message ?? undefined) as unknown as
         | {
@@ -2219,16 +2277,28 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const stopReason =
         typeof sdkMessage?.stop_reason === "string" ? sdkMessage.stop_reason : undefined;
 
-      finishGenAiRequestSpan(context.turnState.currentRequestSpan, {
-        ...(inputTokens > 0 ? { inputTokens } : {}),
-        ...(outputTokens !== undefined && outputTokens > 0 ? { outputTokens } : {}),
-        ...(totalTokens > 0 ? { totalTokens } : {}),
-        ...(cacheRead > 0 ? { cachedInputTokens: cacheRead } : {}),
-        ...(cacheWrite > 0 ? { cacheWriteInputTokens: cacheWrite } : {}),
+      Sentry.logger.info("gen_ai.request span closing", { threadId: context.session.threadId, turnId: context.turnState.turnId, stopReason: stopReason ?? "none", inputTokens, outputTokens: outputTokens ?? 0, toolCalls: toolCalls.length });
+
+      const requestFinish: import("../../observability/GenAiSpan.ts").GenAiRequestSpanFinish = {
+        inputTokens,
+        outputTokens: outputTokens ?? 0,
+        totalTokens,
+        cachedInputTokens: cacheRead,
+        cacheWriteInputTokens: cacheWrite,
         ...(responseText !== undefined ? { responseText } : {}),
         ...(toolCallsJson !== undefined ? { toolCallsJson } : {}),
         ...(stopReason !== undefined ? { finishReason: stopReason } : {}),
+      };
+      Sentry.logger.info("gen_ai.request span closing from assistant message", {
+        threadId: context.session.threadId,
+        turnId: context.turnState.turnId,
+        stopReason: stopReason ?? "none",
+        inputTokens,
+        outputTokens: outputTokens ?? 0,
+        toolCalls: toolCalls.length,
+        hasResponseText: responseText !== undefined,
       });
+      finishGenAiRequestSpan(context.turnState.currentRequestSpan, requestFinish);
       context.turnState.currentRequestSpan = undefined;
     }
 
@@ -2533,6 +2603,31 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
   ) {
     yield* logNativeSdkMessage(context, message);
     yield* ensureThreadId(context, message);
+
+    if (message.type === "stream_event" && message.event?.type === "content_block_start") {
+      Sentry.logger.debug("sdk message: content_block_start", {
+        threadId: context.session.threadId,
+        blockType: message.event.content_block?.type ?? "unknown",
+        blockIndex: message.event.index ?? -1,
+        hasRequestSpan: !!context.turnState?.currentRequestSpan,
+      });
+    } else if (message.type === "assistant") {
+      const msg = message.message as { stop_reason?: unknown; usage?: unknown; model?: unknown } | undefined;
+      Sentry.logger.debug("sdk message: assistant", {
+        threadId: context.session.threadId,
+        stopReason: typeof msg?.stop_reason === "string" ? msg.stop_reason : "none",
+        hasUsage: msg?.usage !== undefined,
+        hasRequestSpan: !!context.turnState?.currentRequestSpan,
+      });
+    } else if (message.type === "result") {
+      const stopReason = (message as { stop_reason?: unknown }).stop_reason;
+      Sentry.logger.debug("sdk message: result", {
+        threadId: context.session.threadId,
+        subtype: message.subtype,
+        stopReason: typeof stopReason === "string" ? stopReason : "none",
+        hasRequestSpan: !!context.turnState?.currentRequestSpan,
+      });
+    }
 
     switch (message.type) {
       case "stream_event":
@@ -3315,6 +3410,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       assistantTextBlockOrder: [],
       capturedProposedPlanKeys: new Set(),
       nextSyntheticAssistantBlockIndex: -1,
+      currentResponseText: "",
       genAiSpan: startInvokeAgentSpan({
         agentName: genAiAgentName(context.session.cwd),
         system: "anthropic",
@@ -3330,6 +3426,8 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       }),
       ...(userMessagesJson ? { genAiUserMessages: userMessagesJson } : {}),
     };
+
+    Sentry.logger.info("gen_ai.invoke_agent span opened", { threadId: context.session.threadId, turnId, model: turnModel });
 
     const updatedAt = yield* nowIso;
     context.turnState = turnState;

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -19,6 +19,9 @@ import {
   type SDKUserMessage,
   type ModelUsage,
 } from "@anthropic-ai/claude-agent-sdk";
+import type { Span } from "@sentry/node";
+import * as path from "node:path";
+
 import { parseCliArgs } from "@t3tools/shared/cliArgs";
 import {
   ApprovalRequestId,
@@ -70,6 +73,14 @@ import { resolveAttachmentPath } from "../../attachmentStore.ts";
 import { ServerConfig } from "../../config.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
 import {
+  finishExecuteToolSpan,
+  finishGenAiRequestSpan,
+  finishInvokeAgentSpan,
+  startExecuteToolSpan,
+  startGenAiRequestSpan,
+  startInvokeAgentSpan,
+} from "../../observability/GenAiSpan.ts";
+import {
   getClaudeModelCapabilities,
   normalizeClaudeCliEffort,
   resolveClaudeApiModelId,
@@ -118,6 +129,18 @@ interface ClaudeTurnState {
   readonly assistantTextBlockOrder: Array<AssistantTextBlockState>;
   readonly capturedProposedPlanKeys: Set<string>;
   nextSyntheticAssistantBlockIndex: number;
+  readonly genAiSpan?: Span;
+  /** JSON-stringified messages sent to start the turn, reused on each request span. */
+  readonly genAiUserMessages?: string;
+  /**
+   * Open `gen_ai.request` span for the in-flight model HTTP request. Opened
+   * lazily on the first stream event after a turn starts (or after the
+   * previous request finished); closed when the matching assistant message
+   * is delivered. Mutated as the turn progresses through multiple model calls.
+   * The explicit `| undefined` is required because the field is reassigned to
+   * `undefined` when a request span closes (`exactOptionalPropertyTypes`).
+   */
+  currentRequestSpan?: Span | undefined;
 }
 
 interface AssistantTextBlockState {
@@ -150,6 +173,8 @@ interface ToolInFlight {
   readonly input: Record<string, unknown>;
   readonly partialInputJson: string;
   readonly lastEmittedInputFingerprint?: string;
+  /** Open `gen_ai.execute_tool` span for this tool call; closed when the matching tool_result arrives. */
+  readonly genAiToolSpan?: Span;
 }
 
 interface ClaudeSessionContext {
@@ -361,6 +386,44 @@ function normalizeClaudeTokenUsage(
     ...(typeof usage.duration_ms === "number" && Number.isFinite(usage.duration_ms)
       ? { durationMs: usage.duration_ms }
       : {}),
+  };
+}
+
+function readFiniteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function genAiAgentName(cwd: string | undefined): string {
+  if (cwd) {
+    const base = path.basename(cwd).trim();
+    if (base.length > 0) return base;
+  }
+  return "claude";
+}
+
+function claudeGenAiSpanFinish(
+  status: ProviderRuntimeTurnStatus,
+  errorMessage: string | undefined,
+  result: SDKResultMessage | undefined,
+): import("../../observability/GenAiSpan.ts").InvokeAgentSpanFinish {
+  const usage = (result?.usage ?? undefined) as Record<string, unknown> | undefined;
+  const fresh = readFiniteNumber(usage?.input_tokens) ?? 0;
+  const cacheRead = readFiniteNumber(usage?.cache_read_input_tokens) ?? 0;
+  const cacheWrite = readFiniteNumber(usage?.cache_creation_input_tokens) ?? 0;
+  // Per Sentry conventions: gen_ai.usage.input_tokens is the TOTAL (already
+  // includes cached). cached/cache_write are subset attributes.
+  const inputTokens = fresh + cacheRead + cacheWrite;
+  const outputTokens = readFiniteNumber(usage?.output_tokens);
+  const totalTokens = readFiniteNumber(usage?.total_tokens) ?? inputTokens + (outputTokens ?? 0);
+  const failureMessage = errorMessage ?? (status === "failed" ? "Claude turn failed" : undefined);
+
+  return {
+    ...(inputTokens > 0 ? { inputTokens } : {}),
+    ...(outputTokens !== undefined && outputTokens > 0 ? { outputTokens } : {}),
+    ...(totalTokens > 0 ? { totalTokens } : {}),
+    ...(cacheRead > 0 ? { cachedInputTokens: cacheRead } : {}),
+    ...(cacheWrite > 0 ? { cacheWriteInputTokens: cacheWrite } : {}),
+    ...(failureMessage ? { errorMessage: failureMessage } : {}),
   };
 }
 
@@ -1564,6 +1627,24 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       providerRefs: nativeProviderRefs(context),
     });
 
+    // Defensively close any in-flight gen_ai child spans BEFORE the parent
+    // invoke_agent span ends, so they remain valid descendants of the trace.
+    if (turnState.currentRequestSpan) {
+      finishGenAiRequestSpan(turnState.currentRequestSpan, {
+        ...(errorMessage ? { errorMessage } : {}),
+      });
+      turnState.currentRequestSpan = undefined;
+    }
+    for (const inFlightTool of context.inFlightTools.values()) {
+      if (inFlightTool.genAiToolSpan) {
+        finishExecuteToolSpan(inFlightTool.genAiToolSpan, {
+          errorMessage: errorMessage ?? "tool did not complete before turn ended",
+        });
+      }
+    }
+
+    finishInvokeAgentSpan(turnState.genAiSpan, claudeGenAiSpanFinish(status, errorMessage, result));
+
     const updatedAt = yield* nowIso;
     context.turnState = undefined;
     context.session = {
@@ -1739,6 +1820,25 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     if (event.type === "content_block_start") {
+      // Lazily open the per-request gen_ai.request span on the first content
+      // block of the current model response. We re-open across multiple model
+      // calls within a single turn (e.g. after tool_results trigger another
+      // assistant message).
+      if (
+        context.turnState &&
+        context.turnState.genAiSpan &&
+        !context.turnState.currentRequestSpan
+      ) {
+        context.turnState.currentRequestSpan = startGenAiRequestSpan(context.turnState.genAiSpan, {
+          model: context.session.model ?? "unknown",
+          system: "anthropic",
+          ...(context.session.threadId ? { conversationId: context.session.threadId } : {}),
+          ...(context.turnState.genAiUserMessages
+            ? { messages: context.turnState.genAiUserMessages }
+            : {}),
+        });
+      }
+
       const { index, content_block: block } = event;
       if (block.type === "text") {
         yield* ensureAssistantTextBlock(context, index, {
@@ -1765,6 +1865,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const inputFingerprint =
         Object.keys(toolInput).length > 0 ? toolInputFingerprint(toolInput) : undefined;
 
+      const genAiToolSpan = context.turnState?.genAiSpan
+        ? startExecuteToolSpan(context.turnState.genAiSpan, {
+            toolName,
+            toolInput: JSON.stringify(toolInput),
+            toolType:
+              block.type === "mcp_tool_use"
+                ? "mcp"
+                : block.type === "server_tool_use"
+                  ? "server"
+                  : "function",
+          })
+        : undefined;
+
       const tool: ToolInFlight = {
         itemId,
         itemType,
@@ -1774,6 +1887,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         input: toolInput,
         partialInputJson: "",
         ...(inputFingerprint ? { lastEmittedInputFingerprint: inputFingerprint } : {}),
+        ...(genAiToolSpan ? { genAiToolSpan } : {}),
       };
       context.inFlightTools.set(index, tool);
 
@@ -1932,6 +2046,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         },
       });
 
+      // Close the gen_ai.execute_tool span for this tool call, capturing the
+      // tool's output text (or full result block JSON if no plain text).
+      if (tool.genAiToolSpan) {
+        const toolOutput =
+          toolResult.text.length > 0 ? toolResult.text : JSON.stringify(toolResult.block);
+        finishExecuteToolSpan(tool.genAiToolSpan, {
+          toolOutput,
+          ...(toolResult.isError
+            ? { errorMessage: toolResult.text || "tool execution failed" }
+            : {}),
+        });
+      }
+
       context.inFlightTools.delete(index);
     }
   });
@@ -1957,6 +2084,19 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         assistantTextBlockOrder: [],
         capturedProposedPlanKeys: new Set(),
         nextSyntheticAssistantBlockIndex: -1,
+        genAiSpan: startInvokeAgentSpan({
+          agentName: genAiAgentName(context.session.cwd),
+          system: "anthropic",
+          model: context.session.model ?? "unknown",
+          conversationId: context.session.threadId,
+          extraAttributes: {
+            "t3.provider": PROVIDER,
+            "t3.thread.id": context.session.threadId,
+            "t3.turn.id": turnId,
+            "t3.turn.synthetic": true,
+            ...(context.session.cwd ? { "t3.workspace.cwd": context.session.cwd } : {}),
+          },
+        }),
       };
       context.session = {
         ...context.session,
@@ -2017,6 +2157,79 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     if (context.turnState) {
       context.turnState.items.push(message.message);
       yield* backfillAssistantTextBlocksFromSnapshot(context, message);
+    }
+
+    // Close the per-request gen_ai.request span using usage data from this
+    // assistant message. Per-message usage (not the cumulative result usage)
+    // is what we want here so each request's token cost is attributable.
+    //
+    // With `includePartialMessages: true` the SDK emits multiple `assistant`
+    // SDKMessages per real API call (partial running states plus the final).
+    // Only the final message has `stop_reason` set; partials leave it null.
+    // Gate on stop_reason so each real API call produces exactly one span —
+    // verified empirically against trace 75d8c8c3... where ungated closing
+    // produced 1–3 duplicate spans per call, all stamped with the cumulative
+    // running totals at their close moment.
+    if (context.turnState?.currentRequestSpan) {
+      const sdkMessage = (message.message ?? undefined) as unknown as
+        | {
+            usage?: Record<string, unknown>;
+            content?: unknown;
+            stop_reason?: unknown;
+            model?: unknown;
+          }
+        | undefined;
+      if (typeof sdkMessage?.stop_reason !== "string") {
+        return;
+      }
+      const usage = sdkMessage?.usage ?? {};
+      const fresh = readFiniteNumber(usage.input_tokens) ?? 0;
+      const cacheRead = readFiniteNumber(usage.cache_read_input_tokens) ?? 0;
+      const cacheWrite = readFiniteNumber(usage.cache_creation_input_tokens) ?? 0;
+      // Sentry conventions: input_tokens is the TOTAL (already includes cached).
+      const inputTokens = fresh + cacheRead + cacheWrite;
+      const outputTokens = readFiniteNumber(usage.output_tokens);
+      const totalTokens = readFiniteNumber(usage.total_tokens) ?? inputTokens + (outputTokens ?? 0);
+
+      const blocks = Array.isArray(sdkMessage?.content) ? sdkMessage.content : [];
+      const textParts: Array<string> = [];
+      const toolCalls: Array<{
+        id: unknown;
+        name: unknown;
+        input: unknown;
+      }> = [];
+      for (const entry of blocks) {
+        if (!entry || typeof entry !== "object") continue;
+        const b = entry as {
+          type?: unknown;
+          text?: unknown;
+          id?: unknown;
+          name?: unknown;
+          input?: unknown;
+        };
+        if (b.type === "text" && typeof b.text === "string") {
+          textParts.push(b.text);
+        }
+        if (b.type === "tool_use" || b.type === "server_tool_use" || b.type === "mcp_tool_use") {
+          toolCalls.push({ id: b.id, name: b.name, input: b.input });
+        }
+      }
+      const responseText = textParts.length > 0 ? textParts.join("\n") : undefined;
+      const toolCallsJson = toolCalls.length > 0 ? JSON.stringify(toolCalls) : undefined;
+      const stopReason =
+        typeof sdkMessage?.stop_reason === "string" ? sdkMessage.stop_reason : undefined;
+
+      finishGenAiRequestSpan(context.turnState.currentRequestSpan, {
+        ...(inputTokens > 0 ? { inputTokens } : {}),
+        ...(outputTokens !== undefined && outputTokens > 0 ? { outputTokens } : {}),
+        ...(totalTokens > 0 ? { totalTokens } : {}),
+        ...(cacheRead > 0 ? { cachedInputTokens: cacheRead } : {}),
+        ...(cacheWrite > 0 ? { cacheWriteInputTokens: cacheWrite } : {}),
+        ...(responseText !== undefined ? { responseText } : {}),
+        ...(toolCallsJson !== undefined ? { toolCallsJson } : {}),
+        ...(stopReason !== undefined ? { finishReason: stopReason } : {}),
+      });
+      context.turnState.currentRequestSpan = undefined;
     }
 
     context.lastAssistantUuid = message.uuid;
@@ -3088,6 +3301,12 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     const turnId = TurnId.make(yield* Random.nextUUIDv4);
+    const turnModel = modelSelection?.model ?? context.session.model ?? "unknown";
+    const userPromptText = buildPromptText(input, boundInstanceId);
+    const userMessagesJson =
+      userPromptText.length > 0
+        ? JSON.stringify([{ role: "user", content: userPromptText }])
+        : undefined;
     const turnState: ClaudeTurnState = {
       turnId,
       startedAt: yield* nowIso,
@@ -3096,6 +3315,20 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       assistantTextBlockOrder: [],
       capturedProposedPlanKeys: new Set(),
       nextSyntheticAssistantBlockIndex: -1,
+      genAiSpan: startInvokeAgentSpan({
+        agentName: genAiAgentName(context.session.cwd),
+        system: "anthropic",
+        model: turnModel,
+        conversationId: context.session.threadId,
+        ...(userMessagesJson ? { messages: userMessagesJson } : {}),
+        extraAttributes: {
+          "t3.provider": PROVIDER,
+          "t3.thread.id": context.session.threadId,
+          "t3.turn.id": turnId,
+          ...(context.session.cwd ? { "t3.workspace.cwd": context.session.cwd } : {}),
+        },
+      }),
+      ...(userMessagesJson ? { genAiUserMessages: userMessagesJson } : {}),
     };
 
     const updatedAt = yield* nowIso;

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1715,6 +1715,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       input.modelSelection?.instanceId === boundInstanceId
         ? getModelSelectionBooleanOptionValue(input.modelSelection, "fastMode")
         : undefined;
+    Sentry.setConversationId(input.threadId);
     if (input.input !== undefined) {
       const userText = typeof input.input === "string" ? input.input : JSON.stringify(input.input);
       const messagesJson = JSON.stringify([{ role: "user", content: userText }]);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -109,6 +109,7 @@ interface CodexAdapterSessionContext {
   readonly runtime: CodexSessionRuntimeShape;
   readonly eventFiber: Fiber.Fiber<void, never>;
   readonly turnSpans: Map<string, CodexTurnSpanState>;
+  readonly sentryScope: ReturnType<typeof Sentry.getIsolationScope>;
   stopped: boolean;
 }
 
@@ -1607,14 +1608,19 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection.model : "unknown";
         let sessionCwd: string | undefined = input.cwd ?? process.cwd();
 
+        const sentryScope = Sentry.getIsolationScope().clone();
+        sentryScope.setConversationId(input.threadId);
+
         const eventFiber = yield* Stream.runForEach(runtime.events, (event) =>
           Effect.gen(function* () {
-            processCodexGenAiEvent(
-              event,
-              input.threadId,
-              () => sessionModel,
-              () => sessionCwd,
-              turnSpans,
+            Sentry.withIsolationScope(sentryScope, () =>
+              processCodexGenAiEvent(
+                event,
+                input.threadId,
+                () => sessionModel,
+                () => sessionCwd,
+                turnSpans,
+              ),
             );
             yield* writeNativeEvent(event);
             const runtimeEvents = mapToRuntimeEvents(event, event.threadId);
@@ -1659,6 +1665,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           runtime,
           eventFiber,
           turnSpans,
+          sentryScope,
           stopped: false,
         });
         sessionScopeTransferred = true;
@@ -1715,15 +1722,16 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       input.modelSelection?.instanceId === boundInstanceId
         ? getModelSelectionBooleanOptionValue(input.modelSelection, "fastMode")
         : undefined;
-    Sentry.setConversationId(input.threadId);
-    if (input.input !== undefined) {
-      const userText = typeof input.input === "string" ? input.input : JSON.stringify(input.input);
-      const messagesJson = JSON.stringify([{ role: "user", content: userText }]);
-      for (const state of session.turnSpans.values()) {
-        state.invokeAgentSpan.setAttribute("gen_ai.input.messages", messagesJson);
-        state.requestSpan?.setAttribute("gen_ai.input.messages", messagesJson);
+    Sentry.withIsolationScope(session.sentryScope, () => {
+      if (input.input !== undefined) {
+        const userText = typeof input.input === "string" ? input.input : JSON.stringify(input.input);
+        const messagesJson = JSON.stringify([{ role: "user", content: userText }]);
+        for (const state of session.turnSpans.values()) {
+          state.invokeAgentSpan.setAttribute("gen_ai.input.messages", messagesJson);
+          state.requestSpan?.setAttribute("gen_ai.input.messages", messagesJson);
+        }
       }
-    }
+    });
 
     return yield* session.runtime
       .sendTurn({

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -39,6 +39,8 @@ import {
 import {
   startInvokeAgentSpan,
   finishInvokeAgentSpan,
+  startGenAiRequestSpan,
+  finishGenAiRequestSpan,
   startExecuteToolSpan,
   finishExecuteToolSpan,
 } from "../../observability/GenAiSpan.ts";
@@ -69,12 +71,14 @@ const PROVIDER = ProviderDriverKind.make("codex");
 
 interface CodexTurnSpanState {
   invokeAgentSpan: Span;
+  requestSpan?: Span;
   toolSpans: Map<string, Span>;
   lastInputTokens?: number;
   lastOutputTokens?: number;
   lastTotalTokens?: number;
   lastCachedInputTokens?: number;
   lastReasoningOutputTokens?: number;
+  lastResponseText?: string;
 }
 
 function codexAgentName(cwd: string | undefined): string {
@@ -1351,6 +1355,21 @@ function mapToRuntimeEvents(
   return [];
 }
 
+const CODEX_TOOL_ITEM_TYPES = new Set([
+  "commandExecution",
+  "fileChange",
+  "mcpToolCall",
+  "dynamicToolCall",
+]);
+
+function codexItemToolName(item: { type: string; command?: string }): string {
+  if (item.type === "commandExecution") return item.command ?? "command";
+  if (item.type === "fileChange") return "file_edit";
+  if (item.type === "mcpToolCall") return "mcp_tool";
+  if (item.type === "dynamicToolCall") return "dynamic_tool";
+  return item.type;
+}
+
 function processCodexGenAiEvent(
   event: ProviderEvent,
   threadId: ThreadId,
@@ -1358,19 +1377,14 @@ function processCodexGenAiEvent(
   getCwd: () => string | undefined,
   turnSpans: Map<string, CodexTurnSpanState>,
 ): void {
-  // readRouteFields in CodexSessionRuntime doesn't extract turnId for all event
-  // types (rawResponseItem/completed, thread/tokenUsage/updated fall to default).
-  // Fall back to the payload's turnId when event.turnId is missing.
   const turnId =
     event.turnId ??
     ((event.payload as { turnId?: string } | undefined)?.turnId as string | undefined);
 
-  Sentry.logger.debug("codex event", { method: event.method, turnId: turnId ?? "none" });
-
   if (event.method === "turn/started" && turnId) {
     const cwd = getCwd();
     const model = getModel();
-    const span = startInvokeAgentSpan({
+    const invokeSpan = startInvokeAgentSpan({
       agentName: codexAgentName(cwd),
       system: "openai",
       model,
@@ -1382,64 +1396,77 @@ function processCodexGenAiEvent(
         ...(cwd ? { "t3.workspace.cwd": cwd } : {}),
       },
     });
+    const requestSpan = startGenAiRequestSpan(invokeSpan, {
+      model,
+      system: "openai",
+      conversationId: threadId,
+    });
     turnSpans.set(turnId, {
-      invokeAgentSpan: span,
+      invokeAgentSpan: invokeSpan,
+      requestSpan,
       toolSpans: new Map(),
     });
-    Sentry.logger.info("codex gen_ai.invoke_agent span opened", { threadId, turnId, model });
     return;
   }
 
-  if (event.method === "thread/tokenUsage/updated" && turnId) {
-    const state = turnSpans.get(turnId);
-    if (state) {
-      const payload = readPayload(
-        EffectCodexSchema.V2ThreadTokenUsageUpdatedNotification,
-        event.payload,
-      );
-      const last = payload?.tokenUsage.last;
-      if (last) {
-        state.lastInputTokens = last.inputTokens;
-        state.lastOutputTokens = last.outputTokens;
-        state.lastTotalTokens = last.totalTokens;
-        state.lastCachedInputTokens = last.cachedInputTokens;
-        state.lastReasoningOutputTokens = last.reasoningOutputTokens;
-      }
+  if (event.method === "thread/tokenUsage/updated") {
+    const payload = readPayload(
+      EffectCodexSchema.V2ThreadTokenUsageUpdatedNotification,
+      event.payload,
+    );
+    const payloadTurnId = payload?.turnId ?? turnId;
+    const state = payloadTurnId ? turnSpans.get(payloadTurnId) : undefined;
+    if (state && payload) {
+      const last = payload.tokenUsage.last;
+      state.lastInputTokens = last.inputTokens;
+      state.lastOutputTokens = last.outputTokens;
+      state.lastTotalTokens = last.totalTokens;
+      state.lastCachedInputTokens = last.cachedInputTokens;
+      state.lastReasoningOutputTokens = last.reasoningOutputTokens;
     }
     return;
   }
 
-  if (event.method === "rawResponseItem/completed" && turnId) {
+  if (event.method === "item/started" && turnId) {
     const state = turnSpans.get(turnId);
-    if (state) {
-      const payload = readPayload(
-        EffectCodexSchema.V2RawResponseItemCompletedNotification,
-        event.payload,
-      );
-      const item = payload?.item;
-      if (!item) {
-        Sentry.logger.warn("codex rawResponseItem/completed: payload parse failed", { threadId, turnId });
-        return;
-      }
-      if (
-        item.type === "function_call" ||
-        item.type === "local_shell_call" ||
-        item.type === "custom_tool_call"
-      ) {
-        const toolName =
-          ("name" in item ? item.name : undefined) ?? item.type;
-        const toolInput =
-          "arguments" in item && typeof item.arguments === "string"
-            ? item.arguments
-            : "input" in item && typeof item.input === "string"
-              ? item.input
-              : undefined;
-        const toolSpan = startExecuteToolSpan(state.invokeAgentSpan, {
-          toolName,
-          ...(toolInput ? { toolInput } : {}),
-        });
-        Sentry.logger.info("codex gen_ai.execute_tool span", { threadId, turnId, tool: toolName });
-        finishExecuteToolSpan(toolSpan, {});
+    if (!state) return;
+    const payload = readPayload(EffectCodexSchema.V2ItemStartedNotification, event.payload);
+    const item = payload?.item;
+    if (!item || !CODEX_TOOL_ITEM_TYPES.has(item.type)) return;
+    const toolName = codexItemToolName(item as { type: string; command?: string });
+    const toolSpan = startExecuteToolSpan(state.invokeAgentSpan, { toolName });
+    if (event.itemId) {
+      state.toolSpans.set(event.itemId, toolSpan);
+    }
+    return;
+  }
+
+  if (event.method === "item/completed" && turnId) {
+    const state = turnSpans.get(turnId);
+    if (!state) return;
+    const payload = readPayload(EffectCodexSchema.V2ItemCompletedNotification, event.payload);
+    const item = payload?.item;
+    if (!item) return;
+
+    if (item.type === "agentMessage" && "text" in item && typeof item.text === "string") {
+      state.lastResponseText = (state.lastResponseText ?? "") + item.text;
+    }
+
+    if (CODEX_TOOL_ITEM_TYPES.has(item.type)) {
+      const existingSpan = event.itemId ? state.toolSpans.get(event.itemId) : undefined;
+      const toolName = codexItemToolName(item as { type: string; command?: string });
+      const toolOutput =
+        "aggregatedOutput" in item && typeof item.aggregatedOutput === "string"
+          ? item.aggregatedOutput
+          : undefined;
+      const finish: import("../../observability/GenAiSpan.ts").ExecuteToolSpanFinish =
+        toolOutput !== undefined ? { toolOutput } : {};
+      if (existingSpan) {
+        finishExecuteToolSpan(existingSpan, finish);
+        if (event.itemId) state.toolSpans.delete(event.itemId);
+      } else {
+        const toolSpan = startExecuteToolSpan(state.invokeAgentSpan, { toolName });
+        finishExecuteToolSpan(toolSpan, finish);
       }
     }
     return;
@@ -1447,33 +1474,42 @@ function processCodexGenAiEvent(
 
   if (event.method === "turn/completed" && turnId) {
     const state = turnSpans.get(turnId);
-    if (state) {
-      for (const toolSpan of state.toolSpans.values()) {
-        finishExecuteToolSpan(toolSpan, {});
-      }
+    if (!state) return;
 
-      const payload = readPayload(
-        EffectCodexSchema.V2TurnCompletedNotification,
-        event.payload,
-      );
-      const errorMessage =
-        payload?.turn.status === "failed" ? payload.turn.error?.message : undefined;
-
-      Sentry.logger.info("codex gen_ai.invoke_agent span closing", { threadId, turnId, inputTokens: state.lastInputTokens ?? 0, outputTokens: state.lastOutputTokens ?? 0 });
-      finishInvokeAgentSpan(state.invokeAgentSpan, {
-        ...(state.lastInputTokens !== undefined ? { inputTokens: state.lastInputTokens } : {}),
-        ...(state.lastOutputTokens !== undefined ? { outputTokens: state.lastOutputTokens } : {}),
-        ...(state.lastTotalTokens !== undefined ? { totalTokens: state.lastTotalTokens } : {}),
-        ...(state.lastCachedInputTokens !== undefined
-          ? { cachedInputTokens: state.lastCachedInputTokens }
-          : {}),
-        ...(state.lastReasoningOutputTokens !== undefined
-          ? { reasoningOutputTokens: state.lastReasoningOutputTokens }
-          : {}),
-        ...(errorMessage ? { errorMessage } : {}),
-      });
-      turnSpans.delete(turnId);
+    for (const toolSpan of state.toolSpans.values()) {
+      finishExecuteToolSpan(toolSpan, {});
     }
+
+    const payload = readPayload(EffectCodexSchema.V2TurnCompletedNotification, event.payload);
+    const errorMessage =
+      payload?.turn.status === "failed" ? payload.turn.error?.message : undefined;
+    const tokenFinish = {
+      inputTokens: state.lastInputTokens ?? 0,
+      outputTokens: state.lastOutputTokens ?? 0,
+      totalTokens: state.lastTotalTokens ?? 0,
+      ...(state.lastCachedInputTokens !== undefined
+        ? { cachedInputTokens: state.lastCachedInputTokens }
+        : {}),
+      ...(state.lastReasoningOutputTokens !== undefined
+        ? { reasoningOutputTokens: state.lastReasoningOutputTokens }
+        : {}),
+    };
+
+    if (state.requestSpan) {
+      finishGenAiRequestSpan(state.requestSpan, {
+        ...tokenFinish,
+        ...(state.lastResponseText ? { responseText: state.lastResponseText } : {}),
+        ...(errorMessage ? { errorMessage } : {}),
+        finishReason: errorMessage ? "error" : "stop",
+      });
+    }
+
+    finishInvokeAgentSpan(state.invokeAgentSpan, {
+      ...tokenFinish,
+      ...(state.lastResponseText ? { responseText: state.lastResponseText } : {}),
+      ...(errorMessage ? { errorMessage } : {}),
+    });
+    turnSpans.delete(turnId);
     return;
   }
 }
@@ -1482,6 +1518,9 @@ function cleanupCodexTurnSpans(turnSpans: Map<string, CodexTurnSpanState>): void
   for (const state of turnSpans.values()) {
     for (const toolSpan of state.toolSpans.values()) {
       finishExecuteToolSpan(toolSpan, { errorMessage: "session closed" });
+    }
+    if (state.requestSpan) {
+      finishGenAiRequestSpan(state.requestSpan, { errorMessage: "session closed" });
     }
     finishInvokeAgentSpan(state.invokeAgentSpan, { errorMessage: "session closed" });
   }

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1715,6 +1715,15 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       input.modelSelection?.instanceId === boundInstanceId
         ? getModelSelectionBooleanOptionValue(input.modelSelection, "fastMode")
         : undefined;
+    if (input.input !== undefined) {
+      const userText = typeof input.input === "string" ? input.input : JSON.stringify(input.input);
+      const messagesJson = JSON.stringify([{ role: "user", content: userText }]);
+      for (const state of session.turnSpans.values()) {
+        state.invokeAgentSpan.setAttribute("gen_ai.input.messages", messagesJson);
+        state.requestSpan?.setAttribute("gen_ai.input.messages", messagesJson);
+      }
+    }
+
     return yield* session.runtime
       .sendTurn({
         ...(input.input !== undefined ? { input: input.input } : {}),

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -28,11 +28,20 @@ import { Effect, Exit, Fiber, FileSystem, Queue, Schema, Scope, Stream } from "e
 import { ChildProcessSpawner } from "effect/unstable/process";
 import * as CodexErrors from "effect-codex-app-server/errors";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
+import * as Sentry from "@sentry/node";
+import type { Span } from "@sentry/node";
 
 import {
   getModelSelectionBooleanOptionValue,
   getModelSelectionStringOptionValue,
 } from "@t3tools/shared/model";
+
+import {
+  startInvokeAgentSpan,
+  finishInvokeAgentSpan,
+  startExecuteToolSpan,
+  finishExecuteToolSpan,
+} from "../../observability/GenAiSpan.ts";
 
 import {
   ProviderAdapterRequestError,
@@ -54,8 +63,27 @@ import {
   type CodexSessionRuntimeShape,
 } from "./CodexSessionRuntime.ts";
 import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+import path from "node:path";
 
 const PROVIDER = ProviderDriverKind.make("codex");
+
+interface CodexTurnSpanState {
+  invokeAgentSpan: Span;
+  toolSpans: Map<string, Span>;
+  lastInputTokens?: number;
+  lastOutputTokens?: number;
+  lastTotalTokens?: number;
+  lastCachedInputTokens?: number;
+  lastReasoningOutputTokens?: number;
+}
+
+function codexAgentName(cwd: string | undefined): string {
+  if (cwd) {
+    const base = path.basename(cwd).trim();
+    if (base.length > 0) return base;
+  }
+  return "codex";
+}
 
 export interface CodexAdapterLiveOptions {
   readonly instanceId?: ProviderInstanceId;
@@ -76,6 +104,7 @@ interface CodexAdapterSessionContext {
   readonly scope: Scope.Closeable;
   readonly runtime: CodexSessionRuntimeShape;
   readonly eventFiber: Fiber.Fiber<void, never>;
+  readonly turnSpans: Map<string, CodexTurnSpanState>;
   stopped: boolean;
 }
 
@@ -1322,15 +1351,143 @@ function mapToRuntimeEvents(
   return [];
 }
 
-/**
- * Build a Codex provider adapter bound to a specific `CodexSettings` payload.
- *
- * The adapter is a captured closure over `codexConfig` — the `binaryPath` and
- * `homePath` are read from that payload, not from `ServerSettingsService`.
- * This is what makes multi-instance routing possible: each `ProviderInstance`
- * in the registry owns its own closure with its own config, so two Codex
- * instances with different `homePath`s cannot step on each other.
- */
+function processCodexGenAiEvent(
+  event: ProviderEvent,
+  threadId: ThreadId,
+  getModel: () => string,
+  getCwd: () => string | undefined,
+  turnSpans: Map<string, CodexTurnSpanState>,
+): void {
+  // readRouteFields in CodexSessionRuntime doesn't extract turnId for all event
+  // types (rawResponseItem/completed, thread/tokenUsage/updated fall to default).
+  // Fall back to the payload's turnId when event.turnId is missing.
+  const turnId =
+    event.turnId ??
+    ((event.payload as { turnId?: string } | undefined)?.turnId as string | undefined);
+
+  Sentry.logger.debug("codex event", { method: event.method, turnId: turnId ?? "none" });
+
+  if (event.method === "turn/started" && turnId) {
+    const cwd = getCwd();
+    const model = getModel();
+    const span = startInvokeAgentSpan({
+      agentName: codexAgentName(cwd),
+      system: "openai",
+      model,
+      conversationId: threadId,
+      extraAttributes: {
+        "t3.provider": PROVIDER,
+        "t3.thread.id": threadId,
+        "t3.turn.id": turnId,
+        ...(cwd ? { "t3.workspace.cwd": cwd } : {}),
+      },
+    });
+    turnSpans.set(turnId, {
+      invokeAgentSpan: span,
+      toolSpans: new Map(),
+    });
+    Sentry.logger.info("codex gen_ai.invoke_agent span opened", { threadId, turnId, model });
+    return;
+  }
+
+  if (event.method === "thread/tokenUsage/updated" && turnId) {
+    const state = turnSpans.get(turnId);
+    if (state) {
+      const payload = readPayload(
+        EffectCodexSchema.V2ThreadTokenUsageUpdatedNotification,
+        event.payload,
+      );
+      const last = payload?.tokenUsage.last;
+      if (last) {
+        state.lastInputTokens = last.inputTokens;
+        state.lastOutputTokens = last.outputTokens;
+        state.lastTotalTokens = last.totalTokens;
+        state.lastCachedInputTokens = last.cachedInputTokens;
+        state.lastReasoningOutputTokens = last.reasoningOutputTokens;
+      }
+    }
+    return;
+  }
+
+  if (event.method === "rawResponseItem/completed" && turnId) {
+    const state = turnSpans.get(turnId);
+    if (state) {
+      const payload = readPayload(
+        EffectCodexSchema.V2RawResponseItemCompletedNotification,
+        event.payload,
+      );
+      const item = payload?.item;
+      if (!item) {
+        Sentry.logger.warn("codex rawResponseItem/completed: payload parse failed", { threadId, turnId });
+        return;
+      }
+      if (
+        item.type === "function_call" ||
+        item.type === "local_shell_call" ||
+        item.type === "custom_tool_call"
+      ) {
+        const toolName =
+          ("name" in item ? item.name : undefined) ?? item.type;
+        const toolInput =
+          "arguments" in item && typeof item.arguments === "string"
+            ? item.arguments
+            : "input" in item && typeof item.input === "string"
+              ? item.input
+              : undefined;
+        const toolSpan = startExecuteToolSpan(state.invokeAgentSpan, {
+          toolName,
+          ...(toolInput ? { toolInput } : {}),
+        });
+        Sentry.logger.info("codex gen_ai.execute_tool span", { threadId, turnId, tool: toolName });
+        finishExecuteToolSpan(toolSpan, {});
+      }
+    }
+    return;
+  }
+
+  if (event.method === "turn/completed" && turnId) {
+    const state = turnSpans.get(turnId);
+    if (state) {
+      for (const toolSpan of state.toolSpans.values()) {
+        finishExecuteToolSpan(toolSpan, {});
+      }
+
+      const payload = readPayload(
+        EffectCodexSchema.V2TurnCompletedNotification,
+        event.payload,
+      );
+      const errorMessage =
+        payload?.turn.status === "failed" ? payload.turn.error?.message : undefined;
+
+      Sentry.logger.info("codex gen_ai.invoke_agent span closing", { threadId, turnId, inputTokens: state.lastInputTokens ?? 0, outputTokens: state.lastOutputTokens ?? 0 });
+      finishInvokeAgentSpan(state.invokeAgentSpan, {
+        ...(state.lastInputTokens !== undefined ? { inputTokens: state.lastInputTokens } : {}),
+        ...(state.lastOutputTokens !== undefined ? { outputTokens: state.lastOutputTokens } : {}),
+        ...(state.lastTotalTokens !== undefined ? { totalTokens: state.lastTotalTokens } : {}),
+        ...(state.lastCachedInputTokens !== undefined
+          ? { cachedInputTokens: state.lastCachedInputTokens }
+          : {}),
+        ...(state.lastReasoningOutputTokens !== undefined
+          ? { reasoningOutputTokens: state.lastReasoningOutputTokens }
+          : {}),
+        ...(errorMessage ? { errorMessage } : {}),
+      });
+      turnSpans.delete(turnId);
+    }
+    return;
+  }
+}
+
+function cleanupCodexTurnSpans(turnSpans: Map<string, CodexTurnSpanState>): void {
+  for (const state of turnSpans.values()) {
+    for (const toolSpan of state.toolSpans.values()) {
+      finishExecuteToolSpan(toolSpan, { errorMessage: "session closed" });
+    }
+    finishInvokeAgentSpan(state.invokeAgentSpan, { errorMessage: "session closed" });
+  }
+  turnSpans.clear();
+}
+
 export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
   codexConfig: CodexSettings,
   options?: CodexAdapterLiveOptions,
@@ -1406,8 +1563,20 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           ),
         );
 
+        const turnSpans = new Map<string, CodexTurnSpanState>();
+        let sessionModel =
+          input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection.model : "unknown";
+        let sessionCwd: string | undefined = input.cwd ?? process.cwd();
+
         const eventFiber = yield* Stream.runForEach(runtime.events, (event) =>
           Effect.gen(function* () {
+            processCodexGenAiEvent(
+              event,
+              input.threadId,
+              () => sessionModel,
+              () => sessionCwd,
+              turnSpans,
+            );
             yield* writeNativeEvent(event);
             const runtimeEvents = mapToRuntimeEvents(event, event.threadId);
             if (runtimeEvents.length === 0) {
@@ -1442,11 +1611,15 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           ),
         );
 
+        if (started.model) sessionModel = started.model;
+        if (started.cwd) sessionCwd = started.cwd;
+
         sessions.set(input.threadId, {
           threadId: input.threadId,
           scope: sessionScope,
           runtime,
           eventFiber,
+          turnSpans,
           stopped: false,
         });
         sessionScopeTransferred = true;
@@ -1620,6 +1793,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     }
     session.stopped = true;
     sessions.delete(session.threadId);
+    cleanupCodexTurnSpans(session.turnSpans);
     yield* session.runtime.close.pipe(Effect.ignore);
     yield* Effect.ignore(Scope.close(session.scope, Exit.void));
     yield* Fiber.interrupt(session.eventFiber).pipe(Effect.ignore);

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -110,6 +110,7 @@ interface CodexAdapterSessionContext {
   readonly eventFiber: Fiber.Fiber<void, never>;
   readonly turnSpans: Map<string, CodexTurnSpanState>;
   readonly sentryScope: ReturnType<typeof Sentry.getIsolationScope>;
+  pendingTurnSpan?: CodexTurnSpanState | undefined;
   stopped: boolean;
 }
 
@@ -1374,39 +1375,21 @@ function codexItemToolName(item: { type: string; command?: string }): string {
 function processCodexGenAiEvent(
   event: ProviderEvent,
   threadId: ThreadId,
-  getModel: () => string,
-  getCwd: () => string | undefined,
   turnSpans: Map<string, CodexTurnSpanState>,
+  getPendingSpan: () => CodexTurnSpanState | undefined,
+  clearPendingSpan: () => void,
 ): void {
   const turnId =
     event.turnId ??
     ((event.payload as { turnId?: string } | undefined)?.turnId as string | undefined);
 
   if (event.method === "turn/started" && turnId) {
-    const cwd = getCwd();
-    const model = getModel();
-    const invokeSpan = startInvokeAgentSpan({
-      agentName: codexAgentName(cwd),
-      system: "openai",
-      model,
-      conversationId: threadId,
-      extraAttributes: {
-        "t3.provider": PROVIDER,
-        "t3.thread.id": threadId,
-        "t3.turn.id": turnId,
-        ...(cwd ? { "t3.workspace.cwd": cwd } : {}),
-      },
-    });
-    const requestSpan = startGenAiRequestSpan(invokeSpan, {
-      model,
-      system: "openai",
-      conversationId: threadId,
-    });
-    turnSpans.set(turnId, {
-      invokeAgentSpan: invokeSpan,
-      requestSpan,
-      toolSpans: new Map(),
-    });
+    const pending = getPendingSpan();
+    if (pending) {
+      pending.invokeAgentSpan.setAttribute("t3.turn.id", turnId);
+      turnSpans.set(turnId, pending);
+      clearPendingSpan();
+    }
     return;
   }
 
@@ -1604,6 +1587,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         );
 
         const turnSpans = new Map<string, CodexTurnSpanState>();
+        let sessionRef: CodexAdapterSessionContext | undefined;
         let sessionModel =
           input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection.model : "unknown";
         let sessionCwd: string | undefined = input.cwd ?? process.cwd();
@@ -1617,9 +1601,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
               processCodexGenAiEvent(
                 event,
                 input.threadId,
-                () => sessionModel,
-                () => sessionCwd,
                 turnSpans,
+                () => sessionRef?.pendingTurnSpan,
+                () => { if (sessionRef) sessionRef.pendingTurnSpan = undefined; },
               ),
             );
             yield* writeNativeEvent(event);
@@ -1659,7 +1643,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
         if (started.model) sessionModel = started.model;
         if (started.cwd) sessionCwd = started.cwd;
 
-        sessions.set(input.threadId, {
+        const sessionCtx: CodexAdapterSessionContext = {
           threadId: input.threadId,
           scope: sessionScope,
           runtime,
@@ -1667,7 +1651,9 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           turnSpans,
           sentryScope,
           stopped: false,
-        });
+        };
+        sessions.set(input.threadId, sessionCtx);
+        sessionRef = sessionCtx;
         sessionScopeTransferred = true;
 
         return started;
@@ -1722,15 +1708,44 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
       input.modelSelection?.instanceId === boundInstanceId
         ? getModelSelectionBooleanOptionValue(input.modelSelection, "fastMode")
         : undefined;
+
+    const model =
+      input.modelSelection?.instanceId === boundInstanceId
+        ? input.modelSelection.model
+        : "unknown";
+    const userText =
+      input.input !== undefined
+        ? typeof input.input === "string"
+          ? input.input
+          : JSON.stringify(input.input)
+        : undefined;
+    const messagesJson = userText ? JSON.stringify([{ role: "user", content: userText }]) : undefined;
+    const cwd = process.cwd();
+
     Sentry.withIsolationScope(session.sentryScope, () => {
-      if (input.input !== undefined) {
-        const userText = typeof input.input === "string" ? input.input : JSON.stringify(input.input);
-        const messagesJson = JSON.stringify([{ role: "user", content: userText }]);
-        for (const state of session.turnSpans.values()) {
-          state.invokeAgentSpan.setAttribute("gen_ai.input.messages", messagesJson);
-          state.requestSpan?.setAttribute("gen_ai.input.messages", messagesJson);
-        }
-      }
+      const invokeSpan = startInvokeAgentSpan({
+        agentName: codexAgentName(cwd),
+        system: "openai",
+        model,
+        conversationId: input.threadId,
+        ...(messagesJson ? { messages: messagesJson } : {}),
+        extraAttributes: {
+          "t3.provider": PROVIDER,
+          "t3.thread.id": input.threadId,
+          ...(cwd ? { "t3.workspace.cwd": cwd } : {}),
+        },
+      });
+      const requestSpan = startGenAiRequestSpan(invokeSpan, {
+        model,
+        system: "openai",
+        conversationId: input.threadId,
+        ...(messagesJson ? { messages: messagesJson } : {}),
+      });
+      session.pendingTurnSpan = {
+        invokeAgentSpan: invokeSpan,
+        requestSpan,
+        toolSpans: new Map(),
+      };
     });
 
     return yield* session.runtime

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1723,6 +1723,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
     const cwd = process.cwd();
 
     Sentry.withIsolationScope(session.sentryScope, () => {
+      const activeSpan = Sentry.getActiveSpan();
       const invokeSpan = startInvokeAgentSpan({
         agentName: codexAgentName(cwd),
         system: "openai",
@@ -1734,7 +1735,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           "t3.thread.id": input.threadId,
           ...(cwd ? { "t3.workspace.cwd": cwd } : {}),
         },
-      });
+      }, activeSpan ?? undefined);
       const requestSpan = startGenAiRequestSpan(invokeSpan, {
         model,
         system: "openai",

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/node";
+import { propagationContextFromHeaders } from "@sentry/core";
 import { Cause, Duration, Effect, Layer, Option, Queue, Ref, Schema, Stream } from "effect";
 import {
   type AuthAccessStreamEvent,
@@ -1076,6 +1078,22 @@ export const websocketRpcRouteLayer = Layer.unwrap(
         const serverAuth = yield* ServerAuth;
         const sessions = yield* SessionCredentialService;
         const session = yield* serverAuth.authenticateWebSocketUpgrade(request);
+
+        // Browser injects sentry-trace/baggage as WS URL query params.
+        // Set the propagation context on the isolation scope so gen_ai spans
+        // created during this WS session are linked to the browser's trace.
+        // Safe for the single-user local server model t3code targets.
+        const url = HttpServerRequest.toURL(request);
+        if (Option.isSome(url)) {
+          const sentryTrace = url.value.searchParams.get("sentry-trace") ?? undefined;
+          const baggage = url.value.searchParams.get("baggage") ?? undefined;
+          if (sentryTrace) {
+            Sentry.getIsolationScope().setPropagationContext(
+              propagationContextFromHeaders(sentryTrace, baggage),
+            );
+          }
+        }
+
         const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(WsRpcGroup, {
           spanPrefix: "ws.rpc",
           spanAttributes: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@legendapp/list": "3.0.0-beta.44",
     "@lexical/react": "^0.41.0",
     "@pierre/diffs": "^1.1.0-beta.16",
+    "@sentry/react": "^10.50.0",
     "@t3tools/client-runtime": "workspace:*",
     "@t3tools/contracts": "workspace:*",
     "@t3tools/shared": "workspace:*",
@@ -46,6 +47,7 @@
   "devDependencies": {
     "@effect/language-service": "catalog:",
     "@rolldown/plugin-babel": "^0.2.0",
+    "@sentry/vite-plugin": "^5.2.1",
     "@tailwindcss/vite": "^4.0.0",
     "@tanstack/router-plugin": "^1.161.0",
     "@types/babel__core": "^7.20.5",

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react";
 import {
   type ApprovalRequestId,
   DEFAULT_MODEL,
@@ -2633,23 +2634,41 @@ export default function ChatView(props: ChatViewProps) {
             }
           : undefined;
       beginLocalDispatch({ preparingWorktree: false });
-      await api.orchestration.dispatchCommand({
-        type: "thread.turn.start",
-        commandId: newCommandId(),
-        threadId: threadIdForSend,
-        message: {
-          messageId: messageIdForSend,
-          role: "user",
-          text: outgoingMessageText,
-          attachments: turnAttachments,
+      await Sentry.startSpan(
+        {
+          op: "ui.submit_prompt",
+          name: `prompt ${ctxSelectedProvider ?? "unknown"}`,
+          attributes: {
+            "t3.thread.id": threadIdForSend,
+            "t3.provider": ctxSelectedProvider ?? "unknown",
+            "t3.model": ctxSelectedModel ?? "unknown",
+            "t3.runtime_mode": runtimeMode,
+            "t3.interaction_mode": interactionMode,
+            "t3.instance_id": ctxSelectedModelSelection.instanceId,
+            "t3.prompt_length": outgoingMessageText.length,
+            "t3.has_attachments": turnAttachments.length > 0,
+            "t3.effort": ctxSelectedPromptEffort ?? "default",
+          },
         },
-        modelSelection: ctxSelectedModelSelection,
-        titleSeed: title,
-        runtimeMode,
-        interactionMode,
-        ...(bootstrap ? { bootstrap } : {}),
-        createdAt: messageCreatedAt,
-      });
+        () =>
+          api.orchestration.dispatchCommand({
+            type: "thread.turn.start",
+            commandId: newCommandId(),
+            threadId: threadIdForSend,
+            message: {
+              messageId: messageIdForSend,
+              role: "user",
+              text: outgoingMessageText,
+              attachments: turnAttachments,
+            },
+            modelSelection: ctxSelectedModelSelection,
+            titleSeed: title,
+            runtimeMode,
+            interactionMode,
+            ...(bootstrap ? { bootstrap } : {}),
+            createdAt: messageCreatedAt,
+          }),
+      );
       turnStartSucceeded = true;
     })().catch(async (err: unknown) => {
       if (

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2650,8 +2650,9 @@ export default function ChatView(props: ChatViewProps) {
             "t3.effort": ctxSelectedPromptEffort ?? "default",
           },
         },
-        () =>
-          api.orchestration.dispatchCommand({
+        () => {
+          const traceData = Sentry.getTraceData();
+          return api.orchestration.dispatchCommand({
             type: "thread.turn.start",
             commandId: newCommandId(),
             threadId: threadIdForSend,
@@ -2667,7 +2668,10 @@ export default function ChatView(props: ChatViewProps) {
             interactionMode,
             ...(bootstrap ? { bootstrap } : {}),
             createdAt: messageCreatedAt,
-          }),
+            ...(traceData["sentry-trace"] ? { sentryTrace: traceData["sentry-trace"] } : {}),
+            ...(traceData.baggage ? { sentryBaggage: traceData.baggage } : {}),
+          });
+        },
       );
       turnStartSucceeded = true;
     })().catch(async (err: unknown) => {

--- a/apps/web/src/instrument.ts
+++ b/apps/web/src/instrument.ts
@@ -1,0 +1,23 @@
+import * as Sentry from "@sentry/react";
+
+Sentry.init({
+  dsn: "https://09574f0c4afde19df8e9d5d4c64c7de2@o4509446862274560.ingest.us.sentry.io/4511299398008832",
+  environment: import.meta.env.MODE,
+
+  sendDefaultPii: true,
+
+  integrations: [
+    Sentry.replayIntegration(),
+    Sentry.browserTracingIntegration({
+      shouldCreateSpanForRequest: (url) => !url.includes("/api/observability/"),
+    }),
+  ],
+
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: ["localhost", /^\//],
+
+  replaysSessionSampleRate: 1.0,
+  replaysOnErrorSampleRate: 1.0,
+
+  enableLogs: true,
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,3 +1,5 @@
+import "./instrument";
+import * as Sentry from "@sentry/react";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import { RouterProvider } from "@tanstack/react-router";
@@ -16,13 +18,23 @@ const history = isElectron ? createHashHistory() : createBrowserHistory();
 
 const router = getRouter(history);
 
+Sentry.addIntegration(
+  Sentry.tanstackRouterBrowserTracingIntegration(router),
+);
+
 if (isElectron) {
   syncDocumentWindowControlsOverlayClass();
 }
 
 document.title = APP_DISPLAY_NAME;
 
-ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement, {
+  // @ts-expect-error Sentry's ErrorInfo uses `string | null` for componentStack while React 19's types use `string | undefined`
+  onUncaughtError: Sentry.reactErrorHandler(),
+  // @ts-expect-error same Sentry/React 19 type mismatch
+  onCaughtError: Sentry.reactErrorHandler(),
+  onRecoverableError: Sentry.reactErrorHandler(),
+}).render(
   <React.StrictMode>
     <RouterProvider router={router} />
   </React.StrictMode>,

--- a/apps/web/src/rpc/protocol.ts
+++ b/apps/web/src/rpc/protocol.ts
@@ -1,4 +1,5 @@
 import { WsRpcGroup } from "@t3tools/contracts";
+import * as Sentry from "@sentry/react";
 import { Duration, Effect, Layer, Schedule } from "effect";
 import { RpcClient, RpcSerialization } from "effect/unstable/rpc";
 import * as Socket from "effect/unstable/socket/Socket";
@@ -36,6 +37,17 @@ function formatSocketErrorMessage(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+function appendSentryTraceContext(socketUrl: string): string {
+  const traceData = Sentry.getTraceData();
+  if (!traceData["sentry-trace"]) return socketUrl;
+  const url = new URL(socketUrl);
+  url.searchParams.set("sentry-trace", traceData["sentry-trace"]);
+  if (traceData.baggage) {
+    url.searchParams.set("baggage", traceData.baggage);
+  }
+  return url.toString();
 }
 
 function resolveWsRpcSocketUrl(rawUrl: string): string {
@@ -125,7 +137,8 @@ export function createWsRpcProtocolLayer(
     Socket.WebSocketConstructor,
     (socketUrl, protocols) => {
       lifecycle.onAttempt(socketUrl);
-      const socket = new globalThis.WebSocket(socketUrl, protocols);
+      const tracedUrl = appendSentryTraceContext(socketUrl);
+      const socket = new globalThis.WebSocket(tracedUrl, protocols);
 
       socket.addEventListener(
         "open",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,3 +1,4 @@
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
 import babel from "@rolldown/plugin-babel";
@@ -54,6 +55,11 @@ export default defineConfig({
       presets: [reactCompilerPreset()],
     }),
     tailwindcss(),
+    sentryVitePlugin({
+      org: "sentry-developer-experience",
+      project: "t3toolsweb",
+      sourcemaps: { filesToDeleteAfterUpload: ["./dist/**/*.map"] },
+    }),
   ],
   optimizeDeps: {
     include: [

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
         "@legendapp/list": "3.0.0-beta.44",
         "@lexical/react": "^0.41.0",
         "@pierre/diffs": "^1.1.0-beta.16",
+        "@sentry/react": "^10.50.0",
         "@t3tools/client-runtime": "workspace:*",
         "@t3tools/contracts": "workspace:*",
         "@t3tools/shared": "workspace:*",
@@ -110,6 +111,7 @@
       "devDependencies": {
         "@effect/language-service": "catalog:",
         "@rolldown/plugin-babel": "^0.2.0",
+        "@sentry/vite-plugin": "^5.2.1",
         "@tailwindcss/vite": "^4.0.0",
         "@tanstack/router-plugin": "^1.161.0",
         "@types/babel__core": "^7.20.5",
@@ -766,7 +768,39 @@
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
+    "@sentry-internal/browser-utils": ["@sentry-internal/browser-utils@10.50.0", "", { "dependencies": { "@sentry/core": "10.50.0" } }, "sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA=="],
+
+    "@sentry-internal/feedback": ["@sentry-internal/feedback@10.50.0", "", { "dependencies": { "@sentry/core": "10.50.0" } }, "sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w=="],
+
     "@sentry-internal/node-cpu-profiler": ["@sentry-internal/node-cpu-profiler@2.2.0", "", { "dependencies": { "detect-libc": "^2.0.3", "node-abi": "^3.73.0" } }, "sha512-oLHVYurqZfADPh5hvmQYS5qx8t0UZzT2u6+/68VXsFruQEOnYJTODKgU3BVLmemRs3WE6kCJjPeFdHVYOQGSzQ=="],
+
+    "@sentry-internal/replay": ["@sentry-internal/replay@10.50.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.50.0", "@sentry/core": "10.50.0" } }, "sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ=="],
+
+    "@sentry-internal/replay-canvas": ["@sentry-internal/replay-canvas@10.50.0", "", { "dependencies": { "@sentry-internal/replay": "10.50.0", "@sentry/core": "10.50.0" } }, "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw=="],
+
+    "@sentry/babel-plugin-component-annotate": ["@sentry/babel-plugin-component-annotate@5.2.1", "", {}, "sha512-QQ9AL5EXIbSK26ObLVtiU6l3tCUdpGSJ/6VwDkPhC3qvtoksSlcoU9Yzm7XC0NBcvu1N2abL5R7gckKGZ4JewQ=="],
+
+    "@sentry/browser": ["@sentry/browser@10.50.0", "", { "dependencies": { "@sentry-internal/browser-utils": "10.50.0", "@sentry-internal/feedback": "10.50.0", "@sentry-internal/replay": "10.50.0", "@sentry-internal/replay-canvas": "10.50.0", "@sentry/core": "10.50.0" } }, "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA=="],
+
+    "@sentry/bundler-plugin-core": ["@sentry/bundler-plugin-core@5.2.1", "", { "dependencies": { "@babel/core": "^7.18.5", "@sentry/babel-plugin-component-annotate": "5.2.1", "@sentry/cli": "^2.58.5", "dotenv": "^16.3.1", "find-up": "^5.0.0", "glob": "^13.0.6", "magic-string": "~0.30.8" } }, "sha512-uXb+TOZKXxm2STsP3iR70Jh/yYHwlHOvql7w/bUVYgDyiB/1Mv0D6oNGS0kelsgBsBwCq3ngyJYlyNy3oM1pPw=="],
+
+    "@sentry/cli": ["@sentry/cli@2.58.5", "", { "dependencies": { "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.7", "progress": "^2.0.3", "proxy-from-env": "^1.1.0", "which": "^2.0.2" }, "optionalDependencies": { "@sentry/cli-darwin": "2.58.5", "@sentry/cli-linux-arm": "2.58.5", "@sentry/cli-linux-arm64": "2.58.5", "@sentry/cli-linux-i686": "2.58.5", "@sentry/cli-linux-x64": "2.58.5", "@sentry/cli-win32-arm64": "2.58.5", "@sentry/cli-win32-i686": "2.58.5", "@sentry/cli-win32-x64": "2.58.5" }, "bin": { "sentry-cli": "bin/sentry-cli" } }, "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg=="],
+
+    "@sentry/cli-darwin": ["@sentry/cli-darwin@2.58.5", "", { "os": "darwin" }, "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ=="],
+
+    "@sentry/cli-linux-arm": ["@sentry/cli-linux-arm@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm" }, "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw=="],
+
+    "@sentry/cli-linux-arm64": ["@sentry/cli-linux-arm64@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "arm64" }, "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ=="],
+
+    "@sentry/cli-linux-i686": ["@sentry/cli-linux-i686@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "ia32" }, "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw=="],
+
+    "@sentry/cli-linux-x64": ["@sentry/cli-linux-x64@2.58.5", "", { "os": [ "linux", "android", "freebsd", ], "cpu": "x64" }, "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g=="],
+
+    "@sentry/cli-win32-arm64": ["@sentry/cli-win32-arm64@2.58.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA=="],
+
+    "@sentry/cli-win32-i686": ["@sentry/cli-win32-i686@2.58.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g=="],
+
+    "@sentry/cli-win32-x64": ["@sentry/cli-win32-x64@2.58.5", "", { "os": "win32", "cpu": "x64" }, "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg=="],
 
     "@sentry/core": ["@sentry/core@10.50.0", "", {}, "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg=="],
 
@@ -777,6 +811,12 @@
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.50.0", "", { "dependencies": { "@sentry/core": "10.50.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw=="],
 
     "@sentry/profiling-node": ["@sentry/profiling-node@10.50.0", "", { "dependencies": { "@sentry-internal/node-cpu-profiler": "^2.2.0", "@sentry/core": "10.50.0", "@sentry/node": "10.50.0" }, "bin": { "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js" } }, "sha512-fKavmoOJdst07/Mf8Zvz8QEbn8RDM10I1tdwSTmC8n77zm5IEQll7eYHP8e77VWuXHXggfVn5WNQfG2uDrECaA=="],
+
+    "@sentry/react": ["@sentry/react@10.50.0", "", { "dependencies": { "@sentry/browser": "10.50.0", "@sentry/core": "10.50.0" }, "peerDependencies": { "react": "^16.14.0 || 17.x || 18.x || 19.x" } }, "sha512-MZHYjEZAtFIa4zPrWS4oXlo+gMppRvfETqUqF920Sj2jN2U7WjboU03lDmjfDqEcH7QiwjQyl13jHd2nwAyrrw=="],
+
+    "@sentry/rollup-plugin": ["@sentry/rollup-plugin@5.2.1", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.2.1", "magic-string": "~0.30.8" }, "peerDependencies": { "rollup": ">=3.2.0" }, "optionalPeers": ["rollup"] }, "sha512-LKJyL4fzcHnHExipVN0/QinhBNoGZt+UXg8xJaqc6MwOolOhxHW0ii2hu1OZsiOhX0+r9MK7T+a7Sx0F0bzdMQ=="],
+
+    "@sentry/vite-plugin": ["@sentry/vite-plugin@5.2.1", "", { "dependencies": { "@sentry/bundler-plugin-core": "5.2.1", "@sentry/rollup-plugin": "5.2.1" } }, "sha512-sSQzOhN8xvo/R70vqgyonnC/fwXpJ1kbkJ0g81Xy/OR+N89+v5tPN4VlKTAq3T2c5yAPE39XCbdgeEnI4kbWGg=="],
 
     "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
@@ -986,6 +1026,8 @@
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
@@ -1180,6 +1222,8 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
@@ -1274,6 +1318,8 @@
 
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
     "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
@@ -1305,6 +1351,8 @@
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
+
+    "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -1367,6 +1415,8 @@
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http2-wrapper": ["http2-wrapper@1.0.3", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.0.0" } }, "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1485,6 +1535,8 @@
     "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash.defaults": ["lodash.defaults@4.2.0", "", {}, "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="],
 
@@ -1618,6 +1670,8 @@
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
@@ -1647,6 +1701,8 @@
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "node-fetch-native": ["node-fetch-native@1.6.7", "", {}, "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q=="],
 
@@ -1696,6 +1752,8 @@
 
     "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
 
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
     "p-queue": ["p-queue@9.1.0", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-O/ZPaXuQV29uSLbxWBGGZO1mCQXV2BLIwUr59JUU9SoH76mnYvtms7aafH/isNSNGwuEfP6W/4xD0/TJXxrizw=="],
 
     "p-timeout": ["p-timeout@7.0.1", "", {}, "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg=="],
@@ -1712,7 +1770,11 @@
 
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
@@ -1759,6 +1821,8 @@
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
 
@@ -1978,6 +2042,8 @@
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
@@ -2122,7 +2188,11 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -2258,6 +2328,8 @@
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
+    "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -2375,6 +2447,8 @@
     "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.2", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.2", "@babel/helper-validator-identifier": "^8.0.0-rc.2" } }, "sha512-91gAaWRznDwSX4E2tZ1YjBuIfnQVOFDCQ2r0Toby0gu4XEbyF623kXLMA8d4ZbCu+fINcrudkmEcwSUHgDDkNw=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "rolldown-plugin-dts/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.2", "", {}, "sha512-noLx87RwlBEMrTzncWd/FvTxoJ9+ycHNg0n8yyYydIoDsLZuxknKgWRJUqcrVkNrJ74uGyhWQzQaS3q8xfGAhQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "@t3tools/monorepo",
@@ -54,6 +53,8 @@
         "@effect/sql-sqlite-bun": "catalog:",
         "@opencode-ai/sdk": "^1.3.15",
         "@pierre/diffs": "^1.1.0-beta.16",
+        "@sentry/node": "^10.50.0",
+        "@sentry/profiling-node": "^10.50.0",
         "effect": "catalog:",
         "node-pty": "^1.1.0",
         "open": "^10.1.0",
@@ -417,6 +418,8 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.4", "", { "os": "win32", "cpu": "x64" }, "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg=="],
 
+    "@fastify/otel": ["@fastify/otel@0.18.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.212.0", "@opentelemetry/semantic-conventions": "^1.28.0", "minimatch": "^10.2.4" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA=="],
+
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
@@ -575,6 +578,64 @@
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.3.15", "", { "dependencies": { "cross-spawn": "7.0.6" } }, "sha512-Uk59C7wsK20wpdr277yx7Xz7TqG5jGqlZUpSW3wDH/7a2K2iBg0lXc2wskHuCXLRXMhXpPZtb4a3SOpPENkkbg=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
+
+    "@opentelemetry/instrumentation-amqplib": ["@opentelemetry/instrumentation-amqplib@0.61.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q=="],
+
+    "@opentelemetry/instrumentation-connect": ["@opentelemetry/instrumentation-connect@0.57.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.27.0", "@types/connect": "3.4.38" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg=="],
+
+    "@opentelemetry/instrumentation-dataloader": ["@opentelemetry/instrumentation-dataloader@0.31.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g=="],
+
+    "@opentelemetry/instrumentation-fs": ["@opentelemetry/instrumentation-fs@0.33.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA=="],
+
+    "@opentelemetry/instrumentation-generic-pool": ["@opentelemetry/instrumentation-generic-pool@0.57.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow=="],
+
+    "@opentelemetry/instrumentation-graphql": ["@opentelemetry/instrumentation-graphql@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg=="],
+
+    "@opentelemetry/instrumentation-hapi": ["@opentelemetry/instrumentation-hapi@0.60.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w=="],
+
+    "@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.214.0", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/instrumentation": "0.214.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg=="],
+
+    "@opentelemetry/instrumentation-ioredis": ["@opentelemetry/instrumentation-ioredis@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ=="],
+
+    "@opentelemetry/instrumentation-kafkajs": ["@opentelemetry/instrumentation-kafkajs@0.23.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.30.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ=="],
+
+    "@opentelemetry/instrumentation-knex": ["@opentelemetry/instrumentation-knex@0.58.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw=="],
+
+    "@opentelemetry/instrumentation-koa": ["@opentelemetry/instrumentation-koa@0.62.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.36.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA=="],
+
+    "@opentelemetry/instrumentation-lru-memoizer": ["@opentelemetry/instrumentation-lru-memoizer@0.58.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q=="],
+
+    "@opentelemetry/instrumentation-mongodb": ["@opentelemetry/instrumentation-mongodb@0.67.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ=="],
+
+    "@opentelemetry/instrumentation-mongoose": ["@opentelemetry/instrumentation-mongoose@0.60.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg=="],
+
+    "@opentelemetry/instrumentation-mysql": ["@opentelemetry/instrumentation-mysql@0.60.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/mysql": "2.15.27" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ=="],
+
+    "@opentelemetry/instrumentation-mysql2": ["@opentelemetry/instrumentation-mysql2@0.60.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@opentelemetry/sql-common": "^0.41.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw=="],
+
+    "@opentelemetry/instrumentation-pg": ["@opentelemetry/instrumentation-pg@0.66.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.34.0", "@opentelemetry/sql-common": "^0.41.2", "@types/pg": "8.15.6", "@types/pg-pool": "2.0.7" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA=="],
+
+    "@opentelemetry/instrumentation-redis": ["@opentelemetry/instrumentation-redis@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ=="],
+
+    "@opentelemetry/instrumentation-tedious": ["@opentelemetry/instrumentation-tedious@0.33.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/tedious": "^4.0.14" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w=="],
+
+    "@opentelemetry/redis-common": ["@opentelemetry/redis-common@0.38.3", "", {}, "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.0", "", { "dependencies": { "@opentelemetry/core": "2.7.0", "@opentelemetry/resources": "2.7.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
+
+    "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.41.2", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ=="],
+
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@oxc-project/runtime": ["@oxc-project/runtime@0.115.0", "", {}, "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ=="],
@@ -665,6 +726,8 @@
 
     "@preact/signals-core": ["@preact/signals-core@1.14.0", "", {}, "sha512-AowtCcCU/33lFlh1zRFf/u+12rfrhtNakj7UpaGEsmMwUKpKWMVvcktOGcwBBNiB4lWrZWc01LhiyyzVklJyaQ=="],
 
+    "@prisma/instrumentation": ["@prisma/instrumentation@7.6.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ=="],
+
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.3", "", { "os": "android", "cpu": "arm64" }, "sha512-0T1k9FinuBZ/t7rZ8jN6OpUKPnUjNdYHoj/cESWrQ3ZraAJ4OMm6z7QjSfCxqj8mOp9kTKc1zHK3kGz5vMu+nQ=="],
@@ -702,6 +765,18 @@
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
+
+    "@sentry-internal/node-cpu-profiler": ["@sentry-internal/node-cpu-profiler@2.2.0", "", { "dependencies": { "detect-libc": "^2.0.3", "node-abi": "^3.73.0" } }, "sha512-oLHVYurqZfADPh5hvmQYS5qx8t0UZzT2u6+/68VXsFruQEOnYJTODKgU3BVLmemRs3WE6kCJjPeFdHVYOQGSzQ=="],
+
+    "@sentry/core": ["@sentry/core@10.50.0", "", {}, "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg=="],
+
+    "@sentry/node": ["@sentry/node@10.50.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-ioredis": "0.62.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-redis": "0.62.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.50.0", "@sentry/node-core": "10.50.0", "@sentry/opentelemetry": "10.50.0", "import-in-the-middle": "^3.0.0" } }, "sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q=="],
+
+    "@sentry/node-core": ["@sentry/node-core@10.50.0", "", { "dependencies": { "@sentry/core": "10.50.0", "@sentry/opentelemetry": "10.50.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw=="],
+
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.50.0", "", { "dependencies": { "@sentry/core": "10.50.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw=="],
+
+    "@sentry/profiling-node": ["@sentry/profiling-node@10.50.0", "", { "dependencies": { "@sentry-internal/node-cpu-profiler": "^2.2.0", "@sentry/core": "10.50.0", "@sentry/node": "10.50.0" }, "bin": { "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js" } }, "sha512-fKavmoOJdst07/Mf8Zvz8QEbn8RDM10I1tdwSTmC8n77zm5IEQll7eYHP8e77VWuXHXggfVn5WNQfG2uDrECaA=="],
 
     "@shikijs/core": ["@shikijs/core@4.0.2", "", { "dependencies": { "@shikijs/primitive": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw=="],
 
@@ -815,6 +890,8 @@
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -835,9 +912,15 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
+    "@types/mysql": ["@types/mysql@2.15.27", "", { "dependencies": { "@types/node": "*" } }, "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA=="],
+
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
 
     "@types/node": ["@types/node@24.12.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ=="],
+
+    "@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
+
+    "@types/pg-pool": ["@types/pg-pool@2.0.7", "", { "dependencies": { "@types/pg": "*" } }, "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -846,6 +929,8 @@
     "@types/responselike": ["@types/responselike@1.0.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
+
+    "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -899,6 +984,8 @@
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
+
     "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
@@ -935,6 +1022,8 @@
 
     "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.8", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
@@ -946,6 +1035,8 @@
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
@@ -988,6 +1079,8 @@
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -1189,6 +1282,8 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
+    "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
+
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
@@ -1274,6 +1369,8 @@
     "http2-wrapper": ["http2-wrapper@1.0.3", "", { "dependencies": { "quick-lru": "^5.1.1", "resolve-alpn": "^1.0.0" } }, "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
 
     "import-without-cache": ["import-without-cache@0.2.5", "", {}, "sha512-B6Lc2s6yApwnD2/pMzFh/d5AVjdsDXjgkeJ766FmFuJELIGHNycKRj+l3A39yZPM4CchqNCB4RITEAYB1KUM6A=="],
 
@@ -1519,6 +1616,10 @@
 
     "mimic-response": ["mimic-response@3.1.0", "", {}, "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="],
 
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
     "mrmime": ["mrmime@2.0.1", "", {}, "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -1542,6 +1643,8 @@
     "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
+
+    "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
     "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
 
@@ -1617,6 +1720,12 @@
 
     "pend": ["pend@1.2.0", "", {}, "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="],
 
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
     "piccolore": ["piccolore@0.1.3", "", {}, "sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
@@ -1632,6 +1741,14 @@
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
@@ -1704,6 +1821,8 @@
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
@@ -2019,6 +2138,8 @@
 
     "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
 
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
@@ -2075,9 +2196,15 @@
 
     "@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@fastify/otel/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.212.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.212.0", "import-in-the-middle": "^2.0.6", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg=="],
+
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
+    "@opentelemetry/instrumentation-http/@opentelemetry/core": ["@opentelemetry/core@2.6.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g=="],
+
     "@pierre/diffs/shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+
+    "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
 
     "@rolldown/plugin-babel/rolldown": ["rolldown@1.0.0-rc.9", "", { "dependencies": { "@oxc-project/types": "=0.115.0", "@rolldown/pluginutils": "1.0.0-rc.9" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-arm64": "1.0.0-rc.9", "@rolldown/binding-darwin-x64": "1.0.0-rc.9", "@rolldown/binding-freebsd-x64": "1.0.0-rc.9", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q=="],
 
@@ -2169,6 +2296,10 @@
 
     "@electron/get/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
+    "@fastify/otel/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.212.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg=="],
+
+    "@fastify/otel/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
+
     "@pierre/diffs/shiki/@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
     "@pierre/diffs/shiki/@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
@@ -2180,6 +2311,10 @@
     "@pierre/diffs/shiki/@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
 
     "@pierre/diffs/shiki/@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
+
+    "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "@rolldown/plugin-babel/rolldown/@oxc-project/types": ["@oxc-project/types@0.115.0", "", {}, "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw=="],
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -577,6 +577,8 @@ export const ThreadTurnStartCommand = Schema.Struct({
   bootstrap: Schema.optional(ThreadTurnStartBootstrap),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
   createdAt: IsoDateTime,
+  sentryTrace: Schema.optional(Schema.String),
+  sentryBaggage: Schema.optional(Schema.String),
 });
 
 const ClientThreadTurnStartCommand = Schema.Struct({


### PR DESCRIPTION
## Summary
- Add Sentry server-side observability with gen_ai instrumentation (invoke_agent, request, execute_tool spans)
- Add frontend instrumentation with `ui.submit_prompt` spans, Replay, and structured logs
- Enable distributed tracing: frontend propagates sentry-trace/baggage per prompt via WebSocket, server continues the trace so gen_ai spans appear on the same trace waterfall
- Scope Codex Sentry isolation per session via `withIsolationScope`
- Fix trace propagation across Effect fiber boundary by setting propagation context directly on isolation scope

## Test plan
- [ ] Run `bun run build && bun run start`, send a prompt
- [ ] Verify in Sentry that a single trace contains both `t3toolsweb` (ui.submit_prompt) and `t3` (gen_ai.invoke_agent, gen_ai.request) spans
- [ ] Verify gen_ai spans have correct token usage, model, and conversation_id attributes
- [ ] Verify Replay sessions capture correctly
- [ ] Verify structured logs appear in Sentry Logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Sentry telemetry (including `sendDefaultPii` and local-variable capture) across both server and web, plus trace propagation changes; mistakes could leak sensitive data or add overhead/noise in production.
> 
> **Overview**
> Adds end-to-end Sentry observability across the app, initializing Sentry on both **server** (`src/instrument.ts` imported via Node `--import`) and **web** (`src/instrument.ts` + router/error integrations), plus source-map upload via the Vite Sentry plugin.
> 
> Implements Sentry *GenAI semantic* spans (`gen_ai.invoke_agent`, `gen_ai.request`, `gen_ai.execute_tool`) and wires them into the Claude and Codex provider adapters, including span lifecycle handling for streaming responses, token usage attribution, tool execution spans, and forced cleanup on turn/session end.
> 
> Enables distributed tracing from the browser to the server by attaching `sentry-trace`/`baggage` to `thread.turn.start` commands and WebSocket URLs, then restoring propagation context on the server (WS upgrade + turn-start reactor) so UI spans and GenAI spans appear in the same trace; also bridges Effect fatal causes to Sentry before process exit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9b56b24e5ed504bede1d683f11ddd45cf3decc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Sentry distributed tracing and observability to web and server
> - Initializes Sentry in both the web ([instrument.ts](https://github.com/pingdotgg/t3code/pull/2450/files#diff-48f48077e169761ca239a100dbb4a3bd34b136273bb38171c1deaee32c89bbd5)) and server ([instrument.ts](https://github.com/pingdotgg/t3code/pull/2450/files#diff-af222df6ffac9776b0021d743599b5c6548650f8660571f8824ec822801dec68)) at startup, enabling performance tracing, profiling, session replay, and error capture.
> - Propagates Sentry trace context from the browser through WebSocket connections and command payloads, so server-side spans are linked to the originating UI interaction.
> - Adds structured `gen_ai` spans ([GenAiSpan.ts](https://github.com/pingdotgg/t3code/pull/2450/files#diff-de0e1ffd723f336dbd16d010131d8c9650b8b847f9ed2321bcef037151e58597)) for agent invocations, LLM requests, and tool executions in both the Claude and Codex adapters, including token usage, response text, and finish reasons.
> - Uploads sourcemaps to Sentry via the Vite plugin during web builds.
> - Risk: `tracesSampleRate=1.0` means 100% of transactions are traced, which may have performance and quota implications in production.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6e9b56b. 15 files reviewed, 8 issues evaluated, 1 issue filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/provider/Layers/CodexAdapter.ts — 1 comment posted, 3 evaluated, 1 filtered</summary>
>
> - [line 1421](https://github.com/pingdotgg/t3code/blob/6e9b56b24e5ed504bede1d683f11ddd45cf3decc/apps/server/src/provider/Layers/CodexAdapter.ts#L1421): Tool span created at line 1421 leaks if `event.itemId` is undefined. When `item/started` fires without an `itemId`, `startExecuteToolSpan` creates a span, but the span is not stored in `state.toolSpans` (line 1422-1424 only stores if `event.itemId` is truthy). Later, when `item/completed` arrives (also without `itemId`), line 1440 sets `existingSpan` to `undefined`, causing lines 1452-1453 to create a *new* span and immediately finish it. The original span from `item/started` is orphaned and never finished, leaking the telemetry span. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->