### PR TITLE
bitubicket base brnach

### DIFF
--- a/apps/server/src/sourceControl/BitbucketApi.test.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.test.ts
@@ -287,7 +287,18 @@ it.effect("expands all-state pull request listing instead of relying on Bitbucke
 
 it.effect("reads repository clone URLs and default branch", () => {
   const { layer } = makeLayer({
-    response: () => Response.json(repositoryJson),
+    response: (request) =>
+      Response.json(
+        request.url.endsWith("/branching-model")
+          ? {
+              development: {
+                branch: { name: "main" },
+                name: "main",
+                use_mainbranch: true,
+              },
+            }
+          : repositoryJson,
+      ),
   });
 
   return Effect.gen(function* () {
@@ -306,6 +317,86 @@ it.effect("reads repository clone URLs and default branch", () => {
     assert.strictEqual(defaultBranch, "main");
   }).pipe(Effect.provide(layer));
 });
+
+it.effect(
+  "prefers the Bitbucket branching model development branch as the default PR target",
+  () => {
+    const { execute, layer } = makeLayer({
+      response: (request) =>
+        Response.json(
+          request.url.endsWith("/branching-model")
+            ? {
+                development: {
+                  branch: { name: "develop" },
+                  name: "develop",
+                  use_mainbranch: false,
+                },
+              }
+            : repositoryJson,
+        ),
+    });
+
+    return Effect.gen(function* () {
+      const bitbucket = yield* BitbucketApi.BitbucketApi;
+      const defaultBranch = yield* bitbucket.getDefaultBranch({ cwd: "/repo" });
+
+      assert.strictEqual(defaultBranch, "develop");
+      assert.deepStrictEqual(
+        execute.mock.calls.map((call) => call[0].url).toSorted(),
+        [
+          "https://api.test.local/2.0/repositories/pingdotgg/t3code",
+          "https://api.test.local/2.0/repositories/pingdotgg/t3code/branching-model",
+        ].toSorted(),
+      );
+    }).pipe(Effect.provide(layer));
+  },
+);
+
+it.effect(
+  "falls back to the repository main branch when the Bitbucket development branch is invalid",
+  () => {
+    const { layer } = makeLayer({
+      response: (request) =>
+        Response.json(
+          request.url.endsWith("/branching-model")
+            ? {
+                development: {
+                  name: "develop",
+                  use_mainbranch: false,
+                  is_valid: false,
+                },
+              }
+            : repositoryJson,
+        ),
+    });
+
+    return Effect.gen(function* () {
+      const bitbucket = yield* BitbucketApi.BitbucketApi;
+      const defaultBranch = yield* bitbucket.getDefaultBranch({ cwd: "/repo" });
+
+      assert.strictEqual(defaultBranch, "main");
+    }).pipe(Effect.provide(layer));
+  },
+);
+
+it.effect(
+  "falls back to the repository main branch when the Bitbucket branching model is unavailable",
+  () => {
+    const { layer } = makeLayer({
+      response: (request) =>
+        request.url.endsWith("/branching-model")
+          ? Response.json({ error: { message: "Not found" } }, { status: 404 })
+          : Response.json(repositoryJson),
+    });
+
+    return Effect.gen(function* () {
+      const bitbucket = yield* BitbucketApi.BitbucketApi;
+      const defaultBranch = yield* bitbucket.getDefaultBranch({ cwd: "/repo" });
+
+      assert.strictEqual(defaultBranch, "main");
+    }).pipe(Effect.provide(layer));
+  },
+);
 
 it.effect("creates repositories through the Bitbucket REST API", () => {
   const { execute, layer } = makeLayer({

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -65,6 +65,23 @@ const RawBitbucketRepositorySchema = Schema.Struct({
   ),
 });
 
+const RawBitbucketBranchingModelSchema = Schema.Struct({
+  development: Schema.optional(
+    Schema.Struct({
+      branch: Schema.optional(
+        Schema.NullOr(
+          Schema.Struct({
+            name: Schema.optional(TrimmedNonEmptyString),
+          }),
+        ),
+      ),
+      is_valid: Schema.optional(Schema.Boolean),
+      name: Schema.optional(Schema.NullOr(Schema.String)),
+      use_mainbranch: Schema.optional(Schema.Boolean),
+    }),
+  ),
+});
+
 const BitbucketUserSchema = Schema.Struct({
   username: Schema.optional(TrimmedNonEmptyString),
   display_name: Schema.optional(TrimmedNonEmptyString),
@@ -228,6 +245,24 @@ function normalizeRepositoryCloneUrls(
     url: httpClone ?? raw.links.html?.href ?? raw.full_name,
     sshUrl: sshClone ?? httpClone ?? raw.full_name,
   };
+}
+
+function defaultChangeRequestTargetBranch(input: {
+  readonly repository: Schema.Schema.Type<typeof RawBitbucketRepositorySchema>;
+  readonly branchingModel: Schema.Schema.Type<typeof RawBitbucketBranchingModelSchema> | null;
+}): string | null {
+  const repositoryMainBranch = input.repository.mainbranch?.name ?? null;
+  const development = input.branchingModel?.development;
+  if (!development || development.use_mainbranch === true || development.is_valid === false) {
+    return repositoryMainBranch;
+  }
+
+  const developmentBranch = development.branch?.name?.trim() ?? development.name?.trim() ?? "";
+  if (developmentBranch.length === 0 || developmentBranch === "null") {
+    return repositoryMainBranch;
+  }
+
+  return developmentBranch;
 }
 
 function shouldPreferSshRemote(originRemoteUrl: string | null): boolean {
@@ -430,23 +465,32 @@ export const make = Effect.fn("makeBitbucketApi")(function* () {
     });
   });
 
+  const getRepositoryFromLocator = (repository: BitbucketRepositoryLocator) =>
+    executeJson(
+      "getRepository",
+      HttpClientRequest.get(
+        apiUrl(
+          `/repositories/${encodeURIComponent(repository.workspace)}/${encodeURIComponent(repository.repoSlug)}`,
+        ),
+      ),
+      RawBitbucketRepositorySchema,
+    );
+
   const getRepository = (input: {
     readonly cwd: string;
     readonly context?: SourceControlProvider.SourceControlProviderContext;
     readonly repository?: string;
-  }) =>
-    resolveRepository(input).pipe(
-      Effect.flatMap((repository) =>
-        executeJson(
-          "getRepository",
-          HttpClientRequest.get(
-            apiUrl(
-              `/repositories/${encodeURIComponent(repository.workspace)}/${encodeURIComponent(repository.repoSlug)}`,
-            ),
-          ),
-          RawBitbucketRepositorySchema,
+  }) => resolveRepository(input).pipe(Effect.flatMap(getRepositoryFromLocator));
+
+  const getBranchingModelFromLocator = (repository: BitbucketRepositoryLocator) =>
+    executeJson(
+      "getBranchingModel",
+      HttpClientRequest.get(
+        apiUrl(
+          `/repositories/${encodeURIComponent(repository.workspace)}/${encodeURIComponent(repository.repoSlug)}/branching-model`,
         ),
       ),
+      RawBitbucketBranchingModelSchema,
     );
 
   const getRawPullRequestFromRepository = (
@@ -628,7 +672,21 @@ export const make = Effect.fn("makeBitbucketApi")(function* () {
         );
       }),
     getDefaultBranch: (input) =>
-      getRepository(input).pipe(Effect.map((repository) => repository.mainbranch?.name ?? null)),
+      resolveRepository(input).pipe(
+        Effect.flatMap((locator) =>
+          Effect.all({
+            repository: getRepositoryFromLocator(locator),
+            branchingModel: getBranchingModelFromLocator(locator).pipe(
+              Effect.catch(() =>
+                Effect.succeed<Schema.Schema.Type<typeof RawBitbucketBranchingModelSchema> | null>(
+                  null,
+                ),
+              ),
+            ),
+          }),
+        ),
+        Effect.map(defaultChangeRequestTargetBranch),
+      ),
     // Bitbucket Cloud pull requests are Git-backed and Bitbucket does not provide
     // an official checkout CLI. This provider-local path uses GitVcsDriver as a
     // narrow escape hatch to materialize Bitbucket PR refs. Do not generalize this

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -674,16 +674,19 @@ export const make = Effect.fn("makeBitbucketApi")(function* () {
     getDefaultBranch: (input) =>
       resolveRepository(input).pipe(
         Effect.flatMap((locator) =>
-          Effect.all({
-            repository: getRepositoryFromLocator(locator),
-            branchingModel: getBranchingModelFromLocator(locator).pipe(
-              Effect.catch(() =>
-                Effect.succeed<Schema.Schema.Type<typeof RawBitbucketBranchingModelSchema> | null>(
-                  null,
+          Effect.all(
+            {
+              repository: getRepositoryFromLocator(locator),
+              branchingModel: getBranchingModelFromLocator(locator).pipe(
+                Effect.catch(() =>
+                  Effect.succeed<Schema.Schema.Type<
+                    typeof RawBitbucketBranchingModelSchema
+                  > | null>(null),
                 ),
               ),
-            ),
-          }),
+            },
+            { concurrency: "unbounded" },
+          ),
         ),
         Effect.map(defaultChangeRequestTargetBranch),
       ),

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -233,7 +233,7 @@ function parseBitbucketRemoteUrl(remoteUrl: string): BitbucketRepositoryLocator 
 }
 
 function normalizeRepositoryCloneUrls(
-  raw: Schema.Schema.Type<typeof RawBitbucketRepositorySchema>,
+  raw: typeof RawBitbucketRepositorySchema.Type,
 ): SourceControlRepositoryCloneUrls {
   const httpClone =
     raw.links.clone?.find((entry) => entry.name.toLowerCase() === "https")?.href ??
@@ -248,8 +248,8 @@ function normalizeRepositoryCloneUrls(
 }
 
 function defaultChangeRequestTargetBranch(input: {
-  readonly repository: Schema.Schema.Type<typeof RawBitbucketRepositorySchema>;
-  readonly branchingModel: Schema.Schema.Type<typeof RawBitbucketBranchingModelSchema> | null;
+  readonly repository: typeof RawBitbucketRepositorySchema.Type;
+  readonly branchingModel: typeof RawBitbucketBranchingModelSchema.Type | null;
 }): string | null {
   const repositoryMainBranch = input.repository.mainbranch?.name ?? null;
   const development = input.branchingModel?.development;
@@ -679,9 +679,7 @@ export const make = Effect.fn("makeBitbucketApi")(function* () {
               repository: getRepositoryFromLocator(locator),
               branchingModel: getBranchingModelFromLocator(locator).pipe(
                 Effect.catch(() =>
-                  Effect.succeed<Schema.Schema.Type<
-                    typeof RawBitbucketBranchingModelSchema
-                  > | null>(null),
+                  Effect.succeed<typeof RawBitbucketBranchingModelSchema.Type | null>(null),
                 ),
               ),
             },


### PR DESCRIPTION
Closes #2496 

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Bitbucket default-branch resolution to prefer the branching-model development branch and adds an extra API call (with silent fallback on errors), which can affect which base branch new PRs target.
> 
> **Overview**
> Updates Bitbucket `getDefaultBranch` to fetch both the repository metadata and Bitbucket `/branching-model` in parallel, and to **prefer the branching model’s development branch** when it’s valid and `use_mainbranch` is false.
> 
> Adds schema decoding and a `defaultChangeRequestTargetBranch` helper, and expands tests to cover preferring `develop` plus fallback to the repository main branch when the branching model is missing, invalid, or unavailable (e.g., 404).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ddde624ec97030355b8b505ee2b168bf62ffb77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer Bitbucket branching model development branch as default PR target branch
> - `getDefaultBranch` in [BitbucketApi.ts](https://github.com/pingdotgg/t3code/pull/2500/files#diff-0f26cbc52f3a4bd71850ee2ab91de644c5e26ecd24de9283ea456101105b01e8) now concurrently fetches the repository and its `/branching-model` endpoint, returning the development branch name when it is present, valid (`is_valid !== false`), and `use_mainbranch` is not `true`.
> - Falls back to the repository's `mainbranch` when the branching model is unavailable (404 or any error) or the development branch is invalid.
> - New tests cover the preferred development branch, invalid development branch, and unavailable branching model cases.
> - Behavioral Change: `getDefaultBranch` now makes an additional HTTP request to `/branching-model` on every call; failures from that endpoint are silently swallowed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ddde62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->