### PR TITLE
feat(web): add theme gallery and custom palettes

### DIFF
--- a/apps/desktop/src/clientPersistence.test.ts
+++ b/apps/desktop/src/clientPersistence.test.ts
@@ -63,6 +63,8 @@ const clientSettings: ClientSettings = {
   sidebarProjectSortOrder: "manual",
   sidebarThreadSortOrder: "created_at",
   timestampFormat: "24-hour",
+  theme: "system",
+  customCSS: "",
 };
 
 const savedRegistryRecord: PersistedSavedEnvironmentRecord = {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1,4 +1,11 @@
-import { ArchiveIcon, ArchiveX, LoaderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
+import {
+  ArchiveIcon,
+  ArchiveX,
+  CheckIcon,
+  LoaderIcon,
+  PlusIcon,
+  RefreshCwIcon,
+} from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
@@ -10,7 +17,7 @@ import {
   type ScopedThreadRef,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime";
-import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { DEFAULT_UNIFIED_SETTINGS, type ThemeMode } from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
 import { Equal } from "effect";
 import { APP_VERSION } from "../../branding";
@@ -25,7 +32,7 @@ import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { TraitsPicker } from "../chat/TraitsPicker";
 import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
 import { isElectron } from "../../env";
-import { useTheme } from "../../hooks/useTheme";
+import { useTheme, THEMES } from "../../hooks/useTheme";
 import { useSettings, useUpdateSettings } from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import {
@@ -74,20 +81,178 @@ import {
   useServerProviders,
 } from "../../rpc/serverState";
 
-const THEME_OPTIONS = [
-  {
-    value: "system",
-    label: "System",
-  },
-  {
-    value: "light",
-    label: "Light",
-  },
-  {
-    value: "dark",
-    label: "Dark",
-  },
+const BUILT_IN_THEME_OPTIONS = [
+  { value: "system", label: "System" },
+  { value: "light", label: "Light" },
+  { value: "dark", label: "Dark" },
+  ...Object.entries(THEMES).map(([value, definition]) => ({
+    value: value as Exclude<ThemeMode, "system" | "light" | "dark" | "custom">,
+    label: definition.label,
+  })),
 ] as const;
+
+function themePreviewTokens(value: ThemeMode) {
+  if (value === "system" || value === "light") {
+    return {
+      background: "0 0% 100%",
+      foreground: "220 18% 16%",
+      card: "0 0% 100%",
+      primary: "262 83% 58%",
+      secondary: "220 14% 96%",
+      accent: "220 14% 92%",
+      border: "220 13% 88%",
+    };
+  }
+
+  if (value === "dark") {
+    return {
+      background: "220 18% 10%",
+      foreground: "220 20% 92%",
+      card: "220 18% 12%",
+      primary: "262 83% 68%",
+      secondary: "220 18% 16%",
+      accent: "220 18% 22%",
+      border: "220 18% 20%",
+    };
+  }
+
+  const customTheme = THEMES[value as keyof typeof THEMES];
+  return {
+    background: customTheme?.colors.bg ?? "0 0% 10%",
+    foreground: customTheme?.colors.fg ?? "0 0% 90%",
+    card: customTheme?.colors.card ?? "0 0% 14%",
+    primary: customTheme?.colors.primary ?? "0 0% 90%",
+    secondary: customTheme?.colors.secondary ?? "0 0% 18%",
+    accent: customTheme?.colors.accent ?? "0 0% 24%",
+    border: customTheme?.colors.secondary ?? "0 0% 18%",
+  };
+}
+
+function ThemePreview({ themeMode, selected }: { themeMode: ThemeMode; selected: boolean }) {
+  const tokens = themePreviewTokens(themeMode);
+  const sidebarBackground =
+    themeMode === "light" || themeMode === "system"
+      ? "0 0% 98%"
+      : `color-mix(in srgb, hsl(${tokens.background}) 82%, black)`;
+
+  return (
+    <div
+      className="relative h-28 overflow-hidden rounded-xl border shadow-sm"
+      style={
+        {
+          backgroundColor: `hsl(${tokens.background})`,
+          borderColor: `hsl(${tokens.border})`,
+          color: `hsl(${tokens.foreground})`,
+        } as React.CSSProperties
+      }
+    >
+      <div className="absolute inset-0 opacity-[0.06] [background-image:radial-gradient(circle_at_top_right,currentColor_0,transparent_42%)]" />
+      <div className="grid h-full grid-cols-[30%_1fr]">
+        <div
+          className="border-r p-2"
+          style={{
+            backgroundColor:
+              themeMode === "light" || themeMode === "system"
+                ? `hsl(${sidebarBackground})`
+                : sidebarBackground,
+            borderColor: `hsl(${tokens.border})`,
+          }}
+        >
+          <div className="mb-2 flex items-center gap-1.5">
+            <div
+              className="size-2 rounded-full"
+              style={{ backgroundColor: `hsl(${tokens.primary})` }}
+            />
+            <div
+              className="h-1.5 w-8 rounded-full opacity-85"
+              style={{ backgroundColor: `hsl(${tokens.foreground})` }}
+            />
+          </div>
+          <div className="space-y-1.5">
+            <div
+              className="h-4 rounded-md"
+              style={{ backgroundColor: `hsl(${tokens.secondary})` }}
+            />
+            <div
+              className="h-4 rounded-md"
+              style={{ backgroundColor: `hsl(${tokens.accent})`, opacity: 0.8 }}
+            />
+            <div
+              className="h-4 w-3/4 rounded-md opacity-70"
+              style={{ backgroundColor: `hsl(${tokens.secondary})` }}
+            />
+          </div>
+        </div>
+        <div className="p-2">
+          <div
+            className="mb-2 flex items-center justify-between rounded-md border px-2 py-1"
+            style={{
+              backgroundColor: `hsl(${tokens.card})`,
+              borderColor: `hsl(${tokens.border})`,
+            }}
+          >
+            <div
+              className="h-1.5 w-10 rounded-full opacity-70"
+              style={{ backgroundColor: `hsl(${tokens.foreground})` }}
+            />
+            <div
+              className="h-4 w-4 rounded-md"
+              style={{ backgroundColor: `hsl(${tokens.secondary})` }}
+            />
+          </div>
+          <div className="space-y-2">
+            <div
+              className="ml-auto w-3/4 rounded-lg px-2 py-1.5"
+              style={{
+                backgroundColor: `hsl(${tokens.primary})`,
+                color: `hsl(${tokens.background})`,
+              }}
+            >
+              <div className="h-1.5 w-full rounded-full bg-current opacity-35" />
+            </div>
+            <div
+              className="w-4/5 rounded-lg border px-2 py-1.5"
+              style={{
+                backgroundColor: `hsl(${tokens.card})`,
+                borderColor: `hsl(${tokens.border})`,
+              }}
+            >
+              <div
+                className="mb-1 h-1.5 w-5/6 rounded-full opacity-75"
+                style={{ backgroundColor: `hsl(${tokens.foreground})` }}
+              />
+              <div
+                className="h-1.5 w-2/3 rounded-full opacity-40"
+                style={{ backgroundColor: `hsl(${tokens.foreground})` }}
+              />
+            </div>
+          </div>
+          <div
+            className="absolute bottom-2 right-2 left-[calc(30%+0.5rem)] flex items-center gap-1 rounded-md border px-2 py-1"
+            style={{
+              backgroundColor: `hsl(${tokens.card})`,
+              borderColor: `hsl(${tokens.border})`,
+            }}
+          >
+            <div
+              className="h-1.5 flex-1 rounded-full opacity-40"
+              style={{ backgroundColor: `hsl(${tokens.foreground})` }}
+            />
+            <div
+              className="h-5 w-6 rounded-md"
+              style={{ backgroundColor: `hsl(${tokens.primary})` }}
+            />
+          </div>
+        </div>
+      </div>
+      {selected ? (
+        <div className="absolute top-2 right-2 flex size-5 items-center justify-center rounded-full border border-white/35 bg-primary text-primary-foreground shadow-sm">
+          <CheckIcon className="size-3" />
+        </div>
+      ) : null}
+    </div>
+  );
+}
 
 const TIMESTAMP_FORMAT_LABELS = {
   locale: "System default",
@@ -448,7 +613,6 @@ export function useSettingsRestore(onRestored?: () => void) {
 }
 
 export function GeneralSettingsPanel() {
-  const { theme, setTheme } = useTheme();
   const settings = useSettings();
   const { updateSettings } = useUpdateSettings();
   const [openingPathByTarget, setOpeningPathByTarget] = useState({
@@ -794,39 +958,6 @@ export function GeneralSettingsPanel() {
   return (
     <SettingsPageContainer>
       <SettingsSection title="General">
-        <SettingsRow
-          title="Theme"
-          description="Choose how T3 Code looks across the app."
-          resetAction={
-            theme !== "system" ? (
-              <SettingResetButton label="theme" onClick={() => setTheme("system")} />
-            ) : null
-          }
-          control={
-            <Select
-              value={theme}
-              onValueChange={(value) => {
-                if (value === "system" || value === "light" || value === "dark") {
-                  setTheme(value);
-                }
-              }}
-            >
-              <SelectTrigger className="w-full sm:w-40" aria-label="Theme preference">
-                <SelectValue>
-                  {THEME_OPTIONS.find((option) => option.value === theme)?.label ?? "System"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectPopup align="end" alignItemWithTrigger={false}>
-                {THEME_OPTIONS.map((option) => (
-                  <SelectItem hideIndicator key={option.value} value={option.value}>
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectPopup>
-            </Select>
-          }
-        />
-
         <SettingsRow
           title="Time format"
           description="System default follows your browser or OS clock preference."
@@ -1489,6 +1620,81 @@ export function ArchivedThreadsPanel() {
           </SettingsSection>
         ))
       )}
+    </SettingsPageContainer>
+  );
+}
+
+export function ThemesPanel() {
+  const { theme, setTheme, customCSS } = useTheme();
+  const { updateSettings } = useUpdateSettings();
+
+  const handleCustomCSSChange = useCallback(
+    (next: string) => {
+      updateSettings({ customCSS: next });
+    },
+    [updateSettings],
+  );
+
+  return (
+    <SettingsPageContainer>
+      <SettingsSection title="Theme">
+        <div className="grid grid-cols-1 gap-4 p-4 sm:grid-cols-2 xl:grid-cols-3">
+          {BUILT_IN_THEME_OPTIONS.map((t) => {
+            const isSelected = theme === t.value;
+            return (
+              <button
+                key={t.value}
+                type="button"
+                className={`flex flex-col gap-3 rounded-2xl border p-3 text-left transition-all ${
+                  isSelected
+                    ? "border-primary bg-accent/30 ring-1 ring-primary"
+                    : "border-border/60 hover:border-muted-foreground/40 hover:bg-accent/15"
+                }`}
+                onClick={() => setTheme(t.value as ThemeMode)}
+              >
+                <ThemePreview themeMode={t.value as ThemeMode} selected={isSelected} />
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-foreground">{t.label}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {t.value === "system"
+                        ? "Follows your OS appearance"
+                        : t.value === "light"
+                          ? "Default light UI"
+                          : t.value === "dark"
+                            ? "Default dark UI"
+                            : "Built-in theme"}
+                    </div>
+                  </div>
+                  {isSelected ? (
+                    <span className="rounded-full bg-primary/12 px-2 py-1 text-[11px] font-medium text-primary">
+                      Active
+                    </span>
+                  ) : null}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title="Custom CSS">
+        <div className="space-y-2 px-4 py-2">
+          <p className="text-xs text-muted-foreground">
+            Add custom CSS to further customize the theme. Use CSS variables like{" "}
+            <code className="text-[10px]">--background</code>,{" "}
+            <code className="text-[10px]">--foreground</code>,{" "}
+            <code className="text-[10px]">--primary</code>, etc.
+          </p>
+          <textarea
+            className="min-h-[200px] w-full rounded-md border border-border bg-background p-3 font-mono text-xs focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
+            value={customCSS}
+            onChange={(e) => handleCustomCSSChange(e.target.value)}
+            placeholder={`/* Example: Change the primary color */\n--primary: 210 100% 50%;\n\n/* Or add custom styles */\nbody {\n  font-family: 'Fira Code', monospace;\n}`}
+            spellCheck={false}
+          />
+        </div>
+      </SettingsSection>
     </SettingsPageContainer>
   );
 }

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -1,5 +1,12 @@
 import { useCallback, type ComponentType } from "react";
-import { ArchiveIcon, ArrowLeftIcon, GitBranchIcon, Link2Icon, Settings2Icon } from "lucide-react";
+import {
+  ArchiveIcon,
+  ArrowLeftIcon,
+  GitBranchIcon,
+  Link2Icon,
+  PaletteIcon,
+  Settings2Icon,
+} from "lucide-react";
 import { useCanGoBack, useNavigate } from "@tanstack/react-router";
 
 import {
@@ -17,6 +24,7 @@ export type SettingsSectionPath =
   | "/settings/general"
   | "/settings/source-control"
   | "/settings/connections"
+  | "/settings/themes"
   | "/settings/archived";
 
 export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
@@ -25,6 +33,7 @@ export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
   icon: ComponentType<{ className?: string }>;
 }> = [
   { label: "General", to: "/settings/general", icon: Settings2Icon },
+  { label: "Themes", to: "/settings/themes", icon: PaletteIcon },
   { label: "Source Control", to: "/settings/source-control", icon: GitBranchIcon },
   { label: "Connections", to: "/settings/connections", icon: Link2Icon },
   { label: "Archive", to: "/settings/archived", icon: ArchiveIcon },

--- a/apps/web/src/hooks/useTheme.ts
+++ b/apps/web/src/hooks/useTheme.ts
@@ -1,41 +1,13 @@
-import { useCallback, useEffect, useSyncExternalStore } from "react";
+import { type ThemeMode } from "@t3tools/contracts/settings";
+import { useCallback, useEffect, useMemo } from "react";
+import { useSettings, useUpdateSettings } from "./useSettings";
 
-type Theme = "light" | "dark" | "system";
-type ThemeSnapshot = {
-  theme: Theme;
-  systemDark: boolean;
-};
-
-const STORAGE_KEY = "t3code:theme";
 const MEDIA_QUERY = "(prefers-color-scheme: dark)";
-const DEFAULT_THEME_SNAPSHOT: ThemeSnapshot = {
-  theme: "system",
-  systemDark: false,
-};
 const THEME_COLOR_META_NAME = "theme-color";
 const DYNAMIC_THEME_COLOR_SELECTOR = `meta[name="${THEME_COLOR_META_NAME}"][data-dynamic-theme-color="true"]`;
 
-let listeners: Array<() => void> = [];
-let lastSnapshot: ThemeSnapshot | null = null;
-let lastDesktopTheme: Theme | null = null;
-
-function emitChange() {
-  for (const listener of listeners) listener();
-}
-
-function hasThemeStorage() {
-  return typeof window !== "undefined" && typeof localStorage !== "undefined";
-}
-
 function getSystemDark() {
   return typeof window !== "undefined" && window.matchMedia(MEDIA_QUERY).matches;
-}
-
-function getStored(): Theme {
-  if (!hasThemeStorage()) return DEFAULT_THEME_SNAPSHOT.theme;
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (raw === "light" || raw === "dark" || raw === "system") return raw;
-  return DEFAULT_THEME_SNAPSHOT.theme;
 }
 
 function ensureThemeColorMetaTag(): HTMLMetaElement {
@@ -87,15 +59,351 @@ export function syncBrowserChromeTheme() {
   ensureThemeColorMetaTag().setAttribute("content", backgroundColor);
 }
 
-function applyTheme(theme: Theme, suppressTransitions = false) {
+export const THEMES = {
+  dracula: {
+    label: "Dracula",
+    colors: {
+      bg: "231 15% 18%",
+      fg: "60 30% 96%",
+      card: "231 15% 16%",
+      primary: "265 89% 78%",
+      secondary: "231 15% 25%",
+      accent: "326 100% 74%",
+    },
+    css: `
+      .dark.dracula {
+        color-scheme: dark;
+        --background: hsl(231 15% 18%);
+        --app-chrome-background: hsl(231 15% 18%);
+        --foreground: hsl(60 30% 96%);
+        --card: hsl(231 15% 16%);
+        --card-foreground: hsl(60 30% 96%);
+        --popover: hsl(231 15% 14%);
+        --popover-foreground: hsl(60 30% 96%);
+        --primary: hsl(265 89% 78%);
+        --primary-foreground: hsl(231 15% 10%);
+        --secondary: hsl(231 15% 25%);
+        --secondary-foreground: hsl(60 30% 96%);
+        --muted: hsl(231 15% 22%);
+        --muted-foreground: hsl(60 10% 65%);
+        --accent: hsl(326 100% 74%);
+        --accent-foreground: hsl(60 30% 96%);
+        --destructive: hsl(0 100% 67%);
+        --destructive-foreground: hsl(60 30% 96%);
+        --border: hsl(231 15% 22%);
+        --input: hsl(231 15% 22%);
+        --ring: hsl(265 89% 78%);
+        --sidebar-background: hsl(231 15% 15%);
+        --sidebar-foreground: hsl(60 30% 90%);
+        --sidebar-primary: hsl(265 89% 78%);
+        --sidebar-primary-foreground: hsl(231 15% 10%);
+        --sidebar-accent: hsl(231 15% 22%);
+        --sidebar-accent-foreground: hsl(60 30% 96%);
+        --sidebar-border: hsl(231 15% 18%);
+        --sidebar-ring: hsl(265 89% 78%);
+      }
+    `,
+  },
+  "one-dark": {
+    label: "One Dark Borderless",
+    colors: {
+      bg: "220 12% 14%",
+      fg: "220 14% 71%",
+      card: "220 12% 12%",
+      primary: "187 47% 55%",
+      secondary: "220 12% 20%",
+      accent: "95 38% 62%",
+    },
+    css: `
+      .dark.one-dark {
+        color-scheme: dark;
+        --background: hsl(220 12% 14%);
+        --app-chrome-background: hsl(220 12% 14%);
+        --foreground: hsl(220 14% 71%);
+        --card: hsl(220 12% 12%);
+        --card-foreground: hsl(220 14% 71%);
+        --popover: hsl(220 12% 10%);
+        --popover-foreground: hsl(220 14% 71%);
+        --primary: hsl(187 47% 55%);
+        --primary-foreground: hsl(220 12% 10%);
+        --secondary: hsl(220 12% 20%);
+        --secondary-foreground: hsl(220 14% 91%);
+        --muted: hsl(220 12% 16%);
+        --muted-foreground: hsl(220 8% 50%);
+        --accent: hsl(95 38% 62%);
+        --accent-foreground: hsl(220 12% 10%);
+        --destructive: hsl(355 65% 65%);
+        --destructive-foreground: hsl(220 14% 91%);
+        --border: hsl(220 12% 16%);
+        --input: hsl(220 12% 16%);
+        --ring: hsl(187 47% 55%);
+        --sidebar-background: hsl(220 12% 11%);
+        --sidebar-foreground: hsl(220 14% 71%);
+        --sidebar-primary: hsl(187 47% 55%);
+        --sidebar-primary-foreground: hsl(220 12% 11%);
+        --sidebar-accent: hsl(220 12% 16%);
+        --sidebar-accent-foreground: hsl(220 14% 91%);
+        --sidebar-border: hsl(220 12% 11%);
+        --sidebar-ring: hsl(187 47% 55%);
+      }
+    `,
+  },
+  "oled-dark": {
+    label: "OLED Dark",
+    colors: {
+      bg: "0 0% 0%",
+      fg: "0 0% 90%",
+      card: "0 0% 2%",
+      primary: "0 0% 90%",
+      secondary: "0 0% 8%",
+      accent: "0 0% 20%",
+    },
+    css: `
+      .dark.oled-dark {
+        color-scheme: dark;
+        --background: hsl(0 0% 0%);
+        --app-chrome-background: hsl(0 0% 0%);
+        --foreground: hsl(0 0% 90%);
+        --card: hsl(0 0% 2%);
+        --card-foreground: hsl(0 0% 90%);
+        --popover: hsl(0 0% 0%);
+        --popover-foreground: hsl(0 0% 90%);
+        --primary: hsl(0 0% 95%);
+        --primary-foreground: hsl(0 0% 0%);
+        --secondary: hsl(0 0% 8%);
+        --secondary-foreground: hsl(0 0% 90%);
+        --muted: hsl(0 0% 6%);
+        --muted-foreground: hsl(0 0% 50%);
+        --accent: hsl(0 0% 12%);
+        --accent-foreground: hsl(0 0% 100%);
+        --destructive: hsl(0 84% 60%);
+        --destructive-foreground: hsl(0 0% 100%);
+        --border: hsl(0 0% 10%);
+        --input: hsl(0 0% 10%);
+        --ring: hsl(0 0% 90%);
+        --sidebar-background: hsl(0 0% 0%);
+        --sidebar-foreground: hsl(0 0% 80%);
+        --sidebar-primary: hsl(0 0% 95%);
+        --sidebar-primary-foreground: hsl(0 0% 0%);
+        --sidebar-accent: hsl(0 0% 8%);
+        --sidebar-accent-foreground: hsl(0 0% 100%);
+        --sidebar-border: hsl(0 0% 5%);
+        --sidebar-ring: hsl(0 0% 90%);
+      }
+    `,
+  },
+  nord: {
+    label: "Nord",
+    colors: {
+      bg: "220 16% 22%",
+      fg: "218 27% 92%",
+      card: "220 16% 20%",
+      primary: "193 43% 67%",
+      secondary: "220 16% 28%",
+      accent: "213 32% 52%",
+    },
+    css: `
+      .dark.nord {
+        color-scheme: dark;
+        --background: hsl(220 16% 22%);
+        --app-chrome-background: hsl(220 16% 22%);
+        --foreground: hsl(218 27% 92%);
+        --card: hsl(220 16% 20%);
+        --card-foreground: hsl(218 27% 92%);
+        --popover: hsl(220 16% 18%);
+        --popover-foreground: hsl(218 27% 92%);
+        --primary: hsl(193 43% 67%);
+        --primary-foreground: hsl(220 16% 14%);
+        --secondary: hsl(220 16% 28%);
+        --secondary-foreground: hsl(218 27% 92%);
+        --muted: hsl(220 16% 26%);
+        --muted-foreground: hsl(218 16% 70%);
+        --accent: hsl(213 32% 52%);
+        --accent-foreground: hsl(218 27% 96%);
+        --destructive: hsl(354 42% 56%);
+        --destructive-foreground: hsl(218 27% 96%);
+        --border: hsl(220 16% 30%);
+        --input: hsl(220 16% 30%);
+        --ring: hsl(193 43% 67%);
+        --sidebar-background: hsl(220 16% 19%);
+        --sidebar-foreground: hsl(218 27% 88%);
+        --sidebar-primary: hsl(193 43% 67%);
+        --sidebar-primary-foreground: hsl(220 16% 14%);
+        --sidebar-accent: hsl(220 16% 26%);
+        --sidebar-accent-foreground: hsl(218 27% 96%);
+        --sidebar-border: hsl(220 16% 26%);
+        --sidebar-ring: hsl(193 43% 67%);
+      }
+    `,
+  },
+  "tokyo-night": {
+    label: "Tokyo Night",
+    colors: {
+      bg: "229 26% 18%",
+      fg: "220 27% 92%",
+      card: "229 26% 15%",
+      primary: "210 93% 76%",
+      secondary: "229 22% 24%",
+      accent: "262 83% 78%",
+    },
+    css: `
+      .dark.tokyo-night {
+        color-scheme: dark;
+        --background: hsl(229 26% 18%);
+        --app-chrome-background: hsl(229 26% 18%);
+        --foreground: hsl(220 27% 92%);
+        --card: hsl(229 26% 15%);
+        --card-foreground: hsl(220 27% 92%);
+        --popover: hsl(229 26% 13%);
+        --popover-foreground: hsl(220 27% 92%);
+        --primary: hsl(210 93% 76%);
+        --primary-foreground: hsl(229 26% 10%);
+        --secondary: hsl(229 22% 24%);
+        --secondary-foreground: hsl(220 27% 92%);
+        --muted: hsl(229 22% 22%);
+        --muted-foreground: hsl(220 18% 68%);
+        --accent: hsl(262 83% 78%);
+        --accent-foreground: hsl(229 26% 10%);
+        --destructive: hsl(352 89% 71%);
+        --destructive-foreground: hsl(220 27% 96%);
+        --border: hsl(229 22% 28%);
+        --input: hsl(229 22% 28%);
+        --ring: hsl(210 93% 76%);
+        --sidebar-background: hsl(229 26% 14%);
+        --sidebar-foreground: hsl(220 27% 88%);
+        --sidebar-primary: hsl(210 93% 76%);
+        --sidebar-primary-foreground: hsl(229 26% 10%);
+        --sidebar-accent: hsl(229 22% 22%);
+        --sidebar-accent-foreground: hsl(220 27% 96%);
+        --sidebar-border: hsl(229 22% 24%);
+        --sidebar-ring: hsl(210 93% 76%);
+      }
+    `,
+  },
+  "gruvbox-dark": {
+    label: "Gruvbox Dark",
+    colors: {
+      bg: "30 8% 12%",
+      fg: "39 24% 78%",
+      card: "30 8% 15%",
+      primary: "96 31% 61%",
+      secondary: "186 33% 40%",
+      accent: "43 55% 38%",
+    },
+    css: `
+      .dark.gruvbox-dark {
+        color-scheme: dark;
+        --background: hsl(30 8% 12%);
+        --app-chrome-background: hsl(30 8% 12%);
+        --foreground: hsl(39 24% 78%);
+        --card: hsl(30 8% 15%);
+        --card-foreground: hsl(39 24% 78%);
+        --popover: hsl(30 8% 13%);
+        --popover-foreground: hsl(39 24% 78%);
+        --primary: hsl(96 31% 61%);
+        --primary-foreground: hsl(30 8% 10%);
+        --secondary: hsl(186 33% 40%);
+        --secondary-foreground: hsl(39 24% 82%);
+        --muted: hsl(30 8% 18%);
+        --muted-foreground: hsl(39 14% 58%);
+        --accent: hsl(43 55% 38%);
+        --accent-foreground: hsl(30 8% 10%);
+        --destructive: hsl(2 75% 46%);
+        --destructive-foreground: hsl(39 24% 82%);
+        --border: hsl(30 8% 20%);
+        --input: hsl(30 8% 20%);
+        --ring: hsl(43 55% 38%);
+        --sidebar-background: hsl(30 8% 11%);
+        --sidebar-foreground: hsl(39 20% 74%);
+        --sidebar-primary: hsl(96 31% 61%);
+        --sidebar-primary-foreground: hsl(30 8% 10%);
+        --sidebar-accent: hsl(186 33% 40%);
+        --sidebar-accent-foreground: hsl(39 24% 82%);
+        --sidebar-border: hsl(30 8% 18%);
+        --sidebar-ring: hsl(43 55% 38%);
+      }
+    `,
+  },
+} as const;
+
+export interface ThemeDefinition {
+  readonly label: string;
+  readonly colors: {
+    readonly bg: string;
+    readonly fg: string;
+    readonly card: string;
+    readonly primary: string;
+    readonly secondary: string;
+    readonly accent: string;
+  };
+  readonly css: string;
+}
+
+export type ThemeColors = ThemeDefinition["colors"];
+
+function applyTheme(theme: ThemeMode, customCSS: string, suppressTransitions = false) {
   if (typeof document === "undefined" || typeof window === "undefined") return;
+
   if (suppressTransitions) {
     document.documentElement.classList.add("no-transitions");
   }
-  const isDark = theme === "dark" || (theme === "system" && getSystemDark());
-  document.documentElement.classList.toggle("dark", isDark);
+
+  // DEFINITIVELY clear all possible theme classes first
+  const allThemeClasses = [
+    "dark",
+    "light",
+    "dracula",
+    "one-dark",
+    "oled-dark",
+    "nord",
+    "tokyo-night",
+    "gruvbox-dark",
+    "custom",
+  ];
+  document.documentElement.classList.remove(...allThemeClasses);
+
+  const isDark =
+    theme === "dark" ||
+    theme === "dracula" ||
+    theme === "one-dark" ||
+    theme === "oled-dark" ||
+    theme === "nord" ||
+    theme === "tokyo-night" ||
+    theme === "gruvbox-dark" ||
+    (theme === "system" && getSystemDark());
+
+  const isBaseTheme = theme === "system" || theme === "light" || theme === "dark";
+
+  if (isBaseTheme) {
+    document.documentElement.classList.add(isDark ? "dark" : "light");
+  } else {
+    if (isDark) {
+      document.documentElement.classList.add("dark");
+    }
+    document.documentElement.classList.add(theme);
+  }
+
+  // Inject Custom CSS
+
+  let styleElement = document.getElementById("t3code-custom-theme-css");
+  if (!styleElement) {
+    styleElement = document.createElement("style");
+    styleElement.id = "t3code-custom-theme-css";
+    document.head.appendChild(styleElement);
+  }
+
+  let fullCSS = "";
+  for (const t of Object.values(THEMES)) {
+    fullCSS += (t as ThemeDefinition).css;
+  }
+  if (theme === "custom" && customCSS) {
+    fullCSS += `\n.custom {\n${customCSS}\n}`;
+  }
+  styleElement.textContent = fullCSS;
+
   syncBrowserChromeTheme();
-  syncDesktopTheme(theme);
+  syncDesktopTheme(isDark ? "dark" : "light");
+
   if (suppressTransitions) {
     // Force a reflow so the no-transitions class takes effect before removal
     // oxlint-disable-next-line no-unused-expressions
@@ -106,89 +414,52 @@ function applyTheme(theme: Theme, suppressTransitions = false) {
   }
 }
 
-function syncDesktopTheme(theme: Theme) {
+function syncDesktopTheme(theme: "light" | "dark") {
   if (typeof window === "undefined") return;
   const bridge = window.desktopBridge;
-  if (!bridge || lastDesktopTheme === theme) {
+  if (!bridge) {
     return;
   }
 
-  lastDesktopTheme = theme;
-  void bridge.setTheme(theme).catch(() => {
-    if (lastDesktopTheme === theme) {
-      lastDesktopTheme = null;
-    }
-  });
-}
-
-// Apply immediately on module load to prevent flash
-if (typeof document !== "undefined" && hasThemeStorage()) {
-  applyTheme(getStored());
-}
-
-function getSnapshot(): ThemeSnapshot {
-  if (!hasThemeStorage()) return DEFAULT_THEME_SNAPSHOT;
-  const theme = getStored();
-  const systemDark = theme === "system" ? getSystemDark() : false;
-
-  if (lastSnapshot && lastSnapshot.theme === theme && lastSnapshot.systemDark === systemDark) {
-    return lastSnapshot;
-  }
-
-  lastSnapshot = { theme, systemDark };
-  return lastSnapshot;
-}
-
-function getServerSnapshot() {
-  return DEFAULT_THEME_SNAPSHOT;
-}
-
-function subscribe(listener: () => void): () => void {
-  if (typeof window === "undefined") return () => {};
-  listeners.push(listener);
-
-  // Listen for system preference changes
-  const mq = window.matchMedia(MEDIA_QUERY);
-  const handleChange = () => {
-    if (getStored() === "system") applyTheme("system", true);
-    emitChange();
-  };
-  mq.addEventListener("change", handleChange);
-
-  // Listen for storage changes from other tabs
-  const handleStorage = (e: StorageEvent) => {
-    if (e.key === STORAGE_KEY) {
-      applyTheme(getStored(), true);
-      emitChange();
-    }
-  };
-  window.addEventListener("storage", handleStorage);
-
-  return () => {
-    listeners = listeners.filter((l) => l !== listener);
-    mq.removeEventListener("change", handleChange);
-    window.removeEventListener("storage", handleStorage);
-  };
+  void bridge.setTheme(theme).catch(() => {});
 }
 
 export function useTheme() {
-  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
-  const theme = snapshot.theme;
+  const { theme, customCSS } = useSettings((s) => ({
+    theme: s.theme,
+    customCSS: s.customCSS,
+  }));
+  const { updateSettings } = useUpdateSettings();
 
-  const resolvedTheme: "light" | "dark" =
-    theme === "system" ? (snapshot.systemDark ? "dark" : "light") : theme;
+  const systemDark = useMemo(() => getSystemDark(), []);
 
-  const setTheme = useCallback((next: Theme) => {
-    if (!hasThemeStorage()) return;
-    localStorage.setItem(STORAGE_KEY, next);
-    applyTheme(next, true);
-    emitChange();
-  }, []);
+  const resolvedTheme: "light" | "dark" = useMemo(() => {
+    if (theme === "system") return systemDark ? "dark" : "light";
+    if (theme === "light") return "light";
+    return "dark"; // All custom themes are dark for now
+  }, [theme, systemDark]);
 
-  // Keep DOM in sync on mount/change
+  const setTheme = useCallback(
+    (next: ThemeMode) => {
+      updateSettings({ theme: next });
+    },
+    [updateSettings],
+  );
+
   useEffect(() => {
-    applyTheme(theme);
-  }, [theme]);
+    applyTheme(theme, customCSS, true);
+  }, [theme, customCSS]);
 
-  return { theme, setTheme, resolvedTheme } as const;
+  // Handle system dark mode changes
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia(MEDIA_QUERY);
+    const handleChange = () => {
+      applyTheme("system", customCSS, true);
+    };
+    mq.addEventListener("change", handleChange);
+    return () => mq.removeEventListener("change", handleChange);
+  }, [theme, customCSS]);
+
+  return { theme, setTheme, resolvedTheme, customCSS } as const;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -112,36 +112,36 @@
   --success-foreground: var(--color-emerald-700);
   --warning: var(--color-amber-500);
   --warning-foreground: var(--color-amber-700);
+}
 
-  @variant dark {
-    color-scheme: dark;
-    --background: color-mix(in srgb, var(--color-neutral-950) 95%, var(--color-white));
-    --app-chrome-background: var(--background);
-    --foreground: var(--color-neutral-100);
-    --card: color-mix(in srgb, var(--background) 98%, var(--color-white));
-    --card-foreground: var(--color-neutral-100);
-    --popover: color-mix(in srgb, var(--background) 98%, var(--color-white));
-    --popover-foreground: var(--color-neutral-100);
-    --primary: oklch(0.588 0.217 264);
-    --primary-foreground: var(--color-white);
-    --secondary: --alpha(var(--color-white) / 4%);
-    --secondary-foreground: var(--color-neutral-100);
-    --muted: --alpha(var(--color-white) / 4%);
-    --muted-foreground: color-mix(in srgb, var(--color-neutral-500) 90%, var(--color-white));
-    --accent: --alpha(var(--color-white) / 4%);
-    --accent-foreground: var(--color-neutral-100);
-    --destructive: color-mix(in srgb, var(--color-red-500) 90%, var(--color-white));
-    --border: --alpha(var(--color-white) / 6%);
-    --input: --alpha(var(--color-white) / 8%);
-    --ring: oklch(0.588 0.217 264);
-    --destructive-foreground: var(--color-red-400);
-    --info: var(--color-blue-500);
-    --info-foreground: var(--color-blue-400);
-    --success: var(--color-emerald-500);
-    --success-foreground: var(--color-emerald-400);
-    --warning: var(--color-amber-500);
-    --warning-foreground: var(--color-amber-400);
-  }
+:root.dark {
+  color-scheme: dark;
+  --background: color-mix(in srgb, var(--color-neutral-950) 95%, var(--color-white));
+  --app-chrome-background: var(--background);
+  --foreground: var(--color-neutral-100);
+  --card: color-mix(in srgb, var(--background) 98%, var(--color-white));
+  --card-foreground: var(--color-neutral-100);
+  --popover: color-mix(in srgb, var(--background) 98%, var(--color-white));
+  --popover-foreground: var(--color-neutral-100);
+  --primary: oklch(0.588 0.217 264);
+  --primary-foreground: var(--color-white);
+  --secondary: --alpha(var(--color-white) / 4%);
+  --secondary-foreground: var(--color-neutral-100);
+  --muted: --alpha(var(--color-white) / 4%);
+  --muted-foreground: color-mix(in srgb, var(--color-neutral-500) 90%, var(--color-white));
+  --accent: --alpha(var(--color-white) / 4%);
+  --accent-foreground: var(--color-neutral-100);
+  --destructive: color-mix(in srgb, var(--color-red-500) 90%, var(--color-white));
+  --border: --alpha(var(--color-white) / 6%);
+  --input: --alpha(var(--color-white) / 8%);
+  --ring: oklch(0.588 0.217 264);
+  --destructive-foreground: var(--color-red-400);
+  --info: var(--color-blue-500);
+  --info-foreground: var(--color-blue-400);
+  --success: var(--color-emerald-500);
+  --success-foreground: var(--color-emerald-400);
+  --warning: var(--color-amber-500);
+  --warning-foreground: var(--color-amber-400);
 }
 
 body {

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -584,6 +584,8 @@ describe("wsApi", () => {
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
       timestampFormat: "24-hour" as const,
+      theme: "system" as const,
+      customCSS: "",
     };
     const getClientSettings = vi.fn().mockResolvedValue({
       ...clientSettings,
@@ -645,6 +647,8 @@ describe("wsApi", () => {
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
       timestampFormat: "24-hour" as const,
+      theme: "system" as const,
+      customCSS: "",
     };
 
     await api.persistence.setClientSettings(clientSettings);

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as PairRouteImport } from './routes/pair'
 import { Route as ChatRouteImport } from './routes/_chat'
 import { Route as ChatIndexRouteImport } from './routes/_chat.index'
+import { Route as SettingsThemesRouteImport } from './routes/settings.themes'
 import { Route as SettingsSourceControlRouteImport } from './routes/settings.source-control'
 import { Route as SettingsGeneralRouteImport } from './routes/settings.general'
 import { Route as SettingsConnectionsRouteImport } from './routes/settings.connections'
@@ -38,6 +39,11 @@ const ChatIndexRoute = ChatIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => ChatRoute,
+} as any)
+const SettingsThemesRoute = SettingsThemesRouteImport.update({
+  id: '/themes',
+  path: '/themes',
+  getParentRoute: () => SettingsRoute,
 } as any)
 const SettingsSourceControlRoute = SettingsSourceControlRouteImport.update({
   id: '/source-control',
@@ -79,6 +85,7 @@ export interface FileRoutesByFullPath {
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
+  '/settings/themes': typeof SettingsThemesRoute
   '/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
   '/draft/$draftId': typeof ChatDraftDraftIdRoute
 }
@@ -89,6 +96,7 @@ export interface FileRoutesByTo {
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
+  '/settings/themes': typeof SettingsThemesRoute
   '/': typeof ChatIndexRoute
   '/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
   '/draft/$draftId': typeof ChatDraftDraftIdRoute
@@ -102,6 +110,7 @@ export interface FileRoutesById {
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/general': typeof SettingsGeneralRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
+  '/settings/themes': typeof SettingsThemesRoute
   '/_chat/': typeof ChatIndexRoute
   '/_chat/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
   '/_chat/draft/$draftId': typeof ChatDraftDraftIdRoute
@@ -116,6 +125,7 @@ export interface FileRouteTypes {
     | '/settings/connections'
     | '/settings/general'
     | '/settings/source-control'
+    | '/settings/themes'
     | '/$environmentId/$threadId'
     | '/draft/$draftId'
   fileRoutesByTo: FileRoutesByTo
@@ -126,6 +136,7 @@ export interface FileRouteTypes {
     | '/settings/connections'
     | '/settings/general'
     | '/settings/source-control'
+    | '/settings/themes'
     | '/'
     | '/$environmentId/$threadId'
     | '/draft/$draftId'
@@ -138,6 +149,7 @@ export interface FileRouteTypes {
     | '/settings/connections'
     | '/settings/general'
     | '/settings/source-control'
+    | '/settings/themes'
     | '/_chat/'
     | '/_chat/$environmentId/$threadId'
     | '/_chat/draft/$draftId'
@@ -178,6 +190,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/'
       preLoaderRoute: typeof ChatIndexRouteImport
       parentRoute: typeof ChatRoute
+    }
+    '/settings/themes': {
+      id: '/settings/themes'
+      path: '/themes'
+      fullPath: '/settings/themes'
+      preLoaderRoute: typeof SettingsThemesRouteImport
+      parentRoute: typeof SettingsRoute
     }
     '/settings/source-control': {
       id: '/settings/source-control'
@@ -243,6 +262,7 @@ interface SettingsRouteChildren {
   SettingsConnectionsRoute: typeof SettingsConnectionsRoute
   SettingsGeneralRoute: typeof SettingsGeneralRoute
   SettingsSourceControlRoute: typeof SettingsSourceControlRoute
+  SettingsThemesRoute: typeof SettingsThemesRoute
 }
 
 const SettingsRouteChildren: SettingsRouteChildren = {
@@ -250,6 +270,7 @@ const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsConnectionsRoute: SettingsConnectionsRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
   SettingsSourceControlRoute: SettingsSourceControlRoute,
+  SettingsThemesRoute: SettingsThemesRoute,
 }
 
 const SettingsRouteWithChildren = SettingsRoute._addFileChildren(

--- a/apps/web/src/routes/settings.themes.tsx
+++ b/apps/web/src/routes/settings.themes.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { ThemesPanel } from "../components/settings/SettingsPanels";
+
+export const Route = createFileRoute("/settings/themes")({
+  component: ThemesPanel,
+});

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "@t3tools/monorepo",
+      "dependencies": {
+        "@t3tools/monorepo": ".",
+      },
       "devDependencies": {
         "@types/node": "catalog:",
         "oxfmt": "^0.40.0",
@@ -776,6 +779,8 @@
     "@t3tools/desktop": ["@t3tools/desktop@workspace:apps/desktop"],
 
     "@t3tools/marketing": ["@t3tools/marketing@workspace:apps/marketing"],
+
+    "@t3tools/monorepo": ["@t3tools/monorepo@root:", {}],
 
     "@t3tools/scripts": ["@t3tools/scripts@workspace:scripts"],
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,9 @@
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules apps/*/dist apps/*/dist-electron packages/*/dist .turbo apps/*/.turbo packages/*/.turbo",
     "sync:vscode-icons": "node scripts/sync-vscode-icons.mjs"
   },
+  "dependencies": {
+    "@t3tools/monorepo": "."
+  },
   "devDependencies": {
     "@types/node": "catalog:",
     "oxfmt": "^0.40.0",

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -12,6 +12,21 @@ export const TimestampFormat = Schema.Literals(["locale", "12-hour", "24-hour"])
 export type TimestampFormat = typeof TimestampFormat.Type;
 export const DEFAULT_TIMESTAMP_FORMAT: TimestampFormat = "locale";
 
+export const ThemeMode = Schema.Literals([
+  "system",
+  "light",
+  "dark",
+  "dracula",
+  "one-dark",
+  "oled-dark",
+  "nord",
+  "tokyo-night",
+  "gruvbox-dark",
+  "custom",
+]);
+export type ThemeMode = typeof ThemeMode.Type;
+export const DEFAULT_THEME_MODE: ThemeMode = "system";
+
 export const SidebarProjectSortOrder = Schema.Literals(["updated_at", "created_at", "manual"]);
 export type SidebarProjectSortOrder = typeof SidebarProjectSortOrder.Type;
 export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "updated_at";
@@ -50,6 +65,8 @@ export const ClientSettingsSchema = Schema.Struct({
       model: TrimmedNonEmptyString,
     }),
   ).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
+  theme: ThemeMode.pipe(Schema.withDecodingDefault(Effect.succeed(DEFAULT_THEME_MODE))),
+  customCSS: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   providerModelPreferences: Schema.Record(
     ProviderInstanceId,
     Schema.Struct({
@@ -482,5 +499,7 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   timestampFormat: Schema.optionalKey(TimestampFormat),
+  theme: Schema.optionalKey(ThemeMode),
+  customCSS: Schema.optionalKey(Schema.String),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds new persisted settings (`theme`, `customCSS`) and rewrites client-side theme application to inject CSS and toggle root classes, which can impact global styling across the app and desktop bridge theme syncing.
> 
> **Overview**
> Adds a dedicated **Themes** settings section with a gallery-style picker (including multiple built-in dark themes) and a **Custom CSS** editor, wired to persisted client settings.
> 
> Extends `ClientSettings`/patch schema to store `theme` and `customCSS`, updates tests to include these fields, and refactors `useTheme` to read/write via settings, apply theme classes deterministically, inject theme CSS into a `<style>` tag, and sync browser/desktop chrome colors. Also updates base CSS to use `:root.dark` for dark variables and adds a new `/settings/themes` route + sidebar nav item.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f2724fc067dfb7395c14a04e47d3e7b56a49753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add theme gallery and custom CSS palette editor to settings
> - Adds a dedicated `/settings/themes` page with a visual grid of clickable theme previews (system, light, dark, dracula, one-dark, oled-dark, nord, tokyo-night, gruvbox-dark, custom) and removes theme selection from the General settings panel.
> - Adds `ThemePreview` cards that render representative color tokens for each theme; selecting a theme applies it immediately via class toggling on `<html>` and CSS injection.
> - Persists `theme` and `customCSS` in `ClientSettingsSchema` (with defaults `"system"` and `""`) instead of localStorage; the `useTheme` hook reads/writes via `useSettings`/`useUpdateSettings`.
> - Behavioral Change: dark-mode CSS variables are now applied via `:root.dark` class selector instead of a Tailwind `@variant dark` block, which may affect any custom CSS that relied on the old variant.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 85c6016. 6 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->