### PR TITLE
fix(claude-agent): opt into claude_code system prompt preset

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2873,6 +2873,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(input.cwd ? { cwd: input.cwd } : {}),
         ...(apiModelId ? { model: apiModelId } : {}),
         pathToClaudeCodeExecutable: claudeBinaryPath,
+        systemPrompt: { type: "preset", preset: "claude_code" },
         settingSources: [...CLAUDE_SETTING_SOURCES],
         // The SDK type lags the CLI here: Opus 4.7 accepts `xhigh` even though
         // the published `Options["effort"]` union currently stops at `max`.


### PR DESCRIPTION
## Summary

The Claude Agent provider initializes the SDK without a `systemPrompt`, so the agent runs with the SDK's default empty system prompt. As of `@anthropic-ai/claude-agent-sdk` v0.1.0+, the SDK no longer injects Claude Code's system prompt by default — callers must opt in explicitly.

The practical consequence inside t3code: the Claude Agent receives no tool-use guidance, no working-directory context, no env block (OS / shell / date), and none of the response-style guidance that the Claude Code CLI ships with. It frequently asks the user for project context it should have inferred from the cwd, and tool calls trend toward over-asking and under-grounding.

This PR wires the `claude_code` preset into `query()` so the agent gets the same system prompt as the Claude Code CLI.

## Why this is correct

- The SDK's documented migration path (v0.0.x → v0.1.0) for "previous default behavior" is exactly this:
  ```ts
  systemPrompt: { type: "preset", preset: "claude_code" }
  ```
  Reference: [Anthropic's migration guide](https://docs.anthropic.com/en/docs/claude-code/sdk/migration-guide).
- `settingSources: ["user", "project", "local"]` is already passed, so `CLAUDE.md` from project/user dirs continues to load on top of the preset (the preset alone does not load CLAUDE.md — `settingSources` is required, which is already set).
- The preset is the only documented value for `systemPrompt.preset` in the current SDK type definition (`sdk.d.ts`), so this is forward-compatible.

## Diff

```ts
const queryOptions: ClaudeQueryOptions = {
  ...(input.cwd ? { cwd: input.cwd } : {}),
  ...(apiModelId ? { model: apiModelId } : {}),
  pathToClaudeCodeExecutable: claudeBinaryPath,
+ systemPrompt: { type: "preset", preset: "claude_code" },
  settingSources: [...CLAUDE_SETTING_SOURCES],
  ...
};
```

One line, scoped to `apps/server/src/provider/Layers/ClaudeAdapter.ts`.

## Before / After

Same prompt (`In what order does the Hello appear in the loading screen?`) on the same project.

**Before** — agent has no awareness of the cwd, asks which project/file to look at:

<img width="865" height="221" alt="image" src="https://github.com/user-attachments/assets/74bebe80-94cf-480b-a66c-c8a0dd09f9b5" />

**After** — agent infers the cwd, runs `Grep` to find the relevant file, and answers:

<img width="823" height="353" alt="image" src="https://github.com/user-attachments/assets/901d9a68-a22b-482a-ba62-4f06f4b67e82" />

## Test plan

- [x] Build desktop DMG, open in a project directory, ask a question that requires cwd awareness — agent should resolve files via tools instead of asking for the project path.
- [x] Confirm `CLAUDE.md` in the project root still influences responses (preset + `settingSources` interaction).
- [x] Existing Claude Agent integration tests still pass (no API surface changed).

## Risk

Very low. Single-line change, opts back into the SDK's previously-default behavior. No breaking changes for users.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set `claude_code` system prompt preset in `ClaudeAdapter` queries
> Adds `systemPrompt: { type: "preset", preset: "claude_code" }` to the `ClaudeQueryOptions` constructed in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/2472/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc). This applies the preset to all queries issued through this adapter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized afd0395.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->