### PR TITLE
feat(sidebar): group threads by worktree

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -25,8 +25,10 @@ const clientSettings: ClientSettings = {
     "environment-1:/tmp/project-a": "separate",
   },
   sidebarProjectSortOrder: "manual",
+  sidebarThreadGroupingMode: "worktree",
   sidebarThreadSortOrder: "created_at",
   sidebarThreadPreviewCount: 6,
+  sidebarWorktreePreviewCount: 4,
   timestampFormat: "24-hour",
 };
 

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -3181,36 +3181,126 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
-  it.effect("rejects worktree prep when the PR head branch is checked out in the main repo", () =>
+  it.effect("reuses the launch worktree when T3 starts inside the PR head worktree", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");
       yield* initRepo(repoDir);
-      yield* runGit(repoDir, ["checkout", "-b", "feature/pr-root-only"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature/pr-launch-worktree"]);
+      fs.writeFileSync(path.join(repoDir, "launch-worktree.txt"), "launch worktree\n");
+      yield* runGit(repoDir, ["add", "launch-worktree.txt"]);
+      yield* runGit(repoDir, ["commit", "-m", "Launch worktree PR branch"]);
+      yield* runGit(repoDir, ["checkout", "main"]);
+      const worktreePath = path.join(repoDir, "..", `pr-launch-${path.basename(repoDir)}`);
+      yield* runGit(repoDir, ["worktree", "add", worktreePath, "feature/pr-launch-worktree"]);
 
       const { manager } = yield* makeManager({
         ghScenario: {
           pullRequest: {
-            number: 79,
-            title: "Root-only PR",
-            url: "https://github.com/pingdotgg/codething-mvp/pull/79",
+            number: 179,
+            title: "Launch Worktree PR",
+            url: "https://github.com/pingdotgg/codething-mvp/pull/179",
             baseRefName: "main",
-            headRefName: "feature/pr-root-only",
+            headRefName: "feature/pr-launch-worktree",
             state: "open",
           },
         },
       });
 
-      const errorMessage = yield* preparePullRequestThread(manager, {
-        cwd: repoDir,
-        reference: "79",
+      const result = yield* preparePullRequestThread(manager, {
+        cwd: worktreePath,
+        reference: "179",
         mode: "worktree",
-      }).pipe(
-        Effect.flip,
-        Effect.map((error) => error.message),
-      );
+      });
 
-      expect(errorMessage).toContain("already checked out in the main repo");
+      expect(result.worktreePath && fs.realpathSync.native(result.worktreePath)).toBe(
+        fs.realpathSync.native(worktreePath),
+      );
+      expect(result.branch).toBe("feature/pr-launch-worktree");
     }),
+  );
+
+  it.effect(
+    "rejects worktree prep when launched from a linked worktree but the PR head is in the main checkout",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("t3code-git-manager-");
+        yield* initRepo(repoDir);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/pr-main-checkout"]);
+        fs.writeFileSync(path.join(repoDir, "main-checkout.txt"), "main checkout\n");
+        yield* runGit(repoDir, ["add", "main-checkout.txt"]);
+        yield* runGit(repoDir, ["commit", "-m", "Main checkout PR branch"]);
+        const launchWorktreePath = path.join(
+          repoDir,
+          "..",
+          `pr-launcher-${path.basename(repoDir)}`,
+        );
+        yield* runGit(repoDir, [
+          "worktree",
+          "add",
+          "-b",
+          "feature/launcher-worktree",
+          launchWorktreePath,
+          "HEAD",
+        ]);
+
+        const { manager } = yield* makeManager({
+          ghScenario: {
+            pullRequest: {
+              number: 181,
+              title: "Main Checkout PR",
+              url: "https://github.com/pingdotgg/codething-mvp/pull/181",
+              baseRefName: "main",
+              headRefName: "feature/pr-main-checkout",
+              state: "open",
+            },
+          },
+        });
+
+        const errorMessage = yield* preparePullRequestThread(manager, {
+          cwd: launchWorktreePath,
+          reference: "181",
+          mode: "worktree",
+        }).pipe(
+          Effect.flip,
+          Effect.map((error) => error.message),
+        );
+
+        expect(errorMessage).toContain("already checked out in the main checkout");
+      }),
+  );
+
+  it.effect(
+    "rejects worktree prep when the PR head branch is checked out in the main checkout",
+    () =>
+      Effect.gen(function* () {
+        const repoDir = yield* makeTempDir("t3code-git-manager-");
+        yield* initRepo(repoDir);
+        yield* runGit(repoDir, ["checkout", "-b", "feature/pr-root-only"]);
+
+        const { manager } = yield* makeManager({
+          ghScenario: {
+            pullRequest: {
+              number: 79,
+              title: "Root-only PR",
+              url: "https://github.com/pingdotgg/codething-mvp/pull/79",
+              baseRefName: "main",
+              headRefName: "feature/pr-root-only",
+              state: "open",
+            },
+          },
+        });
+
+        const errorMessage = yield* preparePullRequestThread(manager, {
+          cwd: repoDir,
+          reference: "79",
+          mode: "worktree",
+        }).pipe(
+          Effect.flip,
+          Effect.map((error) => error.message),
+        );
+
+        expect(errorMessage).toContain("already checked out in the main checkout");
+      }),
   );
 
   it.effect("emits ordered progress events for commit hooks", () =>

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -104,6 +104,19 @@ function isNotGitRepositoryError(error: GitCommandError): boolean {
   return error.message.toLowerCase().includes("not a git repository");
 }
 
+function parsePrimaryWorktreePath(worktreeListPorcelain: string): string | null {
+  for (const line of worktreeListPorcelain.split("\n")) {
+    if (!line.startsWith("worktree ")) {
+      continue;
+    }
+
+    const worktreePath = line.slice("worktree ".length);
+    return worktreePath.length > 0 ? worktreePath : null;
+  }
+
+  return null;
+}
+
 interface OpenPrInfo {
   number: number;
   title: string;
@@ -698,6 +711,29 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
   const canonicalizeExistingPath = (value: string) =>
     fileSystem.realPath(value).pipe(Effect.catch(() => Effect.succeed(value)));
   const normalizeStatusCacheKey = canonicalizeExistingPath;
+  const resolvePrimaryWorktreePath = Effect.fn("resolvePrimaryWorktreePath")(function* (
+    cwd: string,
+  ) {
+    const fallbackPath = yield* canonicalizeExistingPath(cwd);
+    const worktreeList = yield* gitCore
+      .execute({
+        operation: "GitManager.resolvePrimaryWorktreePath",
+        cwd,
+        args: ["worktree", "list", "--porcelain"],
+        allowNonZeroExit: true,
+        timeoutMs: 5_000,
+      })
+      .pipe(Effect.catch(() => Effect.succeed(null)));
+
+    if (!worktreeList || worktreeList.exitCode !== 0) {
+      return fallbackPath;
+    }
+
+    const primaryWorktreePath = parsePrimaryWorktreePath(worktreeList.stdout);
+    return primaryWorktreePath
+      ? yield* canonicalizeExistingPath(primaryWorktreePath)
+      : fallbackPath;
+  });
   const nonRepositoryStatusDetails = {
     isRepo: false,
     hasOriginRemote: false,
@@ -1411,7 +1447,6 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     };
     return yield* Effect.gen(function* () {
       const normalizedReference = normalizePullRequestReference(input.reference);
-      const rootWorktreePath = yield* canonicalizeExistingPath(input.cwd);
       const pullRequestSummary = yield* (yield* sourceControlProvider(input.cwd)).getChangeRequest({
         cwd: input.cwd,
         reference: normalizedReference,
@@ -1439,6 +1474,8 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
           worktreePath: null,
         };
       }
+
+      const primaryWorktreePath = yield* resolvePrimaryWorktreePath(input.cwd);
 
       const ensureExistingWorktreeUpstream = Effect.fn("ensureExistingWorktreeUpstream")(function* (
         worktreePath: string,
@@ -1479,7 +1516,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
           }
 
           const worktreePath = yield* canonicalizeExistingPath(branch.worktreePath);
-          if (worktreePath !== rootWorktreePath) {
+          if (worktreePath !== primaryWorktreePath) {
             return branch;
           }
         }
@@ -1493,7 +1530,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
         : null;
       if (
         existingBranchBeforeFetch?.worktreePath &&
-        existingBranchBeforeFetchPath !== rootWorktreePath
+        existingBranchBeforeFetchPath !== primaryWorktreePath
       ) {
         yield* ensureExistingWorktreeUpstream(existingBranchBeforeFetch.worktreePath);
         return {
@@ -1502,10 +1539,10 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
           worktreePath: existingBranchBeforeFetch.worktreePath,
         };
       }
-      if (existingBranchBeforeFetchPath === rootWorktreePath) {
+      if (existingBranchBeforeFetchPath === primaryWorktreePath) {
         return yield* gitManagerError(
           "preparePullRequestThread",
-          "This PR branch is already checked out in the main repo. Use Local, or switch the main repo off that branch before creating a worktree thread.",
+          "This PR branch is already checked out in the main checkout. Use Local, or switch the main checkout off that branch before creating a worktree thread.",
         );
       }
 
@@ -1521,7 +1558,7 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
         : null;
       if (
         existingBranchAfterFetch?.worktreePath &&
-        existingBranchAfterFetchPath !== rootWorktreePath
+        existingBranchAfterFetchPath !== primaryWorktreePath
       ) {
         yield* ensureExistingWorktreeUpstream(existingBranchAfterFetch.worktreePath);
         return {
@@ -1530,10 +1567,10 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
           worktreePath: existingBranchAfterFetch.worktreePath,
         };
       }
-      if (existingBranchAfterFetchPath === rootWorktreePath) {
+      if (existingBranchAfterFetchPath === primaryWorktreePath) {
         return yield* gitManagerError(
           "preparePullRequestThread",
-          "This PR branch is already checked out in the main repo. Use Local, or switch the main repo off that branch before creating a worktree thread.",
+          "This PR branch is already checked out in the main checkout. Use Local, or switch the main checkout off that branch before creating a worktree thread.",
         );
       }
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -176,6 +176,46 @@ describe("buildSidebarWorktreeThreadGroups", () => {
     ]);
   });
 
+  it("uses worktree path rather than branch name to identify the current checkout", () => {
+    const currentCheckoutThread = {
+      branch: "feature/current-checkout",
+      worktreePath: null,
+      title: "Current checkout",
+    };
+    const mainBranchWorktreeThread = {
+      branch: "main",
+      worktreePath: "/repo/.t3/worktrees/main",
+      title: "Main branch worktree",
+    };
+
+    expect(
+      buildSidebarWorktreeThreadGroups([currentCheckoutThread, mainBranchWorktreeThread]),
+    ).toEqual([
+      {
+        expanded: true,
+        key: SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY,
+        uiKey: currentCheckoutGroupUiKey,
+        label: "Current checkout",
+        threadsExpanded: false,
+        totalThreadCount: 1,
+        hiddenThreadCount: 0,
+        overflowThreadCount: 0,
+        threads: [currentCheckoutThread],
+      },
+      {
+        expanded: true,
+        key: "/repo/.t3/worktrees/main",
+        uiKey: "::/repo/.t3/worktrees/main",
+        label: "main",
+        threadsExpanded: false,
+        totalThreadCount: 1,
+        hiddenThreadCount: 0,
+        overflowThreadCount: 0,
+        threads: [mainBranchWorktreeThread],
+      },
+    ]);
+  });
+
   it("groups contiguous worktree threads by worktree path", () => {
     const currentThread = { branch: "main", worktreePath: null, title: "Current" };
     const firstWorktreeThread = {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -3,6 +3,10 @@ import { ProviderDriverKind } from "@t3tools/contracts";
 
 import {
   createThreadJumpHintVisibilityController,
+  buildSidebarProjectThreadRenderState,
+  buildSidebarThreadRenderModel,
+  buildSidebarWorktreeThreadGroups,
+  getSidebarWorktreeGroupUiKey,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
   resolveAdjacentThreadId,
@@ -19,6 +23,8 @@ import {
   resolveThreadStatusPill,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
+  SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY,
+  SIDEBAR_FLAT_THREADS_GROUP_KEY,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
 } from "./Sidebar.logic";
 import {
@@ -36,6 +42,11 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+const currentCheckoutGroupUiKey = getSidebarWorktreeGroupUiKey(
+  "",
+  SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY,
+);
+const flatThreadsGroupUiKey = getSidebarWorktreeGroupUiKey("", SIDEBAR_FLAT_THREADS_GROUP_KEY);
 
 function makeLatestTurn(overrides?: {
   completedAt?: string | null;
@@ -140,6 +151,482 @@ describe("getSidebarThreadIdsToPrewarm", () => {
 
   it("returns no thread ids when the limit is zero", () => {
     expect(getSidebarThreadIdsToPrewarm(["t1", "t2"], 0)).toEqual([]);
+  });
+});
+
+describe("buildSidebarWorktreeThreadGroups", () => {
+  it("groups local checkout threads under the current checkout", () => {
+    const threads = [
+      { branch: "main", worktreePath: null, title: "One" },
+      { branch: "main", worktreePath: null, title: "Two" },
+    ];
+
+    expect(buildSidebarWorktreeThreadGroups(threads)).toEqual([
+      {
+        expanded: true,
+        key: SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY,
+        uiKey: currentCheckoutGroupUiKey,
+        label: "Current checkout",
+        threadsExpanded: false,
+        totalThreadCount: 2,
+        hiddenThreadCount: 0,
+        overflowThreadCount: 0,
+        threads,
+      },
+    ]);
+  });
+
+  it("groups contiguous worktree threads by worktree path", () => {
+    const currentThread = { branch: "main", worktreePath: null, title: "Current" };
+    const firstWorktreeThread = {
+      branch: "feature/workspaces",
+      worktreePath: "/repo/.t3/worktrees/workspaces",
+      title: "First",
+    };
+    const secondWorktreeThread = {
+      branch: "feature/workspaces",
+      worktreePath: "/repo/.t3/worktrees/workspaces",
+      title: "Second",
+    };
+
+    expect(
+      buildSidebarWorktreeThreadGroups([currentThread, firstWorktreeThread, secondWorktreeThread]),
+    ).toEqual([
+      {
+        expanded: true,
+        key: SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY,
+        uiKey: currentCheckoutGroupUiKey,
+        label: "Current checkout",
+        threadsExpanded: false,
+        totalThreadCount: 1,
+        hiddenThreadCount: 0,
+        overflowThreadCount: 0,
+        threads: [currentThread],
+      },
+      {
+        expanded: true,
+        key: "/repo/.t3/worktrees/workspaces",
+        uiKey: "::/repo/.t3/worktrees/workspaces",
+        label: "feature/workspaces",
+        threadsExpanded: false,
+        totalThreadCount: 2,
+        hiddenThreadCount: 0,
+        overflowThreadCount: 0,
+        threads: [firstWorktreeThread, secondWorktreeThread],
+      },
+    ]);
+  });
+
+  it("groups interleaved worktree threads in first-seen worktree order", () => {
+    const firstWorktreeThread = {
+      branch: "feature/a",
+      worktreePath: "/repo/.t3/worktrees/a",
+      title: "First",
+    };
+    const currentThread = { branch: "main", worktreePath: null, title: "Current" };
+    const secondWorktreeThread = {
+      branch: "feature/a",
+      worktreePath: "/repo/.t3/worktrees/a",
+      title: "Second",
+    };
+
+    expect(
+      buildSidebarWorktreeThreadGroups([firstWorktreeThread, currentThread, secondWorktreeThread]),
+    ).toEqual([
+      {
+        expanded: true,
+        key: "/repo/.t3/worktrees/a",
+        uiKey: "::/repo/.t3/worktrees/a",
+        label: "feature/a",
+        threadsExpanded: false,
+        totalThreadCount: 2,
+        hiddenThreadCount: 0,
+        overflowThreadCount: 0,
+        threads: [firstWorktreeThread, secondWorktreeThread],
+      },
+      {
+        expanded: true,
+        key: SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY,
+        uiKey: currentCheckoutGroupUiKey,
+        label: "Current checkout",
+        threadsExpanded: false,
+        totalThreadCount: 1,
+        hiddenThreadCount: 0,
+        overflowThreadCount: 0,
+        threads: [currentThread],
+      },
+    ]);
+  });
+
+  it("falls back to the worktree directory name when branch is unavailable", () => {
+    const thread = {
+      branch: null,
+      worktreePath: "/repo/.t3/worktrees/generated",
+      title: "Generated",
+    };
+
+    expect(buildSidebarWorktreeThreadGroups([thread])[0]?.label).toBe("generated");
+  });
+
+  it("uses a generic worktree label when the worktree path has no basename", () => {
+    const thread = {
+      branch: null,
+      worktreePath: "/",
+      title: "Generated",
+    };
+
+    expect(buildSidebarWorktreeThreadGroups([thread])[0]?.label).toBe("Worktree");
+  });
+});
+
+describe("buildSidebarThreadRenderModel", () => {
+  it("keeps separate mode flat and preserves input order", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "feature/a", worktreePath: "/repo/a" },
+    ];
+
+    const model = buildSidebarThreadRenderModel<(typeof threads)[number]>({
+      threads,
+      groupingMode: "separate",
+      expanded: false,
+      threadPreviewCount: 2,
+      worktreePreviewCount: 2,
+    });
+
+    expect(model.visibleThreads.map((thread) => thread.id)).toEqual(["1", "2"]);
+    expect(model.hiddenThreads.map((thread) => thread.id)).toEqual(["3"]);
+    expect(model.groups).toEqual([
+      {
+        expanded: true,
+        key: SIDEBAR_FLAT_THREADS_GROUP_KEY,
+        uiKey: flatThreadsGroupUiKey,
+        label: "",
+        threadsExpanded: true,
+        totalThreadCount: 3,
+        hiddenThreadCount: 1,
+        overflowThreadCount: 1,
+        threads: [threads[0], threads[1]],
+      },
+    ]);
+    expect(model.hiddenGroupCount).toBe(0);
+  });
+
+  it("groups worktree mode before applying worktree and per-worktree limits", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "4", branch: "feature/b", worktreePath: "/repo/b" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: false,
+      threadPreviewCount: 1,
+      worktreePreviewCount: 2,
+    });
+
+    expect(model.visibleThreads.map((thread) => thread.id)).toEqual(["1", "2"]);
+    expect(model.hiddenThreads.map((thread) => thread.id)).toEqual(["3", "4"]);
+    expect(model.hiddenGroupCount).toBe(1);
+    expect(model.groups.map((group) => group.key)).toEqual([
+      "/repo/a",
+      SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY,
+    ]);
+    expect(model.groups[0]?.hiddenThreadCount).toBe(1);
+  });
+
+  it("keeps overflow true after grouped worktree rows are expanded", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "4", branch: "feature/b", worktreePath: "/repo/b" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: true,
+      threadPreviewCount: 10,
+      worktreePreviewCount: 2,
+    });
+
+    expect(model.hiddenThreads).toEqual([]);
+    expect(model.hasOverflowingGroups).toBe(true);
+    expect(model.hasOverflowingThreads).toBe(true);
+  });
+
+  it("uses top-level expansion for single current-checkout worktree groups", () => {
+    const threads = [
+      { id: "1", branch: "main", worktreePath: null },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "main", worktreePath: null },
+    ];
+
+    const collapsedModel = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: false,
+      threadPreviewCount: 2,
+      worktreePreviewCount: 2,
+    });
+    const expandedModel = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: true,
+      threadPreviewCount: 2,
+      worktreePreviewCount: 2,
+    });
+
+    expect(collapsedModel.groups[0]?.threads.map((thread) => thread.id)).toEqual(["1", "2"]);
+    expect(collapsedModel.hiddenThreads.map((thread) => thread.id)).toEqual(["3"]);
+    expect(collapsedModel.hasOverflowingGroups).toBe(false);
+    expect(collapsedModel.hasOverflowingThreads).toBe(true);
+    expect(expandedModel.groups[0]?.threads.map((thread) => thread.id)).toEqual(["1", "2", "3"]);
+    expect(expandedModel.hiddenThreads).toEqual([]);
+    expect(expandedModel.hasOverflowingGroups).toBe(false);
+    expect(expandedModel.hasOverflowingThreads).toBe(true);
+  });
+
+  it("keeps per-worktree overflow available after grouped thread rows are expanded", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "3", branch: "feature/a", worktreePath: "/repo/a" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: true,
+      expandedWorktreeThreadKeys: new Set(["::/repo/a"]),
+      threadPreviewCount: 2,
+      worktreePreviewCount: 2,
+    });
+
+    expect(model.groups[0]?.threads.map((thread) => thread.id)).toEqual(["1", "2", "3"]);
+    expect(model.groups[0]?.hiddenThreadCount).toBe(0);
+    expect(model.groups[0]?.overflowThreadCount).toBe(1);
+  });
+
+  it("keeps the active thread visible when it is past the per-worktree preview", () => {
+    const threads = Array.from({ length: 7 }, (_, index) => ({
+      id: String(index + 1),
+      branch: "feature/a",
+      worktreePath: "/repo/a",
+    }));
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: false,
+      threadPreviewCount: 4,
+      worktreePreviewCount: 2,
+      pinnedThread: threads[6]!,
+    });
+
+    expect(model.groups[0]?.threads.map((thread) => thread.id)).toEqual(["1", "2", "3", "4", "7"]);
+    expect(model.hiddenThreads.map((thread) => thread.id)).toEqual(["5", "6"]);
+    expect(model.visibleThreads.map((thread) => thread.id)).toEqual(["1", "2", "3", "4", "7"]);
+  });
+
+  it("keeps the active worktree visible when it is past the worktree preview", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "feature/b", worktreePath: "/repo/b" },
+      { id: "4", branch: "feature/b", worktreePath: "/repo/b" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: false,
+      threadPreviewCount: 1,
+      worktreePreviewCount: 1,
+      pinnedThread: threads[3]!,
+    });
+
+    expect(model.groups.map((group) => group.key)).toEqual(["/repo/a", "/repo/b"]);
+    expect(model.groups.map((group) => group.threads.map((thread) => thread.id))).toEqual([
+      ["1"],
+      ["3", "4"],
+    ]);
+    expect(model.hiddenGroupCount).toBe(1);
+    expect(model.hiddenThreads.map((thread) => thread.id)).toEqual(["2"]);
+    expect(model.visibleThreads.map((thread) => thread.id)).toEqual(["1", "3", "4"]);
+  });
+
+  it("keeps the active thread visible when its worktree is collapsed past the worktree preview", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "feature/b", worktreePath: "/repo/b" },
+      { id: "4", branch: "feature/b", worktreePath: "/repo/b" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: false,
+      threadPreviewCount: 1,
+      worktreePreviewCount: 1,
+      projectKey: "repo",
+      collapsedWorktreeKeys: new Set([getSidebarWorktreeGroupUiKey("repo", "/repo/b")]),
+      pinnedThread: threads[3]!,
+    });
+
+    expect(model.groups.map((group) => group.key)).toEqual(["/repo/a", "/repo/b"]);
+    expect(model.groups.map((group) => group.threads.map((thread) => thread.id))).toEqual([
+      ["1"],
+      ["4"],
+    ]);
+    expect(model.hiddenGroupCount).toBe(1);
+    expect(model.hiddenThreads.map((thread) => thread.id)).toEqual(["3", "2"]);
+    expect(model.visibleThreads.map((thread) => thread.id)).toEqual(["1", "4"]);
+  });
+
+  it("keeps a pinned-only thread visible inside a collapsed worktree", () => {
+    const thread = {
+      id: "1",
+      branch: "feature/a",
+      worktreePath: "/repo/a",
+    };
+
+    const model = buildSidebarThreadRenderModel({
+      threads: [thread],
+      groupingMode: "worktree",
+      expanded: true,
+      threadPreviewCount: 1,
+      worktreePreviewCount: 1,
+      projectKey: "repo",
+      collapsedWorktreeKeys: new Set([getSidebarWorktreeGroupUiKey("repo", "/repo/a")]),
+      pinnedThread: thread,
+    });
+
+    expect(model.groups[0]).toMatchObject({
+      key: "/repo/a",
+      expanded: false,
+      threads: [thread],
+    });
+    expect(model.visibleThreads).toEqual([thread]);
+  });
+
+  it("returns grouped flattened order for shortcuts, prewarming, and range selection", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "4", branch: "feature/b", worktreePath: "/repo/b" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: true,
+      expandedWorktreeThreadKeys: new Set(["::/repo/a"]),
+      threadPreviewCount: 1,
+      worktreePreviewCount: 1,
+    });
+
+    expect(model.groups.map((group) => group.threads.map((thread) => thread.id))).toEqual([
+      ["1", "3"],
+      ["2"],
+      ["4"],
+    ]);
+    expect(model.visibleThreads.map((thread) => thread.id)).toEqual(["1", "3", "2", "4"]);
+  });
+
+  it("excludes collapsed worktree rows from visible order", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "4", branch: "feature/b", worktreePath: "/repo/b" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: true,
+      threadPreviewCount: 1,
+      worktreePreviewCount: 1,
+      projectKey: "repo",
+      collapsedWorktreeKeys: new Set([getSidebarWorktreeGroupUiKey("repo", "/repo/a")]),
+    });
+
+    expect(model.groups[0]).toMatchObject({
+      key: "/repo/a",
+      uiKey: "repo::/repo/a",
+      expanded: false,
+      totalThreadCount: 2,
+      threads: [],
+      hiddenThreadCount: 0,
+    });
+    expect(model.visibleThreads.map((thread) => thread.id)).toEqual(["2", "4"]);
+  });
+
+  it("keeps the active thread visible inside a collapsed worktree", () => {
+    const threads = [
+      { id: "1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "2", branch: "main", worktreePath: null },
+      { id: "3", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "4", branch: "feature/b", worktreePath: "/repo/b" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: true,
+      threadPreviewCount: 1,
+      worktreePreviewCount: 1,
+      projectKey: "repo",
+      collapsedWorktreeKeys: new Set([getSidebarWorktreeGroupUiKey("repo", "/repo/a")]),
+      pinnedThread: threads[2]!,
+    });
+
+    expect(model.groups[0]).toMatchObject({
+      key: "/repo/a",
+      expanded: false,
+      threads: [threads[2]],
+      hiddenThreadCount: 0,
+    });
+    expect(model.visibleThreads.map((thread) => thread.id)).toEqual(["3", "2", "4"]);
+  });
+});
+
+describe("buildSidebarProjectThreadRenderState", () => {
+  it("pins the active thread when its project is collapsed", () => {
+    const threads = Array.from({ length: 7 }, (_, index) => ({
+      id: String(index + 1),
+      branch: "feature/a",
+      worktreePath: "/repo/a",
+    }));
+
+    const renderState = buildSidebarProjectThreadRenderState({
+      activeThreadKey: "7",
+      collapsedWorktreeKeys: new Set(),
+      expandedWorktreeThreadKeys: new Set(),
+      getThreadKey: (thread) => thread.id,
+      isThreadListExpanded: false,
+      projectExpanded: false,
+      projectKey: "repo",
+      threadGroupingMode: "worktree",
+      threadPreviewCount: 4,
+      threads,
+      worktreePreviewCount: 1,
+    });
+
+    expect(renderState.shouldShowThreadPanel).toBe(true);
+    expect(renderState.pinnedCollapsedThread).toBe(threads[6]);
+    expect(renderState.hasOverflowingThreads).toBe(false);
+    expect(renderState.hasOverflowingWorktrees).toBe(false);
+    expect(renderState.orderedThreadKeys).toEqual(["7"]);
+    expect(renderState.renderModel.visibleThreads).toEqual([threads[6]]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -339,6 +339,27 @@ describe("buildSidebarThreadRenderModel", () => {
     expect(model.groups[0]?.hiddenThreadCount).toBe(1);
   });
 
+  it("separates hidden worktree threads from hidden rows inside visible worktrees", () => {
+    const threads = [
+      { id: "a1", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "b1", branch: "feature/b", worktreePath: "/repo/b" },
+      { id: "a2", branch: "feature/a", worktreePath: "/repo/a" },
+      { id: "c1", branch: "feature/c", worktreePath: "/repo/c" },
+    ];
+
+    const model = buildSidebarThreadRenderModel({
+      threads,
+      groupingMode: "worktree",
+      expanded: false,
+      threadPreviewCount: 1,
+      worktreePreviewCount: 2,
+    });
+
+    expect(model.groups.map((group) => group.key)).toEqual(["/repo/a", "/repo/b"]);
+    expect(model.hiddenThreads.map((thread) => thread.id)).toEqual(["a2", "c1"]);
+    expect(model.hiddenGroupThreads.map((thread) => thread.id)).toEqual(["c1"]);
+  });
+
   it("keeps overflow true after grouped worktree rows are expanded", () => {
     const threads = [
       { id: "1", branch: "feature/a", worktreePath: "/repo/a" },

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -36,6 +36,7 @@ export interface SidebarWorktreeThreadGroup<TThread> {
 export interface SidebarThreadRenderModel<TThread> {
   groups: SidebarWorktreeThreadGroup<TThread>[];
   hiddenGroupCount: number;
+  hiddenGroupThreads: TThread[];
   hiddenThreads: TThread[];
   hasOverflowingGroups: boolean;
   hasOverflowingThreads: boolean;
@@ -409,6 +410,7 @@ export function buildSidebarThreadRenderModel<
         },
       ],
       hiddenGroupCount: 0,
+      hiddenGroupThreads: [],
       hiddenThreads: input.threads.filter((thread) => !visibleThreadSet.has(thread)),
       hasOverflowingGroups: false,
       hasOverflowingThreads,
@@ -447,6 +449,7 @@ export function buildSidebarThreadRenderModel<
         },
       ],
       hiddenGroupCount: 0,
+      hiddenGroupThreads: [],
       hiddenThreads: group.threads.filter((thread) => !visibleThreadSet.has(thread)),
       hasOverflowingGroups: false,
       hasOverflowingThreads,
@@ -499,12 +502,13 @@ export function buildSidebarThreadRenderModel<
     ];
   });
   const hiddenGroups = allGroups.filter((_, index) => !visibleGroupIndexes.has(index));
+  const hiddenGroupThreads = hiddenGroups.flatMap((group) => group.threads);
   const renderedThreadSet = new Set(visibleGroups.flatMap((group) => group.threads));
   const hiddenThreads = [
     ...allGroups
       .filter((_, index) => visibleGroupIndexes.has(index))
       .flatMap((group) => group.threads.filter((thread) => !renderedThreadSet.has(thread))),
-    ...hiddenGroups.flatMap((group) => group.threads),
+    ...hiddenGroupThreads,
   ];
   const hasOverflowingGroups = allGroups.length > input.worktreePreviewCount;
   const hasOverflowingThreads =
@@ -513,6 +517,7 @@ export function buildSidebarThreadRenderModel<
   return {
     groups: visibleGroups,
     hiddenGroupCount: hiddenGroups.length,
+    hiddenGroupThreads,
     hiddenThreads,
     hasOverflowingGroups,
     hasOverflowingThreads,
@@ -559,6 +564,7 @@ export function buildSidebarProjectThreadRenderState<
     : {
         groups: [],
         hiddenGroupCount: 0,
+        hiddenGroupThreads: [],
         hiddenThreads: [],
         hasOverflowingGroups: false,
         hasOverflowingThreads: false,

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,5 +1,9 @@
 import * as React from "react";
-import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import type {
+  SidebarProjectSortOrder,
+  SidebarThreadGroupingMode,
+  SidebarThreadSortOrder,
+} from "@t3tools/contracts/settings";
 import {
   getThreadSortTimestamp,
   sortThreads,
@@ -12,10 +16,41 @@ import { isLatestTurnSettled } from "../session-logic";
 
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
+export const SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY = "__current_checkout__";
+export const SIDEBAR_FLAT_THREADS_GROUP_KEY = "__flat_threads__";
 // Visible sidebar rows are prewarmed into the thread-detail cache so opening a
 // nearby thread usually reuses an already-hot subscription.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
 export type SidebarNewThreadEnvMode = "local" | "worktree";
+export interface SidebarWorktreeThreadGroup<TThread> {
+  key: string;
+  uiKey: string;
+  label: string;
+  expanded: boolean;
+  threadsExpanded: boolean;
+  totalThreadCount: number;
+  threads: TThread[];
+  hiddenThreadCount: number;
+  overflowThreadCount: number;
+}
+export interface SidebarThreadRenderModel<TThread> {
+  groups: SidebarWorktreeThreadGroup<TThread>[];
+  hiddenGroupCount: number;
+  hiddenThreads: TThread[];
+  hasOverflowingGroups: boolean;
+  hasOverflowingThreads: boolean;
+  visibleThreads: TThread[];
+}
+export type SidebarProjectThreadRenderState<TThread> = {
+  hasOverflowingThreads: boolean;
+  hasOverflowingWorktrees: boolean;
+  hiddenWorktreeCount: number;
+  orderedThreadKeys: string[];
+  pinnedCollapsedThread: TThread | null;
+  renderModel: SidebarThreadRenderModel<TThread>;
+  shouldShowThreadPanel: boolean;
+  showEmptyThreadState: boolean;
+};
 type SidebarProject = {
   id: string;
   name: string;
@@ -257,6 +292,289 @@ export function getSidebarThreadIdsToPrewarm<TThreadId>(
   limit = SIDEBAR_THREAD_PREWARM_LIMIT,
 ): TThreadId[] {
   return visibleThreadIds.slice(0, Math.max(0, limit));
+}
+
+function basenameOfPath(path: string): string {
+  const normalized = path.replace(/[\\/]+$/, "");
+  const separatorIndex = Math.max(normalized.lastIndexOf("/"), normalized.lastIndexOf("\\"));
+  return separatorIndex >= 0 ? normalized.slice(separatorIndex + 1) : normalized;
+}
+
+export function getSidebarWorktreeGroupUiKey(projectKey: string, worktreeKey: string): string {
+  return `${projectKey}::${worktreeKey}`;
+}
+
+export function getSidebarThreadWorktreeKey(thread: { worktreePath: string | null }): string {
+  return thread.worktreePath ?? SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY;
+}
+
+function includePinnedThread<TThread>(
+  threads: readonly TThread[],
+  visibleThreads: readonly TThread[],
+  pinnedThread: TThread | null | undefined,
+): TThread[] {
+  if (!pinnedThread || visibleThreads.includes(pinnedThread) || !threads.includes(pinnedThread)) {
+    return [...visibleThreads];
+  }
+
+  const visibleThreadSet = new Set([...visibleThreads, pinnedThread]);
+  return threads.filter((thread) => visibleThreadSet.has(thread));
+}
+
+export function buildSidebarWorktreeThreadGroups<
+  TThread extends {
+    branch: string | null;
+    worktreePath: string | null;
+  },
+>(
+  threads: readonly TThread[],
+  options?: {
+    projectKey?: string;
+    collapsedWorktreeKeys?: ReadonlySet<string>;
+  },
+): SidebarWorktreeThreadGroup<TThread>[] {
+  const groups: SidebarWorktreeThreadGroup<TThread>[] = [];
+  const groupByKey = new Map<string, SidebarWorktreeThreadGroup<TThread>>();
+
+  for (const thread of threads) {
+    const key = getSidebarThreadWorktreeKey(thread);
+    let group = groupByKey.get(key);
+    if (!group) {
+      const uiKey = getSidebarWorktreeGroupUiKey(options?.projectKey ?? "", key);
+      group = {
+        key,
+        uiKey,
+        label: thread.worktreePath
+          ? (thread.branch ?? (basenameOfPath(thread.worktreePath) || "Worktree"))
+          : "Current checkout",
+        expanded: !options?.collapsedWorktreeKeys?.has(uiKey),
+        threadsExpanded: false,
+        totalThreadCount: 0,
+        hiddenThreadCount: 0,
+        overflowThreadCount: 0,
+        threads: [],
+      };
+      groups.push(group);
+      groupByKey.set(key, group);
+    }
+    group.totalThreadCount += 1;
+    group.threads.push(thread);
+  }
+
+  return groups;
+}
+
+export function buildSidebarThreadRenderModel<
+  TThread extends {
+    branch: string | null;
+    worktreePath: string | null;
+  },
+>(input: {
+  threads: readonly TThread[];
+  groupingMode: SidebarThreadGroupingMode;
+  expanded: boolean;
+  expandedWorktreeThreadKeys?: ReadonlySet<string>;
+  threadPreviewCount: number;
+  worktreePreviewCount: number;
+  projectKey?: string;
+  collapsedWorktreeKeys?: ReadonlySet<string>;
+  pinnedThread?: TThread | null;
+}): SidebarThreadRenderModel<TThread> {
+  if (input.groupingMode === "separate") {
+    const hasOverflowingThreads = input.threads.length > input.threadPreviewCount;
+    const visibleThreads =
+      input.expanded || !hasOverflowingThreads
+        ? [...input.threads]
+        : includePinnedThread(
+            input.threads,
+            input.threads.slice(0, input.threadPreviewCount),
+            input.pinnedThread,
+          );
+    const visibleThreadSet = new Set(visibleThreads);
+    return {
+      groups: [
+        {
+          key: SIDEBAR_FLAT_THREADS_GROUP_KEY,
+          uiKey: getSidebarWorktreeGroupUiKey(
+            input.projectKey ?? "",
+            SIDEBAR_FLAT_THREADS_GROUP_KEY,
+          ),
+          label: "",
+          expanded: true,
+          threadsExpanded: true,
+          totalThreadCount: input.threads.length,
+          threads: visibleThreads,
+          hiddenThreadCount: input.threads.length - visibleThreads.length,
+          overflowThreadCount: Math.max(input.threads.length - input.threadPreviewCount, 0),
+        },
+      ],
+      hiddenGroupCount: 0,
+      hiddenThreads: input.threads.filter((thread) => !visibleThreadSet.has(thread)),
+      hasOverflowingGroups: false,
+      hasOverflowingThreads,
+      visibleThreads,
+    };
+  }
+
+  const allGroups = buildSidebarWorktreeThreadGroups(input.threads, {
+    ...(input.projectKey !== undefined ? { projectKey: input.projectKey } : {}),
+    ...(input.collapsedWorktreeKeys !== undefined
+      ? { collapsedWorktreeKeys: input.collapsedWorktreeKeys }
+      : {}),
+  });
+  if (allGroups.length === 1 && allGroups[0]?.key === SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY) {
+    const group = allGroups[0];
+    const hasOverflowingThreads = group.threads.length > input.threadPreviewCount;
+    const visibleThreads =
+      input.expanded || !hasOverflowingThreads
+        ? group.threads
+        : includePinnedThread(
+            group.threads,
+            group.threads.slice(0, input.threadPreviewCount),
+            input.pinnedThread,
+          );
+    const visibleThreadSet = new Set(visibleThreads);
+    return {
+      groups: [
+        {
+          ...group,
+          expanded: true,
+          threadsExpanded: true,
+          totalThreadCount: group.threads.length,
+          threads: visibleThreads,
+          hiddenThreadCount: group.threads.length - visibleThreads.length,
+          overflowThreadCount: Math.max(group.threads.length - input.threadPreviewCount, 0),
+        },
+      ],
+      hiddenGroupCount: 0,
+      hiddenThreads: group.threads.filter((thread) => !visibleThreadSet.has(thread)),
+      hasOverflowingGroups: false,
+      hasOverflowingThreads,
+      visibleThreads,
+    };
+  }
+  const visibleGroupCount = input.expanded
+    ? allGroups.length
+    : Math.min(allGroups.length, input.worktreePreviewCount);
+  const visibleGroupIndexes = new Set(
+    Array.from({ length: visibleGroupCount }, (_, index) => index),
+  );
+  if (input.pinnedThread) {
+    const pinnedGroupKey = getSidebarThreadWorktreeKey(input.pinnedThread);
+    const pinnedGroupIndex = allGroups.findIndex((group) => group.key === pinnedGroupKey);
+    if (pinnedGroupIndex >= 0) {
+      visibleGroupIndexes.add(pinnedGroupIndex);
+    }
+  }
+  const visibleGroups = allGroups.flatMap((group, index) => {
+    if (!visibleGroupIndexes.has(index)) {
+      return [];
+    }
+    const previewThreads = group.threads.slice(0, input.threadPreviewCount);
+    const threadsExpanded = input.expandedWorktreeThreadKeys?.has(group.uiKey) ?? false;
+    const pinnedThread =
+      input.pinnedThread && getSidebarThreadWorktreeKey(input.pinnedThread) === group.key
+        ? input.pinnedThread
+        : null;
+    const visibleThreads = threadsExpanded
+      ? group.threads
+      : includePinnedThread(group.threads, previewThreads, pinnedThread);
+    const renderedThreads = group.expanded ? visibleThreads : pinnedThread ? [pinnedThread] : [];
+    const baselineHiddenThreadCount = group.threads.length - previewThreads.length;
+    const renderedThreadSet = new Set(renderedThreads);
+    return [
+      {
+        key: group.key,
+        uiKey: group.uiKey,
+        label: group.label,
+        expanded: group.expanded,
+        threadsExpanded,
+        totalThreadCount: group.threads.length,
+        threads: renderedThreads,
+        hiddenThreadCount: group.expanded
+          ? group.threads.filter((thread) => !renderedThreadSet.has(thread)).length
+          : 0,
+        overflowThreadCount: Math.max(baselineHiddenThreadCount, 0),
+      },
+    ];
+  });
+  const hiddenGroups = allGroups.filter((_, index) => !visibleGroupIndexes.has(index));
+  const renderedThreadSet = new Set(visibleGroups.flatMap((group) => group.threads));
+  const hiddenThreads = [
+    ...allGroups
+      .filter((_, index) => visibleGroupIndexes.has(index))
+      .flatMap((group) => group.threads.filter((thread) => !renderedThreadSet.has(thread))),
+    ...hiddenGroups.flatMap((group) => group.threads),
+  ];
+  const hasOverflowingGroups = allGroups.length > input.worktreePreviewCount;
+  const hasOverflowingThreads =
+    hasOverflowingGroups ||
+    allGroups.some((group) => group.threads.length > input.threadPreviewCount);
+  return {
+    groups: visibleGroups,
+    hiddenGroupCount: hiddenGroups.length,
+    hiddenThreads,
+    hasOverflowingGroups,
+    hasOverflowingThreads,
+    visibleThreads: visibleGroups.flatMap((group) => group.threads),
+  };
+}
+
+export function buildSidebarProjectThreadRenderState<
+  TThread extends {
+    branch: string | null;
+    worktreePath: string | null;
+  },
+>(input: {
+  activeThreadKey: string | null;
+  collapsedWorktreeKeys: ReadonlySet<string>;
+  expandedWorktreeThreadKeys: ReadonlySet<string>;
+  getThreadKey: (thread: TThread) => string;
+  isThreadListExpanded: boolean;
+  projectExpanded: boolean;
+  projectKey: string;
+  threadGroupingMode: SidebarThreadGroupingMode;
+  threadPreviewCount: number;
+  threads: readonly TThread[];
+  worktreePreviewCount: number;
+}): SidebarProjectThreadRenderState<TThread> {
+  const activeThread = input.activeThreadKey
+    ? (input.threads.find((thread) => input.getThreadKey(thread) === input.activeThreadKey) ?? null)
+    : null;
+  const pinnedCollapsedThread = input.projectExpanded ? null : activeThread;
+  const shouldShowThreadPanel = input.projectExpanded || pinnedCollapsedThread !== null;
+  const renderThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : input.threads;
+  const renderModel = shouldShowThreadPanel
+    ? buildSidebarThreadRenderModel({
+        threads: renderThreads,
+        groupingMode: input.threadGroupingMode,
+        expanded: input.isThreadListExpanded || pinnedCollapsedThread !== null,
+        expandedWorktreeThreadKeys: input.expandedWorktreeThreadKeys,
+        threadPreviewCount: input.threadPreviewCount,
+        worktreePreviewCount: input.worktreePreviewCount,
+        projectKey: input.projectKey,
+        collapsedWorktreeKeys: input.collapsedWorktreeKeys,
+        pinnedThread: pinnedCollapsedThread ?? activeThread,
+      })
+    : {
+        groups: [],
+        hiddenGroupCount: 0,
+        hiddenThreads: [],
+        hasOverflowingGroups: false,
+        hasOverflowingThreads: false,
+        visibleThreads: [],
+      };
+
+  return {
+    hasOverflowingThreads: pinnedCollapsedThread ? false : renderModel.hasOverflowingThreads,
+    hasOverflowingWorktrees: pinnedCollapsedThread ? false : renderModel.hasOverflowingGroups,
+    hiddenWorktreeCount: pinnedCollapsedThread ? 0 : renderModel.hiddenGroupCount,
+    orderedThreadKeys: renderModel.visibleThreads.map(input.getThreadKey),
+    pinnedCollapsedThread,
+    renderModel,
+    shouldShowThreadPanel,
+    showEmptyThreadState: input.projectExpanded && input.threads.length === 0,
+  };
 }
 
 export function resolveAdjacentThreadId<T>(input: {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1301,6 +1301,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     });
     const { pinnedCollapsedThread, renderModel } = renderState;
     const worktreeStatusByKey = new Map<string, ThreadStatusPill | null>();
+    const hiddenStatusThreads =
+      threadGroupingMode === "worktree" && renderModel.hasOverflowingGroups
+        ? renderModel.hiddenGroupThreads
+        : renderModel.hiddenThreads;
     if (threadGroupingMode === "worktree") {
       const sourceThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : visibleProjectThreads;
       for (const group of renderModel.groups) {
@@ -1316,7 +1320,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       hasOverflowingWorktrees: renderState.hasOverflowingWorktrees,
       hiddenWorktreeCount: renderState.hiddenWorktreeCount,
       hiddenThreadStatus: resolveProjectStatusIndicator(
-        renderModel.hiddenThreads.map((thread) => resolveProjectThreadStatus(thread)),
+        hiddenStatusThreads.map((thread) => resolveProjectThreadStatus(thread)),
       ),
       orderedProjectThreadKeys: renderState.orderedThreadKeys,
       renderedThreadGroups: renderModel.groups.map((group) =>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -55,10 +55,14 @@ import {
 import { Link, useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
 import {
   MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
+  MAX_SIDEBAR_WORKTREE_PREVIEW_COUNT,
   MIN_SIDEBAR_THREAD_PREVIEW_COUNT,
+  MIN_SIDEBAR_WORKTREE_PREVIEW_COUNT,
   type SidebarProjectSortOrder,
+  type SidebarThreadGroupingMode,
   type SidebarThreadPreviewCount,
   type SidebarThreadSortOrder,
+  type SidebarWorktreePreviewCount,
 } from "@t3tools/contracts/settings";
 import { usePrimaryEnvironmentId } from "../environments/primary";
 import { isElectron } from "../env";
@@ -158,19 +162,23 @@ import {
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useCommandPaletteStore } from "../commandPaletteStore";
 import {
+  buildSidebarProjectThreadRenderState,
   getSidebarThreadIdsToPrewarm,
-  resolveAdjacentThreadId,
+  getSidebarThreadWorktreeKey,
   isContextMenuPointerDown,
+  orderItemsByPreferredIds,
+  resolveAdjacentThreadId,
   resolveProjectStatusIndicator,
-  resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
+  resolveSidebarNewThreadSeedContext,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
-  orderItemsByPreferredIds,
   shouldClearThreadSelectionOnMouseDown,
+  SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY,
   sortProjectsForSidebar,
-  useThreadJumpHintVisibility,
+  type SidebarThreadRenderModel,
   ThreadStatusPill,
+  useThreadJumpHintVisibility,
 } from "./Sidebar.logic";
 import { sortThreads } from "../lib/threadSort";
 import { SidebarUpdatePill } from "./sidebar/SidebarUpdatePill";
@@ -206,6 +214,10 @@ const SIDEBAR_THREAD_SORT_LABELS: Record<SidebarThreadSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
 };
+const SIDEBAR_THREAD_GROUPING_LABELS: Record<SidebarThreadGroupingMode, string> = {
+  worktree: "Group by worktree",
+  separate: "Keep separate",
+};
 const SIDEBAR_LIST_ANIMATION_OPTIONS = {
   duration: 180,
   easing: "ease-out",
@@ -216,12 +228,46 @@ const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> =
   repository_path: "Group by repository path",
   separate: "Keep separate",
 };
+type RenderedSidebarWorktreeThreadGroup =
+  SidebarThreadRenderModel<SidebarThreadSummary>["groups"][number] & {
+    status: ThreadStatusPill | null;
+  };
 
 function clampSidebarThreadPreviewCount(value: number): SidebarThreadPreviewCount {
   return Math.min(
     MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
     Math.max(MIN_SIDEBAR_THREAD_PREVIEW_COUNT, value),
   ) as SidebarThreadPreviewCount;
+}
+
+function clampSidebarWorktreePreviewCount(value: number): SidebarWorktreePreviewCount {
+  return Math.min(
+    MAX_SIDEBAR_WORKTREE_PREVIEW_COUNT,
+    Math.max(MIN_SIDEBAR_WORKTREE_PREVIEW_COUNT, value),
+  ) as SidebarWorktreePreviewCount;
+}
+
+function getSidebarThreadKey(thread: Pick<SidebarThreadSummary, "environmentId" | "id">): string {
+  return scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+}
+
+function createSidebarThreadStatusResolver(
+  threads: readonly SidebarThreadSummary[],
+  lastVisitedAts: readonly (string | null | undefined)[],
+): (thread: SidebarThreadSummary) => ThreadStatusPill | null {
+  const lastVisitedAtByThreadKey = new Map(
+    threads.map((thread, index) => [getSidebarThreadKey(thread), lastVisitedAts[index] ?? null]),
+  );
+
+  return (thread) => {
+    const lastVisitedAt = lastVisitedAtByThreadKey.get(getSidebarThreadKey(thread));
+    return resolveThreadStatusPill({
+      thread: {
+        ...thread,
+        ...(lastVisitedAt !== null && lastVisitedAt !== undefined ? { lastVisitedAt } : {}),
+      },
+    });
+  };
 }
 
 function formatProjectMemberActionLabel(
@@ -721,10 +767,13 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
 interface SidebarProjectThreadListProps {
   projectKey: string;
   projectExpanded: boolean;
+  threadGroupingMode: SidebarThreadGroupingMode;
   hasOverflowingThreads: boolean;
+  hasOverflowingWorktrees: boolean;
+  hiddenWorktreeCount: number;
   hiddenThreadStatus: ThreadStatusPill | null;
   orderedProjectThreadKeys: readonly string[];
-  renderedThreads: readonly SidebarThreadSummary[];
+  renderedThreadGroups: readonly RenderedSidebarWorktreeThreadGroup[];
   showEmptyThreadState: boolean;
   shouldShowThreadPanel: boolean;
   isThreadListExpanded: boolean;
@@ -763,6 +812,9 @@ interface SidebarProjectThreadListProps {
   openPrLink: (event: React.MouseEvent<HTMLElement>, prUrl: string) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
+  expandWorktreeThreads: (worktreeKey: string) => void;
+  collapseWorktreeThreads: (worktreeKey: string) => void;
+  toggleWorktree: (worktreeKey: string) => void;
 }
 
 const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
@@ -771,10 +823,13 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
   const {
     projectKey,
     projectExpanded,
+    threadGroupingMode,
     hasOverflowingThreads,
+    hasOverflowingWorktrees,
+    hiddenWorktreeCount,
     hiddenThreadStatus,
     orderedProjectThreadKeys,
-    renderedThreads,
+    renderedThreadGroups,
     showEmptyThreadState,
     shouldShowThreadPanel,
     isThreadListExpanded,
@@ -802,9 +857,20 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     openPrLink,
     expandThreadListForProject,
     collapseThreadListForProject,
+    expandWorktreeThreads,
+    collapseWorktreeThreads,
+    toggleWorktree,
   } = props;
   const showMoreButtonRender = useMemo(() => <button type="button" />, []);
   const showLessButtonRender = useMemo(() => <button type="button" />, []);
+  const showWorktreeGroups =
+    threadGroupingMode === "worktree" &&
+    renderedThreadGroups.some((group) => group.key !== SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY);
+  const hasHiddenWorktrees = threadGroupingMode === "worktree" && hiddenWorktreeCount > 0;
+  const projectOverflowControlsWorktrees = threadGroupingMode === "worktree" && showWorktreeGroups;
+  const showProjectOverflowControl = projectOverflowControlsWorktrees
+    ? hasOverflowingWorktrees || hasHiddenWorktrees
+    : hasOverflowingThreads;
 
   return (
     <SidebarMenuSub
@@ -822,71 +888,147 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
         </SidebarMenuSubItem>
       ) : null}
       {shouldShowThreadPanel &&
-        renderedThreads.map((thread) => {
-          const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-          return (
-            <SidebarThreadRow
-              key={threadKey}
-              thread={thread}
-              projectCwd={projectCwd}
-              orderedProjectThreadKeys={orderedProjectThreadKeys}
-              isActive={activeRouteThreadKey === threadKey}
-              jumpLabel={threadJumpLabelByKey.get(threadKey) ?? null}
-              appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}
-              renamingThreadKey={renamingThreadKey}
-              renamingTitle={renamingTitle}
-              setRenamingTitle={setRenamingTitle}
-              renamingInputRef={renamingInputRef}
-              renamingCommittedRef={renamingCommittedRef}
-              confirmingArchiveThreadKey={confirmingArchiveThreadKey}
-              setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
-              confirmArchiveButtonRefs={confirmArchiveButtonRefs}
-              handleThreadClick={handleThreadClick}
-              navigateToThread={navigateToThread}
-              handleMultiSelectContextMenu={handleMultiSelectContextMenu}
-              handleThreadContextMenu={handleThreadContextMenu}
-              clearSelection={clearSelection}
-              commitRename={commitRename}
-              cancelRename={cancelRename}
-              attemptArchiveThread={attemptArchiveThread}
-              openPrLink={openPrLink}
-            />
-          );
-        })}
+        renderedThreadGroups.map((group) => (
+          <React.Fragment key={group.key}>
+            {showWorktreeGroups ? (
+              <SidebarMenuSubItem className="w-full" data-thread-selection-safe>
+                <SidebarMenuSubButton
+                  render={<button type="button" />}
+                  data-thread-selection-safe
+                  size="sm"
+                  aria-expanded={group.expanded}
+                  className="h-6 w-full translate-x-0 justify-start px-1.5 text-left text-[10px] font-medium text-muted-foreground/65 hover:bg-accent hover:text-foreground"
+                  title={
+                    group.key === SIDEBAR_CURRENT_CHECKOUT_WORKTREE_KEY ? undefined : group.key
+                  }
+                  onClick={() => {
+                    toggleWorktree(group.uiKey);
+                  }}
+                >
+                  <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                    {!group.expanded && group.status ? (
+                      <span
+                        aria-hidden="true"
+                        title={group.status.label}
+                        className={`relative inline-flex size-3 shrink-0 items-center justify-center ${group.status.colorClass}`}
+                      >
+                        <span className="absolute inset-0 flex items-center justify-center transition-opacity duration-150 group-hover/menu-sub-item:opacity-0">
+                          <span
+                            className={`size-[9px] rounded-full ${group.status.dotClass} ${
+                              group.status.pulse ? "animate-pulse" : ""
+                            }`}
+                          />
+                        </span>
+                        <ChevronRightIcon className="absolute inset-0 m-auto size-3 text-muted-foreground/55 opacity-0 transition-opacity duration-150 group-hover/menu-sub-item:opacity-100" />
+                      </span>
+                    ) : (
+                      <ChevronRightIcon
+                        className={`size-3 shrink-0 text-muted-foreground/55 transition-transform duration-150 ${
+                          group.expanded ? "rotate-90" : ""
+                        }`}
+                      />
+                    )}
+                    <span className="min-w-0 truncate">{group.label}</span>
+                  </span>
+                </SidebarMenuSubButton>
+              </SidebarMenuSubItem>
+            ) : null}
+            {group.threads.map((thread) => {
+              const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+              return (
+                <SidebarThreadRow
+                  key={threadKey}
+                  thread={thread}
+                  projectCwd={projectCwd}
+                  orderedProjectThreadKeys={orderedProjectThreadKeys}
+                  isActive={activeRouteThreadKey === threadKey}
+                  jumpLabel={threadJumpLabelByKey.get(threadKey) ?? null}
+                  appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}
+                  renamingThreadKey={renamingThreadKey}
+                  renamingTitle={renamingTitle}
+                  setRenamingTitle={setRenamingTitle}
+                  renamingInputRef={renamingInputRef}
+                  renamingCommittedRef={renamingCommittedRef}
+                  confirmingArchiveThreadKey={confirmingArchiveThreadKey}
+                  setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
+                  confirmArchiveButtonRefs={confirmArchiveButtonRefs}
+                  handleThreadClick={handleThreadClick}
+                  navigateToThread={navigateToThread}
+                  handleMultiSelectContextMenu={handleMultiSelectContextMenu}
+                  handleThreadContextMenu={handleThreadContextMenu}
+                  clearSelection={clearSelection}
+                  commitRename={commitRename}
+                  cancelRename={cancelRename}
+                  attemptArchiveThread={attemptArchiveThread}
+                  openPrLink={openPrLink}
+                />
+              );
+            })}
+            {showWorktreeGroups && group.expanded && group.overflowThreadCount > 0 ? (
+              <SidebarMenuSubItem className="w-full" data-thread-selection-safe>
+                <SidebarMenuSubButton
+                  render={<button type="button" />}
+                  data-thread-selection-safe
+                  size="sm"
+                  className="h-6 w-full translate-x-0 justify-start px-2 text-left text-[10px] text-muted-foreground/60 hover:bg-accent hover:text-muted-foreground/80"
+                  onClick={() => {
+                    if (group.threadsExpanded) {
+                      collapseWorktreeThreads(group.uiKey);
+                    } else {
+                      expandWorktreeThreads(group.uiKey);
+                    }
+                  }}
+                >
+                  <span>{group.threadsExpanded ? "Show fewer threads" : "Show more threads"}</span>
+                </SidebarMenuSubButton>
+              </SidebarMenuSubItem>
+            ) : null}
+          </React.Fragment>
+        ))}
 
-      {projectExpanded && hasOverflowingThreads && !isThreadListExpanded && (
-        <SidebarMenuSubItem className="w-full">
-          <SidebarMenuSubButton
-            render={showMoreButtonRender}
-            data-thread-selection-safe
-            size="sm"
-            className="h-6 w-full translate-x-0 justify-start px-2 text-left text-[10px] text-muted-foreground/60 hover:bg-accent hover:text-muted-foreground/80"
-            onClick={() => {
-              expandThreadListForProject(projectKey);
-            }}
-          >
-            <span className="flex min-w-0 flex-1 items-center gap-2">
-              {hiddenThreadStatus && <ThreadStatusLabel status={hiddenThreadStatus} compact />}
-              <span>Show more</span>
-            </span>
-          </SidebarMenuSubButton>
-        </SidebarMenuSubItem>
-      )}
-      {projectExpanded && hasOverflowingThreads && isThreadListExpanded && (
-        <SidebarMenuSubItem className="w-full">
-          <SidebarMenuSubButton
-            render={showLessButtonRender}
-            data-thread-selection-safe
-            size="sm"
-            className="h-6 w-full translate-x-0 justify-start px-2 text-left text-[10px] text-muted-foreground/60 hover:bg-accent hover:text-muted-foreground/80"
-            onClick={() => {
-              collapseThreadListForProject(projectKey);
-            }}
-          >
-            <span>Show less</span>
-          </SidebarMenuSubButton>
-        </SidebarMenuSubItem>
-      )}
+      {projectExpanded &&
+        hasOverflowingThreads &&
+        showProjectOverflowControl &&
+        !isThreadListExpanded && (
+          <SidebarMenuSubItem className="w-full">
+            <SidebarMenuSubButton
+              render={showMoreButtonRender}
+              data-thread-selection-safe
+              size="sm"
+              className="h-6 w-full translate-x-0 justify-start px-2 text-left text-[10px] text-muted-foreground/60 hover:bg-accent hover:text-muted-foreground/80"
+              onClick={() => {
+                expandThreadListForProject(projectKey);
+              }}
+            >
+              <span className="flex min-w-0 flex-1 items-center gap-2">
+                {hiddenThreadStatus && <ThreadStatusLabel status={hiddenThreadStatus} compact />}
+                <span>
+                  {projectOverflowControlsWorktrees ? "Show more worktrees" : "Show more threads"}
+                </span>
+              </span>
+            </SidebarMenuSubButton>
+          </SidebarMenuSubItem>
+        )}
+      {projectExpanded &&
+        hasOverflowingThreads &&
+        showProjectOverflowControl &&
+        isThreadListExpanded && (
+          <SidebarMenuSubItem className="w-full">
+            <SidebarMenuSubButton
+              render={showLessButtonRender}
+              data-thread-selection-safe
+              size="sm"
+              className="h-6 w-full translate-x-0 justify-start px-2 text-left text-[10px] text-muted-foreground/60 hover:bg-accent hover:text-muted-foreground/80"
+              onClick={() => {
+                collapseThreadListForProject(projectKey);
+              }}
+            >
+              <span>
+                {projectOverflowControlsWorktrees ? "Show fewer worktrees" : "Show fewer threads"}
+              </span>
+            </SidebarMenuSubButton>
+          </SidebarMenuSubItem>
+        )}
     </SidebarMenuSub>
   );
 });
@@ -894,6 +1036,8 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
 interface SidebarProjectItemProps {
   project: SidebarProjectSnapshot;
   isThreadListExpanded: boolean;
+  expandedWorktreeThreadKeys: ReadonlySet<string>;
+  collapsedWorktreeKeys: ReadonlySet<string>;
   activeRouteThreadKey: string | null;
   newThreadShortcutLabel: string | null;
   handleNewThread: ReturnType<typeof useNewThreadHandler>["handleNewThread"];
@@ -903,6 +1047,8 @@ interface SidebarProjectItemProps {
   attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
+  expandWorktreeThreads: (worktreeKey: string) => void;
+  collapseWorktreeThreads: (worktreeKey: string) => void;
   dragInProgressRef: React.RefObject<boolean>;
   suppressProjectClickAfterDragRef: React.RefObject<boolean>;
   suppressProjectClickForContextMenuRef: React.RefObject<boolean>;
@@ -914,6 +1060,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const {
     project,
     isThreadListExpanded,
+    expandedWorktreeThreadKeys,
+    collapsedWorktreeKeys,
     activeRouteThreadKey,
     newThreadShortcutLabel,
     handleNewThread,
@@ -923,6 +1071,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     attachThreadListAutoAnimateRef,
     expandThreadListForProject,
     collapseThreadListForProject,
+    expandWorktreeThreads,
+    collapseWorktreeThreads,
     dragInProgressRef,
     suppressProjectClickAfterDragRef,
     suppressProjectClickForContextMenuRef,
@@ -931,6 +1081,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   } = props;
   const threadSortOrder = useSettings<SidebarThreadSortOrder>(
     (settings) => settings.sidebarThreadSortOrder,
+  );
+  const threadGroupingMode = useSettings<SidebarThreadGroupingMode>(
+    (settings) => settings.sidebarThreadGroupingMode,
   );
   const appSettingsConfirmThreadDelete = useSettings<boolean>(
     (settings) => settings.confirmThreadDelete,
@@ -946,10 +1099,14 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const sidebarThreadPreviewCount = useSettings<SidebarThreadPreviewCount>(
     (settings) => settings.sidebarThreadPreviewCount,
   );
+  const sidebarWorktreePreviewCount = useSettings<SidebarWorktreePreviewCount>(
+    (settings) => settings.sidebarWorktreePreviewCount,
+  );
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
   const markThreadUnread = useUiStateStore((state) => state.markThreadUnread);
   const toggleProject = useUiStateStore((state) => state.toggleProject);
+  const toggleWorktree = useUiStateStore((state) => state.toggleWorktree);
   const toggleThreadSelection = useThreadSelectionStore((state) => state.toggleThread);
   const rangeSelectTo = useThreadSelectionStore((state) => state.rangeSelectTo);
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
@@ -1097,24 +1254,11 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     return counts;
   }, [memberProjectByScopedKey, project.memberProjects, projectThreads]);
 
-  const { projectStatus, visibleProjectThreads, orderedProjectThreadKeys } = useMemo(() => {
-    const lastVisitedAtByThreadKey = new Map(
-      projectThreads.map((thread, index) => [
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-        threadLastVisitedAts[index] ?? null,
-      ]),
+  const { projectStatus, visibleProjectThreads } = useMemo(() => {
+    const resolveProjectThreadStatus = createSidebarThreadStatusResolver(
+      projectThreads,
+      threadLastVisitedAts,
     );
-    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
-      const lastVisitedAt = lastVisitedAtByThreadKey.get(
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      );
-      return resolveThreadStatusPill({
-        thread: {
-          ...thread,
-          ...(lastVisitedAt !== null && lastVisitedAt !== undefined ? { lastVisitedAt } : {}),
-        },
-      });
-    };
     const visibleProjectThreads = sortThreads(
       projectThreads.filter((thread) => thread.archivedAt === null),
       threadSortOrder,
@@ -1123,86 +1267,78 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       visibleProjectThreads.map((thread) => resolveProjectThreadStatus(thread)),
     );
     return {
-      orderedProjectThreadKeys: visibleProjectThreads.map((thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      ),
       projectStatus,
       visibleProjectThreads,
     };
   }, [projectThreads, threadLastVisitedAts, threadSortOrder]);
 
-  const pinnedCollapsedThread = useMemo(() => {
-    const activeThreadKey = activeRouteThreadKey ?? undefined;
-    if (!activeThreadKey || projectExpanded) {
-      return null;
-    }
-    return (
-      visibleProjectThreads.find(
-        (thread) =>
-          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) === activeThreadKey,
-      ) ?? null
-    );
-  }, [activeRouteThreadKey, projectExpanded, visibleProjectThreads]);
-
   const {
     hasOverflowingThreads,
+    hasOverflowingWorktrees,
+    hiddenWorktreeCount,
     hiddenThreadStatus,
-    renderedThreads,
+    renderedThreadGroups,
+    orderedProjectThreadKeys,
     showEmptyThreadState,
     shouldShowThreadPanel,
   } = useMemo(() => {
-    const lastVisitedAtByThreadKey = new Map(
-      projectThreads.map((thread, index) => [
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-        threadLastVisitedAts[index] ?? null,
-      ]),
+    const resolveProjectThreadStatus = createSidebarThreadStatusResolver(
+      projectThreads,
+      threadLastVisitedAts,
     );
-    const resolveProjectThreadStatus = (thread: SidebarThreadSummary) => {
-      const lastVisitedAt = lastVisitedAtByThreadKey.get(
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      );
-      return resolveThreadStatusPill({
-        thread: {
-          ...thread,
-          ...(lastVisitedAt !== null && lastVisitedAt !== undefined ? { lastVisitedAt } : {}),
-        },
-      });
-    };
-    const hasOverflowingThreads = visibleProjectThreads.length > sidebarThreadPreviewCount;
-    const previewThreads =
-      isThreadListExpanded || !hasOverflowingThreads
-        ? visibleProjectThreads
-        : visibleProjectThreads.slice(0, sidebarThreadPreviewCount);
-    const visibleThreadKeys = new Set(
-      [...previewThreads, ...(pinnedCollapsedThread ? [pinnedCollapsedThread] : [])].map((thread) =>
-        scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-      ),
-    );
-    const renderedThreads = pinnedCollapsedThread
-      ? [pinnedCollapsedThread]
-      : visibleProjectThreads.filter((thread) =>
-          visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-        );
-    const hiddenThreads = visibleProjectThreads.filter(
-      (thread) =>
-        !visibleThreadKeys.has(scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id))),
-    );
+    const renderState = buildSidebarProjectThreadRenderState({
+      activeThreadKey: activeRouteThreadKey,
+      collapsedWorktreeKeys,
+      expandedWorktreeThreadKeys,
+      isThreadListExpanded,
+      projectExpanded,
+      projectKey: project.projectKey,
+      threadGroupingMode,
+      threadPreviewCount: sidebarThreadPreviewCount,
+      threads: visibleProjectThreads,
+      worktreePreviewCount: sidebarWorktreePreviewCount,
+      getThreadKey: getSidebarThreadKey,
+    });
+    const { pinnedCollapsedThread, renderModel } = renderState;
+    const worktreeStatusByKey = new Map<string, ThreadStatusPill | null>();
+    if (threadGroupingMode === "worktree") {
+      const sourceThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : visibleProjectThreads;
+      for (const group of renderModel.groups) {
+        const groupStatuses = sourceThreads.flatMap((thread) => {
+          const threadGroupKey = getSidebarThreadWorktreeKey(thread);
+          return threadGroupKey === group.key ? [resolveProjectThreadStatus(thread)] : [];
+        });
+        worktreeStatusByKey.set(group.key, resolveProjectStatusIndicator(groupStatuses));
+      }
+    }
     return {
-      hasOverflowingThreads,
+      hasOverflowingThreads: renderState.hasOverflowingThreads,
+      hasOverflowingWorktrees: renderState.hasOverflowingWorktrees,
+      hiddenWorktreeCount: renderState.hiddenWorktreeCount,
       hiddenThreadStatus: resolveProjectStatusIndicator(
-        hiddenThreads.map((thread) => resolveProjectThreadStatus(thread)),
+        renderModel.hiddenThreads.map((thread) => resolveProjectThreadStatus(thread)),
       ),
-      renderedThreads,
-      showEmptyThreadState: projectExpanded && visibleProjectThreads.length === 0,
-      shouldShowThreadPanel: projectExpanded || pinnedCollapsedThread !== null,
+      orderedProjectThreadKeys: renderState.orderedThreadKeys,
+      renderedThreadGroups: renderModel.groups.map((group) =>
+        Object.assign({}, group, {
+          status: worktreeStatusByKey.get(group.key) ?? null,
+        }),
+      ),
+      showEmptyThreadState: renderState.showEmptyThreadState,
+      shouldShowThreadPanel: renderState.shouldShowThreadPanel,
     };
   }, [
     isThreadListExpanded,
-    pinnedCollapsedThread,
+    expandedWorktreeThreadKeys,
+    activeRouteThreadKey,
     projectExpanded,
+    project.projectKey,
     projectThreads,
     sidebarThreadPreviewCount,
+    sidebarWorktreePreviewCount,
+    collapsedWorktreeKeys,
     threadLastVisitedAts,
+    threadGroupingMode,
     visibleProjectThreads,
   ]);
 
@@ -2075,10 +2211,13 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       <SidebarProjectThreadList
         projectKey={project.projectKey}
         projectExpanded={projectExpanded}
+        threadGroupingMode={threadGroupingMode}
         hasOverflowingThreads={hasOverflowingThreads}
+        hasOverflowingWorktrees={hasOverflowingWorktrees}
+        hiddenWorktreeCount={hiddenWorktreeCount}
         hiddenThreadStatus={hiddenThreadStatus}
         orderedProjectThreadKeys={orderedProjectThreadKeys}
-        renderedThreads={renderedThreads}
+        renderedThreadGroups={renderedThreadGroups}
         showEmptyThreadState={showEmptyThreadState}
         shouldShowThreadPanel={shouldShowThreadPanel}
         isThreadListExpanded={isThreadListExpanded}
@@ -2106,6 +2245,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         openPrLink={openPrLink}
         expandThreadListForProject={expandThreadListForProject}
         collapseThreadListForProject={collapseThreadListForProject}
+        expandWorktreeThreads={expandWorktreeThreads}
+        collapseWorktreeThreads={collapseWorktreeThreads}
+        toggleWorktree={toggleWorktree}
       />
 
       <Dialog
@@ -2262,20 +2404,28 @@ function ProjectSortMenu({
   projectSortOrder,
   threadSortOrder,
   projectGroupingMode,
+  threadGroupingMode,
   threadPreviewCount,
+  worktreePreviewCount,
   onProjectSortOrderChange,
   onThreadSortOrderChange,
   onProjectGroupingModeChange,
+  onThreadGroupingModeChange,
   onThreadPreviewCountChange,
+  onWorktreePreviewCountChange,
 }: {
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
   projectGroupingMode: SidebarProjectGroupingMode;
+  threadGroupingMode: SidebarThreadGroupingMode;
   threadPreviewCount: SidebarThreadPreviewCount;
+  worktreePreviewCount: SidebarWorktreePreviewCount;
   onProjectSortOrderChange: (sortOrder: SidebarProjectSortOrder) => void;
   onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
   onProjectGroupingModeChange: (mode: SidebarProjectGroupingMode) => void;
+  onThreadGroupingModeChange: (mode: SidebarThreadGroupingMode) => void;
   onThreadPreviewCountChange: (count: SidebarThreadPreviewCount) => void;
+  onWorktreePreviewCountChange: (count: SidebarWorktreePreviewCount) => void;
 }) {
   const handleThreadPreviewCountChange = useCallback(
     (nextValue: number | null) => {
@@ -2290,7 +2440,16 @@ function ProjectSortMenu({
     },
     [onThreadPreviewCountChange, threadPreviewCount],
   );
-
+  const handleWorktreePreviewCountChange = useCallback(
+    (nextValue: number | null) => {
+      if (nextValue === null) return;
+      const clampedValue = clampSidebarWorktreePreviewCount(nextValue);
+      if (clampedValue !== worktreePreviewCount) {
+        onWorktreePreviewCountChange(clampedValue);
+      }
+    },
+    [onWorktreePreviewCountChange, worktreePreviewCount],
+  );
   return (
     <Menu>
       <Tooltip>
@@ -2324,6 +2483,30 @@ function ProjectSortMenu({
           </MenuRadioGroup>
         </MenuGroup>
         <MenuGroup>
+          <div className="px-2 pt-2 pb-1 font-medium text-muted-foreground sm:text-xs">
+            Group projects
+          </div>
+          <MenuRadioGroup
+            value={projectGroupingMode}
+            onValueChange={(value) => {
+              if (value === "repository" || value === "repository_path" || value === "separate") {
+                onProjectGroupingModeChange(value);
+              }
+            }}
+          >
+            {(
+              Object.entries(PROJECT_GROUPING_MODE_LABELS) as Array<
+                [SidebarProjectGroupingMode, string]
+              >
+            ).map(([value, label]) => (
+              <MenuRadioItem key={value} value={value} className="min-h-7 py-1 sm:text-xs">
+                {label}
+              </MenuRadioItem>
+            ))}
+          </MenuRadioGroup>
+        </MenuGroup>
+        <MenuSeparator />
+        <MenuGroup>
           <div className="px-2 pt-2 pb-1 sm:text-xs font-medium text-muted-foreground">
             Sort threads
           </div>
@@ -2335,6 +2518,29 @@ function ProjectSortMenu({
           >
             {(
               Object.entries(SIDEBAR_THREAD_SORT_LABELS) as Array<[SidebarThreadSortOrder, string]>
+            ).map(([value, label]) => (
+              <MenuRadioItem key={value} value={value} className="min-h-7 py-1 sm:text-xs">
+                {label}
+              </MenuRadioItem>
+            ))}
+          </MenuRadioGroup>
+        </MenuGroup>
+        <MenuGroup>
+          <div className="px-2 pt-2 pb-1 sm:text-xs font-medium text-muted-foreground">
+            Group threads
+          </div>
+          <MenuRadioGroup
+            value={threadGroupingMode}
+            onValueChange={(value) => {
+              if (value === "worktree" || value === "separate") {
+                onThreadGroupingModeChange(value);
+              }
+            }}
+          >
+            {(
+              Object.entries(SIDEBAR_THREAD_GROUPING_LABELS) as Array<
+                [SidebarThreadGroupingMode, string]
+              >
             ).map(([value, label]) => (
               <MenuRadioItem key={value} value={value} className="min-h-7 py-1 sm:text-xs">
                 {label}
@@ -2378,30 +2584,44 @@ function ProjectSortMenu({
             </NumberField>
           </div>
         </MenuGroup>
-        <MenuSeparator />
-        <MenuGroup>
-          <div className="px-2 pt-2 pb-1 font-medium text-muted-foreground sm:text-xs">
-            Group projects
-          </div>
-          <MenuRadioGroup
-            value={projectGroupingMode}
-            onValueChange={(value) => {
-              if (value === "repository" || value === "repository_path" || value === "separate") {
-                onProjectGroupingModeChange(value);
-              }
-            }}
-          >
-            {(
-              Object.entries(PROJECT_GROUPING_MODE_LABELS) as Array<
-                [SidebarProjectGroupingMode, string]
+        {threadGroupingMode === "worktree" ? (
+          <MenuGroup>
+            <div className="px-2 pt-2 pb-1 text-muted-foreground sm:text-xs font-medium">
+              Visible worktrees
+            </div>
+            <div className="px-2 py-1">
+              <NumberField
+                aria-label="Visible worktree count"
+                className="w-28 gap-0"
+                max={MAX_SIDEBAR_WORKTREE_PREVIEW_COUNT}
+                min={MIN_SIDEBAR_WORKTREE_PREVIEW_COUNT}
+                onValueChange={handleWorktreePreviewCountChange}
+                size="sm"
+                step={1}
+                value={worktreePreviewCount}
               >
-            ).map(([value, label]) => (
-              <MenuRadioItem key={value} value={value} className="min-h-7 py-1 sm:text-xs">
-                {label}
-              </MenuRadioItem>
-            ))}
-          </MenuRadioGroup>
-        </MenuGroup>
+                <NumberFieldGroup className="h-7 rounded-md sm:h-6.5">
+                  <NumberFieldDecrement
+                    aria-label="Decrease visible worktree count"
+                    className="size-6"
+                  />
+                  <NumberFieldInput
+                    aria-label="Visible worktree count"
+                    className="h-7 w-9 grow-0 px-0 text-xs leading-7 sm:h-6.5 sm:leading-6.5"
+                    inputMode="numeric"
+                    onKeyDownCapture={(event) => {
+                      event.stopPropagation();
+                    }}
+                  />
+                  <NumberFieldIncrement
+                    aria-label="Increase visible worktree count"
+                    className="size-6"
+                  />
+                </NumberFieldGroup>
+              </NumberField>
+            </div>
+          </MenuGroup>
+        ) : null}
       </MenuPopup>
     </Menu>
   );
@@ -2525,7 +2745,9 @@ interface SidebarProjectsContentProps {
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
   projectGroupingMode: SidebarProjectGroupingMode;
+  threadGroupingMode: SidebarThreadGroupingMode;
   threadPreviewCount: SidebarThreadPreviewCount;
+  worktreePreviewCount: SidebarWorktreePreviewCount;
   updateSettings: ReturnType<typeof useUpdateSettings>["updateSettings"];
   openAddProject: () => void;
   isManualProjectSorting: boolean;
@@ -2539,6 +2761,8 @@ interface SidebarProjectsContentProps {
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
   expandedThreadListsByProject: ReadonlySet<string>;
+  expandedWorktreeThreadKeys: ReadonlySet<string>;
+  collapsedWorktreeKeys: ReadonlySet<string>;
   activeRouteProjectKey: string | null;
   routeThreadKey: string | null;
   newThreadShortcutLabel: string | null;
@@ -2547,6 +2771,8 @@ interface SidebarProjectsContentProps {
   attachThreadListAutoAnimateRef: (node: HTMLElement | null) => void;
   expandThreadListForProject: (projectKey: string) => void;
   collapseThreadListForProject: (projectKey: string) => void;
+  expandWorktreeThreads: (worktreeKey: string) => void;
+  collapseWorktreeThreads: (worktreeKey: string) => void;
   dragInProgressRef: React.RefObject<boolean>;
   suppressProjectClickAfterDragRef: React.RefObject<boolean>;
   suppressProjectClickForContextMenuRef: React.RefObject<boolean>;
@@ -2566,7 +2792,9 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     projectSortOrder,
     threadSortOrder,
     projectGroupingMode,
+    threadGroupingMode,
     threadPreviewCount,
+    worktreePreviewCount,
     updateSettings,
     openAddProject,
     isManualProjectSorting,
@@ -2580,6 +2808,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     deleteThread,
     sortedProjects,
     expandedThreadListsByProject,
+    expandedWorktreeThreadKeys,
+    collapsedWorktreeKeys,
     activeRouteProjectKey,
     routeThreadKey,
     newThreadShortcutLabel,
@@ -2588,6 +2818,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     attachThreadListAutoAnimateRef,
     expandThreadListForProject,
     collapseThreadListForProject,
+    expandWorktreeThreads,
+    collapseWorktreeThreads,
     dragInProgressRef,
     suppressProjectClickAfterDragRef,
     suppressProjectClickForContextMenuRef,
@@ -2613,13 +2845,24 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     },
     [updateSettings],
   );
+  const handleThreadGroupingModeChange = useCallback(
+    (groupingMode: SidebarThreadGroupingMode) => {
+      updateSettings({ sidebarThreadGroupingMode: groupingMode });
+    },
+    [updateSettings],
+  );
   const handleThreadPreviewCountChange = useCallback(
     (count: SidebarThreadPreviewCount) => {
       updateSettings({ sidebarThreadPreviewCount: count });
     },
     [updateSettings],
   );
-
+  const handleWorktreePreviewCountChange = useCallback(
+    (count: SidebarWorktreePreviewCount) => {
+      updateSettings({ sidebarWorktreePreviewCount: count });
+    },
+    [updateSettings],
+  );
   return (
     <SidebarContent className="gap-0">
       <SidebarGroup className="px-2 pt-2 pb-1">
@@ -2678,11 +2921,15 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
               projectSortOrder={projectSortOrder}
               threadSortOrder={threadSortOrder}
               projectGroupingMode={projectGroupingMode}
+              threadGroupingMode={threadGroupingMode}
               threadPreviewCount={threadPreviewCount}
+              worktreePreviewCount={worktreePreviewCount}
               onProjectSortOrderChange={handleProjectSortOrderChange}
               onThreadSortOrderChange={handleThreadSortOrderChange}
               onProjectGroupingModeChange={handleProjectGroupingModeChange}
+              onThreadGroupingModeChange={handleThreadGroupingModeChange}
               onThreadPreviewCountChange={handleThreadPreviewCountChange}
+              onWorktreePreviewCountChange={handleWorktreePreviewCountChange}
             />
             <Tooltip>
               <TooltipTrigger
@@ -2723,6 +2970,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                       <SidebarProjectItem
                         project={project}
                         isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
+                        expandedWorktreeThreadKeys={expandedWorktreeThreadKeys}
+                        collapsedWorktreeKeys={collapsedWorktreeKeys}
                         activeRouteThreadKey={
                           activeRouteProjectKey === project.projectKey ? routeThreadKey : null
                         }
@@ -2734,6 +2983,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                         attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
                         expandThreadListForProject={expandThreadListForProject}
                         collapseThreadListForProject={collapseThreadListForProject}
+                        expandWorktreeThreads={expandWorktreeThreads}
+                        collapseWorktreeThreads={collapseWorktreeThreads}
                         dragInProgressRef={dragInProgressRef}
                         suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
                         suppressProjectClickForContextMenuRef={
@@ -2755,6 +3006,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 key={project.projectKey}
                 project={project}
                 isThreadListExpanded={expandedThreadListsByProject.has(project.projectKey)}
+                expandedWorktreeThreadKeys={expandedWorktreeThreadKeys}
+                collapsedWorktreeKeys={collapsedWorktreeKeys}
                 activeRouteThreadKey={
                   activeRouteProjectKey === project.projectKey ? routeThreadKey : null
                 }
@@ -2766,6 +3019,8 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
                 attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
                 expandThreadListForProject={expandThreadListForProject}
                 collapseThreadListForProject={collapseThreadListForProject}
+                expandWorktreeThreads={expandWorktreeThreads}
+                collapseWorktreeThreads={collapseWorktreeThreads}
                 dragInProgressRef={dragInProgressRef}
                 suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
                 suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
@@ -2790,6 +3045,7 @@ export default function Sidebar() {
   const projects = useStore(useShallow(selectProjectsAcrossEnvironments));
   const sidebarThreads = useStore(useShallow(selectSidebarThreadsAcrossEnvironments));
   const projectExpandedById = useUiStateStore((store) => store.projectExpandedById);
+  const worktreeExpandedById = useUiStateStore((store) => store.worktreeExpandedById);
   const projectOrder = useUiStateStore((store) => store.projectOrder);
   const reorderProjects = useUiStateStore((store) => store.reorderProjects);
   const navigate = useNavigate();
@@ -2798,8 +3054,10 @@ export default function Sidebar() {
   const sidebarThreadSortOrder = useSettings((s) => s.sidebarThreadSortOrder);
   const sidebarProjectSortOrder = useSettings((s) => s.sidebarProjectSortOrder);
   const sidebarProjectGroupingMode = useSettings((s) => s.sidebarProjectGroupingMode);
+  const sidebarThreadGroupingMode = useSettings((s) => s.sidebarThreadGroupingMode);
   const projectGroupingSettings = useSettings(selectProjectGroupingSettings);
   const sidebarThreadPreviewCount = useSettings((s) => s.sidebarThreadPreviewCount);
+  const sidebarWorktreePreviewCount = useSettings((s) => s.sidebarWorktreePreviewCount);
   const { updateSettings } = useUpdateSettings();
   const { handleNewThread } = useNewThreadHandler();
   const { archiveThread, deleteThread } = useThreadActions();
@@ -2814,6 +3072,9 @@ export default function Sidebar() {
   const [expandedThreadListsByProject, setExpandedThreadListsByProject] = useState<
     ReadonlySet<string>
   >(() => new Set());
+  const [expandedWorktreeThreadKeys, setExpandedWorktreeThreadKeys] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
   const { showThreadJumpHints, updateThreadJumpHintsVisibility } = useThreadJumpHintVisibility();
   const dragInProgressRef = useRef(false);
   const suppressProjectClickAfterDragRef = useRef(false);
@@ -3038,6 +3299,15 @@ export default function Sidebar() {
     () => sidebarThreads.filter((thread) => thread.archivedAt === null),
     [sidebarThreads],
   );
+  const collapsedWorktreeKeys = useMemo(
+    () =>
+      new Set(
+        Object.entries(worktreeExpandedById).flatMap(([worktreeKey, expanded]) =>
+          expanded ? [] : [worktreeKey],
+        ),
+      ),
+    [worktreeExpandedById],
+  );
   const sortedProjects = useMemo(() => {
     const sortableProjects = sidebarProjects.map((project) => ({
       ...project,
@@ -3080,34 +3350,30 @@ export default function Sidebar() {
           sidebarThreadSortOrder,
         );
         const projectExpanded = projectExpandedById[project.projectKey] ?? true;
-        const activeThreadKey = routeThreadKey ?? undefined;
-        const pinnedCollapsedThread =
-          !projectExpanded && activeThreadKey
-            ? (projectThreads.find(
-                (thread) =>
-                  scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)) ===
-                  activeThreadKey,
-              ) ?? null)
-            : null;
-        const shouldShowThreadPanel = projectExpanded || pinnedCollapsedThread !== null;
-        if (!shouldShowThreadPanel) {
-          return [];
-        }
         const isThreadListExpanded = expandedThreadListsByProject.has(project.projectKey);
-        const hasOverflowingThreads = projectThreads.length > sidebarThreadPreviewCount;
-        const previewThreads =
-          isThreadListExpanded || !hasOverflowingThreads
-            ? projectThreads
-            : projectThreads.slice(0, sidebarThreadPreviewCount);
-        const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
-        return renderedThreads.map((thread) =>
-          scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
-        );
+        const renderState = buildSidebarProjectThreadRenderState({
+          activeThreadKey: routeThreadKey,
+          collapsedWorktreeKeys,
+          expandedWorktreeThreadKeys,
+          isThreadListExpanded,
+          projectExpanded,
+          projectKey: project.projectKey,
+          threadGroupingMode: sidebarThreadGroupingMode,
+          threadPreviewCount: sidebarThreadPreviewCount,
+          threads: projectThreads,
+          worktreePreviewCount: sidebarWorktreePreviewCount,
+          getThreadKey: getSidebarThreadKey,
+        });
+        return renderState.orderedThreadKeys;
       }),
     [
       sidebarThreadSortOrder,
+      sidebarThreadGroupingMode,
       sidebarThreadPreviewCount,
+      sidebarWorktreePreviewCount,
       expandedThreadListsByProject,
+      expandedWorktreeThreadKeys,
+      collapsedWorktreeKeys,
       projectExpandedById,
       routeThreadKey,
       sortedProjects,
@@ -3412,6 +3678,24 @@ export default function Sidebar() {
     });
   }, []);
 
+  const expandWorktreeThreads = useCallback((worktreeKey: string) => {
+    setExpandedWorktreeThreadKeys((current) => {
+      if (current.has(worktreeKey)) return current;
+      const next = new Set(current);
+      next.add(worktreeKey);
+      return next;
+    });
+  }, []);
+
+  const collapseWorktreeThreads = useCallback((worktreeKey: string) => {
+    setExpandedWorktreeThreadKeys((current) => {
+      if (!current.has(worktreeKey)) return current;
+      const next = new Set(current);
+      next.delete(worktreeKey);
+      return next;
+    });
+  }, []);
+
   return (
     <>
       <SidebarChromeHeader isElectron={isElectron} />
@@ -3429,7 +3713,9 @@ export default function Sidebar() {
             projectSortOrder={sidebarProjectSortOrder}
             threadSortOrder={sidebarThreadSortOrder}
             projectGroupingMode={sidebarProjectGroupingMode}
+            threadGroupingMode={sidebarThreadGroupingMode}
             threadPreviewCount={sidebarThreadPreviewCount}
+            worktreePreviewCount={sidebarWorktreePreviewCount}
             updateSettings={updateSettings}
             openAddProject={openAddProjectCommandPalette}
             isManualProjectSorting={isManualProjectSorting}
@@ -3443,6 +3729,8 @@ export default function Sidebar() {
             deleteThread={deleteThread}
             sortedProjects={sortedProjects}
             expandedThreadListsByProject={expandedThreadListsByProject}
+            expandedWorktreeThreadKeys={expandedWorktreeThreadKeys}
+            collapsedWorktreeKeys={collapsedWorktreeKeys}
             activeRouteProjectKey={activeRouteProjectKey}
             routeThreadKey={routeThreadKey}
             newThreadShortcutLabel={newThreadShortcutLabel}
@@ -3451,6 +3739,8 @@ export default function Sidebar() {
             attachThreadListAutoAnimateRef={attachThreadListAutoAnimateRef}
             expandThreadListForProject={expandThreadListForProject}
             collapseThreadListForProject={collapseThreadListForProject}
+            expandWorktreeThreads={expandWorktreeThreads}
+            collapseWorktreeThreads={collapseWorktreeThreads}
             dragInProgressRef={dragInProgressRef}
             suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
             suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -396,6 +396,13 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.sidebarThreadPreviewCount !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount
         ? ["Visible threads"]
         : []),
+      ...(settings.sidebarThreadGroupingMode !== DEFAULT_UNIFIED_SETTINGS.sidebarThreadGroupingMode
+        ? ["Thread grouping"]
+        : []),
+      ...(settings.sidebarWorktreePreviewCount !==
+      DEFAULT_UNIFIED_SETTINGS.sidebarWorktreePreviewCount
+        ? ["Shown worktrees"]
+        : []),
       ...(settings.diffWordWrap !== DEFAULT_UNIFIED_SETTINGS.diffWordWrap
         ? ["Diff line wrapping"]
         : []),
@@ -437,7 +444,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.diffWordWrap,
       settings.automaticGitFetchInterval,
       settings.enableAssistantStreaming,
+      settings.sidebarThreadGroupingMode,
       settings.sidebarThreadPreviewCount,
+      settings.sidebarWorktreePreviewCount,
       settings.timestampFormat,
       theme,
     ],
@@ -458,7 +467,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       diffWordWrap: DEFAULT_UNIFIED_SETTINGS.diffWordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
+      sidebarThreadGroupingMode: DEFAULT_UNIFIED_SETTINGS.sidebarThreadGroupingMode,
       sidebarThreadPreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarThreadPreviewCount,
+      sidebarWorktreePreviewCount: DEFAULT_UNIFIED_SETTINGS.sidebarWorktreePreviewCount,
       autoOpenPlanSidebar: DEFAULT_UNIFIED_SETTINGS.autoOpenPlanSidebar,
       enableAssistantStreaming: DEFAULT_UNIFIED_SETTINGS.enableAssistantStreaming,
       automaticGitFetchInterval: DEFAULT_UNIFIED_SETTINGS.automaticGitFetchInterval,

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -612,8 +612,10 @@ describe("wsApi", () => {
         "environment-local:/tmp/project": "separate" as const,
       },
       sidebarProjectSortOrder: "manual" as const,
+      sidebarThreadGroupingMode: "worktree" as const,
       sidebarThreadSortOrder: "created_at" as const,
       sidebarThreadPreviewCount: 6,
+      sidebarWorktreePreviewCount: 4,
       timestampFormat: "24-hour" as const,
     };
     const getClientSettings = vi.fn().mockResolvedValue({
@@ -675,8 +677,10 @@ describe("wsApi", () => {
         "environment-local:/tmp/project": "separate" as const,
       },
       sidebarProjectSortOrder: "manual" as const,
+      sidebarThreadGroupingMode: "worktree" as const,
       sidebarThreadSortOrder: "created_at" as const,
       sidebarThreadPreviewCount: 6,
+      sidebarWorktreePreviewCount: 4,
       timestampFormat: "24-hour" as const,
     };
 

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   clearThreadUi,
   hydratePersistedProjectState,
+  hydratePersistedWorktreeState,
   markThreadVisited,
   markThreadUnread,
   PERSISTED_STATE_KEY,
@@ -15,12 +16,14 @@ import {
   setThreadChangedFilesExpanded,
   syncProjects,
   syncThreads,
+  toggleWorktree,
   type UiState,
 } from "./uiStateStore";
 
 function makeUiState(overrides: Partial<UiState> = {}): UiState {
   return {
     projectExpandedById: {},
+    worktreeExpandedById: {},
     projectOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
@@ -523,6 +526,29 @@ describe("uiStateStore persistence round-trip", () => {
       [projectA.key]: true,
       [projectB.key]: false,
       [projectC.key]: true,
+    });
+  });
+
+  it("preserves collapsed worktree state across restart", () => {
+    const collapsedWorktreeId = "repo::/repo/.t3/worktrees/worktree-a";
+    const expandedWorktreeId = "repo::/repo/.t3/worktrees/worktree-b";
+    let state = makeUiState();
+
+    state = toggleWorktree(state, collapsedWorktreeId);
+    state = toggleWorktree(toggleWorktree(state, expandedWorktreeId), expandedWorktreeId);
+    persistState(state);
+
+    expect(state.worktreeExpandedById).toEqual({
+      [collapsedWorktreeId]: false,
+    });
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+
+    expect(persisted.collapsedWorktreeIds).toEqual([collapsedWorktreeId]);
+    expect(hydratePersistedWorktreeState(persisted)).toEqual({
+      [collapsedWorktreeId]: false,
     });
   });
 

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -18,6 +18,7 @@ const LEGACY_PERSISTED_STATE_KEYS = [
 export interface PersistedUiState {
   collapsedProjectCwds?: string[];
   expandedProjectCwds?: string[];
+  collapsedWorktreeIds?: string[];
   projectOrderCwds?: string[];
   defaultAdvertisedEndpointKey?: string | null;
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
@@ -25,6 +26,7 @@ export interface PersistedUiState {
 
 export interface UiProjectState {
   projectExpandedById: Record<string, boolean>;
+  worktreeExpandedById: Record<string, boolean>;
   projectOrder: string[];
 }
 
@@ -54,6 +56,7 @@ export interface SyncThreadInput {
 
 const initialState: UiState = {
   projectExpandedById: {},
+  worktreeExpandedById: {},
   projectOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
@@ -94,6 +97,7 @@ function readPersistedState(): UiState {
     hydratePersistedProjectState(parsed);
     return {
       ...initialState,
+      worktreeExpandedById: hydratePersistedWorktreeState(parsed),
       defaultAdvertisedEndpointKey:
         typeof parsed.defaultAdvertisedEndpointKey === "string" &&
         parsed.defaultAdvertisedEndpointKey.length > 0
@@ -106,6 +110,16 @@ function readPersistedState(): UiState {
   } catch {
     return initialState;
   }
+}
+
+export function hydratePersistedWorktreeState(parsed: PersistedUiState): Record<string, boolean> {
+  const nextState: Record<string, boolean> = {};
+  for (const worktreeId of parsed.collapsedWorktreeIds ?? []) {
+    if (typeof worktreeId === "string" && worktreeId.length > 0) {
+      nextState[worktreeId] = false;
+    }
+  }
+  return nextState;
 }
 
 function sanitizePersistedThreadChangedFilesExpanded(
@@ -172,6 +186,9 @@ export function persistState(state: UiState): void {
     const expandedProjectCwds = Object.entries(state.projectExpandedById)
       .filter(([, expanded]) => expanded)
       .flatMap(([logicalKey]) => currentProjectCwdsByLogicalKey.get(logicalKey) ?? []);
+    const collapsedWorktreeIds = Object.entries(state.worktreeExpandedById).flatMap(
+      ([worktreeId, expanded]) => (!expanded && worktreeId.length > 0 ? [worktreeId] : []),
+    );
     const projectOrderCwds = state.projectOrder.flatMap((projectId) => {
       const cwd = currentProjectCwdById.get(projectId);
       return cwd ? [cwd] : [];
@@ -189,6 +206,7 @@ export function persistState(state: UiState): void {
       JSON.stringify({
         collapsedProjectCwds,
         expandedProjectCwds,
+        collapsedWorktreeIds,
         projectOrderCwds,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpandedById,
@@ -566,6 +584,20 @@ export function toggleProject(state: UiState, projectId: string): UiState {
   };
 }
 
+export function toggleWorktree(state: UiState, worktreeId: string): UiState {
+  const expanded = state.worktreeExpandedById[worktreeId] ?? true;
+  const nextWorktreeExpandedById = { ...state.worktreeExpandedById };
+  if (expanded) {
+    nextWorktreeExpandedById[worktreeId] = false;
+  } else {
+    delete nextWorktreeExpandedById[worktreeId];
+  }
+  return {
+    ...state,
+    worktreeExpandedById: nextWorktreeExpandedById,
+  };
+}
+
 export function setProjectExpanded(state: UiState, projectId: string, expanded: boolean): UiState {
   if ((state.projectExpandedById[projectId] ?? true) === expanded) {
     return state;
@@ -631,6 +663,7 @@ interface UiStateStore extends UiState {
   setThreadChangedFilesExpanded: (threadId: string, turnId: string, expanded: boolean) => void;
   setDefaultAdvertisedEndpointKey: (key: string | null) => void;
   toggleProject: (projectId: string) => void;
+  toggleWorktree: (worktreeId: string) => void;
   setProjectExpanded: (projectId: string, expanded: boolean) => void;
   reorderProjects: (
     draggedProjectIds: readonly string[],
@@ -652,6 +685,7 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
   setDefaultAdvertisedEndpointKey: (key) =>
     set((state) => setDefaultAdvertisedEndpointKey(state, key)),
   toggleProject: (projectId) => set((state) => toggleProject(state, projectId)),
+  toggleWorktree: (worktreeId) => set((state) => toggleWorktree(state, worktreeId)),
   setProjectExpanded: (projectId, expanded) =>
     set((state) => setProjectExpanded(state, projectId, expanded)),
   reorderProjects: (draggedProjectIds, targetProjectIds) =>

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -21,6 +21,10 @@ export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 
+export const SidebarThreadGroupingMode = Schema.Literals(["separate", "worktree"]);
+export type SidebarThreadGroupingMode = typeof SidebarThreadGroupingMode.Type;
+export const DEFAULT_SIDEBAR_THREAD_GROUPING_MODE: SidebarThreadGroupingMode = "worktree";
+
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
   "repository_path",
@@ -38,6 +42,16 @@ export const SidebarThreadPreviewCount = Schema.Int.check(
 );
 export type SidebarThreadPreviewCount = typeof SidebarThreadPreviewCount.Type;
 export const DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT: SidebarThreadPreviewCount = 6;
+export const MIN_SIDEBAR_WORKTREE_PREVIEW_COUNT = 1;
+export const MAX_SIDEBAR_WORKTREE_PREVIEW_COUNT = 15;
+export const SidebarWorktreePreviewCount = Schema.Int.check(
+  Schema.isBetween({
+    minimum: MIN_SIDEBAR_WORKTREE_PREVIEW_COUNT,
+    maximum: MAX_SIDEBAR_WORKTREE_PREVIEW_COUNT,
+  }),
+);
+export type SidebarWorktreePreviewCount = typeof SidebarWorktreePreviewCount.Type;
+export const DEFAULT_SIDEBAR_WORKTREE_PREVIEW_COUNT: SidebarWorktreePreviewCount = 4;
 
 export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
@@ -86,8 +100,14 @@ export const ClientSettingsSchema = Schema.Struct({
   sidebarThreadSortOrder: SidebarThreadSortOrder.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER)),
   ),
+  sidebarThreadGroupingMode: SidebarThreadGroupingMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_GROUPING_MODE)),
+  ),
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
+  ),
+  sidebarWorktreePreviewCount: SidebarWorktreePreviewCount.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_WORKTREE_PREVIEW_COUNT)),
   ),
   timestampFormat: TimestampFormat.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_TIMESTAMP_FORMAT)),
@@ -507,7 +527,9 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
+  sidebarThreadGroupingMode: Schema.optionalKey(SidebarThreadGroupingMode),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
+  sidebarWorktreePreviewCount: Schema.optionalKey(SidebarWorktreePreviewCount),
   timestampFormat: Schema.optionalKey(TimestampFormat),
 });
 export type ClientSettingsPatch = typeof ClientSettingsPatch.Type;


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- add option to group threads by worktree, enabled by default
- grouping only shows when there is more than one worktree with active threads
- visible thread ordering after grouping so jump shortcuts, prewarming, and range selection match the rendered sidebar

## Why
<!-- Explain the problem being solved and why this approach is the right one. -->

TLDR I wanna stop using conductor but T3's worktree's absolutely suck to use

T3's worktree support is capable but requires a lot of mental load. It's easy to run all your chats in the main worktree, and its easy to run all your chats in separate worktrees, but as soon as you want to do any amount of mixing and matching in different worktrees it gets absolutely impossible to manage.

This is one of the most obvious UX improvements here, and makes it much more clear when threads are operating in the same worktree. Better display of worktrees also paves the way for other improvements, like clearer UX around creating new threads in specific worktrees. Those improvements are beyond the scope of this PR.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

Sort & group settings before and after:
<img width="324" height="638" alt="Screenshot 2026-05-14 at 11 14 50 PM" src="https://github.com/user-attachments/assets/ef5d901d-52ed-4227-b5c1-a0b2a9351c3d" /><img width="322" height="851" alt="Screenshot 2026-05-14 at 11 15 31 PM" src="https://github.com/user-attachments/assets/b6c51245-a63e-4cf4-9e68-d2bc3d36b9d9" />

Sidebar before
Sidebar still looks like this when threads are not grouped by worktree
<img width="344" height="493" alt="Screenshot 2026-05-14 at 11 14 40 PM" src="https://github.com/user-attachments/assets/457bd9bd-7b68-48ea-8ba6-5c50a5fdb1da" />

Sidebar after
<img width="345" height="556" alt="Screenshot 2026-05-14 at 11 16 06 PM" src="https://github.com/user-attachments/assets/40c320e6-41e8-41c9-a809-83d2dd964d20" />
<img width="347" height="616" alt="Screenshot 2026-05-14 at 11 16 38 PM" src="https://github.com/user-attachments/assets/f705be9a-937b-44cd-baab-4f4303446442" />

indicators
<img width="340" height="394" alt="Screenshot 2026-05-14 at 11 26 59 PM" src="https://github.com/user-attachments/assets/4859220b-4c3d-4dfc-8af8-a06a7b3efcee" />
<img width="334" height="293" alt="Screenshot 2026-05-14 at 11 27 30 PM" src="https://github.com/user-attachments/assets/20e32057-335a-4a42-908c-21178999f917" />


## Checklist

- [ ] This PR is small and focused
(not very small, but focused at least. my b)
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sidebar thread rendering/ordering and adds new persisted UI state and client settings defaults, which could affect navigation shortcuts/selection and user-configured sidebar behavior. Risk is moderated by extensive new unit test coverage for grouping/overflow/pinning edge cases.
> 
> **Overview**
> **Adds worktree-grouped thread lists in the sidebar (default behavior).** Threads can now render under expandable worktree headers (with a special “Current checkout” group), while preserving a flat `separate` mode.
> 
> Introduces new sidebar render modeling in `Sidebar.logic.ts` (group building, overflow/preview limits per worktree, and “pin active thread” behavior) and updates `Sidebar.tsx` to use the grouped model for visible ordering (jump shortcuts, prewarming, range selection) plus new per-worktree and per-project “show more/less” controls.
> 
> Adds two new client settings in `contracts/settings.ts`—`sidebarThreadGroupingMode` and `sidebarWorktreePreviewCount`—wires them into the sort/group menu and “Restore defaults”, and persists collapsed worktree UI state via `uiStateStore` (`collapsedWorktreeIds`) with associated tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20b9a1feed7a8a222a862348c60e74dfb3c2f9d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group sidebar threads by worktree with per-worktree expand/collapse controls
> - Adds a 'worktree' grouping mode to the sidebar that organizes threads under their associated worktree, with expandable group headers and per-worktree overflow controls. A 'separate' (flat) mode retains the previous behavior.
> - Introduces `buildSidebarWorktreeThreadGroups`, `buildSidebarThreadRenderModel`, and `buildSidebarProjectThreadRenderState` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/2708/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) to compute grouped render state with pinned active thread, preview limits, and hidden/overflow accounting.
> - Adds `sidebarThreadGroupingMode` (default `'worktree'`) and `sidebarWorktreePreviewCount` (default 4, range 1–15) as persisted client settings, configurable from `ProjectSortMenu`.
> - Persists collapsed worktree IDs to localStorage via `uiStateStore`, restoring expansion state on reload.
> - Behavioral Change: the default sidebar view now groups threads by worktree rather than showing a flat list.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e915a02. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->