### PR TITLE
Bulk hydrate shell snapshots in the web store

### DIFF
--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -592,6 +592,44 @@ describe("shell snapshot sync", () => {
     expect(environmentState.threadIdsByProjectId[first.projectId]).toEqual([threadId]);
     expect(environmentState.threadShellById[threadId]?.title).toBe("First duplicate");
   });
+
+  it("stores server-provided ids as data keys during bulk shell sync", () => {
+    const threadId = ThreadId.make("__proto__");
+    const projectId = ProjectId.make("__proto__");
+    const thread = makeShellThread({
+      id: threadId,
+      projectId,
+      title: "Prototype-looking thread",
+    });
+
+    const next = syncServerShellSnapshot(
+      makeEmptyState(),
+      makeShellSnapshot(
+        [thread],
+        [
+          {
+            id: projectId,
+            title: "Prototype-looking project",
+            workspaceRoot: "/tmp/proto",
+            defaultModelSelection: null,
+            scripts: [],
+            createdAt: "2026-02-27T00:00:00.000Z",
+            updatedAt: "2026-02-27T00:00:00.000Z",
+          },
+        ],
+      ),
+      localEnvironmentId,
+    );
+    const environmentState = localEnvironmentStateOf(next);
+
+    expect(Object.hasOwn(environmentState.threadIdsByProjectId, projectId)).toBe(true);
+    expect(Object.hasOwn(environmentState.threadShellById, threadId)).toBe(true);
+    expect(Object.hasOwn(environmentState.threadSessionById, threadId)).toBe(true);
+    expect(Object.hasOwn(environmentState.threadTurnStateById, threadId)).toBe(true);
+    expect(Object.hasOwn(environmentState.sidebarThreadSummaryById, threadId)).toBe(true);
+    expect(environmentState.threadIdsByProjectId[projectId]).toEqual([threadId]);
+    expect(environmentState.threadShellById[threadId]?.title).toBe("Prototype-looking thread");
+  });
 });
 
 describe("setThreadBranch", () => {

--- a/apps/web/src/store.test.ts
+++ b/apps/web/src/store.test.ts
@@ -9,6 +9,7 @@ import {
   ProviderInstanceId,
   ThreadId,
   TurnId,
+  type OrchestrationShellSnapshot,
   type OrchestrationEvent,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
@@ -22,6 +23,7 @@ import {
   selectThreadByRef,
   selectThreadExistsByRef,
   setThreadBranch,
+  syncServerShellSnapshot,
   selectThreadsAcrossEnvironments,
   type AppState,
   type EnvironmentState,
@@ -247,6 +249,61 @@ function makeEvent<T extends OrchestrationEvent["type"]>(
   } as Extract<OrchestrationEvent, { type: T }>;
 }
 
+function makeShellSnapshot(
+  threads: OrchestrationShellSnapshot["threads"],
+  projects: OrchestrationShellSnapshot["projects"] = [
+    {
+      id: ProjectId.make("project-1"),
+      title: "Project",
+      workspaceRoot: "/tmp/project",
+      defaultModelSelection: {
+        instanceId: ProviderInstanceId.make("codex"),
+        model: DEFAULT_MODEL,
+      },
+      scripts: [],
+      createdAt: "2026-02-27T00:00:00.000Z",
+      updatedAt: "2026-02-27T00:00:00.000Z",
+    },
+  ],
+): OrchestrationShellSnapshot {
+  return {
+    snapshotSequence: 1,
+    projects,
+    threads,
+    updatedAt: "2026-02-27T00:00:00.000Z",
+  };
+}
+
+function makeShellThread(
+  overrides: Partial<OrchestrationShellSnapshot["threads"][number]> = {},
+): OrchestrationShellSnapshot["threads"][number] {
+  const threadId = overrides.id ?? ThreadId.make("thread-shell-1");
+  const projectId = overrides.projectId ?? ProjectId.make("project-1");
+  return {
+    id: threadId,
+    projectId,
+    title: "Shell thread",
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: DEFAULT_MODEL,
+    },
+    runtimeMode: DEFAULT_RUNTIME_MODE,
+    interactionMode: DEFAULT_INTERACTION_MODE,
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: "2026-02-27T00:00:00.000Z",
+    updatedAt: "2026-02-27T00:00:00.000Z",
+    archivedAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...overrides,
+  };
+}
+
 describe("environment state removal", () => {
   it("drops local state for removed environments", () => {
     const removedThread = makeThread({
@@ -399,6 +456,141 @@ describe("thread selection memoization", () => {
       ),
     ).toBe(false);
     expect(selectThreadExistsByRef(state, null)).toBe(false);
+  });
+});
+
+describe("shell snapshot sync", () => {
+  it("registers shell threads by project without materializing detail records", () => {
+    const project1 = ProjectId.make("project-1");
+    const project2 = ProjectId.make("project-2");
+    const thread1 = makeShellThread({
+      id: ThreadId.make("thread-shell-1"),
+      projectId: project1,
+      title: "First shell thread",
+    });
+    const thread2 = makeShellThread({
+      id: ThreadId.make("thread-shell-2"),
+      projectId: project2,
+      title: "Second shell thread",
+      hasPendingUserInput: true,
+    });
+    const state = makeEmptyState({ bootstrapComplete: false });
+
+    const next = syncServerShellSnapshot(
+      state,
+      makeShellSnapshot(
+        [thread1, thread2],
+        [
+          {
+            id: project1,
+            title: "Project 1",
+            workspaceRoot: "/tmp/project-1",
+            defaultModelSelection: null,
+            scripts: [],
+            createdAt: "2026-02-27T00:00:00.000Z",
+            updatedAt: "2026-02-27T00:00:00.000Z",
+          },
+          {
+            id: project2,
+            title: "Project 2",
+            workspaceRoot: "/tmp/project-2",
+            defaultModelSelection: null,
+            scripts: [],
+            createdAt: "2026-02-27T00:00:00.000Z",
+            updatedAt: "2026-02-27T00:00:00.000Z",
+          },
+        ],
+      ),
+      localEnvironmentId,
+    );
+    const environmentState = localEnvironmentStateOf(next);
+
+    expect(environmentState.bootstrapComplete).toBe(true);
+    expect(environmentState.threadIds).toEqual([thread1.id, thread2.id]);
+    expect(environmentState.threadIdsByProjectId).toEqual({
+      [project1]: [thread1.id],
+      [project2]: [thread2.id],
+    });
+    expect(environmentState.threadShellById[thread1.id]?.title).toBe("First shell thread");
+    expect(environmentState.sidebarThreadSummaryById[thread2.id]?.hasPendingUserInput).toBe(true);
+    expect(environmentState.messageIdsByThreadId).toEqual({});
+    expect(environmentState.activityIdsByThreadId).toEqual({});
+  });
+
+  it("retains detail slices for threads still present in the shell snapshot", () => {
+    const keptThread = makeThread({
+      id: ThreadId.make("thread-kept"),
+      messages: [
+        {
+          id: MessageId.make("message-kept"),
+          role: "user",
+          text: "keep",
+          createdAt: "2026-02-27T00:00:00.000Z",
+          streaming: false,
+        },
+      ],
+    });
+    const removedThread = makeThread({ id: ThreadId.make("thread-removed") });
+    const baseState = makeState(keptThread);
+    const baseEnvironmentState = localEnvironmentStateOf(baseState);
+    const state = withActiveEnvironmentState(baseEnvironmentState, {
+      threadIds: [keptThread.id, removedThread.id],
+      messageIdsByThreadId: {
+        ...baseEnvironmentState.messageIdsByThreadId,
+        [removedThread.id]: [MessageId.make("message-removed")],
+      },
+      messageByThreadId: {
+        ...baseEnvironmentState.messageByThreadId,
+        [removedThread.id]: {
+          [MessageId.make("message-removed")]: {
+            id: MessageId.make("message-removed"),
+            role: "assistant",
+            text: "drop",
+            createdAt: "2026-02-27T00:00:01.000Z",
+            streaming: false,
+          },
+        },
+      },
+    });
+
+    const next = syncServerShellSnapshot(
+      state,
+      makeShellSnapshot([
+        makeShellThread({
+          id: keptThread.id,
+          projectId: keptThread.projectId,
+          title: "Kept shell",
+        }),
+      ]),
+      localEnvironmentId,
+    );
+    const environmentState = localEnvironmentStateOf(next);
+
+    expect(environmentState.messageIdsByThreadId[keptThread.id]).toEqual([
+      MessageId.make("message-kept"),
+    ]);
+    expect(
+      environmentState.messageByThreadId[keptThread.id]?.[MessageId.make("message-kept")],
+    ).toMatchObject({ text: "keep" });
+    expect(environmentState.messageIdsByThreadId[removedThread.id]).toBeUndefined();
+    expect(environmentState.messageByThreadId[removedThread.id]).toBeUndefined();
+  });
+
+  it("deduplicates malformed shell snapshots before building project indexes", () => {
+    const threadId = ThreadId.make("thread-duplicate");
+    const first = makeShellThread({ id: threadId, title: "First duplicate" });
+    const second = makeShellThread({ id: threadId, title: "Second duplicate" });
+
+    const next = syncServerShellSnapshot(
+      makeEmptyState(),
+      makeShellSnapshot([first, second]),
+      localEnvironmentId,
+    );
+    const environmentState = localEnvironmentStateOf(next);
+
+    expect(environmentState.threadIds).toEqual([threadId]);
+    expect(environmentState.threadIdsByProjectId[first.projectId]).toEqual([threadId]);
+    expect(environmentState.threadShellById[threadId]?.title).toBe("First duplicate");
   });
 });
 

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -1081,16 +1081,44 @@ function syncEnvironmentShellSnapshot(
   environmentId: EnvironmentId,
 ): EnvironmentState {
   const nextProjects = snapshot.projects.map((project) => mapProject(project, environmentId));
-  const nextThreadIds = new Set(snapshot.threads.map((thread) => thread.id));
-  let nextState: EnvironmentState = {
+  const nextThreadIds = new Set<ThreadId>();
+  const threadIds: ThreadId[] = [];
+  const threadIdsByProjectId: Record<ProjectId, ThreadId[]> = {};
+  const threadShellById: Record<ThreadId, ThreadShell> = {};
+  const threadSessionById: Record<ThreadId, ThreadSession | null> = {};
+  const threadTurnStateById: Record<ThreadId, ThreadTurnState> = {};
+  const sidebarThreadSummaryById: Record<ThreadId, SidebarThreadSummary> = {};
+
+  for (const thread of snapshot.threads) {
+    if (nextThreadIds.has(thread.id)) {
+      continue;
+    }
+    nextThreadIds.add(thread.id);
+    threadIds.push(thread.id);
+
+    const projectThreadIds = threadIdsByProjectId[thread.projectId];
+    if (projectThreadIds) {
+      projectThreadIds.push(thread.id);
+    } else {
+      threadIdsByProjectId[thread.projectId] = [thread.id];
+    }
+
+    const mappedThread = mapThreadShell(thread, environmentId);
+    threadShellById[thread.id] = mappedThread.shell;
+    threadSessionById[thread.id] = mappedThread.session;
+    threadTurnStateById[thread.id] = mappedThread.turnState;
+    sidebarThreadSummaryById[thread.id] = mappedThread.summary;
+  }
+
+  return {
     ...state,
     ...buildProjectState(nextProjects),
-    threadIds: [],
-    threadIdsByProjectId: {},
-    threadShellById: {},
-    threadSessionById: {},
-    threadTurnStateById: {},
-    sidebarThreadSummaryById: {},
+    threadIds,
+    threadIdsByProjectId,
+    threadShellById,
+    threadSessionById,
+    threadTurnStateById,
+    sidebarThreadSummaryById,
     messageIdsByThreadId: retainThreadScopedRecord(state.messageIdsByThreadId, nextThreadIds),
     messageByThreadId: retainThreadScopedRecord(state.messageByThreadId, nextThreadIds),
     activityIdsByThreadId: retainThreadScopedRecord(state.activityIdsByThreadId, nextThreadIds),
@@ -1107,12 +1135,6 @@ function syncEnvironmentShellSnapshot(
     ),
     bootstrapComplete: true,
   };
-
-  for (const thread of snapshot.threads) {
-    nextState = writeThreadShellState(nextState, mapThreadShell(thread, environmentId));
-  }
-
-  return nextState;
 }
 
 export function syncServerShellSnapshot(

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -39,6 +39,10 @@ import { sanitizeThreadErrorMessage } from "./rpc/transportError";
 import { getThreadFromEnvironmentState } from "./threadDerivation";
 const isProviderDriverKindValue = Schema.is(ProviderDriverKind);
 
+function createRecord<Key extends PropertyKey, Value>(): Record<Key, Value> {
+  return Object.create(null) as Record<Key, Value>;
+}
+
 export interface EnvironmentState {
   projectIds: ProjectId[];
   projectById: Record<ProjectId, Project>;
@@ -1083,16 +1087,18 @@ function syncEnvironmentShellSnapshot(
   const nextProjects = snapshot.projects.map((project) => mapProject(project, environmentId));
   const nextThreadIds = new Set<ThreadId>();
   const threadIds: ThreadId[] = [];
-  const threadIdsByProjectId: Record<ProjectId, ThreadId[]> = {};
-  const threadShellById: Record<ThreadId, ThreadShell> = {};
-  const threadSessionById: Record<ThreadId, ThreadSession | null> = {};
-  const threadTurnStateById: Record<ThreadId, ThreadTurnState> = {};
-  const sidebarThreadSummaryById: Record<ThreadId, SidebarThreadSummary> = {};
+  const threadIdsByProjectId = createRecord<ProjectId, ThreadId[]>();
+  const threadShellById = createRecord<ThreadId, ThreadShell>();
+  const threadSessionById = createRecord<ThreadId, ThreadSession | null>();
+  const threadTurnStateById = createRecord<ThreadId, ThreadTurnState>();
+  const sidebarThreadSummaryById = createRecord<ThreadId, SidebarThreadSummary>();
 
   for (const thread of snapshot.threads) {
     if (nextThreadIds.has(thread.id)) {
       continue;
     }
+    // Malformed snapshots can repeat a thread id. Keep the first shell entry so
+    // all derived shell maps agree with the first index position.
     nextThreadIds.add(thread.id);
     threadIds.push(thread.id);
 


### PR DESCRIPTION
## What Changed

Changed shell snapshot sync from N single-thread writes into one bulk pass that builds thread IDs, project indexes, shell records, session records, turn state, and sidebar summaries together.

## Why

The old path repeatedly spread growing maps while hydrating large snapshots. On the synthetic 10,000-thread fixture, that made startup spend seconds in web store hydration.

Chrome first-load click profile against a synthetic 10,000-thread home (100 projects x 100 threads, 0 activities/thread, projected seed). Each side used 5 measured runs, and each run seeded a fresh synthetic home before Chrome opened `Startup Thread 29/69`. Table shows medians:

| metric | main | after | delta |
|---|---:|---:|---:|
| initial render | 4956.4 ms | 2568.6 ms | -2387.8 ms (-48.2%) |
| click settle | 9658.0 ms | 9221.2 ms | -436.8 ms (-4.5%) |
| total | 14702.0 ms | 11939.9 ms | -2762.1 ms (-18.8%) |
| RunTask | 4383.6 ms | 2179.2 ms | -2204.4 ms (-50.3%) |
| FunctionCall | 3302.9 ms | 1116.1 ms | -2186.8 ms (-66.2%) |
| UpdateLayoutTree | 662.3 ms | 651.1 ms | -11.2 ms (-1.7%) |

## UI Changes

No visual UI changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

Verification:

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewrites `syncEnvironmentShellSnapshot` to rebuild multiple thread-related indices/maps in one pass; mistakes could drop/reshuffle thread bookkeeping or sidebar data during bootstrap. Adds tests and keeps detail slices only for threads present, but changes touch core state hydration behavior.
> 
> **Overview**
> **Shell snapshot hydration is rewritten to run as a single bulk pass.** `syncEnvironmentShellSnapshot` now builds `threadIds`, `threadIdsByProjectId`, `threadShellById`, `threadSessionById`, `threadTurnStateById`, and `sidebarThreadSummaryById` directly while iterating `snapshot.threads`, instead of repeatedly applying per-thread writes.
> 
> During sync it **deduplicates duplicate thread IDs** (keeps first occurrence), **retains existing per-thread detail slices only for threads still present** in the snapshot, and initializes the new thread maps with `Object.create(null)` to safely accept server-provided IDs like `__proto__`.
> 
> Adds focused tests for bulk shell sync covering project indexing, bootstrap completion, detail-slice retention/removal, deduplication behavior, and prototype-pollution-style IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7392fcad7d8164f1d37168d972e6adc60d74d10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bulk hydrate shell snapshots in the web store with deduplication and safe key handling
> - Rewrites `syncEnvironmentShellSnapshot` in [store.ts](https://github.com/pingdotgg/t3code/pull/2780/files#diff-36a9aa51c26c72ab34502441a0b9d3fd0ab70a68e7e25e7e9195a4f088584b82) to build all thread maps in a single pass over the snapshot rather than iterating and calling `writeThreadShellState` per thread.
> - Deduplicates threads with the same id by keeping the first occurrence, constructing `threadIds`, `threadIdsByProjectId`, and shell-derived maps in first-seen order.
> - Uses `createRecord` (null-prototype objects via `Object.create(null)`) so keys like `__proto__` are stored verbatim without triggering prototype pollution.
> - Retains existing per-thread detail slices (messages, activities, diffs, etc.) only for threads still present in the incoming snapshot.
> - Adds tests in [store.test.ts](https://github.com/pingdotgg/t3code/pull/2780/files#diff-da5bb58321c36f9d05fab4094aeab97a54cb8eb30f13d85a80ab85bbbd7f3405) covering project indexing, detail slice retention, duplicate thread handling, and unsafe key storage.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7392fca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->