### PR TITLE
feat(desktop): show toast with release notes link when app updates to a new version

### DIFF
--- a/apps/web/src/components/NewVersionToastCoordinator.tsx
+++ b/apps/web/src/components/NewVersionToastCoordinator.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useDesktopUpdateState } from "../lib/desktopUpdateReactQuery";
+import { toastManager } from "./ui/toast";
+import {
+  acknowledgeCurrentVersion,
+  getNewVersionReleaseNotesUrl,
+  shouldShowNewVersionToast,
+} from "./desktopUpdate.logic";
+
+export function NewVersionToastCoordinator() {
+  const { data: updateState } = useDesktopUpdateState();
+  const toastIdRef = useRef<ReturnType<typeof toastManager.add> | null>(null);
+
+  useEffect(() => {
+    if (!shouldShowNewVersionToast(updateState)) return;
+
+    const version = updateState!.currentVersion;
+    acknowledgeCurrentVersion(updateState);
+
+    if (toastIdRef.current) {
+      toastManager.close(toastIdRef.current);
+    }
+
+    toastIdRef.current = toastManager.add({
+      type: "success",
+      title: `Updated to v${version}`,
+      description: "View what's new in this release",
+      timeout: 0,
+      actionProps: {
+        children: "View release notes",
+        onClick: async () => {
+          const bridge = window.desktopBridge;
+          const url = getNewVersionReleaseNotesUrl(version);
+          if (bridge?.openExternal) {
+            await bridge.openExternal(url);
+          } else {
+            window.open(url, "_blank", "noopener,noreferrer");
+          }
+        },
+      },
+    });
+  }, [updateState]);
+
+  useEffect(() => {
+    return () => {
+      if (toastIdRef.current) {
+        toastManager.close(toastIdRef.current);
+        toastIdRef.current = null;
+      }
+    };
+  }, []);
+
+  return null;
+}

--- a/apps/web/src/components/NewVersionToastCoordinator.tsx
+++ b/apps/web/src/components/NewVersionToastCoordinator.tsx
@@ -6,6 +6,7 @@ import { toastManager } from "./ui/toast";
 import {
   acknowledgeCurrentVersion,
   getNewVersionReleaseNotesUrl,
+  readLastAcknowledgedVersion,
   shouldShowNewVersionToast,
 } from "./desktopUpdate.logic";
 
@@ -14,9 +15,17 @@ export function NewVersionToastCoordinator() {
   const toastIdRef = useRef<ReturnType<typeof toastManager.add> | null>(null);
 
   useEffect(() => {
+    if (!updateState?.enabled) return;
+    const currentVersion = updateState.currentVersion;
+    if (!currentVersion) return;
+
+    if (readLastAcknowledgedVersion() === null) {
+      acknowledgeCurrentVersion(updateState);
+      return;
+    }
+
     if (!shouldShowNewVersionToast(updateState)) return;
 
-    const version = updateState!.currentVersion;
     acknowledgeCurrentVersion(updateState);
 
     if (toastIdRef.current) {
@@ -25,14 +34,14 @@ export function NewVersionToastCoordinator() {
 
     toastIdRef.current = toastManager.add({
       type: "success",
-      title: `Updated to v${version}`,
+      title: `Updated to v${currentVersion}`,
       description: "View what's new in this release",
       timeout: 0,
       actionProps: {
         children: "View release notes",
         onClick: async () => {
           const bridge = window.desktopBridge;
-          const url = getNewVersionReleaseNotesUrl(version);
+          const url = getNewVersionReleaseNotesUrl(currentVersion);
           if (bridge?.openExternal) {
             await bridge.openExternal(url);
           } else {

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -1,17 +1,21 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
 
 import {
+  acknowledgeCurrentVersion,
   canCheckForUpdate,
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
+  getNewVersionReleaseNotesUrl,
   isDesktopUpdateButtonDisabled,
+  readLastAcknowledgedVersion,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
   shouldShowDesktopUpdateButton,
   shouldToastDesktopUpdateActionResult,
+  shouldShowNewVersionToast,
 } from "./desktopUpdate.logic";
 
 const baseState: DesktopUpdateState = {
@@ -288,5 +292,77 @@ describe("getDesktopUpdateButtonTooltip", () => {
     expect(getDesktopUpdateButtonTooltip({ ...baseState, status: "up-to-date" })).toBe(
       "Up to date",
     );
+  });
+});
+
+describe("new version toast", () => {
+  beforeEach(() => {
+    const store: Record<string, string> = {};
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => store[key] ?? null,
+      setItem: (key: string, value: string) => {
+        store[key] = value;
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        for (const k of Object.keys(store)) delete store[k];
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("constructs the correct release notes URL", () => {
+    expect(getNewVersionReleaseNotesUrl("1.2.3")).toBe(
+      "https://github.com/pingdotgg/t3code/releases/tag/v1.2.3",
+    );
+  });
+
+  it("does not show toast when update state is null", () => {
+    expect(shouldShowNewVersionToast(null)).toBe(false);
+    expect(shouldShowNewVersionToast(undefined)).toBe(false);
+  });
+
+  it("does not show toast when updates are disabled", () => {
+    expect(shouldShowNewVersionToast({ ...baseState, enabled: false })).toBe(false);
+  });
+
+  it("does not show toast on first launch (no acknowledged version stored)", () => {
+    expect(readLastAcknowledgedVersion()).toBeNull();
+    expect(shouldShowNewVersionToast(baseState)).toBe(false);
+    expect(readLastAcknowledgedVersion()).toBe("1.0.0");
+  });
+
+  it("shows toast when version changes from acknowledged version", () => {
+    acknowledgeCurrentVersion(baseState);
+    expect(readLastAcknowledgedVersion()).toBe("1.0.0");
+
+    const updatedState: DesktopUpdateState = { ...baseState, currentVersion: "1.1.0" };
+    expect(shouldShowNewVersionToast(updatedState)).toBe(true);
+  });
+
+  it("does not show toast when version matches acknowledged version", () => {
+    acknowledgeCurrentVersion(baseState);
+    expect(shouldShowNewVersionToast(baseState)).toBe(false);
+  });
+
+  it("acknowledgeCurrentVersion persists the current version", () => {
+    const state: DesktopUpdateState = { ...baseState, currentVersion: "2.0.0" };
+    acknowledgeCurrentVersion(state);
+    expect(readLastAcknowledgedVersion()).toBe("2.0.0");
+  });
+
+  it("acknowledgeCurrentVersion does nothing for disabled updates", () => {
+    acknowledgeCurrentVersion({ ...baseState, enabled: false });
+    expect(readLastAcknowledgedVersion()).toBeNull();
+  });
+
+  it("does not show toast when acknowledged version matches after first launch", () => {
+    expect(shouldShowNewVersionToast(baseState)).toBe(false);
+    expect(shouldShowNewVersionToast(baseState)).toBe(false);
   });
 });

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -331,10 +331,10 @@ describe("new version toast", () => {
     expect(shouldShowNewVersionToast({ ...baseState, enabled: false })).toBe(false);
   });
 
-  it("does not show toast on first launch (no acknowledged version stored)", () => {
+  it("does not show toast when no acknowledged version is stored and has no side effects", () => {
     expect(readLastAcknowledgedVersion()).toBeNull();
     expect(shouldShowNewVersionToast(baseState)).toBe(false);
-    expect(readLastAcknowledgedVersion()).toBe("1.0.0");
+    expect(readLastAcknowledgedVersion()).toBeNull();
   });
 
   it("shows toast when version changes from acknowledged version", () => {
@@ -362,6 +362,7 @@ describe("new version toast", () => {
   });
 
   it("does not show toast when acknowledged version matches after first launch", () => {
+    acknowledgeCurrentVersion(baseState);
     expect(shouldShowNewVersionToast(baseState)).toBe(false);
     expect(shouldShowNewVersionToast(baseState)).toBe(false);
   });

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -16,10 +16,7 @@ export function shouldShowNewVersionToast(
   if (!currentVersion) return false;
 
   const lastAcknowledged = readLastAcknowledgedVersion();
-  if (lastAcknowledged === null) {
-    persistLastAcknowledgedVersion(currentVersion);
-    return false;
-  }
+  if (lastAcknowledged === null) return false;
   return currentVersion !== lastAcknowledged;
 }
 

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -1,5 +1,54 @@
 import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/contracts";
 
+const LAST_ACKNOWLEDGED_VERSION_KEY = "t3code:lastAcknowledgedDesktopVersion";
+
+export const GITHUB_RELEASES_URL = "https://github.com/pingdotgg/t3code/releases/tag";
+
+export function getNewVersionReleaseNotesUrl(version: string): string {
+  return `${GITHUB_RELEASES_URL}/v${version}`;
+}
+
+export function shouldShowNewVersionToast(
+  updateState: DesktopUpdateState | null | undefined,
+): boolean {
+  if (!updateState?.enabled) return false;
+  const currentVersion = updateState.currentVersion;
+  if (!currentVersion) return false;
+
+  const lastAcknowledged = readLastAcknowledgedVersion();
+  if (lastAcknowledged === null) {
+    persistLastAcknowledgedVersion(currentVersion);
+    return false;
+  }
+  return currentVersion !== lastAcknowledged;
+}
+
+export function acknowledgeCurrentVersion(
+  updateState: DesktopUpdateState | null | undefined,
+): void {
+  if (!updateState?.enabled) return;
+  const currentVersion = updateState.currentVersion;
+  if (currentVersion) {
+    persistLastAcknowledgedVersion(currentVersion);
+  }
+}
+
+export function readLastAcknowledgedVersion(): string | null {
+  try {
+    return localStorage.getItem(LAST_ACKNOWLEDGED_VERSION_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function persistLastAcknowledgedVersion(version: string): void {
+  try {
+    localStorage.setItem(LAST_ACKNOWLEDGED_VERSION_KEY, version);
+  } catch {
+    // localStorage may be unavailable (incognito, SSR, etc.)
+  }
+}
+
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
 export function resolveDesktopUpdateButtonAction(

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -13,6 +13,7 @@ import { QueryClient, useQueryClient } from "@tanstack/react-query";
 import { APP_DISPLAY_NAME } from "../branding";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
+import { NewVersionToastCoordinator } from "../components/NewVersionToastCoordinator";
 import {
   SlowRpcAckToastCoordinator,
   WebSocketConnectionCoordinator,
@@ -102,6 +103,7 @@ function RootRouteView() {
         <EnvironmentConnectionManagerBootstrap />
         <EventRouter />
         <WebSocketConnectionCoordinator />
+        <NewVersionToastCoordinator />
         <SlowRpcAckToastCoordinator />
         <WebSocketConnectionSurface>
           <CommandPalette>


### PR DESCRIPTION
## Summary

When the desktop app is updated to a new version, a toast now appears on the
next launch announcing the new version with a button linking to the GitHub
release notes.

This addresses the lack of in-app feedback after an update — users previously
had no indication that something changed or where to find release notes.

## Changes

- Added `shouldShowNewVersionToast`, `acknowledgeCurrentVersion`,
  `readLastAcknowledgedVersion`, and `getNewVersionReleaseNotesUrl` to
  `desktopUpdate.logic.ts` — pure functions that compare the running version
  against a `localStorage`-persisted acknowledged version.
- Created `NewVersionToastCoordinator.tsx` — a coordinator component that
  subscribes to `useDesktopUpdateState()` and triggers the toast when the
  version changes.
- Mounted the coordinator in `__root.tsx` inside the `ToastProvider`.

## Behavior

| Scenario | Result |
|---|---|
| First launch (no prior version stored) | No toast; current version persisted |
| Version matches acknowledged version | No toast |
| Version differs from acknowledged version | Toast: "Updated to vX.Y.Z" + "View release notes" button |
| Click "View release notes" | Opens `https://github.com/pingdotgg/t3code/releases/tag/vX.Y.Z` |
| Browser mode (no desktop bridge) | No-op (update state is null) |
| Updates disabled | No-op |

## Risk

Low. All new code is client-side only, uses localStorage for persistence
(gracefully handles unavailable storage), and follows the exact coordinator
pattern used by `SlowRpcAckToastCoordinator`. The toast is informational only
— no blocking, no side effects.

## Rollback

Revert the four touched files.

Closes #2309

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an informational client-side toast driven by desktop update state and `localStorage`, with guarded access/fallbacks and no server-side or auth changes.
> 
> **Overview**
> Shows an **“Updated to vX.Y.Z”** persistent toast after the desktop app launches on a *new* version, with an action to open GitHub release notes (via `desktopBridge.openExternal` when available, otherwise `window.open`).
> 
> Introduces `desktopUpdate.logic` helpers to track the last acknowledged version in `localStorage` and decide when the toast should appear, adds coverage for this logic, and mounts the new `NewVersionToastCoordinator` in the authenticated root route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84b0444e456b4fd97f4eae5f466e4164a4ec33e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show a toast with release notes link when the desktop app updates to a new version
> - Adds [`NewVersionToastCoordinator`](https://github.com/pingdotgg/t3code/pull/2454/files#diff-a6e44d73427fc734c49f875be1f65c20535175ea087af806f79e113f8deb7b11), a client-side component mounted in the authenticated root that watches desktop update state and shows a persistent success toast when a new version is detected.
> - The toast includes an action button that opens the GitHub release notes URL for the new version via `desktopBridge.openExternal` or `window.open`.
> - Adds utilities in [`desktopUpdate.logic.ts`](https://github.com/pingdotgg/t3code/pull/2454/files#diff-ad19260d118b0d961892078ed35b67240d359da2ae4b4c8bd33e258537c503af) to construct the release notes URL, check whether the toast should be shown, and persist the acknowledged version to `localStorage` to prevent repeat toasts.
> - The toast only appears when updates are enabled, a current version exists, and the version differs from the last acknowledged version stored in `localStorage`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 84b0444.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->