### PR TITLE
Add provider profiles to settings

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -289,6 +289,45 @@ validationLayer("CodexAdapterLive validation", (it) => {
   );
 });
 
+it.layer(
+  Layer.effect(
+    CodexAdapter,
+    Effect.gen(function* () {
+      const codexConfig = decodeCodexSettings({
+        profileName: "work",
+        launchArgs: "--config foo=bar",
+      });
+      return yield* makeCodexAdapter(codexConfig, {
+        makeRuntime: validationRuntimeFactory.factory,
+      });
+    }),
+  ).pipe(
+    Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+    Layer.provideMerge(ServerSettingsService.layerTest()),
+    Layer.provideMerge(providerSessionDirectoryTestLayer),
+    Layer.provideMerge(NodeServices.layer),
+  ),
+)("CodexAdapterLive profile launch args", (it) => {
+  it.effect("passes codex profile and launch args to session runtime", () =>
+    Effect.gen(function* () {
+      validationRuntimeFactory.factory.mockClear();
+      const adapter = yield* CodexAdapter;
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-profile"),
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(validationRuntimeFactory.factory.mock.calls[0]?.[0].profileName, "work");
+      assert.equal(
+        validationRuntimeFactory.factory.mock.calls[0]?.[0].launchArgs,
+        "--config foo=bar",
+      );
+    }),
+  );
+});
+
 const sessionRuntimeFactory = makeRuntimeFactory();
 const sessionErrorLayer = it.layer(
   Layer.effect(

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1385,6 +1385,8 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           binaryPath: codexConfig.binaryPath,
           ...(options?.environment ? { environment: options.environment } : {}),
           ...(codexConfig.homePath ? { homePath: codexConfig.homePath } : {}),
+          ...(codexConfig.profileName ? { profileName: codexConfig.profileName } : {}),
+          ...(codexConfig.launchArgs ? { launchArgs: codexConfig.launchArgs } : {}),
           ...(isCodexResumeCursorSchema(input.resumeCursor)
             ? { resumeCursor: input.resumeCursor }
             : {}),

--- a/apps/server/src/provider/Layers/CodexCliArgs.ts
+++ b/apps/server/src/provider/Layers/CodexCliArgs.ts
@@ -1,0 +1,10 @@
+import type { CodexSettings } from "@t3tools/contracts";
+
+export function buildCodexGlobalArgs(
+  config: Partial<Pick<CodexSettings, "profileName" | "launchArgs">>,
+) {
+  return [
+    ...(config.profileName ? ["-p", config.profileName] : []),
+    ...(config.launchArgs?.trim().split(/\s+/).filter(Boolean) ?? []),
+  ];
+}

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -29,6 +29,7 @@ import {
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
+import { buildCodexGlobalArgs } from "./CodexCliArgs.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
 
@@ -251,6 +252,8 @@ export function buildCodexInitializeParams(): CodexSchema.V1InitializeParams {
 const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
   readonly binaryPath: string;
   readonly homePath?: string;
+  readonly profileName?: string;
+  readonly launchArgs?: string;
   readonly cwd: string;
   readonly customModels?: ReadonlyArray<string>;
   readonly environment?: NodeJS.ProcessEnv;
@@ -263,7 +266,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   const clientContext = yield* Layer.build(
     CodexClient.layerCommand({
       command: input.binaryPath,
-      args: ["app-server"],
+      args: [...buildCodexGlobalArgs(input), "app-server"],
       cwd: input.cwd,
       env: {
         ...(input.environment ?? process.env),
@@ -404,6 +407,8 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   probe: (input: {
     readonly binaryPath: string;
     readonly homePath?: string;
+    readonly profileName?: string;
+    readonly launchArgs?: string;
     readonly cwd: string;
     readonly customModels: ReadonlyArray<string>;
     readonly environment?: NodeJS.ProcessEnv;
@@ -441,6 +446,8 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   const probeResult = yield* probe({
     binaryPath: codexSettings.binaryPath,
     homePath: codexSettings.homePath,
+    ...(codexSettings.profileName ? { profileName: codexSettings.profileName } : {}),
+    ...(codexSettings.launchArgs ? { launchArgs: codexSettings.launchArgs } : {}),
     cwd: process.cwd(),
     customModels: codexSettings.customModels,
     environment,

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -94,6 +94,29 @@ function codexAccountEmail(account: CodexSchema.V2GetAccountResponse["account"])
   return account.email;
 }
 
+const nonEmpty = (value: string | null | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+export function resolveCodexRequiresOpenaiAuth(
+  config: CodexSchema.V2ConfigReadResponse["config"],
+  profileName?: string,
+): boolean | undefined {
+  const modelProvider =
+    (profileName ? nonEmpty(config.profiles?.[profileName]?.model_provider) : undefined) ??
+    nonEmpty(config.model_provider);
+  if (!modelProvider) return undefined;
+
+  const provider = isRecord(config.model_providers) ? config.model_providers[modelProvider] : null;
+  return isRecord(provider) && typeof provider.requires_openai_auth === "boolean"
+    ? provider.requires_openai_auth
+    : undefined;
+}
+
 function mapCodexModelCapabilities(
   model: CodexSchema.V2ModelListResponse__Model,
 ): ModelCapabilities {
@@ -294,10 +317,18 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   const versionMatch = initialize.userAgent.match(/\/([^\s]+)/);
   const version = versionMatch ? versionMatch[1] : undefined;
 
-  const accountResponse = yield* client.request("account/read", {});
-  if (!accountResponse.account && accountResponse.requiresOpenaiAuth) {
+  const [accountResponse, configResponse] = yield* Effect.all(
+    [client.request("account/read", {}), client.request("config/read", {})],
+    { concurrency: "unbounded" },
+  );
+  const requiresOpenaiAuth =
+    resolveCodexRequiresOpenaiAuth(configResponse.config, input.profileName) ??
+    accountResponse.requiresOpenaiAuth;
+  const account = { ...accountResponse, requiresOpenaiAuth };
+
+  if (!account.account && account.requiresOpenaiAuth) {
     return {
-      account: accountResponse,
+      account,
       version,
       models: appendCustomCodexModels([], input.customModels ?? []),
       skills: [],
@@ -315,7 +346,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   );
 
   return {
-    account: accountResponse,
+    account,
     version,
     models: appendCustomCodexModels(models, input.customModels ?? []),
     skills: parseCodexSkillsListResponse(skillsResponse, input.cwd),

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -225,6 +225,7 @@ describe("openCodexThread", () => {
         runtimeMode: "full-access",
         cwd: "/tmp/project",
         requestedModel: "gpt-5.3-codex",
+        requestedModelProvider: undefined,
         serviceTier: undefined,
         resumeThreadId: "stale-thread",
       }),
@@ -265,6 +266,7 @@ describe("openCodexThread", () => {
           runtimeMode: "full-access",
           cwd: "/tmp/project",
           requestedModel: "gpt-5.3-codex",
+          requestedModelProvider: undefined,
           serviceTier: undefined,
           resumeThreadId: "stale-thread",
         }),
@@ -273,5 +275,44 @@ describe("openCodexThread", () => {
         isCodexAppServerRequestError(error) &&
         error.errorMessage === "timed out waiting for server",
     );
+  });
+
+  it("passes the configured model provider when opening a thread", async () => {
+    const calls: Array<{ method: "thread/start" | "thread/resume"; payload: unknown }> = [];
+    const client = {
+      request: <M extends "thread/start" | "thread/resume">(
+        method: M,
+        payload: CodexRpc.ClientRequestParamsByMethod[M],
+      ) => {
+        calls.push({ method, payload });
+        return Effect.succeed(
+          makeThreadOpenResponse("fresh-thread") as CodexRpc.ClientRequestResponsesByMethod[M],
+        );
+      },
+    };
+
+    await Effect.runPromise(
+      openCodexThread({
+        client,
+        threadId: ThreadId.make("thread-1"),
+        runtimeMode: "full-access",
+        cwd: "/tmp/project",
+        requestedModel: "gpt-5.5",
+        requestedModelProvider: "codex-lb",
+        serviceTier: undefined,
+        resumeThreadId: undefined,
+      }),
+    );
+
+    assert.deepStrictEqual(calls[0], {
+      method: "thread/start",
+      payload: {
+        cwd: "/tmp/project",
+        approvalPolicy: "never",
+        sandbox: "danger-full-access",
+        model: "gpt-5.5",
+        modelProvider: "codex-lb",
+      },
+    });
   });
 });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -289,6 +289,7 @@ function buildThreadStartParams(input: {
   readonly cwd: string;
   readonly runtimeMode: RuntimeMode;
   readonly model: string | undefined;
+  readonly modelProvider: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
 }): EffectCodexSchema.V2ThreadStartParams {
   const config = runtimeModeToThreadConfig(input.runtimeMode);
@@ -297,9 +298,30 @@ function buildThreadStartParams(input: {
     approvalPolicy: config.approvalPolicy,
     sandbox: config.sandbox,
     ...(input.model ? { model: input.model } : {}),
+    ...(input.modelProvider ? { modelProvider: input.modelProvider } : {}),
     ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
   };
 }
+
+const nonEmpty = (value: string | null | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const readCodexProfileModelProvider = (
+  client: CodexClient.CodexAppServerClientShape,
+  profileName: string | undefined,
+): Effect.Effect<string | undefined, CodexErrors.CodexAppServerError> =>
+  client.request("config/read", {}).pipe(
+    Effect.map((response) => {
+      const config = response.config;
+      return (
+        (profileName ? nonEmpty(config.profiles?.[profileName]?.model_provider) : undefined) ??
+        nonEmpty(config.model_provider)
+      );
+    }),
+    Effect.catch(() => Effect.sync((): string | undefined => undefined)),
+  );
 
 function runtimeModeToTurnSandboxPolicy(
   input: RuntimeMode,
@@ -438,6 +460,7 @@ export const openCodexThread = (input: {
   readonly runtimeMode: RuntimeMode;
   readonly cwd: string;
   readonly requestedModel: string | undefined;
+  readonly requestedModelProvider: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
   readonly resumeThreadId: string | undefined;
 }): Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> => {
@@ -446,6 +469,7 @@ export const openCodexThread = (input: {
     cwd: input.cwd,
     runtimeMode: input.runtimeMode,
     model: input.requestedModel,
+    modelProvider: input.requestedModelProvider,
     serviceTier: input.serviceTier,
   });
 
@@ -1188,6 +1212,10 @@ export const makeCodexSessionRuntime = (
       yield* client.notify("initialized", undefined);
 
       const requestedModel = normalizeCodexModelSlug(options.model);
+      const requestedModelProvider = yield* readCodexProfileModelProvider(
+        client,
+        options.profileName,
+      );
 
       const opened = yield* openCodexThread({
         client,
@@ -1195,6 +1223,7 @@ export const makeCodexSessionRuntime = (
         runtimeMode: options.runtimeMode,
         cwd: options.cwd,
         requestedModel,
+        requestedModelProvider,
         serviceTier: options.serviceTier,
         resumeThreadId: readResumeCursorThreadId(options.resumeCursor),
       });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -41,6 +41,7 @@ import {
   CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
   CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
 } from "../CodexDeveloperInstructions.ts";
+import { buildCodexGlobalArgs } from "./CodexCliArgs.ts";
 const decodeV2TurnStartResponse = Schema.decodeUnknownEffect(EffectCodexSchema.V2TurnStartResponse);
 
 const PROVIDER = ProviderDriverKind.make("codex");
@@ -97,6 +98,8 @@ export interface CodexSessionRuntimeOptions {
   readonly providerInstanceId?: ProviderInstanceId;
   readonly binaryPath: string;
   readonly homePath?: string;
+  readonly profileName?: string;
+  readonly launchArgs?: string;
   readonly environment?: NodeJS.ProcessEnv;
   readonly cwd: string;
   readonly runtimeMode: RuntimeMode;
@@ -719,7 +722,7 @@ export const makeCodexSessionRuntime = (
     };
     const child = yield* spawner
       .spawn(
-        ChildProcess.make(options.binaryPath, ["app-server"], {
+        ChildProcess.make(options.binaryPath, [...buildCodexGlobalArgs(options), "app-server"], {
           cwd: options.cwd,
           env,
           forceKillAfter: CODEX_APP_SERVER_FORCE_KILL_AFTER,
@@ -731,7 +734,9 @@ export const makeCodexSessionRuntime = (
         Effect.mapError(
           (cause) =>
             new CodexErrors.CodexAppServerSpawnError({
-              command: `${options.binaryPath} app-server`,
+              command: [options.binaryPath, ...buildCodexGlobalArgs(options), "app-server"].join(
+                " ",
+              ),
               cause,
             }),
         ),

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -58,6 +58,8 @@ const makeCodexConfig = (overrides: Partial<CodexSettings>): CodexSettings => ({
   binaryPath: "codex",
   homePath: "",
   shadowHomePath: "",
+  profileName: "",
+  launchArgs: "",
   customModels: [],
   ...overrides,
 });

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -30,7 +30,11 @@ import { deepMerge } from "@t3tools/shared/Struct";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
 
-import { checkCodexProviderStatus, type CodexAppServerProviderSnapshot } from "./CodexProvider.ts";
+import {
+  checkCodexProviderStatus,
+  resolveCodexRequiresOpenaiAuth,
+  type CodexAppServerProviderSnapshot,
+} from "./CodexProvider.ts";
 import { checkClaudeProviderStatus } from "./ClaudeProvider.ts";
 import { OpenCodeRuntimeLive } from "../opencodeRuntime.ts";
 import { NoOpProviderEventLoggers, ProviderEventLoggers } from "./ProviderEventLoggers.ts";
@@ -302,6 +306,29 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
   "ProviderRegistry",
   (it) => {
     describe("checkCodexProviderStatus", () => {
+      it("resolves OpenAI auth requirements from the configured Codex profile provider", () => {
+        assert.strictEqual(
+          resolveCodexRequiresOpenaiAuth(
+            {
+              model_provider: null,
+              profiles: {
+                work: {
+                  model: "gpt-5.5",
+                  model_provider: "codex-lb",
+                },
+              },
+              model_providers: {
+                "codex-lb": {
+                  requires_openai_auth: false,
+                },
+              },
+            },
+            "work",
+          ),
+          false,
+        );
+      });
+
       it.effect("uses the app-server account and model list for provider status", () =>
         Effect.gen(function* () {
           const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -346,6 +346,31 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
         }),
       );
 
+      it.effect("passes codex profile and launch args to the app-server probe", () =>
+        Effect.gen(function* () {
+          let probeInput:
+            | {
+                readonly profileName?: string;
+                readonly launchArgs?: string;
+              }
+            | undefined;
+          yield* checkCodexProviderStatus(
+            {
+              ...defaultCodexSettings,
+              profileName: "work",
+              launchArgs: "--config foo=bar",
+            },
+            (input) => {
+              probeInput = input;
+              return Effect.succeed(makeCodexProbeSnapshot());
+            },
+          );
+
+          assert.equal(probeInput?.profileName, "work");
+          assert.equal(probeInput?.launchArgs, "--config foo=bar");
+        }),
+      );
+
       it.effect("returns unauthenticated when app-server requires OpenAI auth", () =>
         Effect.gen(function* () {
           const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -118,6 +118,8 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         binaryPath: "/opt/homebrew/bin/codex",
         homePath: "/Users/julius/.codex",
         shadowHomePath: "",
+        profileName: "",
+        launchArgs: "",
         customModels: [],
       });
       assert.deepEqual(next.providers.claudeAgent, {
@@ -359,6 +361,8 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         binaryPath: "/opt/homebrew/bin/codex",
         homePath: "",
         shadowHomePath: "",
+        profileName: "",
+        launchArgs: "",
         customModels: [],
       });
       assert.deepEqual(next.providers.claudeAgent, {

--- a/apps/server/src/textGeneration/CodexTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.test.ts
@@ -35,6 +35,7 @@ function makeFakeCodexBinary(
     requireFastServiceTier?: boolean;
     requireReasoningEffort?: string;
     forbidReasoningEffort?: boolean;
+    requireArgPrefix?: ReadonlyArray<string>;
     stdinMustContain?: string;
     stdinMustNotContain?: string;
   },
@@ -54,6 +55,12 @@ function makeFakeCodexBinary(
         'seen_image="0"',
         'seen_fast_service_tier="0"',
         'seen_reasoning_effort=""',
+        ...(input.requireArgPrefix
+          ? input.requireArgPrefix.map(
+              (arg, index) =>
+                `[ "$${index + 1}" = ${JSON.stringify(arg)} ] || { printf "%s\\n" "missing arg prefix" >&2; exit 8; }`,
+            )
+          : []),
         "while [ $# -gt 0 ]; do",
         '  if [ "$1" = "--image" ]; then',
         "    shift",
@@ -164,6 +171,7 @@ function withFakeCodexEnv<A, E, R>(
     requireFastServiceTier?: boolean;
     requireReasoningEffort?: string;
     forbidReasoningEffort?: boolean;
+    requireArgPrefix?: ReadonlyArray<string>;
     stdinMustContain?: string;
     stdinMustNotContain?: string;
   },
@@ -173,7 +181,10 @@ function withFakeCodexEnv<A, E, R>(
     const fs = yield* FileSystem.FileSystem;
     const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-codex-text-" });
     const codexPath = yield* makeFakeCodexBinary(tempDir, input);
-    const config = decodeCodexSettings({ binaryPath: codexPath });
+    const config = decodeCodexSettings({
+      binaryPath: codexPath,
+      ...(input.requireArgPrefix ? { profileName: "work", launchArgs: "--config foo=bar" } : {}),
+    });
     const textGeneration = yield* makeCodexTextGeneration(config);
     return yield* effectFn(textGeneration);
   }).pipe(Effect.scoped);
@@ -233,6 +244,26 @@ it.layer(CodexTextGenerationTestLayer)("CodexTextGeneration", (it) => {
             ]),
           }),
       ),
+  );
+
+  it.effect("passes codex profile and extra args before exec", () =>
+    withFakeCodexEnv(
+      {
+        output: JSON.stringify({
+          subject: "Add important change",
+          body: "",
+        }),
+        requireArgPrefix: ["-p", "work", "--config", "foo=bar", "exec"],
+      },
+      (textGeneration) =>
+        textGeneration.generateCommitMessage({
+          cwd: process.cwd(),
+          branch: "feature/codex-effect",
+          stagedSummary: "M README.md",
+          stagedPatch: "diff --git a/README.md b/README.md",
+          modelSelection: DEFAULT_TEST_MODEL_SELECTION,
+        }),
+    ),
   );
 
   it.effect("defaults git text generation codex effort to low", () =>

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -37,6 +37,7 @@ import {
   getModelSelectionBooleanOptionValue,
   getModelSelectionStringOptionValue,
 } from "@t3tools/shared/model";
+import { buildCodexGlobalArgs } from "../provider/Layers/CodexCliArgs.ts";
 
 const CODEX_GIT_TEXT_GENERATION_REASONING_EFFORT = "low";
 const CODEX_TIMEOUT_MS = 180_000;
@@ -190,6 +191,7 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       const command = ChildProcess.make(
         codexConfig.binaryPath || "codex",
         [
+          ...buildCodexGlobalArgs(codexConfig),
           "exec",
           "--ephemeral",
           "--skip-git-repo-check",

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -113,6 +113,8 @@ function createBaseServerConfig(): ServerConfig {
           binaryPath: "",
           homePath: "",
           shadowHomePath: "",
+          profileName: "",
+          launchArgs: "",
           customModels: [],
         },
         claudeAgent: {

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -562,6 +562,10 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // Store subscriptions (prompt / images / terminal contexts)
   // ------------------------------------------------------------------
   const composerDraft = useComposerThreadDraft(composerDraftTarget);
+  const stickyModelSelectionByProvider = useComposerDraftStore(
+    (store) => store.stickyModelSelectionByProvider,
+  );
+  const stickyActiveProvider = useComposerDraftStore((store) => store.stickyActiveProvider);
   const prompt = composerDraft.prompt;
   const composerImages = composerDraft.images;
   const composerTerminalContexts = composerDraft.terminalContexts;
@@ -667,6 +671,33 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     if (explicitSelectedInstanceId) {
       return ProviderInstanceId.make(explicitSelectedInstanceId);
     }
+    if (stickyActiveProvider) {
+      const stickyEntry = providerInstanceEntries.find(
+        (entry) => entry.instanceId === stickyActiveProvider && entry.enabled,
+      );
+      if (
+        stickyEntry &&
+        stickyEntry.driverKind === selectedProvider &&
+        (!lockedContinuationGroupKey ||
+          stickyEntry.continuationGroupKey === lockedContinuationGroupKey)
+      ) {
+        return stickyEntry.instanceId;
+      }
+    }
+    for (const stickySelection of Object.values(stickyModelSelectionByProvider)) {
+      if (!stickySelection) continue;
+      const stickyEntry = providerInstanceEntries.find(
+        (entry) => entry.instanceId === stickySelection.instanceId && entry.enabled,
+      );
+      if (
+        stickyEntry &&
+        stickyEntry.driverKind === selectedProvider &&
+        (!lockedContinuationGroupKey ||
+          stickyEntry.continuationGroupKey === lockedContinuationGroupKey)
+      ) {
+        return stickyEntry.instanceId;
+      }
+    }
     const byKind = providerInstanceEntries.find(
       (entry) =>
         entry.enabled &&
@@ -692,6 +723,8 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     lockedProvider,
     providerInstanceEntries,
     selectedProvider,
+    stickyActiveProvider,
+    stickyModelSelectionByProvider,
   ]);
 
   const { modelOptions: composerModelOptions, selectedModel } = useEffectiveComposerModelState({

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -57,6 +57,11 @@ function renderWithTestRouter(children: ReactNode) {
   return render(<RouterProvider router={router} />);
 }
 
+async function chooseProfileOption(profileLabel: string, optionText: string) {
+  await page.getByRole("combobox", { name: profileLabel }).click();
+  await page.getByRole("option", { name: optionText }).click();
+}
+
 const authAccessHarness = vi.hoisted(() => {
   type Snapshot = AuthAccessSnapshot;
   let snapshot: Snapshot = {
@@ -481,6 +486,13 @@ describe("GeneralSettingsPanel observability", () => {
     resetServerStateForTests();
     await __resetLocalApiForTests();
     localStorage.clear();
+    useComposerDraftStore.setState({
+      draftsByThreadKey: {},
+      draftThreadsByThreadKey: {},
+      logicalProjectDraftThreadKeyByLogicalProjectKey: {},
+      stickyModelSelectionByProvider: {},
+      stickyActiveProvider: null,
+    });
     useUiStateStore.setState({ defaultAdvertisedEndpointKey: null });
     authAccessHarness.reset();
     mockConnectDesktopSshEnvironment.mockReset();
@@ -809,13 +821,66 @@ describe("GeneralSettingsPanel observability", () => {
     await expect.element(page.getByText("Codex default")).toBeInTheDocument();
     await expect.element(page.getByText("Claude default")).not.toBeInTheDocument();
 
-    await page.getByRole("button", { name: "Add profile" }).first().click();
-    await expect.element(page.getByText("codex_profile_1")).toBeInTheDocument();
-
-    await page.getByRole("button", { name: "Switch" }).first().click();
+    await chooseProfileOption("Codex profile", "Add profile");
+    await expect
+      .element(page.getByRole("combobox", { name: "Codex profile" }))
+      .toHaveTextContent("codex_profile_1");
+    await expect
+      .element(page.getByRole("button", { name: "Toggle Codex profile details" }))
+      .toHaveAttribute("aria-expanded", "true");
     expect(useComposerDraftStore.getState().stickyActiveProvider).toBe(
       ProviderInstanceId.make("codex_profile_1"),
     );
+  });
+
+  it("keeps one active profile per enabled provider", async () => {
+    setServerConfigSnapshot({
+      ...createBaseServerConfig(),
+      settings: {
+        ...DEFAULT_SERVER_SETTINGS,
+        providerInstances: {
+          ...DEFAULT_SERVER_SETTINGS.providerInstances,
+          [ProviderInstanceId.make("codex_profile_1")]: {
+            driver: ProviderDriverKind.make("codex"),
+            enabled: true,
+          },
+          [ProviderInstanceId.make("claudeAgent_profile_1")]: {
+            driver: ProviderDriverKind.make("claudeAgent"),
+            enabled: true,
+          },
+        },
+      },
+    });
+
+    mounted = await renderWithTestRouter(
+      <AppAtomRegistryProvider>
+        <GeneralSettingsPanel />
+      </AppAtomRegistryProvider>,
+    );
+
+    await expect
+      .element(page.getByRole("combobox", { name: "Codex profile" }))
+      .toHaveTextContent("Codex default");
+    await expect
+      .element(page.getByRole("combobox", { name: "Claude profile" }))
+      .toHaveTextContent("Claude default");
+    await expect
+      .element(page.getByRole("button", { name: "Toggle Codex profile details" }))
+      .toHaveAttribute("aria-expanded", "false");
+
+    await chooseProfileOption("Codex profile", "codex_profile_1");
+    await chooseProfileOption("Claude profile", "claudeAgent_profile_1");
+
+    await expect
+      .element(page.getByRole("combobox", { name: "Codex profile" }))
+      .toHaveTextContent("codex_profile_1");
+    await expect
+      .element(page.getByRole("combobox", { name: "Claude profile" }))
+      .toHaveTextContent("claudeAgent_profile_1");
+    expect(useComposerDraftStore.getState().stickyModelSelectionByProvider).toMatchObject({
+      codex_profile_1: { instanceId: "codex_profile_1" },
+      claudeAgent_profile_1: { instanceId: "claudeAgent_profile_1" },
+    });
   });
 
   it("creates and shows a pairing link when network access is enabled", async () => {

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -34,6 +34,7 @@ import {
 import { __resetLocalApiForTests } from "../../localApi";
 import { AppAtomRegistryProvider, resetAppAtomRegistryForTests } from "../../rpc/atomRegistry";
 import { resetServerStateForTests, setServerConfigSnapshot } from "../../rpc/serverState";
+import { useComposerDraftStore } from "../../composerDraftStore";
 import { useUiStateStore } from "../../uiStateStore";
 import { ConnectionsSettings } from "./ConnectionsSettings";
 import { DiagnosticsSettingsPanel } from "./DiagnosticsSettings";
@@ -759,6 +760,62 @@ describe("GeneralSettingsPanel observability", () => {
         ),
       )
       .toBeInTheDocument();
+  });
+
+  it("shows enabled provider profiles, adds profiles, and switches sticky composer selection", async () => {
+    const updateSettings = vi
+      .fn<LocalApi["server"]["updateSettings"]>()
+      .mockResolvedValue(DEFAULT_SERVER_SETTINGS);
+    window.nativeApi = {
+      persistence: {
+        getClientSettings: vi.fn().mockResolvedValue(null),
+        setClientSettings: vi.fn().mockResolvedValue(undefined),
+      },
+      server: { updateSettings },
+    } as unknown as LocalApi;
+    setServerConfigSnapshot({
+      ...createBaseServerConfig(),
+      settings: {
+        ...DEFAULT_SERVER_SETTINGS,
+        providers: {
+          ...DEFAULT_SERVER_SETTINGS.providers,
+          claudeAgent: { ...DEFAULT_SERVER_SETTINGS.providers.claudeAgent, enabled: false },
+        },
+      },
+      providers: [
+        {
+          instanceId: ProviderInstanceId.make("codex"),
+          driver: ProviderDriverKind.make("codex"),
+          enabled: true,
+          installed: true,
+          version: null,
+          status: "ready",
+          auth: { status: "authenticated" },
+          checkedAt: "2036-04-07T00:00:00.000Z",
+          models: [{ slug: "gpt-5.4", name: "GPT 5.4", capabilities: null, isCustom: false }],
+          slashCommands: [],
+          skills: [],
+        },
+      ],
+    });
+
+    mounted = await renderWithTestRouter(
+      <AppAtomRegistryProvider>
+        <GeneralSettingsPanel />
+      </AppAtomRegistryProvider>,
+    );
+
+    await expect.element(page.getByRole("heading", { name: "Profiles" })).toBeInTheDocument();
+    await expect.element(page.getByText("Codex default")).toBeInTheDocument();
+    await expect.element(page.getByText("Claude default")).not.toBeInTheDocument();
+
+    await page.getByRole("button", { name: "Add profile" }).first().click();
+    await expect.element(page.getByText("codex_profile_1")).toBeInTheDocument();
+
+    await page.getByRole("button", { name: "Switch" }).first().click();
+    expect(useComposerDraftStore.getState().stickyActiveProvider).toBe(
+      ProviderInstanceId.make("codex_profile_1"),
+    );
   });
 
   it("creates and shows a pairing link when network access is enabled", async () => {

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -2,9 +2,11 @@ import type {
   ProviderDriverKind,
   ProviderInstanceConfig,
   ProviderInstanceId,
+  ServerProvider,
   ServerSettings,
   UnifiedSettings,
 } from "@t3tools/contracts";
+import { defaultInstanceIdForDriver } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 
 function collapseOtelSignalsUrl(input: {
@@ -88,4 +90,74 @@ export function buildProviderInstanceUpdatePatch(input: {
       ? { textGenerationModelSelection: input.textGenerationModelSelection }
       : {}),
   };
+}
+
+export interface ProviderProfileRow {
+  readonly instanceId: ProviderInstanceId;
+  readonly instance: ProviderInstanceConfig;
+  readonly isDefault: boolean;
+}
+
+export interface ProviderProfileGroup {
+  readonly driver: ProviderDriverKind;
+  readonly rows: ReadonlyArray<ProviderProfileRow>;
+}
+
+export function nextProviderProfileId(
+  providerInstances: Readonly<Record<ProviderInstanceId, ProviderInstanceConfig>>,
+  driver: ProviderDriverKind,
+): ProviderInstanceId {
+  let index = 1;
+  while (providerInstances[ProviderInstanceId.make(`${driver}_profile_${index}`)] !== undefined) {
+    index++;
+  }
+  return ProviderInstanceId.make(`${driver}_profile_${index}`);
+}
+
+export function buildProviderProfileGroups(input: {
+  readonly settings: Pick<ServerSettings, "providers" | "providerInstances">;
+  readonly serverProviders: ReadonlyArray<ServerProvider>;
+  readonly drivers: ReadonlyArray<ProviderDriverKind>;
+}): ReadonlyArray<ProviderProfileGroup> {
+  type LegacyProviderSettings = ServerSettings["providers"][keyof ServerSettings["providers"]];
+  const legacyProviders = input.settings.providers as Record<string, LegacyProviderSettings>;
+
+  return input.drivers
+    .filter((driver) => {
+      const defaultId = defaultInstanceIdForDriver(driver);
+      return (
+        (input.settings.providerInstances[defaultId]?.enabled ??
+          legacyProviders[driver]?.enabled ??
+          false) &&
+        (input.serverProviders.find((provider) => provider.instanceId === defaultId)?.enabled ??
+          true)
+      );
+    })
+    .map((driver) => {
+      const defaultId = defaultInstanceIdForDriver(driver);
+      const defaultConfig = legacyProviders[driver]!;
+      const defaultInstance =
+        input.settings.providerInstances[defaultId] ??
+        ({
+          driver,
+          enabled: defaultConfig.enabled,
+          config: defaultConfig,
+        } satisfies ProviderInstanceConfig);
+
+      const rows: ProviderProfileRow[] = [
+        { instanceId: defaultId, instance: defaultInstance, isDefault: true },
+        ...Object.entries(input.settings.providerInstances)
+          .filter(
+            ([id, instance]) =>
+              id !== defaultId && instance.driver === driver && (instance.enabled ?? true),
+          )
+          .map(([instanceId, instance]) => ({
+            instanceId: instanceId as ProviderInstanceId,
+            instance,
+            isDefault: false,
+          })),
+      ];
+
+      return { driver, rows };
+    });
 }

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,12 +1,10 @@
 import type {
   ProviderDriverKind,
   ProviderInstanceConfig,
-  ProviderInstanceId,
-  ServerProvider,
   ServerSettings,
   UnifiedSettings,
 } from "@t3tools/contracts";
-import { defaultInstanceIdForDriver } from "@t3tools/contracts";
+import type { ProviderInstanceId } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 
 function collapseOtelSignalsUrl(input: {
@@ -90,74 +88,4 @@ export function buildProviderInstanceUpdatePatch(input: {
       ? { textGenerationModelSelection: input.textGenerationModelSelection }
       : {}),
   };
-}
-
-export interface ProviderProfileRow {
-  readonly instanceId: ProviderInstanceId;
-  readonly instance: ProviderInstanceConfig;
-  readonly isDefault: boolean;
-}
-
-export interface ProviderProfileGroup {
-  readonly driver: ProviderDriverKind;
-  readonly rows: ReadonlyArray<ProviderProfileRow>;
-}
-
-export function nextProviderProfileId(
-  providerInstances: Readonly<Record<ProviderInstanceId, ProviderInstanceConfig>>,
-  driver: ProviderDriverKind,
-): ProviderInstanceId {
-  let index = 1;
-  while (providerInstances[ProviderInstanceId.make(`${driver}_profile_${index}`)] !== undefined) {
-    index++;
-  }
-  return ProviderInstanceId.make(`${driver}_profile_${index}`);
-}
-
-export function buildProviderProfileGroups(input: {
-  readonly settings: Pick<ServerSettings, "providers" | "providerInstances">;
-  readonly serverProviders: ReadonlyArray<ServerProvider>;
-  readonly drivers: ReadonlyArray<ProviderDriverKind>;
-}): ReadonlyArray<ProviderProfileGroup> {
-  type LegacyProviderSettings = ServerSettings["providers"][keyof ServerSettings["providers"]];
-  const legacyProviders = input.settings.providers as Record<string, LegacyProviderSettings>;
-
-  return input.drivers
-    .filter((driver) => {
-      const defaultId = defaultInstanceIdForDriver(driver);
-      return (
-        (input.settings.providerInstances[defaultId]?.enabled ??
-          legacyProviders[driver]?.enabled ??
-          false) &&
-        (input.serverProviders.find((provider) => provider.instanceId === defaultId)?.enabled ??
-          true)
-      );
-    })
-    .map((driver) => {
-      const defaultId = defaultInstanceIdForDriver(driver);
-      const defaultConfig = legacyProviders[driver]!;
-      const defaultInstance =
-        input.settings.providerInstances[defaultId] ??
-        ({
-          driver,
-          enabled: defaultConfig.enabled,
-          config: defaultConfig,
-        } satisfies ProviderInstanceConfig);
-
-      const rows: ProviderProfileRow[] = [
-        { instanceId: defaultId, instance: defaultInstance, isDefault: true },
-        ...Object.entries(input.settings.providerInstances)
-          .filter(
-            ([id, instance]) =>
-              id !== defaultId && instance.driver === driver && (instance.enabled ?? true),
-          )
-          .map(([instanceId, instance]) => ({
-            instanceId: instanceId as ProviderInstanceId,
-            instance,
-            isDefault: false,
-          })),
-      ];
-
-      return { driver, rows };
-    });
 }

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,10 +1,10 @@
 import type {
   ProviderDriverKind,
   ProviderInstanceConfig,
+  ProviderInstanceId,
   ServerSettings,
   UnifiedSettings,
 } from "@t3tools/contracts";
-import type { ProviderInstanceId } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 
 function collapseOtelSignalsUrl(input: {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -3,12 +3,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
+  DEFAULT_MODEL,
+  DEFAULT_MODEL_BY_PROVIDER,
   defaultInstanceIdForDriver,
   type DesktopUpdateChannel,
   PROVIDER_DISPLAY_NAMES,
   ProviderDriverKind,
   type ProviderInstanceConfig,
-  type ProviderInstanceId,
+  ProviderInstanceId,
   type ScopedThreadRef,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime";
@@ -48,6 +50,7 @@ import { useShallow } from "zustand/react/shallow";
 import { selectProjectsAcrossEnvironments, useStore } from "../../store";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTime, formatRelativeTimeLabel } from "../../timestampFormat";
+import { useComposerDraftStore } from "../../composerDraftStore";
 import { Button } from "../ui/button";
 import { DraftInput } from "../ui/draft-input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
@@ -66,7 +69,9 @@ import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
   buildProviderInstanceUpdatePatch,
+  buildProviderProfileGroups,
   formatDiagnosticsDescription,
+  nextProviderProfileId,
 } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -77,6 +82,7 @@ import {
 } from "./settingsLayout";
 import { ProjectFavicon } from "../ProjectFavicon";
 import { useServerObservability, useServerProviders } from "../../rpc/serverState";
+import { ProviderSettingsForm } from "./ProviderSettingsForm";
 
 const THEME_OPTIONS = [
   {
@@ -117,9 +123,11 @@ function withoutProviderInstanceFavorites(
   return favorites.filter((favorite) => favorite.provider !== instanceId);
 }
 
-const PROVIDER_SETTINGS = DRIVER_OPTIONS.map((definition) => ({
-  provider: definition.value,
-}));
+const PROVIDER_SETTINGS = DRIVER_OPTIONS.map((definition) => ({ provider: definition.value }));
+
+function providerProfileDisplayName(instance: ProviderInstanceConfig, fallback: string): string {
+  return instance.displayName?.trim() || fallback;
+}
 
 function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }) {
   useRelativeTimeTick();
@@ -483,6 +491,8 @@ export function GeneralSettingsPanel() {
   const { updateSettings } = useUpdateSettings();
   const observability = useServerObservability();
   const serverProviders = useServerProviders();
+  const stickyActiveProvider = useComposerDraftStore((store) => store.stickyActiveProvider);
+  const setStickyModelSelection = useComposerDraftStore((store) => store.setStickyModelSelection);
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
     otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
@@ -513,9 +523,169 @@ export function GeneralSettingsPanel() {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
+  const profileGroups = buildProviderProfileGroups({
+    settings,
+    serverProviders,
+    drivers: DRIVER_OPTIONS.map((option) => option.value),
+  });
+  const activeProfileId = stickyActiveProvider ?? ProviderInstanceId.make("codex");
+
+  const switchProfile = (instanceId: ProviderInstanceId, driver: ProviderDriverKind) => {
+    const liveProvider = serverProviders.find((provider) => provider.instanceId === instanceId);
+    setStickyModelSelection(
+      createModelSelection(
+        instanceId,
+        liveProvider?.models.find((model) => !model.isCustom)?.slug ??
+          liveProvider?.models[0]?.slug ??
+          DEFAULT_MODEL_BY_PROVIDER[driver] ??
+          DEFAULT_MODEL,
+      ),
+    );
+  };
+
+  const addProfile = (driver: ProviderDriverKind) => {
+    const driverOption = getDriverOption(driver);
+    const instanceId = nextProviderProfileId(settings.providerInstances, driver);
+    updateSettings({
+      providerInstances: {
+        ...settings.providerInstances,
+        [instanceId]: {
+          driver,
+          enabled: true,
+          displayName: `${driverOption?.label ?? String(driver)} profile`,
+        },
+      },
+    });
+  };
+
+  const updateProfile = (
+    row: {
+      readonly instanceId: ProviderInstanceId;
+      readonly instance: ProviderInstanceConfig;
+      readonly isDefault: boolean;
+    },
+    next: ProviderInstanceConfig,
+  ) => {
+    updateSettings(
+      buildProviderInstanceUpdatePatch({
+        settings,
+        instanceId: row.instanceId,
+        instance: next,
+        driver: row.instance.driver,
+        isDefault: row.isDefault,
+      }),
+    );
+  };
 
   return (
     <SettingsPageContainer>
+      <SettingsSection title="Profiles">
+        {profileGroups.map((group) => {
+          const driverOption = getDriverOption(group.driver);
+          if (!driverOption) return null;
+          return (
+            <div key={group.driver} className="border-t border-border/60 first:border-t-0">
+              <SettingsRow
+                title={driverOption.label}
+                description="Named provider presets for new composer selections."
+                control={
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="outline"
+                    className="gap-1.5"
+                    onClick={() => addProfile(group.driver)}
+                  >
+                    <PlusIcon className="size-3.5" />
+                    Add profile
+                  </Button>
+                }
+              />
+              <div className="grid gap-2 px-4 pb-4 sm:px-5">
+                {group.rows.map((row) => {
+                  const isActive = activeProfileId === row.instanceId;
+                  const displayName = providerProfileDisplayName(
+                    row.instance,
+                    row.isDefault ? `${driverOption.label} default` : row.instanceId,
+                  );
+                  const updateDisplayName = (value: string) => {
+                    const trimmed = value.trim();
+                    const { displayName: _displayName, ...rest } = row.instance;
+                    updateProfile(
+                      row,
+                      trimmed
+                        ? ({ ...rest, displayName: trimmed } as ProviderInstanceConfig)
+                        : (rest as ProviderInstanceConfig),
+                    );
+                  };
+                  const updateConfig = (config: Record<string, unknown> | undefined) => {
+                    const { config: _config, ...rest } = row.instance;
+                    updateProfile(
+                      row,
+                      config
+                        ? ({ ...rest, config } as ProviderInstanceConfig)
+                        : (rest as ProviderInstanceConfig),
+                    );
+                  };
+                  return (
+                    <div
+                      key={row.instanceId}
+                      className="overflow-hidden rounded-md border border-border/70 bg-background"
+                    >
+                      <div className="flex flex-col gap-2 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="min-w-0">
+                          <div className="flex min-w-0 flex-wrap items-center gap-2">
+                            <span className="truncate text-sm font-medium">{displayName}</span>
+                            <code className="truncate rounded bg-muted/60 px-1 py-0.5 text-[10px] text-muted-foreground">
+                              {row.instanceId}
+                            </code>
+                          </div>
+                          <span className="text-xs text-muted-foreground">
+                            {row.isDefault ? "Default profile" : "Custom profile"}
+                          </span>
+                        </div>
+                        {isActive ? (
+                          <span className="text-xs font-medium text-primary">Active</span>
+                        ) : (
+                          <Button
+                            type="button"
+                            size="xs"
+                            variant="outline"
+                            onClick={() => switchProfile(row.instanceId, group.driver)}
+                          >
+                            Switch
+                          </Button>
+                        )}
+                      </div>
+                      <div className="border-t border-border/60 px-3 py-3">
+                        <label className="block">
+                          <span className="text-xs font-medium text-foreground">Display name</span>
+                          <DraftInput
+                            className="mt-1.5"
+                            value={row.instance.displayName ?? ""}
+                            onCommit={updateDisplayName}
+                            placeholder={driverOption.label}
+                            spellCheck={false}
+                            aria-label={`${displayName} display name`}
+                          />
+                        </label>
+                      </div>
+                      <ProviderSettingsForm
+                        definition={driverOption}
+                        value={row.instance.config}
+                        idPrefix={`profile-${row.instanceId}`}
+                        variant="card"
+                        onChange={updateConfig}
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </SettingsSection>
+
       <SettingsSection title="General">
         <SettingsRow
           title="Theme"

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -601,6 +601,9 @@ export function GeneralSettingsPanel() {
     });
   };
 
+  const setProfileDetailsOpen = (driver: ProviderDriverKind, open: boolean) =>
+    setOpenProfileDetails((existing) => ({ ...existing, [driver]: open }));
+
   const updateProfile = (
     row: {
       readonly instanceId: ProviderInstanceId;
@@ -623,170 +626,161 @@ export function GeneralSettingsPanel() {
   return (
     <SettingsPageContainer>
       <SettingsSection title="Profiles">
-        <div>
-          {enabledProfileDrivers.map((driverOption) => {
-            const driver = driverOption.value;
-            const detailsOpen = openProfileDetails[driver] ?? false;
-            const defaultId = defaultInstanceIdForDriver(driver);
-            const defaultConfig = legacyProviders[driver]!;
-            const defaultInstance =
-              settings.providerInstances[defaultId] ??
-              ({
-                driver,
-                enabled: defaultConfig.enabled,
-                config: defaultConfig,
-              } satisfies ProviderInstanceConfig);
-            const rows = [
-              { instanceId: defaultId, instance: defaultInstance, isDefault: true },
-              ...Object.entries(settings.providerInstances)
-                .filter(
-                  ([id, instance]) =>
-                    id !== defaultId && instance.driver === driver && (instance.enabled ?? true),
-                )
-                .map(([instanceId, instance]) => ({
-                  instanceId: instanceId as ProviderInstanceId,
-                  instance,
-                  isDefault: false,
-                })),
-            ];
-            const rowIds = rows.map((row) => row.instanceId);
-            const activeProfileId =
-              stickyActiveProvider !== null && rowIds.includes(stickyActiveProvider)
-                ? stickyActiveProvider
-                : (rows.find((row) => stickyModelSelectionByProvider[row.instanceId])?.instanceId ??
-                  defaultId);
-            const activeRow = rows.find((row) => row.instanceId === activeProfileId) ?? rows[0]!;
-            const profileName = (row: (typeof rows)[number]) =>
-              row.instance.displayName?.trim() ||
-              (row.isDefault ? `${driverOption.label} default` : row.instanceId);
-            const updateDisplayName = (value: string) => {
-              const trimmed = value.trim();
-              const { displayName: _displayName, ...rest } = activeRow.instance;
-              updateProfile(
-                activeRow,
-                trimmed
-                  ? ({ ...rest, displayName: trimmed } as ProviderInstanceConfig)
-                  : (rest as ProviderInstanceConfig),
-              );
-            };
-            const updateConfig = (config: Record<string, unknown> | undefined) => {
-              const { config: _config, ...rest } = activeRow.instance;
-              updateProfile(
-                activeRow,
-                config
-                  ? ({ ...rest, config } as ProviderInstanceConfig)
-                  : (rest as ProviderInstanceConfig),
-              );
-            };
-            return (
-              <SettingsRow
-                key={driver}
-                className="py-3.5"
-                title={driverOption.label}
-                description="Provider profile used for new composer selections."
-                control={
-                  <div className="flex w-full items-center justify-end gap-1.5 sm:w-auto">
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
-                      onClick={() =>
-                        setOpenProfileDetails((existing) => ({
-                          ...existing,
-                          [driver]: !detailsOpen,
-                        }))
-                      }
-                      aria-expanded={detailsOpen}
-                      aria-label={`Toggle ${driverOption.label} profile details`}
-                    >
-                      <ChevronDownIcon
-                        className={`size-3.5 transition-transform ${detailsOpen ? "rotate-180" : ""}`}
-                      />
-                    </Button>
-                    <Select
-                      value={activeProfileId}
-                      onValueChange={(value) => {
-                        if (value === "__add_profile__") {
-                          const instanceId = addProfile(driver);
-                          switchProfile(instanceId, driver, [...rowIds, instanceId]);
-                          setOpenProfileDetails((existing) => ({ ...existing, [driver]: true }));
-                          return;
-                        }
-                        switchProfile(value as ProviderInstanceId, driver, rowIds);
-                      }}
-                    >
-                      <SelectTrigger
-                        size="sm"
-                        className="w-full sm:w-40"
-                        aria-label={`${driverOption.label} profile`}
-                      >
-                        <SelectValue>{profileName(activeRow)}</SelectValue>
-                      </SelectTrigger>
-                      <SelectPopup align="end" alignItemWithTrigger={false} matchTriggerWidth>
-                        {rows.map((row) => (
-                          <SelectItem hideIndicator key={row.instanceId} value={row.instanceId}>
-                            {profileName(row)}
-                          </SelectItem>
-                        ))}
-                        <SelectSeparator />
-                        <SelectItem hideIndicator value="__add_profile__">
-                          <span className="inline-flex items-center gap-1.5">
-                            <PlusIcon className="size-3.5" />
-                            Add profile
-                          </span>
-                        </SelectItem>
-                      </SelectPopup>
-                    </Select>
-                  </div>
-                }
-              >
-                <Collapsible
-                  open={detailsOpen}
-                  onOpenChange={(open) =>
-                    setOpenProfileDetails((existing) => ({ ...existing, [driver]: open }))
-                  }
-                >
-                  <CollapsibleContent>
-                    <div className="mt-3.5 border-t border-border/60 px-4 py-3 sm:px-5">
-                      <label className="block">
-                        <span className="text-xs font-medium text-foreground">Display name</span>
-                        <DraftInput
-                          className="mt-1.5"
-                          value={activeRow.instance.displayName ?? ""}
-                          onCommit={updateDisplayName}
-                          placeholder={driverOption.label}
-                          spellCheck={false}
-                          aria-label={`${profileName(activeRow)} display name`}
-                        />
-                      </label>
-                    </div>
-                    <ProviderSettingsForm
-                      definition={driverOption}
-                      value={activeRow.instance.config}
-                      idPrefix={`profile-${activeRow.instanceId}`}
-                      variant="card"
-                      onChange={updateConfig}
-                    />
-                    {!activeRow.isDefault ? (
-                      <div className="flex justify-end border-t border-border/60 px-4 py-3 sm:px-5">
-                        <Button
-                          type="button"
-                          size="xs"
-                          variant="ghost"
-                          className="gap-1.5 text-destructive hover:text-destructive"
-                          onClick={() => deleteProfile(activeRow.instanceId, driver)}
-                        >
-                          <Trash2Icon className="size-3.5" />
-                          Delete profile
-                        </Button>
-                      </div>
-                    ) : null}
-                  </CollapsibleContent>
-                </Collapsible>
-              </SettingsRow>
+        {enabledProfileDrivers.map((driverOption) => {
+          const driver = driverOption.value;
+          const detailsOpen = openProfileDetails[driver] ?? false;
+          const defaultId = defaultInstanceIdForDriver(driver);
+          const defaultConfig = legacyProviders[driver]!;
+          const defaultInstance =
+            settings.providerInstances[defaultId] ??
+            ({
+              driver,
+              enabled: defaultConfig.enabled,
+              config: defaultConfig,
+            } satisfies ProviderInstanceConfig);
+          const rows = [
+            { instanceId: defaultId, instance: defaultInstance, isDefault: true },
+            ...Object.entries(settings.providerInstances)
+              .filter(
+                ([id, instance]) =>
+                  id !== defaultId && instance.driver === driver && (instance.enabled ?? true),
+              )
+              .map(([instanceId, instance]) => ({
+                instanceId: instanceId as ProviderInstanceId,
+                instance,
+                isDefault: false,
+              })),
+          ];
+          const rowIds = rows.map((row) => row.instanceId);
+          const activeProfileId =
+            stickyActiveProvider !== null && rowIds.includes(stickyActiveProvider)
+              ? stickyActiveProvider
+              : (rows.find((row) => stickyModelSelectionByProvider[row.instanceId])?.instanceId ??
+                defaultId);
+          const activeRow = rows.find((row) => row.instanceId === activeProfileId) ?? rows[0]!;
+          const profileName = (row: (typeof rows)[number]) =>
+            row.instance.displayName?.trim() ||
+            (row.isDefault ? `${driverOption.label} default` : row.instanceId);
+          const updateDisplayName = (value: string) => {
+            const trimmed = value.trim();
+            const { displayName: _displayName, ...rest } = activeRow.instance;
+            updateProfile(
+              activeRow,
+              trimmed
+                ? ({ ...rest, displayName: trimmed } as ProviderInstanceConfig)
+                : (rest as ProviderInstanceConfig),
             );
-          })}
-        </div>
+          };
+          const updateConfig = (config: Record<string, unknown> | undefined) => {
+            const { config: _config, ...rest } = activeRow.instance;
+            updateProfile(
+              activeRow,
+              config
+                ? ({ ...rest, config } as ProviderInstanceConfig)
+                : (rest as ProviderInstanceConfig),
+            );
+          };
+          return (
+            <SettingsRow
+              key={driver}
+              className="py-3.5"
+              title={driverOption.label}
+              description="Provider profile used for new composer selections."
+              control={
+                <div className="flex w-full items-center justify-end gap-1.5 sm:w-auto">
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+                    onClick={() => setProfileDetailsOpen(driver, !detailsOpen)}
+                    aria-expanded={detailsOpen}
+                    aria-label={`Toggle ${driverOption.label} profile details`}
+                  >
+                    <ChevronDownIcon
+                      className={`size-3.5 transition-transform ${detailsOpen ? "rotate-180" : ""}`}
+                    />
+                  </Button>
+                  <Select
+                    value={activeProfileId}
+                    onValueChange={(value) => {
+                      if (value === "__add_profile__") {
+                        const instanceId = addProfile(driver);
+                        switchProfile(instanceId, driver, [...rowIds, instanceId]);
+                        setProfileDetailsOpen(driver, true);
+                        return;
+                      }
+                      switchProfile(value as ProviderInstanceId, driver, rowIds);
+                    }}
+                  >
+                    <SelectTrigger
+                      size="sm"
+                      className="w-full sm:w-40"
+                      aria-label={`${driverOption.label} profile`}
+                    >
+                      <SelectValue>{profileName(activeRow)}</SelectValue>
+                    </SelectTrigger>
+                    <SelectPopup align="end" alignItemWithTrigger={false} matchTriggerWidth>
+                      {rows.map((row) => (
+                        <SelectItem hideIndicator key={row.instanceId} value={row.instanceId}>
+                          {profileName(row)}
+                        </SelectItem>
+                      ))}
+                      <SelectSeparator />
+                      <SelectItem hideIndicator value="__add_profile__">
+                        <span className="inline-flex items-center gap-1.5">
+                          <PlusIcon className="size-3.5" />
+                          Add profile
+                        </span>
+                      </SelectItem>
+                    </SelectPopup>
+                  </Select>
+                </div>
+              }
+            >
+              <Collapsible
+                open={detailsOpen}
+                onOpenChange={(open) => setProfileDetailsOpen(driver, open)}
+              >
+                <CollapsibleContent>
+                  <div className="mt-3.5 border-t border-border/60 px-4 py-3 sm:px-5">
+                    <label className="block">
+                      <span className="text-xs font-medium text-foreground">Display name</span>
+                      <DraftInput
+                        className="mt-1.5"
+                        value={activeRow.instance.displayName ?? ""}
+                        onCommit={updateDisplayName}
+                        placeholder={driverOption.label}
+                        spellCheck={false}
+                        aria-label={`${profileName(activeRow)} display name`}
+                      />
+                    </label>
+                  </div>
+                  <ProviderSettingsForm
+                    definition={driverOption}
+                    value={activeRow.instance.config}
+                    idPrefix={`profile-${activeRow.instanceId}`}
+                    variant="card"
+                    onChange={updateConfig}
+                  />
+                  {!activeRow.isDefault ? (
+                    <div className="flex justify-end border-t border-border/60 px-4 py-3 sm:px-5">
+                      <Button
+                        type="button"
+                        size="xs"
+                        variant="ghost"
+                        className="gap-1.5 text-destructive hover:text-destructive"
+                        onClick={() => deleteProfile(activeRow.instanceId, driver)}
+                      >
+                        <Trash2Icon className="size-3.5" />
+                        Delete profile
+                      </Button>
+                    </div>
+                  ) : null}
+                </CollapsibleContent>
+              </Collapsible>
+            </SettingsRow>
+          );
+        })}
       </SettingsSection>
 
       <SettingsSection title="General">

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1,4 +1,12 @@
-import { ArchiveIcon, ArchiveX, LoaderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
+import {
+  ArchiveIcon,
+  ArchiveX,
+  ChevronDownIcon,
+  LoaderIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  Trash2Icon,
+} from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -53,7 +61,14 @@ import { formatRelativeTime, formatRelativeTimeLabel } from "../../timestampForm
 import { useComposerDraftStore } from "../../composerDraftStore";
 import { Button } from "../ui/button";
 import { DraftInput } from "../ui/draft-input";
-import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select";
 import { Switch } from "../ui/switch";
 import { stackedThreadToast, toastManager } from "../ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -69,9 +84,7 @@ import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
   buildProviderInstanceUpdatePatch,
-  buildProviderProfileGroups,
   formatDiagnosticsDescription,
-  nextProviderProfileId,
 } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -83,6 +96,7 @@ import {
 import { ProjectFavicon } from "../ProjectFavicon";
 import { useServerObservability, useServerProviders } from "../../rpc/serverState";
 import { ProviderSettingsForm } from "./ProviderSettingsForm";
+import { Collapsible, CollapsibleContent } from "../ui/collapsible";
 
 const THEME_OPTIONS = [
   {
@@ -124,10 +138,6 @@ function withoutProviderInstanceFavorites(
 }
 
 const PROVIDER_SETTINGS = DRIVER_OPTIONS.map((definition) => ({ provider: definition.value }));
-
-function providerProfileDisplayName(instance: ProviderInstanceConfig, fallback: string): string {
-  return instance.displayName?.trim() || fallback;
-}
 
 function ProviderLastChecked({ lastCheckedAt }: { lastCheckedAt: string | null }) {
   useRelativeTimeTick();
@@ -492,7 +502,15 @@ export function GeneralSettingsPanel() {
   const observability = useServerObservability();
   const serverProviders = useServerProviders();
   const stickyActiveProvider = useComposerDraftStore((store) => store.stickyActiveProvider);
-  const setStickyModelSelection = useComposerDraftStore((store) => store.setStickyModelSelection);
+  const stickyModelSelectionByProvider = useComposerDraftStore(
+    (store) => store.stickyModelSelectionByProvider,
+  );
+  const setStickyModelSelectionForInstances = useComposerDraftStore(
+    (store) => store.setStickyModelSelectionForInstances,
+  );
+  const [openProfileDetails, setOpenProfileDetails] = useState<
+    Partial<Record<ProviderDriverKind, boolean>>
+  >({});
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
     otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
@@ -523,16 +541,24 @@ export function GeneralSettingsPanel() {
     settings.textGenerationModelSelection ?? null,
     DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection ?? null,
   );
-  const profileGroups = buildProviderProfileGroups({
-    settings,
-    serverProviders,
-    drivers: DRIVER_OPTIONS.map((option) => option.value),
+  type LegacyProviderSettings = (typeof settings.providers)[keyof typeof settings.providers];
+  const legacyProviders = settings.providers as Record<string, LegacyProviderSettings>;
+  const enabledProfileDrivers = DRIVER_OPTIONS.filter((option) => {
+    const defaultId = defaultInstanceIdForDriver(option.value);
+    return (
+      (settings.providerInstances[defaultId]?.enabled ??
+        legacyProviders[option.value]?.enabled ??
+        false) &&
+      (serverProviders.find((provider) => provider.instanceId === defaultId)?.enabled ?? true)
+    );
   });
-  const activeProfileId = stickyActiveProvider ?? ProviderInstanceId.make("codex");
-
-  const switchProfile = (instanceId: ProviderInstanceId, driver: ProviderDriverKind) => {
+  const switchProfile = (
+    instanceId: ProviderInstanceId,
+    driver: ProviderDriverKind,
+    instanceIds: ReadonlyArray<ProviderInstanceId>,
+  ) => {
     const liveProvider = serverProviders.find((provider) => provider.instanceId === instanceId);
-    setStickyModelSelection(
+    setStickyModelSelectionForInstances(
       createModelSelection(
         instanceId,
         liveProvider?.models.find((model) => !model.isCustom)?.slug ??
@@ -540,21 +566,38 @@ export function GeneralSettingsPanel() {
           DEFAULT_MODEL_BY_PROVIDER[driver] ??
           DEFAULT_MODEL,
       ),
+      instanceIds,
     );
   };
 
-  const addProfile = (driver: ProviderDriverKind) => {
-    const driverOption = getDriverOption(driver);
-    const instanceId = nextProviderProfileId(settings.providerInstances, driver);
+  const addProfile = (driver: ProviderDriverKind): ProviderInstanceId => {
+    let index = 1;
+    while (settings.providerInstances[ProviderInstanceId.make(`${driver}_profile_${index}`)]) {
+      index++;
+    }
+    const instanceId = ProviderInstanceId.make(`${driver}_profile_${index}`);
     updateSettings({
       providerInstances: {
         ...settings.providerInstances,
         [instanceId]: {
           driver,
           enabled: true,
-          displayName: `${driverOption?.label ?? String(driver)} profile`,
         },
       },
+    });
+    return instanceId;
+  };
+
+  const deleteProfile = (instanceId: ProviderInstanceId, driver: ProviderDriverKind) => {
+    const defaultId = defaultInstanceIdForDriver(driver);
+    switchProfile(defaultId, driver, [defaultId, instanceId]);
+    updateSettings({
+      providerInstances: withoutProviderInstanceKey(settings.providerInstances, instanceId),
+      providerModelPreferences: withoutProviderInstanceKey(
+        settings.providerModelPreferences,
+        instanceId,
+      ),
+      favorites: withoutProviderInstanceFavorites(settings.favorites ?? [], instanceId),
     });
   };
 
@@ -580,110 +623,170 @@ export function GeneralSettingsPanel() {
   return (
     <SettingsPageContainer>
       <SettingsSection title="Profiles">
-        {profileGroups.map((group) => {
-          const driverOption = getDriverOption(group.driver);
-          if (!driverOption) return null;
-          return (
-            <div key={group.driver} className="border-t border-border/60 first:border-t-0">
+        <div>
+          {enabledProfileDrivers.map((driverOption) => {
+            const driver = driverOption.value;
+            const detailsOpen = openProfileDetails[driver] ?? false;
+            const defaultId = defaultInstanceIdForDriver(driver);
+            const defaultConfig = legacyProviders[driver]!;
+            const defaultInstance =
+              settings.providerInstances[defaultId] ??
+              ({
+                driver,
+                enabled: defaultConfig.enabled,
+                config: defaultConfig,
+              } satisfies ProviderInstanceConfig);
+            const rows = [
+              { instanceId: defaultId, instance: defaultInstance, isDefault: true },
+              ...Object.entries(settings.providerInstances)
+                .filter(
+                  ([id, instance]) =>
+                    id !== defaultId && instance.driver === driver && (instance.enabled ?? true),
+                )
+                .map(([instanceId, instance]) => ({
+                  instanceId: instanceId as ProviderInstanceId,
+                  instance,
+                  isDefault: false,
+                })),
+            ];
+            const rowIds = rows.map((row) => row.instanceId);
+            const activeProfileId =
+              stickyActiveProvider !== null && rowIds.includes(stickyActiveProvider)
+                ? stickyActiveProvider
+                : (rows.find((row) => stickyModelSelectionByProvider[row.instanceId])?.instanceId ??
+                  defaultId);
+            const activeRow = rows.find((row) => row.instanceId === activeProfileId) ?? rows[0]!;
+            const profileName = (row: (typeof rows)[number]) =>
+              row.instance.displayName?.trim() ||
+              (row.isDefault ? `${driverOption.label} default` : row.instanceId);
+            const updateDisplayName = (value: string) => {
+              const trimmed = value.trim();
+              const { displayName: _displayName, ...rest } = activeRow.instance;
+              updateProfile(
+                activeRow,
+                trimmed
+                  ? ({ ...rest, displayName: trimmed } as ProviderInstanceConfig)
+                  : (rest as ProviderInstanceConfig),
+              );
+            };
+            const updateConfig = (config: Record<string, unknown> | undefined) => {
+              const { config: _config, ...rest } = activeRow.instance;
+              updateProfile(
+                activeRow,
+                config
+                  ? ({ ...rest, config } as ProviderInstanceConfig)
+                  : (rest as ProviderInstanceConfig),
+              );
+            };
+            return (
               <SettingsRow
+                key={driver}
+                className="py-3.5"
                 title={driverOption.label}
-                description="Named provider presets for new composer selections."
+                description="Provider profile used for new composer selections."
                 control={
-                  <Button
-                    type="button"
-                    size="xs"
-                    variant="outline"
-                    className="gap-1.5"
-                    onClick={() => addProfile(group.driver)}
-                  >
-                    <PlusIcon className="size-3.5" />
-                    Add profile
-                  </Button>
-                }
-              />
-              <div className="grid gap-2 px-4 pb-4 sm:px-5">
-                {group.rows.map((row) => {
-                  const isActive = activeProfileId === row.instanceId;
-                  const displayName = providerProfileDisplayName(
-                    row.instance,
-                    row.isDefault ? `${driverOption.label} default` : row.instanceId,
-                  );
-                  const updateDisplayName = (value: string) => {
-                    const trimmed = value.trim();
-                    const { displayName: _displayName, ...rest } = row.instance;
-                    updateProfile(
-                      row,
-                      trimmed
-                        ? ({ ...rest, displayName: trimmed } as ProviderInstanceConfig)
-                        : (rest as ProviderInstanceConfig),
-                    );
-                  };
-                  const updateConfig = (config: Record<string, unknown> | undefined) => {
-                    const { config: _config, ...rest } = row.instance;
-                    updateProfile(
-                      row,
-                      config
-                        ? ({ ...rest, config } as ProviderInstanceConfig)
-                        : (rest as ProviderInstanceConfig),
-                    );
-                  };
-                  return (
-                    <div
-                      key={row.instanceId}
-                      className="overflow-hidden rounded-md border border-border/70 bg-background"
+                  <div className="flex w-full items-center justify-end gap-1.5 sm:w-auto">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
+                      onClick={() =>
+                        setOpenProfileDetails((existing) => ({
+                          ...existing,
+                          [driver]: !detailsOpen,
+                        }))
+                      }
+                      aria-expanded={detailsOpen}
+                      aria-label={`Toggle ${driverOption.label} profile details`}
                     >
-                      <div className="flex flex-col gap-2 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between">
-                        <div className="min-w-0">
-                          <div className="flex min-w-0 flex-wrap items-center gap-2">
-                            <span className="truncate text-sm font-medium">{displayName}</span>
-                            <code className="truncate rounded bg-muted/60 px-1 py-0.5 text-[10px] text-muted-foreground">
-                              {row.instanceId}
-                            </code>
-                          </div>
-                          <span className="text-xs text-muted-foreground">
-                            {row.isDefault ? "Default profile" : "Custom profile"}
-                          </span>
-                        </div>
-                        {isActive ? (
-                          <span className="text-xs font-medium text-primary">Active</span>
-                        ) : (
-                          <Button
-                            type="button"
-                            size="xs"
-                            variant="outline"
-                            onClick={() => switchProfile(row.instanceId, group.driver)}
-                          >
-                            Switch
-                          </Button>
-                        )}
-                      </div>
-                      <div className="border-t border-border/60 px-3 py-3">
-                        <label className="block">
-                          <span className="text-xs font-medium text-foreground">Display name</span>
-                          <DraftInput
-                            className="mt-1.5"
-                            value={row.instance.displayName ?? ""}
-                            onCommit={updateDisplayName}
-                            placeholder={driverOption.label}
-                            spellCheck={false}
-                            aria-label={`${displayName} display name`}
-                          />
-                        </label>
-                      </div>
-                      <ProviderSettingsForm
-                        definition={driverOption}
-                        value={row.instance.config}
-                        idPrefix={`profile-${row.instanceId}`}
-                        variant="card"
-                        onChange={updateConfig}
+                      <ChevronDownIcon
+                        className={`size-3.5 transition-transform ${detailsOpen ? "rotate-180" : ""}`}
                       />
+                    </Button>
+                    <Select
+                      value={activeProfileId}
+                      onValueChange={(value) => {
+                        if (value === "__add_profile__") {
+                          const instanceId = addProfile(driver);
+                          switchProfile(instanceId, driver, [...rowIds, instanceId]);
+                          setOpenProfileDetails((existing) => ({ ...existing, [driver]: true }));
+                          return;
+                        }
+                        switchProfile(value as ProviderInstanceId, driver, rowIds);
+                      }}
+                    >
+                      <SelectTrigger
+                        size="sm"
+                        className="w-full sm:w-40"
+                        aria-label={`${driverOption.label} profile`}
+                      >
+                        <SelectValue>{profileName(activeRow)}</SelectValue>
+                      </SelectTrigger>
+                      <SelectPopup align="end" alignItemWithTrigger={false} matchTriggerWidth>
+                        {rows.map((row) => (
+                          <SelectItem hideIndicator key={row.instanceId} value={row.instanceId}>
+                            {profileName(row)}
+                          </SelectItem>
+                        ))}
+                        <SelectSeparator />
+                        <SelectItem hideIndicator value="__add_profile__">
+                          <span className="inline-flex items-center gap-1.5">
+                            <PlusIcon className="size-3.5" />
+                            Add profile
+                          </span>
+                        </SelectItem>
+                      </SelectPopup>
+                    </Select>
+                  </div>
+                }
+              >
+                <Collapsible
+                  open={detailsOpen}
+                  onOpenChange={(open) =>
+                    setOpenProfileDetails((existing) => ({ ...existing, [driver]: open }))
+                  }
+                >
+                  <CollapsibleContent>
+                    <div className="mt-3.5 border-t border-border/60 px-4 py-3 sm:px-5">
+                      <label className="block">
+                        <span className="text-xs font-medium text-foreground">Display name</span>
+                        <DraftInput
+                          className="mt-1.5"
+                          value={activeRow.instance.displayName ?? ""}
+                          onCommit={updateDisplayName}
+                          placeholder={driverOption.label}
+                          spellCheck={false}
+                          aria-label={`${profileName(activeRow)} display name`}
+                        />
+                      </label>
                     </div>
-                  );
-                })}
-              </div>
-            </div>
-          );
-        })}
+                    <ProviderSettingsForm
+                      definition={driverOption}
+                      value={activeRow.instance.config}
+                      idPrefix={`profile-${activeRow.instanceId}`}
+                      variant="card"
+                      onChange={updateConfig}
+                    />
+                    {!activeRow.isDefault ? (
+                      <div className="flex justify-end border-t border-border/60 px-4 py-3 sm:px-5">
+                        <Button
+                          type="button"
+                          size="xs"
+                          variant="ghost"
+                          className="gap-1.5 text-destructive hover:text-destructive"
+                          onClick={() => deleteProfile(activeRow.instanceId, driver)}
+                        >
+                          <Trash2Icon className="size-3.5" />
+                          Delete profile
+                        </Button>
+                      </div>
+                    ) : null}
+                  </CollapsibleContent>
+                </Collapsible>
+              </SettingsRow>
+            );
+          })}
+        </div>
       </SettingsSection>
 
       <SettingsSection title="General">

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -33,6 +33,8 @@ export interface ProviderClientDefinition {
   readonly badgeLabel?: string;
 }
 
+// When adding a provider or changing settings fields, update profile metadata
+// here too: Settings > General > Profiles renders from these definitions.
 export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = [
   {
     value: ProviderDriverKind.make("codex"),

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -53,6 +53,7 @@ export function SettingsRow({
   control,
   children,
   className,
+  contentClassName,
   ...rowProps
 }: Omit<ComponentPropsWithoutRef<"div">, "title"> & {
   title: ReactNode;
@@ -61,6 +62,7 @@ export function SettingsRow({
   resetAction?: ReactNode;
   control?: ReactNode;
   children?: ReactNode;
+  contentClassName?: string;
 }) {
   return (
     <div
@@ -71,7 +73,12 @@ export function SettingsRow({
         className,
       )}
     >
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div
+        className={cn(
+          "flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between",
+          contentClassName,
+        )}
+      >
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex min-h-5 items-center gap-1.5">
             <h3 className="text-[13px] font-semibold tracking-[-0.01em] text-foreground">

--- a/apps/web/src/composerDraftStore.test.ts
+++ b/apps/web/src/composerDraftStore.test.ts
@@ -1277,6 +1277,27 @@ describe("composerDraftStore sticky composer settings", () => {
     expect(useComposerDraftStore.getState().stickyActiveProvider).toBe("codex");
   });
 
+  it("replaces active drafts scoped to the same provider instances when storing a sticky profile", () => {
+    const store = useComposerDraftStore.getState();
+    const threadId = ThreadId.make("thread-sticky-profile");
+    const threadRef = scopeThreadRef(TEST_ENVIRONMENT_ID, threadId);
+    const profileInstance = ProviderInstanceId.make("codex_work");
+
+    store.setModelSelection(threadRef, modelSelection(CODEX_DRIVER, "gpt-5.4"));
+    store.setStickyModelSelectionForInstances(createModelSelection(profileInstance, "gpt-5.4"), [
+      CODEX_INSTANCE,
+      profileInstance,
+    ]);
+
+    expect(draftFor(threadId, TEST_ENVIRONMENT_ID)).toMatchObject({
+      activeProvider: profileInstance,
+      modelSelectionByProvider: {
+        [profileInstance]: createModelSelection(profileInstance, "gpt-5.4"),
+      },
+    });
+    expect(useComposerDraftStore.getState().stickyActiveProvider).toBe(profileInstance);
+  });
+
   it("normalizes empty sticky model options by dropping selection options", () => {
     const store = useComposerDraftStore.getState();
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -2279,12 +2279,34 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               }
             }
             nextMap[normalized.instanceId] = normalized;
+            const nextDraftsByThreadKey = { ...state.draftsByThreadKey };
+            for (const [threadKey, draft] of Object.entries(state.draftsByThreadKey)) {
+              if (!draft.activeProvider || !replaceable.has(draft.activeProvider)) {
+                continue;
+              }
+              const current = draft.modelSelectionByProvider[normalized.instanceId];
+              const nextDraftMap = {
+                ...draft.modelSelectionByProvider,
+                [normalized.instanceId]: createModelSelection(
+                  normalized.instanceId,
+                  current?.model ?? normalized.model,
+                  current?.options ?? normalized.options,
+                ),
+              };
+              nextDraftsByThreadKey[threadKey] = {
+                ...draft,
+                modelSelectionByProvider: nextDraftMap,
+                activeProvider: normalized.instanceId,
+              };
+            }
             return Equal.equals(state.stickyModelSelectionByProvider, nextMap) &&
-              state.stickyActiveProvider === normalized.instanceId
+              state.stickyActiveProvider === normalized.instanceId &&
+              Equal.equals(state.draftsByThreadKey, nextDraftsByThreadKey)
               ? state
               : {
                   stickyModelSelectionByProvider: nextMap,
                   stickyActiveProvider: normalized.instanceId,
+                  draftsByThreadKey: nextDraftsByThreadKey,
                 };
           });
         },

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -351,6 +351,10 @@ interface ComposerDraftStoreState {
   finalizePromotedDraftThread: (threadRef: ComposerThreadTarget) => void;
   clearDraftThread: (threadRef: ComposerThreadTarget) => void;
   setStickyModelSelection: (modelSelection: ModelSelection | null | undefined) => void;
+  setStickyModelSelectionForInstances: (
+    modelSelection: ModelSelection | null | undefined,
+    instanceIds: ReadonlyArray<ProviderInstanceId>,
+  ) => void;
   setPrompt: (threadRef: ComposerThreadTarget, prompt: string) => void;
   setTerminalContexts: (threadRef: ComposerThreadTarget, contexts: TerminalContextDraft[]) => void;
   setModelSelection: (
@@ -2259,6 +2263,29 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
               stickyModelSelectionByProvider: nextMap,
               stickyActiveProvider: normalized.instanceId,
             };
+          });
+        },
+        setStickyModelSelectionForInstances: (modelSelection, instanceIds) => {
+          const normalized = normalizeModelSelection(modelSelection);
+          if (!normalized) return;
+          const replaceable = new Set(instanceIds);
+          set((state) => {
+            const nextMap: Partial<Record<ProviderInstanceId, ModelSelection>> = {};
+            for (const [instanceId, selection] of Object.entries(
+              state.stickyModelSelectionByProvider,
+            ) as Array<[ProviderInstanceId, ModelSelection]>) {
+              if (!replaceable.has(instanceId)) {
+                nextMap[instanceId] = selection;
+              }
+            }
+            nextMap[normalized.instanceId] = normalized;
+            return Equal.equals(state.stickyModelSelectionByProvider, nextMap) &&
+              state.stickyActiveProvider === normalized.instanceId
+              ? state
+              : {
+                  stickyModelSelectionByProvider: nextMap,
+                  stickyActiveProvider: normalized.instanceId,
+                };
           });
         },
         applyStickyState: (threadRef) => {

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -2,11 +2,43 @@ import { describe, expect, it } from "vitest";
 import * as Schema from "effect/Schema";
 
 import { ProviderInstanceId } from "./providerInstance.ts";
-import { DEFAULT_SERVER_SETTINGS, ServerSettings, ServerSettingsPatch } from "./settings.ts";
+import {
+  CodexSettings,
+  DEFAULT_SERVER_SETTINGS,
+  ServerSettings,
+  ServerSettingsPatch,
+} from "./settings.ts";
 
+const decodeCodexSettings = Schema.decodeUnknownSync(CodexSettings);
 const decodeServerSettings = Schema.decodeUnknownSync(ServerSettings);
 const decodeServerSettingsPatch = Schema.decodeUnknownSync(ServerSettingsPatch);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
+
+describe("CodexSettings profile fields", () => {
+  it("decodes profile name and launch args", () => {
+    const decoded = decodeCodexSettings({
+      profileName: "work",
+      launchArgs: "--config sandbox_workspace_write.network_access=true",
+    });
+
+    expect(decoded.profileName).toBe("work");
+    expect(decoded.launchArgs).toBe("--config sandbox_workspace_write.network_access=true");
+  });
+
+  it("accepts codex profile fields in server settings patches", () => {
+    const patch = decodeServerSettingsPatch({
+      providers: {
+        codex: {
+          profileName: "work",
+          launchArgs: "--config foo=bar",
+        },
+      },
+    });
+
+    expect(patch.providers?.codex?.profileName).toBe("work");
+    expect(patch.providers?.codex?.launchArgs).toBe("--config foo=bar");
+  });
+});
 
 describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   it("defaults to an empty record so legacy configs without the key still decode", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -191,13 +191,35 @@ export const CodexSettings = makeProviderSettingsSchema(
         },
       }),
     ),
+    profileName: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Config profile",
+        description: "Codex config profile passed as -p <name>.",
+        providerSettingsForm: {
+          placeholder: "work",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    launchArgs: Schema.String.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Extra args",
+        description: "Additional Codex CLI arguments passed before the subcommand.",
+        providerSettingsForm: {
+          placeholder: "e.g. --config sandbox_workspace_write.network_access=true",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
     customModels: Schema.Array(Schema.String).pipe(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
   },
   {
-    order: ["binaryPath", "homePath", "shadowHomePath"],
+    order: ["binaryPath", "homePath", "shadowHomePath", "profileName", "launchArgs"],
   },
 );
 export type CodexSettings = typeof CodexSettings.Type;
@@ -419,6 +441,8 @@ const CodexSettingsPatch = Schema.Struct({
   binaryPath: Schema.optionalKey(TrimmedString),
   homePath: Schema.optionalKey(TrimmedString),
   shadowHomePath: Schema.optionalKey(TrimmedString),
+  profileName: Schema.optionalKey(TrimmedString),
+  launchArgs: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 


### PR DESCRIPTION
## What Changed

- Adds a Profiles section to Settings > General for enabled provider instances.
- Lets users select, add, configure, and delete provider profiles backed by providerInstances.
- Passes Codex profile and launch args through app-server, session runtime, and codex exec paths.
- Resolves Codex profile model providers so custom providers like codex-lb do not incorrectly require codex login.

## Why

Provider settings need named per-provider presets without changing active sessions. Reusing providerInstances keeps the behavior aligned with existing provider architecture, while sticky composer selection makes profile changes apply to future composer selections.

The Codex status/runtime fixes make profile-specific settings actually affect launched sessions and status/model discovery.

## UI Changes

Settings > General now shows a Profiles section above General. Each enabled provider appears as a row with a profile selector, Add profile action, collapsible profile settings, and delete action for custom profiles.

Screenshots/video not attached yet because this is a draft PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add provider profiles to Codex settings with sticky composer profile selection
> - Adds `profileName` and `launchArgs` fields to `CodexSettings` and `CodexSettingsPatch` in [settings.ts](https://github.com/pingdotgg/t3code/pull/2747/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), allowing users to configure named Codex profiles and extra CLI arguments.
> - Settings UI gains a new Profiles section in [SettingsPanels.tsx](https://github.com/pingdotgg/t3code/pull/2747/files#diff-9dbbb4f86928d777550dead352b372341ccfb3f589782aa6d99b98f792c89d18) where users can add, edit, delete, and switch between provider profiles per driver.
> - Codex CLI invocations (text generation, session runtime, app-server probe) now prepend `-p <profileName>` and extra `launchArgs` before subcommands via a shared `buildCodexGlobalArgs` helper in [CodexCliArgs.ts](https://github.com/pingdotgg/t3code/pull/2747/files#diff-a1eb25c223c6f12a4b7e919e285af4acdb916efab196ca0c22c8aba769a4aabb).
> - Thread start requests now include a `modelProvider` resolved from the active Codex profile via `readCodexProfileModelProvider`, and the app-server probe derives `requiresOpenaiAuth` from profile config when available.
> - Switching profiles in settings calls `setStickyModelSelectionForInstances` in [composerDraftStore.ts](https://github.com/pingdotgg/t3code/pull/2747/files#diff-fe25f0ac6b3f15bcb25522be5eddf9c2db913c035393f9a4dc019a9afda80f8a), rebinding existing drafts that target the affected provider instances to the newly selected profile.
> - Behavioral Change: `snapshot.account.requiresOpenaiAuth` returned by `checkCodexProviderStatus` may now differ from prior behavior when a Codex profile overrides the model provider.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 868f998.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->