### PR TITLE
Add a shortcut to archive a thread

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -19,6 +19,7 @@ import {
 import { useNavigate, useParams } from "@tanstack/react-router";
 import * as Option from "effect/Option";
 import {
+  ArchiveIcon,
   ArrowDownIcon,
   ArrowLeftIcon,
   ArrowUpIcon,
@@ -48,6 +49,7 @@ import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { useClientSettings } from "../hooks/useSettings";
+import { useThreadActions } from "../hooks/useThreadActions";
 import { readLocalApi } from "../localApi";
 import { desktopLocalBackendId } from "../connection/desktopLocal";
 import { filesystemEnvironment } from "../state/filesystem";
@@ -490,6 +492,7 @@ function OpenCommandPaletteDialog(props: {
   const primaryEnvironment = usePrimaryEnvironment();
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
     useHandleNewThread();
+  const { attemptArchiveThread } = useThreadActions();
   const projects = useProjects();
   const threads = useThreadShells();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
@@ -1053,6 +1056,21 @@ function OpenCommandPaletteDialog(props: {
       icon: <SquarePenIcon className={ITEM_ICON_CLASS} />,
       addonIcon: <SquarePenIcon className={ADDON_ICON_CLASS} />,
       groups: [{ value: "projects", label: "Projects", items: projectThreadItems }],
+    });
+  }
+
+  if (activeThread) {
+    actionItems.push({
+      kind: "action",
+      value: "action:archive-current-thread",
+      searchTerms: ["archive", "current thread", "hide thread"],
+      title: "Archive current thread",
+      description: activeThread.title,
+      icon: <ArchiveIcon className={ITEM_ICON_CLASS} />,
+      shortcutCommand: "thread.archiveCurrent",
+      run: async () => {
+        await attemptArchiveThread(scopeThreadRef(activeThread.environmentId, activeThread.id));
+      },
     });
   }
 

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1072,6 +1072,7 @@ interface SidebarProjectItemProps {
   newThreadShortcutLabel: string | null;
   handleNewThread: ReturnType<typeof useNewThreadHandler>;
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
+  attemptArchiveThread: ReturnType<typeof useThreadActions>["attemptArchiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   threadJumpLabelByKey: ReadonlyMap<string, string>;
   attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
@@ -1092,6 +1093,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     newThreadShortcutLabel,
     handleNewThread,
     archiveThread,
+    attemptArchiveThread,
     deleteThread,
     threadJumpLabelByKey,
     attachThreadListAutoAnimateRef,
@@ -2010,23 +2012,6 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     [createThreadForProjectMember, project.groupedProjectCount, project.memberProjects],
   );
 
-  const attemptArchiveThread = useCallback(
-    async (threadRef: ScopedThreadRef) => {
-      const result = await archiveThread(threadRef);
-      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
-        const error = squashAtomCommandFailure(result);
-        toastManager.add(
-          stackedThreadToast({
-            type: "error",
-            title: "Failed to archive thread",
-            description: error instanceof Error ? error.message : "An error occurred.",
-          }),
-        );
-      }
-    },
-    [archiveThread],
-  );
-
   const cancelRename = useCallback(() => {
     setRenamingThreadKey(null);
     renamingInputRef.current = null;
@@ -2806,6 +2791,7 @@ interface SidebarProjectsContentProps {
   handleProjectDragCancel: (event: DragCancelEvent) => void;
   handleNewThread: ReturnType<typeof useNewThreadHandler>;
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
+  attemptArchiveThread: ReturnType<typeof useThreadActions>["attemptArchiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
   expandedThreadListsByProject: ReadonlySet<string>;
@@ -2847,6 +2833,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     handleProjectDragCancel,
     handleNewThread,
     archiveThread,
+    attemptArchiveThread,
     deleteThread,
     sortedProjects,
     expandedThreadListsByProject,
@@ -2998,6 +2985,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         newThreadShortcutLabel={newThreadShortcutLabel}
                         handleNewThread={handleNewThread}
                         archiveThread={archiveThread}
+                        attemptArchiveThread={attemptArchiveThread}
                         deleteThread={deleteThread}
                         threadJumpLabelByKey={threadJumpLabelByKey}
                         attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
@@ -3030,6 +3018,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 newThreadShortcutLabel={newThreadShortcutLabel}
                 handleNewThread={handleNewThread}
                 archiveThread={archiveThread}
+                attemptArchiveThread={attemptArchiveThread}
                 deleteThread={deleteThread}
                 threadJumpLabelByKey={threadJumpLabelByKey}
                 attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
@@ -3071,7 +3060,7 @@ export default function Sidebar() {
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
   const updateSettings = useUpdateClientSettings();
   const handleNewThread = useNewThreadHandler();
-  const { archiveThread, deleteThread } = useThreadActions();
+  const { archiveThread, attemptArchiveThread, deleteThread } = useThreadActions();
   const { isMobile, setOpenMobile } = useSidebar();
   const routeTarget = useParams({
     strict: false,
@@ -3688,6 +3677,7 @@ export default function Sidebar() {
             handleProjectDragCancel={handleProjectDragCancel}
             handleNewThread={handleNewThread}
             archiveThread={archiveThread}
+            attemptArchiveThread={attemptArchiveThread}
             deleteThread={deleteThread}
             sortedProjects={sortedProjects}
             expandedThreadListsByProject={expandedThreadListsByProject}

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -3,7 +3,11 @@ import {
   scopeProjectRef,
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
-import { settlePromise, squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import {
+  isAtomCommandInterrupted,
+  settlePromise,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
 import { canSettle } from "@t3tools/client-runtime/state/thread-settled";
 import { EnvironmentId, type ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -167,6 +171,23 @@ export function useThreadActions() {
       return archiveResult;
     },
     [archiveThreadMutation, getCurrentRouteThreadRef, resolveThreadTarget],
+  );
+
+  const attemptArchiveThread = useCallback(
+    async (target: ScopedThreadRef) => {
+      const result = await archiveThread(target);
+      if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+        const error = squashAtomCommandFailure(result);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to archive thread",
+            description: error instanceof Error ? error.message : "An error occurred.",
+          }),
+        );
+      }
+    },
+    [archiveThread],
   );
 
   const unarchiveThread = useCallback(
@@ -472,6 +493,7 @@ export function useThreadActions() {
   return useMemo(
     () => ({
       archiveThread,
+      attemptArchiveThread,
       unarchiveThread,
       deleteThread,
       confirmAndDeleteThread,
@@ -480,6 +502,7 @@ export function useThreadActions() {
     }),
     [
       archiveThread,
+      attemptArchiveThread,
       confirmAndDeleteThread,
       deleteThread,
       settleThread,

--- a/apps/web/src/lib/chatGlobalShortcuts.test.ts
+++ b/apps/web/src/lib/chatGlobalShortcuts.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { shouldIgnoreChatGlobalShortcutEvent } from "./chatGlobalShortcuts";
+
+describe("chat global shortcuts", () => {
+  it("does not dispatch archive for repeated keydown events", () => {
+    const archiveCurrentThread = vi.fn();
+    const event = {
+      defaultPrevented: false,
+      repeat: true,
+    } satisfies Pick<KeyboardEvent, "defaultPrevented" | "repeat">;
+
+    if (!shouldIgnoreChatGlobalShortcutEvent(event)) {
+      archiveCurrentThread();
+    }
+
+    expect(archiveCurrentThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/chatGlobalShortcuts.ts
+++ b/apps/web/src/lib/chatGlobalShortcuts.ts
@@ -1,0 +1,5 @@
+export function shouldIgnoreChatGlobalShortcutEvent(
+  event: Pick<KeyboardEvent, "defaultPrevented" | "repeat">,
+): boolean {
+  return event.defaultPrevented || event.repeat;
+}

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -8,10 +8,12 @@ import { openCommandPalette } from "../commandPaletteBus";
 import { useProjects } from "../state/entities";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useThreadActions } from "../hooks/useThreadActions";
 import {
   startNewLocalThreadFromContext,
   startNewThreadFromContext,
 } from "../lib/chatThreadActions";
+import { shouldIgnoreChatGlobalShortcutEvent } from "../lib/chatGlobalShortcuts";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { resolveShortcutCommand } from "../keybindings";
@@ -27,6 +29,7 @@ function ChatRouteGlobalShortcuts() {
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
   const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
     useHandleNewThread();
+  const { attemptArchiveThread } = useThreadActions();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const sidebarV2Enabled = useClientSettings((settings) => settings.sidebarV2Enabled);
   const projectCount = useProjects().length;
@@ -45,7 +48,7 @@ function ChatRouteGlobalShortcuts() {
   );
   useEffect(() => {
     const onWindowKeyDown = (event: KeyboardEvent) => {
-      if (event.defaultPrevented) return;
+      if (shouldIgnoreChatGlobalShortcutEvent(event)) return;
       const command = resolveShortcutCommand(event, keybindings, {
         context: {
           terminalFocus: isTerminalFocused(),
@@ -137,6 +140,15 @@ function ChatRouteGlobalShortcuts() {
                   ? "zoom-out"
                   : "reset-zoom";
         dispatchPreviewAction(action);
+        return;
+      }
+
+      if (command === "thread.archiveCurrent") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!routeThreadRef) return;
+        void attemptArchiveThread(routeThreadRef);
+        return;
       }
     };
 
@@ -147,6 +159,7 @@ function ChatRouteGlobalShortcuts() {
   }, [
     activeDraftThread,
     activeThread,
+    attemptArchiveThread,
     clearSelection,
     handleNewThread,
     keybindings,

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -33,7 +33,8 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
   { "key": "mod+n", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+o", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+n", "command": "chat.newLocal", "when": "!terminalFocus" },
-  { "key": "mod+o", "command": "editor.openFavorite" }
+  { "key": "mod+o", "command": "editor.openFavorite" },
+  { "key": "mod+shift+a", "command": "thread.archiveCurrent", "when": "!terminalFocus" }
 ]
 ```
 
@@ -67,6 +68,7 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 - `chat.new`: create a new chat thread preserving the active thread's branch/worktree state
 - `chat.newLocal`: create a new chat thread for the active project in a new environment (local/worktree determined by app settings (default `local`))
 - `editor.openFavorite`: open current project/worktree in the last-used editor
+- `thread.archiveCurrent`: archive the current thread
 - `script.{id}.run`: run a project script by id (for example `script.test.run`)
 
 ### Key Syntax

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -82,6 +82,12 @@ it.effect("parses keybinding rules", () =>
       command: "thread.previous",
     });
     assert.strictEqual(parsedThreadPrevious.command, "thread.previous");
+
+    const parsedArchiveCurrent = yield* decode(KeybindingRule, {
+      key: "mod+shift+a",
+      command: "thread.archiveCurrent",
+    });
+    assert.strictEqual(parsedArchiveCurrent.command, "thread.archiveCurrent");
   }),
 );
 

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -37,6 +37,7 @@ export type ModelPickerJumpKeybindingCommand =
 export const THREAD_KEYBINDING_COMMANDS = [
   "thread.previous",
   "thread.next",
+  "thread.archiveCurrent",
   ...THREAD_JUMP_KEYBINDING_COMMANDS,
 ] as const;
 export type ThreadKeybindingCommand = (typeof THREAD_KEYBINDING_COMMANDS)[number];

--- a/packages/shared/src/keybindings.test.ts
+++ b/packages/shared/src/keybindings.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { DEFAULT_KEYBINDINGS } from "./keybindings.ts";
+
+describe("default keybindings", () => {
+  it("archives the current thread with mod+shift+a outside terminal focus", () => {
+    expect(
+      DEFAULT_KEYBINDINGS.find((binding) => binding.command === "thread.archiveCurrent"),
+    ).toEqual({
+      key: "mod+shift+a",
+      command: "thread.archiveCurrent",
+      when: "!terminalFocus",
+    });
+  });
+});

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -42,6 +42,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+o", command: "editor.openFavorite" },
   { key: "mod+shift+[", command: "thread.previous" },
   { key: "mod+shift+]", command: "thread.next" },
+  { key: "mod+shift+a", command: "thread.archiveCurrent", when: "!terminalFocus" },
   ...THREAD_JUMP_KEYBINDING_COMMANDS.map((command, index) => ({
     key: `mod+${index + 1}`,
     command,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Add `thread.archiveCurrent` so the current thread can be archived without leaving the keyboard.

- Bind `mod+shift+a` when the in-app terminal is not focused.
- Add “Archive current thread” to the command palette.
- Reuse the sidebar archive flow so success navigates to a fresh draft and failures show an error toast.
- Ignore repeated keydown events so holding the shortcut archives exactly once.

## Why

The existing Cmd+1, Cmd+2, etc. shortcuts make switching threads fast, but stale threads still require pointer interaction to archive. This keeps the entire switch-and-clean-up workflow on the keyboard.

## UI Changes

### Before

Searching for `archive` on upstream main returns no matching command.

![Before — upstream main command palette has no Archive thread action](https://agent-images.24letters.com/i/e3300ca6-e69b-4c4f-ac59-17f6003e2609)

### After

Searching for `archive` on this PR shows “Archive current thread” with ⇧⌘A.

![After — PR #2699 command palette shows Archive current thread with Shift-Command-A](https://agent-images.24letters.com/i/51cbcd50-5768-4f47-b922-5c7aa06adc8c)

### Interaction

The shortcut archives the active thread and navigates to a fresh draft.

https://github.com/user-attachments/assets/6838797f-68e7-4544-9669-dc468494c284

## Verification

### Automated

- `vp check` — passed
- `vp run typecheck` — passed
- `vp test run apps/web/src/lib/chatGlobalShortcuts.test.ts packages/contracts/src/keybindings.test.ts packages/shared/src/keybindings.test.ts` — 121 tests passed

### Manual GUI verification

Verified in a disposable, paired T3 Code environment at head `3759679409cf`:

- [x] Active thread + `mod+shift+a`: archived once and navigated to a fresh draft.
- [x] Command palette: “Archive current thread” is visible and archives successfully.
- [x] New-draft route: shortcut is a no-op with no toast or browser side effect.
- [x] In-app terminal focused: shortcut does not archive the thread.
- [x] Held shortcut/repeat stream: exactly one archive event and no spurious failure toast.
- [x] Running thread: “Failed to archive thread — Cannot archive a running thread.” toast appears.
- [x] Three selected sidebar threads: context menu shows “Archive (3)”; all three archive with no error toast.

Evidence is captured locally as `before-command-palette.png`, `after-command-palette.png`, `after-archive-shortcut.png`, `after-archive-toast.png`, `terminal-focus-noop.png`, `hold-chord-single-archive.png`, `multi-select-selected.png`, `multi-select-archive-result.png`, and `archive-shortcut.mp4`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Focused UX and keybinding wiring reusing existing archive behavior; no auth or data-model changes.
> 
> **Overview**
> Adds **`thread.archiveCurrent`** so users can archive the active thread from the keyboard without using the sidebar.
> 
> **`mod+shift+a`** is registered as the default binding (when the terminal is not focused), documented in user keybindings, and validated in contracts/shared tests. Chat route global shortcuts handle the command by calling **`attemptArchiveThread`** on the routed thread; draft routes no-op.
> 
> **`attemptArchiveThread`** is moved into **`useThreadActions`** (archive + failure toast), replacing duplicated logic in the sidebar. The command palette gains **Archive current thread** when a server thread is active, wired to the same helper.
> 
> **`shouldIgnoreChatGlobalShortcutEvent`** centralizes ignoring `defaultPrevented` and **repeat** keydowns so holding the chord does not archive multiple times.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 959d9a787e80984ea45df7621e7380d6f6f10b40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `thread.archiveCurrent` keyboard shortcut to archive the active thread
> - Adds a default keybinding `mod+shift+a` for `thread.archiveCurrent` (when terminal is not focused) via [keybindings.ts](https://github.com/pingdotgg/t3code/pull/2699/files#diff-43f35e6edaf374f5ed53b0c61409d76e733a1b8e06098a0e8ded132d3b433f06) and the contracts schema in [keybindings.ts](https://github.com/pingdotgg/t3code/pull/2699/files#diff-4eff8b6cf08dc64a9d8f37ff97b369a5719340e4c6203ab7070cc8cfffd28db6).
> - The global shortcut handler in [_chat.tsx](https://github.com/pingdotgg/t3code/pull/2699/files#diff-57ccd85378cde777d8acfd2c8581caf212ad22cf0d96b993b064a9a9f2c77691) calls `attemptArchiveThread` on the current thread, skipping repeated or already-handled keydown events via the new `shouldIgnoreChatGlobalShortcutEvent` guard.
> - The command palette in [CommandPalette.tsx](https://github.com/pingdotgg/t3code/pull/2699/files#diff-30c525d0ef54c6971e43ab0660a73ea227ef51e009f79e4083049d3349175a7a) surfaces an "Archive current thread" action when a thread is active, advertising the same shortcut.
> - `attemptArchiveThread` is extracted into [useThreadActions.ts](https://github.com/pingdotgg/t3code/pull/2699/files#diff-7d3463056176ee1e173c0ae885b4305a70a7cc854fee7040d9b9a5a28dfbda50) and shows a stacked toast on non-interruption failures; the sidebar now consumes it via props instead of its own local implementation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 959d9a7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

