### PR TITLE
[codex] add diagnostics resource history

### DIFF
--- a/apps/server/src/diagnostics/ProcessDiagnostics.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.ts
@@ -15,7 +15,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { collectUint8StreamText } from "../stream/collectUint8StreamText.ts";
 
-interface ProcessRow {
+export interface ProcessRow {
   readonly pid: number;
   readonly ppid: number;
   readonly pgid: number | null;
@@ -186,7 +186,7 @@ function parseWindowsProcessRows(output: string): ReadonlyArray<ProcessRow> {
   }
 }
 
-function buildDescendantEntries(
+export function buildDescendantEntries(
   rows: ReadonlyArray<ProcessRow>,
   serverPid: number,
 ): ReadonlyArray<ServerProcessDiagnosticsEntry> {
@@ -230,7 +230,7 @@ function buildDescendantEntries(
   return entries;
 }
 
-function isDiagnosticsQueryProcess(row: ProcessRow, serverPid: number): boolean {
+export function isDiagnosticsQueryProcess(row: ProcessRow, serverPid: number): boolean {
   if (row.ppid !== serverPid) return false;
 
   const command = row.command.trim();
@@ -370,7 +370,7 @@ function readWindowsProcessRows(): Effect.Effect<
   );
 }
 
-const readProcessRows = (platform = process.platform) =>
+export const readProcessRows = (platform = process.platform) =>
   platform === "win32" ? readWindowsProcessRows() : readPosixProcessRows();
 
 export function aggregateProcessDiagnostics(input: {

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import {
+  aggregateProcessResourceHistory,
+  collectMonitoredSamples,
+} from "./ProcessResourceMonitor.ts";
+
+describe("ProcessResourceMonitor", () => {
+  it.effect("samples the server root process and descendants", () =>
+    Effect.sync(() => {
+      const sampledAt = DateTime.makeUnsafe("2026-05-05T10:00:00.000Z");
+      const samples = collectMonitoredSamples({
+        serverPid: 100,
+        sampledAt,
+        sampledAtMs: DateTime.toEpochMillis(sampledAt),
+        rows: [
+          {
+            pid: 100,
+            ppid: 1,
+            pgid: 100,
+            status: "S",
+            cpuPercent: 2,
+            rssBytes: 1_000,
+            elapsed: "01:00",
+            command: "t3 server",
+          },
+          {
+            pid: 101,
+            ppid: 100,
+            pgid: 100,
+            status: "S",
+            cpuPercent: 10,
+            rssBytes: 2_000,
+            elapsed: "00:20",
+            command: "codex app-server",
+          },
+          {
+            pid: 102,
+            ppid: 101,
+            pgid: 100,
+            status: "R",
+            cpuPercent: 50,
+            rssBytes: 3_000,
+            elapsed: "00:05",
+            command: "rg needle",
+          },
+          {
+            pid: 200,
+            ppid: 1,
+            pgid: 200,
+            status: "R",
+            cpuPercent: 99,
+            rssBytes: 9_000,
+            elapsed: "00:05",
+            command: "unrelated",
+          },
+        ],
+      });
+
+      expect(samples.map((sample) => sample.pid)).toEqual([100, 101, 102]);
+      expect(samples.map((sample) => sample.depth)).toEqual([0, 1, 2]);
+      expect(samples[0]?.isServerRoot).toBe(true);
+      expect(samples[1]?.isServerRoot).toBe(false);
+    }),
+  );
+
+  it.effect("rolls samples up by process and CPU time", () =>
+    Effect.sync(() => {
+      const firstAt = DateTime.makeUnsafe("2026-05-05T10:00:00.000Z");
+      const secondAt = DateTime.makeUnsafe("2026-05-05T10:00:05.000Z");
+      const samples = [
+        ...collectMonitoredSamples({
+          serverPid: 100,
+          sampledAt: firstAt,
+          sampledAtMs: DateTime.toEpochMillis(firstAt),
+          rows: [
+            {
+              pid: 100,
+              ppid: 1,
+              pgid: 100,
+              status: "S",
+              cpuPercent: 10,
+              rssBytes: 1_000,
+              elapsed: "01:00",
+              command: "t3 server",
+            },
+          ],
+        }),
+        ...collectMonitoredSamples({
+          serverPid: 100,
+          sampledAt: secondAt,
+          sampledAtMs: DateTime.toEpochMillis(secondAt),
+          rows: [
+            {
+              pid: 100,
+              ppid: 1,
+              pgid: 100,
+              status: "S",
+              cpuPercent: 30,
+              rssBytes: 2_000,
+              elapsed: "01:05",
+              command: "t3 server",
+            },
+          ],
+        }),
+      ];
+
+      const result = aggregateProcessResourceHistory({
+        samples,
+        readAt: secondAt,
+        readAtMs: DateTime.toEpochMillis(secondAt),
+        windowMs: 60_000,
+        bucketMs: 10_000,
+        lastError: null,
+      });
+
+      expect(Option.isNone(result.error)).toBe(true);
+      expect(result.topProcesses).toHaveLength(1);
+      expect(result.topProcesses[0]?.avgCpuPercent).toBe(20);
+      expect(result.topProcesses[0]?.maxCpuPercent).toBe(30);
+      expect(result.topProcesses[0]?.cpuSecondsApprox).toBe(2);
+      expect(result.totalCpuSecondsApprox).toBe(2);
+      expect(result.buckets.some((bucket) => bucket.maxCpuPercent === 30)).toBe(true);
+    }),
+  );
+});

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
@@ -126,4 +126,106 @@ describe("ProcessResourceMonitor", () => {
       expect(result.buckets.some((bucket) => bucket.maxCpuPercent === 30)).toBe(true);
     }),
   );
+
+  it.effect("keeps a process grouped when elapsed time drifts between samples", () =>
+    Effect.sync(() => {
+      const firstAt = DateTime.makeUnsafe("2026-05-05T10:00:00.400Z");
+      const secondAt = DateTime.makeUnsafe("2026-05-05T10:00:05.900Z");
+      const samples = [
+        ...collectMonitoredSamples({
+          serverPid: 100,
+          sampledAt: firstAt,
+          sampledAtMs: DateTime.toEpochMillis(firstAt),
+          rows: [
+            {
+              pid: 100,
+              ppid: 1,
+              pgid: 100,
+              status: "S",
+              cpuPercent: 1,
+              rssBytes: 1_000,
+              elapsed: "01:00",
+              command: "t3 server",
+            },
+          ],
+        }),
+        ...collectMonitoredSamples({
+          serverPid: 100,
+          sampledAt: secondAt,
+          sampledAtMs: DateTime.toEpochMillis(secondAt),
+          rows: [
+            {
+              pid: 100,
+              ppid: 1,
+              pgid: 100,
+              status: "S",
+              cpuPercent: 2,
+              rssBytes: 2_000,
+              elapsed: "01:06",
+              command: "t3 server",
+            },
+          ],
+        }),
+      ];
+
+      const result = aggregateProcessResourceHistory({
+        samples,
+        readAt: secondAt,
+        readAtMs: DateTime.toEpochMillis(secondAt),
+        windowMs: 60_000,
+        bucketMs: 10_000,
+        lastError: null,
+      });
+
+      expect(result.topProcesses).toHaveLength(1);
+      expect(result.topProcesses[0]?.isServerRoot).toBe(true);
+      expect(result.topProcesses[0]?.sampleCount).toBe(2);
+      expect(result.topProcesses[0]?.maxRssBytes).toBe(2_000);
+    }),
+  );
+
+  it.effect("returns all process summaries in the selected window", () =>
+    Effect.sync(() => {
+      const sampledAt = DateTime.makeUnsafe("2026-05-05T10:00:00.000Z");
+      const samples = collectMonitoredSamples({
+        serverPid: 100,
+        sampledAt,
+        sampledAtMs: DateTime.toEpochMillis(sampledAt),
+        rows: [
+          {
+            pid: 100,
+            ppid: 1,
+            pgid: 100,
+            status: "S",
+            cpuPercent: 1,
+            rssBytes: 1_000,
+            elapsed: "01:00",
+            command: "t3 server",
+          },
+          ...Array.from({ length: 35 }, (_, index) => ({
+            pid: 200 + index,
+            ppid: index === 0 ? 100 : 199 + index,
+            pgid: 100,
+            status: "S",
+            cpuPercent: 35 - index,
+            rssBytes: 2_000 + index,
+            elapsed: "00:10",
+            command: `worker ${index}`,
+          })),
+        ],
+      });
+
+      const result = aggregateProcessResourceHistory({
+        samples,
+        readAt: sampledAt,
+        readAtMs: DateTime.toEpochMillis(sampledAt),
+        windowMs: 60_000,
+        bucketMs: 10_000,
+        lastError: null,
+      });
+
+      expect(result.topProcesses).toHaveLength(36);
+      expect(result.topProcesses.some((process) => process.command === "worker 34")).toBe(true);
+    }),
+  );
 });

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.ts
@@ -1,0 +1,330 @@
+import type {
+  ServerProcessResourceHistoryBucket,
+  ServerProcessResourceHistoryInput,
+  ServerProcessResourceHistoryResult,
+  ServerProcessResourceHistorySummary,
+} from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import {
+  buildDescendantEntries,
+  isDiagnosticsQueryProcess,
+  type ProcessRow,
+  readProcessRows,
+} from "./ProcessDiagnostics.ts";
+
+const SAMPLE_INTERVAL_MS = 5_000;
+const RETENTION_MS = 60 * 60_000;
+const MAX_RETAINED_SAMPLES = 20_000;
+const DEFAULT_TOP_PROCESS_LIMIT = 30;
+
+export interface ProcessResourceSample {
+  readonly sampledAt: DateTime.Utc;
+  readonly sampledAtMs: number;
+  readonly processKey: string;
+  readonly pid: number;
+  readonly ppid: number;
+  readonly command: string;
+  readonly cpuPercent: number;
+  readonly rssBytes: number;
+  readonly depth: number;
+  readonly isServerRoot: boolean;
+}
+
+interface MonitorState {
+  readonly samples: ReadonlyArray<ProcessResourceSample>;
+  readonly lastError: string | null;
+}
+
+export interface ProcessResourceMonitorShape {
+  readonly readHistory: (
+    input: ServerProcessResourceHistoryInput,
+  ) => Effect.Effect<ServerProcessResourceHistoryResult>;
+}
+
+export class ProcessResourceMonitor extends Context.Service<
+  ProcessResourceMonitor,
+  ProcessResourceMonitorShape
+>()("t3/diagnostics/ProcessResourceMonitor") {}
+
+function dateTimeFromMillis(ms: number): DateTime.Utc {
+  return DateTime.makeUnsafe(ms);
+}
+
+function parseElapsedMs(elapsed: string): number | null {
+  const [daysPrefix, timeText] = elapsed.includes("-")
+    ? (elapsed.split("-", 2) as [string, string])
+    : (["0", elapsed] as const);
+  const days = Number.parseInt(daysPrefix, 10);
+  if (!Number.isFinite(days) || days < 0) return null;
+
+  const parts = timeText.split(":");
+  const secondsText = parts.pop();
+  if (!secondsText) return null;
+  const seconds = Number.parseFloat(secondsText);
+  if (!Number.isFinite(seconds) || seconds < 0) return null;
+
+  const minutesText = parts.pop();
+  const minutes = minutesText === undefined ? 0 : Number.parseInt(minutesText, 10);
+  if (!Number.isFinite(minutes) || minutes < 0) return null;
+
+  const hoursText = parts.pop();
+  const hours = hoursText === undefined ? 0 : Number.parseInt(hoursText, 10);
+  if (!Number.isFinite(hours) || hours < 0 || parts.length > 0) return null;
+
+  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1_000;
+}
+
+function sampleKey(
+  row: Pick<ProcessRow, "pid" | "command" | "elapsed">,
+  sampledAtMs: number,
+): string {
+  const elapsedMs = parseElapsedMs(row.elapsed);
+  const startedAtMs = elapsedMs === null ? null : Math.round((sampledAtMs - elapsedMs) / 1_000);
+  return `${row.pid}:${startedAtMs ?? "unknown"}:${row.command}`;
+}
+
+function findServerRootRow(rows: ReadonlyArray<ProcessRow>, serverPid: number): ProcessRow | null {
+  return rows.find((row) => row.pid === serverPid) ?? null;
+}
+
+export function collectMonitoredSamples(input: {
+  readonly rows: ReadonlyArray<ProcessRow>;
+  readonly serverPid: number;
+  readonly sampledAt: DateTime.Utc;
+  readonly sampledAtMs: number;
+}): ReadonlyArray<ProcessResourceSample> {
+  const rows = input.rows.filter((row) => !isDiagnosticsQueryProcess(row, input.serverPid));
+  const root = findServerRootRow(rows, input.serverPid);
+  const descendants = buildDescendantEntries(rows, input.serverPid);
+  const samples: ProcessResourceSample[] = [];
+
+  if (root) {
+    samples.push({
+      sampledAt: input.sampledAt,
+      sampledAtMs: input.sampledAtMs,
+      processKey: sampleKey(root, input.sampledAtMs),
+      pid: root.pid,
+      ppid: root.ppid,
+      command: root.command,
+      cpuPercent: root.cpuPercent,
+      rssBytes: root.rssBytes,
+      depth: 0,
+      isServerRoot: true,
+    });
+  }
+
+  for (const process of descendants) {
+    samples.push({
+      sampledAt: input.sampledAt,
+      sampledAtMs: input.sampledAtMs,
+      processKey: sampleKey(process, input.sampledAtMs),
+      pid: process.pid,
+      ppid: process.ppid,
+      command: process.command,
+      cpuPercent: process.cpuPercent,
+      rssBytes: process.rssBytes,
+      depth: process.depth + 1,
+      isServerRoot: false,
+    });
+  }
+
+  return samples;
+}
+
+function trimSamples(
+  samples: ReadonlyArray<ProcessResourceSample>,
+  nowMs: number,
+): ReadonlyArray<ProcessResourceSample> {
+  const minSampledAtMs = nowMs - RETENTION_MS;
+  const retained = samples.filter((sample) => sample.sampledAtMs >= minSampledAtMs);
+  return retained.length <= MAX_RETAINED_SAMPLES
+    ? retained
+    : retained.slice(retained.length - MAX_RETAINED_SAMPLES);
+}
+
+function summarizeProcesses(
+  samples: ReadonlyArray<ProcessResourceSample>,
+): ReadonlyArray<ServerProcessResourceHistorySummary> {
+  const groups = new Map<string, ProcessResourceSample[]>();
+  for (const sample of samples) {
+    const processSamples = groups.get(sample.processKey) ?? [];
+    processSamples.push(sample);
+    groups.set(sample.processKey, processSamples);
+  }
+
+  return [...groups.entries()]
+    .map(([processKey, processSamples]) => {
+      const sorted = processSamples.toSorted((left, right) => left.sampledAtMs - right.sampledAtMs);
+      const first = sorted[0]!;
+      const latest = sorted[sorted.length - 1]!;
+      const cpuPercentTotal = sorted.reduce((total, sample) => total + sample.cpuPercent, 0);
+      const maxCpuPercent = Math.max(...sorted.map((sample) => sample.cpuPercent));
+      const maxRssBytes = Math.max(...sorted.map((sample) => sample.rssBytes));
+      const cpuSecondsApprox = sorted.reduce(
+        (total, sample) => total + (sample.cpuPercent / 100) * (SAMPLE_INTERVAL_MS / 1_000),
+        0,
+      );
+
+      return {
+        processKey,
+        pid: latest.pid,
+        ppid: latest.ppid,
+        command: latest.command,
+        depth: latest.depth,
+        isServerRoot: latest.isServerRoot,
+        firstSeenAt: first.sampledAt,
+        lastSeenAt: latest.sampledAt,
+        currentCpuPercent: latest.cpuPercent,
+        avgCpuPercent: cpuPercentTotal / sorted.length,
+        maxCpuPercent,
+        cpuSecondsApprox,
+        currentRssBytes: latest.rssBytes,
+        maxRssBytes,
+        sampleCount: sorted.length,
+      } satisfies ServerProcessResourceHistorySummary;
+    })
+    .toSorted((left, right) => right.cpuSecondsApprox - left.cpuSecondsApprox)
+    .slice(0, DEFAULT_TOP_PROCESS_LIMIT);
+}
+
+function buildBuckets(input: {
+  readonly samples: ReadonlyArray<ProcessResourceSample>;
+  readonly nowMs: number;
+  readonly windowMs: number;
+  readonly bucketMs: number;
+}): ReadonlyArray<ServerProcessResourceHistoryBucket> {
+  const bucketMs = Math.max(1_000, input.bucketMs);
+  const windowStartMs = input.nowMs - input.windowMs;
+  const buckets: ServerProcessResourceHistoryBucket[] = [];
+
+  for (let startedAtMs = windowStartMs; startedAtMs < input.nowMs; startedAtMs += bucketMs) {
+    const endedAtMs = Math.min(input.nowMs, startedAtMs + bucketMs);
+    const bucketSamples = input.samples.filter(
+      (sample) =>
+        sample.sampledAtMs >= startedAtMs &&
+        (endedAtMs === input.nowMs
+          ? sample.sampledAtMs <= endedAtMs
+          : sample.sampledAtMs < endedAtMs),
+    );
+    const samplesByRead = new Map<number, ProcessResourceSample[]>();
+    for (const sample of bucketSamples) {
+      const samplesAtTime = samplesByRead.get(sample.sampledAtMs) ?? [];
+      samplesAtTime.push(sample);
+      samplesByRead.set(sample.sampledAtMs, samplesAtTime);
+    }
+
+    const readTotals = [...samplesByRead.values()].map((samplesAtTime) => ({
+      cpuPercent: samplesAtTime.reduce((total, sample) => total + sample.cpuPercent, 0),
+      rssBytes: samplesAtTime.reduce((total, sample) => total + sample.rssBytes, 0),
+      processCount: samplesAtTime.length,
+    }));
+    const avgCpuPercent =
+      readTotals.length === 0
+        ? 0
+        : readTotals.reduce((total, read) => total + read.cpuPercent, 0) / readTotals.length;
+
+    buckets.push({
+      startedAt: dateTimeFromMillis(startedAtMs),
+      endedAt: dateTimeFromMillis(endedAtMs),
+      avgCpuPercent,
+      maxCpuPercent: readTotals.length ? Math.max(...readTotals.map((read) => read.cpuPercent)) : 0,
+      maxRssBytes: readTotals.length ? Math.max(...readTotals.map((read) => read.rssBytes)) : 0,
+      maxProcessCount: readTotals.length
+        ? Math.max(...readTotals.map((read) => read.processCount))
+        : 0,
+    });
+  }
+
+  return buckets;
+}
+
+export function aggregateProcessResourceHistory(input: {
+  readonly samples: ReadonlyArray<ProcessResourceSample>;
+  readonly readAt: DateTime.Utc;
+  readonly readAtMs: number;
+  readonly windowMs: number;
+  readonly bucketMs: number;
+  readonly lastError: string | null;
+}): ServerProcessResourceHistoryResult {
+  const windowMs = Math.max(1_000, input.windowMs);
+  const bucketMs = Math.max(1_000, input.bucketMs);
+  const minSampledAtMs = input.readAtMs - windowMs;
+  const samples = input.samples.filter((sample) => sample.sampledAtMs >= minSampledAtMs);
+  const topProcesses = summarizeProcesses(samples);
+  const totalCpuSecondsApprox = samples.reduce(
+    (total, sample) => total + (sample.cpuPercent / 100) * (SAMPLE_INTERVAL_MS / 1_000),
+    0,
+  );
+
+  return {
+    readAt: input.readAt,
+    windowMs,
+    bucketMs,
+    sampleIntervalMs: SAMPLE_INTERVAL_MS,
+    retainedSampleCount: input.samples.length,
+    totalCpuSecondsApprox,
+    buckets: buildBuckets({ samples, nowMs: input.readAtMs, windowMs, bucketMs }),
+    topProcesses,
+    error: input.lastError ? Option.some({ message: input.lastError }) : Option.none(),
+  };
+}
+
+export const make = Effect.fn("makeProcessResourceMonitor")(function* () {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const state = yield* Ref.make<MonitorState>({ samples: [], lastError: null });
+
+  const sampleOnce = Effect.gen(function* () {
+    const sampledAt = yield* DateTime.now;
+    const sampledAtMs = DateTime.toEpochMillis(sampledAt);
+    const rows = yield* readProcessRows().pipe(
+      Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    );
+    const samples = collectMonitoredSamples({
+      rows,
+      serverPid: process.pid,
+      sampledAt,
+      sampledAtMs,
+    });
+    yield* Ref.update(state, (current) => ({
+      samples: trimSamples([...current.samples, ...samples], sampledAtMs),
+      lastError: null,
+    }));
+  }).pipe(
+    Effect.catch((error: unknown) =>
+      Ref.update(state, (current) => ({
+        ...current,
+        lastError: error instanceof Error ? error.message : "Failed to sample process resources.",
+      })),
+    ),
+  );
+
+  yield* Effect.forever(sampleOnce.pipe(Effect.andThen(Effect.sleep(SAMPLE_INTERVAL_MS)))).pipe(
+    Effect.forkScoped,
+  );
+
+  const readHistory: ProcessResourceMonitorShape["readHistory"] = (input) =>
+    Effect.gen(function* () {
+      const readAt = yield* DateTime.now;
+      const readAtMs = DateTime.toEpochMillis(readAt);
+      const current = yield* Ref.get(state);
+      return aggregateProcessResourceHistory({
+        samples: current.samples,
+        readAt,
+        readAtMs,
+        windowMs: input.windowMs,
+        bucketMs: input.bucketMs,
+        lastError: current.lastError,
+      });
+    });
+
+  return ProcessResourceMonitor.of({ readHistory });
+});
+
+export const layer = Layer.effect(ProcessResourceMonitor, make());

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.ts
@@ -22,7 +22,6 @@ import {
 const SAMPLE_INTERVAL_MS = 5_000;
 const RETENTION_MS = 60 * 60_000;
 const MAX_RETAINED_SAMPLES = 20_000;
-const DEFAULT_TOP_PROCESS_LIMIT = 30;
 
 export interface ProcessResourceSample {
   readonly sampledAt: DateTime.Utc;
@@ -57,37 +56,8 @@ function dateTimeFromMillis(ms: number): DateTime.Utc {
   return DateTime.makeUnsafe(ms);
 }
 
-function parseElapsedMs(elapsed: string): number | null {
-  const [daysPrefix, timeText] = elapsed.includes("-")
-    ? (elapsed.split("-", 2) as [string, string])
-    : (["0", elapsed] as const);
-  const days = Number.parseInt(daysPrefix, 10);
-  if (!Number.isFinite(days) || days < 0) return null;
-
-  const parts = timeText.split(":");
-  const secondsText = parts.pop();
-  if (!secondsText) return null;
-  const seconds = Number.parseFloat(secondsText);
-  if (!Number.isFinite(seconds) || seconds < 0) return null;
-
-  const minutesText = parts.pop();
-  const minutes = minutesText === undefined ? 0 : Number.parseInt(minutesText, 10);
-  if (!Number.isFinite(minutes) || minutes < 0) return null;
-
-  const hoursText = parts.pop();
-  const hours = hoursText === undefined ? 0 : Number.parseInt(hoursText, 10);
-  if (!Number.isFinite(hours) || hours < 0 || parts.length > 0) return null;
-
-  return (((days * 24 + hours) * 60 + minutes) * 60 + seconds) * 1_000;
-}
-
-function sampleKey(
-  row: Pick<ProcessRow, "pid" | "command" | "elapsed">,
-  sampledAtMs: number,
-): string {
-  const elapsedMs = parseElapsedMs(row.elapsed);
-  const startedAtMs = elapsedMs === null ? null : Math.round((sampledAtMs - elapsedMs) / 1_000);
-  return `${row.pid}:${startedAtMs ?? "unknown"}:${row.command}`;
+function sampleKey(row: Pick<ProcessRow, "pid" | "command">): string {
+  return `${row.pid}:${row.command}`;
 }
 
 function findServerRootRow(rows: ReadonlyArray<ProcessRow>, serverPid: number): ProcessRow | null {
@@ -109,7 +79,7 @@ export function collectMonitoredSamples(input: {
     samples.push({
       sampledAt: input.sampledAt,
       sampledAtMs: input.sampledAtMs,
-      processKey: sampleKey(root, input.sampledAtMs),
+      processKey: sampleKey(root),
       pid: root.pid,
       ppid: root.ppid,
       command: root.command,
@@ -124,7 +94,7 @@ export function collectMonitoredSamples(input: {
     samples.push({
       sampledAt: input.sampledAt,
       sampledAtMs: input.sampledAtMs,
-      processKey: sampleKey(process, input.sampledAtMs),
+      processKey: sampleKey(process),
       pid: process.pid,
       ppid: process.ppid,
       command: process.command,
@@ -190,8 +160,7 @@ function summarizeProcesses(
         sampleCount: sorted.length,
       } satisfies ServerProcessResourceHistorySummary;
     })
-    .toSorted((left, right) => right.cpuSecondsApprox - left.cpuSecondsApprox)
-    .slice(0, DEFAULT_TOP_PROCESS_LIMIT);
+    .toSorted((left, right) => right.cpuSecondsApprox - left.cpuSecondsApprox);
 }
 
 function buildBuckets(input: {

--- a/apps/server/src/observability/RpcInstrumentation.ts
+++ b/apps/server/src/observability/RpcInstrumentation.ts
@@ -18,6 +18,7 @@ const DEFAULT_RPC_SPAN_ATTRIBUTES = {
 const RPC_METHODS_WITH_TRACING_DISABLED: ReadonlySet<string> = new Set([
   WS_METHODS.serverGetTraceDiagnostics,
   WS_METHODS.serverGetProcessDiagnostics,
+  WS_METHODS.serverGetProcessResourceHistory,
   WS_METHODS.serverSignalProcess,
 ]);
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -115,6 +115,7 @@ import * as SourceControlRepositoryService from "./sourceControl/SourceControlRe
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore.ts";
 import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
+import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
 import * as Data from "effect/Data";
 
@@ -561,6 +562,22 @@ const buildAppUnderTest = (options?: {
               signal: input.signal,
               signaled: true,
               message: Option.none(),
+            }),
+        }),
+      ),
+      Layer.provide(
+        Layer.mock(ProcessResourceMonitor.ProcessResourceMonitor)({
+          readHistory: (input) =>
+            Effect.succeed({
+              readAt: TEST_EPOCH,
+              windowMs: input.windowMs,
+              bucketMs: input.bucketMs,
+              sampleIntervalMs: 5_000,
+              retainedSampleCount: 0,
+              totalCpuSecondsApprox: 0,
+              buckets: [],
+              topProcesses: [],
+              error: Option.none(),
             }),
         }),
       ),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -76,6 +76,7 @@ import {
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore.ts";
 import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
+import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import {
@@ -280,6 +281,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
 const RuntimeDependenciesLive = RuntimeCoreDependenciesLive.pipe(
   // Misc.
   Layer.provideMerge(ProcessDiagnostics.layer),
+  Layer.provideMerge(ProcessResourceMonitor.layer),
   Layer.provideMerge(TraceDiagnostics.layer),
   Layer.provideMerge(AnalyticsServiceLayerLive),
   Layer.provideMerge(OpenLive),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -66,6 +66,7 @@ import { RepositoryIdentityResolver } from "./project/Services/RepositoryIdentit
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
+import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
 import * as SourceControlDiscoveryLayer from "./sourceControl/SourceControlDiscovery.ts";
 import { SourceControlRepositoryService } from "./sourceControl/SourceControlRepositoryService.ts";
@@ -193,6 +194,7 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
       const bootstrapCredentials = yield* BootstrapCredentialService;
       const sessions = yield* SessionCredentialService;
       const processDiagnostics = yield* ProcessDiagnostics.ProcessDiagnostics;
+      const processResourceMonitor = yield* ProcessResourceMonitor.ProcessResourceMonitor;
       const serverCommandId = (tag: string) =>
         CommandId.make(`server:${tag}:${crypto.randomUUID()}`);
 
@@ -909,6 +911,14 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
           observeRpcEffect(WS_METHODS.serverGetProcessDiagnostics, processDiagnostics.read, {
             "rpc.aggregate": "server",
           }),
+        [WS_METHODS.serverGetProcessResourceHistory]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.serverGetProcessResourceHistory,
+            processResourceMonitor.readHistory(input),
+            {
+              "rpc.aggregate": "server",
+            },
+          ),
         [WS_METHODS.serverSignalProcess]: (input) =>
           observeRpcEffect(WS_METHODS.serverSignalProcess, processDiagnostics.signal(input), {
             "rpc.aggregate": "server",

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -8,7 +8,11 @@ import {
   RefreshCwIcon,
 } from "lucide-react";
 import { useCallback, useMemo, useState, type ReactNode } from "react";
-import type { ServerProcessDiagnosticsEntry, ServerProcessSignal } from "@t3tools/contracts";
+import type {
+  ServerProcessDiagnosticsEntry,
+  ServerProcessResourceHistorySummary,
+  ServerProcessSignal,
+} from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
 
@@ -17,7 +21,10 @@ import { cn } from "../../lib/utils";
 import { resolveAndPersistPreferredEditor } from "../../editorPreferences";
 import { formatRelativeTime } from "../../timestampFormat";
 import { useServerAvailableEditors, useServerObservability } from "../../rpc/serverState";
-import { useProcessDiagnostics } from "../../lib/processDiagnosticsState";
+import {
+  useProcessDiagnostics,
+  useProcessResourceHistory,
+} from "../../lib/processDiagnosticsState";
 import { useTraceDiagnostics } from "../../lib/traceDiagnosticsState";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
@@ -502,6 +509,195 @@ function ProcessDiagnosticsTable({
   );
 }
 
+const RESOURCE_HISTORY_WINDOWS = [
+  { label: "5m", windowMs: 5 * 60_000, bucketMs: 30_000 },
+  { label: "15m", windowMs: 15 * 60_000, bucketMs: 60_000 },
+  { label: "30m", windowMs: 30 * 60_000, bucketMs: 2 * 60_000 },
+  { label: "1h", windowMs: 60 * 60_000, bucketMs: 5 * 60_000 },
+] as const;
+
+function formatCpuTime(seconds: number): string {
+  if (seconds < 60) return `${seconds.toFixed(seconds >= 10 ? 1 : 2)}s`;
+  const minutes = seconds / 60;
+  if (minutes < 60) return `${minutes.toFixed(minutes >= 10 ? 1 : 2)}m`;
+  return `${(minutes / 60).toFixed(2)}h`;
+}
+
+function formatShortProcessName(command: string): string {
+  const name = formatProcessName(command);
+  return name.length > 42 ? `${name.slice(0, 39)}...` : name;
+}
+
+function ProcessResourceHistoryChart({
+  buckets,
+}: {
+  buckets: ReadonlyArray<{
+    readonly startedAt: DateTime.Utc;
+    readonly avgCpuPercent: number;
+    readonly maxCpuPercent: number;
+  }>;
+}) {
+  const maxCpuPercent = Math.max(1, ...buckets.map((bucket) => bucket.maxCpuPercent));
+
+  return (
+    <div className="border-t border-border/60 px-4 py-3 sm:px-5">
+      <div className="flex h-28 items-end gap-1 overflow-hidden rounded-sm bg-muted/10 px-2 py-2">
+        {buckets.map((bucket) => {
+          const height = Math.max(2, (bucket.avgCpuPercent / maxCpuPercent) * 100);
+          return (
+            <Tooltip key={DateTime.formatIso(bucket.startedAt)}>
+              <TooltipTrigger
+                render={
+                  <div className="flex h-full min-w-1 flex-1 items-end">
+                    <div
+                      className="w-full rounded-t-sm bg-foreground/55 transition-colors hover:bg-foreground"
+                      style={{ height: `${height}%` }}
+                    />
+                  </div>
+                }
+              />
+              <TooltipPopup side="top">
+                Avg {bucket.avgCpuPercent.toFixed(1)}%, peak {bucket.maxCpuPercent.toFixed(1)}%
+              </TooltipPopup>
+            </Tooltip>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ResourceHistoryWindowSelector({
+  selectedWindowMs,
+  onSelect,
+}: {
+  selectedWindowMs: number;
+  onSelect: (windowMs: number) => void;
+}) {
+  return (
+    <div className="flex items-center rounded-md border border-border/60 p-0.5">
+      {RESOURCE_HISTORY_WINDOWS.map((option) => (
+        <button
+          key={option.windowMs}
+          type="button"
+          className={cn(
+            "h-6 rounded-sm px-2 text-[11px] font-medium text-muted-foreground hover:text-foreground",
+            selectedWindowMs === option.windowMs && "bg-muted text-foreground",
+          )}
+          onClick={() => onSelect(option.windowMs)}
+        >
+          {option.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ProcessResourceHistoryTable({
+  processes,
+  emptyLabel,
+}: {
+  processes: ReadonlyArray<ServerProcessResourceHistorySummary>;
+  emptyLabel: string;
+}) {
+  return (
+    <ScrollArea
+      chainVerticalScroll
+      scrollFade
+      hideScrollbars
+      className="w-full max-w-full border-t border-border/60"
+    >
+      <table className="w-full min-w-[980px] table-fixed text-left text-xs">
+        <colgroup>
+          <col className="w-[24%]" />
+          <col className="w-[10%]" />
+          <col className="w-[10%]" />
+          <col className="w-[10%]" />
+          <col className="w-[10%]" />
+          <col className="w-[10%]" />
+          <col className="w-[16%]" />
+          <col className="w-[10%]" />
+        </colgroup>
+        <thead className="border-b border-border/60 bg-muted/15 text-[11px] uppercase tracking-[0.08em] text-muted-foreground/70">
+          <tr>
+            <th className="px-4 py-2 font-semibold sm:pl-5">Process</th>
+            <th className="px-3 py-2 text-right font-semibold">CPU Time</th>
+            <th className="px-3 py-2 text-right font-semibold">Current</th>
+            <th className="px-3 py-2 text-right font-semibold">Average</th>
+            <th className="px-3 py-2 text-right font-semibold">Peak</th>
+            <th className="px-3 py-2 text-right font-semibold">Max Mem</th>
+            <th className="px-3 py-2 font-semibold">Command</th>
+            <th className="px-3 py-2 text-right font-semibold sm:pr-5">PID</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/50">
+          {processes.length === 0 ? (
+            <tr>
+              <td colSpan={8} className="px-4 py-4 text-xs text-muted-foreground sm:px-5">
+                {emptyLabel}
+              </td>
+            </tr>
+          ) : null}
+          {processes.map((process) => (
+            <tr key={process.processKey} className="hover:bg-muted/20">
+              <td className="px-4 py-2 align-middle sm:pl-5">
+                <div
+                  className="flex min-w-0 items-center gap-2"
+                  style={{ paddingLeft: `${Math.min(process.depth, 8) * 14}px` }}
+                >
+                  <span
+                    className={cn(
+                      "inline-flex h-5 shrink-0 items-center rounded-sm border border-border/70 px-1.5 text-[10px] font-medium uppercase text-muted-foreground",
+                      process.isServerRoot &&
+                        "border-amber-500/50 text-amber-700 dark:text-amber-300",
+                    )}
+                  >
+                    {process.isServerRoot ? "Root" : "Child"}
+                  </span>
+                  <span className="min-w-0 truncate font-medium">
+                    {formatShortProcessName(process.command)}
+                  </span>
+                </div>
+              </td>
+              <td className="px-3 py-2 text-right align-middle font-mono tabular-nums">
+                {formatCpuTime(process.cpuSecondsApprox)}
+              </td>
+              <td className="px-3 py-2 text-right align-middle font-mono tabular-nums">
+                {process.currentCpuPercent.toFixed(1)}%
+              </td>
+              <td className="px-3 py-2 text-right align-middle font-mono tabular-nums">
+                {process.avgCpuPercent.toFixed(1)}%
+              </td>
+              <td className="px-3 py-2 text-right align-middle font-mono tabular-nums">
+                {process.maxCpuPercent.toFixed(1)}%
+              </td>
+              <td className="px-3 py-2 text-right align-middle font-mono tabular-nums">
+                {formatBytes(process.maxRssBytes)}
+              </td>
+              <td className="px-3 py-2 align-middle text-muted-foreground">
+                <Tooltip>
+                  <TooltipTrigger
+                    render={<span className="block truncate">{process.command}</span>}
+                  />
+                  <TooltipPopup
+                    side="top"
+                    className="max-w-[min(440px,calc(100vw-2rem))] whitespace-normal break-words text-left font-mono text-[11px] leading-relaxed text-wrap"
+                  >
+                    {process.command}
+                  </TooltipPopup>
+                </Tooltip>
+              </td>
+              <td className="px-3 py-2 text-right align-middle font-mono tabular-nums text-muted-foreground sm:pr-5">
+                {process.pid}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </ScrollArea>
+  );
+}
+
 function DiagnosticsLastChecked({ checkedAt }: { checkedAt: DateTime.Utc | null }) {
   useRelativeTimeTick();
   const relative = checkedAt ? formatRelativeTime(DateTime.formatIso(checkedAt)) : null;
@@ -556,6 +752,10 @@ function DiagnosticsRefreshButton({
 export function DiagnosticsSettingsPanel() {
   const observability = useServerObservability();
   const availableEditors = useServerAvailableEditors();
+  const [resourceWindowMs, setResourceWindowMs] = useState(15 * 60_000);
+  const selectedResourceWindow =
+    RESOURCE_HISTORY_WINDOWS.find((option) => option.windowMs === resourceWindowMs) ??
+    RESOURCE_HISTORY_WINDOWS[1];
   const { data, error, isPending, refresh } = useTraceDiagnostics();
   const {
     data: processData,
@@ -563,6 +763,15 @@ export function DiagnosticsSettingsPanel() {
     isPending: isProcessPending,
     refresh: refreshProcesses,
   } = useProcessDiagnostics();
+  const {
+    data: resourceData,
+    error: resourceError,
+    isPending: isResourcePending,
+    refresh: refreshResources,
+  } = useProcessResourceHistory({
+    windowMs: selectedResourceWindow.windowMs,
+    bucketMs: selectedResourceWindow.bucketMs,
+  });
   const [isOpeningLogsDirectory, setIsOpeningLogsDirectory] = useState(false);
   const [openLogsDirectoryError, setOpenLogsDirectoryError] = useState<string | null>(null);
   const [signalingPid, setSignalingPid] = useState<number | null>(null);
@@ -643,6 +852,7 @@ export function DiagnosticsSettingsPanel() {
   );
 
   const processDiagnosticsError = processData ? Option.getOrNull(processData.error) : null;
+  const processResourceError = resourceData ? Option.getOrNull(resourceData.error) : null;
   const traceDiagnosticsError = data ? Option.getOrNull(data.error) : null;
   const traceDiagnosticsPartialFailure = data
     ? Option.getOrElse(data.partialFailure, () => false)
@@ -707,6 +917,70 @@ export function DiagnosticsSettingsPanel() {
             isProcessInitialLoading
               ? "Loading live processes..."
               : "No live descendant processes found."
+          }
+        />
+      </SettingsSection>
+
+      <SettingsSection
+        title="Resource History"
+        headerAction={
+          <div className="flex items-center gap-1.5">
+            <ResourceHistoryWindowSelector
+              selectedWindowMs={resourceWindowMs}
+              onSelect={setResourceWindowMs}
+            />
+            <DiagnosticsLastChecked checkedAt={resourceData?.readAt ?? null} />
+            <DiagnosticsRefreshButton
+              isPending={isResourcePending}
+              label="Refresh resource history"
+              onClick={refreshResources}
+            />
+          </div>
+        }
+      >
+        <StatsGrid>
+          <StatBlock
+            label="CPU Time"
+            value={resourceData ? formatCpuTime(resourceData.totalCpuSecondsApprox) : "..."}
+            tooltip="Approximate cumulative CPU time for the T3 server root process and its descendant processes during the selected window."
+          />
+          <StatBlock
+            label="Samples"
+            value={resourceData ? formatCount(resourceData.retainedSampleCount) : "..."}
+            tooltip="In-memory process samples retained by the server. This resets when the server restarts."
+          />
+          <StatBlock
+            label="Interval"
+            value={resourceData ? formatDuration(resourceData.sampleIntervalMs) : "..."}
+          />
+          <StatBlock
+            label="Processes"
+            value={resourceData ? formatCount(resourceData.topProcesses.length) : "..."}
+          />
+        </StatsGrid>
+        {processResourceError || resourceError ? (
+          <div className="space-y-2 border-t border-border/60 px-4 py-3 text-xs text-muted-foreground sm:px-5">
+            {processResourceError ? (
+              <div className="flex items-start gap-2 text-destructive">
+                <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
+                <span>{processResourceError.message}</span>
+              </div>
+            ) : null}
+            {resourceError ? (
+              <div className="flex items-start gap-2 text-destructive">
+                <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
+                <span>{resourceError}</span>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+        <ProcessResourceHistoryChart buckets={resourceData?.buckets ?? []} />
+        <ProcessResourceHistoryTable
+          processes={resourceData?.topProcesses ?? []}
+          emptyLabel={
+            isResourcePending && resourceData === null
+              ? "Collecting process resource samples..."
+              : "No process resource samples found for this window."
           }
         />
       </SettingsSection>

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -316,7 +316,7 @@ function ProcessNameCell({
   return (
     <div
       className="grid min-w-0 grid-cols-[1.25rem_0.375rem_minmax(0,1fr)] items-center gap-2"
-      style={{ paddingLeft: `${Math.min(process.depth, 8) * 16}px` }}
+      style={{ paddingLeft: `${Math.min(process.depth, 6) * 10}px` }}
     >
       {hasChildren ? (
         <button
@@ -331,7 +331,17 @@ function ProcessNameCell({
         <span className="size-5 shrink-0" aria-hidden="true" />
       )}
       <span className="size-1.5 shrink-0 rounded-full bg-emerald-500/80" />
-      <span className="min-w-0 truncate font-medium text-foreground">{name}</span>
+      <Tooltip>
+        <TooltipTrigger
+          render={<span className="min-w-0 truncate font-medium text-foreground">{name}</span>}
+        />
+        <TooltipPopup
+          side="top"
+          className="max-w-[min(440px,calc(100vw-2rem))] whitespace-normal break-words text-left font-mono text-[11px] leading-relaxed text-wrap"
+        >
+          {process.command}
+        </TooltipPopup>
+      </Tooltip>
     </div>
   );
 }
@@ -429,7 +439,7 @@ function ProcessDiagnosticsTable({
       chainVerticalScroll
       scrollFade
       hideScrollbars
-      className="w-full max-w-full rounded-none border-t border-border/60"
+      className="max-h-[min(64vh,44rem)] w-full max-w-full rounded-none border-t border-border/60"
     >
       <table className="w-full min-w-[1040px] table-fixed text-left text-xs">
         <colgroup>
@@ -441,7 +451,7 @@ function ProcessDiagnosticsTable({
           <col className="w-[11%]" />
           <col className="w-[6%]" />
         </colgroup>
-        <thead className="border-b border-border/60 bg-muted/15 text-[11px] uppercase tracking-[0.08em] text-muted-foreground/70">
+        <thead className="sticky top-0 z-10 border-b border-border/60 bg-card text-[11px] uppercase tracking-[0.08em] text-muted-foreground/70">
           <tr>
             <th className="px-4 py-2 font-semibold sm:pl-5">Name</th>
             <th className="px-3 py-2 text-right font-semibold">CPU</th>
@@ -449,7 +459,7 @@ function ProcessDiagnosticsTable({
             <th className="px-3 py-2 font-semibold">Command</th>
             <th className="px-3 py-2 text-right font-semibold">PID</th>
             <th className="px-3 py-2 font-semibold">Type</th>
-            <th className="px-2 py-2 text-right font-semibold sm:pr-4">Kill</th>
+            <th className="p-2 text-right font-semibold sm:pr-4">Kill</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-border/50">
@@ -494,7 +504,7 @@ function ProcessDiagnosticsTable({
               <td className="truncate px-3 py-2 align-middle text-muted-foreground">
                 {formatProcessType(process)}
               </td>
-              <td className="px-2 py-2 align-middle sm:pr-4">
+              <td className="p-2 align-middle sm:pr-4">
                 <ProcessSignalActions
                   process={process}
                   isSignaling={signalingPid === process.pid}
@@ -528,6 +538,43 @@ function formatShortProcessName(command: string): string {
   return name.length > 42 ? `${name.slice(0, 39)}...` : name;
 }
 
+function ResourceHistoryProcessNameCell({
+  process,
+  visualDepth,
+}: {
+  process: ServerProcessResourceHistorySummary;
+  visualDepth: number;
+}) {
+  const name = formatShortProcessName(process.command);
+
+  return (
+    <div
+      className="grid min-w-0 grid-cols-[1.25rem_0.375rem_minmax(0,1fr)] items-center gap-2"
+      style={{ paddingLeft: `${Math.min(visualDepth, 6) * 10}px` }}
+      aria-label={`${process.isServerRoot ? "Root" : "Child"} process ${name}`}
+    >
+      <span className="size-5 shrink-0" aria-hidden="true" />
+      <span
+        className={cn(
+          "size-1.5 shrink-0 rounded-full",
+          process.isServerRoot ? "bg-amber-500/90" : "bg-emerald-500/80",
+        )}
+      />
+      <Tooltip>
+        <TooltipTrigger
+          render={<span className="min-w-0 truncate font-medium text-foreground">{name}</span>}
+        />
+        <TooltipPopup
+          side="top"
+          className="max-w-[min(440px,calc(100vw-2rem))] whitespace-normal break-words text-left font-mono text-[11px] leading-relaxed text-wrap"
+        >
+          {process.command}
+        </TooltipPopup>
+      </Tooltip>
+    </div>
+  );
+}
+
 function ProcessResourceHistoryChart({
   buckets,
 }: {
@@ -541,18 +588,28 @@ function ProcessResourceHistoryChart({
 
   return (
     <div className="border-t border-border/60 px-4 py-3 sm:px-5">
-      <div className="flex h-28 items-end gap-1 overflow-hidden rounded-sm bg-muted/10 px-2 py-2">
+      <div className="flex h-28 items-end gap-1 overflow-hidden rounded-sm bg-muted/10 p-2">
         {buckets.map((bucket) => {
-          const height = Math.max(2, (bucket.avgCpuPercent / maxCpuPercent) * 100);
+          const peakHeight = Math.max(2, (bucket.maxCpuPercent / maxCpuPercent) * 100);
+          const averageHeight = Math.max(2, (bucket.avgCpuPercent / maxCpuPercent) * 100);
           return (
             <Tooltip key={DateTime.formatIso(bucket.startedAt)}>
               <TooltipTrigger
                 render={
                   <div className="flex h-full min-w-1 flex-1 items-end">
                     <div
-                      className="w-full rounded-t-sm bg-foreground/55 transition-colors hover:bg-foreground"
-                      style={{ height: `${height}%` }}
-                    />
+                      className="relative h-full w-full"
+                      aria-label={`Average CPU ${bucket.avgCpuPercent.toFixed(1)}%, peak CPU ${bucket.maxCpuPercent.toFixed(1)}%`}
+                    >
+                      <div
+                        className="absolute inset-x-0 bottom-0 rounded-t-sm bg-foreground/15 transition-colors"
+                        style={{ height: `${peakHeight}%` }}
+                      />
+                      <div
+                        className="absolute inset-x-0 bottom-0 rounded-t-sm bg-foreground/60 transition-colors"
+                        style={{ height: `${averageHeight}%` }}
+                      />
+                    </div>
                   </div>
                 }
               />
@@ -600,12 +657,17 @@ function ProcessResourceHistoryTable({
   processes: ReadonlyArray<ServerProcessResourceHistorySummary>;
   emptyLabel: string;
 }) {
+  const shallowestChildDepth = processes.reduce<number | null>((minDepth, process) => {
+    if (process.isServerRoot) return minDepth;
+    return minDepth === null ? process.depth : Math.min(minDepth, process.depth);
+  }, null);
+
   return (
     <ScrollArea
       chainVerticalScroll
       scrollFade
       hideScrollbars
-      className="w-full max-w-full border-t border-border/60"
+      className="max-h-[min(64vh,44rem)] w-full max-w-full border-t border-border/60"
     >
       <table className="w-full min-w-[980px] table-fixed text-left text-xs">
         <colgroup>
@@ -618,7 +680,7 @@ function ProcessResourceHistoryTable({
           <col className="w-[16%]" />
           <col className="w-[10%]" />
         </colgroup>
-        <thead className="border-b border-border/60 bg-muted/15 text-[11px] uppercase tracking-[0.08em] text-muted-foreground/70">
+        <thead className="sticky top-0 z-10 border-b border-border/60 bg-card text-[11px] uppercase tracking-[0.08em] text-muted-foreground/70">
           <tr>
             <th className="px-4 py-2 font-semibold sm:pl-5">Process</th>
             <th className="px-3 py-2 text-right font-semibold">CPU Time</th>
@@ -641,23 +703,14 @@ function ProcessResourceHistoryTable({
           {processes.map((process) => (
             <tr key={process.processKey} className="hover:bg-muted/20">
               <td className="px-4 py-2 align-middle sm:pl-5">
-                <div
-                  className="flex min-w-0 items-center gap-2"
-                  style={{ paddingLeft: `${Math.min(process.depth, 8) * 14}px` }}
-                >
-                  <span
-                    className={cn(
-                      "inline-flex h-5 shrink-0 items-center rounded-sm border border-border/70 px-1.5 text-[10px] font-medium uppercase text-muted-foreground",
-                      process.isServerRoot &&
-                        "border-amber-500/50 text-amber-700 dark:text-amber-300",
-                    )}
-                  >
-                    {process.isServerRoot ? "Root" : "Child"}
-                  </span>
-                  <span className="min-w-0 truncate font-medium">
-                    {formatShortProcessName(process.command)}
-                  </span>
-                </div>
+                <ResourceHistoryProcessNameCell
+                  process={process}
+                  visualDepth={
+                    process.isServerRoot || shallowestChildDepth === null
+                      ? 0
+                      : Math.max(1, process.depth - shallowestChildDepth + 1)
+                  }
+                />
               </td>
               <td className="px-3 py-2 text-right align-middle font-mono tabular-nums">
                 {formatCpuTime(process.cpuSecondsApprox)}
@@ -942,7 +995,7 @@ export function DiagnosticsSettingsPanel() {
           <StatBlock
             label="CPU Time"
             value={resourceData ? formatCpuTime(resourceData.totalCpuSecondsApprox) : "..."}
-            tooltip="Approximate cumulative CPU time for the T3 server root process and its descendant processes during the selected window."
+            tooltip="Approximate active CPU time for the T3 server root process and its descendants during the selected window. It grows only while sampled processes use CPU and older samples leave as the window moves."
           />
           <StatBlock
             label="Samples"

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -13,6 +13,7 @@ import {
   ProviderDriverKind,
   ProviderInstanceId,
   type ServerConfig,
+  type ServerProcessResourceHistoryResult,
   type ServerProvider,
   type SourceControlDiscoveryResult,
 } from "@t3tools/contracts";
@@ -263,6 +264,20 @@ function createOutdatedProvider(driver: string): ServerProvider {
 
 function makeUtc(value: string) {
   return DateTime.makeUnsafe(value);
+}
+
+function createEmptyProcessResourceHistoryResult(): ServerProcessResourceHistoryResult {
+  return {
+    readAt: makeUtc("2036-04-07T00:00:00.000Z"),
+    windowMs: 15 * 60_000,
+    bucketMs: 60_000,
+    sampleIntervalMs: 5_000,
+    retainedSampleCount: 0,
+    totalCpuSecondsApprox: 0,
+    buckets: [],
+    topProcesses: [],
+    error: Option.none(),
+  };
 }
 
 function makePairingLink(input: {
@@ -1062,6 +1077,9 @@ describe("GeneralSettingsPanel observability", () => {
           processes: [],
           error: Option.none(),
         }),
+        getProcessResourceHistory: vi
+          .fn()
+          .mockResolvedValue(createEmptyProcessResourceHistoryResult()),
         getTraceDiagnostics: vi.fn().mockResolvedValue({
           traceFilePath: "/repo/project/.t3/traces.jsonl",
           scannedFilePaths: ["/repo/project/.t3/traces.jsonl"],

--- a/apps/web/src/lib/processDiagnosticsState.ts
+++ b/apps/web/src/lib/processDiagnosticsState.ts
@@ -1,16 +1,20 @@
 import { useAtomValue } from "@effect/atom-react";
-import type { ServerProcessDiagnosticsResult } from "@t3tools/contracts";
+import type {
+  ServerProcessDiagnosticsResult,
+  ServerProcessResourceHistoryResult,
+} from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { ensureLocalApi } from "../localApi";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 
 const PROCESS_DIAGNOSTICS_STALE_TIME_MS = 2_000;
 const PROCESS_DIAGNOSTICS_IDLE_TTL_MS = 5 * 60_000;
+const PROCESS_RESOURCE_HISTORY_REFRESH_MS = 5_000;
 
 const processDiagnosticsAtom = Atom.make(
   Effect.promise(() => ensureLocalApi().server.getProcessDiagnostics()),
@@ -25,6 +29,13 @@ const processDiagnosticsAtom = Atom.make(
 
 export interface ProcessDiagnosticsState {
   readonly data: ServerProcessDiagnosticsResult | null;
+  readonly error: string | null;
+  readonly isPending: boolean;
+  readonly refresh: () => void;
+}
+
+export interface ProcessResourceHistoryState {
+  readonly data: ServerProcessResourceHistoryResult | null;
   readonly error: string | null;
   readonly isPending: boolean;
   readonly refresh: () => void;
@@ -62,4 +73,61 @@ export function useProcessDiagnostics(): ProcessDiagnosticsState {
     isPending: result.waiting,
     refresh,
   };
+}
+
+export function useProcessResourceHistory(input: {
+  readonly windowMs: number;
+  readonly bucketMs: number;
+}): ProcessResourceHistoryState {
+  const { bucketMs, windowMs } = input;
+  const [data, setData] = useState<ServerProcessResourceHistoryResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, setIsPending] = useState(true);
+
+  const refresh = useCallback(() => {
+    setIsPending(true);
+    void ensureLocalApi()
+      .server.getProcessResourceHistory({ bucketMs, windowMs })
+      .then((result) => {
+        setData(result);
+        setError(null);
+      })
+      .catch((cause: unknown) => {
+        setError(formatProcessDiagnosticsError(cause));
+      })
+      .finally(() => {
+        setIsPending(false);
+      });
+  }, [bucketMs, windowMs]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const read = () => {
+      setIsPending(true);
+      void ensureLocalApi()
+        .server.getProcessResourceHistory({ bucketMs, windowMs })
+        .then((result) => {
+          if (!isMounted) return;
+          setData(result);
+          setError(null);
+        })
+        .catch((cause: unknown) => {
+          if (!isMounted) return;
+          setError(formatProcessDiagnosticsError(cause));
+        })
+        .finally(() => {
+          if (!isMounted) return;
+          setIsPending(false);
+        });
+    };
+
+    read();
+    const interval = window.setInterval(read, PROCESS_RESOURCE_HISTORY_REFRESH_MS);
+    return () => {
+      isMounted = false;
+      window.clearInterval(interval);
+    };
+  }, [bucketMs, windowMs]);
+
+  return { data, error, isPending, refresh };
 }

--- a/apps/web/src/lib/processDiagnosticsState.ts
+++ b/apps/web/src/lib/processDiagnosticsState.ts
@@ -7,14 +7,15 @@ import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 
 import { ensureLocalApi } from "../localApi";
 import { appAtomRegistry } from "../rpc/atomRegistry";
 
 const PROCESS_DIAGNOSTICS_STALE_TIME_MS = 2_000;
 const PROCESS_DIAGNOSTICS_IDLE_TTL_MS = 5 * 60_000;
-const PROCESS_RESOURCE_HISTORY_REFRESH_MS = 5_000;
+const PROCESS_RESOURCE_HISTORY_STALE_TIME_MS = 5_000;
+const PROCESS_RESOURCE_HISTORY_INPUT_SEPARATOR = ":";
 
 const processDiagnosticsAtom = Atom.make(
   Effect.promise(() => ensureLocalApi().server.getProcessDiagnostics()),
@@ -26,6 +27,38 @@ const processDiagnosticsAtom = Atom.make(
   Atom.setIdleTTL(PROCESS_DIAGNOSTICS_IDLE_TTL_MS),
   Atom.withLabel("process-diagnostics"),
 );
+
+function formatProcessResourceHistoryKey(input: {
+  readonly windowMs: number;
+  readonly bucketMs: number;
+}): string {
+  return `${input.windowMs}${PROCESS_RESOURCE_HISTORY_INPUT_SEPARATOR}${input.bucketMs}`;
+}
+
+function parseProcessResourceHistoryKey(key: string): {
+  readonly windowMs: number;
+  readonly bucketMs: number;
+} {
+  const [windowMs = "0", bucketMs = "0"] = key.split(PROCESS_RESOURCE_HISTORY_INPUT_SEPARATOR);
+  return {
+    windowMs: Number(windowMs),
+    bucketMs: Number(bucketMs),
+  };
+}
+
+const processResourceHistoryAtom = Atom.family((key: string) => {
+  const input = parseProcessResourceHistoryKey(key);
+  return Atom.make(
+    Effect.promise(() => ensureLocalApi().server.getProcessResourceHistory(input)),
+  ).pipe(
+    Atom.swr({
+      staleTime: PROCESS_RESOURCE_HISTORY_STALE_TIME_MS,
+      revalidateOnMount: true,
+    }),
+    Atom.setIdleTTL(PROCESS_DIAGNOSTICS_IDLE_TTL_MS),
+    Atom.withLabel(`process-resource-history:${key}`),
+  );
+});
 
 export interface ProcessDiagnosticsState {
   readonly data: ServerProcessDiagnosticsResult | null;
@@ -47,6 +80,17 @@ function formatProcessDiagnosticsError(error: unknown): string {
 
 function readProcessDiagnosticsError(
   result: AsyncResult.AsyncResult<ServerProcessDiagnosticsResult, unknown>,
+): string | null {
+  if (result._tag !== "Failure") {
+    return null;
+  }
+
+  const squashed = Cause.squash(result.cause);
+  return formatProcessDiagnosticsError(squashed);
+}
+
+function readProcessResourceHistoryError(
+  result: AsyncResult.AsyncResult<ServerProcessResourceHistoryResult, unknown>,
 ): string | null {
   if (result._tag !== "Failure") {
     return null;
@@ -79,55 +123,18 @@ export function useProcessResourceHistory(input: {
   readonly windowMs: number;
   readonly bucketMs: number;
 }): ProcessResourceHistoryState {
-  const { bucketMs, windowMs } = input;
-  const [data, setData] = useState<ServerProcessResourceHistoryResult | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isPending, setIsPending] = useState(true);
+  const atom = processResourceHistoryAtom(formatProcessResourceHistoryKey(input));
+  const result = useAtomValue(atom);
+  const data = Option.getOrNull(AsyncResult.value(result));
 
   const refresh = useCallback(() => {
-    setIsPending(true);
-    void ensureLocalApi()
-      .server.getProcessResourceHistory({ bucketMs, windowMs })
-      .then((result) => {
-        setData(result);
-        setError(null);
-      })
-      .catch((cause: unknown) => {
-        setError(formatProcessDiagnosticsError(cause));
-      })
-      .finally(() => {
-        setIsPending(false);
-      });
-  }, [bucketMs, windowMs]);
+    appAtomRegistry.refresh(atom);
+  }, [atom]);
 
-  useEffect(() => {
-    let isMounted = true;
-    const read = () => {
-      setIsPending(true);
-      void ensureLocalApi()
-        .server.getProcessResourceHistory({ bucketMs, windowMs })
-        .then((result) => {
-          if (!isMounted) return;
-          setData(result);
-          setError(null);
-        })
-        .catch((cause: unknown) => {
-          if (!isMounted) return;
-          setError(formatProcessDiagnosticsError(cause));
-        })
-        .finally(() => {
-          if (!isMounted) return;
-          setIsPending(false);
-        });
-    };
-
-    read();
-    const interval = window.setInterval(read, PROCESS_RESOURCE_HISTORY_REFRESH_MS);
-    return () => {
-      isMounted = false;
-      window.clearInterval(interval);
-    };
-  }, [bucketMs, windowMs]);
-
-  return { data, error, isPending, refresh };
+  return {
+    data,
+    error: readProcessResourceHistoryError(result),
+    isPending: result.waiting,
+    refresh,
+  };
 }

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -155,6 +155,10 @@ function createBrowserLocalApi(rpcClient?: WsRpcClient): LocalApi {
         rpcClient
           ? rpcClient.server.getProcessDiagnostics()
           : Promise.reject(unavailableLocalBackendError()),
+      getProcessResourceHistory: (input) =>
+        rpcClient
+          ? rpcClient.server.getProcessResourceHistory(input)
+          : Promise.reject(unavailableLocalBackendError()),
       signalProcess: (input) =>
         rpcClient
           ? rpcClient.server.signalProcess(input)

--- a/apps/web/src/rpc/wsRpcClient.ts
+++ b/apps/web/src/rpc/wsRpcClient.ts
@@ -134,6 +134,9 @@ export interface WsRpcClient {
     readonly getProcessDiagnostics: RpcUnaryNoArgMethod<
       typeof WS_METHODS.serverGetProcessDiagnostics
     >;
+    readonly getProcessResourceHistory: RpcUnaryMethod<
+      typeof WS_METHODS.serverGetProcessResourceHistory
+    >;
     readonly signalProcess: RpcUnaryMethod<typeof WS_METHODS.serverSignalProcess>;
     readonly subscribeConfig: RpcStreamMethod<typeof WS_METHODS.subscribeServerConfig>;
     readonly subscribeLifecycle: RpcStreamMethod<typeof WS_METHODS.subscribeServerLifecycle>;
@@ -263,6 +266,12 @@ export function createWsRpcClient(transport: WsTransport): WsRpcClient {
       getProcessDiagnostics: () =>
         transport.request((client) =>
           client[WS_METHODS.serverGetProcessDiagnostics]({}).pipe(Effect.withTracerEnabled(false)),
+        ),
+      getProcessResourceHistory: (input) =>
+        transport.request((client) =>
+          client[WS_METHODS.serverGetProcessResourceHistory](input).pipe(
+            Effect.withTracerEnabled(false),
+          ),
         ),
       signalProcess: (input) =>
         transport.request((client) =>

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -29,6 +29,8 @@ import type { ProviderInstanceId } from "./providerInstance.ts";
 import type {
   ServerConfig,
   ServerProcessDiagnosticsResult,
+  ServerProcessResourceHistoryInput,
+  ServerProcessResourceHistoryResult,
   ServerProviderUpdateInput,
   ServerProviderUpdatedPayload,
   ServerRemoveKeybindingResult,
@@ -475,6 +477,9 @@ export interface LocalApi {
     discoverSourceControl: () => Promise<SourceControlDiscoveryResult>;
     getTraceDiagnostics: () => Promise<ServerTraceDiagnosticsResult>;
     getProcessDiagnostics: () => Promise<ServerProcessDiagnosticsResult>;
+    getProcessResourceHistory: (
+      input: ServerProcessResourceHistoryInput,
+    ) => Promise<ServerProcessResourceHistoryResult>;
     signalProcess: (input: ServerSignalProcessInput) => Promise<ServerSignalProcessResult>;
   };
 }

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -79,6 +79,8 @@ import {
   ServerProviderUpdatedPayload,
   ServerTraceDiagnosticsResult,
   ServerProcessDiagnosticsResult,
+  ServerProcessResourceHistoryInput,
+  ServerProcessResourceHistoryResult,
   ServerSignalProcessInput,
   ServerSignalProcessResult,
   ServerUpsertKeybindingInput,
@@ -145,6 +147,7 @@ export const WS_METHODS = {
   serverDiscoverSourceControl: "server.discoverSourceControl",
   serverGetTraceDiagnostics: "server.getTraceDiagnostics",
   serverGetProcessDiagnostics: "server.getProcessDiagnostics",
+  serverGetProcessResourceHistory: "server.getProcessResourceHistory",
   serverSignalProcess: "server.signalProcess",
 
   // Source control methods
@@ -223,6 +226,14 @@ export const WsServerGetProcessDiagnosticsRpc = Rpc.make(WS_METHODS.serverGetPro
   payload: Schema.Struct({}),
   success: ServerProcessDiagnosticsResult,
 });
+
+export const WsServerGetProcessResourceHistoryRpc = Rpc.make(
+  WS_METHODS.serverGetProcessResourceHistory,
+  {
+    payload: ServerProcessResourceHistoryInput,
+    success: ServerProcessResourceHistoryResult,
+  },
+);
 
 export const WsServerSignalProcessRpc = Rpc.make(WS_METHODS.serverSignalProcess, {
   payload: ServerSignalProcessInput,
@@ -472,6 +483,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsServerDiscoverSourceControlRpc,
   WsServerGetTraceDiagnosticsRpc,
   WsServerGetProcessDiagnosticsRpc,
+  WsServerGetProcessResourceHistoryRpc,
   WsServerSignalProcessRpc,
   WsSourceControlLookupRepositoryRpc,
   WsSourceControlCloneRepositoryRpc,

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -328,6 +328,58 @@ export const ServerProcessDiagnosticsResult = Schema.Struct({
 });
 export type ServerProcessDiagnosticsResult = typeof ServerProcessDiagnosticsResult.Type;
 
+export const ServerProcessResourceHistoryInput = Schema.Struct({
+  windowMs: NonNegativeInt,
+  bucketMs: NonNegativeInt,
+});
+export type ServerProcessResourceHistoryInput = typeof ServerProcessResourceHistoryInput.Type;
+
+export const ServerProcessResourceHistoryBucket = Schema.Struct({
+  startedAt: Schema.DateTimeUtc,
+  endedAt: Schema.DateTimeUtc,
+  avgCpuPercent: Schema.Number,
+  maxCpuPercent: Schema.Number,
+  maxRssBytes: NonNegativeInt,
+  maxProcessCount: NonNegativeInt,
+});
+export type ServerProcessResourceHistoryBucket = typeof ServerProcessResourceHistoryBucket.Type;
+
+export const ServerProcessResourceHistorySummary = Schema.Struct({
+  processKey: TrimmedNonEmptyString,
+  pid: PositiveInt,
+  ppid: NonNegativeInt,
+  command: TrimmedNonEmptyString,
+  depth: NonNegativeInt,
+  isServerRoot: Schema.Boolean,
+  firstSeenAt: Schema.DateTimeUtc,
+  lastSeenAt: Schema.DateTimeUtc,
+  currentCpuPercent: Schema.Number,
+  avgCpuPercent: Schema.Number,
+  maxCpuPercent: Schema.Number,
+  cpuSecondsApprox: Schema.Number,
+  currentRssBytes: NonNegativeInt,
+  maxRssBytes: NonNegativeInt,
+  sampleCount: NonNegativeInt,
+});
+export type ServerProcessResourceHistorySummary = typeof ServerProcessResourceHistorySummary.Type;
+
+export const ServerProcessResourceHistoryResult = Schema.Struct({
+  readAt: Schema.DateTimeUtc,
+  windowMs: NonNegativeInt,
+  bucketMs: NonNegativeInt,
+  sampleIntervalMs: NonNegativeInt,
+  retainedSampleCount: NonNegativeInt,
+  totalCpuSecondsApprox: Schema.Number,
+  buckets: Schema.Array(ServerProcessResourceHistoryBucket),
+  topProcesses: Schema.Array(ServerProcessResourceHistorySummary),
+  error: Schema.Option(
+    Schema.Struct({
+      message: TrimmedNonEmptyString,
+    }),
+  ),
+});
+export type ServerProcessResourceHistoryResult = typeof ServerProcessResourceHistoryResult.Type;
+
 export const ServerSignalProcessInput = Schema.Struct({
   pid: PositiveInt,
   signal: ServerProcessSignal,


### PR DESCRIPTION
Just a quick way to get some intel... might need to be a separate binary later that uses platform specific native APIS

## Summary

Adds an in-memory process resource monitor for Diagnostics that samples the T3 server root process and live descendants over time. The new history API rolls samples up into CPU-time summaries and chart buckets so the UI can show cumulative CPU, current/average/peak CPU, and memory peaks across selectable windows.

## Details

- Adds a `ProcessResourceMonitor` service with a bounded 60-minute in-memory ring buffer.
- Includes the root T3 server process in the sampled state alongside descendants.
- Adds `server.getProcessResourceHistory` contracts/RPC/client wiring.
- Extends Settings -> Diagnostics with a Resource History section, window selector, CPU timeline, and top process table.
- Keeps existing live process diagnostics and process signaling behavior unchanged.

## Validation

- `bun fmt`
- `bun typecheck`
- `bun lint` (passes with existing warnings)
- `bun run test src/diagnostics/ProcessDiagnostics.test.ts src/diagnostics/ProcessResourceMonitor.test.ts` from `apps/server`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add process resource history to the diagnostics settings panel
> - Introduces `ProcessResourceMonitor` ([ProcessResourceMonitor.ts](https://github.com/pingdotgg/t3code/pull/2685/files#diff-531add2e9c8cf312f695a676a24b959ff83264a563fac3914620ab8e1f516d6b)) that samples server process metrics every 5s, retaining a rolling window of results, and exposes a `readHistory` method returning bucketed CPU/memory aggregates per process.
> - Adds a `server.getProcessResourceHistory` RPC ([rpc.ts](https://github.com/pingdotgg/t3code/pull/2685/files#diff-64c16995299d1af309c72e94a298ffcb5c2ee5c65774cf0c73bf997358e9c266)) with full schema definitions for input, per-bucket metrics, per-process summaries, and the result envelope.
> - The diagnostics settings UI ([DiagnosticsSettings.tsx](https://github.com/pingdotgg/t3code/pull/2685/files#diff-0ad64a4db537a1bcf890acdbd8ea37bfa6ca9d003bbbefdba6a7845e8428dd8a)) gains a selectable time window (5m/15m/30m/1h), a stacked CPU bar chart, a process summary table, and total CPU seconds stats.
> - Client-side state uses an `Atom.family` keyed by window/bucket sizes for SWR-style caching and refresh via `useProcessResourceHistory`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b5ab2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new background sampler that periodically shells out to read process stats and retains in-memory history, plus a new RPC endpoint and UI surface; main risk is performance/memory overhead and correctness of aggregation across platforms.
> 
> **Overview**
> Adds a new `ProcessResourceMonitor` service that samples the server root process plus live descendants every 5s, retains a bounded in-memory history, and aggregates samples into per-process CPU-time/memory summaries and time buckets.
> 
> Wires a new `server.getProcessResourceHistory` WebSocket RPC end-to-end (contracts, server handler, client/local API, and atom-based caching) and disables tracing for it alongside other diagnostics RPCs.
> 
> Extends Settings → Diagnostics with a **Resource History** section (window selector, CPU timeline chart, and top-process table) and makes small usability tweaks to the existing Live Processes table (sticky header, tooltip for full command, adjusted indentation/scrolling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5ab2f95a37bdd85b7b8ef646c3a73779a9af15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->