### PR TITLE
feat(web): expand context meter into a session context tab

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1716,7 +1716,9 @@ export default function ChatView(props: ChatViewProps) {
       replace: true,
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
+        return diffOpen
+          ? { ...rest, diff: undefined, tab: undefined }
+          : { ...rest, diff: "1", tab: undefined };
       },
     });
   }, [diffOpen, environmentId, isServerThread, navigate, onDiffPanelOpen, threadId]);
@@ -3472,8 +3474,8 @@ export default function ChatView(props: ChatViewProps) {
         search: (previous) => {
           const rest = stripDiffSearchParams(previous);
           return filePath
-            ? { ...rest, diff: "1", diffTurnId: turnId, diffFilePath: filePath }
-            : { ...rest, diff: "1", diffTurnId: turnId };
+            ? { ...rest, diff: "1", diffTurnId: turnId, diffFilePath: filePath, tab: undefined }
+            : { ...rest, diff: "1", diffTurnId: turnId, tab: undefined };
         },
       });
     },

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -340,6 +340,7 @@ type ChatViewProps =
       environmentId: EnvironmentId;
       threadId: ThreadId;
       onDiffPanelOpen?: () => void;
+      onOpenContextTab?: () => void;
       reserveTitleBarControlInset?: boolean;
       routeKind: "server";
       draftId?: never;
@@ -348,6 +349,7 @@ type ChatViewProps =
       environmentId: EnvironmentId;
       threadId: ThreadId;
       onDiffPanelOpen?: () => void;
+      onOpenContextTab?: () => void;
       reserveTitleBarControlInset?: boolean;
       routeKind: "draft";
       draftId: DraftId;
@@ -3676,6 +3678,7 @@ export default function ChatView(props: ChatViewProps) {
                   scheduleComposerFocus={scheduleComposerFocus}
                   setThreadError={setThreadError}
                   onExpandImage={onExpandTimelineImage}
+                  {...(props.onOpenContextTab ? { onOpenContextTab: props.onOpenContextTab } : {})}
                 />
               </div>
             </div>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -310,10 +310,10 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
 }) {
   return (
     <>
-      {props.activeContextWindow ? (
+      {props.activeContextWindow && props.onOpenContextTab ? (
         <ContextWindowMeter
           usage={props.activeContextWindow}
-          {...(props.onOpenContextTab ? { onOpenContextTab: props.onOpenContextTab } : {})}
+          onOpenContextTab={props.onOpenContextTab}
         />
       ) : null}
       {props.isPreparingWorktree ? (

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -306,10 +306,16 @@ const ComposerFooterPrimaryActions = memo(function ComposerFooterPrimaryActions(
   onPreviousPendingQuestion: () => void;
   onInterrupt: () => void;
   onImplementPlanInNewThread: () => void;
+  onOpenContextTab?: () => void;
 }) {
   return (
     <>
-      {props.activeContextWindow ? <ContextWindowMeter usage={props.activeContextWindow} /> : null}
+      {props.activeContextWindow ? (
+        <ContextWindowMeter
+          usage={props.activeContextWindow}
+          {...(props.onOpenContextTab ? { onOpenContextTab: props.onOpenContextTab } : {})}
+        />
+      ) : null}
       {props.isPreparingWorktree ? (
         <span className="text-muted-foreground/70 text-xs">Preparing worktree...</span>
       ) : null}
@@ -483,6 +489,7 @@ export interface ChatComposerProps {
   scheduleComposerFocus: () => void;
   setThreadError: (threadId: ThreadId | null, error: string | null) => void;
   onExpandImage: (preview: ExpandedImagePreview) => void;
+  onOpenContextTab?: () => void;
 }
 
 // --------------------------------------------------------------------------
@@ -556,6 +563,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     scheduleComposerFocus,
     setThreadError,
     onExpandImage,
+    onOpenContextTab,
   } = props;
 
   // ------------------------------------------------------------------
@@ -2406,6 +2414,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   onPreviousPendingQuestion={onPreviousActivePendingUserInputQuestion}
                   onInterrupt={handleInterruptPrimaryAction}
                   onImplementPlanInNewThread={handleImplementPlanInNewThreadPrimaryAction}
+                  {...(onOpenContextTab ? { onOpenContextTab } : {})}
                 />
               </div>
             </div>

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -1,6 +1,5 @@
 import { cn } from "~/lib/utils";
 import { type ContextWindowSnapshot, formatContextWindowTokens } from "~/lib/contextWindow";
-import { Popover, PopoverPopup, PopoverTrigger } from "../ui/popover";
 
 function formatPercentage(value: number | null): string | null {
   if (value === null || !Number.isFinite(value)) {
@@ -12,7 +11,10 @@ function formatPercentage(value: number | null): string | null {
   return `${Math.round(value)}%`;
 }
 
-export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpenContextTab?: () => void }) {
+export function ContextWindowMeter(props: {
+  usage: ContextWindowSnapshot;
+  onOpenContextTab: () => void;
+}) {
   const { usage, onOpenContextTab } = props;
   const usedPercentage = formatPercentage(usage.usedPercentage);
   const normalizedPercentage = Math.max(0, Math.min(100, usage.usedPercentage ?? 0));
@@ -20,149 +22,55 @@ export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpen
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference - (normalizedPercentage / 100) * circumference;
 
-  if (onOpenContextTab) {
-    return (
-      <button
-        type="button"
-        onClick={onOpenContextTab}
-        className="group/meter inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-        aria-label={
-          usage.maxTokens !== null && usedPercentage
-            ? `Context window ${usedPercentage} used`
-            : `Context window ${formatContextWindowTokens(usage.usedTokens)} tokens used`
-        }
-      >
-        <span className="relative flex h-6 w-6 items-center justify-center">
-          <svg
-            viewBox="0 0 24 24"
-            className="-rotate-90 absolute inset-0 h-full w-full transform-gpu"
-            aria-hidden="true"
-          >
-            <circle
-              cx="12"
-              cy="12"
-              r={radius}
-              fill="none"
-              stroke="color-mix(in oklab, var(--color-muted) 70%, transparent)"
-              strokeWidth="3"
-            />
-            <circle
-              cx="12"
-              cy="12"
-              r={radius}
-              fill="none"
-              stroke="var(--color-muted-foreground)"
-              strokeWidth="3"
-              strokeLinecap="round"
-              strokeDasharray={circumference}
-              strokeDashoffset={dashOffset}
-              className="transition-[stroke-dashoffset] duration-500 ease-out motion-reduce:transition-none"
-            />
-          </svg>
-          <span
-            className={cn(
-              "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium transition-colors group-hover/meter:bg-accent",
-              "text-muted-foreground",
-            )}
-          >
-            {usage.usedPercentage !== null
-              ? Math.round(usage.usedPercentage)
-              : formatContextWindowTokens(usage.usedTokens)}
-          </span>
-        </span>
-      </button>
-    );
-  }
-
   return (
-    <Popover>
-      <PopoverTrigger
-        openOnHover
-        delay={150}
-        closeDelay={0}
-        render={
-          <button
-            type="button"
-            className="group/meter inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
-            aria-label={
-              usage.maxTokens !== null && usedPercentage
-                ? `Context window ${usedPercentage} used`
-                : `Context window ${formatContextWindowTokens(usage.usedTokens)} tokens used`
-            }
-          >
-            <span className="relative flex h-6 w-6 items-center justify-center">
-              <svg
-                viewBox="0 0 24 24"
-                className="-rotate-90 absolute inset-0 h-full w-full transform-gpu"
-                aria-hidden="true"
-              >
-                <circle
-                  cx="12"
-                  cy="12"
-                  r={radius}
-                  fill="none"
-                  stroke="color-mix(in oklab, var(--color-muted) 70%, transparent)"
-                  strokeWidth="3"
-                />
-                <circle
-                  cx="12"
-                  cy="12"
-                  r={radius}
-                  fill="none"
-                  stroke="var(--color-muted-foreground)"
-                  strokeWidth="3"
-                  strokeLinecap="round"
-                  strokeDasharray={circumference}
-                  strokeDashoffset={dashOffset}
-                  className="transition-[stroke-dashoffset] duration-500 ease-out motion-reduce:transition-none"
-                />
-              </svg>
-              <span
-                className={cn(
-                  "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium",
-                  "text-muted-foreground",
-                )}
-              >
-                {usage.usedPercentage !== null
-                  ? Math.round(usage.usedPercentage)
-                  : formatContextWindowTokens(usage.usedTokens)}
-              </span>
-            </span>
-          </button>
-        }
-      />
-      <PopoverPopup tooltipStyle side="top" align="end" className="w-max max-w-none px-3 py-2">
-        <div className="space-y-1.5 leading-tight">
-          <div className="text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-            Context window
-          </div>
-          {usage.maxTokens !== null && usedPercentage ? (
-            <div className="whitespace-nowrap text-xs font-medium text-foreground">
-              <span>{usedPercentage}</span>
-              <span className="mx-1">⋅</span>
-              <span>{formatContextWindowTokens(usage.usedTokens)}</span>
-              <span>/</span>
-              <span>{formatContextWindowTokens(usage.maxTokens ?? null)} context used</span>
-            </div>
-          ) : (
-            <div className="text-sm text-foreground">
-              {formatContextWindowTokens(usage.usedTokens)} tokens used so far
-            </div>
+    <button
+      type="button"
+      onClick={onOpenContextTab}
+      className="group/meter inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+      aria-label={
+        usage.maxTokens !== null && usedPercentage
+          ? `Context window ${usedPercentage} used`
+          : `Context window ${formatContextWindowTokens(usage.usedTokens)} tokens used`
+      }
+    >
+      <span className="relative flex h-6 w-6 items-center justify-center">
+        <svg
+          viewBox="0 0 24 24"
+          className="-rotate-90 absolute inset-0 h-full w-full transform-gpu"
+          aria-hidden="true"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r={radius}
+            fill="none"
+            stroke="color-mix(in oklab, var(--color-muted) 70%, transparent)"
+            strokeWidth="3"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            r={radius}
+            fill="none"
+            stroke="var(--color-muted-foreground)"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeDasharray={circumference}
+            strokeDashoffset={dashOffset}
+            className="transition-[stroke-dashoffset] duration-500 ease-out motion-reduce:transition-none"
+          />
+        </svg>
+        <span
+          className={cn(
+            "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium transition-colors group-hover/meter:bg-accent",
+            "text-muted-foreground",
           )}
-          {(usage.totalProcessedTokens ?? null) !== null &&
-          (usage.totalProcessedTokens ?? 0) > usage.usedTokens ? (
-            <div className="text-xs text-muted-foreground">
-              Total processed: {formatContextWindowTokens(usage.totalProcessedTokens ?? null)}{" "}
-              tokens
-            </div>
-          ) : null}
-          {usage.compactsAutomatically ? (
-            <div className="text-xs text-muted-foreground">
-              Automatically compacts its context when needed.
-            </div>
-          ) : null}
-        </div>
-      </PopoverPopup>
-    </Popover>
+        >
+          {usage.usedPercentage !== null
+            ? Math.round(usage.usedPercentage)
+            : formatContextWindowTokens(usage.usedTokens)}
+        </span>
+      </span>
+    </button>
   );
 }

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -62,7 +62,7 @@ export function ContextWindowMeter(props: {
         </svg>
         <span
           className={cn(
-            "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium transition-colors group-hover/meter:bg-accent",
+            "relative flex h-3.75 w-3.75 items-center justify-center rounded-full bg-background text-[8px] font-medium transition-colors group-hover/meter:bg-accent",
             "text-muted-foreground",
           )}
         >

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -25,7 +25,7 @@ export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpen
       <button
         type="button"
         onClick={onOpenContextTab}
-        className="group inline-flex items-center justify-center rounded-full transition-opacity hover:opacity-85"
+        className="group inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
         aria-label={
           usage.maxTokens !== null && usedPercentage
             ? `Context window ${usedPercentage} used`
@@ -61,7 +61,7 @@ export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpen
           </svg>
           <span
             className={cn(
-              "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium",
+              "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium transition-colors group-hover:bg-accent",
               "text-muted-foreground",
             )}
           >
@@ -83,7 +83,7 @@ export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpen
         render={
           <button
             type="button"
-            className="group inline-flex items-center justify-center rounded-full transition-opacity hover:opacity-85"
+            className="group inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             aria-label={
               usage.maxTokens !== null && usedPercentage
                 ? `Context window ${usedPercentage} used`

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -25,7 +25,7 @@ export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpen
       <button
         type="button"
         onClick={onOpenContextTab}
-        className="group inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+        className="group/meter inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
         aria-label={
           usage.maxTokens !== null && usedPercentage
             ? `Context window ${usedPercentage} used`
@@ -61,7 +61,7 @@ export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpen
           </svg>
           <span
             className={cn(
-              "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium transition-colors group-hover:bg-accent",
+              "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium transition-colors group-hover/meter:bg-accent",
               "text-muted-foreground",
             )}
           >
@@ -83,7 +83,7 @@ export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpen
         render={
           <button
             type="button"
-            className="group inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
+            className="group/meter inline-flex cursor-pointer items-center justify-center rounded-full p-1 transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
             aria-label={
               usage.maxTokens !== null && usedPercentage
                 ? `Context window ${usedPercentage} used`

--- a/apps/web/src/components/chat/ContextWindowMeter.tsx
+++ b/apps/web/src/components/chat/ContextWindowMeter.tsx
@@ -12,13 +12,67 @@ function formatPercentage(value: number | null): string | null {
   return `${Math.round(value)}%`;
 }
 
-export function ContextWindowMeter(props: { usage: ContextWindowSnapshot }) {
-  const { usage } = props;
+export function ContextWindowMeter(props: { usage: ContextWindowSnapshot; onOpenContextTab?: () => void }) {
+  const { usage, onOpenContextTab } = props;
   const usedPercentage = formatPercentage(usage.usedPercentage);
   const normalizedPercentage = Math.max(0, Math.min(100, usage.usedPercentage ?? 0));
   const radius = 9.75;
   const circumference = 2 * Math.PI * radius;
   const dashOffset = circumference - (normalizedPercentage / 100) * circumference;
+
+  if (onOpenContextTab) {
+    return (
+      <button
+        type="button"
+        onClick={onOpenContextTab}
+        className="group inline-flex items-center justify-center rounded-full transition-opacity hover:opacity-85"
+        aria-label={
+          usage.maxTokens !== null && usedPercentage
+            ? `Context window ${usedPercentage} used`
+            : `Context window ${formatContextWindowTokens(usage.usedTokens)} tokens used`
+        }
+      >
+        <span className="relative flex h-6 w-6 items-center justify-center">
+          <svg
+            viewBox="0 0 24 24"
+            className="-rotate-90 absolute inset-0 h-full w-full transform-gpu"
+            aria-hidden="true"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r={radius}
+              fill="none"
+              stroke="color-mix(in oklab, var(--color-muted) 70%, transparent)"
+              strokeWidth="3"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              r={radius}
+              fill="none"
+              stroke="var(--color-muted-foreground)"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeDasharray={circumference}
+              strokeDashoffset={dashOffset}
+              className="transition-[stroke-dashoffset] duration-500 ease-out motion-reduce:transition-none"
+            />
+          </svg>
+          <span
+            className={cn(
+              "relative flex h-[15px] w-[15px] items-center justify-center rounded-full bg-background text-[8px] font-medium",
+              "text-muted-foreground",
+            )}
+          >
+            {usage.usedPercentage !== null
+              ? Math.round(usage.usedPercentage)
+              : formatContextWindowTokens(usage.usedTokens)}
+          </span>
+        </span>
+      </button>
+    );
+  }
 
   return (
     <Popover>

--- a/apps/web/src/components/chat/SessionContextTab.tsx
+++ b/apps/web/src/components/chat/SessionContextTab.tsx
@@ -159,8 +159,8 @@ function StatsGrid({
   metrics: SessionContextMetrics;
   formatter: ReturnType<typeof createSessionContextFormatter>;
 }) {
-  const entries: Array<{ label: string; value: string }> = [
-    { label: "Session", value: metrics.sessionTitle || "—" },
+  const rawEntries: Array<{ label: string; value: string }> = [
+    { label: "Session", value: metrics.sessionTitle },
     { label: "Messages", value: formatter.number(metrics.messageCount) },
     { label: "Provider", value: metrics.providerLabel },
     { label: "Model", value: metrics.modelLabel },
@@ -171,12 +171,17 @@ function StatsGrid({
     { label: "Output", value: formatter.number(metrics.output) },
     { label: "Reasoning", value: formatter.number(metrics.reasoning) },
     { label: "Cache Read", value: formatter.number(metrics.cacheRead) },
-    { label: "Cache Write", value: formatter.number(metrics.cacheWrite) },
     { label: "User Messages", value: formatter.number(metrics.userMessageCount) },
     { label: "Assistant Messages", value: formatter.number(metrics.assistantMessageCount) },
     { label: "Session Created", value: formatter.time(metrics.sessionCreatedAt) },
     { label: "Last Activity", value: formatter.time(metrics.lastActivityAt) },
   ];
+  const entries = rawEntries.filter((entry) => {
+    const trimmed = entry.value.trim();
+    if (trimmed.length === 0 || trimmed === "—") return false;
+    if (trimmed === "0" || trimmed === "0%") return false;
+    return true;
+  });
 
   return (
     <section aria-label="Session statistics">

--- a/apps/web/src/components/chat/SessionContextTab.tsx
+++ b/apps/web/src/components/chat/SessionContextTab.tsx
@@ -283,7 +283,7 @@ function RawMessagesSection({
                       className="group flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-xs"
                     >
                       <ChevronDown
-                        className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-180"
+                        className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-panel-open:rotate-180"
                         aria-hidden
                       />
                       <span className="font-medium uppercase tracking-[0.06em] text-muted-foreground">

--- a/apps/web/src/components/chat/SessionContextTab.tsx
+++ b/apps/web/src/components/chat/SessionContextTab.tsx
@@ -2,11 +2,7 @@ import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { BarChart3, ChevronDown, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "~/components/ui/collapsible";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "~/components/ui/collapsible";
 import { useServerProviders } from "~/rpc/serverState";
 import { useStore } from "~/store";
 import { createThreadSelectorByRef } from "~/storeSelectors";
@@ -19,10 +15,7 @@ import {
   type SessionContextBreakdownSegment,
 } from "./sessionContextBreakdown";
 import { createSessionContextFormatter } from "./sessionContextFormat";
-import {
-  getSessionContextMetrics,
-  type SessionContextMetrics,
-} from "./sessionContextMetrics";
+import { getSessionContextMetrics, type SessionContextMetrics } from "./sessionContextMetrics";
 
 const SEGMENT_COLORS: Record<SessionContextBreakdownKey, string> = {
   system: "bg-amber-500",
@@ -48,15 +41,8 @@ interface SessionContextTabProps {
   onClose: () => void;
 }
 
-export function SessionContextTab({
-  environmentId,
-  threadId,
-  onClose,
-}: SessionContextTabProps) {
-  const threadRef = useMemo(
-    () => ({ environmentId, threadId }),
-    [environmentId, threadId],
-  );
+export function SessionContextTab({ environmentId, threadId, onClose }: SessionContextTabProps) {
+  const threadRef = useMemo(() => ({ environmentId, threadId }), [environmentId, threadId]);
   const thread = useStore(useMemo(() => createThreadSelectorByRef(threadRef), [threadRef]));
   const providers = useServerProviders();
 
@@ -138,7 +124,7 @@ function SessionContextTabHeader({ onClose }: { onClose: () => void }) {
     <div className="flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border px-4">
       <div className="flex min-w-0 items-center gap-2">
         <BarChart3 className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-        <span className="truncate text-sm font-medium text-foreground">Context</span>
+        <span className="truncate text-sm font-medium text-foreground">Context Usage</span>
       </div>
       <button
         type="button"
@@ -166,6 +152,7 @@ function StatsGrid({
     { label: "Model", value: metrics.modelLabel },
     { label: "Context Limit", value: formatter.number(metrics.limit) },
     { label: "Total Tokens", value: formatter.number(metrics.total) },
+    { label: "Total Processed", value: formatter.number(metrics.totalProcessedTokens) },
     { label: "Usage", value: formatter.percent(metrics.usage) },
     { label: "Input", value: formatter.number(metrics.input) },
     { label: "Output", value: formatter.number(metrics.output) },
@@ -194,15 +181,17 @@ function StatsGrid({
             <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
               {entry.label}
             </span>
-            <span
-              className="truncate text-sm font-medium text-foreground"
-              title={entry.value}
-            >
+            <span className="truncate text-sm font-medium text-foreground" title={entry.value}>
               {entry.value}
             </span>
           </div>
         ))}
       </div>
+      {metrics.compactsAutomatically ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Automatically compacts its context when needed.
+        </p>
+      ) : null}
     </section>
   );
 }
@@ -220,9 +209,7 @@ function BreakdownSection({
         Breakdown
       </h3>
       {segments.length === 0 ? (
-        <p className="text-xs text-muted-foreground">
-          Not enough data to compute a breakdown yet.
-        </p>
+        <p className="text-xs text-muted-foreground">Not enough data to compute a breakdown yet.</p>
       ) : (
         <>
           <div

--- a/apps/web/src/components/chat/SessionContextTab.tsx
+++ b/apps/web/src/components/chat/SessionContextTab.tsx
@@ -1,0 +1,320 @@
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { BarChart3, ChevronDown, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "~/components/ui/collapsible";
+import { useServerProviders } from "~/rpc/serverState";
+import { useStore } from "~/store";
+import { createThreadSelectorByRef } from "~/storeSelectors";
+import { cn } from "~/lib/utils";
+import type { Thread } from "~/types";
+
+import {
+  estimateSessionContextBreakdown,
+  type SessionContextBreakdownKey,
+  type SessionContextBreakdownSegment,
+} from "./sessionContextBreakdown";
+import { createSessionContextFormatter } from "./sessionContextFormat";
+import {
+  getSessionContextMetrics,
+  type SessionContextMetrics,
+} from "./sessionContextMetrics";
+
+const SEGMENT_COLORS: Record<SessionContextBreakdownKey, string> = {
+  system: "bg-amber-500",
+  user: "bg-sky-500",
+  assistant: "bg-emerald-500",
+  tool: "bg-violet-500",
+  other: "bg-muted-foreground/40",
+};
+
+const SEGMENT_LABELS: Record<SessionContextBreakdownKey, string> = {
+  system: "System",
+  user: "User",
+  assistant: "Assistant",
+  tool: "Tool",
+  other: "Other",
+};
+
+const scrollPositionByKey = new Map<string, number>();
+
+interface SessionContextTabProps {
+  environmentId: EnvironmentId;
+  threadId: ThreadId;
+  onClose: () => void;
+}
+
+export function SessionContextTab({
+  environmentId,
+  threadId,
+  onClose,
+}: SessionContextTabProps) {
+  const threadRef = useMemo(
+    () => ({ environmentId, threadId }),
+    [environmentId, threadId],
+  );
+  const thread = useStore(useMemo(() => createThreadSelectorByRef(threadRef), [threadRef]));
+  const providers = useServerProviders();
+
+  const formatter = useMemo(() => createSessionContextFormatter(), []);
+
+  const metrics = useMemo<SessionContextMetrics | null>(
+    () => (thread ? getSessionContextMetrics(thread, providers) : null),
+    [thread, providers],
+  );
+
+  const breakdown = useMemo<SessionContextBreakdownSegment[]>(
+    () =>
+      thread
+        ? estimateSessionContextBreakdown({
+            messages: thread.messages,
+            activities: thread.activities,
+            input: metrics?.input ?? null,
+          })
+        : [],
+    [thread, metrics?.input],
+  );
+
+  const scrollKey = `${environmentId}:${threadId}`;
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const rafHandleRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const node = scrollContainerRef.current;
+    if (!node) return;
+    const saved = scrollPositionByKey.get(scrollKey) ?? 0;
+    node.scrollTop = saved;
+  }, [scrollKey]);
+
+  useEffect(() => {
+    return () => {
+      if (rafHandleRef.current !== null) {
+        cancelAnimationFrame(rafHandleRef.current);
+        rafHandleRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleScroll = useCallback(() => {
+    if (rafHandleRef.current !== null) return;
+    rafHandleRef.current = window.requestAnimationFrame(() => {
+      rafHandleRef.current = null;
+      const node = scrollContainerRef.current;
+      if (!node) return;
+      scrollPositionByKey.set(scrollKey, node.scrollTop);
+    });
+  }, [scrollKey]);
+
+  return (
+    <div className="flex h-full min-w-0 flex-col bg-background text-foreground">
+      <SessionContextTabHeader onClose={onClose} />
+      <div
+        ref={scrollContainerRef}
+        onScroll={handleScroll}
+        className="min-h-0 flex-1 overflow-auto overscroll-contain"
+      >
+        {!thread || !metrics ? (
+          <div className="flex h-full items-center justify-center p-6 text-sm text-muted-foreground">
+            Thread is not loaded.
+          </div>
+        ) : (
+          <div className="space-y-6 px-4 py-4">
+            <StatsGrid metrics={metrics} formatter={formatter} />
+            <BreakdownSection segments={breakdown} formatter={formatter} />
+            <RawMessagesSection thread={thread} formatter={formatter} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SessionContextTabHeader({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="flex h-12 shrink-0 items-center justify-between gap-2 border-b border-border px-4">
+      <div className="flex min-w-0 items-center gap-2">
+        <BarChart3 className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+        <span className="truncate text-sm font-medium text-foreground">Context</span>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        aria-label="Close context panel"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  );
+}
+
+function StatsGrid({
+  metrics,
+  formatter,
+}: {
+  metrics: SessionContextMetrics;
+  formatter: ReturnType<typeof createSessionContextFormatter>;
+}) {
+  const entries: Array<{ label: string; value: string }> = [
+    { label: "Session", value: metrics.sessionTitle || "—" },
+    { label: "Messages", value: formatter.number(metrics.messageCount) },
+    { label: "Provider", value: metrics.providerLabel },
+    { label: "Model", value: metrics.modelLabel },
+    { label: "Context Limit", value: formatter.number(metrics.limit) },
+    { label: "Total Tokens", value: formatter.number(metrics.total) },
+    { label: "Usage", value: formatter.percent(metrics.usage) },
+    { label: "Input", value: formatter.number(metrics.input) },
+    { label: "Output", value: formatter.number(metrics.output) },
+    { label: "Reasoning", value: formatter.number(metrics.reasoning) },
+    { label: "Cache Read", value: formatter.number(metrics.cacheRead) },
+    { label: "Cache Write", value: formatter.number(metrics.cacheWrite) },
+    { label: "User Messages", value: formatter.number(metrics.userMessageCount) },
+    { label: "Assistant Messages", value: formatter.number(metrics.assistantMessageCount) },
+    { label: "Session Created", value: formatter.time(metrics.sessionCreatedAt) },
+    { label: "Last Activity", value: formatter.time(metrics.lastActivityAt) },
+  ];
+
+  return (
+    <section aria-label="Session statistics">
+      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+        {entries.map((entry) => (
+          <div
+            key={entry.label}
+            className="flex flex-col gap-0.5 rounded-md border border-border/60 bg-card/40 px-3 py-2"
+          >
+            <span className="text-[10px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+              {entry.label}
+            </span>
+            <span
+              className="truncate text-sm font-medium text-foreground"
+              title={entry.value}
+            >
+              {entry.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function BreakdownSection({
+  segments,
+  formatter,
+}: {
+  segments: SessionContextBreakdownSegment[];
+  formatter: ReturnType<typeof createSessionContextFormatter>;
+}) {
+  return (
+    <section aria-label="Context breakdown">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+        Breakdown
+      </h3>
+      {segments.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Not enough data to compute a breakdown yet.
+        </p>
+      ) : (
+        <>
+          <div
+            className="flex h-2 w-full overflow-hidden rounded bg-muted/60"
+            role="img"
+            aria-label="Token distribution"
+          >
+            {segments.map((segment) => (
+              <div
+                key={segment.key}
+                className={cn("h-full", SEGMENT_COLORS[segment.key])}
+                style={{ width: `${segment.width}%` }}
+              />
+            ))}
+          </div>
+          <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+            {segments.map((segment) => (
+              <div key={segment.key} className="flex items-center gap-2 text-xs">
+                <span
+                  className={cn("size-2.5 shrink-0 rounded-sm", SEGMENT_COLORS[segment.key])}
+                  aria-hidden
+                />
+                <span className="text-muted-foreground">{SEGMENT_LABELS[segment.key]}</span>
+                <span className="ml-auto font-medium text-foreground">
+                  {segment.percent.toLocaleString()}%
+                </span>
+                <span className="w-16 text-right text-muted-foreground">
+                  {formatter.number(segment.tokens)}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+function RawMessagesSection({
+  thread,
+  formatter,
+}: {
+  thread: Thread;
+  formatter: ReturnType<typeof createSessionContextFormatter>;
+}) {
+  return (
+    <section aria-label="Raw messages">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-[0.08em] text-muted-foreground">
+        Raw messages
+      </h3>
+      {thread.messages.length === 0 ? (
+        <p className="text-xs text-muted-foreground">No messages yet.</p>
+      ) : (
+        <div className="space-y-1">
+          {thread.messages.map((message) => {
+            const idSuffix = String(message.id).slice(-8);
+            const json = JSON.stringify(
+              { ...message, attachments: message.attachments ?? [] },
+              null,
+              2,
+            );
+            return (
+              <Collapsible
+                key={message.id}
+                className="rounded-md border border-border/60 bg-card/30"
+              >
+                <CollapsibleTrigger
+                  render={
+                    <button
+                      type="button"
+                      className="group flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-xs"
+                    >
+                      <ChevronDown
+                        className="size-3.5 shrink-0 text-muted-foreground transition-transform group-data-[panel-open]:rotate-180"
+                        aria-hidden
+                      />
+                      <span className="font-medium uppercase tracking-[0.06em] text-muted-foreground">
+                        {message.role}
+                      </span>
+                      <span className="text-muted-foreground/80">·</span>
+                      <span className="font-mono text-muted-foreground">{idSuffix}</span>
+                      <span className="ml-auto text-muted-foreground/80">
+                        {formatter.time(message.createdAt)}
+                      </span>
+                    </button>
+                  }
+                />
+                <CollapsibleContent>
+                  <pre className="overflow-x-auto border-t border-border/40 bg-muted/30 px-3 py-2 font-mono text-[11px] leading-relaxed text-foreground">
+                    {json}
+                  </pre>
+                </CollapsibleContent>
+              </Collapsible>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/chat/sessionContextBreakdown.test.ts
+++ b/apps/web/src/components/chat/sessionContextBreakdown.test.ts
@@ -136,10 +136,7 @@ describe("sessionContextBreakdown", () => {
 
   it("emits widths matching the per-segment ratios", () => {
     const breakdown = estimateSessionContextBreakdown({
-      messages: [
-        makeMessage("user", "a".repeat(400)),
-        makeMessage("assistant", "b".repeat(400)),
-      ],
+      messages: [makeMessage("user", "a".repeat(400)), makeMessage("assistant", "b".repeat(400))],
       activities: [],
       input: 1000,
     });

--- a/apps/web/src/components/chat/sessionContextBreakdown.test.ts
+++ b/apps/web/src/components/chat/sessionContextBreakdown.test.ts
@@ -1,0 +1,152 @@
+import { EventId, MessageId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "~/types";
+import { estimateSessionContextBreakdown } from "./sessionContextBreakdown";
+
+let idCounter = 0;
+function makeMessage(role: ChatMessage["role"], text: string): ChatMessage {
+  idCounter += 1;
+  return {
+    id: MessageId.make(`msg-${idCounter}`),
+    role,
+    text,
+    createdAt: "2026-01-01T00:00:00Z",
+    streaming: false,
+  };
+}
+
+function makeToolActivity(
+  kind: "tool.started" | "tool.updated" | "tool.completed",
+  payload: unknown,
+  id = `act-${idCounter++}`,
+): OrchestrationThreadActivity {
+  return {
+    id: EventId.make(id),
+    tone: "tool",
+    kind,
+    summary: kind,
+    payload,
+    turnId: null,
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("sessionContextBreakdown", () => {
+  it("estimates token counts from character lengths per role", () => {
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [makeMessage("user", "a".repeat(400)), makeMessage("assistant", "b".repeat(800))],
+      activities: [],
+      input: 1000,
+    });
+    const user = breakdown.find((s) => s.key === "user");
+    const assistant = breakdown.find((s) => s.key === "assistant");
+    expect(user?.tokens).toBe(100);
+    expect(assistant?.tokens).toBe(200);
+  });
+
+  it("includes the system prompt length in the system segment", () => {
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [],
+      activities: [],
+      systemPrompt: "x".repeat(40),
+      input: 1000,
+    });
+    const system = breakdown.find((s) => s.key === "system");
+    expect(system?.tokens).toBe(10);
+  });
+
+  it("counts tool activities by JSON payload length", () => {
+    const payload = { name: "edit", args: "y".repeat(396) };
+    const activities = [makeToolActivity("tool.started", payload)];
+    const expected = Math.ceil(JSON.stringify(payload).length / 4);
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [],
+      activities,
+      input: 5000,
+    });
+    expect(breakdown.find((s) => s.key === "tool")?.tokens).toBe(expected);
+  });
+
+  it("ignores non-tool activities for the tool segment", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      {
+        id: EventId.make("act-other"),
+        tone: "info",
+        kind: "context-window.updated",
+        summary: "ctx",
+        payload: { usedTokens: 100 },
+        turnId: null,
+        createdAt: "2026-01-01T00:00:00Z",
+      },
+    ];
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [],
+      activities,
+      input: 1000,
+    });
+    expect(breakdown.find((s) => s.key === "tool")).toBeUndefined();
+  });
+
+  it("fills remainder into the other segment when estimated tokens fit", () => {
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [makeMessage("user", "hello")],
+      activities: [],
+      input: 1000,
+    });
+    const other = breakdown.find((s) => s.key === "other");
+    expect(other).toBeDefined();
+    const totalTokens = breakdown.reduce((sum, s) => sum + s.tokens, 0);
+    expect(totalTokens).toBe(1000);
+  });
+
+  it("scales segments proportionally when estimated exceeds input", () => {
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [
+        makeMessage("user", "a".repeat(10_000)),
+        makeMessage("assistant", "b".repeat(10_000)),
+      ],
+      activities: [],
+      input: 1000,
+    });
+    const total = breakdown.reduce((sum, s) => sum + s.tokens, 0);
+    expect(total).toBe(1000);
+    expect(breakdown.find((s) => s.key === "user")?.tokens ?? 0).toBeGreaterThan(0);
+    expect(breakdown.find((s) => s.key === "assistant")?.tokens ?? 0).toBeGreaterThan(0);
+  });
+
+  it("filters out zero-token segments", () => {
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [makeMessage("user", "hi")],
+      activities: [],
+      input: 1000,
+    });
+    expect(breakdown.every((s) => s.tokens > 0)).toBe(true);
+    expect(breakdown.find((s) => s.key === "assistant")).toBeUndefined();
+  });
+
+  it("returns empty array when there is no data and no input budget", () => {
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [],
+      activities: [],
+      input: null,
+    });
+    expect(breakdown).toEqual([]);
+  });
+
+  it("emits widths matching the per-segment ratios", () => {
+    const breakdown = estimateSessionContextBreakdown({
+      messages: [
+        makeMessage("user", "a".repeat(400)),
+        makeMessage("assistant", "b".repeat(400)),
+      ],
+      activities: [],
+      input: 1000,
+    });
+    const total = breakdown.reduce((sum, s) => sum + s.tokens, 0);
+    for (const segment of breakdown) {
+      const expected = (segment.tokens / total) * 100;
+      expect(Math.abs(segment.width - expected)).toBeLessThan(1e-6);
+    }
+  });
+});

--- a/apps/web/src/components/chat/sessionContextBreakdown.ts
+++ b/apps/web/src/components/chat/sessionContextBreakdown.ts
@@ -1,0 +1,113 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+
+import type { ChatMessage } from "~/types";
+
+export type SessionContextBreakdownKey =
+  | "system"
+  | "user"
+  | "assistant"
+  | "tool"
+  | "other";
+
+export interface SessionContextBreakdownSegment {
+  key: SessionContextBreakdownKey;
+  tokens: number;
+  width: number;
+  percent: number;
+}
+
+const CHARS_PER_TOKEN = 4;
+const ORDERED_KEYS: SessionContextBreakdownKey[] = [
+  "system",
+  "user",
+  "assistant",
+  "tool",
+  "other",
+];
+
+function charsToTokens(chars: number): number {
+  if (chars <= 0) return 0;
+  return Math.ceil(chars / CHARS_PER_TOKEN);
+}
+
+function safeJsonLength(value: unknown): number {
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return 0;
+  }
+}
+
+export function estimateSessionContextBreakdown(input: {
+  messages: ReadonlyArray<ChatMessage>;
+  activities: ReadonlyArray<OrchestrationThreadActivity>;
+  systemPrompt?: string | null;
+  input: number | null;
+}): SessionContextBreakdownSegment[] {
+  const { messages, activities, systemPrompt, input: inputTokens } = input;
+
+  let systemChars = systemPrompt?.length ?? 0;
+  let userChars = 0;
+  let assistantChars = 0;
+  for (const message of messages) {
+    const length = message.text?.length ?? 0;
+    if (message.role === "user") userChars += length;
+    else if (message.role === "assistant") assistantChars += length;
+    else if (message.role === "system") systemChars += length;
+  }
+
+  let toolChars = 0;
+  for (const activity of activities) {
+    if (
+      activity.kind === "tool.started" ||
+      activity.kind === "tool.updated" ||
+      activity.kind === "tool.completed"
+    ) {
+      toolChars += safeJsonLength(activity.payload);
+    }
+  }
+
+  const tokens: Record<SessionContextBreakdownKey, number> = {
+    system: charsToTokens(systemChars),
+    user: charsToTokens(userChars),
+    assistant: charsToTokens(assistantChars),
+    tool: charsToTokens(toolChars),
+    other: 0,
+  };
+
+  const estimatedTotal = tokens.system + tokens.user + tokens.assistant + tokens.tool;
+
+  if (inputTokens !== null && inputTokens > 0) {
+    if (estimatedTotal <= inputTokens) {
+      tokens.other = inputTokens - estimatedTotal;
+    } else {
+      const scale = inputTokens / estimatedTotal;
+      tokens.system = Math.floor(tokens.system * scale);
+      tokens.user = Math.floor(tokens.user * scale);
+      tokens.assistant = Math.floor(tokens.assistant * scale);
+      tokens.tool = Math.floor(tokens.tool * scale);
+      const sum = tokens.system + tokens.user + tokens.assistant + tokens.tool;
+      tokens.other = Math.max(0, inputTokens - sum);
+    }
+  }
+
+  const total = ORDERED_KEYS.reduce((sum, key) => sum + tokens[key], 0);
+  if (total <= 0) {
+    return [];
+  }
+
+  const segments: SessionContextBreakdownSegment[] = [];
+  for (const key of ORDERED_KEYS) {
+    const count = tokens[key];
+    if (count <= 0) continue;
+    const ratio = count / total;
+    const percent = Math.round(ratio * 1000) / 10;
+    segments.push({
+      key,
+      tokens: count,
+      width: ratio * 100,
+      percent,
+    });
+  }
+  return segments;
+}

--- a/apps/web/src/components/chat/sessionContextBreakdown.ts
+++ b/apps/web/src/components/chat/sessionContextBreakdown.ts
@@ -2,12 +2,7 @@ import type { OrchestrationThreadActivity } from "@t3tools/contracts";
 
 import type { ChatMessage } from "~/types";
 
-export type SessionContextBreakdownKey =
-  | "system"
-  | "user"
-  | "assistant"
-  | "tool"
-  | "other";
+export type SessionContextBreakdownKey = "system" | "user" | "assistant" | "tool" | "other";
 
 export interface SessionContextBreakdownSegment {
   key: SessionContextBreakdownKey;
@@ -17,13 +12,7 @@ export interface SessionContextBreakdownSegment {
 }
 
 const CHARS_PER_TOKEN = 4;
-const ORDERED_KEYS: SessionContextBreakdownKey[] = [
-  "system",
-  "user",
-  "assistant",
-  "tool",
-  "other",
-];
+const ORDERED_KEYS: SessionContextBreakdownKey[] = ["system", "user", "assistant", "tool", "other"];
 
 function charsToTokens(chars: number): number {
   if (chars <= 0) return 0;

--- a/apps/web/src/components/chat/sessionContextFormat.ts
+++ b/apps/web/src/components/chat/sessionContextFormat.ts
@@ -1,0 +1,39 @@
+export interface SessionContextFormatter {
+  number(value: number | null): string;
+  percent(value: number | null): string;
+  time(value: string | null | undefined): string;
+}
+
+const FALLBACK = "—";
+
+export function createSessionContextFormatter(
+  locale?: string | ReadonlyArray<string>,
+): SessionContextFormatter {
+  const localeArg = locale === undefined ? undefined : (locale as string | string[]);
+  const numberFormatter = new Intl.NumberFormat(localeArg);
+  const dateTimeFormatter = new Intl.DateTimeFormat(localeArg, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+  const percentFormatter = new Intl.NumberFormat(localeArg, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  });
+
+  return {
+    number(value) {
+      if (value === null || !Number.isFinite(value)) return FALLBACK;
+      return numberFormatter.format(value);
+    },
+    percent(value) {
+      if (value === null || !Number.isFinite(value)) return FALLBACK;
+      return `${percentFormatter.format(value)}%`;
+    },
+    time(value) {
+      if (!value) return FALLBACK;
+      const date = new Date(value);
+      if (Number.isNaN(date.getTime())) return FALLBACK;
+      return dateTimeFormatter.format(date);
+    },
+  };
+}

--- a/apps/web/src/components/chat/sessionContextMetrics.test.ts
+++ b/apps/web/src/components/chat/sessionContextMetrics.test.ts
@@ -138,11 +138,30 @@ describe("sessionContextMetrics", () => {
     expect(metrics.output).toBe(300);
     expect(metrics.reasoning).toBe(50);
     expect(metrics.cacheRead).toBe(100);
-    expect(metrics.cacheWrite).toBeNull();
-    expect(metrics.total).toBe(950);
+    expect(metrics.total).toBe(1500);
     expect(metrics.limit).toBe(10_000);
     expect(metrics.usage).toBe(15);
     expect(metrics.lastActivityAt).toBe("2026-01-01T00:00:10Z");
+  });
+
+  it("falls back to cumulative token fields when last* fields are absent", () => {
+    const thread = makeThread({
+      activities: [
+        makeContextWindowActivity({
+          usedTokens: 50_000,
+          maxTokens: 200_000,
+          inputTokens: 30_000,
+          outputTokens: 15_000,
+          cachedInputTokens: 4_500,
+        }),
+      ],
+    });
+    const metrics = getSessionContextMetrics(thread, [makeProvider()]);
+    expect(metrics.input).toBe(30_000);
+    expect(metrics.output).toBe(15_000);
+    expect(metrics.cacheRead).toBe(4_500);
+    expect(metrics.total).toBe(50_000);
+    expect(metrics.usage).toBe(25);
   });
 
   it("returns null token fields when no snapshot exists", () => {

--- a/apps/web/src/components/chat/sessionContextMetrics.test.ts
+++ b/apps/web/src/components/chat/sessionContextMetrics.test.ts
@@ -11,7 +11,12 @@ import {
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vitest";
 
-import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatMessage, type Thread } from "~/types";
+import {
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type ChatMessage,
+  type Thread,
+} from "~/types";
 import { getSessionContextMetrics } from "./sessionContextMetrics";
 
 const environmentId = EnvironmentId.make("env-1");

--- a/apps/web/src/components/chat/sessionContextMetrics.test.ts
+++ b/apps/web/src/components/chat/sessionContextMetrics.test.ts
@@ -1,0 +1,199 @@
+import {
+  EnvironmentId,
+  EventId,
+  MessageId,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  type OrchestrationThreadActivity,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE, type ChatMessage, type Thread } from "~/types";
+import { getSessionContextMetrics } from "./sessionContextMetrics";
+
+const environmentId = EnvironmentId.make("env-1");
+const instanceId = ProviderInstanceId.make("codex");
+
+function makeMessage(role: ChatMessage["role"], text: string, suffix: string): ChatMessage {
+  return {
+    id: MessageId.make(`msg-${suffix}`),
+    role,
+    text,
+    createdAt: `2026-01-01T00:00:${suffix.padStart(2, "0")}Z`,
+    streaming: false,
+  };
+}
+
+function makeContextWindowActivity(
+  payload: Record<string, number | boolean>,
+  createdAt = "2026-01-01T00:00:05Z",
+  id = "activity-1",
+): OrchestrationThreadActivity {
+  return {
+    id: EventId.make(id),
+    tone: "info",
+    kind: "context-window.updated",
+    summary: "context",
+    payload,
+    turnId: null,
+    createdAt,
+  };
+}
+
+function makeThread(overrides: Partial<Thread> = {}): Thread {
+  return {
+    id: ThreadId.make("thread-1"),
+    environmentId,
+    codexThreadId: null,
+    projectId: ProjectId.make("project-1"),
+    title: "Test Thread",
+    modelSelection: {
+      instanceId,
+      model: "gpt-5-codex",
+    },
+    runtimeMode: DEFAULT_RUNTIME_MODE,
+    interactionMode: DEFAULT_INTERACTION_MODE,
+    session: null,
+    messages: [],
+    proposedPlans: [],
+    error: null,
+    createdAt: "2026-01-01T00:00:00Z",
+    archivedAt: null,
+    latestTurn: null,
+    branch: null,
+    worktreePath: null,
+    turnDiffSummaries: [],
+    activities: [],
+    ...overrides,
+  };
+}
+
+function makeProvider(overrides: Partial<ServerProvider> = {}): ServerProvider {
+  return {
+    instanceId,
+    driver: ProviderDriverKind.make("codex"),
+    displayName: "Codex Primary",
+    enabled: true,
+    installed: true,
+    version: null,
+    status: "ready",
+    auth: { status: "unknown" },
+    checkedAt: "2026-01-01T00:00:00Z",
+    models: [
+      {
+        slug: "gpt-5-codex",
+        name: "GPT-5 Codex",
+        isCustom: false,
+        capabilities: null,
+      },
+    ],
+    slashCommands: [],
+    skills: [],
+    ...overrides,
+  } as ServerProvider;
+}
+
+describe("sessionContextMetrics", () => {
+  it("extracts metrics from the latest assistant turn snapshot", () => {
+    const thread = makeThread({
+      messages: [
+        makeMessage("user", "hi", "1"),
+        makeMessage("assistant", "hello", "2"),
+        makeMessage("user", "ok", "3"),
+      ],
+      activities: [
+        makeContextWindowActivity(
+          {
+            usedTokens: 50,
+            maxTokens: 1000,
+            lastInputTokens: 10,
+            lastOutputTokens: 20,
+            lastReasoningOutputTokens: 5,
+            lastCachedInputTokens: 7,
+          },
+          "2026-01-01T00:00:04Z",
+          "activity-old",
+        ),
+        makeContextWindowActivity(
+          {
+            usedTokens: 1500,
+            maxTokens: 10_000,
+            lastInputTokens: 500,
+            lastOutputTokens: 300,
+            lastReasoningOutputTokens: 50,
+            lastCachedInputTokens: 100,
+          },
+          "2026-01-01T00:00:10Z",
+          "activity-latest",
+        ),
+      ],
+    });
+
+    const metrics = getSessionContextMetrics(thread, [makeProvider()]);
+
+    expect(metrics.input).toBe(500);
+    expect(metrics.output).toBe(300);
+    expect(metrics.reasoning).toBe(50);
+    expect(metrics.cacheRead).toBe(100);
+    expect(metrics.cacheWrite).toBeNull();
+    expect(metrics.total).toBe(950);
+    expect(metrics.limit).toBe(10_000);
+    expect(metrics.usage).toBe(15);
+    expect(metrics.lastActivityAt).toBe("2026-01-01T00:00:10Z");
+  });
+
+  it("returns null token fields when no snapshot exists", () => {
+    const thread = makeThread();
+    const metrics = getSessionContextMetrics(thread, [makeProvider()]);
+    expect(metrics.input).toBeNull();
+    expect(metrics.output).toBeNull();
+    expect(metrics.total).toBeNull();
+    expect(metrics.limit).toBeNull();
+    expect(metrics.usage).toBeNull();
+  });
+
+  it("falls back to slug when provider/model cannot be resolved", () => {
+    const thread = makeThread({
+      modelSelection: {
+        instanceId: ProviderInstanceId.make("unknown-instance"),
+        model: "mystery-model",
+      },
+    });
+    const metrics = getSessionContextMetrics(thread, []);
+    expect(metrics.providerLabel).toBe("unknown-instance");
+    expect(metrics.modelLabel).toBe("mystery-model");
+  });
+
+  it("returns null usage when maxTokens is missing", () => {
+    const thread = makeThread({
+      activities: [
+        makeContextWindowActivity({
+          usedTokens: 1000,
+          lastInputTokens: 500,
+        }),
+      ],
+    });
+    const metrics = getSessionContextMetrics(thread, [makeProvider()]);
+    expect(metrics.usage).toBeNull();
+    expect(metrics.limit).toBeNull();
+  });
+
+  it("splits message counts by role", () => {
+    const thread = makeThread({
+      messages: [
+        makeMessage("user", "1", "1"),
+        makeMessage("assistant", "2", "2"),
+        makeMessage("user", "3", "3"),
+        makeMessage("assistant", "4", "4"),
+        makeMessage("assistant", "5", "5"),
+      ],
+    });
+    const metrics = getSessionContextMetrics(thread, [makeProvider()]);
+    expect(metrics.userMessageCount).toBe(2);
+    expect(metrics.assistantMessageCount).toBe(3);
+    expect(metrics.messageCount).toBe(5);
+  });
+});

--- a/apps/web/src/components/chat/sessionContextMetrics.ts
+++ b/apps/web/src/components/chat/sessionContextMetrics.ts
@@ -12,6 +12,8 @@ export interface SessionContextMetrics {
   reasoning: number | null;
   cacheRead: number | null;
   total: number | null;
+  totalProcessedTokens: number | null;
+  compactsAutomatically: boolean;
   usage: number | null;
   userMessageCount: number;
   assistantMessageCount: number;
@@ -74,6 +76,8 @@ export function getSessionContextMetrics(
     reasoning,
     cacheRead,
     total,
+    totalProcessedTokens: snapshot?.totalProcessedTokens ?? null,
+    compactsAutomatically: snapshot?.compactsAutomatically ?? false,
     usage,
     userMessageCount,
     assistantMessageCount,

--- a/apps/web/src/components/chat/sessionContextMetrics.ts
+++ b/apps/web/src/components/chat/sessionContextMetrics.ts
@@ -11,7 +11,6 @@ export interface SessionContextMetrics {
   output: number | null;
   reasoning: number | null;
   cacheRead: number | null;
-  cacheWrite: number | null;
   total: number | null;
   usage: number | null;
   userMessageCount: number;
@@ -37,20 +36,18 @@ export function getSessionContextMetrics(
     provider?.displayName?.trim() || provider?.driver || thread.modelSelection.instanceId;
   const modelLabel = model?.name?.trim() || modelSlug;
 
-  const input = snapshot?.lastInputTokens ?? null;
-  const output = snapshot?.lastOutputTokens ?? null;
-  const reasoning = snapshot?.lastReasoningOutputTokens ?? null;
-  const cacheRead = snapshot?.lastCachedInputTokens ?? null;
-  const cacheWrite: number | null = null;
-
-  const hasAnyToken =
-    input !== null || output !== null || reasoning !== null || cacheRead !== null;
-  const total = hasAnyToken
-    ? (input ?? 0) + (output ?? 0) + (reasoning ?? 0) + (cacheRead ?? 0)
-    : null;
+  const input = snapshot?.lastInputTokens ?? snapshot?.inputTokens ?? null;
+  const output = snapshot?.lastOutputTokens ?? snapshot?.outputTokens ?? null;
+  const reasoning = snapshot?.lastReasoningOutputTokens ?? snapshot?.reasoningOutputTokens ?? null;
+  const cacheRead = snapshot?.lastCachedInputTokens ?? snapshot?.cachedInputTokens ?? null;
 
   const limit = snapshot?.maxTokens ?? null;
   const usedTokens = snapshot?.usedTokens ?? null;
+  const hasAnyToken =
+    input !== null || output !== null || reasoning !== null || cacheRead !== null;
+  const total =
+    usedTokens ??
+    (hasAnyToken ? (input ?? 0) + (output ?? 0) + (reasoning ?? 0) + (cacheRead ?? 0) : null);
   const usage =
     limit !== null && limit > 0 && usedTokens !== null && usedTokens > 0
       ? Math.round((usedTokens / limit) * 100)
@@ -76,7 +73,6 @@ export function getSessionContextMetrics(
     output,
     reasoning,
     cacheRead,
-    cacheWrite,
     total,
     usage,
     userMessageCount,

--- a/apps/web/src/components/chat/sessionContextMetrics.ts
+++ b/apps/web/src/components/chat/sessionContextMetrics.ts
@@ -1,0 +1,88 @@
+import type { ServerProvider } from "@t3tools/contracts";
+import { deriveLatestContextWindowSnapshot } from "~/lib/contextWindow";
+import type { Thread } from "~/types";
+
+export interface SessionContextMetrics {
+  sessionTitle: string;
+  providerLabel: string;
+  modelLabel: string;
+  limit: number | null;
+  input: number | null;
+  output: number | null;
+  reasoning: number | null;
+  cacheRead: number | null;
+  cacheWrite: number | null;
+  total: number | null;
+  usage: number | null;
+  userMessageCount: number;
+  assistantMessageCount: number;
+  messageCount: number;
+  sessionCreatedAt: string;
+  lastActivityAt: string | null;
+}
+
+export function getSessionContextMetrics(
+  thread: Thread,
+  providers: ReadonlyArray<ServerProvider>,
+): SessionContextMetrics {
+  const snapshot = deriveLatestContextWindowSnapshot(thread.activities);
+
+  const provider = providers.find(
+    (candidate) => candidate.instanceId === thread.modelSelection.instanceId,
+  );
+  const modelSlug = thread.modelSelection.model;
+  const model = provider?.models.find((candidate) => candidate.slug === modelSlug);
+
+  const providerLabel =
+    provider?.displayName?.trim() || provider?.driver || thread.modelSelection.instanceId;
+  const modelLabel = model?.name?.trim() || modelSlug;
+
+  const input = snapshot?.lastInputTokens ?? null;
+  const output = snapshot?.lastOutputTokens ?? null;
+  const reasoning = snapshot?.lastReasoningOutputTokens ?? null;
+  const cacheRead = snapshot?.lastCachedInputTokens ?? null;
+  const cacheWrite: number | null = null;
+
+  const hasAnyToken =
+    input !== null || output !== null || reasoning !== null || cacheRead !== null;
+  const total = hasAnyToken
+    ? (input ?? 0) + (output ?? 0) + (reasoning ?? 0) + (cacheRead ?? 0)
+    : null;
+
+  const limit = snapshot?.maxTokens ?? null;
+  const usedTokens = snapshot?.usedTokens ?? null;
+  const usage =
+    limit !== null && limit > 0 && usedTokens !== null && usedTokens > 0
+      ? Math.round((usedTokens / limit) * 100)
+      : null;
+
+  let userMessageCount = 0;
+  let assistantMessageCount = 0;
+  for (const message of thread.messages) {
+    if (message.role === "user") userMessageCount += 1;
+    else if (message.role === "assistant") assistantMessageCount += 1;
+  }
+
+  const lastActivity = thread.activities[thread.activities.length - 1];
+  const lastMessage = thread.messages[thread.messages.length - 1];
+  const lastActivityAt = lastActivity?.createdAt ?? lastMessage?.createdAt ?? null;
+
+  return {
+    sessionTitle: thread.title,
+    providerLabel,
+    modelLabel,
+    limit,
+    input,
+    output,
+    reasoning,
+    cacheRead,
+    cacheWrite,
+    total,
+    usage,
+    userMessageCount,
+    assistantMessageCount,
+    messageCount: thread.messages.length,
+    sessionCreatedAt: thread.createdAt,
+    lastActivityAt,
+  };
+}

--- a/apps/web/src/components/chat/sessionContextMetrics.ts
+++ b/apps/web/src/components/chat/sessionContextMetrics.ts
@@ -45,8 +45,7 @@ export function getSessionContextMetrics(
 
   const limit = snapshot?.maxTokens ?? null;
   const usedTokens = snapshot?.usedTokens ?? null;
-  const hasAnyToken =
-    input !== null || output !== null || reasoning !== null || cacheRead !== null;
+  const hasAnyToken = input !== null || output !== null || reasoning !== null || cacheRead !== null;
   const total =
     usedTokens ??
     (hasAnyToken ? (input ?? 0) + (output ?? 0) + (reasoning ?? 0) + (cacheRead ?? 0) : null);

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -4,6 +4,7 @@ export interface DiffRouteSearch {
   diff?: "1" | undefined;
   diffTurnId?: TurnId | undefined;
   diffFilePath?: string | undefined;
+  tab?: "context" | undefined;
 }
 
 function isDiffOpenValue(value: unknown): boolean {
@@ -20,12 +21,18 @@ function normalizeSearchString(value: unknown): string | undefined {
 
 export function stripDiffSearchParams<T extends Record<string, unknown>>(
   params: T,
-): Omit<T, "diff" | "diffTurnId" | "diffFilePath"> {
-  const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, ...rest } = params;
-  return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath">;
+): Omit<T, "diff" | "diffTurnId" | "diffFilePath" | "tab"> {
+  const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, tab: _tab, ...rest } = params;
+  return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath" | "tab">;
 }
 
 export function parseDiffRouteSearch(search: Record<string, unknown>): DiffRouteSearch {
+  const tab = search.tab === "context" ? "context" : undefined;
+
+  if (tab === "context") {
+    return { tab };
+  }
+
   const diff = isDiffOpenValue(search.diff) ? "1" : undefined;
   const diffTurnIdRaw = diff ? normalizeSearchString(search.diffTurnId) : undefined;
   const diffTurnId = diffTurnIdRaw ? TurnId.make(diffTurnIdRaw) : undefined;

--- a/apps/web/src/diffRouteSearch.ts
+++ b/apps/web/src/diffRouteSearch.ts
@@ -22,7 +22,13 @@ function normalizeSearchString(value: unknown): string | undefined {
 export function stripDiffSearchParams<T extends Record<string, unknown>>(
   params: T,
 ): Omit<T, "diff" | "diffTurnId" | "diffFilePath" | "tab"> {
-  const { diff: _diff, diffTurnId: _diffTurnId, diffFilePath: _diffFilePath, tab: _tab, ...rest } = params;
+  const {
+    diff: _diff,
+    diffTurnId: _diffTurnId,
+    diffFilePath: _diffFilePath,
+    tab: _tab,
+    ...rest
+  } = params;
   return rest as Omit<T, "diff" | "diffTurnId" | "diffFilePath" | "tab">;
 }
 

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -265,7 +265,7 @@ function ChatThreadRouteView() {
       params: buildThreadRouteParams(threadRef),
       search: (previous) => {
         const rest = stripDiffSearchParams(previous);
-        return { ...rest, diff: "1" };
+        return { ...rest, diff: "1", tab: undefined };
       },
     });
   }, [markDiffOpened, navigate, threadRef]);

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -23,6 +23,7 @@ import { createThreadSelectorByRef } from "../storeSelectors";
 import { resolveThreadRouteRef, buildThreadRouteParams } from "../threadRoutes";
 import { RightPanelSheet } from "../components/RightPanelSheet";
 import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
+import { SessionContextTab } from "../components/chat/SessionContextTab";
 
 const DiffPanel = lazy(() => import("../components/DiffPanel"));
 const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
@@ -30,6 +31,10 @@ const DIFF_INLINE_DEFAULT_WIDTH = "clamp(24rem,34vw,36rem)";
 const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 22 * 16;
 const DIFF_INLINE_SIDEBAR_MAX_WIDTH = 256 * 16;
 const COMPOSER_COMPACT_MIN_LEFT_CONTROLS_WIDTH_PX = 208;
+const CONTEXT_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_context_sidebar_width";
+const CONTEXT_INLINE_DEFAULT_WIDTH = "clamp(22rem,30vw,32rem)";
+const CONTEXT_INLINE_SIDEBAR_MIN_WIDTH = 20 * 16;
+const CONTEXT_INLINE_SIDEBAR_MAX_WIDTH = 256 * 16;
 
 const DiffLoadingFallback = (props: { mode: DiffPanelMode }) => {
   return (
@@ -138,6 +143,56 @@ const DiffPanelInlineSidebar = (props: {
   );
 };
 
+const ContextPanelInlineSidebar = (props: {
+  contextOpen: boolean;
+  onCloseContext: () => void;
+  onOpenContext: () => void;
+  environmentId: import("@t3tools/contracts").EnvironmentId;
+  threadId: import("@t3tools/contracts").ThreadId;
+}) => {
+  const { contextOpen, onCloseContext, onOpenContext, environmentId, threadId } = props;
+  const onOpenChange = useCallback(
+    (open: boolean) => {
+      if (open) {
+        onOpenContext();
+        return;
+      }
+      onCloseContext();
+    },
+    [onCloseContext, onOpenContext],
+  );
+
+  return (
+    <SidebarProvider
+      defaultOpen={false}
+      open={contextOpen}
+      onOpenChange={onOpenChange}
+      className="w-auto min-h-0 flex-none bg-transparent"
+      style={{ "--sidebar-width": CONTEXT_INLINE_DEFAULT_WIDTH } as React.CSSProperties}
+    >
+      <Sidebar
+        side="right"
+        collapsible="offcanvas"
+        className="border-l border-border bg-card text-foreground"
+        resizable={{
+          maxWidth: CONTEXT_INLINE_SIDEBAR_MAX_WIDTH,
+          minWidth: CONTEXT_INLINE_SIDEBAR_MIN_WIDTH,
+          storageKey: CONTEXT_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
+        }}
+      >
+        {contextOpen ? (
+          <SessionContextTab
+            environmentId={environmentId}
+            threadId={threadId}
+            onClose={onCloseContext}
+          />
+        ) : null}
+        <SidebarRail />
+      </Sidebar>
+    </SidebarProvider>
+  );
+};
+
 function ChatThreadRouteView() {
   const navigate = useNavigate();
   const threadRef = Route.useParams({
@@ -168,6 +223,7 @@ function ChatThreadRouteView() {
   const serverThreadStarted = threadHasStarted(serverThread);
   const environmentHasAnyThreads = environmentHasServerThreads || environmentHasDraftThreads;
   const diffOpen = search.diff === "1";
+  const contextOpen = search.tab === "context";
   const shouldUseDiffSheet = useMediaQuery(RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY);
   const currentThreadKey = threadRef ? `${threadRef.environmentId}:${threadRef.threadId}` : null;
   const [diffPanelMountState, setDiffPanelMountState] = useState(() => ({
@@ -213,6 +269,32 @@ function ChatThreadRouteView() {
       },
     });
   }, [markDiffOpened, navigate, threadRef]);
+  const closeContext = useCallback(() => {
+    if (!threadRef) {
+      return;
+    }
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: buildThreadRouteParams(threadRef),
+      search: (previous) => {
+        const rest = stripDiffSearchParams(previous);
+        return { ...rest, tab: undefined };
+      },
+    });
+  }, [navigate, threadRef]);
+  const openContext = useCallback(() => {
+    if (!threadRef) {
+      return;
+    }
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: buildThreadRouteParams(threadRef),
+      search: (previous) => {
+        const rest = stripDiffSearchParams(previous);
+        return { ...rest, tab: "context" };
+      },
+    });
+  }, [navigate, threadRef]);
 
   useEffect(() => {
     if (!threadRef || !bootstrapComplete) {
@@ -245,16 +327,27 @@ function ChatThreadRouteView() {
             environmentId={threadRef.environmentId}
             threadId={threadRef.threadId}
             onDiffPanelOpen={markDiffOpened}
-            reserveTitleBarControlInset={!diffOpen}
+            onOpenContextTab={openContext}
+            reserveTitleBarControlInset={!diffOpen && !contextOpen}
             routeKind="server"
           />
         </SidebarInset>
-        <DiffPanelInlineSidebar
-          diffOpen={diffOpen}
-          onCloseDiff={closeDiff}
-          onOpenDiff={openDiff}
-          renderDiffContent={shouldRenderDiffContent}
-        />
+        {contextOpen ? (
+          <ContextPanelInlineSidebar
+            contextOpen={contextOpen}
+            onCloseContext={closeContext}
+            onOpenContext={openContext}
+            environmentId={threadRef.environmentId}
+            threadId={threadRef.threadId}
+          />
+        ) : (
+          <DiffPanelInlineSidebar
+            diffOpen={diffOpen}
+            onCloseDiff={closeDiff}
+            onOpenDiff={openDiff}
+            renderDiffContent={shouldRenderDiffContent}
+          />
+        )}
       </>
     );
   }
@@ -266,11 +359,23 @@ function ChatThreadRouteView() {
           environmentId={threadRef.environmentId}
           threadId={threadRef.threadId}
           onDiffPanelOpen={markDiffOpened}
+          onOpenContextTab={openContext}
           routeKind="server"
         />
       </SidebarInset>
-      <RightPanelSheet open={diffOpen} onClose={closeDiff}>
-        {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
+      <RightPanelSheet
+        open={diffOpen || contextOpen}
+        onClose={contextOpen ? closeContext : closeDiff}
+      >
+        {contextOpen ? (
+          <SessionContextTab
+            environmentId={threadRef.environmentId}
+            threadId={threadRef.threadId}
+            onClose={closeContext}
+          />
+        ) : shouldRenderDiffContent ? (
+          <LazyDiffPanel mode="sheet" />
+        ) : null}
       </RightPanelSheet>
     </>
   );
@@ -279,7 +384,7 @@ function ChatThreadRouteView() {
 export const Route = createFileRoute("/_chat/$environmentId/$threadId")({
   validateSearch: (search) => parseDiffRouteSearch(search),
   search: {
-    middlewares: [retainSearchParams<DiffRouteSearch>(["diff"])],
+    middlewares: [retainSearchParams<DiffRouteSearch>(["diff", "tab"])],
   },
   component: ChatThreadRouteView,
 });


### PR DESCRIPTION
## What Changed

Adds a "Session context" tab that opens from the context window meter in the composer (Inspired by OpenCode).

- Provider / model and whether the session auto-compacts
- Total tokens used vs. the model's context limit, with a usage percentage
- Per-bucket breakdown: input, output, reasoning, cache-read, total processed
- Message counts (user / assistant / total) and session timing (created, last activity)
- An estimated "where context is going" segmented bar across system / user / assistant / tool / other, derived from the thread's messages and activities

## Why

Today the only context-window signal in the UI is the small ring in the composer footer. For long sessions it's hard to answer:

- How close am I actually to the limit, in tokens, not just "a ring color"?
- Is my context dominated by tool output, by a large system prompt, or by message history?

Surfacing this in a dedicated tab (rather than a hover popover) keeps the composer footer compact while giving an auditable view when the user actually wants to inspect a session. The breakdown is explicitly an estimate, useful for "where is my context going?" intuition without claiming provider-exact accounting.

**Click the context ring to trigger this**

Related: #2518 (compact per-turn session stats footer) asks for a related but per-turn view; this PR adds the session-level counterpart. Not intended to close that issue.

Distinct from #1732, which surfaces account-level provider quota (session/weekly plan usage) in Settings; this PR is about per-thread context-window usage shown off the composer.

## UI Changes

### Context Tab

<img width="457" height="904" alt="image" src="https://github.com/user-attachments/assets/c0e510d1-0fb4-4db3-8117-eaa6c3cf5c58" />


## Checklist

- [ ] This PR is small and focused (Not very small, but definitely focused)
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (No before screenshots)
- [ ] I included a video for animation/interaction changes (N/A)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand context meter into a session context tab in the chat thread route
> - Adds a new `SessionContextTab` right-hand panel that displays token usage, a per-role breakdown bar, and a collapsible raw messages list, driven by new `getSessionContextMetrics` and `estimateSessionContextBreakdown` utilities.
> - Adds a `tab=context` URL search param that opens the panel inline (resizable sidebar) or in a sheet on narrow layouts, with width persisted to local storage.
> - Converts `ContextWindowMeter` from a hover popover to a clickable button that sets `tab=context` in the URL.
> - `ContextWindowMeter` is now only rendered when an `onOpenContextTab` handler is provided, so it is hidden in contexts that don't support the tab.
> - Behavioral Change: opening or closing the diff panel now clears the `tab` search param, and vice versa; `stripDiffSearchParams` also strips `tab`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bbad50.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->