### PR TITLE
Handle auth timestamps and SSH ControlMaster handoff

### DIFF
--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -109,7 +109,7 @@ export const AuthBootstrapResult = Schema.Struct({
   authenticated: Schema.Literal(true),
   role: AuthSessionRole,
   sessionMethod: ServerAuthSessionMethod,
-  expiresAt: Schema.DateTimeUtc,
+  expiresAt: Schema.DateTimeUtcFromString,
 });
 export type AuthBootstrapResult = typeof AuthBootstrapResult.Type;
 
@@ -117,14 +117,14 @@ export const AuthBearerBootstrapResult = Schema.Struct({
   authenticated: Schema.Literal(true),
   role: AuthSessionRole,
   sessionMethod: Schema.Literal("bearer-session-token"),
-  expiresAt: Schema.DateTimeUtc,
+  expiresAt: Schema.DateTimeUtcFromString,
   sessionToken: TrimmedNonEmptyString,
 });
 export type AuthBearerBootstrapResult = typeof AuthBearerBootstrapResult.Type;
 
 export const AuthWebSocketTokenResult = Schema.Struct({
   token: TrimmedNonEmptyString,
-  expiresAt: Schema.DateTimeUtc,
+  expiresAt: Schema.DateTimeUtcFromString,
 });
 export type AuthWebSocketTokenResult = typeof AuthWebSocketTokenResult.Type;
 
@@ -132,7 +132,7 @@ export const AuthPairingCredentialResult = Schema.Struct({
   id: TrimmedNonEmptyString,
   credential: TrimmedNonEmptyString,
   label: Schema.optionalKey(TrimmedNonEmptyString),
-  expiresAt: Schema.DateTimeUtc,
+  expiresAt: Schema.DateTimeUtcFromString,
 });
 export type AuthPairingCredentialResult = typeof AuthPairingCredentialResult.Type;
 
@@ -142,8 +142,8 @@ export const AuthPairingLink = Schema.Struct({
   role: AuthSessionRole,
   subject: TrimmedNonEmptyString,
   label: Schema.optionalKey(TrimmedNonEmptyString),
-  createdAt: Schema.DateTimeUtc,
-  expiresAt: Schema.DateTimeUtc,
+  createdAt: Schema.DateTimeUtcFromString,
+  expiresAt: Schema.DateTimeUtcFromString,
 });
 export type AuthPairingLink = typeof AuthPairingLink.Type;
 
@@ -172,9 +172,9 @@ export const AuthClientSession = Schema.Struct({
   role: AuthSessionRole,
   method: ServerAuthSessionMethod,
   client: AuthClientMetadata,
-  issuedAt: Schema.DateTimeUtc,
-  expiresAt: Schema.DateTimeUtc,
-  lastConnectedAt: Schema.NullOr(Schema.DateTimeUtc),
+  issuedAt: Schema.DateTimeUtcFromString,
+  expiresAt: Schema.DateTimeUtcFromString,
+  lastConnectedAt: Schema.NullOr(Schema.DateTimeUtcFromString),
   connected: Schema.Boolean,
   current: Schema.Boolean,
 });
@@ -261,6 +261,6 @@ export const AuthSessionState = Schema.Struct({
   auth: ServerAuthDescriptor,
   role: Schema.optionalKey(AuthSessionRole),
   sessionMethod: Schema.optionalKey(ServerAuthSessionMethod),
-  expiresAt: Schema.optionalKey(Schema.DateTimeUtc),
+  expiresAt: Schema.optionalKey(Schema.DateTimeUtcFromString),
 });
 export type AuthSessionState = typeof AuthSessionState.Type;

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -322,7 +322,7 @@ function probe() {
       (response) => {
         response.resume();
         response.once("end", () => {
-          resolve(response.statusCode >= 200 && response.statusCode < 300);
+          resolve(true);
         });
       },
     );
@@ -895,7 +895,6 @@ export const waitForHttpReady = Effect.fn("ssh/tunnel.waitForHttpReady")(functio
   });
 
   const readinessClient = client.pipe(
-    HttpClient.filterStatusOk,
     HttpClient.transform((effect) =>
       Effect.gen(function* () {
         attempt += 1;
@@ -1212,6 +1211,19 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
         }),
     ),
     Effect.flatMap(([stderr, exitCode]) => {
+      // Exit 0 with no stderr means SSH handed off to a ControlMaster mux
+      // connection. The port forward is still alive via the master process, so
+      // this is not a failure — let waitForHttpReady determine readiness.
+      if (exitCode === 0 && stderr.trim().length === 0) {
+        return Effect.logDebug("ssh.tunnel.process.controlmaster.handoff", {
+          ...sshTargetLogFields(input.resolvedTarget),
+          command: tunnelCommand,
+          pid: child.pid,
+          localPort: input.localPort,
+          remotePort: input.remotePort,
+          httpBaseUrl: input.httpBaseUrl,
+        }).pipe(Effect.andThen(Effect.never));
+      }
       const error = new SshCommandError({
         command: tunnelCommand,
         exitCode,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Accept ISO string timestamps in auth contract schemas
- Treat zero-exit SSH ControlMaster handoff as a live tunnel

## Why

- ISO formatting parsing was just a type guard, not a parsing transformation
- Control master is a performance optimization required for Corporate machines behind firewalls/proxy. 

## UI Changes

N/A

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [N/A] I included before/after screenshots for any UI changes
- [N/A] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle SSH ControlMaster handoff and fix auth timestamp parsing
> - Auth contract schemas in [`packages/contracts/src/auth.ts`](https://github.com/pingdotgg/t3code/pull/2795/files#diff-ff0457cc1ebe1a7b4a4a5c946a6d6725020e9dcb88aa053aad376b5dac686046) change all `DateTimeUtc` timestamp fields to `DateTimeUtcFromString` so that string-encoded UTC datetimes are correctly parsed from API responses.
> - SSH tunnel readiness check in [`packages/ssh/src/tunnel.ts`](https://github.com/pingdotgg/t3code/pull/2795/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) now accepts any HTTP response (not just 2xx) as a signal that the service is ready.
> - An SSH process that exits with code 0 and no stderr is now treated as a ControlMaster handoff: the tunnel is kept alive rather than surfacing an error.
> - Behavioral Change: auth schemas now expect string input for datetime fields; any upstream code passing `Date` objects directly will fail validation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d69eb1f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->