### PR TITLE
fix(server): handle proposed_plan fallback after mode switch

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -738,6 +738,61 @@ describe("ProviderRuntimeIngestion", () => {
     expect(message?.streaming).toBe(false);
   });
 
+  it("projects a proposed plan from assistant message text tagged with proposed_plan", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-plan-1"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-assistant-plan"),
+      itemId: asItemId("item-assistant-plan"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "<proposed_plan>\n# Streamed fallback plan\n\n- one\n</proposed_plan>",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-message-completed-plan"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-assistant-plan"),
+      itemId: asItemId("item-assistant-plan"),
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.proposedPlans.some(
+        (proposedPlan: ProviderRuntimeTestProposedPlan) =>
+          proposedPlan.id === "plan:thread-1:turn:turn-assistant-plan",
+      ),
+    );
+
+    expect(
+      thread.messages.find(
+        (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-assistant-plan",
+      ),
+    ).toMatchObject({
+      text: "",
+      streaming: false,
+      turnId: "turn-assistant-plan",
+    });
+    expect(
+      thread.proposedPlans.find(
+        (entry: ProviderRuntimeTestProposedPlan) =>
+          entry.id === "plan:thread-1:turn:turn-assistant-plan",
+      )?.planMarkdown,
+    ).toBe("# Streamed fallback plan\n\n- one");
+  });
+
   it("preserves completed tool metadata on projected tool activities", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -1716,6 +1716,77 @@ describe("ProviderRuntimeIngestion", () => {
     expect(message?.streaming).toBe(false);
   });
 
+  it("projects a proposed plan when an approval request opens after buffered tagged assistant text", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "turn.started",
+      eventId: asEventId("evt-turn-started-buffered-request-plan-flush"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-buffered-request-plan-flush"),
+    });
+    await waitForThread(
+      harness.engine,
+      (thread) =>
+        thread.session?.status === "running" &&
+        thread.session?.activeTurnId === "turn-buffered-request-plan-flush",
+    );
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-buffered-request-plan-flush"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-buffered-request-plan-flush"),
+      itemId: asItemId("item-buffered-request-plan-flush"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "<proposed_plan>\n# Approval boundary plan\n\n- one\n</proposed_plan>",
+      },
+    });
+    harness.emit({
+      type: "request.opened",
+      eventId: asEventId("evt-request-opened-buffered-request-plan-flush"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-buffered-request-plan-flush"),
+      requestId: ApprovalRequestId.make("req-buffered-request-plan-flush"),
+      payload: {
+        requestType: "command_execution_approval",
+        detail: "pwd",
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.proposedPlans.some(
+        (proposedPlan: ProviderRuntimeTestProposedPlan) =>
+          proposedPlan.id === "plan:thread-1:turn:turn-buffered-request-plan-flush",
+      ),
+    );
+
+    expect(
+      thread.messages.find(
+        (entry: ProviderRuntimeTestMessage) =>
+          entry.id === "assistant:item-buffered-request-plan-flush",
+      ),
+    ).toMatchObject({
+      text: "",
+      streaming: false,
+      turnId: "turn-buffered-request-plan-flush",
+    });
+    expect(
+      thread.proposedPlans.find(
+        (entry: ProviderRuntimeTestProposedPlan) =>
+          entry.id === "plan:thread-1:turn:turn-buffered-request-plan-flush",
+      )?.planMarkdown,
+    ).toBe("# Approval boundary plan\n\n- one");
+  });
+
   it("flushes and completes buffered assistant text when user input is requested", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -793,6 +793,60 @@ describe("ProviderRuntimeIngestion", () => {
     ).toBe("# Streamed fallback plan\n\n- one");
   });
 
+  it("projects a proposed plan from assistant message text tagged with proposed_plan on turn completion", async () => {
+    const harness = await createHarness();
+    const now = new Date().toISOString();
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-message-delta-plan-turn-complete-1"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-assistant-plan-turn-complete"),
+      itemId: asItemId("item-assistant-plan-turn-complete"),
+      payload: {
+        streamKind: "assistant_text",
+        delta: "<proposed_plan>\n# Turn completion fallback plan\n\n- one\n</proposed_plan>",
+      },
+    });
+    harness.emit({
+      type: "turn.completed",
+      eventId: asEventId("evt-turn-completed-plan-turn-complete"),
+      provider: ProviderDriverKind.make("codex"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-assistant-plan-turn-complete"),
+      payload: {
+        summary: "done",
+      },
+    });
+
+    const thread = await waitForThread(harness.engine, (entry) =>
+      entry.proposedPlans.some(
+        (proposedPlan: ProviderRuntimeTestProposedPlan) =>
+          proposedPlan.id === "plan:thread-1:turn:turn-assistant-plan-turn-complete",
+      ),
+    );
+
+    expect(
+      thread.messages.find(
+        (entry: ProviderRuntimeTestMessage) =>
+          entry.id === "assistant:item-assistant-plan-turn-complete",
+      ),
+    ).toMatchObject({
+      text: "",
+      streaming: false,
+      turnId: "turn-assistant-plan-turn-complete",
+    });
+    expect(
+      thread.proposedPlans.find(
+        (entry: ProviderRuntimeTestProposedPlan) =>
+          entry.id === "plan:thread-1:turn:turn-assistant-plan-turn-complete",
+      )?.planMarkdown,
+    ).toBe("# Turn completion fallback plan\n\n- one");
+  });
+
   it("preserves completed tool metadata on projected tool activities", async () => {
     const harness = await createHarness();
     const now = new Date().toISOString();

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -769,6 +769,10 @@ const make = Effect.gen(function* () {
       if (!hasRenderableAssistantText(bufferedText)) {
         return false;
       }
+      if (extractProposedPlanMarkdown(bufferedText)) {
+        yield* Cache.set(bufferedAssistantTextByMessageId, input.messageId, bufferedText);
+        return false;
+      }
 
       yield* orchestrationEngine.dispatch({
         type: "thread.message.assistant.delta",
@@ -867,6 +871,12 @@ const make = Effect.gen(function* () {
   const finalizeActiveAssistantSegmentForTurn = (input: {
     event: ProviderRuntimeEvent;
     threadId: ThreadId;
+    threadProposedPlans: ReadonlyArray<{
+      id: string;
+      createdAt: string;
+      implementedAt: string | null;
+      implementationThreadId: ThreadId | null;
+    }>;
     turnId: TurnId;
     createdAt: string;
     commandTag: string;
@@ -883,7 +893,7 @@ const make = Effect.gen(function* () {
         return;
       }
 
-      yield* finalizeAssistantMessage({
+      const completedAssistantText = yield* finalizeAssistantMessage({
         event: input.event,
         threadId: input.threadId,
         messageId: activeMessageId.value,
@@ -895,6 +905,18 @@ const make = Effect.gen(function* () {
           input.hasProjectedMessage ||
           (input.flushedMessageIds?.has(activeMessageId.value) ?? false),
       });
+      const proposedPlanFromAssistantMessage = extractProposedPlanMarkdown(completedAssistantText);
+      if (proposedPlanFromAssistantMessage) {
+        yield* finalizeBufferedProposedPlan({
+          event: input.event,
+          threadId: input.threadId,
+          threadProposedPlans: input.threadProposedPlans,
+          planId: proposedPlanIdForTurn(input.threadId, input.turnId),
+          turnId: input.turnId,
+          fallbackMarkdown: proposedPlanFromAssistantMessage,
+          updatedAt: input.createdAt,
+        });
+      }
       yield* forgetAssistantMessageId(input.threadId, input.turnId, activeMessageId.value);
 
       const state = yield* getAssistantSegmentStateForTurn(input.threadId, input.turnId);
@@ -1307,6 +1329,7 @@ const make = Effect.gen(function* () {
         yield* finalizeActiveAssistantSegmentForTurn({
           event,
           threadId: thread.id,
+          threadProposedPlans: thread.proposedPlans,
           turnId: pauseForUserTurnId,
           createdAt: now,
           commandTag:

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -834,7 +834,8 @@ const make = Effect.gen(function* () {
           : (input.fallbackText?.trim().length ?? 0) > 0
             ? input.fallbackText!
             : "";
-      const text = rawText.replace(PROPOSED_PLAN_BLOCK_REGEX, "").trim();
+      const hasProposedPlanBlock = PROPOSED_PLAN_CAPTURE_REGEX.test(rawText);
+      const text = hasProposedPlanBlock ? rawText.replace(PROPOSED_PLAN_BLOCK_REGEX, "") : rawText;
       const hasRenderableText = hasRenderableAssistantText(text);
 
       if (hasRenderableText) {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -81,6 +81,13 @@ function truncateDetail(value: string, limit = 180): string {
   return value.length > limit ? `${value.slice(0, limit - 3)}...` : value;
 }
 
+const PROPOSED_PLAN_BLOCK_REGEX = /<proposed_plan>\s*[\s\S]*?\s*<\/proposed_plan>/g;
+const PROPOSED_PLAN_CAPTURE_REGEX = /<proposed_plan>\s*([\s\S]*?)\s*<\/proposed_plan>/;
+
+function extractProposedPlanMarkdown(text: string | undefined): string | undefined {
+  return text?.trim().match(PROPOSED_PLAN_CAPTURE_REGEX)?.[1]?.trim() || undefined;
+}
+
 function normalizeProposedPlanMarkdown(planMarkdown: string | undefined): string | undefined {
   const trimmed = planMarkdown?.trim();
   if (!trimmed) {
@@ -821,12 +828,13 @@ const make = Effect.gen(function* () {
   }) =>
     Effect.gen(function* () {
       const bufferedText = yield* takeBufferedAssistantText(input.messageId);
-      const text =
+      const rawText =
         bufferedText.length > 0
           ? bufferedText
           : (input.fallbackText?.trim().length ?? 0) > 0
             ? input.fallbackText!
             : "";
+      const text = rawText.replace(PROPOSED_PLAN_BLOCK_REGEX, "").trim();
       const hasRenderableText = hasRenderableAssistantText(text);
 
       if (hasRenderableText) {
@@ -841,7 +849,7 @@ const make = Effect.gen(function* () {
         });
       }
 
-      if (input.hasProjectedMessage || hasRenderableText) {
+      if (input.hasProjectedMessage || hasRenderableText || rawText.length > 0) {
         yield* orchestrationEngine.dispatch({
           type: "thread.message.assistant.complete",
           commandId: providerCommandId(input.event, input.commandTag),
@@ -852,6 +860,7 @@ const make = Effect.gen(function* () {
         });
       }
       yield* clearAssistantMessageState(input.messageId);
+      return rawText;
     });
 
   const finalizeActiveAssistantSegmentForTurn = (input: {
@@ -1368,7 +1377,7 @@ const make = Effect.gen(function* () {
             yield* rememberAssistantMessageId(thread.id, turnId, assistantMessageId);
           }
 
-          yield* finalizeAssistantMessage({
+          const completedAssistantText = yield* finalizeAssistantMessage({
             event,
             threadId: thread.id,
             messageId: assistantMessageId,
@@ -1381,6 +1390,20 @@ const make = Effect.gen(function* () {
               ? { fallbackText: assistantCompletion.fallbackText }
               : {}),
           });
+
+          const proposedPlanFromAssistantMessage =
+            extractProposedPlanMarkdown(completedAssistantText);
+          if (proposedPlanFromAssistantMessage) {
+            yield* finalizeBufferedProposedPlan({
+              event,
+              threadId: thread.id,
+              threadProposedPlans: thread.proposedPlans,
+              planId: proposedPlanIdFromEvent(event, thread.id),
+              ...(turnId ? { turnId } : {}),
+              fallbackMarkdown: proposedPlanFromAssistantMessage,
+              updatedAt: now,
+            });
+          }
 
           if (turnId) {
             yield* forgetAssistantMessageId(thread.id, turnId, assistantMessageId);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1435,17 +1435,33 @@ const make = Effect.gen(function* () {
           yield* Effect.forEach(
             assistantMessageIds,
             (assistantMessageId) =>
-              finalizeAssistantMessage({
-                event,
-                threadId: thread.id,
-                messageId: assistantMessageId,
-                turnId,
-                createdAt: now,
-                commandTag: "assistant-complete-finalize",
-                finalDeltaCommandTag: "assistant-delta-finalize-fallback",
-                hasProjectedMessage: thread.messages.some(
-                  (entry) => entry.id === assistantMessageId,
-                ),
+              Effect.gen(function* () {
+                const completedAssistantText = yield* finalizeAssistantMessage({
+                  event,
+                  threadId: thread.id,
+                  messageId: assistantMessageId,
+                  turnId,
+                  createdAt: now,
+                  commandTag: "assistant-complete-finalize",
+                  finalDeltaCommandTag: "assistant-delta-finalize-fallback",
+                  hasProjectedMessage: thread.messages.some(
+                    (entry) => entry.id === assistantMessageId,
+                  ),
+                });
+
+                const proposedPlanFromAssistantMessage =
+                  extractProposedPlanMarkdown(completedAssistantText);
+                if (proposedPlanFromAssistantMessage) {
+                  yield* finalizeBufferedProposedPlan({
+                    event,
+                    threadId: thread.id,
+                    threadProposedPlans: thread.proposedPlans,
+                    planId: proposedPlanIdForTurn(thread.id, turnId),
+                    turnId,
+                    fallbackMarkdown: proposedPlanFromAssistantMessage,
+                    updatedAt: now,
+                  });
+                }
               }),
             { concurrency: 1 },
           ).pipe(Effect.asVoid);


### PR DESCRIPTION
## What Changed

This fixes proposed-plan rendering when a user starts in Plan mode, switches the same thread back to Build mode, and then asks for another plan.

On the server side, proposed-plan fallback extraction now runs when an assistant message completes with `<proposed_plan>...</proposed_plan>` in its final text, even if the provider did not emit a canonical `turn.proposed.completed` event.

When that happens, T3 Code now:
- extracts the markdown inside `<proposed_plan>`
- upserts a real proposed plan for the thread
- strips the `<proposed_plan>` block out of the visible assistant chat message so the raw tagged text is not rendered alongside the plan card
- still records the assistant completion state needed for the normal plan follow-up flow

As a result, the Build-mode fallback now behaves like a normal proposed plan:
- the plan card appears correctly
- the raw tagged assistant text does not remain visible
- if the user later switches back to Plan mode, they can implement or refine that plan as normal

Regression coverage was added around assistant-message completion so the plan is projected correctly and the assistant message is suppressed visually while preserving the turn bookkeeping required by the follow-up UI.

## Why

There was a mode-transition bug in the Codex flow:

1. Start in Plan mode
2. Generate a plan
3. Switch the thread to Build mode
4. Ask the assistant to propose another plan

In that path, the provider could return a `<proposed_plan>` block as ordinary assistant text instead of emitting the canonical proposed-plan event.

Before this fix, the UI could render the raw tagged markdown as a normal assistant message, or render both the raw tagged message and the proposed plan card at the same time. A follow-up regression also showed that suppressing the assistant text too aggressively could break the normal `Implement` flow when switching back to Plan mode.

That behavior was incorrect. Proposed-plan blocks should project as first-class proposed plans, the raw tagged payload should not remain in the chat transcript when it only exists to back the plan card, and the resulting plan should still behave like a normal actionable plan afterward.

This server-side fallback is the smallest fix because it reuses the existing proposed-plan projection pipeline instead of changing web rendering rules or broader mode behavior.

## UI Changes

Before
<img width="1919" height="1031" alt="2026-05-02_01-25" src="https://github.com/user-attachments/assets/a6542bb8-c432-437f-bb50-f22517bfea09" />

After
<img width="1919" height="947" alt="2026-05-02_01-26" src="https://github.com/user-attachments/assets/03dd770f-a670-4585-be2b-bd75e33e4fea" />
<img width="1919" height="944" alt="2026-05-02_01-24" src="https://github.com/user-attachments/assets/d0ead16a-f539-465d-883e-1400b68d1146" />

Repro shown in before/after:
1. Start in Plan mode
2. Switch to Build mode
3. Ask for another plan
4. Observe raw `<proposed_plan>` text in chat before this fix
5. Observe only the proposed plan card after this fix
6. Switch back to Plan mode
7. Confirm the plan can still be implemented normally



## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `ProviderRuntimeIngestion` message finalization/proposed-plan projection, which can affect chat transcript rendering and plan upsert behavior across turn/approval boundaries, but is scoped and covered by new tests.
> 
> **Overview**
> Ensures proposed plans still project when providers return a `<proposed_plan>...</proposed_plan>` block as plain assistant text (e.g., after mode switches), by **extracting the block on assistant completion** and upserting it into `thread.proposedPlans`.
> 
> `finalizeAssistantMessage` now strips `<proposed_plan>` blocks from emitted assistant deltas, still completes the assistant message even if the visible text becomes empty, and returns the raw text so callers can derive fallback plan markdown; this fallback projection is triggered on `item.completed`, `turn.completed`, and approval-boundary finalization.
> 
> Adds regression tests covering plan extraction from tagged assistant text on message completion, turn completion, and buffered text flushed at `request.opened`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbc954c95d5971e7ca240c170ad8de1807c172e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `proposed_plan` block handling in assistant messages after mode switch
> - Adds detection and extraction of `<proposed_plan>` blocks embedded in assistant message text using two new regex constants and a helper in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/2455/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7).
> - Strips `<proposed_plan>` content from assistant message deltas so plan markup is never rendered as chat text; instead, a `proposedPlan` entity is projected for the active turn.
> - Handles three completion paths: `assistant.message.completed`, `turn.completed`, and `request.opened` (pause boundary) — each now extracts and finalizes any buffered proposed plan.
> - Buffered assistant text containing a proposed plan is held back from flushing as a delta until a completion event arrives.
> - Behavioral Change: `assistant.complete` is now emitted even when visible text is empty, as long as raw content (e.g. a plan block) was present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbc954c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->