### PR TITLE
feat(web): make auto-create PR on push optional

### DIFF
--- a/apps/desktop/src/clientPersistence.test.ts
+++ b/apps/desktop/src/clientPersistence.test.ts
@@ -49,6 +49,7 @@ function makeSecretStorage(available: boolean): DesktopSecretStorage {
 }
 
 const clientSettings: ClientSettings = {
+  autoCreatePrOnPush: true,
   autoOpenPlanSidebar: false,
   confirmThreadArchive: true,
   confirmThreadDelete: false,

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1131,3 +1131,79 @@ describe("resolveAutoFeatureBranchName", () => {
     assert.equal(ref, "feature/update");
   });
 });
+
+describe("when: autoCreatePr is disabled", () => {
+  it("downgrades feature-branch commit+push from PR to plain commit & push", () => {
+    const quick = resolveQuickAction(
+      status({ hasWorkingTreeChanges: true }),
+      false,
+      false,
+      true,
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "run_action",
+      action: "commit_push",
+      label: "Commit & push",
+      disabled: false,
+    });
+  });
+
+  it("downgrades feature-branch ahead-with-upstream from create PR to plain push", () => {
+    const quick = resolveQuickAction(
+      status({ aheadCount: 2 }),
+      false,
+      false,
+      true,
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "run_action",
+      action: "push",
+      label: "Push",
+      disabled: false,
+    });
+  });
+
+  it("downgrades feature-branch ahead-without-upstream from create PR to plain push", () => {
+    const quick = resolveQuickAction(
+      status({ aheadCount: 1, hasUpstream: false }),
+      false,
+      false,
+      true,
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "run_action",
+      action: "push",
+      label: "Push",
+      disabled: false,
+    });
+  });
+
+  it("preserves Commit, push & PR when autoCreatePr is true (default)", () => {
+    const quick = resolveQuickAction(
+      status({ hasWorkingTreeChanges: true }),
+      false,
+      false,
+      true,
+      true,
+    );
+    assert.deepInclude(quick, {
+      kind: "run_action",
+      action: "commit_push_pr",
+      label: "Commit, push & PR",
+      disabled: false,
+    });
+  });
+
+  it("preserves Push & create PR when autoCreatePr is true (default)", () => {
+    const quick = resolveQuickAction(status({ aheadCount: 2 }), false, false, true, true);
+    assert.deepInclude(quick, {
+      kind: "run_action",
+      action: "create_pr",
+      label: "Push & create PR",
+      disabled: false,
+    });
+  });
+});

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1150,13 +1150,7 @@ describe("when: autoCreatePr is disabled", () => {
   });
 
   it("downgrades feature-branch ahead-with-upstream from create PR to plain push", () => {
-    const quick = resolveQuickAction(
-      status({ aheadCount: 2 }),
-      false,
-      false,
-      true,
-      false,
-    );
+    const quick = resolveQuickAction(status({ aheadCount: 2 }), false, false, true, false);
     assert.deepInclude(quick, {
       kind: "run_action",
       action: "push",

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -169,6 +169,7 @@ export function resolveQuickAction(
   isBusy: boolean,
   isDefaultRef = false,
   hasPrimaryRemote = true,
+  autoCreatePr = true,
 ): GitQuickAction {
   if (isBusy) {
     return { label: "Commit", disabled: true, kind: "show_hint", hint: "Git action in progress." };
@@ -205,7 +206,7 @@ export function resolveQuickAction(
     if (!gitStatus.hasUpstream && !hasPrimaryRemote) {
       return { label: "Commit", disabled: false, kind: "run_action", action: "commit" };
     }
-    if (hasOpenPr || isDefaultRef) {
+    if (hasOpenPr || isDefaultRef || !autoCreatePr) {
       return { label: "Commit & push", disabled: false, kind: "run_action", action: "commit_push" };
     }
     return {
@@ -238,7 +239,7 @@ export function resolveQuickAction(
         hint: "No local commits to push.",
       };
     }
-    if (hasOpenPr || isDefaultRef) {
+    if (hasOpenPr || isDefaultRef || !autoCreatePr) {
       return {
         label: "Push",
         disabled: false,
@@ -272,7 +273,7 @@ export function resolveQuickAction(
   }
 
   if (isAhead) {
-    if (hasOpenPr || isDefaultRef) {
+    if (hasOpenPr || isDefaultRef || !autoCreatePr) {
       return {
         label: "Push",
         disabled: false,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -44,6 +44,7 @@ import {
   resolveThreadBranchUpdate,
 } from "./GitActionsControl.logic";
 import { AnimatedHeight } from "./AnimatedHeight";
+import { useSettings } from "../hooks/useSettings";
 import { Button } from "~/components/ui/button";
 import { Checkbox } from "~/components/ui/checkbox";
 import {
@@ -1136,10 +1137,17 @@ export default function GitActionsControl({
     () => buildMenuItems(gitStatusForActions, isGitActionRunning, hasPrimaryRemote),
     [gitStatusForActions, hasPrimaryRemote, isGitActionRunning],
   );
+  const autoCreatePrOnPush = useSettings((s) => s.autoCreatePrOnPush);
   const quickAction = useMemo(
     () =>
-      resolveQuickAction(gitStatusForActions, isGitActionRunning, isDefaultRef, hasPrimaryRemote),
-    [gitStatusForActions, hasPrimaryRemote, isDefaultRef, isGitActionRunning],
+      resolveQuickAction(
+        gitStatusForActions,
+        isGitActionRunning,
+        isDefaultRef,
+        hasPrimaryRemote,
+        autoCreatePrOnPush,
+      ),
+    [autoCreatePrOnPush, gitStatusForActions, hasPrimaryRemote, isDefaultRef, isGitActionRunning],
   );
   const quickActionDisabledReason = quickAction.disabled
     ? (quickAction.hint ?? "This action is currently unavailable.")

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -973,6 +973,32 @@ export function GeneralSettingsPanel() {
         />
 
         <SettingsRow
+          title="Auto-create PR on push"
+          description="When pushing a feature branch with no open PR, also create a pull request automatically."
+          resetAction={
+            settings.autoCreatePrOnPush !== DEFAULT_UNIFIED_SETTINGS.autoCreatePrOnPush ? (
+              <SettingResetButton
+                label="auto-create PR on push"
+                onClick={() =>
+                  updateSettings({
+                    autoCreatePrOnPush: DEFAULT_UNIFIED_SETTINGS.autoCreatePrOnPush,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.autoCreatePrOnPush}
+              onCheckedChange={(checked) =>
+                updateSettings({ autoCreatePrOnPush: Boolean(checked) })
+              }
+              aria-label="Auto-create PR on push"
+            />
+          }
+        />
+
+        <SettingsRow
           title="New threads"
           description="Pick the default workspace mode for newly created draft threads."
           resetAction={

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -570,6 +570,7 @@ describe("wsApi", () => {
 
   it("reads and writes persistence through the desktop bridge when available", async () => {
     const clientSettings = {
+      autoCreatePrOnPush: true,
       autoOpenPlanSidebar: false,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
@@ -631,6 +632,7 @@ describe("wsApi", () => {
     const { createLocalApi } = await import("./localApi");
     const api = createLocalApi(rpcClientMock as never);
     const clientSettings = {
+      autoCreatePrOnPush: true,
       autoOpenPlanSidebar: false,
       confirmThreadArchive: true,
       confirmThreadDelete: false,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -29,6 +29,7 @@ export type SidebarProjectGroupingMode = typeof SidebarProjectGroupingMode.Type;
 export const DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE: SidebarProjectGroupingMode = "repository";
 
 export const ClientSettingsSchema = Schema.Struct({
+  autoCreatePrOnPush: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),


### PR DESCRIPTION
## What Changed

Adds a client setting **"Auto-create PR on push"** (default on, preserves current behaviour). When switched off, the commit button on a feature branch with no open PR drops the PR step:

- `Commit, push & PR` → `Commit & push`
- `Push & create PR` → `Push`

Pushing to the default branch, pushing into an existing open PR, and the standalone `Create PR` affordance (when a clean branch is only ahead of default) are unchanged. The dropdown menu still exposes a separate **Create PR** entry, so opening a PR later is one click.

## Why

Right now, on a feature branch with uncommitted changes (or just commits to push), the quick action insists on opening a PR alongside the push. That's the right default for a lot of workflows, but not all — sometimes you want to push a WIP branch, share the ref, and only open a PR once it's actually ready for review. Today the only way to do that is to use the dropdown each time, which adds friction to the common case.

This makes it a one-time toggle in settings rather than a per-push decision.

## UI Changes

New row in General settings, next to the existing workflow toggles (Auto-open task panel, etc.). No change to the commit button itself when the setting is left at its default.

## Screenshots

### Before (PR button)

<img width="457" height="84" alt="image" src="https://github.com/user-attachments/assets/2cc20326-5d6c-496a-9f8a-d94218e581ee" />

### After (Settings toggle and PR button)

<img width="883" height="147" alt="image" src="https://github.com/user-attachments/assets/c725658a-0c4a-40ed-ad55-044ad2aa33bc" />

______________

<img width="442" height="84" alt="image" src="https://github.com/user-attachments/assets/72cc594f-4176-4017-8085-7f98c1c8c689" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ]  I included a video for animation/interaction changes (n/a)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add opt-in toggle to disable auto-create PR on push
> - Adds `autoCreatePrOnPush` boolean to `ClientSettingsSchema` (default `true`) and exposes a toggle in the General settings panel.
> - `resolveQuickAction` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/2524/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) accepts a new `autoCreatePr` parameter; when `false`, it returns `Commit & push` or `Push` instead of `Commit, push & PR` or `Push & create PR`.
> - [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/2524/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) reads `autoCreatePrOnPush` from settings and passes it to `resolveQuickAction`.
> - Behavioral Change: existing users are unaffected (default is `true`), but toggling the setting off removes PR-creation from the quick action button.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cd3500b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->