### PR TITLE
feat(web): keyboard navigation between user messages in chat

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -54,6 +54,8 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 - `commandPalette.toggle`: open or close the global command palette
 - `chat.new`: create a new chat thread preserving the active thread's branch/worktree state
 - `chat.newLocal`: create a new chat thread for the active project in a new environment (local/worktree determined by app settings (default `local`))
+- `chat.previousUserMessage`: scroll to the previous user message in the active chat
+- `chat.nextUserMessage`: scroll to the next user message in the active chat
 - `editor.openFavorite`: open current project/worktree in the last-used editor
 - `script.{id}.run`: run a project script by id (for example `script.test.run`)
 

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -71,6 +71,8 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "alt+[", command: "chat.previousUserMessage", when: "!terminalFocus" },
+  { key: "alt+]", command: "chat.nextUserMessage", when: "!terminalFocus" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -101,7 +101,11 @@ import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import { BranchToolbar } from "./BranchToolbar";
-import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
+import {
+  chatUserMessageDirectionFromCommand,
+  resolveShortcutCommand,
+  shortcutLabelForCommand,
+} from "../keybindings";
 import PlanSidebar from "./PlanSidebar";
 import ThreadTerminalDrawer from "./ThreadTerminalDrawer";
 import { ChevronDownIcon } from "lucide-react";
@@ -141,7 +145,7 @@ import { selectThreadTerminalState, useTerminalStateStore } from "../terminalSta
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
-import { MessagesTimeline } from "./chat/MessagesTimeline";
+import { MessagesTimeline, type MessagesTimelineHandle } from "./chat/MessagesTimeline";
 import { ChatHeader } from "./chat/ChatHeader";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
@@ -710,6 +714,7 @@ export default function ChatView(props: ChatViewProps) {
     LastInvokedScriptByProjectSchema,
   );
   const legendListRef = useRef<LegendListRef | null>(null);
+  const messagesTimelineHandleRef = useRef<MessagesTimelineHandle | null>(null);
   const isAtEndRef = useRef(true);
   const attachmentPreviewHandoffByMessageIdRef = useRef<Record<string, string[]>>({});
   const attachmentPreviewPromotionInFlightByMessageIdRef = useRef<Record<string, true>>({});
@@ -2323,6 +2328,16 @@ export default function ChatView(props: ChatViewProps) {
         return;
       }
 
+      const chatUserMessageDirection = chatUserMessageDirectionFromCommand(command);
+      if (chatUserMessageDirection !== null) {
+        event.preventDefault();
+        event.stopPropagation();
+        messagesTimelineHandleRef.current?.scrollToAdjacentUserMessage(
+          chatUserMessageDirection,
+        );
+        return;
+      }
+
       const scriptId = projectScriptIdFromCommand(command);
       if (!scriptId || !activeProject) return;
       const script = activeProject.scripts.find((entry) => entry.id === scriptId);
@@ -3340,6 +3355,7 @@ export default function ChatView(props: ChatViewProps) {
               activeTurnId={activeLatestTurn?.turnId ?? null}
               activeTurnStartedAt={activeWorkStartedAt}
               listRef={legendListRef}
+              handleRef={messagesTimelineHandleRef}
               timelineEntries={timelineEntries}
               completionDividerBeforeEntryId={completionDividerBeforeEntryId}
               completionSummary={completionSummary}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -500,7 +500,7 @@ describe("resolveNavigationAnchorIndex", () => {
     userRow("u6"),
   ];
 
-  it("returns the pending index first so chained presses keep advancing during scroll animation", () => {
+  it("honors a pending index that is still inside the visible range", () => {
     expect(
       resolveNavigationAnchorIndex({
         rows,
@@ -509,6 +509,20 @@ describe("resolveNavigationAnchorIndex", () => {
         direction: "previous",
       }),
     ).toBe(4);
+  });
+
+  it("ignores a stale pending index outside the visible range and re-derives from the viewport", () => {
+    // Manual scroll moved the viewport away from the previously navigated row.
+    // The visible range only contains user messages at 2 and 4, so PREV picks
+    // the topmost (2) instead of the stale pending=0 from a prior keybind.
+    expect(
+      resolveNavigationAnchorIndex({
+        rows,
+        state: { start: 1, end: 5, scrollLength: 600 },
+        pendingIndex: 0,
+        direction: "previous",
+      }),
+    ).toBe(2);
   });
 
   it("picks the topmost user msg for previous and bottommost for next within the visible range", () => {
@@ -522,8 +536,7 @@ describe("resolveNavigationAnchorIndex", () => {
     ).toBe(4);
   });
 
-  it("falls back to a direction-specific sentinel when no usable visible user message exists", () => {
-    // State unmeasured (mount race) → sentinel covers fresh-mount fallback.
+  it("uses the rows.length sentinel when state is unmeasured (mount race)", () => {
     expect(
       resolveNavigationAnchorIndex({
         rows,
@@ -532,14 +545,18 @@ describe("resolveNavigationAnchorIndex", () => {
         direction: "previous",
       }),
     ).toBe(rows.length);
-    // Visible range covers only assistants → same fallback.
+  });
+
+  it("walks outward from the viewport when the visible range has no user messages", () => {
+    // Visible range covers only assistant a3. PREV should look ABOVE the
+    // viewport (anchor = rangeStart=3 → walk back to find u2). NEXT should
+    // look BELOW (anchor = rangeEnd=3 → walk forward to find u4).
+    const state = { start: 3, end: 3, scrollLength: 600 };
     expect(
-      resolveNavigationAnchorIndex({
-        rows,
-        state: { start: 3, end: 3, scrollLength: 600 },
-        pendingIndex: null,
-        direction: "next",
-      }),
-    ).toBe(-1);
+      resolveNavigationAnchorIndex({ rows, state, pendingIndex: null, direction: "previous" }),
+    ).toBe(3);
+    expect(
+      resolveNavigationAnchorIndex({ rows, state, pendingIndex: null, direction: "next" }),
+    ).toBe(3);
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -3,9 +3,13 @@ import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
+  findUserMessageRowIndex,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  resolveNavigationAnchorIndex,
+  type MessagesTimelineRow,
 } from "./MessagesTimeline.logic";
+import { MessageId } from "@t3tools/contracts";
 
 describe("computeMessageDurationStart", () => {
   it("returns message createdAt when there is no preceding user message", () => {
@@ -431,5 +435,111 @@ describe("computeStableMessagesTimelineRows", () => {
 
     expect(reordered).not.toBe(initial);
     expect(reordered.result).toEqual([initial.result[1], initial.result[0]]);
+  });
+});
+
+function userRow(id: string): MessagesTimelineRow {
+  return {
+    kind: "message",
+    id,
+    createdAt: "2026-01-01T00:00:00Z",
+    message: {
+      id: MessageId.make(id),
+      role: "user",
+      text: id,
+      turnId: null,
+      createdAt: "2026-01-01T00:00:00Z",
+      streaming: false,
+    },
+    durationStart: "2026-01-01T00:00:00Z",
+    showCompletionDivider: false,
+    showAssistantCopyButton: false,
+  };
+}
+
+function gap(id: string): MessagesTimelineRow {
+  return { kind: "working", id, createdAt: null };
+}
+
+describe("findUserMessageRowIndex", () => {
+  // u0  g1  u2  g3  u4
+  const sample: MessagesTimelineRow[] = [
+    userRow("u0"),
+    gap("g1"),
+    userRow("u2"),
+    gap("g3"),
+    userRow("u4"),
+  ];
+
+  it("walks past the anchor to the adjacent user message in either direction", () => {
+    // Forward: skips non-user rows, returns first user past anchor.
+    expect(findUserMessageRowIndex(sample, 0, "next")).toBe(2);
+    expect(findUserMessageRowIndex(sample, 2, "next")).toBe(4);
+    // Backward: symmetric.
+    expect(findUserMessageRowIndex(sample, 4, "previous")).toBe(2);
+    expect(findUserMessageRowIndex(sample, 2, "previous")).toBe(0);
+  });
+
+  it("returns null when nothing is left in the requested direction", () => {
+    expect(findUserMessageRowIndex(sample, 4, "next")).toBeNull();
+    expect(findUserMessageRowIndex(sample, 0, "previous")).toBeNull();
+    expect(findUserMessageRowIndex([], 0, "next")).toBeNull();
+    expect(findUserMessageRowIndex([gap("g0")], 0, "previous")).toBeNull();
+  });
+});
+
+describe("resolveNavigationAnchorIndex", () => {
+  // u0  g1  u2  g3  u4  g5  u6
+  const rows: MessagesTimelineRow[] = [
+    userRow("u0"),
+    gap("g1"),
+    userRow("u2"),
+    gap("g3"),
+    userRow("u4"),
+    gap("g5"),
+    userRow("u6"),
+  ];
+
+  it("returns the pending index first so chained presses keep advancing during scroll animation", () => {
+    expect(
+      resolveNavigationAnchorIndex({
+        rows,
+        state: { start: 1, end: 5, scrollLength: 600 },
+        pendingIndex: 4,
+        direction: "previous",
+      }),
+    ).toBe(4);
+  });
+
+  it("picks the topmost user msg for previous and bottommost for next within the visible range", () => {
+    // Visible rows 1..5 → user messages at 2 and 4.
+    const state = { start: 1, end: 5, scrollLength: 600 };
+    expect(
+      resolveNavigationAnchorIndex({ rows, state, pendingIndex: null, direction: "previous" }),
+    ).toBe(2);
+    expect(
+      resolveNavigationAnchorIndex({ rows, state, pendingIndex: null, direction: "next" }),
+    ).toBe(4);
+  });
+
+  it("falls back to a direction-specific sentinel when no usable visible user message exists", () => {
+    // State unmeasured (mount race) → sentinel covers fresh-mount fallback.
+    expect(
+      resolveNavigationAnchorIndex({
+        rows,
+        state: { start: 0, end: 6, scrollLength: 0 },
+        pendingIndex: null,
+        direction: "previous",
+      }),
+    ).toBe(rows.length);
+    // Visible range covers only assistants → same fallback.
+    expect(
+      resolveNavigationAnchorIndex({
+        rows,
+        state: { start: 3, end: 3, scrollLength: 600 },
+        pendingIndex: null,
+        direction: "next",
+      }),
+    ).toBe(-1);
   });
 });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -244,13 +244,18 @@ export function resolveNavigationAnchorIndex({
   pendingIndex: number | null;
   direction: UserMessageRowDirection;
 }): number {
-  if (pendingIndex !== null) return pendingIndex;
   if (!state || state.scrollLength === 0) {
+    if (pendingIndex !== null) return pendingIndex;
     return direction === "previous" ? rows.length : -1;
   }
 
   const rangeStart = Math.max(0, state.start);
   const rangeEnd = Math.min(rows.length - 1, state.end);
+
+  if (pendingIndex !== null && pendingIndex >= rangeStart && pendingIndex <= rangeEnd) {
+    return pendingIndex;
+  }
+
   const visible = (row: MessagesTimelineRow, i: number) =>
     i >= rangeStart &&
     i <= rangeEnd &&
@@ -259,7 +264,8 @@ export function resolveNavigationAnchorIndex({
 
   const found = direction === "previous" ? rows.findIndex(visible) : rows.findLastIndex(visible);
   if (found !== -1) return found;
-  return direction === "previous" ? rows.length : -1;
+
+  return direction === "previous" ? rangeStart : rangeEnd;
 }
 
 /** Shallow field comparison per row variant — avoids deep equality cost. */

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -211,6 +211,57 @@ export function computeStableMessagesTimelineRows(
   return anyChanged ? { byId: next, result } : previous;
 }
 
+export type UserMessageRowDirection = "previous" | "next";
+
+export function findUserMessageRowIndex(
+  rows: ReadonlyArray<MessagesTimelineRow>,
+  anchorIndex: number,
+  direction: UserMessageRowDirection,
+): number | null {
+  const matches = (row: MessagesTimelineRow, i: number) =>
+    (direction === "next" ? i > anchorIndex : i < anchorIndex) &&
+    row.kind === "message" &&
+    row.message.role === "user";
+
+  const target = direction === "next" ? rows.findIndex(matches) : rows.findLastIndex(matches);
+  return target === -1 ? null : target;
+}
+
+export interface LegendListVisibleRangeState {
+  start: number;
+  end: number;
+  scrollLength: number;
+}
+
+export function resolveNavigationAnchorIndex({
+  rows,
+  state,
+  pendingIndex,
+  direction,
+}: {
+  rows: ReadonlyArray<MessagesTimelineRow>;
+  state: LegendListVisibleRangeState | null;
+  pendingIndex: number | null;
+  direction: UserMessageRowDirection;
+}): number {
+  if (pendingIndex !== null) return pendingIndex;
+  if (!state || state.scrollLength === 0) {
+    return direction === "previous" ? rows.length : -1;
+  }
+
+  const rangeStart = Math.max(0, state.start);
+  const rangeEnd = Math.min(rows.length - 1, state.end);
+  const visible = (row: MessagesTimelineRow, i: number) =>
+    i >= rangeStart &&
+    i <= rangeEnd &&
+    row.kind === "message" &&
+    row.message.role === "user";
+
+  const found = direction === "previous" ? rows.findIndex(visible) : rows.findLastIndex(visible);
+  if (found !== -1) return found;
+  return direction === "previous" ? rows.length : -1;
+}
+
 /** Shallow field comparison per row variant — avoids deep equality cost. */
 function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean {
   if (a.kind !== b.kind || a.id !== b.id) return false;

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -5,6 +5,7 @@ import {
   use,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -39,10 +40,13 @@ import {
   computeStableMessagesTimelineRows,
   MAX_VISIBLE_WORK_LOG_ENTRIES,
   deriveMessagesTimelineRows,
+  findUserMessageRowIndex,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
+  resolveNavigationAnchorIndex,
   type StableMessagesTimelineRowsState,
   type MessagesTimelineRow,
+  type UserMessageRowDirection,
 } from "./MessagesTimeline.logic";
 import { TerminalContextInlineChip } from "./TerminalContextInlineChip";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -92,12 +96,17 @@ const TimelineRowCtx = createContext<TimelineRowSharedState>(null!);
 // Props (public API)
 // ---------------------------------------------------------------------------
 
+export interface MessagesTimelineHandle {
+  scrollToAdjacentUserMessage(direction: UserMessageRowDirection): void;
+}
+
 interface MessagesTimelineProps {
   isWorking: boolean;
   activeTurnInProgress: boolean;
   activeTurnId?: TurnId | null;
   activeTurnStartedAt: string | null;
   listRef: React.RefObject<LegendListRef | null>;
+  handleRef?: React.RefObject<MessagesTimelineHandle | null>;
   timelineEntries: ReturnType<typeof deriveTimelineEntries>;
   completionDividerBeforeEntryId: string | null;
   completionSummary: string | null;
@@ -126,6 +135,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   activeTurnId,
   activeTurnStartedAt,
   listRef,
+  handleRef,
   timelineEntries,
   completionDividerBeforeEntryId,
   completionSummary,
@@ -163,6 +173,43 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     ],
   );
   const rows = useStableRows(rawRows);
+
+  const pendingNavigationIndexRef = useRef<number | null>(null);
+
+  useImperativeHandle(
+    handleRef,
+    () => ({
+      scrollToAdjacentUserMessage(direction) {
+        const list = listRef.current;
+        if (!list) return;
+
+        const anchorRowIndex = resolveNavigationAnchorIndex({
+          rows,
+          state: list.getState?.() ?? null,
+          pendingIndex: pendingNavigationIndexRef.current,
+          direction,
+        });
+        const targetRowIndex = findUserMessageRowIndex(rows, anchorRowIndex, direction);
+        if (targetRowIndex === null) return;
+
+        pendingNavigationIndexRef.current = targetRowIndex;
+
+        const isFirstUserMessage =
+          findUserMessageRowIndex(rows, targetRowIndex, "previous") === null;
+
+        if (isFirstUserMessage) {
+          void list.scrollToOffset?.({ offset: 0, animated: false });
+        } else {
+          void list.scrollToIndex?.({
+            index: targetRowIndex,
+            animated: false,
+            viewPosition: 0.5,
+          });
+        }
+      },
+    }),
+    [handleRef, listRef, rows],
+  );
 
   const handleScroll = useCallback(() => {
     const state = listRef.current?.getState?.();

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -203,7 +203,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
           void list.scrollToIndex?.({
             index: targetRowIndex,
             animated: false,
-            viewPosition: 0.5,
+            viewPosition: 0,
           });
         }
       },

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -274,6 +274,14 @@ export function threadTraversalDirectionFromCommand(
   return null;
 }
 
+export function chatUserMessageDirectionFromCommand(
+  command: string | null,
+): "previous" | "next" | null {
+  if (command === "chat.previousUserMessage") return "previous";
+  if (command === "chat.nextUserMessage") return "next";
+  return null;
+}
+
 export function shouldShowThreadJumpHints(
   event: ShortcutEventLike,
   keybindings: ResolvedKeybindingsConfig,

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -56,6 +56,8 @@ const STATIC_KEYBINDING_COMMANDS = [
   "commandPalette.toggle",
   "chat.new",
   "chat.newLocal",
+  "chat.previousUserMessage",
+  "chat.nextUserMessage",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,


### PR DESCRIPTION
## What Changed

- Two new keybinding commands: `chat.previousUserMessage` and `chat.nextUserMessage`
- Default bindings: `alt+[` (previous), `alt+]` (next), scoped to `!terminalFocus` (because thread keybinding is `cmd + alt + [ or ]` wanted to make them similar
- Scrolls the chat timeline by jumping between user messages; the first user message lands at absolute scroll 0 so the list header stays visible
- Documented in `KEYBINDINGS.md` available-commands list

## Why

When reviewing a long thread it is useful to scan back through the questions you asked without manually scrolling the entire transcript. Mirrors the existing `thread.previous` / `thread.next` pattern but operates within a thread instead of across threads. Implementation reuses LegendList's documented `getState()` visible-range API and `scrollToIndex` / `scrollToOffset` — no DOM walking, no wrapper components, no new dependencies.

## UI Changes

No visual changes. Interaction is keyboard-driven scroll.


https://github.com/user-attachments/assets/8e7e845a-f22d-4f8b-9302-2a164a66b788


## Checklist

- [x] This PR is small and focused (~240 line diff, 8 files including tests + docs)
- [x] I explained what changed and why
- [x] No visual changes — N/A for screenshots
- [x] Recording showing alt+[ / alt+] navigation

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keyboard navigation between user messages in chat with Alt+[ and Alt+]
> - Binds `alt+[` and `alt+]` to `chat.previousUserMessage` and `chat.nextUserMessage` in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/2488/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e), active when the terminal is not focused.
> - Adds an imperative `MessagesTimelineHandle` with `scrollToAdjacentUserMessage(direction)` to [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/2488/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588), exposed via `useImperativeHandle`.
> - Navigation anchors to the current viewport using `resolveNavigationAnchorIndex`, then finds the adjacent user message row with `findUserMessageRowIndex`, storing a pending index for chained keypresses.
> - [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2488/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) wires the global keydown handler to translate command strings into a direction and invoke the timeline handle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f6c767.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new keybinding commands and client-side scroll logic without affecting auth, persistence, or server behavior beyond default keybinding config.
> 
> **Overview**
> Adds two new keybinding commands, `chat.previousUserMessage` and `chat.nextUserMessage`, with default bindings `alt+[` / `alt+]` (disabled when `terminalFocus`).
> 
> Implements in-thread keyboard navigation by exposing a `MessagesTimeline` imperative handle (`scrollToAdjacentUserMessage`) and invoking it from `ChatView`; navigation uses LegendList visible-range state plus a pending anchor to jump between *user* messages, scrolling the first user message to absolute offset 0.
> 
> Updates keybinding contracts/docs and adds unit tests for the new navigation helper logic (`findUserMessageRowIndex`, `resolveNavigationAnchorIndex`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6c7673b6792f05ef0f3679be308c6fec883b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->