### PR TITLE
Revert "Cache desktop build assets in CI and release workflows"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,8 @@ jobs:
         with:
           node-version-file: package.json
 
-      - id: bun_turbo_cache
-        name: Restore Bun and Turbo cache
-        uses: actions/cache/restore@v5
+      - name: Cache Bun and Turbo
+        uses: actions/cache@v5
         with:
           path: |
             ~/.bun/install/cache
@@ -36,9 +35,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-
 
-      - id: playwright_cache
-        name: Restore Playwright browsers
-        uses: actions/cache/restore@v5
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
@@ -70,22 +68,6 @@ jobs:
 
       - name: Build desktop pipeline
         run: bun run build:desktop
-
-      - name: Save Playwright browsers
-        if: steps.playwright_cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('bun.lock') }}
-
-      - name: Save Bun and Turbo cache
-        if: steps.bun_turbo_cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ~/.bun/install/cache
-            .turbo
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}-${{ hashFiles('turbo.json') }}
 
       - name: Verify preload bundle output
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,9 +311,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          asset_dir="release-artifacts/desktop-${{ matrix.platform }}-${{ matrix.arch }}"
-          rm -rf "$asset_dir"
-          mkdir -p "$asset_dir"
+          mkdir -p release-publish
 
           shopt -s nullglob
           for pattern in \
@@ -324,13 +322,13 @@ jobs:
             "release/*.blockmap" \
             "release/*.yml"; do
             for file in $pattern; do
-              cp "$file" "$asset_dir"/
+              cp "$file" release-publish/
             done
           done
 
           if [[ "${{ matrix.platform }}" == "mac" && "${{ matrix.arch }}" != "arm64" ]]; then
             shopt -s nullglob
-            for manifest in "$asset_dir"/*-mac.yml; do
+            for manifest in release-publish/*-mac.yml; do
               mv "$manifest" "${manifest%.yml}-${{ matrix.arch }}.yml"
             done
           fi
@@ -342,23 +340,17 @@ jobs:
           # canonical manifest per channel.
           # if [[ "${{ matrix.platform }}" == "win" ]]; then
           #   shopt -s nullglob
-          #   for manifest in "$asset_dir"/*.yml; do
+          #   for manifest in release-publish/*.yml; do
           #     mv "$manifest" "${manifest%.yml}-win-${{ matrix.arch }}.yml"
           #   done
           # fi
 
-          assets=("$asset_dir"/*)
-          if (( ${#assets[@]} == 0 )); then
-            echo "No release assets were collected for ${{ matrix.platform }} ${{ matrix.arch }}." >&2
-            exit 1
-          fi
-
-      - name: Save build artifacts
-        uses: actions/cache/save@v5
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v7
         with:
-          path: release-artifacts/desktop-${{ matrix.platform }}-${{ matrix.arch }}
-          key: release-assets-${{ github.run_id }}-${{ matrix.platform }}-${{ matrix.arch }}-${{ github.run_attempt }}
-          enableCrossOsArchive: true
+          name: desktop-${{ matrix.platform }}-${{ matrix.arch }}
+          path: release-publish/*
+          if-no-files-found: error
 
   publish_cli:
     name: Publish CLI to npm
@@ -431,70 +423,12 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile --filter=@t3tools/scripts
 
-      # Keep these restore steps in sync with the desktop build matrix.
-      # Cache restore cannot enumerate a key pattern like download-artifact did.
-      - name: Restore macOS arm64 desktop assets
-        uses: actions/cache/restore@v5
+      - name: Download all desktop artifacts
+        uses: actions/download-artifact@v8
         with:
-          path: release-artifacts/desktop-mac-arm64
-          key: release-assets-${{ github.run_id }}-mac-arm64-${{ github.run_attempt }}
-          restore-keys: |
-            release-assets-${{ github.run_id }}-mac-arm64-
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-
-      - name: Restore macOS x64 desktop assets
-        uses: actions/cache/restore@v5
-        with:
-          path: release-artifacts/desktop-mac-x64
-          key: release-assets-${{ github.run_id }}-mac-x64-${{ github.run_attempt }}
-          restore-keys: |
-            release-assets-${{ github.run_id }}-mac-x64-
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-
-      - name: Restore Linux x64 desktop assets
-        uses: actions/cache/restore@v5
-        with:
-          path: release-artifacts/desktop-linux-x64
-          key: release-assets-${{ github.run_id }}-linux-x64-${{ github.run_attempt }}
-          restore-keys: |
-            release-assets-${{ github.run_id }}-linux-x64-
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-
-      - name: Restore Windows x64 desktop assets
-        uses: actions/cache/restore@v5
-        with:
-          path: release-artifacts/desktop-win-x64
-          key: release-assets-${{ github.run_id }}-win-x64-${{ github.run_attempt }}
-          restore-keys: |
-            release-assets-${{ github.run_id }}-win-x64-
-          fail-on-cache-miss: true
-          enableCrossOsArchive: true
-
-      - name: Stage desktop assets
-        shell: bash
-        run: |
-          set -euo pipefail
-          rm -rf release-assets
-          mkdir -p release-assets
-
-          shopt -s nullglob
-          for dir in release-artifacts/desktop-*; do
-            files=("$dir"/*)
-            if (( ${#files[@]} == 0 )); then
-              echo "No release assets were restored from $dir." >&2
-              exit 1
-            fi
-            cp "${files[@]}" release-assets/
-          done
-
-          assets=(release-assets/*)
-          if (( ${#assets[@]} == 0 )); then
-            echo "No desktop release assets were staged." >&2
-            exit 1
-          fi
+          pattern: desktop-*
+          merge-multiple: true
+          path: release-assets
 
       - name: Merge macOS updater manifests
         run: |


### PR DESCRIPTION
Reverts pingdotgg/t3code#2543

<img width="2012" height="932" alt="CleanShot 2026-05-06 at 15 59 42@2x" src="https://github.com/user-attachments/assets/9fdf25e8-59ed-4e32-bd67-5ef84b46a67a" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI/release workflows for caching and release artifact handoff; failures here can break builds or publishing even though no application code changes.
> 
> **Overview**
> Reverts the previous approach of caching desktop build assets across jobs and instead uses GitHub Artifacts to pass desktop release outputs from the `build` matrix to the `release` job.
> 
> In `ci.yml`, replaces separate `actions/cache/restore` + conditional `actions/cache/save` steps with single `actions/cache` steps for Bun/Turbo and Playwright, removing the explicit save phases.
> 
> In `release.yml`, collects build outputs into `release-publish/`, uploads them via `actions/upload-artifact`, and later downloads/merges them via `actions/download-artifact` (removing the per-platform cache restore + staging logic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c8fa76d60dd626863d61df8651bc39c547c789. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert desktop build asset caching to use upload/download artifact steps in CI and release workflows
> - Reverts the previously cached CI build approach: [ci.yml](.github/workflows/ci.yml) switches back to unified `actions/cache@v5` steps (combined restore/save) for Bun/Turbo and Playwright caches, removing separate restore and save steps.
> - In [release.yml](.github/workflows/release.yml), the `build` matrix job now uploads artifacts via `actions/upload-artifact@v7` into a flat `release-publish` directory instead of saving to cache; the step errors if no files are found.
> - The `publish_cli` job now downloads all `desktop-*` artifacts via `actions/download-artifact@v8` with `merge-multiple: true` directly into `release-assets`, replacing four separate cache restore steps and an intermediate staging copy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 11c8fa7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->