### PR TITLE
Keep active turns running until session settles

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.test.ts
@@ -2165,6 +2165,282 @@ it.effect("restores pending turn-start metadata across projection pipeline resta
   ),
 );
 
+it.layer(Layer.fresh(makeProjectionPipelinePrefixedTestLayer("t3-active-turn-segment-")))(
+  "OrchestrationProjectionPipeline",
+  (it) => {
+    it.effect("keeps the active running turn open across non-streaming assistant segments", () =>
+      Effect.gen(function* () {
+        const projectionPipeline = yield* OrchestrationProjectionPipeline;
+        const eventStore = yield* OrchestrationEventStore;
+        const sql = yield* SqlClient.SqlClient;
+        const appendAndProject = (event: Parameters<typeof eventStore.append>[0]) =>
+          eventStore
+            .append(event)
+            .pipe(Effect.flatMap((savedEvent) => projectionPipeline.projectEvent(savedEvent)));
+
+        const projectId = ProjectId.make("project-active-turn-segment");
+        const threadId = ThreadId.make("thread-active-turn-segment");
+        const turnId = TurnId.make("turn-active-segment");
+        const userMessageId = MessageId.make("user-active-segment");
+        const interimMessageId = MessageId.make("assistant-active-segment-interim");
+        const finalMessageId = MessageId.make("assistant-active-segment-final");
+
+        yield* appendAndProject({
+          type: "project.created",
+          eventId: EventId.make("evt-active-segment-1"),
+          aggregateKind: "project",
+          aggregateId: projectId,
+          occurredAt: "2026-05-05T03:20:00.000Z",
+          commandId: CommandId.make("cmd-active-segment-1"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-active-segment-1"),
+          metadata: {},
+          payload: {
+            projectId,
+            title: "Active Turn Segment Project",
+            workspaceRoot: "/tmp/active-turn-segment",
+            defaultModelSelection: null,
+            scripts: [],
+            createdAt: "2026-05-05T03:20:00.000Z",
+            updatedAt: "2026-05-05T03:20:00.000Z",
+          },
+        });
+
+        yield* appendAndProject({
+          type: "thread.created",
+          eventId: EventId.make("evt-active-segment-2"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-05-05T03:20:01.000Z",
+          commandId: CommandId.make("cmd-active-segment-2"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-active-segment-2"),
+          metadata: {},
+          payload: {
+            threadId,
+            projectId,
+            title: "Active Turn Segment Thread",
+            modelSelection: {
+              instanceId: ProviderInstanceId.make("codex"),
+              model: "gpt-5-codex",
+            },
+            runtimeMode: "full-access",
+            branch: null,
+            worktreePath: null,
+            createdAt: "2026-05-05T03:20:01.000Z",
+            updatedAt: "2026-05-05T03:20:01.000Z",
+          },
+        });
+
+        yield* appendAndProject({
+          type: "thread.turn-start-requested",
+          eventId: EventId.make("evt-active-segment-3"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-05-05T03:20:04.714Z",
+          commandId: CommandId.make("cmd-active-segment-3"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-active-segment-3"),
+          metadata: {},
+          payload: {
+            threadId,
+            messageId: userMessageId,
+            runtimeMode: "full-access",
+            createdAt: "2026-05-05T03:20:04.714Z",
+          },
+        });
+
+        yield* appendAndProject({
+          type: "thread.session-set",
+          eventId: EventId.make("evt-active-segment-4"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-05-05T03:20:20.549Z",
+          commandId: CommandId.make("cmd-active-segment-4"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-active-segment-4"),
+          metadata: {},
+          payload: {
+            threadId,
+            session: {
+              threadId,
+              status: "running",
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId: turnId,
+              lastError: null,
+              updatedAt: "2026-05-05T03:20:20.549Z",
+            },
+          },
+        });
+
+        yield* appendAndProject({
+          type: "thread.message-sent",
+          eventId: EventId.make("evt-active-segment-5"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-05-05T03:20:31.834Z",
+          commandId: CommandId.make("cmd-active-segment-5"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-active-segment-5"),
+          metadata: {},
+          payload: {
+            threadId,
+            messageId: interimMessageId,
+            role: "assistant",
+            text: "",
+            turnId,
+            streaming: false,
+            createdAt: "2026-05-05T03:20:31.834Z",
+            updatedAt: "2026-05-05T03:20:31.834Z",
+          },
+        });
+
+        const runningRows = yield* sql<{
+          readonly state: string;
+          readonly completedAt: string | null;
+          readonly assistantMessageId: string | null;
+          readonly sessionStatus: string;
+          readonly activeTurnId: string | null;
+        }>`
+          SELECT
+            turns.state,
+            turns.completed_at AS "completedAt",
+            turns.assistant_message_id AS "assistantMessageId",
+            sessions.status AS "sessionStatus",
+            sessions.active_turn_id AS "activeTurnId"
+          FROM projection_turns AS turns
+          JOIN projection_thread_sessions AS sessions
+            ON sessions.thread_id = turns.thread_id
+          WHERE turns.thread_id = ${threadId}
+            AND turns.turn_id = ${turnId}
+        `;
+
+        assert.deepEqual(runningRows, [
+          {
+            state: "running",
+            completedAt: null,
+            assistantMessageId: "assistant-active-segment-interim",
+            sessionStatus: "running",
+            activeTurnId: "turn-active-segment",
+          },
+        ]);
+
+        yield* appendAndProject({
+          type: "thread.session-set",
+          eventId: EventId.make("evt-active-segment-6"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-05-05T03:20:45.000Z",
+          commandId: CommandId.make("cmd-active-segment-6"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-active-segment-6"),
+          metadata: {},
+          payload: {
+            threadId,
+            session: {
+              threadId,
+              status: "ready",
+              providerName: "codex",
+              runtimeMode: "full-access",
+              activeTurnId: null,
+              lastError: null,
+              updatedAt: "2026-05-05T03:20:45.000Z",
+            },
+          },
+        });
+
+        yield* appendAndProject({
+          type: "thread.message-sent",
+          eventId: EventId.make("evt-active-segment-7"),
+          aggregateKind: "thread",
+          aggregateId: threadId,
+          occurredAt: "2026-05-05T03:20:46.000Z",
+          commandId: CommandId.make("cmd-active-segment-7"),
+          causationEventId: null,
+          correlationId: CorrelationId.make("cmd-active-segment-7"),
+          metadata: {},
+          payload: {
+            threadId,
+            messageId: finalMessageId,
+            role: "assistant",
+            text: "",
+            turnId,
+            streaming: false,
+            createdAt: "2026-05-05T03:20:46.000Z",
+            updatedAt: "2026-05-05T03:20:46.000Z",
+          },
+        });
+
+        const completedRows = yield* sql<{
+          readonly state: string;
+          readonly completedAt: string | null;
+          readonly assistantMessageId: string | null;
+          readonly sessionStatus: string;
+          readonly activeTurnId: string | null;
+        }>`
+          SELECT
+            turns.state,
+            turns.completed_at AS "completedAt",
+            turns.assistant_message_id AS "assistantMessageId",
+            sessions.status AS "sessionStatus",
+            sessions.active_turn_id AS "activeTurnId"
+          FROM projection_turns AS turns
+          JOIN projection_thread_sessions AS sessions
+            ON sessions.thread_id = turns.thread_id
+          WHERE turns.thread_id = ${threadId}
+            AND turns.turn_id = ${turnId}
+        `;
+
+        assert.deepEqual(completedRows, [
+          {
+            state: "completed",
+            completedAt: "2026-05-05T03:20:45.000Z",
+            assistantMessageId: "assistant-active-segment-final",
+            sessionStatus: "ready",
+            activeTurnId: null,
+          },
+        ]);
+
+        yield* sql`DELETE FROM projection_turns`;
+        yield* sql`DELETE FROM projection_thread_sessions`;
+        yield* sql`DELETE FROM projection_state`;
+        yield* projectionPipeline.bootstrap;
+
+        const rebuiltRows = yield* sql<{
+          readonly state: string;
+          readonly completedAt: string | null;
+          readonly assistantMessageId: string | null;
+          readonly sessionStatus: string;
+          readonly activeTurnId: string | null;
+        }>`
+          SELECT
+            turns.state,
+            turns.completed_at AS "completedAt",
+            turns.assistant_message_id AS "assistantMessageId",
+            sessions.status AS "sessionStatus",
+            sessions.active_turn_id AS "activeTurnId"
+          FROM projection_turns AS turns
+          JOIN projection_thread_sessions AS sessions
+            ON sessions.thread_id = turns.thread_id
+          WHERE turns.thread_id = ${threadId}
+            AND turns.turn_id = ${turnId}
+        `;
+
+        assert.deepEqual(rebuiltRows, [
+          {
+            state: "completed",
+            completedAt: "2026-05-05T03:20:45.000Z",
+            assistantMessageId: "assistant-active-segment-final",
+            sessionStatus: "ready",
+            activeTurnId: null,
+          },
+        ]);
+      }),
+    );
+  },
+);
+
 const engineLayer = it.layer(
   OrchestrationEngineLive.pipe(
     Layer.provide(OrchestrationProjectionSnapshotQueryLive),

--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -993,6 +993,25 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
         case "thread.session-set": {
           const turnId = event.payload.session.activeTurnId;
           if (turnId === null || event.payload.session.status !== "running") {
+            if (event.payload.session.status === "running") {
+              return;
+            }
+            const existingTurns = yield* projectionTurnRepository.listByThreadId({
+              threadId: event.payload.threadId,
+            });
+            const runningTurn = existingTurns
+              .toReversed()
+              .find((entry) => entry.turnId !== null && entry.state === "running");
+            if (!runningTurn || runningTurn.turnId === null) {
+              return;
+            }
+
+            yield* projectionTurnRepository.upsertByTurnId({
+              ...runningTurn,
+              turnId: runningTurn.turnId,
+              state: event.payload.session.status === "error" ? "error" : "completed",
+              completedAt: runningTurn.completedAt ?? event.payload.session.updatedAt,
+            });
             return;
           }
 
@@ -1004,13 +1023,11 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             threadId: event.payload.threadId,
           });
           if (Option.isSome(existingTurn)) {
-            const nextState =
-              existingTurn.value.state === "completed" || existingTurn.value.state === "error"
-                ? existingTurn.value.state
-                : "running";
+            const nextState = existingTurn.value.state === "error" ? "error" : "running";
             yield* projectionTurnRepository.upsertByTurnId({
               ...existingTurn.value,
               state: nextState,
+              completedAt: nextState === "running" ? null : existingTurn.value.completedAt,
               pendingMessageId:
                 existingTurn.value.pendingMessageId ??
                 (Option.isSome(pendingTurnStart) ? pendingTurnStart.value.messageId : null),
@@ -1079,19 +1096,26 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             turnId: event.payload.turnId,
           });
           if (Option.isSome(existingTurn)) {
+            const preserveSettledFailure =
+              existingTurn.value.state === "interrupted" || existingTurn.value.state === "error";
+            const nextState = event.payload.streaming
+              ? existingTurn.value.state
+              : existingTurn.value.state === "running"
+                ? "running"
+                : preserveSettledFailure
+                  ? existingTurn.value.state
+                  : "completed";
+            const completedAt =
+              event.payload.streaming || existingTurn.value.state === "running"
+                ? existingTurn.value.completedAt
+                : preserveSettledFailure
+                  ? existingTurn.value.completedAt
+                  : (existingTurn.value.completedAt ?? event.payload.updatedAt);
             yield* projectionTurnRepository.upsertByTurnId({
               ...existingTurn.value,
               assistantMessageId: event.payload.messageId,
-              state: event.payload.streaming
-                ? existingTurn.value.state
-                : existingTurn.value.state === "interrupted"
-                  ? "interrupted"
-                  : existingTurn.value.state === "error"
-                    ? "error"
-                    : "completed",
-              completedAt: event.payload.streaming
-                ? existingTurn.value.completedAt
-                : (existingTurn.value.completedAt ?? event.payload.updatedAt),
+              state: nextState,
+              completedAt,
               startedAt: existingTurn.value.startedAt ?? event.payload.createdAt,
               requestedAt: existingTurn.value.requestedAt ?? event.payload.createdAt,
             });


### PR DESCRIPTION
## What changed
- Keep a projected turn in `running` while the thread session still reports that same turn as active.
- Complete or error the latest running turn when the session settles instead of completing it from every non-streaming assistant message.
- Reopen a stale completed turn if a later running session update reports that turn as active again.
- Add a regression test that covers both live projection and replay from the event log.

## Why this should exist
This is a focused server projection correctness fix.

A local T3 Code 0.0.22 desktop state showed this inconsistent projection:

```text
projection_thread_sessions.status = running
projection_thread_sessions.active_turn_id = 019df64c-8cf7-79f0-8b0f-7591e0dbbbbc
projection_turns.state for active turn = completed
projection_turns.completed_at = 2026-05-05T04:01:59.270Z
provider_session_runtime.status = running
provider_session_runtime.runtime_payload.activeTurnId = 019df650-a59b-7fa3-870e-b47ea9d1bf61
later assistant messages for the completed turn = yes
```

The event stream showed a running session, then a non-streaming assistant message for the active turn, then more provider activity. The old projection logic treated that non-streaming assistant message as final turn completion. That is too early for providers that emit non-streaming assistant segments during longer work.

The regression test mirrors that sequence. It then deletes the projection rows and bootstraps from the event log again, so the test covers both online projection and replay.

## Scope
- Server projection only.
- No UI change.
- No provider runtime behavior change.
- No reconnect behavior change.
- Separate from the visited-state fix in #2506 and the reconnect retry fix in #2513.
- The diff is larger than the logic change because the regression test needs full orchestration event envelopes.

## Validation
- `npx --yes bun@1.3.11 run --filter t3 test src/orchestration/Layers/ProjectionPipeline.test.ts` - 19 passed
- `npx --yes bun@1.3.11 run --filter t3 test src/orchestration/Layers/ProviderRuntimeIngestion.test.ts` - 38 passed
- `npx --yes bun@1.3.11 run --filter t3 test` - 121 files passed, 961 tests passed, 1 file / 4 tests skipped
- `npx --yes bun@1.3.11 run fmt:check` - passed
- `npx --yes bun@1.3.11 run lint` - 0 errors, existing warnings only
- `npx --yes bun@1.3.11 run --filter t3 typecheck` - exit 0, existing Effect language-service messages only