### PR TITLE
fix:perf: slow startup due to blocking provider probes at startup

### DIFF
--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -686,6 +686,162 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         }),
       );
 
+      it.effect(
+        "bounds slow and failed snapshots while preserving ready providers and stream ordering",
+        () =>
+          Effect.gen(function* () {
+            const codexDriver = ProviderDriverKind.make("codex");
+            const codexInstanceId = ProviderInstanceId.make("codex");
+            const cursorDriver = ProviderDriverKind.make("cursor");
+            const cursorInstanceId = ProviderInstanceId.make("cursor");
+            const claudeDriver = ProviderDriverKind.make("claudeAgent");
+            const claudeInstanceId = ProviderInstanceId.make("claudeAgent");
+            const slowProviderReady = {
+              instanceId: codexInstanceId,
+              driver: codexDriver,
+              status: "ready",
+              enabled: true,
+              installed: true,
+              auth: { status: "authenticated" },
+              checkedAt: "2026-07-20T10:00:00.000Z",
+              version: "1.0.0",
+              models: [],
+              slashCommands: [],
+              skills: [],
+            } as const satisfies ServerProvider;
+            const fastProvider = {
+              instanceId: claudeInstanceId,
+              driver: claudeDriver,
+              status: "ready",
+              enabled: true,
+              installed: true,
+              auth: { status: "authenticated" },
+              checkedAt: "2026-07-20T10:00:00.000Z",
+              version: "2.0.0",
+              models: [],
+              slashCommands: [],
+              skills: [],
+            } as const satisfies ServerProvider;
+            const slowChanges = yield* PubSub.unbounded<ServerProvider>();
+            const makeInstance = (input: {
+              readonly instanceId: ProviderInstanceId;
+              readonly driver: ProviderDriverKind;
+              readonly getSnapshot: Effect.Effect<ServerProvider, never, never>;
+              readonly streamChanges: Stream.Stream<ServerProvider>;
+            }): ProviderInstance => ({
+              instanceId: input.instanceId,
+              driverKind: input.driver,
+              continuationIdentity: {
+                driverKind: input.driver,
+                continuationKey: `${input.driver}:instance:${input.instanceId}`,
+              },
+              displayName: undefined,
+              enabled: true,
+              snapshot: {
+                maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+                  provider: input.driver,
+                  packageName: null,
+                }),
+                getSnapshot: input.getSnapshot,
+                refresh: input.getSnapshot,
+                streamChanges: input.streamChanges,
+              },
+              adapter: {} as ProviderInstance["adapter"],
+              textGeneration: {} as ProviderInstance["textGeneration"],
+            });
+            const slowInstance = makeInstance({
+              instanceId: codexInstanceId,
+              driver: codexDriver,
+              getSnapshot: Effect.never,
+              streamChanges: Stream.fromPubSub(slowChanges),
+            });
+            const failedInstance = makeInstance({
+              instanceId: cursorInstanceId,
+              driver: cursorDriver,
+              getSnapshot: Effect.die(new Error("simulated snapshot failure")),
+              streamChanges: Stream.empty,
+            });
+            const fastInstance = makeInstance({
+              instanceId: claudeInstanceId,
+              driver: claudeDriver,
+              getSnapshot: Effect.succeed(fastProvider),
+              streamChanges: Stream.empty,
+            });
+            const instances: ReadonlyArray<ProviderInstance> = [
+              slowInstance,
+              failedInstance,
+              fastInstance,
+            ];
+            const instanceRegistryLayer = Layer.succeed(
+              ProviderInstanceRegistry.ProviderInstanceRegistry,
+              {
+                getInstance: (instanceId) =>
+                  Effect.succeed(instances.find((instance) => instance.instanceId === instanceId)),
+                listInstances: Effect.succeed(instances),
+                listUnavailable: Effect.succeed([]),
+                streamChanges: Stream.empty,
+                subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), PubSub.subscribe),
+              },
+            );
+            const scope = yield* Scope.make();
+            yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+            // Use the live clock for this build because the boot fallback
+            // and post-subscription pass each exercise a real timeout.
+            const runtimeServices = yield* TestClock.withLive(
+              Layer.build(
+                ProviderRegistryLive.pipe(
+                  Layer.provideMerge(instanceRegistryLayer),
+                  Layer.provideMerge(
+                    ServerConfig.layerTest(process.cwd(), {
+                      prefix: "t3-provider-registry-bounded-boot-",
+                    }),
+                  ),
+                  Layer.provideMerge(NodeServices.layer),
+                ),
+              ).pipe(Scope.provide(scope)),
+            );
+
+            yield* Effect.gen(function* () {
+              const registry = yield* ProviderRegistry.ProviderRegistry;
+              const providersAtReadiness = yield* registry.getProviders;
+              assert.strictEqual(
+                providersAtReadiness.find((provider) => provider.instanceId === claudeInstanceId)
+                  ?.status,
+                "ready",
+              );
+              assert.strictEqual(
+                providersAtReadiness.find((provider) => provider.instanceId === codexInstanceId)
+                  ?.status,
+                "pending",
+              );
+              assert.strictEqual(
+                providersAtReadiness.find((provider) => provider.instanceId === cursorInstanceId)
+                  ?.status,
+                "pending",
+              );
+
+              // The registry subscribes before declaring readiness, so a
+              // later background probe result replaces the pending state.
+              yield* PubSub.publish(slowChanges, slowProviderReady);
+              let providers = yield* registry.getProviders;
+              for (
+                let attempt = 0;
+                attempt < 50 &&
+                providers.find((provider) => provider.instanceId === codexInstanceId)?.status !==
+                  "ready";
+                attempt += 1
+              ) {
+                yield* Effect.yieldNow;
+                providers = yield* registry.getProviders;
+              }
+              assert.deepStrictEqual(
+                providers.find((provider) => provider.instanceId === codexInstanceId),
+                slowProviderReady,
+              );
+            }).pipe(Effect.provide(runtimeServices));
+          }),
+      );
+
       it("persists merged provider snapshots for the providers that were refreshed", () => {
         const previousProviders = [
           {
@@ -1270,10 +1426,10 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             // `SettingsWatcherLive` consumes this via `streamChanges`,
             // calls `reconcile`, which rebuilds the codex instance (the
             // envelope changed because `binaryPath` differs → `entryEqual`
-            // is false). The registry's `Stream.runForEach(
-            // instanceRegistry.streamChanges, () => syncLiveSources)`
-            // fires `syncLiveSources`, which subscribes and launches a fresh
-            // background refresh on the rebuilt instance.
+            // is false). The registry's pre-acquired subscription fires
+            // `syncLiveSources`, which subscribes to the rebuilt instance and
+            // snapshots its current state; the managed provider's background
+            // probe publishes the fresh result through that subscription.
             yield* serverSettings.updateSettings({
               providers: {
                 codex: { enabled: true, binaryPath: secondMissing },

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -30,10 +30,12 @@ import {
   type ServerProviderUpdateState,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
@@ -55,19 +57,32 @@ import type { ProviderInstance } from "../ProviderDriver.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
 import type { ProviderSnapshotSource } from "../builtInProviderCatalog.ts";
 
+const BOOT_SNAPSHOT_FALLBACK_BUDGET = Duration.millis(100);
+
+const loadProviderWithinBootBudget = (
+  providerSource: ProviderSnapshotSource,
+): Effect.Effect<Option.Option<ServerProvider>> =>
+  providerSource.getSnapshot.pipe(
+    Effect.flatMap((snapshot) => correlateSnapshotWithSource(providerSource, snapshot)),
+    Effect.timeoutOption(BOOT_SNAPSHOT_FALLBACK_BUDGET),
+    Effect.catchCause((cause) => {
+      if (Cause.hasInterruptsOnly(cause)) {
+        return Effect.interrupt;
+      }
+      return Effect.logWarning("provider boot snapshot failed; using fallback state", {
+        instanceId: providerSource.instanceId,
+        driver: providerSource.driverKind,
+        cause: Cause.pretty(cause),
+      }).pipe(Effect.as(Option.none<ServerProvider>()));
+    }),
+  );
+
 const loadProviders = (
   providerSources: ReadonlyArray<ProviderSnapshotSource>,
 ): Effect.Effect<ReadonlyArray<ServerProvider>> =>
-  Effect.forEach(
-    providerSources,
-    (providerSource) =>
-      providerSource.getSnapshot.pipe(
-        Effect.flatMap((snapshot) => correlateSnapshotWithSource(providerSource, snapshot)),
-      ),
-    {
-      concurrency: "unbounded",
-    },
-  );
+  Effect.forEach(providerSources, loadProviderWithinBootBudget, {
+    concurrency: "unbounded",
+  }).pipe(Effect.map((providers) => providers.flatMap(Option.toArray)));
 
 const makeManualProviderMaintenanceCapabilities = (provider: ProviderDriverKind) =>
   makeManualOnlyProviderMaintenanceCapabilities({
@@ -184,6 +199,21 @@ const buildSnapshotSource = (instance: ProviderInstance): ProviderSnapshotSource
   streamChanges: instance.snapshot.streamChanges,
 });
 
+const buildPendingSnapshot = (instance: ProviderInstance): ServerProvider => ({
+  instanceId: instance.instanceId,
+  driver: instance.driverKind,
+  displayName: instance.displayName,
+  enabled: instance.enabled,
+  installed: false,
+  version: null,
+  status: "pending",
+  auth: { status: "unknown" },
+  checkedAt: "1970-01-01T00:00:00.000Z",
+  models: [],
+  slashCommands: [],
+  skills: [],
+});
+
 export const ProviderRegistryLive = Layer.effect(
   ProviderRegistry,
   Effect.gen(function* () {
@@ -207,17 +237,14 @@ export const ProviderRegistryLive = Layer.effect(
     const bootInstances = yield* instanceRegistry.listInstances;
     const bootSources = bootInstances.map(buildSnapshotSource);
     const fallbackProviders = yield* loadProviders(bootSources);
-    const fallbackByInstance = new Map<ProviderInstanceId, ServerProvider>();
-    for (let index = 0; index < fallbackProviders.length; index++) {
-      const provider = fallbackProviders[index];
-      const source = bootSources[index];
-      if (provider === undefined || source === undefined) {
-        continue;
-      }
-      fallbackByInstance.set(source.instanceId, provider);
-    }
+    const fallbackByInstance = new Map(
+      fallbackProviders.map((provider) => [provider.instanceId, provider] as const),
+    );
+    const bootInstanceByInstanceId = new Map(
+      bootInstances.map((instance) => [instance.instanceId, instance] as const),
+    );
 
-    const cachedProviders = yield* Effect.forEach(
+    const hydratedBootProviders = yield* Effect.forEach(
       bootSources,
       (source) =>
         Effect.gen(function* () {
@@ -231,15 +258,15 @@ export const ProviderRegistryLive = Layer.effect(
             cacheDir: config.providerStatusCacheDir,
             instanceId: source.instanceId,
           }).pipe(Effect.provideService(Path.Path, path));
-          const fallbackProvider = fallbackByInstance.get(source.instanceId);
-          if (fallbackProvider === undefined) {
-            return undefined;
-          }
+          const instance = bootInstanceByInstanceId.get(source.instanceId);
+          if (instance === undefined) return undefined;
+          const fallbackProvider =
+            fallbackByInstance.get(source.instanceId) ?? buildPendingSnapshot(instance);
           return yield* readProviderStatusCache(filePath).pipe(
             Effect.provideService(FileSystem.FileSystem, fileSystem),
             Effect.flatMap((cachedProvider) => {
               if (cachedProvider === undefined) {
-                return Effect.void.pipe(Effect.as(undefined as ServerProvider | undefined));
+                return Effect.succeed(fallbackProvider);
               }
               const correlation = {
                 cachedProvider,
@@ -266,7 +293,7 @@ export const ProviderRegistryLive = Layer.effect(
         ),
       ),
     );
-    const providersRef = yield* Ref.make<ReadonlyArray<ServerProvider>>(cachedProviders);
+    const providersRef = yield* Ref.make<ReadonlyArray<ServerProvider>>(hydratedBootProviders);
     const maintenanceActionStatesRef = yield* Ref.make<
       ReadonlyMap<ProviderInstanceId, { readonly update?: ServerProviderUpdateState | undefined }>
     >(new Map());
@@ -556,17 +583,19 @@ export const ProviderRegistryLive = Layer.effect(
         // Snapshot current state without starting a probe. Managed providers
         // launch their startup refresh independently, so this closes the
         // subscription race without putting external work on the registry
-        // or HTTP server construction path.
+        // or HTTP server construction path. Keep this bounded because a
+        // third-party driver can still accidentally make getSnapshot slow.
         yield* Effect.forEach(
           newlyAdded,
           ([, instance]) =>
             Effect.gen(function* () {
               const source = buildSnapshotSource(instance);
-              const provider = yield* source.getSnapshot;
-              yield* correlateSnapshotWithSource(source, provider).pipe(
-                Effect.flatMap(syncProvider),
-              );
-            }).pipe(Effect.ignoreCause({ log: true })),
+              const maybeProvider = yield* loadProviderWithinBootBudget(source);
+              if (Option.isNone(maybeProvider)) {
+                return;
+              }
+              yield* syncProvider(maybeProvider.value);
+            }),
           { concurrency: "unbounded", discard: true },
         );
         yield* upsertProviders(unavailableProviders, {
@@ -621,13 +650,14 @@ export const ProviderRegistryLive = Layer.effect(
       }),
     );
 
-    // Seed `providersRef` with the boot-time fallback snapshots so
-    // consumers calling `getProviders` immediately after layer build see
-    // a populated list — even before the first `syncLiveSources` refresh
-    // resolves. Cached snapshots (already in `providersRef`) merge with
-    // these via `upsertProviders` so on-disk state wins where present
-    // and pending fallbacks fill the gaps.
-    yield* upsertProviders(fallbackProviders, { publish: false });
+    // `providersRef` already contains cache-hydrated snapshots or a pending
+    // placeholder for every configured instance. Unavailable instances do
+    // not have live snapshot sources, so merge them explicitly at boot.
+    yield* upsertProviders(yield* instanceRegistry.listUnavailable, {
+      persist: false,
+      replace: true,
+      publish: false,
+    });
     // Subscribe to registry mutations BEFORE running the initial sync.
     // `subscribeChanges` acquires the dequeue synchronously in this
     // fibre; the subscription is active the instant this `yield*`

--- a/apps/web/src/components/settings/providerStatus.test.ts
+++ b/apps/web/src/components/settings/providerStatus.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "@effect/vitest";
+import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
+
+import { getProviderSummary, PROVIDER_STATUS_STYLES } from "./providerStatus";
+
+describe("providerStatus", () => {
+  it("renders pending providers as an in-progress availability check", () => {
+    const provider = {
+      instanceId: ProviderInstanceId.make("codex"),
+      driver: ProviderDriverKind.make("codex"),
+      status: "pending",
+      enabled: true,
+      installed: false,
+      auth: { status: "unknown" },
+      checkedAt: "1970-01-01T00:00:00.000Z",
+      version: null,
+      models: [],
+      slashCommands: [],
+      skills: [],
+    } as const satisfies ServerProvider;
+
+    expect(PROVIDER_STATUS_STYLES.pending).toEqual({
+      dot: "bg-muted-foreground/50",
+    });
+    expect(getProviderSummary(provider)).toEqual({
+      headline: "Checking provider status",
+      detail: "Waiting for installation and authentication details.",
+    });
+  });
+});

--- a/apps/web/src/components/settings/providerStatus.ts
+++ b/apps/web/src/components/settings/providerStatus.ts
@@ -1,4 +1,8 @@
-import type { ServerProvider, ServerProviderVersionAdvisory } from "@t3tools/contracts";
+import type {
+  ServerProvider,
+  ServerProviderState,
+  ServerProviderVersionAdvisory,
+} from "@t3tools/contracts";
 
 /**
  * Visual treatment for each server-reported provider status. Centralized so
@@ -14,10 +18,13 @@ export const PROVIDER_STATUS_STYLES = {
   ready: {
     dot: "bg-success",
   },
+  pending: {
+    dot: "bg-muted-foreground/50",
+  },
   warning: {
     dot: "bg-warning",
   },
-} as const;
+} as const satisfies Record<ServerProviderState, { readonly dot: string }>;
 
 export type ProviderStatusKey = keyof typeof PROVIDER_STATUS_STYLES;
 
@@ -40,6 +47,12 @@ export function getProviderSummary(provider: ServerProvider | undefined) {
       headline: "Disabled",
       detail:
         provider.message ?? "This provider is installed but disabled for new sessions in T3 Code.",
+    };
+  }
+  if (provider.status === "pending") {
+    return {
+      headline: "Checking provider status",
+      detail: provider.message ?? "Waiting for installation and authentication details.",
     };
   }
   if (!provider.installed) {

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -40,7 +40,13 @@ export type ServerConfigIssue = typeof ServerConfigIssue.Type;
 
 const ServerConfigIssues = Schema.Array(ServerConfigIssue);
 
-export const ServerProviderState = Schema.Literals(["ready", "warning", "error", "disabled"]);
+export const ServerProviderState = Schema.Literals([
+  "ready",
+  "warning",
+  "error",
+  "disabled",
+  "pending",
+]);
 export type ServerProviderState = typeof ServerProviderState.Type;
 
 export const ServerProviderAuthStatus = Schema.Literals([


### PR DESCRIPTION
## What Changed

Make the initial provider refresh purely background. Boot-time providersRef is now seeded from:
1. On-disk per-instance cache.
2. Pending fallbacks (new "pending" status) for configured instances missing a cache hit.
3. Eager unavailable instances.

The background syncLiveSources is now forked, so regardless of probe latency the backend server is ready asap and renderer can start the window paint.

## Why
Backend HTTP readiness was coupled to provider probing. If a provider took time to time to respond or maybe in future have many providers, until each provider is resolved, the backend server doesn't start causing renderer to not start painting, leading to slow startup time.

By decoupling the provider probing (with cache check initially) we eliminate the synchronous dependency and app starts pretty quickly.

## Benchmarks
I benchmarked the wall clock time for start to window open and as you can see there is a good degree of improvement, and this doesn't encapsulate if any provider itself is buggy which can cause even longer startup time.

<img width="2532" height="660" alt="t3code-startup-benchmark" src="https://github.com/user-attachments/assets/6b3a21cf-31b0-45c5-b6a1-8c4961aa54cc" />

Ideally the startup time should be atleast sub 1 second, but I think this is step in that direction.

---
# Latest Update (11-June-2026)
## What Changed

Decouple backend readiness from provider probing.

Boot-time `providersRef` is seeded from:

1. On-disk per-instance cache.
2. Pending fallback snapshots for configured instances missing a cache hit.
3. Eager unavailable instance snapshots.

Provider probes run in managed provider background fibers. The registry's initial `syncLiveSources` remains synchronous so subscriptions are attached deterministically, but it only snapshots bounded current state and does not start slow provider probes.

The sync snapshot read is bounded by the boot fallback budget so a slow or buggy `getSnapshot` cannot block provider registry startup.

## Why

Backend HTTP readiness was coupled to provider probing. Slow providers, many providers, or buggy provider status checks could delay server startup and renderer window paint.

By using cache/pending state immediately and letting provider probes update asynchronously, startup can proceed quickly while provider status resolves in the background.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

> [!NOTE]
> few of the line changes are not actually code changes,
> but formatting fixes that were auto applied with `bun run fmt`


fixes #2726 and maybe #2442


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core startup and provider aggregation behavior; mis-tuned timeouts could briefly show pending or skip snapshots, but probes still update via background streams.
> 
> **Overview**
> **Decouples HTTP/server readiness from blocking provider probes** by capping boot-time `getSnapshot` work at **100ms** (`BOOT_SNAPSHOT_FALLBACK_BUDGET`) and treating timeouts or failures as “no snapshot” instead of stalling registry construction.
> 
> Boot **`providersRef`** is seeded from on-disk cache when valid, otherwise a new **`pending`** placeholder (`buildPendingSnapshot`) per configured instance, with unavailable instances merged explicitly at boot. The post-subscribe sync pass uses the same bounded loader so slow third-party `getSnapshot` cannot block startup.
> 
> **`ServerProviderState`** adds **`pending`** in contracts; settings UI shows “Checking provider status” and a muted status dot for that state. Tests cover slow/failed snapshots, fast providers staying ready, and stream updates replacing pending.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc7f4c56d9e6b054f884de7c3ccaf700818d7f31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix slow startup caused by blocking provider snapshot probes at boot
> - Provider registry startup was blocking on slow or failing provider snapshot calls; this adds a 100ms timeout (`BOOT_SNAPSHOT_FALLBACK_BUDGET`) per provider via `loadProviderWithinBootBudget`.
> - Providers that time out or fail during boot now receive a `pending` snapshot instead of blocking or crashing initialization; all instances are represented in `providersRef` from the start.
> - Adds a new `pending` state to `ServerProviderState` in [server.ts](https://github.com/pingdotgg/t3code/pull/2728/files#diff-e575e7eac4053ca860f2d99f4f5bf09331b4e959961ac7bfed0562e916fc5dbb) with corresponding UI styling and summary text in the settings provider status view.
> - Subscription to live source changes is acquired before the initial sync runs, ensuring no published snapshots are lost during boot.
> - Behavioral Change: providers that previously resolved (slowly) at startup will now appear as `pending` in the UI until their background probe completes.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cc7f4c5. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->