### PR TITLE
archive threads with middle click

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -416,6 +416,20 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
     },
     [handleThreadClick, orderedProjectThreadKeys, threadRef],
   );
+  const handleRowMouseDown = useCallback((event: React.MouseEvent) => {
+    if (event.button !== 1) return;
+    event.preventDefault();
+  }, []);
+  const handleRowAuxClick = useCallback(
+    (event: React.MouseEvent) => {
+      if (event.button !== 1) return;
+      event.preventDefault();
+      event.stopPropagation();
+      clearConfirmingArchive();
+      void attemptArchiveThread(threadRef);
+    },
+    [attemptArchiveThread, clearConfirmingArchive, threadRef],
+  );
   const handleRowKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (event.key !== "Enter" && event.key !== " ") return;
@@ -555,6 +569,8 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
           isSelected,
         })} relative isolate`}
         onClick={handleRowClick}
+        onMouseDown={handleRowMouseDown}
+        onAuxClick={handleRowAuxClick}
         onKeyDown={handleRowKeyDown}
         onContextMenu={handleRowContextMenu}
       >


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Middle-clicking a sidebar thread now archives it.

## Why

Faster thread cleanup without changing normal left-click navigation or context menu behavior.
Everyone do similar: browsers/editors close tabs on middle mouse click.

## UI Changes

[Трансляція_20260522_101801.webm](https://github.com/user-attachments/assets/fac6ae79-1bf6-4269-b630-092b3b1f239b)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI interaction change localized to the sidebar thread row; main risk is unintended interference with mouse events (e.g., selection/navigation) on different browsers/platforms.
> 
> **Overview**
> Adds middle-click (mouse button 1) handling on sidebar thread rows to archive a thread directly. A `mousedown` handler prevents the default middle-click behavior, and an `auxclick` handler stops propagation, clears any pending archive confirmation state, and calls `attemptArchiveThread` for the clicked thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c1925001368fe3e509843fd237b889a6ad1e4e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Archive threads with middle click in sidebar
> Adds middle-click support to `SidebarThreadRow` in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2782/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1). A `mousedown` handler prevents the default browser scroll behavior, and an `auxclick` handler calls `attemptArchiveThread` on the target thread while clearing any pending archive confirmation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c19250.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->