### PR TITLE
fix(composer): support spaces in file mentions

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -10,6 +10,7 @@ import type {
 import {
   detectComposerTrigger,
   replaceTextRange,
+  serializeComposerMentionPath,
   type ComposerTrigger,
 } from "@t3tools/shared/composerTrigger";
 import { TextInputWrapper } from "expo-paste-input";
@@ -408,7 +409,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
 
       let replacement = "";
       if (item.type === "path") {
-        replacement = `@${item.path} `;
+        replacement = `@${serializeComposerMentionPath(item.path)} `;
       } else if (item.type === "skill") {
         replacement = `$${item.skill.name} `;
       } else if (item.type === "slash-command") {

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -6,6 +6,7 @@ import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
 import { OnChangePlugin } from "@lexical/react/LexicalOnChangePlugin";
 import { PlainTextPlugin } from "@lexical/react/LexicalPlainTextPlugin";
 import { type ServerProviderSkill } from "@t3tools/contracts";
+import { serializeComposerMentionPath } from "@t3tools/shared/composerTrigger";
 import {
   $applyNodeReplacement,
   $createRangeSelection,
@@ -198,7 +199,7 @@ class ComposerMentionNode extends DecoratorNode<React.ReactElement> {
   }
 
   override getTextContent(): string {
-    return `@${this.__path}`;
+    return `@${serializeComposerMentionPath(this.__path)}`;
   }
 
   override isInline(): true {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -17,6 +17,7 @@ import {
   PROVIDER_SEND_TURN_MAX_ATTACHMENTS,
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
 } from "@t3tools/contracts";
+import { serializeComposerMentionPath } from "@t3tools/shared/composerTrigger";
 import { createModelSelection, normalizeModelSlug } from "@t3tools/shared/model";
 import {
   memo,
@@ -1471,7 +1472,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       const { snapshot, trigger } = resolveActiveComposerTrigger();
       if (!trigger) return;
       if (item.type === "path") {
-        const replacement = `@${item.path} `;
+        const replacement = `@${serializeComposerMentionPath(item.path)} `;
         const replacementRangeEnd = extendReplacementRangeForTrailingSpace(
           snapshot.value,
           trigger.rangeEnd,

--- a/apps/web/src/composer-editor-mentions.test.ts
+++ b/apps/web/src/composer-editor-mentions.test.ts
@@ -29,6 +29,22 @@ describe("splitPromptIntoComposerSegments", () => {
     ]);
   });
 
+  it("splits quoted mention tokens containing whitespace", () => {
+    expect(splitPromptIntoComposerSegments('Inspect @"My File.md" please')).toEqual([
+      { type: "text", text: "Inspect " },
+      { type: "mention", path: "My File.md" },
+      { type: "text", text: " please" },
+    ]);
+  });
+
+  it("unescapes quoted mention token content", () => {
+    expect(splitPromptIntoComposerSegments('Inspect @"docs/My \\"File\\".md" please')).toEqual([
+      { type: "text", text: "Inspect " },
+      { type: "mention", path: 'docs/My "File".md' },
+      { type: "text", text: " please" },
+    ]);
+  });
+
   it("splits skill tokens followed by whitespace into skill segments", () => {
     expect(splitPromptIntoComposerSegments("Use $review-follow-up please")).toEqual([
       { type: "text", text: "Use " },
@@ -122,6 +138,16 @@ describe("selectionTouchesMentionBoundary", () => {
         prompt,
         `${INLINE_TERMINAL_CONTEXT_PLACEHOLDER}@AGENTS.md`.length,
         prompt.length,
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when selection includes whitespace after a quoted mention", () => {
+    expect(
+      selectionTouchesMentionBoundary(
+        'hi @"My File.md" there',
+        'hi @"My File.md"'.length,
+        'hi @"My File.md" there'.length,
       ),
     ).toBe(true);
   });

--- a/apps/web/src/composer-editor-mentions.ts
+++ b/apps/web/src/composer-editor-mentions.ts
@@ -21,8 +21,8 @@ export type ComposerPromptSegment =
       context: TerminalContextDraft | null;
     };
 
-const MENTION_TOKEN_REGEX = /(^|\s)@([^\s@]+)(?=\s)/g;
 const SKILL_TOKEN_REGEX = /(^|\s)\$([a-zA-Z][a-zA-Z0-9:_-]*)(?=\s)/g;
+const MENTION_TOKEN_REGEX = /(^|\s)@(?:"((?:\\.|[^"\\])*)"|([^\s@"]+))(?=\s)/g;
 
 function rangeIncludesIndex(start: number, end: number, index: number): boolean {
   return start <= index && index < end;
@@ -52,13 +52,18 @@ type InlineTokenMatch =
       end: number;
     };
 
-function collectInlineTokenMatches(text: string): InlineTokenMatch[] {
-  const matches: InlineTokenMatch[] = [];
+type MentionTokenMatch = Extract<InlineTokenMatch, { type: "mention" }>;
+
+function collectMentionTokenMatches(text: string): MentionTokenMatch[] {
+  const matches: MentionTokenMatch[] = [];
 
   for (const match of text.matchAll(MENTION_TOKEN_REGEX)) {
     const fullMatch = match[0];
     const prefix = match[1] ?? "";
-    const path = match[2] ?? "";
+    const quotedPath = match[2];
+    const unquotedPath = match[3];
+    const path =
+      quotedPath !== undefined ? quotedPath.replace(/\\(.)/g, "$1") : (unquotedPath ?? "");
     const matchIndex = match.index ?? 0;
     const start = matchIndex + prefix.length;
     const end = start + fullMatch.length - prefix.length;
@@ -66,6 +71,12 @@ function collectInlineTokenMatches(text: string): InlineTokenMatch[] {
       matches.push({ type: "mention", value: path, start, end });
     }
   }
+
+  return matches;
+}
+
+function collectInlineTokenMatches(text: string): InlineTokenMatch[] {
+  const matches: InlineTokenMatch[] = collectMentionTokenMatches(text);
 
   for (const match of text.matchAll(SKILL_TOKEN_REGEX)) {
     const fullMatch = match[0];
@@ -148,10 +159,10 @@ function forEachPromptTextSlice(
 
 function forEachMentionMatch(
   prompt: string,
-  visitor: (match: RegExpMatchArray, promptOffset: number) => boolean | void,
+  visitor: (match: MentionTokenMatch, promptOffset: number) => boolean | void,
 ): boolean {
   return forEachPromptTextSlice(prompt, (text, promptOffset) => {
-    for (const match of text.matchAll(MENTION_TOKEN_REGEX)) {
+    for (const match of collectMentionTokenMatches(text)) {
       if (visitor(match, promptOffset) === true) {
         return true;
       }
@@ -203,11 +214,8 @@ export function selectionTouchesMentionBoundary(
   }
 
   return forEachMentionMatch(prompt, (match, promptOffset) => {
-    const fullMatch = match[0];
-    const prefix = match[1] ?? "";
-    const matchIndex = match.index ?? 0;
-    const mentionStart = promptOffset + matchIndex + prefix.length;
-    const mentionEnd = mentionStart + fullMatch.length - prefix.length;
+    const mentionStart = promptOffset + match.start;
+    const mentionEnd = promptOffset + match.end;
     const beforeMentionIndex = mentionStart - 1;
     const afterMentionIndex = mentionEnd;
 

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -157,6 +157,16 @@ describe("expandCollapsedComposerCursor", () => {
     );
   });
 
+  it("maps collapsed quoted mention cursor to expanded text cursor", () => {
+    const text = 'what is in @"My File.md" please';
+    const collapsedCursorAfterMention = "what is in ".length + 2;
+    const expandedCursorAfterMention = 'what is in @"My File.md" '.length;
+
+    expect(expandCollapsedComposerCursor(text, collapsedCursorAfterMention)).toBe(
+      expandedCursorAfterMention,
+    );
+  });
+
   it("allows path trigger detection to close after selecting a mention", () => {
     const text = "what's in my @AGENTS.md ";
     const collapsedCursorAfterMention = "what's in my ".length + 2;
@@ -185,6 +195,16 @@ describe("collapseExpandedComposerCursor", () => {
     const text = "what's in my @AGENTS.md fsfdas";
     const collapsedCursorAfterMention = "what's in my ".length + 2;
     const expandedCursorAfterMention = "what's in my @AGENTS.md ".length;
+
+    expect(collapseExpandedComposerCursor(text, expandedCursorAfterMention)).toBe(
+      collapsedCursorAfterMention,
+    );
+  });
+
+  it("maps expanded quoted mention cursor back to collapsed cursor", () => {
+    const text = 'what is in @"My File.md" please';
+    const collapsedCursorAfterMention = "what is in ".length + 2;
+    const expandedCursorAfterMention = 'what is in @"My File.md" '.length;
 
     expect(collapseExpandedComposerCursor(text, expandedCursorAfterMention)).toBe(
       collapsedCursorAfterMention,

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -1,3 +1,4 @@
+import { serializeComposerMentionPath } from "@t3tools/shared/composerTrigger";
 import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
@@ -54,7 +55,7 @@ export function expandCollapsedComposerCursor(text: string, cursorInput: number)
 
   for (const segment of segments) {
     if (segment.type === "mention") {
-      const expandedLength = segment.path.length + 1;
+      const expandedLength = serializeComposerMentionPath(segment.path).length + 1;
       if (remaining <= 1) {
         return expandedCursor + (remaining === 0 ? 0 : expandedLength);
       }
@@ -142,7 +143,7 @@ export function collapseExpandedComposerCursor(text: string, cursorInput: number
 
   for (const segment of segments) {
     if (segment.type === "mention") {
-      const expandedLength = segment.path.length + 1;
+      const expandedLength = serializeComposerMentionPath(segment.path).length + 1;
       if (remaining === 0) {
         return collapsedCursor;
       }

--- a/packages/shared/src/composerTrigger.test.ts
+++ b/packages/shared/src/composerTrigger.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { serializeComposerMentionPath } from "./composerTrigger.ts";
+
+describe("serializeComposerMentionPath", () => {
+  it("keeps simple mention paths unquoted", () => {
+    expect(serializeComposerMentionPath("src/index.ts")).toBe("src/index.ts");
+  });
+
+  it("quotes mention paths containing whitespace", () => {
+    expect(serializeComposerMentionPath("docs/My File.md")).toBe('"docs/My File.md"');
+  });
+
+  it("escapes quoted mention path content", () => {
+    expect(serializeComposerMentionPath('docs/My "File".md')).toBe('"docs/My \\"File\\".md"');
+  });
+});

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -8,6 +8,15 @@ export interface ComposerTrigger {
   rangeEnd: number;
 }
 
+const SIMPLE_MENTION_PATH_REGEX = /^[^\s@"\\]+$/;
+
+export function serializeComposerMentionPath(path: string): string {
+  if (SIMPLE_MENTION_PATH_REGEX.test(path)) {
+    return path;
+  }
+  return `"${path.replaceAll("\\", "\\\\").replaceAll('"', '\\"')}"`;
+}
+
 function clampCursor(text: string, cursor: number): number {
   if (!Number.isFinite(cursor)) return text.length;
   return Math.max(0, Math.min(text.length, Math.floor(cursor)));


### PR DESCRIPTION
## What Changed

Fixed composer file mentions for files and folders whose paths contain whitespace.

The composer now serializes paths with spaces as quoted mention tokens, while leaving simple paths unchanged:

- `@src/index.ts`
- `@"My File.md"`

Quoted tokens are parsed back into a single web mention chip, and mobile uses the same serialized format when inserting file mentions.

Fixes #2571.

## Why

The previous mention parser treated a mention as `@` followed by non-whitespace characters. That worked for paths like `@AGENTS.md`, but broke for paths containing spaces.

Selecting `MY FILE.md` inserted `@MY FILE.md `, and on re-parse only `@MY` became a mention while ` FILE.md` stayed as plain text. This was visible in the composer and could also send an incomplete file reference to the agent.

Quoting only paths that need it keeps the common representation backwards-compatible and readable, while giving whitespace-containing paths a clear token boundary.

## UI Changes

**Before:**

<img width="1952" height="354" alt="image" src="https://github.com/user-attachments/assets/afac48d9-36e3-4205-8b8c-a11c368965e9" />

<img width="498" height="154" alt="image" src="https://github.com/user-attachments/assets/9d7177c0-043b-49cf-a118-b354c48872fa" />

**After:**

<img width="806" height="348" alt="image" src="https://github.com/user-attachments/assets/5ca818f7-358f-4f5b-87dc-1553d8e9b27b" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused composer parsing/serialization change with broad test coverage; simple unquoted mentions stay unchanged.
> 
> **Overview**
> Composer file mentions now support paths with **spaces and special characters** by introducing shared **`serializeComposerMentionPath`**, which leaves simple paths unquoted and emits **`@"..."`** tokens with escaping when needed.
> 
> **Web** inserts and serializes mentions through that helper in `ChatComposer`, `ComposerPromptEditor`, and **`composer-editor-mentions`** (updated regex + unescaping). **Collapsed/expanded cursor math** in `composer-logic` uses serialized mention length so chips and `@` triggers stay aligned. **Mobile** uses the same serialization when picking a path from the command menu.
> 
> Tests cover quoting, parsing quoted tokens, selection boundaries, and cursor mapping for quoted mentions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e8a0db6cc6de1efe4fa3152080430c9077faf61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix file mention parsing to support spaces in paths
> - Adds `serializeComposerMentionPath` in [`composerTrigger.ts`](https://github.com/pingdotgg/t3code/pull/2625/files#diff-b4159167bd9a29da87e9151654616f69eb910aa170ac2d930c07130f06f93cb9) that quotes and escapes mention paths containing spaces or special characters, leaving simple paths unmodified.
> - Updates `MENTION_TOKEN_REGEX` in [`composer-editor-mentions.ts`](https://github.com/pingdotgg/t3code/pull/2625/files#diff-fe3b0266af75d6e06d8819ee307b1048dd163e07bfc6758027f84a441c92be3c) to parse both quoted (with escape sequences) and unquoted mention tokens.
> - Applies serialization when inserting path mentions in the web and mobile composers, and when rendering mention node text content.
> - Updates cursor expand/collapse logic in [`composer-logic.ts`](https://github.com/pingdotgg/t3code/pull/2625/files#diff-d8bf01d2c2c41e34161141355950c042b07686d185ea476beb91213ecf6466a6) to use serialized path length so cursor positions stay accurate for quoted mentions.
> - Behavioral Change: mentions with spaces in their paths are now inserted and parsed as `@"path with spaces"` rather than `@path with spaces`, which would previously break mention detection.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e8a0db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->