### PR TITLE
Refactor provider settings to declarative metadata

### DIFF
--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -62,6 +62,7 @@ function deriveInstanceId(driver: ProviderDriverKind, label: string): string {
 const INSTANCE_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
 const DEFAULT_DRIVER_KIND = ProviderDriverKind.make("codex");
 const DEFAULT_DRIVER_OPTION = DRIVER_OPTIONS[0]!;
+const EMPTY_CONFIG_DRAFT: Record<string, unknown> = {};
 interface ComingSoonDriverOption {
   readonly value: ProviderDriverKind;
   readonly label: string;
@@ -165,7 +166,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
   const wizardSteps = ["Driver", "Identity", "Config"] as const;
   const wizardStepSummaries = [driverOption.label, previewLabel, null] as const;
 
-  const configDraft = configByDriver[driver] ?? {};
+  const configDraft = configByDriver[driver] ?? EMPTY_CONFIG_DRAFT;
   const setConfigDraft = useCallback(
     (config: Record<string, unknown> | undefined) => {
       setConfigByDriver((existing) => {

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -13,7 +13,7 @@ import { useSettings, useUpdateSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
-import { ACPRegistryIcon, Gemini, GithubCopilotIcon, PiAgentIcon } from "../Icons";
+import { ACPRegistryIcon, Gemini, GithubCopilotIcon, PiAgentIcon, type Icon } from "../Icons";
 import {
   Dialog,
   DialogDescription,
@@ -26,7 +26,8 @@ import { Badge } from "../ui/badge";
 import { Input } from "../ui/input";
 import { RadioGroup } from "../ui/radio-group";
 import { toastManager } from "../ui/toast";
-import { DRIVER_OPTION_BY_VALUE, DRIVER_OPTIONS, type DriverOption } from "./providerDriverMeta";
+import { DRIVER_OPTION_BY_VALUE, DRIVER_OPTIONS } from "./providerDriverMeta";
+import { ProviderSettingsForm, deriveProviderSettingsFields } from "./ProviderSettingsForm";
 
 const PROVIDER_ACCENT_SWATCHES = [
   "#2563eb",
@@ -61,30 +62,32 @@ function deriveInstanceId(driver: ProviderDriverKind, label: string): string {
 const INSTANCE_ID_PATTERN = /^[a-zA-Z][a-zA-Z0-9_-]*$/;
 const DEFAULT_DRIVER_KIND = ProviderDriverKind.make("codex");
 const DEFAULT_DRIVER_OPTION = DRIVER_OPTIONS[0]!;
-const COMING_SOON_DRIVER_OPTIONS: readonly DriverOption[] = [
+interface ComingSoonDriverOption {
+  readonly value: ProviderDriverKind;
+  readonly label: string;
+  readonly icon: Icon;
+}
+
+const COMING_SOON_DRIVER_OPTIONS: readonly ComingSoonDriverOption[] = [
   {
     value: ProviderDriverKind.make("githubCopilot"),
     label: "Github Copilot",
     icon: GithubCopilotIcon,
-    fields: [],
   },
   {
     value: ProviderDriverKind.make("gemini"),
     label: "Gemini",
     icon: Gemini,
-    fields: [],
   },
   {
     value: ProviderDriverKind.make("acpRegistry"),
     label: "ACP Registry",
     icon: ACPRegistryIcon,
-    fields: [],
   },
   {
     value: ProviderDriverKind.make("piAgent"),
     label: "Pi Agent",
     icon: PiAgentIcon,
-    fields: [],
   },
 ];
 
@@ -118,10 +121,9 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
   const [accentColor, setAccentColor] = useState<string>("");
   const [instanceId, setInstanceId] = useState("");
   const [instanceIdDirty, setInstanceIdDirty] = useState(false);
-  // Driver-specific field values keyed by `${driver}:${fieldKey}` so toggling
-  // between drivers during the same dialog session doesn't lose in-progress
-  // input. Only the active driver's values are persisted on save.
-  const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
+  // Driver-specific config drafts keyed by driver so toggling between drivers
+  // during the same dialog session does not lose in-progress input.
+  const [configByDriver, setConfigByDriver] = useState<Record<string, Record<string, unknown>>>({});
   // Errors are suppressed until the user has tried to submit once. After that
   // they update live so fixing the problem clears the message in place.
   const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false);
@@ -141,7 +143,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
     setInstanceId("");
     setWizardStep(0);
     setInstanceIdDirty(false);
-    setFieldValues({});
+    setConfigByDriver({});
     setHasAttemptedSubmit(false);
   }, [open]);
 
@@ -153,23 +155,28 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
   }, [driver, label, instanceIdDirty]);
 
   const driverOption = DRIVER_OPTION_BY_VALUE[driver] ?? DEFAULT_DRIVER_OPTION;
+  const driverSettingsFields = useMemo(
+    () => deriveProviderSettingsFields(driverOption),
+    [driverOption],
+  );
   const instanceIdError = validateInstanceId(instanceId, existingIds);
   const showInstanceIdError = hasAttemptedSubmit && instanceIdError !== null;
   const previewLabel = label.trim() || `${driverOption.label} Workspace`;
   const wizardSteps = ["Driver", "Identity", "Config"] as const;
   const wizardStepSummaries = [driverOption.label, previewLabel, null] as const;
 
-  const getFieldValue = useCallback(
-    (fieldKey: string) => fieldValues[`${driver}:${fieldKey}`] ?? "",
-    [driver, fieldValues],
-  );
-
-  const setFieldValue = useCallback(
-    (fieldKey: string, value: string) => {
-      setFieldValues((existing) => ({
-        ...existing,
-        [`${driver}:${fieldKey}`]: value,
-      }));
+  const configDraft = configByDriver[driver] ?? {};
+  const setConfigDraft = useCallback(
+    (config: Record<string, unknown> | undefined) => {
+      setConfigByDriver((existing) => {
+        const next = { ...existing };
+        if (config === undefined || Object.keys(config).length === 0) {
+          delete next[driver];
+        } else {
+          next[driver] = config;
+        }
+        return next;
+      });
     },
     [driver],
   );
@@ -178,13 +185,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
     setHasAttemptedSubmit(true);
     if (instanceIdError !== null) return;
 
-    // Build the config blob from non-empty driver-specific field values.
-    // Empty strings are dropped so defaults remain in effect on the server.
-    const config: Record<string, string> = {};
-    for (const field of driverOption.fields) {
-      const value = (fieldValues[`${driver}:${field.key}`] ?? "").trim();
-      if (value.length > 0) config[field.key] = value;
-    }
+    const config = configByDriver[driver] ?? {};
     const hasConfig = Object.keys(config).length > 0;
     const normalizedAccentColor = normalizeProviderAccentColor(accentColor);
 
@@ -222,7 +223,7 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
   }, [
     driver,
     driverOption,
-    fieldValues,
+    configByDriver,
     instanceId,
     instanceIdError,
     label,
@@ -433,25 +434,15 @@ export function AddProviderInstanceDialog({ open, onOpenChange }: AddProviderIns
               </span>
             </div>
 
-            {driverOption.fields.length > 0 ? (
+            {driverSettingsFields.length > 0 ? (
               <div className={cn("grid gap-4", wizardStep !== 2 && "hidden")}>
-                {driverOption.fields.map((field) => (
-                  <label key={field.key} className="grid gap-1.5">
-                    <span className="text-xs font-medium text-foreground">{field.label}</span>
-                    <Input
-                      className="bg-background"
-                      type={field.type === "password" ? "password" : undefined}
-                      autoComplete={field.type === "password" ? "off" : undefined}
-                      placeholder={field.placeholder}
-                      value={getFieldValue(field.key)}
-                      onChange={(event) => setFieldValue(field.key, event.target.value)}
-                      spellCheck={false}
-                    />
-                    {field.description ? (
-                      <span className="text-[11px] text-muted-foreground">{field.description}</span>
-                    ) : null}
-                  </label>
-                ))}
+                <ProviderSettingsForm
+                  definition={driverOption}
+                  value={configDraft}
+                  idPrefix={`add-provider-${driver}`}
+                  variant="dialog"
+                  onChange={setConfigDraft}
+                />
               </div>
             ) : wizardStep === 2 ? (
               <div className="grid gap-2">

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDownIcon, PlusIcon, Trash2Icon, XIcon } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import {
   isProviderDriverKind,
   type ProviderInstanceConfig,
@@ -21,6 +21,7 @@ import { DraftInput } from "../ui/draft-input";
 import { Switch } from "../ui/switch";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import type { DriverOption } from "./providerDriverMeta";
+import { ProviderSettingsForm } from "./ProviderSettingsForm";
 import { ProviderModelsSection } from "./ProviderModelsSection";
 import { ProviderInstanceIcon } from "../chat/ProviderInstanceIcon";
 import {
@@ -87,20 +88,6 @@ function redactedEmailPlaceholder(email: string): string {
 }
 
 /**
- * Read a string value at `key` from the opaque per-driver config blob.
- * Returns an empty string when the key is missing or the stored value is
- * not a string. The permissive shape reflects that `config` is
- * `Schema.Unknown` at the contract boundary — forks may populate it with
- * non-string values that the built-in UI should round-trip without
- * throwing.
- */
-function readConfigString(config: unknown, key: string): string {
-  if (config === null || typeof config !== "object") return "";
-  const value = (config as Record<string, unknown>)[key];
-  return typeof value === "string" ? value : "";
-}
-
-/**
  * Read a string[] at `key` from the opaque config blob, filtering out
  * non-string entries. Used for `customModels`, which is always typed as
  * `string[]` by the concrete driver schemas but arrives here as
@@ -114,34 +101,8 @@ function readConfigStringArray(config: unknown, key: string): ReadonlyArray<stri
 }
 
 /**
- * Produce the next config blob after setting `key` to `value`. Empty
- * strings drop the key so server defaults stay in effect, mirroring the
- * save-time normalization in `AddProviderInstanceDialog`. Returns
- * `undefined` when the resulting blob has no keys, which matches
- * `ProviderInstanceConfig.config` being optional.
- *
- * Non-string values already stored in the blob are carried through
- * verbatim so fork-owned fields survive edits made through this UI.
- */
-function nextConfigBlobWithString(
-  config: unknown,
-  key: string,
-  value: string,
-): Record<string, unknown> | undefined {
-  const base: Record<string, unknown> =
-    config !== null && typeof config === "object" ? { ...(config as Record<string, unknown>) } : {};
-  const trimmed = value.trim();
-  if (trimmed.length > 0) {
-    base[key] = value;
-  } else {
-    delete base[key];
-  }
-  return Object.keys(base).length > 0 ? base : undefined;
-}
-
-/**
  * Set `key` to an arbitrary value on the opaque config blob. Unlike
- * `nextConfigBlobWithString`, does not drop empty-looking values — the
+ * provider settings field updates, does not drop empty-looking values — the
  * caller is responsible for deciding whether an empty array / empty
  * object should be stored explicitly (e.g. `customModels: []` is a
  * meaningful "user cleared their custom list" state distinct from
@@ -473,7 +434,7 @@ interface ProviderInstanceCardProps {
    * default slots supply a reset-to-factory control here; custom instances
    * omit it.
    */
-  readonly headerAction?: React.ReactNode | undefined;
+  readonly headerAction?: ReactNode | undefined;
   readonly hiddenModels: ReadonlyArray<string>;
   readonly favoriteModels: ReadonlyArray<string>;
   readonly modelOrder: ReadonlyArray<string>;
@@ -585,8 +546,7 @@ export function ProviderInstanceCard({
     );
   };
 
-  const updateConfigField = (key: string, value: string) => {
-    const nextConfig = nextConfigBlobWithString(instance.config, key, value);
+  const updateConfig = (nextConfig: Record<string, unknown> | undefined) => {
     const { config: _omit, ...rest } = instance;
     onUpdate(
       nextConfig !== undefined
@@ -759,28 +719,15 @@ export function ProviderInstanceCard({
               />
             </div>
 
-            {driverOption?.fields.map((field) => (
-              <div key={field.key} className="border-t border-border/60 px-4 py-3 sm:px-5">
-                <label htmlFor={`provider-instance-${instanceId}-${field.key}`} className="block">
-                  <span className="text-xs font-medium text-foreground">{field.label}</span>
-                  <DraftInput
-                    id={`provider-instance-${instanceId}-${field.key}`}
-                    className="mt-1.5"
-                    type={field.type === "password" ? "password" : undefined}
-                    autoComplete={field.type === "password" ? "off" : undefined}
-                    value={readConfigString(instance.config, field.key)}
-                    onCommit={(next) => updateConfigField(field.key, next)}
-                    placeholder={field.placeholder}
-                    spellCheck={false}
-                  />
-                  {field.description ? (
-                    <span className="mt-1 block text-xs text-muted-foreground">
-                      {field.description}
-                    </span>
-                  ) : null}
-                </label>
-              </div>
-            ))}
+            {driverOption ? (
+              <ProviderSettingsForm
+                definition={driverOption}
+                value={instance.config}
+                idPrefix={`provider-instance-${instanceId}`}
+                variant="card"
+                onChange={updateConfig}
+              />
+            ) : null}
 
             {driverOption !== undefined ? (
               <ProviderModelsSection

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -5,6 +5,7 @@ import { DRIVER_OPTION_BY_VALUE } from "./providerDriverMeta";
 import {
   deriveProviderSettingsFields,
   nextProviderConfigWithFieldValue,
+  readProviderConfigBoolean,
   readProviderConfigString,
 } from "./ProviderSettingsForm";
 
@@ -55,5 +56,39 @@ describe("ProviderSettingsForm helpers", () => {
 
   it("reads non-string config values as blank strings", () => {
     expect(readProviderConfigString({ binaryPath: 123 }, "binaryPath")).toBe("");
+  });
+
+  it("omits false boolean fields when clearWhenEmpty is omit", () => {
+    const next = nextProviderConfigWithFieldValue(
+      { forkOwned: 1, experimental: true },
+      {
+        key: "experimental",
+        control: "switch",
+        label: "Experimental",
+        clearWhenEmpty: "omit",
+      },
+      false,
+    );
+
+    expect(next).toEqual({ forkOwned: 1 });
+  });
+
+  it("preserves false boolean fields when clearWhenEmpty is persist", () => {
+    const next = nextProviderConfigWithFieldValue(
+      undefined,
+      {
+        key: "experimental",
+        control: "switch",
+        label: "Experimental",
+        clearWhenEmpty: "persist",
+      },
+      false,
+    );
+
+    expect(next).toEqual({ experimental: false });
+  });
+
+  it("reads non-boolean config values as false booleans", () => {
+    expect(readProviderConfigBoolean({ experimental: "true" }, "experimental")).toBe(false);
   });
 });

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -20,6 +20,21 @@ describe("ProviderSettingsForm helpers", () => {
     ]);
   });
 
+  it("sources labels and descriptions from schema annotations", () => {
+    const opencode = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("opencode")];
+    expect(opencode).toBeDefined();
+
+    const serverPassword = deriveProviderSettingsFields(opencode!).find(
+      (field) => field.key === "serverPassword",
+    );
+
+    expect(serverPassword).toMatchObject({
+      label: "Server password",
+      description: "Stored in plain text on disk.",
+      control: "password",
+    });
+  });
+
   it("preserves unknown config keys while omitting empty configurable fields", () => {
     const opencode = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("opencode")];
     expect(opencode).toBeDefined();

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -66,11 +66,44 @@ describe("ProviderSettingsForm helpers", () => {
         control: "switch",
         label: "Experimental",
         clearWhenEmpty: "omit",
+        defaultBooleanValue: false,
       },
       false,
     );
 
     expect(next).toEqual({ forkOwned: 1 });
+  });
+
+  it("omits true boolean fields when true is the default", () => {
+    const next = nextProviderConfigWithFieldValue(
+      { forkOwned: 1, experimental: false },
+      {
+        key: "experimental",
+        control: "switch",
+        label: "Experimental",
+        clearWhenEmpty: "omit",
+        defaultBooleanValue: true,
+      },
+      true,
+    );
+
+    expect(next).toEqual({ forkOwned: 1 });
+  });
+
+  it("stores false boolean fields when true is the default", () => {
+    const next = nextProviderConfigWithFieldValue(
+      undefined,
+      {
+        key: "experimental",
+        control: "switch",
+        label: "Experimental",
+        clearWhenEmpty: "omit",
+        defaultBooleanValue: true,
+      },
+      false,
+    );
+
+    expect(next).toEqual({ experimental: false });
   });
 
   it("preserves false boolean fields when clearWhenEmpty is persist", () => {
@@ -90,5 +123,9 @@ describe("ProviderSettingsForm helpers", () => {
 
   it("reads non-boolean config values as false booleans", () => {
     expect(readProviderConfigBoolean({ experimental: "true" }, "experimental")).toBe(false);
+  });
+
+  it("reads missing boolean config values from the supplied default", () => {
+    expect(readProviderConfigBoolean({}, "experimental", true)).toBe(true);
   });
 });

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { ProviderDriverKind } from "@t3tools/contracts";
+
+import { DRIVER_OPTION_BY_VALUE } from "./providerDriverMeta";
+import {
+  deriveProviderSettingsFields,
+  nextProviderConfigWithFieldValue,
+  readProviderConfigString,
+} from "./ProviderSettingsForm";
+
+describe("ProviderSettingsForm helpers", () => {
+  it("derives visible provider config fields from the client definition schema", () => {
+    const codex = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("codex")];
+
+    expect(codex).toBeDefined();
+    expect(deriveProviderSettingsFields(codex!).map((field) => field.key)).toEqual([
+      "binaryPath",
+      "homePath",
+      "shadowHomePath",
+    ]);
+  });
+
+  it("preserves unknown config keys while omitting empty configurable fields", () => {
+    const opencode = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("opencode")];
+    expect(opencode).toBeDefined();
+
+    const serverUrl = deriveProviderSettingsFields(opencode!).find(
+      (field) => field.key === "serverUrl",
+    );
+    expect(serverUrl).toBeDefined();
+
+    const next = nextProviderConfigWithFieldValue(
+      { forkOwned: 1, serverUrl: "http://127.0.0.1:4096" },
+      serverUrl!,
+      "",
+    );
+
+    expect(next).toEqual({ forkOwned: 1 });
+  });
+
+  it("reads non-string config values as blank strings", () => {
+    expect(readProviderConfigString({ binaryPath: 123 }, "binaryPath")).toBe("");
+  });
+});

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, type ReactNode } from "react";
+import { Schema } from "effect";
 
 import { cn } from "../../lib/utils";
 import { DraftInput } from "../ui/draft-input";
@@ -33,6 +34,16 @@ function fieldControlFromUi(ui: ProviderSettingsFieldUi | undefined): ProviderSe
   return ui?.control ?? "text";
 }
 
+function readFieldAnnotationString(
+  fieldSchema: ProviderClientDefinition["settingsSchema"]["fields"][string],
+  key: "title" | "description",
+): string | undefined {
+  const annotations =
+    Schema.resolveAnnotationsKey(fieldSchema) ?? Schema.resolveAnnotations(fieldSchema);
+  const value = annotations?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
 export function deriveProviderSettingsFields(
   definition: ProviderClientDefinition,
 ): ReadonlyArray<ProviderSettingsFieldModel> {
@@ -46,12 +57,19 @@ export function deriveProviderSettingsFields(
   return orderedKeys.flatMap((key) => {
     const ui = definition.settingsUi.fields?.[key];
     if (ui?.hidden) return [];
+    const fieldSchema = definition.settingsSchema.fields[key]!;
+    const annotatedTitle = readFieldAnnotationString(fieldSchema, "title");
+    const annotatedDescription = readFieldAnnotationString(fieldSchema, "description");
     return [
       {
         key,
         control: fieldControlFromUi(ui),
-        label: ui?.label ?? titleizeFieldKey(key),
-        ...(ui?.description !== undefined ? { description: ui.description } : {}),
+        label: ui?.label ?? annotatedTitle ?? titleizeFieldKey(key),
+        ...(ui?.description !== undefined
+          ? { description: ui.description }
+          : annotatedDescription !== undefined
+            ? { description: annotatedDescription }
+            : {}),
         ...(ui?.placeholder !== undefined ? { placeholder: ui.placeholder } : {}),
         clearWhenEmpty: ui?.clearWhenEmpty ?? "omit",
       } satisfies ProviderSettingsFieldModel,
@@ -111,6 +129,108 @@ function FieldFrame(props: {
   return <div className="grid gap-1.5">{props.children}</div>;
 }
 
+interface ProviderSettingsFieldRowProps {
+  readonly field: ProviderSettingsFieldModel;
+  readonly value: unknown;
+  readonly idPrefix: string;
+  readonly variant: ProviderSettingsFormProps["variant"];
+  readonly onChange: ProviderSettingsFormProps["onChange"];
+}
+
+function ProviderSettingsFieldRow({
+  field,
+  value,
+  idPrefix,
+  variant,
+  onChange,
+}: ProviderSettingsFieldRowProps) {
+  const inputId = `${idPrefix}-${field.key}`;
+  const descriptionClassName =
+    variant === "card"
+      ? "mt-1 block text-xs text-muted-foreground"
+      : "text-[11px] text-muted-foreground";
+  const label = <span className="text-xs font-medium text-foreground">{field.label}</span>;
+  const description = field.description ? (
+    <span className={descriptionClassName}>{field.description}</span>
+  ) : null;
+
+  if (field.control === "switch") {
+    return (
+      <FieldFrame variant={variant}>
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            {label}
+            {description}
+          </div>
+          <Switch
+            checked={readProviderConfigBoolean(value, field.key)}
+            onCheckedChange={(checked) =>
+              onChange(nextProviderConfigWithFieldValue(value, field, Boolean(checked)))
+            }
+            aria-label={field.label}
+          />
+        </div>
+      </FieldFrame>
+    );
+  }
+
+  if (field.control === "textarea") {
+    return (
+      <FieldFrame variant={variant}>
+        <label htmlFor={inputId} className={cn(variant === "card" && "block")}>
+          {label}
+          <Textarea
+            id={inputId}
+            className={cn(variant === "card" && "mt-1.5")}
+            value={readProviderConfigString(value, field.key)}
+            onChange={(event) =>
+              onChange(nextProviderConfigWithFieldValue(value, field, event.target.value))
+            }
+            placeholder={field.placeholder}
+            spellCheck={false}
+          />
+          {description}
+        </label>
+      </FieldFrame>
+    );
+  }
+
+  const type = field.control === "password" ? "password" : undefined;
+  return (
+    <FieldFrame variant={variant}>
+      <label htmlFor={inputId} className={cn(variant === "card" && "block")}>
+        {label}
+        {variant === "card" ? (
+          <DraftInput
+            id={inputId}
+            className="mt-1.5"
+            type={type}
+            autoComplete={field.control === "password" ? "off" : undefined}
+            value={readProviderConfigString(value, field.key)}
+            onCommit={(next) => onChange(nextProviderConfigWithFieldValue(value, field, next))}
+            placeholder={field.placeholder}
+            spellCheck={false}
+          />
+        ) : (
+          <Input
+            id={inputId}
+            className="bg-background"
+            type={type}
+            autoComplete={field.control === "password" ? "off" : undefined}
+            value={readProviderConfigString(value, field.key)}
+            onChange={(event) =>
+              onChange(nextProviderConfigWithFieldValue(value, field, event.target.value))
+            }
+            placeholder={field.placeholder}
+            spellCheck={false}
+          />
+        )}
+        {description}
+      </label>
+    </FieldFrame>
+  );
+}
+
 export function ProviderSettingsForm({
   definition,
   value,
@@ -126,95 +246,16 @@ export function ProviderSettingsForm({
 
   return (
     <>
-      {fields.map((field) => {
-        const inputId = `${idPrefix}-${field.key}`;
-        const descriptionClassName =
-          variant === "card"
-            ? "mt-1 block text-xs text-muted-foreground"
-            : "text-[11px] text-muted-foreground";
-        const label = <span className="text-xs font-medium text-foreground">{field.label}</span>;
-        const description = field.description ? (
-          <span className={descriptionClassName}>{field.description}</span>
-        ) : null;
-
-        if (field.control === "switch") {
-          return (
-            <FieldFrame key={field.key} variant={variant}>
-              <div className="flex items-center justify-between gap-3">
-                <div className="min-w-0">
-                  {label}
-                  {description}
-                </div>
-                <Switch
-                  checked={readProviderConfigBoolean(value, field.key)}
-                  onCheckedChange={(checked) =>
-                    onChange(nextProviderConfigWithFieldValue(value, field, Boolean(checked)))
-                  }
-                  aria-label={field.label}
-                />
-              </div>
-            </FieldFrame>
-          );
-        }
-
-        if (field.control === "textarea") {
-          return (
-            <FieldFrame key={field.key} variant={variant}>
-              <label htmlFor={inputId} className={cn(variant === "card" && "block")}>
-                {label}
-                <Textarea
-                  id={inputId}
-                  className={cn(variant === "card" && "mt-1.5")}
-                  value={readProviderConfigString(value, field.key)}
-                  onChange={(event) =>
-                    onChange(nextProviderConfigWithFieldValue(value, field, event.target.value))
-                  }
-                  placeholder={field.placeholder}
-                  spellCheck={false}
-                />
-                {description}
-              </label>
-            </FieldFrame>
-          );
-        }
-
-        const type = field.control === "password" ? "password" : undefined;
-        return (
-          <FieldFrame key={field.key} variant={variant}>
-            <label htmlFor={inputId} className={cn(variant === "card" && "block")}>
-              {label}
-              {variant === "card" ? (
-                <DraftInput
-                  id={inputId}
-                  className="mt-1.5"
-                  type={type}
-                  autoComplete={field.control === "password" ? "off" : undefined}
-                  value={readProviderConfigString(value, field.key)}
-                  onCommit={(next) =>
-                    onChange(nextProviderConfigWithFieldValue(value, field, next))
-                  }
-                  placeholder={field.placeholder}
-                  spellCheck={false}
-                />
-              ) : (
-                <Input
-                  id={inputId}
-                  className="bg-background"
-                  type={type}
-                  autoComplete={field.control === "password" ? "off" : undefined}
-                  value={readProviderConfigString(value, field.key)}
-                  onChange={(event) =>
-                    onChange(nextProviderConfigWithFieldValue(value, field, event.target.value))
-                  }
-                  placeholder={field.placeholder}
-                  spellCheck={false}
-                />
-              )}
-              {description}
-            </label>
-          </FieldFrame>
-        );
-      })}
+      {fields.map((field) => (
+        <ProviderSettingsFieldRow
+          key={field.key}
+          field={field}
+          value={value}
+          idPrefix={idPrefix}
+          variant={variant}
+          onChange={onChange}
+        />
+      ))}
     </>
   );
 }

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useMemo, type ReactNode } from "react";
+
+import { cn } from "../../lib/utils";
+import { DraftInput } from "../ui/draft-input";
+import { Input } from "../ui/input";
+import { Switch } from "../ui/switch";
+import { Textarea } from "../ui/textarea";
+import type {
+  ProviderClientDefinition,
+  ProviderSettingsControl,
+  ProviderSettingsFieldUi,
+} from "./providerDriverMeta";
+
+export interface ProviderSettingsFieldModel {
+  readonly key: string;
+  readonly control: ProviderSettingsControl;
+  readonly label: string;
+  readonly description?: string | undefined;
+  readonly placeholder?: string | undefined;
+  readonly clearWhenEmpty: "omit" | "persist";
+}
+
+function titleizeFieldKey(key: string): string {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .replace(/[-_]+/g, " ")
+    .replace(/^./, (char) => char.toUpperCase());
+}
+
+function fieldControlFromUi(ui: ProviderSettingsFieldUi | undefined): ProviderSettingsControl {
+  return ui?.control ?? "text";
+}
+
+export function deriveProviderSettingsFields(
+  definition: ProviderClientDefinition,
+): ReadonlyArray<ProviderSettingsFieldModel> {
+  const schemaKeys = Object.keys(definition.settingsSchema.fields);
+  const schemaKeySet = new Set(schemaKeys);
+  const orderedKeys = [
+    ...(definition.settingsUi.order ?? []).filter((key) => schemaKeySet.has(key)),
+    ...schemaKeys.filter((key) => !(definition.settingsUi.order ?? []).includes(key)),
+  ];
+
+  return orderedKeys.flatMap((key) => {
+    const ui = definition.settingsUi.fields?.[key];
+    if (ui?.hidden) return [];
+    return [
+      {
+        key,
+        control: fieldControlFromUi(ui),
+        label: ui?.label ?? titleizeFieldKey(key),
+        ...(ui?.description !== undefined ? { description: ui.description } : {}),
+        ...(ui?.placeholder !== undefined ? { placeholder: ui.placeholder } : {}),
+        clearWhenEmpty: ui?.clearWhenEmpty ?? "omit",
+      } satisfies ProviderSettingsFieldModel,
+    ];
+  });
+}
+
+export function readProviderConfigString(config: unknown, key: string): string {
+  if (config === null || typeof config !== "object") return "";
+  const value = (config as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : "";
+}
+
+export function readProviderConfigBoolean(config: unknown, key: string): boolean {
+  if (config === null || typeof config !== "object") return false;
+  const value = (config as Record<string, unknown>)[key];
+  return typeof value === "boolean" ? value : false;
+}
+
+export function nextProviderConfigWithFieldValue(
+  config: unknown,
+  field: ProviderSettingsFieldModel,
+  value: string | boolean,
+): Record<string, unknown> | undefined {
+  const base: Record<string, unknown> =
+    config !== null && typeof config === "object" ? { ...(config as Record<string, unknown>) } : {};
+
+  if (typeof value === "boolean") {
+    base[field.key] = value;
+    return Object.keys(base).length > 0 ? base : undefined;
+  }
+
+  const trimmed = value.trim();
+  if (field.clearWhenEmpty === "omit" && trimmed.length === 0) {
+    delete base[field.key];
+  } else {
+    base[field.key] = value;
+  }
+  return Object.keys(base).length > 0 ? base : undefined;
+}
+
+interface ProviderSettingsFormProps {
+  readonly definition: ProviderClientDefinition;
+  readonly value: unknown;
+  readonly idPrefix: string;
+  readonly variant: "card" | "dialog";
+  readonly onChange: (nextConfig: Record<string, unknown> | undefined) => void;
+}
+
+function FieldFrame(props: {
+  readonly variant: ProviderSettingsFormProps["variant"];
+  readonly children: ReactNode;
+}) {
+  if (props.variant === "card") {
+    return <div className="border-t border-border/60 px-4 py-3 sm:px-5">{props.children}</div>;
+  }
+  return <div className="grid gap-1.5">{props.children}</div>;
+}
+
+export function ProviderSettingsForm({
+  definition,
+  value,
+  idPrefix,
+  variant,
+  onChange,
+}: ProviderSettingsFormProps) {
+  const fields = useMemo(() => deriveProviderSettingsFields(definition), [definition]);
+
+  if (fields.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {fields.map((field) => {
+        const inputId = `${idPrefix}-${field.key}`;
+        const descriptionClassName =
+          variant === "card"
+            ? "mt-1 block text-xs text-muted-foreground"
+            : "text-[11px] text-muted-foreground";
+        const label = <span className="text-xs font-medium text-foreground">{field.label}</span>;
+        const description = field.description ? (
+          <span className={descriptionClassName}>{field.description}</span>
+        ) : null;
+
+        if (field.control === "switch") {
+          return (
+            <FieldFrame key={field.key} variant={variant}>
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  {label}
+                  {description}
+                </div>
+                <Switch
+                  checked={readProviderConfigBoolean(value, field.key)}
+                  onCheckedChange={(checked) =>
+                    onChange(nextProviderConfigWithFieldValue(value, field, Boolean(checked)))
+                  }
+                  aria-label={field.label}
+                />
+              </div>
+            </FieldFrame>
+          );
+        }
+
+        if (field.control === "textarea") {
+          return (
+            <FieldFrame key={field.key} variant={variant}>
+              <label htmlFor={inputId} className={cn(variant === "card" && "block")}>
+                {label}
+                <Textarea
+                  id={inputId}
+                  className={cn(variant === "card" && "mt-1.5")}
+                  value={readProviderConfigString(value, field.key)}
+                  onChange={(event) =>
+                    onChange(nextProviderConfigWithFieldValue(value, field, event.target.value))
+                  }
+                  placeholder={field.placeholder}
+                  spellCheck={false}
+                />
+                {description}
+              </label>
+            </FieldFrame>
+          );
+        }
+
+        const type = field.control === "password" ? "password" : undefined;
+        return (
+          <FieldFrame key={field.key} variant={variant}>
+            <label htmlFor={inputId} className={cn(variant === "card" && "block")}>
+              {label}
+              {variant === "card" ? (
+                <DraftInput
+                  id={inputId}
+                  className="mt-1.5"
+                  type={type}
+                  autoComplete={field.control === "password" ? "off" : undefined}
+                  value={readProviderConfigString(value, field.key)}
+                  onCommit={(next) =>
+                    onChange(nextProviderConfigWithFieldValue(value, field, next))
+                  }
+                  placeholder={field.placeholder}
+                  spellCheck={false}
+                />
+              ) : (
+                <Input
+                  id={inputId}
+                  className="bg-background"
+                  type={type}
+                  autoComplete={field.control === "password" ? "off" : undefined}
+                  value={readProviderConfigString(value, field.key)}
+                  onChange={(event) =>
+                    onChange(nextProviderConfigWithFieldValue(value, field, event.target.value))
+                  }
+                  placeholder={field.placeholder}
+                  spellCheck={false}
+                />
+              )}
+              {description}
+            </label>
+          </FieldFrame>
+        );
+      })}
+    </>
+  );
+}

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -5,6 +5,7 @@ import { Schema } from "effect";
 import type {
   ProviderSettingsFormAnnotation,
   ProviderSettingsFormControl,
+  ProviderSettingsFormSchemaAnnotation,
 } from "@t3tools/contracts";
 
 import { cn } from "../../lib/utils";
@@ -52,19 +53,28 @@ function readProviderSettingsFormAnnotation(
   return annotation ?? {};
 }
 
+function readProviderSettingsFormSchemaAnnotation(
+  definition: ProviderClientDefinition,
+): ProviderSettingsFormSchemaAnnotation {
+  return Schema.resolveAnnotations(definition.settingsSchema)?.providerSettingsFormSchema ?? {};
+}
+
 export function deriveProviderSettingsFields(
   definition: ProviderClientDefinition,
 ): ReadonlyArray<ProviderSettingsFieldModel> {
+  const schemaAnnotation = readProviderSettingsFormSchemaAnnotation(definition);
+  const orderedKeys = new Map(
+    (schemaAnnotation.order ?? []).map((key, index) => [key, index] as const),
+  );
+  const orderFallbackOffset = orderedKeys.size;
+
   return Object.keys(definition.settingsSchema.fields)
     .map((key, index) => ({ key, index }))
     .toSorted((left, right) => {
-      const leftAnnotation = readProviderSettingsFormAnnotation(
-        definition.settingsSchema.fields[left.key]!,
+      return (
+        (orderedKeys.get(left.key) ?? orderFallbackOffset + left.index) -
+        (orderedKeys.get(right.key) ?? orderFallbackOffset + right.index)
       );
-      const rightAnnotation = readProviderSettingsFormAnnotation(
-        definition.settingsSchema.fields[right.key]!,
-      );
-      return (leftAnnotation.order ?? left.index) - (rightAnnotation.order ?? right.index);
     })
     .flatMap(({ key }) => {
       const fieldSchema = definition.settingsSchema.fields[key]!;

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -119,7 +119,11 @@ export function nextProviderConfigWithFieldValue(
     config !== null && typeof config === "object" ? { ...(config as Record<string, unknown>) } : {};
 
   if (typeof value === "boolean") {
-    base[field.key] = value;
+    if (field.clearWhenEmpty === "omit" && value === false) {
+      delete base[field.key];
+    } else {
+      base[field.key] = value;
+    }
     return Object.keys(base).length > 0 ? base : undefined;
   }
 

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -2,21 +2,21 @@
 
 import { useMemo, type ReactNode } from "react";
 import { Schema } from "effect";
+import type {
+  ProviderSettingsFormAnnotation,
+  ProviderSettingsFormControl,
+} from "@t3tools/contracts";
 
 import { cn } from "../../lib/utils";
 import { DraftInput } from "../ui/draft-input";
 import { Input } from "../ui/input";
 import { Switch } from "../ui/switch";
 import { Textarea } from "../ui/textarea";
-import type {
-  ProviderClientDefinition,
-  ProviderSettingsControl,
-  ProviderSettingsFieldUi,
-} from "./providerDriverMeta";
+import type { ProviderClientDefinition } from "./providerDriverMeta";
 
 export interface ProviderSettingsFieldModel {
   readonly key: string;
-  readonly control: ProviderSettingsControl;
+  readonly control: ProviderSettingsFormControl;
   readonly label: string;
   readonly description?: string | undefined;
   readonly placeholder?: string | undefined;
@@ -30,51 +30,62 @@ function titleizeFieldKey(key: string): string {
     .replace(/^./, (char) => char.toUpperCase());
 }
 
-function fieldControlFromUi(ui: ProviderSettingsFieldUi | undefined): ProviderSettingsControl {
-  return ui?.control ?? "text";
+function readFieldAnnotations(
+  fieldSchema: ProviderClientDefinition["settingsSchema"]["fields"][string],
+) {
+  return Schema.resolveAnnotationsKey(fieldSchema) ?? Schema.resolveAnnotations(fieldSchema);
 }
 
 function readFieldAnnotationString(
   fieldSchema: ProviderClientDefinition["settingsSchema"]["fields"][string],
   key: "title" | "description",
 ): string | undefined {
-  const annotations =
-    Schema.resolveAnnotationsKey(fieldSchema) ?? Schema.resolveAnnotations(fieldSchema);
+  const annotations = readFieldAnnotations(fieldSchema);
   const value = annotations?.[key];
   return typeof value === "string" ? value : undefined;
+}
+
+function readProviderSettingsFormAnnotation(
+  fieldSchema: ProviderClientDefinition["settingsSchema"]["fields"][string],
+): ProviderSettingsFormAnnotation {
+  const annotation = readFieldAnnotations(fieldSchema)?.providerSettingsForm;
+  return annotation ?? {};
 }
 
 export function deriveProviderSettingsFields(
   definition: ProviderClientDefinition,
 ): ReadonlyArray<ProviderSettingsFieldModel> {
-  const schemaKeys = Object.keys(definition.settingsSchema.fields);
-  const schemaKeySet = new Set(schemaKeys);
-  const orderedKeys = [
-    ...(definition.settingsUi.order ?? []).filter((key) => schemaKeySet.has(key)),
-    ...schemaKeys.filter((key) => !(definition.settingsUi.order ?? []).includes(key)),
-  ];
+  return Object.keys(definition.settingsSchema.fields)
+    .map((key, index) => ({ key, index }))
+    .toSorted((left, right) => {
+      const leftAnnotation = readProviderSettingsFormAnnotation(
+        definition.settingsSchema.fields[left.key]!,
+      );
+      const rightAnnotation = readProviderSettingsFormAnnotation(
+        definition.settingsSchema.fields[right.key]!,
+      );
+      return (leftAnnotation.order ?? left.index) - (rightAnnotation.order ?? right.index);
+    })
+    .flatMap(({ key }) => {
+      const fieldSchema = definition.settingsSchema.fields[key]!;
+      const formAnnotation = readProviderSettingsFormAnnotation(fieldSchema);
+      if (formAnnotation.hidden) return [];
 
-  return orderedKeys.flatMap((key) => {
-    const ui = definition.settingsUi.fields?.[key];
-    if (ui?.hidden) return [];
-    const fieldSchema = definition.settingsSchema.fields[key]!;
-    const annotatedTitle = readFieldAnnotationString(fieldSchema, "title");
-    const annotatedDescription = readFieldAnnotationString(fieldSchema, "description");
-    return [
-      {
-        key,
-        control: fieldControlFromUi(ui),
-        label: ui?.label ?? annotatedTitle ?? titleizeFieldKey(key),
-        ...(ui?.description !== undefined
-          ? { description: ui.description }
-          : annotatedDescription !== undefined
-            ? { description: annotatedDescription }
+      const annotatedTitle = readFieldAnnotationString(fieldSchema, "title");
+      const annotatedDescription = readFieldAnnotationString(fieldSchema, "description");
+      return [
+        {
+          key,
+          control: formAnnotation.control ?? "text",
+          label: annotatedTitle ?? titleizeFieldKey(key),
+          ...(annotatedDescription !== undefined ? { description: annotatedDescription } : {}),
+          ...(formAnnotation.placeholder !== undefined
+            ? { placeholder: formAnnotation.placeholder }
             : {}),
-        ...(ui?.placeholder !== undefined ? { placeholder: ui.placeholder } : {}),
-        clearWhenEmpty: ui?.clearWhenEmpty ?? "omit",
-      } satisfies ProviderSettingsFieldModel,
-    ];
-  });
+          clearWhenEmpty: formAnnotation.clearWhenEmpty ?? "omit",
+        } satisfies ProviderSettingsFieldModel,
+      ];
+    });
 }
 
 export function readProviderConfigString(config: unknown, key: string): string {

--- a/apps/web/src/components/settings/ProviderSettingsForm.tsx
+++ b/apps/web/src/components/settings/ProviderSettingsForm.tsx
@@ -22,6 +22,7 @@ export interface ProviderSettingsFieldModel {
   readonly description?: string | undefined;
   readonly placeholder?: string | undefined;
   readonly clearWhenEmpty: "omit" | "persist";
+  readonly defaultBooleanValue?: boolean | undefined;
 }
 
 function titleizeFieldKey(key: string): string {
@@ -59,6 +60,17 @@ function readProviderSettingsFormSchemaAnnotation(
   return Schema.resolveAnnotations(definition.settingsSchema)?.providerSettingsFormSchema ?? {};
 }
 
+function readFieldBooleanDefault(
+  fieldSchema: ProviderClientDefinition["settingsSchema"]["fields"][string],
+): boolean | undefined {
+  try {
+    const decoded = Schema.decodeUnknownSync(fieldSchema as Schema.Decoder<unknown>)(undefined);
+    return typeof decoded === "boolean" ? decoded : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function deriveProviderSettingsFields(
   definition: ProviderClientDefinition,
 ): ReadonlyArray<ProviderSettingsFieldModel> {
@@ -93,6 +105,9 @@ export function deriveProviderSettingsFields(
             ? { placeholder: formAnnotation.placeholder }
             : {}),
           clearWhenEmpty: formAnnotation.clearWhenEmpty ?? "omit",
+          ...(formAnnotation.control === "switch"
+            ? { defaultBooleanValue: readFieldBooleanDefault(fieldSchema) }
+            : {}),
         } satisfies ProviderSettingsFieldModel,
       ];
     });
@@ -104,10 +119,14 @@ export function readProviderConfigString(config: unknown, key: string): string {
   return typeof value === "string" ? value : "";
 }
 
-export function readProviderConfigBoolean(config: unknown, key: string): boolean {
-  if (config === null || typeof config !== "object") return false;
+export function readProviderConfigBoolean(
+  config: unknown,
+  key: string,
+  defaultValue = false,
+): boolean {
+  if (config === null || typeof config !== "object") return defaultValue;
   const value = (config as Record<string, unknown>)[key];
-  return typeof value === "boolean" ? value : false;
+  return typeof value === "boolean" ? value : defaultValue;
 }
 
 export function nextProviderConfigWithFieldValue(
@@ -119,7 +138,8 @@ export function nextProviderConfigWithFieldValue(
     config !== null && typeof config === "object" ? { ...(config as Record<string, unknown>) } : {};
 
   if (typeof value === "boolean") {
-    if (field.clearWhenEmpty === "omit" && value === false) {
+    const emptyBooleanValue = field.defaultBooleanValue ?? false;
+    if (field.clearWhenEmpty === "omit" && value === emptyBooleanValue) {
       delete base[field.key];
     } else {
       base[field.key] = value;
@@ -188,7 +208,7 @@ function ProviderSettingsFieldRow({
             {description}
           </div>
           <Switch
-            checked={readProviderConfigBoolean(value, field.key)}
+            checked={readProviderConfigBoolean(value, field.key, field.defaultBooleanValue)}
             onCheckedChange={(checked) =>
               onChange(nextProviderConfigWithFieldValue(value, field, Boolean(checked)))
             }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1,6 +1,6 @@
 import { ArchiveIcon, ArchiveX, LoaderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
-import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   defaultInstanceIdForDriver,
   type DesktopUpdateChannel,
@@ -57,7 +57,7 @@ import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { AddProviderInstanceDialog } from "./AddProviderInstanceDialog";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
-import { getDriverOption } from "./providerDriverMeta";
+import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import { buildProviderInstanceUpdatePatch } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -113,56 +113,9 @@ function withoutProviderInstanceFavorites(
   return favorites.filter((favorite) => favorite.provider !== instanceId);
 }
 
-type InstallProviderSettings = {
-  provider: ProviderDriverKind;
-  title: string;
-  badgeLabel?: string;
-  binaryPlaceholder: string;
-  binaryDescription: ReactNode;
-  serverUrlPlaceholder?: string;
-  serverUrlDescription?: ReactNode;
-  serverPasswordPlaceholder?: string;
-  serverPasswordDescription?: ReactNode;
-  homePathKey?: "codexHomePath";
-  homePlaceholder?: string;
-  homeDescription?: ReactNode;
-};
-
-const PROVIDER_SETTINGS: readonly InstallProviderSettings[] = [
-  {
-    provider: ProviderDriverKind.make("codex"),
-    title: "Codex",
-    binaryPlaceholder: "Codex binary path",
-    binaryDescription: "Path to the Codex binary",
-    homePathKey: "codexHomePath",
-    homePlaceholder: "CODEX_HOME",
-    homeDescription: "Optional custom Codex home and config directory.",
-  },
-  {
-    provider: ProviderDriverKind.make("claudeAgent"),
-    title: "Claude",
-    binaryPlaceholder: "Claude binary path",
-    binaryDescription: "Path to the Claude binary",
-  },
-  {
-    provider: ProviderDriverKind.make("cursor"),
-    title: "Cursor",
-    badgeLabel: "Early Access",
-    binaryPlaceholder: "Cursor agent binary path",
-    binaryDescription: "Path to the Cursor agent binary",
-  },
-  {
-    provider: ProviderDriverKind.make("opencode"),
-    title: "OpenCode",
-    binaryPlaceholder: "OpenCode binary path",
-    binaryDescription: "Path to the OpenCode binary",
-    serverUrlPlaceholder: "http://127.0.0.1:4096",
-    serverUrlDescription: "Leave blank to let T3 Code spawn the server when needed",
-    serverPasswordPlaceholder: "Server password (optional)",
-    serverPasswordDescription:
-      "If your OpenCode server requires authentication, enter the password here. NOTE: Stored in plain text on disk",
-  },
-] as const;
+const PROVIDER_SETTINGS = DRIVER_OPTIONS.map((definition) => ({
+  provider: definition.value,
+}));
 
 function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }) {
   useRelativeTimeTick();

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -5,10 +5,11 @@ import {
   OpenCodeSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
+import type { Schema } from "effect";
 import { ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
 
 type ProviderSettingsSchema = {
-  readonly fields: Readonly<Record<string, unknown>>;
+  readonly fields: Readonly<Record<string, Schema.Top>>;
 };
 
 export type ProviderSettingsControl = "text" | "password" | "textarea" | "switch";
@@ -60,22 +61,15 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
         enabled: { hidden: true },
         customModels: { hidden: true },
         binaryPath: {
-          label: "Binary path",
           placeholder: "codex",
-          description: "Path to the Codex binary used by this instance.",
           clearWhenEmpty: "omit",
         },
         homePath: {
-          label: "CODEX_HOME path",
           placeholder: "~/.codex",
-          description: "Custom Codex home and config directory.",
           clearWhenEmpty: "omit",
         },
         shadowHomePath: {
-          label: "Shadow home path",
           placeholder: "~/.codex-t3/personal",
-          description:
-            "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME.",
           clearWhenEmpty: "omit",
         },
       },
@@ -92,22 +86,15 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
         enabled: { hidden: true },
         customModels: { hidden: true },
         binaryPath: {
-          label: "Binary path",
           placeholder: "claude",
-          description: "Path to the Claude binary used by this instance.",
           clearWhenEmpty: "omit",
         },
         homePath: {
-          label: "Claude HOME path",
           placeholder: "~",
-          description:
-            "Custom HOME used when running this Claude instance. Keeps .claude.json and .claude separate.",
           clearWhenEmpty: "omit",
         },
         launchArgs: {
-          label: "Launch arguments",
           placeholder: "e.g. --chrome",
-          description: "Additional CLI arguments passed on session start.",
           clearWhenEmpty: "omit",
         },
       },
@@ -125,15 +112,11 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
         enabled: { hidden: true },
         customModels: { hidden: true },
         binaryPath: {
-          label: "Binary path",
           placeholder: "agent",
-          description: "Path to the Cursor agent binary.",
           clearWhenEmpty: "omit",
         },
         apiEndpoint: {
-          label: "API endpoint",
           placeholder: "https://...",
-          description: "Override the Cursor API endpoint for this instance.",
           clearWhenEmpty: "omit",
         },
       },
@@ -150,22 +133,16 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
         enabled: { hidden: true },
         customModels: { hidden: true },
         binaryPath: {
-          label: "Binary path",
           placeholder: "opencode",
-          description: "Path to the OpenCode binary.",
           clearWhenEmpty: "omit",
         },
         serverUrl: {
-          label: "Server URL",
           placeholder: "http://127.0.0.1:4096",
-          description: "Leave blank to let T3 Code spawn the server when needed.",
           clearWhenEmpty: "omit",
         },
         serverPassword: {
           control: "password",
-          label: "Server password",
           placeholder: "Optional",
-          description: "Stored in plain text on disk.",
           clearWhenEmpty: "omit",
         },
       },

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -10,7 +10,7 @@ import { ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons"
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
-};
+} & Schema.Top;
 
 /**
  * Browser-safe provider definition. This is deliberately shaped like the

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -1,31 +1,43 @@
-import { ProviderDriverKind } from "@t3tools/contracts";
+import {
+  ClaudeSettings,
+  CodexSettings,
+  CursorSettings,
+  OpenCodeSettings,
+  ProviderDriverKind,
+} from "@t3tools/contracts";
 import { ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
 
-/**
- * A single editable field exposed on a provider instance. `key` must match
- * the corresponding driver config schema in
- * `packages/contracts/src/settings.ts` — values are merged into the saved
- * `ProviderInstanceConfig.config` blob (or the legacy
- * `ServerSettings.providers[kind]` struct) under this key verbatim.
- */
-export interface DriverFieldDef {
-  readonly key: string;
-  readonly label: string;
+type ProviderSettingsSchema = {
+  readonly fields: Readonly<Record<string, unknown>>;
+};
+
+export type ProviderSettingsControl = "text" | "password" | "textarea" | "switch";
+
+export interface ProviderSettingsFieldUi {
+  readonly control?: ProviderSettingsControl;
+  readonly label?: string;
   readonly placeholder?: string;
   readonly description?: string;
-  readonly type?: "text" | "password";
+  readonly hidden?: boolean;
+  readonly clearWhenEmpty?: "omit" | "persist";
+}
+
+export interface ProviderSettingsUi {
+  readonly order?: readonly string[];
+  readonly fields?: Readonly<Record<string, ProviderSettingsFieldUi>>;
 }
 
 /**
- * Presentation + editable-field metadata for a registered driver. Shared
- * between the Add-Instance dialog and the per-instance settings card so
- * both surfaces offer the same keys for the same driver.
+ * Browser-safe provider definition. This is deliberately shaped like the
+ * future provider package client export: the core web app gets a schema,
+ * presentation metadata, and a small UI hint layer, then renders generically.
  */
-export interface DriverOption {
+export interface ProviderClientDefinition {
   readonly value: ProviderDriverKind;
   readonly label: string;
   readonly icon: Icon;
-  readonly fields: readonly DriverFieldDef[];
+  readonly settingsSchema: ProviderSettingsSchema;
+  readonly settingsUi: ProviderSettingsUi;
   /**
    * Optional short label rendered as a `variant="warning"` badge next to
    * the instance title. Used to flag drivers that still ship under an
@@ -36,109 +48,140 @@ export interface DriverOption {
   readonly badgeLabel?: string;
 }
 
-export const DRIVER_OPTIONS: readonly DriverOption[] = [
+export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = [
   {
     value: ProviderDriverKind.make("codex"),
     label: "Codex",
     icon: OpenAI,
-    fields: [
-      {
-        key: "binaryPath",
-        label: "Binary path",
-        placeholder: "codex",
-        description: "Path to the Codex binary used by this instance.",
+    settingsSchema: CodexSettings,
+    settingsUi: {
+      order: ["binaryPath", "homePath", "shadowHomePath"],
+      fields: {
+        enabled: { hidden: true },
+        customModels: { hidden: true },
+        binaryPath: {
+          label: "Binary path",
+          placeholder: "codex",
+          description: "Path to the Codex binary used by this instance.",
+          clearWhenEmpty: "omit",
+        },
+        homePath: {
+          label: "CODEX_HOME path",
+          placeholder: "~/.codex",
+          description: "Custom Codex home and config directory.",
+          clearWhenEmpty: "omit",
+        },
+        shadowHomePath: {
+          label: "Shadow home path",
+          placeholder: "~/.codex-t3/personal",
+          description:
+            "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME.",
+          clearWhenEmpty: "omit",
+        },
       },
-      {
-        key: "homePath",
-        label: "CODEX_HOME path",
-        placeholder: "~/.codex",
-        description: "Custom Codex home and config directory.",
-      },
-      {
-        key: "shadowHomePath",
-        label: "Shadow home path",
-        placeholder: "~/.codex-t3/personal",
-        description:
-          "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME.",
-      },
-    ],
+    },
   },
   {
     value: ProviderDriverKind.make("claudeAgent"),
     label: "Claude",
     icon: ClaudeAI,
-    fields: [
-      {
-        key: "binaryPath",
-        label: "Binary path",
-        placeholder: "claude",
-        description: "Path to the Claude binary used by this instance.",
+    settingsSchema: ClaudeSettings,
+    settingsUi: {
+      order: ["binaryPath", "homePath", "launchArgs"],
+      fields: {
+        enabled: { hidden: true },
+        customModels: { hidden: true },
+        binaryPath: {
+          label: "Binary path",
+          placeholder: "claude",
+          description: "Path to the Claude binary used by this instance.",
+          clearWhenEmpty: "omit",
+        },
+        homePath: {
+          label: "Claude HOME path",
+          placeholder: "~",
+          description:
+            "Custom HOME used when running this Claude instance. Keeps .claude.json and .claude separate.",
+          clearWhenEmpty: "omit",
+        },
+        launchArgs: {
+          label: "Launch arguments",
+          placeholder: "e.g. --chrome",
+          description: "Additional CLI arguments passed on session start.",
+          clearWhenEmpty: "omit",
+        },
       },
-      {
-        key: "homePath",
-        label: "Claude HOME path",
-        placeholder: "~",
-        description:
-          "Custom HOME used when running this Claude instance. Keeps .claude.json and .claude separate.",
-      },
-      {
-        key: "launchArgs",
-        label: "Launch arguments",
-        placeholder: "e.g. --chrome",
-        description: "Additional CLI arguments passed on session start.",
-      },
-    ],
+    },
   },
   {
     value: ProviderDriverKind.make("cursor"),
     label: "Cursor",
     icon: CursorIcon,
     badgeLabel: "Early Access",
-    fields: [
-      {
-        key: "binaryPath",
-        label: "Binary path",
-        placeholder: "agent",
-        description: "Path to the Cursor agent binary.",
+    settingsSchema: CursorSettings,
+    settingsUi: {
+      order: ["binaryPath", "apiEndpoint"],
+      fields: {
+        enabled: { hidden: true },
+        customModels: { hidden: true },
+        binaryPath: {
+          label: "Binary path",
+          placeholder: "agent",
+          description: "Path to the Cursor agent binary.",
+          clearWhenEmpty: "omit",
+        },
+        apiEndpoint: {
+          label: "API endpoint",
+          placeholder: "https://...",
+          description: "Override the Cursor API endpoint for this instance.",
+          clearWhenEmpty: "omit",
+        },
       },
-      {
-        key: "apiEndpoint",
-        label: "API endpoint",
-        placeholder: "https://…",
-        description: "Override the Cursor API endpoint for this instance.",
-      },
-    ],
+    },
   },
   {
     value: ProviderDriverKind.make("opencode"),
     label: "OpenCode",
     icon: OpenCodeIcon,
-    fields: [
-      {
-        key: "binaryPath",
-        label: "Binary path",
-        placeholder: "opencode",
-        description: "Path to the OpenCode binary.",
+    settingsSchema: OpenCodeSettings,
+    settingsUi: {
+      order: ["binaryPath", "serverUrl", "serverPassword"],
+      fields: {
+        enabled: { hidden: true },
+        customModels: { hidden: true },
+        binaryPath: {
+          label: "Binary path",
+          placeholder: "opencode",
+          description: "Path to the OpenCode binary.",
+          clearWhenEmpty: "omit",
+        },
+        serverUrl: {
+          label: "Server URL",
+          placeholder: "http://127.0.0.1:4096",
+          description: "Leave blank to let T3 Code spawn the server when needed.",
+          clearWhenEmpty: "omit",
+        },
+        serverPassword: {
+          control: "password",
+          label: "Server password",
+          placeholder: "Optional",
+          description: "Stored in plain text on disk.",
+          clearWhenEmpty: "omit",
+        },
       },
-      {
-        key: "serverUrl",
-        label: "Server URL",
-        placeholder: "http://127.0.0.1:4096",
-        description: "Leave blank to let T3 Code spawn the server when needed.",
-      },
-      {
-        key: "serverPassword",
-        label: "Server password",
-        placeholder: "Optional",
-        type: "password",
-        description: "Stored in plain text on disk.",
-      },
-    ],
+    },
   },
 ];
 
-export const DRIVER_OPTION_BY_VALUE: Partial<Record<ProviderDriverKind, DriverOption>> =
-  Object.fromEntries(DRIVER_OPTIONS.map((option) => [option.value, option]));
+export const PROVIDER_CLIENT_DEFINITION_BY_VALUE: Partial<
+  Record<ProviderDriverKind, ProviderClientDefinition>
+> = Object.fromEntries(
+  PROVIDER_CLIENT_DEFINITIONS.map((definition) => [definition.value, definition]),
+);
+
+export const DRIVER_OPTIONS = PROVIDER_CLIENT_DEFINITIONS;
+export const DRIVER_OPTION_BY_VALUE = PROVIDER_CLIENT_DEFINITION_BY_VALUE;
+export type DriverOption = ProviderClientDefinition;
 
 /**
  * Look up the driver metadata for an instance's `driver` field. Accepts
@@ -147,5 +190,5 @@ export const DRIVER_OPTION_BY_VALUE: Partial<Record<ProviderDriverKind, DriverOp
  */
 export function getDriverOption(driver: ProviderDriverKind | undefined): DriverOption | undefined {
   if (driver === undefined) return undefined;
-  return DRIVER_OPTION_BY_VALUE[driver];
+  return PROVIDER_CLIENT_DEFINITION_BY_VALUE[driver];
 }

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -12,33 +12,17 @@ type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
 };
 
-export type ProviderSettingsControl = "text" | "password" | "textarea" | "switch";
-
-export interface ProviderSettingsFieldUi {
-  readonly control?: ProviderSettingsControl;
-  readonly label?: string;
-  readonly placeholder?: string;
-  readonly description?: string;
-  readonly hidden?: boolean;
-  readonly clearWhenEmpty?: "omit" | "persist";
-}
-
-export interface ProviderSettingsUi {
-  readonly order?: readonly string[];
-  readonly fields?: Readonly<Record<string, ProviderSettingsFieldUi>>;
-}
-
 /**
  * Browser-safe provider definition. This is deliberately shaped like the
- * future provider package client export: the core web app gets a schema,
- * presentation metadata, and a small UI hint layer, then renders generically.
+ * future provider package client export: the core web app gets a schema with
+ * field annotations plus provider-level presentation metadata, then renders
+ * settings generically.
  */
 export interface ProviderClientDefinition {
   readonly value: ProviderDriverKind;
   readonly label: string;
   readonly icon: Icon;
   readonly settingsSchema: ProviderSettingsSchema;
-  readonly settingsUi: ProviderSettingsUi;
   /**
    * Optional short label rendered as a `variant="warning"` badge next to
    * the instance title. Used to flag drivers that still ship under an
@@ -55,50 +39,12 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "Codex",
     icon: OpenAI,
     settingsSchema: CodexSettings,
-    settingsUi: {
-      order: ["binaryPath", "homePath", "shadowHomePath"],
-      fields: {
-        enabled: { hidden: true },
-        customModels: { hidden: true },
-        binaryPath: {
-          placeholder: "codex",
-          clearWhenEmpty: "omit",
-        },
-        homePath: {
-          placeholder: "~/.codex",
-          clearWhenEmpty: "omit",
-        },
-        shadowHomePath: {
-          placeholder: "~/.codex-t3/personal",
-          clearWhenEmpty: "omit",
-        },
-      },
-    },
   },
   {
     value: ProviderDriverKind.make("claudeAgent"),
     label: "Claude",
     icon: ClaudeAI,
     settingsSchema: ClaudeSettings,
-    settingsUi: {
-      order: ["binaryPath", "homePath", "launchArgs"],
-      fields: {
-        enabled: { hidden: true },
-        customModels: { hidden: true },
-        binaryPath: {
-          placeholder: "claude",
-          clearWhenEmpty: "omit",
-        },
-        homePath: {
-          placeholder: "~",
-          clearWhenEmpty: "omit",
-        },
-        launchArgs: {
-          placeholder: "e.g. --chrome",
-          clearWhenEmpty: "omit",
-        },
-      },
-    },
   },
   {
     value: ProviderDriverKind.make("cursor"),
@@ -106,47 +52,12 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     icon: CursorIcon,
     badgeLabel: "Early Access",
     settingsSchema: CursorSettings,
-    settingsUi: {
-      order: ["binaryPath", "apiEndpoint"],
-      fields: {
-        enabled: { hidden: true },
-        customModels: { hidden: true },
-        binaryPath: {
-          placeholder: "agent",
-          clearWhenEmpty: "omit",
-        },
-        apiEndpoint: {
-          placeholder: "https://...",
-          clearWhenEmpty: "omit",
-        },
-      },
-    },
   },
   {
     value: ProviderDriverKind.make("opencode"),
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
-    settingsUi: {
-      order: ["binaryPath", "serverUrl", "serverPassword"],
-      fields: {
-        enabled: { hidden: true },
-        customModels: { hidden: true },
-        binaryPath: {
-          placeholder: "opencode",
-          clearWhenEmpty: "omit",
-        },
-        serverUrl: {
-          placeholder: "http://127.0.0.1:4096",
-          clearWhenEmpty: "omit",
-        },
-        serverPassword: {
-          control: "password",
-          placeholder: "Optional",
-          clearWhenEmpty: "omit",
-        },
-      },
-    },
   },
 ];
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -98,34 +98,98 @@ const makeBinaryPathSetting = (fallback: string) =>
 
 export const CodexSettings = Schema.Struct({
   enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
-  binaryPath: makeBinaryPathSetting("codex"),
-  homePath: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
-  shadowHomePath: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  binaryPath: makeBinaryPathSetting("codex").pipe(
+    Schema.annotateKey({
+      title: "Binary path",
+      description: "Path to the Codex binary used by this instance.",
+    }),
+  ),
+  homePath: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+    Schema.annotateKey({
+      title: "CODEX_HOME path",
+      description: "Custom Codex home and config directory.",
+    }),
+  ),
+  shadowHomePath: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+    Schema.annotateKey({
+      title: "Shadow home path",
+      description:
+        "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME.",
+    }),
+  ),
   customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
 });
 export type CodexSettings = typeof CodexSettings.Type;
 
 export const ClaudeSettings = Schema.Struct({
   enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
-  binaryPath: makeBinaryPathSetting("claude"),
-  homePath: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  binaryPath: makeBinaryPathSetting("claude").pipe(
+    Schema.annotateKey({
+      title: "Binary path",
+      description: "Path to the Claude binary used by this instance.",
+    }),
+  ),
+  homePath: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+    Schema.annotateKey({
+      title: "Claude HOME path",
+      description:
+        "Custom HOME used when running this Claude instance. Keeps .claude.json and .claude separate.",
+    }),
+  ),
   customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
-  launchArgs: Schema.String.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  launchArgs: Schema.String.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+    Schema.annotateKey({
+      title: "Launch arguments",
+      description: "Additional CLI arguments passed on session start.",
+    }),
+  ),
 });
 export type ClaudeSettings = typeof ClaudeSettings.Type;
 
 export const CursorSettings = Schema.Struct({
   enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
-  binaryPath: makeBinaryPathSetting("agent"),
-  apiEndpoint: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  binaryPath: makeBinaryPathSetting("agent").pipe(
+    Schema.annotateKey({
+      title: "Binary path",
+      description: "Path to the Cursor agent binary.",
+    }),
+  ),
+  apiEndpoint: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+    Schema.annotateKey({
+      title: "API endpoint",
+      description: "Override the Cursor API endpoint for this instance.",
+    }),
+  ),
   customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
 });
 export type CursorSettings = typeof CursorSettings.Type;
 export const OpenCodeSettings = Schema.Struct({
   enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
-  binaryPath: makeBinaryPathSetting("opencode"),
-  serverUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
-  serverPassword: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
+  binaryPath: makeBinaryPathSetting("opencode").pipe(
+    Schema.annotateKey({
+      title: "Binary path",
+      description: "Path to the OpenCode binary.",
+    }),
+  ),
+  serverUrl: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+    Schema.annotateKey({
+      title: "Server URL",
+      description: "Leave blank to let T3 Code spawn the server when needed.",
+    }),
+  ),
+  serverPassword: TrimmedString.pipe(
+    Schema.withDecodingDefault(Effect.succeed("")),
+    Schema.annotateKey({
+      title: "Server password",
+      description: "Stored in plain text on disk.",
+    }),
+  ),
   customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
 });
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -96,12 +96,34 @@ const makeBinaryPathSetting = (fallback: string) =>
     Schema.withDecodingDefault(Effect.succeed(fallback)),
   );
 
+export type ProviderSettingsFormControl = "text" | "password" | "textarea" | "switch";
+
+export interface ProviderSettingsFormAnnotation {
+  readonly control?: ProviderSettingsFormControl | undefined;
+  readonly placeholder?: string | undefined;
+  readonly hidden?: boolean | undefined;
+  readonly clearWhenEmpty?: "omit" | "persist" | undefined;
+  readonly order?: number | undefined;
+}
+
+declare module "effect/Schema" {
+  namespace Annotations {
+    interface Annotations {
+      readonly providerSettingsForm?: ProviderSettingsFormAnnotation | undefined;
+    }
+  }
+}
+
 export const CodexSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  enabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
   binaryPath: makeBinaryPathSetting("codex").pipe(
     Schema.annotateKey({
       title: "Binary path",
       description: "Path to the Codex binary used by this instance.",
+      providerSettingsForm: { placeholder: "codex", clearWhenEmpty: "omit", order: 10 },
     }),
   ),
   homePath: TrimmedString.pipe(
@@ -109,6 +131,7 @@ export const CodexSettings = Schema.Struct({
     Schema.annotateKey({
       title: "CODEX_HOME path",
       description: "Custom Codex home and config directory.",
+      providerSettingsForm: { placeholder: "~/.codex", clearWhenEmpty: "omit", order: 20 },
     }),
   ),
   shadowHomePath: TrimmedString.pipe(
@@ -117,18 +140,30 @@ export const CodexSettings = Schema.Struct({
       title: "Shadow home path",
       description:
         "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME.",
+      providerSettingsForm: {
+        placeholder: "~/.codex-t3/personal",
+        clearWhenEmpty: "omit",
+        order: 30,
+      },
     }),
   ),
-  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  customModels: Schema.Array(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
 });
 export type CodexSettings = typeof CodexSettings.Type;
 
 export const ClaudeSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  enabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
   binaryPath: makeBinaryPathSetting("claude").pipe(
     Schema.annotateKey({
       title: "Binary path",
       description: "Path to the Claude binary used by this instance.",
+      providerSettingsForm: { placeholder: "claude", clearWhenEmpty: "omit", order: 10 },
     }),
   ),
   homePath: TrimmedString.pipe(
@@ -137,25 +172,34 @@ export const ClaudeSettings = Schema.Struct({
       title: "Claude HOME path",
       description:
         "Custom HOME used when running this Claude instance. Keeps .claude.json and .claude separate.",
+      providerSettingsForm: { placeholder: "~", clearWhenEmpty: "omit", order: 20 },
     }),
   ),
-  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  customModels: Schema.Array(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
   launchArgs: Schema.String.pipe(
     Schema.withDecodingDefault(Effect.succeed("")),
     Schema.annotateKey({
       title: "Launch arguments",
       description: "Additional CLI arguments passed on session start.",
+      providerSettingsForm: { placeholder: "e.g. --chrome", clearWhenEmpty: "omit", order: 30 },
     }),
   ),
 });
 export type ClaudeSettings = typeof ClaudeSettings.Type;
 
 export const CursorSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  enabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
   binaryPath: makeBinaryPathSetting("agent").pipe(
     Schema.annotateKey({
       title: "Binary path",
       description: "Path to the Cursor agent binary.",
+      providerSettingsForm: { placeholder: "agent", clearWhenEmpty: "omit", order: 10 },
     }),
   ),
   apiEndpoint: TrimmedString.pipe(
@@ -163,17 +207,25 @@ export const CursorSettings = Schema.Struct({
     Schema.annotateKey({
       title: "API endpoint",
       description: "Override the Cursor API endpoint for this instance.",
+      providerSettingsForm: { placeholder: "https://...", clearWhenEmpty: "omit", order: 20 },
     }),
   ),
-  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  customModels: Schema.Array(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
 });
 export type CursorSettings = typeof CursorSettings.Type;
 export const OpenCodeSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  enabled: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(true)),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
   binaryPath: makeBinaryPathSetting("opencode").pipe(
     Schema.annotateKey({
       title: "Binary path",
       description: "Path to the OpenCode binary.",
+      providerSettingsForm: { placeholder: "opencode", clearWhenEmpty: "omit", order: 10 },
     }),
   ),
   serverUrl: TrimmedString.pipe(
@@ -181,6 +233,11 @@ export const OpenCodeSettings = Schema.Struct({
     Schema.annotateKey({
       title: "Server URL",
       description: "Leave blank to let T3 Code spawn the server when needed.",
+      providerSettingsForm: {
+        placeholder: "http://127.0.0.1:4096",
+        clearWhenEmpty: "omit",
+        order: 20,
+      },
     }),
   ),
   serverPassword: TrimmedString.pipe(
@@ -188,9 +245,18 @@ export const OpenCodeSettings = Schema.Struct({
     Schema.annotateKey({
       title: "Server password",
       description: "Stored in plain text on disk.",
+      providerSettingsForm: {
+        control: "password",
+        placeholder: "Optional",
+        clearWhenEmpty: "omit",
+        order: 30,
+      },
     }),
   ),
-  customModels: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  customModels: Schema.Array(Schema.String).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+  ),
 });
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -103,161 +103,195 @@ export interface ProviderSettingsFormAnnotation {
   readonly placeholder?: string | undefined;
   readonly hidden?: boolean | undefined;
   readonly clearWhenEmpty?: "omit" | "persist" | undefined;
-  readonly order?: number | undefined;
+}
+
+export interface ProviderSettingsFormSchemaAnnotation {
+  readonly order?: readonly string[] | undefined;
 }
 
 declare module "effect/Schema" {
   namespace Annotations {
     interface Annotations {
       readonly providerSettingsForm?: ProviderSettingsFormAnnotation | undefined;
+      readonly providerSettingsFormSchema?: ProviderSettingsFormSchemaAnnotation | undefined;
     }
   }
 }
 
-export const CodexSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(
-    Schema.withDecodingDefault(Effect.succeed(true)),
-    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
-  ),
-  binaryPath: makeBinaryPathSetting("codex").pipe(
-    Schema.annotateKey({
-      title: "Binary path",
-      description: "Path to the Codex binary used by this instance.",
-      providerSettingsForm: { placeholder: "codex", clearWhenEmpty: "omit", order: 10 },
+export type ProviderSettingsOrder<Fields extends Schema.Struct.Fields> = readonly Extract<
+  keyof Fields,
+  string
+>[];
+
+export function makeProviderSettingsSchema<const Fields extends Schema.Struct.Fields>(
+  fields: Fields,
+  options?: {
+    readonly order?: ProviderSettingsOrder<Fields> | undefined;
+  },
+): Schema.Struct<Fields> {
+  return Schema.Struct(fields).pipe(
+    Schema.annotate({
+      providerSettingsFormSchema:
+        options?.order === undefined ? undefined : { order: options.order },
     }),
-  ),
-  homePath: TrimmedString.pipe(
-    Schema.withDecodingDefault(Effect.succeed("")),
-    Schema.annotateKey({
-      title: "CODEX_HOME path",
-      description: "Custom Codex home and config directory.",
-      providerSettingsForm: { placeholder: "~/.codex", clearWhenEmpty: "omit", order: 20 },
-    }),
-  ),
-  shadowHomePath: TrimmedString.pipe(
-    Schema.withDecodingDefault(Effect.succeed("")),
-    Schema.annotateKey({
-      title: "Shadow home path",
-      description:
-        "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME.",
-      providerSettingsForm: {
-        placeholder: "~/.codex-t3/personal",
-        clearWhenEmpty: "omit",
-        order: 30,
-      },
-    }),
-  ),
-  customModels: Schema.Array(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.succeed([])),
-    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
-  ),
-});
+  );
+}
+
+export const CodexSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("codex").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Codex binary used by this instance.",
+        providerSettingsForm: { placeholder: "codex", clearWhenEmpty: "omit" },
+      }),
+    ),
+    homePath: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "CODEX_HOME path",
+        description: "Custom Codex home and config directory.",
+        providerSettingsForm: { placeholder: "~/.codex", clearWhenEmpty: "omit" },
+      }),
+    ),
+    shadowHomePath: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Shadow home path",
+        description:
+          "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME.",
+        providerSettingsForm: { placeholder: "~/.codex-t3/personal", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "homePath", "shadowHomePath"],
+  },
+);
 export type CodexSettings = typeof CodexSettings.Type;
 
-export const ClaudeSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(
-    Schema.withDecodingDefault(Effect.succeed(true)),
-    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
-  ),
-  binaryPath: makeBinaryPathSetting("claude").pipe(
-    Schema.annotateKey({
-      title: "Binary path",
-      description: "Path to the Claude binary used by this instance.",
-      providerSettingsForm: { placeholder: "claude", clearWhenEmpty: "omit", order: 10 },
-    }),
-  ),
-  homePath: TrimmedString.pipe(
-    Schema.withDecodingDefault(Effect.succeed("")),
-    Schema.annotateKey({
-      title: "Claude HOME path",
-      description:
-        "Custom HOME used when running this Claude instance. Keeps .claude.json and .claude separate.",
-      providerSettingsForm: { placeholder: "~", clearWhenEmpty: "omit", order: 20 },
-    }),
-  ),
-  customModels: Schema.Array(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.succeed([])),
-    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
-  ),
-  launchArgs: Schema.String.pipe(
-    Schema.withDecodingDefault(Effect.succeed("")),
-    Schema.annotateKey({
-      title: "Launch arguments",
-      description: "Additional CLI arguments passed on session start.",
-      providerSettingsForm: { placeholder: "e.g. --chrome", clearWhenEmpty: "omit", order: 30 },
-    }),
-  ),
-});
+export const ClaudeSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("claude").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Claude binary used by this instance.",
+        providerSettingsForm: { placeholder: "claude", clearWhenEmpty: "omit" },
+      }),
+    ),
+    homePath: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Claude HOME path",
+        description:
+          "Custom HOME used when running this Claude instance. Keeps .claude.json and .claude separate.",
+        providerSettingsForm: { placeholder: "~", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    launchArgs: Schema.String.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Launch arguments",
+        description: "Additional CLI arguments passed on session start.",
+        providerSettingsForm: { placeholder: "e.g. --chrome", clearWhenEmpty: "omit" },
+      }),
+    ),
+  },
+  {
+    order: ["binaryPath", "homePath", "launchArgs"],
+  },
+);
 export type ClaudeSettings = typeof ClaudeSettings.Type;
 
-export const CursorSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(
-    Schema.withDecodingDefault(Effect.succeed(false)),
-    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
-  ),
-  binaryPath: makeBinaryPathSetting("agent").pipe(
-    Schema.annotateKey({
-      title: "Binary path",
-      description: "Path to the Cursor agent binary.",
-      providerSettingsForm: { placeholder: "agent", clearWhenEmpty: "omit", order: 10 },
-    }),
-  ),
-  apiEndpoint: TrimmedString.pipe(
-    Schema.withDecodingDefault(Effect.succeed("")),
-    Schema.annotateKey({
-      title: "API endpoint",
-      description: "Override the Cursor API endpoint for this instance.",
-      providerSettingsForm: { placeholder: "https://...", clearWhenEmpty: "omit", order: 20 },
-    }),
-  ),
-  customModels: Schema.Array(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.succeed([])),
-    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
-  ),
-});
+export const CursorSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("agent").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Cursor agent binary.",
+        providerSettingsForm: { placeholder: "agent", clearWhenEmpty: "omit" },
+      }),
+    ),
+    apiEndpoint: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "API endpoint",
+        description: "Override the Cursor API endpoint for this instance.",
+        providerSettingsForm: { placeholder: "https://...", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "apiEndpoint"],
+  },
+);
 export type CursorSettings = typeof CursorSettings.Type;
-export const OpenCodeSettings = Schema.Struct({
-  enabled: Schema.Boolean.pipe(
-    Schema.withDecodingDefault(Effect.succeed(true)),
-    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
-  ),
-  binaryPath: makeBinaryPathSetting("opencode").pipe(
-    Schema.annotateKey({
-      title: "Binary path",
-      description: "Path to the OpenCode binary.",
-      providerSettingsForm: { placeholder: "opencode", clearWhenEmpty: "omit", order: 10 },
-    }),
-  ),
-  serverUrl: TrimmedString.pipe(
-    Schema.withDecodingDefault(Effect.succeed("")),
-    Schema.annotateKey({
-      title: "Server URL",
-      description: "Leave blank to let T3 Code spawn the server when needed.",
-      providerSettingsForm: {
-        placeholder: "http://127.0.0.1:4096",
-        clearWhenEmpty: "omit",
-        order: 20,
-      },
-    }),
-  ),
-  serverPassword: TrimmedString.pipe(
-    Schema.withDecodingDefault(Effect.succeed("")),
-    Schema.annotateKey({
-      title: "Server password",
-      description: "Stored in plain text on disk.",
-      providerSettingsForm: {
-        control: "password",
-        placeholder: "Optional",
-        clearWhenEmpty: "omit",
-        order: 30,
-      },
-    }),
-  ),
-  customModels: Schema.Array(Schema.String).pipe(
-    Schema.withDecodingDefault(Effect.succeed([])),
-    Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
-  ),
-});
+export const OpenCodeSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("opencode").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the OpenCode binary.",
+        providerSettingsForm: { placeholder: "opencode", clearWhenEmpty: "omit" },
+      }),
+    ),
+    serverUrl: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Server URL",
+        description: "Leave blank to let T3 Code spawn the server when needed.",
+        providerSettingsForm: { placeholder: "http://127.0.0.1:4096", clearWhenEmpty: "omit" },
+      }),
+    ),
+    serverPassword: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Server password",
+        description: "Stored in plain text on disk.",
+        providerSettingsForm: {
+          control: "password",
+          placeholder: "Optional",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "serverUrl", "serverPassword"],
+  },
+);
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
 export const ObservabilitySettings = Schema.Struct({

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -155,7 +155,10 @@ export const CodexSettings = makeProviderSettingsSchema(
       Schema.annotateKey({
         title: "CODEX_HOME path",
         description: "Custom Codex home and config directory.",
-        providerSettingsForm: { placeholder: "~/.codex", clearWhenEmpty: "omit" },
+        providerSettingsForm: {
+          placeholder: "~/.codex",
+          clearWhenEmpty: "omit",
+        },
       }),
     ),
     shadowHomePath: TrimmedString.pipe(
@@ -164,7 +167,10 @@ export const CodexSettings = makeProviderSettingsSchema(
         title: "Shadow home path",
         description:
           "Account-specific Codex home. Keeps auth.json separate while sharing state from CODEX_HOME.",
-        providerSettingsForm: { placeholder: "~/.codex-t3/personal", clearWhenEmpty: "omit" },
+        providerSettingsForm: {
+          placeholder: "~/.codex-t3/personal",
+          clearWhenEmpty: "omit",
+        },
       }),
     ),
     customModels: Schema.Array(Schema.String).pipe(
@@ -209,7 +215,10 @@ export const ClaudeSettings = makeProviderSettingsSchema(
       Schema.annotateKey({
         title: "Launch arguments",
         description: "Additional CLI arguments passed on session start.",
-        providerSettingsForm: { placeholder: "e.g. --chrome", clearWhenEmpty: "omit" },
+        providerSettingsForm: {
+          placeholder: "e.g. --chrome",
+          clearWhenEmpty: "omit",
+        },
       }),
     ),
   },
@@ -237,7 +246,10 @@ export const CursorSettings = makeProviderSettingsSchema(
       Schema.annotateKey({
         title: "API endpoint",
         description: "Override the Cursor API endpoint for this instance.",
-        providerSettingsForm: { placeholder: "https://...", clearWhenEmpty: "omit" },
+        providerSettingsForm: {
+          placeholder: "https://...",
+          clearWhenEmpty: "omit",
+        },
       }),
     ),
     customModels: Schema.Array(Schema.String).pipe(
@@ -260,7 +272,10 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
       Schema.annotateKey({
         title: "Binary path",
         description: "Path to the OpenCode binary.",
-        providerSettingsForm: { placeholder: "opencode", clearWhenEmpty: "omit" },
+        providerSettingsForm: {
+          placeholder: "opencode",
+          clearWhenEmpty: "omit",
+        },
       }),
     ),
     serverUrl: TrimmedString.pipe(
@@ -268,7 +283,10 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
       Schema.annotateKey({
         title: "Server URL",
         description: "Leave blank to let T3 Code spawn the server when needed.",
-        providerSettingsForm: { placeholder: "http://127.0.0.1:4096", clearWhenEmpty: "omit" },
+        providerSettingsForm: {
+          placeholder: "http://127.0.0.1:4096",
+          clearWhenEmpty: "omit",
+        },
       }),
     ),
     serverPassword: TrimmedString.pipe(


### PR DESCRIPTION
## Summary
- Replaced per-surface hardcoded provider setting fields with shared declarative provider definitions.
- Added a generic `ProviderSettingsForm` that renders text, password, textarea, and switch controls for both the add-instance dialog and provider cards.
- Preserved opaque provider config keys while tightening field read/write helpers and adding unit coverage for field derivation and config normalization.

## Testing
- `Not run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors how provider instance configs are rendered and normalized, and changes contract schemas/annotations that multiple surfaces may rely on. Risk is mainly UI/config persistence regressions (fields hidden/ordered differently, empty values omitted) rather than security.
> 
> **Overview**
> Provider instance configuration is now rendered from declarative, schema-annotated metadata instead of hardcoded per-surface field arrays, via a new reusable `ProviderSettingsForm` used in both the add-instance dialog and instance cards.
> 
> Driver metadata in `providerDriverMeta.ts` is updated to reference typed Effect Schemas (`CodexSettings`, `ClaudeSettings`, `CursorSettings`, `OpenCodeSettings`) and the contracts add schema annotations for field labels/descriptions/placeholders, ordering, hidden fields, and empty-value persistence rules. The add-instance flow switches to per-driver config drafts, and save/update logic now round-trips unknown config keys while omitting empty fields according to `clearWhenEmpty`, with unit tests covering derivation and normalization helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ac493f472b895f38398541a289255bb337f0f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor provider settings to use schema-driven declarative metadata
> - Replaces hand-coded `fields` arrays on driver definitions with `settingsSchema` annotations in [packages/contracts/src/settings.ts](https://github.com/pingdotgg/t3code/pull/2452/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), covering titles, descriptions, placeholders, control types (text, password, textarea, switch), and `clearWhenEmpty` policies.
> - Introduces a new [ProviderSettingsForm.tsx](https://github.com/pingdotgg/t3code/pull/2452/files#diff-b52caebd4ff96e2d8864b718516b72b7eef42adc6efd55cfdd68a1be1c4eb09e) component that derives and renders form fields from the schema annotations, supporting `card` and `dialog` visual variants.
> - Updates both `AddProviderInstanceDialog` and `ProviderInstanceCard` to use `ProviderSettingsForm` instead of manual field rendering; per-driver config drafts are preserved when switching tabs in the dialog.
> - `SettingsPanels` now derives its provider list from `DRIVER_OPTIONS` rather than a separate hard-coded array.
> - Behavioral Change: empty field values are now omitted from saved configs according to per-field `clearWhenEmpty` policy rather than being stored as empty strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a4ac493.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->