### PR TITLE
fix(source-control): handle self-hosted GitLab, multi-account GitHub auth & azure devops web url

### DIFF
--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -64,6 +64,7 @@ describe("AzureDevOpsCli.layer", () => {
 
       assert.strictEqual(result.number, 42);
       assert.strictEqual(result.title, "Add Azure provider");
+      assert.strictEqual(result.url, "https://dev.azure.com/acme/project/_git/repo/pullrequest/42");
       assert.strictEqual(result.baseRefName, "main");
       assert.strictEqual(result.headRefName, "feature/source-control");
       assert.strictEqual(result.state, "open");
@@ -86,6 +87,43 @@ describe("AzureDevOpsCli.layer", () => {
         cwd: "/repo",
         timeoutMs: 30_000,
       });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("builds a web URL when Azure returns only the pull request REST URL", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              pullRequestId: 863,
+              title: "Fix Azure link",
+              url: "https://dev.azure.com/saplyai/a8fe4088-ad76-4eda-aaaa-e3329713a097/_apis/git/repositories/16108a25-93a3-4eff-b77d-85e894ee0fe4/pullRequests/863",
+              repository: {
+                name: "CV-engine",
+                project: {
+                  name: "CV-engine",
+                },
+              },
+              sourceRefName: "refs/heads/feature/azure-pr-link",
+              targetRefName: "refs/heads/main",
+              status: "active",
+            }),
+          ),
+        ),
+      );
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      const result = yield* az.getPullRequest({
+        cwd: "/repo",
+        reference: "863",
+      });
+
+      assert.strictEqual(
+        result.url,
+        "https://dev.azure.com/saplyai/CV-engine/_git/CV-engine/pullrequest/863",
+      );
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -208,6 +208,41 @@ it("accepts active authenticated GitHub accounts when another account fails", ()
   );
 });
 
+it("parses GitHub auth JSON from stdout when stderr has warnings", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth(
+    processResult(
+      JSON.stringify({
+        hosts: {
+          "github.com": [
+            {
+              state: "success",
+              active: true,
+              host: "github.com",
+              login: "active-user",
+              tokenSource: "keyring",
+              gitProtocol: "ssh",
+            },
+          ],
+        },
+      }),
+      { stderr: "warning: ignored diagnostic from gh\n" },
+    ),
+  );
+
+  assert.deepStrictEqual(
+    {
+      status: auth.status,
+      account: auth.account,
+      host: auth.host,
+    },
+    {
+      status: "authenticated",
+      account: Option.some("active-user"),
+      host: Option.some("github.com"),
+    },
+  );
+});
+
 it("parses GitHub auth status accounts by host and active state", () => {
   assert.deepStrictEqual(
     parseGitHubAuthStatus(

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -7,12 +7,19 @@ import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as GitHubCli from "./GitHubCli.ts";
+import { parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
 import * as GitHubSourceControlProvider from "./GitHubSourceControlProvider.ts";
 
-const processResult = (stdout: string): VcsProcess.VcsProcessOutput => ({
-  exitCode: ChildProcessSpawner.ExitCode(0),
+const processResult = (
+  stdout: string,
+  options?: {
+    readonly stderr?: string;
+    readonly exitCode?: ChildProcessSpawner.ExitCode;
+  },
+): VcsProcess.VcsProcessOutput => ({
+  exitCode: options?.exitCode ?? ChildProcessSpawner.ExitCode(0),
   stdout,
-  stderr: "",
+  stderr: options?.stderr ?? "",
   stdoutTruncated: false,
   stderrTruncated: false,
 });
@@ -157,3 +164,143 @@ it.effect("creates GitHub PRs through provider-neutral input names", () =>
     });
   }),
 );
+
+it("accepts active authenticated GitHub accounts when another account fails", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth(
+    processResult(
+      JSON.stringify({
+        hosts: {
+          "github.com": [
+            {
+              state: "success",
+              active: true,
+              host: "github.com",
+              login: "active-user",
+              tokenSource: "keyring",
+              gitProtocol: "ssh",
+            },
+            {
+              state: "error",
+              active: false,
+              host: "github.com",
+              login: "stale-user",
+              tokenSource: "keyring",
+              gitProtocol: "ssh",
+              error: "The token in keyring is invalid.",
+            },
+          ],
+        },
+      }),
+    ),
+  );
+
+  assert.deepStrictEqual(
+    {
+      status: auth.status,
+      account: auth.account,
+      host: auth.host,
+    },
+    {
+      status: "authenticated",
+      account: Option.some("active-user"),
+      host: Option.some("github.com"),
+    },
+  );
+});
+
+it("parses GitHub auth status accounts by host and active state", () => {
+  assert.deepStrictEqual(
+    parseGitHubAuthStatus(
+      JSON.stringify({
+        hosts: {
+          "github.com": [
+            {
+              state: "success",
+              active: true,
+              host: "github.com",
+              login: "active-user",
+              tokenSource: "keyring",
+              gitProtocol: "ssh",
+            },
+            {
+              state: "error",
+              active: false,
+              host: "github.com",
+              login: "stale-user",
+              tokenSource: "keyring",
+              gitProtocol: "ssh",
+            },
+          ],
+          "github.example.test": [
+            {
+              state: "success",
+              active: false,
+              host: "github.example.test",
+              login: "enterprise-user",
+              tokenSource: "keyring",
+              gitProtocol: "ssh",
+            },
+          ],
+        },
+      }),
+    ).accounts,
+    [
+      {
+        host: "github.com",
+        account: "active-user",
+        authenticated: true,
+        active: true,
+        error: null,
+      },
+      {
+        host: "github.com",
+        account: "stale-user",
+        authenticated: false,
+        active: false,
+        error: null,
+      },
+      {
+        host: "github.example.test",
+        account: "enterprise-user",
+        authenticated: true,
+        active: false,
+        error: null,
+      },
+    ],
+  );
+});
+
+it("reports unauthenticated when GitHub JSON has accounts but none are valid", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth(
+    processResult(
+      JSON.stringify({
+        hosts: {
+          "github.com": [
+            {
+              state: "error",
+              active: true,
+              host: "github.com",
+              login: "stale-user",
+              tokenSource: "keyring",
+              gitProtocol: "ssh",
+              error: "The token in keyring is invalid.",
+            },
+          ],
+        },
+      }),
+    ),
+  );
+
+  assert.deepStrictEqual(
+    {
+      status: auth.status,
+      host: auth.host,
+      detail: auth.detail,
+    },
+    {
+      status: "unauthenticated",
+      host: Option.some("github.com"),
+      detail: Option.some("The token in keyring is invalid."),
+    },
+  );
+});

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -52,7 +52,7 @@ function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeReq
 
 function parseGitHubAuth(input: SourceControlProviderDiscovery.SourceControlAuthProbeInput) {
   const output = SourceControlProviderDiscovery.combinedAuthOutput(input);
-  const authStatus = parseGitHubAuthStatus(output);
+  const authStatus = parseGitHubAuthStatus(input.stdout);
   const authenticatedAccount = findAuthenticatedGitHubAccount(authStatus.accounts);
   const host = authenticatedAccount?.host;
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -10,6 +10,7 @@ import {
 } from "@t3tools/contracts";
 
 import * as GitHubCli from "./GitHubCli.ts";
+import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
 import * as GitHubPullRequests from "./gitHubPullRequests.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
 import * as SourceControlProviderDiscovery from "./SourceControlProviderDiscovery.ts";
@@ -51,11 +52,28 @@ function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeReq
 
 function parseGitHubAuth(input: SourceControlProviderDiscovery.SourceControlAuthProbeInput) {
   const output = SourceControlProviderDiscovery.combinedAuthOutput(input);
-  const account = SourceControlProviderDiscovery.matchFirst(output, [
-    /Logged in to .* account\s+([^\s(]+)/iu,
-    /Logged in to .* as\s+([^\s(]+)/iu,
-  ]);
-  const host = SourceControlProviderDiscovery.parseCliHost(output);
+  const authStatus = parseGitHubAuthStatus(output);
+  const authenticatedAccount = findAuthenticatedGitHubAccount(authStatus.accounts);
+  const host = authenticatedAccount?.host;
+
+  if (authenticatedAccount) {
+    return SourceControlProviderDiscovery.providerAuth({
+      status: "authenticated",
+      account: authenticatedAccount.account,
+      host,
+    });
+  }
+
+  const failedAccount = authStatus.accounts.find((entry) => entry.active) ?? authStatus.accounts[0];
+  if (authStatus.parsed) {
+    return SourceControlProviderDiscovery.providerAuth({
+      status: "unauthenticated",
+      host: failedAccount?.host,
+      detail:
+        failedAccount?.error ??
+        "Run `gh auth login` to authenticate GitHub CLI with an active account.",
+    });
+  }
 
   if (input.exitCode !== 0) {
     return SourceControlProviderDiscovery.providerAuth({
@@ -65,10 +83,6 @@ function parseGitHubAuth(input: SourceControlProviderDiscovery.SourceControlAuth
         SourceControlProviderDiscovery.firstSafeAuthLine(output) ??
         "Run `gh auth login` to authenticate GitHub CLI.",
     });
-  }
-
-  if (account) {
-    return SourceControlProviderDiscovery.providerAuth({ status: "authenticated", account, host });
   }
 
   return SourceControlProviderDiscovery.providerAuth({
@@ -86,7 +100,7 @@ export const discovery = {
   label: "GitHub",
   executable: "gh",
   versionArgs: ["--version"],
-  authArgs: ["auth", "status"],
+  authArgs: ["auth", "status", "--json", "hosts"],
   parseAuth: parseGitHubAuth,
   installHint:
     "Install the GitHub command-line tool (`gh`) via https://cli.github.com/ or your package manager (for example `brew install gh`).",

--- a/apps/server/src/sourceControl/GitLabSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitLabSourceControlProvider.test.ts
@@ -2,8 +2,10 @@ import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
 import * as GitLabCli from "./GitLabCli.ts";
+import { parseGitLabAuthStatusHosts } from "./gitLabAuthStatus.ts";
 import * as GitLabSourceControlProvider from "./GitLabSourceControlProvider.ts";
 
 function makeProvider(gitlab: Partial<GitLabCli.GitLabCliShape>) {
@@ -107,3 +109,44 @@ it.effect("creates GitLab MRs through provider-neutral input names", () =>
     });
   }),
 );
+
+it("accepts authenticated GitLab hosts when another configured host fails", () => {
+  const auth = GitLabSourceControlProvider.discovery.parseAuth({
+    exitCode: ChildProcessSpawner.ExitCode(1),
+    stdout: `gitlab.com
+  x gitlab.com: API call failed: 401 Unauthorized
+  ! No token found
+self-hosted.example.test
+  ✓ Logged in to self-hosted.example.test as gitlab-user
+  ✓ Token found: ******
+`,
+    stderr: "",
+  });
+
+  assert.deepStrictEqual(
+    {
+      status: auth.status,
+      account: auth.account,
+      host: auth.host,
+    },
+    {
+      status: "authenticated",
+      account: Option.some("gitlab-user"),
+      host: Option.some("self-hosted.example.test"),
+    },
+  );
+});
+
+it("parses authenticated GitLab auth status hosts with ports and single-label names", () => {
+  assert.deepStrictEqual(
+    parseGitLabAuthStatusHosts(`localhost:8080
+  ✓ Logged in to localhost:8080 as local-user
+selfhosted
+  ✓ Logged in to selfhosted as single-label-user
+`),
+    [
+      { host: "localhost:8080", account: "local-user" },
+      { host: "selfhosted", account: "single-label-user" },
+    ],
+  );
+});

--- a/apps/server/src/sourceControl/GitLabSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitLabSourceControlProvider.test.ts
@@ -137,6 +137,35 @@ self-hosted.example.test
   );
 });
 
+it("refines unknown GitLab remotes with mixed-case provider hosts", () => {
+  const provider = GitLabSourceControlProvider.discovery.refineUnknownRemote?.({
+    cwd: "/repo",
+    context: {
+      provider: {
+        kind: "unknown",
+        name: "Self-Hosted.Example.Test",
+        baseUrl: "https://Self-Hosted.Example.Test",
+      },
+      remoteName: "origin",
+      remoteUrl: "https://Self-Hosted.Example.Test/group/project.git",
+    },
+    auth: {
+      exitCode: ChildProcessSpawner.ExitCode(0),
+      stdout: `self-hosted.example.test
+  ✓ Logged in to self-hosted.example.test as gitlab-user
+  ✓ Token found: ******
+`,
+      stderr: "",
+    },
+  });
+
+  assert.deepStrictEqual(provider, {
+    kind: "gitlab",
+    name: "GitLab Self-Hosted",
+    baseUrl: "https://Self-Hosted.Example.Test",
+  });
+});
+
 it("parses authenticated GitLab auth status hosts with ports and single-label names", () => {
   assert.deepStrictEqual(
     parseGitLabAuthStatusHosts(`localhost:8080

--- a/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
@@ -80,7 +80,7 @@ function parseGitLabAuth(input: SourceControlProviderDiscovery.SourceControlAuth
 function refineUnknownGitLabRemote(
   input: SourceControlProviderDiscovery.SourceControlUnknownRemoteRefinementInput,
 ) {
-  const host = input.context.provider.name;
+  const host = input.context.provider.name.toLowerCase();
   const authenticated = parseGitLabAuthStatusHosts(
     SourceControlProviderDiscovery.combinedAuthOutput(input.auth),
   ).some((entry) => entry.account !== null && entry.host === host);

--- a/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
@@ -6,6 +6,7 @@ import { SourceControlProviderError, type ChangeRequest } from "@t3tools/contrac
 import * as GitLabCli from "./GitLabCli.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
 import * as SourceControlProviderDiscovery from "./SourceControlProviderDiscovery.ts";
+import { findAuthenticatedGitLabHost, parseGitLabAuthStatusHosts } from "./gitLabAuthStatus.ts";
 
 function providerError(
   operation: string,
@@ -43,12 +44,19 @@ function toChangeRequest(summary: GitLabCli.GitLabMergeRequestSummary): ChangeRe
 
 function parseGitLabAuth(input: SourceControlProviderDiscovery.SourceControlAuthProbeInput) {
   const output = SourceControlProviderDiscovery.combinedAuthOutput(input);
-  const account = SourceControlProviderDiscovery.matchFirst(output, [
-    /Logged in to .* as\s+([^\s(]+)/iu,
-    /Logged in to .* account\s+([^\s(]+)/iu,
-    /account:\s*([^\s(]+)/iu,
-  ]);
-  const host = SourceControlProviderDiscovery.parseCliHost(output);
+  const authenticatedHost = findAuthenticatedGitLabHost(parseGitLabAuthStatusHosts(output));
+  const account =
+    authenticatedHost?.account ??
+    SourceControlProviderDiscovery.matchFirst(output, [
+      /Logged in to .* as\s+([^\s(]+)/iu,
+      /Logged in to .* account\s+([^\s(]+)/iu,
+      /account:\s*([^\s(]+)/iu,
+    ]);
+  const host = authenticatedHost?.host ?? SourceControlProviderDiscovery.parseCliHost(output);
+
+  if (account) {
+    return SourceControlProviderDiscovery.providerAuth({ status: "authenticated", account, host });
+  }
 
   if (input.exitCode !== 0) {
     return SourceControlProviderDiscovery.providerAuth({
@@ -60,10 +68,6 @@ function parseGitLabAuth(input: SourceControlProviderDiscovery.SourceControlAuth
     });
   }
 
-  if (account) {
-    return SourceControlProviderDiscovery.providerAuth({ status: "authenticated", account, host });
-  }
-
   return SourceControlProviderDiscovery.providerAuth({
     status: "unknown",
     host,
@@ -71,6 +75,25 @@ function parseGitLabAuth(input: SourceControlProviderDiscovery.SourceControlAuth
       SourceControlProviderDiscovery.firstSafeAuthLine(output) ??
       "GitLab CLI auth status could not be parsed.",
   });
+}
+
+function refineUnknownGitLabRemote(
+  input: SourceControlProviderDiscovery.SourceControlUnknownRemoteRefinementInput,
+) {
+  const host = input.context.provider.name;
+  const authenticated = parseGitLabAuthStatusHosts(
+    SourceControlProviderDiscovery.combinedAuthOutput(input.auth),
+  ).some((entry) => entry.account !== null && entry.host === host);
+
+  if (!authenticated) {
+    return null;
+  }
+
+  return {
+    kind: "gitlab",
+    name: host === "gitlab.com" ? "GitLab" : "GitLab Self-Hosted",
+    baseUrl: input.context.provider.baseUrl,
+  } as const;
 }
 
 export const discovery = {
@@ -81,6 +104,7 @@ export const discovery = {
   versionArgs: ["--version"],
   authArgs: ["auth", "status"],
   parseAuth: parseGitLabAuth,
+  refineUnknownRemote: refineUnknownGitLabRemote,
   installHint:
     "Install the GitLab command-line tool (`glab`) from https://gitlab.com/gitlab-org/cli or your package manager (for example `brew install glab`).",
 } satisfies SourceControlProviderDiscovery.SourceControlCliDiscoverySpec;

--- a/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitLabSourceControlProvider.ts
@@ -91,7 +91,7 @@ function refineUnknownGitLabRemote(
 
   return {
     kind: "gitlab",
-    name: host === "gitlab.com" ? "GitLab" : "GitLab Self-Hosted",
+    name: "GitLab Self-Hosted",
     baseUrl: input.context.provider.baseUrl,
   } as const;
 }

--- a/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
+++ b/apps/server/src/sourceControl/SourceControlDiscovery.test.ts
@@ -59,15 +59,24 @@ it.effect("reports implemented tools separately from locally available executabl
       if (input.command === "gh" && input.args[0] === "--version") {
         return Effect.succeed(processOutput("gh version 2.83.0\n"));
       }
-      if (input.command === "gh" && input.args.join(" ") === "auth status") {
+      if (input.command === "gh" && input.args.join(" ") === "auth status --json hosts") {
         return Effect.succeed(
-          processOutput(`github.com
-Logged in to github.com account juliusmarminge (keyring)
-- Active account: true
-- Git operations protocol: ssh
-- Token: gho_************************************
-- Token scopes: 'admin:public_key', 'gist', 'read:org', 'repo'
-`),
+          processOutput(
+            JSON.stringify({
+              hosts: {
+                "github.com": [
+                  {
+                    state: "success",
+                    active: true,
+                    host: "github.com",
+                    login: "juliusmarminge",
+                    tokenSource: "keyring",
+                    gitProtocol: "ssh",
+                  },
+                ],
+              },
+            }),
+          ),
         );
       }
       return Effect.fail(
@@ -164,13 +173,24 @@ it.effect("probes provider authentication without exposing token details", () =>
       if (input.args[0] === "--version") {
         return Effect.succeed(processOutput(`${input.command} version test\n`));
       }
-      if (input.command === "gh" && input.args.join(" ") === "auth status") {
+      if (input.command === "gh" && input.args.join(" ") === "auth status --json hosts") {
         return Effect.succeed(
-          processOutput(`github.com
-Logged in to github.com account octocat (keyring)
-- Token: gho_************************************
-- Token scopes: 'repo'
-`),
+          processOutput(
+            JSON.stringify({
+              hosts: {
+                "github.com": [
+                  {
+                    state: "success",
+                    active: true,
+                    host: "github.com",
+                    login: "octocat",
+                    tokenSource: "keyring",
+                    gitProtocol: "ssh",
+                  },
+                ],
+              },
+            }),
+          ),
         );
       }
       if (input.command === "glab" && input.args.join(" ") === "auth status") {

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -281,7 +281,7 @@ export function refineUnknownRemoteProvider(input: {
           allowNonZeroExit: true,
           timeoutMs: 5_000,
           maxOutputBytes: 8_000,
-          truncateOutputAtMaxBytes: true,
+          appendTruncationMarker: true,
         })
         .pipe(
           Effect.map(

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -48,6 +48,10 @@ export type SourceControlProviderDiscoverySpec =
   | SourceControlCliDiscoverySpec
   | SourceControlApiDiscoverySpec;
 
+type SourceControlCliRemoteRefinementSpec = SourceControlCliDiscoverySpec & {
+  readonly refineUnknownRemote: NonNullable<SourceControlCliDiscoverySpec["refineUnknownRemote"]>;
+};
+
 interface DiscoveryProbeResult {
   readonly kind: SourceControlProviderKind;
   readonly label: string;
@@ -144,6 +148,12 @@ export function matchFirst(text: string, patterns: ReadonlyArray<RegExp>): strin
     if (value && value.length > 0) return value;
   }
   return undefined;
+}
+
+function isCliRemoteRefinementSpec(
+  spec: SourceControlProviderDiscoverySpec,
+): spec is SourceControlCliRemoteRefinementSpec {
+  return spec.type === "cli" && spec.refineUnknownRemote !== undefined;
 }
 
 function probeCli(input: {
@@ -257,22 +267,20 @@ export function probeSourceControlProvider(input: {
   );
 }
 
-export function refineUnknownRemoteProvider(input: {
-  readonly specs: ReadonlyArray<SourceControlProviderDiscoverySpec>;
-  readonly process: VcsProcess.VcsProcessShape;
-  readonly cwd: string;
-  readonly context: SourceControlProvider.SourceControlProviderContext | null;
-}): Effect.Effect<SourceControlProvider.SourceControlProviderContext | null> {
-  if (input.context === null || input.context.provider.kind !== "unknown") {
-    return Effect.succeed(input.context);
-  }
-  const context = input.context;
+export const refineUnknownRemoteProvider = Effect.fn("refineUnknownRemoteProvider")(
+  function* (input: {
+    readonly specs: ReadonlyArray<SourceControlProviderDiscoverySpec>;
+    readonly process: VcsProcess.VcsProcessShape;
+    readonly cwd: string;
+    readonly context: SourceControlProvider.SourceControlProviderContext | null;
+  }): Effect.fn.Return<SourceControlProvider.SourceControlProviderContext | null> {
+    if (input.context === null || input.context.provider.kind !== "unknown") {
+      return input.context;
+    }
+    const context = input.context;
 
-  return Effect.gen(function* () {
-    for (const spec of input.specs) {
-      if (spec.type !== "cli" || !spec.refineUnknownRemote) continue;
-
-      const provider = yield* input.process
+    const providers = yield* Effect.forEach(input.specs.filter(isCliRemoteRefinementSpec), (spec) =>
+      input.process
         .run({
           operation: "source-control.discovery.refine-unknown-remote",
           command: spec.executable,
@@ -284,22 +292,18 @@ export function refineUnknownRemoteProvider(input: {
           appendTruncationMarker: true,
         })
         .pipe(
-          Effect.map(
-            (auth) =>
-              spec.refineUnknownRemote?.({
-                cwd: input.cwd,
-                context,
-                auth,
-              }) ?? null,
+          Effect.map((auth) =>
+            spec.refineUnknownRemote({
+              cwd: input.cwd,
+              context,
+              auth,
+            }),
           ),
           Effect.catch(() => Effect.succeed(null)),
-        );
+        ),
+    );
+    const provider = providers.find((candidate) => candidate !== null);
 
-      if (provider) {
-        return { ...context, provider };
-      }
-    }
-
-    return context;
-  });
-}
+    return provider ? { ...context, provider } : context;
+  },
+);

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -1,17 +1,25 @@
 import type {
   SourceControlProviderAuth,
   SourceControlProviderDiscoveryItem,
+  SourceControlProviderInfo,
   SourceControlProviderKind,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 
+import type * as SourceControlProvider from "./SourceControlProvider.ts";
 import type * as VcsProcess from "../vcs/VcsProcess.ts";
 
 export interface SourceControlAuthProbeInput {
   readonly stdout: string;
   readonly stderr: string;
   readonly exitCode: VcsProcess.VcsProcessOutput["exitCode"];
+}
+
+export interface SourceControlUnknownRemoteRefinementInput {
+  readonly cwd: string;
+  readonly context: SourceControlProvider.SourceControlProviderContext;
+  readonly auth: SourceControlAuthProbeInput;
 }
 
 interface SourceControlDiscoverySpecBase {
@@ -26,6 +34,9 @@ export type SourceControlCliDiscoverySpec = SourceControlDiscoverySpecBase & {
   readonly versionArgs: ReadonlyArray<string>;
   readonly authArgs: ReadonlyArray<string>;
   readonly parseAuth: (input: SourceControlAuthProbeInput) => SourceControlProviderAuth;
+  readonly refineUnknownRemote?: (
+    input: SourceControlUnknownRemoteRefinementInput,
+  ) => SourceControlProviderInfo | null;
 };
 
 export type SourceControlApiDiscoverySpec = SourceControlDiscoverySpecBase & {
@@ -244,4 +255,51 @@ export function probeSourceControlProvider(input: {
         );
     }),
   );
+}
+
+export function refineUnknownRemoteProvider(input: {
+  readonly specs: ReadonlyArray<SourceControlProviderDiscoverySpec>;
+  readonly process: VcsProcess.VcsProcessShape;
+  readonly cwd: string;
+  readonly context: SourceControlProvider.SourceControlProviderContext | null;
+}): Effect.Effect<SourceControlProvider.SourceControlProviderContext | null> {
+  if (input.context === null || input.context.provider.kind !== "unknown") {
+    return Effect.succeed(input.context);
+  }
+  const context = input.context;
+
+  return Effect.gen(function* () {
+    for (const spec of input.specs) {
+      if (spec.type !== "cli" || !spec.refineUnknownRemote) continue;
+
+      const provider = yield* input.process
+        .run({
+          operation: "source-control.discovery.refine-unknown-remote",
+          command: spec.executable,
+          args: spec.authArgs,
+          cwd: input.cwd,
+          allowNonZeroExit: true,
+          timeoutMs: 5_000,
+          maxOutputBytes: 8_000,
+          truncateOutputAtMaxBytes: true,
+        })
+        .pipe(
+          Effect.map(
+            (auth) =>
+              spec.refineUnknownRemote?.({
+                cwd: input.cwd,
+                context,
+                auth,
+              }) ?? null,
+          ),
+          Effect.catch(() => Effect.succeed(null)),
+        );
+
+      if (provider) {
+        return { ...context, provider };
+      }
+    }
+
+    return context;
+  });
 }

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.test.ts
@@ -4,6 +4,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
 import { ServerConfig } from "../config.ts";
 import type * as VcsDriver from "../vcs/VcsDriver.ts";
@@ -17,11 +18,26 @@ import * as SourceControlProviderRegistry from "./SourceControlProviderRegistry.
 
 const TEST_EPOCH = DateTime.makeUnsafe("1970-01-01T00:00:00.000Z");
 
+const processOutput = (
+  stdout: string,
+  options?: {
+    readonly stderr?: string;
+    readonly exitCode?: ChildProcessSpawner.ExitCode;
+  },
+): VcsProcess.VcsProcessOutput => ({
+  exitCode: options?.exitCode ?? ChildProcessSpawner.ExitCode(0),
+  stdout,
+  stderr: options?.stderr ?? "",
+  stdoutTruncated: false,
+  stderrTruncated: false,
+});
+
 function makeRegistry(input: {
   readonly remotes: ReadonlyArray<{
     readonly name: string;
     readonly url: string;
   }>;
+  readonly process?: Partial<VcsProcess.VcsProcessShape>;
 }) {
   const driver = {
     listRemotes: () =>
@@ -58,15 +74,20 @@ function makeRegistry(input: {
       }),
   });
 
+  const processLayer = Layer.mock(VcsProcess.VcsProcess)({
+    run: () => Effect.succeed(processOutput("")),
+    ...input.process,
+  });
+
   return SourceControlProviderRegistry.make().pipe(
     Effect.provide(
       Layer.mergeAll(
         registryLayer,
+        processLayer,
         Layer.mock(AzureDevOpsCli.AzureDevOpsCli)({}),
         Layer.mock(BitbucketApi.BitbucketApi)({}),
         Layer.mock(GitHubCli.GitHubCli)({}),
         Layer.mock(GitLabCli.GitLabCli)({}),
-        Layer.mock(VcsProcess.VcsProcess)({}),
         ServerConfig.layerTest(process.cwd(), { prefix: "t3-source-control-registry-test-" }).pipe(
           Layer.provide(NodeServices.layer),
         ),
@@ -103,6 +124,56 @@ it.effect("routes GitLab remotes to the GitLab provider", () =>
   Effect.gen(function* () {
     const registry = yield* makeRegistry({
       remotes: [{ name: "origin", url: "git@gitlab.com:group/project.git" }],
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+
+    assert.strictEqual(provider.kind, "gitlab");
+  }),
+);
+
+it.effect("routes authenticated self-hosted GitLab remotes without relying on host naming", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [{ name: "origin", url: "https://self-hosted.example.test/group/project.git" }],
+      process: {
+        run: () =>
+          Effect.succeed(
+            processOutput(
+              `gitlab.com
+  x gitlab.com: API call failed: 401 Unauthorized
+  ! No token found
+self-hosted.example.test
+  ✓ Logged in to self-hosted.example.test as gitlab-user
+  ✓ Token found: ******
+`,
+              { exitCode: ChildProcessSpawner.ExitCode(1) },
+            ),
+          ),
+      },
+    });
+
+    const provider = yield* registry.resolve({ cwd: "/repo" });
+
+    assert.strictEqual(provider.kind, "gitlab");
+  }),
+);
+
+it.effect("routes authenticated self-hosted GitLab remotes on non-standard ports", () =>
+  Effect.gen(function* () {
+    const registry = yield* makeRegistry({
+      remotes: [{ name: "origin", url: "https://self-hosted.example.test:8443/group/project.git" }],
+      process: {
+        run: () =>
+          Effect.succeed(
+            processOutput(
+              `self-hosted.example.test:8443
+  ✓ Logged in to self-hosted.example.test:8443 as gitlab-user
+  ✓ Token found: ******
+`,
+            ),
+          ),
+      },
     });
 
     const provider = yield* registry.resolve({ cwd: "/repo" });

--- a/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderRegistry.ts
@@ -178,8 +178,14 @@ export const makeWithProviders = Effect.fn("makeSourceControlProviderRegistryWit
         const remotes = yield* handle.driver
           .listRemotes(cwd)
           .pipe(Effect.mapError((error) => providerDetectionError("detectProvider", cwd, error)));
+        const context = selectProviderContext(remotes.remotes);
 
-        return selectProviderContext(remotes.remotes);
+        return yield* SourceControlProviderDiscovery.refineUnknownRemoteProvider({
+          specs: discoverySpecs,
+          process,
+          cwd,
+          context,
+        });
       },
     );
 

--- a/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
+++ b/apps/server/src/sourceControl/azureDevOpsPullRequests.ts
@@ -21,6 +21,17 @@ const AzureDevOpsPullRequestSchema = Schema.Struct({
   pullRequestId: PositiveInt,
   title: TrimmedNonEmptyString,
   url: Schema.optional(Schema.String),
+  repository: Schema.optional(
+    Schema.Struct({
+      name: Schema.optional(Schema.String),
+      webUrl: Schema.optional(Schema.String),
+      project: Schema.optional(
+        Schema.Struct({
+          name: Schema.optional(Schema.String),
+        }),
+      ),
+    }),
+  ),
   sourceRefName: TrimmedNonEmptyString,
   targetRefName: TrimmedNonEmptyString,
   status: Schema.String,
@@ -57,13 +68,74 @@ function normalizeAzureDevOpsPullRequestState(status: string): "open" | "closed"
   }
 }
 
+function encodeAzureDevOpsPathSegment(segment: string): string {
+  return encodeURIComponent(segment);
+}
+
+function azureDevOpsOrganizationBaseFromRestApiUrl(
+  value: string | null | undefined,
+): string | null {
+  const rawUrl = trimOptionalString(value);
+  if (!rawUrl) {
+    return null;
+  }
+
+  try {
+    const url = new URL(rawUrl);
+    const hostname = url.hostname.toLowerCase();
+    const pathSegments = url.pathname.split("/").filter((segment) => segment.length > 0);
+    const isAzureRestUrl = pathSegments.some((segment) => segment.toLowerCase() === "_apis");
+    if (!isAzureRestUrl) {
+      return null;
+    }
+
+    if (hostname === "dev.azure.com") {
+      const organization = pathSegments[0];
+      return organization ? `${url.origin}/${organization}` : null;
+    }
+
+    if (hostname.endsWith(".visualstudio.com")) {
+      return url.origin;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAzureDevOpsPullRequestUrl(
+  raw: Schema.Schema.Type<typeof AzureDevOpsPullRequestSchema>,
+): string {
+  const webLink = trimOptionalString(raw._links?.web?.href);
+  if (webLink) {
+    return webLink;
+  }
+
+  const repositoryWebUrl = trimOptionalString(raw.repository?.webUrl);
+  if (repositoryWebUrl) {
+    return `${repositoryWebUrl.replace(/\/+$/, "")}/pullrequest/${raw.pullRequestId}`;
+  }
+
+  const organizationBase = azureDevOpsOrganizationBaseFromRestApiUrl(raw.url);
+  const projectName = trimOptionalString(raw.repository?.project?.name);
+  const repositoryName = trimOptionalString(raw.repository?.name);
+  if (organizationBase && projectName && repositoryName) {
+    const encodedProjectName = encodeAzureDevOpsPathSegment(projectName);
+    const encodedRepositoryName = encodeAzureDevOpsPathSegment(repositoryName);
+    return `${organizationBase}/${encodedProjectName}/_git/${encodedRepositoryName}/pullrequest/${raw.pullRequestId}`;
+  }
+
+  return trimOptionalString(raw.url) ?? "";
+}
+
 function normalizeAzureDevOpsPullRequestRecord(
   raw: Schema.Schema.Type<typeof AzureDevOpsPullRequestSchema>,
 ): NormalizedAzureDevOpsPullRequestRecord {
   return {
     number: raw.pullRequestId,
     title: raw.title,
-    url: trimOptionalString(raw._links?.web?.href) ?? trimOptionalString(raw.url) ?? "",
+    url: normalizeAzureDevOpsPullRequestUrl(raw),
     baseRefName: normalizeRefName(raw.targetRefName),
     headRefName: normalizeRefName(raw.sourceRefName),
     state: normalizeAzureDevOpsPullRequestState(raw.status),

--- a/apps/server/src/sourceControl/gitHubAuthStatus.ts
+++ b/apps/server/src/sourceControl/gitHubAuthStatus.ts
@@ -1,0 +1,72 @@
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+const GitHubAuthStatusAccountSchema = Schema.Struct({
+  state: Schema.String,
+  error: Schema.optional(Schema.String),
+  active: Schema.Boolean,
+  host: Schema.String,
+  login: Schema.String,
+});
+
+const GitHubAuthStatusSchema = Schema.Struct({
+  hosts: Schema.Record(Schema.String, Schema.Array(GitHubAuthStatusAccountSchema)),
+});
+
+const decodeGitHubAuthStatusJson = Schema.decodeUnknownOption(
+  Schema.fromJsonString(GitHubAuthStatusSchema),
+);
+
+export interface GitHubAuthStatusAccount {
+  readonly host: string;
+  readonly account: string;
+  readonly authenticated: boolean;
+  readonly active: boolean;
+  readonly error: string | null;
+}
+
+export interface GitHubAuthStatus {
+  readonly parsed: boolean;
+  readonly accounts: ReadonlyArray<GitHubAuthStatusAccount>;
+}
+
+function nonEmptyString(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function parseGitHubAuthStatus(text: string): GitHubAuthStatus {
+  return Option.match(decodeGitHubAuthStatusJson(text), {
+    onNone: () => ({ parsed: false, accounts: [] }),
+    onSome: (status) =>
+      ({
+        parsed: true,
+        accounts: Object.values(status.hosts).flatMap((accounts) =>
+          accounts.flatMap((account) => {
+            const host = nonEmptyString(account.host);
+            const login = nonEmptyString(account.login);
+            if (host === null || login === null) return [];
+
+            return [
+              {
+                host: host.toLowerCase(),
+                account: login,
+                authenticated: account.state === "success",
+                active: account.active,
+                error: account.error?.trim() || null,
+              },
+            ];
+          }),
+        ),
+      }) satisfies GitHubAuthStatus,
+  });
+}
+
+export function findAuthenticatedGitHubAccount(
+  accounts: ReadonlyArray<GitHubAuthStatusAccount>,
+): GitHubAuthStatusAccount | undefined {
+  return (
+    accounts.find((account) => account.authenticated && account.active) ??
+    accounts.find((account) => account.authenticated)
+  );
+}

--- a/apps/server/src/sourceControl/gitLabAuthStatus.ts
+++ b/apps/server/src/sourceControl/gitLabAuthStatus.ts
@@ -1,0 +1,48 @@
+const HOST_LINE_PATTERN = /^(?:[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?|\[[a-f0-9:.]+\])(?::\d+)?$/iu;
+const LOGGED_IN_PATTERN = /Logged in to .+? as\s+([^\s(]+)/iu;
+
+export interface GitLabAuthStatusHost {
+  readonly host: string;
+  readonly account: string | null;
+}
+
+export function parseGitLabAuthStatusHosts(text: string): ReadonlyArray<GitLabAuthStatusHost> {
+  const hosts: GitLabAuthStatusHost[] = [];
+  let currentHost: string | null = null;
+  let currentLines: string[] = [];
+
+  const flush = () => {
+    if (currentHost === null) return;
+
+    const account = LOGGED_IN_PATTERN.exec(currentLines.join("\n"))?.[1]?.trim() || null;
+    hosts.push({ host: currentHost, account });
+    currentHost = null;
+    currentLines = [];
+  };
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+
+    const isHostLine =
+      rawLine.length === rawLine.trimStart().length && HOST_LINE_PATTERN.test(line);
+    if (isHostLine) {
+      flush();
+      currentHost = line.toLowerCase();
+      continue;
+    }
+
+    if (currentHost !== null) {
+      currentLines.push(line);
+    }
+  }
+
+  flush();
+  return hosts;
+}
+
+export function findAuthenticatedGitLabHost(
+  hosts: ReadonlyArray<GitLabAuthStatusHost>,
+): GitLabAuthStatusHost | undefined {
+  return hosts.find((host) => host.account !== null);
+}

--- a/packages/shared/src/sourceControl.test.ts
+++ b/packages/shared/src/sourceControl.test.ts
@@ -56,4 +56,23 @@ describe("detectSourceControlProviderFromRemoteUrl", () => {
       detectSourceControlProviderFromRemoteUrl("git@bitbucket.org:workspace/repo.git")?.kind,
     ).toBe("bitbucket");
   });
+
+  it("preserves ports while classifying by hostname", () => {
+    expect(
+      detectSourceControlProviderFromRemoteUrl("https://gitlab.com:8443/group/repo.git"),
+    ).toEqual({
+      kind: "gitlab",
+      name: "GitLab",
+      baseUrl: "https://gitlab.com:8443",
+    });
+    expect(
+      detectSourceControlProviderFromRemoteUrl(
+        "https://self-hosted.example.test:8443/group/repo.git",
+      ),
+    ).toEqual({
+      kind: "unknown",
+      name: "self-hosted.example.test:8443",
+      baseUrl: "https://self-hosted.example.test:8443",
+    });
+  });
 });

--- a/packages/shared/src/sourceControl.ts
+++ b/packages/shared/src/sourceControl.ts
@@ -149,9 +149,17 @@ function parseRemoteHost(remoteUrl: string): string | null {
   }
 
   try {
-    return new URL(trimmed).hostname.toLowerCase();
+    return new URL(trimmed).host.toLowerCase();
   } catch {
     return null;
+  }
+}
+
+function parseHostName(host: string): string {
+  try {
+    return new URL(`https://${host}`).hostname.toLowerCase();
+  } catch {
+    return host.replace(/:\d+$/u, "").toLowerCase();
   }
 }
 
@@ -182,24 +190,25 @@ export function detectSourceControlProviderFromRemoteUrl(
   if (!host) {
     return null;
   }
+  const hostname = parseHostName(host);
 
-  if (isGitHubHost(host)) {
+  if (isGitHubHost(hostname)) {
     return {
       kind: "github",
-      name: host === "github.com" ? "GitHub" : "GitHub Self-Hosted",
+      name: hostname === "github.com" ? "GitHub" : "GitHub Self-Hosted",
       baseUrl: toBaseUrl(host),
     };
   }
 
-  if (isGitLabHost(host)) {
+  if (isGitLabHost(hostname)) {
     return {
       kind: "gitlab",
-      name: host === "gitlab.com" ? "GitLab" : "GitLab Self-Hosted",
+      name: hostname === "gitlab.com" ? "GitLab" : "GitLab Self-Hosted",
       baseUrl: toBaseUrl(host),
     };
   }
 
-  if (isAzureDevOpsHost(host)) {
+  if (isAzureDevOpsHost(hostname)) {
     return {
       kind: "azure-devops",
       name: "Azure DevOps",
@@ -207,10 +216,10 @@ export function detectSourceControlProviderFromRemoteUrl(
     };
   }
 
-  if (isBitbucketHost(host)) {
+  if (isBitbucketHost(hostname)) {
     return {
       kind: "bitbucket",
-      name: host === "bitbucket.org" ? "Bitbucket" : "Bitbucket Self-Hosted",
+      name: hostname === "bitbucket.org" ? "Bitbucket" : "Bitbucket Self-Hosted",
       baseUrl: toBaseUrl(host),
     };
   }


### PR DESCRIPTION
Fixes #2842
Related #2643

## What Changed

Improved source-control auth discovery for mixed provider auth states.

For GitLab:

- Detect authenticated self-hosted GitLab remotes even when the remote host does not contain `gitlab`.
- Keep normal remote URL heuristics as the first path, but allow providers to refine an `unknown` remote when they have a stronger auth signal.
- Parse `glab auth status` by host, so one failing configured GitLab host does not hide another authenticated host.
- Only claim an unknown remote as GitLab when the remote host exactly matches an authenticated `glab` host.

For GitHub:

- Use `gh auth status --json hosts` instead of parsing human-readable output.
- Support multiple GitHub accounts on the same host.
- Prefer the active successful account, then fall back to any successful account.
- Treat parsed GitHub auth JSON with no successful accounts as unauthenticated.
- Keep GitHub authenticated when at least one account is valid, preferring the active valid account.

## Why

Self-hosted GitLab instances can live on arbitrary domains, so checking whether a remote host contains `gitlab` is not enough.

The GitLab issue showed up when `glab auth status` returned a mixed result: one configured host failed auth, while the repo's self-hosted instance was authenticated. The old path treated the whole command as unauthenticated because the command exited non-zero, and provider routing still saw the repo as `unknown` because the remote host did not look like GitLab.

The GitHub issue is the same class of auth-discovery problem: `gh auth status` can include multiple accounts for `github.com`, and one stale inactive account should not make GitHub look unauthenticated when another account is active and valid. GitHub exposes this state as structured JSON, so this now uses the CLI's JSON contract instead of human-readable terminal text.

Bitbucket and Azure DevOps are left unchanged because their auth models are different: Bitbucket is API-token based in T3 Code, and Azure DevOps relies on Azure CLI login plus `az repos --detect`.

## UI Changes

No UI changes. The settings screen now receives more accurate source-control auth state.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how provider auth and remote-to-provider mapping are determined for GitHub/GitLab CLI flows, which can alter which integration handles a repo; Azure URL normalization is lower risk but user-facing.
> 
> **Overview**
> Improves **source-control discovery and routing** when CLI auth output is ambiguous or remotes do not match hostname heuristics.
> 
> **GitHub** now probes with `gh auth status --json hosts` and picks an authenticated account (active success first, then any success), so a stale sibling account no longer marks the host unauthenticated. **GitLab** parses `glab auth status` per configured host and can report authenticated even when the command exits non-zero because another host failed.
> 
> **Provider resolution** adds optional `refineUnknownRemote`: after URL heuristics yield `unknown`, the registry can reclassify a remote as GitLab when `glab` shows a login for that exact host (including custom domains and ports). Shared remote parsing keeps **port in `baseUrl`** while still classifying known SaaS hosts by hostname only.
> 
> **Azure DevOps** pull request records now normalize **browser PR URLs** when Azure returns only REST `_apis` links, using repository/project metadata when web links are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f93374d042f3164c7c5f051152d5e560ba606f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix source control auth to handle self-hosted GitLab and multi-account GitHub
> - GitHub CLI auth detection switches from regex parsing to `gh auth status --json hosts`, selecting an authenticated (preferably active) account and reporting specific error details when unauthenticated.
> - GitLab adds a `refineUnknownGitLabRemote` function that checks `glab auth status` output to identify self-hosted GitLab instances, routing unknown remotes to the GitLab provider when a matching authenticated host is found.
> - Port numbers are now preserved in `baseUrl` for self-hosted HTTP(S) remotes, while host classification (GitHub vs GitLab vs unknown) still uses the hostname without port.
> - Azure DevOps pull request URL normalization now constructs a usable web URL from the REST API URL or repository metadata when `_links.web.href` is absent.
> - Behavioral Change: `gh auth` probes now run `auth status --json hosts` instead of the plain status command, which changes the expected CLI output format in tests and live auth checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4f93374.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->