### PR TITLE
fix(marketing): polish download page, platform CTAs, and nav

### DIFF
--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -370,13 +370,13 @@ const {
   .nav-gh {
     display: inline-flex;
     align-items: center;
-    gap: 6px;
-    padding: 7px 12px;
+    gap: 8px;
+    padding: 10px 14px;
     border: 1px solid var(--border);
     border-radius: 8px;
     color: var(--fg-muted);
     font-family: var(--font-mono);
-    font-size: 12px;
+    font-size: 14px;
     transition:
       color 0.2s ease,
       background 0.2s ease,

--- a/apps/marketing/src/layouts/Layout.astro
+++ b/apps/marketing/src/layouts/Layout.astro
@@ -41,12 +41,20 @@ const {
               target="_blank"
               rel="noopener noreferrer"
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                <path d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.93c.58.1.79-.25.79-.56v-2c-3.2.69-3.88-1.37-3.88-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.33.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.67 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 015.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.74.8 1.18 1.83 1.18 3.08 0 4.41-2.7 5.38-5.27 5.66.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"/>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.93c.58.1.79-.25.79-.56v-2c-3.2.69-3.88-1.37-3.88-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.33.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.67 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 015.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.74.8 1.18 1.83 1.18 3.08 0 4.41-2.7 5.38-5.27 5.66.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"
+                ></path>
               </svg>
               <span>GitHub</span>
             </a>
-            <a class="btn btn-primary" href="/#download">Download</a>
+            <a class="btn btn-primary" href="/download">Download</a>
           </div>
         </div>
       </nav>
@@ -59,11 +67,21 @@ const {
         <div class="footer-inner">
           <div class="footer-brand">
             <img src="/icon.webp" alt="" />
-            <span>&copy; {new Date().getFullYear()} T3 Tools Inc · MIT licensed</span>
+            <span
+              >&copy; {new Date().getFullYear()} T3 Tools Inc · MIT licensed</span
+            >
           </div>
           <div class="footer-links">
-            <a href="https://github.com/pingdotgg/t3code" target="_blank" rel="noopener noreferrer">GitHub</a>
-            <a href="https://discord.gg/jn4EGJjrvv" target="_blank" rel="noopener noreferrer">Discord</a>
+            <a
+              href="https://github.com/pingdotgg/t3code"
+              target="_blank"
+              rel="noopener noreferrer">GitHub</a
+            >
+            <a
+              href="https://discord.gg/jn4EGJjrvv"
+              target="_blank"
+              rel="noopener noreferrer">Discord</a
+            >
             <a href="/download">Download</a>
           </div>
         </div>
@@ -99,8 +117,10 @@ const {
     --accent-dim: oklch(0.68 0.17 var(--accent-h) / 0.15);
     --ok: oklch(0.72 0.16 150);
     --warn: oklch(0.76 0.15 75);
-    --font-sans: "DM Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+    --font-sans:
+      "DM Sans", -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+    --font-mono:
+      "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
     --radius: 12px;
     --radius-sm: 8px;
     --radius-lg: 16px;
@@ -191,8 +211,11 @@ const {
     font-size: 14px;
     padding: 10px 18px;
     border-radius: 8px;
-    transition: transform 0.18s ease, background 0.18s ease,
-      border-color 0.18s ease, color 0.18s ease;
+    transition:
+      transform 0.18s ease,
+      background 0.18s ease,
+      border-color 0.18s ease,
+      color 0.18s ease;
     white-space: nowrap;
   }
 
@@ -233,7 +256,11 @@ const {
     position: relative;
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.015), rgba(255, 255, 255, 0));
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.015),
+      rgba(255, 255, 255, 0)
+    );
     overflow: hidden;
   }
 
@@ -255,20 +282,31 @@ const {
   }
 
   @keyframes pulse {
-    50% { opacity: 0.4; }
+    50% {
+      opacity: 0.4;
+    }
   }
 
   @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+      transform: rotate(360deg);
+    }
   }
 
   @keyframes floatDrift {
-    0%, 100% { translate: 0 0; }
-    50%      { translate: 0 -10px; }
+    0%,
+    100% {
+      translate: 0 0;
+    }
+    50% {
+      translate: 0 -10px;
+    }
   }
 
   @keyframes blink {
-    50% { opacity: 0; }
+    50% {
+      opacity: 0;
+    }
   }
 </style>
 
@@ -339,7 +377,10 @@ const {
     color: var(--fg-muted);
     font-family: var(--font-mono);
     font-size: 12px;
-    transition: color 0.2s ease, background 0.2s ease, border-color 0.2s ease;
+    transition:
+      color 0.2s ease,
+      background 0.2s ease,
+      border-color 0.2s ease;
   }
 
   .nav-gh:hover {

--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -294,28 +294,38 @@ import { RELEASES_URL } from "../lib/releases";
       const code = block.querySelector("code");
       if (!code) return;
 
+      const wrap = document.createElement("div");
+      wrap.className = "cmd-block-wrap";
+      block.parentNode?.insertBefore(wrap, block);
+      wrap.appendChild(block);
+
+      const tooltip = document.createElement("span");
+      tooltip.className = "cmd-tooltip";
+      tooltip.textContent = "Copy";
+      wrap.appendChild(tooltip);
+
       const button = document.createElement("button");
       button.type = "button";
       button.className = "cmd-copy";
-      button.title = "Copy command";
       button.setAttribute("aria-label", "Copy command to clipboard");
       button.innerHTML = COPY_ICON_SVG + CHECK_ICON_SVG;
+      block.appendChild(button);
 
       let resetTimer: number | undefined;
-      button.addEventListener("click", async () => {
+      block.addEventListener("click", async () => {
         try {
           await navigator.clipboard.writeText(code.textContent ?? "");
           button.classList.add("is-copied");
+          tooltip.textContent = "Copied";
           if (resetTimer !== undefined) window.clearTimeout(resetTimer);
           resetTimer = window.setTimeout(() => {
             button.classList.remove("is-copied");
+            tooltip.textContent = "Copy";
           }, 1600);
         } catch {
           // Ignore clipboard failures (insecure context, denied permission).
         }
       });
-
-      block.appendChild(button);
     });
   }
 
@@ -397,11 +407,18 @@ import { RELEASES_URL } from "../lib/releases";
     letter-spacing: -0.005em;
   }
 
-  .cli-callout .cmd-block {
+  .cli-callout :global(.cmd-block-wrap) {
     flex: 1 1 220px;
+    min-width: 0;
   }
 
   /* ── Shared command block ── */
+
+  :global(.cmd-block-wrap) {
+    position: relative;
+    display: block;
+    width: 100%;
+  }
 
   .cmd-block {
     position: relative;
@@ -415,6 +432,42 @@ import { RELEASES_URL } from "../lib/releases";
     overflow-x: auto;
     display: flex;
     align-items: center;
+    cursor: pointer;
+    transition:
+      border-color 0.18s ease,
+      background 0.18s ease;
+  }
+
+  .cmd-block:hover {
+    border-color: var(--border-strong);
+    background: rgba(0, 0, 0, 0.35);
+  }
+
+  :global(.cmd-tooltip) {
+    position: absolute;
+    bottom: calc(100% + 6px);
+    right: 0;
+    background: rgba(0, 0, 0, 0.9);
+    color: var(--fg);
+    font-family: var(--font-sans);
+    font-size: 11px;
+    font-weight: 500;
+    padding: 4px 8px;
+    border-radius: 6px;
+    border: 1px solid var(--border);
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(4px);
+    transition:
+      opacity 0.18s ease,
+      transform 0.18s ease;
+    white-space: nowrap;
+    z-index: 5;
+  }
+
+  :global(.cmd-block-wrap:hover .cmd-tooltip) {
+    opacity: 1;
+    transform: translateY(0);
   }
 
   .cmd-block code {

--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -3,68 +3,240 @@ import Layout from "../layouts/Layout.astro";
 import { RELEASES_URL } from "../lib/releases";
 ---
 
-<Layout title="Download — T3 Code" description="Download T3 Code for macOS, Windows, or Linux.">
+<Layout
+  title="Download — T3 Code"
+  description="Download T3 Code for macOS, Windows, or Linux."
+>
   <div class="download-page">
-  <h1 class="heading">Download T3 Code</h1>
-  <p class="subheading">
-    <span id="version-label">Loading latest release&hellip;</span>
-    <a id="changelog-link" class="changelog-link" href="#" target="_blank" rel="noopener noreferrer" style="display:none">View changelog<span aria-hidden="true"> &#8599;</span></a>
-  </p>
+    <h1 class="heading">Download T3 Code</h1>
+    <p class="subheading">
+      <span id="version-label">Loading latest release&hellip;</span>
+      <a
+        id="changelog-link"
+        class="changelog-link"
+        href="#"
+        target="_blank"
+        rel="noopener noreferrer"
+        style="display:none"
+        >View changelog<span aria-hidden="true"> &#8599;</span></a
+      >
+    </p>
 
-  <div class="platforms" id="platforms">
-    <!-- macOS -->
-    <section class="platform-section">
-      <div class="platform-header">
-        <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 814 1000" aria-hidden="true"><path fill="currentColor" d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg>
-        <h2 class="platform-name">macOS</h2>
+    <section class="cli-callout">
+      <div class="cli-callout-meta">
+        <h2 class="cli-callout-title">Run without installing</h2>
+        <p class="cli-callout-desc">
+          Spin up T3 Code straight from your terminal — no download required.
+        </p>
       </div>
-      <div class="download-cards">
-        <a class="download-card" data-asset="arm64.dmg" href={RELEASES_URL}>
-          <span class="card-arch">Apple Silicon (arm64)</span>
-          <span class="card-format">.dmg</span>
-        </a>
-        <a class="download-card" data-asset="x64.dmg" href={RELEASES_URL}>
-          <span class="card-arch">Intel (x64)</span>
-          <span class="card-format">.dmg</span>
-        </a>
+      <div class="cmd-block">
+        <span class="cmd-prompt">$</span><code>npx t3</code>
       </div>
     </section>
 
-    <!-- Windows -->
-    <section class="platform-section">
-      <div class="platform-header">
-        <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88" aria-hidden="true"><path fill="currentColor" d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"/></svg>
-        <h2 class="platform-name">Windows</h2>
-      </div>
-      <div class="download-cards">
-        <a class="download-card" data-asset="x64.exe" href={RELEASES_URL}>
-          <span class="card-arch">Windows 10, 11</span>
-          <span class="card-format">.exe</span>
-        </a>
-      </div>
-    </section>
+    <div class="platforms" id="platforms">
+      <!-- macOS -->
+      <section class="platform-section">
+        <div class="platform-header">
+          <svg
+            class="platform-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 814 1000"
+            aria-hidden="true"
+            ><path
+              fill="currentColor"
+              d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"
+            ></path></svg
+          >
+          <h2 class="platform-name">macOS</h2>
+        </div>
+        <div class="download-cards">
+          <a class="download-card" data-asset="arm64.dmg" href={RELEASES_URL}>
+            <span class="card-arch">Apple Silicon (arm64)</span>
+            <span class="card-format">.dmg</span>
+          </a>
+          <a class="download-card" data-asset="x64.dmg" href={RELEASES_URL}>
+            <span class="card-arch">Intel (x64)</span>
+            <span class="card-format">.dmg</span>
+          </a>
+        </div>
+        <div class="cli-install">
+          <span class="cli-install-label">Or install with Homebrew</span>
+          <div class="cmd-block">
+            <span class="cmd-prompt">$</span><code
+              >brew install --cask t3-code</code
+            >
+          </div>
+        </div>
+      </section>
 
-    <!-- Linux -->
-    <section class="platform-section">
-      <div class="platform-header">
-        <svg class="platform-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 295" aria-hidden="true"><defs><linearGradient id="lt0" x1="48.548%" x2="51.047%" y1="115.276%" y2="41.364%"><stop offset="0%" stop-color="#FFEED7"/><stop offset="100%" stop-color="#BDBFC2"/></linearGradient><linearGradient id="lt6" x1="49.984%" x2="49.984%" y1="89.845%" y2="40.632%"><stop offset="0%" stop-color="#FFEED7"/><stop offset="100%" stop-color="#BDBFC2"/></linearGradient><linearGradient id="lt8" x1="49.841%" x2="50.241%" y1="13.229%" y2="94.673%"><stop offset="0%" stop-color="#FFF" stop-opacity=".8"/><stop offset="100%" stop-color="#FFF" stop-opacity="0"/></linearGradient><linearGradient id="ltc" x1="53.467%" x2="38.949%" y1="48.921%" y2="98.1%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient><linearGradient id="lte" x1="30.581%" x2="65.887%" y1="34.024%" y2="89.175%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient><linearGradient id="lti" x1="49.733%" x2="50.558%" y1="17.609%" y2="99.385%"><stop offset="0%" stop-color="#FFA63F"/><stop offset="100%" stop-color="#FF0"/></linearGradient></defs><g fill="none"><path fill="#000" d="M63.213 215.474c-11.387-16.346-13.591-69.606 12.947-102.39C89.292 97.383 92.69 86.455 93.7 71.67c.734-16.805-11.846-66.851 35.537-70.616 48.027-3.857 45.364 43.526 45.088 68.596-.183 21.12 15.52 33.15 26.355 49.68 19.927 30.303 18.274 82.461-3.765 110.745-27.916 35.354-51.791 20.018-67.678 21.304-29.752 1.745-30.762 17.54-66.024-35.905"/><path fill="url(#lt6)" d="M81.027 145.684c6.52-14.785 20.386-40.772 20.662-60.883 0-15.978 47.843-19.835 51.7-3.856 3.856 15.978 13.59 39.853 19.834 51.424 6.245 11.478 24.335 48.118 5.051 80.074-17.356 28.284-69.973 50.69-98.073-3.856-9.55-18.917-7.806-42.333.826-62.903"/><path fill="url(#lt8)" d="M166.428 151.285c0 16.162-15.519 37.1-42.15 36.916-27.456.183-39.118-20.754-39.118-36.916 0-16.161 18.182-29.293 40.588-29.293 22.498.092 40.68 13.132 40.68 29.293"/><path fill="#000" stroke="#000" stroke-width=".977" d="M176.805 117.86c13.59 11.02 38.292 49.587 2.204 74.748-11.846 7.806 10.468 32.508 23.049 19.927 43.618-43.894-1.102-94.308-16.53-111.664-13.774-15.151-25.987 3.49-8.723 16.989z"/><path fill="#000" stroke="#000" stroke-width="1.25" d="M79.925 122.727c-8.907 14.509-30.211 48.669-1.652 66.484 38.384 23.6 27.548 47.108-7.53 25.895-49.404-29.568-5.97-89.257 13.774-112.03 22.59-25.529 4.316 4.683-4.592 19.65z"/><path fill="url(#ltc)" stroke="#E68C3F" stroke-width="6.25" d="M51.835 258.542c-20.57-10.928-50.414 2.112-39.578-27.457 2.204-6.704-3.214-16.805.275-23.325 4.133-7.989 13.04-6.244 18.366-11.57 5.234-5.51 8.54-15.06 18.366-13.59 9.734 1.468 16.254 13.406 23.049 28.099 5.05 10.468 22.865 25.253 21.672 37.007-1.47 17.998-21.948 21.396-42.15 10.836z" transform="translate(10)"/><path fill="url(#lte)" stroke="#E68C3F" stroke-width="6.251" d="M194.445 253.49c15.06-18.273 48.578-14.508 25.988-39.577-4.775-5.418-3.306-16.989-9.183-21.947-6.887-6.061-14.509-1.102-21.488-4.224-6.979-3.398-14.325-9.918-22.865-5.327-8.54 4.684-9.459 16.805-10.285 32.783-.735 11.479-11.203 30.671-5.602 41.231 8.081 16.346 29.11 14.142 43.435-2.938z" transform="translate(10)"/><path fill="url(#lti)" stroke="#E68C3F" stroke-width="3.75" d="M97.107 66.344c3.673-3.398 12.58-13.774 29.477-2.939 3.122 2.02 5.693 2.204 11.662 4.775 12.03 4.96 6.336 16.897-6.52 20.937-5.51 1.745-10.468 8.449-20.386 7.806-8.54-.46-10.744-6.06-15.978-9.091-9.275-5.234-10.652-12.305-5.602-16.07 5.051-3.765 6.98-5.143 7.347-5.418z" transform="translate(10)"/><path fill="#000" d="M133.186 57.712c-.092 5.234 2.48 9.458 5.877 9.458 3.306 0 6.153-4.224 6.245-9.366.091-5.234-2.48-9.459-5.878-9.459-3.397 0-6.152 4.225-6.244 9.367m-21.212.092c.459 4.316-1.194 7.989-3.582 8.356-2.387.276-4.683-2.938-5.142-7.254-.46-4.316 1.194-7.99 3.581-8.357 2.388-.275 4.684 2.939 5.143 7.255"/></g></svg>
-        <h2 class="platform-name">Linux</h2>
-      </div>
-      <div class="download-cards">
-        <a class="download-card" data-asset="x86_64.AppImage" href={RELEASES_URL}>
-          <span class="card-arch">x86_64</span>
-          <span class="card-format">AppImage</span>
-        </a>
-      </div>
-    </section>
-  </div>
+      <!-- Windows -->
+      <section class="platform-section">
+        <div class="platform-header">
+          <svg
+            class="platform-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 88 88"
+            aria-hidden="true"
+            ><path
+              fill="currentColor"
+              d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"
+            ></path></svg
+          >
+          <h2 class="platform-name">Windows</h2>
+        </div>
+        <div class="download-cards">
+          <a class="download-card" data-asset="x64.exe" href={RELEASES_URL}>
+            <span class="card-arch">Windows 10, 11</span>
+            <span class="card-format">.exe</span>
+          </a>
+        </div>
+        <div class="cli-install">
+          <span class="cli-install-label">Or install with winget</span>
+          <div class="cmd-block">
+            <span class="cmd-prompt">$</span><code
+              >winget install T3Tools.T3Code</code
+            >
+          </div>
+        </div>
+      </section>
 
-  <p class="releases-link">
-    Looking for older versions? Check the
-    <a href="https://github.com/pingdotgg/t3code/releases" target="_blank" rel="noopener noreferrer">
-      GitHub releases page<span aria-hidden="true"> &#8599;</span>
-    </a>
-  </p>
+      <!-- Linux -->
+      <section class="platform-section">
+        <div class="platform-header">
+          <svg
+            class="platform-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 256 295"
+            aria-hidden="true"
+            ><defs
+              ><linearGradient
+                id="lt0"
+                x1="48.548%"
+                x2="51.047%"
+                y1="115.276%"
+                y2="41.364%"
+                ><stop offset="0%" stop-color="#FFEED7"></stop><stop
+                  offset="100%"
+                  stop-color="#BDBFC2"></stop></linearGradient
+              ><linearGradient
+                id="lt6"
+                x1="49.984%"
+                x2="49.984%"
+                y1="89.845%"
+                y2="40.632%"
+                ><stop offset="0%" stop-color="#FFEED7"></stop><stop
+                  offset="100%"
+                  stop-color="#BDBFC2"></stop></linearGradient
+              ><linearGradient
+                id="lt8"
+                x1="49.841%"
+                x2="50.241%"
+                y1="13.229%"
+                y2="94.673%"
+                ><stop offset="0%" stop-color="#FFF" stop-opacity=".8"
+                ></stop><stop offset="100%" stop-color="#FFF" stop-opacity="0"
+                ></stop></linearGradient
+              ><linearGradient
+                id="ltc"
+                x1="53.467%"
+                x2="38.949%"
+                y1="48.921%"
+                y2="98.1%"
+                ><stop offset="0%" stop-color="#FFA63F"></stop><stop
+                  offset="100%"
+                  stop-color="#FF0"></stop></linearGradient
+              ><linearGradient
+                id="lte"
+                x1="30.581%"
+                x2="65.887%"
+                y1="34.024%"
+                y2="89.175%"
+                ><stop offset="0%" stop-color="#FFA63F"></stop><stop
+                  offset="100%"
+                  stop-color="#FF0"></stop></linearGradient
+              ><linearGradient
+                id="lti"
+                x1="49.733%"
+                x2="50.558%"
+                y1="17.609%"
+                y2="99.385%"
+                ><stop offset="0%" stop-color="#FFA63F"></stop><stop
+                  offset="100%"
+                  stop-color="#FF0"></stop></linearGradient
+              ></defs
+            ><g fill="none"
+              ><path
+                fill="#000"
+                d="M63.213 215.474c-11.387-16.346-13.591-69.606 12.947-102.39C89.292 97.383 92.69 86.455 93.7 71.67c.734-16.805-11.846-66.851 35.537-70.616 48.027-3.857 45.364 43.526 45.088 68.596-.183 21.12 15.52 33.15 26.355 49.68 19.927 30.303 18.274 82.461-3.765 110.745-27.916 35.354-51.791 20.018-67.678 21.304-29.752 1.745-30.762 17.54-66.024-35.905"
+              ></path><path
+                fill="url(#lt6)"
+                d="M81.027 145.684c6.52-14.785 20.386-40.772 20.662-60.883 0-15.978 47.843-19.835 51.7-3.856 3.856 15.978 13.59 39.853 19.834 51.424 6.245 11.478 24.335 48.118 5.051 80.074-17.356 28.284-69.973 50.69-98.073-3.856-9.55-18.917-7.806-42.333.826-62.903"
+              ></path><path
+                fill="url(#lt8)"
+                d="M166.428 151.285c0 16.162-15.519 37.1-42.15 36.916-27.456.183-39.118-20.754-39.118-36.916 0-16.161 18.182-29.293 40.588-29.293 22.498.092 40.68 13.132 40.68 29.293"
+              ></path><path
+                fill="#000"
+                stroke="#000"
+                stroke-width=".977"
+                d="M176.805 117.86c13.59 11.02 38.292 49.587 2.204 74.748-11.846 7.806 10.468 32.508 23.049 19.927 43.618-43.894-1.102-94.308-16.53-111.664-13.774-15.151-25.987 3.49-8.723 16.989z"
+              ></path><path
+                fill="#000"
+                stroke="#000"
+                stroke-width="1.25"
+                d="M79.925 122.727c-8.907 14.509-30.211 48.669-1.652 66.484 38.384 23.6 27.548 47.108-7.53 25.895-49.404-29.568-5.97-89.257 13.774-112.03 22.59-25.529 4.316 4.683-4.592 19.65z"
+              ></path><path
+                fill="url(#ltc)"
+                stroke="#E68C3F"
+                stroke-width="6.25"
+                d="M51.835 258.542c-20.57-10.928-50.414 2.112-39.578-27.457 2.204-6.704-3.214-16.805.275-23.325 4.133-7.989 13.04-6.244 18.366-11.57 5.234-5.51 8.54-15.06 18.366-13.59 9.734 1.468 16.254 13.406 23.049 28.099 5.05 10.468 22.865 25.253 21.672 37.007-1.47 17.998-21.948 21.396-42.15 10.836z"
+                transform="translate(10)"></path><path
+                fill="url(#lte)"
+                stroke="#E68C3F"
+                stroke-width="6.251"
+                d="M194.445 253.49c15.06-18.273 48.578-14.508 25.988-39.577-4.775-5.418-3.306-16.989-9.183-21.947-6.887-6.061-14.509-1.102-21.488-4.224-6.979-3.398-14.325-9.918-22.865-5.327-8.54 4.684-9.459 16.805-10.285 32.783-.735 11.479-11.203 30.671-5.602 41.231 8.081 16.346 29.11 14.142 43.435-2.938z"
+                transform="translate(10)"></path><path
+                fill="url(#lti)"
+                stroke="#E68C3F"
+                stroke-width="3.75"
+                d="M97.107 66.344c3.673-3.398 12.58-13.774 29.477-2.939 3.122 2.02 5.693 2.204 11.662 4.775 12.03 4.96 6.336 16.897-6.52 20.937-5.51 1.745-10.468 8.449-20.386 7.806-8.54-.46-10.744-6.06-15.978-9.091-9.275-5.234-10.652-12.305-5.602-16.07 5.051-3.765 6.98-5.143 7.347-5.418z"
+                transform="translate(10)"></path><path
+                fill="#000"
+                d="M133.186 57.712c-.092 5.234 2.48 9.458 5.877 9.458 3.306 0 6.153-4.224 6.245-9.366.091-5.234-2.48-9.459-5.878-9.459-3.397 0-6.152 4.225-6.244 9.367m-21.212.092c.459 4.316-1.194 7.989-3.582 8.356-2.387.276-4.683-2.938-5.142-7.254-.46-4.316 1.194-7.99 3.581-8.357 2.388-.275 4.684 2.939 5.143 7.255"
+              ></path></g
+            ></svg
+          >
+          <h2 class="platform-name">Linux</h2>
+        </div>
+        <div class="download-cards">
+          <a
+            class="download-card"
+            data-asset="x86_64.AppImage"
+            href={RELEASES_URL}
+          >
+            <span class="card-arch">x86_64</span>
+            <span class="card-format">AppImage</span>
+          </a>
+        </div>
+        <div class="cli-install">
+          <span class="cli-install-label">Or install from the AUR</span>
+          <div class="cmd-block">
+            <span class="cmd-prompt">$</span><code>yay -S t3code-bin</code>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <p class="releases-link">
+      Looking for older versions? Check the
+      <a
+        href="https://github.com/pingdotgg/t3code/releases"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        GitHub releases page<span aria-hidden="true"> &#8599;</span>
+      </a>
+    </p>
   </div>
 </Layout>
 
@@ -73,7 +245,8 @@ import { RELEASES_URL } from "../lib/releases";
 
   async function init() {
     const versionLabel = document.getElementById("version-label");
-    const cards = document.querySelectorAll<HTMLAnchorElement>(".download-card");
+    const cards =
+      document.querySelectorAll<HTMLAnchorElement>(".download-card");
 
     try {
       const release = await fetchLatestRelease();
@@ -82,7 +255,9 @@ import { RELEASES_URL } from "../lib/releases";
         versionLabel.textContent = `Latest (${release.tag_name})`;
       }
 
-      const changelogLink = document.getElementById("changelog-link") as HTMLAnchorElement | null;
+      const changelogLink = document.getElementById(
+        "changelog-link",
+      ) as HTMLAnchorElement | null;
       if (changelogLink && release.html_url) {
         changelogLink.href = release.html_url;
         changelogLink.style.display = "";
@@ -92,7 +267,9 @@ import { RELEASES_URL } from "../lib/releases";
         const suffix = card.dataset.asset;
         if (!suffix) return;
 
-        const match = (release.assets ?? []).find((a) => a.name.endsWith(`-${suffix}`));
+        const match = (release.assets ?? []).find((a) =>
+          a.name.endsWith(`-${suffix}`),
+        );
         if (match) {
           card.href = match.browser_download_url;
         } else {
@@ -109,7 +286,41 @@ import { RELEASES_URL } from "../lib/releases";
     }
   }
 
+  const COPY_ICON_SVG = `<svg class="cmd-copy-icon cmd-copy-icon--default" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="13" height="13" x="9" y="9" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>`;
+  const CHECK_ICON_SVG = `<svg class="cmd-copy-icon cmd-copy-icon--success" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>`;
+
+  function initCopyButtons() {
+    document.querySelectorAll<HTMLElement>(".cmd-block").forEach((block) => {
+      const code = block.querySelector("code");
+      if (!code) return;
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "cmd-copy";
+      button.title = "Copy command";
+      button.setAttribute("aria-label", "Copy command to clipboard");
+      button.innerHTML = COPY_ICON_SVG + CHECK_ICON_SVG;
+
+      let resetTimer: number | undefined;
+      button.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(code.textContent ?? "");
+          button.classList.add("is-copied");
+          if (resetTimer !== undefined) window.clearTimeout(resetTimer);
+          resetTimer = window.setTimeout(() => {
+            button.classList.remove("is-copied");
+          }, 1600);
+        } catch {
+          // Ignore clipboard failures (insecure context, denied permission).
+        }
+      });
+
+      block.appendChild(button);
+    });
+  }
+
   init();
+  initCopyButtons();
 </script>
 
 <style>
@@ -137,12 +348,151 @@ import { RELEASES_URL } from "../lib/releases";
   .subheading {
     font-size: 0.9rem;
     color: var(--fg-dim);
-    margin-bottom: 3.5rem;
+    margin-bottom: 2rem;
     opacity: 0;
     animation: fade-in 1s ease-out 0.1s forwards;
     display: flex;
     align-items: center;
     gap: 0.75rem;
+  }
+
+  /* ── Run-without-install callout ── */
+
+  .cli-callout {
+    width: 100%;
+    max-width: 720px;
+    margin-bottom: 2.5rem;
+    padding: 1.1rem 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.025),
+      rgba(255, 255, 255, 0)
+    );
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    opacity: 0;
+    animation: fade-in 1s ease-out 0.15s forwards;
+  }
+
+  .cli-callout-meta {
+    flex: 1 1 220px;
+    min-width: 0;
+  }
+
+  .cli-callout-title {
+    font-weight: 500;
+    font-size: 1rem;
+    letter-spacing: -0.01em;
+    margin-bottom: 0.25rem;
+  }
+
+  .cli-callout-desc {
+    font-size: 0.825rem;
+    color: var(--fg-dim);
+    line-height: 1.4;
+    letter-spacing: -0.005em;
+  }
+
+  .cli-callout .cmd-block {
+    flex: 1 1 220px;
+  }
+
+  /* ── Shared command block ── */
+
+  .cmd-block {
+    position: relative;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    padding: 0.55rem 2.6rem 0.55rem 0.9rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    background: rgba(0, 0, 0, 0.25);
+    color: var(--fg);
+    overflow-x: auto;
+    display: flex;
+    align-items: center;
+  }
+
+  .cmd-block code {
+    font-family: inherit;
+    white-space: pre;
+  }
+
+  .cmd-prompt {
+    color: var(--accent);
+    margin-right: 0.55rem;
+    user-select: none;
+  }
+
+  :global(.cmd-copy) {
+    position: absolute;
+    right: 0.35rem;
+    top: 50%;
+    transform: translateY(-50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    color: var(--fg-dim);
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition:
+      color 0.18s ease,
+      background 0.18s ease,
+      border-color 0.18s ease;
+  }
+
+  :global(.cmd-copy:hover),
+  :global(.cmd-copy:focus-visible) {
+    color: var(--fg);
+    background: rgba(255, 255, 255, 0.08);
+    border-color: var(--border);
+  }
+
+  :global(.cmd-copy-icon) {
+    width: 14px;
+    height: 14px;
+    transition:
+      opacity 0.18s ease,
+      transform 0.18s ease;
+  }
+
+  :global(.cmd-copy-icon--success) {
+    position: absolute;
+    color: var(--ok);
+    opacity: 0;
+    transform: scale(0.7);
+  }
+
+  :global(.cmd-copy.is-copied .cmd-copy-icon--default) {
+    opacity: 0;
+    transform: scale(0.7);
+  }
+
+  :global(.cmd-copy.is-copied .cmd-copy-icon--success) {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  /* ── Per-platform CLI install ── */
+
+  .cli-install {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    margin-top: 0.25rem;
+  }
+
+  .cli-install-label {
+    font-size: 0.78rem;
+    color: var(--fg-dim);
   }
 
   .changelog-link {
@@ -151,7 +501,9 @@ import { RELEASES_URL } from "../lib/releases";
     text-decoration: underline;
     text-decoration-color: rgba(161, 161, 170, 0.4);
     text-underline-offset: 3px;
-    transition: color 0.3s ease, text-decoration-color 0.3s ease;
+    transition:
+      color 0.3s ease,
+      text-decoration-color 0.3s ease;
   }
 
   .changelog-link:hover {
@@ -214,7 +566,10 @@ import { RELEASES_URL } from "../lib/releases";
     border-radius: 10px;
     border: 1px solid var(--border);
     background: rgba(255, 255, 255, 0.02);
-    transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+    transition:
+      background 0.2s ease,
+      border-color 0.2s ease,
+      transform 0.2s ease;
   }
 
   .download-card:hover {
@@ -252,7 +607,9 @@ import { RELEASES_URL } from "../lib/releases";
     text-decoration: underline;
     text-decoration-color: rgba(161, 161, 170, 0.4);
     text-underline-offset: 3px;
-    transition: color 0.3s ease, text-decoration-color 0.3s ease;
+    transition:
+      color 0.3s ease,
+      text-decoration-color 0.3s ease;
   }
 
   .releases-link a:hover {

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -20,7 +20,7 @@ const mobileEndorsementRows = [
   <section class="hero">
     <div class="hero-grid" aria-hidden="true"></div>
 
-    <div class="container hero-float" aria-hidden="true">
+    <div class="hero-float" aria-hidden="true">
       <span class="hero-float-mark hf-claude" title="Claude Code">
         <img src="/harnesses/claude-ai-icon.svg" alt="" />
       </span>
@@ -923,6 +923,10 @@ const mobileEndorsementRows = [
     inset: 0;
     pointer-events: none;
     z-index: 1;
+    width: 100%;
+    max-width: 1440px;
+    margin: 0 auto;
+    padding: 0 32px;
   }
 
   .hero-float-mark {

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -20,7 +20,7 @@ const mobileEndorsementRows = [
   <section class="hero">
     <div class="hero-grid" aria-hidden="true"></div>
 
-    <div class="hero-float" aria-hidden="true">
+    <div class="container hero-float" aria-hidden="true">
       <span class="hero-float-mark hf-claude" title="Claude Code">
         <img src="/harnesses/claude-ai-icon.svg" alt="" />
       </span>
@@ -51,14 +51,45 @@ const mobileEndorsementRows = [
           href="https://github.com/pingdotgg/t3code/releases"
           class="btn btn-primary btn-lg"
         >
-          <svg class="dl-icon dl-icon--apple" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 814 1000" aria-hidden="true"><path fill="currentColor" d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg>
-          <svg class="dl-icon dl-icon--windows" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88" aria-hidden="true"><path fill="currentColor" d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"/></svg>
+          <svg
+            class="dl-icon dl-icon--apple"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 814 1000"
+            aria-hidden="true"
+            ><path
+              fill="currentColor"
+              d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"
+            ></path></svg
+          >
+          <svg
+            class="dl-icon dl-icon--windows"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 88 88"
+            aria-hidden="true"
+            ><path
+              fill="currentColor"
+              d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"
+            ></path></svg
+          >
           <TuxIcon class="dl-icon dl-icon--linux" idPrefix="hero-linux-" />
           <span id="download-label">Download for macOS</span>
         </a>
-        <a href="https://github.com/pingdotgg/t3code" target="_blank" rel="noopener noreferrer" class="btn btn-ghost btn-lg">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-            <path d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.93c.58.1.79-.25.79-.56v-2c-3.2.69-3.88-1.37-3.88-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.33.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.67 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 015.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.74.8 1.18 1.83 1.18 3.08 0 4.41-2.7 5.38-5.27 5.66.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"/>
+        <a
+          href="https://github.com/pingdotgg/t3code"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="btn btn-ghost btn-lg"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.93c.58.1.79-.25.79-.56v-2c-3.2.69-3.88-1.37-3.88-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.33.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.67 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 015.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.74.8 1.18 1.83 1.18 3.08 0 4.41-2.7 5.38-5.27 5.66.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"
+            ></path>
           </svg>
           Star on GitHub
         </a>
@@ -80,7 +111,11 @@ const mobileEndorsementRows = [
   </section>
 
   <!-- ── Endorsements ─────────────────────────────────────────── -->
-  <section id="endorsements" class="sec-endorsements" aria-labelledby="endorsements-title">
+  <section
+    id="endorsements"
+    class="sec-endorsements"
+    aria-labelledby="endorsements-title"
+  >
     <div class="container">
       <div class="endorsements-head">
         <h2 id="endorsements-title">Developers love T3 Code</h2>
@@ -88,80 +123,92 @@ const mobileEndorsementRows = [
       </div>
     </div>
 
-    <div class="endorsement-carousel endorsement-carousel--desktop" aria-label="Developer endorsements">
-        {
-          desktopEndorsementRows.map((row, rowIndex) => (
-            <div class:list={["endorsement-row", rowIndex === 1 && "is-reverse"]}>
-              <div class="endorsement-track">
-                {[0, 1].map((groupIndex) => (
-                  <div class="endorsement-track-group" aria-hidden={groupIndex === 1 ? "true" : undefined}>
-                    {row.map((tweet) => (
-                      <a
-                        class="endorsement-card"
-                        href={tweet.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`Read ${tweet.handle}'s post on X`}
-                        tabindex={groupIndex === 1 ? "-1" : undefined}
-                      >
-                        <div class="endorsement-author">
-                          <img
-                            src={`/pfps/${tweet.handle}.webp`}
-                            alt=""
-                            width="28"
-                            height="28"
-                            loading="lazy"
-                            decoding="async"
-                          />
-                          <div class="endorsement-handle">@{tweet.handle}</div>
-                        </div>
-                        <p>{tweet.excerpt ?? tweet.content}</p>
-                      </a>
-                    ))}
-                  </div>
-                ))}
-              </div>
+    <div
+      class="endorsement-carousel endorsement-carousel--desktop"
+      aria-label="Developer endorsements"
+    >
+      {
+        desktopEndorsementRows.map((row, rowIndex) => (
+          <div class:list={["endorsement-row", rowIndex === 1 && "is-reverse"]}>
+            <div class="endorsement-track">
+              {[0, 1].map((groupIndex) => (
+                <div
+                  class="endorsement-track-group"
+                  aria-hidden={groupIndex === 1 ? "true" : undefined}
+                >
+                  {row.map((tweet) => (
+                    <a
+                      class="endorsement-card"
+                      href={tweet.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Read ${tweet.handle}'s post on X`}
+                      tabindex={groupIndex === 1 ? "-1" : undefined}
+                    >
+                      <div class="endorsement-author">
+                        <img
+                          src={`/pfps/${tweet.handle}.webp`}
+                          alt=""
+                          width="28"
+                          height="28"
+                          loading="lazy"
+                          decoding="async"
+                        />
+                        <div class="endorsement-handle">@{tweet.handle}</div>
+                      </div>
+                      <p>{tweet.excerpt ?? tweet.content}</p>
+                    </a>
+                  ))}
+                </div>
+              ))}
             </div>
-          ))
-        }
+          </div>
+        ))
+      }
     </div>
 
-    <div class="endorsement-carousel endorsement-carousel--mobile" aria-label="Developer endorsements">
-        {
-          mobileEndorsementRows.map((row, rowIndex) => (
-            <div class:list={["endorsement-row", rowIndex === 1 && "is-reverse"]}>
-              <div class="endorsement-track">
-                {[0, 1].map((groupIndex) => (
-                  <div class="endorsement-track-group" aria-hidden={groupIndex === 1 ? "true" : undefined}>
-                    {row.map((tweet) => (
-                      <a
-                        class="endorsement-card"
-                        href={tweet.link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`Read ${tweet.handle}'s post on X`}
-                        tabindex={groupIndex === 1 ? "-1" : undefined}
-                      >
-                        <div class="endorsement-author">
-                          <img
-                            src={`/pfps/${tweet.handle}.webp`}
-                            alt=""
-                            width="28"
-                            height="28"
-                            loading="lazy"
-                            decoding="async"
-                          />
-                          <div class="endorsement-handle">@{tweet.handle}</div>
-                        </div>
-                        <p>{tweet.excerpt ?? tweet.content}</p>
-                      </a>
-                    ))}
-                  </div>
-                ))}
-              </div>
+    <div
+      class="endorsement-carousel endorsement-carousel--mobile"
+      aria-label="Developer endorsements"
+    >
+      {
+        mobileEndorsementRows.map((row, rowIndex) => (
+          <div class:list={["endorsement-row", rowIndex === 1 && "is-reverse"]}>
+            <div class="endorsement-track">
+              {[0, 1].map((groupIndex) => (
+                <div
+                  class="endorsement-track-group"
+                  aria-hidden={groupIndex === 1 ? "true" : undefined}
+                >
+                  {row.map((tweet) => (
+                    <a
+                      class="endorsement-card"
+                      href={tweet.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`Read ${tweet.handle}'s post on X`}
+                      tabindex={groupIndex === 1 ? "-1" : undefined}
+                    >
+                      <div class="endorsement-author">
+                        <img
+                          src={`/pfps/${tweet.handle}.webp`}
+                          alt=""
+                          width="28"
+                          height="28"
+                          loading="lazy"
+                          decoding="async"
+                        />
+                        <div class="endorsement-handle">@{tweet.handle}</div>
+                      </div>
+                      <p>{tweet.excerpt ?? tweet.content}</p>
+                    </a>
+                  ))}
+                </div>
+              ))}
             </div>
-          ))
-        }
+          </div>
+        ))
+      }
     </div>
   </section>
 
@@ -172,35 +219,43 @@ const mobileEndorsementRows = [
         <h2>Bring your own sub</h2>
         <p>
           T3 Code doesn't resell tokens. Plug in Claude Code, Codex, OpenCode,
-          or Cursor with the credentials you already have — we orchestrate
-          them, you keep your plan.
+          or Cursor with the credentials you already have — we orchestrate them,
+          you keep your plan.
         </p>
       </div>
 
       <div class="harness-grid">
         <div class="harness">
-          <div class="harness-mark"><img src="/harnesses/claude-ai-icon.svg" alt="" /></div>
+          <div class="harness-mark">
+            <img src="/harnesses/claude-ai-icon.svg" alt="" />
+          </div>
           <div class="harness-meta">
             <div class="harness-name">Claude Code</div>
             <div class="harness-tag">claude auth login</div>
           </div>
         </div>
         <div class="harness">
-          <div class="harness-mark"><img src="/harnesses/openai_dark.svg" alt="" /></div>
+          <div class="harness-mark">
+            <img src="/harnesses/openai_dark.svg" alt="" />
+          </div>
           <div class="harness-meta">
             <div class="harness-name">Codex CLI</div>
             <div class="harness-tag">codex login</div>
           </div>
         </div>
         <div class="harness">
-          <div class="harness-mark"><img src="/harnesses/opencode-dark.svg" alt="" /></div>
+          <div class="harness-mark">
+            <img src="/harnesses/opencode-dark.svg" alt="" />
+          </div>
           <div class="harness-meta">
             <div class="harness-name">OpenCode</div>
             <div class="harness-tag">opencode auth</div>
           </div>
         </div>
         <div class="harness">
-          <div class="harness-mark"><img src="/harnesses/cursor_light.svg" alt="" /></div>
+          <div class="harness-mark">
+            <img src="/harnesses/cursor_light.svg" alt="" />
+          </div>
           <div class="harness-meta">
             <div class="harness-name">Cursor</div>
             <div class="harness-tag">cursor-agent</div>
@@ -209,9 +264,42 @@ const mobileEndorsementRows = [
       </div>
 
       <div class="harness-footer">
-        <div class="harness-footer-item"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12l5 5L20 6"/></svg> No keys resold. No quota caps.</div>
-        <div class="harness-footer-item"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12l5 5L20 6"/></svg> Switch models mid-thread.</div>
-        <div class="harness-footer-item"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12l5 5L20 6"/></svg> More harnesses shipping weekly.</div>
+        <div class="harness-footer-item">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"><path d="M4 12l5 5L20 6"></path></svg
+          > No keys resold. No quota caps.
+        </div>
+        <div class="harness-footer-item">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"><path d="M4 12l5 5L20 6"></path></svg
+          > Switch models mid-thread.
+        </div>
+        <div class="harness-footer-item">
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"><path d="M4 12l5 5L20 6"></path></svg
+          > More harnesses shipping weekly.
+        </div>
       </div>
     </div>
   </section>
@@ -222,24 +310,78 @@ const mobileEndorsementRows = [
       <div class="git-visual">
         <div class="pr-card tile">
           <div class="pr-head">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.2"/><circle cx="6" cy="18" r="2.2"/><circle cx="18" cy="6" r="2.2"/><path d="M6 8v8M18 8v5a3 3 0 01-3 3h-3M13 13l-2 3 2 3"/></svg>
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              ><circle cx="6" cy="6" r="2.2"></circle><circle
+                cx="6"
+                cy="18"
+                r="2.2"></circle><circle cx="18" cy="6" r="2.2"></circle><path
+                d="M6 8v8M18 8v5a3 3 0 01-3 3h-3M13 13l-2 3 2 3"></path></svg
+            >
             <span class="pr-title">Add marketing hero animation</span>
             <span class="pr-status">Ready</span>
           </div>
           <div class="pr-meta">
-            <span><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.2"/><circle cx="6" cy="18" r="2.2"/><circle cx="18" cy="6" r="2.2"/><path d="M6 8v8M6 12a6 6 0 006-6h6"/></svg> feat/marketing-hero → main</span>
+            <span
+              ><svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                ><circle cx="6" cy="6" r="2.2"></circle><circle
+                  cx="6"
+                  cy="18"
+                  r="2.2"></circle><circle cx="18" cy="6" r="2.2"></circle><path
+                  d="M6 8v8M6 12a6 6 0 006-6h6"></path></svg
+              > feat/marketing-hero → main</span
+            >
             <span>+142 −38</span>
             <span>3 commits</span>
           </div>
           <div class="pr-files">
-            <div><code>apps/marketing/src/pages/index.astro</code> <span>+14 −2</span></div>
-            <div><code>apps/marketing/src/layouts/Layout.astro</code> <span>+8 −0</span></div>
-            <div><code>apps/marketing/public/hero.css</code> <span>+120 −36</span></div>
+            <div>
+              <code>apps/marketing/src/pages/index.astro</code>
+              <span>+14 −2</span>
+            </div>
+            <div>
+              <code>apps/marketing/src/layouts/Layout.astro</code>
+              <span>+8 −0</span>
+            </div>
+            <div>
+              <code>apps/marketing/public/hero.css</code>
+              <span>+120 −36</span>
+            </div>
           </div>
           <div class="pr-foot">
-            <button class="btn btn-ghost" style="font-size:12px;padding:6px 10px">View diff</button>
-            <button class="btn btn-primary" style="font-size:12px;padding:6px 12px">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.93c.58.1.79-.25.79-.56v-2c-3.2.69-3.88-1.37-3.88-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.33.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.67 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 015.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.74.8 1.18 1.83 1.18 3.08 0 4.41-2.7 5.38-5.27 5.66.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"/></svg>
+            <button
+              class="btn btn-ghost"
+              style="font-size:12px;padding:6px 10px">View diff</button
+            >
+            <button
+              class="btn btn-primary"
+              style="font-size:12px;padding:6px 12px"
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+                ><path
+                  d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.93c.58.1.79-.25.79-.56v-2c-3.2.69-3.88-1.37-3.88-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.33.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.67 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 015.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.74.8 1.18 1.83 1.18 3.08 0 4.41-2.7 5.38-5.27 5.66.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"
+                ></path></svg
+              >
               Open pull request
             </button>
           </div>
@@ -251,7 +393,21 @@ const mobileEndorsementRows = [
         </div>
         <div class="pr-button-shell">
           <button class="pr-button">
-            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="6" r="2.2"/><circle cx="6" cy="18" r="2.2"/><circle cx="18" cy="6" r="2.2"/><path d="M6 8v8M18 8v5a3 3 0 01-3 3h-3M13 13l-2 3 2 3"/></svg>
+            <svg
+              width="13"
+              height="13"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.6"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              ><circle cx="6" cy="6" r="2.2"></circle><circle
+                cx="6"
+                cy="18"
+                r="2.2"></circle><circle cx="18" cy="6" r="2.2"></circle><path
+                d="M6 8v8M18 8v5a3 3 0 01-3 3h-3M13 13l-2 3 2 3"></path></svg
+            >
             Commit &amp; push
             <span class="pr-button-kbd">⌘⏎</span>
           </button>
@@ -267,10 +423,54 @@ const mobileEndorsementRows = [
             changelog. No terminal dance required.
           </p>
           <ul class="checklist" style="margin-top:24px">
-            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12l5 5L20 6"/></svg> Auto-generated PR titles &amp; bodies</li>
-            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12l5 5L20 6"/></svg> Inline diff review before you push</li>
-            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12l5 5L20 6"/></svg> Draft PRs, stack PRs, amend PRs</li>
-            <li><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12l5 5L20 6"/></svg> Works with your existing GitHub auth</li>
+            <li>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"><path d="M4 12l5 5L20 6"></path></svg
+              > Auto-generated PR titles &amp; bodies
+            </li>
+            <li>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"><path d="M4 12l5 5L20 6"></path></svg
+              > Inline diff review before you push
+            </li>
+            <li>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"><path d="M4 12l5 5L20 6"></path></svg
+              > Draft PRs, stack PRs, amend PRs
+            </li>
+            <li>
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"><path d="M4 12l5 5L20 6"></path></svg
+              > Works with your existing GitHub auth
+            </li>
           </ul>
         </div>
       </div>
@@ -296,13 +496,23 @@ const mobileEndorsementRows = [
             <span class="open-term-title">~/code</span>
           </div>
           <div class="open-term-body">
-            <div><span class="prompt">$</span> gh repo fork pingdotgg/t3code --clone</div>
+            <div>
+              <span class="prompt">$</span> gh repo fork pingdotgg/t3code --clone
+            </div>
             <div class="dim">✓ Cloned t3code into ./t3code</div>
-            <div><span class="prompt">$</span> cd t3code &amp;&amp; bun install</div>
+            <div>
+              <span class="prompt">$</span> cd t3code &amp;&amp; bun install
+            </div>
             <div class="dim">✓ 1 284 packages installed in 4.2s</div>
             <div><span class="prompt">$</span> bun dev</div>
-            <div class="dim">▲ T3 Code dev server → <span class="accent">http://localhost:4001</span></div>
-            <div class="cursor"><span class="prompt">$</span><span class="caret"></span></div>
+            <div class="dim">
+              ▲ T3 Code dev server → <span class="accent"
+                >http://localhost:4001</span
+              >
+            </div>
+            <div class="cursor">
+              <span class="prompt">$</span><span class="caret"></span>
+            </div>
           </div>
         </div>
 
@@ -327,20 +537,97 @@ const mobileEndorsementRows = [
       </div>
 
       <div class="open-ctas">
-        <a class="btn btn-ghost" href="https://github.com/pingdotgg/t3code" target="_blank" rel="noopener noreferrer">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.93c.58.1.79-.25.79-.56v-2c-3.2.69-3.88-1.37-3.88-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.33.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.67 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 015.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.74.8 1.18 1.83 1.18 3.08 0 4.41-2.7 5.38-5.27 5.66.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"/></svg>
+        <a
+          class="btn btn-ghost"
+          href="https://github.com/pingdotgg/t3code"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+            ><path
+              d="M12 .5C5.65.5.5 5.65.5 12a11.5 11.5 0 007.86 10.93c.58.1.79-.25.79-.56v-2c-3.2.69-3.88-1.37-3.88-1.37-.52-1.33-1.27-1.69-1.27-1.69-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.68 1.25 3.33.96.1-.75.4-1.25.72-1.54-2.55-.29-5.24-1.27-5.24-5.67 0-1.25.45-2.28 1.18-3.08-.12-.29-.51-1.45.11-3.02 0 0 .96-.31 3.15 1.18a10.96 10.96 0 015.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.57.23 2.73.11 3.02.74.8 1.18 1.83 1.18 3.08 0 4.41-2.7 5.38-5.27 5.66.41.36.78 1.06.78 2.13v3.16c0 .31.21.67.8.56A11.5 11.5 0 0023.5 12C23.5 5.65 18.35.5 12 .5z"
+            ></path></svg
+          >
           Star on GitHub
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M8 7h9v9"/></svg>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"><path d="M7 17L17 7M8 7h9v9"></path></svg
+          >
         </a>
-        <a class="btn btn-ghost" href="https://github.com/pingdotgg/t3code/fork" target="_blank" rel="noopener noreferrer">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="6" cy="5" r="2.2"/><circle cx="18" cy="5" r="2.2"/><circle cx="12" cy="19" r="2.2"/><path d="M6 7.2v2A3 3 0 009 12.2h6A3 3 0 0018 9.2v-2M12 14v2.8"/></svg>
+        <a
+          class="btn btn-ghost"
+          href="https://github.com/pingdotgg/t3code/fork"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><circle cx="6" cy="5" r="2.2"></circle><circle
+              cx="18"
+              cy="5"
+              r="2.2"></circle><circle cx="12" cy="19" r="2.2"></circle><path
+              d="M6 7.2v2A3 3 0 009 12.2h6A3 3 0 0018 9.2v-2M12 14v2.8"
+            ></path></svg
+          >
           Fork the repo
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M8 7h9v9"/></svg>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"><path d="M7 17L17 7M8 7h9v9"></path></svg
+          >
         </a>
-        <a class="btn btn-ghost" href="https://github.com/pingdotgg/t3code/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2.5" y="4.5" width="19" height="15" rx="2"/><path d="M7 10l3 2-3 2M12 16h5"/></svg>
+        <a
+          class="btn btn-ghost"
+          href="https://github.com/pingdotgg/t3code/blob/main/CONTRIBUTING.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            ><rect x="2.5" y="4.5" width="19" height="15" rx="2"></rect><path
+              d="M7 10l3 2-3 2M12 16h5"></path></svg
+          >
           Read CONTRIBUTING.md
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M8 7h9v9"/></svg>
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"><path d="M7 17L17 7M8 7h9v9"></path></svg
+          >
         </a>
       </div>
     </div>
@@ -357,20 +644,48 @@ const mobileEndorsementRows = [
         you already pay for, and let your agents get to work.
       </p>
       <div class="cta-actions">
-        <a id="cta-download-btn" class="btn btn-primary btn-lg" href="https://github.com/pingdotgg/t3code/releases">
-          <svg class="dl-icon dl-icon--apple" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 814 1000" aria-hidden="true"><path fill="currentColor" d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"/></svg>
-          <svg class="dl-icon dl-icon--windows" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88 88" aria-hidden="true"><path fill="currentColor" d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"/></svg>
+        <a
+          id="cta-download-btn"
+          class="btn btn-primary btn-lg"
+          href="https://github.com/pingdotgg/t3code/releases"
+        >
+          <svg
+            class="dl-icon dl-icon--apple"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 814 1000"
+            aria-hidden="true"
+            ><path
+              fill="currentColor"
+              d="M788.1 340.9c-5.8 4.5-108.2 62.2-108.2 190.5 0 148.4 130.3 200.9 134.2 202.2-.6 3.2-20.7 71.9-68.7 141.9-42.8 61.6-87.5 123.1-155.5 123.1s-85.5-39.5-164-39.5c-76.5 0-103.7 40.8-165.9 40.8s-105.6-57-155.5-127C46.7 790.7 0 663 0 541.8c0-194.4 126.4-297.5 250.8-297.5 66.1 0 121.2 43.4 162.7 43.4 39.5 0 101.1-46 176.3-46 28.5 0 130.9 2.6 198.3 99.2zm-234-181.5c31.1-36.9 53.1-88.1 53.1-139.3 0-7.1-.6-14.3-1.9-20.1-50.6 1.9-110.8 33.7-147.1 75.8-28.5 32.4-55.1 83.6-55.1 135.5 0 7.8 1.3 15.6 1.9 18.1 3.2.6 8.4 1.3 13.6 1.3 45.4 0 102.5-30.4 135.5-71.3z"
+            ></path></svg
+          >
+          <svg
+            class="dl-icon dl-icon--windows"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 88 88"
+            aria-hidden="true"
+            ><path
+              fill="currentColor"
+              d="m0 12.402 35.687-4.86.016 34.423-35.67.203zm35.67 33.529.028 34.453L.028 75.48.026 45.7zm4.326-39.025L87.314 0v41.527l-47.318.376zm47.329 39.349-.011 41.34-47.318-6.678-.066-34.739z"
+            ></path></svg
+          >
           <TuxIcon class="dl-icon dl-icon--linux" idPrefix="cta-linux-" />
           <span id="cta-download-label">Download for macOS</span>
         </a>
-        <a class="btn btn-ghost btn-lg" href="/download">Windows · Linux · other</a>
+        <a id="cta-other-link" class="btn btn-ghost btn-lg" href="/download"
+          >Windows · Linux</a
+        >
       </div>
     </div>
   </section>
 </Layout>
 
 <script>
-  import { fetchLatestRelease, RELEASES_URL, type ReleaseAsset } from "../lib/releases";
+  import {
+    fetchLatestRelease,
+    RELEASES_URL,
+    type ReleaseAsset,
+  } from "../lib/releases";
 
   type Platform = { os: "mac" | "win" | "linux"; label: string; arch?: string };
 
@@ -384,32 +699,60 @@ const mobileEndorsementRows = [
     return null;
   }
 
-  function pickAsset(assets: ReleaseAsset[], platform: Platform): string | null {
+  function pickAsset(
+    assets: ReleaseAsset[],
+    platform: Platform,
+  ): string | null {
     if (platform.os === "win") {
-      return assets.find((a) => a.name.endsWith("-x64.exe"))?.browser_download_url ?? null;
+      return (
+        assets.find((a) => a.name.endsWith("-x64.exe"))?.browser_download_url ??
+        null
+      );
     }
     if (platform.os === "mac") {
-      const preferred = assets.find((a) => a.name.endsWith(`-${platform.arch}.dmg`));
+      const preferred = assets.find((a) =>
+        a.name.endsWith(`-${platform.arch}.dmg`),
+      );
       const fallback = assets.find((a) => a.name.endsWith(".dmg"));
       return (preferred ?? fallback)?.browser_download_url ?? null;
     }
     if (platform.os === "linux") {
-      return assets.find((a) => a.name.endsWith(".AppImage"))?.browser_download_url ?? null;
+      return (
+        assets.find((a) => a.name.endsWith(".AppImage"))
+          ?.browser_download_url ?? null
+      );
     }
     return null;
   }
 
+  const OTHER_PLATFORM_NAMES: Record<Platform["os"], string> = {
+    mac: "macOS",
+    win: "Windows",
+    linux: "Linux",
+  };
+
   async function init() {
-    const btn = document.getElementById("download-btn") as HTMLAnchorElement | null;
+    const btn = document.getElementById(
+      "download-btn",
+    ) as HTMLAnchorElement | null;
     const label = document.getElementById("download-label");
-    const ctaBtn = document.getElementById("cta-download-btn") as HTMLAnchorElement | null;
+    const ctaBtn = document.getElementById(
+      "cta-download-btn",
+    ) as HTMLAnchorElement | null;
     const ctaLabel = document.getElementById("cta-download-label");
+    const ctaOther = document.getElementById("cta-other-link");
 
     const platform = detectPlatform();
     if (!platform) return;
     document.documentElement.dataset.platform = platform.os;
     if (label) label.textContent = platform.label;
     if (ctaLabel) ctaLabel.textContent = platform.label;
+    if (ctaOther) {
+      const others = (Object.keys(OTHER_PLATFORM_NAMES) as Platform["os"][])
+        .filter((os) => os !== platform.os)
+        .map((os) => OTHER_PLATFORM_NAMES[os]);
+      ctaOther.textContent = others.join(" · ");
+    }
 
     try {
       const release = await fetchLatestRelease();
@@ -501,11 +844,27 @@ const mobileEndorsementRows = [
     inset: 0;
     pointer-events: none;
     background-image:
-      linear-gradient(to right, rgba(255, 255, 255, 0.035) 1px, transparent 1px),
-      linear-gradient(to bottom, rgba(255, 255, 255, 0.035) 1px, transparent 1px);
+      linear-gradient(
+        to right,
+        rgba(255, 255, 255, 0.035) 1px,
+        transparent 1px
+      ),
+      linear-gradient(
+        to bottom,
+        rgba(255, 255, 255, 0.035) 1px,
+        transparent 1px
+      );
     background-size: 48px 48px;
-    mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 40%, transparent 100%);
-    -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 40%, black 40%, transparent 100%);
+    mask-image: radial-gradient(
+      ellipse 80% 60% at 50% 40%,
+      black 40%,
+      transparent 100%
+    );
+    -webkit-mask-image: radial-gradient(
+      ellipse 80% 60% at 50% 40%,
+      black 40%,
+      transparent 100%
+    );
   }
 
   .hero-inner {
@@ -545,10 +904,18 @@ const mobileEndorsementRows = [
     flex-shrink: 0;
   }
 
-  :global([data-platform="mac"]) .dl-icon--apple { display: block; }
-  :global([data-platform="win"]) .dl-icon--windows { display: block; }
-  :global([data-platform="linux"]) .dl-icon--linux { display: block; }
-  :global(:not([data-platform])) .dl-icon--apple { display: block; }
+  :global(html[data-platform="mac"]) .dl-icon--apple {
+    display: block;
+  }
+  :global(html[data-platform="win"]) .dl-icon--windows {
+    display: block;
+  }
+  :global(html[data-platform="linux"]) .dl-icon--linux {
+    display: block;
+  }
+  :global(html:not([data-platform])) .dl-icon--apple {
+    display: block;
+  }
 
   /* Floating harness marks */
   .hero-float {
@@ -582,18 +949,77 @@ const mobileEndorsementRows = [
     object-fit: contain;
   }
 
-  .hero-float-mark.hf-claude   { background: radial-gradient(circle at 30% 25%, rgba(217, 119, 87, 0.22), rgba(20, 20, 24, 0.92) 65%); top: 8%;  left: 7%;  animation-delay: 0s;    transform: rotate(-8deg); }
-  .hero-float-mark.hf-codex    { background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.08), rgba(20, 20, 24, 0.92) 65%); top: 6%;  right: 7%; animation-delay: -2.5s; transform: rotate(6deg); }
-  .hero-float-mark.hf-opencode { background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.06), rgba(20, 20, 24, 0.92) 65%); top: 32%; left: 5%;  animation-delay: -5s;   transform: rotate(4deg); }
-  .hero-float-mark.hf-cursor   { background: radial-gradient(circle at 30% 25%, rgba(255, 255, 255, 0.08), rgba(20, 20, 24, 0.92) 65%); top: 30%; right: 5%; animation-delay: -7s;   transform: rotate(-5deg); }
+  .hero-float-mark.hf-claude {
+    background: radial-gradient(
+      circle at 30% 25%,
+      rgba(217, 119, 87, 0.22),
+      rgba(20, 20, 24, 0.92) 65%
+    );
+    top: 8%;
+    left: 7%;
+    animation-delay: 0s;
+    transform: rotate(-8deg);
+  }
+  .hero-float-mark.hf-codex {
+    background: radial-gradient(
+      circle at 30% 25%,
+      rgba(255, 255, 255, 0.08),
+      rgba(20, 20, 24, 0.92) 65%
+    );
+    top: 6%;
+    right: 7%;
+    animation-delay: -2.5s;
+    transform: rotate(6deg);
+  }
+  .hero-float-mark.hf-opencode {
+    background: radial-gradient(
+      circle at 30% 25%,
+      rgba(255, 255, 255, 0.06),
+      rgba(20, 20, 24, 0.92) 65%
+    );
+    top: 32%;
+    left: 5%;
+    animation-delay: -5s;
+    transform: rotate(4deg);
+  }
+  .hero-float-mark.hf-cursor {
+    background: radial-gradient(
+      circle at 30% 25%,
+      rgba(255, 255, 255, 0.08),
+      rgba(20, 20, 24, 0.92) 65%
+    );
+    top: 30%;
+    right: 5%;
+    animation-delay: -7s;
+    transform: rotate(-5deg);
+  }
 
   @media (max-width: 1180px) {
-    .hero-float-mark { width: 76px; height: 76px; border-radius: 20px; }
-    .hero-float-mark img { width: 42px; height: 42px; }
-    .hero-float-mark.hf-claude   { top: 4%;  left: 3%; }
-    .hero-float-mark.hf-codex    { top: 2%;  right: 3%; }
-    .hero-float-mark.hf-opencode { top: 26%; left: 2%; }
-    .hero-float-mark.hf-cursor   { top: 24%; right: 2%; }
+    .hero-float-mark {
+      width: 76px;
+      height: 76px;
+      border-radius: 20px;
+    }
+    .hero-float-mark img {
+      width: 42px;
+      height: 42px;
+    }
+    .hero-float-mark.hf-claude {
+      top: 4%;
+      left: 3%;
+    }
+    .hero-float-mark.hf-codex {
+      top: 2%;
+      right: 3%;
+    }
+    .hero-float-mark.hf-opencode {
+      top: 26%;
+      left: 2%;
+    }
+    .hero-float-mark.hf-cursor {
+      top: 24%;
+      right: 2%;
+    }
   }
 
   @media (max-width: 820px) {
@@ -691,7 +1117,9 @@ const mobileEndorsementRows = [
   }
 
   /* ── Harnesses ─────────────────────────────────────────── */
-  .sec-harness { background: #09090b; }
+  .sec-harness {
+    background: #09090b;
+  }
 
   .harness-grid {
     display: grid;
@@ -704,42 +1132,74 @@ const mobileEndorsementRows = [
 
   .harness {
     padding: 22px 20px;
-    display: flex; align-items: center; gap: 14px;
+    display: flex;
+    align-items: center;
+    gap: 14px;
     border-right: 1px solid var(--border);
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.015), transparent);
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 0.015),
+      transparent
+    );
     transition: background 0.2s ease;
   }
-  .harness:last-child { border-right: 0; }
-  .harness:hover { background: rgba(255, 255, 255, 0.025); }
+  .harness:last-child {
+    border-right: 0;
+  }
+  .harness:hover {
+    background: rgba(255, 255, 255, 0.025);
+  }
 
   .harness-mark {
-    color: var(--fg); opacity: 0.95;
-    flex-shrink: 0; width: 28px; height: 28px;
-    display: grid; place-items: center;
+    color: var(--fg);
+    opacity: 0.95;
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
   }
-  .harness-mark img { width: 22px; height: 22px; object-fit: contain; }
+  .harness-mark img {
+    width: 22px;
+    height: 22px;
+    object-fit: contain;
+  }
 
-  .harness-meta { flex: 1; min-width: 0; }
+  .harness-meta {
+    flex: 1;
+    min-width: 0;
+  }
   .harness-name {
-    font-size: 14px; font-weight: 500;
-    letter-spacing: -0.01em; margin-bottom: 2px;
+    font-size: 14px;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+    margin-bottom: 2px;
   }
   .harness-tag {
     font-family: var(--font-mono);
-    font-size: 11px; color: var(--fg-dim);
+    font-size: 11px;
+    color: var(--fg-dim);
   }
 
   .harness-footer {
-    display: flex; gap: 24px; flex-wrap: wrap;
-    margin-top: 28px; padding-top: 24px;
+    display: flex;
+    gap: 24px;
+    flex-wrap: wrap;
+    margin-top: 28px;
+    padding-top: 24px;
     border-top: 1px dashed var(--border);
-    font-size: 13px; color: var(--fg-muted);
-  }
-  .harness-footer-item {
-    display: inline-flex; gap: 8px; align-items: center;
+    font-size: 13px;
     color: var(--fg-muted);
   }
-  .harness-footer-item svg { color: var(--ok); }
+  .harness-footer-item {
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+    color: var(--fg-muted);
+  }
+  .harness-footer-item svg {
+    color: var(--ok);
+  }
 
   /* ── Endorsements ─────────────────────────────────────── */
   .sec-endorsements {
@@ -886,75 +1346,128 @@ const mobileEndorsementRows = [
   .git-inner {
     display: grid;
     grid-template-columns: 1.1fr 1fr;
-    gap: 64px; align-items: center;
+    gap: 64px;
+    align-items: center;
   }
 
   .git-visual {
     position: relative;
-    display: flex; flex-direction: column;
-    align-items: stretch; gap: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 20px;
   }
 
-  .pr-card { padding: 20px; }
+  .pr-card {
+    padding: 20px;
+  }
   .pr-head {
-    display: flex; align-items: center; gap: 10px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
     margin-bottom: 12px;
   }
-  .pr-head svg { color: var(--ok); }
-  .pr-title { font-weight: 500; font-size: 15px; flex: 1; }
+  .pr-head svg {
+    color: var(--ok);
+  }
+  .pr-title {
+    font-weight: 500;
+    font-size: 15px;
+    flex: 1;
+  }
   .pr-status {
-    font-family: var(--font-mono); font-size: 10px;
-    color: var(--ok); padding: 2px 8px;
-    border: 1px solid var(--ok); border-radius: 999px;
-    letter-spacing: 0.08em; text-transform: uppercase;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--ok);
+    padding: 2px 8px;
+    border: 1px solid var(--ok);
+    border-radius: 999px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
   .pr-meta {
-    display: flex; gap: 14px;
-    font-family: var(--font-mono); font-size: 11px;
-    color: var(--fg-dim); margin-bottom: 14px; flex-wrap: wrap;
+    display: flex;
+    gap: 14px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg-dim);
+    margin-bottom: 14px;
+    flex-wrap: wrap;
   }
-  .pr-meta span { display: inline-flex; align-items: center; gap: 5px; }
+  .pr-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+  }
   .pr-files {
-    border: 1px solid var(--border); border-radius: 8px;
-    overflow: hidden; margin-bottom: 16px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    margin-bottom: 16px;
   }
   .pr-files > div {
-    display: flex; justify-content: space-between;
-    padding: 8px 12px; font-family: var(--font-mono);
-    font-size: 11px; border-top: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 12px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    border-top: 1px solid var(--border);
     color: var(--fg-muted);
   }
-  .pr-files > div:first-child { border-top: 0; }
-  .pr-files span { color: var(--fg-dim); }
-  .pr-foot { display: flex; justify-content: flex-end; gap: 8px; }
+  .pr-files > div:first-child {
+    border-top: 0;
+  }
+  .pr-files span {
+    color: var(--fg-dim);
+  }
+  .pr-foot {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
 
   .pr-trail {
-    display: flex; flex-direction: column;
-    align-items: center; justify-content: center;
-    gap: 0; margin: -4px 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 0;
+    margin: -4px 0;
   }
   .pr-trail-dot {
-    width: 8px; height: 8px; border-radius: 999px;
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
     background: var(--border-strong);
   }
   .pr-trail-line {
-    width: 1px; height: 28px;
+    width: 1px;
+    height: 28px;
     background: linear-gradient(180deg, var(--border-strong), var(--accent));
   }
 
-  .pr-button-shell { display: flex; justify-content: center; }
+  .pr-button-shell {
+    display: flex;
+    justify-content: center;
+  }
   .pr-button {
-    display: inline-flex; align-items: center; gap: 10px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
     padding: 12px 20px;
-    background: var(--fg); color: #09090b;
-    font-weight: 600; font-size: 13px;
+    background: var(--fg);
+    color: #09090b;
+    font-weight: 600;
+    font-size: 13px;
     border-radius: 10px;
     box-shadow: 0 8px 24px -8px rgba(255, 255, 255, 0.2);
   }
   .pr-button-kbd {
-    font-family: var(--font-mono); font-size: 10px;
+    font-family: var(--font-mono);
+    font-size: 10px;
     background: rgba(0, 0, 0, 0.1);
-    padding: 2px 6px; border-radius: 4px;
+    padding: 2px 6px;
+    border-radius: 4px;
   }
 
   /* ── Open source ──────────────────────────────────────── */
@@ -962,48 +1475,79 @@ const mobileEndorsementRows = [
     text-align: center;
     margin: 0 auto 56px;
   }
-  .open-head p { margin: 0 auto; }
+  .open-head p {
+    margin: 0 auto;
+  }
 
   .open-grid {
     display: grid;
     grid-template-columns: 1.25fr 1fr;
-    gap: 20px; margin-bottom: 32px;
+    gap: 20px;
+    margin-bottom: 32px;
   }
 
-  .open-term { padding: 0; overflow: hidden; }
+  .open-term {
+    padding: 0;
+    overflow: hidden;
+  }
   .open-term-head {
-    display: flex; align-items: center; gap: 6px;
-    padding: 10px 14px; border-bottom: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
     background: rgba(255, 255, 255, 0.02);
   }
   .open-term-head span {
-    width: 10px; height: 10px; border-radius: 999px;
-    background: #2a2a30; display: block;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: #2a2a30;
+    display: block;
   }
   .open-term-title {
     margin-left: 10px;
-    font-family: var(--font-mono); font-size: 11px;
-    color: var(--fg-dim); flex: 1; text-align: center;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--fg-dim);
+    flex: 1;
+    text-align: center;
     background: transparent !important;
-    width: auto !important; height: auto !important;
+    width: auto !important;
+    height: auto !important;
     border-radius: 0 !important;
   }
 
   .open-term-body {
     padding: 20px 22px;
-    font-family: var(--font-mono); font-size: 13px;
-    line-height: 1.7; color: var(--fg);
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.7;
+    color: var(--fg);
   }
   .open-term-body > div {
-    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
-  .open-term-body .prompt { color: var(--accent); margin-right: 8px; }
-  .open-term-body .dim { color: var(--fg-dim); }
-  .open-term-body .accent { color: var(--accent); }
-  .open-term-body .cursor { display: flex; align-items: center; }
+  .open-term-body .prompt {
+    color: var(--accent);
+    margin-right: 8px;
+  }
+  .open-term-body .dim {
+    color: var(--fg-dim);
+  }
+  .open-term-body .accent {
+    color: var(--accent);
+  }
+  .open-term-body .cursor {
+    display: flex;
+    align-items: center;
+  }
   .caret {
     display: inline-block;
-    width: 7px; height: 14px;
+    width: 7px;
+    height: 14px;
     background: var(--fg);
     margin-left: 4px;
     animation: blink 1s steps(2) infinite;
@@ -1016,20 +1560,27 @@ const mobileEndorsementRows = [
   }
   .open-stat {
     padding: 22px;
-    display: flex; flex-direction: column; gap: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
   }
   .open-stat-val {
-    font-size: 22px; font-weight: 500;
+    font-size: 22px;
+    font-weight: 500;
     letter-spacing: -0.015em;
   }
   .open-stat-lbl {
-    font-family: var(--font-mono); font-size: 10.5px;
-    color: var(--fg-dim); letter-spacing: 0.04em;
+    font-family: var(--font-mono);
+    font-size: 10.5px;
+    color: var(--fg-dim);
+    letter-spacing: 0.04em;
   }
 
   .open-ctas {
-    display: flex; gap: 10px;
-    justify-content: center; flex-wrap: wrap;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
   }
 
   /* ── Final CTA ────────────────────────────────────────── */
@@ -1044,11 +1595,17 @@ const mobileEndorsementRows = [
     position: absolute;
     inset: auto 0 -50% 0;
     height: 60%;
-    background: radial-gradient(ellipse at center, var(--accent-dim) 0%, transparent 60%);
+    background: radial-gradient(
+      ellipse at center,
+      var(--accent-dim) 0%,
+      transparent 60%
+    );
     pointer-events: none;
     opacity: 0.6;
   }
-  .cta-inner { position: relative; }
+  .cta-inner {
+    position: relative;
+  }
   .cta-title {
     font-size: clamp(40px, 6vw, 72px);
   }
@@ -1061,8 +1618,10 @@ const mobileEndorsementRows = [
     letter-spacing: -0.005em;
   }
   .cta-actions {
-    display: flex; gap: 10px;
-    justify-content: center; flex-wrap: wrap;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+    flex-wrap: wrap;
     margin-bottom: 24px;
   }
 
@@ -1085,18 +1644,39 @@ const mobileEndorsementRows = [
     .hero-preview:hover {
       transform: translateX(-50%) perspective(1600px) rotateX(0deg);
     }
-    .harness-grid { grid-template-columns: 1fr 1fr; }
-    .harness { border-right: 0; border-bottom: 1px solid var(--border); }
-    .harness:nth-child(odd) { border-right: 1px solid var(--border); }
-    .git-inner { grid-template-columns: 1fr; gap: 40px; }
-    .open-grid { grid-template-columns: 1fr; }
+    .harness-grid {
+      grid-template-columns: 1fr 1fr;
+    }
+    .harness {
+      border-right: 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .harness:nth-child(odd) {
+      border-right: 1px solid var(--border);
+    }
+    .git-inner {
+      grid-template-columns: 1fr;
+      gap: 40px;
+    }
+    .open-grid {
+      grid-template-columns: 1fr;
+    }
   }
 
   @media (max-width: 820px) {
-    section { padding: 64px 0; }
-    .sec-cta { padding: 96px 0; }
-    .container { padding-left: 20px; padding-right: 20px; }
-    .hero-preview { display: none; }
+    section {
+      padding: 64px 0;
+    }
+    .sec-cta {
+      padding: 96px 0;
+    }
+    .container {
+      padding-left: 20px;
+      padding-right: 20px;
+    }
+    .hero-preview {
+      display: none;
+    }
     .endorsements-head {
       margin-bottom: 40px;
     }


### PR DESCRIPTION
## What Changed

- Scope dl-icon visibility rules to `html[data-platform]` so the hero/footer download button shows only the detected platform's icon (the prior `:not([data-platform])` selector matched ancestors that never carry the attribute, leaking the macOS icon onto Windows/Linux).
- Replace the static "Windows · Linux · other" secondary CTA with the two non-detected platforms, computed from the detected OS.
- Point the nav Download button at `/download` instead of the homepage `#download` anchor so users land on the dedicated download page.
- Match the nav GitHub button's padding and font-size to the Download button so the two nav controls render at the same height.
- Constrain the floating harness icons to `max-width: 1440px` so they no longer drift apart on wide screens.
- On `/download`, add a "Run without installing" callout (`npx t3`) and per-platform CLI install commands (Homebrew, winget, AUR). Each command block is click-to-copy (the button's click bubbles to the block) with a hover tooltip that swaps between "Copy" and "Copied" in sync with the existing check-mark animation. The block is wrapped in a `.cmd-block-wrap` so the tooltip isn't clipped by the block's `overflow-x: auto`; JS-injected element selectors use `:global()` so Astro's scoped CSS still applies to them.

## Why

The recent marketing rebuild shipped with a few rough edges worth tightening:

- Platform detection on the homepage was incomplete — multiple OS icons rendered at once, and the secondary CTA didn't react to the detected OS.
- The nav Download button scrolled to a homepage anchor rather than the dedicated download page that already exists.
- The hero float layer had no width cap and drifted apart on wide displays.
- The download page only pointed at GitHub releases, but the README also documents `npx t3` plus platform package managers — those install paths should be reachable from the site too, and click-to-copy with a clear tooltip makes the commands easy to grab.

## UI Changes

**Before**
<img width="377" height="87" alt="Screenshot 2026-05-15 102230" src="https://github.com/user-attachments/assets/4782a926-358b-481e-b629-b92e789371e3" />
**After**
<img width="379" height="101" alt="Screenshot 2026-05-15 102259" src="https://github.com/user-attachments/assets/9f58294c-8451-46aa-8310-99866744728c" />

**Before**
<img width="763" height="140" alt="Screenshot 2026-05-15 102243" src="https://github.com/user-attachments/assets/613ac6ee-7690-4480-b894-4d7a7df26d5f" />
**After**
<img width="639" height="148" alt="Screenshot 2026-05-15 102306" src="https://github.com/user-attachments/assets/8ce76dee-1660-4bd9-99bf-c05a709c9443" />

**Before**
<img width="3837" height="1263" alt="Screenshot 2026-05-15 102323" src="https://github.com/user-attachments/assets/a601a305-7ea1-469e-b312-1504fb819843" />
**After**
<img width="3797" height="1374" alt="Screenshot 2026-05-15 102334" src="https://github.com/user-attachments/assets/2c68fcd2-d982-42b9-a16f-5d2ea1958cea" />

**Before**
<img width="2152" height="1354" alt="Screenshot 2026-05-15 102359" src="https://github.com/user-attachments/assets/ade12cfa-1f31-4052-a4d2-008642a03e3d" />
**After**
<img width="2213" height="1835" alt="Screenshot 2026-05-15 102411" src="https://github.com/user-attachments/assets/0b30fc39-4cb0-4040-937f-bf603cf85bb0" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] ~I included a video for animation/interaction changes~

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily marketing UI/UX updates, but adds new client-side clipboard behavior and DOM injection on `/download` that could break copy interactions or styling if selectors change.
> 
> **Overview**
> Tightens the marketing site’s download funnel by updating the global nav Download link to `/download`, aligning the nav GitHub button styling, and refining hero/CTA platform detection so only the correct OS icon shows and the secondary CTA lists the *other* platforms.
> 
> Enhances `/download` with a “Run without installing” callout plus per-OS package-manager install commands (Homebrew/winget/AUR), including new click-to-copy command blocks with tooltip + success-state styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2826f68f5eb10cfff99e0fba3c8353df5a36ccd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Polish download page with CLI install snippets, copy buttons, and nav link fix
> - Adds per-platform CLI install commands (Homebrew, winget, AUR) and a 'Run without installing' `npx t3` callout to the [download page](https://github.com/pingdotgg/t3code/pull/2710/files#diff-9ac8ff1be0976fe42db086d1efaff539e58c29a5da4e782816188ed3cd0c8926)
> - Adds clipboard copy support to command blocks with a transient success indicator
> - Fixes the navbar Download link to point to `/download` instead of `/#download`
> - Updates the secondary CTA on the [index page](https://github.com/pingdotgg/t3code/pull/2710/files#diff-44a2946e1eacc7096aee1ba8a172800aa7d94150585e21ff8486d94f4776677a) to dynamically list non-detected platforms (e.g. 'Windows · Linux' on macOS)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2826f68.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->