### PR TITLE
fix: allow downgrade from nightly to stable by not overriding autoUpdater.allowDowngrade

### DIFF
--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1132,9 +1132,8 @@ function createBaseUpdateState(
 function applyAutoUpdaterChannel(channel: DesktopUpdateChannel): void {
   autoUpdater.channel = channel;
   autoUpdater.allowPrerelease = channel === "nightly";
-  autoUpdater.allowDowngrade = channel === "nightly";
   console.info(
-    `[desktop-updater] Using update channel '${channel}' (allowPrerelease=${channel === "nightly"}, allowDowngrade=${channel === "nightly"}).`,
+    `[desktop-updater] Using update channel '${channel}' (allowPrerelease=${channel === "nightly"}, allowDowngrade=${autoUpdater.allowDowngrade}).`,
   );
 }
 
@@ -1813,14 +1812,7 @@ function registerIpcHandlers(): void {
     }
 
     applyAutoUpdaterChannel(nextChannel);
-    const allowDowngrade = autoUpdater.allowDowngrade;
-    // An explicit channel switch should allow the immediate nightly->stable rollback path.
-    autoUpdater.allowDowngrade = true;
-    try {
-      await checkForUpdates("channel-change");
-    } finally {
-      autoUpdater.allowDowngrade = allowDowngrade;
-    }
+    await checkForUpdates("channel-change");
     return updateState;
   });
 

--- a/apps/desktop/src/updateChannels.test.ts
+++ b/apps/desktop/src/updateChannels.test.ts
@@ -38,4 +38,8 @@ describe("doesVersionMatchDesktopUpdateChannel", () => {
   it("rejects nightly releases on the stable channel", () => {
     expect(doesVersionMatchDesktopUpdateChannel("0.0.17-nightly.20260416.1", "latest")).toBe(false);
   });
+
+  it("accepts stable releases on the stable channel", () => {
+    expect(doesVersionMatchDesktopUpdateChannel("0.0.17", "latest")).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Removes the explicit `allowDowngrade = false` override for the stable
  update channel that prevented electron-updater from finding older
  stable releases as valid downgrades from nightly builds.
- Simplifies the redundant `allowDowngrade` save/restore toggle around
  the channel-switch update check, since `applyAutoUpdaterChannel`
  now correctly preserves the channel setter's default `true`.
- Adds a missing test: stable versions are accepted on the stable
  channel.

## Root cause
`applyAutoUpdaterChannel` set `autoUpdater.channel = channel` (which
electron-updater auto-follows with `allowDowngrade = true`), then
immediately overrode it to `channel === "nightly"`. For the `"latest"`
channel this forced `allowDowngrade = false`, blocking any stable
downgrade after a nightly install.

## Risk
Low. The channel setter's `allowDowngrade = true` default is the
documented electron-updater behavior and is appropriate for both
channels. No other `allowDowngrade` assignments exist in the codebase.

## Rollback
Revert this commit. No data migration needed.

Closes #2340

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Electron auto-update channel switching behavior, which can affect which releases are considered valid and how clients update/rollback. Risk is limited in scope but could impact update eligibility if electron-updater defaults differ across platforms.
> 
> **Overview**
> **Desktop auto-updater channel switching now preserves `electron-updater`’s `allowDowngrade` behavior** instead of forcing it based on channel, enabling nightly installs to roll back to stable releases.
> 
> This removes the temporary `allowDowngrade` toggle around the channel-change update check and updates logging to report the effective `autoUpdater.allowDowngrade`. Adds a test to ensure stable versions are accepted on the `latest` channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f300a81b9443173d3a8ee79ac4fa244216077c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix downgrade from nightly to stable by preserving `autoUpdater.allowDowngrade`
> Previously, `applyAutoUpdaterChannel` in [main.ts](https://github.com/pingdotgg/t3code/pull/2460/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb) overrode `autoUpdater.allowDowngrade` based on the selected channel, and the `SET_CLIENT_SETTINGS_CHANNEL` handler temporarily forced it to `true` during channel-change update checks. This prevented stable versions from being installed when downgrading from nightly.
>
> - `applyAutoUpdaterChannel` no longer sets `allowDowngrade`; it only sets `channel` and `allowPrerelease`
> - The `SET_CLIENT_SETTINGS_CHANNEL` handler calls `checkForUpdates('channel-change')` directly without modifying `allowDowngrade`
> - A new test in [updateChannels.test.ts](https://github.com/pingdotgg/t3code/pull/2460/files#diff-94abc007e8bc7111fd2cce77dd792304df43fae773df8b95682475a5925a5935) verifies stable versions are accepted on the stable channel
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7f300a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->