### PR TITLE
Harden OpenCode probe teardown to avoid leaked processes

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.test.ts
@@ -34,6 +34,7 @@ const runtimeMock = {
     runVersionError: null as Error | null,
     versionStdout: DEFAULT_VERSION_STDOUT,
     inventoryError: null as Error | null,
+    closeError: null as Error | null,
     closeCalls: 0,
     inventory: {
       providerList: { connected: [] as string[], all: [] as unknown[], default: {} },
@@ -44,6 +45,7 @@ const runtimeMock = {
     this.state.runVersionError = null;
     this.state.versionStdout = DEFAULT_VERSION_STDOUT;
     this.state.inventoryError = null;
+    this.state.closeError = null;
     this.state.closeCalls = 0;
     this.state.inventory = {
       providerList: { connected: [], all: [] as unknown[], default: {} },
@@ -64,6 +66,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
         yield* Effect.addFinalizer(() =>
           Effect.sync(() => {
             runtimeMock.state.closeCalls += 1;
+            if (runtimeMock.state.closeError) {
+              throw runtimeMock.state.closeError;
+            }
           }),
         );
       }
@@ -199,6 +204,41 @@ it.layer(testLayer)("checkOpenCodeProviderStatus", (it) => {
       yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
 
       assert.equal(runtimeMock.state.closeCalls, 1);
+    }),
+  );
+
+  it.effect("preserves a successful provider refresh when probe teardown throws", () =>
+    Effect.gen(function* () {
+      runtimeMock.state.inventory = {
+        providerList: {
+          connected: ["openai"],
+          all: [
+            {
+              id: "openai",
+              name: "OpenAI",
+              models: {
+                "gpt-5": {
+                  id: "gpt-5",
+                  name: "GPT-5",
+                  variants: {},
+                },
+              },
+            },
+          ],
+          default: {},
+        },
+        agents: [],
+      };
+      runtimeMock.state.closeError = new Error("close failed");
+
+      const snapshot = yield* checkOpenCodeProviderStatus(makeOpenCodeSettings(), process.cwd());
+
+      assert.equal(runtimeMock.state.closeCalls, 1);
+      assert.equal(snapshot.status, "ready");
+      assert.equal(
+        snapshot.models.some((model) => model.slug === "openai/gpt-5"),
+        true,
+      );
     }),
   );
 });

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -23,6 +23,7 @@ import {
   openCodeRuntimeErrorDetail,
   type OpenCodeInventory,
 } from "../opencodeRuntime.ts";
+import { scopedSafeTeardown } from "./scopedSafeTeardown.ts";
 import type { Agent, ProviderListResponse } from "@opencode-ai/sdk/v2";
 
 const PROVIDER = ProviderDriverKind.make("opencode");
@@ -406,38 +407,34 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   }
 
   const inventoryExit = yield* Effect.exit(
-    Effect.scoped(
-      Effect.gen(function* () {
-        const server = yield* openCodeRuntime
-          .connectToOpenCodeServer({
-            binaryPath: openCodeSettings.binaryPath,
-            serverUrl: openCodeSettings.serverUrl,
-            environment,
-          })
-          .pipe(
-            Effect.mapError(
-              (cause) =>
-                new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
-            ),
-          );
-        return yield* openCodeRuntime
-          .loadOpenCodeInventory(
-            openCodeRuntime.createOpenCodeSdkClient({
-              baseUrl: server.url,
-              directory: cwd,
-              ...(isExternalServer && openCodeSettings.serverPassword
-                ? { serverPassword: openCodeSettings.serverPassword }
-                : {}),
-            }),
-          )
-          .pipe(
-            Effect.mapError(
-              (cause) =>
-                new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
-            ),
-          );
-      }),
-    ),
+    Effect.gen(function* () {
+      const server = yield* openCodeRuntime
+        .connectToOpenCodeServer({
+          binaryPath: openCodeSettings.binaryPath,
+          serverUrl: openCodeSettings.serverUrl,
+          environment,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
+          ),
+        );
+      return yield* openCodeRuntime
+        .loadOpenCodeInventory(
+          openCodeRuntime.createOpenCodeSdkClient({
+            baseUrl: server.url,
+            directory: cwd,
+            ...(isExternalServer && openCodeSettings.serverPassword
+              ? { serverPassword: openCodeSettings.serverPassword }
+              : {}),
+          }),
+        )
+        .pipe(
+          Effect.mapError(
+            (cause) => new OpenCodeProbeError({ cause, detail: openCodeRuntimeErrorDetail(cause) }),
+          ),
+        );
+    }).pipe(scopedSafeTeardown("opencode-provider-probe")),
   );
   if (inventoryExit._tag === "Failure") {
     return fallback(Cause.squash(inventoryExit.cause), version);

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -273,9 +273,99 @@ function ensureRuntimeError(
     : new OpenCodeRuntimeError({ operation, detail, cause });
 }
 
+function commandBasename(commandPath: string): string {
+  return commandPath.split(/[\\/]/).at(-1) ?? commandPath;
+}
+
+function isMatchingOpenCodeServeCommand(input: {
+  readonly command: string;
+  readonly binaryPath: string;
+  readonly hostname: string;
+  readonly port: number;
+}): boolean {
+  const executable = commandBasename(input.binaryPath);
+  const command = input.command;
+  return (
+    command.includes(executable) &&
+    /\bserve\b/.test(command) &&
+    command.includes(`--hostname=${input.hostname}`) &&
+    command.includes(`--port=${input.port}`)
+  );
+}
+
 const makeOpenCodeRuntime = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const netService = yield* NetService.NetService;
+
+  const listProcessCommands: Effect.Effect<
+    ReadonlyArray<{ readonly pid: number; readonly command: string }>
+  > = Effect.gen(function* () {
+    const child = yield* spawner.spawn(ChildProcess.make("ps", ["-axo", "pid=,command="]));
+    const [stdout, code] = yield* Effect.all(
+      [collectStreamAsString(child.stdout), child.exitCode],
+      {
+        concurrency: "unbounded",
+      },
+    );
+    if (Number(code) !== 0) {
+      return [];
+    }
+    return stdout
+      .split("\n")
+      .flatMap((line) => {
+        const match = line.trim().match(/^(\d+)\s+(.+)$/);
+        const command = match?.[2];
+        if (!match || command === undefined) {
+          return [];
+        }
+        return [{ pid: Number(match[1]), command }];
+      })
+      .filter((entry) => Number.isInteger(entry.pid) && entry.pid > 0);
+  }).pipe(
+    Effect.scoped,
+    Effect.catch(() => Effect.succeed([])),
+  );
+
+  const terminateMatchingOpenCodeServeProcesses = (input: {
+    readonly binaryPath: string;
+    readonly hostname: string;
+    readonly port: number;
+    readonly signal: NodeJS.Signals;
+  }): Effect.Effect<void> => {
+    if (process.platform === "win32") {
+      return Effect.void;
+    }
+
+    return listProcessCommands.pipe(
+      Effect.flatMap((processes) =>
+        Effect.forEach(
+          processes,
+          (entry) => {
+            if (
+              entry.pid === process.pid ||
+              !isMatchingOpenCodeServeCommand({
+                command: entry.command,
+                binaryPath: input.binaryPath,
+                hostname: input.hostname,
+                port: input.port,
+              })
+            ) {
+              return Effect.void;
+            }
+            return Effect.sync(() => {
+              try {
+                process.kill(entry.pid, input.signal);
+              } catch {
+                // The process may have exited between `ps` and `kill`.
+              }
+            });
+          },
+          { discard: true },
+        ),
+      ),
+      Effect.ignore,
+    );
+  };
 
   const runOpenCodeCommand: OpenCodeRuntimeShape["runOpenCodeCommand"] = (input) =>
     Effect.gen(function* () {
@@ -370,9 +460,34 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
                 // any serve process left in that group.
               }
             });
-      const terminateChild = killOpenCodeProcessGroup("SIGTERM").pipe(
+      const killDirectChild = (signal: NodeJS.Signals) =>
+        child.kill({ killSignal: signal, forceKillAfter: "1 second" }).pipe(Effect.asVoid);
+      const killMatchingServeProcesses = (signal: NodeJS.Signals) =>
+        terminateMatchingOpenCodeServeProcesses({
+          binaryPath: input.binaryPath,
+          hostname,
+          port,
+          signal,
+        });
+      const terminateChild = Effect.all(
+        [
+          killOpenCodeProcessGroup("SIGTERM"),
+          killDirectChild("SIGTERM"),
+          killMatchingServeProcesses("SIGTERM"),
+        ],
+        { concurrency: "unbounded", discard: true },
+      ).pipe(
         Effect.andThen(Effect.sleep("1 second")),
-        Effect.andThen(killOpenCodeProcessGroup("SIGKILL")),
+        Effect.andThen(
+          Effect.all(
+            [
+              killOpenCodeProcessGroup("SIGKILL"),
+              killDirectChild("SIGKILL"),
+              killMatchingServeProcesses("SIGKILL"),
+            ],
+            { concurrency: "unbounded", discard: true },
+          ),
+        ),
         Effect.ignore,
       );
       yield* Scope.addFinalizer(runtimeScope, terminateChild);


### PR DESCRIPTION
## Summary
- Wrap the OpenCode provider probe in safe scoped teardown so cleanup failures do not mask a successful inventory refresh.
- Strengthen OpenCode runtime shutdown by terminating direct child processes and matching `serve` processes, in addition to the existing process-group cleanup.
- Add coverage for the case where probe teardown throws after a successful inventory load.

## Testing
- Not run (`bun fmt`)
- Not run (`bun lint`)
- Not run (`bun typecheck`)
- Not run (`bun run test`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OpenCode probe lifecycle and subprocess termination logic; mistakes could cause lingering processes or over-aggressive kills on Unix platforms.
> 
> **Overview**
> Wraps the OpenCode provider inventory probe with `scopedSafeTeardown` so finalizer/cleanup errors during scope close no longer mask a successful refresh.
> 
> Hardens OpenCode runtime shutdown by, on non-Windows platforms, additionally killing the direct spawned child and any matching `opencode serve --hostname=... --port=...` processes (via `ps` scan) alongside the existing process-group kill.
> 
> Adds a regression test ensuring `checkOpenCodeProviderStatus` still returns a `ready` snapshot even if probe teardown throws after inventory loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b538723e987a3d35d54731e0e743a576369a4d0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden OpenCode probe teardown to avoid leaked processes on scope finalization
> - Wraps the OpenCode inventory probe in `scopedSafeTeardown` so that teardown/finalizer errors are suppressed and a successful provider refresh result is preserved even if scope cleanup throws.
> - Adds process-enumeration helpers (`listProcessCommands`, `terminateMatchingOpenCodeServeProcesses`) to [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/2657/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) that identify and signal stray OpenCode `serve` processes by matching binary path, hostname, and port.
> - Extends the `runOpenCodeCommand` finalizer to concurrently send SIGTERM to the process group, the direct child, and any matching serve processes; waits 1 second; then sends SIGKILL to all three.
> - Adds a regression test confirming provider refresh results survive teardown errors.
> - Behavioral Change: teardown is now more aggressive and parallelized on non-Windows platforms; stray child processes that previously leaked will now receive explicit kill signals.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b538723.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->