### PR TITLE
Keep WebSocket reconnects alive

### DIFF
--- a/apps/web/src/components/WebSocketConnectionSurface.tsx
+++ b/apps/web/src/components/WebSocketConnectionSurface.tsx
@@ -8,7 +8,6 @@ import {
   type WsConnectionStatus,
   type WsConnectionUiState,
   useWsConnectionStatus,
-  WS_RECONNECT_MAX_ATTEMPTS,
 } from "../rpc/wsConnectionState";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { getPrimaryEnvironmentConnection } from "../environments/runtime";
@@ -42,11 +41,10 @@ function describeOfflineToast(): string {
 }
 
 function formatReconnectAttemptLabel(status: WsConnectionStatus): string {
-  const reconnectAttempt = Math.max(
-    1,
-    Math.min(status.reconnectAttemptCount, WS_RECONNECT_MAX_ATTEMPTS),
-  );
-  return `Attempt ${reconnectAttempt}/${status.reconnectMaxAttempts}`;
+  const reconnectAttempt = Math.max(1, status.reconnectAttemptCount);
+  return status.reconnectMaxAttempts === null
+    ? `Attempt ${reconnectAttempt}`
+    : `Attempt ${Math.min(reconnectAttempt, status.reconnectMaxAttempts)}/${status.reconnectMaxAttempts}`;
 }
 
 function describeExhaustedToast(): string {

--- a/apps/web/src/rpc/protocol.ts
+++ b/apps/web/src/rpc/protocol.ts
@@ -15,7 +15,6 @@ import {
   recordWsConnectionErrored,
   recordWsConnectionOpened,
   type WsConnectionMetadata,
-  WS_RECONNECT_MAX_RETRIES,
 } from "./wsConnectionState";
 
 export interface WsProtocolCloseContext {
@@ -213,7 +212,7 @@ export function createWsRpcProtocolLayer(
   const socketLayer = Socket.layerWebSocket(resolvedUrl).pipe(
     Layer.provide(trackingWebSocketConstructorLayer),
   );
-  const retryPolicy = Schedule.addDelay(Schedule.recurs(WS_RECONNECT_MAX_RETRIES), (retryCount) =>
+  const retryPolicy = Schedule.addDelay(Schedule.forever, (retryCount) =>
     Effect.succeed(Duration.millis(getWsReconnectDelayMsForRetry(retryCount) ?? 0)),
   );
   const protocolLayer = Layer.effect(

--- a/apps/web/src/rpc/wsConnectionState.test.ts
+++ b/apps/web/src/rpc/wsConnectionState.test.ts
@@ -10,7 +10,7 @@ import {
   recordWsConnectionOpened,
   resetWsConnectionStateForTests,
   setBrowserOnlineStatus,
-  WS_RECONNECT_MAX_ATTEMPTS,
+  WS_RECONNECT_MAX_DELAY_MS,
 } from "./wsConnectionState";
 
 describe("wsConnectionState", () => {
@@ -92,16 +92,16 @@ describe("wsConnectionState", () => {
     });
   });
 
-  it("marks the reconnect cycle as exhausted after the final attempt fails", () => {
-    for (let attempt = 0; attempt < WS_RECONNECT_MAX_ATTEMPTS; attempt += 1) {
+  it("continues scheduling reconnect attempts with a capped delay", () => {
+    for (let attempt = 0; attempt < 12; attempt += 1) {
       recordWsConnectionAttempt("ws://localhost:3020/ws");
       recordWsConnectionErrored("Unable to connect to the T3 server WebSocket.");
     }
 
     expect(getWsConnectionStatus()).toMatchObject({
-      nextRetryAt: null,
-      reconnectAttemptCount: WS_RECONNECT_MAX_ATTEMPTS,
-      reconnectPhase: "exhausted",
+      nextRetryAt: new Date(Date.now() + WS_RECONNECT_MAX_DELAY_MS).toISOString(),
+      reconnectAttemptCount: 12,
+      reconnectPhase: "waiting",
     });
   });
 });

--- a/apps/web/src/rpc/wsConnectionState.ts
+++ b/apps/web/src/rpc/wsConnectionState.ts
@@ -9,8 +9,6 @@ export type WsReconnectPhase = "attempting" | "exhausted" | "idle" | "waiting";
 export const WS_RECONNECT_INITIAL_DELAY_MS = 1_000;
 export const WS_RECONNECT_BACKOFF_FACTOR = 2;
 export const WS_RECONNECT_MAX_DELAY_MS = 64_000;
-export const WS_RECONNECT_MAX_RETRIES = 7;
-export const WS_RECONNECT_MAX_ATTEMPTS = WS_RECONNECT_MAX_RETRIES + 1;
 
 export interface WsConnectionStatus {
   readonly attemptCount: number;
@@ -26,7 +24,7 @@ export interface WsConnectionStatus {
   readonly online: boolean;
   readonly phase: "idle" | "connecting" | "connected" | "disconnected";
   readonly reconnectAttemptCount: number;
-  readonly reconnectMaxAttempts: number;
+  readonly reconnectMaxAttempts: number | null;
   readonly reconnectPhase: WsReconnectPhase;
   readonly socketUrl: string | null;
 }
@@ -45,7 +43,7 @@ const INITIAL_WS_CONNECTION_STATUS = Object.freeze<WsConnectionStatus>({
   online: typeof navigator === "undefined" ? true : navigator.onLine !== false,
   phase: "idle",
   reconnectAttemptCount: 0,
-  reconnectMaxAttempts: WS_RECONNECT_MAX_ATTEMPTS,
+  reconnectMaxAttempts: null,
   reconnectPhase: "idle",
   socketUrl: null,
 });
@@ -201,7 +199,7 @@ export function useWsConnectionStatus(): WsConnectionStatus {
 }
 
 export function getWsReconnectDelayMsForRetry(retryIndex: number): number | null {
-  if (!Number.isInteger(retryIndex) || retryIndex < 0 || retryIndex >= WS_RECONNECT_MAX_RETRIES) {
+  if (!Number.isInteger(retryIndex) || retryIndex < 0) {
     return null;
   }
 
@@ -220,7 +218,7 @@ function applyDisconnectState(
 ): WsConnectionStatus {
   const disconnectedAt = current.disconnectedAt ?? isoNow();
   const nextRetryDelayMs =
-    current.nextRetryAt !== null || current.reconnectPhase === "exhausted"
+    current.nextRetryAt !== null
       ? null
       : getWsReconnectDelayMsForRetry(Math.max(0, current.reconnectAttemptCount - 1));
 
@@ -235,7 +233,7 @@ function applyDisconnectState(
         : new Date(Date.now() + nextRetryDelayMs).toISOString(),
     phase: "disconnected",
     reconnectPhase:
-      current.reconnectPhase === "waiting" || current.reconnectPhase === "exhausted"
+      current.reconnectPhase === "waiting"
         ? current.reconnectPhase
         : nextRetryDelayMs === null
           ? "exhausted"

--- a/apps/web/src/rpc/wsTransport.test.ts
+++ b/apps/web/src/rpc/wsTransport.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../rpc/requestLatencyState";
 import {
   getWsConnectionStatus,
+  getWsReconnectDelayMsForRetry,
   getWsConnectionUiState,
   resetWsConnectionStateForTests,
 } from "../rpc/wsConnectionState";
@@ -108,6 +109,20 @@ async function waitFor(assertion: () => void, timeoutMs = 1_000): Promise<void> 
   }
 }
 
+async function waitForFakeTimerAssertion(assertion: () => void, timeoutMs = 1_000): Promise<void> {
+  let lastError: unknown;
+  for (let elapsedMs = 0; elapsedMs <= timeoutMs; elapsedMs += 10) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await vi.advanceTimersByTimeAsync(10);
+    }
+  }
+  throw lastError;
+}
+
 function createTransport(...args: ConstructorParameters<typeof WsTransport>): WsTransport {
   const transport = new WsTransport(...args);
   transports.push(transport);
@@ -142,6 +157,7 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  vi.useRealTimers();
   await Promise.allSettled(transports.map((transport) => transport.dispose()));
   transports.length = 0;
   globalThis.WebSocket = originalWebSocket;
@@ -255,6 +271,42 @@ describe("WsTransport", () => {
     });
     expect(getWsConnectionUiState(getWsConnectionStatus())).toBe("reconnecting");
 
+    await transport.dispose();
+  });
+
+  it("keeps reconnecting after the previous retry budget would have been exhausted", async () => {
+    const transport = createTransport("ws://localhost:3020");
+
+    await waitFor(() => {
+      expect(sockets).toHaveLength(1);
+    });
+
+    vi.useFakeTimers();
+
+    for (let retryIndex = 0; retryIndex < 8; retryIndex += 1) {
+      const socket = getSocket();
+      socket.error();
+      socket.close(1006, "server unavailable");
+
+      const retryDelayMs = getWsReconnectDelayMsForRetry(retryIndex);
+      if (retryDelayMs === null) {
+        throw new Error(`Expected reconnect delay for retry ${retryIndex}`);
+      }
+
+      await vi.advanceTimersByTimeAsync(retryDelayMs);
+      await waitForFakeTimerAssertion(() => {
+        expect(sockets).toHaveLength(retryIndex + 2);
+      });
+    }
+
+    expect(getWsConnectionStatus()).toMatchObject({
+      attemptCount: 9,
+      phase: "connecting",
+      reconnectAttemptCount: 9,
+      reconnectPhase: "attempting",
+    });
+
+    vi.useRealTimers();
     await transport.dispose();
   });
 


### PR DESCRIPTION
## What changed
- Change the WebSocket RPC retry schedule from a fixed 7-retry budget to continuous retries.
- Keep the existing exponential backoff and 64s maximum delay.
- Update reconnect state/label logic so an unbounded retry loop shows `Attempt N` instead of `Attempt N/max`.
- Add tests that prove reconnect scheduling continues past the old retry budget.

## Why this should exist
This is a small reliability fix.

T3 Code is often used through LAN, tailnet, SSH-forwarded, or other remote endpoints. A temporary server restart or private-network drop should not leave an already connected client permanently stopped after a fixed retry budget. With the previous `Schedule.recurs(7)` policy, the client could exhaust reconnect attempts and require focus/online/manual retry before trying again.

Continuous retry is still bounded by the existing backoff cap, so repeated failures do not spin aggressively.

Important scope clarification from later incident debugging: this PR is not presented as the root-cause fix for one local `:3777` reproducer where a custom hotpatch proxy healthcheck was restarting the proxy process. That local loop was fixed outside this repository. This PR only addresses the upstream web client's behavior after a real WebSocket/server/network drop has already happened.

## Scope
- WebSocket reconnect behavior only.
- No API, persistence, or provider-runtime changes.
- No layout change. The reconnect surface only changes the attempt label for unbounded retries.
- The timing behavior is covered by deterministic reconnect scheduling tests rather than a visual recording; there is no animation or transition change.
- Separate from the visited-state fix in #2506 and the server projection fix in #2517.

## Validation
- `bun run --filter @t3tools/web test src/rpc/wsTransport.test.ts` - 25/25 passed
- `bun run --filter @t3tools/web test src/rpc/wsConnectionState.test.ts src/components/WebSocketConnectionSurface.logic.test.ts` - 10/10 passed
- `bun run --filter @t3tools/web test` - 96 files, 995 tests passed
- `bun run fmt` - passed
- `bun run lint` - 0 errors, existing warnings only
- `bun run typecheck` - 12/12 packages passed, existing Effect language-service messages only