### PR TITLE
Fix remote pairing CORS responses

### DIFF
--- a/apps/server/src/auth/http.ts
+++ b/apps/server/src/auth/http.ts
@@ -12,6 +12,7 @@ import { HttpRouter, HttpServerRequest, HttpServerResponse } from "effect/unstab
 import { AuthError, ServerAuth } from "./Services/ServerAuth.ts";
 import { SessionCredentialService } from "./Services/SessionCredentialService.ts";
 import { deriveAuthClientMetadata } from "./utils.ts";
+import { browserApiCorsHeaders } from "../httpCors.ts";
 
 export const respondToAuthError = (error: AuthError) =>
   Effect.gen(function* () {
@@ -25,7 +26,7 @@ export const respondToAuthError = (error: AuthError) =>
       {
         error: error.message,
       },
-      { status: error.status ?? 500 },
+      { status: error.status ?? 500, headers: browserApiCorsHeaders },
     );
   });
 
@@ -36,7 +37,10 @@ export const authSessionRouteLayer = HttpRouter.add(
     const request = yield* HttpServerRequest.HttpServerRequest;
     const serverAuth = yield* ServerAuth;
     const session = yield* serverAuth.getSessionState(request);
-    return HttpServerResponse.jsonUnsafe(session, { status: 200 });
+    return HttpServerResponse.jsonUnsafe(session, {
+      status: 200,
+      headers: browserApiCorsHeaders,
+    });
   }),
 );
 
@@ -79,7 +83,10 @@ export const authBootstrapRouteLayer = HttpRouter.add(
       deriveAuthClientMetadata({ request }),
     );
 
-    return yield* HttpServerResponse.jsonUnsafe(result.response, { status: 200 }).pipe(
+    return yield* HttpServerResponse.jsonUnsafe(result.response, {
+      status: 200,
+      headers: browserApiCorsHeaders,
+    }).pipe(
       HttpServerResponse.setCookie(sessions.cookieName, result.sessionToken, {
         expires: DateTime.toDate(result.response.expiresAt),
         httpOnly: true,
@@ -112,6 +119,7 @@ export const authBearerBootstrapRouteLayer = HttpRouter.add(
     );
     return HttpServerResponse.jsonUnsafe(result satisfies AuthBearerBootstrapResult, {
       status: 200,
+      headers: browserApiCorsHeaders,
     });
   }).pipe(Effect.catchTag("AuthError", (error) => respondToAuthError(error))),
 );
@@ -126,6 +134,7 @@ export const authWebSocketTokenRouteLayer = HttpRouter.add(
     const result = yield* serverAuth.issueWebSocketToken(session);
     return HttpServerResponse.jsonUnsafe(result satisfies AuthWebSocketTokenResult, {
       status: 200,
+      headers: browserApiCorsHeaders,
     });
   }).pipe(Effect.catchTag("AuthError", (error) => respondToAuthError(error))),
 );

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -24,6 +24,11 @@ import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolve
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import { respondToAuthError } from "./auth/http.ts";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment.ts";
+import {
+  browserApiCorsAllowedHeaders,
+  browserApiCorsAllowedMethods,
+  browserApiCorsHeaders,
+} from "./httpCors.ts";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
@@ -31,8 +36,8 @@ const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
 
 export const browserApiCorsLayer = HttpRouter.cors({
-  allowedMethods: ["GET", "POST", "OPTIONS"],
-  allowedHeaders: ["authorization", "b3", "traceparent", "content-type"],
+  allowedMethods: [...browserApiCorsAllowedMethods],
+  allowedHeaders: [...browserApiCorsAllowedHeaders],
   maxAge: 600,
 });
 
@@ -65,7 +70,10 @@ export const serverEnvironmentRouteLayer = HttpRouter.add(
     const descriptor = yield* Effect.service(ServerEnvironment).pipe(
       Effect.flatMap((serverEnvironment) => serverEnvironment.getDescriptor),
     );
-    return HttpServerResponse.jsonUnsafe(descriptor, { status: 200 });
+    return HttpServerResponse.jsonUnsafe(descriptor, {
+      status: 200,
+      headers: browserApiCorsHeaders,
+    });
   }),
 );
 

--- a/apps/server/src/httpCors.ts
+++ b/apps/server/src/httpCors.ts
@@ -1,0 +1,13 @@
+export const browserApiCorsAllowedMethods = ["GET", "POST", "OPTIONS"] as const;
+export const browserApiCorsAllowedHeaders = [
+  "authorization",
+  "b3",
+  "traceparent",
+  "content-type",
+] as const;
+
+export const browserApiCorsHeaders = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-methods": browserApiCorsAllowedMethods.join(", "),
+  "access-control-allow-headers": browserApiCorsAllowedHeaders.join(", "),
+} as const;

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -796,7 +796,12 @@ const bootstrapBrowserSession = (
     };
   });
 
-const bootstrapBearerSession = (credential = defaultDesktopBootstrapToken) =>
+const bootstrapBearerSession = (
+  credential = defaultDesktopBootstrapToken,
+  options?: {
+    readonly headers?: Record<string, string>;
+  },
+) =>
   Effect.gen(function* () {
     const bootstrapUrl = yield* getHttpServerUrl("/api/auth/bootstrap/bearer");
     const response = yield* Effect.promise(() =>
@@ -804,6 +809,7 @@ const bootstrapBearerSession = (credential = defaultDesktopBootstrapToken) =>
         method: "POST",
         headers: {
           "content-type": "application/json",
+          ...options?.headers,
         },
         body: JSON.stringify({
           credential,
@@ -872,6 +878,22 @@ const splitHeaderTokens = (value: string | null) =>
     .map((token) => token.trim())
     .filter((token) => token.length > 0)
     .toSorted();
+
+const assertBrowserApiCorsHeaders = (headers: Headers) => {
+  assert.equal(headers.get("access-control-allow-origin"), "*");
+  assert.deepEqual(splitHeaderTokens(headers.get("access-control-allow-methods")), [
+    "GET",
+    "OPTIONS",
+    "POST",
+  ]);
+  assert.deepEqual(splitHeaderTokens(headers.get("access-control-allow-headers")), [
+    "authorization",
+    "b3",
+    "content-type",
+    "traceparent",
+  ]);
+};
+const crossOriginClientOrigin = "http://remote-client.test:3773";
 
 const getWsServerUrl = (
   pathname = "",
@@ -990,6 +1012,28 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       )) as typeof testEnvironmentDescriptor;
 
       assert.equal(response.status, 200);
+      assert.deepEqual(body, testEnvironmentDescriptor);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("includes CORS headers on public environment descriptor responses", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const url = yield* getHttpServerUrl("/.well-known/t3/environment");
+      const response = yield* Effect.promise(() =>
+        fetch(url, {
+          headers: {
+            origin: crossOriginClientOrigin,
+          },
+        }),
+      );
+      const body = (yield* Effect.promise(() =>
+        response.json(),
+      )) as typeof testEnvironmentDescriptor;
+
+      assert.equal(response.status, 200);
+      assertBrowserApiCorsHeaders(response.headers);
       assert.deepEqual(body, testEnvironmentDescriptor);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
@@ -1117,6 +1161,62 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("includes CORS headers on remote auth success responses", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const origin = crossOriginClientOrigin;
+      const { response: bootstrapResponse, body: bootstrapBody } = yield* bootstrapBearerSession(
+        defaultDesktopBootstrapToken,
+        {
+          headers: { origin },
+        },
+      );
+
+      assert.equal(bootstrapResponse.status, 200);
+      assertBrowserApiCorsHeaders(bootstrapResponse.headers);
+      assert.equal(bootstrapBody.authenticated, true);
+      assert.equal(typeof bootstrapBody.sessionToken, "string");
+
+      const sessionUrl = yield* getHttpServerUrl("/api/auth/session");
+      const sessionResponse = yield* Effect.promise(() =>
+        fetch(sessionUrl, {
+          headers: {
+            authorization: `Bearer ${bootstrapBody.sessionToken ?? ""}`,
+            origin,
+          },
+        }),
+      );
+      const sessionBody = (yield* Effect.promise(() => sessionResponse.json())) as {
+        readonly authenticated: boolean;
+        readonly sessionMethod?: string;
+      };
+
+      assert.equal(sessionResponse.status, 200);
+      assertBrowserApiCorsHeaders(sessionResponse.headers);
+      assert.equal(sessionBody.authenticated, true);
+      assert.equal(sessionBody.sessionMethod, "bearer-session-token");
+
+      const wsTokenUrl = yield* getHttpServerUrl("/api/auth/ws-token");
+      const wsTokenResponse = yield* Effect.promise(() =>
+        fetch(wsTokenUrl, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${bootstrapBody.sessionToken ?? ""}`,
+            origin,
+          },
+        }),
+      );
+      const wsTokenBody = (yield* Effect.promise(() => wsTokenResponse.json())) as {
+        readonly token: string;
+      };
+
+      assert.equal(wsTokenResponse.status, 200);
+      assertBrowserApiCorsHeaders(wsTokenResponse.headers);
+      assert.equal(typeof wsTokenBody.token, "string");
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect(
     "responds to remote auth websocket-token preflight requests with authorization CORS headers",
     () =>
@@ -1128,7 +1228,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           fetch(wsTokenUrl, {
             method: "OPTIONS",
             headers: {
-              origin: "http://192.168.86.35:3773",
+              origin: crossOriginClientOrigin,
               "access-control-request-method": "POST",
               "access-control-request-headers": "authorization",
             },
@@ -1136,18 +1236,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         );
 
         assert.equal(response.status, 204);
-        assert.equal(response.headers.get("access-control-allow-origin"), "*");
-        assert.deepEqual(splitHeaderTokens(response.headers.get("access-control-allow-methods")), [
-          "GET",
-          "OPTIONS",
-          "POST",
-        ]);
-        assert.deepEqual(splitHeaderTokens(response.headers.get("access-control-allow-headers")), [
-          "authorization",
-          "b3",
-          "content-type",
-          "traceparent",
-        ]);
+        assertBrowserApiCorsHeaders(response.headers);
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
@@ -1160,7 +1249,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         fetch(wsTokenUrl, {
           method: "POST",
           headers: {
-            origin: "http://192.168.86.35:3773",
+            origin: crossOriginClientOrigin,
           },
         }),
       );
@@ -1169,7 +1258,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       };
 
       assert.equal(response.status, 401);
-      assert.equal(response.headers.get("access-control-allow-origin"), "*");
+      assertBrowserApiCorsHeaders(response.headers);
       assert.equal(body.error, "Authentication required.");
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );


### PR DESCRIPTION
## What Changed

Adds CORS headers to the actual JSON responses used by remote environment pairing:

- `/.well-known/t3/environment`
- `/api/auth/session`
- `/api/auth/bootstrap`
- `/api/auth/bootstrap/bearer`
- `/api/auth/websocket-token`

The allowed methods and headers are shared with the existing CORS preflight configuration so OPTIONS and the real GET/POST responses stay aligned.

This also adds server tests for cross-origin environment discovery and the bearer auth bootstrap/session/websocket-token flow.

## Why

Fixes https://github.com/pingdotgg/t3code/issues/1928.

That issue was closed, but I can still reproduce it on the latest nightly I tested: `0.0.23-nightly.20260508.230`.

The backend is reachable directly from the client machine, and the environment descriptor returns `200 OK` from curl/browser navigation. The failure happens when the app does a cross-origin fetch from the web/Electron renderer:

`Failed to fetch remote auth endpoint`

The server already handles OPTIONS preflight, but the actual GET/POST responses do not include `Access-Control-Allow-Origin`, so Chromium blocks the readable response.

This keeps the fix on the server side instead of requiring users to run a reverse proxy that injects the missing CORS headers.

## UI Changes

No UI changes.

The visible behavior change is that remote pairing succeeds instead of failing with `Failed to fetch remote auth endpoint`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --cwd apps/server test src/server.test.ts`

I also verified the fix manually by pairing two machines over Tailscale without a custom proxy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broadens `Access-Control-Allow-*` headers to additional auth and environment responses; while aligned with existing preflight config, it changes cross-origin accessibility for these endpoints and should be reviewed for unintended exposure.
> 
> **Overview**
> Fixes remote pairing/browser fetches by adding `Access-Control-Allow-*` headers to the *actual* JSON responses (not just OPTIONS preflight) for `/.well-known/t3/environment` and key auth endpoints (`/api/auth/session`, `/api/auth/bootstrap`, `/api/auth/bootstrap/bearer`, `/api/auth/ws-token`), including `respondToAuthError`.
> 
> Extracts shared CORS allowlists into new `httpCors.ts` and reuses them in both the CORS middleware and response builders to keep preflight and response headers consistent. Adds/updates server tests to assert these CORS headers on cross-origin success and failure flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea0ca88d5518f7752a2c828fe85bfdb9f3808d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CORS headers on remote pairing auth and environment responses
> - Adds `access-control-allow-origin`, `access-control-allow-methods`, and `access-control-allow-headers` headers to all auth endpoints (`/api/auth/session`, `/api/auth/bootstrap`, `/api/auth/bootstrap/bearer`, `/api/auth/ws-token`) and `/.well-known/t3/environment`.
> - Extracts shared CORS constants into a new [httpCors.ts](https://github.com/pingdotgg/t3code/pull/2594/files#diff-5a641876cf42736bfa6ea1486b7a81fb67cb576d4759136bc2327d5283872375) module so allowed methods and headers are defined once and reused across middleware and response construction.
> - Adds integration tests covering CORS header presence on successful responses, error responses, and preflight requests from cross-origin clients.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea0ca88.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->