### PR TITLE
Add a flake.nix for NixOS Flake users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # T3 Code
 
 T3 Code is a minimal web GUI for coding agents (currently Codex, Claude, Cursor, and OpenCode, more coming soon).
@@ -41,6 +42,29 @@ brew install --cask t3-code
 
 ```bash
 yay -S t3code-bin
+```
+
+#### NixOS (Flakes)
+
+```nix
+# /path/to/your/flake.nix
+{
+  inputs = {
+    # This flake is pinned to nixpkgs stable
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+
+    t3code-flake.url = "github:pingdotgg/t3code";
+    t3code-flake.inputs.nixpkgs.follows = "nixpkgs";
+  };
+}
+```
+```nix
+# /path/to/your/configuration.nix
+{
+  environment.systemPackages = [
+    inputs.t3code-flake.packages."x86_64-linux".default;
+  ];
+}
 ```
 
 ## Some notes
@@ -88,3 +112,4 @@ vp i
 Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening an issue or PR.
 
 Need support? Join the [Discord](https://discord.gg/jn4EGJjrvv).
+

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ yay -S t3code-bin
 {
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
   environment.systemPackages = [
-    inputs.t3code-flake.packages."x86_64-linux".default;
+    pkgs.appimage-run
+    inputs.t3code-flake.packages.${system}
   ];
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # T3 Code
 
 T3 Code is a minimal web GUI for coding agents (currently Codex, Claude, Cursor, and OpenCode, more coming soon).
@@ -54,10 +53,8 @@ yay -S t3code-bin
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
 
     t3code-flake.url = "github:pingdotgg/t3code";
+      # Or pin a version: "github:pingdotgg/t3code?ref=v0.0.23"
     t3code-flake.inputs.nixpkgs.follows = "nixpkgs";
-
-    # Optional: pin to a specific release
-    # t3code-flake.releaseTag = "v0.0.23";
   };
 }
 ```

--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ yay -S t3code-bin
   };
 }
 ```
+
 ```nix
 # /path/to/your/configuration.nix
 {
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
   environment.systemPackages = [
     inputs.t3code-flake.packages."x86_64-linux".default;
   ];
@@ -112,4 +114,3 @@ vp i
 Read [CONTRIBUTING.md](./CONTRIBUTING.md) before opening an issue or PR.
 
 Need support? Join the [Discord](https://discord.gg/jn4EGJjrvv).
-

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ yay -S t3code-bin
 
     t3code-flake.url = "github:pingdotgg/t3code";
     t3code-flake.inputs.nixpkgs.follows = "nixpkgs";
+
+    # Optional: pin to a specific release
+    # t3code-flake.releaseTag = "v0.0.23";
   };
 }
 ```
@@ -65,7 +68,7 @@ yay -S t3code-bin
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
   environment.systemPackages = [
     pkgs.appimage-run
-    inputs.t3code-flake.packages.${system}
+    inputs.t3code-flake.packages.${system}.default
   ];
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1767313136,
@@ -18,8 +36,24 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "t3code-src": "t3code-src"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     },
     "t3code-src": {

--- a/flake.lock
+++ b/flake.lock
@@ -18,24 +18,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs",
-        "t3code-src": "t3code-src"
-      }
-    },
-    "t3code-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1778827213,
-        "narHash": "sha256-lj871RSuJ82xulQAMcGW39x+LWPuNPoQIxEss6/UoKw=",
-        "owner": "pingdotgg",
-        "repo": "t3code",
-        "rev": "d1e85c4e8fdef82fbaded9539532b754080419e0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pingdotgg",
-        "repo": "t3code",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,44 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "t3code-src": "t3code-src"
+      }
+    },
+    "t3code-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1778827213,
+        "narHash": "sha256-lj871RSuJ82xulQAMcGW39x+LWPuNPoQIxEss6/UoKw=",
+        "owner": "pingdotgg",
+        "repo": "t3code",
+        "rev": "d1e85c4e8fdef82fbaded9539532b754080419e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pingdotgg",
+        "repo": "t3code",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,5 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1767313136,
@@ -36,24 +18,8 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "t3code-src": "t3code-src"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     },
     "t3code-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,20 @@
   description = "T3 Code - A harness for coding agents";
 
   # ===== MAINTENANCE NOTES FOR MAINTAINERS =====
+  #
+  #   let
+  #     releaseTag = "v0.0.24";
+  #     version = lib.removePrefix "v" releaseTag;
+  #     appimageHash = "sha256-t8KYAtaQKWmCVOOwvHByosYoqb0Ji35Qe4m+8Gtp/+k=";
+  #   in
+  #   {
+  #     . . .
+  #   };
+  #
   # To update to a new release:
-  #   1. Update `releaseTag` below (e.g., "v0.0.24")
-  #   2. Update `appimageHash` by running: nix hash url <download-url>
-  #   3. Optionally update `supportedSystems` if architecture support changes
+  #   1. Update `releaseTag` to the new version (e.g., "v0.0.25")
+  #   2. Update `appimageHash`:
+  #       nix-prefetch-url https://github.com/pingdotgg/t3code/releases/download/v0.0.25/T3-Code-0.0.25-x86_64.AppImage
   # ==============================================
 
   inputs = {
@@ -17,23 +27,13 @@
     let
       lib = nixpkgs.lib;
 
-      # ----- RELEASES -----
-      # Update this to the new version when a new release is published
-      # Format: "vX.Y.Z" (must match the GitHub release tag)
       releaseTag = "v0.0.24";
-
-      # ----- DOWNLOAD -----
-      # Update this hash when the AppImage URL changes
-      # Run: nix hash url https://github.com/pingdotgg/t3code/releases/download/v0.0.23/T3-Code-0.0.23-x86_64.AppImage
+      version = lib.removePrefix "v" releaseTag;
       appimageHash = "sha256-t8KYAtaQKWmCVOOwvHByosYoqb0Ji35Qe4m+8Gtp/+k=";
 
-      # ----- PLATFORMS -----
-      # Currently only x86_64-linux is supported (no ARM AppImage available)
       supportedSystems = [ "x86_64-linux" ];
 
-      # ----- DERIVATION -----
       pkgs = import nixpkgs { system = "x86_64-linux"; };
-      version = lib.removePrefix "v" releaseTag;
 
       appimage = pkgs.fetchurl {
         url = "https://github.com/pingdotgg/t3code/releases/download/${releaseTag}/T3-Code-${version}-x86_64.AppImage";
@@ -41,36 +41,35 @@
       };
     in
     {
-      packages.x86_64-linux = pkgs.stdenv.mkDerivation {
-        pname = "t3code";
-        inherit version;
+      packages.x86_64-linux = {
+        default = pkgs.stdenv.mkDerivation {
+          pname = "t3code";
+          inherit version;
 
-        src = appimage;
+          src = appimage;
 
-        dontStrip = true;
-        dontUnpack = true;
+          dontStrip = true;
+          dontUnpack = true;
 
-        installPhase = ''
-          mkdir -p $out/bin
-          cp $src $out/bin/t3code.AppImage
-          chmod +x $out/bin/t3code.AppImage
+          installPhase = ''
+            mkdir -p $out/bin
+            cp $src $out/bin/t3code.AppImage
+            chmod +x $out/bin/t3code.AppImage
 
-          # Launcher: uses appimage-run to execute the AppImage
-          cat > $out/bin/t3code << 'LAUNCHER'
-          #!/bin/sh
-          exec appimage-run "$(dirname "$0")/t3code.AppImage" "$@"
-          LAUNCHER
-          chmod +x $out/bin/t3code
-        '';
+            cat > $out/bin/t3code << 'LAUNCHER'
+            #!/bin/sh
+            exec appimage-run "$(dirname "$0")/t3code.AppImage" "$@"
+            LAUNCHER
+            chmod +x $out/bin/t3code
+          '';
 
-        meta = {
-          description = "T3 Code - A harness for coding agents";
-          homepage = "https://t3.codes";
-          license = pkgs.lib.licenses.mit;
-          platforms = supportedSystems;
+          meta = {
+            description = "T3 Code - A harness for coding agents";
+            homepage = "https://t3.codes";
+            license = lib.licenses.mit;
+            platforms = supportedSystems;
+          };
         };
       };
-
-      defaultPackage = self.packages.x86_64-linux;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     # Pinned to stable to avoid breaking changes
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    flake-utils.url = "github:numtide/flake-utils";
     
     # Track upstream repo - run `nix flake update` to check for changes
     t3code-src = {
@@ -12,66 +13,83 @@
     };
   };
 
-  outputs = { self, nixpkgs, t3code-src }:
-    let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
-      
-      # Get version from upstream commit
-      version = t3code-src.shortRev or "latest";
-    in
-    {
-      packages.${system}.default =
-        pkgs.stdenv.mkDerivation {
-          pname = "t3code";
-          inherit version;
+  outputs = { self, nixpkgs, flake-utils, t3code-src }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        
+        # Get version from upstream commit
+        version = t3code-src.shortRev or "latest";
+      in
+      {
+        packages.default =
+          pkgs.stdenv.mkDerivation {
+            pname = "t3code";
+            inherit version;
 
-          src = t3code-src;
+            src = t3code-src;
 
-          # Build dependencies
-          nativeBuildInputs = with pkgs; [
-            bun
-            nodejs
-            git
-          ];
+            # Build dependencies
+            nativeBuildInputs = with pkgs; [
+              bun
+              nodejs
+              git
+            ];
 
-          # Allow network for bun to fetch dependencies
-          allowNetworking = true;
-          
-          configurePhase = ''
-            # Install dependencies
-            bun install
-          '';
-
-          buildPhase = ''
-            # Build the desktop app
-            bun run build:desktop
-          '';
-
-          installPhase = ''
-            mkdir -p $out/bin
+            # Allow network for bun to fetch dependencies
+            allowNetworking = true;
             
-            # Find and copy the built AppImage
-            APPIMAGE=$(find . -path "*/dist/*" -name "*.AppImage" -type f 2>/dev/null | head -1)
-            if [ -n "$APPIMAGE" ]; then
-              cp "$APPIMAGE" "$out/t3code.AppImage"
-              chmod +x "$out/t3code.AppImage"
-            else
-              # Fallback: check other common locations
-              APPIMAGE=$(find . -name "*.AppImage" -type f 2>/dev/null | head -1)
+            configurePhase = ''
+              # Install dependencies
+              bun install
+            '';
+
+            buildPhase = ''
+              # Build the desktop app
+              bun run build:desktop
+            '';
+
+            installPhase = ''
+              mkdir -p $out/bin
+              
+              # Find and copy the built AppImage
+              APPIMAGE=$(find . -path "*/dist/*" -name "*.AppImage" -type f 2>/dev/null | head -1)
               if [ -n "$APPIMAGE" ]; then
                 cp "$APPIMAGE" "$out/t3code.AppImage"
                 chmod +x "$out/t3code.AppImage"
+                
+                # Create a wrapper script in $out/bin for PATH access
+                cat > $out/bin/t3code << 'WRAPPER'
+#!/bin/sh
+exec "$(dirname "$0")/../t3code.AppImage" "$@"
+WRAPPER
+                chmod +x $out/bin/t3code
+              else
+                # Fallback: check other common locations
+                APPIMAGE=$(find . -name "*.AppImage" -type f 2>/dev/null | head -1)
+                if [ -n "$APPIMAGE" ]; then
+                  cp "$APPIMAGE" "$out/t3code.AppImage"
+                  chmod +x "$out/t3code.AppImage"
+                  
+                  cat > $out/bin/t3code << 'WRAPPER'
+#!/bin/sh
+exec "$(dirname "$0")/../t3code.AppImage" "$@"
+WRAPPER
+                  chmod +x $out/bin/t3code
+                else
+                  echo "ERROR: No AppImage found in build output" >&2
+                  exit 1
+                fi
               fi
-            fi
-          '';
+            '';
 
-          meta = {
-            description = "T3 Code - A harness for coding agents";
-            homepage = "https://t3.codes";
-            license = pkgs.lib.licenses.mit;
-            platforms = [ system ];
+            meta = {
+              description = "T3 Code - A harness for coding agents";
+              homepage = "https://t3.codes";
+              license = pkgs.lib.licenses.mit;
+              platforms = [ "x86_64-linux" "aarch64-linux" ];
+            };
           };
-        };
-    };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,6 @@
   inputs = {
     # Pinned to stable to avoid breaking changes
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    flake-utils.url = "github:numtide/flake-utils";
     
     # Track upstream repo - run `nix flake update` to check for changes
     t3code-src = {
@@ -13,83 +12,74 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, t3code-src }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        
-        # Get version from upstream commit
-        version = t3code-src.shortRev or "latest";
-      in
-      {
-        packages.default =
-          pkgs.stdenv.mkDerivation {
-            pname = "t3code";
-            inherit version;
-
-            src = t3code-src;
-
-            # Build dependencies
-            nativeBuildInputs = with pkgs; [
-              bun
-              nodejs
-              git
-            ];
-
-            # Allow network for bun to fetch dependencies
-            allowNetworking = true;
+  outputs = { self, nixpkgs, t3code-src }:
+    let
+      lib = nixpkgs.lib;
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+    in
+    {
+      packages = builtins.listToAttrs (
+        map (system:
+          let
+            pkgs = import nixpkgs { inherit system; };
             
-            configurePhase = ''
-              # Install dependencies
-              bun install
-            '';
+            # Get version from upstream commit
+            version = t3code-src.shortRev or "latest";
+            
+            t3codePkg = pkgs.stdenv.mkDerivation {
+              pname = "t3code";
+              inherit version;
 
-            buildPhase = ''
-              # Build the desktop app
-              bun run build:desktop
-            '';
+              src = t3code-src;
 
-            installPhase = ''
-              mkdir -p $out/bin
+              # Build dependencies
+              nativeBuildInputs = with pkgs; [
+                bun
+                nodejs
+                git
+              ];
+
+              # Allow network for bun to fetch dependencies
+              allowNetworking = true;
               
-              # Find and copy the built AppImage
-              APPIMAGE=$(find . -path "*/dist/*" -name "*.AppImage" -type f 2>/dev/null | head -1)
-              if [ -n "$APPIMAGE" ]; then
-                cp "$APPIMAGE" "$out/t3code.AppImage"
-                chmod +x "$out/t3code.AppImage"
+              configurePhase = ''
+                # Install dependencies
+                bun install
+              '';
+
+              buildPhase = ''
+                # Build the desktop app
+                bun run build:desktop
+              '';
+
+              installPhase = ''
+                mkdir -p $out
                 
-                # Create a wrapper script in $out/bin for PATH access
-                cat > $out/bin/t3code << 'WRAPPER'
-#!/bin/sh
-exec "$(dirname "$0")/../t3code.AppImage" "$@"
-WRAPPER
-                chmod +x $out/bin/t3code
-              else
-                # Fallback: check other common locations
-                APPIMAGE=$(find . -name "*.AppImage" -type f 2>/dev/null | head -1)
+                # Find the built AppImage
+                APPIMAGE=$(find . -path "*/dist/*" -name "*.AppImage" -type f 2>/dev/null | head -1)
+                if [ -z "$APPIMAGE" ]; then
+                  APPIMAGE=$(find . -name "*.AppImage" -type f 2>/dev/null | head -1)
+                fi
+                
                 if [ -n "$APPIMAGE" ]; then
-                  cp "$APPIMAGE" "$out/t3code.AppImage"
-                  chmod +x "$out/t3code.AppImage"
-                  
-                  cat > $out/bin/t3code << 'WRAPPER'
-#!/bin/sh
-exec "$(dirname "$0")/../t3code.AppImage" "$@"
-WRAPPER
-                  chmod +x $out/bin/t3code
+                  cp "$APPIMAGE" "$out/t3code"
+                  chmod +x "$out/t3code"
                 else
                   echo "ERROR: No AppImage found in build output" >&2
                   exit 1
                 fi
-              fi
-            '';
+              '';
 
-            meta = {
-              description = "T3 Code - A harness for coding agents";
-              homepage = "https://t3.codes";
-              license = pkgs.lib.licenses.mit;
-              platforms = [ "x86_64-linux" "aarch64-linux" ];
+              meta = {
+                description = "T3 Code - A harness for coding agents";
+                homepage = "https://t3.codes";
+                license = pkgs.lib.licenses.mit;
+                platforms = [ "x86_64-linux" "aarch64-linux" ];
+              };
             };
-          };
-      }
-    );
+          in
+          lib.nameValuePair system t3codePkg
+        ) systems
+      );
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,63 @@
+{
+  description = "T3 Code - A harness for coding agents";
+
+  inputs = {
+    # Pinned to stable to avoid breaking changes
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
+    
+    # Track upstream repo - run `nix flake update` to check for changes
+    t3code-src = {
+      url = "github:pingdotgg/t3code";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, t3code-src }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+      
+      # Get version from upstream commit
+      version = t3code-src.shortRev or "latest";
+    in
+    {
+      packages.${system}.default =
+        pkgs.stdenv.mkDerivation {
+          pname = "t3code";
+          inherit version;
+
+          src = t3code-src;
+
+          # Build dependencies
+          nativeBuildInputs = with pkgs; [
+            bun
+            nodejs
+            git
+          ];
+
+          configurePhase = ''
+            # Install dependencies
+            bun install --frozen-lockfile
+          '';
+
+          buildPhase = ''
+            # Build the desktop app
+            bun run build:desktop
+          '';
+
+          installPhase = ''
+            mkdir -p $out
+            # The build outputs to apps/desktop/dist or similar
+            find . -name "*.AppImage" -type f 2>/dev/null | head -1 | xargs -I {} cp {} $out/ || true
+            find . -name "t3code" -type f -executable 2>/dev/null | head -1 | xargs -I {} cp {} $out/bin/t3code || true
+          '';
+
+          meta = {
+            description = "T3 Code - A harness for coding agents";
+            homepage = "https://t3.codes";
+            license = pkgs.lib.licenses.mit;
+            platforms = [ system ];
+          };
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,11 +1,15 @@
 {
   description = "T3 Code - A harness for coding agents";
 
+  # ===== MAINTENANCE NOTES FOR MAINTAINERS =====
+  # To update to a new release:
+  #   1. Update `releaseTag` below (e.g., "v0.0.24")
+  #   2. Update `appimageHash` by running: nix hash url <download-url>
+  #   3. Optionally update `supportedSystems` if architecture support changes
+  # ==============================================
+
   inputs = {
-    # Pinned to stable to avoid breaking changes
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    
-    # Track upstream repo - run `nix flake update` to check for changes
     t3code-src = {
       url = "github:pingdotgg/t3code";
       flake = false;
@@ -15,54 +19,61 @@
   outputs = { self, nixpkgs, t3code-src }:
     let
       lib = nixpkgs.lib;
-      systems = [ "x86_64-linux" "aarch64-linux" ];
+
+      # ----- RELEASES -----
+      # Update this to the new version when a new release is published
+      # Format: "vX.Y.Z" (must match the GitHub release tag)
+      releaseTag = "v0.0.23";
+
+      # ----- DOWNLOAD -----
+      # Update this hash when the AppImage URL changes
+      # Run: nix hash url https://github.com/pingdotgg/t3code/releases/download/v0.0.23/T3-Code-0.0.23-x86_64.AppImage
+      appimageHash = "sha256-qMPSxQuiCwLT0As1foSDqaKoNMoLrjbKbDSwQW56T7g=";
+
+      # ----- PLATFORMS -----
+      # Currently only x86_64-linux is supported (no ARM AppImage available)
+      supportedSystems = [ "x86_64-linux" ];
+
+      # ----- DERIVATION -----
+      pkgs = import nixpkgs { system = "x86_64-linux"; };
+      version = lib.removePrefix "v" releaseTag;
+
+      appimage = pkgs.fetchurl {
+        url = "https://github.com/pingdotgg/t3code/releases/download/${releaseTag}/T3-Code-${version}-x86_64.AppImage";
+        sha256 = appimageHash;
+      };
     in
     {
-      packages = builtins.listToAttrs (
-        map (system:
-          let
-            pkgs = import nixpkgs { inherit system; };
-            
-            # Get version from upstream commit
-            version = t3code-src.shortRev or "latest";
-            
-            t3codeDerivation = pkgs.stdenv.mkDerivation {
-              pname = "t3code";
-              inherit version;
+      packages.x86_64-linux = pkgs.stdenv.mkDerivation {
+        pname = "t3code";
+        inherit version;
 
-              # Use latest release from GitHub - update hash when release changes
-              src = pkgs.fetchurl {
-                url = "https://github.com/pingdotgg/t3code/releases/download/v0.0.23/T3-Code-0.0.23-x86_64.AppImage";
-                sha256 = "sha256-qMPSxQuiCwLT0As1foSDqaKoNMoLrjbKbDSwQW56T7g=";
-              };
+        src = appimage;
 
-              # Build dependencies for appimage-run
-              nativeBuildInputs = with pkgs; [
-                appimage-run
-              ];
+        dontStrip = true;
+        dontUnpack = true;
 
-              # Don't strip - AppImages are ELF with appended squashfs
-              dontStrip = true;
-              dontBuild = true;
-              dontConfigure = true;
-              dontUnpack = true;
+        installPhase = ''
+          mkdir -p $out/bin
+          cp $src $out/bin/t3code.AppImage
+          chmod +x $out/bin/t3code.AppImage
 
-              installPhase = ''
-                mkdir -p $out
-                # Extract AppImage to $out
-                appimage-run -x $out $src
-              '';
+          # Launcher: uses appimage-run to execute the AppImage
+          cat > $out/bin/t3code << 'LAUNCHER'
+          #!/bin/sh
+          exec appimage-run "$(dirname "$0")/t3code.AppImage" "$@"
+          LAUNCHER
+          chmod +x $out/bin/t3code
+        '';
 
-              meta = {
-                description = "T3 Code - A harness for coding agents";
-                homepage = "https://t3.codes";
-                license = pkgs.lib.licenses.mit;
-                platforms = [ "x86_64-linux" "aarch64-linux" ];
-              };
-            };
-          in
-          lib.nameValuePair system t3codeDerivation
-        ) systems
-      );
+        meta = {
+          description = "T3 Code - A harness for coding agents";
+          homepage = "https://t3.codes";
+          license = pkgs.lib.licenses.mit;
+          platforms = supportedSystems;
+        };
+      };
+
+      defaultPackage = self.packages.x86_64-linux;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -20,12 +20,12 @@
       # ----- RELEASES -----
       # Update this to the new version when a new release is published
       # Format: "vX.Y.Z" (must match the GitHub release tag)
-      releaseTag = "v0.0.23";
+      releaseTag = "v0.0.24";
 
       # ----- DOWNLOAD -----
       # Update this hash when the AppImage URL changes
       # Run: nix hash url https://github.com/pingdotgg/t3code/releases/download/v0.0.23/T3-Code-0.0.23-x86_64.AppImage
-      appimageHash = "sha256-qMPSxQuiCwLT0As1foSDqaKoNMoLrjbKbDSwQW56T7g=";
+      appimageHash = "sha256-b7c29802d69029698254e3b0bc7072a2c628a9bd098b7e507b89bef06b69ffe9";
 
       # ----- PLATFORMS -----
       # Currently only x86_64-linux is supported (no ARM AppImage available)

--- a/flake.nix
+++ b/flake.nix
@@ -26,48 +26,31 @@
             # Get version from upstream commit
             version = t3code-src.shortRev or "latest";
             
-            t3codePkg = pkgs.stdenv.mkDerivation {
+            t3codeDerivation = pkgs.stdenv.mkDerivation {
               pname = "t3code";
               inherit version;
 
-              src = t3code-src;
+              # Use latest release from GitHub - update hash when release changes
+              src = pkgs.fetchurl {
+                url = "https://github.com/pingdotgg/t3code/releases/download/v0.0.23/T3-Code-0.0.23-x86_64.AppImage";
+                sha256 = "sha256-qMPSxQuiCwLT0As1foSDqaKoNMoLrjbKbDSwQW56T7g=";
+              };
 
-              # Build dependencies
+              # Build dependencies for appimage-run
               nativeBuildInputs = with pkgs; [
-                bun
-                nodejs
-                git
+                appimage-run
               ];
 
-              # Allow network for bun to fetch dependencies
-              allowNetworking = true;
-              
-              configurePhase = ''
-                # Install dependencies
-                bun install
-              '';
-
-              buildPhase = ''
-                # Build the desktop app
-                bun run build:desktop
-              '';
+              # Don't strip - AppImages are ELF with appended squashfs
+              dontStrip = true;
+              dontBuild = true;
+              dontConfigure = true;
+              dontUnpack = true;
 
               installPhase = ''
                 mkdir -p $out
-                
-                # Find the built AppImage
-                APPIMAGE=$(find . -path "*/dist/*" -name "*.AppImage" -type f 2>/dev/null | head -1)
-                if [ -z "$APPIMAGE" ]; then
-                  APPIMAGE=$(find . -name "*.AppImage" -type f 2>/dev/null | head -1)
-                fi
-                
-                if [ -n "$APPIMAGE" ]; then
-                  cp "$APPIMAGE" "$out/t3code"
-                  chmod +x "$out/t3code"
-                else
-                  echo "ERROR: No AppImage found in build output" >&2
-                  exit 1
-                fi
+                # Extract AppImage to $out
+                appimage-run -x $out $src
               '';
 
               meta = {
@@ -78,7 +61,7 @@
               };
             };
           in
-          lib.nameValuePair system t3codePkg
+          lib.nameValuePair system t3codeDerivation
         ) systems
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -35,9 +35,12 @@
             git
           ];
 
+          # Allow network for bun to fetch dependencies
+          allowNetworking = true;
+          
           configurePhase = ''
             # Install dependencies
-            bun install --frozen-lockfile
+            bun install
           '';
 
           buildPhase = ''
@@ -46,10 +49,21 @@
           '';
 
           installPhase = ''
-            mkdir -p $out
-            # The build outputs to apps/desktop/dist or similar
-            find . -name "*.AppImage" -type f 2>/dev/null | head -1 | xargs -I {} cp {} $out/ || true
-            find . -name "t3code" -type f -executable 2>/dev/null | head -1 | xargs -I {} cp {} $out/bin/t3code || true
+            mkdir -p $out/bin
+            
+            # Find and copy the built AppImage
+            APPIMAGE=$(find . -path "*/dist/*" -name "*.AppImage" -type f 2>/dev/null | head -1)
+            if [ -n "$APPIMAGE" ]; then
+              cp "$APPIMAGE" "$out/t3code.AppImage"
+              chmod +x "$out/t3code.AppImage"
+            else
+              # Fallback: check other common locations
+              APPIMAGE=$(find . -name "*.AppImage" -type f 2>/dev/null | head -1)
+              if [ -n "$APPIMAGE" ]; then
+                cp "$APPIMAGE" "$out/t3code.AppImage"
+                chmod +x "$out/t3code.AppImage"
+              fi
+            fi
           '';
 
           meta = {

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
       # ----- DOWNLOAD -----
       # Update this hash when the AppImage URL changes
       # Run: nix hash url https://github.com/pingdotgg/t3code/releases/download/v0.0.23/T3-Code-0.0.23-x86_64.AppImage
-      appimageHash = "sha256-b7c29802d69029698254e3b0bc7072a2c628a9bd098b7e507b89bef06b69ffe9";
+      appimageHash = "sha256-t8KYAtaQKWmCVOOwvHByosYoqb0Ji35Qe4m+8Gtp/+k=";
 
       # ----- PLATFORMS -----
       # Currently only x86_64-linux is supported (no ARM AppImage available)

--- a/flake.nix
+++ b/flake.nix
@@ -10,13 +10,10 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
-    t3code-src = {
-      url = "github:pingdotgg/t3code";
-      flake = false;
-    };
   };
 
-  outputs = { self, nixpkgs, t3code-src }:
+  outputs =
+    { self, nixpkgs }:
     let
       lib = nixpkgs.lib;
 


### PR DESCRIPTION

## What Changed

A - flake.nix
A - flake.lock
M - README.md

`flake.nix` looks at the parent repo (pingdotgg/t3code), pulls it, builds it from source, and caches the build in a `nix/store` directory on first build. unless the user runs 'nix flake update', manually updating their flake inputs, t3code on the user machine will not receive codebase changes from the repository. It also will not rebuild the application unless the nix/store hash, and updated repo hash are different.

`README.md` now includes how to install this application on nixos flake enabled machines.

## Why

Currently using t3code on nixos requires using appimages, and other "not-very-nix" ways of installing applications depending on your mode of attack. Ive spent the past few hours creating a flake.nix that reads the repo, builds it from source, and only rebuilds the app if the repo updates. this enables a simple and easy oneliner installation of t3code on nixos machines.

there is very little maintenance on your behalf, only ever needing to update `flake.nix:6:nixpkgs.url=` to be the latest nixpkgs stable release, OR for a set-and-forget you can set it to `nixos-unstable`, and change the readme accordingly. the flake handles the nixos specific runtime shenanigans, your source code just tells it what to build

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [N/A] I included before/after screenshots for any UI changes
- [N/A] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and documentation only; no application runtime, auth, or data-path changes.
> 
> **Overview**
> Adds **Nix flake** packaging so NixOS users can install T3 Code without ad-hoc AppImage steps.
> 
> New **`flake.nix`** and **`flake.lock`** define a single **`x86_64-linux`** package that **`fetchurl`**s the pinned GitHub release AppImage (`v0.0.24` + fixed hash), installs it under `$out/bin`, and exposes a **`t3code`** launcher that runs it via **`appimage-run`**. Maintainer comments document bumping **`releaseTag`** and **`appimageHash`** on new releases; **`nixpkgs`** is pinned to **`nixos-25.05`**.
> 
> **`README.md`** gains a **NixOS (Flakes)** section: add the repo as a flake input (with optional version pin), enable flakes, and put **`pkgs.appimage-run`** plus **`inputs.t3code-flake.packages.${system}.default`** in **`environment.systemPackages`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5c9ef8b74ff9abc42ce34ae6a0ae084a94b5341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a Nix flake for installing t3code on NixOS
> - Adds [flake.nix](https://github.com/pingdotgg/t3code/pull/2734/files#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0) defining a `default` package for `x86_64-linux` that fetches the t3code AppImage from GitHub releases and wraps it in a launcher script executed via `appimage-run`.
> - Adds [flake.lock](https://github.com/pingdotgg/t3code/pull/2734/files#diff-216b2b7bfde9416c79d133bacb031e95702a20bdedb548c0b055c837aa4f6a9c) pinning `nixpkgs` to `nixos-25.05`.
> - Updates [README.md](https://github.com/pingdotgg/t3code/pull/2734/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with a new 'NixOS (Flakes)' installation section showing how to pin the flake and add `t3code` to `systemPackages`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e5c9ef8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->