### PR TITLE
fix: SSH auth decoding for JSON date strings

### DIFF
--- a/apps/desktop/src/ssh/DesktopSshRemoteApi.test.ts
+++ b/apps/desktop/src/ssh/DesktopSshRemoteApi.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, it } from "@effect/vitest";
 import { SshHttpBridgeError } from "@t3tools/ssh/errors";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
@@ -31,6 +32,13 @@ function makeLayer(
   );
 }
 
+const authDescriptor = {
+  policy: "remote-reachable",
+  bootstrapMethods: ["one-time-token"],
+  sessionMethods: ["bearer-session-token"],
+  sessionCookieName: "t3_session",
+} as const;
+
 describe("DesktopSshRemoteApi", () => {
   it.effect("fetches and decodes the remote environment descriptor", () => {
     const requestUrls: string[] = [];
@@ -55,6 +63,75 @@ describe("DesktopSshRemoteApi", () => {
 
       assert.equal(descriptor.label, "Remote Devbox");
       assert.deepEqual(requestUrls, ["http://127.0.0.1:41773/.well-known/t3/environment"]);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("decodes auth timestamp strings returned by remote JSON endpoints", () => {
+    const expiresAt = "2026-06-26T13:15:36.023Z";
+    const requestUrls: string[] = [];
+    const layer = makeLayer((request) =>
+      Effect.sync(() => {
+        requestUrls.push(request.url);
+
+        switch (new URL(request.url).pathname) {
+          case "/api/auth/bootstrap/bearer":
+            return jsonResponse(request, {
+              authenticated: true,
+              role: "client",
+              sessionMethod: "bearer-session-token",
+              expiresAt,
+              sessionToken: "session-token",
+            });
+          case "/api/auth/session":
+            return jsonResponse(request, {
+              authenticated: true,
+              auth: authDescriptor,
+              role: "client",
+              sessionMethod: "bearer-session-token",
+              expiresAt,
+            });
+          case "/api/auth/ws-token":
+            return jsonResponse(request, {
+              token: "websocket-token",
+              expiresAt,
+            });
+          default:
+            return jsonResponse(request, { error: "unexpected request" }, 404);
+        }
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const remoteApi = yield* DesktopSshRemoteApi.DesktopSshRemoteApi;
+
+      const bootstrap = yield* remoteApi.bootstrapBearerSession({
+        httpBaseUrl: "http://127.0.0.1:41773/",
+        credential: "pairing-token",
+      });
+      assert.equal(bootstrap.sessionToken, "session-token");
+      assert.equal(DateTime.formatIso(bootstrap.expiresAt), expiresAt);
+
+      const session = yield* remoteApi.fetchSessionState({
+        httpBaseUrl: "http://127.0.0.1:41773/",
+        bearerToken: bootstrap.sessionToken,
+      });
+      if (!session.expiresAt) {
+        throw new Error("expected authenticated session expiry");
+      }
+      assert.equal(DateTime.formatIso(session.expiresAt), expiresAt);
+
+      const websocket = yield* remoteApi.issueWebSocketToken({
+        httpBaseUrl: "http://127.0.0.1:41773/",
+        bearerToken: bootstrap.sessionToken,
+      });
+      assert.equal(websocket.token, "websocket-token");
+      assert.equal(DateTime.formatIso(websocket.expiresAt), expiresAt);
+
+      assert.deepEqual(requestUrls, [
+        "http://127.0.0.1:41773/api/auth/bootstrap/bearer",
+        "http://127.0.0.1:41773/api/auth/session",
+        "http://127.0.0.1:41773/api/auth/ws-token",
+      ]);
     }).pipe(Effect.provide(layer));
   });
 

--- a/apps/desktop/src/ssh/DesktopSshRemoteApi.ts
+++ b/apps/desktop/src/ssh/DesktopSshRemoteApi.ts
@@ -1,7 +1,7 @@
 import {
-  AuthBearerBootstrapResult,
-  AuthSessionState,
-  AuthWebSocketTokenResult,
+  AuthBearerBootstrapJsonResult,
+  AuthSessionJsonState,
+  AuthWebSocketTokenJsonResult,
   type AuthBearerBootstrapResult as AuthBearerBootstrapResultType,
   type AuthSessionState as AuthSessionStateType,
   type AuthWebSocketTokenResult as AuthWebSocketTokenResultType,
@@ -58,9 +58,9 @@ export class DesktopSshRemoteApi extends Context.Service<
 const decodeExecutionEnvironmentDescriptor = Schema.decodeUnknownEffect(
   ExecutionEnvironmentDescriptor,
 );
-const decodeAuthBearerBootstrapResult = Schema.decodeUnknownEffect(AuthBearerBootstrapResult);
-const decodeAuthSessionState = Schema.decodeUnknownEffect(AuthSessionState);
-const decodeAuthWebSocketTokenResult = Schema.decodeUnknownEffect(AuthWebSocketTokenResult);
+const decodeAuthBearerBootstrapResult = Schema.decodeUnknownEffect(AuthBearerBootstrapJsonResult);
+const decodeAuthSessionState = Schema.decodeUnknownEffect(AuthSessionJsonState);
+const decodeAuthWebSocketTokenResult = Schema.decodeUnknownEffect(AuthWebSocketTokenJsonResult);
 
 const mapError =
   (operation: DesktopSshRemoteApiOperation) =>

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -122,11 +122,26 @@ export const AuthBearerBootstrapResult = Schema.Struct({
 });
 export type AuthBearerBootstrapResult = typeof AuthBearerBootstrapResult.Type;
 
+export const AuthBearerBootstrapJsonResult = Schema.Struct({
+  authenticated: Schema.Literal(true),
+  role: AuthSessionRole,
+  sessionMethod: Schema.Literal("bearer-session-token"),
+  expiresAt: Schema.DateTimeUtcFromString,
+  sessionToken: TrimmedNonEmptyString,
+});
+export type AuthBearerBootstrapJsonResult = typeof AuthBearerBootstrapJsonResult.Type;
+
 export const AuthWebSocketTokenResult = Schema.Struct({
   token: TrimmedNonEmptyString,
   expiresAt: Schema.DateTimeUtc,
 });
 export type AuthWebSocketTokenResult = typeof AuthWebSocketTokenResult.Type;
+
+export const AuthWebSocketTokenJsonResult = Schema.Struct({
+  token: TrimmedNonEmptyString,
+  expiresAt: Schema.DateTimeUtcFromString,
+});
+export type AuthWebSocketTokenJsonResult = typeof AuthWebSocketTokenJsonResult.Type;
 
 export const AuthPairingCredentialResult = Schema.Struct({
   id: TrimmedNonEmptyString,
@@ -264,3 +279,12 @@ export const AuthSessionState = Schema.Struct({
   expiresAt: Schema.optionalKey(Schema.DateTimeUtc),
 });
 export type AuthSessionState = typeof AuthSessionState.Type;
+
+export const AuthSessionJsonState = Schema.Struct({
+  authenticated: Schema.Boolean,
+  auth: ServerAuthDescriptor,
+  role: Schema.optionalKey(AuthSessionRole),
+  sessionMethod: Schema.optionalKey(ServerAuthSessionMethod),
+  expiresAt: Schema.optionalKey(Schema.DateTimeUtcFromString),
+});
+export type AuthSessionJsonState = typeof AuthSessionJsonState.Type;


### PR DESCRIPTION
Fixes #2786 , #2665

## What Changed

- Add JSON auth result schemas that decode ISO UTC date strings into `DateTime.Utc`.
- Use those schemas when decoding SSH remote auth responses for:
  - bearer bootstrap
  - session state
  - websocket token issuance
- Add regression coverage for the remote response shape reported in #2786.

## Why

The remote server returns `expiresAt` over HTTP JSON as an ISO string, but the desktop SSH client decoded the parsed JSON with schemas expecting `Schema.DateTimeUtc` directly. That caused bootstrap to fail with: `Expected DateTime.Utc, got "2026-06-26T13:15:36.023Z"`

## Testing

- `bun run vitest run apps/desktop/src/ssh/DesktopSshRemoteApi.test.ts`
- `bun run --filter @t3tools/contracts typecheck`
- `bun run --filter @t3tools/desktop typecheck`
- `bun run --filter @t3tools/web typecheck`
- `bun fmt`
- `bun lint`

No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow contract and desktop SSH client decode-path fix with regression tests; no auth policy or server behavior changes.
> 
> **Overview**
> Fixes SSH remote auth failing when the server returns **`expiresAt`** as ISO strings in JSON (e.g. bootstrap error: expected `DateTime.Utc`, got a string).
> 
> Adds parallel **JSON wire** schemas in contracts (`AuthBearerBootstrapJsonResult`, `AuthSessionJsonState`, `AuthWebSocketTokenJsonResult`) that decode `expiresAt` via **`Schema.DateTimeUtcFromString`**, while keeping the existing in-memory types unchanged. **`DesktopSshRemoteApi`** now decodes bearer bootstrap, session state, and WebSocket token responses with those JSON schemas.
> 
> Adds a regression test that stubs the three auth endpoints with string timestamps and asserts they round-trip to **`DateTime`** via **`DateTime.formatIso`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 553ba54f24c72e3626c8fe9a556fd0728eb0a44f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SSH auth decoding of ISO timestamp strings for `expiresAt` fields
> The SSH remote API was failing to decode `expiresAt` fields in JSON responses because the existing schemas expected native date types rather than ISO string representations.
>
> - Adds JSON-specific schemas (`AuthBearerBootstrapJsonResult`, `AuthWebSocketTokenJsonResult`, `AuthSessionJsonState`) in [auth.ts](https://github.com/pingdotgg/t3code/pull/2825/files#diff-ff0457cc1ebe1a7b4a4a5c946a6d6725020e9dcb88aa053aad376b5dac686046) that use `Schema.DateTimeUtcFromString` for `expiresAt`.
> - Updates decoders in [DesktopSshRemoteApi.ts](https://github.com/pingdotgg/t3code/pull/2825/files#diff-2befb11cd040b0f96d0f5c050a712b83acf642dcc0e9e498a83c473df15e70fe) for `bootstrapBearerSession`, `fetchSessionState`, and `issueWebSocketToken` to use the new JSON schemas.
> - Adds tests verifying that ISO timestamp strings round-trip correctly through decoding via `DateTime.formatIso`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 553ba54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->