### PR TITLE
Add sticky user message overlay

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -27,6 +27,8 @@ const clientSettings: ClientSettings = {
   sidebarProjectSortOrder: "manual",
   sidebarThreadSortOrder: "created_at",
   sidebarThreadPreviewCount: 6,
+  stickyUserMessageCount: 2,
+  stickyUserMessageMaxLines: 3,
   timestampFormat: "24-hour",
 };
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3574,6 +3574,8 @@ export default function ChatView(props: ChatViewProps) {
               markdownCwd={gitCwd ?? undefined}
               resolvedTheme={resolvedTheme}
               timestampFormat={timestampFormat}
+              stickyUserMessageCount={settings.stickyUserMessageCount}
+              stickyUserMessageMaxLines={settings.stickyUserMessageMaxLines}
               workspaceRoot={activeWorkspaceRoot}
               skills={activeProviderStatus?.skills ?? EMPTY_PROVIDER_SKILLS}
               onIsAtEndChange={onIsAtEndChange}

--- a/apps/web/src/components/chat/MessagesTimeline.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.browser.tsx
@@ -68,6 +68,8 @@ function buildProps() {
     markdownCwd: undefined,
     resolvedTheme: "dark" as const,
     timestampFormat: "24-hour" as const,
+    stickyUserMessageCount: 0,
+    stickyUserMessageMaxLines: 2,
     workspaceRoot: undefined,
     onIsAtEndChange: vi.fn(),
   };
@@ -79,16 +81,27 @@ function buildLongUserMessageText(tail = "deep hidden detail only after expand")
   ).join("\n");
 }
 
-function buildUserTimelineEntry(text: string) {
+function buildUserTimelineEntry(
+  text: string,
+  {
+    entryId = "entry-1",
+    messageId = "message-1",
+    createdAt = MESSAGE_CREATED_AT,
+  }: {
+    entryId?: string;
+    messageId?: string;
+    createdAt?: string;
+  } = {},
+) {
   return {
-    id: "entry-1",
+    id: entryId,
     kind: "message" as const,
-    createdAt: MESSAGE_CREATED_AT,
+    createdAt,
     message: {
-      id: "message-1" as never,
+      id: messageId as never,
       role: "user" as const,
       text,
-      createdAt: MESSAGE_CREATED_AT,
+      createdAt,
       streaming: false,
     },
   };
@@ -200,6 +213,134 @@ describe("MessagesTimeline", () => {
       expect(messageBody?.className).toContain("overflow-hidden");
       expect(messageBody?.getAttribute("data-user-message-fade")).toBe("true");
       expect(messageBody?.style.maskImage).toContain("linear-gradient");
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("shows a sticky user message only after its source row is above the transcript viewport", async () => {
+    let sourceAboveViewport = true;
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.dataset.testid === "legend-list") {
+          return DOMRect.fromRect({ x: 0, y: 0, width: 640, height: 240 });
+        }
+        if (this.dataset.messageId === "message-1") {
+          return sourceAboveViewport
+            ? DOMRect.fromRect({ x: 0, y: -80, width: 480, height: 60 })
+            : DOMRect.fromRect({ x: 0, y: 80, width: 480, height: 60 });
+        }
+        return originalGetBoundingClientRect.call(this);
+      },
+    );
+
+    const screen = await render(
+      <MessagesTimeline
+        {...buildProps()}
+        stickyUserMessageCount={1}
+        stickyUserMessageMaxLines={2}
+        timelineEntries={[buildUserTimelineEntry("Keep this request visible.")]}
+      />,
+    );
+
+    try {
+      await expect
+        .element(page.getByRole("button", { name: "Scroll to original user message" }))
+        .toBeVisible();
+
+      sourceAboveViewport = false;
+      document.querySelector("[data-testid='legend-list']")?.dispatchEvent(new Event("scroll"));
+
+      await expect
+        .element(page.getByRole("button", { name: "Scroll to original user message" }))
+        .not.toBeInTheDocument();
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("scrolls back to the original user message when the sticky copy is clicked", async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.dataset.testid === "legend-list") {
+          return DOMRect.fromRect({ x: 0, y: 0, width: 640, height: 240 });
+        }
+        if (this.dataset.messageId === "message-1") {
+          return DOMRect.fromRect({ x: 0, y: -80, width: 480, height: 60 });
+        }
+        return originalGetBoundingClientRect.call(this);
+      },
+    );
+    const scrollIntoViewSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(() => undefined);
+
+    const screen = await render(
+      <MessagesTimeline
+        {...buildProps()}
+        stickyUserMessageCount={1}
+        timelineEntries={[buildUserTimelineEntry("Jump back to this prompt.")]}
+      />,
+    );
+
+    try {
+      const stickyButton = page.getByRole("button", { name: "Scroll to original user message" });
+      await expect.element(stickyButton).toBeVisible();
+      await stickyButton.click();
+
+      expect(scrollIntoViewSpy).toHaveBeenCalledWith({ block: "start", behavior: "smooth" });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("shows sticky metadata only on the newest visible sticky user message", async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        if (this.dataset.testid === "legend-list") {
+          return DOMRect.fromRect({ x: 0, y: 0, width: 640, height: 240 });
+        }
+        if (this.dataset.messageId === "message-1" || this.dataset.messageId === "message-2") {
+          return DOMRect.fromRect({ x: 0, y: -80, width: 480, height: 60 });
+        }
+        return originalGetBoundingClientRect.call(this);
+      },
+    );
+
+    const screen = await render(
+      <MessagesTimeline
+        {...buildProps()}
+        stickyUserMessageCount={2}
+        stickyUserMessageMaxLines={2}
+        timelineEntries={[
+          buildUserTimelineEntry("First sticky prompt.", {
+            entryId: "entry-1",
+            messageId: "message-1",
+          }),
+          buildUserTimelineEntry("Second sticky prompt.", {
+            entryId: "entry-2",
+            messageId: "message-2",
+          }),
+        ]}
+      />,
+    );
+
+    try {
+      await vi.waitFor(() => {
+        expect(document.querySelector("[data-sticky-user-message-id='message-1']")).not.toBeNull();
+        expect(document.querySelector("[data-sticky-user-message-id='message-2']")).not.toBeNull();
+
+        const metaRows = document.querySelectorAll("[data-sticky-user-message-meta='true']");
+        expect(metaRows).toHaveLength(1);
+        expect(
+          metaRows[0]
+            ?.closest("[data-sticky-user-message-id]")
+            ?.getAttribute("data-sticky-user-message-id"),
+        ).toBe("message-2");
+      });
     } finally {
       await screen.unmount();
     }

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -91,6 +91,8 @@ function buildProps() {
     markdownCwd: undefined,
     resolvedTheme: "light" as const,
     timestampFormat: "locale" as const,
+    stickyUserMessageCount: 0,
+    stickyUserMessageMaxLines: 2,
     workspaceRoot: undefined,
     onIsAtEndChange: () => {},
   };

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -58,7 +58,16 @@ import {
 import { cn } from "~/lib/utils";
 import { useUiStateStore } from "~/uiStateStore";
 import { type TimestampFormat } from "@t3tools/contracts/settings";
+import type {
+  StickyUserMessageCount,
+  StickyUserMessageMaxLines,
+} from "@t3tools/contracts/settings";
 import { formatTimestamp } from "../../timestampFormat";
+import {
+  deriveStickyUserMessageEntries,
+  StickyUserMessagesOverlay,
+  useHiddenStickyUserMessageIds,
+} from "./StickyUserMessagesOverlay";
 
 import {
   buildInlineTerminalContextText,
@@ -123,6 +132,8 @@ interface MessagesTimelineProps {
   markdownCwd: string | undefined;
   resolvedTheme: "light" | "dark";
   timestampFormat: TimestampFormat;
+  stickyUserMessageCount: StickyUserMessageCount;
+  stickyUserMessageMaxLines: StickyUserMessageMaxLines;
   workspaceRoot: string | undefined;
   skills?: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
   onIsAtEndChange: (isAtEnd: boolean) => void;
@@ -152,6 +163,8 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   markdownCwd,
   resolvedTheme,
   timestampFormat,
+  stickyUserMessageCount,
+  stickyUserMessageMaxLines,
   workspaceRoot,
   skills = EMPTY_TIMELINE_SKILLS,
   onIsAtEndChange,
@@ -182,6 +195,17 @@ export const MessagesTimeline = memo(function MessagesTimeline({
     ],
   );
   const rows = useStableRows(rawRows);
+  const timelineViewportRef = useRef<HTMLDivElement>(null);
+  const stickyUserMessageEntries = useMemo(
+    () => deriveStickyUserMessageEntries(rows, stickyUserMessageCount),
+    [rows, stickyUserMessageCount],
+  );
+  const hiddenStickyUserMessageIds = useHiddenStickyUserMessageIds({
+    entries: stickyUserMessageEntries,
+    listRef,
+    timelineViewportRef,
+    enabled: stickyUserMessageCount > 0,
+  });
 
   const handleScroll = useCallback(() => {
     const state = listRef.current?.getState?.();
@@ -266,21 +290,32 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   return (
     <TimelineRowCtx value={sharedState}>
       <TimelineRowActivityCtx value={activityState}>
-        <LegendList<MessagesTimelineRow>
-          ref={listRef}
-          data={rows}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          estimatedItemSize={90}
-          initialScrollAtEnd
-          maintainScrollAtEnd
-          maintainScrollAtEndThreshold={0.1}
-          maintainVisibleContentPosition
-          onScroll={handleScroll}
-          className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
-          ListHeaderComponent={TIMELINE_LIST_HEADER}
-          ListFooterComponent={TIMELINE_LIST_FOOTER}
-        />
+        <div ref={timelineViewportRef} className="relative h-full min-h-0">
+          <LegendList<MessagesTimelineRow>
+            ref={listRef}
+            data={rows}
+            keyExtractor={keyExtractor}
+            renderItem={renderItem}
+            estimatedItemSize={90}
+            initialScrollAtEnd
+            maintainScrollAtEnd
+            maintainScrollAtEndThreshold={0.1}
+            maintainVisibleContentPosition
+            onScroll={handleScroll}
+            className="h-full overflow-x-hidden overscroll-y-contain px-3 sm:px-5"
+            ListHeaderComponent={TIMELINE_LIST_HEADER}
+            ListFooterComponent={TIMELINE_LIST_FOOTER}
+          />
+          <StickyUserMessagesOverlay
+            entries={stickyUserMessageEntries}
+            hiddenMessageIds={hiddenStickyUserMessageIds}
+            listRef={listRef}
+            maxLines={stickyUserMessageMaxLines}
+            skills={skills}
+            timestampFormat={timestampFormat}
+            timelineViewportRef={timelineViewportRef}
+          />
+        </div>
       </TimelineRowActivityCtx>
     </TimelineRowCtx>
   );
@@ -290,14 +325,14 @@ function keyExtractor(item: MessagesTimelineRow) {
   return item.id;
 }
 
-// ---------------------------------------------------------------------------
-// TimelineRowContent — the actual row component
-// ---------------------------------------------------------------------------
-
 type TimelineEntry = ReturnType<typeof deriveTimelineEntries>[number];
 type TimelineMessage = Extract<TimelineEntry, { kind: "message" }>["message"];
 type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["groupedEntries"][number];
 type TimelineRow = MessagesTimelineRow;
+
+// ---------------------------------------------------------------------------
+// TimelineRowContent — the actual row component
+// ---------------------------------------------------------------------------
 
 const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
   return (
@@ -310,6 +345,9 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
       data-timeline-row-kind={row.kind}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
       data-message-role={row.kind === "message" ? row.message.role : undefined}
+      data-sticky-user-message-source={
+        row.kind === "message" && row.message.role === "user" ? "true" : undefined
+      }
     >
       {row.kind === "work" ? <WorkGroupSection groupedEntries={row.groupedEntries} /> : null}
       {row.kind === "message" && row.message.role === "user" ? <UserTimelineRow row={row} /> : null}

--- a/apps/web/src/components/chat/StickyUserMessagesOverlay.tsx
+++ b/apps/web/src/components/chat/StickyUserMessagesOverlay.tsx
@@ -1,0 +1,356 @@
+import { type MessageId, type ServerProviderSkill } from "@t3tools/contracts";
+import type {
+  StickyUserMessageCount,
+  StickyUserMessageMaxLines,
+  TimestampFormat,
+} from "@t3tools/contracts/settings";
+import type { LegendListRef } from "@legendapp/list/react";
+import * as Equal from "effect/Equal";
+import { useEffect, useRef, useState, type RefObject } from "react";
+
+import type { ChatMessage } from "../../types";
+import { formatTimestamp } from "../../timestampFormat";
+import { cn } from "~/lib/utils";
+import { deriveDisplayedUserMessageState } from "~/lib/terminalContext";
+import { SkillInlineText } from "./SkillInlineText";
+import type { MessagesTimelineRow } from "./MessagesTimeline.logic";
+
+type UserTimelineMessage = ChatMessage & { role: "user" };
+
+export interface StickyUserMessageEntry {
+  id: MessageId;
+  rowIndex: number;
+  message: UserTimelineMessage;
+}
+
+export function deriveStickyUserMessageEntries(
+  rows: ReadonlyArray<MessagesTimelineRow>,
+  count: StickyUserMessageCount,
+): StickyUserMessageEntry[] {
+  if (count <= 0) {
+    return [];
+  }
+
+  const entries: StickyUserMessageEntry[] = [];
+  for (let rowIndex = rows.length - 1; rowIndex >= 0 && entries.length < count; rowIndex -= 1) {
+    const row = rows[rowIndex];
+    if (row?.kind !== "message") {
+      continue;
+    }
+
+    const { message } = row;
+    if (!isUserTimelineMessage(message)) {
+      continue;
+    }
+
+    entries.unshift({
+      id: message.id,
+      rowIndex,
+      message,
+    });
+  }
+
+  return entries;
+}
+
+function isUserTimelineMessage(message: ChatMessage): message is UserTimelineMessage {
+  return message.role === "user";
+}
+
+export function useHiddenStickyUserMessageIds({
+  entries,
+  listRef,
+  timelineViewportRef,
+  enabled,
+}: {
+  entries: ReadonlyArray<StickyUserMessageEntry>;
+  listRef: RefObject<LegendListRef | null>;
+  timelineViewportRef: RefObject<HTMLDivElement | null>;
+  enabled: boolean;
+}): ReadonlySet<MessageId> {
+  const [hiddenMessageIds, setHiddenMessageIds] = useState<ReadonlySet<MessageId>>(() => new Set());
+  const entriesRef = useRef(entries);
+  entriesRef.current = entries;
+  const entryKey = entries.map((entry) => entry.id).join("\n");
+
+  useEffect(() => {
+    if (!enabled || entryKey.length === 0) {
+      setHiddenMessageIds((current) => (current.size === 0 ? current : new Set()));
+      return;
+    }
+
+    const timelineViewport = timelineViewportRef.current;
+    const scrollRoot = getTimelineScrollRoot(timelineViewport);
+    if (!timelineViewport || !scrollRoot) {
+      return;
+    }
+
+    let disposed = false;
+    let animationFrameId: number | null = null;
+
+    const measure = () => {
+      if (disposed) return;
+      const rootRect = scrollRoot.getBoundingClientRect();
+      const listState = listRef.current?.getState?.();
+      const currentEntries = entriesRef.current;
+
+      setHiddenMessageIds((current) => {
+        const next = new Set<MessageId>();
+        for (const entry of currentEntries) {
+          const source = findStickyUserMessageSource(timelineViewport, entry.id);
+          if (!source) {
+            if (
+              (listState && entry.rowIndex < listState.start) ||
+              (!listState && current.has(entry.id))
+            ) {
+              next.add(entry.id);
+            }
+            continue;
+          }
+
+          const sourceRect = source.getBoundingClientRect();
+          const isVisible = sourceRect.bottom > rootRect.top && sourceRect.top < rootRect.bottom;
+          const isAboveViewport = sourceRect.bottom <= rootRect.top;
+          if (!isVisible && isAboveViewport) {
+            next.add(entry.id);
+          }
+        }
+
+        return Equal.equals(current, next) ? current : next;
+      });
+    };
+
+    const scheduleMeasure = () => {
+      if (animationFrameId !== null) {
+        return;
+      }
+      animationFrameId = window.requestAnimationFrame(() => {
+        animationFrameId = null;
+        measure();
+      });
+    };
+
+    measure();
+    scrollRoot.addEventListener("scroll", scheduleMeasure, { passive: true });
+    window.addEventListener("resize", scheduleMeasure);
+
+    return () => {
+      disposed = true;
+      if (animationFrameId !== null) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+      scrollRoot.removeEventListener("scroll", scheduleMeasure);
+      window.removeEventListener("resize", scheduleMeasure);
+    };
+  }, [enabled, entryKey, listRef, timelineViewportRef]);
+
+  return hiddenMessageIds;
+}
+
+export function StickyUserMessagesOverlay({
+  entries,
+  hiddenMessageIds,
+  listRef,
+  maxLines,
+  skills,
+  timestampFormat,
+  timelineViewportRef,
+}: {
+  entries: ReadonlyArray<StickyUserMessageEntry>;
+  hiddenMessageIds: ReadonlySet<MessageId>;
+  listRef: RefObject<LegendListRef | null>;
+  maxLines: StickyUserMessageMaxLines;
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+  timestampFormat: TimestampFormat;
+  timelineViewportRef: RefObject<HTMLDivElement | null>;
+}) {
+  const visibleEntries = entries.filter((entry) => hiddenMessageIds.has(entry.id));
+
+  if (visibleEntries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-20 px-3 pt-2 sm:px-5"
+      data-sticky-user-messages="true"
+    >
+      <div className="mx-auto flex w-full max-w-3xl flex-col items-end gap-1.5">
+        {visibleEntries.map((entry, index) => (
+          <StickyUserMessageBubble
+            key={entry.id}
+            entry={entry}
+            maxLines={maxLines}
+            showMeta={index === visibleEntries.length - 1}
+            skills={skills}
+            timestampFormat={timestampFormat}
+            onClick={() =>
+              scrollToStickyUserMessageSource({
+                entry,
+                listRef,
+                timelineViewportRef,
+              })
+            }
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function StickyUserMessageBubble({
+  entry,
+  maxLines,
+  onClick,
+  showMeta,
+  skills,
+  timestampFormat,
+}: {
+  entry: StickyUserMessageEntry;
+  maxLines: StickyUserMessageMaxLines;
+  onClick: () => void;
+  showMeta: boolean;
+  skills: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">>;
+  timestampFormat: TimestampFormat;
+}) {
+  const [mounted, setMounted] = useState(false);
+  const displayedUserMessage = deriveDisplayedUserMessageState(entry.message.text);
+  const textRef = useRef<HTMLDivElement>(null);
+  const [hiddenLineCount, setHiddenLineCount] = useState(0);
+
+  useEffect(() => {
+    const frameId = window.requestAnimationFrame(() => setMounted(true));
+    return () => window.cancelAnimationFrame(frameId);
+  }, []);
+
+  useEffect(() => {
+    if (!showMeta) {
+      setHiddenLineCount((current) => (current === 0 ? current : 0));
+      return;
+    }
+
+    let frameId: number | null = null;
+    const textElement = textRef.current;
+
+    const measureHiddenLines = () => {
+      if (!textElement) {
+        setHiddenLineCount(0);
+        return;
+      }
+
+      const lineHeight = Number.parseFloat(window.getComputedStyle(textElement).lineHeight);
+      if (!Number.isFinite(lineHeight) || lineHeight <= 0) {
+        setHiddenLineCount(0);
+        return;
+      }
+
+      const totalLines = Math.ceil(textElement.scrollHeight / lineHeight);
+      const nextHiddenLineCount = Math.max(0, totalLines - maxLines);
+      setHiddenLineCount((current) =>
+        current === nextHiddenLineCount ? current : nextHiddenLineCount,
+      );
+    };
+
+    const scheduleMeasure = () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        measureHiddenLines();
+      });
+    };
+
+    scheduleMeasure();
+    window.addEventListener("resize", scheduleMeasure);
+    const observer =
+      typeof ResizeObserver === "undefined" ? null : new ResizeObserver(scheduleMeasure);
+    if (textElement) {
+      observer?.observe(textElement);
+    }
+
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+      observer?.disconnect();
+      window.removeEventListener("resize", scheduleMeasure);
+    };
+  }, [displayedUserMessage.visibleText, maxLines, showMeta]);
+
+  return (
+    <button
+      type="button"
+      aria-label="Scroll to original user message"
+      className={cn(
+        "pointer-events-auto max-w-[80%] rounded-2xl rounded-br-sm border border-border/80 bg-secondary/95 px-3 py-2 text-left shadow-sm backdrop-blur-sm transition-[opacity,transform,background-color,border-color] duration-150 ease-out hover:border-border hover:bg-secondary",
+        mounted ? "translate-y-0 opacity-100" : "-translate-y-1 opacity-0",
+      )}
+      data-sticky-user-message-id={entry.id}
+      onClick={onClick}
+    >
+      <div
+        ref={textRef}
+        className="wrap-break-word overflow-hidden whitespace-pre-wrap text-sm leading-relaxed text-foreground"
+        style={{
+          display: "-webkit-box",
+          WebkitBoxOrient: "vertical",
+          WebkitLineClamp: maxLines,
+        }}
+      >
+        <SkillInlineText text={displayedUserMessage.visibleText} skills={skills} />
+      </div>
+      {showMeta ? (
+        <div
+          className="mt-1.5 flex items-center justify-between gap-3 text-xs text-muted-foreground/50"
+          data-sticky-user-message-meta="true"
+        >
+          <span>{hiddenLineCount > 0 ? formatHiddenLineCount(hiddenLineCount) : null}</span>
+          <span className="ml-auto">
+            {formatTimestamp(entry.message.createdAt, timestampFormat)}
+          </span>
+        </div>
+      ) : null}
+    </button>
+  );
+}
+
+function getTimelineScrollRoot(timelineViewport: HTMLDivElement | null): HTMLElement | null {
+  const firstChild = timelineViewport?.firstElementChild;
+  return firstChild instanceof HTMLElement ? firstChild : null;
+}
+
+function findStickyUserMessageSource(
+  timelineViewport: HTMLDivElement,
+  messageId: MessageId,
+): HTMLElement | null {
+  return timelineViewport.querySelector<HTMLElement>(
+    `[data-sticky-user-message-source='true'][data-message-id="${CSS.escape(messageId)}"]`,
+  );
+}
+
+function scrollToStickyUserMessageSource({
+  entry,
+  listRef,
+  timelineViewportRef,
+}: {
+  entry: StickyUserMessageEntry;
+  listRef: RefObject<LegendListRef | null>;
+  timelineViewportRef: RefObject<HTMLDivElement | null>;
+}) {
+  const timelineViewport = timelineViewportRef.current;
+  const source = timelineViewport ? findStickyUserMessageSource(timelineViewport, entry.id) : null;
+  if (source) {
+    source.scrollIntoView({ block: "start", behavior: "smooth" });
+    return;
+  }
+
+  void listRef.current?.scrollToIndex({
+    index: entry.rowIndex,
+    animated: true,
+  });
+}
+
+function formatHiddenLineCount(hiddenLineCount: number): string {
+  return hiddenLineCount === 1 ? "+1 line" : `+${hiddenLineCount} lines`;
+}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -12,7 +12,11 @@ import {
   type ScopedThreadRef,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime";
-import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import {
+  DEFAULT_UNIFIED_SETTINGS,
+  type StickyUserMessageCount,
+  type StickyUserMessageMaxLines,
+} from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
 import * as Duration from "effect/Duration";
 import * as Equal from "effect/Equal";
@@ -98,6 +102,18 @@ const TIMESTAMP_FORMAT_LABELS = {
   "12-hour": "12-hour",
   "24-hour": "24-hour",
 } as const;
+
+const STICKY_USER_MESSAGE_COUNT_OPTIONS = [
+  { value: "0", setting: 0 as StickyUserMessageCount, label: "Off" },
+  { value: "1", setting: 1 as StickyUserMessageCount, label: "1 message" },
+  { value: "2", setting: 2 as StickyUserMessageCount, label: "2 messages" },
+] as const;
+
+const STICKY_USER_MESSAGE_LINE_OPTIONS = [
+  { value: "1", setting: 1 as StickyUserMessageMaxLines, label: "1 line" },
+  { value: "2", setting: 2 as StickyUserMessageMaxLines, label: "2 lines" },
+  { value: "3", setting: 3 as StickyUserMessageMaxLines, label: "3 lines" },
+] as const;
 
 const DEFAULT_DRIVER_KIND = ProviderDriverKind.make("codex");
 
@@ -386,6 +402,9 @@ export function useSettingsRestore(onRestored?: () => void) {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
+  const isStickyUserMessagesDirty =
+    settings.stickyUserMessageCount !== DEFAULT_UNIFIED_SETTINGS.stickyUserMessageCount ||
+    settings.stickyUserMessageMaxLines !== DEFAULT_UNIFIED_SETTINGS.stickyUserMessageMaxLines;
 
   const changedSettingLabels = useMemo(
     () => [
@@ -405,6 +424,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.autoOpenPlanSidebar !== DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar
         ? ["Auto-open task panel"]
         : []),
+      ...(isStickyUserMessagesDirty ? ["Sticky user messages"] : []),
       ...(settings.enableAssistantStreaming !== DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming
         ? ["Assistant output"]
         : []),
@@ -428,6 +448,7 @@ export function useSettingsRestore(onRestored?: () => void) {
     ],
     [
       isGitWritingModelDirty,
+      isStickyUserMessagesDirty,
       settings.autoOpenPlanSidebar,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
@@ -459,6 +480,8 @@ export function useSettingsRestore(onRestored?: () => void) {
       diffWordWrap: DEFAULT_UNIFIED_SETTINGS.diffWordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+      stickyUserMessageCount: DEFAULT_UNIFIED_SETTINGS.stickyUserMessageCount,
+      stickyUserMessageMaxLines: DEFAULT_UNIFIED_SETTINGS.stickyUserMessageMaxLines,
       autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
       enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,
@@ -513,6 +536,9 @@ export function GeneralSettingsPanel() {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
+  const isStickyUserMessagesDirty =
+    settings.stickyUserMessageCount !== DEFAULT_UNIFIED_SETTINGS.stickyUserMessageCount ||
+    settings.stickyUserMessageMaxLines !== DEFAULT_UNIFIED_SETTINGS.stickyUserMessageMaxLines;
 
   return (
     <SettingsPageContainer>
@@ -666,6 +692,81 @@ export function GeneralSettingsPanel() {
               }
               aria-label="Stream assistant messages"
             />
+          }
+        />
+
+        <SettingsRow
+          title="Sticky user messages"
+          description="Keep recent user prompts visible while long responses scroll past them."
+          resetAction={
+            isStickyUserMessagesDirty ? (
+              <SettingResetButton
+                label="sticky user messages"
+                onClick={() =>
+                  updateSettings({
+                    stickyUserMessageCount: DEFAULT_UNIFIED_SETTINGS.stickyUserMessageCount,
+                    stickyUserMessageMaxLines: DEFAULT_UNIFIED_SETTINGS.stickyUserMessageMaxLines,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
+              <Select
+                value={String(settings.stickyUserMessageCount)}
+                onValueChange={(value) => {
+                  const option = STICKY_USER_MESSAGE_COUNT_OPTIONS.find(
+                    (entry) => entry.value === value,
+                  );
+                  if (option) {
+                    updateSettings({ stickyUserMessageCount: option.setting });
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full sm:w-36" aria-label="Sticky user messages">
+                  <SelectValue>
+                    {STICKY_USER_MESSAGE_COUNT_OPTIONS.find(
+                      (option) => option.setting === settings.stickyUserMessageCount,
+                    )?.label ?? "Off"}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  {STICKY_USER_MESSAGE_COUNT_OPTIONS.map((option) => (
+                    <SelectItem hideIndicator key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectPopup>
+              </Select>
+              <Select
+                value={String(settings.stickyUserMessageMaxLines)}
+                onValueChange={(value) => {
+                  const option = STICKY_USER_MESSAGE_LINE_OPTIONS.find(
+                    (entry) => entry.value === value,
+                  );
+                  if (option) {
+                    updateSettings({ stickyUserMessageMaxLines: option.setting });
+                  }
+                }}
+                disabled={settings.stickyUserMessageCount === 0}
+              >
+                <SelectTrigger className="w-full sm:w-32" aria-label="Max sticky lines">
+                  <SelectValue>
+                    {STICKY_USER_MESSAGE_LINE_OPTIONS.find(
+                      (option) => option.setting === settings.stickyUserMessageMaxLines,
+                    )?.label ?? "2 lines"}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectPopup align="end" alignItemWithTrigger={false}>
+                  {STICKY_USER_MESSAGE_LINE_OPTIONS.map((option) => (
+                    <SelectItem hideIndicator key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectPopup>
+              </Select>
+            </div>
           }
         />
 

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -614,6 +614,8 @@ describe("wsApi", () => {
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
       sidebarThreadPreviewCount: 6,
+      stickyUserMessageCount: 2 as const,
+      stickyUserMessageMaxLines: 3 as const,
       timestampFormat: "24-hour" as const,
     };
     const getClientSettings = vi.fn().mockResolvedValue({
@@ -677,6 +679,8 @@ describe("wsApi", () => {
       sidebarProjectSortOrder: "manual" as const,
       sidebarThreadSortOrder: "created_at" as const,
       sidebarThreadPreviewCount: 6,
+      stickyUserMessageCount: 2 as const,
+      stickyUserMessageMaxLines: 3 as const,
       timestampFormat: "24-hour" as const,
     };
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -2,11 +2,46 @@ import { describe, expect, it } from "vitest";
 import * as Schema from "effect/Schema";
 
 import { ProviderInstanceId } from "./providerInstance.ts";
-import { DEFAULT_SERVER_SETTINGS, ServerSettings, ServerSettingsPatch } from "./settings.ts";
+import {
+  ClientSettingsPatch,
+  ClientSettingsSchema,
+  DEFAULT_CLIENT_SETTINGS,
+  DEFAULT_SERVER_SETTINGS,
+  ServerSettings,
+  ServerSettingsPatch,
+} from "./settings.ts";
 
+const decodeClientSettings = Schema.decodeUnknownSync(ClientSettingsSchema);
+const decodeClientSettingsPatch = Schema.decodeUnknownSync(ClientSettingsPatch);
 const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
+
+describe("ClientSettings sticky user messages", () => {
+  it("defaults sticky user messages off with a two-line clamp", () => {
+    expect(DEFAULT_CLIENT_SETTINGS.stickyUserMessageCount).toBe(0);
+    expect(DEFAULT_CLIENT_SETTINGS.stickyUserMessageMaxLines).toBe(2);
+
+    const decoded = decodeClientSettings({});
+    expect(decoded.stickyUserMessageCount).toBe(0);
+    expect(decoded.stickyUserMessageMaxLines).toBe(2);
+  });
+
+  it("accepts bounded sticky user message patches", () => {
+    expect(
+      decodeClientSettingsPatch({
+        stickyUserMessageCount: 2,
+        stickyUserMessageMaxLines: 3,
+      }),
+    ).toEqual({
+      stickyUserMessageCount: 2,
+      stickyUserMessageMaxLines: 3,
+    });
+
+    expect(() => decodeClientSettingsPatch({ stickyUserMessageCount: 3 })).toThrow();
+    expect(() => decodeClientSettingsPatch({ stickyUserMessageMaxLines: 4 })).toThrow();
+  });
+});
 
 describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   it("defaults to an empty record so legacy configs without the key still decode", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -39,6 +39,28 @@ export const SidebarThreadPreviewCount = Schema.Int.check(
 export type SidebarThreadPreviewCount = typeof SidebarThreadPreviewCount.Type;
 export const DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT: SidebarThreadPreviewCount = 6;
 
+export const MIN_STICKY_USER_MESSAGE_COUNT = 0;
+export const MAX_STICKY_USER_MESSAGE_COUNT = 2;
+export const DEFAULT_STICKY_USER_MESSAGE_COUNT = 0;
+export const StickyUserMessageCount = Schema.Int.check(
+  Schema.isBetween({
+    minimum: MIN_STICKY_USER_MESSAGE_COUNT,
+    maximum: MAX_STICKY_USER_MESSAGE_COUNT,
+  }),
+);
+export type StickyUserMessageCount = typeof StickyUserMessageCount.Type;
+
+export const MIN_STICKY_USER_MESSAGE_LINES = 1;
+export const MAX_STICKY_USER_MESSAGE_LINES = 3;
+export const DEFAULT_STICKY_USER_MESSAGE_MAX_LINES = 2;
+export const StickyUserMessageMaxLines = Schema.Int.check(
+  Schema.isBetween({
+    minimum: MIN_STICKY_USER_MESSAGE_LINES,
+    maximum: MAX_STICKY_USER_MESSAGE_LINES,
+  }),
+);
+export type StickyUserMessageMaxLines = typeof StickyUserMessageMaxLines.Type;
+
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
@@ -88,6 +110,12 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
+  ),
+  stickyUserMessageCount: StickyUserMessageCount.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_STICKY_USER_MESSAGE_COUNT)),
+  ),
+  stickyUserMessageMaxLines: StickyUserMessageMaxLines.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_STICKY_USER_MESSAGE_MAX_LINES)),
   ),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
@@ -508,6 +536,8 @@ export const ClientSettingsPatch = Schema.Struct({
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
+  stickyUserMessageCount: Schema.optionalKey(StickyUserMessageCount),
+  stickyUserMessageMaxLines: Schema.optionalKey(StickyUserMessageMaxLines),
   timestampFormat: Schema.optionalKey(TimestampFormat),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;


### PR DESCRIPTION
## What Changed

Added configurable, sticky user messages in the messages timeline

## Why

Switching between multiple sessions I find that to be a great help for quickly grasping where the conversation left off. Click-to-scroll also doubles as a quick way to jump to the beginning of the agent turn in case the user wants to skim it.

## UI Changes

This changes the chat timeline UI.

Before: user messages scroll out of view during long assistant responses.
<img width="1628" height="1097" alt="Screenshot 2026-05-14 at 21 19 34" src="https://github.com/user-attachments/assets/b2e41707-9082-411b-b124-a458227ed98a" />

After: recent user prompts remain visible as compact sticky bubbles while scrolling. The newest sticky bubble includes the timestamp. Clicking the  bubble scrolls the view to the original position
<img width="1628" height="1097" alt="Screenshot 2026-05-14 at 21 19 58" src="https://github.com/user-attachments/assets/7eba521a-2ef4-45fa-bb1b-5b36840d07a8" />

Demo video:
https://github.com/user-attachments/assets/d92d0b37-da5a-4bd5-bbce-93e457b8cc49


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new persisted client settings and non-trivial scroll/viewport measurement logic that could affect timeline rendering and scrolling behavior.
> 
> **Overview**
> Adds a sticky overlay in `MessagesTimeline` that can pin the last 1–2 user prompts as compact bubbles once their original rows scroll above the viewport, with click-to-scroll back to the source message.
> 
> Introduces new client settings (`stickyUserMessageCount`, `stickyUserMessageMaxLines`) with bounded schema defaults, wires them from `ChatView` into the timeline, and exposes controls plus reset/dirty-state handling in Settings.
> 
> Updates desktop/web/local API/settings contract tests and adds browser-focused timeline tests to validate sticky visibility rules, metadata display, and scroll-to-source behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ea97dfff0914af6fd9194e18a5d063fba549e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add sticky user message overlay to chat transcript
> - Adds a `StickyUserMessagesOverlay` that pins recent user messages to the top of the chat viewport when their source rows scroll above the visible area, with click-to-scroll navigation back to the original message.
> - Introduces `StickyUserMessageBubble` which clamps message text to a configurable max lines and shows a `+N lines` indicator and timestamp on the newest visible bubble.
> - Adds `stickyUserMessageCount` (0–2, default 0) and `stickyUserMessageMaxLines` (1–3, default 2) to client settings with schema validation, defaults, and a settings UI in the General panel.
> - The overlay is driven by `useHiddenStickyUserMessageIds`, which attaches scroll/resize listeners and uses `requestAnimationFrame` to batch DOM measurements of source element positions.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 47ea97d. 6 files reviewed, 4 issues evaluated, 1 issue filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/chat/MessagesTimeline.browser.tsx — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 253](https://github.com/pingdotgg/t3code/blob/47ea97dfff0914af6fd9194e18a5d063fba549e2/apps/web/src/components/chat/MessagesTimeline.browser.tsx#L253): The mock `LegendList` component (lines 16-42) does not forward the `onScroll` prop to the rendered `<div>`. When the test at line 253 dispatches `new Event("scroll")` on `[data-testid='legend-list']`, the component's `onScroll` handler passed to `LegendList` is never invoked. This means the scroll-triggered visibility logic in `useHiddenStickyUserMessageIds` may not execute, causing the test "shows a sticky user message only after its source row is above the transcript viewport" to potentially pass or fail for reasons unrelated to the actual scroll behavior. <b>[ Failed validation ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->