### PR TITLE
Remove outline styling from git success toast action

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1434,7 +1434,6 @@ export default function GitActionsControl({
               description: result.toast.description,
               timeout: 0,
               actionProps: toastActionProps,
-              actionVariant: "outline",
               data: successToastData,
             }),
           );


### PR DESCRIPTION
## Summary
- Remove the `outline` variant from the success toast action in `GitActionsControl`.
- Let the toast action use the default styling instead of forcing an outlined appearance.

## Testing
- Not run (PR content only).
- Verified from diff that the change is limited to one line in `apps/web/src/components/GitActionsControl.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only styling tweak that only changes the button variant used in the git success toast action, with no impact to git behavior or data handling.
> 
> **Overview**
> Removes the forced `actionVariant: "outline"` styling from the success toast action in `GitActionsControl`, allowing the CTA button in git success toasts to use the toast component’s default action styling instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973bbb920ce889cc772d02a4a0893d1883736a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `actionVariant: "outline"` from git success toast action in `GitActionsControl`
> Removes the explicit `actionVariant: "outline"` property from the `stackedThreadToast` call in the success path of [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/2639/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f). The action button in git success toasts will now use the default variant styling instead of the outline style.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 973bbb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->