### PR TITLE
Add desktop update release notes tooltip

### DIFF
--- a/apps/web/src/components/DesktopUpdateTooltip.tsx
+++ b/apps/web/src/components/DesktopUpdateTooltip.tsx
@@ -1,0 +1,79 @@
+import type { DesktopUpdateState } from "@t3tools/contracts";
+import type { ComponentProps } from "react";
+import { ExternalLinkIcon } from "lucide-react";
+
+import {
+  getDesktopUpdateLatestVersion,
+  getDesktopUpdateReleaseNotesUrl,
+} from "./desktopUpdate.logic";
+import { readLocalApi } from "../localApi";
+import { stackedThreadToast, toastManager } from "./ui/toast";
+import { TooltipPopup } from "./ui/tooltip";
+
+type DesktopUpdateTooltipPopupProps = {
+  state: DesktopUpdateState | null;
+  summary: string;
+  side?: ComponentProps<typeof TooltipPopup>["side"];
+};
+
+function getDesktopUpdateTooltipTitle(state: DesktopUpdateState | null): string {
+  if (!state) return "Update Available";
+  if (state.status === "downloaded") return "Restart to Update";
+  if (state.status === "downloading") return "Downloading Update";
+  if (state.status === "error") return "Update Needs Attention";
+  if (state.status === "available") return "Update Available";
+  return "Application Update";
+}
+
+function openReleaseNotes(state: DesktopUpdateState | null) {
+  const api = readLocalApi();
+  const url = getDesktopUpdateReleaseNotesUrl(state);
+  void api?.shell.openExternal(url).catch((error: unknown) => {
+    toastManager.add(
+      stackedThreadToast({
+        type: "error",
+        title: "Could not open release notes",
+        description: error instanceof Error ? error.message : "Unable to open GitHub Releases.",
+      }),
+    );
+  });
+}
+
+export function DesktopUpdateTooltipPopup({
+  state,
+  summary,
+  side = "top",
+}: DesktopUpdateTooltipPopupProps) {
+  const latestVersion = state ? getDesktopUpdateLatestVersion(state) : null;
+
+  return (
+    <TooltipPopup side={side} className="w-72 text-left">
+      <div className="flex flex-col gap-3 py-1">
+        <div className="flex flex-col gap-1">
+          <div className="text-sm font-semibold text-popover-foreground">
+            {getDesktopUpdateTooltipTitle(state)}
+          </div>
+          <div className="text-xs leading-snug text-muted-foreground">{summary}</div>
+        </div>
+        <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-xs">
+          <span className="text-muted-foreground">Current Version</span>
+          <span className="min-w-0 truncate font-mono text-popover-foreground">
+            {state?.currentVersion ?? "Unknown"}
+          </span>
+          <span className="text-muted-foreground">Latest Version</span>
+          <span className="min-w-0 truncate font-mono text-popover-foreground">
+            {latestVersion ?? "Unknown"}
+          </span>
+        </div>
+        <button
+          type="button"
+          className="inline-flex h-8 w-fit items-center gap-1.5 rounded-md border border-border bg-background px-2.5 text-xs font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+          onClick={() => openReleaseNotes(state)}
+        >
+          Release Notes
+          <ExternalLinkIcon className="size-3" />
+        </button>
+      </div>
+    </TooltipPopup>
+  );
+}

--- a/apps/web/src/components/desktopUpdate.logic.test.ts
+++ b/apps/web/src/components/desktopUpdate.logic.test.ts
@@ -7,6 +7,8 @@ import {
   getDesktopUpdateActionError,
   getDesktopUpdateButtonTooltip,
   getDesktopUpdateInstallConfirmationMessage,
+  getDesktopUpdateLatestVersion,
+  getDesktopUpdateReleaseNotesUrl,
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
   shouldShowArm64IntelBuildWarning,
@@ -287,6 +289,50 @@ describe("getDesktopUpdateButtonTooltip", () => {
     expect(getDesktopUpdateButtonTooltip({ ...baseState, status: "idle" })).toBe("Up to date");
     expect(getDesktopUpdateButtonTooltip({ ...baseState, status: "up-to-date" })).toBe(
       "Up to date",
+    );
+  });
+});
+
+describe("desktop update release notes helpers", () => {
+  it("resolves the latest version from downloaded or available state", () => {
+    expect(
+      getDesktopUpdateLatestVersion({
+        ...baseState,
+        availableVersion: "1.1.0",
+        downloadedVersion: "1.1.1",
+      }),
+    ).toBe("1.1.1");
+    expect(getDesktopUpdateLatestVersion({ ...baseState, availableVersion: "1.1.0" })).toBe(
+      "1.1.0",
+    );
+  });
+
+  it("links stable updates to their GitHub release tag", () => {
+    expect(
+      getDesktopUpdateReleaseNotesUrl({
+        ...baseState,
+        channel: "latest",
+        availableVersion: "1.1.0",
+      }),
+    ).toBe("https://github.com/pingdotgg/t3code/releases/tag/v1.1.0");
+  });
+
+  it("links nightly updates to their GitHub release tag", () => {
+    expect(
+      getDesktopUpdateReleaseNotesUrl({
+        ...baseState,
+        channel: "nightly",
+        availableVersion: "1.1.0-nightly.20260501.17",
+      }),
+    ).toBe("https://github.com/pingdotgg/t3code/releases/tag/nightly-v1.1.0-nightly.20260501.17");
+  });
+
+  it("falls back to the releases page when no latest version is known", () => {
+    expect(getDesktopUpdateReleaseNotesUrl(null)).toBe(
+      "https://github.com/pingdotgg/t3code/releases",
+    );
+    expect(getDesktopUpdateReleaseNotesUrl(baseState)).toBe(
+      "https://github.com/pingdotgg/t3code/releases",
     );
   });
 });

--- a/apps/web/src/components/desktopUpdate.logic.ts
+++ b/apps/web/src/components/desktopUpdate.logic.ts
@@ -2,6 +2,8 @@ import type { DesktopUpdateActionResult, DesktopUpdateState } from "@t3tools/con
 
 export type DesktopUpdateButtonAction = "download" | "install" | "none";
 
+const DESKTOP_UPDATE_RELEASES_URL = "https://github.com/pingdotgg/t3code/releases";
+
 export function resolveDesktopUpdateButtonAction(
   state: DesktopUpdateState,
 ): DesktopUpdateButtonAction {
@@ -74,6 +76,20 @@ export function getDesktopUpdateButtonTooltip(state: DesktopUpdateState): string
     return state.message ?? "Update failed";
   }
   return "Up to date";
+}
+
+export function getDesktopUpdateLatestVersion(state: DesktopUpdateState): string | null {
+  return state.downloadedVersion ?? state.availableVersion;
+}
+
+export function getDesktopUpdateReleaseNotesUrl(state: DesktopUpdateState | null): string {
+  const latestVersion = state ? getDesktopUpdateLatestVersion(state) : null;
+  if (!state || !latestVersion) {
+    return DESKTOP_UPDATE_RELEASES_URL;
+  }
+
+  const tag = state.channel === "nightly" ? `nightly-v${latestVersion}` : `v${latestVersion}`;
+  return `${DESKTOP_UPDATE_RELEASES_URL}/tag/${encodeURIComponent(tag)}`;
 }
 
 export function getDesktopUpdateInstallConfirmationMessage(

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -26,6 +26,7 @@ import {
   isDesktopUpdateButtonDisabled,
   resolveDesktopUpdateButtonAction,
 } from "../../components/desktopUpdate.logic";
+import { DesktopUpdateTooltipPopup } from "../../components/DesktopUpdateTooltip";
 import { ProviderModelPicker } from "../chat/ProviderModelPicker";
 import { TraitsPicker } from "../chat/TraitsPicker";
 import { isElectron } from "../../env";
@@ -311,7 +312,9 @@ function AboutVersionSection() {
                 </Button>
               }
             />
-            {buttonTooltip ? <TooltipPopup>{buttonTooltip}</TooltipPopup> : null}
+            {buttonTooltip ? (
+              <DesktopUpdateTooltipPopup state={updateState} summary={buttonTooltip} />
+            ) : null}
           </Tooltip>
         }
       />

--- a/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
+++ b/apps/web/src/components/sidebar/SidebarUpdatePill.tsx
@@ -19,6 +19,7 @@ import {
   shouldToastDesktopUpdateActionResult,
 } from "../desktopUpdate.logic";
 import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
+import { DesktopUpdateTooltipPopup } from "../DesktopUpdateTooltip";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 export function SidebarUpdatePill() {
@@ -158,7 +159,7 @@ export function SidebarUpdatePill() {
                 </button>
               }
             />
-            <TooltipPopup side="top">{tooltip}</TooltipPopup>
+            <DesktopUpdateTooltipPopup state={state} summary={tooltip} side="top" />
           </Tooltip>
           {action === "download" && (
             <Tooltip>


### PR DESCRIPTION
Got inspired by VSCode: 

<img width="666" height="404" alt="image" src="https://github.com/user-attachments/assets/d758c557-7c88-420e-a944-fabf3126540d" />



- Add a shared tooltip popup for desktop update states
- Link update status to the correct GitHub release notes
- Cover latest version and release URL helpers with tests

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to desktop update tooltips and external link handling; no auth, data, or updater core logic changes.
> 
> **Overview**
> Desktop update affordances in the **sidebar pill** and **Settings → About** now show a VS Code–style tooltip instead of a one-line string.
> 
> The new **`DesktopUpdateTooltipPopup`** surfaces a status title, the existing tooltip summary, **current** and **latest** versions, and a **Release Notes** control that opens GitHub via `shell.openExternal`, with an error toast if that fails.
> 
> **`getDesktopUpdateLatestVersion`** and **`getDesktopUpdateReleaseNotesUrl`** build the correct tag URL for stable (`v…`) vs nightly (`nightly-v…`) channels, with a fallback to the releases index when no version is known; unit tests cover these helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f6f68359c4b172a972b09489f329199cf17fa26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add release notes tooltip to desktop update UI with version info and external link
> - Adds `DesktopUpdateTooltipPopup` component that replaces simple text tooltips in the sidebar update pill and settings About section with a richer UI showing current/latest versions, a state-derived title, and a 'Release Notes' button.
> - Adds `getDesktopUpdateReleaseNotesUrl` to build a tag-specific GitHub Releases URL based on update channel (nightly vs stable) and `getDesktopUpdateLatestVersion` to resolve the newest known version from update state.
> - The 'Release Notes' button opens the URL via `api.shell.openExternal` and shows an error toast on failure.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f6f683.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->