### PR TITLE
[codex] support two-digit thread jumps

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -253,6 +253,7 @@ function buildThreadJumpLabelMap(input: {
     string,
     NonNullable<ReturnType<typeof threadJumpCommandForIndex>>
   >;
+  visibleThreadKeys: readonly string[];
 }): ReadonlyMap<string, string> {
   if (input.threadJumpCommandByKey.size === 0) {
     return EMPTY_THREAD_JUMP_LABELS;
@@ -268,6 +269,19 @@ function buildThreadJumpLabelMap(input: {
   const mapping = new Map<string, string>();
   for (const [threadKey, command] of input.threadJumpCommandByKey) {
     const label = shortcutLabelForCommand(input.keybindings, command, shortcutLabelOptions);
+    if (label) {
+      mapping.set(threadKey, label);
+    }
+  }
+  for (const [index, threadKey] of input.visibleThreadKeys.slice(9, 99).entries()) {
+    const threadNumber = index + 10;
+    const firstDigit = Math.floor(threadNumber / 10);
+    const secondDigit = threadNumber % 10;
+    const command = threadJumpCommandForIndex(firstDigit - 1);
+    if (!command) continue;
+
+    const shortcutLabel = shortcutLabelForCommand(input.keybindings, command, shortcutLabelOptions);
+    const label = shortcutLabel ? `${shortcutLabel}${secondDigit}` : null;
     if (label) {
       mapping.set(threadKey, label);
     }
@@ -2820,6 +2834,8 @@ export default function Sidebar() {
     ReadonlySet<string>
   >(() => new Set());
   const { showThreadJumpHints, updateThreadJumpHintsVisibility } = useThreadJumpHintVisibility();
+  const pendingThreadJumpDigitRef = useRef<number | null>(null);
+  const pendingThreadJumpTimeoutRef = useRef<number | null>(null);
   const dragInProgressRef = useRef(false);
   const suppressProjectClickAfterDragRef = useRef(false);
   const suppressProjectClickForContextMenuRef = useRef(false);
@@ -3155,8 +3171,15 @@ export default function Sidebar() {
         platform,
         terminalOpen: sidebarShortcutContext.terminalOpen,
         threadJumpCommandByKey,
+        visibleThreadKeys: visibleSidebarThreadKeys,
       }),
-    [keybindings, platform, sidebarShortcutContext.terminalOpen, threadJumpCommandByKey],
+    [
+      keybindings,
+      platform,
+      sidebarShortcutContext.terminalOpen,
+      threadJumpCommandByKey,
+      visibleSidebarThreadKeys,
+    ],
   );
   const shouldShowThreadJumpHintsNow = shouldShowThreadJumpHintsForModifiers(
     shortcutModifiers,
@@ -3199,12 +3222,55 @@ export default function Sidebar() {
     updateThreadJumpHintsVisibility(shouldShowThreadJumpHintsNow);
   }, [shouldShowThreadJumpHintsNow, updateThreadJumpHintsVisibility]);
 
+  const clearPendingThreadJump = useCallback(() => {
+    pendingThreadJumpDigitRef.current = null;
+    if (pendingThreadJumpTimeoutRef.current !== null) {
+      window.clearTimeout(pendingThreadJumpTimeoutRef.current);
+      pendingThreadJumpTimeoutRef.current = null;
+    }
+  }, []);
+
+  const navigateToThreadKey = useCallback(
+    (threadKey: string | undefined) => {
+      if (!threadKey) return;
+      const targetThread = sidebarThreadByKey.get(threadKey);
+      if (!targetThread) return;
+
+      navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
+    },
+    [navigateToThread, sidebarThreadByKey],
+  );
+
   useEffect(() => {
     const onWindowKeyDown = (event: globalThis.KeyboardEvent) => {
       const shortcutContext = getCurrentSidebarShortcutContext();
 
       if (event.defaultPrevented || event.repeat) {
         return;
+      }
+
+      const pendingThreadJumpDigit = pendingThreadJumpDigitRef.current;
+      if (pendingThreadJumpDigit !== null) {
+        const digitCodeMatch = /^Digit([0-9])$/.exec(event.code);
+        const nextDigit = /^[0-9]$/.test(event.key)
+          ? Number(event.key)
+          : digitCodeMatch?.[1]
+            ? Number(digitCodeMatch[1])
+            : null;
+        if (nextDigit !== null) {
+          const targetIndex = pendingThreadJumpDigit * 10 + nextDigit - 1;
+          clearPendingThreadJump();
+          event.preventDefault();
+          event.stopPropagation();
+          if (targetIndex < orderedSidebarThreadKeys.length) {
+            navigateToThreadKey(orderedSidebarThreadKeys[targetIndex]);
+          }
+          return;
+        }
+
+        if (!["Alt", "Control", "Meta", "Shift"].includes(event.key)) {
+          clearPendingThreadJump();
+        }
       }
 
       const command = resolveShortcutCommand(event, keybindings, {
@@ -3228,6 +3294,7 @@ export default function Sidebar() {
 
         event.preventDefault();
         event.stopPropagation();
+        clearPendingThreadJump();
         navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
         return;
       }
@@ -3237,29 +3304,34 @@ export default function Sidebar() {
         return;
       }
 
-      const targetThreadKey = threadJumpThreadKeys[jumpIndex];
-      if (!targetThreadKey) {
-        return;
-      }
-      const targetThread = sidebarThreadByKey.get(targetThreadKey);
-      if (!targetThread) {
+      const firstDigit = jumpIndex + 1;
+      if (firstDigit > orderedSidebarThreadKeys.length) {
         return;
       }
 
       event.preventDefault();
       event.stopPropagation();
-      navigateToThread(scopeThreadRef(targetThread.environmentId, targetThread.id));
+      clearPendingThreadJump();
+      pendingThreadJumpDigitRef.current = firstDigit;
+      pendingThreadJumpTimeoutRef.current = window.setTimeout(() => {
+        pendingThreadJumpTimeoutRef.current = null;
+        pendingThreadJumpDigitRef.current = null;
+        navigateToThreadKey(threadJumpThreadKeys[jumpIndex]);
+      }, 250);
     };
 
     window.addEventListener("keydown", onWindowKeyDown);
 
     return () => {
       window.removeEventListener("keydown", onWindowKeyDown);
+      clearPendingThreadJump();
     };
   }, [
+    clearPendingThreadJump,
     getCurrentSidebarShortcutContext,
     keybindings,
     navigateToThread,
+    navigateToThreadKey,
     orderedSidebarThreadKeys,
     platform,
     routeThreadKey,


### PR DESCRIPTION
﻿## Summary

- Buffer sidebar thread jump shortcuts briefly so `Ctrl+1`, then `5` jumps to visible thread 15
- Extend sidebar jump hints past 9 using labels like `Ctrl+10` and `Ctrl+15`
- Keep existing keybinding commands unchanged (`thread.jump.1` through `thread.jump.9`)

## Verification

- `bun run test src/components/Sidebar.logic.test.ts` from `apps/web`
- `bun run typecheck --filter=@t3tools/web`
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Support two-digit thread jump navigation in Sidebar
> - Keyboard thread jumping now supports indices 1–99 by buffering the first digit and waiting up to 250ms for an optional second digit before navigating.
> - Adds `resolveBufferedThreadJumpIndex` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/2622/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to convert one- or two-digit input into a zero-based thread index, returning null when out of range.
> - Updates `buildThreadJumpLabelMap` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2622/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) to generate composed two-digit labels for thread indices ≥10.
> - Behavioral Change: single-digit jumps now execute after a 250ms timeout instead of immediately, to allow time for a second digit.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4e6f728. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->