### PR TITLE
[codex] fix remote terminal live event updates

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.browser.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.browser.tsx
@@ -1,13 +1,14 @@
 import "../index.css";
 
 import { scopeThreadRef } from "@t3tools/client-runtime";
-import { ThreadId } from "@t3tools/contracts";
+import { ThreadId, type TerminalEvent } from "@t3tools/contracts";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { render } from "vitest-browser-react";
 
 const {
   terminalConstructorSpy,
   terminalDisposeSpy,
+  terminalWriteSpy,
   fitAddonFitSpy,
   fitAddonLoadSpy,
   environmentApiById,
@@ -16,9 +17,19 @@ const {
 } = vi.hoisted(() => ({
   terminalConstructorSpy: vi.fn(),
   terminalDisposeSpy: vi.fn(),
+  terminalWriteSpy: vi.fn(),
   fitAddonFitSpy: vi.fn(),
   fitAddonLoadSpy: vi.fn(),
-  environmentApiById: new Map<string, { terminal: { open: ReturnType<typeof vi.fn> } }>(),
+  environmentApiById: new Map<
+    string,
+    {
+      terminal: {
+        open: ReturnType<typeof vi.fn>;
+        onEvent: ReturnType<typeof vi.fn>;
+      };
+      emitTerminalEvent: (event: TerminalEvent) => void;
+    }
+  >(),
   readEnvironmentApiMock: vi.fn((environmentId: string) => environmentApiById.get(environmentId)),
   readLocalApiMock: vi.fn<
     () =>
@@ -62,7 +73,9 @@ vi.mock("@xterm/xterm", () => ({
 
     open() {}
 
-    write() {}
+    write(data: string) {
+      terminalWriteSpy(data);
+    }
 
     clear() {}
 
@@ -124,6 +137,7 @@ import { TerminalViewport } from "./ThreadTerminalDrawer";
 const THREAD_ID = ThreadId.make("thread-terminal-browser");
 
 function createEnvironmentApi() {
+  const terminalEventListeners = new Set<(event: TerminalEvent) => void>();
   return {
     terminal: {
       open: vi.fn(async () => ({
@@ -140,6 +154,19 @@ function createEnvironmentApi() {
       })),
       write: vi.fn(async () => undefined),
       resize: vi.fn(async () => undefined),
+      clear: vi.fn(async () => undefined),
+      close: vi.fn(async () => undefined),
+      onEvent: vi.fn((listener: (event: TerminalEvent) => void) => {
+        terminalEventListeners.add(listener);
+        return () => {
+          terminalEventListeners.delete(listener);
+        };
+      }),
+    },
+    emitTerminalEvent: (event: TerminalEvent) => {
+      for (const listener of terminalEventListeners) {
+        listener(event);
+      }
     },
   };
 }
@@ -215,6 +242,7 @@ describe("TerminalViewport", () => {
     readLocalApiMock.mockClear();
     terminalConstructorSpy.mockClear();
     terminalDisposeSpy.mockClear();
+    terminalWriteSpy.mockClear();
     fitAddonFitSpy.mockClear();
     fitAddonLoadSpy.mockClear();
   });
@@ -313,6 +341,37 @@ describe("TerminalViewport", () => {
           }),
         }),
       );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("applies output from the viewport-owned terminal event stream", async () => {
+    const environment = createEnvironmentApi();
+    environmentApiById.set("environment-a", environment);
+
+    const mounted = await mountTerminalViewport({
+      threadRef: scopeThreadRef("environment-a" as never, THREAD_ID),
+    });
+
+    try {
+      await vi.waitFor(() => {
+        expect(environment.terminal.open).toHaveBeenCalledTimes(1);
+        expect(environment.terminal.onEvent).toHaveBeenCalledTimes(1);
+      });
+      terminalWriteSpy.mockClear();
+
+      environment.emitTerminalEvent({
+        type: "output",
+        threadId: THREAD_ID,
+        terminalId: "default",
+        createdAt: "2026-04-07T00:00:01.000Z",
+        data: "ls\r\n",
+      });
+
+      await vi.waitFor(() => {
+        expect(terminalWriteSpy).toHaveBeenCalledWith("ls\r\n");
+      });
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -52,6 +52,7 @@ import { selectTerminalEventEntries, useTerminalStateStore } from "../terminalSt
 const MIN_DRAWER_HEIGHT = 180;
 const MAX_DRAWER_HEIGHT_RATIO = 0.75;
 const MULTI_CLICK_SELECTION_ACTION_DELAY_MS = 260;
+const MAX_APPLIED_TERMINAL_EVENT_KEYS = 500;
 
 function maxDrawerHeight(): number {
   if (typeof window === "undefined") return DEFAULT_THREAD_TERMINAL_HEIGHT;
@@ -87,6 +88,45 @@ export function selectPendingTerminalEventEntries(
   lastAppliedTerminalEventId: number,
 ): ReadonlyArray<{ id: number; event: TerminalEvent }> {
   return entries.filter((entry) => entry.id > lastAppliedTerminalEventId);
+}
+
+function terminalEventDedupeKey(event: TerminalEvent): string {
+  switch (event.type) {
+    case "output":
+      return [event.threadId, event.terminalId, event.createdAt, event.type, event.data].join("\0");
+    case "started":
+    case "restarted":
+      return [
+        event.threadId,
+        event.terminalId,
+        event.createdAt,
+        event.type,
+        event.snapshot.updatedAt,
+      ].join("\0");
+    case "activity":
+      return [
+        event.threadId,
+        event.terminalId,
+        event.createdAt,
+        event.type,
+        String(event.hasRunningSubprocess),
+      ].join("\0");
+    case "error":
+      return [event.threadId, event.terminalId, event.createdAt, event.type, event.message].join(
+        "\0",
+      );
+    case "exited":
+      return [
+        event.threadId,
+        event.terminalId,
+        event.createdAt,
+        event.type,
+        String(event.exitCode),
+        String(event.exitSignal),
+      ].join("\0");
+    case "cleared":
+      return [event.threadId, event.terminalId, event.createdAt, event.type].join("\0");
+  }
 }
 
 function normalizeComputedColor(value: string | null | undefined, fallback: string): string {
@@ -292,6 +332,7 @@ export function TerminalViewport({
   const selectionActionTimerRef = useRef<number | null>(null);
   const keybindingsRef = useRef(keybindings);
   const lastAppliedTerminalEventIdRef = useRef(0);
+  const appliedTerminalEventKeysRef = useRef<Set<string>>(new Set());
   const terminalHydratedRef = useRef(false);
   const handleSessionExited = useEffectEvent(() => {
     onSessionExited();
@@ -405,6 +446,40 @@ export function TerminalViewport({
       }
     };
 
+    const terminalOpenInput = () => {
+      const activeTerminal = terminalRef.current;
+      const activeFitAddon = fitAddonRef.current;
+      if (!activeTerminal || !activeFitAddon) {
+        return null;
+      }
+      activeFitAddon.fit();
+      return {
+        threadId,
+        terminalId,
+        cwd,
+        ...(worktreePath !== undefined ? { worktreePath } : {}),
+        cols: activeTerminal.cols,
+        rows: activeTerminal.rows,
+        ...(runtimeEnv ? { env: runtimeEnv } : {}),
+      };
+    };
+
+    const markTerminalEventApplied = (event: TerminalEvent) => {
+      const key = terminalEventDedupeKey(event);
+      const keys = appliedTerminalEventKeysRef.current;
+      if (keys.has(key)) {
+        return false;
+      }
+      keys.add(key);
+      if (keys.size > MAX_APPLIED_TERMINAL_EVENT_KEYS) {
+        const oldestKey = keys.values().next().value;
+        if (typeof oldestKey === "string") {
+          keys.delete(oldestKey);
+        }
+      }
+      return true;
+    };
+
     const sendTerminalInput = async (data: string, fallbackError: string) => {
       const activeTerminal = terminalRef.current;
       if (!activeTerminal) return;
@@ -514,14 +589,7 @@ export function TerminalViewport({
     });
 
     const inputDisposable = terminal.onData((data) => {
-      void api.terminal
-        .write({ threadId, terminalId, data })
-        .catch((err) =>
-          writeSystemMessage(
-            terminal,
-            err instanceof Error ? err.message : "Terminal write failed",
-          ),
-        );
+      void sendTerminalInput(data, "Terminal write failed");
     });
 
     const selectionDisposable = terminal.onSelectionChange(() => {
@@ -570,6 +638,9 @@ export function TerminalViewport({
     const applyTerminalEvent = (event: TerminalEvent) => {
       const activeTerminal = terminalRef.current;
       if (!activeTerminal) {
+        return;
+      }
+      if (!markTerminalEventApplied(event)) {
         return;
       }
 
@@ -663,6 +734,12 @@ export function TerminalViewport({
 
       applyPendingTerminalEvents(nextEntries);
     });
+    const unsubscribeLiveTerminalEvents = api.terminal.onEvent((event) => {
+      if (event.threadId !== threadId || event.terminalId !== terminalId) {
+        return;
+      }
+      applyTerminalEvent(event);
+    });
 
     const openTerminal = async () => {
       try {
@@ -670,15 +747,9 @@ export function TerminalViewport({
         const activeFitAddon = fitAddonRef.current;
         if (!activeTerminal || !activeFitAddon) return;
         activeFitAddon.fit();
-        const snapshot = await api.terminal.open({
-          threadId,
-          terminalId,
-          cwd,
-          ...(worktreePath !== undefined ? { worktreePath } : {}),
-          cols: activeTerminal.cols,
-          rows: activeTerminal.rows,
-          ...(runtimeEnv ? { env: runtimeEnv } : {}),
-        });
+        const input = terminalOpenInput();
+        if (!input) return;
+        const snapshot = await api.terminal.open(input);
         if (disposed) return;
         writeTerminalSnapshot(activeTerminal, snapshot);
         const bufferedEntries = selectTerminalEventEntries(
@@ -734,7 +805,9 @@ export function TerminalViewport({
       disposed = true;
       terminalHydratedRef.current = false;
       lastAppliedTerminalEventIdRef.current = 0;
+      appliedTerminalEventKeysRef.current.clear();
       unsubscribeTerminalEvents();
+      unsubscribeLiveTerminalEvents();
       window.clearTimeout(fitTimer);
       inputDisposable.dispose();
       selectionDisposable.dispose();


### PR DESCRIPTION
## Summary

Fixes a remote terminal rendering issue where terminal input/output can remain invisible until the user switches terminal tabs. The active terminal viewport now owns a live terminal event subscription in addition to the existing environment-level terminal event store path.

## Root Cause

Terminal `open`/snapshot calls and terminal live events travel through different client paths:

- `terminal.open` returns the server-side terminal history snapshot.
- `subscribeTerminalEvents` pushes incremental `TerminalEvent` updates into the client store.
- `TerminalViewport` previously depended on the environment-level subscription populating `useTerminalStateStore`, then rendered from that store.

When the environment-level terminal event path is stale, gated, or otherwise fails to deliver remote events to the store, the server can still receive PTY output and persist history, but the visible xterm does not receive incremental updates. Switching terminal tabs remounts/reopens the terminal and repaints from the snapshot, making the buffered input/output appear all at once.

## Changes

- Add a viewport-owned `api.terminal.onEvent` subscription inside `TerminalViewport`.
- Filter live terminal events to the active `threadId` and `terminalId` before applying them to xterm.
- De-dupe terminal events so the new viewport-owned stream and the existing store-backed stream can both be active without double-writing output.
- Reuse the existing terminal input helper for `terminal.write` error handling.
- Add browser test coverage proving that output emitted through the viewport-owned terminal event stream is written to xterm.

## User Impact

This keeps active remote terminal panes live even when the broader environment terminal event/store path does not update promptly. In the reported Mac-to-Windows remote case, this fixes commands and results not appearing until switching terminal tabs.

## Validation

- `bun run fmt apps/web/src/components/ThreadTerminalDrawer.tsx apps/web/src/components/ThreadTerminalDrawer.browser.tsx`
- `bun run test -- src/components/ThreadTerminalDrawer.test.ts`
- `bun run test -- src/environments/runtime/service.test.ts`
- `bun run test:browser -- src/components/ThreadTerminalDrawer.browser.tsx`
- `bun run typecheck`
- `git diff --check`

Also manually tested against a Mac client connected to a Windows remote server matching `0.0.25-nightly.20260515.295`; the reporter confirmed terminal updates now appear live instead of only after tab switching.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix live terminal event updates in `TerminalViewport` for remote terminals
> - `TerminalViewport` now subscribes to `api.terminal.onEvent` and applies live `output` events to the terminal for the active thread/terminal, with cleanup on unmount.
> - Adds deduplication via `terminalEventDedupeKey`, tracking up to 500 applied event keys to prevent duplicate writes.
> - Refactors terminal open input construction and input sending into helpers without behavioral changes.
> - Adds browser tests verifying that viewport-owned terminal event stream output is written to the terminal via a new `terminalWriteSpy` and mock event emitter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 649c243.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->