### PR TITLE
fix: sync resume sessions after CLI modifications

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2059,6 +2059,65 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     yield* completeTurn(context, status, errorMessage, message);
   });
 
+  const detectExternalTurns = Effect.fn("detectExternalTurns")(function* (
+    context: ClaudeSessionContext,
+    initMessage: SDKMessage,
+  ) {
+    const sessionCwd = context.session.cwd;
+    const sessionId =
+      (typeof initMessage.session_id === "string" && initMessage.session_id) ||
+      context.resumeSessionId;
+    if (!sessionCwd || !sessionId) {
+      return;
+    }
+
+    const t3TurnCount = context.session.resumeCursor?.turnCount ?? 0;
+    if (t3TurnCount === 0) {
+      return;
+    }
+
+    // Build the path to Claude's session .jsonl file.
+    // Claude encodes the project path by prepending "-" and replacing "/" with "-".
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+    const encoded = "-" + sessionCwd.replace(/^\//, "").replace(/\//g, "-");
+    const jsonlPath = `${home}/.claude/projects/${encoded}/${sessionId}.jsonl`;
+
+    yield* Effect.tryPromise(() =>
+      import("node:fs/promises").then((fs) => fs.readFile(jsonlPath, "utf-8")),
+    ).pipe(
+      Effect.map((content) => {
+        // Count user-originated turns by looking for `"type":"user"` lines.
+        // Each user message in the JSONL represents one turn boundary.
+        const lines = content.split("\n");
+        let fileTurnCount = 0;
+        for (const line of lines) {
+          if (line.length === 0) continue;
+          if (line.includes('"type":"user"')) {
+            fileTurnCount++;
+          }
+        }
+
+        if (fileTurnCount > t3TurnCount) {
+          const delta = fileTurnCount - t3TurnCount;
+          context.session.resumeCursor = {
+            ...context.session.resumeCursor,
+            turnCount: fileTurnCount,
+          };
+          return { synced: true, delta };
+        }
+
+        return { synced: false };
+      }),
+      Effect.catchAll((cause) =>
+        Effect.logWarning("claude.session.sync-failed", {
+          sessionId,
+          cwd: sessionCwd,
+          cause,
+        }),
+      ),
+    );
+  });
+
   const handleSystemMessage = Effect.fn("handleSystemMessage")(function* (
     context: ClaudeSessionContext,
     message: SDKMessage,
@@ -2084,7 +2143,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     };
 
     switch (message.subtype) {
-      case "init":
+      case "init": {
         yield* offerRuntimeEvent({
           ...base,
           type: "session.configured",
@@ -2092,7 +2151,11 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
             config: message as Record<string, unknown>,
           },
         });
+
+        yield* detectExternalTurns(context, message);
+
         return;
+      }
       case "status":
         yield* offerRuntimeEvent({
           ...base,

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -2072,9 +2072,6 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     }
 
     const t3TurnCount = context.session.resumeCursor?.turnCount ?? 0;
-    if (t3TurnCount === 0) {
-      return;
-    }
 
     // Build the path to Claude's session .jsonl file.
     // Claude encodes the project path by prepending "-" and replacing "/" with "-".
@@ -2086,13 +2083,14 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       import("node:fs/promises").then((fs) => fs.readFile(jsonlPath, "utf-8")),
     ).pipe(
       Effect.map((content) => {
-        // Count user-originated turns by looking for `"type":"user"` lines.
-        // Each user message in the JSONL represents one turn boundary.
+        // Count user-prompt turns (not tool-result user entries).
+        // User prompts: `"type":"user"` with `"content":"text"` (string).
+        // Tool results: `"type":"user"` with `"content":[{"type":"tool_result",...}]` (array).
         const lines = content.split("\n");
         let fileTurnCount = 0;
         for (const line of lines) {
           if (line.length === 0) continue;
-          if (line.includes('"type":"user"')) {
+          if (line.includes('"type":"user"') && !line.includes('"tool_result"')) {
             fileTurnCount++;
           }
         }


### PR DESCRIPTION
When a Claude Code session is resumed from the CLI (outside T3), new turns are appended to the session .jsonl file but T3's projection state is unaware of them. On the next session init, detect this by comparing T3's turnCount against the actual user-turn count in the JSONL file.

If the file has more turns, update the resumeCursor so T3's metadata stays in sync. Claude already has full context via --resume on the next turn; this ensures T3's internal state reflects reality.

Related: #2388 (AskUserQuestion resume key by question text)

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized resume-metadata sync on init with best-effort file read; no auth or turn-execution path changes.
> 
> **Overview**
> When a Claude Code session is **resumed after turns were added outside T3** (e.g. CLI), T3’s `resumeCursor.turnCount` could lag behind Claude’s on-disk session log.
> 
> On **`system:init`**, the adapter now runs **`detectExternalTurns`**: it reads `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`, counts user **prompt** lines (user messages that are not `tool_result` payloads), and if that count exceeds T3’s stored `turnCount`, it **updates `context.session.resumeCursor.turnCount`** so internal resume metadata matches the JSONL file. Read/parse failures are **non-fatal** and emit `claude.session.sync-failed` warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62561007a5b10e8b1813eff3e25a0b9b3a755fd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync resume session turn count from Claude's external session file on init
> - Adds a `detectExternalTurns` helper in [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/2814/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc) that reads the Claude session `.jsonl` file from `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl` on session init.
> - Counts user-prompt turns (excluding `tool_result` entries) and updates `resumeCursor.turnCount` if the file reports a higher count than the current session state.
> - Logs a `claude.session.sync-failed` warning if the file cannot be read or parsed.
> - Behavioral Change: `system:init` message handling now triggers a best-effort external turn sync that may mutate `resumeCursor.turnCount` before the session begins.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6256100.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->