### PR TITLE
Add keybindings settings editor

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -354,7 +354,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
-  it.effect("replaces existing custom keybinding for the same command", () =>
+  it.effect("appends additional custom keybindings for the same command", () =>
     Effect.gen(function* () {
       const { keybindingsConfigPath } = yield* ServerConfig;
       yield* writeKeybindingsConfig(keybindingsConfigPath, [
@@ -364,6 +364,55 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
         const keybindings = yield* Keybindings;
         return yield* keybindings.upsertKeybindingRule({
           key: "mod+shift+r",
+          command: "script.run-tests.run",
+        });
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command }) => ({ key, command }));
+      assert.deepEqual(persistedView, [
+        { key: "mod+r", command: "script.run-tests.run" },
+        { key: "mod+shift+r", command: "script.run-tests.run" },
+      ]);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("replaces only the targeted custom keybinding", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+r", command: "script.run-tests.run" },
+        { key: "mod+shift+r", command: "script.run-tests.run" },
+      ]);
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.upsertKeybindingRule({
+          key: "mod+alt+r",
+          command: "script.run-tests.run",
+          replace: { key: "mod+r", command: "script.run-tests.run" },
+        });
+      });
+
+      const persisted = yield* readKeybindingsConfig(keybindingsConfigPath);
+      const persistedView = persisted.map(({ key, command }) => ({ key, command }));
+      assert.deepEqual(persistedView, [
+        { key: "mod+shift+r", command: "script.run-tests.run" },
+        { key: "mod+alt+r", command: "script.run-tests.run" },
+      ]);
+    }).pipe(Effect.provide(makeKeybindingsLayer())),
+  );
+
+  it.effect("removes only the targeted custom keybinding", () =>
+    Effect.gen(function* () {
+      const { keybindingsConfigPath } = yield* ServerConfig;
+      yield* writeKeybindingsConfig(keybindingsConfigPath, [
+        { key: "mod+r", command: "script.run-tests.run" },
+        { key: "mod+shift+r", command: "script.run-tests.run" },
+      ]);
+      yield* Effect.gen(function* () {
+        const keybindings = yield* Keybindings;
+        return yield* keybindings.removeKeybindingRule({
+          key: "mod+r",
           command: "script.run-tests.run",
         });
       });

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -15,6 +15,8 @@ import {
   MAX_KEYBINDINGS_COUNT,
   ResolvedKeybindingRule,
   ResolvedKeybindingsConfig,
+  type ServerRemoveKeybindingInput,
+  type ServerUpsertKeybindingInput,
   type ServerConfigIssue,
 } from "@t3tools/contracts";
 import {
@@ -122,6 +124,25 @@ function hasSameShortcutContext(left: KeybindingRule, right: KeybindingRule): bo
   const rightContext = keybindingShortcutContext(right);
   if (!leftContext || !rightContext) return false;
   return leftContext === rightContext;
+}
+
+function keybindingRuleFromUpsertInput(input: ServerUpsertKeybindingInput): KeybindingRule {
+  return input.when === undefined
+    ? { key: input.key, command: input.command }
+    : { key: input.key, command: input.command, when: input.when };
+}
+
+function replaceTargetFromUpsertInput(input: ServerUpsertKeybindingInput): KeybindingRule | null {
+  if (!input.replace) return null;
+  return input.replace.when === undefined
+    ? { key: input.replace.key, command: input.replace.command }
+    : { key: input.replace.key, command: input.replace.command, when: input.replace.when };
+}
+
+function keybindingRuleFromRemoveInput(input: ServerRemoveKeybindingInput): KeybindingRule {
+  return input.when === undefined
+    ? { key: input.key, command: input.command }
+    : { key: input.key, command: input.command, when: input.when };
 }
 
 function encodeShortcut(shortcut: KeybindingShortcut): string | null {
@@ -259,7 +280,14 @@ export interface KeybindingsShape {
    * oldest entries when needed.
    */
   readonly upsertKeybindingRule: (
-    rule: KeybindingRule,
+    input: ServerUpsertKeybindingInput,
+  ) => Effect.Effect<ResolvedKeybindingsConfig, KeybindingsConfigError>;
+
+  /**
+   * Remove a single persisted keybinding rule by exact key/command/when match.
+   */
+  readonly removeKeybindingRule: (
+    input: ServerRemoveKeybindingInput,
   ) => Effect.Effect<ResolvedKeybindingsConfig, KeybindingsConfigError>;
 }
 
@@ -616,12 +644,19 @@ const makeKeybindings = Effect.gen(function* () {
     get streamChanges() {
       return Stream.fromPubSub(changesPubSub);
     },
-    upsertKeybindingRule: (rule) =>
+    upsertKeybindingRule: (input) =>
       upsertSemaphore.withPermits(1)(
         Effect.gen(function* () {
           const customConfig = yield* loadWritableCustomKeybindingsConfig();
+          const rule = keybindingRuleFromUpsertInput(input);
+          const replaceTarget = replaceTargetFromUpsertInput(input);
           const nextConfig = [
-            ...customConfig.filter((entry) => entry.command !== rule.command),
+            ...customConfig.filter((entry) => {
+              if (replaceTarget) {
+                return !isSameKeybindingRule(entry, replaceTarget);
+              }
+              return !isSameKeybindingRule(entry, rule);
+            }),
             rule,
           ];
           const cappedConfig =
@@ -637,6 +672,27 @@ const makeKeybindings = Effect.gen(function* () {
           yield* writeConfigAtomically(cappedConfig);
           const nextResolved = mergeWithDefaultKeybindings(
             compileResolvedKeybindingsConfig(cappedConfig),
+          );
+          yield* Cache.set(resolvedConfigCache, resolvedConfigCacheKey, {
+            keybindings: nextResolved,
+            issues: [],
+          });
+          yield* emitChange({
+            keybindings: nextResolved,
+            issues: [],
+          });
+          return nextResolved;
+        }),
+      ),
+    removeKeybindingRule: (input) =>
+      upsertSemaphore.withPermits(1)(
+        Effect.gen(function* () {
+          const customConfig = yield* loadWritableCustomKeybindingsConfig();
+          const target = keybindingRuleFromRemoveInput(input);
+          const nextConfig = customConfig.filter((entry) => !isSameKeybindingRule(entry, target));
+          yield* writeConfigAtomically(nextConfig);
+          const nextResolved = mergeWithDefaultKeybindings(
+            compileResolvedKeybindingsConfig(nextConfig),
           );
           yield* Cache.set(resolvedConfigCache, resolvedConfigCacheKey, {
             keybindings: nextResolved,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -1910,6 +1910,42 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("routes websocket rpc server.removeKeybinding", () =>
+    Effect.gen(function* () {
+      const rule: KeybindingRule = {
+        command: "terminal.toggle",
+        key: "ctrl+k",
+      };
+      const resolved: ResolvedKeybindingRule = {
+        command: "terminal.toggle",
+        shortcut: {
+          key: "j",
+          metaKey: false,
+          ctrlKey: false,
+          shiftKey: false,
+          altKey: false,
+          modKey: true,
+        },
+      };
+
+      yield* buildAppUnderTest({
+        layers: {
+          keybindings: {
+            removeKeybindingRule: () => Effect.succeed([resolved]),
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const response = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) => client[WS_METHODS.serverRemoveKeybinding](rule)),
+      );
+
+      assert.deepEqual(response.issues, []);
+      assert.deepEqual(response.keybindings, [resolved]);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("rejects websocket rpc handshake when session authentication is missing", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -783,6 +783,15 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
             }),
             { "rpc.aggregate": "server" },
           ),
+        [WS_METHODS.serverRemoveKeybinding]: (rule) =>
+          observeRpcEffect(
+            WS_METHODS.serverRemoveKeybinding,
+            Effect.gen(function* () {
+              const keybindingsConfig = yield* keybindings.removeKeybindingRule(rule);
+              return { keybindings: keybindingsConfig, issues: [] };
+            }),
+            { "rpc.aggregate": "server" },
+          ),
         [WS_METHODS.serverGetSettings]: (_input) =>
           observeRpcEffect(
             WS_METHODS.serverGetSettings,

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -532,16 +532,20 @@ describe("Keybindings update toast", () => {
     document.body.innerHTML = "";
   });
 
-  it("shows a toast for each consecutive keybinding update with no issues", async () => {
+  it("coalesces rapid consecutive keybinding update toasts with no issues", async () => {
     const mounted = await mountApp();
 
     try {
       sendServerConfigUpdatedPush([]);
       await waitForToast("Keybindings updated", 1);
 
-      // Each server push represents a distinct file change, so it should produce its own toast.
+      // A single edit can produce several reload notifications as the direct update and
+      // filesystem watcher settle, so avoid stacking identical success toasts.
       sendServerConfigUpdatedPush([]);
-      await waitForToast("Keybindings updated", 2);
+      await new Promise((resolve) => setTimeout(resolve, 250));
+
+      const titles = queryToastTitles();
+      expect(titles.filter((title) => title === "Keybindings updated")).toHaveLength(1);
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -20,13 +20,13 @@ import {
   keybindingValueForCommand,
   decodeProjectScriptKeybindingRule,
 } from "~/lib/projectScriptKeybindings";
+import { keybindingFromKeyboardEvent } from "~/components/settings/KeybindingsSettings.logic";
 import {
   commandForProjectScript,
   nextProjectScriptId,
   primaryProjectScript,
 } from "~/projectScripts";
 import { shortcutLabelForCommand } from "~/keybindings";
-import { isMacPlatform } from "~/lib/utils";
 import {
   AlertDialog,
   AlertDialogClose,
@@ -96,57 +96,6 @@ interface ProjectScriptsControlProps {
   onDeleteScript: (scriptId: string) => Promise<void> | void;
 }
 
-function normalizeShortcutKeyToken(key: string): string | null {
-  const normalized = key.toLowerCase();
-  if (
-    normalized === "meta" ||
-    normalized === "control" ||
-    normalized === "ctrl" ||
-    normalized === "shift" ||
-    normalized === "alt" ||
-    normalized === "option"
-  ) {
-    return null;
-  }
-  if (normalized === " ") return "space";
-  if (normalized === "escape") return "esc";
-  if (normalized === "arrowup") return "arrowup";
-  if (normalized === "arrowdown") return "arrowdown";
-  if (normalized === "arrowleft") return "arrowleft";
-  if (normalized === "arrowright") return "arrowright";
-  if (normalized.length === 1) return normalized;
-  if (normalized.startsWith("f") && normalized.length <= 3) return normalized;
-  if (normalized === "enter" || normalized === "tab" || normalized === "backspace") {
-    return normalized;
-  }
-  if (normalized === "delete" || normalized === "home" || normalized === "end") {
-    return normalized;
-  }
-  if (normalized === "pageup" || normalized === "pagedown") return normalized;
-  return null;
-}
-
-function keybindingFromEvent(event: KeyboardEvent<HTMLInputElement>): string | null {
-  const keyToken = normalizeShortcutKeyToken(event.key);
-  if (!keyToken) return null;
-
-  const parts: string[] = [];
-  if (isMacPlatform(navigator.platform)) {
-    if (event.metaKey) parts.push("mod");
-    if (event.ctrlKey) parts.push("ctrl");
-  } else {
-    if (event.ctrlKey) parts.push("mod");
-    if (event.metaKey) parts.push("meta");
-  }
-  if (event.altKey) parts.push("alt");
-  if (event.shiftKey) parts.push("shift");
-  if (parts.length === 0) {
-    return null;
-  }
-  parts.push(keyToken);
-  return parts.join("+");
-}
-
 export default function ProjectScriptsControl({
   scripts,
   keybindings,
@@ -186,7 +135,7 @@ export default function ProjectScriptsControl({
       setKeybinding("");
       return;
     }
-    const next = keybindingFromEvent(event);
+    const next = keybindingFromKeyboardEvent(event, navigator.platform);
     if (!next) return;
     setKeybinding(next);
   };

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
+
+import {
+  buildKeybindingRows,
+  buildWhenVariableOptions,
+  commandLabel,
+  keybindingFromKeyboardEvent,
+  parseWhenExpressionDraft,
+  shortcutToKeybindingInput,
+  unknownWhenVariables,
+  whenAstToExpression,
+} from "./KeybindingsSettings.logic";
+
+describe("KeybindingsSettings.logic", () => {
+  it("builds searchable rows with readable key and when values", () => {
+    const rows = buildKeybindingRows(
+      [
+        {
+          command: "terminal.toggle",
+          shortcut: {
+            key: "j",
+            modKey: true,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: false,
+          },
+          whenAst: {
+            type: "not",
+            node: { type: "identifier", name: "terminalFocus" },
+          },
+        },
+      ] satisfies ResolvedKeybindingsConfig,
+      "terminal",
+    );
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        command: "terminal.toggle",
+        key: "mod+j",
+        when: "!terminalFocus",
+        defaultKey: "mod+j",
+        defaultWhen: "",
+        source: "Custom",
+      }),
+    ]);
+  });
+
+  it("captures platform-specific mod shortcuts", () => {
+    expect(
+      keybindingFromKeyboardEvent(
+        { key: "K", metaKey: true, ctrlKey: false, altKey: false, shiftKey: true },
+        "MacIntel",
+      ),
+    ).toBe("mod+shift+k");
+    expect(
+      keybindingFromKeyboardEvent(
+        { key: "K", metaKey: false, ctrlKey: true, altKey: false, shiftKey: true },
+        "Win32",
+      ),
+    ).toBe("mod+shift+k");
+  });
+
+  it("serializes shortcuts and when expressions for upserts", () => {
+    expect(
+      shortcutToKeybindingInput({
+        key: " ",
+        modKey: true,
+        metaKey: false,
+        ctrlKey: false,
+        altKey: true,
+        shiftKey: false,
+      }),
+    ).toBe("mod+alt+space");
+
+    expect(
+      whenAstToExpression({
+        type: "and",
+        left: { type: "identifier", name: "editorFocus" },
+        right: {
+          type: "not",
+          node: { type: "identifier", name: "terminalFocus" },
+        },
+      }),
+    ).toBe("editorFocus && !terminalFocus");
+
+    expect(parseWhenExpressionDraft("editorFocus && (!terminalFocus || modelPickerOpen)")).toEqual({
+      ok: true,
+      value: {
+        type: "and",
+        left: { type: "identifier", name: "editorFocus" },
+        right: {
+          type: "or",
+          left: {
+            type: "not",
+            node: { type: "identifier", name: "terminalFocus" },
+          },
+          right: { type: "identifier", name: "modelPickerOpen" },
+        },
+      },
+    });
+    expect(parseWhenExpressionDraft("editorFocus &&")).toEqual({
+      ok: false,
+      message: "Use variables with !, &&, ||, and parentheses.",
+    });
+
+    expect(parseWhenExpressionDraft("!(terminalFocus || modelPickerOpen)")).toEqual({
+      ok: true,
+      value: {
+        type: "not",
+        node: {
+          type: "or",
+          left: { type: "identifier", name: "terminalFocus" },
+          right: { type: "identifier", name: "modelPickerOpen" },
+        },
+      },
+    });
+  });
+
+  it("formats static and project script command labels", () => {
+    expect(commandLabel("commandPalette.toggle")).toBe("Command Palette: Toggle");
+    expect(commandLabel("script.setup-db.run")).toBe("Run Script: Setup Db");
+  });
+
+  it("builds known when variable options from defaults without frontend labels", () => {
+    const options = buildWhenVariableOptions([
+      {
+        command: "terminal.toggle",
+        shortcut: {
+          key: "j",
+          modKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+        whenAst: {
+          type: "and",
+          left: { type: "identifier", name: "terminalOpen" },
+          right: { type: "identifier", name: "customModeActive" },
+        },
+      },
+    ] satisfies ResolvedKeybindingsConfig);
+
+    expect(options).toEqual(
+      expect.arrayContaining(["terminalFocus", "terminalOpen", "modelPickerOpen", "true", "false"]),
+    );
+    expect(options).not.toContain("customModeActive");
+  });
+
+  it("reports unknown when variables without rejecting parseable expressions", () => {
+    const parsed = parseWhenExpressionDraft("!terminalFocus && terminalFoc");
+
+    expect(parsed.ok).toBe(true);
+    expect(unknownWhenVariables(parsed.ok ? parsed.value : undefined)).toEqual(["terminalFoc"]);
+  });
+});

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -3,8 +3,10 @@ import type { ResolvedKeybindingsConfig } from "@t3tools/contracts";
 
 import {
   buildKeybindingRows,
+  buildKeybindingCommandOptions,
   buildWhenVariableOptions,
   commandLabel,
+  keybindingConflictLabels,
   keybindingFromKeyboardEvent,
   parseWhenExpressionDraft,
   shortcutToKeybindingInput,
@@ -124,24 +126,7 @@ describe("KeybindingsSettings.logic", () => {
   });
 
   it("builds known when variable options from defaults without frontend labels", () => {
-    const options = buildWhenVariableOptions([
-      {
-        command: "terminal.toggle",
-        shortcut: {
-          key: "j",
-          modKey: true,
-          metaKey: false,
-          ctrlKey: false,
-          altKey: false,
-          shiftKey: false,
-        },
-        whenAst: {
-          type: "and",
-          left: { type: "identifier", name: "terminalOpen" },
-          right: { type: "identifier", name: "customModeActive" },
-        },
-      },
-    ] satisfies ResolvedKeybindingsConfig);
+    const options = buildWhenVariableOptions();
 
     expect(options).toEqual(
       expect.arrayContaining(["terminalFocus", "terminalOpen", "modelPickerOpen", "true", "false"]),
@@ -149,10 +134,115 @@ describe("KeybindingsSettings.logic", () => {
     expect(options).not.toContain("customModeActive");
   });
 
+  it("builds command options from defaults and resolved project bindings", () => {
+    const options = buildKeybindingCommandOptions([
+      {
+        command: "script.setup-db.run",
+        shortcut: {
+          key: "r",
+          modKey: true,
+          metaKey: false,
+          ctrlKey: false,
+          altKey: false,
+          shiftKey: false,
+        },
+      },
+    ] satisfies ResolvedKeybindingsConfig);
+
+    expect(options).toEqual(expect.arrayContaining(["chat.new", "script.setup-db.run"]));
+  });
+
   it("reports unknown when variables without rejecting parseable expressions", () => {
     const parsed = parseWhenExpressionDraft("!terminalFocus && terminalFoc");
 
     expect(parsed.ok).toBe(true);
     expect(unknownWhenVariables(parsed.ok ? parsed.value : undefined)).toEqual(["terminalFoc"]);
+  });
+
+  it("marks each default shortcut for multi-binding commands as default", () => {
+    const rows = buildKeybindingRows(
+      [
+        {
+          command: "chat.new",
+          shortcut: {
+            key: "n",
+            modKey: true,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: false,
+          },
+          whenAst: {
+            type: "not",
+            node: { type: "identifier", name: "terminalFocus" },
+          },
+        },
+        {
+          command: "chat.new",
+          shortcut: {
+            key: "o",
+            modKey: true,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: true,
+          },
+          whenAst: {
+            type: "not",
+            node: { type: "identifier", name: "terminalFocus" },
+          },
+        },
+      ] satisfies ResolvedKeybindingsConfig,
+      "",
+    );
+
+    expect(rows.map((row) => row.source)).toEqual(["Default", "Default"]);
+  });
+
+  it("reports conflicting shortcuts that share an active when context", () => {
+    const rows = buildKeybindingRows(
+      [
+        {
+          command: "chat.new",
+          shortcut: {
+            key: "n",
+            modKey: true,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: false,
+          },
+          whenAst: {
+            type: "not",
+            node: { type: "identifier", name: "terminalFocus" },
+          },
+        },
+        {
+          command: "chat.newLocal",
+          shortcut: {
+            key: "n",
+            modKey: true,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            shiftKey: false,
+          },
+          whenAst: {
+            type: "not",
+            node: { type: "identifier", name: "terminalFocus" },
+          },
+        },
+      ] satisfies ResolvedKeybindingsConfig,
+      "",
+    );
+
+    expect(rows[0]?.conflicts).toEqual(["Chat: New Local"]);
+    expect(
+      keybindingConflictLabels(rows, {
+        rowId: rows[0]?.id ?? "",
+        key: "mod+n",
+        when: "",
+      }),
+    ).toEqual(["Chat: New Local"]);
   });
 });

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -1,0 +1,269 @@
+import {
+  type KeybindingCommand,
+  type KeybindingShortcut,
+  type KeybindingWhenNode,
+  type ResolvedKeybindingRule,
+  type ResolvedKeybindingsConfig,
+} from "@t3tools/contracts";
+import {
+  DEFAULT_RESOLVED_KEYBINDINGS,
+  parseKeybindingWhenExpression,
+} from "@t3tools/shared/keybindings";
+
+import { isMacPlatform } from "../../lib/utils";
+
+export type KeybindingSource = "Default" | "Custom" | "Project";
+
+export interface KeybindingRow {
+  readonly command: KeybindingCommand;
+  readonly key: string;
+  readonly when: string;
+  readonly source: KeybindingSource;
+  readonly defaultKey: string | null;
+  readonly defaultWhen: string;
+  readonly binding: ResolvedKeybindingRule;
+}
+
+export type WhenVariableOption = string;
+
+const CORE_WHEN_VARIABLES = ["terminalFocus", "terminalOpen", "true", "false"] as const;
+
+const DEFAULT_WHEN_VARIABLES = new Set<string>(CORE_WHEN_VARIABLES);
+for (const binding of DEFAULT_RESOLVED_KEYBINDINGS) {
+  collectWhenIdentifiersFromNode(binding.whenAst, DEFAULT_WHEN_VARIABLES);
+}
+
+export const DEFAULT_WHEN_VARIABLE =
+  [...DEFAULT_WHEN_VARIABLES].find(
+    (identifier) => identifier !== "true" && identifier !== "false",
+  ) ?? "terminalFocus";
+const KNOWN_WHEN_VARIABLES = new Set(DEFAULT_WHEN_VARIABLES);
+
+export function shortcutToKeybindingInput(shortcut: KeybindingShortcut): string {
+  const parts: string[] = [];
+  if (shortcut.modKey) parts.push("mod");
+  if (shortcut.metaKey) parts.push("meta");
+  if (shortcut.ctrlKey) parts.push("ctrl");
+  if (shortcut.altKey) parts.push("alt");
+  if (shortcut.shiftKey) parts.push("shift");
+  parts.push(shortcut.key === " " ? "space" : shortcut.key === "escape" ? "esc" : shortcut.key);
+  return parts.join("+");
+}
+
+export function whenAstToExpression(node: KeybindingWhenNode | undefined): string {
+  if (!node) return "";
+  switch (node.type) {
+    case "identifier":
+      return node.name;
+    case "not":
+      return `!${wrapWhenExpression(node.node)}`;
+    case "and":
+      return `${wrapWhenExpression(node.left)} && ${wrapWhenExpression(node.right)}`;
+    case "or":
+      return `${wrapWhenExpression(node.left)} || ${wrapWhenExpression(node.right)}`;
+  }
+}
+
+function wrapWhenExpression(node: KeybindingWhenNode): string {
+  if (node.type === "identifier" || node.type === "not") return whenAstToExpression(node);
+  return `(${whenAstToExpression(node)})`;
+}
+
+export function parseWhenExpressionDraft(
+  expression: string,
+): { ok: true; value: KeybindingWhenNode | undefined } | { ok: false; message: string } {
+  const trimmed = expression.trim();
+  if (trimmed.length === 0) return { ok: true, value: undefined };
+
+  const ast = parseKeybindingWhenExpression(trimmed);
+  if (!ast) {
+    return {
+      ok: false,
+      message: "Use variables with !, &&, ||, and parentheses.",
+    };
+  }
+
+  return { ok: true, value: ast };
+}
+
+function sourceForBinding(binding: ResolvedKeybindingRule): KeybindingSource {
+  if (String(binding.command).startsWith("script.")) {
+    return "Project";
+  }
+
+  const defaultBinding = DEFAULT_RESOLVED_KEYBINDINGS.find(
+    (entry) => entry.command === binding.command,
+  );
+  if (!defaultBinding) {
+    return "Custom";
+  }
+
+  return shortcutToKeybindingInput(defaultBinding.shortcut) ===
+    shortcutToKeybindingInput(binding.shortcut) &&
+    whenAstToExpression(defaultBinding.whenAst) === whenAstToExpression(binding.whenAst)
+    ? "Default"
+    : "Custom";
+}
+
+function defaultBindingForCommand(command: KeybindingCommand): ResolvedKeybindingRule | undefined {
+  return DEFAULT_RESOLVED_KEYBINDINGS.find((entry) => entry.command === command);
+}
+
+export function buildKeybindingRows(
+  keybindings: ResolvedKeybindingsConfig,
+  query: string,
+): ReadonlyArray<KeybindingRow> {
+  const normalizedQuery = query.trim().toLowerCase();
+  const rows = keybindings.map((binding) => {
+    const defaultBinding = defaultBindingForCommand(binding.command);
+    const key = shortcutToKeybindingInput(binding.shortcut);
+    const when = whenAstToExpression(binding.whenAst);
+    return {
+      command: binding.command,
+      key,
+      when,
+      source: sourceForBinding(binding),
+      defaultKey: defaultBinding ? shortcutToKeybindingInput(defaultBinding.shortcut) : null,
+      defaultWhen: whenAstToExpression(defaultBinding?.whenAst),
+      binding,
+    } satisfies KeybindingRow;
+  });
+
+  rows.sort((left, right) => {
+    const commandCompare = left.command.localeCompare(right.command);
+    if (commandCompare !== 0) return commandCompare;
+    return left.key.localeCompare(right.key);
+  });
+
+  if (normalizedQuery.length === 0) {
+    return rows;
+  }
+
+  return rows.filter((row) => {
+    return (
+      row.command.toLowerCase().includes(normalizedQuery) ||
+      row.key.toLowerCase().includes(normalizedQuery) ||
+      row.when.toLowerCase().includes(normalizedQuery) ||
+      row.source.toLowerCase().includes(normalizedQuery)
+    );
+  });
+}
+
+function collectWhenIdentifiersFromNode(
+  node: KeybindingWhenNode | undefined,
+  identifiers: Set<string>,
+): void {
+  if (!node) return;
+  switch (node.type) {
+    case "identifier":
+      identifiers.add(node.name);
+      return;
+    case "not":
+      collectWhenIdentifiersFromNode(node.node, identifiers);
+      return;
+    case "and":
+    case "or":
+      collectWhenIdentifiersFromNode(node.left, identifiers);
+      collectWhenIdentifiersFromNode(node.right, identifiers);
+      return;
+  }
+}
+
+export function isKnownWhenVariable(identifier: string): boolean {
+  return KNOWN_WHEN_VARIABLES.has(identifier);
+}
+
+export function unknownWhenVariables(node: KeybindingWhenNode | undefined): ReadonlyArray<string> {
+  const identifiers = new Set<string>();
+  collectWhenIdentifiersFromNode(node, identifiers);
+  return [...identifiers].filter((identifier) => !isKnownWhenVariable(identifier)).toSorted();
+}
+
+export function buildWhenVariableOptions(
+  _keybindings: ResolvedKeybindingsConfig,
+): ReadonlyArray<WhenVariableOption> {
+  return [...KNOWN_WHEN_VARIABLES].toSorted((left, right) => {
+    const leftCoreIndex = CORE_WHEN_VARIABLES.indexOf(left as (typeof CORE_WHEN_VARIABLES)[number]);
+    const rightCoreIndex = CORE_WHEN_VARIABLES.indexOf(
+      right as (typeof CORE_WHEN_VARIABLES)[number],
+    );
+    if (leftCoreIndex !== -1 || rightCoreIndex !== -1) {
+      return (
+        (leftCoreIndex === -1 ? Number.MAX_SAFE_INTEGER : leftCoreIndex) -
+        (rightCoreIndex === -1 ? Number.MAX_SAFE_INTEGER : rightCoreIndex)
+      );
+    }
+    return left.localeCompare(right);
+  });
+}
+
+export function commandLabel(command: KeybindingCommand): string {
+  const raw = String(command);
+  if (raw.startsWith("script.") && raw.endsWith(".run")) {
+    return `Run Script: ${titleCaseCommandSegment(raw.slice("script.".length, -".run".length))}`;
+  }
+  return raw.split(".").map(titleCaseCommandSegment).join(": ");
+}
+
+function titleCaseCommandSegment(segment: string): string {
+  return segment
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function normalizeShortcutKeyToken(key: string): string | null {
+  const normalized = key.toLowerCase();
+  if (
+    normalized === "meta" ||
+    normalized === "control" ||
+    normalized === "ctrl" ||
+    normalized === "shift" ||
+    normalized === "alt" ||
+    normalized === "option"
+  ) {
+    return null;
+  }
+  if (normalized === " ") return "space";
+  if (normalized === "escape") return "esc";
+  if (normalized === "arrowup") return "arrowup";
+  if (normalized === "arrowdown") return "arrowdown";
+  if (normalized === "arrowleft") return "arrowleft";
+  if (normalized === "arrowright") return "arrowright";
+  if (normalized.length === 1) return normalized;
+  if (/^f\d{1,2}$/.test(normalized)) return normalized;
+  if (normalized === "enter" || normalized === "tab" || normalized === "backspace") {
+    return normalized;
+  }
+  if (normalized === "delete" || normalized === "home" || normalized === "end") {
+    return normalized;
+  }
+  if (normalized === "pageup" || normalized === "pagedown") return normalized;
+  return null;
+}
+
+export function keybindingFromKeyboardEvent(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "altKey" | "shiftKey">,
+  platform: string,
+): string | null {
+  const keyToken = normalizeShortcutKeyToken(event.key);
+  if (!keyToken) return null;
+
+  const parts: string[] = [];
+  if (isMacPlatform(platform)) {
+    if (event.metaKey) parts.push("mod");
+    if (event.ctrlKey) parts.push("ctrl");
+  } else {
+    if (event.ctrlKey) parts.push("mod");
+    if (event.metaKey) parts.push("meta");
+  }
+  if (event.altKey) parts.push("alt");
+  if (event.shiftKey) parts.push("shift");
+  if (parts.length === 0) {
+    return null;
+  }
+  parts.push(keyToken);
+  return parts.join("+");
+}

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.ts
@@ -15,6 +15,7 @@ import { isMacPlatform } from "../../lib/utils";
 export type KeybindingSource = "Default" | "Custom" | "Project";
 
 export interface KeybindingRow {
+  readonly id: string;
   readonly command: KeybindingCommand;
   readonly key: string;
   readonly when: string;
@@ -22,9 +23,11 @@ export interface KeybindingRow {
   readonly defaultKey: string | null;
   readonly defaultWhen: string;
   readonly binding: ResolvedKeybindingRule;
+  readonly conflicts: ReadonlyArray<string>;
 }
 
 export type WhenVariableOption = string;
+export type KeybindingCommandOption = KeybindingCommand;
 
 const CORE_WHEN_VARIABLES = ["terminalFocus", "terminalOpen", "true", "false"] as const;
 
@@ -91,22 +94,61 @@ function sourceForBinding(binding: ResolvedKeybindingRule): KeybindingSource {
     return "Project";
   }
 
-  const defaultBinding = DEFAULT_RESOLVED_KEYBINDINGS.find(
-    (entry) => entry.command === binding.command,
+  const bindingKey = shortcutToKeybindingInput(binding.shortcut);
+  const bindingWhen = whenAstToExpression(binding.whenAst);
+  const isDefault = DEFAULT_RESOLVED_KEYBINDINGS.some(
+    (entry) =>
+      entry.command === binding.command &&
+      shortcutToKeybindingInput(entry.shortcut) === bindingKey &&
+      whenAstToExpression(entry.whenAst) === bindingWhen,
   );
-  if (!defaultBinding) {
-    return "Custom";
-  }
 
-  return shortcutToKeybindingInput(defaultBinding.shortcut) ===
-    shortcutToKeybindingInput(binding.shortcut) &&
-    whenAstToExpression(defaultBinding.whenAst) === whenAstToExpression(binding.whenAst)
-    ? "Default"
-    : "Custom";
+  return isDefault ? "Default" : "Custom";
 }
 
-function defaultBindingForCommand(command: KeybindingCommand): ResolvedKeybindingRule | undefined {
-  return DEFAULT_RESOLVED_KEYBINDINGS.find((entry) => entry.command === command);
+function defaultBindingForBinding(
+  binding: ResolvedKeybindingRule,
+): ResolvedKeybindingRule | undefined {
+  const bindingKey = shortcutToKeybindingInput(binding.shortcut);
+  const bindingWhen = whenAstToExpression(binding.whenAst);
+
+  return (
+    DEFAULT_RESOLVED_KEYBINDINGS.find(
+      (entry) =>
+        entry.command === binding.command &&
+        shortcutToKeybindingInput(entry.shortcut) === bindingKey &&
+        whenAstToExpression(entry.whenAst) === bindingWhen,
+    ) ??
+    DEFAULT_RESOLVED_KEYBINDINGS.find(
+      (entry) =>
+        entry.command === binding.command && whenAstToExpression(entry.whenAst) === bindingWhen,
+    ) ??
+    DEFAULT_RESOLVED_KEYBINDINGS.find((entry) => entry.command === binding.command)
+  );
+}
+
+function keybindingRowId(command: KeybindingCommand, key: string, when: string): string {
+  return `${command}\u0000${key}\u0000${when}`;
+}
+
+function conflictsWithWhen(leftWhen: string, rightWhen: string): boolean {
+  return leftWhen.length === 0 || rightWhen.length === 0 || leftWhen === rightWhen;
+}
+
+export function keybindingConflictLabels(
+  rows: ReadonlyArray<KeybindingRow>,
+  input: { readonly rowId: string; readonly key: string; readonly when: string },
+): ReadonlyArray<string> {
+  if (input.key.trim().length === 0) return [];
+  const conflicts = rows
+    .filter(
+      (candidate) =>
+        candidate.id !== input.rowId &&
+        candidate.key === input.key &&
+        conflictsWithWhen(candidate.when, input.when),
+    )
+    .map((candidate) => commandLabel(candidate.command));
+  return [...new Set(conflicts)].toSorted();
 }
 
 export function buildKeybindingRows(
@@ -114,11 +156,12 @@ export function buildKeybindingRows(
   query: string,
 ): ReadonlyArray<KeybindingRow> {
   const normalizedQuery = query.trim().toLowerCase();
-  const rows = keybindings.map((binding) => {
-    const defaultBinding = defaultBindingForCommand(binding.command);
+  const rows = keybindings.map((binding, index) => {
+    const defaultBinding = defaultBindingForBinding(binding);
     const key = shortcutToKeybindingInput(binding.shortcut);
     const when = whenAstToExpression(binding.whenAst);
     return {
+      id: `${keybindingRowId(binding.command, key, when)}\u0000${index}`,
       command: binding.command,
       key,
       when,
@@ -126,20 +169,32 @@ export function buildKeybindingRows(
       defaultKey: defaultBinding ? shortcutToKeybindingInput(defaultBinding.shortcut) : null,
       defaultWhen: whenAstToExpression(defaultBinding?.whenAst),
       binding,
+      conflicts: [],
     } satisfies KeybindingRow;
   });
 
-  rows.sort((left, right) => {
+  const rowsWithConflicts = rows.map((row) => {
+    const conflicts = keybindingConflictLabels(rows, {
+      rowId: row.id,
+      key: row.key,
+      when: row.when,
+    });
+    return conflicts.length > 0
+      ? Object.assign({}, row, { conflicts: [...new Set(conflicts)].toSorted() })
+      : row;
+  });
+
+  rowsWithConflicts.sort((left, right) => {
     const commandCompare = left.command.localeCompare(right.command);
     if (commandCompare !== 0) return commandCompare;
     return left.key.localeCompare(right.key);
   });
 
   if (normalizedQuery.length === 0) {
-    return rows;
+    return rowsWithConflicts;
   }
 
-  return rows.filter((row) => {
+  return rowsWithConflicts.filter((row) => {
     return (
       row.command.toLowerCase().includes(normalizedQuery) ||
       row.key.toLowerCase().includes(normalizedQuery) ||
@@ -179,9 +234,7 @@ export function unknownWhenVariables(node: KeybindingWhenNode | undefined): Read
   return [...identifiers].filter((identifier) => !isKnownWhenVariable(identifier)).toSorted();
 }
 
-export function buildWhenVariableOptions(
-  _keybindings: ResolvedKeybindingsConfig,
-): ReadonlyArray<WhenVariableOption> {
+export function buildWhenVariableOptions(): ReadonlyArray<WhenVariableOption> {
   return [...KNOWN_WHEN_VARIABLES].toSorted((left, right) => {
     const leftCoreIndex = CORE_WHEN_VARIABLES.indexOf(left as (typeof CORE_WHEN_VARIABLES)[number]);
     const rightCoreIndex = CORE_WHEN_VARIABLES.indexOf(
@@ -195,6 +248,21 @@ export function buildWhenVariableOptions(
     }
     return left.localeCompare(right);
   });
+}
+
+export function buildKeybindingCommandOptions(
+  keybindings: ResolvedKeybindingsConfig,
+): ReadonlyArray<KeybindingCommandOption> {
+  const commands = new Set<KeybindingCommand>();
+  for (const binding of DEFAULT_RESOLVED_KEYBINDINGS) {
+    commands.add(binding.command);
+  }
+  for (const binding of keybindings) {
+    commands.add(binding.command);
+  }
+  return [...commands].toSorted((left, right) =>
+    commandLabel(left).localeCompare(commandLabel(right)),
+  );
 }
 
 export function commandLabel(command: KeybindingCommand): string {

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1,6 +1,7 @@
 import {
   ChevronDownIcon,
   CircleXIcon,
+  FileJsonIcon,
   InfoIcon,
   KeyboardIcon,
   MinusIcon,
@@ -8,14 +9,25 @@ import {
   SearchIcon,
   TriangleAlertIcon,
 } from "lucide-react";
-import { type KeyboardEvent, useCallback, useMemo, useReducer, useState } from "react";
+import {
+  type KeyboardEvent,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { type KeybindingCommand, type KeybindingWhenNode } from "@t3tools/contracts";
 
 import { isElectron } from "../../env";
+import { openInPreferredEditor } from "../../editorPreferences";
 import { formatShortcutLabel } from "../../keybindings";
 import { cn } from "../../lib/utils";
 import { ensureLocalApi } from "../../localApi";
-import { useServerKeybindings } from "../../rpc/serverState";
+import { useServerKeybindings, useServerKeybindingsConfigPath } from "../../rpc/serverState";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
@@ -70,7 +82,7 @@ function StatusBadge({ source }: { source: KeybindingRow["source"] }) {
   return (
     <span
       className={cn(
-        "inline-flex h-5 items-center rounded-sm border px-1.5 text-[11px] font-medium",
+        "inline-flex h-7 items-center rounded-md border px-2.5 text-xs font-medium",
         source === "Default" && "border-border/70 text-muted-foreground",
         source === "Custom" && "border-primary/30 bg-primary/8 text-primary",
         source === "Project" &&
@@ -79,6 +91,73 @@ function StatusBadge({ source }: { source: KeybindingRow["source"] }) {
     >
       {source}
     </span>
+  );
+}
+
+function ExpandableHeaderSearch({
+  query,
+  onChange,
+  isOpen,
+  onOpenChange,
+  inputRef,
+  collapsedAccessory,
+}: {
+  query: string;
+  onChange: (next: string) => void;
+  isOpen: boolean;
+  onOpenChange: (next: boolean) => void;
+  inputRef?: RefObject<HTMLInputElement | null>;
+  collapsedAccessory?: ReactNode;
+}) {
+  if (!isOpen) {
+    return (
+      <>
+        {collapsedAccessory}
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                size="icon-xs"
+                variant="ghost"
+                className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                onClick={() => onOpenChange(true)}
+                aria-label="Search keybindings"
+              >
+                <SearchIcon className="size-3" />
+              </Button>
+            }
+          />
+          <TooltipPopup side="top">Search keybindings</TooltipPopup>
+        </Tooltip>
+      </>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <SearchIcon className="pointer-events-none absolute top-1/2 left-2 size-3 -translate-y-1/2 text-muted-foreground" />
+      <input
+        ref={inputRef}
+        autoFocus
+        type="text"
+        value={query}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        onBlur={() => {
+          if (query.length === 0) onOpenChange(false);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") {
+            event.preventDefault();
+            onChange("");
+            onOpenChange(false);
+          }
+        }}
+        placeholder="Search keybindings"
+        aria-label="Search keybindings"
+        className="h-6 w-44 rounded-md border border-input bg-background pl-7 pr-2 text-[11px] text-foreground outline-none placeholder:text-muted-foreground/72 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24"
+      />
+    </div>
   );
 }
 
@@ -658,6 +737,7 @@ function KeybindingTableRow({
   const isDirty = keyDraft !== row.key || whenDraftExpression !== row.when;
   const displayShortcut = formatShortcutLabel(row.binding.shortcut);
   const canReset = row.source === "Custom" && row.defaultKey !== null;
+  const showPill = !isRecording && keyDraft === row.key && row.key.length > 0 && !isDirty;
 
   const save = () => {
     onSave({ command: row.command, key: keyDraft, when: whenDraftExpression });
@@ -683,24 +763,33 @@ function KeybindingTableRow({
         </div>
       </div>
       <div className="flex min-w-0 items-center gap-2 pr-4">
-        <Input
-          aria-label={`Keybinding for ${commandLabel(row.command)}`}
-          value={isRecording ? "" : keyDraft}
-          placeholder={isRecording ? "Press shortcut" : "Unassigned"}
-          className={cn(
-            "h-7 w-32 rounded-md font-mono text-[12px] sm:h-7",
-            isRecording && "border-primary/70 bg-primary/5",
-          )}
-          onFocus={() => setDraft({ isRecording: true })}
-          onBlur={() => setDraft({ isRecording: false })}
-          onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
-          onKeyDown={captureKeybinding}
-        />
-        {keyDraft === row.key && row.key ? (
-          <div className="hidden min-w-28 sm:block">
+        {showPill ? (
+          <button
+            type="button"
+            onClick={() => setDraft({ isRecording: true })}
+            aria-label={`Edit shortcut for ${commandLabel(row.command)}`}
+            className="group inline-flex h-7 items-center gap-1.5 rounded-md border border-transparent px-1.5 outline-none transition-colors hover:border-border/70 hover:bg-background focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24"
+          >
             <KeybindingPill value={row.key} />
-          </div>
-        ) : null}
+            <span className="text-[10px] uppercase tracking-[0.08em] text-muted-foreground/0 transition-opacity group-hover:text-muted-foreground/70 group-focus-visible:text-muted-foreground/70">
+              Edit
+            </span>
+          </button>
+        ) : (
+          <Input
+            aria-label={`Keybinding for ${commandLabel(row.command)}`}
+            value={isRecording ? "" : keyDraft}
+            placeholder={isRecording ? "Press shortcut" : "Unassigned"}
+            className={cn(
+              "h-7 w-44 rounded-md font-mono text-[12px] sm:h-7",
+              isRecording && "border-primary/70 bg-primary/5",
+            )}
+            onFocus={() => setDraft({ isRecording: true })}
+            onBlur={() => setDraft({ isRecording: false })}
+            onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
+            onKeyDown={captureKeybinding}
+          />
+        )}
       </div>
       <div className="pr-4">
         <Popover>
@@ -757,10 +846,52 @@ function KeybindingTableRow({
 
 export function KeybindingsSettingsPanel() {
   const keybindings = useServerKeybindings();
+  const keybindingsConfigPath = useServerKeybindingsConfigPath();
   const [query, setQuery] = useState("");
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
   const [savingCommand, setSavingCommand] = useState<KeybindingCommand | null>(null);
   const rows = useMemo(() => buildKeybindingRows(keybindings, query), [keybindings, query]);
   const whenVariables = useMemo(() => buildWhenVariableOptions(keybindings), [keybindings]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      const isMod = event.metaKey || event.ctrlKey;
+      if (!isMod || event.altKey || event.key.toLowerCase() !== "f") return;
+
+      const target = event.target;
+      if (
+        target !== searchInputRef.current &&
+        target instanceof HTMLElement &&
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      setIsSearchOpen(true);
+      requestAnimationFrame(() => {
+        searchInputRef.current?.focus();
+        searchInputRef.current?.select();
+      });
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  const openKeybindingsFile = useCallback(() => {
+    if (!keybindingsConfigPath) return;
+    void openInPreferredEditor(ensureLocalApi(), keybindingsConfigPath).catch((error: unknown) => {
+      toastManager.add({
+        title: "Unable to open keybindings file",
+        description:
+          error instanceof Error ? error.message : "The keybindings file was not opened.",
+        type: "error",
+      });
+    });
+  }, [keybindingsConfigPath]);
 
   const saveKeybinding = useCallback(
     (input: { command: KeybindingCommand; key: string; when: string }) => {
@@ -797,15 +928,46 @@ export function KeybindingsSettingsPanel() {
     [saveKeybinding],
   );
 
+  const bindingsCount = (
+    <span className="text-[11px] text-muted-foreground">
+      {rows.length} {rows.length === 1 ? "binding" : "bindings"}
+    </span>
+  );
+
   return (
     <SettingsPageContainer className="max-w-5xl">
       <SettingsSection
         title="Keybindings"
         icon={<KeyboardIcon className="size-3.5" />}
         headerAction={
-          <span className="text-[11px] text-muted-foreground">
-            {rows.length} {rows.length === 1 ? "binding" : "bindings"}
-          </span>
+          <div className="flex items-center gap-1.5">
+            <ExpandableHeaderSearch
+              query={query}
+              onChange={setQuery}
+              isOpen={isSearchOpen}
+              onOpenChange={setIsSearchOpen}
+              inputRef={searchInputRef}
+              collapsedAccessory={bindingsCount}
+            />
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    disabled={!keybindingsConfigPath}
+                    onClick={openKeybindingsFile}
+                    aria-label="Open keybindings.json"
+                  >
+                    <FileJsonIcon className="size-3" />
+                  </Button>
+                }
+              />
+              <TooltipPopup side="top">Open keybindings.json</TooltipPopup>
+            </Tooltip>
+          </div>
         }
       >
         {!isElectron ? (
@@ -817,19 +979,6 @@ export function KeybindingsSettingsPanel() {
             </p>
           </div>
         ) : null}
-
-        <div className="border-b border-border/70 p-3 sm:p-4">
-          <div className="relative">
-            <SearchIcon className="pointer-events-none absolute top-1/2 left-3 z-10 size-4 -translate-y-1/2 text-muted-foreground" />
-            <Input
-              value={query}
-              onChange={(event) => setQuery(event.currentTarget.value)}
-              placeholder="Search keybindings"
-              className="h-9 pl-9 text-sm"
-              aria-label="Search keybindings"
-            />
-          </div>
-        </div>
 
         <div className="overflow-x-auto">
           <div className="grid min-w-[730px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_110px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1,0 +1,852 @@
+import {
+  ChevronDownIcon,
+  CircleXIcon,
+  InfoIcon,
+  KeyboardIcon,
+  MinusIcon,
+  PlusIcon,
+  SearchIcon,
+  TriangleAlertIcon,
+} from "lucide-react";
+import { type KeyboardEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { type KeybindingCommand, type KeybindingWhenNode } from "@t3tools/contracts";
+
+import { isElectron } from "../../env";
+import { formatShortcutLabel } from "../../keybindings";
+import { cn } from "../../lib/utils";
+import { ensureLocalApi } from "../../localApi";
+import { useServerKeybindings } from "../../rpc/serverState";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import { Kbd, KbdGroup } from "../ui/kbd";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
+import { Toggle } from "../ui/toggle";
+import { toastManager } from "../ui/toast";
+import {
+  buildKeybindingRows,
+  buildWhenVariableOptions,
+  commandLabel,
+  DEFAULT_WHEN_VARIABLE,
+  isKnownWhenVariable,
+  keybindingFromKeyboardEvent,
+  parseWhenExpressionDraft,
+  type KeybindingRow,
+  type WhenVariableOption,
+  unknownWhenVariables,
+  whenAstToExpression,
+} from "./KeybindingsSettings.logic";
+import { SettingsPageContainer, SettingsSection } from "./settingsLayout";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+
+function KeybindingPill({ value }: { value: string }) {
+  const parts = value.split("+");
+  return (
+    <KbdGroup className="bg-transparent p-0 shadow-none">
+      {parts.map((part) => (
+        <Kbd key={part} className="min-w-6 justify-center px-1.5">
+          {part === "mod"
+            ? navigator.platform.toLowerCase().includes("mac")
+              ? "⌘"
+              : "Ctrl"
+            : part === "shift"
+              ? "⇧"
+              : part === "alt"
+                ? navigator.platform.toLowerCase().includes("mac")
+                  ? "⌥"
+                  : "Alt"
+                : part === "ctrl"
+                  ? "⌃"
+                  : part.length === 1
+                    ? part.toUpperCase()
+                    : part}
+        </Kbd>
+      ))}
+    </KbdGroup>
+  );
+}
+
+function StatusBadge({ source }: { source: KeybindingRow["source"] }) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-5 items-center rounded-sm border px-1.5 text-[11px] font-medium",
+        source === "Default" && "border-border/70 text-muted-foreground",
+        source === "Custom" && "border-primary/30 bg-primary/8 text-primary",
+        source === "Project" &&
+          "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+      )}
+    >
+      {source}
+    </span>
+  );
+}
+
+type BooleanOperator = "and" | "or";
+
+function flattenWhenChildren(
+  node: KeybindingWhenNode,
+  operator: BooleanOperator,
+): KeybindingWhenNode[] {
+  if (node.type !== operator) return [node];
+  return [
+    ...flattenWhenChildren(node.left, operator),
+    ...flattenWhenChildren(node.right, operator),
+  ];
+}
+
+function buildWhenExpressionGroup(
+  children: readonly KeybindingWhenNode[],
+  operator: BooleanOperator,
+): KeybindingWhenNode | undefined {
+  const first = children[0];
+  if (!first) return undefined;
+  return children.slice(1).reduce<KeybindingWhenNode>(
+    (left, right) => ({
+      type: operator,
+      left,
+      right,
+    }),
+    first,
+  );
+}
+
+function conditionParts(node: KeybindingWhenNode): { identifier: string; negated: boolean } | null {
+  if (node.type === "identifier") return { identifier: node.name, negated: false };
+  if (node.type === "not" && node.node.type === "identifier") {
+    return { identifier: node.node.name, negated: true };
+  }
+  return null;
+}
+
+function setConditionIdentifier(node: KeybindingWhenNode, identifier: string): KeybindingWhenNode {
+  const parts = conditionParts(node);
+  if (!parts) return node;
+  const next: KeybindingWhenNode = { type: "identifier", name: identifier };
+  return parts.negated ? { type: "not", node: next } : next;
+}
+
+function setConditionNegated(node: KeybindingWhenNode, negated: boolean): KeybindingWhenNode {
+  const parts = conditionParts(node);
+  if (!parts) return negated ? { type: "not", node } : node;
+  const identifier: KeybindingWhenNode = { type: "identifier", name: parts.identifier };
+  return negated ? { type: "not", node: identifier } : identifier;
+}
+
+function defaultWhenCondition(): KeybindingWhenNode {
+  return { type: "identifier", name: DEFAULT_WHEN_VARIABLE };
+}
+
+function defaultWhenGroup(operator: BooleanOperator = "and"): KeybindingWhenNode {
+  return {
+    type: operator,
+    left: defaultWhenCondition(),
+    right: { type: "not", node: defaultWhenCondition() },
+  };
+}
+
+function UnknownWhenVariableWarning({
+  identifiers,
+  focusable = true,
+}: {
+  identifiers: ReadonlyArray<string>;
+  focusable?: boolean;
+}) {
+  if (identifiers.length === 0) return null;
+  const label =
+    identifiers.length === 1
+      ? `Unknown condition: ${identifiers[0]}`
+      : `Unknown conditions: ${identifiers.join(", ")}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            tabIndex={focusable ? 0 : undefined}
+            aria-label={label}
+            className="inline-flex size-4.5 shrink-0 items-center justify-center rounded-sm text-warning outline-none transition-colors hover:bg-warning/10 focus-visible:ring-[3px] focus-visible:ring-warning/25"
+          >
+            <TriangleAlertIcon className="size-3.5" />
+          </span>
+        }
+      />
+      <TooltipPopup side="top" className="max-w-72 whitespace-normal leading-relaxed">
+        T3 Code does not recognize this condition yet. It can still be saved, but it may not match
+        unless the runtime provides it.
+      </TooltipPopup>
+    </Tooltip>
+  );
+}
+
+function WhenVariableSelect({
+  value,
+  variables,
+  unknownIdentifiers,
+  onChange,
+}: {
+  value: string;
+  variables: ReadonlyArray<WhenVariableOption>;
+  unknownIdentifiers?: ReadonlyArray<string>;
+  onChange: (value: string) => void;
+}) {
+  const selected = variables.find((option) => option === value);
+  const options =
+    selected || variables.some((option) => option === value) ? variables : [value, ...variables];
+
+  return (
+    <Select value={value} onValueChange={(nextValue) => nextValue && onChange(nextValue)}>
+      <SelectTrigger
+        size="xs"
+        className="h-7 min-h-7 min-w-0 flex-1 rounded-md font-mono text-xs sm:h-7"
+      >
+        <SelectValue placeholder="Condition" className="leading-7" />
+        {unknownIdentifiers && unknownIdentifiers.length > 0 ? (
+          <UnknownWhenVariableWarning identifiers={unknownIdentifiers} focusable={false} />
+        ) : null}
+      </SelectTrigger>
+      <SelectContent
+        alignItemWithTrigger={false}
+        matchTriggerWidth={false}
+        popupClassName="w-fit"
+        className="max-h-72 w-fit min-w-44"
+      >
+        {options.map((option) => (
+          <SelectItem
+            key={option}
+            value={option}
+            className="min-h-7 w-full py-1 font-mono text-[12px]"
+          >
+            <span className="truncate">{option}</span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function WhenExpressionNodeEditor({
+  node,
+  variables,
+  depth = 0,
+  onChange,
+  onRemove,
+}: {
+  node: KeybindingWhenNode;
+  variables: ReadonlyArray<WhenVariableOption>;
+  depth?: number;
+  onChange: (node: KeybindingWhenNode) => void;
+  onRemove?: () => void;
+}) {
+  const condition = conditionParts(node);
+
+  if (condition) {
+    const unknownIdentifiers = isKnownWhenVariable(condition.identifier)
+      ? []
+      : [condition.identifier];
+
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border/70 bg-background/60 px-2 py-2">
+        <Toggle
+          pressed={condition.negated}
+          onPressedChange={(pressed) => onChange(setConditionNegated(node, pressed))}
+          aria-label={`Negate ${condition.identifier}`}
+          variant="outline"
+          size="xs"
+          className="h-7 min-w-10 px-2 text-[11px] sm:h-7"
+        >
+          Not
+        </Toggle>
+        <WhenVariableSelect
+          value={condition.identifier}
+          variables={variables}
+          unknownIdentifiers={unknownIdentifiers}
+          onChange={(value) => onChange(setConditionIdentifier(node, value))}
+        />
+        {onRemove ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="size-7 sm:size-7"
+            aria-label="Remove condition"
+            onClick={onRemove}
+          >
+            <MinusIcon className="size-3.5" />
+          </Button>
+        ) : null}
+      </div>
+    );
+  }
+
+  if (node.type === "not") {
+    return (
+      <div
+        className={cn(
+          "space-y-2 rounded-lg border border-border/70 bg-muted/20 p-2",
+          depth > 0 && "border-border/50 bg-background/50",
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <Toggle
+            pressed
+            onPressedChange={(pressed) => onChange(pressed ? node : node.node)}
+            aria-label="Negate group"
+            variant="outline"
+            size="xs"
+            className="h-7 min-w-10 px-2 text-[11px] sm:h-7"
+          >
+            Not
+          </Toggle>
+          {onRemove ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="ml-auto size-7 sm:size-7"
+              aria-label="Remove negated group"
+              onClick={onRemove}
+            >
+              <MinusIcon className="size-3.5" />
+            </Button>
+          ) : null}
+        </div>
+        <div className="relative pl-4">
+          <span className="absolute top-0 bottom-0 left-1.5 w-px bg-border/70" aria-hidden />
+          <span className="absolute top-4 left-1.5 h-px w-2.5 bg-border/70" aria-hidden />
+          <WhenExpressionNodeEditor
+            node={node.node}
+            variables={variables}
+            depth={depth + 1}
+            onChange={(next) => onChange({ type: "not", node: next })}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const operator: BooleanOperator = node.type === "or" ? "or" : "and";
+  const children = flattenWhenChildren(node, operator);
+  const childKeyCounts = new Map<string, number>();
+  const childEntries = children.map((child) => {
+    const baseKey = `${child.type}-${whenAstToExpression(child)}`;
+    const count = childKeyCounts.get(baseKey) ?? 0;
+    childKeyCounts.set(baseKey, count + 1);
+    return { child, key: count === 0 ? baseKey : `${baseKey}-${count}` };
+  });
+
+  const updateChild = (target: KeybindingWhenNode, next: KeybindingWhenNode) => {
+    let didUpdate = false;
+    const nextChildren = children.map((child) => {
+      if (!didUpdate && child === target) {
+        didUpdate = true;
+        return next;
+      }
+      return child;
+    });
+    const nextNode = buildWhenExpressionGroup(nextChildren, operator);
+    if (nextNode) onChange(nextNode);
+  };
+
+  const removeChild = (target: KeybindingWhenNode) => {
+    let didRemove = false;
+    const nextChildren = children.filter((child) => {
+      if (!didRemove && child === target) {
+        didRemove = true;
+        return false;
+      }
+      return true;
+    });
+    const nextNode = buildWhenExpressionGroup(nextChildren, operator);
+    if (nextNode) {
+      onChange(nextNode);
+    } else {
+      onChange(defaultWhenCondition());
+    }
+  };
+
+  const setOperator = (nextOperator: BooleanOperator) => {
+    if (nextOperator === operator) return;
+    const nextNode = buildWhenExpressionGroup(children, nextOperator);
+    if (nextNode) onChange(nextNode);
+  };
+
+  const addCondition = () => {
+    const nextNode = buildWhenExpressionGroup([...children, defaultWhenCondition()], operator);
+    if (nextNode) onChange(nextNode);
+  };
+
+  const addGroup = () => {
+    const nestedOperator: BooleanOperator = operator === "and" ? "or" : "and";
+    const group: KeybindingWhenNode = {
+      type: nestedOperator,
+      left: defaultWhenCondition(),
+      right: { type: "not", node: defaultWhenCondition() },
+    };
+    const nextNode = buildWhenExpressionGroup([...children, group], operator);
+    if (nextNode) onChange(nextNode);
+  };
+
+  return (
+    <div
+      className={cn(
+        "space-y-2 rounded-lg border border-border/60 bg-muted/10 p-2",
+        depth > 0 && "border-border/70 bg-background/55",
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <Select value={operator} onValueChange={(value) => setOperator(value as BooleanOperator)}>
+          <SelectTrigger size="xs" className="h-7 min-h-7 w-24 rounded-md text-xs sm:h-7">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent
+            alignItemWithTrigger={false}
+            matchTriggerWidth={false}
+            popupClassName="w-fit"
+            className="w-fit min-w-24"
+          >
+            <SelectItem value="and" className="min-h-7 py-1 font-mono text-[12px]">
+              and
+            </SelectItem>
+            <SelectItem value="or" className="min-h-7 py-1 font-mono text-[12px]">
+              or
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          className="h-7 sm:h-7"
+          onClick={addCondition}
+        >
+          <PlusIcon className="size-3.5" />
+          Condition
+        </Button>
+        <Button type="button" variant="outline" size="xs" className="h-7 sm:h-7" onClick={addGroup}>
+          <PlusIcon className="size-3.5" />
+          Group
+        </Button>
+        {onRemove ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            className="ml-auto size-7 sm:size-7"
+            aria-label="Remove group"
+            onClick={onRemove}
+          >
+            <MinusIcon className="size-3.5" />
+          </Button>
+        ) : null}
+      </div>
+      <div className="space-y-2">
+        {childEntries.map(({ child, key }) => (
+          <div key={key} className="relative pl-4">
+            <span
+              className={cn(
+                "absolute top-0 bottom-0 left-1.5 w-px",
+                depth === 0 ? "bg-border" : "bg-border/70",
+              )}
+              aria-hidden
+            />
+            <span
+              className={cn(
+                "absolute top-4 left-1.5 h-px w-2.5",
+                depth === 0 ? "bg-border" : "bg-border/70",
+              )}
+              aria-hidden
+            />
+            <WhenExpressionNodeEditor
+              node={child}
+              variables={variables}
+              depth={depth + 1}
+              onChange={(next) => updateChild(child, next)}
+              onRemove={() => removeChild(child)}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function WhenExpressionBuilder({
+  value,
+  variables,
+  onChange,
+  onValidityChange,
+}: {
+  value: KeybindingWhenNode | undefined;
+  variables: ReadonlyArray<WhenVariableOption>;
+  onChange: (value: KeybindingWhenNode | undefined) => void;
+  onValidityChange?: (valid: boolean) => void;
+}) {
+  const expression = whenAstToExpression(value);
+  const [expressionDraft, setExpressionDraft] = useState(expression);
+  const parseResult = useMemo(() => parseWhenExpressionDraft(expressionDraft), [expressionDraft]);
+  const parseError = parseResult.ok ? null : parseResult.message;
+  const unknownIdentifiers = parseResult.ok ? unknownWhenVariables(parseResult.value) : [];
+
+  useEffect(() => {
+    setExpressionDraft(expression);
+  }, [expression]);
+
+  useEffect(() => {
+    onValidityChange?.(parseResult.ok);
+  }, [onValidityChange, parseResult.ok]);
+
+  const updateExpressionDraft = (nextExpression: string) => {
+    setExpressionDraft(nextExpression);
+    const nextResult = parseWhenExpressionDraft(nextExpression);
+    if (nextResult.ok) {
+      onChange(nextResult.value);
+    }
+  };
+
+  const addRootCondition = () => {
+    if (!value) {
+      onChange(defaultWhenCondition());
+      return;
+    }
+    onChange({ type: "and", left: value, right: defaultWhenCondition() });
+  };
+
+  const addRootGroup = () => {
+    const group = defaultWhenGroup("or");
+    if (!value) {
+      onChange(group);
+      return;
+    }
+    onChange({ type: "and", left: value, right: group });
+  };
+
+  return (
+    <div className="w-[min(34rem,calc(100vw-2rem))] space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-foreground">When</div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            className="h-7 sm:h-7"
+            onClick={addRootCondition}
+          >
+            <PlusIcon className="size-3.5" />
+            Condition
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            className="h-7 sm:h-7"
+            onClick={addRootGroup}
+          >
+            <PlusIcon className="size-3.5" />
+            Group
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <div className="relative">
+          <Input
+            value={expressionDraft}
+            onChange={(event) => updateExpressionDraft(event.currentTarget.value)}
+            placeholder="Always"
+            aria-invalid={Boolean(parseError)}
+            aria-label="When expression"
+            className={cn(
+              "h-7 rounded-md font-mono text-[12px] leading-7 sm:h-7 sm:leading-7",
+              unknownIdentifiers.length > 0 && "pr-9",
+              parseError && "border-destructive/70 focus-visible:border-destructive",
+            )}
+          />
+          {unknownIdentifiers.length > 0 ? (
+            <span className="absolute inset-y-0 right-2 flex items-center">
+              <UnknownWhenVariableWarning identifiers={unknownIdentifiers} />
+            </span>
+          ) : null}
+        </div>
+        {parseError ? (
+          <div className="flex items-center gap-1.5 text-[11px] text-destructive">
+            <CircleXIcon className="size-3.5" />
+            {parseError}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="relative">
+        {value ? (
+          <WhenExpressionNodeEditor
+            node={value}
+            variables={variables}
+            onChange={onChange}
+            onRemove={() => onChange(undefined)}
+          />
+        ) : (
+          <div className="rounded-md border border-dashed border-border/80 bg-muted/15 p-3">
+            <div className="flex flex-wrap gap-2">
+              <Button type="button" size="xs" className="h-7 sm:h-7" onClick={addRootCondition}>
+                <PlusIcon className="size-3.5" />
+                Condition
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                className="h-7 sm:h-7"
+                onClick={addRootGroup}
+              >
+                <PlusIcon className="size-3.5" />
+                Group
+              </Button>
+            </div>
+          </div>
+        )}
+        {parseError ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg border border-destructive/30 bg-background/75 p-4 text-center text-xs text-destructive backdrop-blur-[1px]">
+            Fix the expression above to continue editing visually.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function KeybindingTableRow({
+  row,
+  variables,
+  isSaving,
+  onSave,
+  onReset,
+}: {
+  row: KeybindingRow;
+  variables: ReadonlyArray<WhenVariableOption>;
+  isSaving: boolean;
+  onSave: (input: { command: KeybindingCommand; key: string; when: string }) => void;
+  onReset: (row: KeybindingRow) => void;
+}) {
+  const [keyDraft, setKeyDraft] = useState(row.key);
+  const [whenDraft, setWhenDraft] = useState<KeybindingWhenNode | undefined>(row.binding.whenAst);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isWhenDraftValid, setIsWhenDraftValid] = useState(true);
+  const whenDraftExpression = whenAstToExpression(whenDraft);
+  const isDirty = keyDraft !== row.key || whenDraftExpression !== row.when;
+  const displayShortcut = formatShortcutLabel(row.binding.shortcut);
+  const canReset = row.source === "Custom" && row.defaultKey !== null;
+
+  useEffect(() => {
+    setKeyDraft(row.key);
+    setWhenDraft(row.binding.whenAst);
+    setIsWhenDraftValid(true);
+  }, [row.binding.whenAst, row.key]);
+
+  const save = () => {
+    onSave({ command: row.command, key: keyDraft, when: whenDraftExpression });
+  };
+
+  const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Tab") return;
+    event.preventDefault();
+    if (event.key === "Escape") {
+      setKeyDraft(row.key);
+      setIsRecording(false);
+      return;
+    }
+    const next = keybindingFromKeyboardEvent(event.nativeEvent, navigator.platform);
+    if (!next) return;
+    setKeyDraft(next);
+    setIsRecording(false);
+  };
+
+  return (
+    <div className="grid grid-cols-[minmax(220px,1.1fr)_minmax(250px,0.9fr)_minmax(210px,0.85fr)_150px] items-center px-4 py-2.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+      <div className="min-w-0 pr-4">
+        <div className="truncate text-[13px] font-medium text-foreground">
+          {commandLabel(row.command)}
+        </div>
+        <div className="truncate font-mono text-[11px] text-muted-foreground/70">{row.command}</div>
+      </div>
+      <div className="flex min-w-0 items-center gap-2 pr-4">
+        <Input
+          aria-label={`Keybinding for ${commandLabel(row.command)}`}
+          value={isRecording ? "" : keyDraft}
+          placeholder={isRecording ? "Press shortcut" : "Unassigned"}
+          className={cn(
+            "h-8 w-36 font-mono text-[12px]",
+            isRecording && "border-primary/70 bg-primary/5",
+          )}
+          onFocus={() => setIsRecording(true)}
+          onBlur={() => setIsRecording(false)}
+          onChange={(event) => setKeyDraft(event.currentTarget.value)}
+          onKeyDown={captureKeybinding}
+        />
+        {keyDraft === row.key && row.key ? (
+          <div className="hidden min-w-28 sm:block">
+            <KeybindingPill value={row.key} />
+          </div>
+        ) : null}
+      </div>
+      <div className="pr-4">
+        <Popover>
+          <PopoverTrigger
+            className={cn(
+              "inline-flex h-8 w-full max-w-60 items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              !whenDraftExpression && "text-muted-foreground",
+            )}
+            aria-label={`Edit when clause for ${commandLabel(row.command)}`}
+          >
+            <span className="truncate">{whenDraftExpression || "Always"}</span>
+            <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
+          </PopoverTrigger>
+          <PopoverContent align="start" sideOffset={6}>
+            <WhenExpressionBuilder
+              value={whenDraft}
+              variables={variables}
+              onChange={setWhenDraft}
+              onValidityChange={setIsWhenDraftValid}
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+      <div className="flex items-center gap-2">
+        <div className="w-12">
+          {isDirty ? (
+            <Button
+              size="xs"
+              disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
+              onClick={save}
+            >
+              {isSaving ? "Saving" : "Save"}
+            </Button>
+          ) : null}
+        </div>
+        {canReset ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            disabled={isSaving}
+            onClick={() => onReset(row)}
+          >
+            Reset
+          </Button>
+        ) : (
+          <StatusBadge source={row.source} />
+        )}
+        <span className="sr-only">{displayShortcut}</span>
+      </div>
+    </div>
+  );
+}
+
+export function KeybindingsSettingsPanel() {
+  const keybindings = useServerKeybindings();
+  const [query, setQuery] = useState("");
+  const [savingCommand, setSavingCommand] = useState<KeybindingCommand | null>(null);
+  const rows = useMemo(() => buildKeybindingRows(keybindings, query), [keybindings, query]);
+  const whenVariables = useMemo(() => buildWhenVariableOptions(keybindings), [keybindings]);
+
+  const saveKeybinding = useCallback(
+    (input: { command: KeybindingCommand; key: string; when: string }) => {
+      setSavingCommand(input.command);
+      void ensureLocalApi()
+        .server.upsertKeybinding({
+          command: input.command,
+          key: input.key.trim(),
+          when: input.when.trim().length > 0 ? input.when.trim() : undefined,
+        })
+        .catch((error: unknown) => {
+          toastManager.add({
+            title: "Unable to save keybinding",
+            description: error instanceof Error ? error.message : "The keybinding was not saved.",
+            type: "error",
+          });
+        })
+        .finally(() => {
+          setSavingCommand(null);
+        });
+    },
+    [],
+  );
+
+  const resetKeybinding = useCallback(
+    (row: KeybindingRow) => {
+      if (!row.defaultKey) return;
+      saveKeybinding({
+        command: row.command,
+        key: row.defaultKey,
+        when: row.defaultWhen,
+      });
+    },
+    [saveKeybinding],
+  );
+
+  return (
+    <SettingsPageContainer className="max-w-5xl">
+      <SettingsSection
+        title="Keybindings"
+        icon={<KeyboardIcon className="size-3.5" />}
+        headerAction={
+          <span className="text-[11px] text-muted-foreground">
+            {rows.length} {rows.length === 1 ? "binding" : "bindings"}
+          </span>
+        }
+      >
+        {!isElectron ? (
+          <div className="flex items-start gap-2 border-b border-warning/20 bg-warning/5 px-3 py-2.5 text-[12px] leading-relaxed text-muted-foreground sm:px-4">
+            <InfoIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
+            <p>
+              Some shortcuts may be claimed by the browser before T3 Code sees them. Keybindings are
+              most faithful in the desktop app, where built-in browser shortcuts stay out of the
+              way.
+            </p>
+          </div>
+        ) : null}
+
+        <div className="border-b border-border/70 p-3 sm:p-4">
+          <div className="relative">
+            <SearchIcon className="pointer-events-none absolute top-1/2 left-3 z-10 size-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={query}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              placeholder="Search keybindings"
+              className="h-9 pl-9 text-sm"
+              aria-label="Search keybindings"
+            />
+          </div>
+        </div>
+
+        <div className="overflow-x-auto">
+          <div className="grid min-w-[840px] grid-cols-[minmax(220px,1.1fr)_minmax(250px,0.9fr)_minmax(210px,0.85fr)_150px] border-b border-border/70 bg-muted/25 px-4 py-2.5 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+            <div>Command</div>
+            <div>Keybinding</div>
+            <div>When</div>
+            <div>Status</div>
+          </div>
+          <div className="min-w-[840px] divide-y divide-border/60">
+            {rows.map((row) => (
+              <KeybindingTableRow
+                key={`${row.command}-${row.key}-${row.when}`}
+                row={row}
+                variables={whenVariables}
+                isSaving={savingCommand === row.command}
+                onSave={saveKeybinding}
+                onReset={resetKeybinding}
+              />
+            ))}
+            {rows.length === 0 ? (
+              <div className="px-4 py-12 text-center text-sm text-muted-foreground">
+                No keybindings match your search.
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </SettingsSection>
+    </SettingsPageContainer>
+  );
+}

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -8,7 +8,7 @@ import {
   SearchIcon,
   TriangleAlertIcon,
 } from "lucide-react";
-import { type KeyboardEvent, useCallback, useEffect, useMemo, useState } from "react";
+import { type KeyboardEvent, useCallback, useMemo, useReducer, useState } from "react";
 import { type KeybindingCommand, type KeybindingWhenNode } from "@t3tools/contracts";
 
 import { isElectron } from "../../env";
@@ -488,37 +488,36 @@ function WhenExpressionBuilder({
   const parseError = parseResult.ok ? null : parseResult.message;
   const unknownIdentifiers = parseResult.ok ? unknownWhenVariables(parseResult.value) : [];
 
-  useEffect(() => {
-    setExpressionDraft(expression);
-  }, [expression]);
-
-  useEffect(() => {
-    onValidityChange?.(parseResult.ok);
-  }, [onValidityChange, parseResult.ok]);
-
   const updateExpressionDraft = (nextExpression: string) => {
     setExpressionDraft(nextExpression);
     const nextResult = parseWhenExpressionDraft(nextExpression);
+    onValidityChange?.(nextResult.ok);
     if (nextResult.ok) {
       onChange(nextResult.value);
     }
   };
 
+  const updateExpressionValue = (nextValue: KeybindingWhenNode | undefined) => {
+    setExpressionDraft(whenAstToExpression(nextValue));
+    onValidityChange?.(true);
+    onChange(nextValue);
+  };
+
   const addRootCondition = () => {
     if (!value) {
-      onChange(defaultWhenCondition());
+      updateExpressionValue(defaultWhenCondition());
       return;
     }
-    onChange({ type: "and", left: value, right: defaultWhenCondition() });
+    updateExpressionValue({ type: "and", left: value, right: defaultWhenCondition() });
   };
 
   const addRootGroup = () => {
     const group = defaultWhenGroup("or");
     if (!value) {
-      onChange(group);
+      updateExpressionValue(group);
       return;
     }
-    onChange({ type: "and", left: value, right: group });
+    updateExpressionValue({ type: "and", left: value, right: group });
   };
 
   return (
@@ -584,8 +583,8 @@ function WhenExpressionBuilder({
           <WhenExpressionNodeEditor
             node={value}
             variables={variables}
-            onChange={onChange}
-            onRemove={() => onChange(undefined)}
+            onChange={updateExpressionValue}
+            onRemove={() => updateExpressionValue(undefined)}
           />
         ) : (
           <div className="rounded-md border border-dashed border-border/80 bg-muted/15 p-3">
@@ -617,6 +616,29 @@ function WhenExpressionBuilder({
   );
 }
 
+type KeybindingRowDraftState = {
+  keyDraft: string;
+  whenDraft: KeybindingWhenNode | undefined;
+  isRecording: boolean;
+  isWhenDraftValid: boolean;
+};
+
+function createKeybindingRowDraft(row: KeybindingRow): KeybindingRowDraftState {
+  return {
+    keyDraft: row.key,
+    whenDraft: row.binding.whenAst,
+    isRecording: false,
+    isWhenDraftValid: true,
+  };
+}
+
+function keybindingRowDraftReducer(
+  state: KeybindingRowDraftState,
+  patch: Partial<KeybindingRowDraftState>,
+): KeybindingRowDraftState {
+  return { ...state, ...patch };
+}
+
 function KeybindingTableRow({
   row,
   variables,
@@ -630,20 +652,12 @@ function KeybindingTableRow({
   onSave: (input: { command: KeybindingCommand; key: string; when: string }) => void;
   onReset: (row: KeybindingRow) => void;
 }) {
-  const [keyDraft, setKeyDraft] = useState(row.key);
-  const [whenDraft, setWhenDraft] = useState<KeybindingWhenNode | undefined>(row.binding.whenAst);
-  const [isRecording, setIsRecording] = useState(false);
-  const [isWhenDraftValid, setIsWhenDraftValid] = useState(true);
+  const [draft, setDraft] = useReducer(keybindingRowDraftReducer, row, createKeybindingRowDraft);
+  const { keyDraft, whenDraft, isRecording, isWhenDraftValid } = draft;
   const whenDraftExpression = whenAstToExpression(whenDraft);
   const isDirty = keyDraft !== row.key || whenDraftExpression !== row.when;
   const displayShortcut = formatShortcutLabel(row.binding.shortcut);
   const canReset = row.source === "Custom" && row.defaultKey !== null;
-
-  useEffect(() => {
-    setKeyDraft(row.key);
-    setWhenDraft(row.binding.whenAst);
-    setIsWhenDraftValid(true);
-  }, [row.binding.whenAst, row.key]);
 
   const save = () => {
     onSave({ command: row.command, key: keyDraft, when: whenDraftExpression });
@@ -653,23 +667,20 @@ function KeybindingTableRow({
     if (event.key === "Tab") return;
     event.preventDefault();
     if (event.key === "Escape") {
-      setKeyDraft(row.key);
-      setIsRecording(false);
+      setDraft({ keyDraft: row.key, isRecording: false });
       return;
     }
     const next = keybindingFromKeyboardEvent(event.nativeEvent, navigator.platform);
     if (!next) return;
-    setKeyDraft(next);
-    setIsRecording(false);
+    setDraft({ keyDraft: next, isRecording: false });
   };
 
   return (
-    <div className="grid grid-cols-[minmax(220px,1.1fr)_minmax(250px,0.9fr)_minmax(210px,0.85fr)_150px] items-center px-4 py-2.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_110px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
       <div className="min-w-0 pr-4">
-        <div className="truncate text-[13px] font-medium text-foreground">
+        <div className="truncate text-[13px] font-medium text-foreground" title={row.command}>
           {commandLabel(row.command)}
         </div>
-        <div className="truncate font-mono text-[11px] text-muted-foreground/70">{row.command}</div>
       </div>
       <div className="flex min-w-0 items-center gap-2 pr-4">
         <Input
@@ -677,12 +688,12 @@ function KeybindingTableRow({
           value={isRecording ? "" : keyDraft}
           placeholder={isRecording ? "Press shortcut" : "Unassigned"}
           className={cn(
-            "h-8 w-36 font-mono text-[12px]",
+            "h-7 w-32 rounded-md font-mono text-[12px] sm:h-7",
             isRecording && "border-primary/70 bg-primary/5",
           )}
-          onFocus={() => setIsRecording(true)}
-          onBlur={() => setIsRecording(false)}
-          onChange={(event) => setKeyDraft(event.currentTarget.value)}
+          onFocus={() => setDraft({ isRecording: true })}
+          onBlur={() => setDraft({ isRecording: false })}
+          onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
           onKeyDown={captureKeybinding}
         />
         {keyDraft === row.key && row.key ? (
@@ -695,7 +706,7 @@ function KeybindingTableRow({
         <Popover>
           <PopoverTrigger
             className={cn(
-              "inline-flex h-8 w-full max-w-60 items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              "inline-flex h-7 w-full max-w-56 items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
               !whenDraftExpression && "text-muted-foreground",
             )}
             aria-label={`Edit when clause for ${commandLabel(row.command)}`}
@@ -707,29 +718,29 @@ function KeybindingTableRow({
             <WhenExpressionBuilder
               value={whenDraft}
               variables={variables}
-              onChange={setWhenDraft}
-              onValidityChange={setIsWhenDraftValid}
+              onChange={(nextWhenDraft) => setDraft({ whenDraft: nextWhenDraft })}
+              onValidityChange={(nextIsValid) => setDraft({ isWhenDraftValid: nextIsValid })}
             />
           </PopoverContent>
         </Popover>
       </div>
       <div className="flex items-center gap-2">
-        <div className="w-12">
-          {isDirty ? (
-            <Button
-              size="xs"
-              disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
-              onClick={save}
-            >
-              {isSaving ? "Saving" : "Save"}
-            </Button>
-          ) : null}
-        </div>
+        {isDirty ? (
+          <Button
+            size="xs"
+            className="h-7 sm:h-7"
+            disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
+            onClick={save}
+          >
+            {isSaving ? "Saving" : "Save"}
+          </Button>
+        ) : null}
         {canReset ? (
           <Button
             type="button"
             variant="outline"
             size="xs"
+            className="h-7 sm:h-7"
             disabled={isSaving}
             onClick={() => onReset(row)}
           >
@@ -801,9 +812,8 @@ export function KeybindingsSettingsPanel() {
           <div className="flex items-start gap-2 border-b border-warning/20 bg-warning/5 px-3 py-2.5 text-[12px] leading-relaxed text-muted-foreground sm:px-4">
             <InfoIcon className="mt-0.5 size-3.5 shrink-0 text-warning" />
             <p>
-              Some shortcuts may be claimed by the browser before T3 Code sees them. Keybindings are
-              most faithful in the desktop app, where built-in browser shortcuts stay out of the
-              way.
+              Some shortcuts may be claimed by the browser before T3 Code sees them. Use the desktop
+              app for better keybinding support.
             </p>
           </div>
         ) : null}
@@ -822,13 +832,13 @@ export function KeybindingsSettingsPanel() {
         </div>
 
         <div className="overflow-x-auto">
-          <div className="grid min-w-[840px] grid-cols-[minmax(220px,1.1fr)_minmax(250px,0.9fr)_minmax(210px,0.85fr)_150px] border-b border-border/70 bg-muted/25 px-4 py-2.5 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+          <div className="grid min-w-[730px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_110px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
             <div>Command</div>
             <div>Keybinding</div>
             <div>When</div>
             <div>Status</div>
           </div>
-          <div className="min-w-[840px] divide-y divide-border/60">
+          <div className="min-w-[730px] divide-y divide-border/60">
             {rows.map((row) => (
               <KeybindingTableRow
                 key={`${row.command}-${row.key}-${row.when}`}

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -4,7 +4,6 @@ import {
   EllipsisIcon,
   FileJsonIcon,
   InfoIcon,
-  KeyboardIcon,
   MinusIcon,
   PlusIcon,
   SearchIcon,
@@ -1177,7 +1176,6 @@ export function KeybindingsSettingsPanel() {
     <SettingsPageContainer className="max-w-5xl">
       <SettingsSection
         title="Keybindings"
-        icon={<KeyboardIcon className="size-3.5" />}
         headerAction={
           <div className="flex items-center gap-1.5">
             <ExpandableHeaderSearch

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -863,9 +863,7 @@ export function KeybindingsSettingsPanel() {
       if (
         target !== searchInputRef.current &&
         target instanceof HTMLElement &&
-        (target.tagName === "INPUT" ||
-          target.tagName === "TEXTAREA" ||
-          target.isContentEditable)
+        (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
       ) {
         return;
       }

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1,4 +1,5 @@
 import {
+  BanIcon,
   ChevronDownIcon,
   CircleXIcon,
   FileJsonIcon,
@@ -7,6 +8,7 @@ import {
   MinusIcon,
   PlusIcon,
   SearchIcon,
+  Trash2Icon,
   TriangleAlertIcon,
 } from "lucide-react";
 import {
@@ -20,7 +22,12 @@ import {
   useRef,
   useState,
 } from "react";
-import { type KeybindingCommand, type KeybindingWhenNode } from "@t3tools/contracts";
+import {
+  type KeybindingCommand,
+  type KeybindingWhenNode,
+  type ServerRemoveKeybindingInput,
+  type ServerUpsertKeybindingInput,
+} from "@t3tools/contracts";
 
 import { isElectron } from "../../env";
 import { openInPreferredEditor } from "../../editorPreferences";
@@ -38,12 +45,15 @@ import { Toggle } from "../ui/toggle";
 import { toastManager } from "../ui/toast";
 import {
   buildKeybindingRows,
+  buildKeybindingCommandOptions,
   buildWhenVariableOptions,
   commandLabel,
   DEFAULT_WHEN_VARIABLE,
   isKnownWhenVariable,
+  keybindingConflictLabels,
   keybindingFromKeyboardEvent,
   parseWhenExpressionDraft,
+  type KeybindingCommandOption,
   type KeybindingRow,
   type WhenVariableOption,
   unknownWhenVariables,
@@ -254,6 +264,33 @@ function UnknownWhenVariableWarning({
       <TooltipPopup side="top" className="max-w-72 whitespace-normal leading-relaxed">
         T3 Code does not recognize this condition yet. It can still be saved, but it may not match
         unless the runtime provides it.
+      </TooltipPopup>
+    </Tooltip>
+  );
+}
+
+function KeybindingConflictWarning({ labels }: { labels: ReadonlyArray<string> }) {
+  if (labels.length === 0) return null;
+  const description =
+    labels.length === 1
+      ? `Conflicts with ${labels[0]}.`
+      : `Conflicts with ${labels.slice(0, 3).join(", ")}${labels.length > 3 ? ", and more" : ""}.`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            tabIndex={0}
+            aria-label={description}
+            className="inline-flex size-5 shrink-0 items-center justify-center rounded-sm text-warning outline-none transition-colors hover:bg-warning/10 focus-visible:ring-[3px] focus-visible:ring-warning/25"
+          >
+            <TriangleAlertIcon className="size-3.5" />
+          </span>
+        }
+      />
+      <TooltipPopup side="top" className="max-w-72 whitespace-normal leading-relaxed">
+        {description} The most recent matching binding wins when both conditions can apply.
       </TooltipPopup>
     </Tooltip>
   );
@@ -719,18 +756,32 @@ function keybindingRowDraftReducer(
   return { ...state, ...patch };
 }
 
+function rowKeybindingTarget(row: KeybindingRow): ServerRemoveKeybindingInput {
+  return {
+    command: row.command,
+    key: row.key,
+    ...(row.when.trim().length > 0 ? { when: row.when } : {}),
+  };
+}
+
 function KeybindingTableRow({
   row,
+  allRows,
   variables,
   isSaving,
   onSave,
   onReset,
+  onRemove,
+  onDisable,
 }: {
   row: KeybindingRow;
+  allRows: ReadonlyArray<KeybindingRow>;
   variables: ReadonlyArray<WhenVariableOption>;
   isSaving: boolean;
-  onSave: (input: { command: KeybindingCommand; key: string; when: string }) => void;
+  onSave: (input: ServerUpsertKeybindingInput) => void;
   onReset: (row: KeybindingRow) => void;
+  onRemove: (row: KeybindingRow) => void;
+  onDisable: (row: KeybindingRow) => void;
 }) {
   const [draft, setDraft] = useReducer(keybindingRowDraftReducer, row, createKeybindingRowDraft);
   const { keyDraft, whenDraft, isRecording, isWhenDraftValid } = draft;
@@ -738,10 +789,22 @@ function KeybindingTableRow({
   const isDirty = keyDraft !== row.key || whenDraftExpression !== row.when;
   const displayShortcut = formatShortcutLabel(row.binding.shortcut);
   const canReset = row.source === "Custom" && row.defaultKey !== null;
+  const canRemove = row.source !== "Default";
+  const canDisable = row.when !== "false";
   const showPill = !isRecording && keyDraft === row.key && row.key.length > 0 && !isDirty;
+  const conflictLabels = keybindingConflictLabels(allRows, {
+    rowId: row.id,
+    key: keyDraft,
+    when: whenDraftExpression,
+  });
 
   const save = () => {
-    onSave({ command: row.command, key: keyDraft, when: whenDraftExpression });
+    onSave({
+      command: row.command,
+      key: keyDraft,
+      when: whenDraftExpression.trim().length > 0 ? whenDraftExpression : undefined,
+      replace: rowKeybindingTarget(row),
+    });
   };
 
   const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
@@ -757,10 +820,12 @@ function KeybindingTableRow({
   };
 
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_110px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_190px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
       <div className="min-w-0 pr-4">
-        <div className="truncate text-[13px] font-medium text-foreground" title={row.command}>
-          {commandLabel(row.command)}
+        <div className="flex min-w-0 items-center gap-1.5">
+          <div className="truncate text-[13px] font-medium text-foreground" title={row.command}>
+            {commandLabel(row.command)}
+          </div>
         </div>
       </div>
       <div className="flex min-w-0 items-center gap-2 pr-4">
@@ -814,7 +879,7 @@ function KeybindingTableRow({
           </PopoverContent>
         </Popover>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center justify-end gap-2">
         {isDirty ? (
           <Button
             size="xs"
@@ -839,7 +904,188 @@ function KeybindingTableRow({
         ) : (
           <StatusBadge source={row.source} />
         )}
+        {canDisable ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
+                  disabled={isSaving}
+                  aria-label={`Disable ${commandLabel(row.command)}`}
+                  onClick={() => onDisable(row)}
+                >
+                  <BanIcon className="size-3.5" />
+                </Button>
+              }
+            />
+            <TooltipPopup side="top">Disable binding</TooltipPopup>
+          </Tooltip>
+        ) : null}
+        {canRemove ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  className="size-7 text-muted-foreground hover:text-destructive sm:size-7"
+                  disabled={isSaving}
+                  aria-label={`Remove ${commandLabel(row.command)}`}
+                  onClick={() => onRemove(row)}
+                >
+                  <Trash2Icon className="size-3.5" />
+                </Button>
+              }
+            />
+            <TooltipPopup side="top">Remove binding</TooltipPopup>
+          </Tooltip>
+        ) : null}
         <span className="sr-only">{displayShortcut}</span>
+        <KeybindingConflictWarning labels={conflictLabels} />
+      </div>
+    </div>
+  );
+}
+
+function NewKeybindingTableRow({
+  commandOptions,
+  allRows,
+  variables,
+  isSaving,
+  onSave,
+  onCancel,
+}: {
+  commandOptions: ReadonlyArray<KeybindingCommandOption>;
+  allRows: ReadonlyArray<KeybindingRow>;
+  variables: ReadonlyArray<WhenVariableOption>;
+  isSaving: boolean;
+  onSave: (input: ServerUpsertKeybindingInput) => void;
+  onCancel: () => void;
+}) {
+  const [commandDraft, setCommandDraft] = useState<KeybindingCommand | "">("");
+  const [draft, setDraft] = useReducer(keybindingRowDraftReducer, {
+    keyDraft: "",
+    whenDraft: undefined,
+    isRecording: false,
+    isWhenDraftValid: true,
+  });
+  const { keyDraft, whenDraft, isRecording, isWhenDraftValid } = draft;
+  const whenDraftExpression = whenAstToExpression(whenDraft);
+  const conflictLabels = keybindingConflictLabels(allRows, {
+    rowId: "new",
+    key: keyDraft,
+    when: whenDraftExpression,
+  });
+  const commandLabelText = commandDraft ? commandLabel(commandDraft) : "new keybinding";
+
+  const save = () => {
+    if (!commandDraft) return;
+    onSave({
+      command: commandDraft,
+      key: keyDraft,
+      ...(whenDraftExpression.trim().length > 0 ? { when: whenDraftExpression } : {}),
+    });
+  };
+
+  const captureKeybinding = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Tab") return;
+    event.preventDefault();
+    if (event.key === "Escape") {
+      setDraft({ keyDraft: "", isRecording: false });
+      return;
+    }
+    const next = keybindingFromKeyboardEvent(event.nativeEvent, navigator.platform);
+    if (!next) return;
+    setDraft({ keyDraft: next, isRecording: false });
+  };
+
+  return (
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_190px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+      <div className="min-w-0 pr-4">
+        <Select
+          value={commandDraft}
+          onValueChange={(value) => setCommandDraft(value as KeybindingCommand)}
+        >
+          <SelectTrigger
+            size="xs"
+            className="h-7 min-h-7 w-full max-w-60 rounded-md text-xs sm:h-7"
+          >
+            <SelectValue placeholder="Command" />
+          </SelectTrigger>
+          <SelectContent
+            alignItemWithTrigger={false}
+            matchTriggerWidth={false}
+            className="max-h-72 w-fit min-w-56"
+          >
+            {commandOptions.map((command) => (
+              <SelectItem key={command} value={command} className="min-h-7 w-full py-1 text-[12px]">
+                <span className="truncate">{commandLabel(command)}</span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="flex min-w-0 items-center gap-2 pr-4">
+        <Input
+          aria-label={`Keybinding for ${commandLabelText}`}
+          value={isRecording ? "" : keyDraft}
+          placeholder={isRecording ? "Press shortcut" : "Unassigned"}
+          className={cn(
+            "h-7 w-44 rounded-md font-mono text-[12px] sm:h-7",
+            isRecording && "border-primary/70 bg-primary/5",
+          )}
+          onFocus={() => setDraft({ isRecording: true })}
+          onBlur={() => setDraft({ isRecording: false })}
+          onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
+          onKeyDown={captureKeybinding}
+        />
+      </div>
+      <div className="pr-4">
+        <Popover>
+          <PopoverTrigger
+            className={cn(
+              "inline-flex h-7 w-full max-w-56 items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              !whenDraftExpression && "text-muted-foreground",
+            )}
+            aria-label={`Edit when clause for ${commandLabelText}`}
+          >
+            <span className="truncate">{whenDraftExpression || "Always"}</span>
+            <ChevronDownIcon className="size-3.5 shrink-0 opacity-60" />
+          </PopoverTrigger>
+          <PopoverContent align="start" sideOffset={6}>
+            <WhenExpressionBuilder
+              value={whenDraft}
+              variables={variables}
+              onChange={(nextWhenDraft) => setDraft({ whenDraft: nextWhenDraft })}
+              onValidityChange={(nextIsValid) => setDraft({ isWhenDraftValid: nextIsValid })}
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+      <div className="flex items-center justify-end gap-2">
+        <KeybindingConflictWarning labels={conflictLabels} />
+        <Button
+          size="xs"
+          className="h-7 sm:h-7"
+          disabled={isSaving || !commandDraft || keyDraft.trim().length === 0 || !isWhenDraftValid}
+          onClick={save}
+        >
+          {isSaving ? "Saving" : "Save"}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          className="h-7 sm:h-7"
+          disabled={isSaving}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
       </div>
     </div>
   );
@@ -852,8 +1098,10 @@ export function KeybindingsSettingsPanel() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [savingCommand, setSavingCommand] = useState<KeybindingCommand | null>(null);
+  const [isAddingBinding, setIsAddingBinding] = useState(false);
   const rows = useMemo(() => buildKeybindingRows(keybindings, query), [keybindings, query]);
-  const whenVariables = useMemo(() => buildWhenVariableOptions(keybindings), [keybindings]);
+  const commandOptions = useMemo(() => buildKeybindingCommandOptions(keybindings), [keybindings]);
+  const whenVariables = useMemo(() => buildWhenVariableOptions(), []);
 
   useEffect(() => {
     const handleKeyDown = (event: globalThis.KeyboardEvent) => {
@@ -892,27 +1140,57 @@ export function KeybindingsSettingsPanel() {
     });
   }, [keybindingsConfigPath]);
 
-  const saveKeybinding = useCallback(
-    (input: { command: KeybindingCommand; key: string; when: string }) => {
-      setSavingCommand(input.command);
-      void ensureLocalApi()
-        .server.upsertKeybinding({
-          command: input.command,
-          key: input.key.trim(),
-          when: input.when.trim().length > 0 ? input.when.trim() : undefined,
-        })
-        .catch((error: unknown) => {
-          toastManager.add({
-            title: "Unable to save keybinding",
-            description: error instanceof Error ? error.message : "The keybinding was not saved.",
-            type: "error",
-          });
-        })
-        .finally(() => {
-          setSavingCommand(null);
+  const saveKeybinding = useCallback((input: ServerUpsertKeybindingInput) => {
+    setSavingCommand(input.command);
+    const payload: ServerUpsertKeybindingInput = {
+      command: input.command,
+      key: input.key.trim(),
+      ...(input.when?.trim() ? { when: input.when.trim() } : {}),
+      ...(input.replace ? { replace: input.replace } : {}),
+    };
+    void ensureLocalApi()
+      .server.upsertKeybinding(payload)
+      .then(() => {
+        setIsAddingBinding(false);
+      })
+      .catch((error: unknown) => {
+        toastManager.add({
+          title: "Unable to save keybinding",
+          description: error instanceof Error ? error.message : "The keybinding was not saved.",
+          type: "error",
         });
+      })
+      .finally(() => {
+        setSavingCommand(null);
+      });
+  }, []);
+
+  const removeKeybinding = useCallback((row: KeybindingRow) => {
+    setSavingCommand(row.command);
+    void ensureLocalApi()
+      .server.removeKeybinding(rowKeybindingTarget(row))
+      .catch((error: unknown) => {
+        toastManager.add({
+          title: "Unable to remove keybinding",
+          description: error instanceof Error ? error.message : "The keybinding was not removed.",
+          type: "error",
+        });
+      })
+      .finally(() => {
+        setSavingCommand(null);
+      });
+  }, []);
+
+  const disableKeybinding = useCallback(
+    (row: KeybindingRow) => {
+      saveKeybinding({
+        command: row.command,
+        key: row.key,
+        when: "false",
+        replace: rowKeybindingTarget(row),
+      });
     },
-    [],
+    [saveKeybinding],
   );
 
   const resetKeybinding = useCallback(
@@ -921,7 +1199,12 @@ export function KeybindingsSettingsPanel() {
       saveKeybinding({
         command: row.command,
         key: row.defaultKey,
-        when: row.defaultWhen,
+        when: row.defaultWhen.trim().length > 0 ? row.defaultWhen : undefined,
+        replace: {
+          command: row.command,
+          key: row.key,
+          ...(row.when.trim().length > 0 ? { when: row.when } : {}),
+        },
       });
     },
     [saveKeybinding],
@@ -929,7 +1212,8 @@ export function KeybindingsSettingsPanel() {
 
   const bindingsCount = (
     <span className="text-[11px] text-muted-foreground">
-      {rows.length} {rows.length === 1 ? "binding" : "bindings"}
+      {rows.length + (isAddingBinding ? 1 : 0)}{" "}
+      {rows.length + (isAddingBinding ? 1 : 0) === 1 ? "binding" : "bindings"}
     </span>
   );
 
@@ -948,6 +1232,23 @@ export function KeybindingsSettingsPanel() {
               inputRef={searchInputRef}
               collapsedAccessory={bindingsCount}
             />
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    size="icon-xs"
+                    variant="ghost"
+                    className="size-5 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+                    onClick={() => setIsAddingBinding(true)}
+                    aria-label="Add keybinding"
+                  >
+                    <PlusIcon className="size-3" />
+                  </Button>
+                }
+              />
+              <TooltipPopup side="top">Add keybinding</TooltipPopup>
+            </Tooltip>
             <Tooltip>
               <TooltipTrigger
                 render={
@@ -985,24 +1286,37 @@ export function KeybindingsSettingsPanel() {
           hideScrollbars
           className="w-full max-w-full rounded-none"
         >
-          <div className="grid min-w-[730px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_110px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+          <div className="grid min-w-[810px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_190px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
             <div>Command</div>
             <div>Keybinding</div>
             <div>When</div>
             <div>Status</div>
           </div>
-          <div className="min-w-[730px] divide-y divide-border/60">
+          <div className="min-w-[810px] divide-y divide-border/60">
+            {isAddingBinding ? (
+              <NewKeybindingTableRow
+                commandOptions={commandOptions}
+                allRows={rows}
+                variables={whenVariables}
+                isSaving={savingCommand !== null}
+                onSave={saveKeybinding}
+                onCancel={() => setIsAddingBinding(false)}
+              />
+            ) : null}
             {rows.map((row) => (
               <KeybindingTableRow
-                key={`${row.command}-${row.key}-${row.when}`}
+                key={row.id}
                 row={row}
+                allRows={rows}
                 variables={whenVariables}
                 isSaving={savingCommand === row.command}
                 onSave={saveKeybinding}
                 onReset={resetKeybinding}
+                onRemove={removeKeybinding}
+                onDisable={disableKeybinding}
               />
             ))}
-            {rows.length === 0 ? (
+            {rows.length === 0 && !isAddingBinding ? (
               <div className="px-4 py-12 text-center text-sm text-muted-foreground">
                 No keybindings match your search.
               </div>

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -32,6 +32,7 @@ import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
+import { ScrollArea } from "../ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Toggle } from "../ui/toggle";
 import { toastManager } from "../ui/toast";
@@ -978,7 +979,12 @@ export function KeybindingsSettingsPanel() {
           </div>
         ) : null}
 
-        <div className="overflow-x-auto">
+        <ScrollArea
+          chainVerticalScroll
+          scrollFade
+          hideScrollbars
+          className="w-full max-w-full rounded-none"
+        >
           <div className="grid min-w-[730px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_110px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
             <div>Command</div>
             <div>Keybinding</div>
@@ -1002,7 +1008,7 @@ export function KeybindingsSettingsPanel() {
               </div>
             ) : null}
           </div>
-        </div>
+        </ScrollArea>
       </SettingsSection>
     </SettingsPageContainer>
   );

--- a/apps/web/src/components/settings/KeybindingsSettings.tsx
+++ b/apps/web/src/components/settings/KeybindingsSettings.tsx
@@ -1,15 +1,15 @@
 import {
-  BanIcon,
   ChevronDownIcon,
   CircleXIcon,
+  EllipsisIcon,
   FileJsonIcon,
   InfoIcon,
   KeyboardIcon,
   MinusIcon,
   PlusIcon,
   SearchIcon,
-  Trash2Icon,
   TriangleAlertIcon,
+  XIcon,
 } from "lucide-react";
 import {
   type KeyboardEvent,
@@ -38,6 +38,7 @@ import { useServerKeybindings, useServerKeybindingsConfigPath } from "../../rpc/
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Kbd, KbdGroup } from "../ui/kbd";
+import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
 import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import { ScrollArea } from "../ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
@@ -86,22 +87,6 @@ function KeybindingPill({ value }: { value: string }) {
         </Kbd>
       ))}
     </KbdGroup>
-  );
-}
-
-function StatusBadge({ source }: { source: KeybindingRow["source"] }) {
-  return (
-    <span
-      className={cn(
-        "inline-flex h-7 items-center rounded-md border px-2.5 text-xs font-medium",
-        source === "Default" && "border-border/70 text-muted-foreground",
-        source === "Custom" && "border-primary/30 bg-primary/8 text-primary",
-        source === "Project" &&
-          "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-      )}
-    >
-      {source}
-    </span>
   );
 }
 
@@ -772,7 +757,6 @@ function KeybindingTableRow({
   onSave,
   onReset,
   onRemove,
-  onDisable,
 }: {
   row: KeybindingRow;
   allRows: ReadonlyArray<KeybindingRow>;
@@ -781,7 +765,6 @@ function KeybindingTableRow({
   onSave: (input: ServerUpsertKeybindingInput) => void;
   onReset: (row: KeybindingRow) => void;
   onRemove: (row: KeybindingRow) => void;
-  onDisable: (row: KeybindingRow) => void;
 }) {
   const [draft, setDraft] = useReducer(keybindingRowDraftReducer, row, createKeybindingRowDraft);
   const { keyDraft, whenDraft, isRecording, isWhenDraftValid } = draft;
@@ -790,7 +773,7 @@ function KeybindingTableRow({
   const displayShortcut = formatShortcutLabel(row.binding.shortcut);
   const canReset = row.source === "Custom" && row.defaultKey !== null;
   const canRemove = row.source !== "Default";
-  const canDisable = row.when !== "false";
+  const hasRowActions = canReset || canRemove;
   const showPill = !isRecording && keyDraft === row.key && row.key.length > 0 && !isDirty;
   const conflictLabels = keybindingConflictLabels(allRows, {
     rowId: row.id,
@@ -820,7 +803,7 @@ function KeybindingTableRow({
   };
 
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_190px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
       <div className="min-w-0 pr-4">
         <div className="flex min-w-0 items-center gap-1.5">
           <div className="truncate text-[13px] font-medium text-foreground" title={row.command}>
@@ -843,6 +826,7 @@ function KeybindingTableRow({
           </button>
         ) : (
           <Input
+            autoFocus={isRecording}
             aria-label={`Keybinding for ${commandLabel(row.command)}`}
             value={isRecording ? "" : keyDraft}
             placeholder={isRecording ? "Press shortcut" : "Unassigned"}
@@ -856,12 +840,22 @@ function KeybindingTableRow({
             onKeyDown={captureKeybinding}
           />
         )}
+        {isDirty ? (
+          <Button
+            size="xs"
+            className="h-7 sm:h-7"
+            disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
+            onClick={save}
+          >
+            {isSaving ? "Saving" : "Save"}
+          </Button>
+        ) : null}
       </div>
       <div className="pr-4">
         <Popover>
           <PopoverTrigger
             className={cn(
-              "inline-flex h-7 w-full max-w-56 items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              "inline-flex h-7 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
               !whenDraftExpression && "text-muted-foreground",
             )}
             aria-label={`Edit when clause for ${commandLabel(row.command)}`}
@@ -879,34 +873,11 @@ function KeybindingTableRow({
           </PopoverContent>
         </Popover>
       </div>
-      <div className="flex items-center justify-end gap-2">
-        {isDirty ? (
-          <Button
-            size="xs"
-            className="h-7 sm:h-7"
-            disabled={isSaving || keyDraft.trim().length === 0 || !isWhenDraftValid}
-            onClick={save}
-          >
-            {isSaving ? "Saving" : "Save"}
-          </Button>
-        ) : null}
-        {canReset ? (
-          <Button
-            type="button"
-            variant="outline"
-            size="xs"
-            className="h-7 sm:h-7"
-            disabled={isSaving}
-            onClick={() => onReset(row)}
-          >
-            Reset
-          </Button>
-        ) : (
-          <StatusBadge source={row.source} />
-        )}
-        {canDisable ? (
-          <Tooltip>
-            <TooltipTrigger
+      <div className="flex items-center justify-end gap-1">
+        <KeybindingConflictWarning labels={conflictLabels} />
+        {hasRowActions ? (
+          <Menu>
+            <MenuTrigger
               render={
                 <Button
                   type="button"
@@ -914,38 +885,31 @@ function KeybindingTableRow({
                   size="icon-sm"
                   className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
                   disabled={isSaving}
-                  aria-label={`Disable ${commandLabel(row.command)}`}
-                  onClick={() => onDisable(row)}
-                >
-                  <BanIcon className="size-3.5" />
-                </Button>
+                  aria-label={`Actions for ${commandLabel(row.command)}`}
+                />
               }
-            />
-            <TooltipPopup side="top">Disable binding</TooltipPopup>
-          </Tooltip>
-        ) : null}
-        {canRemove ? (
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="size-7 text-muted-foreground hover:text-destructive sm:size-7"
+            >
+              <EllipsisIcon className="size-3.5" />
+            </MenuTrigger>
+            <MenuPopup align="end" className="min-w-36">
+              {canReset ? (
+                <MenuItem disabled={isSaving} onClick={() => onReset(row)}>
+                  Reset to default
+                </MenuItem>
+              ) : null}
+              {canRemove ? (
+                <MenuItem
+                  variant="destructive"
                   disabled={isSaving}
-                  aria-label={`Remove ${commandLabel(row.command)}`}
                   onClick={() => onRemove(row)}
                 >
-                  <Trash2Icon className="size-3.5" />
-                </Button>
-              }
-            />
-            <TooltipPopup side="top">Remove binding</TooltipPopup>
-          </Tooltip>
+                  Remove
+                </MenuItem>
+              ) : null}
+            </MenuPopup>
+          </Menu>
         ) : null}
         <span className="sr-only">{displayShortcut}</span>
-        <KeybindingConflictWarning labels={conflictLabels} />
       </div>
     </div>
   );
@@ -1004,7 +968,7 @@ function NewKeybindingTableRow({
   };
 
   return (
-    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_190px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
+    <div className="grid grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] items-center px-4 py-1.5 text-sm even:bg-muted/15 hover:bg-accent/40">
       <div className="min-w-0 pr-4">
         <Select
           value={commandDraft}
@@ -1043,12 +1007,20 @@ function NewKeybindingTableRow({
           onChange={(event) => setDraft({ keyDraft: event.currentTarget.value })}
           onKeyDown={captureKeybinding}
         />
+        <Button
+          size="xs"
+          className="h-7 sm:h-7"
+          disabled={isSaving || !commandDraft || keyDraft.trim().length === 0 || !isWhenDraftValid}
+          onClick={save}
+        >
+          {isSaving ? "Saving" : "Save"}
+        </Button>
       </div>
       <div className="pr-4">
         <Popover>
           <PopoverTrigger
             className={cn(
-              "inline-flex h-7 w-full max-w-56 items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
+              "inline-flex h-7 w-full items-center justify-between gap-2 rounded-md border border-input bg-background px-2.5 text-left font-mono text-[12px] text-foreground shadow-xs/5 outline-none transition-colors hover:bg-accent focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/24",
               !whenDraftExpression && "text-muted-foreground",
             )}
             aria-label={`Edit when clause for ${commandLabelText}`}
@@ -1066,26 +1038,26 @@ function NewKeybindingTableRow({
           </PopoverContent>
         </Popover>
       </div>
-      <div className="flex items-center justify-end gap-2">
+      <div className="flex items-center justify-end gap-1">
         <KeybindingConflictWarning labels={conflictLabels} />
-        <Button
-          size="xs"
-          className="h-7 sm:h-7"
-          disabled={isSaving || !commandDraft || keyDraft.trim().length === 0 || !isWhenDraftValid}
-          onClick={save}
-        >
-          {isSaving ? "Saving" : "Save"}
-        </Button>
-        <Button
-          type="button"
-          variant="outline"
-          size="xs"
-          className="h-7 sm:h-7"
-          disabled={isSaving}
-          onClick={onCancel}
-        >
-          Cancel
-        </Button>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="size-7 text-muted-foreground hover:text-foreground sm:size-7"
+                disabled={isSaving}
+                aria-label="Cancel new keybinding"
+                onClick={onCancel}
+              />
+            }
+          >
+            <XIcon className="size-3.5" />
+          </TooltipTrigger>
+          <TooltipPopup side="top">Cancel</TooltipPopup>
+        </Tooltip>
       </div>
     </div>
   );
@@ -1181,18 +1153,6 @@ export function KeybindingsSettingsPanel() {
       });
   }, []);
 
-  const disableKeybinding = useCallback(
-    (row: KeybindingRow) => {
-      saveKeybinding({
-        command: row.command,
-        key: row.key,
-        when: "false",
-        replace: rowKeybindingTarget(row),
-      });
-    },
-    [saveKeybinding],
-  );
-
   const resetKeybinding = useCallback(
     (row: KeybindingRow) => {
       if (!row.defaultKey) return;
@@ -1286,13 +1246,13 @@ export function KeybindingsSettingsPanel() {
           hideScrollbars
           className="w-full max-w-full rounded-none"
         >
-          <div className="grid min-w-[810px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,0.9fr)_190px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+          <div className="grid min-w-[680px] grid-cols-[minmax(190px,1.1fr)_minmax(220px,0.85fr)_minmax(210px,1fr)_60px] border-b border-border/70 bg-muted/25 px-4 py-2 text-[11px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
             <div>Command</div>
             <div>Keybinding</div>
             <div>When</div>
             <div>Status</div>
           </div>
-          <div className="min-w-[810px] divide-y divide-border/60">
+          <div className="min-w-[680px] divide-y divide-border/60">
             {isAddingBinding ? (
               <NewKeybindingTableRow
                 commandOptions={commandOptions}
@@ -1313,7 +1273,6 @@ export function KeybindingsSettingsPanel() {
                 onSave={saveKeybinding}
                 onReset={resetKeybinding}
                 onRemove={removeKeybinding}
-                onDisable={disableKeybinding}
               />
             ))}
             {rows.length === 0 && !isAddingBinding ? (

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -69,7 +69,6 @@ import {
 import { ProjectFavicon } from "../ProjectFavicon";
 import {
   useServerAvailableEditors,
-  useServerKeybindingsConfigPath,
   useServerObservability,
   useServerProviders,
 } from "../../rpc/serverState";
@@ -452,11 +451,10 @@ export function GeneralSettingsPanel() {
   const settings = useSettings();
   const { updateSettings } = useUpdateSettings();
   const [openingPathByTarget, setOpeningPathByTarget] = useState({
-    keybindings: false,
     logsDirectory: false,
   });
   const [openPathErrorByTarget, setOpenPathErrorByTarget] = useState<
-    Partial<Record<"keybindings" | "logsDirectory", string | null>>
+    Partial<Record<"logsDirectory", string | null>>
   >({});
   const [isRefreshingProviders, setIsRefreshingProviders] = useState(false);
   const [isAddInstanceDialogOpen, setIsAddInstanceDialogOpen] = useState(false);
@@ -484,7 +482,6 @@ export function GeneralSettingsPanel() {
       });
   }, []);
 
-  const keybindingsConfigPath = useServerKeybindingsConfigPath();
   const availableEditors = useServerAvailableEditors();
   const observability = useServerObservability();
   const serverProviders = useServerProviders();
@@ -533,7 +530,7 @@ export function GeneralSettingsPanel() {
   );
 
   const openInPreferredEditor = useCallback(
-    (target: "keybindings" | "logsDirectory", path: string | null, failureMessage: string) => {
+    (target: "logsDirectory", path: string | null, failureMessage: string) => {
       if (!path) return;
       setOpenPathErrorByTarget((existing) => ({ ...existing, [target]: null }));
       setOpeningPathByTarget((existing) => ({ ...existing, [target]: true }));
@@ -563,17 +560,11 @@ export function GeneralSettingsPanel() {
     [availableEditors],
   );
 
-  const openKeybindingsFile = useCallback(() => {
-    openInPreferredEditor("keybindings", keybindingsConfigPath, "Unable to open keybindings file.");
-  }, [keybindingsConfigPath, openInPreferredEditor]);
-
   const openLogsDirectory = useCallback(() => {
     openInPreferredEditor("logsDirectory", logsDirectoryPath, "Unable to open logs folder.");
   }, [logsDirectoryPath, openInPreferredEditor]);
 
-  const openKeybindingsError = openPathErrorByTarget.keybindings ?? null;
   const openDiagnosticsError = openPathErrorByTarget.logsDirectory ?? null;
-  const isOpeningKeybindings = openingPathByTarget.keybindings;
   const isOpeningLogsDirectory = openingPathByTarget.logsDirectory;
 
   const lastCheckedAt =
@@ -1296,35 +1287,6 @@ export function GeneralSettingsPanel() {
         open={isAddInstanceDialogOpen}
         onOpenChange={setIsAddInstanceDialogOpen}
       />
-
-      <SettingsSection title="Advanced">
-        <SettingsRow
-          title="Keybindings"
-          description="Open the persisted `keybindings.json` file to edit advanced bindings directly."
-          status={
-            <>
-              <span className="block break-all font-mono text-[11px] text-foreground">
-                {keybindingsConfigPath ?? "Resolving keybindings path..."}
-              </span>
-              {openKeybindingsError ? (
-                <span className="mt-1 block text-destructive">{openKeybindingsError}</span>
-              ) : (
-                <span className="mt-1 block">Opens in your preferred editor.</span>
-              )}
-            </>
-          }
-          control={
-            <Button
-              size="xs"
-              variant="outline"
-              disabled={!keybindingsConfigPath || isOpeningKeybindings}
-              onClick={openKeybindingsFile}
-            >
-              {isOpeningKeybindings ? "Opening..." : "Open file"}
-            </Button>
-          }
-        />
-      </SettingsSection>
 
       <SettingsSection title="About">
         {isElectron ? (

--- a/apps/web/src/components/settings/SettingsSidebarNav.tsx
+++ b/apps/web/src/components/settings/SettingsSidebarNav.tsx
@@ -1,5 +1,12 @@
 import { useCallback, type ComponentType } from "react";
-import { ArchiveIcon, ArrowLeftIcon, GitBranchIcon, Link2Icon, Settings2Icon } from "lucide-react";
+import {
+  ArchiveIcon,
+  ArrowLeftIcon,
+  GitBranchIcon,
+  KeyboardIcon,
+  Link2Icon,
+  Settings2Icon,
+} from "lucide-react";
 import { useCanGoBack, useNavigate } from "@tanstack/react-router";
 
 import {
@@ -15,6 +22,7 @@ import {
 
 export type SettingsSectionPath =
   | "/settings/general"
+  | "/settings/keybindings"
   | "/settings/source-control"
   | "/settings/connections"
   | "/settings/archived";
@@ -25,6 +33,7 @@ export const SETTINGS_NAV_ITEMS: ReadonlyArray<{
   icon: ComponentType<{ className?: string }>;
 }> = [
   { label: "General", to: "/settings/general", icon: Settings2Icon },
+  { label: "Keybindings", to: "/settings/keybindings", icon: KeyboardIcon },
   { label: "Source Control", to: "/settings/source-control", icon: GitBranchIcon },
   { label: "Connections", to: "/settings/connections", icon: Link2Icon },
   { label: "Archive", to: "/settings/archived", icon: ArchiveIcon },

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -113,10 +113,18 @@ export function SettingResetButton({ label, onClick }: { label: string; onClick:
   );
 }
 
-export function SettingsPageContainer({ children }: { children: ReactNode }) {
+export function SettingsPageContainer({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
   return (
     <div className="flex-1 overflow-y-auto p-6 sm:p-8">
-      <div className="mx-auto flex w-full max-w-3xl flex-col gap-8">{children}</div>
+      <div className={cn("mx-auto flex w-full max-w-3xl flex-col gap-8", className)}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -10,11 +10,13 @@ function ScrollArea({
   scrollFade = false,
   scrollbarGutter = false,
   hideScrollbars = false,
+  chainVerticalScroll = false,
   ...props
 }: ScrollAreaPrimitive.Root.Props & {
   scrollFade?: boolean;
   scrollbarGutter?: boolean;
   hideScrollbars?: boolean;
+  chainVerticalScroll?: boolean;
 }) {
   return (
     <ScrollAreaPrimitive.Root
@@ -23,7 +25,8 @@ function ScrollArea({
     >
       <ScrollAreaPrimitive.Viewport
         className={cn(
-          "h-full max-h-[inherit] overflow-y-auto overscroll-contain rounded-[inherit] outline-none transition-shadows focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-has-overflow-x:overscroll-x-contain",
+          "h-full max-h-[inherit] overflow-auto overscroll-contain rounded-[inherit] outline-none transition-shadows focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background data-has-overflow-x:overscroll-x-contain",
+          chainVerticalScroll && "overscroll-y-auto",
           scrollFade &&
             "mask-t-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-start)))] mask-b-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-end)))] mask-l-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-start)))] mask-r-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-end)))] [--fade-size:1.5rem]",
           scrollbarGutter && "[scrollbar-gutter:stable]",

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -105,20 +105,24 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
 
 function SelectPopup({
   className,
+  popupClassName,
   children,
   side = "bottom",
   sideOffset = 4,
   align = "start",
   alignOffset = 0,
   alignItemWithTrigger = true,
+  matchTriggerWidth = true,
   anchor,
   ...props
 }: SelectPrimitive.Popup.Props & {
+  popupClassName?: string;
   side?: SelectPrimitive.Positioner.Props["side"];
   sideOffset?: SelectPrimitive.Positioner.Props["sideOffset"];
   align?: SelectPrimitive.Positioner.Props["align"];
   alignOffset?: SelectPrimitive.Positioner.Props["alignOffset"];
   alignItemWithTrigger?: SelectPrimitive.Positioner.Props["alignItemWithTrigger"];
+  matchTriggerWidth?: boolean;
   anchor?: SelectPrimitive.Positioner.Props["anchor"];
 }) {
   return (
@@ -144,7 +148,13 @@ function SelectPopup({
           >
             <ChevronUpIcon className="relative size-4.5 sm:size-4" />
           </SelectPrimitive.ScrollUpArrow>
-          <div className="relative h-full min-w-(--anchor-width) rounded-lg border bg-popover not-dark:bg-clip-padding shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]">
+          <div
+            className={cn(
+              "relative h-full rounded-lg border bg-popover not-dark:bg-clip-padding shadow-lg/5 before:pointer-events-none before:absolute before:inset-0 before:rounded-[calc(var(--radius-lg)-1px)] before:shadow-[0_1px_--theme(--color-black/4%)] dark:before:shadow-[0_-1px_--theme(--color-white/6%)]",
+              matchTriggerWidth && "min-w-(--anchor-width)",
+              popupClassName,
+            )}
+          >
             <SelectPrimitive.List
               className={cn("max-h-(--available-height) overflow-y-auto p-1", className)}
               data-slot="select-list"

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -129,6 +129,10 @@ function createBrowserLocalApi(rpcClient?: WsRpcClient): LocalApi {
         rpcClient
           ? rpcClient.server.upsertKeybinding(input)
           : Promise.reject(unavailableLocalBackendError()),
+      removeKeybinding: (input) =>
+        rpcClient
+          ? rpcClient.server.removeKeybinding(input)
+          : Promise.reject(unavailableLocalBackendError()),
       getSettings: () =>
         rpcClient ? rpcClient.server.getSettings() : Promise.reject(unavailableLocalBackendError()),
       updateSettings: (patch) =>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as PairRouteImport } from './routes/pair'
 import { Route as ChatRouteImport } from './routes/_chat'
 import { Route as ChatIndexRouteImport } from './routes/_chat.index'
 import { Route as SettingsSourceControlRouteImport } from './routes/settings.source-control'
+import { Route as SettingsKeybindingsRouteImport } from './routes/settings.keybindings'
 import { Route as SettingsGeneralRouteImport } from './routes/settings.general'
 import { Route as SettingsConnectionsRouteImport } from './routes/settings.connections'
 import { Route as SettingsArchivedRouteImport } from './routes/settings.archived'
@@ -42,6 +43,11 @@ const ChatIndexRoute = ChatIndexRouteImport.update({
 const SettingsSourceControlRoute = SettingsSourceControlRouteImport.update({
   id: '/source-control',
   path: '/source-control',
+  getParentRoute: () => SettingsRoute,
+} as any)
+const SettingsKeybindingsRoute = SettingsKeybindingsRouteImport.update({
+  id: '/keybindings',
+  path: '/keybindings',
   getParentRoute: () => SettingsRoute,
 } as any)
 const SettingsGeneralRoute = SettingsGeneralRouteImport.update({
@@ -78,6 +84,7 @@ export interface FileRoutesByFullPath {
   '/settings/archived': typeof SettingsArchivedRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/general': typeof SettingsGeneralRoute
+  '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
   '/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
   '/draft/$draftId': typeof ChatDraftDraftIdRoute
@@ -88,6 +95,7 @@ export interface FileRoutesByTo {
   '/settings/archived': typeof SettingsArchivedRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/general': typeof SettingsGeneralRoute
+  '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
   '/': typeof ChatIndexRoute
   '/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
@@ -101,6 +109,7 @@ export interface FileRoutesById {
   '/settings/archived': typeof SettingsArchivedRoute
   '/settings/connections': typeof SettingsConnectionsRoute
   '/settings/general': typeof SettingsGeneralRoute
+  '/settings/keybindings': typeof SettingsKeybindingsRoute
   '/settings/source-control': typeof SettingsSourceControlRoute
   '/_chat/': typeof ChatIndexRoute
   '/_chat/$environmentId/$threadId': typeof ChatEnvironmentIdThreadIdRoute
@@ -115,6 +124,7 @@ export interface FileRouteTypes {
     | '/settings/archived'
     | '/settings/connections'
     | '/settings/general'
+    | '/settings/keybindings'
     | '/settings/source-control'
     | '/$environmentId/$threadId'
     | '/draft/$draftId'
@@ -125,6 +135,7 @@ export interface FileRouteTypes {
     | '/settings/archived'
     | '/settings/connections'
     | '/settings/general'
+    | '/settings/keybindings'
     | '/settings/source-control'
     | '/'
     | '/$environmentId/$threadId'
@@ -137,6 +148,7 @@ export interface FileRouteTypes {
     | '/settings/archived'
     | '/settings/connections'
     | '/settings/general'
+    | '/settings/keybindings'
     | '/settings/source-control'
     | '/_chat/'
     | '/_chat/$environmentId/$threadId'
@@ -184,6 +196,13 @@ declare module '@tanstack/react-router' {
       path: '/source-control'
       fullPath: '/settings/source-control'
       preLoaderRoute: typeof SettingsSourceControlRouteImport
+      parentRoute: typeof SettingsRoute
+    }
+    '/settings/keybindings': {
+      id: '/settings/keybindings'
+      path: '/keybindings'
+      fullPath: '/settings/keybindings'
+      preLoaderRoute: typeof SettingsKeybindingsRouteImport
       parentRoute: typeof SettingsRoute
     }
     '/settings/general': {
@@ -242,6 +261,7 @@ interface SettingsRouteChildren {
   SettingsArchivedRoute: typeof SettingsArchivedRoute
   SettingsConnectionsRoute: typeof SettingsConnectionsRoute
   SettingsGeneralRoute: typeof SettingsGeneralRoute
+  SettingsKeybindingsRoute: typeof SettingsKeybindingsRoute
   SettingsSourceControlRoute: typeof SettingsSourceControlRoute
 }
 
@@ -249,6 +269,7 @@ const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsArchivedRoute: SettingsArchivedRoute,
   SettingsConnectionsRoute: SettingsConnectionsRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
+  SettingsKeybindingsRoute: SettingsKeybindingsRoute,
   SettingsSourceControlRoute: SettingsSourceControlRoute,
 }
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -286,6 +286,7 @@ function EventRouter() {
   const readPathname = useEffectEvent(() => pathname);
   const handledBootstrapThreadIdRef = useRef<string | null>(null);
   const seenServerConfigUpdateIdRef = useRef(getServerConfigUpdatedNotification()?.id ?? 0);
+  const lastKeybindingsSuccessToastAtRef = useRef(0);
   const disposedRef = useRef(false);
   const serverConfig = useServerConfig();
 
@@ -352,6 +353,11 @@ function EventRouter() {
 
       const issue = payload.issues.find((entry) => entry.kind.startsWith("keybindings."));
       if (!issue) {
+        const now = Date.now();
+        if (now - lastKeybindingsSuccessToastAtRef.current < 2_000) {
+          return;
+        }
+        lastKeybindingsSuccessToastAtRef.current = now;
         toastManager.add({
           type: "success",
           title: "Keybindings updated",

--- a/apps/web/src/routes/settings.keybindings.tsx
+++ b/apps/web/src/routes/settings.keybindings.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { KeybindingsSettingsPanel } from "../components/settings/KeybindingsSettings";
+
+export const Route = createFileRoute("/settings/keybindings")({
+  component: KeybindingsSettingsPanel,
+});

--- a/apps/web/src/rpc/wsRpcClient.ts
+++ b/apps/web/src/rpc/wsRpcClient.ts
@@ -120,6 +120,7 @@ export interface WsRpcClient {
       input?: RpcInput<typeof WS_METHODS.serverRefreshProviders>,
     ) => ReturnType<RpcUnaryMethod<typeof WS_METHODS.serverRefreshProviders>>;
     readonly upsertKeybinding: RpcUnaryMethod<typeof WS_METHODS.serverUpsertKeybinding>;
+    readonly removeKeybinding: RpcUnaryMethod<typeof WS_METHODS.serverRemoveKeybinding>;
     readonly getSettings: RpcUnaryNoArgMethod<typeof WS_METHODS.serverGetSettings>;
     readonly updateSettings: (
       patch: ServerSettingsPatch,
@@ -236,6 +237,8 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
         transport.request((client) => client[WS_METHODS.serverRefreshProviders](input ?? {})),
       upsertKeybinding: (input) =>
         transport.request((client) => client[WS_METHODS.serverUpsertKeybinding](input)),
+      removeKeybinding: (input) =>
+        transport.request((client) => client[WS_METHODS.serverRemoveKeybinding](input)),
       getSettings: () => transport.request((client) => client[WS_METHODS.serverGetSettings]({})),
       updateSettings: (patch) =>
         transport.request((client) => client[WS_METHODS.serverUpdateSettings]({ patch })),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -29,6 +29,7 @@ import type { ProviderInstanceId } from "./providerInstance.ts";
 import type {
   ServerConfig,
   ServerProviderUpdatedPayload,
+  ServerRemoveKeybindingResult,
   ServerUpsertKeybindingResult,
 } from "./server.ts";
 import type {
@@ -41,7 +42,7 @@ import type {
   TerminalSessionSnapshot,
   TerminalWriteInput,
 } from "./terminal.ts";
-import type { ServerUpsertKeybindingInput } from "./server.ts";
+import type { ServerRemoveKeybindingInput, ServerUpsertKeybindingInput } from "./server.ts";
 import type {
   ClientOrchestrationCommand,
   OrchestrationGetFullThreadDiffInput,
@@ -297,6 +298,7 @@ export interface LocalApi {
       readonly instanceId?: ProviderInstanceId;
     }) => Promise<ServerProviderUpdatedPayload>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;
+    removeKeybinding: (input: ServerRemoveKeybindingInput) => Promise<ServerRemoveKeybindingResult>;
     getSettings: () => Promise<ServerSettings>;
     updateSettings: (patch: ServerSettingsPatch) => Promise<ServerSettings>;
     discoverSourceControl: () => Promise<SourceControlDiscoveryResult>;

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -2,7 +2,7 @@ import { Schema } from "effect";
 import { TrimmedString } from "./baseSchemas.ts";
 
 export const MAX_KEYBINDING_VALUE_LENGTH = 64;
-const MAX_KEYBINDING_WHEN_LENGTH = 256;
+export const MAX_KEYBINDING_WHEN_LENGTH = 256;
 export const MAX_WHEN_EXPRESSION_DEPTH = 64;
 export const MAX_SCRIPT_ID_LENGTH = 24;
 export const MAX_KEYBINDINGS_COUNT = 256;
@@ -76,12 +76,12 @@ export const KeybindingCommand = Schema.Union([
 ]);
 export type KeybindingCommand = typeof KeybindingCommand.Type;
 
-const KeybindingValue = TrimmedString.check(
+export const KeybindingValue = TrimmedString.check(
   Schema.isMinLength(1),
   Schema.isMaxLength(MAX_KEYBINDING_VALUE_LENGTH),
 );
 
-const KeybindingWhen = TrimmedString.check(
+export const KeybindingWhen = TrimmedString.check(
   Schema.isMinLength(1),
   Schema.isMaxLength(MAX_KEYBINDING_WHEN_LENGTH),
 );

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -72,6 +72,8 @@ import {
   ServerConfigStreamEvent,
   ServerConfig,
   ServerLifecycleStreamEvent,
+  ServerRemoveKeybindingInput,
+  ServerRemoveKeybindingResult,
   ServerProviderUpdatedPayload,
   ServerUpsertKeybindingInput,
   ServerUpsertKeybindingResult,
@@ -130,6 +132,7 @@ export const WS_METHODS = {
   serverGetConfig: "server.getConfig",
   serverRefreshProviders: "server.refreshProviders",
   serverUpsertKeybinding: "server.upsertKeybinding",
+  serverRemoveKeybinding: "server.removeKeybinding",
   serverGetSettings: "server.getSettings",
   serverUpdateSettings: "server.updateSettings",
   serverDiscoverSourceControl: "server.discoverSourceControl",
@@ -150,6 +153,12 @@ export const WS_METHODS = {
 export const WsServerUpsertKeybindingRpc = Rpc.make(WS_METHODS.serverUpsertKeybinding, {
   payload: ServerUpsertKeybindingInput,
   success: ServerUpsertKeybindingResult,
+  error: KeybindingsConfigError,
+});
+
+export const WsServerRemoveKeybindingRpc = Rpc.make(WS_METHODS.serverRemoveKeybinding, {
+  payload: ServerRemoveKeybindingInput,
+  success: ServerRemoveKeybindingResult,
   error: KeybindingsConfigError,
 });
 
@@ -416,6 +425,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerGetConfigRpc,
   WsServerRefreshProvidersRpc,
   WsServerUpsertKeybindingRpc,
+  WsServerRemoveKeybindingRpc,
   WsServerGetSettingsRpc,
   WsServerUpdateSettingsRpc,
   WsServerDiscoverSourceControlRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -8,7 +8,12 @@ import {
   ThreadId,
   TrimmedNonEmptyString,
 } from "./baseSchemas.ts";
-import { KeybindingRule, ResolvedKeybindingsConfig } from "./keybindings.ts";
+import {
+  KeybindingCommand,
+  KeybindingValue,
+  KeybindingWhen,
+  ResolvedKeybindingsConfig,
+} from "./keybindings.ts";
 import { EditorId } from "./editor.ts";
 import { ModelCapabilities } from "./model.ts";
 import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
@@ -181,14 +186,31 @@ export const ServerConfig = Schema.Struct({
 });
 export type ServerConfig = typeof ServerConfig.Type;
 
-export const ServerUpsertKeybindingInput = KeybindingRule;
+const ServerUpsertKeybindingReplaceTarget = Schema.Struct({
+  key: KeybindingValue,
+  command: KeybindingCommand,
+  when: Schema.optional(KeybindingWhen),
+});
+
+export const ServerUpsertKeybindingInput = Schema.Struct({
+  key: KeybindingValue,
+  command: KeybindingCommand,
+  when: Schema.optional(KeybindingWhen),
+  replace: Schema.optional(ServerUpsertKeybindingReplaceTarget),
+});
 export type ServerUpsertKeybindingInput = typeof ServerUpsertKeybindingInput.Type;
+
+export const ServerRemoveKeybindingInput = ServerUpsertKeybindingReplaceTarget;
+export type ServerRemoveKeybindingInput = typeof ServerRemoveKeybindingInput.Type;
 
 export const ServerUpsertKeybindingResult = Schema.Struct({
   keybindings: ResolvedKeybindingsConfig,
   issues: ServerConfigIssues,
 });
 export type ServerUpsertKeybindingResult = typeof ServerUpsertKeybindingResult.Type;
+
+export const ServerRemoveKeybindingResult = ServerUpsertKeybindingResult;
+export type ServerRemoveKeybindingResult = typeof ServerRemoveKeybindingResult.Type;
 
 export const ServerConfigUpdatedPayload = Schema.Struct({
   issues: ServerConfigIssues,

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -162,7 +162,7 @@ function tokenizeWhenExpression(expression: string): WhenToken[] | null {
   return tokens;
 }
 
-function parseKeybindingWhenExpression(expression: string): KeybindingWhenNode | null {
+export function parseKeybindingWhenExpression(expression: string): KeybindingWhenNode | null {
   const tokens = tokenizeWhenExpression(expression);
   if (!tokens || tokens.length === 0) return null;
   let index = 0;


### PR DESCRIPTION
## Summary
- Adds a full keybindings settings page for viewing, searching, editing, and resetting shortcuts.
- Introduces a visual and text-based `when` clause editor with validation and unknown-condition warnings.
- Extracts keybinding parsing/formatting logic into a shared frontend module with dedicated unit tests.
- Updates settings navigation, routing, and toast behavior to support the new editor flow.

## Testing
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test` (includes `KeybindingsSettings.logic.test.ts`)
- Not run: browser/manual verification of the new settings page in this session

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches keybinding persistence semantics and adds a new RPC (`server.removeKeybinding`) plus a large new settings UI, so regressions could affect shortcut customization and config writes. Changes are scoped to keybindings/settings paths and covered by new/updated unit tests.
> 
> **Overview**
> Adds a new `/settings/keybindings` panel with searchable keybindings table, inline shortcut capture, add/reset/remove actions, conflict warnings, and a visual+text `when` clause editor with validation and unknown-condition warnings.
> 
> Updates keybinding handling end-to-end: `upsertKeybindingRule` now **appends** bindings by default (instead of replacing all rules for a command), supports targeted replacement via an optional `replace` field, and introduces `removeKeybindingRule` plus a new `server.removeKeybinding` websocket/local API contract and routing.
> 
> Refactors shared frontend logic into `KeybindingsSettings.logic.ts` (with new unit tests), reuses `keybindingFromKeyboardEvent` in `ProjectScriptsControl`, moves “open keybindings.json” out of General settings into the new panel, and coalesces rapid “Keybindings updated” success toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bebfdc415dffc7fa1262e87ffe1de7149d4992c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add keybindings settings editor with add, edit, remove, and conflict detection
> - Adds a new `/settings/keybindings` route and sidebar nav item ([KeybindingsSettings.tsx](https://github.com/pingdotgg/t3code/pull/2533/files#diff-12068495a79a13f54503fa3061aafb91f05537621626906b290ed059e660d4d4)) with a full settings panel: searchable list, inline shortcut capture, when-expression builder, conflict indicators, and open-in-editor support.
> - Adds logic module ([KeybindingsSettings.logic.ts](https://github.com/pingdotgg/t3code/pull/2533/files#diff-3e063dd9ee56de309e7e9618f62b33b69ff212f57241c19cc7114065efb919dd)) for building keybinding rows, parsing/serializing when-expressions, detecting conflicts, labeling commands, and converting keyboard events to shortcut strings cross-platform.
> - Extends the server keybindings API ([keybindings.ts](https://github.com/pingdotgg/t3code/pull/2533/files#diff-8ceb6d58b5dd5f4fe3318b65f1602637866a7883986552e17df439ac3f7da19e)) with a `removeKeybindingRule` method and changes `upsertKeybindingRule` to append (rather than replace all same-command bindings) unless an explicit `replace` target is provided.
> - Wires `server.removeKeybinding` end-to-end through the RPC contracts, WebSocket layer, and browser local API.
> - Moves the keybindings file path link out of the General settings panel, which previously housed it.
> - Behavioral Change: upsert no longer removes all keybindings for the same command; it only removes an exact duplicate or the specified `replace` target.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8bebfdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->