### PR TITLE
chore: set up fork devops workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   quality:
     name: Format, Lint, Typecheck, Test, Browser Test, Build
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -76,7 +76,7 @@ jobs:
 
   release_smoke:
     name: Release Smoke
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,12 @@
-name: Release
+name: Upstream Release (disabled for fork)
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
-      - "!v*-nightly.*"
-  schedule:
-    - cron: "0 */3 * * *"
   workflow_dispatch:
     inputs:
+      confirm:
+        description: "This is the upstream release workflow. Use Team macOS DMG for fork builds."
+        required: true
+        type: string
       channel:
         description: "Release channel"
         required: false

--- a/.github/workflows/team-macos-dmg.yml
+++ b/.github/workflows/team-macos-dmg.yml
@@ -1,0 +1,126 @@
+name: Team macOS DMG
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to stamp into the app. Leave empty for 0.0.0-team.<run number>."
+        required: false
+        type: string
+      arch:
+        description: "Mac architecture to build."
+        required: true
+        default: arm64
+        type: choice
+        options:
+          - arm64
+          - x64
+          - universal
+      publish_release:
+        description: "Create or update a GitHub prerelease with the DMG assets."
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build macOS DMG
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: package.json
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: package.json
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Resolve build version
+        id: version
+        shell: bash
+        run: |
+          version="${{ inputs.version }}"
+          if [[ -z "$version" ]]; then
+            version="0.0.0-team.${GITHUB_RUN_NUMBER}"
+          fi
+
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=team-v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build DMG
+        shell: bash
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          T3CODE_DESKTOP_UPDATE_REPOSITORY: ${{ github.repository }}
+        run: |
+          args=(
+            --platform mac
+            --target dmg
+            --arch "${{ inputs.arch }}"
+            --build-version "${{ steps.version.outputs.version }}"
+            --verbose
+          )
+
+          has_all() {
+            for value in "$@"; do
+              if [[ -z "$value" ]]; then
+                return 1
+              fi
+            done
+            return 0
+          }
+
+          if has_all "$CSC_LINK" "$CSC_KEY_PASSWORD" "$APPLE_API_KEY" "$APPLE_API_KEY_ID" "$APPLE_API_ISSUER"; then
+            key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+            printf "%s" "$APPLE_API_KEY" > "$key_path"
+            export APPLE_API_KEY="$key_path"
+            echo "macOS signing and notarization enabled."
+            args+=(--signed)
+          else
+            echo "macOS signing disabled. The DMG will build, but Gatekeeper may warn users."
+          fi
+
+          bun run dist:desktop:artifact -- "${args[@]}"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: t3-code-macos-${{ inputs.arch }}-${{ steps.version.outputs.version }}
+          path: |
+            release/*.dmg
+            release/*.zip
+            release/*.blockmap
+            release/*.yml
+          if-no-files-found: error
+
+      - name: Publish GitHub prerelease
+        if: inputs.publish_release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Team macOS build ${{ steps.version.outputs.version }}
+          prerelease: true
+          make_latest: false
+          files: |
+            release/*.dmg
+            release/*.zip
+            release/*.blockmap
+            release/*.yml

--- a/docs/fork-workflow.md
+++ b/docs/fork-workflow.md
@@ -1,0 +1,82 @@
+# Fork Workflow
+
+This is the lightweight workflow for maintaining our fork.
+
+## One-time setup
+
+1. Create the fork on GitHub from `pingdotgg/t3code`.
+2. Add the fork as `origin` locally:
+
+   ```bash
+   git remote add origin https://github.com/YOUR_GITHUB_NAME/t3code.git
+   git push -u origin main
+   ```
+
+3. In GitHub, open the fork repository and go to **Settings > Branches**.
+4. Add a branch protection rule for `main`:
+   - Require a pull request before merging.
+   - Require approvals. Start with `1`.
+   - Require status checks to pass before merging.
+   - Select the `CI / quality` check once it has run at least once.
+   - Do not allow force pushes.
+   - Do not allow deletions.
+
+## Everyday change flow
+
+Start from an up-to-date `main`:
+
+```bash
+git switch main
+git pull --ff-only origin main
+git fetch upstream
+git merge --ff-only upstream/main
+git push origin main
+```
+
+Create a feature branch:
+
+```bash
+git switch -c feature/short-description
+```
+
+Commit and push your work:
+
+```bash
+git status
+git add path/to/files
+git commit -m "feat: short description"
+git push -u origin feature/short-description
+```
+
+Open a pull request from `feature/short-description` into `main`. Wait for CI,
+review the diff, then merge with **Squash and merge**.
+
+## Building a team DMG
+
+Use **Actions > Team macOS DMG > Run workflow**.
+
+- `arch=arm64` is best for Apple Silicon Macs.
+- `arch=x64` is for Intel Macs.
+- `publish_release=true` attaches the DMG to a GitHub prerelease.
+
+Without Apple signing secrets, the DMG still builds, but macOS may show a
+Gatekeeper warning. Add these GitHub Actions secrets when ready:
+
+- `CSC_LINK`
+- `CSC_KEY_PASSWORD`
+- `APPLE_API_KEY`
+- `APPLE_API_KEY_ID`
+- `APPLE_API_ISSUER`
+
+## Syncing with upstream
+
+Pull upstream changes regularly, especially before starting big work:
+
+```bash
+git switch main
+git fetch upstream
+git merge --ff-only upstream/main
+git push origin main
+```
+
+If the merge is not fast-forward, stop and ask for help before forcing anything.


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to GitHub Actions and documentation, with no product/runtime code changes. Main risk is misconfigured workflows/secrets impacting CI or release automation.
> 
> **Overview**
> Sets the CI workflows to run on `ubuntu-24.04` instead of the custom `blacksmith-*` runners.
> 
> Disables automatic upstream releases by removing tag/schedule triggers from `release.yml` and making it `workflow_dispatch`-only with an explicit `confirm` input.
> 
> Adds a new manually-triggered `Team macOS DMG` workflow to build (optionally sign/notarize) and optionally publish a prerelease with DMG assets, plus `docs/fork-workflow.md` describing the fork update and build process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7039c92fb6700c11e00b13456b60beb5a0602b34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Set up fork DevOps workflow with manual-only release and macOS DMG build
> - Adds a new [team-macos-dmg.yml](.github/workflows/team-macos-dmg.yml) workflow triggered via `workflow_dispatch` that builds macOS DMG artifacts for a chosen architecture (`arm64`/`x64`/`universal`), uploads them as workflow artifacts, and optionally publishes a GitHub prerelease. Signing and notarization are performed when the relevant secrets are present.
> - Disables automatic triggers (tag push, cron) on [release.yml](.github/workflows/release.yml) and renames it to 'Upstream Release (disabled for fork)'; the workflow now requires a manual `confirm` input to run.
> - Switches the `quality` and `release_smoke` CI jobs in [ci.yml](.github/workflows/ci.yml) from the `blacksmith-8vcpu-ubuntu-2404` runner to `ubuntu-24.04`.
> - Adds [docs/fork-workflow.md](https://github.com/pingdotgg/t3code/pull/2739/files#diff-188fa1ac500cef0874689f9a704344fa7e64e484d782f046ffc66b3dd89b8f1d) documenting branch protections, CI requirements, the DMG build process, required signing secrets, and upstream sync instructions.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7039c92. 4 files reviewed, 3 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->