### PR TITLE
Fix repeated effect-language-service prepare hooks during bun install

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -19,7 +19,6 @@
     "build": "node scripts/cli.ts build",
     "build:bundle": "tsdown",
     "start": "node dist/bin.mjs",
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:process-reaper": "vitest run src/server.test.ts src/provider/Layers/ClaudeAdapter.test.ts src/provider/Layers/ProviderSessionDirectory.test.ts src/provider/Layers/ProviderSessionReaper.test.ts src/provider/Layers/CodexAdapter.test.ts"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "prepare": "effect-language-service patch",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,12 @@
     "": {
       "name": "@t3tools/monorepo",
       "devDependencies": {
+        "@effect/language-service": "catalog:",
         "@types/node": "catalog:",
         "oxfmt": "^0.40.0",
         "oxlint": "^1.55.0",
         "turbo": "^2.3.3",
+        "typescript": "catalog:",
         "vitest": "catalog:",
       },
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "type": "module",
   "scripts": {
+    "prepare": "effect-language-service patch",
     "dev": "node scripts/dev-runner.ts dev",
     "dev:server": "node scripts/dev-runner.ts dev:server",
     "dev:web": "node scripts/dev-runner.ts dev:web",
@@ -58,10 +59,12 @@
     "sync:vscode-icons": "node scripts/sync-vscode-icons.mjs"
   },
   "devDependencies": {
+    "@effect/language-service": "catalog:",
     "@types/node": "catalog:",
     "oxfmt": "^0.40.0",
     "oxlint": "^1.55.0",
     "turbo": "^2.3.3",
+    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "overrides": {

--- a/packages/client-runtime/package.json
+++ b/packages/client-runtime/package.json
@@ -10,7 +10,6 @@
     }
   },
   "scripts": {
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,7 +24,6 @@
   "scripts": {
     "dev": "tsdown src/index.ts --format esm,cjs --dts --watch --clean",
     "build": "tsdown src/index.ts --format esm,cjs --dts --clean",
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/effect-acp/package.json
+++ b/packages/effect-acp/package.json
@@ -35,7 +35,6 @@
   "scripts": {
     "dev": "tsdown src/client.ts src/agent.ts src/_generated/schema.gen.ts src/rpc.ts src/protocol.ts src/terminal.ts --format esm,cjs --dts --watch --clean",
     "build": "tsdown src/client.ts src/agent.ts src/_generated/schema.gen.ts src/rpc.ts src/protocol.ts src/terminal.ts --format esm,cjs --dts --clean",
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "generate": "bun run scripts/generate.ts"

--- a/packages/effect-codex-app-server/package.json
+++ b/packages/effect-codex-app-server/package.json
@@ -27,7 +27,6 @@
   "scripts": {
     "dev": "tsdown src/client.ts src/rpc.ts src/protocol.ts src/schema.ts --format esm,cjs --dts --watch --clean",
     "build": "tsdown src/client.ts src/rpc.ts src/protocol.ts src/schema.ts --format esm,cjs --dts --clean",
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "generate": "bun run scripts/generate.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -82,7 +82,6 @@
     }
   },
   "scripts": {
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/ssh/package.json
+++ b/packages/ssh/package.json
@@ -26,7 +26,6 @@
     }
   },
   "scripts": {
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/packages/tailscale/package.json
+++ b/packages/tailscale/package.json
@@ -10,7 +10,6 @@
     }
   },
   "scripts": {
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "prepare": "effect-language-service patch",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },

--- a/scripts/release-smoke.ts
+++ b/scripts/release-smoke.ts
@@ -197,6 +197,8 @@ try {
     },
   );
 
+  rmSync(resolve(tempRoot, "bun.lock"), { force: true });
+
   execFileSync("bun", ["install", "--ignore-scripts"], {
     cwd: tempRoot,
     stdio: "inherit",


### PR DESCRIPTION
## Summary
- move `effect-language-service patch` to the monorepo root `prepare` script
- remove duplicated workspace-level `prepare` hooks that were patching the same shared TypeScript install
- add root `devDependencies` for `@effect/language-service` and `typescript` so the root prepare step can run correctly

I had issues with my macbook dead locking because the prepare script was so aggressive. This solution fixed the issue, it's also recommended by the Effect team.

## Validation
- `bun install` completes instead of stalling on repeated workspace prepare hooks
- `bun fmt`
- `bun lint` (warnings only, no errors)
- `bun typecheck`
- `./node_modules/.bin/effect-language-service check` reports the shared root TypeScript install is patched


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that affects install-time scripts and lockfile generation; main risk is unexpected `bun install`/CI behavior if the root `prepare` step or dependencies are misconfigured.
> 
> **Overview**
> Consolidates `effect-language-service patch` into a single root-level `prepare` script, removing the duplicated per-workspace `prepare` hooks so `bun install` doesn’t repeatedly patch TypeScript across packages.
> 
> Adds root `devDependencies` entries for `@effect/language-service` and `typescript` (and updates `bun.lock` accordingly), and adjusts `scripts/release-smoke.ts` to delete `bun.lock` before reinstalling to force lockfile regeneration during the smoke test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df62da62f81ec0a3611d7599837252fc7c8a28c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate `effect-language-service patch` prepare hook to the monorepo root
> - Removes the `prepare` script running `effect-language-service patch` from all workspace packages (apps, packages, scripts) and moves it to the root [package.json](https://github.com/pingdotgg/t3code/pull/2497/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), so it runs once per `bun install` instead of repeatedly for each workspace.
> - Adds `@effect/language-service` and `typescript` as catalog entries in the root package.json to centralize version management.
> - Deletes the `bun.lock` file before running `bun install --ignore-scripts` in the release smoke test to force lockfile regeneration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2df62da.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->