### PR TITLE
Fix OpenCode events on versions greater than 1.14.40

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1,4 +1,4 @@
-import { setTimeout as sleep } from "node:timers/promises";
+import * as NodeTimersPromises from "node:timers/promises";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Context from "effect/Context";
@@ -190,7 +190,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
                 if (!runtimeMock.state.keepSubscriptionOpen) {
                   break;
                 }
-                await sleep(5);
+                await NodeTimersPromises.setTimeout(5);
               }
             })(),
           };

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -63,6 +63,9 @@ const runtimeMock = {
     closeError: null as Error | null,
     messages: [] as MessageEntry[],
     subscribedEvents: [] as unknown[],
+    subscribedEventDirectory: process.cwd(),
+    globalEventCalls: 0,
+    keepSubscriptionOpen: false,
   },
   reset() {
     this.state.startCalls.length = 0;
@@ -76,8 +79,20 @@ const runtimeMock = {
     this.state.closeError = null;
     this.state.messages = [];
     this.state.subscribedEvents = [];
+    this.state.subscribedEventDirectory = process.cwd();
+    this.state.globalEventCalls = 0;
+    this.state.keepSubscriptionOpen = false;
   },
 };
+
+function toGlobalEvent(event: unknown, directory: string): unknown {
+  return event && typeof event === "object" && "payload" in event
+    ? event
+    : {
+        directory,
+        payload: event,
+      };
+}
 
 const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
   startOpenCodeServerProcess: ({ binaryPath }) =>
@@ -158,14 +173,33 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
               : runtimeMock.state.messages;
         },
       },
+      global: {
+        event: async (options?: { signal?: AbortSignal }) => {
+          runtimeMock.state.globalEventCalls += 1;
+          return {
+            stream: (async function* () {
+              let index = 0;
+              while (!options?.signal?.aborted) {
+                if (index < runtimeMock.state.subscribedEvents.length) {
+                  yield toGlobalEvent(
+                    runtimeMock.state.subscribedEvents[index++],
+                    runtimeMock.state.subscribedEventDirectory,
+                  );
+                  continue;
+                }
+                if (!runtimeMock.state.keepSubscriptionOpen) {
+                  break;
+                }
+                await Effect.runPromise(Effect.sleep("5 millis"));
+              }
+            })(),
+          };
+        },
+      },
       event: {
-        subscribe: async () => ({
-          stream: (async function* () {
-            for (const event of runtimeMock.state.subscribedEvents) {
-              yield event;
-            }
-          })(),
-        }),
+        subscribe: async () => {
+          throw new Error("OpenCodeAdapter should use global.event for runtime events");
+        },
       },
     }) as unknown as ReturnType<OpenCodeRuntimeShape["createOpenCodeSdkClient"]>,
   loadOpenCodeInventory: () =>
@@ -650,6 +684,78 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const completed = events.at(-1);
       if (completed?.type === "item.completed") {
         assert.equal(completed.payload.detail, "A BBonus");
+      }
+    }),
+  );
+
+  it.effect("streams current OpenCode global event payloads for the session directory", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-current-event-shape");
+      runtimeMock.state.keepSubscriptionOpen = true;
+      runtimeMock.state.subscribedEventDirectory = "/repo/current-event-shape";
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.filter((event) => event.type === "content.delta"),
+        Stream.take(1),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        cwd: "/repo/current-event-shape",
+        runtimeMode: "full-access",
+      });
+      const turn = yield* adapter.sendTurn({
+        threadId,
+        input: "Fix it",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("opencode"),
+          model: "openai/gpt-5",
+        },
+      });
+
+      runtimeMock.state.subscribedEvents.push(
+        {
+          type: "message.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            info: {
+              id: "msg-assistant-current-shape",
+              role: "assistant",
+            },
+          },
+        },
+        {
+          type: "message.part.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            part: {
+              id: "prt-assistant-current-shape",
+              sessionID: "http://127.0.0.1:9999/session",
+              messageID: "msg-assistant-current-shape",
+              type: "text",
+              text: "Hello",
+              time: {
+                start: 1_778_000_000_000,
+              },
+            },
+          },
+        },
+      );
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      assert.deepEqual(
+        events.map((event) => event.type),
+        ["content.delta"],
+      );
+      assert.equal(runtimeMock.state.globalEventCalls, 1);
+      const delta = events.find((event) => event.type === "content.delta");
+      assert.equal(delta?.turnId, turn.turnId);
+      if (delta?.type === "content.delta") {
+        assert.equal(delta.payload.delta, "Hello");
       }
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -1,6 +1,6 @@
-import assert from "node:assert/strict";
+import { setTimeout as sleep } from "node:timers/promises";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { it } from "@effect/vitest";
+import { assert, it } from "@effect/vitest";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -190,7 +190,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
                 if (!runtimeMock.state.keepSubscriptionOpen) {
                   break;
                 }
-                await new Promise((resolve) => setTimeout(resolve, 5));
+                await sleep(5);
               }
             })(),
           };

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -190,7 +190,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
                 if (!runtimeMock.state.keepSubscriptionOpen) {
                   break;
                 }
-                await Effect.runPromise(Effect.sleep("5 millis"));
+                await new Promise((resolve) => setTimeout(resolve, 5));
               }
             })(),
           };

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -58,10 +58,12 @@ interface OpenCodeTurnSnapshot {
 }
 
 type OpenCodeSubscribedEvent =
-  Awaited<ReturnType<OpencodeClient["event"]["subscribe"]>> extends {
+  Awaited<ReturnType<OpencodeClient["global"]["event"]>> extends {
     readonly stream: AsyncIterable<infer TEvent>;
   }
-    ? TEvent
+    ? TEvent extends { readonly payload: infer TPayload }
+      ? TPayload
+      : never
     : never;
 
 interface OpenCodeSessionContext {
@@ -89,7 +91,7 @@ interface OpenCodeSessionContext {
   /**
    * Sole lifecycle handle for the session. Closing this scope:
    *   - aborts the `AbortController` registered as a finalizer
-   *     (cancels the in-flight `event.subscribe` fetch),
+   *     (cancels the in-flight `global.event` fetch),
    *   - interrupts the event-pump and server-exit fibers forked
    *     via `Effect.forkIn(sessionScope)`,
    *   - tears down the OpenCode server process for scope-owned servers.
@@ -963,7 +965,7 @@ export function makeOpenCodeAdapter(
     const startEventPump = Effect.fn("startEventPump")(function* (context: OpenCodeSessionContext) {
       // One AbortController per session scope. The finalizer fires when
       // the scope closes (explicit stop, unexpected exit, or layer
-      // shutdown) and cancels the in-flight `event.subscribe` fetch so
+      // shutdown) and cancels the in-flight `global.event` fetch so
       // the async iterable unwinds cleanly.
       const eventsAbortController = new AbortController();
       yield* Scope.addFinalizer(
@@ -974,8 +976,8 @@ export function makeOpenCodeAdapter(
       // Fibers forked into `context.sessionScope` are interrupted
       // automatically when the scope closes — no bookkeeping required.
       yield* Effect.flatMap(
-        runOpenCodeSdk("event.subscribe", () =>
-          context.client.event.subscribe(undefined, {
+        runOpenCodeSdk("global.event", () =>
+          context.client.global.event({
             signal: eventsAbortController.signal,
           }),
         ),
@@ -984,11 +986,18 @@ export function makeOpenCodeAdapter(
             subscription.stream,
             (cause) =>
               new OpenCodeRuntimeError({
-                operation: "event.subscribe",
+                operation: "global.event",
                 detail: openCodeRuntimeErrorDetail(cause),
                 cause,
               }),
-          ).pipe(Stream.runForEach((event) => handleSubscribedEvent(context, event))),
+          ).pipe(
+            Stream.runForEach((event) => {
+              if (!("directory" in event) || event.directory !== context.directory) {
+                return Effect.void;
+              }
+              return handleSubscribedEvent(context, event.payload);
+            }),
+          ),
       ).pipe(
         Effect.exit,
         Effect.flatMap((exit) =>


### PR DESCRIPTION
## Summary
- switch OpenCode runtime events from the now-empty /event stream to /global/event
- unwrap global event payloads for the active session directory before using the existing provider event projection
- add regression coverage that the adapter uses the global event stream and handles wrapped OpenCode message events

Fixes #2633

Replaces #2634, which was closed while still pointing at the old fork branch name.

## Test plan
- bun fmt
- bun lint
- bun typecheck
- bun run --cwd apps/server test src/provider/Layers/OpenCodeAdapter.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sole runtime event subscription path for OpenCode sessions; incorrect directory filtering or payload handling would break streaming or drop events for other workspaces on a shared server.
> 
> **Overview**
> Fixes OpenCode assistant streaming on runtimes where the legacy **`/event`** stream is empty (e.g. versions after 1.14.40) by subscribing to **`client.global.event`** instead of **`event.subscribe`**.
> 
> The event pump now ignores global envelopes whose **`directory`** does not match the session cwd and forwards only **`event.payload`** into the existing **`handleSubscribedEvent`** path. **`OpenCodeSubscribedEvent`** is retargeted to that payload type.
> 
> Tests mock **`global.event`** (with optional keep-alive), make **`event.subscribe`** fail if used, and add coverage that directory-scoped global **`message.*`** events produce **`content.delta`** for the active turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335fe3f6358af1eb5ad52adf15d322b279a26415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix OpenCode event streaming to use `global.event` for versions greater than 1.14.40
> - Switches the event pump in [OpenCodeAdapter.ts](https://github.com/pingdotgg/t3code/pull/2673/files#diff-a4267388b15e5043ae1899beded972cbee9e52533ca3d9d65d438a91a9f7fbe7) from `client.event.subscribe` to `client.global.event`, passing the session `AbortSignal`.
> - Adds directory-based filtering so only events matching the session's working directory are processed; handlers now receive `event.payload` instead of the raw wrapper.
> - Updates the `OpenCodeSubscribedEvent` type to extract the payload from events with a `payload` field, matching the new API shape.
> - Adds a test in [OpenCodeAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/2673/files#diff-2d1ef28752ab2f1ec0f021e6723508dc18e6a9294ebd20255ec3767afe34cf5f) that verifies `global.event` is called once and that `message.updated`/`message.part.updated` events produce the correct `content.delta` output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 335fe3f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->