### PR TITLE
Add analytics tracking for server and RPC actions

### DIFF
--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -6,9 +6,14 @@ import { Command } from "effect/unstable/cli";
 
 import { NetService } from "@t3tools/shared/Net";
 import { cli } from "./cli.ts";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService.ts";
 import packageJson from "../package.json" with { type: "json" };
 
-const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
+const CliRuntimeLayer = Layer.mergeAll(
+  NodeServices.layer,
+  NetService.layer,
+  AnalyticsService.layerTest,
+);
 
 Command.run(cli, { version: packageJson.version }).pipe(
   Effect.scoped,

--- a/apps/server/src/cli.test.ts
+++ b/apps/server/src/cli.test.ts
@@ -32,8 +32,13 @@ import {
 import { WorkspacePathsLive } from "./workspace/Layers/WorkspacePaths.ts";
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore.ts";
 import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService.ts";
 
-const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
+const CliRuntimeLayer = Layer.mergeAll(
+  NodeServices.layer,
+  NetService.layer,
+  AnalyticsService.layerTest,
+);
 
 const runCli = (args: ReadonlyArray<string>) => Command.runWith(cli, { version: "0.0.0" })(args);
 const runCliWithRuntime = (args: ReadonlyArray<string>) =>

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -780,6 +780,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         "provider.request_id": input.requestId,
       });
       yield* routed.adapter.respondToUserInput(routed.threadId, input.requestId, input.answers);
+      yield* analytics.record("provider.user_input.responded", {
+        provider: routed.adapter.provider,
+        answerCount: Object.keys(input.answers).length,
+      });
     }).pipe(
       withMetrics({
         counter: providerTurnsTotal,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -114,6 +114,7 @@ import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore.ts";
 import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService.ts";
 
 const defaultProjectId = ProjectId.make("project-default");
 const defaultThreadId = ThreadId.make("thread-default");
@@ -653,6 +654,7 @@ const buildAppUnderTest = (options?: {
       ),
       Layer.provideMerge(makeAuthTestLayer()),
       Layer.provide(workspaceAndProjectServicesLayer),
+      Layer.provide(AnalyticsService.layerTest),
       Layer.provideMerge(FetchHttpClient.layer),
       Layer.provide(layerConfig),
     );

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1,4 +1,4 @@
-import { Cause, Duration, Effect, Layer, Option, Queue, Ref, Schema, Stream } from "effect";
+import { Cause, Duration, Effect, Exit, Layer, Option, Queue, Ref, Schema, Stream } from "effect";
 import {
   type AuthAccessStreamEvent,
   AuthSessionId,
@@ -35,10 +35,11 @@ import { normalizeDispatchCommand } from "./orchestration/Normalizer.ts";
 import { OrchestrationEngineService } from "./orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import {
-  observeRpcEffect,
-  observeRpcStream,
-  observeRpcStreamEffect,
+  observeRpcEffect as observeBaseRpcEffect,
+  observeRpcStream as observeBaseRpcStream,
+  observeRpcStreamEffect as observeBaseRpcStreamEffect,
 } from "./observability/RpcInstrumentation.ts";
+import { outcomeFromExit } from "./observability/Attributes.ts";
 import { ProviderRegistry } from "./provider/Services/ProviderRegistry.ts";
 import * as ProviderMaintenanceRunner from "./provider/providerMaintenanceRunner.ts";
 import { ServerLifecycleEvents } from "./serverLifecycleEvents.ts";
@@ -75,6 +76,7 @@ import {
   type SessionCredentialChange,
 } from "./auth/Services/SessionCredentialService.ts";
 import { respondToAuthError } from "./auth/http.ts";
+import { AnalyticsService } from "./telemetry/Services/AnalyticsService.ts";
 
 function isThreadDetailEvent(event: OrchestrationEvent): event is Extract<
   OrchestrationEvent,
@@ -99,6 +101,26 @@ function isThreadDetailEvent(event: OrchestrationEvent): event is Extract<
 }
 
 const PROVIDER_STATUS_DEBOUNCE_MS = 200;
+
+const settingPatchKeys = (patch: Readonly<Record<string, unknown>>) =>
+  Object.keys(patch).toSorted();
+
+const highVolumeOrBackgroundRpcMethods = new Set<string>([
+  WS_METHODS.terminalWrite,
+  WS_METHODS.terminalResize,
+  WS_METHODS.vcsRefreshStatus,
+  WS_METHODS.subscribeVcsStatus,
+  WS_METHODS.subscribeTerminalEvents,
+  WS_METHODS.subscribeServerConfig,
+  WS_METHODS.subscribeServerLifecycle,
+  WS_METHODS.subscribeAuthAccess,
+  ORCHESTRATION_WS_METHODS.subscribeShell,
+  ORCHESTRATION_WS_METHODS.subscribeThread,
+]);
+
+function shouldRecordRpcRequestAnalytics(method: string): boolean {
+  return !highVolumeOrBackgroundRpcMethods.has(method);
+}
 
 function toAuthAccessStreamEvent(
   change: BootstrapCredentialChange | SessionCredentialChange,
@@ -168,8 +190,71 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
       const sourceControlRepositories = yield* SourceControlRepositoryService;
       const bootstrapCredentials = yield* BootstrapCredentialService;
       const sessions = yield* SessionCredentialService;
+      const analytics = yield* AnalyticsService;
       const serverCommandId = (tag: string) =>
         CommandId.make(`server:${tag}:${crypto.randomUUID()}`);
+
+      const recordAnalytics = (event: string, properties?: Readonly<Record<string, unknown>>) =>
+        analytics.record(event, properties).pipe(Effect.ignoreCause({ log: true }));
+
+      const recordProductFeatureUsed = (
+        feature: string,
+        properties?: Readonly<Record<string, unknown>>,
+      ) =>
+        recordAnalytics("product.feature.used", {
+          feature,
+          ...properties,
+        });
+
+      const rpcAnalyticsProperties = (
+        method: string,
+        startedAt: number,
+        exit: Exit.Exit<unknown, unknown>,
+        traceAttributes?: Readonly<Record<string, unknown>>,
+      ) => ({
+        method,
+        aggregate:
+          typeof traceAttributes?.["rpc.aggregate"] === "string"
+            ? traceAttributes["rpc.aggregate"]
+            : "unknown",
+        outcome: outcomeFromExit(exit),
+        durationMs: Math.max(0, Date.now() - startedAt),
+      });
+
+      const observeRpcEffect = <A, E, R>(
+        method: string,
+        effect: Effect.Effect<A, E, R>,
+        traceAttributes?: Readonly<Record<string, unknown>>,
+      ): Effect.Effect<A, E, R> =>
+        Effect.gen(function* () {
+          const startedAt = Date.now();
+          const exit = yield* Effect.exit(observeBaseRpcEffect(method, effect, traceAttributes));
+          if (shouldRecordRpcRequestAnalytics(method)) {
+            yield* recordAnalytics(
+              "rpc.request.completed",
+              rpcAnalyticsProperties(method, startedAt, exit, traceAttributes),
+            );
+          }
+          if (Exit.isSuccess(exit)) return exit.value;
+          return yield* Effect.failCause(exit.cause);
+        });
+
+      const observeRpcStream = <A, E, R>(
+        method: string,
+        stream: Stream.Stream<A, E, R>,
+        traceAttributes?: Readonly<Record<string, unknown>>,
+      ): Stream.Stream<A, E, R> => observeBaseRpcStream(method, stream, traceAttributes);
+
+      const observeRpcStreamEffect = <A, StreamError, StreamContext, EffectError, EffectContext>(
+        method: string,
+        effect: Effect.Effect<
+          Stream.Stream<A, StreamError, StreamContext>,
+          EffectError,
+          EffectContext
+        >,
+        traceAttributes?: Readonly<Record<string, unknown>>,
+      ): Stream.Stream<A, StreamError | EffectError, StreamContext | EffectContext> =>
+        observeBaseRpcStreamEffect(method, effect, traceAttributes);
 
       const loadAuthAccessSnapshot = () =>
         Effect.all({
@@ -584,7 +669,71 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
                         Effect.catch(() => Effect.succeed(false)),
                       )
                   : false;
-              const result = yield* dispatchNormalizedCommand(normalizedCommand);
+              const dispatchStartedAt = Date.now();
+              const dispatchExit = yield* Effect.exit(dispatchNormalizedCommand(normalizedCommand));
+              yield* recordAnalytics("orchestration.command.completed", {
+                commandType: normalizedCommand.type,
+                aggregateKind: normalizedCommand.type.startsWith("project.") ? "project" : "thread",
+                outcome: outcomeFromExit(dispatchExit),
+                durationMs: Math.max(0, Date.now() - dispatchStartedAt),
+              });
+              yield* recordProductFeatureUsed("orchestration.command", {
+                commandType: normalizedCommand.type,
+                aggregateKind: normalizedCommand.type.startsWith("project.") ? "project" : "thread",
+                runtimeMode:
+                  "runtimeMode" in normalizedCommand ? normalizedCommand.runtimeMode : undefined,
+                interactionMode:
+                  "interactionMode" in normalizedCommand
+                    ? normalizedCommand.interactionMode
+                    : undefined,
+                providerInstanceId:
+                  "modelSelection" in normalizedCommand
+                    ? normalizedCommand.modelSelection?.instanceId
+                    : undefined,
+                model:
+                  "modelSelection" in normalizedCommand
+                    ? normalizedCommand.modelSelection?.model
+                    : undefined,
+                attachmentCount:
+                  normalizedCommand.type === "thread.turn.start"
+                    ? normalizedCommand.message.attachments.length
+                    : undefined,
+                hasText:
+                  normalizedCommand.type === "thread.turn.start"
+                    ? normalizedCommand.message.text.trim().length > 0
+                    : undefined,
+                usesBootstrap:
+                  normalizedCommand.type === "thread.turn.start"
+                    ? normalizedCommand.bootstrap !== undefined
+                    : undefined,
+                createsThread:
+                  normalizedCommand.type === "thread.turn.start"
+                    ? normalizedCommand.bootstrap?.createThread !== undefined
+                    : undefined,
+                preparesWorktree:
+                  normalizedCommand.type === "thread.turn.start"
+                    ? normalizedCommand.bootstrap?.prepareWorktree !== undefined
+                    : undefined,
+                runsSetupScript:
+                  normalizedCommand.type === "thread.turn.start"
+                    ? normalizedCommand.bootstrap?.runSetupScript === true
+                    : undefined,
+                sourceProposedPlan:
+                  normalizedCommand.type === "thread.turn.start"
+                    ? normalizedCommand.sourceProposedPlan !== undefined
+                    : undefined,
+                approvalDecision:
+                  normalizedCommand.type === "thread.approval.respond"
+                    ? normalizedCommand.decision
+                    : undefined,
+                checkpointTurnCount:
+                  normalizedCommand.type === "thread.checkpoint.revert"
+                    ? normalizedCommand.turnCount
+                    : undefined,
+              });
+              const result = Exit.isSuccess(dispatchExit)
+                ? dispatchExit.value
+                : yield* Effect.failCause(dispatchExit.cause);
               if (normalizedCommand.type === "thread.archive") {
                 if (shouldStopSessionAfterArchive) {
                   yield* Effect.gen(function* () {
@@ -781,16 +930,24 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.serverRefreshProviders]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverRefreshProviders,
-            (input.instanceId !== undefined
-              ? providerRegistry.refreshInstance(input.instanceId)
-              : providerRegistry.refresh()
-            ).pipe(Effect.map((providers) => ({ providers }))),
+            recordProductFeatureUsed("providers.refresh", {
+              targeted: input.instanceId !== undefined,
+            }).pipe(
+              Effect.andThen(
+                input.instanceId !== undefined
+                  ? providerRegistry.refreshInstance(input.instanceId)
+                  : providerRegistry.refresh(),
+              ),
+              Effect.map((providers) => ({ providers })),
+            ),
             { "rpc.aggregate": "server" },
           ),
         [WS_METHODS.serverUpdateProvider]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverUpdateProvider,
-            providerMaintenanceRunner.updateProvider(input),
+            recordProductFeatureUsed("providers.update", {
+              provider: input.provider,
+            }).pipe(Effect.andThen(providerMaintenanceRunner.updateProvider(input))),
             {
               "rpc.aggregate": "server",
             },
@@ -799,6 +956,10 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
           observeRpcEffect(
             WS_METHODS.serverUpsertKeybinding,
             Effect.gen(function* () {
+              yield* recordProductFeatureUsed("keybindings.upsert", {
+                command: rule.command,
+                hasWhen: rule.when !== undefined,
+              });
               const keybindingsConfig = yield* keybindings.upsertKeybindingRule(rule);
               return { keybindings: keybindingsConfig, issues: [] };
             }),
@@ -808,6 +969,9 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
           observeRpcEffect(
             WS_METHODS.serverRemoveKeybinding,
             Effect.gen(function* () {
+              yield* recordProductFeatureUsed("keybindings.remove", {
+                command: rule.command,
+              });
               const keybindingsConfig = yield* keybindings.removeKeybindingRule(rule);
               return { keybindings: keybindingsConfig, issues: [] };
             }),
@@ -824,7 +988,13 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.serverUpdateSettings]: ({ patch }) =>
           observeRpcEffect(
             WS_METHODS.serverUpdateSettings,
-            serverSettings.updateSettings(patch).pipe(Effect.map(redactServerSettingsForClient)),
+            recordProductFeatureUsed("settings.update", {
+              settingKeys: settingPatchKeys(patch),
+              settingKeyCount: settingPatchKeys(patch).length,
+            }).pipe(
+              Effect.andThen(serverSettings.updateSettings(patch)),
+              Effect.map(redactServerSettingsForClient),
+            ),
             {
               "rpc.aggregate": "server",
             },
@@ -832,7 +1002,17 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.serverDiscoverSourceControl]: (_input) =>
           observeRpcEffect(
             WS_METHODS.serverDiscoverSourceControl,
-            sourceControlDiscovery.discover,
+            sourceControlDiscovery.discover.pipe(
+              Effect.tap((result) =>
+                recordProductFeatureUsed("source_control.discover", {
+                  vcsKinds: result.versionControlSystems.map((item) => item.kind),
+                  sourceControlProviders: result.sourceControlProviders.map((item) => item.kind),
+                  authenticatedProviders: result.sourceControlProviders
+                    .filter((item) => item.auth.status === "authenticated")
+                    .map((item) => item.kind),
+                }),
+              ),
+            ),
             {
               "rpc.aggregate": "server",
             },
@@ -840,7 +1020,10 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.sourceControlLookupRepository]: (input) =>
           observeRpcEffect(
             WS_METHODS.sourceControlLookupRepository,
-            sourceControlRepositories.lookupRepository(input),
+            recordProductFeatureUsed("source_control.lookup_repository", {
+              provider: input.provider,
+              hasCwd: input.cwd !== undefined,
+            }).pipe(Effect.andThen(sourceControlRepositories.lookupRepository(input))),
             {
               "rpc.aggregate": "source-control",
             },
@@ -848,7 +1031,20 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.sourceControlCloneRepository]: (input) =>
           observeRpcEffect(
             WS_METHODS.sourceControlCloneRepository,
-            sourceControlRepositories.cloneRepository(input),
+            recordProductFeatureUsed("source_control.clone_repository", {
+              provider: input.provider ?? "auto",
+              protocol: input.protocol ?? "auto",
+              hasRepositorySearchSelection: input.repository !== undefined,
+              hasRemoteUrl: input.remoteUrl !== undefined,
+            }).pipe(
+              Effect.andThen(sourceControlRepositories.cloneRepository(input)),
+              Effect.tap((result) =>
+                recordProductFeatureUsed("source_control.clone_repository.completed", {
+                  provider: result.repository?.provider ?? input.provider ?? "unknown",
+                  resolvedRepository: result.repository !== null,
+                }),
+              ),
+            ),
             {
               "rpc.aggregate": "source-control",
             },
@@ -856,9 +1052,21 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.sourceControlPublishRepository]: (input) =>
           observeRpcEffect(
             WS_METHODS.sourceControlPublishRepository,
-            sourceControlRepositories
-              .publishRepository(input)
-              .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            recordProductFeatureUsed("source_control.publish_repository", {
+              provider: input.provider,
+              protocol: input.protocol ?? "auto",
+              visibility: input.visibility,
+              hasRemoteName: input.remoteName !== undefined,
+            }).pipe(
+              Effect.andThen(sourceControlRepositories.publishRepository(input)),
+              Effect.tap((result) =>
+                recordProductFeatureUsed("source_control.publish_repository.completed", {
+                  provider: result.repository.provider,
+                  status: result.status,
+                }),
+              ),
+              Effect.tap(() => refreshGitStatus(input.cwd)),
+            ),
             {
               "rpc.aggregate": "source-control",
             },
@@ -866,7 +1074,11 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.projectsSearchEntries]: (input) =>
           observeRpcEffect(
             WS_METHODS.projectsSearchEntries,
-            workspaceEntries.search(input).pipe(
+            recordProductFeatureUsed("workspace.search_entries", {
+              limit: input.limit,
+              queryLength: input.query.length,
+            }).pipe(
+              Effect.andThen(workspaceEntries.search(input)),
               Effect.mapError(
                 (cause) =>
                   new ProjectSearchEntriesError({
@@ -880,7 +1092,10 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.projectsWriteFile]: (input) =>
           observeRpcEffect(
             WS_METHODS.projectsWriteFile,
-            workspaceFileSystem.writeFile(input).pipe(
+            recordProductFeatureUsed("workspace.write_file", {
+              contentLength: input.contents.length,
+            }).pipe(
+              Effect.andThen(workspaceFileSystem.writeFile(input)),
               Effect.mapError((cause) => {
                 const message = Schema.is(WorkspacePathOutsideRootError)(cause)
                   ? "Workspace file path must stay within the project root."
@@ -894,13 +1109,22 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
             { "rpc.aggregate": "workspace" },
           ),
         [WS_METHODS.shellOpenInEditor]: (input) =>
-          observeRpcEffect(WS_METHODS.shellOpenInEditor, open.openInEditor(input), {
-            "rpc.aggregate": "workspace",
-          }),
+          observeRpcEffect(
+            WS_METHODS.shellOpenInEditor,
+            recordProductFeatureUsed("workspace.open_in_editor", {
+              editor: input.editor,
+            }).pipe(Effect.andThen(open.openInEditor(input))),
+            {
+              "rpc.aggregate": "workspace",
+            },
+          ),
         [WS_METHODS.filesystemBrowse]: (input) =>
           observeRpcEffect(
             WS_METHODS.filesystemBrowse,
-            workspaceEntries.browse(input).pipe(
+            recordProductFeatureUsed("filesystem.browse", {
+              hasCwd: input.cwd !== undefined,
+            }).pipe(
+              Effect.andThen(workspaceEntries.browse(input)),
               Effect.mapError(
                 (cause) =>
                   new FilesystemBrowseError({
@@ -930,7 +1154,8 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.vcsPull]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsPull,
-            gitWorkflow.pullCurrentBranch(input.cwd).pipe(
+            recordProductFeatureUsed("git.pull").pipe(
+              Effect.andThen(gitWorkflow.pullCurrentBranch(input.cwd)),
               Effect.matchCauseEffect({
                 onFailure: (cause) => Effect.failCause(cause),
                 onSuccess: (result) =>
@@ -943,29 +1168,42 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
           observeRpcStream(
             WS_METHODS.gitRunStackedAction,
             Stream.callback<GitActionProgressEvent, GitManagerServiceError>((queue) =>
-              gitWorkflow
-                .runStackedAction(input, {
-                  actionId: input.actionId,
-                  progressReporter: {
-                    publish: (event) => Queue.offer(queue, event).pipe(Effect.asVoid),
-                  },
-                })
-                .pipe(
-                  Effect.matchCauseEffect({
-                    onFailure: (cause) => Queue.failCause(queue, cause),
-                    onSuccess: () =>
-                      refreshGitStatus(input.cwd).pipe(
-                        Effect.andThen(Queue.end(queue).pipe(Effect.asVoid)),
-                      ),
+              recordProductFeatureUsed("git.stacked_action", {
+                action: input.action,
+                featureBranch: input.featureBranch === true,
+                hasCommitMessage: input.commitMessage !== undefined,
+                selectedFileCount: input.filePaths?.length ?? 0,
+              }).pipe(
+                Effect.andThen(
+                  gitWorkflow.runStackedAction(input, {
+                    actionId: input.actionId,
+                    progressReporter: {
+                      publish: (event) => Queue.offer(queue, event).pipe(Effect.asVoid),
+                    },
                   }),
                 ),
+                Effect.matchCauseEffect({
+                  onFailure: (cause) => Queue.failCause(queue, cause),
+                  onSuccess: () =>
+                    refreshGitStatus(input.cwd).pipe(
+                      Effect.andThen(Queue.end(queue).pipe(Effect.asVoid)),
+                    ),
+                }),
+              ),
             ),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.gitResolvePullRequest]: (input) =>
           observeRpcEffect(
             WS_METHODS.gitResolvePullRequest,
-            gitWorkflow.resolvePullRequest(input),
+            recordProductFeatureUsed("git.resolve_pull_request").pipe(
+              Effect.andThen(gitWorkflow.resolvePullRequest(input)),
+              Effect.tap((result) =>
+                recordProductFeatureUsed("git.resolve_pull_request.completed", {
+                  state: result.pullRequest.state,
+                }),
+              ),
+            ),
             {
               "rpc.aggregate": "git",
             },
@@ -973,51 +1211,101 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
         [WS_METHODS.gitPreparePullRequestThread]: (input) =>
           observeRpcEffect(
             WS_METHODS.gitPreparePullRequestThread,
-            gitWorkflow
-              .preparePullRequestThread(input)
-              .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            recordProductFeatureUsed("git.prepare_pull_request_thread", {
+              mode: input.mode,
+              hasExistingThread: input.threadId !== undefined,
+            }).pipe(
+              Effect.andThen(gitWorkflow.preparePullRequestThread(input)),
+              Effect.tap(() => refreshGitStatus(input.cwd)),
+            ),
             { "rpc.aggregate": "git" },
           ),
         [WS_METHODS.vcsListRefs]: (input) =>
-          observeRpcEffect(WS_METHODS.vcsListRefs, gitWorkflow.listRefs(input), {
-            "rpc.aggregate": "vcs",
-          }),
+          observeRpcEffect(
+            WS_METHODS.vcsListRefs,
+            recordProductFeatureUsed("vcs.list_refs", {
+              hasQuery: input.query !== undefined,
+              limit: input.limit,
+            }).pipe(
+              Effect.andThen(gitWorkflow.listRefs(input)),
+              Effect.tap((result) =>
+                recordProductFeatureUsed("vcs.list_refs.completed", {
+                  isRepo: result.isRepo,
+                  hasPrimaryRemote: result.hasPrimaryRemote,
+                  totalCount: result.totalCount,
+                }),
+              ),
+            ),
+            {
+              "rpc.aggregate": "vcs",
+            },
+          ),
         [WS_METHODS.vcsCreateWorktree]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsCreateWorktree,
-            gitWorkflow.createWorktree(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            recordProductFeatureUsed("vcs.create_worktree", {
+              hasNewRefName: input.newRefName !== undefined,
+              hasCustomPath: input.path !== null,
+            }).pipe(
+              Effect.andThen(gitWorkflow.createWorktree(input)),
+              Effect.tap(() => refreshGitStatus(input.cwd)),
+            ),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.vcsRemoveWorktree]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsRemoveWorktree,
-            gitWorkflow.removeWorktree(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            recordProductFeatureUsed("vcs.remove_worktree", {
+              force: input.force === true,
+            }).pipe(
+              Effect.andThen(gitWorkflow.removeWorktree(input)),
+              Effect.tap(() => refreshGitStatus(input.cwd)),
+            ),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.vcsCreateRef]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsCreateRef,
-            gitWorkflow.createRef(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            recordProductFeatureUsed("vcs.create_ref", {
+              switchRef: input.switchRef === true,
+            }).pipe(
+              Effect.andThen(gitWorkflow.createRef(input)),
+              Effect.tap(() => refreshGitStatus(input.cwd)),
+            ),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.vcsSwitchRef]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsSwitchRef,
-            gitWorkflow.switchRef(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            recordProductFeatureUsed("vcs.switch_ref").pipe(
+              Effect.andThen(gitWorkflow.switchRef(input)),
+              Effect.tap(() => refreshGitStatus(input.cwd)),
+            ),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.vcsInit]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsInit,
-            vcsProvisioning
-              .initRepository(input)
-              .pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            recordProductFeatureUsed("vcs.init", {
+              kind: input.kind ?? "auto",
+            }).pipe(
+              Effect.andThen(vcsProvisioning.initRepository(input)),
+              Effect.tap(() => refreshGitStatus(input.cwd)),
+            ),
             { "rpc.aggregate": "vcs" },
           ),
         [WS_METHODS.terminalOpen]: (input) =>
-          observeRpcEffect(WS_METHODS.terminalOpen, terminalManager.open(input), {
-            "rpc.aggregate": "terminal",
-          }),
+          observeRpcEffect(
+            WS_METHODS.terminalOpen,
+            recordProductFeatureUsed("terminal.open", {
+              hasCwd: input.cwd !== undefined,
+              hasWorktreePath: input.worktreePath !== undefined && input.worktreePath !== null,
+              hasInitialSize: input.cols !== undefined && input.rows !== undefined,
+            }).pipe(Effect.andThen(terminalManager.open(input))),
+            {
+              "rpc.aggregate": "terminal",
+            },
+          ),
         [WS_METHODS.terminalWrite]: (input) =>
           observeRpcEffect(WS_METHODS.terminalWrite, terminalManager.write(input), {
             "rpc.aggregate": "terminal",
@@ -1031,13 +1319,25 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
             "rpc.aggregate": "terminal",
           }),
         [WS_METHODS.terminalRestart]: (input) =>
-          observeRpcEffect(WS_METHODS.terminalRestart, terminalManager.restart(input), {
-            "rpc.aggregate": "terminal",
-          }),
+          observeRpcEffect(
+            WS_METHODS.terminalRestart,
+            recordProductFeatureUsed("terminal.restart").pipe(
+              Effect.andThen(terminalManager.restart(input)),
+            ),
+            {
+              "rpc.aggregate": "terminal",
+            },
+          ),
         [WS_METHODS.terminalClose]: (input) =>
-          observeRpcEffect(WS_METHODS.terminalClose, terminalManager.close(input), {
-            "rpc.aggregate": "terminal",
-          }),
+          observeRpcEffect(
+            WS_METHODS.terminalClose,
+            recordProductFeatureUsed("terminal.close").pipe(
+              Effect.andThen(terminalManager.close(input)),
+            ),
+            {
+              "rpc.aggregate": "terminal",
+            },
+          ),
         [WS_METHODS.subscribeTerminalEvents]: (_input) =>
           observeRpcStream(
             WS_METHODS.subscribeTerminalEvents,


### PR DESCRIPTION
## Summary
- Added analytics recording for WebSocket RPC completion and selected product feature usage across server, workspace, VCS, terminal, and orchestration flows.
- Excluded high-volume/background RPCs from completion tracking to keep telemetry signal useful and low-noise.
- Recorded additional provider-side analytics for user input responses.
- Updated CLI and test runtime layers to provide the analytics service in server test paths.

## Testing
- Not run (changes were prepared from the diff only).
- Existing coverage updated in `apps/server/src/cli.test.ts` and `apps/server/src/server.test.ts` to include `AnalyticsService.layerTest`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds analytics calls across the websocket RPC router and provider flows, including new wrappers around RPC instrumentation; while intended to be best-effort, it touches core request/command paths and could impact latency or error propagation if miswired.
> 
> **Overview**
> Adds **server-side analytics tracking** for websocket RPCs and key product actions.
> 
> `ws.ts` now records `rpc.request.completed` (with method, aggregate, duration, and success/failure outcome) for most RPC methods, explicitly excluding high-volume/background methods, and emits `product.feature.used` events around many user-visible RPC operations (settings, providers, source control, workspace, VCS/git, terminal, and orchestration dispatch). `ProviderService` also records a new event when user-input responses are sent.
> 
> Updates CLI and server test runtimes to provide `AnalyticsService.layerTest` so these new telemetry calls are always wired in tests and CLI execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d9130a130b8b1f6b8851e87c5a6c4f053c05ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add analytics tracking for server and RPC actions
> - Wraps RPC effect handlers in [ws.ts](https://github.com/pingdotgg/t3code/pull/2542/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) to emit `rpc.request.completed` analytics events with method, outcome, and duration for all non-suppressed methods
> - Records `product.feature.used` events for key user actions (providers, keybindings, settings, source control, workspace, terminal, etc.) with contextual properties
> - Tracks `orchestration.command.completed` with outcome and duration for dispatched commands
> - Records `provider.user_input.responded` in [ProviderService.ts](https://github.com/pingdotgg/t3code/pull/2542/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775) when a provider answers user input
> - Injects `AnalyticsService.layerTest` into CLI and test runtimes so analytics calls resolve without error in those contexts
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4d9130.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->