### PR TITLE
Fix Windows server build command quoting

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -151,8 +151,8 @@ const buildCmd = Command.make(
           cwd: serverDir,
           stdout: config.verbose ? "inherit" : "ignore",
           stderr: "inherit",
-          // Windows needs shell mode to resolve `.cmd` shims on PATH.
-          shell: process.platform === "win32",
+          // `process.execPath` is already an absolute executable path. Running it
+          // through the Windows shell breaks when the path contains spaces.
         }),
       );
 


### PR DESCRIPTION
## What Changed

Fixes the Windows server build path used by `apps/server/scripts/cli.ts`.

The build command was launching `process.execPath` with `shell: true` on Windows. That breaks when the executable path contains spaces, which caused `bun run dist:desktop:win:x64` to fail during the server build step with `'C:\Program' is not recognized...`.

This change removes the Windows shell hop for that specific command, since `process.execPath` is already an absolute executable path.

## Why

Building the Windows desktop installer should work reliably on normal Windows setups, including machines where Node/Bun lives under `C:\Program Files\...`.

This is a small, targeted bug fix:
- no feature changes
- no packaging behavior changes beyond fixing the failing build path
- keeps the command invocation more correct because it avoids unnecessary shell wrapping for an already-resolved executable

I verified that a fresh `bun run dist:desktop:win:x64` now succeeds after this change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, targeted change to process spawning in the build CLI, affecting only how the bundle command is invoked on Windows.
> 
> **Overview**
> Fixes the `apps/server` build CLI so the `build:bundle` step no longer uses `shell` on Windows when spawning `process.execPath`, avoiding failures when the executable path contains spaces (e.g., `C:\Program Files\...`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3559abed014bb761b8d73afa7b903d149df23350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows build command quoting by removing shell invocation in `buildCmd`
> On Windows, launching a child process via the shell can fail when `process.execPath` contains spaces. The `shell: process.platform === 'win32'` option is removed from the `ChildProcess.make` call in [cli.ts](https://github.com/pingdotgg/t3code/pull/2466/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9), so the build process is now invoked directly with the absolute executable path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3559abe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->