### PR TITLE
[codex] Fix Vercel release web deploy scope

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -634,10 +634,8 @@ jobs:
             channel_name="nightly"
           fi
 
-          vercel_scope_args=()
-          if [[ -n "${VERCEL_TEAM_SLUG:-}" ]]; then
-            vercel_scope_args=(--scope "$VERCEL_TEAM_SLUG")
-          fi
+          vercel_scope="${VERCEL_TEAM_SLUG:-$VERCEL_ORG_ID}"
+          vercel_scope_args=(--scope "$vercel_scope")
 
           echo "Deploying hosted web app for $channel_name channel."
           deployment_url="$(

--- a/docs/release.md
+++ b/docs/release.md
@@ -44,7 +44,7 @@ Required GitHub Actions secrets:
 
 Optional GitHub Actions variables:
 
-- `VERCEL_TEAM_SLUG`: required only if the token needs an explicit Vercel team scope.
+- `VERCEL_TEAM_SLUG`: overrides the Vercel CLI scope when the team slug is preferred over the `VERCEL_ORG_ID` secret.
 - `T3CODE_WEB_ROUTER_URL`: defaults to `https://app.t3.codes`.
 - `T3CODE_WEB_LATEST_DOMAIN`: defaults to `latest.app.t3.codes`.
 - `T3CODE_WEB_NIGHTLY_DOMAIN`: defaults to `nightly.app.t3.codes`.


### PR DESCRIPTION
## What changed

- Always pass an explicit Vercel CLI scope in the release workflow's hosted web deploy job.
- Use `VERCEL_TEAM_SLUG` when provided, otherwise fall back to the required `VERCEL_ORG_ID` secret.
- Update release docs to describe the new scope behavior.

## Why

The scheduled release run deployed the hosted web app successfully, but failed when aliasing `nightly.app.t3.codes`. Because `VERCEL_TEAM_SLUG` was empty, the Vercel CLI used the default personal scope and rejected the alias operation as unauthorized.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run release:smoke`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Vercel web deploy scope to fall back to `VERCEL_ORG_ID` when `VERCEL_TEAM_SLUG` is unset
> The `--scope` flag is now always passed to the Vercel CLI in [release.yml](.github/workflows/release.yml), using `VERCEL_TEAM_SLUG` if set, otherwise falling back to `VERCEL_ORG_ID`. Previously, no scope was passed when `VERCEL_TEAM_SLUG` was unset, which could cause deploys to target the wrong project. The `VERCEL_TEAM_SLUG` description in [release.md](docs/release.md) is updated to reflect its role as an override rather than a required variable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d0ba1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the release workflow’s Vercel deployment/aliasing steps; a wrong scope value could break production deploys or aliases, but the change is small and localized.
> 
> **Overview**
> Ensures the release workflow *always* passes an explicit Vercel CLI `--scope` when deploying and aliasing the hosted web app, using `VERCEL_TEAM_SLUG` when set and falling back to `VERCEL_ORG_ID` otherwise.
> 
> Updates the release docs to clarify `VERCEL_TEAM_SLUG` is an optional override for the default org scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d0ba1fad37758e2a66f1465dfc4fd0c50810818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->