### PR TITLE
Fix OpenCode raw text delta assembly

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -565,17 +565,98 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
     }),
   );
 
-  it.effect("deduplicates overlapping assistant text deltas after part updates", () =>
+  it.effect("appends raw assistant text deltas and reconciles part update snapshots", () =>
     Effect.sync(() => {
       const firstUpdate = mergeOpenCodeAssistantText(undefined, "Hello");
       const overlapDelta = appendOpenCodeAssistantTextDelta(firstUpdate.latestText, "lo world");
-      const secondUpdate = mergeOpenCodeAssistantText(overlapDelta.nextText, "Hello world!");
+      const secondUpdate = mergeOpenCodeAssistantText(overlapDelta.nextText, "Hellolo world");
 
       assert.deepEqual(
         [firstUpdate.deltaToEmit, overlapDelta.deltaToEmit, secondUpdate.deltaToEmit],
-        ["Hello", " world", "!"],
+        ["Hello", "lo world", ""],
       );
-      assert.equal(secondUpdate.latestText, "Hello world!");
+      assert.equal(secondUpdate.latestText, "Hellolo world");
+    }),
+  );
+
+  it.effect("does not strip coincidental prefix overlap from OpenCode part deltas", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-raw-delta");
+      const part = {
+        id: "part-raw-delta",
+        sessionID: "http://127.0.0.1:9999/session",
+        messageID: "msg-raw-delta",
+        type: "text",
+        text: "A B",
+        time: { start: 1 },
+      };
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "message.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            info: {
+              id: "msg-raw-delta",
+              role: "assistant",
+            },
+          },
+        },
+        {
+          type: "message.part.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            part,
+            time: 1,
+          },
+        },
+        {
+          type: "message.part.delta",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            messageID: "msg-raw-delta",
+            partID: "part-raw-delta",
+            field: "text",
+            delta: "Bonus",
+          },
+        },
+        {
+          type: "message.part.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            part: {
+              ...part,
+              text: "A BBonus",
+              time: { start: 1, end: 2 },
+            },
+            time: 2,
+          },
+        },
+      ];
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(5),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      const deltas = events.filter((event) => event.type === "content.delta");
+      assert.deepEqual(
+        deltas.map((event) => (event.type === "content.delta" ? event.payload.delta : "")),
+        ["A B", "Bonus"],
+      );
+      assert.equal(events.at(-1)?.type, "item.completed");
+      const completed = events.at(-1);
+      if (completed?.type === "item.completed") {
+        assert.equal(completed.payload.detail, "A BBonus");
+      }
     }),
   );
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -302,16 +302,6 @@ function commonPrefixLength(left: string, right: string): number {
   return index;
 }
 
-function suffixPrefixOverlap(text: string, delta: string): number {
-  const maxLength = Math.min(text.length, delta.length);
-  for (let length = maxLength; length > 0; length -= 1) {
-    if (text.endsWith(delta.slice(0, length))) {
-      return length;
-    }
-  }
-  return 0;
-}
-
 function resolveLatestAssistantText(previousText: string | undefined, nextText: string): string {
   if (previousText && previousText.length > nextText.length && previousText.startsWith(nextText)) {
     return previousText;
@@ -340,10 +330,9 @@ export function appendOpenCodeAssistantTextDelta(
   readonly nextText: string;
   readonly deltaToEmit: string;
 } {
-  const deltaToEmit = delta.slice(suffixPrefixOverlap(previousText, delta));
   return {
-    nextText: previousText + deltaToEmit,
-    deltaToEmit,
+    nextText: previousText + delta,
+    deltaToEmit: delta,
   };
 }
 


### PR DESCRIPTION
## What changed

- Treat OpenCode `message.part.delta` text chunks as raw incremental deltas and append them exactly as received.
- Keep `message.part.updated` snapshot handling as the reconciliation path.
- Add regression coverage for coincidental suffix/prefix overlap, where the old dedupe logic could strip valid leading characters from a delta.

## Why this should exist

Fixes #2380.
Likely related to #2379.

OpenCode text deltas are already valid incremental chunks. The previous overlap heuristic tried to dedupe suffix/prefix overlap between the already assembled assistant text and the next delta, but normal text can overlap coincidentally.

For example, if the current text ends in `B` and the next raw delta is `Bonus`, stripping the overlap turns `Bonus` into `onus`. A later `message.part.updated` snapshot then reconciles the missing text by emitting a larger corrective suffix, which can make the assistant response appear duplicated or corrupted near completion.

This change makes raw deltas authoritative and leaves full part snapshots to reconcile state without mutating normal streamed chunks.

## Scope

- OpenCode provider assistant text assembly only.
- No UI change.
- No protocol or persistence change.
- No behavior change for other providers.

## Validation

- `bun fmt`
- `bun lint` - 0 errors, existing warnings only
- `bun typecheck` - passed
- `bun run --cwd apps/server test src/provider/Layers/OpenCodeAdapter.test.ts` - 14 passed

## UI Changes

Not applicable. This is a server-side provider streaming fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (N/A)
- [ ] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OpenCode assistant text streaming assembly; incorrect handling could impact user-visible output ordering/duplication, but scope is limited to a single provider and covered by new regression tests.
> 
> **Overview**
> Fixes OpenCode assistant text assembly by **treating `message.part.delta` text as raw incremental chunks** and appending them verbatim, removing the prior suffix/prefix overlap de-duplication heuristic.
> 
> Keeps `message.part.updated` handling as the reconciliation mechanism, and updates/adds tests to cover overlapping-update scenarios and the regression where coincidental prefix overlap (e.g. `B` + `Bonus`) previously caused valid characters to be stripped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 584ab1c2d389270847151398a3a443e004acbc80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `appendOpenCodeAssistantTextDelta` to append raw deltas without stripping prefix overlaps
> - Removes the `suffixPrefixOverlap` helper and the trimming logic from `appendOpenCodeAssistantTextDelta` in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/2526/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7); deltas are now appended as-is.
> - Behavioral Change: `nextText` is now a direct concatenation of `previousText` and the full delta, and callers receive the original delta string rather than an overlap-trimmed version.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 584ab1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->