### PR TITLE
fix(web): center logo in sidebar header

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -2519,7 +2519,7 @@ const SidebarChromeHeader = memo(function SidebarChromeHeader({
           render={
             <Link
               aria-label="Go to threads"
-              className="ml-1 flex min-w-0 flex-1 cursor-pointer items-center gap-1 rounded-md outline-hidden ring-ring transition-colors hover:text-foreground focus-visible:ring-2"
+              className="ml-1 flex min-w-0 flex-1 cursor-pointer items-center justify-center gap-1 rounded-md outline-hidden ring-ring transition-colors hover:text-foreground focus-visible:ring-2"
               to="/"
             >
               <T3Wordmark />


### PR DESCRIPTION
## What Changed

  Added `justify-center` to the logo link in `SidebarChromeHeader`.                                                   

  One class. One line changed.

  ## Why
  
  I use T3 Code daily and the logo being left-aligned in the sidebar header has been bugging me for a while. It looks off — especially
  when you resize the sidebar and the wordmark just sits there hugging the left edge instead of sitting naturally in the center like
  every other app does.
  
  The logo link already has `flex-1` on it, meaning it spans the full width of the header. The fix is literally just adding
  `justify-center` so the T3 wordmark and "Code" label are centered within that space. No layout changes, no new elements, no side
  effects — the sibling `SidebarTrigger` is outside the link and unaffected.
  
  ## UI Changes

**Before**

  <img width="1440" height="900" alt="before" src="https://github.com/user-attachments/assets/ab178774-5e0f-470c-b8b6-305ef780b6d8" />

  **After**
  
  <img width="1440" height="804" alt="after" src="https://github.com/user-attachments/assets/a6a9c10f-5013-40b7-a372-3a4d15b13d75" />

  ## Checklist

  - [x] This PR is small and focused
  - [x] I explained what changed and why
  - [x] I included before/after screenshots for any UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS utility on a sidebar header link; no logic, routing, or data changes.
> 
> **Overview**
> **Sidebar header branding** is horizontally centered in `SidebarChromeHeader`: the home `Link` that shows the T3 wordmark, "Code" label, and stage badge now includes **`justify-center`** alongside its existing `flex flex-1` layout, so the cluster sits in the middle of the header instead of left-aligned.
> 
> No other layout or behavior changes; the mobile `SidebarTrigger` stays outside that link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41cd0babee037dbc1a9f7863c262fe945381ad46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Center logo in sidebar header
> Adds `justify-center` to the flex container in the `SidebarChromeHeader` wordmark link in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2693/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), horizontally centering the logo within the header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41cd0ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->