### PR TITLE
Prefer upstream repo when creating fork PRs

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -2388,6 +2388,80 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
+  it.effect("creates fork PRs from origin branches against an upstream base repo", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const forkDir = yield* createBareRemote();
+      const upstreamDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", forkDir]);
+      yield* runGit(repoDir, ["remote", "add", "upstream", upstreamDir]);
+      yield* runGit(repoDir, ["checkout", "-b", "felix/integrate-pr-2305-1003"]);
+      fs.writeFileSync(path.join(repoDir, "changes.txt"), "change\n");
+      yield* runGit(repoDir, ["add", "changes.txt"]);
+      yield* runGit(repoDir, ["commit", "-m", "Feature commit"]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "felix/integrate-pr-2305-1003"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "origin",
+        "git@github.com:felixfong227/t3code.git",
+        forkDir,
+      );
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "upstream",
+        "git@github.com:pingdotgg/t3code.git",
+        upstreamDir,
+      );
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListSequenceByHeadSelector: {
+            "felixfong227:felix/integrate-pr-2305-1003": [
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([]),
+              // @effect-diagnostics-next-line preferSchemaOverJson:off
+              JSON.stringify([
+                {
+                  number: 2305,
+                  title: "Add diff context comment drafts and collapsible sidebar",
+                  url: "https://github.com/pingdotgg/t3code/pull/2305",
+                  baseRefName: "main",
+                  headRefName: "felix/integrate-pr-2305-1003",
+                  state: "OPEN",
+                  isCrossRepository: true,
+                  headRepository: {
+                    nameWithOwner: "felixfong227/t3code",
+                  },
+                  headRepositoryOwner: {
+                    login: "felixfong227",
+                  },
+                },
+              ]),
+            ],
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "origin:felix/integrate-pr-2305-1003": [JSON.stringify([])],
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "felix/integrate-pr-2305-1003": [JSON.stringify([])],
+          },
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit_push_pr",
+      });
+
+      expect(result.pr.status).toBe("created");
+      expect(result.pr.number).toBe(2305);
+      expect(
+        ghCalls.some((call) =>
+          call.includes("pr create --base main --head felixfong227:felix/integrate-pr-2305-1003"),
+        ),
+      ).toBe(true);
+    }),
+  );
+
   it.effect("rejects push/pr actions from detached HEAD", () =>
     Effect.gen(function* () {
       const repoDir = yield* makeTempDir("t3code-git-manager-");

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -830,19 +830,22 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     const shouldProbeLocalBranchSelector =
       headBranchFromUpstream.length === 0 || headBranch === details.branch;
 
-    const [remoteRepository, originRepository] = yield* Effect.all(
+    const [remoteRepository, originRepository, upstreamRepository] = yield* Effect.all(
       [
         resolveRemoteRepositoryContext(cwd, remoteName),
         resolveRemoteRepositoryContext(cwd, "origin"),
+        resolveRemoteRepositoryContext(cwd, "upstream"),
       ],
       { concurrency: "unbounded" },
     );
+    const targetRepository =
+      upstreamRepository.repositoryNameWithOwner !== null ? upstreamRepository : originRepository;
 
     const isCrossRepository =
       remoteRepository.repositoryNameWithOwner !== null &&
-      originRepository.repositoryNameWithOwner !== null
+      targetRepository.repositoryNameWithOwner !== null
         ? remoteRepository.repositoryNameWithOwner.toLowerCase() !==
-          originRepository.repositoryNameWithOwner.toLowerCase()
+          targetRepository.repositoryNameWithOwner.toLowerCase()
         : remoteName !== null &&
           remoteName !== "origin" &&
           remoteRepository.repositoryNameWithOwner !== null;


### PR DESCRIPTION
## Summary
- Prefer the `upstream` repository as the PR base when both `origin` and `upstream` remotes are available.
- Keep fork PR detection aligned with the repository that will actually receive the PR, instead of always comparing against `origin`.
- Add a regression test covering a fork branch that should open a PR against the upstream repo with the correct owner-qualified head reference.

## Testing
- Added a GitManager test for creating a fork PR against an upstream base repo.
- Not run: `bun fmt`
- Not run: `bun lint`
- Not run: `bun typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts cross-repo PR detection to compare against `upstream` (when present) instead of always `origin`, which can change which head selectors are probed and where PRs are created. Risk is moderate because it affects PR creation/lookup logic across different remote configurations.
> 
> **Overview**
> When both `origin` and `upstream` remotes are configured, PR creation/lookup now treats `upstream` as the *target/base* repository (falling back to `origin` when `upstream` is missing) when determining whether a branch is cross-repo.
> 
> Adds a regression test that simulates a forked `origin` branch opening a PR against an upstream repo, asserting `gh pr create` uses the owner-qualified head selector (e.g. `owner:branch`) and the upstream base branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7262776d29e5c976320b9bbddf3697526c6bab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prefer upstream remote over origin when resolving base repository for fork PRs
> When creating a PR, `makeGitManager.resolvePullRequest` now selects the `upstream` remote as the target base repository when it is configured, falling back to `origin` otherwise. `isCrossRepository` is computed by comparing the head remote against this resolved target rather than always against `origin`. A new test in [GitManager.test.ts](https://github.com/pingdotgg/t3code/pull/2744/files#diff-913ade748b9dbddd4912c2fd2d736a754c232ed342415f121860f38508455eb1) covers the case where both `origin` and `upstream` remotes exist and verifies the PR is created with the fork head against the upstream base.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b72627.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->