### PR TITLE
Force app-server teardown to terminate promptly

### DIFF
--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -42,6 +42,7 @@ const BENIGN_ERROR_LOG_SNIPPETS = [
   "state db missing rollout path for thread",
   "state db record_discrepancy: find_thread_path_by_id_str_in_subdir, falling_back",
 ];
+const CODEX_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
 const RECOVERABLE_THREAD_RESUME_ERROR_SNIPPETS = [
   "not found",
   "missing thread",
@@ -702,6 +703,7 @@ export const makeCodexSessionRuntime = (
         ChildProcess.make(options.binaryPath, ["app-server"], {
           cwd: options.cwd,
           env,
+          forceKillAfter: CODEX_APP_SERVER_FORCE_KILL_AFTER,
           shell: process.platform === "win32",
         }),
       )

--- a/apps/server/src/provider/Layers/scopedSafeTeardown.test.ts
+++ b/apps/server/src/provider/Layers/scopedSafeTeardown.test.ts
@@ -1,5 +1,5 @@
 import { it } from "@effect/vitest";
-import { Cause, Effect, Exit } from "effect";
+import { Cause, Deferred, Effect, Exit, Fiber } from "effect";
 import { describe, expect } from "vitest";
 
 import { scopedSafeTeardown } from "./scopedSafeTeardown.ts";
@@ -89,6 +89,25 @@ describe("scopedSafeTeardown", () => {
         const squashed = Cause.squash(exit.cause);
         expect(squashed).toBeInstanceOf(BodyError);
       }
+    }),
+  );
+
+  it.effect("runs finalizers when the body is interrupted", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>();
+      const finalized = yield* Deferred.make<void>();
+      const wrapped = Effect.gen(function* () {
+        yield* Effect.addFinalizer(() =>
+          Deferred.succeed(finalized, undefined).pipe(Effect.asVoid),
+        );
+        yield* Deferred.succeed(started, undefined);
+        return yield* Effect.never;
+      }).pipe(scopedSafeTeardown("test"));
+
+      const fiber = yield* wrapped.pipe(Effect.forkChild);
+      yield* Deferred.await(started);
+      yield* Fiber.interrupt(fiber);
+      yield* Deferred.await(finalized);
     }),
   );
 });

--- a/apps/server/src/provider/Layers/scopedSafeTeardown.ts
+++ b/apps/server/src/provider/Layers/scopedSafeTeardown.ts
@@ -23,9 +23,11 @@
  * 1. Make a fresh scope manually.
  * 2. Run the body against that scope, capturing its Exit via
  *    `Effect.exit`.
- * 3. Close the scope, catching any cause (typed failure *or* defect)
+ * 3. Run the body inside an interruptible region, but capture the Exit from
+ *    success, failure, defect, or interruption.
+ * 4. Close the scope, catching any cause (typed failure *or* defect)
  *    with a log.
- * 4. Replay the captured Exit so typed body failures still surface and
+ * 5. Replay the captured Exit so typed body failures still surface and
  *    successes still return their value.
  *
  * The helper deliberately logs teardown causes at `Warning` level —
@@ -34,7 +36,7 @@
  *
  * @module provider/Layers/scopedSafeTeardown
  */
-import { Effect, Exit, Scope } from "effect";
+import { Effect, Scope } from "effect";
 
 /**
  * Run `effect` with a freshly made `Scope.Scope`, guaranteeing that
@@ -49,13 +51,17 @@ import { Effect, Exit, Scope } from "effect";
 export const scopedSafeTeardown =
   (label: string) =>
   <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, E, Exclude<R, Scope.Scope>> =>
-    Effect.gen(function* () {
-      const scope = yield* Scope.make();
-      const bodyExit = yield* effect.pipe(Effect.provideService(Scope.Scope, scope), Effect.exit);
-      yield* Scope.close(scope, Exit.void).pipe(
-        Effect.catchCause((cause) =>
-          Effect.logWarning(`${label} teardown errored; preserving body result`, cause),
-        ),
-      );
-      return yield* bodyExit;
-    }) as Effect.Effect<A, E, Exclude<R, Scope.Scope>>;
+    Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        const scope = yield* Scope.make();
+        const bodyExit = yield* restore(
+          effect.pipe(Effect.provideService(Scope.Scope, scope)),
+        ).pipe(Effect.exit);
+        yield* Scope.close(scope, bodyExit).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning(`${label} teardown errored; preserving body result`, cause),
+          ),
+        );
+        return yield* bodyExit;
+      }),
+    ) as Effect.Effect<A, E, Exclude<R, Scope.Scope>>;

--- a/packages/effect-codex-app-server/src/client.ts
+++ b/packages/effect-codex-app-server/src/client.ts
@@ -17,6 +17,8 @@ import {
 } from "./_internal/shared.ts";
 import { makeChildStdio, makeTerminationError } from "./_internal/stdio.ts";
 
+const DEFAULT_APP_SERVER_FORCE_KILL_AFTER = "2 seconds" as const;
+
 export interface CodexAppServerClientOptions {
   readonly logIncoming?: boolean;
   readonly logOutgoing?: boolean;
@@ -279,6 +281,7 @@ export const layerCommand = (
         const command = ChildProcess.make(options.command, [...(options.args ?? [])], {
           ...(options.cwd ? { cwd: options.cwd } : {}),
           ...(options.env ? { env: { ...process.env, ...options.env } } : {}),
+          forceKillAfter: DEFAULT_APP_SERVER_FORCE_KILL_AFTER,
           shell: process.platform === "win32",
         });
         return yield* spawner.spawn(command).pipe(
@@ -291,7 +294,8 @@ export const layerCommand = (
           ),
         );
       }),
-      (handle) => handle.kill().pipe(Effect.orDie),
+      (handle) =>
+        handle.kill({ forceKillAfter: DEFAULT_APP_SERVER_FORCE_KILL_AFTER }).pipe(Effect.orDie),
     ).pipe(
       Effect.flatMap((handle) =>
         make(makeChildStdio(handle), options, makeTerminationError(handle)),


### PR DESCRIPTION
## Summary
- Add a 2 second forced-kill timeout for Codex app-server child processes during startup and teardown.
- Make scoped teardown interrupt-safe so finalizers still run when the body is interrupted.
- Expand teardown coverage with a test that verifies finalizers execute after interruption.

## Testing
- `bun fmt` not run.
- `bun lint` not run.
- `bun typecheck` not run.
- `bun run test` not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess lifecycle management and scope finalization behavior; mistakes could cause orphaned `codex app-server` processes or missed finalizers, but the change is small and covered by an added interruption test.
> 
> **Overview**
> Ensures `codex app-server` child processes terminate promptly by applying a **2-second `forceKillAfter` timeout** during spawn in `CodexSessionRuntime` and in the `effect-codex-app-server` `layerCommand` acquisition/release path.
> 
> Hardens `scopedSafeTeardown` to be **interrupt-safe** by capturing the body’s `Exit` (including interruption) while still running scope finalizers, logging and swallowing teardown defects without overriding the body result, and adds a test verifying finalizers run when the body fiber is interrupted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32ebbe1a4c19c25a0e368a9b929d5847e3b3ebf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force `codex app-server` child processes to terminate within 2 seconds on teardown
> - Adds `forceKillAfter: "2 seconds"` to child process creation and kill calls in both [`client.ts`](https://github.com/pingdotgg/t3code/pull/2595/files#diff-3d60ac4e051da962d4a1e6f4bd881857f81b3f5ead25e9cf52ac0be96924b717) and [`CodexSessionRuntime.ts`](https://github.com/pingdotgg/t3code/pull/2595/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) so the process is hard-killed if it doesn't exit promptly.
> - Fixes [`scopedSafeTeardown.ts`](https://github.com/pingdotgg/t3code/pull/2595/files#diff-aaf2415e8abaf95b1b0705f3b9af9cd753edc5d511410e2014a8a2fb5e8c7147) to run the body inside `Effect.uninterruptibleMask` with interruptibility restored, capturing the body's `Exit` (including interruption) and passing it to `Scope.close` so finalizers run even when the body is interrupted.
> - Adds a test covering the interrupted-body case in [`scopedSafeTeardown.test.ts`](https://github.com/pingdotgg/t3code/pull/2595/files#diff-d037d70003dc4b42842b12ee48d52933b351f75ccfaad6dc37a8ca45784c7990).
> - Behavioral Change: teardown failures are now logged without overriding the body's original `Exit`, changing what callers observe on combined failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 32ebbe1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->