### PR TITLE
[codex] Fix Windows release signing setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,62 @@ jobs:
                exit $code
              }
 
+      - name: Prepare Azure Trusted Signing
+        if: matrix.platform == 'win'
+        shell: pwsh
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_TRUSTED_SIGNING_ENDPOINT: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          AZURE_TRUSTED_SIGNING_ACCOUNT_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          AZURE_TRUSTED_SIGNING_PUBLISHER_NAME: ${{ secrets.AZURE_TRUSTED_SIGNING_PUBLISHER_NAME }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $requiredSecrets = @(
+            $env:AZURE_TENANT_ID,
+            $env:AZURE_CLIENT_ID,
+            $env:AZURE_CLIENT_SECRET,
+            $env:AZURE_TRUSTED_SIGNING_ENDPOINT,
+            $env:AZURE_TRUSTED_SIGNING_ACCOUNT_NAME,
+            $env:AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME,
+            $env:AZURE_TRUSTED_SIGNING_PUBLISHER_NAME
+          )
+          if ($requiredSecrets | Where-Object { [string]::IsNullOrWhiteSpace($_) }) {
+            Write-Host "Azure Trusted Signing disabled; skipping TrustedSigning module preparation."
+            exit 0
+          }
+
+          Install-PackageProvider `
+            -Name NuGet `
+            -MinimumVersion 2.8.5.201 `
+            -Force `
+            -Scope CurrentUser
+
+          Install-Module `
+            -Name TrustedSigning `
+            -MinimumVersion 0.5.0 `
+            -Force `
+            -AllowClobber `
+            -Repository PSGallery `
+            -Scope CurrentUser
+
+          Import-Module TrustedSigning -MinimumVersion 0.5.0 -Force
+          Get-Command Invoke-TrustedSigning -ErrorAction Stop
+
+          $moduleRoots = @(
+            [System.IO.Path]::Combine([Environment]::GetFolderPath("MyDocuments"), "PowerShell", "Modules"),
+            [System.IO.Path]::Combine([Environment]::GetFolderPath("MyDocuments"), "WindowsPowerShell", "Modules"),
+            [System.IO.Path]::Combine($env:ProgramFiles, "PowerShell", "Modules"),
+            [System.IO.Path]::Combine($env:ProgramFiles, "WindowsPowerShell", "Modules")
+          )
+          $modulePathEntries = @($moduleRoots + ($env:PSModulePath -split ";")) |
+            Where-Object { $_ -and (Test-Path $_) } |
+            Select-Object -Unique
+          "PSModulePath=$($modulePathEntries -join ';')" >> $env:GITHUB_ENV
+
       - name: Build desktop artifact
         shell: bash
         env:


### PR DESCRIPTION
## Summary

This adds an explicit Windows release preparation step for Azure Trusted Signing before `electron-builder` runs.

The failed release was reaching Windows packaging, then failing during code signing because `pwsh -NoProfile` could not resolve `Invoke-TrustedSigning`. The new step only runs when the Azure signing secrets are present, installs and imports the `TrustedSigning` PowerShell module, verifies the cmdlet is available, and persists a known-good `PSModulePath` for the later `electron-builder` signing invocation.

## Validation

- `bun fmt`
- `bun lint` (existing warnings only)
- `bun typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Windows release signing setup by conditionally installing the TrustedSigning PowerShell module
> Adds a 'Prepare Azure Trusted Signing' step to the Windows matrix runs in [release.yml](.github/workflows/release.yml). If all required Azure secrets (tenant, client, secret, endpoint, account name, certificate profile, publisher name) are present, it installs the `TrustedSigning` PowerShell module (≥0.5.0), verifies `Invoke-TrustedSigning` is available, and updates `PSModulePath` in `GITHUB_ENV`. If any secret is missing, the step logs that Trusted Signing is disabled and exits cleanly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b39546c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Windows release/signing workflow and installs PowerShell modules at runtime; failures here can block publishing or alter signing behavior, though it’s gated on required secrets being present.
> 
> **Overview**
> Fixes Windows release signing in `release.yml` by adding a **Windows-only “Prepare Azure Trusted Signing” step** before the desktop build.
> 
> When all Azure signing secrets are present, the workflow installs/imports the `TrustedSigning` PowerShell module (and NuGet provider), verifies `Invoke-TrustedSigning` is available, and persists an explicit `PSModulePath` via `GITHUB_ENV`; otherwise it cleanly skips signing preparation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b39546c1dcf0d330054da7c1f8f6ed93ab29daca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->