### PR TITLE
fix(web): make plan sidebar resizable like diff panel

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3774,7 +3774,6 @@ export default function ChatView(props: ChatViewProps) {
               markdownCwd={gitCwd ?? undefined}
               workspaceRoot={activeWorkspaceRoot}
               timestampFormat={timestampFormat}
-              mode="sidebar"
               onClose={closePlanSidebar}
             />
           </div>
@@ -3809,7 +3808,6 @@ export default function ChatView(props: ChatViewProps) {
             markdownCwd={gitCwd ?? undefined}
             workspaceRoot={activeWorkspaceRoot}
             timestampFormat={timestampFormat}
-            mode="sheet"
             onClose={closePlanSidebar}
           />
         </RightPanelSheet>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -99,7 +99,13 @@ import { useTurnDiffSummaries } from "../hooks/useTurnDiffSummaries";
 import { useCommandPaletteStore } from "../commandPaletteStore";
 import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
 import { useMediaQuery } from "../hooks/useMediaQuery";
-import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
+import {
+  RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY,
+  PLAN_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
+  PLAN_INLINE_DEFAULT_WIDTH,
+  PLAN_INLINE_SIDEBAR_MIN_WIDTH,
+} from "../rightPanelLayout";
+import { useResizeHandle } from "../hooks/useResizeHandle";
 import { BranchToolbar } from "./BranchToolbar";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import PlanSidebar from "./PlanSidebar";
@@ -334,7 +340,6 @@ function formatOutgoingPrompt(params: {
 }
 const SCRIPT_TERMINAL_COLS = 120;
 const SCRIPT_TERMINAL_ROWS = 30;
-
 type ChatViewProps =
   | {
       environmentId: EnvironmentId;
@@ -2147,6 +2152,19 @@ export default function ChatView(props: ChatViewProps) {
     planSidebarDismissedForTurnRef.current =
       activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
   }, [activePlan?.turnId, sidebarProposedPlan?.turnId]);
+  const {
+    handleRef: planResizeHandleRef,
+    setWrapperRef: setPlanSidebarWrapperRef,
+    onPointerDown: handlePlanResizePointerDown,
+    onPointerMove: handlePlanResizePointerMove,
+    onPointerUp: handlePlanResizeEndInteraction,
+    onClick: handlePlanResizeClick,
+  } = useResizeHandle({
+    cssVarName: "--plan-sidebar-width",
+    storageKey: PLAN_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
+    minWidth: PLAN_INLINE_SIDEBAR_MIN_WIDTH,
+    isDisabled: shouldUsePlanSidebarSheet,
+  });
 
   const persistThreadSettingsForNextTurn = useCallback(
     async (input: {
@@ -3722,19 +3740,44 @@ export default function ChatView(props: ChatViewProps) {
         </div>
         {/* end chat column */}
 
-        {/* Plan sidebar */}
+        {/* Plan sidebar (inline, resizable) */}
         {planSidebarOpen && !shouldUsePlanSidebarSheet ? (
-          <PlanSidebar
-            activePlan={activePlan}
-            activeProposedPlan={sidebarProposedPlan}
-            label={planSidebarLabel}
-            environmentId={environmentId}
-            markdownCwd={gitCwd ?? undefined}
-            workspaceRoot={activeWorkspaceRoot}
-            timestampFormat={timestampFormat}
-            mode="sidebar"
-            onClose={closePlanSidebar}
-          />
+          <div
+            ref={setPlanSidebarWrapperRef}
+            className="relative flex h-full min-h-0 flex-none flex-col border-l border-border/70"
+            style={
+              {
+                width: `var(--plan-sidebar-width, ${PLAN_INLINE_DEFAULT_WIDTH})`,
+                transition: "width 0ms",
+              } as React.CSSProperties
+            }
+          >
+            {/* Left-edge drag handle — mirrors SidebarRail behaviour */}
+            <button
+              ref={planResizeHandleRef}
+              type="button"
+              aria-label="Resize plan sidebar"
+              title="Drag to resize"
+              className="absolute inset-y-0 left-0 z-20 hidden w-4 -translate-x-1/2 cursor-e-resize after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-border sm:flex"
+              tabIndex={-1}
+              onPointerDown={handlePlanResizePointerDown}
+              onPointerMove={handlePlanResizePointerMove}
+              onPointerUp={handlePlanResizeEndInteraction}
+              onPointerCancel={handlePlanResizeEndInteraction}
+              onClick={handlePlanResizeClick}
+            />
+            <PlanSidebar
+              activePlan={activePlan}
+              activeProposedPlan={sidebarProposedPlan}
+              label={planSidebarLabel}
+              environmentId={environmentId}
+              markdownCwd={gitCwd ?? undefined}
+              workspaceRoot={activeWorkspaceRoot}
+              timestampFormat={timestampFormat}
+              mode="sidebar"
+              onClose={closePlanSidebar}
+            />
+          </div>
         ) : null}
       </div>
       {/* end horizontal flex container */}

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -71,7 +71,6 @@ const PlanSidebar = memo(function PlanSidebar({
   markdownCwd,
   workspaceRoot,
   timestampFormat,
-  mode = "sidebar",
   onClose,
 }: PlanSidebarProps) {
   const [proposedPlanExpanded, setProposedPlanExpanded] = useState(false);
@@ -127,14 +126,7 @@ const PlanSidebar = memo(function PlanSidebar({
   }, [environmentId, planMarkdown, workspaceRoot]);
 
   return (
-    <div
-      className={cn(
-        "flex min-h-0 flex-col bg-card/50",
-        mode === "sidebar"
-          ? "h-full w-[340px] shrink-0 border-l border-border/70"
-          : "h-full w-full",
-      )}
-    >
+    <div className="flex h-full min-h-0 w-full flex-col bg-card/50">
       {/* Header */}
       <div className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-3">
         <div className="flex items-center gap-2">

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -59,7 +59,6 @@ interface PlanSidebarProps {
   markdownCwd: string | undefined;
   workspaceRoot: string | undefined;
   timestampFormat: TimestampFormat;
-  mode?: "sheet" | "sidebar";
   onClose: () => void;
 }
 

--- a/apps/web/src/hooks/useResizeHandle.ts
+++ b/apps/web/src/hooks/useResizeHandle.ts
@@ -1,0 +1,193 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { createComposerWidthValidator } from "../rightPanelLayout";
+
+interface ResizeState {
+  moved: boolean;
+  pointerId: number;
+  pendingWidth: number;
+  startWidth: number;
+  startX: number;
+  rafId: number | null;
+  width: number;
+}
+
+interface UseResizeHandleOptions {
+  /** CSS custom property on the wrapper element that controls the panel width, e.g. "--plan-sidebar-width" */
+  cssVarName: string;
+  /** localStorage key for persisting the width across sessions */
+  storageKey: string;
+  /** Minimum allowed width in pixels */
+  minWidth: number;
+  /**
+   * When true, any in-progress resize interaction is immediately cancelled and body
+   * styles are cleaned up. Pass `shouldUsePlanSidebarSheet` here so that switching
+   * to sheet mode mid-drag doesn't leave `cursor: col-resize` stuck on document.body.
+   */
+  isDisabled?: boolean;
+}
+
+/**
+ * Encapsulates the pointer-event–based resize interaction for a right-side panel
+ * rendered as a plain flex div (as opposed to the Sidebar component, which uses
+ * position: fixed). Handles RAF-batched width updates, pointer capture, body style
+ * management, click suppression, and localStorage persistence.
+ */
+export function useResizeHandle({
+  cssVarName,
+  storageKey,
+  minWidth,
+  isDisabled = false,
+}: UseResizeHandleOptions) {
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const handleRef = useRef<HTMLButtonElement>(null);
+  const suppressClickRef = useRef(false);
+  const resizeStateRef = useRef<ResizeState | null>(null);
+
+  // Stable width validator — uses the same DOM-measurement logic as shouldAcceptInlineSidebarWidth
+  const shouldAcceptWidth = useMemo(() => createComposerWidthValidator(cssVarName), [cssVarName]);
+
+  const stop = useCallback(
+    (pointerId: number) => {
+      const state = resizeStateRef.current;
+      if (!state) return;
+      if (state.rafId !== null) cancelAnimationFrame(state.rafId);
+      if (Number.isFinite(state.width)) {
+        localStorage.setItem(storageKey, String(state.width));
+      }
+      resizeStateRef.current = null;
+      if (handleRef.current?.hasPointerCapture(pointerId)) {
+        handleRef.current.releasePointerCapture(pointerId);
+      }
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+    },
+    [storageKey],
+  );
+
+  // When the panel switches to sheet mode mid-drag, clean up body styles immediately.
+  // Without this, removing the drag handle from the DOM before onPointerUp fires leaves
+  // cursor: col-resize and user-select: none stuck until ChatView unmounts.
+  useEffect(() => {
+    if (!isDisabled) return;
+    const state = resizeStateRef.current;
+    if (!state) return;
+    stop(state.pointerId);
+  }, [isDisabled, stop]);
+
+  // Unmount cleanup
+  useEffect(() => {
+    return () => {
+      const state = resizeStateRef.current;
+      if (state?.rafId != null) cancelAnimationFrame(state.rafId);
+      document.body.style.removeProperty("cursor");
+      document.body.style.removeProperty("user-select");
+    };
+  }, []);
+
+  /**
+   * Callback ref for the wrapper element.
+   * - On mount: restores the persisted width from localStorage, validated through
+   *   `shouldAcceptWidth` so a stale value can't squeeze the composer below its
+   *   minimum usable width (e.g. if the viewport is narrower than when it was saved).
+   * - On unmount (node === null): cancels any active resize and clears body styles,
+   *   covering the case where `planSidebarOpen` flips to false programmatically
+   *   mid-drag (e.g. auto-close from plan state changes).
+   */
+  const setWrapperRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      (wrapperRef as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      if (!node) {
+        const state = resizeStateRef.current;
+        if (state) stop(state.pointerId);
+        return;
+      }
+      const stored = localStorage.getItem(storageKey);
+      if (!stored) return;
+      const parsed = Number(stored);
+      if (!Number.isFinite(parsed) || parsed < minWidth) return;
+      // Validate against current viewport/composer constraints before restoring.
+      // shouldAcceptWidth temporarily sets the CSS var to measure then restores it,
+      // so it's safe to call before we've applied the value ourselves.
+      if (!shouldAcceptWidth({ nextWidth: parsed, wrapper: node })) return;
+      node.style.setProperty(cssVarName, `${parsed}px`);
+    },
+    [cssVarName, storageKey, minWidth, stop, shouldAcceptWidth],
+  );
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      if (e.button !== 0) return;
+      const wrapper = wrapperRef.current;
+      if (!wrapper) return;
+      const startWidth = wrapper.getBoundingClientRect().width;
+      const clamped = Math.max(minWidth, startWidth);
+      wrapper.style.setProperty(cssVarName, `${clamped}px`);
+      e.preventDefault();
+      e.stopPropagation();
+      e.currentTarget.setPointerCapture(e.pointerId);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+      resizeStateRef.current = {
+        moved: false,
+        pointerId: e.pointerId,
+        pendingWidth: clamped,
+        startWidth: clamped,
+        startX: e.clientX,
+        rafId: null,
+        width: clamped,
+      };
+    },
+    [cssVarName, minWidth],
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      const state = resizeStateRef.current;
+      if (!state || state.pointerId !== e.pointerId) return;
+      e.preventDefault();
+      // Right-side panel: dragging left (decreasing clientX) makes it wider
+      const delta = state.startX - e.clientX;
+      if (Math.abs(delta) > 2) state.moved = true;
+      state.pendingWidth = Math.max(minWidth, state.startWidth + delta);
+      if (state.rafId !== null) return;
+      state.rafId = requestAnimationFrame(() => {
+        const s = resizeStateRef.current;
+        const wrapper = wrapperRef.current;
+        if (!s || !wrapper) return;
+        s.rafId = null;
+        const nextWidth = s.pendingWidth;
+        if (!shouldAcceptWidth({ nextWidth, wrapper })) return;
+        wrapper.style.setProperty(cssVarName, `${nextWidth}px`);
+        s.width = nextWidth;
+      });
+    },
+    [cssVarName, minWidth, shouldAcceptWidth],
+  );
+
+  const onPointerUp = useCallback(
+    (e: React.PointerEvent<HTMLButtonElement>) => {
+      const state = resizeStateRef.current;
+      if (!state || state.pointerId !== e.pointerId) return;
+      e.preventDefault();
+      suppressClickRef.current = state.moved;
+      stop(e.pointerId);
+    },
+    [stop],
+  );
+
+  const onClick = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
+    if (suppressClickRef.current) {
+      suppressClickRef.current = false;
+      e.preventDefault();
+    }
+  }, []);
+
+  return {
+    handleRef,
+    setWrapperRef,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onClick,
+  };
+}

--- a/apps/web/src/rightPanelLayout.ts
+++ b/apps/web/src/rightPanelLayout.ts
@@ -1,3 +1,58 @@
 export const RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY = "(max-width: 980px)";
 export const RIGHT_PANEL_SHEET_CLASS_NAME =
   "w-[min(42vw,28rem)] min-w-80 max-w-[28rem] p-0 max-[760px]:w-[min(88vw,24rem)] max-[760px]:min-w-0 wco:mt-[env(titlebar-area-height)] wco:h-[calc(100%-env(titlebar-area-height))] wco:max-h-[calc(100%-env(titlebar-area-height))]";
+
+export const PLAN_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_plan_sidebar_width";
+export const PLAN_INLINE_DEFAULT_WIDTH = "clamp(20rem,30vw,28rem)";
+export const PLAN_INLINE_SIDEBAR_MIN_WIDTH = 20 * 16; // 320px
+
+export const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
+
+/**
+ * Returns a width-acceptance validator that checks whether applying `nextWidth`
+ * to `cssVarName` on the wrapper element would cause the chat composer to overflow
+ * or drop below its minimum usable width.
+ *
+ * Used by both the diff panel (--sidebar-width) and plan panel (--plan-sidebar-width).
+ */
+export function createComposerWidthValidator(cssVarName: string) {
+  return ({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }): boolean => {
+    const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
+    if (!composerForm) return true;
+    const composerViewport = composerForm.parentElement;
+    if (!composerViewport) return true;
+    const previousWidth = wrapper.style.getPropertyValue(cssVarName);
+    wrapper.style.setProperty(cssVarName, `${nextWidth}px`);
+    const viewportStyle = window.getComputedStyle(composerViewport);
+    const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
+    const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
+    const viewportContentWidth = Math.max(
+      0,
+      composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
+    );
+    const formRect = composerForm.getBoundingClientRect();
+    const composerFooter = composerForm.querySelector<HTMLElement>(
+      "[data-chat-composer-footer='true']",
+    );
+    const composerRightActions = composerForm.querySelector<HTMLElement>(
+      "[data-chat-composer-actions='right']",
+    );
+    const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
+    const composerFooterGap = composerFooter
+      ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
+        Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
+        0
+      : 0;
+    const minimumComposerWidth =
+      COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
+    const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
+    const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
+    const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
+    if (previousWidth.length > 0) {
+      wrapper.style.setProperty(cssVarName, previousWidth);
+    } else {
+      wrapper.style.removeProperty(cssVarName);
+    }
+    return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
+  };
+}

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -17,7 +17,10 @@ import {
   stripDiffSearchParams,
 } from "../diffRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
-import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
+import {
+  RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY,
+  createComposerWidthValidator,
+} from "../rightPanelLayout";
 import { selectEnvironmentState, selectThreadExistsByRef, useStore } from "../store";
 import { createThreadSelectorByRef } from "../storeSelectors";
 import { resolveThreadRouteRef, buildThreadRouteParams } from "../threadRoutes";
@@ -29,7 +32,6 @@ const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
 const DIFF_INLINE_DEFAULT_WIDTH = "clamp(24rem,34vw,36rem)";
 const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 22 * 16;
 const DIFF_INLINE_SIDEBAR_MAX_WIDTH = 256 * 16;
-const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
 
 const DiffLoadingFallback = (props: { mode: DiffPanelMode }) => {
   return (
@@ -66,49 +68,8 @@ const DiffPanelInlineSidebar = (props: {
     },
     [onCloseDiff, onOpenDiff],
   );
-  const shouldAcceptInlineSidebarWidth = useCallback(
-    ({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }) => {
-      const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
-      if (!composerForm) return true;
-      const composerViewport = composerForm.parentElement;
-      if (!composerViewport) return true;
-      const previousSidebarWidth = wrapper.style.getPropertyValue("--sidebar-width");
-      wrapper.style.setProperty("--sidebar-width", `${nextWidth}px`);
-
-      const viewportStyle = window.getComputedStyle(composerViewport);
-      const viewportPaddingLeft = Number.parseFloat(viewportStyle.paddingLeft) || 0;
-      const viewportPaddingRight = Number.parseFloat(viewportStyle.paddingRight) || 0;
-      const viewportContentWidth = Math.max(
-        0,
-        composerViewport.clientWidth - viewportPaddingLeft - viewportPaddingRight,
-      );
-      const formRect = composerForm.getBoundingClientRect();
-      const composerFooter = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-footer='true']",
-      );
-      const composerRightActions = composerForm.querySelector<HTMLElement>(
-        "[data-chat-composer-actions='right']",
-      );
-      const composerRightActionsWidth = composerRightActions?.getBoundingClientRect().width ?? 0;
-      const composerFooterGap = composerFooter
-        ? Number.parseFloat(window.getComputedStyle(composerFooter).columnGap) ||
-          Number.parseFloat(window.getComputedStyle(composerFooter).gap) ||
-          0
-        : 0;
-      const minimumComposerWidth =
-        COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX + composerRightActionsWidth + composerFooterGap;
-      const hasComposerOverflow = composerForm.scrollWidth > composerForm.clientWidth + 0.5;
-      const overflowsViewport = formRect.width > viewportContentWidth + 0.5;
-      const violatesMinimumComposerWidth = composerForm.clientWidth + 0.5 < minimumComposerWidth;
-
-      if (previousSidebarWidth.length > 0) {
-        wrapper.style.setProperty("--sidebar-width", previousSidebarWidth);
-      } else {
-        wrapper.style.removeProperty("--sidebar-width");
-      }
-
-      return !hasComposerOverflow && !overflowsViewport && !violatesMinimumComposerWidth;
-    },
+  const shouldAcceptInlineSidebarWidth = useMemo(
+    () => createComposerWidthValidator("--sidebar-width"),
     [],
   );
 


### PR DESCRIPTION
## What Changed

The plan sidebar panel was rendered as a plain \`<div>\` with a hardcoded \`w-[340px]\` width inside \`ChatView\`. It could not be resized by the user.

This PR adds drag-to-resize support, a max-width constraint, and localStorage width persistence — matching the behavior already present on the diff panel.

Changes across 5 files:

- **\`rightPanelLayout.ts\`** — adds \`PLAN_INLINE_*\` constants, \`COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX\`, and \`createComposerWidthValidator(cssVarName)\` factory (shared by both panels)
- **\`PlanSidebar.tsx\`** — removes hardcoded \`w-[340px] shrink-0 border-l\`; width/border controlled by the parent wrapper
- **\`hooks/useResizeHandle.ts\`** — new hook encapsulating pointer capture, RAF-batched width updates, body style management, click suppression, localStorage persistence with viewport-aware restore validation, and three cleanup paths: (1) \`isDisabled\` effect for sheet-mode flip mid-drag, (2) \`setWrapperRef(null)\` for programmatic sidebar close mid-drag, (3) React unmount effect; uses \`useMemo\` for the width validator
- **\`ChatView.tsx\`** — replaces ~90 lines of inline resize logic with \`useResizeHandle({ cssVarName, storageKey, minWidth, isDisabled: shouldUsePlanSidebarSheet })\`
- **\`routes/_chat.$environmentId.$threadId.tsx\`** — removes duplicate \`COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX\` constant; replaces \`shouldAcceptInlineSidebarWidth\` inline body with \`useMemo(() => createComposerWidthValidator("--sidebar-width"), [])\`

**Why a plain div instead of \`SidebarProvider > Sidebar\`?**

The \`Sidebar\` component uses \`position: fixed; right: 0; z-10\` hardcoded in its JSX. When both the diff and plan panels are open simultaneously, two \`fixed\` elements at \`right: 0\` overlap. The plain flex div stays in normal document flow — it renders to the left of the diff panel's fixed container with no overlap.

Default width: \`clamp(20rem, 30vw, 28rem)\` (~340px). Minimum: 320px. The \`shouldAcceptWidth\` validator rejects resize attempts that would overflow the chat composer or drop it below its minimum usable width — same behaviour as the diff panel. Width persists under \`localStorage\` key \`chat_plan_sidebar_width\`. Sheet/mobile behaviour (≤1180px) is unchanged.

## Why

The diff panel has had resize support since it was introduced. The plan sidebar did not, despite being the same visual pattern. Users working with large plans benefit from being able to widen the panel to read content without scrolling.

## UI Changes

https://github.com/user-attachments/assets/c6ef0974-d67e-4b06-bdbf-9631b7e5765d

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make plan sidebar resizable with persisted width like the diff panel
> - Adds a drag handle to the inline plan sidebar in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/2598/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e), backed by a new [`useResizeHandle`](https://github.com/pingdotgg/t3code/pull/2598/files#diff-e21138618dfc23327cdf88dbd993d3d3868486b0188cf8624395bae5425f6bac) hook that manages pointer capture, RAF-batched width updates, and localStorage persistence.
> - Introduces `createComposerWidthValidator` in [rightPanelLayout.ts](https://github.com/pingdotgg/t3code/pull/2598/files#diff-708fdc0ae5eca767bd4d07ad37720a4c0a1287dde3097a011c305727b6f7c9b1) as a shared utility that validates proposed panel widths by checking for composer overflow; the diff panel's inline sidebar now uses this instead of its own inline implementation.
> - Removes the `mode` prop from `PlanSidebar`, which now fills its parent container and relies on the parent wrapper for sizing and borders.
> - Resizing is disabled when the sheet layout is active, and width is constrained by `PLAN_INLINE_SIDEBAR_MIN_WIDTH`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b79313.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new pointer-driven resize/persist behavior for the plan sidebar and refactors shared layout validation used by both plan and diff panels; bugs here could impact composer layout or leave interaction styles stuck during mode switches.
> 
> **Overview**
> **Plan sidebar can now be resized in inline mode.** `ChatView` wraps `PlanSidebar` in a width-controlled container (`--plan-sidebar-width`) with a left-edge drag handle, persists width to `localStorage`, and enforces a minimum width while keeping sheet/mobile behavior unchanged.
> 
> **Resize/validation logic is centralized.** Adds `useResizeHandle` to encapsulate pointer capture + RAF updates + cleanup, and introduces `createComposerWidthValidator` (plus plan sizing constants) in `rightPanelLayout.ts`; the diff panel route switches to this shared validator and `PlanSidebar` drops its hardcoded width/border so the parent controls sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b793137d3d8b7ca24fd56c48ef68caa64da7292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->