### PR TITLE
Alias stable releases to the router domain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -625,6 +625,9 @@ jobs:
           router_url="${T3CODE_WEB_ROUTER_URL:-https://app.t3.codes}"
           latest_domain="${T3CODE_WEB_LATEST_DOMAIN:-latest.app.t3.codes}"
           nightly_domain="${T3CODE_WEB_NIGHTLY_DOMAIN:-nightly.app.t3.codes}"
+          router_domain="${router_url#http://}"
+          router_domain="${router_domain#https://}"
+          router_domain="${router_domain%%/*}"
 
           if [[ "${{ needs.preflight.outputs.release_channel }}" == "stable" ]]; then
             channel_domain="$latest_domain"
@@ -656,6 +659,13 @@ jobs:
           bunx vercel@53.1.1 alias set "$deployment_url" "$channel_domain" \
             --token "$VERCEL_TOKEN" \
             "${vercel_scope_args[@]}"
+
+          if [[ "$channel_name" == "latest" && -n "$router_domain" && "$router_domain" != "$channel_domain" ]]; then
+            echo "Aliasing $deployment_url to router domain $router_domain."
+            bunx vercel@53.1.1 alias set "$deployment_url" "$router_domain" \
+              --token "$VERCEL_TOKEN" \
+              "${vercel_scope_args[@]}"
+          fi
 
   finalize:
     name: Finalize release

--- a/apps/web/src/branding.test.ts
+++ b/apps/web/src/branding.test.ts
@@ -42,6 +42,8 @@ describe("branding", () => {
 
     expect(branding.HOSTED_APP_CHANNEL).toBe("nightly");
     expect(branding.HOSTED_APP_CHANNEL_LABEL).toBe("Nightly");
+    expect(branding.APP_STAGE_LABEL).toBe("Nightly");
+    expect(branding.APP_DISPLAY_NAME).toBe("T3 Code (Nightly)");
   });
 
   it("ignores unknown hosted app channels", async () => {

--- a/apps/web/src/branding.ts
+++ b/apps/web/src/branding.ts
@@ -11,13 +11,15 @@ function readInjectedDesktopAppBranding(): DesktopAppBranding | null {
 const injectedDesktopAppBranding = readInjectedDesktopAppBranding();
 const hostedAppChannel = import.meta.env.VITE_HOSTED_APP_CHANNEL?.trim().toLowerCase();
 
-export const APP_BASE_NAME = injectedDesktopAppBranding?.baseName ?? "T3 Code";
-export const APP_STAGE_LABEL =
-  injectedDesktopAppBranding?.stageLabel ?? (import.meta.env.DEV ? "Dev" : "Alpha");
-export const APP_DISPLAY_NAME =
-  injectedDesktopAppBranding?.displayName ?? `${APP_BASE_NAME} (${APP_STAGE_LABEL})`;
-export const APP_VERSION = import.meta.env.APP_VERSION || "0.0.0";
 export const HOSTED_APP_CHANNEL =
   hostedAppChannel === "latest" || hostedAppChannel === "nightly" ? hostedAppChannel : null;
 export const HOSTED_APP_CHANNEL_LABEL =
   HOSTED_APP_CHANNEL === "nightly" ? "Nightly" : HOSTED_APP_CHANNEL === "latest" ? "Latest" : null;
+export const APP_BASE_NAME = injectedDesktopAppBranding?.baseName ?? "T3 Code";
+export const APP_STAGE_LABEL =
+  injectedDesktopAppBranding?.stageLabel ??
+  HOSTED_APP_CHANNEL_LABEL ??
+  (import.meta.env.DEV ? "Dev" : "Alpha");
+export const APP_DISPLAY_NAME =
+  injectedDesktopAppBranding?.displayName ?? `${APP_BASE_NAME} (${APP_STAGE_LABEL})`;
+export const APP_VERSION = import.meta.env.APP_VERSION || "0.0.0";

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -892,7 +892,7 @@ export function GeneralSettingsPanel() {
       </SettingsSection>
 
       <SettingsSection title="About">
-        {isElectron ? (
+        {isElectron || HOSTED_APP_CHANNEL ? (
           <AboutVersionSection />
         ) : (
           <SettingsRow

--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -1,9 +1,16 @@
-import { matchers, routes, type VercelConfig } from "@vercel/config/v1";
+import { matchers, routes, type Transform, type VercelConfig } from "@vercel/config/v1";
 
 const ROUTER_HOST = "app.t3.codes";
 const HOSTED_WEB_CHANNEL_COOKIE = "t3code_web_channel";
 const LATEST_ORIGIN = "https://latest.app.t3.codes";
 const NIGHTLY_ORIGIN = "https://nightly.app.t3.codes";
+const CLEAN_CHANNEL_QUERY_TRANSFORMS = [
+  {
+    type: "request.query",
+    op: "delete",
+    target: { key: "channel" },
+  },
+] satisfies Transform[];
 
 function channelCookie(channel: "latest" | "nightly"): string {
   return [
@@ -28,6 +35,7 @@ export const config: VercelConfig = {
     {
       src: "/__t3code/channel",
       has: [matchers.query("channel", "nightly")],
+      transforms: CLEAN_CHANNEL_QUERY_TRANSFORMS,
       headers: {
         Location: "/",
         "Set-Cookie": channelCookie("nightly"),
@@ -36,6 +44,7 @@ export const config: VercelConfig = {
     },
     {
       src: "/__t3code/channel",
+      transforms: CLEAN_CHANNEL_QUERY_TRANSFORMS,
       headers: {
         Location: "/",
         "Set-Cookie": channelCookie("latest"),

--- a/docs/release.md
+++ b/docs/release.md
@@ -51,7 +51,7 @@ Optional GitHub Actions variables:
 
 Required Vercel domains:
 
-- `app.t3.codes`: the stable router domain users open.
+- `app.t3.codes`: the router domain users open, updated by stable releases.
 - `latest.app.t3.codes`: channel alias updated by stable releases.
 - `nightly.app.t3.codes`: channel alias updated by nightly releases.
 
@@ -62,11 +62,13 @@ visiting `/__t3code/channel?channel=latest` or
 the matching channel alias.
 
 The release deploy job rewrites release package versions before upload so the
-hosted app's About panel renders the release version. It also passes
-`VITE_HOSTED_APP_CHANNEL=latest|nightly`, which renders the hosted update track
-selector in the About panel. Changing the selector navigates through
-`/__t3code/channel` on the router domain so the user's channel cookie is updated
-before redirecting to the hosted app root.
+hosted app's About panel renders the release version. Stable deploys alias the
+same deployment to both the `latest` channel and the router domain so the router
+rules stay current. Nightly deploys only alias the `nightly` channel. The job
+also passes `VITE_HOSTED_APP_CHANNEL=latest|nightly`, which renders the hosted
+update track selector in the About panel. Changing the selector navigates
+through `/__t3code/channel` on the router domain so the user's channel cookie is
+updated before redirecting to the hosted app root.
 
 One-time Vercel dashboard setup:
 
@@ -75,9 +77,9 @@ One-time Vercel dashboard setup:
 3. Disable automatic Git deployments in the dashboard if desired; the committed
    `vercel.ts` setting is the source-of-truth, but disconnecting Git in the
    dashboard is also safe.
-4. Promote or alias one deployment containing the router rules in `apps/web/vercel.ts` to
-   `app.t3.codes` once. Future release jobs should only update the channel
-   aliases.
+4. Run one stable release deployment, or manually alias the current stable
+   deployment, so `app.t3.codes` points at a deployment containing the router
+   rules in `apps/web/vercel.ts`. Future stable releases keep this alias current.
 
 ## Nightly builds
 


### PR DESCRIPTION
## Summary
- Updated the release workflow so stable releases alias the `latest` deployment to the router domain (`app.t3.codes`) as well as the channel alias.
- Added domain normalization in the workflow to derive the router hostname from `T3CODE_WEB_ROUTER_URL` before creating the alias.
- Clarified the release docs to describe the router domain as stable-release managed and updated the one-time setup guidance.

## Testing
- Not run (documentation and workflow-only change).
- Verified the diff for the release workflow and release docs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes production release automation and Vercel routing/redirect behavior; a mis-alias or transform could affect which hosted channel users reach.
> 
> **Overview**
> Stable hosted web deploys now also alias the same Vercel deployment to the *router domain* (derived from `T3CODE_WEB_ROUTER_URL`), keeping `app.t3.codes` updated alongside the `latest` channel alias; nightly continues to only update `nightly`.
> 
> The Vercel router config now strips the `channel` query param on `/__t3code/channel` redirects, and hosted builds treat `VITE_HOSTED_APP_CHANNEL` as stage branding (with the About/version panel showing detailed version info when running hosted, not just Electron). Documentation is updated to reflect the new router-domain aliasing and setup guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71a78f3f35d0af373c7df6bc1c9ea2049620243c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Alias stable releases to the router domain in addition to the latest channel domain
> - Stable (`latest`) release deployments in [release.yml](.github/workflows/release.yml) now also alias to the router domain (e.g., `app.t3.codes`) by parsing `router_domain` from `router_url` and running `vercel alias set` when the channel is `latest` and the domains differ.
> - The branding module now sets `APP_STAGE_LABEL` to the channel label (e.g., `'Nightly'`, `'Latest'`) for hosted deployments without injected desktop branding, so `APP_DISPLAY_NAME` reflects the channel.
> - The About version section in general settings is now shown on hosted deployments with a defined channel, not only in Electron.
> - Requests to `/__t3code/channel` routes now strip the `channel` query parameter via new transforms in [vercel.ts](apps/web/vercel.ts).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71a78f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->