### PR TITLE
[codex] fix desktop context menu zoom positioning

### DIFF
--- a/apps/desktop/src/contextMenuPosition.test.ts
+++ b/apps/desktop/src/contextMenuPosition.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { scaleContextMenuPositionForElectron } from "./contextMenuPosition.ts";
+
+describe("scaleContextMenuPositionForElectron", () => {
+  it("scales CSS pixel positions by the renderer zoom factor", () => {
+    expect(scaleContextMenuPositionForElectron({ x: 120, y: 80 }, 0.8)).toEqual({
+      x: 96,
+      y: 64,
+    });
+    expect(scaleContextMenuPositionForElectron({ x: 120, y: 80 }, 1.25)).toEqual({
+      x: 150,
+      y: 100,
+    });
+  });
+
+  it("leaves missing positions missing", () => {
+    expect(scaleContextMenuPositionForElectron(undefined, 0.8)).toBeUndefined();
+  });
+
+  it("falls back to unscaled coordinates for invalid zoom factors", () => {
+    expect(scaleContextMenuPositionForElectron({ x: 120, y: 80 }, 0)).toEqual({
+      x: 120,
+      y: 80,
+    });
+    expect(scaleContextMenuPositionForElectron({ x: 120, y: 80 }, Number.NaN)).toEqual({
+      x: 120,
+      y: 80,
+    });
+  });
+});

--- a/apps/desktop/src/contextMenuPosition.ts
+++ b/apps/desktop/src/contextMenuPosition.ts
@@ -1,0 +1,19 @@
+export interface ContextMenuPosition {
+  readonly x: number;
+  readonly y: number;
+}
+
+export function scaleContextMenuPositionForElectron(
+  position: ContextMenuPosition | undefined,
+  zoomFactor: number,
+): ContextMenuPosition | undefined {
+  if (position === undefined) {
+    return undefined;
+  }
+
+  const normalizedZoomFactor = Number.isFinite(zoomFactor) && zoomFactor > 0 ? zoomFactor : 1;
+  return {
+    x: position.x * normalizedZoomFactor,
+    y: position.y * normalizedZoomFactor,
+  };
+}

--- a/apps/desktop/src/desktopZoom.test.ts
+++ b/apps/desktop/src/desktopZoom.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { normalizeDesktopZoomFactor, resolveDesktopZoomCssVariables } from "./desktopZoom.ts";
+
+describe("desktopZoom", () => {
+  it("gradually reduces zoomed-out titlebar leading spacing", () => {
+    expect(resolveDesktopZoomCssVariables(0.8)).toEqual({
+      titlebarHeight: "65px",
+      titlebarLeadingOffset: "106.5px",
+    });
+    expect(resolveDesktopZoomCssVariables(0.6)).toEqual({
+      titlebarHeight: "86.66666666666667px",
+      titlebarLeadingOffset: "136.66666666666669px",
+    });
+  });
+
+  it("keeps a minimum leading offset clear of the traffic lights", () => {
+    expect(resolveDesktopZoomCssVariables(0.4)).toEqual({
+      titlebarHeight: "130px",
+      titlebarLeadingOffset: "205px",
+    });
+  });
+
+  it("compensates titlebar spacing when zoomed in", () => {
+    expect(resolveDesktopZoomCssVariables(1.25)).toEqual({
+      titlebarHeight: "41.6px",
+      titlebarLeadingOffset: "72px",
+    });
+  });
+
+  it("normalizes invalid zoom factors", () => {
+    expect(normalizeDesktopZoomFactor(0)).toBe(1);
+    expect(normalizeDesktopZoomFactor(Number.NaN)).toBe(1);
+    expect(resolveDesktopZoomCssVariables(0)).toEqual({
+      titlebarHeight: "52px",
+      titlebarLeadingOffset: "90px",
+    });
+  });
+});

--- a/apps/desktop/src/desktopZoom.ts
+++ b/apps/desktop/src/desktopZoom.ts
@@ -1,0 +1,30 @@
+export interface DesktopZoomCssVariables {
+  readonly titlebarHeight: string;
+  readonly titlebarLeadingOffset: string;
+}
+
+export const DESKTOP_TITLEBAR_HEIGHT_PX = 52;
+export const DESKTOP_TITLEBAR_LEADING_OFFSET_PX = 90;
+export const DESKTOP_TITLEBAR_MIN_SCREEN_LEADING_OFFSET_PX = 82;
+export const DESKTOP_TITLEBAR_ZOOM_OUT_SCREEN_OFFSET_STEP_PX = 24;
+
+export function normalizeDesktopZoomFactor(zoomFactor: number): number {
+  return Number.isFinite(zoomFactor) && zoomFactor > 0 ? zoomFactor : 1;
+}
+
+export function resolveDesktopZoomCssVariables(zoomFactor: number): DesktopZoomCssVariables {
+  const normalizedZoomFactor = normalizeDesktopZoomFactor(zoomFactor);
+  const screenLeadingOffset =
+    normalizedZoomFactor >= 1
+      ? DESKTOP_TITLEBAR_LEADING_OFFSET_PX
+      : Math.max(
+          DESKTOP_TITLEBAR_MIN_SCREEN_LEADING_OFFSET_PX,
+          DESKTOP_TITLEBAR_LEADING_OFFSET_PX -
+            (1 - normalizedZoomFactor) * DESKTOP_TITLEBAR_ZOOM_OUT_SCREEN_OFFSET_STEP_PX,
+        );
+
+  return {
+    titlebarHeight: `${DESKTOP_TITLEBAR_HEIGHT_PX / normalizedZoomFactor}px`,
+    titlebarLeadingOffset: `${screenLeadingOffset / normalizedZoomFactor}px`,
+  };
+}

--- a/apps/desktop/src/ipc/channels.ts
+++ b/apps/desktop/src/ipc/channels.ts
@@ -10,6 +10,7 @@ export const CLEAR_CLOUD_AUTH_TOKEN_CHANNEL = "desktop:clear-cloud-auth-token";
 export const FETCH_CLOUD_AUTH_CHANNEL = "desktop:fetch-cloud-auth";
 export const CLOUD_AUTH_CALLBACK_CHANNEL = "desktop:cloud-auth-callback";
 export const MENU_ACTION_CHANNEL = "desktop:menu-action";
+export const ZOOM_FACTOR_CHANGED_CHANNEL = "desktop:zoom-factor-changed";
 export const UPDATE_STATE_CHANNEL = "desktop:update-state";
 export const UPDATE_GET_STATE_CHANNEL = "desktop:update-get-state";
 export const UPDATE_SET_CHANNEL_CHANNEL = "desktop:update-set-channel";

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -4,9 +4,57 @@ import type {
   DesktopPreviewRecordingFrame,
   DesktopPreviewTabState,
 } from "@t3tools/contracts";
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webFrame } from "electron";
 
+import { normalizeDesktopZoomFactor, resolveDesktopZoomCssVariables } from "./desktopZoom.ts";
 import * as IpcChannels from "./ipc/channels.ts";
+import { scaleContextMenuPositionForElectron } from "./contextMenuPosition.ts";
+
+let lastAppliedDesktopZoomFactor: number | undefined;
+let pendingDesktopZoomSyncFrame: number | null = null;
+
+function applyDesktopZoomCssVariables(zoomFactor: number) {
+  const normalizedZoomFactor = normalizeDesktopZoomFactor(zoomFactor);
+  if (lastAppliedDesktopZoomFactor === normalizedZoomFactor) {
+    return;
+  }
+  lastAppliedDesktopZoomFactor = normalizedZoomFactor;
+
+  const variables = resolveDesktopZoomCssVariables(normalizedZoomFactor);
+  document.documentElement.style.setProperty("--desktop-zoom-factor", String(normalizedZoomFactor));
+  document.documentElement.style.setProperty("--desktop-titlebar-height", variables.titlebarHeight);
+  document.documentElement.style.setProperty(
+    "--desktop-titlebar-leading-offset",
+    variables.titlebarLeadingOffset,
+  );
+}
+
+function syncDesktopZoomCssVariables() {
+  applyDesktopZoomCssVariables(webFrame.getZoomFactor());
+}
+
+function scheduleDesktopZoomCssVariableSync() {
+  if (pendingDesktopZoomSyncFrame !== null) {
+    return;
+  }
+  pendingDesktopZoomSyncFrame = window.requestAnimationFrame(() => {
+    pendingDesktopZoomSyncFrame = null;
+    syncDesktopZoomCssVariables();
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", syncDesktopZoomCssVariables, { once: true });
+} else {
+  syncDesktopZoomCssVariables();
+}
+window.addEventListener("resize", scheduleDesktopZoomCssVariableSync);
+window.visualViewport?.addEventListener("resize", scheduleDesktopZoomCssVariableSync);
+
+ipcRenderer.on(IpcChannels.ZOOM_FACTOR_CHANGED_CHANNEL, (_event, zoomFactor: unknown) => {
+  if (typeof zoomFactor !== "number") return;
+  applyDesktopZoomCssVariables(zoomFactor);
+});
 
 function unwrapEnsureSshEnvironmentResult(result: unknown) {
   if (
@@ -98,7 +146,9 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   showContextMenu: (items, position) =>
     ipcRenderer.invoke(IpcChannels.CONTEXT_MENU_CHANNEL, {
       items,
-      ...(position === undefined ? {} : { position }),
+      ...(position === undefined
+        ? {}
+        : { position: scaleContextMenuPositionForElectron(position, webFrame.getZoomFactor()) }),
     }),
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
   createCloudAuthRequest: () => ipcRenderer.invoke(IpcChannels.CREATE_CLOUD_AUTH_REQUEST_CHANNEL),

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -55,6 +55,7 @@ function makeFakeBrowserWindow() {
     openDevTools: vi.fn(),
     replaceMisspelling: vi.fn(),
     send: vi.fn(),
+    getZoomFactor: vi.fn(() => 1),
     setWindowOpenHandler: vi.fn(),
   };
 

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -274,6 +274,16 @@ const make = Effect.gen(function* () {
       void runPromise(electronMenu.popupTemplate({ window, template: menuTemplate }));
     });
 
+    const syncZoomCssVariables = () => {
+      if (window.isDestroyed()) return;
+      window.webContents.send(
+        IpcChannels.ZOOM_FACTOR_CHANGED_CHANNEL,
+        window.webContents.getZoomFactor(),
+      );
+    };
+    window.webContents.on("zoom-changed", syncZoomCssVariables);
+    window.webContents.on("did-finish-load", syncZoomCssVariables);
+
     window.webContents.setWindowOpenHandler(({ url }) => {
       if (Option.isSome(ElectronShell.parseSafeExternalUrl(url))) {
         void runPromise(electronShell.openExternal(url));

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -20,7 +20,15 @@ import {
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { autoAnimate } from "@formkit/auto-animate";
-import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  memo,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useShallow } from "zustand/react/shallow";
 import {
   DndContext,
@@ -2555,8 +2563,70 @@ const SidebarChromeHeader = memo(function SidebarChromeHeader({
 }: {
   isElectron: boolean;
 }) {
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const wordmarkRef = useRef<HTMLDivElement | null>(null);
+  const [isWordmarkVisible, setIsWordmarkVisible] = useState(true);
+
+  useLayoutEffect(() => {
+    if (!isElectron) {
+      setIsWordmarkVisible(true);
+      return;
+    }
+
+    const headerElement = headerRef.current;
+    const wordmarkElement = wordmarkRef.current;
+    if (!headerElement || !wordmarkElement) {
+      return;
+    }
+
+    let frame: number | null = null;
+    const updateWordmarkVisibility = () => {
+      frame = null;
+      const style = window.getComputedStyle(headerElement);
+      const availableWidth =
+        headerElement.clientWidth -
+        (Number.parseFloat(style.paddingLeft) || 0) -
+        (Number.parseFloat(style.paddingRight) || 0);
+      const requiredWidth = wordmarkElement.getBoundingClientRect().width;
+      setIsWordmarkVisible(requiredWidth <= availableWidth + 1);
+    };
+
+    const scheduleUpdate = () => {
+      if (frame !== null) {
+        return;
+      }
+      frame = window.requestAnimationFrame(updateWordmarkVisibility);
+    };
+
+    scheduleUpdate();
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            scheduleUpdate();
+          });
+    resizeObserver?.observe(headerElement);
+    resizeObserver?.observe(wordmarkElement);
+    window.addEventListener("resize", scheduleUpdate);
+    window.visualViewport?.addEventListener("resize", scheduleUpdate);
+
+    return () => {
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+      window.visualViewport?.removeEventListener("resize", scheduleUpdate);
+    };
+  }, [isElectron]);
+
   const wordmark = (
-    <div className="flex items-center gap-2">
+    <div
+      ref={wordmarkRef}
+      className={`flex items-center gap-2 ${
+        isWordmarkVisible ? "" : "invisible pointer-events-none"
+      }`}
+    >
       <SidebarTrigger className="shrink-0 md:hidden" />
       <Tooltip>
         <TooltipTrigger
@@ -2584,7 +2654,10 @@ const SidebarChromeHeader = memo(function SidebarChromeHeader({
   );
 
   return isElectron ? (
-    <SidebarHeader className="drag-region h-[52px] flex-row items-center gap-2 px-4 py-0 pl-[90px] wco:h-[env(titlebar-area-height)] wco:pl-[calc(env(titlebar-area-x)+1em)]">
+    <SidebarHeader
+      ref={headerRef}
+      className="drag-region h-[var(--desktop-titlebar-height,52px)] flex-row items-center gap-2 px-4 py-0 pl-[var(--desktop-titlebar-leading-offset,90px)] wco:h-[env(titlebar-area-height)] wco:pl-[calc(env(titlebar-area-x)+1em)]"
+    >
       {wordmark}
     </SidebarHeader>
   ) : (


### PR DESCRIPTION
## What changed

- Scale desktop context menu coordinates by the renderer zoom factor before sending them to Electron's native `Menu.popup` API.
- Make the macOS destructive trash icon explicit theme-aware by generating separate light/dark native image variants and keeping template-image mode enabled.
- Publish Electron zoom into CSS variables so macOS titlebar chrome spacing stays aligned with the native traffic lights under zoom.
- Tune titlebar X spacing in screen space: zoom-in keeps full native clearance, while zoom-out gradually reduces apparent left spacing with an 82px traffic-light-safe floor. Y/titlebar-height compensation remains unchanged.
- Hide the Electron sidebar wordmark only when the measured rendered wordmark no longer fits between the traffic-light clearance and the sidebar rail.
- Removed the polling-based titlebar zoom sync; the renderer now updates from load, resize/visualViewport resize, and the Electron zoom message path with requestAnimationFrame coalescing.
- Added focused tests for context menu zoom math, theme-matched menu icons, and titlebar zoom CSS variable math.

## Why

React mouse events report positions in the web page's zoomed CSS pixel coordinate space, while Electron's native menu popup positioning expects unzoomed window coordinates. When the user zoomed the desktop app out, right-click context menus opened offset from the pointer.

The trash icon also came from a black named native image and did not reliably tint against dark native menus, so the icon now uses Electron's active native theme when the menu template is built.

The sidebar logo/header used a fixed CSS pixel offset to clear the macOS traffic-light buttons. Electron zoom scales that web offset, but the native titlebar buttons do not move. The horizontal titlebar spacing now follows a gentler zoom-out curve so small zoom levels reduce excessive spacing without letting the logo enter the traffic-light area. At very small zoom levels, the wordmark now hides only once its measured rendered width no longer fits in the remaining header slot.

## Validation

- `bun fmt`
- `bun lint` (passed with existing unrelated warnings)
- `bun typecheck`
- `bun run test --filter=@t3tools/desktop -- desktopZoom contextMenuPosition ElectronMenu DesktopWindow`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop context menu zoom positioning and titlebar CSS variable sync
> - Adds `scaleContextMenuPositionForElectron` in [contextMenuPosition.ts](https://github.com/pingdotgg/t3code/pull/2620/files#diff-72f611d9232e67d734dbeded2fdddd0d0c581af895eb4423146a8164091af3f0) to multiply context menu coordinates by the current `webFrame` zoom factor before sending them via IPC, fixing misaligned menus at non-default zoom levels.
> - Adds `resolveDesktopZoomCssVariables` in [desktopZoom.ts](https://github.com/pingdotgg/t3code/pull/2620/files#diff-830b16242c0d46fe1df3c18eb23156efe899761dfe404e98622dee03ac1115a6) to compute zoom-compensated `--desktop-titlebar-height` and `--desktop-titlebar-leading-offset` CSS variables.
> - The [preload](https://github.com/pingdotgg/t3code/pull/2620/files#diff-eae0078d2bf4ac4beed2884f918b2816a97752917390f09980ba2cfad8c42cac) writes these CSS variables on startup, on window/visualViewport resize, and when the main process sends `desktop:zoom-factor-changed` over a new IPC channel.
> - [DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/2620/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) emits `desktop:zoom-factor-changed` with the current zoom factor on `zoom-changed` and `did-finish-load` events.
> - In Electron, the sidebar wordmark is hidden via a `ResizeObserver`/resize listener when the header has insufficient horizontal space.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 412962e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI/preload IPC changes with focused unit tests; no auth, data, or security-sensitive paths.
> 
> **Overview**
> Fixes **misaligned native context menus** when the desktop app is zoomed by scaling popup coordinates from CSS pixels to what Electron expects before IPC (`scaleContextMenuPositionForElectron` in preload).
> 
> Adds **zoom-aware macOS sidebar titlebar layout**: the main process pushes the current zoom factor via `desktop:zoom-factor-changed`; preload sets `--desktop-zoom-factor`, `--desktop-titlebar-height`, and `--desktop-titlebar-leading-offset` (with a gentler zoom-out curve and a traffic-light-safe minimum leading offset). The Electron sidebar header uses those variables instead of fixed `52px` / `90px` padding.
> 
> The **sidebar wordmark** hides (keeps layout space) when measured width no longer fits the header after padding, using `ResizeObserver` and viewport resize coalescing.
> 
> Unit tests cover context-menu scaling and titlebar CSS math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 412962ec464686d85c85fadb8ef9a888c0a56fb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->