### PR TITLE
Clear stale provider update toast CTA

### DIFF
--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ProviderDriverKind, ProviderInstanceId, type ServerProvider } from "@t3tools/contracts";
 
 import {
+  buildProviderUpdateToastUpdate,
   canOneClickUpdateProviderCandidate,
   collectProviderUpdateCandidates,
   collectUpdatedProviderSnapshots,
@@ -9,13 +10,16 @@ import {
   getProviderUpdateInitialToastView,
   getProviderUpdateProgressToastView,
   getProviderUpdateRejectedToastView,
+  getProviderUpdateRunningToastView,
   getProviderUpdateSidebarPillView,
   getSingleProviderUpdateProgressToastView,
   hasOneClickUpdateProviderCandidate,
   isProviderUpdateCandidate,
   providerUpdateNotificationKey,
   type ProviderUpdateCandidate,
+  type ProviderUpdateToastView,
 } from "./ProviderUpdateLaunchNotification.logic";
+import { stackedThreadToast } from "./ui/toastHelpers";
 
 const checkedAt = "2026-04-23T10:00:00.000Z";
 const sessionStartedAt = "2026-04-23T09:59:00.000Z";
@@ -67,6 +71,28 @@ function provider(input: {
 
 function updateCandidate(input: Parameters<typeof provider>[0]): ProviderUpdateCandidate {
   return provider(input) as ProviderUpdateCandidate;
+}
+
+function promptToastWithUpdateAction() {
+  return stackedThreadToast({
+    type: "warning",
+    title: "Updates Available: 2 providers",
+    description: "Install the update now or review provider settings.",
+    timeout: 0,
+    actionProps: {
+      children: "Update",
+      onClick: () => undefined,
+    },
+    actionVariant: "default",
+    data: {
+      hideCopyButton: true,
+      secondaryActionProps: {
+        children: "Settings",
+        onClick: () => undefined,
+      },
+      secondaryActionVariant: "outline",
+    },
+  });
 }
 
 describe("provider update launch notification logic", () => {
@@ -270,6 +296,40 @@ describe("provider update launch notification logic", () => {
       title: "Update Available: Codex v1.1.0",
       description: "Install the update now or review provider settings.",
     });
+  });
+
+  it("clears the prompt update action from actionless progress toast views", () => {
+    const successView: ProviderUpdateToastView = {
+      phase: "succeeded",
+      type: "success",
+      title: "Provider updates finished",
+      description: "New sessions will use the updated providers.",
+      dismissAfterVisibleMs: 3_000,
+    };
+
+    for (const view of [getProviderUpdateRunningToastView(2), successView]) {
+      const update = buildProviderUpdateToastUpdate({
+        view,
+        openSettings: () => undefined,
+      });
+      const mergedToast = { ...promptToastWithUpdateAction(), ...update };
+
+      expect(Object.hasOwn(update, "actionProps")).toBe(true);
+      expect(mergedToast.actionProps).toBeUndefined();
+      expect(mergedToast.data?.secondaryActionProps).toBeUndefined();
+      expect(mergedToast.data?.actionLayout).toBeUndefined();
+    }
+  });
+
+  it("keeps failed update toast views actionable from settings", () => {
+    const update = buildProviderUpdateToastUpdate({
+      view: getProviderUpdateRejectedToastView(2, "WebSocket closed"),
+      openSettings: () => undefined,
+    });
+    const mergedToast = { ...promptToastWithUpdateAction(), ...update };
+
+    expect(mergedToast.actionProps?.children).toBe("Settings");
+    expect(mergedToast.data?.actionLayout).toBe("stacked-end");
   });
 
   it("describes settings-only updates without one-click support", () => {

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -1,3 +1,4 @@
+import type { ToastManagerUpdateOptions } from "@base-ui/react/toast";
 import {
   defaultInstanceIdForDriver,
   PROVIDER_DISPLAY_NAMES,
@@ -5,6 +6,9 @@ import {
   type ProviderInstanceId,
   type ServerProvider,
 } from "@t3tools/contracts";
+
+import type { ThreadToastData } from "./ui/toast";
+import { stackedThreadToast } from "./ui/toastHelpers";
 
 export type ProviderUpdateCandidate = ServerProvider & {
   readonly versionAdvisory: NonNullable<ServerProvider["versionAdvisory"]> & {
@@ -232,6 +236,45 @@ export function getProviderUpdateRejectedToastView(
     type: "error",
     title: providerCount === 1 ? "Provider update failed" : "Provider updates failed",
     description: message,
+  };
+}
+
+export function buildProviderUpdateToastUpdate(input: {
+  readonly view: ProviderUpdateToastView;
+  readonly openSettings: () => void;
+}): ToastManagerUpdateOptions<ThreadToastData> {
+  if (input.view.type !== "loading" && input.view.type !== "success") {
+    return stackedThreadToast({
+      type: input.view.type,
+      title: input.view.title,
+      description: input.view.description,
+      timeout: 0,
+      actionProps: {
+        children: "Settings",
+        onClick: input.openSettings,
+      },
+      actionVariant: "outline",
+      data: {
+        hideCopyButton: true,
+      },
+    });
+  }
+
+  const data: ThreadToastData = {
+    hideCopyButton: true,
+  };
+  if (input.view.dismissAfterVisibleMs !== undefined) {
+    data.dismissAfterVisibleMs = input.view.dismissAfterVisibleMs;
+  }
+
+  return {
+    type: input.view.type,
+    title: input.view.title,
+    description: input.view.description,
+    timeout: 0,
+    // Base UI shallow-merges toast updates, so the old prompt CTA must be explicitly cleared.
+    actionProps: undefined,
+    data,
   };
 }
 

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.tsx
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.tsx
@@ -9,6 +9,7 @@ import { useServerProviders } from "../rpc/serverState";
 import { PROVIDER_ICON_BY_PROVIDER } from "./chat/providerIconUtils";
 import {
   canOneClickUpdateProviderCandidate,
+  buildProviderUpdateToastUpdate,
   collectProviderUpdateCandidates,
   collectUpdatedProviderSnapshots,
   firstRejectedProviderUpdateMessage,
@@ -60,37 +61,11 @@ function updateProviderUpdateToast(input: {
   readonly view: ProviderUpdateToastView;
   readonly openSettings: () => void;
 }) {
-  if (input.view.type === "loading" || input.view.type === "success") {
-    toastManager.update(input.toastId, {
-      type: input.view.type,
-      title: input.view.title,
-      description: input.view.description,
-      timeout: 0,
-      data: {
-        hideCopyButton: true,
-        ...(input.view.dismissAfterVisibleMs !== undefined
-          ? { dismissAfterVisibleMs: input.view.dismissAfterVisibleMs }
-          : {}),
-      },
-    });
-    return;
-  }
-
   toastManager.update(
     input.toastId,
-    stackedThreadToast({
-      type: input.view.type,
-      title: input.view.title,
-      description: input.view.description,
-      timeout: 0,
-      actionProps: {
-        children: "Settings",
-        onClick: input.openSettings,
-      },
-      actionVariant: "outline",
-      data: {
-        hideCopyButton: true,
-      },
+    buildProviderUpdateToastUpdate({
+      view: input.view,
+      openSettings: input.openSettings,
     }),
   );
 }


### PR DESCRIPTION
## Summary
- Clear stale toast action props when provider update progress toasts move into loading or success states.
- Keep failed provider update toasts actionable via Settings.
- Add regression coverage for Base UI shallow-merge behavior.

## Root Cause
Base UI shallow-merges toast updates. The initial provider update prompt sets the primary CTA to `Update`, and the running toast update previously omitted `actionProps`, so the old CTA remained visible on the `Updating providers` toast.

## Validation
- `bun run test`
- `bun fmt`
- `bun lint`
- `bun typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear stale action buttons from provider update toast on progress and success
> - Adds `buildProviderUpdateToastUpdate` in [`ProviderUpdateLaunchNotification.logic.ts`](https://github.com/pingdotgg/t3code/pull/2755/files#diff-08d466d51f5e8ebb0d9c876490ddfc4c8bd21ca893ad398bc7460c8cb85ee05f) to centralize toast update construction for provider update views.
> - For loading/success views, sets `actionProps: undefined` explicitly to clear any action buttons (e.g. 'Update') left over from a previously shown prompt toast, working around shallow merge behavior in the toast manager.
> - For other views (e.g. rejected), attaches a 'Settings' action button with outline styling.
> - Refactors `updateProviderUpdateToast` in [`ProviderUpdateLaunchNotification.tsx`](https://github.com/pingdotgg/t3code/pull/2755/files#diff-1d243a217de778942d08f15c6120d5a194480005c811dc3d47eba9c3f441e81f) to call the new helper instead of duplicating inline logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6de68fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI logic change that only affects how provider-update toasts are updated, plus targeted regression tests for the toast manager’s shallow-merge behavior.
> 
> **Overview**
> Fixes provider update toasts so *progress/success* states no longer inherit stale CTA buttons from the initial prompt due to Base UI’s shallow-merge updates.
> 
> This introduces `buildProviderUpdateToastUpdate` to centralize toast update payloads, explicitly clearing `actionProps` for `loading`/`success` views while keeping *failed/unchanged* views actionable via a `Settings` button, and refactors `ProviderUpdateLaunchNotification.tsx` to use the helper. Adds regression tests that simulate merging a prompt toast with subsequent updates to ensure actions/secondary actions are cleared or preserved appropriately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6de68fc29094aed9726689b634cb86291ddf5353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->