### PR TITLE
fix(server): force Claude 200k context when selected/(default)

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.test.ts
@@ -156,6 +156,7 @@ function makeHarness(config?: {
   readonly baseDir?: string;
   readonly claudeConfig?: Partial<ClaudeSettings>;
   readonly instanceId?: ProviderInstanceId;
+  readonly environment?: NodeJS.ProcessEnv;
 }) {
   const query = new FakeClaudeQuery();
   let createInput:
@@ -167,6 +168,7 @@ function makeHarness(config?: {
 
   const adapterOptions: ClaudeAdapterLiveOptions = {
     ...(config?.instanceId ? { instanceId: config.instanceId } : {}),
+    ...(config?.environment ? { environment: config.environment } : {}),
     createQuery: (input) => {
       createInput = input;
       return query;
@@ -374,6 +376,79 @@ describe("ClaudeAdapterLive", () => {
 
       const createInput = harness.getLastCreateQueryInput();
       assert.equal(createInput?.options.effort, "max");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("disables Claude Code automatic 1M context when Claude context window is 200k", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-4-6",
+          [{ id: "contextWindow", value: "200k" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.model, "claude-opus-4-6");
+      assert.equal(createInput?.options.env?.CLAUDE_CODE_DISABLE_1M_CONTEXT, "1");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("uses 200k as T3 Code's default Claude context window", () => {
+    const harness = makeHarness();
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-4-6",
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.model, "claude-opus-4-6");
+      assert.equal(createInput?.options.env?.CLAUDE_CODE_DISABLE_1M_CONTEXT, "1");
+    }).pipe(
+      Effect.provideService(Random.Random, makeDeterministicRandomService()),
+      Effect.provide(harness.layer),
+    );
+  });
+
+  it.effect("allows explicit Claude 1M context even when the process env disables it", () => {
+    const harness = makeHarness({
+      environment: { CLAUDE_CODE_DISABLE_1M_CONTEXT: "1" },
+    });
+    return Effect.gen(function* () {
+      const adapter = yield* ClaudeAdapter;
+      yield* adapter.startSession({
+        threadId: THREAD_ID,
+        provider: ProviderDriverKind.make("claudeAgent"),
+        modelSelection: createModelSelection(
+          ProviderInstanceId.make("claudeAgent"),
+          "claude-opus-4-6",
+          [{ id: "contextWindow", value: "1m" }],
+        ),
+        runtimeMode: "full-access",
+      });
+
+      const createInput = harness.getLastCreateQueryInput();
+      assert.equal(createInput?.options.model, "claude-opus-4-6[1m]");
+      assert.equal(createInput?.options.env?.CLAUDE_CODE_DISABLE_1M_CONTEXT, undefined);
     }).pipe(
       Effect.provideService(Random.Random, makeDeterministicRandomService()),
       Effect.provide(harness.layer),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -47,6 +47,7 @@ import {
 import {
   applyClaudePromptEffortPrefix,
   getModelSelectionBooleanOptionValue,
+  getProviderOptionCurrentValue,
   getModelSelectionStringOptionValue,
   getProviderOptionDescriptors,
   resolvePromptInjectedEffort,
@@ -258,6 +259,35 @@ function normalizeClaudeStreamMessages(
 function getEffectiveClaudeAgentEffort(effort: string | null | undefined): ClaudeSdkEffort | null {
   const normalized = normalizeClaudeCliEffort(effort);
   return normalized ? (normalized as ClaudeSdkEffort) : null;
+}
+
+function resolveClaudeOneMillionContextDisabled(
+  descriptors: ReadonlyArray<ReturnType<typeof getProviderOptionDescriptors>[number]>,
+): boolean | undefined {
+  const contextWindowDescriptor = descriptors.find(
+    (descriptor) => descriptor.type === "select" && descriptor.id === "contextWindow",
+  );
+  if (!contextWindowDescriptor) {
+    return undefined;
+  }
+  return getProviderOptionCurrentValue(contextWindowDescriptor) !== "1m";
+}
+
+function withClaudeContextWindowEnvironment(
+  env: NodeJS.ProcessEnv,
+  oneMillionContextDisabled: boolean | undefined,
+): NodeJS.ProcessEnv {
+  if (oneMillionContextDisabled === true) {
+    return {
+      ...env,
+      CLAUDE_CODE_DISABLE_1M_CONTEXT: "1",
+    };
+  }
+  if (oneMillionContextDisabled === false) {
+    const { CLAUDE_CODE_DISABLE_1M_CONTEXT: _unused, ...rest } = env;
+    return rest;
+  }
+  return env;
 }
 
 function isClaudeInterruptedMessage(message: string): boolean {
@@ -2871,10 +2901,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const modelSelection =
         input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
       const caps = getClaudeModelCapabilities(modelSelection?.model);
-      const descriptors = getProviderOptionDescriptors({ caps });
+      const descriptors = getProviderOptionDescriptors({
+        caps,
+        selections: modelSelection?.options,
+      });
       const apiModelId = modelSelection ? resolveClaudeApiModelId(modelSelection) : undefined;
       const rawEffort = getModelSelectionStringOptionValue(modelSelection, "effort");
       const effort = resolveClaudeEffort(caps, rawEffort) ?? null;
+      const oneMillionContextDisabled = resolveClaudeOneMillionContextDisabled(descriptors);
       const fastModeSupported = descriptors.some(
         (descriptor) => descriptor.type === "boolean" && descriptor.id === "fastMode",
       );
@@ -2919,7 +2953,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         ...(newSessionId ? { sessionId: newSessionId } : {}),
         includePartialMessages: true,
         canUseTool,
-        env: claudeEnvironment,
+        env: withClaudeContextWindowEnvironment(claudeEnvironment, oneMillionContextDisabled),
         ...(input.cwd ? { additionalDirectories: [input.cwd] } : {}),
         ...(Object.keys(extraArgs).length > 0 ? { extraArgs } : {}),
       };
@@ -2946,6 +2980,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
         "claude.query.setting_sources": [...CLAUDE_SETTING_SOURCES],
         "claude.query.settings_json": encodeJsonStringForDiagnostics(settings) ?? "",
         "claude.query.extra_args_json": encodeJsonStringForDiagnostics(extraArgs) ?? "",
+        "claude.query.one_million_context_disabled": oneMillionContextDisabled ?? "",
         "claude.query.path_to_executable": claudeBinaryPath,
       });
 


### PR DESCRIPTION
## What Changed

Fixed Claude context window handling so T3 Code’s 200k selection actually disables Claude Code’s automatic 1M context upgrade.

When 1M is explicitly selected, T3 Code still uses the `[1m]` model suffix and clears the disable flag.

## Why

When you start coding with Claude in t3code, 200k is selected by default, but this doesn’t work—the model automatically sets itself to a 1M context window. This fix involves adding the “CLAUDE_CODE_DISABLE_1M_CONTEXT=1” flag directly to the environment and running it; you can also switch between 1M and 200k during the conversation.

Before :
<img width="947" height="244" alt="image" src="https://github.com/user-attachments/assets/3f8e87a0-cf02-4b91-bdae-2dfd3f638581" />

After:
<img width="947" height="244" alt="image" src="https://github.com/user-attachments/assets/7ab030dc-b909-416f-a460-c7a15e73215b" />


## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime environment passed into Claude Code sessions based on the selected `contextWindow`, which can affect model behavior across all Claude sessions; covered by targeted adapter tests but still touches core provider session startup.
> 
> **Overview**
> For Claude provider session startup, the adapter now derives the effective `contextWindow` selection from provider option descriptors and **injects/removes** `CLAUDE_CODE_DISABLE_1M_CONTEXT` in the SDK `env` to prevent Claude Code from auto-upgrading to 1M when 200k (the default) is intended.
> 
> Adds tests verifying: selecting `200k` (and the default selection) sets the disable flag, and explicitly selecting `1m` clears the flag even if the process environment had it set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb6057af0c6d70950e199ed04c8e57c03903329. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Force 200k Claude context window by setting `CLAUDE_CODE_DISABLE_1M_CONTEXT` by default
> - Adds `resolveClaudeOneMillionContextDisabled` in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/2690/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) to check the `contextWindow` provider option: returns `true` (disable 1M) when the value is `200k` or absent, and `false` when explicitly set to `1m`.
> - Adds `withClaudeContextWindowEnvironment` to conditionally set or remove `CLAUDE_CODE_DISABLE_1M_CONTEXT` in the env passed to Claude queries.
> - When the user explicitly selects `1m` context, the env variable is removed and `[1m]` is appended to the model name to override any process-level disable.
> - Behavioral Change: `CLAUDE_CODE_DISABLE_1M_CONTEXT=1` is now injected by default (200k is the default context window), overriding any external env that had previously enabled 1M context silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized acb6057.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->