### PR TITLE
Always collapsable sidebar. More space in the window

### DIFF
--- a/apps/web/src/components/NoActiveThreadState.tsx
+++ b/apps/web/src/components/NoActiveThreadState.tsx
@@ -1,9 +1,12 @@
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "./ui/empty";
-import { SidebarInset, SidebarTrigger } from "./ui/sidebar";
+import { SidebarInset, SidebarTrigger, useSidebar } from "./ui/sidebar";
 import { isElectron } from "../env";
 import { cn } from "~/lib/utils";
 
 export function NoActiveThreadState() {
+  const { isMobile, open, openMobile } = useSidebar();
+  const sidebarOpen = isMobile ? openMobile : open;
+
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
@@ -21,7 +24,7 @@ export function NoActiveThreadState() {
             </span>
           ) : (
             <div className="flex items-center gap-2">
-              <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+              {!sidebarOpen ? <SidebarTrigger className="size-7 shrink-0" /> : null}
               <span className="text-sm font-medium text-foreground md:text-muted-foreground/60">
                 No active thread
               </span>

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -271,7 +271,7 @@ export default function ProjectScriptsControl({
       {primaryScript ? (
         <Group aria-label="Project scripts">
           <Button
-            size="xs"
+            size="sm"
             variant="outline"
             onClick={() => onRunScript(primaryScript)}
             title={`Run ${primaryScript.name}`}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2364,7 +2364,7 @@ const SidebarChromeHeader = memo(function SidebarChromeHeader({
 }) {
   const wordmark = (
     <div className="flex items-center gap-2">
-      <SidebarTrigger className="shrink-0 md:hidden" />
+      <SidebarTrigger className="shrink-0" />
       <Tooltip>
         <TooltipTrigger
           render={

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -14,7 +14,7 @@ import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
 import { Toggle } from "../ui/toggle";
-import { SidebarTrigger } from "../ui/sidebar";
+import { SidebarTrigger, useSidebar } from "../ui/sidebar";
 import { OpenInPicker } from "./OpenInPicker";
 
 interface ChatHeaderProps {
@@ -68,10 +68,13 @@ export const ChatHeader = memo(function ChatHeader({
   onToggleTerminal,
   onToggleDiff,
 }: ChatHeaderProps) {
+  const { isMobile, open, openMobile } = useSidebar();
+  const sidebarOpen = isMobile ? openMobile : open;
+
   return (
     <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
-        <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+        {!sidebarOpen ? <SidebarTrigger className="size-7 shrink-0" /> : null}
         <h2
           className="min-w-0 shrink truncate text-sm font-medium text-foreground"
           title={activeThreadTitle}
@@ -89,7 +92,7 @@ export const ChatHeader = memo(function ChatHeader({
           </Badge>
         )}
       </div>
-      <div className="flex shrink-0 items-center justify-end gap-2 @3xl/header-actions:gap-3">
+      <div className="flex shrink-0 items-center justify-end gap-1 @3xl/header-actions:gap-2">
         {activeProjectScripts && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}

--- a/apps/web/src/components/chat/MessageCopyButton.tsx
+++ b/apps/web/src/components/chat/MessageCopyButton.tsx
@@ -22,7 +22,10 @@ const onCopy = (ref: React.RefObject<HTMLButtonElement | null>) => {
   }
 };
 
-const onCopyError = (ref: React.RefObject<HTMLButtonElement | null>, error: Error) => {
+const onCopyError = (
+  ref: React.RefObject<HTMLButtonElement | null>,
+  error: Error,
+) => {
   if (ref.current) {
     anchoredToastManager.add({
       data: {
@@ -41,7 +44,7 @@ const onCopyError = (ref: React.RefObject<HTMLButtonElement | null>, error: Erro
 export const MessageCopyButton = memo(function MessageCopyButton({
   text,
   size = "xs",
-  variant = "outline",
+  variant = "ghost",
   className,
 }: {
   text: string;
@@ -72,7 +75,11 @@ export const MessageCopyButton = memo(function MessageCopyButton({
           />
         }
       >
-        {isCopied ? <CheckIcon className="size-3 text-success" /> : <CopyIcon className="size-3" />}
+        {isCopied ? (
+          <CheckIcon className="size-3 text-success" />
+        ) : (
+          <CopyIcon className="size-3" />
+        )}
       </TooltipTrigger>
       <TooltipPopup>
         <p>Copy to clipboard</p>

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -376,15 +376,19 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                   />
                 )}
               </div>
-              <div className="flex items-center gap-1.5 mt-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+              <div className="flex items-center gap-1.5 mt-1.5">
                 {displayedUserMessage.copyText && (
-                  <MessageCopyButton text={displayedUserMessage.copyText} />
+                  <MessageCopyButton
+                    className="transition-opacity duration-200 opacity-0 focus-within:opacity-100 group-hover:opacity-100"
+                    text={displayedUserMessage.copyText}
+                  />
                 )}
                 {canRevertAgentWork && (
                   <Button
                     type="button"
                     size="xs"
                     variant="ghost"
+                    className="transition-opacity duration-200 opacity-0 focus-within:opacity-100 group-hover:opacity-100"
                     disabled={ctx.isRevertingCheckpoint || ctx.isWorking}
                     onClick={() => ctx.onRevertUserMessage(row.message.id)}
                     title="Revert to this message"

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1,4 +1,8 @@
-import { type EnvironmentId, type MessageId, type TurnId } from "@t3tools/contracts";
+import {
+  type EnvironmentId,
+  type MessageId,
+  type TurnId,
+} from "@t3tools/contracts";
 import {
   createContext,
   memo,
@@ -30,7 +34,10 @@ import {
   ZapIcon,
 } from "lucide-react";
 import { Button } from "../ui/button";
-import { buildExpandedImagePreview, ExpandedImagePreview } from "./ExpandedImagePreview";
+import {
+  buildExpandedImagePreview,
+  ExpandedImagePreview,
+} from "./ExpandedImagePreview";
 import { ProposedPlanCard } from "./ProposedPlanCard";
 import { ChangedFilesTree } from "./ChangedFilesTree";
 import { DiffStatLabel, hasNonZeroStat } from "./DiffStatLabel";
@@ -230,7 +237,10 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   // from TimelineRowCtx, which propagates through LegendList's memo.
   const renderItem = useCallback(
     ({ item }: { item: MessagesTimelineRow }) => (
-      <div className="mx-auto w-full min-w-0 max-w-3xl overflow-x-hidden" data-timeline-root="true">
+      <div
+        className="mx-auto w-full min-w-0 max-w-3xl overflow-x-hidden"
+        data-timeline-root="true"
+      >
         <TimelineRowContent row={item} />
       </div>
     ),
@@ -278,7 +288,10 @@ function keyExtractor(item: MessagesTimelineRow) {
 
 type TimelineEntry = ReturnType<typeof deriveTimelineEntries>[number];
 type TimelineMessage = Extract<TimelineEntry, { kind: "message" }>["message"];
-type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["groupedEntries"][number];
+type TimelineWorkEntry = Extract<
+  MessagesTimelineRow,
+  { kind: "work" }
+>["groupedEntries"][number];
 type TimelineRow = MessagesTimelineRow;
 
 function TimelineRowContent({ row }: { row: TimelineRow }) {
@@ -288,29 +301,39 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
     <div
       className={cn(
         "pb-4",
-        row.kind === "message" && row.message.role === "assistant" ? "group/assistant" : null,
+        row.kind === "message" && row.message.role === "assistant"
+          ? "group/assistant"
+          : null,
       )}
       data-timeline-row-id={row.id}
       data-timeline-row-kind={row.kind}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
       data-message-role={row.kind === "message" ? row.message.role : undefined}
     >
-      {row.kind === "work" && <WorkGroupSection groupedEntries={row.groupedEntries} />}
+      {row.kind === "work" && (
+        <WorkGroupSection groupedEntries={row.groupedEntries} />
+      )}
 
       {row.kind === "message" &&
         row.message.role === "user" &&
         (() => {
           const userImages = row.message.attachments ?? [];
-          const displayedUserMessage = deriveDisplayedUserMessageState(row.message.text);
+          const displayedUserMessage = deriveDisplayedUserMessageState(
+            row.message.text,
+          );
           const terminalContexts = displayedUserMessage.contexts;
           const canRevertAgentWork = typeof row.revertTurnCount === "number";
           return (
-            <div className="flex justify-end">
+            <div className="flex flex-col items-end justify-end group">
               <div className="group relative max-w-[80%] rounded-2xl rounded-br-sm border border-border bg-secondary px-4 py-3">
                 {userImages.length > 0 && (
                   <div className="mb-2 grid max-w-[420px] grid-cols-2 gap-2">
                     {userImages.map(
-                      (image: NonNullable<TimelineMessage["attachments"]>[number]) => (
+                      (
+                        image: NonNullable<
+                          TimelineMessage["attachments"]
+                        >[number],
+                      ) => (
                         <div
                           key={image.id}
                           className="overflow-hidden rounded-lg border border-border/80 bg-background/70"
@@ -321,7 +344,10 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                               className="h-full w-full cursor-zoom-in"
                               aria-label={`Preview ${image.name}`}
                               onClick={() => {
-                                const preview = buildExpandedImagePreview(userImages, image.id);
+                                const preview = buildExpandedImagePreview(
+                                  userImages,
+                                  image.id,
+                                );
                                 if (!preview) return;
                                 ctx.onImageExpand(preview);
                               }}
@@ -349,28 +375,26 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                     terminalContexts={terminalContexts}
                   />
                 )}
-                <div className="mt-1.5 flex items-center justify-end gap-2">
-                  <div className="flex items-center gap-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
-                    {displayedUserMessage.copyText && (
-                      <MessageCopyButton text={displayedUserMessage.copyText} />
-                    )}
-                    {canRevertAgentWork && (
-                      <Button
-                        type="button"
-                        size="xs"
-                        variant="outline"
-                        disabled={ctx.isRevertingCheckpoint || ctx.isWorking}
-                        onClick={() => ctx.onRevertUserMessage(row.message.id)}
-                        title="Revert to this message"
-                      >
-                        <Undo2Icon className="size-3" />
-                      </Button>
-                    )}
-                  </div>
-                  <p className="text-right text-xs text-muted-foreground/50">
-                    {formatTimestamp(row.message.createdAt, ctx.timestampFormat)}
-                  </p>
-                </div>
+              </div>
+              <div className="flex items-center gap-1.5 mt-1.5 opacity-0 transition-opacity duration-200 focus-within:opacity-100 group-hover:opacity-100">
+                {displayedUserMessage.copyText && (
+                  <MessageCopyButton text={displayedUserMessage.copyText} />
+                )}
+                {canRevertAgentWork && (
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="ghost"
+                    disabled={ctx.isRevertingCheckpoint || ctx.isWorking}
+                    onClick={() => ctx.onRevertUserMessage(row.message.id)}
+                    title="Revert to this message"
+                  >
+                    <Undo2Icon className="size-3" />
+                  </Button>
+                )}
+                <p className="text-right text-[10px] text-muted-foreground/30">
+                  {formatTimestamp(row.message.createdAt, ctx.timestampFormat)}
+                </p>
               </div>
             </div>
           );
@@ -379,7 +403,9 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
       {row.kind === "message" &&
         row.message.role === "assistant" &&
         (() => {
-          const messageText = row.message.text || (row.message.streaming ? "" : "(empty response)");
+          const messageText =
+            row.message.text ||
+            (row.message.streaming ? "" : "(empty response)");
           const assistantTurnStillInProgress =
             ctx.activeTurnInProgress &&
             ctx.activeTurnId !== null &&
@@ -396,7 +422,9 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                 <div className="my-3 flex items-center gap-3">
                   <span className="h-px flex-1 bg-border" />
                   <span className="rounded-full border border-border bg-background px-2.5 py-1 text-[10px] uppercase tracking-[0.14em] text-muted-foreground/80">
-                    {ctx.completionSummary ? `Response • ${ctx.completionSummary}` : "Response"}
+                    {ctx.completionSummary
+                      ? `Response • ${ctx.completionSummary}`
+                      : "Response"}
                   </span>
                   <span className="h-px flex-1 bg-border" />
                 </div>
@@ -424,7 +452,10 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                     ) : (
                       formatMessageMeta(
                         row.message.createdAt,
-                        formatElapsed(row.durationStart, row.message.completedAt),
+                        formatElapsed(
+                          row.durationStart,
+                          row.message.completedAt,
+                        ),
                         ctx.timestampFormat,
                       )
                     )}
@@ -434,8 +465,7 @@ function TimelineRowContent({ row }: { row: TimelineRow }) {
                       <MessageCopyButton
                         text={assistantCopyState.text ?? ""}
                         size="icon-xs"
-                        variant="outline"
-                        className="border-border/50 bg-background/35 text-muted-foreground/45 shadow-none hover:border-border/70 hover:bg-background/55 hover:text-muted-foreground/70"
+                        variant="ghost"
                       />
                     </div>
                   ) : null}
@@ -493,7 +523,9 @@ function WorkingTimer({ createdAt }: { createdAt: string }) {
     const id = setInterval(() => setNowMs(Date.now()), 1000);
     return () => clearInterval(id);
   }, [createdAt]);
-  return <>{formatWorkingTimer(createdAt, new Date(nowMs).toISOString()) ?? "0s"}</>;
+  return (
+    <>{formatWorkingTimer(createdAt, new Date(nowMs).toISOString()) ?? "0s"}</>
+  );
 }
 
 /** Live timestamp + elapsed duration for a streaming assistant message. */
@@ -527,7 +559,10 @@ function LiveMessageMeta({
 const WorkGroupSection = memo(function WorkGroupSection({
   groupedEntries,
 }: {
-  groupedEntries: Extract<MessagesTimelineRow, { kind: "work" }>["groupedEntries"];
+  groupedEntries: Extract<
+    MessagesTimelineRow,
+    { kind: "work" }
+  >["groupedEntries"];
 }) {
   const { workspaceRoot } = use(TimelineRowCtx);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -537,7 +572,9 @@ const WorkGroupSection = memo(function WorkGroupSection({
       ? groupedEntries.slice(-MAX_VISIBLE_WORK_LOG_ENTRIES)
       : groupedEntries;
   const hiddenCount = groupedEntries.length - visibleEntries.length;
-  const onlyToolEntries = groupedEntries.every((entry) => entry.tone === "tool");
+  const onlyToolEntries = groupedEntries.every(
+    (entry) => entry.tone === "tool",
+  );
   const showHeader = hasOverflow || !onlyToolEntries;
   const groupLabel = onlyToolEntries ? "Tool calls" : "Work log";
 
@@ -574,31 +611,33 @@ const WorkGroupSection = memo(function WorkGroupSection({
 
 /** Subscribes directly to the UI state store for expand/collapse state,
  *  so toggling re-renders only this component — not the entire list. */
-const AssistantChangedFilesSection = memo(function AssistantChangedFilesSection({
-  turnSummary,
-  routeThreadKey,
-  resolvedTheme,
-  onOpenTurnDiff,
-}: {
-  turnSummary: TurnDiffSummary | undefined;
-  routeThreadKey: string;
-  resolvedTheme: "light" | "dark";
-  onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
-}) {
-  if (!turnSummary) return null;
-  const checkpointFiles = turnSummary.files;
-  if (checkpointFiles.length === 0) return null;
+const AssistantChangedFilesSection = memo(
+  function AssistantChangedFilesSection({
+    turnSummary,
+    routeThreadKey,
+    resolvedTheme,
+    onOpenTurnDiff,
+  }: {
+    turnSummary: TurnDiffSummary | undefined;
+    routeThreadKey: string;
+    resolvedTheme: "light" | "dark";
+    onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+  }) {
+    if (!turnSummary) return null;
+    const checkpointFiles = turnSummary.files;
+    if (checkpointFiles.length === 0) return null;
 
-  return (
-    <AssistantChangedFilesSectionInner
-      turnSummary={turnSummary}
-      checkpointFiles={checkpointFiles}
-      routeThreadKey={routeThreadKey}
-      resolvedTheme={resolvedTheme}
-      onOpenTurnDiff={onOpenTurnDiff}
-    />
-  );
-});
+    return (
+      <AssistantChangedFilesSectionInner
+        turnSummary={turnSummary}
+        checkpointFiles={checkpointFiles}
+        routeThreadKey={routeThreadKey}
+        resolvedTheme={resolvedTheme}
+        onOpenTurnDiff={onOpenTurnDiff}
+      />
+    );
+  },
+);
 
 /** Inner component that only mounts when there are actual changed files,
  *  so the store subscription is unconditional (no hooks after early return). */
@@ -616,9 +655,14 @@ function AssistantChangedFilesSectionInner({
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
 }) {
   const allDirectoriesExpanded = useUiStateStore(
-    (store) => store.threadChangedFilesExpandedById[routeThreadKey]?.[turnSummary.turnId] ?? true,
+    (store) =>
+      store.threadChangedFilesExpandedById[routeThreadKey]?.[
+        turnSummary.turnId
+      ] ?? true,
   );
-  const setExpanded = useUiStateStore((store) => store.setThreadChangedFilesExpanded);
+  const setExpanded = useUiStateStore(
+    (store) => store.setThreadChangedFilesExpanded,
+  );
   const summaryStat = summarizeTurnDiffStats(checkpointFiles);
   const changedFileCountLabel = String(checkpointFiles.length);
 
@@ -630,7 +674,10 @@ function AssistantChangedFilesSectionInner({
           {hasNonZeroStat(summaryStat) && (
             <>
               <span className="mx-1">•</span>
-              <DiffStatLabel additions={summaryStat.additions} deletions={summaryStat.deletions} />
+              <DiffStatLabel
+                additions={summaryStat.additions}
+                deletions={summaryStat.deletions}
+              />
             </>
           )}
         </p>
@@ -640,7 +687,13 @@ function AssistantChangedFilesSectionInner({
             size="xs"
             variant="outline"
             data-scroll-anchor-ignore
-            onClick={() => setExpanded(routeThreadKey, turnSummary.turnId, !allDirectoriesExpanded)}
+            onClick={() =>
+              setExpanded(
+                routeThreadKey,
+                turnSummary.turnId,
+                !allDirectoriesExpanded,
+              )
+            }
           >
             {allDirectoriesExpanded ? "Collapse all" : "Expand all"}
           </Button>
@@ -648,7 +701,9 @@ function AssistantChangedFilesSectionInner({
             type="button"
             size="xs"
             variant="outline"
-            onClick={() => onOpenTurnDiff(turnSummary.turnId, checkpointFiles[0]?.path)}
+            onClick={() =>
+              onOpenTurnDiff(turnSummary.turnId, checkpointFiles[0]?.path)
+            }
           >
             View diff
           </Button>
@@ -671,13 +726,20 @@ function AssistantChangedFilesSectionInner({
 // ---------------------------------------------------------------------------
 
 const UserMessageTerminalContextInlineLabel = memo(
-  function UserMessageTerminalContextInlineLabel(props: { context: ParsedTerminalContextEntry }) {
+  function UserMessageTerminalContextInlineLabel(props: {
+    context: ParsedTerminalContextEntry;
+  }) {
     const tooltipText =
       props.context.body.length > 0
         ? `${props.context.header}\n${props.context.body}`
         : props.context.header;
 
-    return <TerminalContextInlineChip label={props.context.header} tooltipText={tooltipText} />;
+    return (
+      <TerminalContextInlineChip
+        label={props.context.header}
+        tooltipText={tooltipText}
+      />
+    );
   },
 );
 
@@ -705,7 +767,9 @@ const UserMessageBody = memo(function UserMessageBody(props: {
         }
         if (matchIndex > cursor) {
           inlineNodes.push(
-            <span key={`user-terminal-context-inline-before:${context.header}:${cursor}`}>
+            <span
+              key={`user-terminal-context-inline-before:${context.header}:${cursor}`}
+            >
               {props.text.slice(cursor, matchIndex)}
             </span>,
           );
@@ -744,14 +808,21 @@ const UserMessageBody = memo(function UserMessageBody(props: {
         />,
       );
       inlineNodes.push(
-        <span key={`user-terminal-context-inline-space:${context.header}`} aria-hidden="true">
+        <span
+          key={`user-terminal-context-inline-space:${context.header}`}
+          aria-hidden="true"
+        >
           {" "}
         </span>,
       );
     }
 
     if (props.text.length > 0) {
-      inlineNodes.push(<span key="user-message-terminal-context-inline-text">{props.text}</span>);
+      inlineNodes.push(
+        <span key="user-message-terminal-context-inline-text">
+          {props.text}
+        </span>,
+      );
     } else if (inlinePrefix.length === 0) {
       return null;
     }
@@ -788,7 +859,10 @@ function useStableRows(rows: MessagesTimelineRow[]): MessagesTimelineRow[] {
   });
 
   return useMemo(() => {
-    const nextState = computeStableMessagesTimelineRows(rows, prevState.current);
+    const nextState = computeStableMessagesTimelineRows(
+      rows,
+      prevState.current,
+    );
     prevState.current = nextState;
     return nextState.result;
   }, [rows]);
@@ -805,7 +879,10 @@ function formatWorkingTimer(startIso: string, endIso: string): string | null {
     return null;
   }
 
-  const elapsedSeconds = Math.max(0, Math.floor((endedAtMs - startedAtMs) / 1000));
+  const elapsedSeconds = Math.max(
+    0,
+    Math.floor((endedAtMs - startedAtMs) / 1000),
+  );
   if (elapsedSeconds < 60) {
     return `${elapsedSeconds}s`;
   }
@@ -898,7 +975,10 @@ function workEntryIcon(workEntry: TimelineWorkEntry): LucideIcon {
   if (workEntry.itemType === "command_execution" || workEntry.command) {
     return TerminalIcon;
   }
-  if (workEntry.itemType === "file_change" || (workEntry.changedFiles?.length ?? 0) > 0) {
+  if (
+    workEntry.itemType === "file_change" ||
+    (workEntry.changedFiles?.length ?? 0) > 0
+  ) {
     return SquarePenIcon;
   }
   if (workEntry.itemType === "web_search") return GlobeIcon;
@@ -948,13 +1028,17 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const rawCommand = workEntryRawCommand(workEntry);
   const displayText = preview ? `${heading} - ${preview}` : heading;
   const hasChangedFiles = (workEntry.changedFiles?.length ?? 0) > 0;
-  const previewIsChangedFiles = hasChangedFiles && !workEntry.command && !workEntry.detail;
+  const previewIsChangedFiles =
+    hasChangedFiles && !workEntry.command && !workEntry.detail;
 
   return (
     <div className="rounded-lg px-1 py-1">
       <div className="flex items-center gap-2 transition-[opacity,translate] duration-200">
         <span
-          className={cn("flex size-5 shrink-0 items-center justify-center", iconConfig.className)}
+          className={cn(
+            "flex size-5 shrink-0 items-center justify-center",
+            iconConfig.className,
+          )}
         >
           <EntryIcon className="size-3" />
         </span>
@@ -969,7 +1053,12 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                 )}
                 title={displayText}
               >
-                <span className={cn("text-foreground/80", workToneClass(workEntry.tone))}>
+                <span
+                  className={cn(
+                    "text-foreground/80",
+                    workToneClass(workEntry.tone),
+                  )}
+                >
                   {heading}
                 </span>
                 {preview && (
@@ -1011,10 +1100,20 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
                     preview ? "text-muted-foreground/70" : "",
                   )}
                 >
-                  <span className={cn("text-foreground/80", workToneClass(workEntry.tone))}>
+                  <span
+                    className={cn(
+                      "text-foreground/80",
+                      workToneClass(workEntry.tone),
+                    )}
+                  >
                     {heading}
                   </span>
-                  {preview && <span className="text-muted-foreground/55"> - {preview}</span>}
+                  {preview && (
+                    <span className="text-muted-foreground/55">
+                      {" "}
+                      - {preview}
+                    </span>
+                  )}
                 </p>
               </TooltipTrigger>
               <TooltipPopup className="max-w-[min(720px,calc(100vw-2rem))]">
@@ -1029,7 +1128,10 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
       {hasChangedFiles && !previewIsChangedFiles && (
         <div className="mt-1 flex flex-wrap gap-1 pl-6">
           {workEntry.changedFiles?.slice(0, 4).map((filePath) => {
-            const displayPath = formatWorkspaceRelativePath(filePath, workspaceRoot);
+            const displayPath = formatWorkspaceRelativePath(
+              filePath,
+              workspaceRoot,
+            );
             return (
               <span
                 key={`${workEntry.id}:${filePath}`}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -1,7 +1,7 @@
 import { mergeProps } from "@base-ui/react/merge-props";
 import { useRender } from "@base-ui/react/use-render";
 import { cva, type VariantProps } from "class-variance-authority";
-import { PanelLeftCloseIcon, PanelLeftIcon } from "lucide-react";
+import { PanelLeftCloseIcon, PanelLeftIcon, PanelRight, PanelRightIcon } from "lucide-react";
 import * as React from "react";
 import { cn } from "~/lib/utils";
 import { Button } from "~/components/ui/button";
@@ -303,22 +303,23 @@ function Sidebar({
 }
 
 function SidebarTrigger({ className, onClick, ...props }: React.ComponentProps<typeof Button>) {
-  const { toggleSidebar, openMobile } = useSidebar();
+  const { isMobile, open, openMobile, toggleSidebar } = useSidebar();
+  const isOpen = isMobile ? openMobile : open;
 
   return (
     <Button
-      className={cn("size-7", className)}
+      className={cn("size-5", className)}
       data-sidebar="trigger"
       data-slot="sidebar-trigger"
       onClick={(event) => {
         onClick?.(event);
         toggleSidebar();
       }}
-      size="icon"
-      variant="ghost"
+      size="icon-xs"
+      variant="outline"
       {...props}
     >
-      {openMobile ? <PanelLeftCloseIcon /> : <PanelLeftIcon />}
+      {isOpen ? <PanelLeftIcon /> : <PanelRightIcon />}
       <span className="sr-only">Toggle Sidebar</span>
     </Button>
   );

--- a/apps/web/src/routes/settings.tsx
+++ b/apps/web/src/routes/settings.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 
 import { useSettingsRestore } from "../components/settings/SettingsPanels";
 import { Button } from "../components/ui/button";
-import { SidebarInset, SidebarTrigger } from "../components/ui/sidebar";
+import { SidebarInset, SidebarTrigger, useSidebar } from "../components/ui/sidebar";
 import { isElectron } from "../env";
 
 function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
@@ -25,9 +25,11 @@ function RestoreDefaultsButton({ onRestored }: { onRestored: () => void }) {
 
 function SettingsContentLayout() {
   const location = useLocation();
+  const { isMobile, open, openMobile } = useSidebar();
   const [restoreSignal, setRestoreSignal] = useState(0);
   const showRestoreDefaults = location.pathname === "/settings/general";
   const handleRestored = () => setRestoreSignal((value) => value + 1);
+  const sidebarOpen = isMobile ? openMobile : open;
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -50,7 +52,7 @@ function SettingsContentLayout() {
         {!isElectron && (
           <header className="border-b border-border px-3 py-2 sm:px-5">
             <div className="flex min-h-7 items-center gap-2 sm:min-h-6">
-              <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+              {!sidebarOpen ? <SidebarTrigger className="size-7 shrink-0" /> : null}
               <span className="text-sm font-medium text-foreground">Settings</span>
               {showRestoreDefaults ? (
                 <div className="ms-auto flex items-center gap-2">

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -7,7 +7,7 @@ export function getTimestampFormatOptions(
   const baseOptions: Intl.DateTimeFormatOptions = {
     hour: "numeric",
     minute: "2-digit",
-    // ...(includeSeconds ? { second: "2-digit" } : {}),
+    ...(includeSeconds ? { second: "2-digit" } : {}),
   };
 
   if (timestampFormat === "locale") {

--- a/apps/web/src/timestampFormat.ts
+++ b/apps/web/src/timestampFormat.ts
@@ -7,7 +7,7 @@ export function getTimestampFormatOptions(
   const baseOptions: Intl.DateTimeFormatOptions = {
     hour: "numeric",
     minute: "2-digit",
-    ...(includeSeconds ? { second: "2-digit" } : {}),
+    // ...(includeSeconds ? { second: "2-digit" } : {}),
   };
 
   if (timestampFormat === "locale") {
@@ -40,12 +40,20 @@ function getTimestampFormatter(
   return formatter;
 }
 
-export function formatTimestamp(isoDate: string, timestampFormat: TimestampFormat): string {
+export function formatTimestamp(
+  isoDate: string,
+  timestampFormat: TimestampFormat,
+): string {
   return getTimestampFormatter(timestampFormat, true).format(new Date(isoDate));
 }
 
-export function formatShortTimestamp(isoDate: string, timestampFormat: TimestampFormat): string {
-  return getTimestampFormatter(timestampFormat, false).format(new Date(isoDate));
+export function formatShortTimestamp(
+  isoDate: string,
+  timestampFormat: TimestampFormat,
+): string {
+  return getTimestampFormatter(timestampFormat, false).format(
+    new Date(isoDate),
+  );
 }
 
 /**
@@ -53,7 +61,10 @@ export function formatShortTimestamp(isoDate: string, timestampFormat: Timestamp
  * Returns `{ value: "20s", suffix: "ago" }` or `{ value: "just now", suffix: null }`
  * so callers can style the numeric portion independently.
  */
-export function formatRelativeTime(isoDate: string): { value: string; suffix: string | null } {
+export function formatRelativeTime(isoDate: string): {
+  value: string;
+  suffix: string | null;
+} {
   const diffMs = Date.now() - new Date(isoDate).getTime();
   if (diffMs < 0) return { value: "just now", suffix: null };
   const seconds = Math.floor(diffMs / 1000);
@@ -68,14 +79,19 @@ export function formatRelativeTime(isoDate: string): { value: string; suffix: st
 
 export function formatRelativeTimeLabel(isoDate: string) {
   const relative = formatRelativeTime(isoDate);
-  return relative.suffix ? `${relative.value} ${relative.suffix}` : relative.value;
+  return relative.suffix
+    ? `${relative.value} ${relative.suffix}`
+    : relative.value;
 }
 
 /**
  * Relative elapsed duration since an ISO instant, without an "ago" suffix.
  * Useful for labels like "Connected for 3m".
  */
-export function formatElapsedDurationLabel(isoDate: string, nowMs: number = Date.now()): string {
+export function formatElapsedDurationLabel(
+  isoDate: string,
+  nowMs: number = Date.now(),
+): string {
   const diffMs = nowMs - new Date(isoDate).getTime();
   if (diffMs <= 0) return "just now";
 
@@ -96,7 +112,10 @@ export function formatElapsedDurationLabel(isoDate: string, nowMs: number = Date
 /**
  * Relative time until an ISO instant (e.g. expiry). Mirrors {@link formatRelativeTime} but for future times.
  */
-export function formatRelativeTimeUntil(isoDate: string): { value: string; suffix: string | null } {
+export function formatRelativeTimeUntil(isoDate: string): {
+  value: string;
+  suffix: string | null;
+} {
   const diffMs = new Date(isoDate).getTime() - Date.now();
   if (diffMs <= 0) return { value: "Expired", suffix: null };
   const seconds = Math.floor(diffMs / 1000);
@@ -112,14 +131,19 @@ export function formatRelativeTimeUntil(isoDate: string): { value: string; suffi
 
 export function formatRelativeTimeUntilLabel(isoDate: string): string {
   const relative = formatRelativeTimeUntil(isoDate);
-  return relative.suffix ? `${relative.value} ${relative.suffix}` : relative.value;
+  return relative.suffix
+    ? `${relative.value} ${relative.suffix}`
+    : relative.value;
 }
 
 /**
  * Countdown for a future instant (e.g. link expiry): "Expires in 4m 12s", with second precision under one hour.
  * Pass `nowMs` when a parent tick drives re-renders so the diff matches that snapshot.
  */
-export function formatExpiresInLabel(isoDate: string, nowMs: number = Date.now()): string {
+export function formatExpiresInLabel(
+  isoDate: string,
+  nowMs: number = Date.now(),
+): string {
   const diffMs = new Date(isoDate).getTime() - nowMs;
   if (diffMs <= 0) return "Expired";
 
@@ -130,7 +154,9 @@ export function formatExpiresInLabel(isoDate: string, nowMs: number = Date.now()
   if (totalSeconds < 3600) {
     const minutes = Math.floor(totalSeconds / 60);
     const seconds = totalSeconds % 60;
-    return seconds === 0 ? `Expires in ${minutes}m` : `Expires in ${minutes}m ${seconds}s`;
+    return seconds === 0
+      ? `Expires in ${minutes}m`
+      : `Expires in ${minutes}m ${seconds}s`;
   }
 
   if (totalSeconds < 86_400) {
@@ -155,5 +181,7 @@ export function formatExpiresInLabel(isoDate: string, nowMs: number = Date.now()
   if (hours > 0) tail.push(`${hours}h`);
   if (minutes > 0) tail.push(`${minutes}m`);
   if (seconds > 0) tail.push(`${seconds}s`);
-  return tail.length > 0 ? `Expires in ${days}d ${tail.join(" ")}` : `Expires in ${days}d`;
+  return tail.length > 0
+    ? `Expires in ${days}d ${tail.join(" ")}`
+    : `Expires in ${days}d`;
 }


### PR DESCRIPTION
## What Changed

Made the sidebar collapsable, also in settings page, make the message compoenent, like the assistant message with copy button outside the div, and also reduced the spacing in chat header button that looks neat.

## Why

This are ui changes and below is the screenshots of changes

## UI Changes

### New
<img width="1919" height="944" alt="image" src="https://github.com/user-attachments/assets/e3b098ae-69eb-4523-9c95-1af7e0b7a2d6" />

### Old
<img width="1143" height="782" alt="image" src="https://github.com/user-attachments/assets/0e7bffb9-a01c-4451-9c27-91229a553869" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to sidebar toggling and chat message/header controls; low risk aside from potential layout/regression across breakpoints (mobile vs desktop) due to new `useSidebar()`-based visibility logic.
> 
> **Overview**
> Makes the sidebar *consistently collapsible* by standardizing `SidebarTrigger` styling/behavior and removing breakpoint-only visibility, while updating headers (chat, settings, no-active-thread, sidebar chrome) to show the toggle only when the sidebar is currently closed.
> 
> Tweaks chat UI: reduces header action spacing, adjusts primary project-script button sizing, and repositions user-message actions (copy/revert) below the bubble with hover/focus fade-in; copy buttons default to `ghost` styling. Mostly formatting-only cleanup elsewhere (e.g. `timestampFormat.ts`, `MessagesTimeline.tsx`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74317834fa7c24868d114bbe843506dda71207d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make sidebar collapsable at all breakpoints and show trigger only when sidebar is closed
> - The `SidebarTrigger` is now always visible in the sidebar header (not just on mobile), and toggles between left/right panel icons based on open state.
> - In the chat header, settings layout, and no-active-thread state, the trigger is rendered only when the sidebar is closed, replacing breakpoint-based (`md:hidden`) visibility logic.
> - User message action buttons (copy, revert) are moved outside the message bubble, use ghost styling, and reveal on row hover/focus; timestamps are smaller and lower contrast.
> - The `MessageCopyButton` default variant changes from `outline` to `ghost`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7431783.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->