### PR TITLE
Preserve thread visited state across partial syncs

### DIFF
--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -336,7 +336,7 @@ describe("uiStateStore pure functions", () => {
     expect(next.projectExpandedById[nextLogicalKey]).toBe(false);
   });
 
-  it("syncThreads prunes missing thread UI state", () => {
+  it("syncThreads keeps visited state when transient snapshots omit a thread", () => {
     const thread1 = ThreadId.make("thread-1");
     const thread2 = ThreadId.make("thread-2");
     const initialState = makeUiState({
@@ -358,12 +358,26 @@ describe("uiStateStore pure functions", () => {
 
     expect(next.threadLastVisitedAtById).toEqual({
       [thread1]: "2026-02-25T12:35:00.000Z",
+      [thread2]: "2026-02-25T12:36:00.000Z",
     });
     expect(next.threadChangedFilesExpandedById).toEqual({
       [thread1]: {
         "turn-1": false,
       },
     });
+  });
+
+  it("syncThreads keeps markThreadVisited idempotent after partial snapshots", () => {
+    const thread1 = ThreadId.make("thread-1");
+    const completedAt = "2026-02-25T12:35:00.000Z";
+    const visitedState = markThreadVisited(makeUiState(), thread1, completedAt);
+
+    const afterPartialSnapshot = syncThreads(visitedState, []);
+
+    expect(afterPartialSnapshot.threadLastVisitedAtById[thread1]).toBe(completedAt);
+    expect(markThreadVisited(afterPartialSnapshot, thread1, completedAt)).toBe(
+      afterPartialSnapshot,
+    );
   });
 
   it("syncThreads seeds visit state for unseen snapshot threads", () => {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -408,11 +408,7 @@ export function syncProjects(state: UiState, projects: readonly SyncProjectInput
 
 export function syncThreads(state: UiState, threads: readonly SyncThreadInput[]): UiState {
   const retainedThreadIds = new Set(threads.map((thread) => thread.key));
-  const nextThreadLastVisitedAtById = Object.fromEntries(
-    Object.entries(state.threadLastVisitedAtById).filter(([threadId]) =>
-      retainedThreadIds.has(threadId),
-    ),
-  );
+  const nextThreadLastVisitedAtById = { ...state.threadLastVisitedAtById };
   for (const thread of threads) {
     if (
       nextThreadLastVisitedAtById[thread.key] === undefined &&


### PR DESCRIPTION
## What changed
- Preserve `threadLastVisitedAtById` entries when `syncThreads` receives a partial snapshot that does not include a thread.
- Keep the existing pruning behavior for `threadChangedFilesExpandedById`.
- Add a regression test for the partial-snapshot visited-state case.

## Why this should exist
This is a small, focused frontend state bug fix.

A production crash report showed React error 185 with `markThreadVisited` in the stack. On current `main`, `ChatView` calls `markThreadVisited(threadKey, completedAt)`, but `syncThreads` could delete that completed-turn timestamp when a partial/recovery snapshot omitted the active thread. After that, the same completed turn could be marked visited again instead of remaining idempotent.

The regression test proves the exact state transition:
1. mark a thread visited at `completedAt`
2. run `syncThreads([])` as a partial snapshot
3. call `markThreadVisited(thread, completedAt)` again

With the old pruning behavior, the timestamp is lost. With this change, it is preserved and the second mark returns the same state object.

## Scope
- No UI or layout change.
- Does not change WebSocket reconnect behavior.
- Does not change server/provider turn lifecycle behavior.
- Separate from the server projection issue tracked in later work.

## Validation
- `npx --yes bun@1.3.11 run --filter @t3tools/web test src/uiStateStore.test.ts`
- `npx --yes bun@1.3.11 fmt`
- `npx --yes bun@1.3.11 lint` - exit 0, existing warnings only
- `npx --yes bun@1.3.11 typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to client UI state sync with regression tests; no auth, server, or persistence behavior changes.
> 
> **Overview**
> **`syncThreads` no longer drops `threadLastVisitedAtById` for threads missing from a snapshot.** Visit timestamps are kept across partial or recovery syncs; only **new** snapshot threads still get `seedVisitedAt` when they have no entry. **`threadChangedFilesExpandedById` is still pruned** to threads in the snapshot.
> 
> Tests cover omitted threads keeping visit state and **`markThreadVisited` staying idempotent** after `syncThreads([])`—addressing a path where wiping the timestamp could re-trigger visits and contribute to React error 185 in `ChatView`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcb46b574df0da130b554858b65dec5b9be89623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->