### PR TITLE
fix(web): show provider skills in slash menu

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -5952,6 +5952,48 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("shows provider skills in the slash-command menu", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-slash-skill-target" as MessageId,
+        targetText: "slash skill menu thread",
+      }),
+      configureFixture: (nextFixture) => {
+        const provider = nextFixture.serverConfig.providers[0];
+        if (!provider) {
+          throw new Error("Expected default provider in test fixture.");
+        }
+        (
+          provider as {
+            skills: ServerConfig["providers"][number]["skills"];
+          }
+        ).skills = [
+          {
+            name: "agent-browser",
+            displayName: "Agent Browser",
+            shortDescription: "Open pages, click around, and inspect web apps.",
+            path: "/Users/test/.agents/skills/agent-browser/SKILL.md",
+            enabled: true,
+          },
+        ];
+      },
+    });
+
+    try {
+      await waitForComposerEditor();
+      await page.getByTestId("composer-editor").fill("/");
+
+      const skillItem = await waitForComposerMenuItem("skill:codex:agent-browser");
+      expect(skillItem.textContent).toContain("Agent Browser");
+
+      await skillItem.click();
+      await waitForComposerText("$agent-browser ");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("opens the model picker when selecting /model", async () => {
     const mounted = await mountChatView({
       viewport: DEFAULT_VIEWPORT,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -115,6 +115,23 @@ import { useMediaQuery } from "../../hooks/useMediaQuery";
 
 const IMAGE_SIZE_LIMIT_LABEL = `${Math.round(PROVIDER_SEND_TURN_MAX_IMAGE_BYTES / (1024 * 1024))}MB`;
 
+function toSkillComposerCommandItem(
+  provider: ProviderDriverKind,
+  skill: ServerProvider["skills"][number],
+): Extract<ComposerCommandItem, { type: "skill" }> {
+  return {
+    id: `skill:${provider}:${skill.name}`,
+    type: "skill",
+    provider,
+    skill,
+    label: formatProviderSkillDisplayName(skill),
+    description:
+      skill.shortDescription ??
+      skill.description ??
+      (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+  };
+}
+
 const runtimeModeConfig: Record<
   RuntimeMode,
   { label: string; description: string; icon: LucideIcon }
@@ -900,17 +917,7 @@ export const ChatComposer = memo(
         );
         const query = composerTrigger.query.trim().toLowerCase();
         const skillItems = searchProviderSkills(selectedProviderStatus?.skills ?? [], query).map(
-          (skill) => ({
-            id: `skill:${selectedProvider}:${skill.name}`,
-            type: "skill" as const,
-            provider: selectedProvider,
-            skill,
-            label: formatProviderSkillDisplayName(skill),
-            description:
-              skill.shortDescription ??
-              skill.description ??
-              (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-          }),
+          (skill) => toSkillComposerCommandItem(selectedProvider, skill),
         );
         const slashCommandItems = [...builtInSlashCommandItems, ...providerSlashCommandItems];
         if (!query) {
@@ -922,17 +929,7 @@ export const ChatComposer = memo(
         return searchProviderSkills(
           selectedProviderStatus?.skills ?? [],
           composerTrigger.query,
-        ).map((skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }));
+        ).map((skill) => toSkillComposerCommandItem(selectedProvider, skill));
       }
       return [];
     }, [composerTrigger, selectedProvider, selectedProviderStatus, workspaceEntries]);

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -899,11 +899,24 @@ export const ChatComposer = memo(
           }),
         );
         const query = composerTrigger.query.trim().toLowerCase();
+        const skillItems = searchProviderSkills(selectedProviderStatus?.skills ?? [], query).map(
+          (skill) => ({
+            id: `skill:${selectedProvider}:${skill.name}`,
+            type: "skill" as const,
+            provider: selectedProvider,
+            skill,
+            label: formatProviderSkillDisplayName(skill),
+            description:
+              skill.shortDescription ??
+              skill.description ??
+              (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+          }),
+        );
         const slashCommandItems = [...builtInSlashCommandItems, ...providerSlashCommandItems];
         if (!query) {
-          return slashCommandItems;
+          return [...slashCommandItems, ...skillItems];
         }
-        return searchSlashCommandItems(slashCommandItems, query);
+        return [...searchSlashCommandItems(slashCommandItems, query), ...skillItems];
       }
       if (composerTrigger.kind === "skill") {
         return searchProviderSkills(

--- a/apps/web/src/components/chat/ComposerCommandMenu.tsx
+++ b/apps/web/src/components/chat/ComposerCommandMenu.tsx
@@ -92,6 +92,7 @@ function groupCommandItems(
 
   const builtInItems = items.filter((item) => item.type === "slash-command");
   const providerItems = items.filter((item) => item.type === "provider-slash-command");
+  const skillItems = items.filter((item) => item.type === "skill");
 
   const groups: ComposerCommandGroup[] = [];
   if (builtInItems.length > 0) {
@@ -99,6 +100,9 @@ function groupCommandItems(
   }
   if (providerItems.length > 0) {
     groups.push({ id: "provider", label: "Provider", items: providerItems });
+  }
+  if (skillItems.length > 0) {
+    groups.push({ id: "skills", label: "Skills", items: skillItems });
   }
   return groups;
 }


### PR DESCRIPTION
## Summary
- include provider skills when the composer slash-command menu opens
- keep selection behavior inserting the existing $skill token format
- add browser coverage for selecting a Codex skill from /

## Scope
This partially addresses #2637 by surfacing detected Codex/provider skills from the / menu. It does not add Codex CLI-only slash commands such as /help or /status, which do not appear to be exposed through the current provider status shape.

## Verification
- 
px --yes bun@1.3.11 run fmt
- 
px --yes bun@1.3.11 run --bun lint (passes with pre-existing warnings)
- 
px --yes bun@1.3.11 run --bun typecheck
- 
px --yes bun@1.3.11 run test:browser -- src/components/ChatView.browser.tsx from pps/web (76 passed)
- 
px --yes bun@1.3.11 run --bun test -- src/components/chat/MessagesTimeline.test.tsx from pps/web (6 passed)

## Full-suite note

px --yes bun@1.3.11 run --bun test hit unrelated 5s timeout flakes locally under load. First run timed out in @t3tools/oxlint-plugin-t3code; second run timed out in effect-acp; --concurrency=1 later timed out in MessagesTimeline.test.tsx, which passed in isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/menu behavior change limited to chat composer command suggestions and grouping; main risk is minor UX regressions in command ordering/filtering.
> 
> **Overview**
> The chat composer `/` menu now also surfaces provider skills (in addition to built-in and provider slash commands), using provider-skill search and keeping insertion behavior as the existing `$skill-name` token.
> 
> The command menu grouping logic is updated to include a **Skills** section when opened via `/`, and a browser test is added to verify selecting a skill from the slash menu inserts the expected token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 847b12ad05e8ec5caa07f6963549b37a4dc98576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show provider skills in the slash-command menu of ChatComposer
> - Adds provider skills to the slash-command (`/`) menu in [ChatComposer.tsx](https://github.com/pingdotgg/t3code/pull/2650/files#diff-c968a393420901e312c24fcfdef204d8969fa91d9c2df9c52d32b6612bcc8d9a), both with and without a search query, alongside existing built-in and provider slash-command items.
> - Introduces a `toSkillComposerCommandItem` helper to build standardized `ComposerCommandItem` objects for provider skills.
> - Updates [ComposerCommandMenu.tsx](https://github.com/pingdotgg/t3code/pull/2650/files#diff-ca7de5ada90d0c74157405378c7182002eab97a1ea23cd71e4376f8db6ba81a4) to render a separate "Skills" group when slash-command grouping is active and skill items are present.
> - Adds a browser test in [ChatView.browser.tsx](https://github.com/pingdotgg/t3code/pull/2650/files#diff-3ac0341759c65966f9abd3e9446f2f1a2059647c36f47795ea1da3c12afe2b5f) verifying that typing `/` surfaces a provider skill and inserts the correct token into the composer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 847b12a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->