### PR TITLE
[codex] Fix sidebar preview settings reset

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -424,6 +424,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       diffWordWrap: DEFAULT_UNIFIED_SETTINGS.diffWordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+      sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
       autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
       enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
       defaultThreadEnvMode: DEFAULT_UNIFIED_SETTINGS.defaultThreadEnvMode,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -497,6 +497,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
+  sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   timestampFormat: Schema.optionalKey(TimestampFormat),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;


### PR DESCRIPTION
## Summary

This follow-up addresses two useful review findings left on the already-merged sidebar thread preview setting PR (#1856).

The visible-thread setting was included in the restore-defaults confirmation copy, but it was not part of the payload sent to `updateSettings`. That meant a user could confirm a reset that explicitly listed "Visible threads" while the saved sidebar preview count stayed unchanged. The fix adds `sidebarThreadPreviewCount` to the restore-defaults patch alongside the other client settings.

The new setting was also present in `ClientSettingsSchema` but absent from `ClientSettingsPatch`. That left the patch contract inconsistent with the settings schema and would drop the field if the patch schema were used for decoding or validation. The fix adds the optional patch entry using the existing `SidebarThreadPreviewCount` schema.

I checked the Vite-related review thread too. Current `main` no longer has the startup-crash fallback change, and the remaining Vite comment is about an unrelated build-contract decision, so this PR stays scoped to the two still-actionable settings issues.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test --filter=@t3tools/contracts --filter=@t3tools/web`
- `npx -y react-doctor@latest . --verbose --diff`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix sidebar preview settings reset to exclude `sidebarThreadPreviewCount`
> The `useSettingsRestore` hook was not resetting `sidebarThreadPreviewCount` (Visible threads) when restoring defaults. This fix adds the field to the reset payload and extends the `ClientSettingsPatch` schema in [settings.ts](https://github.com/pingdotgg/t3code/pull/2587/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) to accept it as an optional field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8897a78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix limited to client settings reset behavior and the settings patch contract; no auth/security or complex logic changes.
> 
> **Overview**
> Fixes a mismatch where restoring default settings did not actually reset `sidebarThreadPreviewCount` ("Visible threads") despite being listed in the confirmation prompt.
> 
> Also updates the contracts layer so `ClientSettingsPatch` accepts `sidebarThreadPreviewCount`, keeping the patch schema consistent with `ClientSettingsSchema` and preventing the field from being dropped during validation/decoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8897a78dacfb427cb0f0e81ee41b0c8e93e994be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->