### PR TITLE
fix(codex): use longer and shared auth probe timeout for provider status check

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -22,13 +22,16 @@ import type {
 import { ServerSettingsError } from "@t3tools/contracts";
 
 import { createModelCapabilities } from "@t3tools/shared/model";
-import { buildServerProvider, type ServerProviderDraft } from "../providerSnapshot.ts";
+import {
+  AUTH_PROBE_TIMEOUT_MS,
+  buildServerProvider,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import { scopedSafeTeardown } from "./scopedSafeTeardown.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
 
-const PROVIDER_PROBE_TIMEOUT_MS = 8_000;
 const CODEX_PRESENTATION = {
   displayName: "Codex",
   showInteractionModeToggle: true,
@@ -447,7 +450,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     cwd: process.cwd(),
     customModels: codexSettings.customModels,
     environment,
-  }).pipe(Effect.timeoutOption(Duration.millis(PROVIDER_PROBE_TIMEOUT_MS)), Effect.result);
+  }).pipe(Effect.timeoutOption(Duration.millis(AUTH_PROBE_TIMEOUT_MS)), Effect.result);
 
   if (Result.isFailure(probeResult)) {
     const error = probeResult.failure;


### PR DESCRIPTION
## What Changed

Align Codex provider probe timeout with shared auth probe timeout by switching to AUTH_PROBE_TIMEOUT_MS (10s) in CodexProvider.

## Why

Prevent flaky false-error provider status on slower startup/auth checks (especially Windows), matching the robustness already applied to Claude.

Error Fixed:
<img width="1482" height="277" alt="image" src="https://github.com/user-attachments/assets/3df7e0ed-ac2c-4b28-b072-89a14dcb9062" />

<img width="1113" height="178" alt="image" src="https://github.com/user-attachments/assets/b739baad-73b5-47ce-8c22-afae04c21451" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the Codex provider probe timeout from a local 8s value to the shared `AUTH_PROBE_TIMEOUT_MS` (10s), affecting how long status checks wait before timing out.
> 
> **Overview**
> Codex provider status checks now use the shared `AUTH_PROBE_TIMEOUT_MS` timeout (imported from `providerSnapshot.ts`) instead of a local 8s constant.
> 
> This aligns Codex probe behavior with other providers and reduces false error states on slower startup/auth checks by allowing a longer window before reporting a timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c6c28d6fc529734726679fb0d0e73f2a241d98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use shared `AUTH_PROBE_TIMEOUT_MS` constant in `checkCodexProviderStatus` probe timeout
> Replaces the local `PROVIDER_PROBE_TIMEOUT_MS` constant in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/2616/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) with the shared `AUTH_PROBE_TIMEOUT_MS` imported from `providerSnapshot`, aligning the Codex provider's probe timeout with the value used elsewhere for auth probes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20c6c28.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->