### PR TITLE
feat(pi): add Pi provider settings and runtime support

### DIFF
--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -130,6 +130,11 @@ function createBaseServerConfig(): ServerConfig {
           serverPassword: "",
           customModels: [],
         },
+        pi: {
+          enabled: false,
+          binaryPath: "pi",
+          customModels: [],
+        },
       },
     },
   };

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,5 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, Icon, OpenAI, OpenCodeIcon, PiAgentIcon } from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -7,6 +7,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("claudeAgent")]: ClaudeAI,
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
+  [ProviderDriverKind.make("pi")]: PiAgentIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
+++ b/apps/web/src/components/settings/AddProviderInstanceDialog.tsx
@@ -13,7 +13,7 @@ import { useSettings, useUpdateSettings } from "../../hooks/useSettings";
 import { cn } from "../../lib/utils";
 import { normalizeProviderAccentColor } from "../../providerInstances";
 import { Button } from "../ui/button";
-import { ACPRegistryIcon, Gemini, GithubCopilotIcon, PiAgentIcon, type Icon } from "../Icons";
+import { ACPRegistryIcon, Gemini, GithubCopilotIcon, type Icon } from "../Icons";
 import {
   Dialog,
   DialogDescription,
@@ -85,11 +85,6 @@ const COMING_SOON_DRIVER_OPTIONS: readonly ComingSoonDriverOption[] = [
     value: ProviderDriverKind.make("acpRegistry"),
     label: "ACP Registry",
     icon: ACPRegistryIcon,
-  },
-  {
-    value: ProviderDriverKind.make("piAgent"),
-    label: "Pi Agent",
-    icon: PiAgentIcon,
   },
 ];
 

--- a/apps/web/src/components/settings/ProviderSettingsForm.test.ts
+++ b/apps/web/src/components/settings/ProviderSettingsForm.test.ts
@@ -36,6 +36,13 @@ describe("ProviderSettingsForm helpers", () => {
     });
   });
 
+  it("exposes Pi as an active configurable driver", () => {
+    const pi = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("pi")];
+    expect(pi).toBeDefined();
+    expect(pi?.label).toBe("Pi");
+    expect(deriveProviderSettingsFields(pi!).map((field) => field.key)).toEqual(["binaryPath"]);
+  });
+
   it("preserves unknown config keys while omitting empty configurable fields", () => {
     const opencode = DRIVER_OPTION_BY_VALUE[ProviderDriverKind.make("opencode")];
     expect(opencode).toBeDefined();

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -3,10 +3,11 @@ import {
   CodexSettings,
   CursorSettings,
   OpenCodeSettings,
+  PiSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon, PiAgentIcon } from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -58,6 +59,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("pi"),
+    label: "Pi",
+    icon: PiAgentIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: PiSettings,
   },
 ];
 

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -131,6 +131,7 @@ const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const PI_DRIVER_KIND = ProviderDriverKind.make("pi");
 
 export const DEFAULT_MODEL = "gpt-5.4";
 export const DEFAULT_GIT_TEXT_GENERATION_MODEL = "gpt-5.4-mini";
@@ -200,4 +201,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CLAUDE_DRIVER_KIND]: "Claude",
   [CURSOR_DRIVER_KIND]: "Cursor",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [PI_DRIVER_KIND]: "Pi",
 };

--- a/packages/contracts/src/providerRuntime.test.ts
+++ b/packages/contracts/src/providerRuntime.test.ts
@@ -130,6 +130,27 @@ describe("ProviderRuntimeEvent", () => {
     expect(parsed.payload.answers.sandbox_mode).toBe("workspace-write");
   });
 
+  it("accepts Pi RPC raw event source subcategories", () => {
+    const parsed = decodeRuntimeEvent({
+      type: "runtime.warning",
+      eventId: "event-pi-raw-1",
+      provider: "pi",
+      providerInstanceId: "pi",
+      createdAt: "2026-02-28T00:00:02.000Z",
+      threadId: "thread-2",
+      raw: {
+        source: "pi.rpc.response",
+        method: "get_state",
+        payload: { type: "response", command: "get_state", success: true },
+      },
+      payload: {
+        message: "Pi RPC state refreshed.",
+      },
+    });
+
+    expect(parsed.raw?.source).toBe("pi.rpc.response");
+  });
+
   it("rejects legacy message.delta type", () => {
     expect(() =>
       decodeRuntimeEvent({

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -28,6 +28,7 @@ const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("opencode.sdk.event"),
   Schema.Literal("acp.jsonrpc"),
   Schema.TemplateLiteral(["acp.", Schema.String, ".extension"]),
+  Schema.TemplateLiteral(["pi.rpc.", Schema.String]),
 ]);
 export type RuntimeEventRawSource = typeof RuntimeEventRawSource.Type;
 

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -64,6 +64,44 @@ describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   });
 });
 
+describe("ServerSettings.providers.pi", () => {
+  it("defaults Pi legacy settings to disabled without requiring an on-disk key", () => {
+    const decoded = decodeServerSettings({});
+
+    expect(decoded.providers.pi).toEqual({
+      enabled: false,
+      binaryPath: "pi",
+      customModels: [],
+    });
+  });
+
+  it("decodes empty and enabled Pi provider settings", () => {
+    expect(
+      decodeServerSettings({
+        providers: {
+          pi: {},
+        },
+      }).providers.pi,
+    ).toEqual({
+      enabled: false,
+      binaryPath: "pi",
+      customModels: [],
+    });
+
+    expect(
+      decodeServerSettings({
+        providers: {
+          pi: { enabled: true },
+        },
+      }).providers.pi,
+    ).toEqual({
+      enabled: true,
+      binaryPath: "pi",
+      customModels: [],
+    });
+  });
+});
+
 describe("ServerSettingsPatch.providerInstances", () => {
   it("treats providerInstances as an optional whole-map replacement", () => {
     const patch = decodeServerSettingsPatch({});
@@ -107,6 +145,9 @@ describe("ServerSettingsPatch string normalization", () => {
           binaryPath: "  /opt/homebrew/bin/codex  ",
           homePath: "  ~/.codex  ",
         },
+        pi: {
+          binaryPath: "  /usr/local/bin/pi  ",
+        },
       },
       providerInstances: {
         codex_personal: {
@@ -122,6 +163,7 @@ describe("ServerSettingsPatch string normalization", () => {
     expect(patch.observability?.otlpTracesUrl).toBe("http://localhost:4318/v1/traces");
     expect(patch.providers?.codex?.binaryPath).toBe("/opt/homebrew/bin/codex");
     expect(patch.providers?.codex?.homePath).toBe("~/.codex");
+    expect(patch.providers?.pi?.binaryPath).toBe("/usr/local/bin/pi");
     expect(patch.providerInstances?.[ProviderInstanceId.make("codex_personal")]?.driver).toBe(
       "codex",
     );
@@ -144,10 +186,15 @@ describe("ServerSettingsPatch string normalization", () => {
           ...defaultSettings.providers.codex,
           binaryPath: "  /opt/homebrew/bin/codex  ",
         },
+        pi: {
+          ...defaultSettings.providers.pi,
+          binaryPath: "  /usr/local/bin/pi  ",
+        },
       },
     });
 
     expect(encoded.addProjectBaseDirectory).toBe("~/Development");
     expect(encoded.providers?.codex?.binaryPath).toBe("/opt/homebrew/bin/codex");
+    expect(encoded.providers?.pi?.binaryPath).toBe("/usr/local/bin/pi");
   });
 });

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -331,6 +331,33 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const PiSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("pi").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Pi binary.",
+        providerSettingsForm: {
+          placeholder: "pi",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath"],
+  },
+);
+export type PiSettings = typeof PiSettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -370,6 +397,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    pi: PiSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -445,6 +473,12 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const PiSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
@@ -464,6 +498,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      pi: Schema.optionalKey(PiSettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual


### PR DESCRIPTION
> I understand this may not get merged.  I'm getting this working on my own fork and hope others can benefit, so I'm breaking the work into digestible chunks and opening PRs for each if they get accepted

## What Changed

- Introduced `PiSettings` schema for configuration.
- Added `Pi` driver kind and associated metadata.
- Updated server settings to include `Pi` provider.
- Implemented tests for `Pi` settings and runtime event handling.
- Enhanced UI components to support `Pi` provider integration.

## Why

This is the initial groundwork to add support for the [`pi` agent](https://pi.dev) (see: #402)

This PR adds Pi as a recognized provider in T3 Code's contracts and web UI layer. It establishes the `PiSettings` schema, wires up the driver metadata and icon in the settings UI, adds the `pi.rpc.*` runtime event source template for future RPC streaming, and removes the old `piAgent` coming-soon placeholder now that Pi is becoming a real provider. No server-side runtime yet.

## UI Changes

No new visual components, no layout changes, no new pages. 

It's purely "Pi now exists as a selectable option in the provider settings UI" with correct iconography. The provider won't actually appear in the model picker sidebar (`PROVIDER_OPTIONS` in `session-logic.ts`) until a later PR wires up the server-side availability reporting.

### Before

<img width="1057" height="670" alt="Screenshot 2026-05-25 092954" src="https://github.com/user-attachments/assets/9dee92f6-1d4d-4c24-aefc-133e6e7236e2" />

### After

<img width="830" height="435" alt="image" src="https://github.com/user-attachments/assets/eb1943ff-a199-4418-a2d3-5c13630177bb" />

<img width="833" height="659" alt="Screenshot 2026-05-25 092625" src="https://github.com/user-attachments/assets/c507b791-1c91-4e21-91b8-996f1bc7c6a8" />

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and UI-only changes with Pi disabled by default; no auth, session, or server execution paths modified in this diff.
> 
> **Overview**
> Adds **Pi** as a first-class provider in contracts and the web settings layer: `PiSettings` on legacy `ServerSettings.providers` (defaults **disabled**, binary `pi`), patch/encode paths, and display name wiring.
> 
> The settings UI treats Pi like other active drivers (**Early Access** badge, **binary path** only) and maps **`PiAgentIcon`** for provider icons. The add-instance dialog drops the old **`piAgent`** “coming soon” stub in favor of the real **`pi`** driver.
> 
> Runtime contracts accept **`pi.rpc.*`** raw event sources for future RPC streaming, with tests for decode defaults and event validation. **No server runtime** in this PR—model picker availability stays unchanged until a follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef3d6625bce2021b9209daa5c933fbf92019295d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Pi provider settings and runtime support
> - Adds a `PiSettings` schema to [settings.ts](https://github.com/pingdotgg/t3code/pull/2800/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c) with `binaryPath` (default `'pi'`), `enabled` (default `false`), and `customModels` fields; integrates into `ServerSettings` and `ServerSettingsPatch`.
> - Registers Pi as an active, configurable provider in the settings UI via [providerDriverMeta.ts](https://github.com/pingdotgg/t3code/pull/2800/files#diff-85c0e0270187750635f7fedc543a86f3a11511b2709940b62774f268dbfb5c57) with an 'Early Access' badge, replacing its previous 'Coming soon' entry.
> - Extends `RuntimeEventRawSource` in [providerRuntime.ts](https://github.com/pingdotgg/t3code/pull/2800/files#diff-448aaf2dfbb7547d852cc74c6bba5caea16c3c782a5f9cfbf43da71648ec61f7) to accept `pi.rpc.*` raw event sources.
> - Adds `PI_DRIVER_KIND` constant and `'Pi'` display name to [model.ts](https://github.com/pingdotgg/t3code/pull/2800/files#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ef3d662.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->