### PR TITLE
fix: retain first turn messages and restore last user message to composer on revert

### DIFF
--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -575,15 +575,16 @@ export function projectEvent(
             return nextBase;
           }
 
+          const effectiveTurnCount = Math.max(1, payload.turnCount);
           const checkpoints = thread.checkpoints
-            .filter((entry) => entry.checkpointTurnCount <= payload.turnCount)
+            .filter((entry) => entry.checkpointTurnCount <= effectiveTurnCount)
             .toSorted((left, right) => left.checkpointTurnCount - right.checkpointTurnCount)
             .slice(-MAX_THREAD_CHECKPOINTS);
           const retainedTurnIds = new Set(checkpoints.map((checkpoint) => checkpoint.turnId));
           const messages = retainThreadMessagesAfterRevert(
             thread.messages,
             retainedTurnIds,
-            payload.turnCount,
+            effectiveTurnCount,
           ).slice(-MAX_THREAD_MESSAGES);
           const proposedPlans = retainThreadProposedPlansAfterRevert(
             thread.proposedPlans,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -74,6 +74,7 @@ import {
 } from "../pendingUserInput";
 import {
   selectProjectsAcrossEnvironments,
+  selectThreadByRef,
   selectThreadsAcrossEnvironments,
   useStore,
 } from "../store";
@@ -2379,6 +2380,17 @@ export default function ChatView(props: ChatViewProps) {
           turnCount,
           createdAt: new Date().toISOString(),
         });
+
+        const threadRef = scopeThreadRef(activeThread.environmentId, activeThread.id);
+        const updatedThread = selectThreadByRef(useStore.getState(), threadRef);
+        if (updatedThread && promptRef.current.trim().length === 0) {
+          const lastUserMessage = [...updatedThread.messages]
+            .reverse()
+            .find((m) => m.role === "user");
+          if (lastUserMessage) {
+            setComposerDraftPrompt(composerDraftTarget, lastUserMessage.text);
+          }
+        }
       } catch (err) {
         setThreadError(
           activeThread.id,
@@ -2389,11 +2401,13 @@ export default function ChatView(props: ChatViewProps) {
     },
     [
       activeThread,
+      composerDraftTarget,
       environmentId,
       isConnecting,
       isRevertingCheckpoint,
       isSendBusy,
       phase,
+      setComposerDraftPrompt,
       setThreadError,
     ],
   );

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -1015,4 +1015,84 @@ describe("incremental orchestration updates", () => {
     });
     expect(threadsOf(next)[0]?.latestTurn?.sourceProposedPlan).toBeUndefined();
   });
+
+  it("retains first turn messages when reverting single-turn conversation (turnCount=0)", () => {
+    const state = makeState(
+      makeThread({
+        messages: [
+          {
+            id: MessageId.make("user-1"),
+            role: "user",
+            text: "hello",
+            turnId: TurnId.make("turn-1"),
+            createdAt: "2026-02-27T00:00:00.000Z",
+            completedAt: "2026-02-27T00:00:00.000Z",
+            streaming: false,
+          },
+          {
+            id: MessageId.make("assistant-1"),
+            role: "assistant",
+            text: "hi there",
+            turnId: TurnId.make("turn-1"),
+            createdAt: "2026-02-27T00:00:01.000Z",
+            completedAt: "2026-02-27T00:00:01.000Z",
+            streaming: false,
+          },
+        ],
+        proposedPlans: [
+          {
+            id: "plan-1",
+            turnId: TurnId.make("turn-1"),
+            planMarkdown: "plan 1",
+            implementedAt: null,
+            implementationThreadId: null,
+            createdAt: "2026-02-27T00:00:00.000Z",
+            updatedAt: "2026-02-27T00:00:00.000Z",
+          },
+        ],
+        activities: [
+          {
+            id: EventId.make("activity-1"),
+            tone: "info",
+            kind: "step",
+            summary: "step one",
+            payload: {},
+            turnId: TurnId.make("turn-1"),
+            createdAt: "2026-02-27T00:00:00.000Z",
+          },
+        ],
+        turnDiffSummaries: [
+          {
+            turnId: TurnId.make("turn-1"),
+            completedAt: "2026-02-27T00:00:01.000Z",
+            status: "ready",
+            checkpointTurnCount: 1,
+            checkpointRef: CheckpointRef.make("ref-1"),
+            files: [],
+          },
+        ],
+      }),
+    );
+
+    const next = applyOrchestrationEvent(
+      state,
+      makeEvent("thread.reverted", {
+        threadId: ThreadId.make("thread-1"),
+        turnCount: 0,
+      }),
+      localEnvironmentId,
+    );
+
+    expect(threadsOf(next)[0]?.messages.map((message) => message.id)).toEqual([
+      "user-1",
+      "assistant-1",
+    ]);
+    expect(threadsOf(next)[0]?.proposedPlans.map((plan) => plan.id)).toEqual(["plan-1"]);
+    expect(threadsOf(next)[0]?.activities.map((activity) => activity.id)).toEqual([
+      EventId.make("activity-1"),
+    ]);
+    expect(threadsOf(next)[0]?.turnDiffSummaries.map((summary) => summary.turnId)).toEqual([
+      TurnId.make("turn-1"),
+    ]);
+  });
 });

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -1562,11 +1562,12 @@ function applyEnvironmentOrchestrationEvent(
 
     case "thread.reverted":
       return updateThreadState(state, event.payload.threadId, (thread) => {
+        const effectiveTurnCount = Math.max(1, event.payload.turnCount);
         const turnDiffSummaries = thread.turnDiffSummaries
           .filter(
             (entry) =>
               entry.checkpointTurnCount !== undefined &&
-              entry.checkpointTurnCount <= event.payload.turnCount,
+              entry.checkpointTurnCount <= effectiveTurnCount,
           )
           .toSorted(
             (left, right) =>
@@ -1578,7 +1579,7 @@ function applyEnvironmentOrchestrationEvent(
         const messages = retainThreadMessagesAfterRevert(
           thread.messages,
           retainedTurnIds,
-          event.payload.turnCount,
+          effectiveTurnCount,
         ).slice(-MAX_THREAD_MESSAGES);
         const proposedPlans = retainThreadProposedPlansAfterRevert(
           thread.proposedPlans,


### PR DESCRIPTION
## Summary

Fixes two issues when clicking "Revert to this point" on a single-turn conversation:

1. **Blank screen**: The revert turn count was computed as `checkpointTurnCount - 1 = 0`, but the checkpoint filter (`checkpointTurnCount <= 0`) matched no checkpoints (first checkpoint is at `checkpointTurnCount = 1`), causing all messages to be removed.

2. **Lost input text**: After revert completed, the composer input was not populated with the last retained user message text.

## Changes

- **`apps/web/src/store.ts`** — Use `Math.max(1, turnCount)` as the effective filter threshold in the `"thread.reverted"` reducer so the first checkpoint is always retained.
- **`apps/server/src/orchestration/projector.ts`** — Same fix in the server-side projector for consistency.
- **`apps/web/src/components/ChatView.tsx`** — After revert completes, restore the last retained user message text into the composer input.
- **`apps/web/src/store.test.ts`** — Regression test for `turnCount: 0` revert.

## Verification

- `apps/web`: typecheck ✓, 90 test files / 926 tests pass ✓
- `apps/server`: 3 test files / 41 orchestration tests pass ✓

Closes #2268

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches both server and client `thread.reverted` projection/reducer logic, which can affect message retention during revert (potentially user-visible data loss if incorrect). Scope is small and covered by a new regression test for `turnCount=0`.
> 
> **Overview**
> **Fixes single-turn thread revert behavior.** When handling `thread.reverted`, both the server projector and web store now clamp the effective `turnCount` to at least `1`, ensuring the first checkpoint/turn diff and its related messages/plans/activities aren’t wiped when the UI computes `turnCount=0`.
> 
> **Improves UX after revert.** After a successful revert, `ChatView` reloads the updated thread from the store and, if the composer is empty, restores the last retained user message text into the composer draft. A regression test was added to verify that reverting with `turnCount: 0` preserves first-turn state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b75e804f1310354bf6bbfccded3d2441315ede7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix thread revert to retain first-turn messages and restore last user message to composer
> - Clamps `turnCount` to a minimum of 1 when handling `thread.reverted` events in both [store.ts](https://github.com/pingdotgg/t3code/pull/2457/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82) and [projector.ts](https://github.com/pingdotgg/t3code/pull/2457/files#diff-3da4865ecd7a117ebdca42c25e9526bc69b87696dc8209029ecb2809f8e6a937), preventing a `turnCount <= 0` from clearing the first turn's messages, plans, activities, and diff summaries.
> - After reverting to a checkpoint in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2457/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), if the composer prompt is empty, it is auto-filled with the text of the last user message from the updated thread.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b75e80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->