### PR TITLE
feat(server): load OpenCode skills from .agents/skills/ directory

### DIFF
--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -17,10 +17,12 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { HttpClient } from "effect/unstable/http";
 import { ChildProcessSpawner } from "effect/unstable/process";
+import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem";
 
 import { makeOpenCodeTextGeneration } from "../../textGeneration/OpenCodeTextGeneration.ts";
 import { ServerConfig } from "../../config.ts";
@@ -138,7 +140,11 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         effectiveConfig,
         serverConfig.cwd,
         processEnv,
-      ).pipe(Effect.map(stampIdentity), Effect.provideService(OpenCodeRuntime, openCodeRuntime));
+      ).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(OpenCodeRuntime, openCodeRuntime),
+        Effect.provide(Layer.merge(Path.layer, NodeFileSystem.layer)),
+      );
 
       const snapshot = yield* makeManagedServerProvider<OpenCodeSettings>({
         maintenanceCapabilities,
@@ -146,7 +152,10 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         streamSettings: Stream.never,
         haveSettingsChanged: () => false,
         initialSnapshot: (settings) =>
-          makePendingOpenCodeProvider(settings).pipe(Effect.map(stampIdentity)),
+          makePendingOpenCodeProvider(settings, serverConfig.cwd).pipe(
+            Effect.map(stampIdentity),
+            Effect.provide(Layer.merge(Path.layer, NodeFileSystem.layer)),
+          ),
         checkProvider,
         enrichSnapshot: ({ snapshot, publishSnapshot }) =>
           enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities).pipe(

--- a/apps/server/src/provider/Layers/OpenCodeProvider.ts
+++ b/apps/server/src/provider/Layers/OpenCodeProvider.ts
@@ -3,11 +3,14 @@ import {
   type ModelCapabilities,
   type OpenCodeSettings,
   type ServerProviderModel,
+  type ServerProviderSkill,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 
 import { createModelCapabilities } from "@t3tools/shared/model";
 import { compareSemverVersions } from "@t3tools/shared/semver";
@@ -217,6 +220,112 @@ function openCodeCapabilitiesForModel(input: {
   });
 }
 
+const SKILLS_DIR_NAME = ".agents";
+const SKILLS_SUBDIR_NAME = "skills";
+const SKILL_FILE_NAME = "SKILL.md";
+
+function parseSkillFrontmatter(
+  content: string,
+): { name: string; description?: string; displayName?: string } | null {
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatterMatch) {
+    return null;
+  }
+
+  const frontmatter = frontmatterMatch[1]!;
+  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+  if (!nameMatch) {
+    return null;
+  }
+
+  const name = nameMatch[1]!.trim();
+  if (name.length === 0) {
+    return null;
+  }
+
+  const descMatch = frontmatter.match(/^description:\s*(?:>\s*\n([\s\S]*?)|(.+))?$/m);
+  let description: string | undefined;
+  if (descMatch) {
+    const raw = descMatch[1] ?? descMatch[2];
+    if (raw) {
+      description = raw
+        .split("\n")
+        .map((line) => line.replace(/^\s*\|?\s*/, ""))
+        .join(" ")
+        .trim();
+    }
+  }
+
+  const displayNameMatch = frontmatter.match(/^displayName:\s*(.+)$/m);
+  const displayName = displayNameMatch ? displayNameMatch[1]!.trim() : undefined;
+
+  const result: { name: string; description?: string; displayName?: string } = { name };
+  if (description !== undefined) {
+    result.description = description;
+  }
+  if (displayName !== undefined) {
+    result.displayName = displayName;
+  }
+  return result;
+}
+
+function loadOpenCodeSkills(
+  cwd: string,
+): Effect.Effect<ReadonlyArray<ServerProviderSkill>, never, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    const skillsDir = path.join(cwd, SKILLS_DIR_NAME, SKILLS_SUBDIR_NAME);
+    const entriesExit = yield* Effect.exit(fs.readDirectory(skillsDir, { recursive: false }));
+
+    if (entriesExit._tag !== "Success") {
+      return [];
+    }
+
+    const skills: Array<ServerProviderSkill> = [];
+
+    for (const entryName of entriesExit.value) {
+      const fullPath = path.join(skillsDir, entryName);
+      const statExit = yield* Effect.exit(fs.stat(fullPath));
+
+      if (statExit._tag !== "Success" || statExit.value.type !== "Directory") {
+        continue;
+      }
+
+      const contentExit = yield* Effect.exit(
+        fs.readFileString(path.join(fullPath, SKILL_FILE_NAME)),
+      );
+
+      if (contentExit._tag !== "Success") {
+        continue;
+      }
+
+      const parsed = parseSkillFrontmatter(contentExit.value);
+      if (!parsed) {
+        continue;
+      }
+
+      const shortDescription =
+        parsed.description && parsed.description.length > 200
+          ? parsed.description.slice(0, 200) + "..."
+          : parsed.description;
+
+      const skill: ServerProviderSkill = {
+        name: parsed.name,
+        path: fullPath,
+        enabled: true,
+        ...(parsed.description !== undefined ? { description: parsed.description } : {}),
+        ...(parsed.displayName !== undefined ? { displayName: parsed.displayName } : {}),
+        ...(shortDescription !== undefined ? { shortDescription } : {}),
+      };
+      skills.push(skill);
+    }
+
+    return skills;
+  });
+}
+
 function flattenOpenCodeModels(input: OpenCodeInventory): ReadonlyArray<ServerProviderModel> {
   const connected = new Set(input.providerList.connected);
   const models: Array<ServerProviderModel> = [];
@@ -252,7 +361,8 @@ function flattenOpenCodeModels(input: OpenCodeInventory): ReadonlyArray<ServerPr
 
 export const makePendingOpenCodeProvider = (
   openCodeSettings: OpenCodeSettings,
-): Effect.Effect<ServerProviderDraft> =>
+  cwd: string,
+): Effect.Effect<ServerProviderDraft, never, FileSystem.FileSystem | Path.Path> =>
   Effect.gen(function* () {
     const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
     const models = providerModelsFromSettings(
@@ -261,6 +371,7 @@ export const makePendingOpenCodeProvider = (
       openCodeSettings.customModels,
       DEFAULT_OPENCODE_MODEL_CAPABILITIES,
     );
+    const skills = yield* loadOpenCodeSkills(cwd);
 
     if (!openCodeSettings.enabled) {
       return buildServerProvider({
@@ -268,6 +379,7 @@ export const makePendingOpenCodeProvider = (
         enabled: false,
         checkedAt,
         models,
+        skills,
         probe: {
           installed: false,
           version: null,
@@ -286,6 +398,7 @@ export const makePendingOpenCodeProvider = (
       enabled: true,
       checkedAt,
       models,
+      skills,
       probe: {
         installed: false,
         version: null,
@@ -300,11 +413,17 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
   openCodeSettings: OpenCodeSettings,
   cwd: string,
   environment: NodeJS.ProcessEnv = process.env,
-): Effect.fn.Return<ServerProviderDraft, never, OpenCodeRuntime> {
+): Effect.fn.Return<
+  ServerProviderDraft,
+  never,
+  OpenCodeRuntime | FileSystem.FileSystem | Path.Path
+> {
   const openCodeRuntime = yield* OpenCodeRuntime;
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const customModels = openCodeSettings.customModels;
   const isExternalServer = openCodeSettings.serverUrl.trim().length > 0;
+
+  const skills = yield* loadOpenCodeSkills(cwd);
 
   const fallback = (cause: unknown, version: string | null = null) => {
     const failure = formatOpenCodeProbeError({
@@ -322,6 +441,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
         customModels,
         DEFAULT_OPENCODE_MODEL_CAPABILITIES,
       ),
+      skills,
       probe: {
         installed: failure.installed,
         version,
@@ -343,6 +463,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
         customModels,
         DEFAULT_OPENCODE_MODEL_CAPABILITIES,
       ),
+      skills,
       probe: {
         installed: false,
         version: null,
@@ -394,6 +515,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
           customModels,
           DEFAULT_OPENCODE_MODEL_CAPABILITIES,
         ),
+        skills,
         probe: {
           installed: true,
           version,
@@ -455,6 +577,7 @@ export const checkOpenCodeProviderStatus = Effect.fn("checkOpenCodeProviderStatu
     enabled: true,
     checkedAt,
     models,
+    skills,
     probe: {
       installed: true,
       version,


### PR DESCRIPTION
## Problem

When using the **OpenCode provider** in t3code, skills defined in `.`/agents/skills/` were not available in the slash command menu (triggered by `$``). This is because the OpenCode driver never loaded skills into the provider snapshot — only the Codex driver did (via `skills/list` RPC).

The Codex driver calls `client.request("skills/list", { cwds: [cwd] })` and includes the result in the provider snapshot. The OpenCode driver only loads models and agents, never skills.

## Solution

Add skill loading directly in the OpenCode provider by reading `.`/agents/skills/` directory on disk:

- **`parseSkillFrontmatter()`** — Parses YAML frontmatter from `SKILL.md` files (supports `name`, `description` with `>` folding, `displayName`)
- **`loadOpenCodeSkills()`** — Reads `.`/agents/skills/` directory, parses each `SKILL.md`, builds `ServerProviderSkill` entries
- Skills are included in **all** provider snapshot paths: `makePendingOpenCodeProvider` and `checkOpenCodeProviderStatus` (including error cases)

## Changes

- `apps/server/src/provider/Layers/OpenCodeProvider.ts` — +119 lines (skill loading + wiring)
- `apps/server/src/provider/Drivers/OpenCodeDriver.ts` — +17 lines (pass cwd, provide FileSystem/Path layers)

## Verification

- `bun typecheck` — passes
- `bun fmt` — passes
- `bun lint` — passes (0 errors, warnings are pre-existing)

This is a small, focused fix that mirrors the Codex driver's behavior for skills.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only local filesystem discovery with graceful empty fallback; no auth or runtime behavior changes beyond enriching the provider snapshot.
> 
> **Overview**
> The OpenCode provider now **loads agent skills from the workspace** (`.agents/skills/*/SKILL.md`) and attaches them to every provider snapshot, so slash-command skill menus work the same way they already do for Codex.
> 
> **`OpenCodeProvider`** gains `parseSkillFrontmatter` (YAML `name`, folded `description`, `displayName`) and `loadOpenCodeSkills`, which scans skill directories, skips invalid entries, and builds `ServerProviderSkill` objects (including truncated `shortDescription`). **`makePendingOpenCodeProvider`** and **`checkOpenCodeProviderStatus`** both take `cwd`, require `FileSystem` / `Path`, and pass `skills` into `buildServerProvider` on success, pending, disabled, and error paths.
> 
> **`OpenCodeDriver`** passes `serverConfig.cwd` into those effects and **`Effect.provide`s** merged `Path.layer` and `NodeFileSystem.layer` for the initial snapshot and status check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 532a15e45f73f5d05fbe06e5168743e7fc3ea69b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Load OpenCode skills from `.agents/skills/` directory into provider snapshots
> - Adds `loadOpenCodeSkills` in [OpenCodeProvider.ts](https://github.com/pingdotgg/t3code/pull/2811/files#diff-4477b51690b8bf5db4f32c13ac9bb4ed2be7798d366111f84b38be236cc034bd) that scans `<cwd>/.agents/skills/`, reads each subdirectory's `SKILL.md`, parses YAML-like frontmatter for `name`, `description`, and `displayName`, and returns a list of `ServerProviderSkill` objects with `enabled: true`.
> - Updates `makePendingOpenCodeProvider` and `checkOpenCodeProviderStatus` to call `loadOpenCodeSkills` and include the resulting skills array in all returned `ServerProviderDraft` objects, including error and disabled states.
> - Wires `Path.layer` and `NodeFileSystem.layer` into the provider creation effects in [OpenCodeDriver.ts](https://github.com/pingdotgg/t3code/pull/2811/files#diff-5a06651977dc543feb1fa81fc993b93165158b17e4204e51ac4b4c97c362d2f6) and passes `serverConfig.cwd` to the snapshot builder.
> - Invalid or unreadable skill entries are skipped; an unreadable skills directory returns an empty list rather than failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 634f4c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->