### PR TITLE
fix(ssh): fix support for remotes that use fnm

### DIFF
--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -105,7 +105,9 @@ describe("ssh tunnel scripts", () => {
     assert.include(script, 'prepend_path_if_dir "$VOLTA_HOME/bin"');
     assert.include(script, 'prepend_path_if_dir "$HOME/.asdf/shims"');
     assert.include(script, 'prepend_path_if_dir "$HOME/.local/share/mise/shims"');
-    assert.include(script, 'eval "$(fnm env --use-on-cd --shell sh)"');
+    assert.include(script, 'eval "$(fnm env --shell bash)"');
+    assert.include(script, "fnm use --silent-if-unchanged");
+    assert.include(script, "fnm use default");
     assert.include(script, 'prepend_path_if_dir "$HOME/.nodenv/shims"');
     assert.include(script, 'NVM_DIR="$HOME/.nvm"');
     assert.include(script, "nvm use --silent default");

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -398,7 +398,8 @@ ensure_remote_node_path() {
   prepend_path_if_dir "$FNM_DIR"
   prepend_path_if_dir "$HOME/.fnm"
   if ! command -v node >/dev/null 2>&1 && command -v fnm >/dev/null 2>&1; then
-    eval "$(fnm env --use-on-cd --shell sh)" >/dev/null 2>&1 || eval "$(fnm env --shell sh)" >/dev/null 2>&1 || true
+    eval "$(fnm env --shell bash)" >/dev/null 2>&1 || true
+    fnm use --silent-if-unchanged >/dev/null 2>&1 || fnm use default >/dev/null 2>&1 || true
   fi
 
   prepend_path_if_dir "$HOME/.nodenv/bin"


### PR DESCRIPTION
## Summary
- Replace the remote SSH fnm bootstrap's invalid `fnm env --shell sh` usage with `fnm env --shell bash`.
- Run `fnm use` once after environment initialization so remote Node resolution matches the one-shot activation pattern used for other version managers.
- Update SSH tunnel script coverage to assert the new fnm activation commands.

## Why
`fnm env --shell sh` is not a supported fnm shell value, so the existing remote bootstrap could silently fail to initialize fnm in non-interactive SSH sessions.

We also avoid `fnm env --use-on-cd --shell sh` because `--use-on-cd` emits hook code containing Bash-style `[[ ... ]]` conditionals, which are not supported by `dash` or POSIX `sh`. The remote runner is a `#!/bin/sh` script, so one-shot `fnm use` is a better fit than installing directory-change hooks.

## Test Plan
- `bun --filter @t3tools/ssh test -- src/tunnel.test.ts`
- `bun fmt && bun lint && bun typecheck`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to the generated remote shell bootstrap for `fnm`, plus test expectation updates; main risk is behavior differences on systems where `fnm env --shell bash` isn’t available.
> 
> **Overview**
> Fixes remote Node bootstrapping for hosts using `fnm` by replacing the unsupported `fnm env --shell sh`/`--use-on-cd` initialization with `eval "$(fnm env --shell bash)"` and then running a one-shot `fnm use` (`--silent-if-unchanged` with fallback to `default`).
> 
> Updates tunnel script tests to assert the new `fnm` activation and `fnm use` commands in the generated remote runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7434d75f2b1bed5d8f7ed96fc19868997842c7f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix fnm support in SSH remote node path setup
> The `ensure_remote_node_path` function in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/2641/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) previously tried to initialize fnm using `sh` with `--use-on-cd` but never called `fnm use`, so the correct Node version was not activated.
>
> - Now evaluates `fnm env --shell bash` and explicitly runs `fnm use --silent-if-unchanged`, falling back to `fnm use default` on failure.
> - All fnm invocations are silenced (`>/dev/null 2>&1`) and guarded to avoid errors on remotes where fnm is absent.
> - Behavioral Change: remotes using fnm will now have an active Node version on PATH where previously they did not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5479d62.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->