### PR TITLE
fix(desktop): allow Codex Computer Use automation on macOS

### DIFF
--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -593,6 +593,12 @@ const createBuildConfig = Effect.fn("createBuildConfig")(function* (
       target: target === "dmg" ? [target, "zip"] : [target],
       icon: "icon.icns",
       category: "public.app-category.developer-tools",
+      entitlements: "apps/desktop/resources/entitlements.mac.plist",
+      entitlementsInherit: "apps/desktop/resources/entitlements.mac.plist",
+      extendInfo: {
+        NSAppleEventsUsageDescription:
+          "T3 Code needs Automation access so Codex Computer Use can inspect and control apps you explicitly ask it to use.",
+      },
     };
   }
 


### PR DESCRIPTION
## What Changed

This adds the macOS Automation entitlement and usage description to the packaged desktop app so Codex Computer Use can request the normal macOS Automation prompt when it needs to inspect/control another app.

Specifically:
- Adds `apps/desktop/resources/entitlements.mac.plist`.
- Keeps the existing hardened runtime allowances in that plist.
- Adds `com.apple.security.automation.apple-events`.
- Wires the plist into electron-builder for the app and inherited helper signing.
- Adds `NSAppleEventsUsageDescription` for the macOS prompt text.

## Why

When Codex calls Computer Use from inside the packaged T3 Code desktop app, macOS can reject the Apple Event request with:

```text
Apple event error -1743
```

I hit this while testing Codex Computer Use through T3 Code. Codex itself could run, the Computer Use server could run, and the target app was available, but the packaged Electron app did not have the Automation entitlement/prompt wiring needed for macOS to grant that path.

This is related to #2156, but it does not try to solve the whole Computer Use approval/support UX. It only fixes the concrete macOS packaging permission blocker I ran into.

## Validation

Ran focused checks locally:

```text
bun lint scripts/build-desktop-artifact.ts apps/desktop/resources/entitlements.mac.plist
bun typecheck --filter=@t3tools/scripts
```

I also built and tested a local preview app with this entitlement path. After macOS showed the Automation prompt and I allowed it, nested Codex Computer Use from T3 Code was able to inspect Helium successfully instead of failing with `Apple event error -1743`.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

The last two are marked complete because this PR has no UI, animation, or interaction changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only macOS signing/Info.plist changes with no runtime app logic changes.
> 
> **Overview**
> Fixes macOS **Automation** for Codex Computer Use in the packaged desktop app by adding a dedicated entitlements plist and wiring it into the mac build.
> 
> The new `entitlements.mac.plist` grants **Apple Events** (`com.apple.security.automation.apple-events`) alongside the existing hardened-runtime allowances (JIT, unsigned executable memory, library validation). `scripts/build-desktop-artifact.ts` points electron-builder at that plist for both the app and inherited helpers, and sets `NSAppleEventsUsageDescription` so macOS can show the Automation prompt instead of failing with Apple event error **-1743**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f36f4b5b90feb9425c85fb9b1dae363b8b689346. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow Codex Computer Use automation on macOS via Apple Events entitlements
> - Adds [entitlements.mac.plist](https://github.com/pingdotgg/t3code/pull/2796/files#diff-0d67d2256dfed432806e6c4d57d91c849267bb1649c995a8a17ff21bdb30bbdd) declaring `com.apple.security.automation.apple-events`, JIT, unsigned executable memory, and disabled library validation entitlements.
> - Updates [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/2796/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to sign macOS builds with these entitlements and inject `NSAppleEventsUsageDescription` into Info.plist.
> - Risk: `cs.disable-library-validation` and `cs.allow-unsigned-executable-memory` relax code signing checks at runtime, which broadens the app's security surface.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f36f4b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->