### PR TITLE
[codex] Fix hosted channel bootstrap

### DIFF
--- a/apps/web/src/hostedPairing.test.ts
+++ b/apps/web/src/hostedPairing.test.ts
@@ -79,4 +79,16 @@ describe("hostedPairing", () => {
     vi.stubEnv("VITE_HTTP_URL", "https://backend.example.com");
     expect(isHostedStaticApp(new URL("https://preview.t3.codes/"))).toBe(false);
   });
+
+  it("detects hosted channel aliases as static apps", () => {
+    vi.stubEnv("VITE_HOSTED_APP_URL", "https://app.t3.codes");
+    vi.stubEnv("VITE_HOSTED_APP_CHANNEL", "nightly");
+    vi.stubEnv("VITE_HTTP_URL", "");
+    vi.stubEnv("VITE_WS_URL", "");
+
+    expect(isHostedStaticApp(new URL("https://nightly.app.t3.codes/"))).toBe(true);
+
+    vi.stubEnv("VITE_HTTP_URL", "https://backend.example.com");
+    expect(isHostedStaticApp(new URL("https://nightly.app.t3.codes/"))).toBe(false);
+  });
 });

--- a/apps/web/src/hostedPairing.ts
+++ b/apps/web/src/hostedPairing.ts
@@ -18,6 +18,11 @@ function configuredBackendUrl(): string {
   return import.meta.env.VITE_HTTP_URL?.trim() || import.meta.env.VITE_WS_URL?.trim() || "";
 }
 
+function configuredHostedAppChannel(): HostedAppChannel | null {
+  const channel = import.meta.env.VITE_HOSTED_APP_CHANNEL?.trim().toLowerCase();
+  return channel === "latest" || channel === "nightly" ? channel : null;
+}
+
 function originFromUrl(value: string): string | null {
   try {
     return new URL(value).origin;
@@ -29,6 +34,10 @@ function originFromUrl(value: string): string | null {
 export function isHostedStaticApp(url: URL = new URL(window.location.href)): boolean {
   if (configuredBackendUrl()) {
     return false;
+  }
+
+  if (configuredHostedAppChannel()) {
+    return true;
   }
 
   const hostedOrigin = originFromUrl(configuredHostedAppUrl());

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -18,7 +18,7 @@ function channelCookie(channel: "latest" | "nightly"): string {
 
 export const config: VercelConfig = {
   buildCommand:
-    "turbo build --filter @t3tools/web && bun ../../scripts/apply-web-brand-assets.ts production",
+    'turbo build --filter @t3tools/web && bun ../../scripts/apply-web-brand-assets.ts --channel "${VITE_HOSTED_APP_CHANNEL:-latest}"',
   git: {
     deploymentEnabled: false,
   },

--- a/scripts/apply-web-brand-assets.ts
+++ b/scripts/apply-web-brand-assets.ts
@@ -6,11 +6,17 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
-import { Argument, Command } from "effect/unstable/cli";
-import { resolveWebIconOverrides, type WebAssetBrand } from "./lib/brand-assets.ts";
+import { Argument, Command, Flag } from "effect/unstable/cli";
+import {
+  resolveWebAssetBrandForChannel,
+  resolveWebIconOverrides,
+  WEB_ASSET_CHANNELS,
+  type WebAssetBrand,
+} from "./lib/brand-assets.ts";
 
 const WEB_ASSET_BRANDS = [
   "development",
+  "nightly",
   "production",
 ] as const satisfies ReadonlyArray<WebAssetBrand>;
 
@@ -38,15 +44,25 @@ export const applyWebBrandAssetsCommand = Command.make(
   {
     brand: Argument.choice("brand", WEB_ASSET_BRANDS).pipe(
       Argument.withDescription("Asset brand to copy into the hosted web output directory."),
+      Argument.optional,
+    ),
+    channel: Flag.choice("channel", WEB_ASSET_CHANNELS).pipe(
+      Flag.withDescription("Hosted release channel to map to a web asset brand."),
+      Flag.optional,
     ),
     targetDirectory: Argument.string("target-directory").pipe(
       Argument.withDescription("Output directory that contains the hosted web build assets."),
       Argument.optional,
     ),
   },
-  ({ brand, targetDirectory }) =>
+  ({ brand, channel, targetDirectory }) =>
     applyWebBrandAssets(
-      brand,
+      Option.getOrElse(brand, () =>
+        Option.match(channel, {
+          onNone: () => "production" as const,
+          onSome: resolveWebAssetBrandForChannel,
+        }),
+      ),
       Option.getOrElse(targetDirectory, () => "apps/web/dist"),
     ),
 ).pipe(Command.withDescription("Copy web brand assets into a built hosted web app."));

--- a/scripts/lib/brand-assets.test.ts
+++ b/scripts/lib/brand-assets.test.ts
@@ -4,6 +4,7 @@ import {
   BRAND_ASSET_PATHS,
   DEVELOPMENT_ICON_OVERRIDES,
   PUBLISH_ICON_OVERRIDES,
+  resolveWebAssetBrandForChannel,
   resolveWebIconOverrides,
 } from "./brand-assets.ts";
 
@@ -41,5 +42,17 @@ describe("brand-assets", () => {
       sourceRelativePath: BRAND_ASSET_PATHS.productionWebAppleTouchIconPng,
       targetRelativePath: "apps/web/dist/apple-touch-icon.png",
     });
+  });
+
+  it("maps hosted nightly web assets to nightly icons", () => {
+    expect(resolveWebIconOverrides("nightly", "apps/web/dist")).toContainEqual({
+      sourceRelativePath: BRAND_ASSET_PATHS.nightlyWebFaviconIco,
+      targetRelativePath: "apps/web/dist/favicon.ico",
+    });
+  });
+
+  it("maps hosted release channels to web asset brands", () => {
+    expect(resolveWebAssetBrandForChannel("latest")).toBe("production");
+    expect(resolveWebAssetBrandForChannel("nightly")).toBe("nightly");
   });
 });

--- a/scripts/lib/brand-assets.ts
+++ b/scripts/lib/brand-assets.ts
@@ -10,6 +10,10 @@ export const BRAND_ASSET_PATHS = {
   nightlyMacIconPng: "assets/nightly/blueprint-macos-1024.png",
   nightlyLinuxIconPng: "assets/nightly/blueprint-universal-1024.png",
   nightlyWindowsIconIco: "assets/nightly/blueprint-windows.ico",
+  nightlyWebFaviconIco: "assets/nightly/blueprint-web-favicon.ico",
+  nightlyWebFavicon16Png: "assets/nightly/blueprint-web-favicon-16x16.png",
+  nightlyWebFavicon32Png: "assets/nightly/blueprint-web-favicon-32x32.png",
+  nightlyWebAppleTouchIconPng: "assets/nightly/blueprint-web-apple-touch-180.png",
 
   developmentDesktopIconPng: "assets/dev/blueprint-macos-1024.png",
   developmentWindowsIconIco: "assets/dev/blueprint-windows.ico",
@@ -19,7 +23,15 @@ export const BRAND_ASSET_PATHS = {
   developmentWebAppleTouchIconPng: "assets/dev/blueprint-web-apple-touch-180.png",
 } as const;
 
-export type WebAssetBrand = "development" | "production";
+export type WebAssetBrand = "development" | "nightly" | "production";
+
+export const WEB_ASSET_CHANNELS = ["latest", "nightly"] as const;
+
+export type WebAssetChannel = (typeof WEB_ASSET_CHANNELS)[number];
+
+export function resolveWebAssetBrandForChannel(channel: WebAssetChannel): WebAssetBrand {
+  return channel === "nightly" ? "nightly" : "production";
+}
 
 export interface IconOverride {
   readonly sourceRelativePath: string;
@@ -39,6 +51,12 @@ const WEB_ICON_SOURCE_PATHS_BY_BRAND = {
     favicon16Png: BRAND_ASSET_PATHS.developmentWebFavicon16Png,
     favicon32Png: BRAND_ASSET_PATHS.developmentWebFavicon32Png,
     appleTouchIconPng: BRAND_ASSET_PATHS.developmentWebAppleTouchIconPng,
+  },
+  nightly: {
+    faviconIco: BRAND_ASSET_PATHS.nightlyWebFaviconIco,
+    favicon16Png: BRAND_ASSET_PATHS.nightlyWebFavicon16Png,
+    favicon32Png: BRAND_ASSET_PATHS.nightlyWebFavicon32Png,
+    appleTouchIconPng: BRAND_ASSET_PATHS.nightlyWebAppleTouchIconPng,
   },
   production: {
     faviconIco: BRAND_ASSET_PATHS.productionWebFaviconIco,


### PR DESCRIPTION
## What changed

- Treat release builds with `VITE_HOSTED_APP_CHANNEL=latest|nightly` as hosted static apps when no backend URL is configured.
- Add coverage for direct channel aliases such as `https://nightly.app.t3.codes`.

## Why

The hosted-static guard only recognized the router origin from `VITE_HOSTED_APP_URL` (`https://app.t3.codes`). Direct channel aliases like `nightly.app.t3.codes` fell through to the primary/local environment bootstrap path, which fetched `/.well-known/t3/environment` from Vercel. Vercel served `index.html`, and the client tried to parse it as JSON, causing `Unexpected token '<', "<!doctype"... is not valid JSON`.

## Validation

- `bun --filter=@t3tools/web run test -- hostedPairing.test.ts`
- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run release:smoke`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix hosted channel bootstrap to support nightly and latest release channels
> - Adds `configuredHostedAppChannel` in [hostedPairing.ts](https://github.com/pingdotgg/t3code/pull/2613/files#diff-f791c48c17f96ca81a039bf7675078f1327912cc3498bbc304fcc289408524ea) to read `VITE_HOSTED_APP_CHANNEL` from env; returns `"latest"` or `"nightly"` if set, otherwise `null`.
> - Updates `isHostedStaticApp` to return `true` when a valid hosted channel is configured and no backend URL is set, instead of relying solely on URL origin matching.
> - Introduces `resolveWebAssetBrandForChannel` in [brand-assets.ts](https://github.com/pingdotgg/t3code/pull/2613/files#diff-b73b620b017c1a849abeae456edae96b0683ad451284af25dbc3295f01a8f0af) mapping `"nightly"` → `"nightly"` brand and `"latest"` → `"production"`, with nightly-specific favicon and icon paths.
> - Updates the Vercel build command in [vercel.ts](https://github.com/pingdotgg/t3code/pull/2613/files#diff-1a4d1119041bfb6fb5a4ce82060d10113bf5a2236b3c00ff3e2df8f83ae5de88) to pass `--channel` (defaulting to `"latest"`) to `apply-web-brand-assets`, so the correct brand assets are applied per channel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0422aff.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hosted/static bootstrap decision and Vercel build-time asset selection, which could affect how hosted deployments initialize and display branding across channels. Scope is limited and covered by new unit tests for channel alias handling and asset mapping.
> 
> **Overview**
> Fixes hosted-static detection to treat builds with `VITE_HOSTED_APP_CHANNEL` (`latest`/`nightly`) as hosted static apps when no backend URL is configured, so channel alias domains (e.g. `nightly.app.t3.codes`) don’t fall into the primary/local bootstrap path.
> 
> Updates the Vercel build to pass the release channel into `apply-web-brand-assets`, expands branding assets to include a `nightly` web icon set, and adds tests for the new channel-to-brand mapping and nightly icon overrides.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0422affb375d92af65c915a2f1fb02ee2fa0aed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->