### PR TITLE
Personal fork setup: .bnpnecode home dir, worktree default, .env* carryover

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ build/
 .logs/
 release/
 release-mock/
-.t3
+.bnpnecode
 .idea/
 apps/web/.playwright
 apps/web/playwright-report

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,231 @@
+# BUILD.md — Personal Desktop Build with GitHub Auto-Updates
+
+This guide walks through building T3 Code as a personal desktop app (`.dmg` on macOS) wired to **your own GitHub repository** for auto-updates. The app will check your repo's Releases on startup and let you download/install updates from inside the app.
+
+> **Replace `OWNER/REPO` everywhere below with your GitHub `username/repo-name`** (e.g. `bnpne/ottawa` or wherever your fork lives).
+
+---
+
+## How auto-update works here
+
+- `electron-updater` is wired into the desktop app (`apps/desktop/src/updates/DesktopUpdates.ts`).
+- At **build time**, the `T3CODE_DESKTOP_UPDATE_REPOSITORY` env var is baked into the artifact's `app-update.yml` via `scripts/build-desktop-artifact.ts:514` → `resolveGitHubPublishConfig`.
+- At **runtime**, the app checks `https://github.com/OWNER/REPO/releases/latest` for a `latest-mac.yml` (or `latest.yml` / `latest-linux.yml`).
+- Update UX is manual: a rocket icon appears in the UI; click once to download, click again to restart & install. No silent auto-install.
+- Required Release assets:
+  - the installer (`.dmg`, `.exe`, or `.AppImage`)
+  - macOS also needs the `.zip` (Squirrel.Mac uses it for the update payload)
+  - `latest-mac.yml` / `latest.yml` / `latest-linux.yml` (channel metadata)
+  - `*.blockmap` (differential downloads)
+
+---
+
+## Prerequisites
+
+1. Bun `^1.3.11`, Node `^24.13.1` (`bun --version`, `node --version`).
+2. A GitHub repo you own (fork or otherwise) to host releases — call it `OWNER/REPO`.
+3. `gh` CLI installed and authenticated (`gh auth status`). Used to create the GitHub Release and upload assets.
+4. (macOS only, optional but recommended) Apple Developer ID certificate if you want updates to install without a Gatekeeper prompt. See "macOS signing caveat" below.
+
+---
+
+## 1. One-time setup
+
+### Make sure your repo has a `main` remote
+
+```bash
+# from inside the repo root
+git remote -v
+# expect: origin  git@github.com:OWNER/REPO.git ...
+```
+
+If you forked from `pingdotgg/t3code`, add your fork as a remote and push:
+
+```bash
+git remote add personal git@github.com:OWNER/REPO.git
+git push personal HEAD:main
+```
+
+### Install dependencies
+
+```bash
+bun install
+```
+
+---
+
+## 2. Build the `.dmg` (Apple Silicon)
+
+The build command bakes your repo into the artifact's auto-update config.
+
+```bash
+export T3CODE_DESKTOP_UPDATE_REPOSITORY="OWNER/REPO"
+
+# Apple Silicon
+bun dist:desktop:dmg:arm64
+
+# OR Intel Mac
+bun dist:desktop:dmg:x64
+
+# OR both archs in one DMG (universal)
+bun dist:desktop:dmg
+```
+
+Other targets if you ever need them:
+
+```bash
+bun dist:desktop:linux        # Linux x64 AppImage
+bun dist:desktop:win          # Windows NSIS installer
+```
+
+Artifacts land in `./release/`. For an arm64 build at version `0.0.24` you should see:
+
+```
+release/
+├── T3-Code-0.0.24-arm64.dmg
+├── T3-Code-0.0.24-arm64.dmg.blockmap
+├── T3-Code-0.0.24-arm64-mac.zip
+├── T3-Code-0.0.24-arm64-mac.zip.blockmap
+└── latest-mac.yml
+```
+
+All of those need to go into the GitHub Release.
+
+> The version comes from `apps/server/package.json` `version` field. Bump it there (e.g. `0.0.25`) before each new build so the updater sees a newer version.
+
+---
+
+## 3. Create the GitHub Release
+
+The version tag must match the version inside the build. With `version = 0.0.24`:
+
+```bash
+export VERSION="0.0.24"
+
+git tag "v${VERSION}"
+git push origin "v${VERSION}"
+
+gh release create "v${VERSION}" \
+  --repo OWNER/REPO \
+  --title "v${VERSION}" \
+  --notes "Personal build" \
+  ./release/T3-Code-${VERSION}-arm64.dmg \
+  ./release/T3-Code-${VERSION}-arm64.dmg.blockmap \
+  ./release/T3-Code-${VERSION}-arm64-mac.zip \
+  ./release/T3-Code-${VERSION}-arm64-mac.zip.blockmap \
+  ./release/latest-mac.yml
+```
+
+> **Important:** the release tag must be in the `vX.Y.Z` format and must **not** be marked as a prerelease, otherwise the `latest` channel won't pick it up. (Tags with suffixes like `-nightly.*` go to the `nightly` channel — keep things on plain `vX.Y.Z` unless you want that.)
+
+---
+
+## 4. Install the app
+
+Open the `.dmg` from `./release/` and drag T3 Code into Applications.
+
+First launch on macOS will be blocked by Gatekeeper because the build is unsigned. Either:
+
+```bash
+# Remove the quarantine flag
+xattr -dr com.apple.quarantine "/Applications/T3 Code.app"
+```
+
+…or right-click the app → **Open** → confirm the warning once.
+
+---
+
+## 5. Shipping an update
+
+When you want to push an update:
+
+1. Bump version in `apps/server/package.json` (e.g. `0.0.24` → `0.0.25`).
+2. Commit and push.
+3. Rebuild:
+   ```bash
+   export T3CODE_DESKTOP_UPDATE_REPOSITORY="OWNER/REPO"
+   bun dist:desktop:dmg:arm64
+   ```
+4. Tag and create the Release:
+   ```bash
+   export VERSION="0.0.25"
+   git tag "v${VERSION}"
+   git push origin "v${VERSION}"
+   gh release create "v${VERSION}" --repo OWNER/REPO --title "v${VERSION}" --notes "" \
+     ./release/T3-Code-${VERSION}-arm64.dmg \
+     ./release/T3-Code-${VERSION}-arm64.dmg.blockmap \
+     ./release/T3-Code-${VERSION}-arm64-mac.zip \
+     ./release/T3-Code-${VERSION}-arm64-mac.zip.blockmap \
+     ./release/latest-mac.yml
+   ```
+5. Open the installed T3 Code app. Within the startup check interval it will detect the update and show the rocket icon in the UI. Click it to download, click again to restart & install.
+
+---
+
+## Private-repo auth
+
+If `OWNER/REPO` is private, the desktop app needs a token to read your releases. Set this in the runtime environment **of the installed app** (not the build):
+
+```bash
+# in your shell rc / launchd plist / however you launch the app
+export T3CODE_DESKTOP_UPDATE_GITHUB_TOKEN="ghp_xxx"   # or GH_TOKEN=...
+```
+
+The app forwards it as `Authorization: Bearer <token>` on updater HTTP calls (see `docs/release.md:111-113`).
+
+---
+
+## macOS signing caveat (read this if updates fail to install)
+
+Unsigned macOS apps can be **installed manually**, but `electron-updater`'s install step uses Squirrel.Mac, which **requires a code-signed app** to apply updates. With no signing:
+
+- The update will download.
+- Clicking "install" will fail silently or kick you back to a manual reinstall.
+
+Options:
+
+1. **Just reinstall manually each time** — simplest. Skip auto-install entirely; download the new `.dmg` from your Releases page.
+2. **Self-sign with an ad-hoc identity** — not enough; Squirrel.Mac still rejects ad-hoc.
+3. **Use a real Developer ID** — needed for true in-app auto-install. If you have an Apple Developer account, set these env vars before building and pass `--signed`:
+   ```bash
+   export CSC_LINK="$(base64 < /path/to/cert.p12)"
+   export CSC_KEY_PASSWORD="..."
+   export APPLE_API_KEY="$(cat AuthKey_XXX.p8)"
+   export APPLE_API_KEY_ID="XXX"
+   export APPLE_API_ISSUER="UUID"
+   node scripts/build-desktop-artifact.ts --platform mac --target dmg --arch arm64 --signed
+   ```
+
+For a personal-use build, option (1) is the realistic path: auto-update can still **notify** you and **download** the new version even unsigned — you just finish the install by mounting the DMG yourself.
+
+---
+
+## Quick reference: env vars
+
+| Variable | Where | Purpose |
+| --- | --- | --- |
+| `T3CODE_DESKTOP_UPDATE_REPOSITORY` | build-time | Baked into `app-update.yml`. Format: `owner/repo`. |
+| `T3CODE_DESKTOP_UPDATE_GITHUB_TOKEN` | runtime | Token for private repo updater HTTP. |
+| `GH_TOKEN` | runtime | Fallback if `T3CODE_DESKTOP_UPDATE_GITHUB_TOKEN` is not set. |
+| `T3CODE_DESKTOP_VERSION` | build-time | Override version baked into artifact. |
+| `T3CODE_DESKTOP_OUTPUT_DIR` | build-time | Override output dir (defaults to `release/`). |
+| `T3CODE_DESKTOP_VERBOSE` | build-time | Stream subprocess stdout for debugging. |
+
+---
+
+## Build commands cheat sheet
+
+```bash
+# Local install only — no installer
+bun build:desktop
+bun start:desktop
+
+# Build a .dmg for personal use (Apple Silicon)
+T3CODE_DESKTOP_UPDATE_REPOSITORY=OWNER/REPO bun dist:desktop:dmg:arm64
+
+# Cut a release
+gh release create vX.Y.Z --repo OWNER/REPO ./release/*
+
+# Dev mode (Electron + hot reload, not packaged)
+bun dev:desktop
+```

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -151,7 +151,7 @@ const makeDesktopEnvironment = Effect.fn("desktop.environment.make")(function* (
       : input.platform === "darwin"
         ? path.join(homeDirectory, "Library", "Application Support")
         : Option.getOrElse(config.xdgConfigHome, () => path.join(homeDirectory, ".config"));
-  const baseDir = Option.getOrElse(config.t3Home, () => path.join(homeDirectory, ".t3"));
+  const baseDir = Option.getOrElse(config.t3Home, () => path.join(homeDirectory, ".bnpnecode"));
   const rootDir = path.resolve(input.dirname, "../../..");
   const appRoot = input.isPackaged ? input.appPath : rootDir;
   const branding = resolveDesktopAppBranding({

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1884,12 +1884,33 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       fallbackErrorMessage: "git worktree add failed",
     });
 
+    yield* copyGitignoredEnvFiles(input.cwd, worktreePath);
+
     return {
       worktree: {
         path: worktreePath,
         refName: targetBranch,
       },
     };
+  });
+
+  const copyGitignoredEnvFiles = Effect.fn("copyGitignoredEnvFiles")(function* (
+    sourceCwd: string,
+    worktreePath: string,
+  ) {
+    const entries: ReadonlyArray<string> = yield* fileSystem
+      .readDirectory(sourceCwd)
+      .pipe(Effect.catch(() => Effect.succeed<ReadonlyArray<string>>([])));
+    const envEntries = entries.filter((entry: string) => entry.startsWith(".env"));
+    for (const entry of envEntries) {
+      const from = path.join(sourceCwd, entry);
+      const to = path.join(worktreePath, entry);
+      const stat = yield* fileSystem
+        .stat(from)
+        .pipe(Effect.catch(() => Effect.succeed(null)));
+      if (!stat || stat.type !== "File") continue;
+      yield* fileSystem.copyFile(from, to).pipe(Effect.catch(() => Effect.void));
+    }
   });
 
   const fetchPullRequestBranch: GitVcsDriver.GitVcsDriverShape["fetchPullRequestBranch"] =

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -64,7 +64,7 @@ export function resolveEffectiveEnvMode(input: {
     if (activeWorktreePath) {
       return "local";
     }
-    return draftThreadEnvMode === "worktree" ? "worktree" : "local";
+    return draftThreadEnvMode === "local" ? "local" : "worktree";
   }
   return activeWorktreePath ? "worktree" : "local";
 }

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -465,8 +465,8 @@ exit 1
 export const REMOTE_LAUNCH_SCRIPT = `set -eu
 @@T3_NODE_ENV_SCRIPT@@
 STATE_KEY="$1"
-STATE_DIR="$HOME/.t3/ssh-launch/$STATE_KEY"
-DEFAULT_SERVER_HOME="$HOME/.t3"
+STATE_DIR="$HOME/.bnpnecode/ssh-launch/$STATE_KEY"
+DEFAULT_SERVER_HOME="$HOME/.bnpnecode"
 DEFAULT_RUNTIME_FILE="$DEFAULT_SERVER_HOME/userdata/server-runtime.json"
 PORT_FILE="$STATE_DIR/port"
 PID_FILE="$STATE_DIR/pid"
@@ -618,8 +618,8 @@ printf '{"remotePort":%s,"serverKind":"%s"}\\n' "$REMOTE_PORT" "\${REMOTE_MANAGE
 `;
 
 export const REMOTE_PAIRING_SCRIPT = `set -eu
-STATE_DIR="$HOME/.t3/ssh-launch/@@T3_STATE_KEY@@"
-DEFAULT_SERVER_HOME="$HOME/.t3"
+STATE_DIR="$HOME/.bnpnecode/ssh-launch/@@T3_STATE_KEY@@"
+DEFAULT_SERVER_HOME="$HOME/.bnpnecode"
 RUNNER_FILE="$STATE_DIR/run-t3.sh"
 mkdir -p "$STATE_DIR"
 cat >"$RUNNER_FILE" <<'SH'

--- a/scripts/dev-runner.test.ts
+++ b/scripts/dev-runner.test.ts
@@ -47,7 +47,7 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
   });
 
   describe("createDevRunnerEnv", () => {
-    it.effect("defaults T3CODE_HOME to ~/.t3 when not provided", () =>
+    it.effect("defaults T3CODE_HOME to ~/.bnpnecode when not provided", () =>
       Effect.gen(function* () {
         const path = yield* Path.Path;
         const env = yield* createDevRunnerEnv({
@@ -64,7 +64,7 @@ it.layer(NodeServices.layer)("dev-runner", (it) => {
           devUrl: undefined,
         });
 
-        assert.equal(env.T3CODE_HOME, path.resolve(NodeOS.homedir(), ".t3"));
+        assert.equal(env.T3CODE_HOME, path.resolve(NodeOS.homedir(), ".bnpnecode"));
       }),
     );
 

--- a/scripts/dev-runner.ts
+++ b/scripts/dev-runner.ts
@@ -25,7 +25,7 @@ const DESKTOP_DEV_LOOPBACK_HOST = "127.0.0.1";
 const DEV_PORT_PROBE_HOSTS = ["127.0.0.1", "0.0.0.0", "::1", "::"] as const;
 
 export const DEFAULT_T3_HOME = Effect.map(Effect.service(Path.Path), (path) =>
-  path.join(NodeOS.homedir(), ".t3"),
+  path.join(NodeOS.homedir(), ".bnpnecode"),
 );
 
 const MODE_ARGS = {


### PR DESCRIPTION
## What Changed

- Renamed the default home directory from `~/.t3` to `~/.bnpnecode` across the dev runner, desktop fallback, SSH remote launcher, `.gitignore`, and tests. The `T3CODE_HOME` env var name is unchanged, so existing overrides still work.
- `resolveEffectiveEnvMode` now defaults a brand-new draft thread to `"worktree"` instead of `"local"`. Behavior when already inside a worktree is unchanged.
- After `git worktree add` succeeds, root-level `.env*` files are copied from the source repo into the new worktree so threads inherit env vars. Copy failures are swallowed per-file and never fail the worktree creation.
- Added `BUILD.md` with personal-build + GitHub-Releases-based auto-update instructions.

## Why

Personal-fork ergonomics: I want a single command to build a self-updating app for myself, and I want every new thread to land in its own worktree with `.env*` already populated so I don't have to re-paste secrets each time.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes (n/a)
- [ ] I included a video for animation/interaction changes (n/a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes default filesystem locations and environment/worktree behavior, which can affect existing local state and thread/worktree creation flows across desktop, SSH, and dev tooling.
> 
> **Overview**
> Shifts the default T3 Code data directory from `~/.t3` to `~/.bnpnecode` across the desktop app, SSH remote launch/pairing scripts, dev runner defaults/tests, and `.gitignore` (while keeping `T3CODE_HOME` as the override).
> 
> Adjusts branch toolbar logic so a brand-new draft thread defaults to `worktree` mode unless explicitly set to `local`.
> 
> Enhances `GitVcsDriver.createWorktree` to copy root-level `.env*` files into newly created worktrees (best-effort; failures are swallowed), and adds `BUILD.md` documenting personal desktop builds with GitHub Releases-based auto-updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 574e78a16ff59f2ac07b74489b7d2197f5571ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Change default home directory from `~/.t3` to `~/.bnpnecode` and copy `.env*` files into new worktrees
> - Updates all references to the default home directory (`~/.t3` → `~/.bnpnecode`) across the desktop app, dev runner, SSH tunnel scripts, and `.gitignore`.
> - When creating a new git worktree, `.env*` files from the source repo root are now copied into the worktree directory; copy errors are silently ignored.
> - Adjusts `resolveEffectiveEnvMode` fallback in [BranchToolbar.logic.ts](https://github.com/pingdotgg/t3code/pull/2721/files#diff-22eaeeb6cc7f6e680a66d29924a8aa6c56a51450578462389a4b649102ea655f) to default to `'worktree'` mode unless the draft explicitly requests `'local'`.
> - Adds [BUILD.md](https://github.com/pingdotgg/t3code/pull/2721/files#diff-40f60e1037245d7b8a98a7325d53890a717da9979adeb54a61a795c4ba07f9c9) documenting how to build and release a personal desktop app with auto-updates.
> - Behavioral Change: any existing data stored under `~/.t3` will not be migrated automatically; users must move it manually.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 574e78a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->