### PR TITLE
Add Codex config profile setting

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -287,6 +287,32 @@ validationLayer("CodexAdapterLive validation", (it) => {
       });
     }),
   );
+
+  it.effect("passes configured profile names to Codex app-server sessions", () => {
+    const runtimeFactory = makeRuntimeFactory();
+    const layer = Layer.effect(
+      CodexAdapter,
+      makeCodexAdapter(decodeCodexSettings({ profileName: "work" }), {
+        makeRuntime: runtimeFactory.factory,
+      }),
+    ).pipe(
+      Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
+      Layer.provideMerge(ServerSettingsService.layerTest()),
+      Layer.provideMerge(providerSessionDirectoryTestLayer),
+      Layer.provideMerge(NodeServices.layer),
+    );
+
+    return Effect.gen(function* () {
+      const adapter = yield* CodexAdapter;
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("codex"),
+        threadId: asThreadId("thread-profile"),
+        runtimeMode: "full-access",
+      });
+
+      assert.equal(runtimeFactory.factory.mock.calls[0]?.[0].profileName, "work");
+    }).pipe(Effect.provide(layer));
+  });
 });
 
 const sessionRuntimeFactory = makeRuntimeFactory();

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1385,6 +1385,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           binaryPath: codexConfig.binaryPath,
           ...(options?.environment ? { environment: options.environment } : {}),
           ...(codexConfig.homePath ? { homePath: codexConfig.homePath } : {}),
+          ...(codexConfig.profileName ? { profileName: codexConfig.profileName } : {}),
           ...(isCodexResumeCursorSchema(input.resumeCursor)
             ? { resumeCursor: input.resumeCursor }
             : {}),

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -251,6 +251,7 @@ export function buildCodexInitializeParams(): CodexSchema.V1InitializeParams {
 const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(function* (input: {
   readonly binaryPath: string;
   readonly homePath?: string;
+  readonly profileName?: string;
   readonly cwd: string;
   readonly customModels?: ReadonlyArray<string>;
   readonly environment?: NodeJS.ProcessEnv;
@@ -263,7 +264,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   const clientContext = yield* Layer.build(
     CodexClient.layerCommand({
       command: input.binaryPath,
-      args: ["app-server"],
+      args: [...(input.profileName ? ["-p", input.profileName] : []), "app-server"],
       cwd: input.cwd,
       env: {
         ...(input.environment ?? process.env),
@@ -292,7 +293,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
   const version = versionMatch ? versionMatch[1] : undefined;
 
   const accountResponse = yield* client.request("account/read", {});
-  if (!accountResponse.account && accountResponse.requiresOpenaiAuth) {
+  if (!input.profileName && !accountResponse.account && accountResponse.requiresOpenaiAuth) {
     return {
       account: accountResponse,
       version,
@@ -404,6 +405,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   probe: (input: {
     readonly binaryPath: string;
     readonly homePath?: string;
+    readonly profileName?: string;
     readonly cwd: string;
     readonly customModels: ReadonlyArray<string>;
     readonly environment?: NodeJS.ProcessEnv;
@@ -441,6 +443,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   const probeResult = yield* probe({
     binaryPath: codexSettings.binaryPath,
     homePath: codexSettings.homePath,
+    profileName: codexSettings.profileName,
     cwd: process.cwd(),
     customModels: codexSettings.customModels,
     environment,
@@ -489,7 +492,11 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   }
 
   const snapshot = probeResult.success.value;
-  const accountStatus = accountProbeStatus(snapshot.account);
+  const hasProviderModels = snapshot.models.some((model) => !model.isCustom);
+  const account = hasProviderModels
+    ? { ...snapshot.account, requiresOpenaiAuth: false }
+    : snapshot.account;
+  const accountStatus = accountProbeStatus(account);
 
   return buildServerProvider({
     presentation: CODEX_PRESENTATION,

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -225,6 +225,7 @@ describe("openCodexThread", () => {
         runtimeMode: "full-access",
         cwd: "/tmp/project",
         requestedModel: "gpt-5.3-codex",
+        modelProvider: "codex-lb",
         serviceTier: undefined,
         resumeThreadId: "stale-thread",
       }),
@@ -235,6 +236,7 @@ describe("openCodexThread", () => {
       calls.map((call) => call.method),
       ["thread/resume", "thread/start"],
     );
+    assert.equal((calls[0]!.payload as { modelProvider?: string }).modelProvider, "codex-lb");
   });
 
   it("propagates non-recoverable resume failures", async () => {
@@ -265,6 +267,7 @@ describe("openCodexThread", () => {
           runtimeMode: "full-access",
           cwd: "/tmp/project",
           requestedModel: "gpt-5.3-codex",
+          modelProvider: undefined,
           serviceTier: undefined,
           resumeThreadId: "stale-thread",
         }),

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -97,6 +97,7 @@ export interface CodexSessionRuntimeOptions {
   readonly providerInstanceId?: ProviderInstanceId;
   readonly binaryPath: string;
   readonly homePath?: string;
+  readonly profileName?: string;
   readonly environment?: NodeJS.ProcessEnv;
   readonly cwd: string;
   readonly runtimeMode: RuntimeMode;
@@ -286,6 +287,7 @@ function buildThreadStartParams(input: {
   readonly cwd: string;
   readonly runtimeMode: RuntimeMode;
   readonly model: string | undefined;
+  readonly modelProvider: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
 }): EffectCodexSchema.V2ThreadStartParams {
   const config = runtimeModeToThreadConfig(input.runtimeMode);
@@ -294,6 +296,7 @@ function buildThreadStartParams(input: {
     approvalPolicy: config.approvalPolicy,
     sandbox: config.sandbox,
     ...(input.model ? { model: input.model } : {}),
+    ...(input.modelProvider ? { modelProvider: input.modelProvider } : {}),
     ...(input.serviceTier ? { serviceTier: input.serviceTier } : {}),
   };
 }
@@ -435,6 +438,7 @@ export const openCodexThread = (input: {
   readonly runtimeMode: RuntimeMode;
   readonly cwd: string;
   readonly requestedModel: string | undefined;
+  readonly modelProvider: string | undefined;
   readonly serviceTier: CodexServiceTier | undefined;
   readonly resumeThreadId: string | undefined;
 }): Effect.Effect<CodexThreadOpenResponse, CodexErrors.CodexAppServerError> => {
@@ -443,6 +447,7 @@ export const openCodexThread = (input: {
     cwd: input.cwd,
     runtimeMode: input.runtimeMode,
     model: input.requestedModel,
+    modelProvider: input.modelProvider,
     serviceTier: input.serviceTier,
   });
 
@@ -717,9 +722,12 @@ export const makeCodexSessionRuntime = (
       ...(options.environment ?? process.env),
       ...(resolvedHomePath ? { CODEX_HOME: resolvedHomePath } : {}),
     };
+    const appServerArgs = options.profileName
+      ? ["-p", options.profileName, "app-server"]
+      : ["app-server"];
     const child = yield* spawner
       .spawn(
-        ChildProcess.make(options.binaryPath, ["app-server"], {
+        ChildProcess.make(options.binaryPath, appServerArgs, {
           cwd: options.cwd,
           env,
           forceKillAfter: CODEX_APP_SERVER_FORCE_KILL_AFTER,
@@ -1183,6 +1191,16 @@ export const makeCodexSessionRuntime = (
       yield* client.notify("initialized", undefined);
 
       const requestedModel = normalizeCodexModelSlug(options.model);
+      const codexConfig = yield* client.request("config/read", { cwd: options.cwd }).pipe(
+        Effect.map((response) => response.config),
+        Effect.orElseSucceed(() => undefined),
+      );
+      const modelProvider =
+        (
+          (options.profileName
+            ? codexConfig?.profiles?.[options.profileName]?.model_provider
+            : undefined) ?? codexConfig?.model_provider
+        )?.trim() || undefined;
 
       const opened = yield* openCodexThread({
         client,
@@ -1190,6 +1208,7 @@ export const makeCodexSessionRuntime = (
         runtimeMode: options.runtimeMode,
         cwd: options.cwd,
         requestedModel,
+        modelProvider,
         serviceTier: options.serviceTier,
         resumeThreadId: readResumeCursorThreadId(options.resumeCursor),
       });

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -58,6 +58,7 @@ const makeCodexConfig = (overrides: Partial<CodexSettings>): CodexSettings => ({
   binaryPath: "codex",
   homePath: "",
   shadowHomePath: "",
+  profileName: "",
   customModels: [],
   ...overrides,
 });

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -355,6 +355,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
                   account: null,
                   requiresOpenaiAuth: true,
                 },
+                models: [],
               }),
             ),
           );
@@ -365,6 +366,52 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
             status.message,
             "Codex CLI is not authenticated. Run `codex login` and try again.",
           );
+        }),
+      );
+
+      it.effect("keeps profiled Codex providers ready when models are available", () =>
+        Effect.gen(function* () {
+          const status = yield* checkCodexProviderStatus(
+            { ...defaultCodexSettings, profileName: "work" },
+            () =>
+              Effect.succeed(
+                makeCodexProbeSnapshot({
+                  account: {
+                    account: null,
+                    requiresOpenaiAuth: true,
+                  },
+                }),
+              ),
+          );
+
+          assert.strictEqual(status.status, "ready");
+          assert.strictEqual(status.auth.status, "unknown");
+        }),
+      );
+
+      it.effect("keeps OpenAI auth required when only custom models are available", () =>
+        Effect.gen(function* () {
+          const status = yield* checkCodexProviderStatus(defaultCodexSettings, () =>
+            Effect.succeed(
+              makeCodexProbeSnapshot({
+                account: {
+                  account: null,
+                  requiresOpenaiAuth: true,
+                },
+                models: [
+                  {
+                    slug: "custom-model",
+                    name: "custom-model",
+                    isCustom: true,
+                    capabilities: null,
+                  },
+                ],
+              }),
+            ),
+          );
+
+          assert.strictEqual(status.status, "error");
+          assert.strictEqual(status.auth.status, "unauthenticated");
         }),
       );
 
@@ -386,6 +433,21 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
             assert.strictEqual(status.status, "ready");
             assert.strictEqual(status.auth.status, "unknown");
           }),
+      );
+
+      it.effect("passes the configured Codex profile to the app-server probe", () =>
+        Effect.gen(function* () {
+          let profileName: string | undefined;
+          yield* checkCodexProviderStatus(
+            { ...defaultCodexSettings, profileName: "work" },
+            (input) => {
+              profileName = input.profileName;
+              return Effect.succeed(makeCodexProbeSnapshot());
+            },
+          );
+
+          assert.strictEqual(profileName, "work");
+        }),
       );
 
       it.effect("returns an api key label for codex api key auth", () =>

--- a/apps/server/src/serverSettings.test.ts
+++ b/apps/server/src/serverSettings.test.ts
@@ -35,6 +35,9 @@ it.layer(NodeServices.layer)("server settings", (it) => {
       assert.deepEqual(decodePatch({ providers: { codex: { binaryPath: "/tmp/codex" } } }), {
         providers: { codex: { binaryPath: "/tmp/codex" } },
       });
+      assert.deepEqual(decodePatch({ providers: { codex: { profileName: "work" } } }), {
+        providers: { codex: { profileName: "work" } },
+      });
 
       assert.deepEqual(
         decodePatch({
@@ -118,6 +121,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         binaryPath: "/opt/homebrew/bin/codex",
         homePath: "/Users/julius/.codex",
         shadowHomePath: "",
+        profileName: "",
         customModels: [],
       });
       assert.deepEqual(next.providers.claudeAgent, {
@@ -359,6 +363,7 @@ it.layer(NodeServices.layer)("server settings", (it) => {
         binaryPath: "/opt/homebrew/bin/codex",
         homePath: "",
         shadowHomePath: "",
+        profileName: "",
         customModels: [],
       });
       assert.deepEqual(next.providers.claudeAgent, {

--- a/apps/server/src/textGeneration/CodexTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.test.ts
@@ -34,6 +34,7 @@ function makeFakeCodexBinary(
     requireImage?: boolean;
     requireFastServiceTier?: boolean;
     requireReasoningEffort?: string;
+    requireProfileName?: string;
     forbidReasoningEffort?: boolean;
     stdinMustContain?: string;
     stdinMustNotContain?: string;
@@ -54,7 +55,14 @@ function makeFakeCodexBinary(
         'seen_image="0"',
         'seen_fast_service_tier="0"',
         'seen_reasoning_effort=""',
+        'seen_profile_name=""',
         "while [ $# -gt 0 ]; do",
+        '  if [ "$1" = "-p" ]; then',
+        "    shift",
+        '    seen_profile_name="$1"',
+        "    shift",
+        "    continue",
+        "  fi",
         '  if [ "$1" = "--image" ]; then',
         "    shift",
         '    if [ -n "$1" ]; then',
@@ -106,6 +114,14 @@ function makeFakeCodexBinary(
               `if [ "$seen_reasoning_effort" != "model_reasoning_effort=\\"${input.requireReasoningEffort}\\"" ]; then`,
               '  printf "%s\\n" "unexpected reasoning effort config: $seen_reasoning_effort" >&2',
               `  exit 6`,
+              "fi",
+            ]
+          : []),
+        ...(input.requireProfileName !== undefined
+          ? [
+              `if [ "$seen_profile_name" != "${input.requireProfileName}" ]; then`,
+              '  printf "%s\\n" "unexpected profile name: $seen_profile_name" >&2',
+              `  exit 8`,
               "fi",
             ]
           : []),
@@ -163,6 +179,7 @@ function withFakeCodexEnv<A, E, R>(
     requireImage?: boolean;
     requireFastServiceTier?: boolean;
     requireReasoningEffort?: string;
+    requireProfileName?: string;
     forbidReasoningEffort?: boolean;
     stdinMustContain?: string;
     stdinMustNotContain?: string;
@@ -173,7 +190,10 @@ function withFakeCodexEnv<A, E, R>(
     const fs = yield* FileSystem.FileSystem;
     const tempDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-codex-text-" });
     const codexPath = yield* makeFakeCodexBinary(tempDir, input);
-    const config = decodeCodexSettings({ binaryPath: codexPath });
+    const config = decodeCodexSettings({
+      binaryPath: codexPath,
+      ...(input.requireProfileName ? { profileName: input.requireProfileName } : {}),
+    });
     const textGeneration = yield* makeCodexTextGeneration(config);
     return yield* effectFn(textGeneration);
   }).pipe(Effect.scoped);
@@ -219,6 +239,7 @@ it.layer(CodexTextGenerationTestLayer)("CodexTextGeneration", (it) => {
           }),
           requireFastServiceTier: true,
           requireReasoningEffort: "xhigh",
+          requireProfileName: "work",
           stdinMustNotContain: "branch must be a short semantic git branch fragment",
         },
         (textGeneration) =>

--- a/apps/server/src/textGeneration/CodexTextGeneration.ts
+++ b/apps/server/src/textGeneration/CodexTextGeneration.ts
@@ -190,6 +190,7 @@ export const makeCodexTextGeneration = Effect.fn("makeCodexTextGeneration")(func
       const command = ChildProcess.make(
         codexConfig.binaryPath || "codex",
         [
+          ...(codexConfig.profileName ? ["-p", codexConfig.profileName] : []),
           "exec",
           "--ephemeral",
           "--skip-git-repo-check",

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -113,6 +113,7 @@ function createBaseServerConfig(): ServerConfig {
           binaryPath: "",
           homePath: "",
           shadowHomePath: "",
+          profileName: "",
           customModels: [],
         },
         claudeAgent: {

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -18,6 +18,7 @@ describe("ProviderSettingsForm helpers", () => {
       "binaryPath",
       "homePath",
       "shadowHomePath",
+      "profileName",
     ]);
   });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -191,6 +191,10 @@ export const CodexSettings = makeProviderSettingsSchema(
         },
       }),
     ),
+    profileName: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({ title: "Config profile" }),
+    ),
     customModels: Schema.Array(Schema.String).pipe(
       Schema.withDecodingDefault(Effect.succeed([])),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
@@ -419,6 +423,7 @@ const CodexSettingsPatch = Schema.Struct({
   binaryPath: Schema.optionalKey(TrimmedString),
   homePath: Schema.optionalKey(TrimmedString),
   shadowHomePath: Schema.optionalKey(TrimmedString),
+  profileName: Schema.optionalKey(TrimmedString),
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 


### PR DESCRIPTION
## What Changed

Adds a minimal Codex `Config profile` provider setting and threads it through Codex launch paths:

- Passes `-p <profile>` to Codex app-server status probes, app-server sessions, and `codex exec` text generation.
- Reads the selected profile's `model_provider` from Codex config and passes it into app-server `thread/start` / `thread/resume` startup.
- Avoids showing the OpenAI auth error as blocking when the profiled app-server returns models.
- Adds focused schema/runtime tests for the new setting and launch behavior.

## Why

This lets T3 Code use Codex config profiles backed by non-default providers, such as a custom provider profile.

The explicit config lookup exists because of an upstream Codex app-server bug/limitation: `codex -p <profile> app-server` does not apply the profile's `model_provider` to `thread/start` by default, even though `codex -p <profile> exec ...` does. Without passing `modelProvider` explicitly, app-server starts threads with `modelProvider: "openai"` and can hit OpenAI 401s for custom-provider profiles.

Upstream issue: https://github.com/openai/codex/issues/23417

## UI Changes

Adds a small `Config profile` text field to the existing Codex provider settings form.
Before:
<img width="812" height="538" alt="Screenshot 2026-05-19 at 3 27 38 pm" src="https://github.com/user-attachments/assets/7e294b4c-4f5d-44b8-a738-98dd7a8123d8" />

After:
<img width="811" height="628" alt="Screenshot 2026-05-19 at 3 26 15 pm" src="https://github.com/user-attachments/assets/97eb1661-7d64-4fb5-92bf-b3cd358379e8" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Verification:

- `bun fmt`
- `bun lint` (passes with existing warnings)
- `bun typecheck`
- `cd apps/server && bun run test src/provider/Layers/CodexProvider.test.ts src/provider/Layers/CodexSessionRuntime.test.ts src/textGeneration/CodexTextGeneration.test.ts src/serverSettings.test.ts`


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex provider launch/probe behavior and thread-start parameters (including auth-status determination), which can affect whether Codex sessions start and how they authenticate, but scope is limited to the Codex integration and is covered by new tests.
> 
> **Overview**
> Adds a new Codex provider setting, `profileName`, surfaced in the settings schema/UI and supported in settings patches.
> 
> When set, Codex commands now run with `-p <profileName>` for app-server probes, app-server session spawn, and `codex exec` text generation; session startup also reads Codex config (`config/read`) to extract `model_provider` (profile-specific first) and forwards it via `modelProvider` in `thread/start`/`thread/resume`.
> 
> Provider status probing is adjusted so profiled providers don’t treat `requiresOpenaiAuth` as blocking when non-custom models are present; tests are updated/added to validate profile propagation, `modelProvider` forwarding, and the auth/model readiness behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03a7261a21158209c140ffa3abe530770de17ba2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `profileName` config profile setting to Codex provider
> - Adds `profileName` to `CodexSettings` in [settings.ts](https://github.com/pingdotgg/t3code/pull/2756/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c), wiring it through the provider status check, session runtime, and text generation layers.
> - When set, prepends `-p {profileName}` to app-server and `codex exec` command args, and reads profile-specific model config for thread start/resume requests.
> - Providers with a configured profile treat `requiresOpenaiAuth` as non-blocking when models are available, allowing the provider to report `ready` without OpenAI auth.
> - Behavioral Change: unauthenticated Codex accounts with a profile set no longer block provider readiness on OpenAI auth.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 03a7261.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional "Config profile" setting for the Codex provider, enabling profile-scoped configuration and model-provider selection; the Codex helper now forwards a selected profile to the Codex server process.

* **Tests**
  * Added and updated tests to validate profile handling, model-provider propagation, probe behavior, and settings patch/encoding for Codex profile.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pingdotgg/t3code/pull/2756?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->