### PR TITLE
Advertise Tailscale Serve HTTPS startup URLs

### DIFF
--- a/REMOTE.md
+++ b/REMOTE.md
@@ -89,8 +89,17 @@ For hosted web pairing over Tailscale HTTPS, opt in to Tailscale Serve:
 npx t3 serve --tailscale-serve
 ```
 
-By default this configures Tailscale Serve on HTTPS port 443 and advertises
-`https://machine.tailnet.ts.net/`. Advanced users can choose a different HTTPS port:
+By default this configures Tailscale Serve on HTTPS port 443, discovers the machine's MagicDNS
+name, and advertises `https://machine.tailnet.ts.net/`. If MagicDNS discovery is unavailable, the
+CLI falls back to the normal headless pairing URL.
+
+Use `--tailscale-serve-host` when the advertised HTTPS host should be fixed instead of discovered:
+
+```bash
+npx t3 serve --tailscale-serve --tailscale-serve-host machine.tailnet.ts.net
+```
+
+Advanced users can also choose a different HTTPS port:
 
 ```bash
 npx t3 serve --tailscale-serve --tailscale-serve-port 8443

--- a/apps/server/src/cli/config.test.ts
+++ b/apps/server/src/cli/config.test.ts
@@ -75,6 +75,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           logWebSocketEvents: Option.none(),
           tailscaleServeEnabled: Option.none(),
           tailscaleServePort: Option.none(),
+          tailscaleServeHost: Option.none(),
         },
         Option.none(),
       ).pipe(
@@ -92,6 +93,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
                   T3CODE_NO_BROWSER: "true",
                   T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: "false",
                   T3CODE_LOG_WS_EVENTS: "true",
+                  T3CODE_TAILSCALE_SERVE_HOST: "env-tailnet.example.ts.net",
                 },
               }),
             ),
@@ -118,6 +120,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: true,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        tailscaleServeHost: "env-tailnet.example.ts.net",
       });
     }),
   );
@@ -141,6 +144,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           logWebSocketEvents: Option.some(true),
           tailscaleServeEnabled: Option.some(true),
           tailscaleServePort: Option.some(8443),
+          tailscaleServeHost: Option.some("cli-tailnet.example.ts.net"),
         },
         Option.some("Debug"),
       ).pipe(
@@ -158,6 +162,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
                   T3CODE_NO_BROWSER: "false",
                   T3CODE_AUTO_BOOTSTRAP_PROJECT_FROM_CWD: "false",
                   T3CODE_LOG_WS_EVENTS: "false",
+                  T3CODE_TAILSCALE_SERVE_HOST: "ignored-env-tailnet.example.ts.net",
                 },
               }),
             ),
@@ -184,6 +189,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: true,
         tailscaleServeEnabled: true,
         tailscaleServePort: 8443,
+        tailscaleServeHost: "cli-tailnet.example.ts.net",
       });
     }),
   );
@@ -215,6 +221,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           logWebSocketEvents: Option.some(false),
           tailscaleServeEnabled: Option.none(),
           tailscaleServePort: Option.none(),
+          tailscaleServeHost: Option.none(),
         },
         Option.none(),
       ).pipe(
@@ -253,6 +260,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: false,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        tailscaleServeHost: undefined,
       });
     }),
   );
@@ -290,6 +298,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           logWebSocketEvents: Option.none(),
           tailscaleServeEnabled: Option.none(),
           tailscaleServePort: Option.none(),
+          tailscaleServeHost: Option.none(),
         },
         Option.none(),
       ).pipe(
@@ -327,6 +336,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: false,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        tailscaleServeHost: undefined,
       });
       assert.equal(join(baseDir, "userdata"), resolved.stateDir);
     }),
@@ -353,6 +363,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           logWebSocketEvents: Option.none(),
           tailscaleServeEnabled: Option.none(),
           tailscaleServePort: Option.none(),
+          tailscaleServeHost: Option.none(),
         },
         Option.none(),
       ).pipe(
@@ -412,6 +423,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           logWebSocketEvents: Option.none(),
           tailscaleServeEnabled: Option.none(),
           tailscaleServePort: Option.none(),
+          tailscaleServeHost: Option.none(),
         },
         Option.some("Debug"),
       ).pipe(
@@ -452,6 +464,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: true,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        tailscaleServeHost: undefined,
       });
     }),
   );
@@ -488,6 +501,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           logWebSocketEvents: Option.none(),
           tailscaleServeEnabled: Option.none(),
           tailscaleServePort: Option.none(),
+          tailscaleServeHost: Option.none(),
         },
         Option.none(),
       ).pipe(
@@ -521,6 +535,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: false,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        tailscaleServeHost: undefined,
       });
     }),
   );
@@ -545,6 +560,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
           logWebSocketEvents: Option.none(),
           tailscaleServeEnabled: Option.none(),
           tailscaleServePort: Option.none(),
+          tailscaleServeHost: Option.none(),
         },
         Option.none(),
         {
@@ -584,6 +600,7 @@ it.layer(NodeServices.layer)("cli config resolution", (it) => {
         logWebSocketEvents: false,
         tailscaleServeEnabled: false,
         tailscaleServePort: 443,
+        tailscaleServeHost: undefined,
       });
     }),
   );

--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -80,6 +80,10 @@ export const tailscaleServePortFlag = Flag.integer("tailscale-serve-port").pipe(
   Flag.withDescription("HTTPS port for Tailscale Serve when --tailscale-serve is enabled."),
   Flag.optional,
 );
+export const tailscaleServeHostFlag = Flag.string("tailscale-serve-host").pipe(
+  Flag.withDescription("Host name for Tailscale Serve when --tailscale-serve is enabled."),
+  Flag.optional,
+);
 
 const EnvServerConfig = Config.all({
   logLevel: Config.logLevel("T3CODE_LOG_LEVEL").pipe(Config.withDefault("Info")),
@@ -136,6 +140,10 @@ const EnvServerConfig = Config.all({
     Config.option,
     Config.map(Option.getOrUndefined),
   ),
+  tailscaleServeHost: Config.string("T3CODE_TAILSCALE_SERVE_HOST").pipe(
+    Config.option,
+    Config.map(Option.getOrUndefined),
+  ),
 });
 
 export interface CliServerFlags {
@@ -151,6 +159,7 @@ export interface CliServerFlags {
   readonly logWebSocketEvents: Option.Option<boolean>;
   readonly tailscaleServeEnabled: Option.Option<boolean>;
   readonly tailscaleServePort: Option.Option<number>;
+  readonly tailscaleServeHost: Option.Option<string>;
 }
 
 export interface CliAuthLocationFlags {
@@ -185,6 +194,7 @@ export const sharedServerCommandFlags = {
   logWebSocketEvents: logWebSocketEventsFlag,
   tailscaleServeEnabled: tailscaleServeFlag,
   tailscaleServePort: tailscaleServePortFlag,
+  tailscaleServeHost: tailscaleServeHostFlag,
 } as const;
 
 export const authLocationFlags = sharedServerLocationFlags;
@@ -230,6 +240,7 @@ export const resolveServerConfig = (
       logWebSocketEvents: flags.logWebSocketEvents ?? Option.none(),
       tailscaleServeEnabled: flags.tailscaleServeEnabled ?? Option.none(),
       tailscaleServePort: flags.tailscaleServePort ?? Option.none(),
+      tailscaleServeHost: flags.tailscaleServeHost ?? Option.none(),
     } satisfies CliServerFlags;
     const bootstrapFd = Option.getOrUndefined(normalizedFlags.bootstrapFd) ?? env.bootstrapFd;
     const bootstrapEnvelope =
@@ -330,6 +341,13 @@ export const resolveServerConfig = (
       ),
       () => 443,
     );
+    const tailscaleServeHost = Option.getOrElse(
+      resolveOptionPrecedence(
+        normalizedFlags.tailscaleServeHost,
+        Option.fromUndefinedOr(env.tailscaleServeHost),
+      ),
+      () => undefined,
+    );
     const staticDir = devUrl ? undefined : yield* resolveStaticDir();
     const host = Option.getOrElse(
       resolveOptionPrecedence(
@@ -374,6 +392,7 @@ export const resolveServerConfig = (
       logWebSocketEvents,
       tailscaleServeEnabled,
       tailscaleServePort,
+      tailscaleServeHost,
     };
 
     return config;
@@ -397,6 +416,7 @@ export const resolveCliAuthConfig = (
       logWebSocketEvents: Option.none(),
       tailscaleServeEnabled: Option.none(),
       tailscaleServePort: Option.none(),
+      tailscaleServeHost: Option.none(),
     },
     cliLogLevel,
   );

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -73,6 +73,7 @@ export interface ServerConfigShape extends ServerDerivedPaths {
   readonly logWebSocketEvents: boolean;
   readonly tailscaleServeEnabled: boolean;
   readonly tailscaleServePort: number;
+  readonly tailscaleServeHost?: string | undefined;
 }
 
 export const deriveServerPaths = Effect.fn(function* (
@@ -168,6 +169,7 @@ export class ServerConfig extends Context.Service<ServerConfig, ServerConfigShap
           logWebSocketEvents: false,
           tailscaleServeEnabled: false,
           tailscaleServePort: 443,
+          tailscaleServeHost: undefined,
           port: 0,
           host: undefined,
           desktopBootstrapToken: undefined,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -36,6 +36,7 @@ import { TerminalManagerLive } from "./terminal/Layers/Manager.ts";
 import * as GitManager from "./git/GitManager.ts";
 import { KeybindingsLive } from "./keybindings.ts";
 import { ServerRuntimeStartup, ServerRuntimeStartupLive } from "./serverRuntimeStartup.ts";
+import { TailscaleServeRuntime, TailscaleServeRuntimeLive } from "./tailscaleServeRuntime.ts";
 import { OrchestrationReactorLive } from "./orchestration/Layers/OrchestrationReactor.ts";
 import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus.ts";
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion.ts";
@@ -352,9 +353,11 @@ export const makeServerLayer = Layer.unwrap(
       ? Layer.effectDiscard(
           Effect.acquireRelease(
             Effect.gen(function* () {
+              const tailscaleServeRuntime = yield* TailscaleServeRuntime;
               const server = yield* HttpServer.HttpServer;
               const address = server.address;
               if (typeof address === "string" || !("port" in address)) {
+                yield* tailscaleServeRuntime.markUnavailable;
                 return null;
               }
 
@@ -365,6 +368,7 @@ export const makeServerLayer = Layer.unwrap(
                 localHost: "127.0.0.1",
               }).pipe(
                 Effect.as({ localPort, servePort: config.tailscaleServePort }),
+                Effect.tap(() => tailscaleServeRuntime.markConfigured),
                 Effect.tap(() =>
                   Effect.logInfo("Tailscale Serve configured", {
                     localPort,
@@ -372,11 +376,16 @@ export const makeServerLayer = Layer.unwrap(
                   }),
                 ),
                 Effect.catch((cause) =>
-                  Effect.logWarning("Failed to configure Tailscale Serve", {
-                    cause,
-                    localPort,
-                    servePort: config.tailscaleServePort,
-                  }).pipe(Effect.as(null)),
+                  tailscaleServeRuntime.markUnavailable.pipe(
+                    Effect.andThen(
+                      Effect.logWarning("Failed to configure Tailscale Serve", {
+                        cause,
+                        localPort,
+                        servePort: config.tailscaleServePort,
+                      }),
+                    ),
+                    Effect.as(null),
+                  ),
                 ),
               );
             }),
@@ -411,6 +420,7 @@ export const makeServerLayer = Layer.unwrap(
 
     return serverApplicationLayer.pipe(
       Layer.provideMerge(RuntimeServicesLive),
+      Layer.provideMerge(TailscaleServeRuntimeLive),
       Layer.provideMerge(HttpServerLive),
       Layer.provide(ObservabilityLive),
       Layer.provideMerge(FetchHttpClient.layer),

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -38,6 +38,7 @@ import {
   formatHostForUrl,
   isWildcardHost,
   issueHeadlessServeAccessInfo,
+  resolveAdvertisedStartupBaseUrl,
 } from "./startupAccess.ts";
 
 export class ServerRuntimeStartupError extends Data.TaggedError("ServerRuntimeStartupError")<{
@@ -247,7 +248,13 @@ const resolveStartupBrowserTarget = Effect.gen(function* () {
     serverConfig.host && !isWildcardHost(serverConfig.host)
       ? `http://${formatHostForUrl(serverConfig.host)}:${serverConfig.port}`
       : localUrl;
-  const baseTarget = serverConfig.devUrl?.toString() ?? bindUrl;
+  const httpBaseTarget = serverConfig.devUrl?.toString() ?? bindUrl;
+  const baseTarget = yield* resolveAdvertisedStartupBaseUrl({
+    httpBaseUrl: httpBaseTarget,
+    tailscaleServeEnabled: serverConfig.tailscaleServeEnabled,
+    tailscaleServePort: serverConfig.tailscaleServePort,
+    tailscaleServeHost: serverConfig.tailscaleServeHost,
+  });
   return yield* Effect.succeed(serverConfig.mode === "desktop" ? baseTarget : undefined).pipe(
     Effect.flatMap((target) =>
       target ? Effect.succeed(target) : serverAuth.issueStartupPairingUrl(baseTarget),

--- a/apps/server/src/startupAccess.test.ts
+++ b/apps/server/src/startupAccess.test.ts
@@ -1,13 +1,60 @@
 import { assert, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   buildPairingUrl,
   formatHeadlessServeOutput,
   renderTerminalQrCode,
+  resolveAdvertisedStartupBaseUrl,
   resolveHeadlessConnectionHost,
   resolveHeadlessConnectionString,
   resolveListeningPort,
 } from "./startupAccess.ts";
+import { TailscaleServeRuntime } from "./tailscaleServeRuntime.ts";
+
+const encoder = new TextEncoder();
+
+function mockHandle(result: {
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly code?: number;
+}) {
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(result.code ?? 0)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(result.stdout ?? "")),
+    stderr: Stream.make(encoder.encode(result.stderr ?? "")),
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
+}
+
+function mockSpawnerLayer(result: {
+  readonly stdout?: string;
+  readonly stderr?: string;
+  readonly code?: number;
+}) {
+  return Layer.succeed(
+    ChildProcessSpawner.ChildProcessSpawner,
+    ChildProcessSpawner.make(() => Effect.succeed(mockHandle(result))),
+  );
+}
+
+const mockTailscaleServeRuntimeLayer = (configured: boolean) =>
+  Layer.succeed(TailscaleServeRuntime, {
+    awaitConfigured: Effect.succeed(configured),
+    markConfigured: Effect.void,
+    markUnavailable: Effect.void,
+  });
 
 it("prefers localhost when no explicit host is configured", () => {
   expect(resolveHeadlessConnectionHost(undefined)).toBe("localhost");
@@ -51,6 +98,87 @@ it("prefers the actual bound port when an http server address is available", () 
   expect(resolveListeningPort("pipe", 3773)).toBe(3773);
   expect(resolveListeningPort(null, 3773)).toBe(3773);
 });
+
+it.effect("uses an explicit Tailscale Serve host for the advertised startup base URL", () =>
+  Effect.gen(function* () {
+    const baseUrl = yield* resolveAdvertisedStartupBaseUrl({
+      httpBaseUrl: "http://192.168.1.42:3773",
+      tailscaleServeEnabled: true,
+      tailscaleServePort: 443,
+      tailscaleServeHost: "desktop.tail.ts.net",
+    }).pipe(
+      Effect.provide(Layer.mergeAll(mockSpawnerLayer({}), mockTailscaleServeRuntimeLayer(true))),
+    );
+
+    expect(baseUrl).toBe("https://desktop.tail.ts.net/");
+  }),
+);
+
+it.effect(
+  "resolves the advertised startup base URL from Tailscale status when no host is set",
+  () =>
+    Effect.gen(function* () {
+      const baseUrl = yield* resolveAdvertisedStartupBaseUrl({
+        httpBaseUrl: "http://192.168.1.42:3773",
+        tailscaleServeEnabled: true,
+        tailscaleServePort: 8443,
+        tailscaleServeHost: undefined,
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            mockSpawnerLayer({
+              stdout: `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.100.100.100"]}}`,
+            }),
+            mockTailscaleServeRuntimeLayer(true),
+          ),
+        ),
+      );
+
+      expect(baseUrl).toBe("https://desktop.tail.ts.net:8443/");
+    }),
+);
+
+it.effect("falls back to the HTTP startup base URL when Tailscale status cannot be resolved", () =>
+  Effect.gen(function* () {
+    const baseUrl = yield* resolveAdvertisedStartupBaseUrl({
+      httpBaseUrl: "http://192.168.1.42:3773",
+      tailscaleServeEnabled: true,
+      tailscaleServePort: 443,
+      tailscaleServeHost: undefined,
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          mockSpawnerLayer({ code: 1, stderr: "not running" }),
+          mockTailscaleServeRuntimeLayer(true),
+        ),
+      ),
+    );
+
+    expect(baseUrl).toBe("http://192.168.1.42:3773");
+  }),
+);
+
+it.effect("falls back to HTTP when Tailscale Serve setup did not complete", () =>
+  Effect.gen(function* () {
+    const baseUrl = yield* resolveAdvertisedStartupBaseUrl({
+      httpBaseUrl: "http://192.168.1.42:3773",
+      tailscaleServeEnabled: true,
+      tailscaleServePort: 443,
+      tailscaleServeHost: "desktop.tail.ts.net",
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          mockSpawnerLayer({
+            stdout: `{"Self":{"DNSName":"desktop.tail.ts.net.","TailscaleIPs":["100.100.100.100"]}}`,
+          }),
+          mockTailscaleServeRuntimeLayer(false),
+        ),
+      ),
+    );
+
+    expect(baseUrl).toBe("http://192.168.1.42:3773");
+  }),
+);
 
 it("builds a pairing URL that embeds the token in the hash", () => {
   expect(buildPairingUrl("http://192.168.1.42:3773", "PAIRCODE")).toBe(

--- a/apps/server/src/startupAccess.ts
+++ b/apps/server/src/startupAccess.ts
@@ -1,11 +1,13 @@
 import { networkInterfaces } from "node:os";
 
 import { QrCode } from "@t3tools/shared/qrCode";
+import { buildTailscaleHttpsBaseUrl, resolveTailscaleHttpsBaseUrl } from "@t3tools/tailscale";
 import * as Effect from "effect/Effect";
 import { HttpServer } from "effect/unstable/http";
 
 import { ServerConfig } from "./config.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
+import { TailscaleServeRuntime } from "./tailscaleServeRuntime.ts";
 
 export interface HeadlessServeAccessInfo {
   readonly connectionString: string;
@@ -77,6 +79,41 @@ export const resolveHeadlessConnectionString = (
   return `http://${formatHostForUrl(connectionHost)}:${port}`;
 };
 
+export const resolveAdvertisedStartupBaseUrl = (input: {
+  readonly httpBaseUrl: string;
+  readonly tailscaleServeEnabled: boolean;
+  readonly tailscaleServePort: number;
+  readonly tailscaleServeHost: string | undefined;
+}) => {
+  if (!input.tailscaleServeEnabled) {
+    return Effect.succeed(input.httpBaseUrl);
+  }
+
+  return Effect.gen(function* () {
+    const tailscaleServeRuntime = yield* TailscaleServeRuntime;
+    if (!(yield* tailscaleServeRuntime.awaitConfigured)) {
+      return input.httpBaseUrl;
+    }
+
+    const explicitTailscaleHost = input.tailscaleServeHost?.trim();
+    if (explicitTailscaleHost) {
+      return buildTailscaleHttpsBaseUrl({
+        magicDnsName: explicitTailscaleHost,
+        servePort: input.tailscaleServePort,
+      });
+    }
+
+    return yield* resolveTailscaleHttpsBaseUrl({ servePort: input.tailscaleServePort }).pipe(
+      Effect.catch((cause) =>
+        Effect.logDebug("failed to resolve tailscale https startup url", { cause }).pipe(
+          Effect.as(null),
+        ),
+      ),
+      Effect.map((tailscaleBaseUrl) => tailscaleBaseUrl ?? input.httpBaseUrl),
+    );
+  });
+};
+
 export const resolveListeningPort = (address: unknown, fallbackPort: number): number => {
   if (
     typeof address === "object" &&
@@ -138,11 +175,17 @@ export const issueHeadlessServeAccessInfo = Effect.fn("issueHeadlessServeAccessI
     serverConfig.host,
     resolveListeningPort(httpServer.address, serverConfig.port),
   );
+  const advertisedBaseUrl = yield* resolveAdvertisedStartupBaseUrl({
+    httpBaseUrl: connectionString,
+    tailscaleServeEnabled: serverConfig.tailscaleServeEnabled,
+    tailscaleServePort: serverConfig.tailscaleServePort,
+    tailscaleServeHost: serverConfig.tailscaleServeHost,
+  });
   const issued = yield* serverAuth.issuePairingCredential({ role: "owner" });
 
   return {
-    connectionString,
+    connectionString: advertisedBaseUrl,
     token: issued.credential,
-    pairingUrl: buildPairingUrl(connectionString, issued.credential),
+    pairingUrl: buildPairingUrl(advertisedBaseUrl, issued.credential),
   } satisfies HeadlessServeAccessInfo;
 });

--- a/apps/server/src/tailscaleServeRuntime.ts
+++ b/apps/server/src/tailscaleServeRuntime.ts
@@ -1,0 +1,29 @@
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+export interface TailscaleServeRuntimeShape {
+  readonly awaitConfigured: Effect.Effect<boolean>;
+  readonly markConfigured: Effect.Effect<void>;
+  readonly markUnavailable: Effect.Effect<void>;
+}
+
+export class TailscaleServeRuntime extends Context.Service<
+  TailscaleServeRuntime,
+  TailscaleServeRuntimeShape
+>()("t3/tailscaleServeRuntime") {}
+
+export const TailscaleServeRuntimeLive = Layer.effect(
+  TailscaleServeRuntime,
+  Effect.gen(function* () {
+    const configured = yield* Deferred.make<boolean>();
+    const complete = (value: boolean) => Deferred.succeed(configured, value).pipe(Effect.ignore);
+
+    return {
+      awaitConfigured: Deferred.await(configured),
+      markConfigured: complete(true),
+      markUnavailable: complete(false),
+    } satisfies TailscaleServeRuntimeShape;
+  }),
+);


### PR DESCRIPTION
Related to #2834

## Summary

- advertise the Tailscale Serve HTTPS URL in startup and pairing output after Serve setup completes
- add `--tailscale-serve-host` / `T3CODE_TAILSCALE_SERVE_HOST` for explicit MagicDNS host overrides
- fall back to the normal HTTP startup URL when Serve setup or Tailscale status discovery is unavailable

## Notes

I saw the project note that PRs are not currently being accepted, so this is offered as a small implementation reference for the linked feature request. Please feel free to use, adapt, or ignore it.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bunx vitest run --reporter=verbose` in `apps/server`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Advertise Tailscale Serve HTTPS URLs at server startup
> - Adds `resolveAdvertisedStartupBaseUrl` in [startupAccess.ts](https://github.com/pingdotgg/t3code/pull/2835/files#diff-3a0fbfc502b14ad507197a6d42ebe2a5bed6044f9b1bebedae7628964d15536e) that builds an HTTPS Tailnet base URL when Tailscale Serve is configured, using either an explicit `--tailscale-serve-host` flag or MagicDNS name from `tailscale status`.
> - Headless serve access info (connection string and pairing URL) now uses the HTTPS Tailnet URL when available, falling back to the local HTTP base URL on error or when Tailscale Serve is unconfigured.
> - Introduces `TailscaleServeRuntime` in [tailscaleServeRuntime.ts](https://github.com/pingdotgg/t3code/pull/2835/files#diff-e1b91c705a53b398d78a1d9e3eecaff51824d7a516b9e63b46cc00dc37d2d34a), a coordination service using a `Deferred<boolean>` to signal whether Tailscale Serve was configured successfully during server startup.
> - Adds the `--tailscale-serve-host` CLI flag and `T3CODE_TAILSCALE_SERVE_HOST` env var to override the advertised hostname.
> - Behavioral Change: startup URLs shown to users (including pairing URLs) may now be HTTPS Tailnet addresses rather than local HTTP URLs when Tailscale Serve is active.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c019e8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what users see for pairing and browser open URLs when Tailscale Serve is enabled; misconfiguration could point clients at the wrong host, but failures fall back to HTTP.
> 
> **Overview**
> When **`--tailscale-serve`** is enabled, startup and headless pairing output can now advertise an **HTTPS Tailnet base URL** instead of only the local HTTP bind address.
> 
> The server adds **`resolveAdvertisedStartupBaseUrl`**, which waits on a new **`TailscaleServeRuntime`** signal (Serve setup succeeded or not), then builds the URL from **`--tailscale-serve-host`** / **`T3CODE_TAILSCALE_SERVE_HOST`** or from MagicDNS via **`tailscale status`**, with fallback to the existing HTTP URL if Serve or discovery fails. **Headless** connection strings, pairing URLs, and **browser** startup targets use that advertised URL.
> 
> Config and docs cover the new host override and MagicDNS discovery behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c019e81e036fe2f78aa6d3226b6195cefb4776e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->