### PR TITLE
Fix mobile composer focus race on expand

### DIFF
--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -30,7 +30,6 @@ import {
   useRef,
   useState,
 } from "react";
-import { flushSync } from "react-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
@@ -141,13 +140,6 @@ const runtimeModeConfig: Record<
 const runtimeModeOptions = Object.keys(runtimeModeConfig) as RuntimeMode[];
 const COMPOSER_PATH_QUERY_DEBOUNCE_MS = 120;
 const EMPTY_PROJECT_ENTRIES: ProjectEntry[] = [];
-const COMPOSER_FLOATING_LAYER_SELECTOR = [
-  '[data-slot="popover-popup"]',
-  '[data-slot="menu-popup"]',
-  '[data-slot="select-popup"]',
-  '[data-slot="combobox-popup"]',
-  '[data-slot="autocomplete-popup"]',
-].join(",");
 
 const extendReplacementRangeForTrailingSpace = (
   text: string,
@@ -176,10 +168,6 @@ const terminalContextIdListsEqual = (
   ids: ReadonlyArray<string>,
 ): boolean =>
   contexts.length === ids.length && contexts.every((context, index) => context.id === ids[index]);
-
-function isInsideComposerFloatingLayer(element: Element): boolean {
-  return element.closest(COMPOSER_FLOATING_LAYER_SELECTOR) !== null;
-}
 
 const ComposerFooterModeControls = memo(function ComposerFooterModeControls(props: {
   showInteractionModeToggle: boolean;
@@ -797,9 +785,13 @@ export const ChatComposer = memo(
     const [isComposerFooterCompact, setIsComposerFooterCompact] = useState(false);
     const [isComposerPrimaryActionsCompact, setIsComposerPrimaryActionsCompact] = useState(false);
     const [isComposerModelPickerOpen, setIsComposerModelPickerOpen] = useState(false);
-    const [isComposerFocused, setIsComposerFocused] = useState(false);
     const isMobileViewport = useMediaQuery("max-sm");
-    const isComposerCollapsedMobile = isMobileViewport && !isComposerFocused;
+    const mobileCollapsedOnlyClassName =
+      "sm:hidden max-sm:group-focus-within/composer:hidden max-sm:group-data-[mobile-focus-primed=true]/composer:hidden";
+    const mobileExpandedOnlyClassName =
+      "max-sm:hidden max-sm:group-focus-within/composer:block max-sm:group-data-[mobile-focus-primed=true]/composer:block";
+    const mobileExpandedFlexOnlyClassName =
+      "max-sm:hidden max-sm:group-focus-within/composer:flex max-sm:group-data-[mobile-focus-primed=true]/composer:flex";
 
     // ------------------------------------------------------------------
     // Refs
@@ -812,10 +804,7 @@ export const ChatComposer = memo(
     const composerMenuOpenRef = useRef(false);
     const composerMenuItemsRef = useRef<ComposerCommandItem[]>([]);
     const activeComposerMenuItemRef = useRef<ComposerCommandItem | null>(null);
-    const composerBlurFrameRef = useRef<number | null>(null);
-    const mobileComposerExpandFrameRef = useRef<number | null>(null);
-    const mobileComposerExpandReleaseFrameRef = useRef<number | null>(null);
-    const mobileComposerExpandInFlightRef = useRef(false);
+    const mobileComposerPrimeReleaseFrameRef = useRef<number | null>(null);
     const dragDepthRef = useRef(0);
 
     // ------------------------------------------------------------------
@@ -960,8 +949,7 @@ export const ChatComposer = memo(
       isComposerApprovalState ||
       pendingUserInputs.length > 0 ||
       (showPlanFollowUpPrompt && activeProposedPlan !== null);
-    const showCollapsedMobilePromptRow =
-      isComposerCollapsedMobile && !isComposerApprovalState && pendingUserInputs.length === 0;
+    const showCollapsedMobilePromptRow = !isComposerApprovalState && pendingUserInputs.length === 0;
 
     const composerFooterHasWideActions = showPlanFollowUpPrompt || activePendingProgress !== null;
     const showPlanSidebarToggle = Boolean(activePlan || sidebarProposedPlan || planSidebarOpen);
@@ -1057,8 +1045,7 @@ export const ChatComposer = memo(
     const collapsedComposerPrimaryActionDisabled =
       phase === "running" || isSendBusy || isConnecting || !composerSendState.hasSendableContent;
     const collapsedComposerPrimaryActionLabel = "Send message";
-    const showMobilePendingAnswerActions =
-      isMobileViewport && !isComposerCollapsedMobile && pendingPrimaryAction !== null;
+    const showMobilePendingAnswerActions = isMobileViewport && pendingPrimaryAction !== null;
 
     // ------------------------------------------------------------------
     // Prompt helpers
@@ -1590,15 +1577,15 @@ export const ChatComposer = memo(
 
     const blurMobileComposerAfterSend = useCallback(() => {
       if (!isMobileViewport) return;
-      if (composerBlurFrameRef.current !== null) {
-        window.cancelAnimationFrame(composerBlurFrameRef.current);
-        composerBlurFrameRef.current = null;
+      if (mobileComposerPrimeReleaseFrameRef.current !== null) {
+        window.cancelAnimationFrame(mobileComposerPrimeReleaseFrameRef.current);
+        mobileComposerPrimeReleaseFrameRef.current = null;
       }
+      composerSurfaceRef.current?.setAttribute("data-mobile-focus-primed", "false");
       const activeElement = document.activeElement;
       if (activeElement instanceof HTMLElement) {
         activeElement.blur();
       }
-      setIsComposerFocused(false);
     }, [isMobileViewport]);
 
     const shouldBlurMobileComposerOnSubmit = useCallback(() => {
@@ -1630,39 +1617,22 @@ export const ChatComposer = memo(
     );
     const expandMobileComposer = useCallback(() => {
       expandMobileComposerForKeyboard({
-        cancelPendingBlur: () => {
-          if (composerBlurFrameRef.current !== null) {
-            window.cancelAnimationFrame(composerBlurFrameRef.current);
-            composerBlurFrameRef.current = null;
-          }
-        },
-        cancelPendingExpandFocus: () => {
-          if (mobileComposerExpandFrameRef.current !== null) {
-            window.cancelAnimationFrame(mobileComposerExpandFrameRef.current);
-            mobileComposerExpandFrameRef.current = null;
-          }
-        },
         cancelPendingRelease: () => {
-          if (mobileComposerExpandReleaseFrameRef.current !== null) {
-            window.cancelAnimationFrame(mobileComposerExpandReleaseFrameRef.current);
-            mobileComposerExpandReleaseFrameRef.current = null;
+          if (mobileComposerPrimeReleaseFrameRef.current !== null) {
+            window.cancelAnimationFrame(mobileComposerPrimeReleaseFrameRef.current);
+            mobileComposerPrimeReleaseFrameRef.current = null;
           }
         },
-        setExpandInFlight: (inFlight) => {
-          mobileComposerExpandInFlightRef.current = inFlight;
-        },
-        commitExpandedState: () => {
-          flushSync(() => {
-            setIsComposerFocused(true);
-          });
+        primeExpandedState: () => {
+          composerSurfaceRef.current?.setAttribute("data-mobile-focus-primed", "true");
         },
         focusEditorAtEnd: () => {
           composerEditorRef.current?.focusAtEnd();
         },
         scheduleRelease: () => {
-          mobileComposerExpandReleaseFrameRef.current = window.requestAnimationFrame(() => {
-            mobileComposerExpandReleaseFrameRef.current = null;
-            mobileComposerExpandInFlightRef.current = false;
+          mobileComposerPrimeReleaseFrameRef.current = window.requestAnimationFrame(() => {
+            mobileComposerPrimeReleaseFrameRef.current = null;
+            composerSurfaceRef.current?.setAttribute("data-mobile-focus-primed", "false");
           });
         },
       });
@@ -1808,47 +1778,10 @@ export const ChatComposer = memo(
     const handleImplementPlanInNewThreadPrimaryAction = useCallback(() => {
       void onImplementPlanInNewThread();
     }, [onImplementPlanInNewThread]);
-    const scheduleComposerCollapseCheck = useCallback(() => {
-      if (!isMobileViewport) {
-        return;
-      }
-      if (mobileComposerExpandInFlightRef.current) {
-        return;
-      }
-      if (composerBlurFrameRef.current !== null) {
-        window.cancelAnimationFrame(composerBlurFrameRef.current);
-      }
-      composerBlurFrameRef.current = window.requestAnimationFrame(() => {
-        composerBlurFrameRef.current = null;
-        if (mobileComposerExpandInFlightRef.current) {
-          return;
-        }
-        const composerSurface = composerSurfaceRef.current;
-        const activeElement = document.activeElement;
-        if (activeElement instanceof Element && isInsideComposerFloatingLayer(activeElement)) {
-          return;
-        }
-        if (
-          composerSurface &&
-          activeElement instanceof Node &&
-          composerSurface.contains(activeElement)
-        ) {
-          return;
-        }
-        setIsComposerFocused(false);
-      });
-    }, [isMobileViewport]);
-
     useEffect(() => {
       return () => {
-        if (composerBlurFrameRef.current !== null) {
-          window.cancelAnimationFrame(composerBlurFrameRef.current);
-        }
-        if (mobileComposerExpandFrameRef.current !== null) {
-          window.cancelAnimationFrame(mobileComposerExpandFrameRef.current);
-        }
-        if (mobileComposerExpandReleaseFrameRef.current !== null) {
-          window.cancelAnimationFrame(mobileComposerExpandReleaseFrameRef.current);
+        if (mobileComposerPrimeReleaseFrameRef.current !== null) {
+          window.cancelAnimationFrame(mobileComposerPrimeReleaseFrameRef.current);
         }
       };
     }, []);
@@ -1981,63 +1914,62 @@ export const ChatComposer = memo(
         >
           <div
             ref={composerSurfaceRef}
-            data-chat-composer-mobile-collapsed={isComposerCollapsedMobile ? "true" : "false"}
+            data-mobile-focus-primed="false"
             className={cn(
-              "rounded-[20px] border bg-card transition-colors duration-200 has-focus-visible:border-ring/45",
+              "group/composer rounded-[20px] border bg-card transition-colors duration-200 has-focus-visible:border-ring/45",
               isDragOverComposer ? "border-primary/70 bg-accent/30" : "border-border",
               environmentUnavailable ? "opacity-75" : null,
               composerProviderState.composerSurfaceClassName,
             )}
-            onFocusCapture={(event) => {
-              const activeElement = event.target;
-              if (
-                isComposerCollapsedMobile &&
-                activeElement instanceof HTMLElement &&
-                activeElement.closest('[data-chat-composer-collapsed-controls="true"]')
-              ) {
-                return;
-              }
-              if (composerBlurFrameRef.current !== null) {
-                window.cancelAnimationFrame(composerBlurFrameRef.current);
-                composerBlurFrameRef.current = null;
-              }
-              setIsComposerFocused(true);
-            }}
-            onBlurCapture={() => {
-              scheduleComposerCollapseCheck();
-            }}
           >
-            {!isComposerCollapsedMobile &&
-              (activePendingApproval ? (
-                <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
-                  <ComposerPendingApprovalPanel
-                    approval={activePendingApproval}
-                    pendingCount={pendingApprovals.length}
-                  />
-                </div>
-              ) : pendingUserInputs.length > 0 ? (
-                <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
-                  <ComposerPendingUserInputPanel
-                    pendingUserInputs={pendingUserInputs}
-                    respondingRequestIds={respondingRequestIds}
-                    answers={activePendingDraftAnswers}
-                    questionIndex={activePendingQuestionIndex}
-                    onToggleOption={onSelectActivePendingUserInputOption}
-                    onAdvance={onAdvanceActivePendingUserInput}
-                  />
-                </div>
-              ) : showPlanFollowUpPrompt && activeProposedPlan ? (
-                <div className="rounded-t-[19px] border-b border-border/65 bg-muted/20">
-                  <ComposerPlanFollowUpBanner
-                    key={activeProposedPlan.id}
-                    planTitle={proposedPlanTitle(activeProposedPlan.planMarkdown) ?? null}
-                  />
-                </div>
-              ) : null)}
-
-            {isComposerCollapsedMobile && activePendingApproval ? (
+            {activePendingApproval ? (
               <div
-                className="rounded-t-[19px] border-b border-border/65 bg-muted/20"
+                className={cn(
+                  "rounded-t-[19px] border-b border-border/65 bg-muted/20",
+                  mobileExpandedOnlyClassName,
+                )}
+              >
+                <ComposerPendingApprovalPanel
+                  approval={activePendingApproval}
+                  pendingCount={pendingApprovals.length}
+                />
+              </div>
+            ) : pendingUserInputs.length > 0 ? (
+              <div
+                className={cn(
+                  "rounded-t-[19px] border-b border-border/65 bg-muted/20",
+                  mobileExpandedOnlyClassName,
+                )}
+              >
+                <ComposerPendingUserInputPanel
+                  pendingUserInputs={pendingUserInputs}
+                  respondingRequestIds={respondingRequestIds}
+                  answers={activePendingDraftAnswers}
+                  questionIndex={activePendingQuestionIndex}
+                  onToggleOption={onSelectActivePendingUserInputOption}
+                  onAdvance={onAdvanceActivePendingUserInput}
+                />
+              </div>
+            ) : showPlanFollowUpPrompt && activeProposedPlan ? (
+              <div
+                className={cn(
+                  "rounded-t-[19px] border-b border-border/65 bg-muted/20",
+                  mobileExpandedOnlyClassName,
+                )}
+              >
+                <ComposerPlanFollowUpBanner
+                  key={activeProposedPlan.id}
+                  planTitle={proposedPlanTitle(activeProposedPlan.planMarkdown) ?? null}
+                />
+              </div>
+            ) : null}
+
+            {activePendingApproval ? (
+              <div
+                className={cn(
+                  "rounded-t-[19px] border-b border-border/65 bg-muted/20",
+                  mobileCollapsedOnlyClassName,
+                )}
                 data-chat-composer-collapsed-controls="true"
               >
                 <ComposerPendingApprovalPanel
@@ -2052,9 +1984,12 @@ export const ChatComposer = memo(
                   />
                 </div>
               </div>
-            ) : isComposerCollapsedMobile && pendingUserInputs.length > 0 ? (
+            ) : pendingUserInputs.length > 0 ? (
               <div
-                className="rounded-t-[19px] border-b border-border/65 bg-muted/20"
+                className={cn(
+                  "rounded-t-[19px] border-b border-border/65 bg-muted/20",
+                  mobileCollapsedOnlyClassName,
+                )}
                 data-chat-composer-collapsed-controls="true"
               >
                 <ComposerPendingUserInputPanel
@@ -2115,7 +2050,12 @@ export const ChatComposer = memo(
             ) : null}
 
             {showCollapsedMobilePromptRow ? (
-              <div className="flex items-center justify-between gap-2 px-3 py-2">
+              <div
+                className={cn(
+                  "flex items-center justify-between gap-2 px-3 py-2",
+                  mobileCollapsedOnlyClassName,
+                )}
+              >
                 <button
                   type="button"
                   className={cn(
@@ -2164,7 +2104,7 @@ export const ChatComposer = memo(
               className={cn(
                 "relative px-3 pb-2 sm:px-4",
                 hasComposerHeader ? "pt-2.5 sm:pt-3" : "pt-3.5 sm:pt-4",
-                isComposerCollapsedMobile && "hidden",
+                mobileExpandedOnlyClassName,
               )}
             >
               {composerMenuOpen && !isComposerApprovalState && (
@@ -2186,73 +2126,72 @@ export const ChatComposer = memo(
                 </div>
               )}
 
-              {!isComposerCollapsedMobile &&
-                !isComposerApprovalState &&
-                pendingUserInputs.length === 0 &&
-                composerImages.length > 0 && (
-                  <div className="mb-3 flex flex-wrap gap-2">
-                    {composerImages.map((image) => (
-                      <div
-                        key={image.id}
-                        className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
-                      >
-                        {image.previewUrl ? (
-                          <button
-                            type="button"
-                            className="h-full w-full cursor-zoom-in"
-                            aria-label={`Preview ${image.name}`}
-                            onClick={() => {
-                              const preview = buildExpandedImagePreview(composerImages, image.id);
-                              if (!preview) return;
-                              onExpandImage(preview);
-                            }}
-                          >
-                            <img
-                              src={image.previewUrl}
-                              alt={image.name}
-                              className="h-full w-full object-cover"
-                            />
-                          </button>
-                        ) : (
-                          <div className="flex h-full w-full items-center justify-center px-1 text-center text-[10px] text-muted-foreground/70">
-                            {image.name}
-                          </div>
-                        )}
-                        {nonPersistedComposerImageIdSet.has(image.id) && (
-                          <Tooltip>
-                            <TooltipTrigger
-                              render={
-                                <span
-                                  role="img"
-                                  aria-label="Draft attachment may not persist"
-                                  className="absolute left-1 top-1 inline-flex items-center justify-center rounded bg-background/85 p-0.5 text-amber-600"
-                                >
-                                  <CircleAlertIcon className="size-3" />
-                                </span>
-                              }
-                            />
-                            <TooltipPopup
-                              side="top"
-                              className="max-w-64 whitespace-normal leading-tight"
-                            >
-                              Draft attachment could not be saved locally and may be lost on
-                              navigation.
-                            </TooltipPopup>
-                          </Tooltip>
-                        )}
-                        <Button
-                          variant="ghost"
-                          size="icon-xs"
-                          className="absolute right-1 top-1 bg-background/80 hover:bg-background/90"
-                          onClick={() => removeComposerImage(image.id)}
-                          aria-label={`Remove ${image.name}`}
+              {!isComposerApprovalState &&
+              pendingUserInputs.length === 0 &&
+              composerImages.length > 0 ? (
+                <div className="mb-3 flex flex-wrap gap-2">
+                  {composerImages.map((image) => (
+                    <div
+                      key={image.id}
+                      className="relative h-16 w-16 overflow-hidden rounded-lg border border-border/80 bg-background"
+                    >
+                      {image.previewUrl ? (
+                        <button
+                          type="button"
+                          className="h-full w-full cursor-zoom-in"
+                          aria-label={`Preview ${image.name}`}
+                          onClick={() => {
+                            const preview = buildExpandedImagePreview(composerImages, image.id);
+                            if (!preview) return;
+                            onExpandImage(preview);
+                          }}
                         >
-                          <XIcon />
-                        </Button>
-                      </div>
-                    ))}
-                  </div>
-                )}
+                          <img
+                            src={image.previewUrl}
+                            alt={image.name}
+                            className="h-full w-full object-cover"
+                          />
+                        </button>
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center px-1 text-center text-[10px] text-muted-foreground/70">
+                          {image.name}
+                        </div>
+                      )}
+                      {nonPersistedComposerImageIdSet.has(image.id) && (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <span
+                                role="img"
+                                aria-label="Draft attachment may not persist"
+                                className="absolute left-1 top-1 inline-flex items-center justify-center rounded bg-background/85 p-0.5 text-amber-600"
+                              >
+                                <CircleAlertIcon className="size-3" />
+                              </span>
+                            }
+                          />
+                          <TooltipPopup
+                            side="top"
+                            className="max-w-64 whitespace-normal leading-tight"
+                          >
+                            Draft attachment could not be saved locally and may be lost on
+                            navigation.
+                          </TooltipPopup>
+                        </Tooltip>
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        className="absolute right-1 top-1 bg-background/80 hover:bg-background/90"
+                        onClick={() => removeComposerImage(image.id)}
+                        aria-label={`Remove ${image.name}`}
+                      >
+                        <XIcon />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
 
               <div className="relative">
                 <ComposerPromptEditor
@@ -2327,8 +2266,13 @@ export const ChatComposer = memo(
             </div>
 
             {/* Bottom toolbar */}
-            {isComposerCollapsedMobile ? null : activePendingApproval ? (
-              <div className="flex items-center justify-end gap-2 px-2.5 pb-2.5 sm:px-3 sm:pb-3">
+            {activePendingApproval ? (
+              <div
+                className={cn(
+                  "flex items-center justify-end gap-2 px-2.5 pb-2.5 sm:px-3 sm:pb-3",
+                  mobileExpandedFlexOnlyClassName,
+                )}
+              >
                 <ComposerPendingApprovalActions
                   requestId={activePendingApproval.requestId}
                   isResponding={respondingRequestIds.includes(activePendingApproval.requestId)}
@@ -2342,7 +2286,9 @@ export const ChatComposer = memo(
                 className={cn(
                   "flex min-w-0 flex-nowrap items-center justify-between gap-2 overflow-visible px-2.5 pb-2.5 sm:px-3 sm:pb-3",
                   isComposerFooterCompact ? "gap-1.5" : "gap-2 sm:gap-0",
-                  showMobilePendingAnswerActions && "hidden sm:flex",
+                  showMobilePendingAnswerActions
+                    ? "max-sm:hidden"
+                    : mobileExpandedFlexOnlyClassName,
                 )}
               >
                 <div className="-m-1 flex min-w-0 flex-1 items-center gap-1 overflow-x-auto p-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -30,6 +30,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { flushSync } from "react-dom";
 import { useQuery } from "@tanstack/react-query";
 import { useDebouncedValue } from "@tanstack/react-pacer";
 import { projectSearchEntriesQueryOptions } from "~/lib/projectReactQuery";
@@ -71,6 +72,7 @@ import { ComposerPendingUserInputPanel } from "./ComposerPendingUserInputPanel";
 import { ComposerPlanFollowUpBanner } from "./ComposerPlanFollowUpBanner";
 import { resolveComposerMenuActiveItemId } from "./composerMenuHighlight";
 import { searchSlashCommandItems } from "./composerSlashCommandSearch";
+import { expandMobileComposerForKeyboard } from "./mobileComposerFocus";
 import {
   getComposerProviderState,
   renderProviderTraitsMenuContent,
@@ -1627,25 +1629,42 @@ export const ChatComposer = memo(
       [blurMobileComposerAfterSend, onSend, shouldBlurMobileComposerOnSubmit],
     );
     const expandMobileComposer = useCallback(() => {
-      if (composerBlurFrameRef.current !== null) {
-        window.cancelAnimationFrame(composerBlurFrameRef.current);
-        composerBlurFrameRef.current = null;
-      }
-      if (mobileComposerExpandFrameRef.current !== null) {
-        window.cancelAnimationFrame(mobileComposerExpandFrameRef.current);
-      }
-      if (mobileComposerExpandReleaseFrameRef.current !== null) {
-        window.cancelAnimationFrame(mobileComposerExpandReleaseFrameRef.current);
-      }
-      mobileComposerExpandInFlightRef.current = true;
-      setIsComposerFocused(true);
-      mobileComposerExpandFrameRef.current = window.requestAnimationFrame(() => {
-        mobileComposerExpandFrameRef.current = null;
-        composerEditorRef.current?.focusAtEnd();
-        mobileComposerExpandReleaseFrameRef.current = window.requestAnimationFrame(() => {
-          mobileComposerExpandReleaseFrameRef.current = null;
-          mobileComposerExpandInFlightRef.current = false;
-        });
+      expandMobileComposerForKeyboard({
+        cancelPendingBlur: () => {
+          if (composerBlurFrameRef.current !== null) {
+            window.cancelAnimationFrame(composerBlurFrameRef.current);
+            composerBlurFrameRef.current = null;
+          }
+        },
+        cancelPendingExpandFocus: () => {
+          if (mobileComposerExpandFrameRef.current !== null) {
+            window.cancelAnimationFrame(mobileComposerExpandFrameRef.current);
+            mobileComposerExpandFrameRef.current = null;
+          }
+        },
+        cancelPendingRelease: () => {
+          if (mobileComposerExpandReleaseFrameRef.current !== null) {
+            window.cancelAnimationFrame(mobileComposerExpandReleaseFrameRef.current);
+            mobileComposerExpandReleaseFrameRef.current = null;
+          }
+        },
+        setExpandInFlight: (inFlight) => {
+          mobileComposerExpandInFlightRef.current = inFlight;
+        },
+        commitExpandedState: () => {
+          flushSync(() => {
+            setIsComposerFocused(true);
+          });
+        },
+        focusEditorAtEnd: () => {
+          composerEditorRef.current?.focusAtEnd();
+        },
+        scheduleRelease: () => {
+          mobileComposerExpandReleaseFrameRef.current = window.requestAnimationFrame(() => {
+            mobileComposerExpandReleaseFrameRef.current = null;
+            mobileComposerExpandInFlightRef.current = false;
+          });
+        },
       });
     }, []);
 
@@ -2063,7 +2082,10 @@ export const ChatComposer = memo(
                           : "text-muted-foreground/60",
                         !activePendingProgress?.activeQuestion?.multiSelect && "px-3 py-2",
                       )}
-                      onPointerDown={(event) => event.preventDefault()}
+                      onPointerDown={(event) => {
+                        event.preventDefault();
+                        expandMobileComposer();
+                      }}
                       onClick={expandMobileComposer}
                       aria-label="Write custom answer"
                     >
@@ -2102,7 +2124,10 @@ export const ChatComposer = memo(
                       ? "text-foreground"
                       : "text-muted-foreground/35",
                   )}
-                  onPointerDown={(event) => event.preventDefault()}
+                  onPointerDown={(event) => {
+                    event.preventDefault();
+                    expandMobileComposer();
+                  }}
                   onClick={expandMobileComposer}
                   aria-label="Expand composer"
                 >

--- a/apps/web/src/components/chat/mobileComposerFocus.test.ts
+++ b/apps/web/src/components/chat/mobileComposerFocus.test.ts
@@ -6,23 +6,12 @@ describe("expandMobileComposerForKeyboard", () => {
     const calls: string[] = [];
 
     expandMobileComposerForKeyboard({
-      cancelPendingBlur: vi.fn(() => calls.push("cancel-blur")),
-      cancelPendingExpandFocus: vi.fn(() => calls.push("cancel-expand-focus")),
       cancelPendingRelease: vi.fn(() => calls.push("cancel-release")),
-      setExpandInFlight: vi.fn((inFlight) => calls.push(`in-flight:${inFlight}`)),
-      commitExpandedState: vi.fn(() => calls.push("commit-expanded")),
+      primeExpandedState: vi.fn(() => calls.push("prime-expanded")),
       focusEditorAtEnd: vi.fn(() => calls.push("focus")),
       scheduleRelease: vi.fn(() => calls.push("schedule-release")),
     });
 
-    expect(calls).toEqual([
-      "cancel-blur",
-      "cancel-expand-focus",
-      "cancel-release",
-      "in-flight:true",
-      "commit-expanded",
-      "focus",
-      "schedule-release",
-    ]);
+    expect(calls).toEqual(["cancel-release", "prime-expanded", "focus", "schedule-release"]);
   });
 });

--- a/apps/web/src/components/chat/mobileComposerFocus.test.ts
+++ b/apps/web/src/components/chat/mobileComposerFocus.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { expandMobileComposerForKeyboard } from "./mobileComposerFocus";
+
+describe("expandMobileComposerForKeyboard", () => {
+  it("focuses after the expanded composer is committed and before release is scheduled", () => {
+    const calls: string[] = [];
+
+    expandMobileComposerForKeyboard({
+      cancelPendingBlur: vi.fn(() => calls.push("cancel-blur")),
+      cancelPendingExpandFocus: vi.fn(() => calls.push("cancel-expand-focus")),
+      cancelPendingRelease: vi.fn(() => calls.push("cancel-release")),
+      setExpandInFlight: vi.fn((inFlight) => calls.push(`in-flight:${inFlight}`)),
+      commitExpandedState: vi.fn(() => calls.push("commit-expanded")),
+      focusEditorAtEnd: vi.fn(() => calls.push("focus")),
+      scheduleRelease: vi.fn(() => calls.push("schedule-release")),
+    });
+
+    expect(calls).toEqual([
+      "cancel-blur",
+      "cancel-expand-focus",
+      "cancel-release",
+      "in-flight:true",
+      "commit-expanded",
+      "focus",
+      "schedule-release",
+    ]);
+  });
+});

--- a/apps/web/src/components/chat/mobileComposerFocus.ts
+++ b/apps/web/src/components/chat/mobileComposerFocus.ts
@@ -1,19 +1,13 @@
 export interface MobileComposerExpandOptions {
-  cancelPendingBlur: () => void;
-  cancelPendingExpandFocus: () => void;
   cancelPendingRelease: () => void;
-  setExpandInFlight: (inFlight: boolean) => void;
-  commitExpandedState: () => void;
+  primeExpandedState: () => void;
   focusEditorAtEnd: () => void;
   scheduleRelease: () => void;
 }
 
 export function expandMobileComposerForKeyboard(options: MobileComposerExpandOptions) {
-  options.cancelPendingBlur();
-  options.cancelPendingExpandFocus();
   options.cancelPendingRelease();
-  options.setExpandInFlight(true);
-  options.commitExpandedState();
+  options.primeExpandedState();
   options.focusEditorAtEnd();
   options.scheduleRelease();
 }

--- a/apps/web/src/components/chat/mobileComposerFocus.ts
+++ b/apps/web/src/components/chat/mobileComposerFocus.ts
@@ -1,0 +1,19 @@
+export interface MobileComposerExpandOptions {
+  cancelPendingBlur: () => void;
+  cancelPendingExpandFocus: () => void;
+  cancelPendingRelease: () => void;
+  setExpandInFlight: (inFlight: boolean) => void;
+  commitExpandedState: () => void;
+  focusEditorAtEnd: () => void;
+  scheduleRelease: () => void;
+}
+
+export function expandMobileComposerForKeyboard(options: MobileComposerExpandOptions) {
+  options.cancelPendingBlur();
+  options.cancelPendingExpandFocus();
+  options.cancelPendingRelease();
+  options.setExpandInFlight(true);
+  options.commitExpandedState();
+  options.focusEditorAtEnd();
+  options.scheduleRelease();
+}


### PR DESCRIPTION
## Summary
- Extracted the mobile composer expansion sequence into a dedicated helper to make the focus flow deterministic.
- Switched the expansion path to `flushSync` so the focused state commits before the editor is focused.
- Cancelled any pending blur, expand-focus, and release frames before re-expanding, and triggered expansion on pointer down as well as click to avoid mobile tap races.
- Added a unit test covering the exact call order for the mobile composer expansion sequence.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: rewires mobile expand/collapse behavior from React focus state to CSS/data attributes and changes event timing (`pointerdown` + RAF), which could regress mobile-only composer visibility/focus edge cases.
> 
> **Overview**
> Fixes a mobile chat composer expand/focus race by removing the `isComposerFocused` state + blur/expand RAF bookkeeping and instead driving collapsed/expanded UI purely via CSS `group-focus-within` plus a temporary `data-mobile-focus-primed` attribute.
> 
> Extracts the expansion sequence into `expandMobileComposerForKeyboard` and triggers expansion on `pointerdown` (not just click) for collapsed prompt/custom-answer interactions; adds a small unit test asserting the helper’s call order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 699caa754c00115c9a1aacd04ce6fb0bd08e29d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile composer focus race on expand by replacing state with CSS and a primed data attribute
> - Removes React state (`isComposerFocused`) and multiple animation frame refs used to manage mobile composer expand/collapse, eliminating the race condition they caused.
> - Collapsed/expanded visibility is now controlled by CSS `group focus-within` and a `data-mobile-focus-primed` attribute on the composer surface, set in [`ChatComposer.tsx`](https://github.com/pingdotgg/t3code/pull/2499/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a).
> - Extracts the expansion sequence into [`mobileComposerFocus.ts`](https://github.com/pingdotgg/t3code/pull/2499/files#diff-e041d0d121fdc3e3402d45f381a3c0e91b043a79baf4be354b43daeb45d7cb1b): cancel pending release → prime expanded state → focus editor → schedule release.
> - Tapping the collapsed prompt row or custom answer field now primes expansion on `pointerDown` before the click fires.
> - Behavioral Change: `onFocusCapture`/`onBlurCapture` handlers are removed; expand/collapse is no longer driven by focus events on the composer surface.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 699caa7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->