### PR TITLE
[codex] Handle NuGet provider bootstrap failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,11 +272,16 @@ jobs:
             exit 0
           }
 
-          Install-PackageProvider `
-            -Name NuGet `
-            -MinimumVersion 2.8.5.201 `
-            -Force `
-            -Scope CurrentUser
+          try {
+            Install-PackageProvider `
+              -Name NuGet `
+              -MinimumVersion 2.8.5.201 `
+              -Force `
+              -Scope CurrentUser `
+              -ErrorAction Stop
+          } catch {
+            Write-Warning "Could not bootstrap NuGet package provider. Continuing because the runner may already have a usable provider. $($_.Exception.Message)"
+          }
 
           Install-Module `
             -Name TrustedSigning `
@@ -284,7 +289,8 @@ jobs:
             -Force `
             -AllowClobber `
             -Repository PSGallery `
-            -Scope CurrentUser
+            -Scope CurrentUser `
+            -ErrorAction Stop
 
           Import-Module TrustedSigning -MinimumVersion 0.5.0 -Force
           Get-Command Invoke-TrustedSigning -ErrorAction Stop


### PR DESCRIPTION
## Summary

Follow-up to #2606. The latest scheduled release failed earlier in the new `Prepare Azure Trusted Signing` step because `Install-PackageProvider NuGet` returned a provider lookup error on the Windows runner.

`electron-builder` treats that NuGet bootstrap as best-effort and continues because the runner may already have a usable provider. This change mirrors that behavior: NuGet provider bootstrap failures now warn and continue, while `Install-Module TrustedSigning` and `Get-Command Invoke-TrustedSigning` remain strict.

## Validation

- `bun fmt`
- `bun lint` (existing warnings only)
- `bun typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle NuGet provider bootstrap failures in the release signing workflow
> Wraps `Install-PackageProvider` in a try/catch with `-ErrorAction Stop` in [release.yml](.github/workflows/release.yml) so that failures emit a warning and allow the step to continue. `Install-Module TrustedSigning` retains `-ErrorAction Stop` so it still fails the step if the module cannot be installed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8eb97d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Windows release-signing workflow behavior, which could impact release pipelines if the NuGet provider is actually required on a runner. Scope is small and keeps module installation/command validation strict.
> 
> **Overview**
> Improves resilience of the Windows "Prepare Azure Trusted Signing" step in `release.yml` by treating `Install-PackageProvider NuGet` as *best-effort*: it now runs with `-ErrorAction Stop` inside a `try/catch`, logging a warning and continuing on failure.
> 
> Keeps the rest of the signing setup strict by adding `-ErrorAction Stop` to `Install-Module TrustedSigning`, so the workflow still fails if the TrustedSigning module cannot be installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb97d7cb12404fe94506982b158b17c029d9cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->