### PR TITLE
Fix Claude context usage normalization for UI meter, Fixes #2034

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -1637,7 +1637,6 @@ describe("ClaudeAdapterLive", () => {
             lastUsedTokens: 24542,
             inputTokens: 23863,
             outputTokens: 679,
-            maxTokens: 200000,
           },
         });
       }
@@ -1647,7 +1646,7 @@ describe("ClaudeAdapterLive", () => {
     );
   });
 
-  it.effect("clamps oversized Claude usage to the reported context window", () => {
+  it.effect("keeps oversized Claude result totals when no context-accurate usage exists", () => {
     const harness = makeHarness();
     return Effect.gen(function* () {
       const adapter = yield* ClaudeAdapter;
@@ -1697,10 +1696,8 @@ describe("ClaudeAdapterLive", () => {
       if (usageEvent?.type === "thread.token-usage.updated") {
         assert.deepEqual(usageEvent.payload, {
           usage: {
-            usedTokens: 200000,
-            lastUsedTokens: 200000,
-            totalProcessedTokens: 535000,
-            maxTokens: 200000,
+            usedTokens: 535000,
+            lastUsedTokens: 535000,
           },
         });
       }

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -337,7 +337,23 @@ function normalizeClaudeTokenUsage(
     (typeof usage.total_tokens === "number" && Number.isFinite(usage.total_tokens)
       ? usage.total_tokens
       : undefined) ?? (derivedTotalProcessedTokens > 0 ? derivedTotalProcessedTokens : undefined);
-  if (totalProcessedTokens === undefined || totalProcessedTokens <= 0) {
+  const directUsedTokens =
+    (typeof usage.used_tokens === "number" && Number.isFinite(usage.used_tokens)
+      ? usage.used_tokens
+      : undefined) ??
+    (typeof usage.usedTokens === "number" && Number.isFinite(usage.usedTokens)
+      ? usage.usedTokens
+      : undefined) ??
+    (typeof usage.last_used_tokens === "number" && Number.isFinite(usage.last_used_tokens)
+      ? usage.last_used_tokens
+      : undefined) ??
+    (typeof usage.lastUsedTokens === "number" && Number.isFinite(usage.lastUsedTokens)
+      ? usage.lastUsedTokens
+      : undefined);
+  if (
+    (totalProcessedTokens === undefined || totalProcessedTokens <= 0) &&
+    (directUsedTokens === undefined || directUsedTokens <= 0)
+  ) {
     return undefined;
   }
 
@@ -345,16 +361,22 @@ function normalizeClaudeTokenUsage(
     typeof contextWindow === "number" && Number.isFinite(contextWindow) && contextWindow > 0
       ? contextWindow
       : undefined;
-  const usedTokens =
-    maxTokens !== undefined ? Math.min(totalProcessedTokens, maxTokens) : totalProcessedTokens;
+  const usedTokens = (() => {
+    if (directUsedTokens !== undefined && directUsedTokens > 0) {
+      return maxTokens !== undefined ? Math.min(directUsedTokens, maxTokens) : directUsedTokens;
+    }
+    return totalProcessedTokens ?? 0;
+  })();
 
   return {
     usedTokens,
     lastUsedTokens: usedTokens,
-    ...(totalProcessedTokens > usedTokens ? { totalProcessedTokens } : {}),
+    ...(totalProcessedTokens !== undefined && totalProcessedTokens > usedTokens
+      ? { totalProcessedTokens }
+      : {}),
     ...(inputTokens > 0 ? { inputTokens } : {}),
     ...(outputTokens > 0 ? { outputTokens } : {}),
-    ...(maxTokens !== undefined ? { maxTokens } : {}),
+    ...(maxTokens !== undefined && directUsedTokens !== undefined ? { maxTokens } : {}),
     ...(typeof usage.tool_uses === "number" && Number.isFinite(usage.tool_uses)
       ? { toolUses: usage.tool_uses }
       : {}),
@@ -1417,10 +1439,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     // This does NOT represent the current context window size.
     // Instead, use the last known context-window-accurate usage from task_progress
     // events and treat the accumulated total as totalProcessedTokens.
-    const accumulatedSnapshot = normalizeClaudeTokenUsage(
-      result?.usage,
-      resultContextWindow ?? context.lastKnownContextWindow,
-    );
+    const accumulatedSnapshot = normalizeClaudeTokenUsage(result?.usage);
     const accumulatedTotalProcessedTokens =
       accumulatedSnapshot?.totalProcessedTokens ?? accumulatedSnapshot?.usedTokens;
     const lastGoodUsage = context.lastKnownTokenUsage;

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -361,8 +361,9 @@ function normalizeClaudeTokenUsage(
     typeof contextWindow === "number" && Number.isFinite(contextWindow) && contextWindow > 0
       ? contextWindow
       : undefined;
+  const hasDirectContextUsedTokens = directUsedTokens !== undefined && directUsedTokens > 0;
   const usedTokens = (() => {
-    if (directUsedTokens !== undefined && directUsedTokens > 0) {
+    if (hasDirectContextUsedTokens) {
       return maxTokens !== undefined ? Math.min(directUsedTokens, maxTokens) : directUsedTokens;
     }
     return totalProcessedTokens ?? 0;
@@ -376,7 +377,7 @@ function normalizeClaudeTokenUsage(
       : {}),
     ...(inputTokens > 0 ? { inputTokens } : {}),
     ...(outputTokens > 0 ? { outputTokens } : {}),
-    ...(maxTokens !== undefined && directUsedTokens !== undefined ? { maxTokens } : {}),
+    ...(maxTokens !== undefined && hasDirectContextUsedTokens ? { maxTokens } : {}),
     ...(typeof usage.tool_uses === "number" && Number.isFinite(usage.tool_uses)
       ? { toolUses: usage.tool_uses }
       : {}),


### PR DESCRIPTION
## What Changed
Treat Claude accumulated totals as processed-token telemetry unless a context-accurate used-token field is present, so context percentage indicators no longer pin to 100% on result-only snapshots.

## Why

Bug Fix: when using ClaudeCode context usage is always 100%

## UI Changes
**before:**
<img width="1119" height="260" alt="image" src="https://github.com/user-attachments/assets/58c10abd-0730-4b42-b2b4-a6e20c5e4bbc" />
**after:**
<img width="1125" height="242" alt="image" src="https://github.com/user-attachments/assets/43c7afc5-88db-49b5-ad23-f7e2862eedd9" />

 
## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bug fix limited to Claude token-usage normalization and related tests; it only affects telemetry emitted in `thread.token-usage.updated` events.
> 
> **Overview**
> Fixes Claude token-usage normalization so **accumulated `result.usage` totals are no longer clamped to the model context window** unless a context-accurate `used_tokens`/`last_used_tokens` field is present.
> 
> `normalizeClaudeTokenUsage` now prefers direct context-usage fields (and only then clamps and includes `maxTokens`), while result-only snapshots keep oversized `usedTokens` totals (optionally surfaced as `totalProcessedTokens` when combined with a prior context-accurate snapshot). Tests were updated to reflect the new event payload behavior for oversized totals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a1013a9f83414ca5f6a661b23966fe25c11cb5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude context usage normalization to preserve oversized token totals in UI meter
> - `normalizeClaudeTokenUsage` now distinguishes between context-accurate usage (from direct `usedTokens`/`lastUsedTokens` fields) and accumulated totals from `result.usage`, which can exceed the context window.
> - When context-accurate usage is available, `usedTokens` is clamped to `contextWindow` and `maxTokens` is included in the snapshot. When only accumulated totals exist, they are preserved unclamped and `maxTokens` is omitted.
> - In [`ClaudeAdapter.ts`](https://github.com/pingdotgg/t3code/pull/2551/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), the call to `normalizeClaudeTokenUsage` for accumulated `result.usage` no longer passes a `contextWindow`, so those totals are never clamped.
> - Behavioral Change: `thread.token-usage.updated` events for accumulated-only usage will no longer include `maxTokens`, and `usedTokens` may exceed the context window size.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a1013a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->