### PR TITLE
Add split-thread drag and diff routing support

### DIFF
--- a/apps/desktop/src/backendReadiness.test.ts
+++ b/apps/desktop/src/backendReadiness.test.ts
@@ -22,7 +22,7 @@ describe("waitForHttpReady", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2);
     expect(fetchImpl).toHaveBeenNthCalledWith(
       1,
-      "http://127.0.0.1:3773/",
+      "http://127.0.0.1:3773/.well-known/t3/environment",
       expect.objectContaining({ redirect: "manual" }),
     );
   });

--- a/apps/desktop/src/backendReadiness.ts
+++ b/apps/desktop/src/backendReadiness.ts
@@ -8,6 +8,13 @@ export interface WaitForHttpReadyOptions {
   readonly isReady?: (response: Response) => boolean;
 }
 
+/**
+ * Unauthenticated 200 from the T3 HTTP server. Avoids probing `/`, which returns 302 to the Vite
+ * dev URL when `devUrl` is configured — `response.ok` is false for redirects, so readiness would
+ * never succeed in desktop dev.
+ */
+export const T3_BACKEND_READINESS_PATH = "/.well-known/t3/environment";
+
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_INTERVAL_MS = 100;
 const DEFAULT_REQUEST_TIMEOUT_MS = 1_000;
@@ -59,7 +66,7 @@ export async function waitForHttpReady(
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const intervalMs = options?.intervalMs ?? DEFAULT_INTERVAL_MS;
   const requestTimeoutMs = options?.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
-  const readinessPath = options?.path ?? "/";
+  const readinessPath = options?.path ?? T3_BACKEND_READINESS_PATH;
   const isReady = options?.isReady ?? ((response: Response) => response.ok);
   const deadline = Date.now() + timeoutMs;
 

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -151,8 +151,9 @@ const buildCmd = Command.make(
           cwd: serverDir,
           stdout: config.verbose ? "inherit" : "ignore",
           stderr: "inherit",
-          // Windows needs shell mode to resolve `.cmd` shims on PATH.
-          shell: process.platform === "win32",
+          // Avoid shell on Windows: `shell: true` routes through cmd.exe, which splits
+          // unquoted paths such as `C:\Program Files\nodejs\node.exe` at the space.
+          shell: false,
         }),
       );
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -124,7 +124,7 @@ import {
   useSavedEnvironmentRegistryStore,
   useSavedEnvironmentRuntimeStore,
 } from "../environments/runtime";
-import { buildDraftThreadRouteParams } from "../threadRoutes";
+import { buildDraftThreadRouteParams, buildThreadRouteParams } from "../threadRoutes";
 import {
   type ComposerImageAttachment,
   type DraftThreadEnvMode,
@@ -325,6 +325,9 @@ type ChatViewProps =
       reserveTitleBarControlInset?: boolean;
       routeKind: "server";
       draftId?: never;
+      /** URL path thread when this pane shows a split secondary thread. */
+      pathThreadRefForRoute?: ScopedThreadRef;
+      onCloseSplitView?: () => void;
     }
   | {
       environmentId: EnvironmentId;
@@ -594,12 +597,18 @@ export default function ChatView(props: ChatViewProps) {
     onDiffPanelOpen,
     reserveTitleBarControlInset = true,
   } = props;
+  const pathThreadRefForRoute = routeKind === "server" ? props.pathThreadRefForRoute : undefined;
+  const onCloseSplitView = routeKind === "server" ? props.onCloseSplitView : undefined;
   const draftId = routeKind === "draft" ? props.draftId : null;
   const routeThreadRef = useMemo(
     () => scopeThreadRef(environmentId, threadId),
     [environmentId, threadId],
   );
   const routeThreadKey = useMemo(() => scopedThreadKey(routeThreadRef), [routeThreadRef]);
+  const urlPathThreadRef = useMemo(
+    () => pathThreadRefForRoute ?? routeThreadRef,
+    [pathThreadRefForRoute, routeThreadRef],
+  );
   const composerDraftTarget: ScopedThreadRef | DraftId =
     routeKind === "server" ? routeThreadRef : props.draftId;
   const serverThread = useStore(
@@ -1453,6 +1462,27 @@ export default function ChatView(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.cwd ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
+  const composerThreadContextLabel = useMemo(() => {
+    if (!activeThread) {
+      return "";
+    }
+    const threadTitle = activeThread.title.trim() || "Untitled thread";
+    if (!activeProject) {
+      return threadTitle;
+    }
+    const named = activeProject.name?.trim();
+    if (named) {
+      return `${named}/${threadTitle}`;
+    }
+    const cwd = activeProject.cwd?.trim();
+    if (!cwd) {
+      return threadTitle;
+    }
+    const normalized = cwd.replace(/[/\\]+$/, "");
+    const sep = Math.max(normalized.lastIndexOf("/"), normalized.lastIndexOf("\\"));
+    const folder = sep === -1 ? normalized : normalized.slice(sep + 1);
+    return folder ? `${folder}/${threadTitle}` : threadTitle;
+  }, [activeProject, activeThread]);
   const activeTerminalLaunchContext =
     terminalLaunchContext?.threadId === activeThreadId
       ? terminalLaunchContext
@@ -1504,19 +1534,31 @@ export default function ChatView(props: ChatViewProps) {
     if (!diffOpen) {
       onDiffPanelOpen?.();
     }
+    const needsDiffThreadOverride =
+      routeThreadRef.environmentId !== urlPathThreadRef.environmentId ||
+      routeThreadRef.threadId !== urlPathThreadRef.threadId;
     void navigate({
       to: "/$environmentId/$threadId",
-      params: {
-        environmentId,
-        threadId,
-      },
+      params: buildThreadRouteParams(urlPathThreadRef),
       replace: true,
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
+        if (diffOpen) {
+          return { ...rest };
+        }
+        return {
+          ...rest,
+          ...(needsDiffThreadOverride
+            ? {
+                diffThreadEnvironmentId: routeThreadRef.environmentId,
+                diffThreadId: routeThreadRef.threadId,
+              }
+            : {}),
+          diff: "1",
+        };
       },
     });
-  }, [diffOpen, environmentId, isServerThread, navigate, onDiffPanelOpen, threadId]);
+  }, [diffOpen, isServerThread, navigate, onDiffPanelOpen, routeThreadRef, urlPathThreadRef]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -3241,21 +3283,42 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
       onDiffPanelOpen?.();
+      const needsDiffThreadOverride =
+        routeThreadRef.environmentId !== urlPathThreadRef.environmentId ||
+        routeThreadRef.threadId !== urlPathThreadRef.threadId;
       void navigate({
         to: "/$environmentId/$threadId",
-        params: {
-          environmentId,
-          threadId,
-        },
+        params: buildThreadRouteParams(urlPathThreadRef),
         search: (previous) => {
           const rest = stripDiffSearchParams(previous);
           return filePath
-            ? { ...rest, diff: "1", diffTurnId: turnId, diffFilePath: filePath }
-            : { ...rest, diff: "1", diffTurnId: turnId };
+            ? {
+                ...rest,
+                ...(needsDiffThreadOverride
+                  ? {
+                      diffThreadEnvironmentId: routeThreadRef.environmentId,
+                      diffThreadId: routeThreadRef.threadId,
+                    }
+                  : {}),
+                diff: "1",
+                diffTurnId: turnId,
+                diffFilePath: filePath,
+              }
+            : {
+                ...rest,
+                ...(needsDiffThreadOverride
+                  ? {
+                      diffThreadEnvironmentId: routeThreadRef.environmentId,
+                      diffThreadId: routeThreadRef.threadId,
+                    }
+                  : {}),
+                diff: "1",
+                diffTurnId: turnId,
+              };
         },
       });
     },
-    [environmentId, isServerThread, navigate, onDiffPanelOpen, threadId],
+    [isServerThread, navigate, onDiffPanelOpen, routeThreadRef, urlPathThreadRef],
   );
   // Both the Map and the revert handler are read from refs at call-time so
   // the callback reference is fully stable and never busts context identity.
@@ -3317,6 +3380,7 @@ export default function ChatView(props: ChatViewProps) {
           onDeleteProjectScript={deleteProjectScript}
           onToggleTerminal={toggleTerminalVisibility}
           onToggleDiff={onToggleDiff}
+          {...(onCloseSplitView ? { onCloseSplitView } : {})}
         />
       </header>
 
@@ -3329,7 +3393,7 @@ export default function ChatView(props: ChatViewProps) {
       {/* Main content area with optional plan sidebar */}
       <div className="flex min-h-0 min-w-0 flex-1">
         {/* Chat column */}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col @container/chat-pane">
           {/* Messages Wrapper */}
           <div className="relative flex min-h-0 flex-1 flex-col">
             {/* Messages — LegendList handles virtualization and scrolling internally */}
@@ -3382,6 +3446,19 @@ export default function ChatView(props: ChatViewProps) {
                 : "pb-[calc(env(safe-area-inset-bottom)+0.75rem)] sm:pb-[calc(env(safe-area-inset-bottom)+1rem)]",
             )}
           >
+            {composerThreadContextLabel ? (
+              <div
+                className={cn(
+                  "min-w-0 pb-1.5 text-xs leading-tight @min-[64rem]/chat-pane:hidden",
+                  "[-webkit-app-region:no-drag]",
+                )}
+                title={composerThreadContextLabel}
+              >
+                <span className="block truncate text-foreground/90">
+                  {composerThreadContextLabel}
+                </span>
+              </div>
+            ) : null}
             <ChatComposer
               ref={composerRef}
               composerDraftTarget={composerDraftTarget}

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -19,6 +19,7 @@ import {
   useRef,
   useState,
 } from "react";
+import type { ScopedThreadRef } from "@t3tools/contracts";
 import { openInPreferredEditor } from "../editorPreferences";
 import { useGitStatus } from "~/lib/gitStatusState";
 import { checkpointDiffQueryOptions } from "~/lib/providerReactQuery";
@@ -177,15 +178,27 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   const previousDiffOpenRef = useRef(false);
   const [canScrollTurnStripLeft, setCanScrollTurnStripLeft] = useState(false);
   const [canScrollTurnStripRight, setCanScrollTurnStripRight] = useState(false);
-  const routeThreadRef = useParams({
+  const pathThreadRef = useParams({
     strict: false,
     select: (params) => resolveThreadRouteRef(params),
   });
   const diffSearch = useSearch({ strict: false, select: (search) => parseDiffRouteSearch(search) });
   const diffOpen = diffSearch.diff === "1";
-  const activeThreadId = routeThreadRef?.threadId ?? null;
+  const diffDisplayThreadRef: ScopedThreadRef | null = useMemo(() => {
+    if (!pathThreadRef) {
+      return null;
+    }
+    if (diffSearch.diff !== "1") {
+      return pathThreadRef;
+    }
+    if (diffSearch.diffThreadEnvironmentId && diffSearch.diffThreadId) {
+      return scopeThreadRef(diffSearch.diffThreadEnvironmentId, diffSearch.diffThreadId);
+    }
+    return pathThreadRef;
+  }, [diffSearch.diff, diffSearch.diffThreadEnvironmentId, diffSearch.diffThreadId, pathThreadRef]);
+  const activeThreadId = diffDisplayThreadRef?.threadId ?? null;
   const activeThread = useStore(
-    useMemo(() => createThreadSelectorByRef(routeThreadRef), [routeThreadRef]),
+    useMemo(() => createThreadSelectorByRef(diffDisplayThreadRef), [diffDisplayThreadRef]),
   );
   const activeProjectId = activeThread?.projectId ?? null;
   const activeProject = useStore((store) =>
@@ -344,24 +357,53 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
   );
 
   const selectTurn = (turnId: TurnId) => {
-    if (!activeThread) return;
+    if (!activeThread || !pathThreadRef) {
+      return;
+    }
+    const needsDiffThreadOverride =
+      activeThread.environmentId !== pathThreadRef.environmentId ||
+      activeThread.id !== pathThreadRef.threadId;
     void navigate({
       to: "/$environmentId/$threadId",
-      params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
+      params: buildThreadRouteParams(pathThreadRef),
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1", diffTurnId: turnId };
+        return {
+          ...rest,
+          ...(needsDiffThreadOverride
+            ? {
+                diffThreadEnvironmentId: activeThread.environmentId,
+                diffThreadId: activeThread.id,
+              }
+            : {}),
+          diff: "1",
+          diffTurnId: turnId,
+        };
       },
     });
   };
   const selectWholeConversation = () => {
-    if (!activeThread) return;
+    if (!activeThread || !pathThreadRef) {
+      return;
+    }
+    const needsDiffThreadOverride =
+      activeThread.environmentId !== pathThreadRef.environmentId ||
+      activeThread.id !== pathThreadRef.threadId;
     void navigate({
       to: "/$environmentId/$threadId",
-      params: buildThreadRouteParams(scopeThreadRef(activeThread.environmentId, activeThread.id)),
+      params: buildThreadRouteParams(pathThreadRef),
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
+        return {
+          ...rest,
+          ...(needsDiffThreadOverride
+            ? {
+                diffThreadEnvironmentId: activeThread.environmentId,
+                diffThreadId: activeThread.id,
+              }
+            : {}),
+          diff: "1",
+        };
       },
     });
   };

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -573,7 +573,7 @@ describe("resolveThreadStatusPill", () => {
 });
 
 describe("resolveThreadRowClassName", () => {
-  it("uses the darker selected palette when a thread is both selected and active", () => {
+  it("uses the primary emphasis palette when a thread is both selected and active", () => {
     const className = resolveThreadRowClassName({ isActive: true, isSelected: true });
     expect(className).toContain("bg-primary/22");
     expect(className).toContain("hover:bg-primary/26");
@@ -581,12 +581,13 @@ describe("resolveThreadRowClassName", () => {
     expect(className).not.toContain("bg-accent/85");
   });
 
-  it("uses selected hover colors for selected threads", () => {
+  it("uses the same primary emphasis for selected threads as for active+selected", () => {
     const className = resolveThreadRowClassName({ isActive: false, isSelected: true });
-    expect(className).toContain("bg-primary/15");
-    expect(className).toContain("hover:bg-primary/19");
-    expect(className).toContain("dark:bg-primary/22");
-    expect(className).not.toContain("hover:bg-accent");
+    expect(className).toContain("bg-primary/22");
+    expect(className).toContain("hover:bg-primary/26");
+    expect(className).toContain("dark:bg-primary/30");
+    expect(className).toContain("font-medium");
+    expect(className).not.toContain("bg-primary/15");
   });
 
   it("keeps the accent palette for active-only threads", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -302,17 +302,10 @@ export function resolveThreadRowClassName(input: {
   const baseClassName =
     "h-7 w-full translate-x-0 cursor-pointer justify-start px-2 text-left select-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring";
 
-  if (input.isSelected && input.isActive) {
-    return cn(
-      baseClassName,
-      "bg-primary/22 text-foreground font-medium hover:bg-primary/26 hover:text-foreground dark:bg-primary/30 dark:hover:bg-primary/36",
-    );
-  }
-
   if (input.isSelected) {
     return cn(
       baseClassName,
-      "bg-primary/15 text-foreground hover:bg-primary/19 hover:text-foreground dark:bg-primary/22 dark:hover:bg-primary/28",
+      "bg-primary/22 text-foreground font-medium hover:bg-primary/26 hover:text-foreground dark:bg-primary/30 dark:hover:bg-primary/36",
     );
   }
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -94,6 +94,7 @@ import {
   resolveThreadRouteRef,
   resolveThreadRouteTarget,
 } from "../threadRoutes";
+import { writeScopedThreadToDataTransfer } from "../threadSplitDnD";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { formatRelativeTimeLabel } from "../timestampFormat";
 import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
@@ -525,6 +526,15 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
     },
     [attemptArchiveThread, threadRef],
   );
+  const handleThreadRowDragStart = useCallback(
+    (event: React.DragEvent) => {
+      if (!event.dataTransfer) {
+        return;
+      }
+      writeScopedThreadToDataTransfer(event.dataTransfer, threadRef);
+    },
+    [threadRef],
+  );
   const rowButtonRender = useMemo(() => <div role="button" tabIndex={0} />, []);
 
   return (
@@ -546,6 +556,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
         onClick={handleRowClick}
         onKeyDown={handleRowKeyDown}
         onContextMenu={handleRowContextMenu}
+        draggable={renamingThreadKey !== threadKey && !isConfirmingArchive}
+        onDragStart={handleThreadRowDragStart}
       >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
           {prStatus && (

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -9,11 +9,12 @@ import { scopeThreadRef } from "@t3tools/client-runtime";
 import { memo } from "react";
 import GitActionsControl from "../GitActionsControl";
 import { type DraftId } from "~/composerDraftStore";
-import { DiffIcon, TerminalSquareIcon } from "lucide-react";
+import { DiffIcon, TerminalSquareIcon, XIcon } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
 import { Toggle } from "../ui/toggle";
+import { Button } from "../ui/button";
 import { SidebarTrigger } from "../ui/sidebar";
 import { OpenInPicker } from "./OpenInPicker";
 import { usePrimaryEnvironmentId } from "../../environments/primary";
@@ -42,6 +43,7 @@ interface ChatHeaderProps {
   onDeleteProjectScript: (scriptId: string) => Promise<void>;
   onToggleTerminal: () => void;
   onToggleDiff: () => void;
+  onCloseSplitView?: () => void;
 }
 
 export const ChatHeader = memo(function ChatHeader({
@@ -68,6 +70,7 @@ export const ChatHeader = memo(function ChatHeader({
   onDeleteProjectScript,
   onToggleTerminal,
   onToggleDiff,
+  onCloseSplitView,
 }: ChatHeaderProps) {
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const isRemoteEnvironment =
@@ -94,7 +97,26 @@ export const ChatHeader = memo(function ChatHeader({
           </Badge>
         )}
       </div>
-      <div className="flex shrink-0 items-center justify-end gap-2 @3xl/header-actions:gap-3">
+      <div className="flex shrink-0 items-center justify-end gap-2 [-webkit-app-region:no-drag] @3xl/header-actions:gap-3">
+        {onCloseSplitView ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-xs"
+                  className="shrink-0"
+                  aria-label="Close split view"
+                  onClick={onCloseSplitView}
+                >
+                  <XIcon className="size-3.5" />
+                </Button>
+              }
+            />
+            <TooltipPopup side="bottom">Close split view</TooltipPopup>
+          </Tooltip>
+        ) : null}
         {activeProjectScripts && (
           <ProjectScriptsControl
             scripts={activeProjectScripts}

--- a/apps/web/src/diffRouteSearch.test.ts
+++ b/apps/web/src/diffRouteSearch.test.ts
@@ -71,4 +71,51 @@ describe("parseDiffRouteSearch", () => {
       diff: "1",
     });
   });
+
+  it("parses split thread params independently of diff", () => {
+    expect(
+      parseDiffRouteSearch({
+        splitEnvironmentId: "env-a",
+        splitThreadId: "thread-b",
+      }),
+    ).toEqual({
+      splitEnvironmentId: "env-a",
+      splitThreadId: "thread-b",
+    });
+  });
+
+  it("ignores split params when only one side is present", () => {
+    expect(
+      parseDiffRouteSearch({
+        splitEnvironmentId: "env-a",
+      }),
+    ).toEqual({});
+
+    expect(
+      parseDiffRouteSearch({
+        splitThreadId: "thread-b",
+      }),
+    ).toEqual({});
+  });
+
+  it("parses diff thread target override only when diff is open", () => {
+    expect(
+      parseDiffRouteSearch({
+        diff: "1",
+        diffThreadEnvironmentId: "env-x",
+        diffThreadId: "thread-y",
+      }),
+    ).toEqual({
+      diff: "1",
+      diffThreadEnvironmentId: "env-x",
+      diffThreadId: "thread-y",
+    });
+
+    expect(
+      parseDiffRouteSearch({
+        diffThreadEnvironmentId: "env-x",
+        diffThreadId: "thread-y",
+      }),
+    ).toEqual({});
+  });
 });

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -1,9 +1,17 @@
-import { TurnId } from "@t3tools/contracts";
+import { type EnvironmentId, type ThreadId, TurnId } from "@t3tools/contracts";
 
 export interface DiffRouteSearch {
   diff?: "1" | undefined;
   diffTurnId?: TurnId | undefined;
   diffFilePath?: string | undefined;
+  /** Secondary thread shown beside the route thread (split view). */
+  splitEnvironmentId?: EnvironmentId | undefined;
+  splitThreadId?: ThreadId | undefined;
+  /**
+   * When the diff panel shows a thread other than the route thread (e.g. split secondary pane).
+   */
+  diffThreadEnvironmentId?: EnvironmentId | undefined;
+  diffThreadId?: ThreadId | undefined;
 }
 
 function isDiffOpenValue(value: unknown): boolean {
@@ -20,9 +28,30 @@ function normalizeSearchString(value: unknown): string | undefined {
 
 export function stripDiffSearchParams<T extends Record<string, unknown>>(
   params: T,
-): Omit<T, "diff" | "diffTurnId" | "diffFilePath"> {
-  const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, ...rest } = params;
-  return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
+): Omit<T, "diff" | "diffTurnId" | "diffFilePath" | "diffThreadEnvironmentId" | "diffThreadId"> {
+  const {
+    diff: _diff,
+    diffTurnId: _diffTurnId,
+    diffFilePath: _diffFilePath,
+    diffThreadEnvironmentId: _diffThreadEnvironmentId,
+    diffThreadId: _diffThreadId,
+    ...rest
+  } = params;
+  return rest as Omit<
+    T,
+    "diff" | "diffTurnId" | "diffFilePath" | "diffThreadEnvironmentId" | "diffThreadId"
+  >;
+}
+
+export function stripSplitThreadSearchParams<T extends Record<string, unknown>>(
+  params: T,
+): Omit<T, "splitEnvironmentId" | "splitThreadId"> {
+  const {
+    splitEnvironmentId: _splitEnvironmentId,
+    splitThreadId: _splitThreadId,
+    ...rest
+  } = params;
+  return rest as Omit<T, "splitEnvironmentId" | "splitThreadId">;
 }
 
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
@@ -31,9 +60,33 @@ export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRoute
   const diffTurnId = diffTurnIdRaw ? TurnId.make(diffTurnIdRaw) : undefined;
   const diffFilePath = diff && diffTurnId ? normalizeSearchString(search.diffFilePath) : undefined;
 
+  const splitEnvironmentIdRaw = normalizeSearchString(search.splitEnvironmentId);
+  const splitThreadIdRaw = normalizeSearchString(search.splitThreadId);
+  const splitPair =
+    splitEnvironmentIdRaw && splitThreadIdRaw
+      ? {
+          splitEnvironmentId: splitEnvironmentIdRaw as EnvironmentId,
+          splitThreadId: splitThreadIdRaw as ThreadId,
+        }
+      : null;
+
+  const diffThreadEnvironmentIdRaw = diff
+    ? normalizeSearchString(search.diffThreadEnvironmentId)
+    : undefined;
+  const diffThreadIdRaw = diff ? normalizeSearchString(search.diffThreadId) : undefined;
+  const diffThreadPair =
+    diff && diffThreadEnvironmentIdRaw && diffThreadIdRaw
+      ? {
+          diffThreadEnvironmentId: diffThreadEnvironmentIdRaw as EnvironmentId,
+          diffThreadId: diffThreadIdRaw as ThreadId,
+        }
+      : null;
+
   return {
     ...(diff ? { diff } : {}),
     ...(diffTurnId ? { diffTurnId } : {}),
     ...(diffFilePath ? { diffFilePath } : {}),
+    ...(splitPair ? splitPair : {}),
+    ...(diffThreadPair ? diffThreadPair : {}),
   };
 }

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -15,14 +15,21 @@ import {
   type DiffRouteSearch,
   parseDiffRouteSearch,
   stripDiffSearchParams,
+  stripSplitThreadSearchParams,
 } from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import { selectEnvironmentState, selectThreadExistsByRef, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
 import { resolveThreadRouteRef, buildThreadRouteParams } from "../threadRoutes";
+import {
+  ChatThreadSplitDropInset,
+  resolveSplitThreadRefFromSearch,
+  ThreadSplitRow,
+  usePersistedChatSplitRatio,
+} from "../threadSplitView";
 import { RightPanelSheet } from "../components/RightPanelSheet";
-import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
+import { Sidebar, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
 
 const DiffPanel = lazy(() => import("../components/DiffPanel"));
 const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
@@ -196,7 +203,7 @@ function ChatThreadRouteView() {
     void navigate({
       to: "/$environmentId/$threadId",
       params: buildThreadRouteParams(threadRef),
-      search: { diff: undefined },
+      search: (previous) => stripDiffSearchParams(previous as Record<string, unknown>),
     });
   }, [navigate, threadRef]);
   const openDiff = useCallback(() => {
@@ -208,11 +215,49 @@ function ChatThreadRouteView() {
       to: "/$environmentId/$threadId",
       params: buildThreadRouteParams(threadRef),
       search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
+        const rest = stripDiffSearchParams(previous as Record<string, unknown>);
         return { ...rest, diff: "1" };
       },
     });
   }, [markDiffOpened, navigate, threadRef]);
+
+  const splitThreadRef = threadRef ? resolveSplitThreadRefFromSearch(threadRef, search) : null;
+  const splitThreadExists = useStore((store) =>
+    splitThreadRef ? selectThreadExistsByRef(store, splitThreadRef) : true,
+  );
+  const [splitLeftRatio, setSplitLeftRatio] = usePersistedChatSplitRatio();
+  const onSplitRatioDelta = useCallback(
+    (deltaFraction: number) => {
+      setSplitLeftRatio(splitLeftRatio + deltaFraction);
+    },
+    [setSplitLeftRatio, splitLeftRatio],
+  );
+  const closeSplitView = useCallback(() => {
+    if (!threadRef) {
+      return;
+    }
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: buildThreadRouteParams(threadRef),
+      search: (previous) => stripSplitThreadSearchParams(previous as Record<string, unknown>),
+      replace: true,
+    });
+  }, [navigate, threadRef]);
+
+  useEffect(() => {
+    if (!threadRef || !bootstrapComplete || !splitThreadRef) {
+      return;
+    }
+    if (splitThreadExists) {
+      return;
+    }
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: buildThreadRouteParams(threadRef),
+      search: (previous) => stripSplitThreadSearchParams(previous as Record<string, unknown>),
+      replace: true,
+    });
+  }, [bootstrapComplete, navigate, splitThreadExists, splitThreadRef, threadRef]);
 
   useEffect(() => {
     if (!threadRef || !bootstrapComplete) {
@@ -237,18 +282,57 @@ function ChatThreadRouteView() {
 
   const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
 
+  const primaryChatView = (options: { reserveTitleBarControlInset: boolean }) => (
+    <ChatView
+      environmentId={threadRef.environmentId}
+      threadId={threadRef.threadId}
+      onDiffPanelOpen={markDiffOpened}
+      reserveTitleBarControlInset={options.reserveTitleBarControlInset}
+      routeKind="server"
+    />
+  );
+
+  const mainColumn = (
+    <ThreadSplitRow
+      leftRatio={splitLeftRatio}
+      onRatioDelta={onSplitRatioDelta}
+      left={
+        <ChatThreadSplitDropInset
+          pathThreadRef={threadRef}
+          splitThreadRef={splitThreadRef}
+          dropRole="primary"
+          navigate={navigate}
+        >
+          {primaryChatView({ reserveTitleBarControlInset: !diffOpen })}
+        </ChatThreadSplitDropInset>
+      }
+      right={
+        splitThreadRef !== null ? (
+          <ChatThreadSplitDropInset
+            pathThreadRef={threadRef}
+            splitThreadRef={splitThreadRef}
+            dropRole="secondary"
+            navigate={navigate}
+          >
+            <ChatView
+              environmentId={splitThreadRef.environmentId}
+              threadId={splitThreadRef.threadId}
+              onDiffPanelOpen={markDiffOpened}
+              reserveTitleBarControlInset={!diffOpen}
+              routeKind="server"
+              pathThreadRefForRoute={threadRef}
+              onCloseSplitView={closeSplitView}
+            />
+          </ChatThreadSplitDropInset>
+        ) : null
+      }
+    />
+  );
+
   if (!shouldUseDiffSheet) {
     return (
       <>
-        <SidebarInset className="h-svh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground md:h-dvh">
-          <ChatView
-            environmentId={threadRef.environmentId}
-            threadId={threadRef.threadId}
-            onDiffPanelOpen={markDiffOpened}
-            reserveTitleBarControlInset={!diffOpen}
-            routeKind="server"
-          />
-        </SidebarInset>
+        {mainColumn}
         <DiffPanelInlineSidebar
           diffOpen={diffOpen}
           onCloseDiff={closeDiff}
@@ -261,14 +345,7 @@ function ChatThreadRouteView() {
 
   return (
     <>
-      <SidebarInset className="h-svh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground md:h-dvh">
-        <ChatView
-          environmentId={threadRef.environmentId}
-          threadId={threadRef.threadId}
-          onDiffPanelOpen={markDiffOpened}
-          routeKind="server"
-        />
-      </SidebarInset>
+      {mainColumn}
       <RightPanelSheet open={diffOpen} onClose={closeDiff}>
         {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
       </RightPanelSheet>
@@ -279,7 +356,17 @@ function ChatThreadRouteView() {
 export const Route = createFileRoute("/_chat/$environmentId/$threadId")({
   validateSearch: (search) => parseDiffRouteSearch(search),
   search: {
-    middlewares: [retainSearchParams<DiffRouteSearch>(["diff"])],
+    middlewares: [
+      retainSearchParams<DiffRouteSearch>([
+        "diff",
+        "diffTurnId",
+        "diffFilePath",
+        // Split params are omitted so navigations can clear them (e.g. close split).
+        // Call sites merge `search: (prev) => ({ ...prev, ... })` when split must persist.
+        "diffThreadEnvironmentId",
+        "diffThreadId",
+      ]),
+    ],
   },
   component: ChatThreadRouteView,
 });

--- a/apps/web/src/threadSplitDnD.test.ts
+++ b/apps/web/src/threadSplitDnD.test.ts
@@ -1,0 +1,54 @@
+import { scopeThreadRef } from "@t3tools/client-runtime";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import {
+  readScopedThreadRefFromDataTransfer,
+  THREAD_SCOPED_DRAG_MIME,
+  writeScopedThreadToDataTransfer,
+} from "./threadSplitDnD";
+
+function mockDataTransfer(map: Record<string, string>): DataTransfer {
+  return {
+    setData(type: string, data: string) {
+      map[type] = data;
+    },
+    getData(type: string) {
+      return map[type] ?? "";
+    },
+  } as DataTransfer;
+}
+
+describe("threadSplitDnD", () => {
+  it("round-trips scoped thread refs through DataTransfer", () => {
+    const store: Record<string, string> = {};
+    const dt = mockDataTransfer(store);
+    const ref = scopeThreadRef(EnvironmentId.make("env-1"), ThreadId.make("thread-1"));
+    writeScopedThreadToDataTransfer(dt, ref);
+    expect(readScopedThreadRefFromDataTransfer(dt)).toEqual(ref);
+  });
+
+  it("reads from the text/plain fallback", () => {
+    const store: Record<string, string> = {
+      "text/plain": JSON.stringify({ environmentId: "env-2", threadId: "thread-2" }),
+    };
+    const dt = mockDataTransfer(store);
+    expect(readScopedThreadRefFromDataTransfer(dt)).toEqual(
+      scopeThreadRef(EnvironmentId.make("env-2"), ThreadId.make("thread-2")),
+    );
+  });
+
+  it("prefers the custom MIME over text/plain", () => {
+    const store: Record<string, string> = {
+      [THREAD_SCOPED_DRAG_MIME]: JSON.stringify({
+        environmentId: "env-a",
+        threadId: "thread-a",
+      }),
+      "text/plain": JSON.stringify({ environmentId: "env-b", threadId: "thread-b" }),
+    };
+    const dt = mockDataTransfer(store);
+    expect(readScopedThreadRefFromDataTransfer(dt)).toEqual(
+      scopeThreadRef(EnvironmentId.make("env-a"), ThreadId.make("thread-a")),
+    );
+  });
+});

--- a/apps/web/src/threadSplitDnD.ts
+++ b/apps/web/src/threadSplitDnD.ts
@@ -1,0 +1,60 @@
+import { scopeThreadRef } from "@t3tools/client-runtime";
+import type { EnvironmentId, ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+
+export const THREAD_SCOPED_DRAG_MIME = "application/x-t3-scoped-thread";
+
+export interface ThreadScopedDragPayload {
+  environmentId: string;
+  threadId: string;
+}
+
+export function writeScopedThreadToDataTransfer(
+  dataTransfer: DataTransfer,
+  threadRef: ScopedThreadRef,
+): void {
+  const payload: ThreadScopedDragPayload = {
+    environmentId: threadRef.environmentId,
+    threadId: threadRef.threadId,
+  };
+  const json = JSON.stringify(payload);
+  dataTransfer.setData(THREAD_SCOPED_DRAG_MIME, json);
+  dataTransfer.setData("text/plain", json);
+  dataTransfer.effectAllowed = "copy";
+}
+
+export function readScopedThreadRefFromDataTransfer(
+  dataTransfer: DataTransfer,
+): ScopedThreadRef | null {
+  const primary = dataTransfer.getData(THREAD_SCOPED_DRAG_MIME).trim();
+  const fallback = dataTransfer.getData("text/plain").trim();
+  const raw = primary.length > 0 ? primary : fallback;
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    const environmentId = (parsed as ThreadScopedDragPayload).environmentId;
+    const threadId = (parsed as ThreadScopedDragPayload).threadId;
+    if (typeof environmentId !== "string" || typeof threadId !== "string") {
+      return null;
+    }
+    if (!environmentId.trim() || !threadId.trim()) {
+      return null;
+    }
+    return scopeThreadRef(environmentId.trim() as EnvironmentId, threadId.trim() as ThreadId);
+  } catch {
+    return null;
+  }
+}
+
+export function dragEventHasScopedThreadPayload(event: {
+  readonly dataTransfer: DataTransfer | null;
+}): boolean {
+  return (
+    event.dataTransfer?.types.includes(THREAD_SCOPED_DRAG_MIME) === true ||
+    event.dataTransfer?.types.includes("text/plain") === true
+  );
+}

--- a/apps/web/src/threadSplitView.test.ts
+++ b/apps/web/src/threadSplitView.test.ts
@@ -1,0 +1,38 @@
+import { scopeThreadRef } from "@t3tools/client-runtime";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import { parseDiffRouteSearch } from "./diffRouteSearch";
+import { resolveSplitThreadRefFromSearch } from "./threadSplitView";
+
+describe("resolveSplitThreadRefFromSearch", () => {
+  it("returns null when split matches path thread", () => {
+    const env = EnvironmentId.make("environment-a");
+    const threadId = ThreadId.make("thread-1");
+    const path = scopeThreadRef(env, threadId);
+    expect(
+      resolveSplitThreadRefFromSearch(
+        path,
+        parseDiffRouteSearch({
+          splitEnvironmentId: env,
+          splitThreadId: threadId,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns secondary ref when split differs from path", () => {
+    const env = EnvironmentId.make("environment-a");
+    const path = scopeThreadRef(env, ThreadId.make("thread-1"));
+    const secondary = scopeThreadRef(env, ThreadId.make("thread-2"));
+    expect(
+      resolveSplitThreadRefFromSearch(
+        path,
+        parseDiffRouteSearch({
+          splitEnvironmentId: secondary.environmentId,
+          splitThreadId: secondary.threadId,
+        }),
+      ),
+    ).toEqual(secondary);
+  });
+});

--- a/apps/web/src/threadSplitView.tsx
+++ b/apps/web/src/threadSplitView.tsx
@@ -1,0 +1,249 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime";
+import type { ScopedThreadRef } from "@t3tools/contracts";
+import { useNavigate } from "@tanstack/react-router";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+
+import { SidebarInset } from "~/components/ui/sidebar";
+import { parseDiffRouteSearch } from "./diffRouteSearch";
+import { buildThreadRouteParams } from "./threadRoutes";
+import {
+  dragEventHasScopedThreadPayload,
+  readScopedThreadRefFromDataTransfer,
+} from "./threadSplitDnD";
+
+const SPLIT_RATIO_STORAGE_KEY = "t3code:chat-thread-split-left-ratio:v1";
+
+function clampSplitRatio(value: number): number {
+  return Math.min(0.72, Math.max(0.28, value));
+}
+
+export function usePersistedChatSplitRatio(): readonly [number, (next: number) => void] {
+  const [leftRatio, setLeftRatioState] = useState(0.5);
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(SPLIT_RATIO_STORAGE_KEY);
+      if (!raw) {
+        return;
+      }
+      const n = Number.parseFloat(raw);
+      if (Number.isFinite(n)) {
+        setLeftRatioState(clampSplitRatio(n));
+      }
+    } catch {
+      // Ignore localStorage failures.
+    }
+  }, []);
+  const setLeftRatio = useCallback((next: number) => {
+    const clamped = clampSplitRatio(next);
+    setLeftRatioState(clamped);
+    try {
+      window.localStorage.setItem(SPLIT_RATIO_STORAGE_KEY, String(clamped));
+    } catch {
+      // Ignore quota failures.
+    }
+  }, []);
+  return [leftRatio, setLeftRatio] as const;
+}
+
+function SplitGutter(props: { onResizeDelta: (deltaX: number, totalWidth: number) => void }) {
+  const gutterRef = useRef<HTMLDivElement>(null);
+  const { onResizeDelta } = props;
+  const onPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const row = gutterRef.current?.parentElement;
+      if (!row) {
+        return;
+      }
+      const totalWidth = row.clientWidth;
+      const startX = event.clientX;
+      const onMove = (moveEvent: PointerEvent) => {
+        onResizeDelta(moveEvent.clientX - startX, totalWidth);
+      };
+      const onUp = () => {
+        window.removeEventListener("pointermove", onMove);
+        window.removeEventListener("pointerup", onUp);
+      };
+      window.addEventListener("pointermove", onMove);
+      window.addEventListener("pointerup", onUp);
+    },
+    [onResizeDelta],
+  );
+  return (
+    <div
+      ref={gutterRef}
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize split panes"
+      className="w-px shrink-0 cursor-col-resize bg-border hover:bg-primary/40"
+      onPointerDown={onPointerDown}
+    />
+  );
+}
+
+export function ThreadSplitRow(props: {
+  leftRatio: number;
+  onRatioDelta: (deltaFraction: number) => void;
+  left: ReactNode;
+  /** When null, only the left pane is shown at full width (no gutter). Keeps the same DOM ancestry as split mode so the primary pane does not remount when toggling split. */
+  right: ReactNode | null;
+}) {
+  const { leftRatio, onRatioDelta, left, right } = props;
+  const split = right !== null;
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-row">
+      <div
+        className="flex min-h-0 min-w-0 flex-col"
+        style={{ flex: split ? `${leftRatio} 1 0%` : "1 1 0%" }}
+      >
+        {left}
+      </div>
+      {split ? (
+        <>
+          <SplitGutter
+            onResizeDelta={(deltaX, totalWidth) => {
+              if (totalWidth <= 0) {
+                return;
+              }
+              onRatioDelta(deltaX / totalWidth);
+            }}
+          />
+          <div className="flex min-h-0 min-w-0 flex-col" style={{ flex: `${1 - leftRatio} 1 0%` }}>
+            {right}
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}
+
+function mergeSearchForSplitUpdate(
+  previous: Record<string, unknown>,
+  splitRef: ScopedThreadRef,
+): Record<string, unknown> {
+  const parsed = parseDiffRouteSearch(previous);
+  const next: Record<string, unknown> = { ...previous };
+  next.splitEnvironmentId = splitRef.environmentId;
+  next.splitThreadId = splitRef.threadId;
+  if (parsed.diff === "1" && (parsed.diffThreadEnvironmentId || parsed.diffThreadId)) {
+    delete next.diffThreadEnvironmentId;
+    delete next.diffThreadId;
+  }
+  return next;
+}
+
+type ThreadRouteNavigate = ReturnType<typeof useNavigate>;
+
+export function ChatThreadSplitDropInset(props: {
+  pathThreadRef: ScopedThreadRef;
+  splitThreadRef: ScopedThreadRef | null;
+  dropRole: "primary" | "secondary";
+  navigate: ThreadRouteNavigate;
+  children: ReactNode;
+}) {
+  const { pathThreadRef, splitThreadRef, dropRole, navigate, children } = props;
+  const dragDepthRef = useRef(0);
+  const [highlight, setHighlight] = useState(false);
+
+  const acceptDrop = useCallback(
+    (dropped: ScopedThreadRef) => {
+      if (scopedThreadKey(dropped) === scopedThreadKey(pathThreadRef)) {
+        return;
+      }
+      if (
+        dropRole === "primary" &&
+        splitThreadRef &&
+        scopedThreadKey(dropped) === scopedThreadKey(splitThreadRef)
+      ) {
+        return;
+      }
+      if (
+        dropRole === "secondary" &&
+        splitThreadRef &&
+        scopedThreadKey(dropped) === scopedThreadKey(splitThreadRef)
+      ) {
+        return;
+      }
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: buildThreadRouteParams(pathThreadRef),
+        search: (previous) =>
+          mergeSearchForSplitUpdate(previous as Record<string, unknown>, dropped),
+      });
+    },
+    [dropRole, navigate, pathThreadRef, splitThreadRef],
+  );
+
+  const onDragEnter = useCallback((event: React.DragEvent) => {
+    if (!dragEventHasScopedThreadPayload(event)) {
+      return;
+    }
+    event.preventDefault();
+    dragDepthRef.current += 1;
+    setHighlight(true);
+  }, []);
+
+  const onDragLeave = useCallback((event: React.DragEvent) => {
+    if (!dragEventHasScopedThreadPayload(event)) {
+      return;
+    }
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) {
+      setHighlight(false);
+    }
+  }, []);
+
+  const onDragOver = useCallback((event: React.DragEvent) => {
+    if (!dragEventHasScopedThreadPayload(event)) {
+      return;
+    }
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  const onDrop = useCallback(
+    (event: React.DragEvent) => {
+      dragDepthRef.current = 0;
+      setHighlight(false);
+      if (!dragEventHasScopedThreadPayload(event)) {
+        return;
+      }
+      event.preventDefault();
+      const dropped = readScopedThreadRefFromDataTransfer(event.dataTransfer);
+      if (!dropped) {
+        return;
+      }
+      acceptDrop(dropped);
+    },
+    [acceptDrop],
+  );
+
+  return (
+    <SidebarInset
+      className={`relative h-svh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground md:h-dvh ${
+        highlight ? "ring-2 ring-inset ring-primary/50" : ""
+      }`}
+      onDragEnter={onDragEnter}
+      onDragLeave={onDragLeave}
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      data-chat-split-drop={dropRole}
+    >
+      {children}
+    </SidebarInset>
+  );
+}
+
+export function resolveSplitThreadRefFromSearch(
+  pathThreadRef: ScopedThreadRef,
+  search: ReturnType<typeof parseDiffRouteSearch>,
+): ScopedThreadRef | null {
+  if (!search.splitEnvironmentId || !search.splitThreadId) {
+    return null;
+  }
+  const splitRef = scopeThreadRef(search.splitEnvironmentId, search.splitThreadId);
+  if (scopedThreadKey(splitRef) === scopedThreadKey(pathThreadRef)) {
+    return null;
+  }
+  return splitRef;
+}


### PR DESCRIPTION
- enable dragging threads into split views
- preserve diff thread context in route search
- tighten sidebar active-state styling and backend readiness checks


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new split-view routing/search-param behavior and diff targeting logic, which could regress navigation state or diff display across threads. Also changes Windows build CLI process spawning behavior, which could affect build execution on that platform.
> 
> **Overview**
> Adds a resizable **chat split view** driven by URL search params (`splitEnvironmentId`/`splitThreadId`), including drag-and-drop from the sidebar to open a secondary thread pane and a header control to close the split.
> 
> Updates diff routing to support split panes by introducing `diffThreadEnvironmentId`/`diffThreadId` overrides, ensuring diff toggles/turn-diff navigation and `DiffPanel` selection target the intended thread while keeping the path thread stable.
> 
> Tightens a few related behaviors: backend readiness checks now probe `/.well-known/t3/environment` by default (avoiding dev redirects), the server build CLI disables `shell` execution on Windows to avoid path-splitting issues, and sidebar selected-row styling is unified to the primary emphasis palette.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 972135f0264b53cf9512bab29ee0283738989714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add split-thread drag-and-drop and diff routing support to chat route
> - Adds a resizable split-pane layout to the chat route: users can drag a thread from the sidebar into either pane to open it side-by-side, with the split ratio persisted in localStorage via [`usePersistedChatSplitRatio`](https://github.com/pingdotgg/t3code/pull/2487/files#diff-20ff4d58c5bfc55c7c51285b07331097f13978d8ede85f155e3fef9cf3b0083d)
> - [`ChatThreadSplitDropInset`](https://github.com/pingdotgg/t3code/pull/2487/files#diff-20ff4d58c5bfc55c7c51285b07331097f13978d8ede85f155e3fef9cf3b0083d) provides visual drag feedback and updates `splitEnvironmentId`/`splitThreadId` URL search params on drop; [`SidebarThreadRow`](https://github.com/pingdotgg/t3code/pull/2487/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) emits a scoped thread payload on drag start
> - Extends `DiffRouteSearch` in [`diffRouteSearch.ts`](https://github.com/pingdotgg/t3code/pull/2487/files#diff-625b76b0ee5e0cd241579df3eec55eaf0d42a2403fe980a4f5dfffa6af912f8f) with `diffThreadEnvironmentId`/`diffThreadId` overrides so the diff panel targets the correct thread in split view
> - [`ChatView`](https://github.com/pingdotgg/t3code/pull/2487/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and [`DiffPanel`](https://github.com/pingdotgg/t3code/pull/2487/files#diff-432b64436ab58eaa9098a7db8382164d4d30470236045f6b3844eef9f8a257f3) are updated to read and write these override params when toggling diffs in split view
> - [`ChatHeader`](https://github.com/pingdotgg/t3code/pull/2487/files#diff-124f699b87245f05f11a8bf7ef3d0b17dbe34657c443a51e23125ce90e0fcf0c) gains an optional close-split button; the route strips split params when the split thread is absent or the view is closed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 972135f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->