### PR TITLE
Match sticky changed-files header tint to card background

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -698,7 +698,7 @@ function AssistantChangedFilesSectionInner({
 
   return (
     <div className="mt-2 rounded-lg border border-border/80 bg-card/45 p-2.5">
-      <div className="sticky top-2 z-10 mb-1.5 flex items-center justify-between gap-2 bg-background before:absolute before:inset-x-0 before:-top-2 before:h-2 before:bg-background before:content-['']">
+      <div className="sticky top-2 z-10 mb-1.5 flex items-center justify-between gap-2 bg-[color-mix(in_srgb,var(--card)_45%,var(--background))] before:absolute before:inset-x-0 before:-top-2 before:h-2 before:bg-[color-mix(in_srgb,var(--card)_45%,var(--background))] before:content-['']">
         <p className="text-[10px] uppercase tracking-[0.12em] text-muted-foreground/65">
           <span>Changed files ({changedFileCountLabel})</span>
           {hasNonZeroStat(summaryStat) && (


### PR DESCRIPTION
### Before

<img width="1702" height="222" alt="CleanShot 2026-05-07 at 22 15 03@2x" src="https://github.com/user-attachments/assets/0cf947fd-b2a7-40a7-9cb4-70ca2ee33bd5" />

### After

<img width="1874" height="300" alt="CleanShot 2026-05-07 at 22 15 40@2x" src="https://github.com/user-attachments/assets/1165e528-18f5-4808-b958-493b07a3e2c9" />


## Summary
- Updated the sticky changed-files section header to use the same mixed card/background tint as its container.
- Applied the same tint to the header’s top background extension so the sticky edge blends cleanly while scrolling.

## Testing
- Not run (PR content only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling tweak that changes background colors for a sticky header; no logic, data, or API behavior is modified.
> 
> **Overview**
> Updates the sticky **Changed files** header in `MessagesTimeline.tsx` to use the same `color-mix()` card/background tint as its container instead of `bg-background`.
> 
> Applies the same tinted background to the header’s `before` pseudo-element so the sticky top edge blends consistently while scrolling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28b6e5c0617eab81a43e81820a8d845b616409dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Match sticky changed-files header background to card color
> Updates the sticky header in `AssistantChangedFilesSectionInner` to use a CSS `color-mix` value (45% `--card`, 55% `--background`) instead of the plain `--background` color, applied to both the element and its `::before` pseudo-element in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/2592/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28b6e5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->