### PR TITLE
feat(web): add inline rename for terminals and split groups in termin…

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1916,6 +1916,7 @@ describe("ChatView timeline estimator parity (full app)", () => {
           activeTerminalId: "default",
           terminalGroups: [{ id: "group-default", terminalIds: ["default"] }],
           activeTerminalGroupId: "group-default",
+          terminalNamesById: {},
         },
       },
       terminalLaunchContextByThreadKey: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -469,6 +469,8 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
   const storeNewTerminal = useTerminalStateStore((state) => state.newTerminal);
   const storeSetActiveTerminal = useTerminalStateStore((state) => state.setActiveTerminal);
   const storeCloseTerminal = useTerminalStateStore((state) => state.closeTerminal);
+  const storeRenameTerminal = useTerminalStateStore((state) => state.renameTerminal);
+  const storeRenameTerminalGroup = useTerminalStateStore((state) => state.renameTerminalGroup);
   const [localFocusRequestId, setLocalFocusRequestId] = useState(0);
   const worktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const effectiveWorktreePath = useMemo(() => {
@@ -560,6 +562,20 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
     [bumpFocusRequestId, storeCloseTerminal, terminalState.terminalIds.length, threadId, threadRef],
   );
 
+  const renameTerminal = useCallback(
+    (terminalId: string, name: string | null) => {
+      storeRenameTerminal(threadRef, terminalId, name);
+    },
+    [storeRenameTerminal, threadRef],
+  );
+
+  const renameTerminalGroup = useCallback(
+    (groupId: string, name: string | null) => {
+      storeRenameTerminalGroup(threadRef, groupId, name);
+    },
+    [storeRenameTerminalGroup, threadRef],
+  );
+
   const handleAddTerminalContext = useCallback(
     (selection: TerminalContextSelection) => {
       if (!visible) {
@@ -588,6 +604,7 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         activeTerminalId={terminalState.activeTerminalId}
         terminalGroups={terminalState.terminalGroups}
         activeTerminalGroupId={terminalState.activeTerminalGroupId}
+        terminalNamesById={terminalState.terminalNamesById}
         focusRequestId={focusRequestId + localFocusRequestId + (visible ? 1 : 0)}
         onSplitTerminal={splitTerminal}
         onNewTerminal={createNewTerminal}
@@ -597,6 +614,8 @@ const PersistentThreadTerminalDrawer = memo(function PersistentThreadTerminalDra
         keybindings={keybindings}
         onActiveTerminalChange={activateTerminal}
         onCloseTerminal={closeTerminal}
+        onRenameTerminal={renameTerminal}
+        onRenameTerminalGroup={renameTerminalGroup}
         onHeightChange={setTerminalHeight}
         onAddTerminalContext={handleAddTerminalContext}
       />

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -1,5 +1,12 @@
 import { FitAddon } from "@xterm/addon-fit";
-import { Plus, SquareSplitHorizontal, TerminalSquare, Trash2, XIcon } from "lucide-react";
+import {
+  Pencil,
+  Plus,
+  SquareSplitHorizontal,
+  TerminalSquare,
+  Trash2,
+  XIcon,
+} from "lucide-react";
 import {
   type ResolvedKeybindingsConfig,
   type ScopedThreadRef,
@@ -810,6 +817,7 @@ interface ThreadTerminalDrawerProps {
   activeTerminalId: string;
   terminalGroups: ThreadTerminalGroup[];
   activeTerminalGroupId: string;
+  terminalNamesById: Record<string, string>;
   focusRequestId: number;
   onSplitTerminal: () => void;
   onNewTerminal: () => void;
@@ -818,6 +826,8 @@ interface ThreadTerminalDrawerProps {
   closeShortcutLabel?: string | undefined;
   onActiveTerminalChange: (terminalId: string) => void;
   onCloseTerminal: (terminalId: string) => void;
+  onRenameTerminal: (terminalId: string, name: string | null) => void;
+  onRenameTerminalGroup: (groupId: string, name: string | null) => void;
   onHeightChange: (height: number) => void;
   onAddTerminalContext: (selection: TerminalContextSelection) => void;
   keybindings: ResolvedKeybindingsConfig;
@@ -852,6 +862,78 @@ function TerminalActionButton({ label, className, onClick, children }: TerminalA
   );
 }
 
+interface TerminalRenameInputProps {
+  initialValue: string;
+  defaultValue: string;
+  ariaLabel: string;
+  className?: string;
+  onCommit: (name: string | null) => void;
+  onCancel: () => void;
+}
+
+function TerminalRenameInput({
+  initialValue,
+  defaultValue,
+  ariaLabel,
+  className,
+  onCommit,
+  onCancel,
+}: TerminalRenameInputProps) {
+  const [value, setValue] = useState(initialValue);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    const input = inputRef.current;
+    if (!input) return;
+    input.focus();
+    input.select();
+  }, []);
+
+  const commit = useCallback(() => {
+    const trimmed = value.trim();
+    if (trimmed === initialValue.trim()) {
+      onCancel();
+      return;
+    }
+    if (trimmed.length === 0) {
+      onCommit(null);
+      return;
+    }
+    if (trimmed === defaultValue) {
+      onCommit(null);
+      return;
+    }
+    onCommit(trimmed);
+  }, [defaultValue, initialValue, onCancel, onCommit, value]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      value={value}
+      aria-label={ariaLabel}
+      className={
+        className ??
+        "min-w-0 flex-1 rounded bg-background px-1 py-0 text-[11px] text-foreground outline-none ring-1 ring-border focus:ring-ring"
+      }
+      onChange={(event) => setValue(event.target.value)}
+      onKeyDown={(event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          commit();
+        } else if (event.key === "Escape") {
+          event.preventDefault();
+          onCancel();
+        }
+      }}
+      onBlur={commit}
+      onClick={(event) => event.stopPropagation()}
+      onMouseDown={(event) => event.stopPropagation()}
+      placeholder={defaultValue}
+    />
+  );
+}
+
 export default function ThreadTerminalDrawer({
   threadRef,
   threadId,
@@ -864,6 +946,7 @@ export default function ThreadTerminalDrawer({
   activeTerminalId,
   terminalGroups,
   activeTerminalGroupId,
+  terminalNamesById,
   focusRequestId,
   onSplitTerminal,
   onNewTerminal,
@@ -872,6 +955,8 @@ export default function ThreadTerminalDrawer({
   closeShortcutLabel,
   onActiveTerminalChange,
   onCloseTerminal,
+  onRenameTerminal,
+  onRenameTerminalGroup,
   onHeightChange,
   onAddTerminalContext,
   keybindings,
@@ -935,10 +1020,16 @@ export default function ThreadTerminalDrawer({
         terminalGroup.id.trim().length > 0
           ? terminalGroup.id.trim()
           : `group-${nextTerminalIds[0] ?? DEFAULT_THREAD_TERMINAL_ID}`;
-      nextGroups.push({
+      const trimmedGroupName =
+        typeof terminalGroup.name === "string" ? terminalGroup.name.trim() : "";
+      const nextGroup: ThreadTerminalGroup = {
         id: assignUniqueGroupId(baseGroupId),
         terminalIds: nextTerminalIds,
-      });
+      };
+      if (trimmedGroupName.length > 0) {
+        nextGroup.name = trimmedGroupName;
+      }
+      nextGroups.push(nextGroup);
     }
 
     for (const terminalId of normalizedTerminalIds) {
@@ -984,10 +1075,39 @@ export default function ThreadTerminalDrawer({
   const terminalLabelById = useMemo(
     () =>
       new Map(
+        normalizedTerminalIds.map((terminalId, index) => {
+          const customName = terminalNamesById?.[terminalId]?.trim();
+          if (customName && customName.length > 0) {
+            return [terminalId, customName];
+          }
+          return [terminalId, `Terminal ${index + 1}`];
+        }),
+      ),
+    [normalizedTerminalIds, terminalNamesById],
+  );
+  const defaultTerminalLabelById = useMemo(
+    () =>
+      new Map(
         normalizedTerminalIds.map((terminalId, index) => [terminalId, `Terminal ${index + 1}`]),
       ),
     [normalizedTerminalIds],
   );
+  const groupDisplayLabel = useCallback(
+    (group: ThreadTerminalGroup, groupIndex: number): string => {
+      const customName = typeof group.name === "string" ? group.name.trim() : "";
+      if (customName.length > 0) return customName;
+      return group.terminalIds.length > 1 ? `Split ${groupIndex + 1}` : `Terminal ${groupIndex + 1}`;
+    },
+    [],
+  );
+  const [editingTerminalId, setEditingTerminalId] = useState<string | null>(null);
+  const [editingGroupId, setEditingGroupId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (editingTerminalId && !normalizedTerminalIds.includes(editingTerminalId)) {
+      setEditingTerminalId(null);
+    }
+  }, [editingTerminalId, normalizedTerminalIds]);
   const splitTerminalActionLabel = hasReachedSplitLimit
     ? `Split Terminal (max ${MAX_TERMINALS_PER_GROUP} per group)`
     : splitShortcutLabel
@@ -1261,23 +1381,76 @@ export default function ThreadTerminalDrawer({
                   const groupActiveTerminalId = isGroupActive
                     ? resolvedActiveTerminalId
                     : (terminalGroup.terminalIds[0] ?? resolvedActiveTerminalId);
+                  const isEditingGroup = editingGroupId === terminalGroup.id;
+                  const defaultGroupName =
+                    terminalGroup.terminalIds.length > 1
+                      ? `Split ${groupIndex + 1}`
+                      : `Terminal ${groupIndex + 1}`;
+                  const groupName = groupDisplayLabel(terminalGroup, groupIndex);
+                  const renameGroupLabel = `Rename ${groupName}`;
 
                   return (
                     <div key={terminalGroup.id} className="pb-0.5">
                       {showGroupHeaders && (
-                        <button
-                          type="button"
-                          className={`flex w-full items-center rounded px-1 py-0.5 text-[10px] uppercase tracking-[0.08em] ${
+                        <div
+                          className={`group flex w-full items-center gap-1 rounded px-1 py-0.5 text-[10px] uppercase tracking-[0.08em] ${
                             isGroupActive
                               ? "bg-accent/70 text-foreground"
                               : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
                           }`}
-                          onClick={() => onActiveTerminalChange(groupActiveTerminalId)}
                         >
-                          {terminalGroup.terminalIds.length > 1
-                            ? `Split ${groupIndex + 1}`
-                            : `Terminal ${groupIndex + 1}`}
-                        </button>
+                          {isEditingGroup ? (
+                            <TerminalRenameInput
+                              initialValue={groupName}
+                              defaultValue={defaultGroupName}
+                              ariaLabel={`Rename ${defaultGroupName}`}
+                              className="min-w-0 flex-1 rounded bg-background px-1 py-0 text-[10px] uppercase tracking-[0.08em] text-foreground outline-none ring-1 ring-border focus:ring-ring"
+                              onCommit={(name) => {
+                                onRenameTerminalGroup(terminalGroup.id, name);
+                                setEditingGroupId(null);
+                              }}
+                              onCancel={() => setEditingGroupId(null)}
+                            />
+                          ) : (
+                            <>
+                              <button
+                                type="button"
+                                className="flex min-w-0 flex-1 items-center text-left"
+                                onClick={() => onActiveTerminalChange(groupActiveTerminalId)}
+                              >
+                                <span className="truncate">{groupName}</span>
+                              </button>
+                              <Popover>
+                                <PopoverTrigger
+                                  openOnHover
+                                  render={
+                                    <button
+                                      type="button"
+                                      className="inline-flex size-3.5 items-center justify-center rounded text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground group-hover:opacity-100"
+                                      onClick={(event) => {
+                                        event.stopPropagation();
+                                        setEditingTerminalId(null);
+                                        setEditingGroupId(terminalGroup.id);
+                                      }}
+                                      aria-label={renameGroupLabel}
+                                    />
+                                  }
+                                >
+                                  <Pencil className="size-2.5" />
+                                </PopoverTrigger>
+                                <PopoverPopup
+                                  tooltipStyle
+                                  side="bottom"
+                                  sideOffset={6}
+                                  align="center"
+                                  className="pointer-events-none select-none"
+                                >
+                                  {renameGroupLabel}
+                                </PopoverPopup>
+                              </Popover>
+                            </>
+                          )}
+                        </div>
                       )}
 
                       <div
@@ -1285,9 +1458,15 @@ export default function ThreadTerminalDrawer({
                       >
                         {terminalGroup.terminalIds.map((terminalId) => {
                           const isActive = terminalId === resolvedActiveTerminalId;
-                          const closeTerminalLabel = `Close ${
-                            terminalLabelById.get(terminalId) ?? "terminal"
-                          }${isActive && closeShortcutLabel ? ` (${closeShortcutLabel})` : ""}`;
+                          const terminalLabel =
+                            terminalLabelById.get(terminalId) ?? "Terminal";
+                          const defaultTerminalLabel =
+                            defaultTerminalLabelById.get(terminalId) ?? "Terminal";
+                          const closeTerminalLabel = `Close ${terminalLabel}${
+                            isActive && closeShortcutLabel ? ` (${closeShortcutLabel})` : ""
+                          }`;
+                          const renameTerminalLabel = `Rename ${terminalLabel}`;
+                          const isEditingTerminal = editingTerminalId === terminalId;
                           return (
                             <div
                               key={terminalId}
@@ -1300,41 +1479,85 @@ export default function ThreadTerminalDrawer({
                               {showGroupHeaders && (
                                 <span className="text-[10px] text-muted-foreground/80">└</span>
                               )}
-                              <button
-                                type="button"
-                                className="flex min-w-0 flex-1 items-center gap-1 text-left"
-                                onClick={() => onActiveTerminalChange(terminalId)}
-                              >
-                                <TerminalSquare className="size-3 shrink-0" />
-                                <span className="truncate">
-                                  {terminalLabelById.get(terminalId) ?? "Terminal"}
-                                </span>
-                              </button>
-                              {normalizedTerminalIds.length > 1 && (
-                                <Popover>
-                                  <PopoverTrigger
-                                    openOnHover
-                                    render={
-                                      <button
-                                        type="button"
-                                        className="inline-flex size-3.5 items-center justify-center rounded text-xs font-medium leading-none text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground group-hover:opacity-100"
-                                        onClick={() => onCloseTerminal(terminalId)}
-                                        aria-label={closeTerminalLabel}
-                                      />
-                                    }
-                                  >
-                                    <XIcon className="size-2.5" />
-                                  </PopoverTrigger>
-                                  <PopoverPopup
-                                    tooltipStyle
-                                    side="bottom"
-                                    sideOffset={6}
-                                    align="center"
-                                    className="pointer-events-none select-none"
-                                  >
-                                    {closeTerminalLabel}
-                                  </PopoverPopup>
-                                </Popover>
+                              {isEditingTerminal ? (
+                                <>
+                                  <TerminalSquare className="size-3 shrink-0" />
+                                  <TerminalRenameInput
+                                    initialValue={terminalLabel}
+                                    defaultValue={defaultTerminalLabel}
+                                    ariaLabel={`Rename ${defaultTerminalLabel}`}
+                                    onCommit={(name) => {
+                                      onRenameTerminal(terminalId, name);
+                                      setEditingTerminalId(null);
+                                    }}
+                                    onCancel={() => setEditingTerminalId(null)}
+                                  />
+                                </>
+                              ) : (
+                                <button
+                                  type="button"
+                                  className="flex min-w-0 flex-1 items-center gap-1 text-left"
+                                  onClick={() => onActiveTerminalChange(terminalId)}
+                                >
+                                  <TerminalSquare className="size-3 shrink-0" />
+                                  <span className="truncate">{terminalLabel}</span>
+                                </button>
+                              )}
+                              {!isEditingTerminal && normalizedTerminalIds.length > 1 && (
+                                <>
+                                  <Popover>
+                                    <PopoverTrigger
+                                      openOnHover
+                                      render={
+                                        <button
+                                          type="button"
+                                          className="inline-flex size-3.5 items-center justify-center rounded text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground group-hover:opacity-100"
+                                          onClick={(event) => {
+                                            event.stopPropagation();
+                                            setEditingGroupId(null);
+                                            setEditingTerminalId(terminalId);
+                                          }}
+                                          aria-label={renameTerminalLabel}
+                                        />
+                                      }
+                                    >
+                                      <Pencil className="size-2.5" />
+                                    </PopoverTrigger>
+                                    <PopoverPopup
+                                      tooltipStyle
+                                      side="bottom"
+                                      sideOffset={6}
+                                      align="center"
+                                      className="pointer-events-none select-none"
+                                    >
+                                      {renameTerminalLabel}
+                                    </PopoverPopup>
+                                  </Popover>
+                                  <Popover>
+                                    <PopoverTrigger
+                                      openOnHover
+                                      render={
+                                        <button
+                                          type="button"
+                                          className="inline-flex size-3.5 items-center justify-center rounded text-xs font-medium leading-none text-muted-foreground opacity-0 transition hover:bg-accent hover:text-foreground group-hover:opacity-100"
+                                          onClick={() => onCloseTerminal(terminalId)}
+                                          aria-label={closeTerminalLabel}
+                                        />
+                                      }
+                                    >
+                                      <XIcon className="size-2.5" />
+                                    </PopoverTrigger>
+                                    <PopoverPopup
+                                      tooltipStyle
+                                      side="bottom"
+                                      sideOffset={6}
+                                      align="center"
+                                      className="pointer-events-none select-none"
+                                    >
+                                      {closeTerminalLabel}
+                                    </PopoverPopup>
+                                  </Popover>
+                                </>
                               )}
                             </div>
                           );

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -881,6 +881,7 @@ function TerminalRenameInput({
 }: TerminalRenameInputProps) {
   const [value, setValue] = useState(initialValue);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const cancelledRef = useRef(false);
 
   useEffect(() => {
     const input = inputRef.current;
@@ -890,6 +891,7 @@ function TerminalRenameInput({
   }, []);
 
   const commit = useCallback(() => {
+    if (cancelledRef.current) return;
     const trimmed = value.trim();
     if (trimmed === initialValue.trim()) {
       onCancel();
@@ -905,6 +907,11 @@ function TerminalRenameInput({
     }
     onCommit(trimmed);
   }, [defaultValue, initialValue, onCancel, onCommit, value]);
+
+  const cancel = useCallback(() => {
+    cancelledRef.current = true;
+    onCancel();
+  }, [onCancel]);
 
   return (
     <input
@@ -923,7 +930,7 @@ function TerminalRenameInput({
           commit();
         } else if (event.key === "Escape") {
           event.preventDefault();
-          onCancel();
+          cancel();
         }
       }}
       onBlur={commit}
@@ -1108,6 +1115,17 @@ export default function ThreadTerminalDrawer({
       setEditingTerminalId(null);
     }
   }, [editingTerminalId, normalizedTerminalIds]);
+
+  const resolvedTerminalGroupIds = useMemo(
+    () => new Set(resolvedTerminalGroups.map((group) => group.id)),
+    [resolvedTerminalGroups],
+  );
+
+  useEffect(() => {
+    if (editingGroupId && !resolvedTerminalGroupIds.has(editingGroupId)) {
+      setEditingGroupId(null);
+    }
+  }, [editingGroupId, resolvedTerminalGroupIds]);
   const splitTerminalActionLabel = hasReachedSplitLimit
     ? `Split Terminal (max ${MAX_TERMINALS_PER_GROUP} per group)`
     : splitShortcutLabel

--- a/apps/web/src/terminalStateStore.test.ts
+++ b/apps/web/src/terminalStateStore.test.ts
@@ -80,6 +80,7 @@ describe("terminalStateStore actions", () => {
       activeTerminalId: "default",
       terminalGroups: [{ id: "group-default", terminalIds: ["default"] }],
       activeTerminalGroupId: "group-default",
+      terminalNamesById: {},
     });
   });
 
@@ -211,6 +212,7 @@ describe("terminalStateStore actions", () => {
           activeTerminalId: "default",
           terminalGroups: [{ id: "group-default", terminalIds: ["default"] }],
           activeTerminalGroupId: "group-default",
+          terminalNamesById: {},
         },
       },
     });
@@ -392,5 +394,116 @@ describe("terminalStateStore actions", () => {
     store.clearTerminalState(THREAD_REF);
 
     expect(useTerminalStateStore.getState()).toBe(before);
+  });
+
+  it("renames a terminal and clears the name when called with an empty string", () => {
+    const store = useTerminalStateStore.getState();
+    store.splitTerminal(THREAD_REF, "terminal-2");
+    store.renameTerminal(THREAD_REF, "terminal-2", "dev server");
+
+    let terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadKey,
+      THREAD_REF,
+    );
+    expect(terminalState.terminalNamesById).toEqual({ "terminal-2": "dev server" });
+
+    store.renameTerminal(THREAD_REF, "terminal-2", "  ");
+    terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadKey,
+      THREAD_REF,
+    );
+    expect(terminalState.terminalNamesById).toEqual({});
+  });
+
+  it("trims whitespace and ignores rename for unknown terminals", () => {
+    const store = useTerminalStateStore.getState();
+    store.splitTerminal(THREAD_REF, "terminal-2");
+    store.renameTerminal(THREAD_REF, "terminal-2", "  tests  ");
+    store.renameTerminal(THREAD_REF, "missing-terminal", "ignored");
+
+    const terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadKey,
+      THREAD_REF,
+    );
+    expect(terminalState.terminalNamesById).toEqual({ "terminal-2": "tests" });
+  });
+
+  it("clears the custom name when closing the renamed terminal", () => {
+    const store = useTerminalStateStore.getState();
+    store.splitTerminal(THREAD_REF, "terminal-2");
+    store.renameTerminal(THREAD_REF, "terminal-2", "dev server");
+    store.closeTerminal(THREAD_REF, "terminal-2");
+
+    const terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadKey,
+      THREAD_REF,
+    );
+    expect(terminalState.terminalNamesById).toEqual({});
+    expect(terminalState.terminalIds).toEqual(["default"]);
+  });
+
+  it("renames a terminal group and survives splits", () => {
+    const store = useTerminalStateStore.getState();
+    store.newTerminal(THREAD_REF, "terminal-2");
+    store.renameTerminalGroup(THREAD_REF, "group-terminal-2", "backend");
+
+    let terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadKey,
+      THREAD_REF,
+    );
+    const renamedGroup = terminalState.terminalGroups.find(
+      (group) => group.id === "group-terminal-2",
+    );
+    expect(renamedGroup?.name).toBe("backend");
+
+    store.splitTerminal(THREAD_REF, "terminal-3");
+    terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadKey,
+      THREAD_REF,
+    );
+    const groupAfterSplit = terminalState.terminalGroups.find(
+      (group) => group.id === "group-terminal-2",
+    );
+    expect(groupAfterSplit?.name).toBe("backend");
+    expect(groupAfterSplit?.terminalIds).toEqual(["terminal-2", "terminal-3"]);
+  });
+
+  it("clears the group name when called with a null value", () => {
+    const store = useTerminalStateStore.getState();
+    store.newTerminal(THREAD_REF, "terminal-2");
+    store.renameTerminalGroup(THREAD_REF, "group-terminal-2", "backend");
+    store.renameTerminalGroup(THREAD_REF, "group-terminal-2", null);
+
+    const terminalState = selectThreadTerminalState(
+      useTerminalStateStore.getState().terminalStateByThreadKey,
+      THREAD_REF,
+    );
+    const group = terminalState.terminalGroups.find((g) => g.id === "group-terminal-2");
+    expect(group?.name).toBeUndefined();
+  });
+
+  it("migrates v2 persisted terminal state without terminalNamesById", () => {
+    const migrated = migratePersistedTerminalStateStoreState(
+      {
+        terminalStateByThreadKey: {
+          [scopedThreadKey(THREAD_REF)]: {
+            terminalOpen: true,
+            terminalHeight: 320,
+            terminalIds: ["default", "terminal-2"],
+            runningTerminalIds: [],
+            activeTerminalId: "terminal-2",
+            terminalGroups: [
+              { id: "group-default", terminalIds: ["default", "terminal-2"] },
+            ],
+            activeTerminalGroupId: "group-default",
+          },
+        },
+      },
+      2,
+    );
+
+    expect(
+      migrated.terminalStateByThreadKey?.[scopedThreadKey(THREAD_REF)]?.terminalNamesById,
+    ).toEqual({});
   });
 });

--- a/apps/web/src/terminalStateStore.ts
+++ b/apps/web/src/terminalStateStore.ts
@@ -26,6 +26,7 @@ interface ThreadTerminalState {
   activeTerminalId: string;
   terminalGroups: ThreadTerminalGroup[];
   activeTerminalGroupId: string;
+  terminalNamesById: Record<string, string>;
 }
 
 export interface ThreadTerminalLaunchContext {
@@ -50,12 +51,21 @@ export function migratePersistedTerminalStateStoreState(
   persistedState: unknown,
   version: number,
 ): PersistedTerminalStateStoreState {
-  if (version === 1 && persistedState && typeof persistedState === "object") {
+  if (version >= 1 && persistedState && typeof persistedState === "object") {
     const candidate = persistedState as PersistedTerminalStateStoreState;
     const nextTerminalStateByThreadKey = Object.fromEntries(
-      Object.entries(candidate.terminalStateByThreadKey ?? {}).filter(([threadKey]) =>
-        parseScopedThreadKey(threadKey),
-      ),
+      Object.entries(candidate.terminalStateByThreadKey ?? {})
+        .filter(([threadKey]) => parseScopedThreadKey(threadKey))
+        .map(([threadKey, state]) => [
+          threadKey,
+          {
+            ...state,
+            terminalNamesById:
+              state && typeof state === "object" && state.terminalNamesById
+                ? state.terminalNamesById
+                : {},
+          },
+        ]),
     );
     return { terminalStateByThreadKey: nextTerminalStateByThreadKey };
   }
@@ -131,10 +141,15 @@ function normalizeTerminalGroups(
       group.id.trim().length > 0
         ? group.id.trim()
         : fallbackGroupId(groupTerminalIds[0] ?? DEFAULT_THREAD_TERMINAL_ID);
-    nextGroups.push({
+    const trimmedName = typeof group.name === "string" ? group.name.trim() : "";
+    const nextGroup: ThreadTerminalGroup = {
       id: assignUniqueGroupId(baseGroupId, usedGroupIds),
       terminalIds: groupTerminalIds,
-    });
+    };
+    if (trimmedName.length > 0) {
+      nextGroup.name = trimmedName;
+    }
+    nextGroups.push(nextGroup);
   }
 
   for (const terminalId of terminalIds) {
@@ -172,7 +187,21 @@ function terminalGroupsEqual(left: ThreadTerminalGroup[], right: ThreadTerminalG
     const rightGroup = right[index];
     if (!leftGroup || !rightGroup) return false;
     if (leftGroup.id !== rightGroup.id) return false;
+    if ((leftGroup.name ?? "") !== (rightGroup.name ?? "")) return false;
     if (!arraysEqual(leftGroup.terminalIds, rightGroup.terminalIds)) return false;
+  }
+  return true;
+}
+
+function terminalNamesEqual(
+  left: Record<string, string>,
+  right: Record<string, string>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  const rightKeys = Object.keys(right);
+  if (leftKeys.length !== rightKeys.length) return false;
+  for (const key of leftKeys) {
+    if (left[key] !== right[key]) return false;
   }
   return true;
 }
@@ -185,7 +214,8 @@ function threadTerminalStateEqual(left: ThreadTerminalState, right: ThreadTermin
     left.activeTerminalGroupId === right.activeTerminalGroupId &&
     arraysEqual(left.terminalIds, right.terminalIds) &&
     arraysEqual(left.runningTerminalIds, right.runningTerminalIds) &&
-    terminalGroupsEqual(left.terminalGroups, right.terminalGroups)
+    terminalGroupsEqual(left.terminalGroups, right.terminalGroups) &&
+    terminalNamesEqual(left.terminalNamesById, right.terminalNamesById)
   );
 }
 
@@ -202,6 +232,7 @@ const DEFAULT_THREAD_TERMINAL_STATE: ThreadTerminalState = Object.freeze({
     },
   ],
   activeTerminalGroupId: fallbackGroupId(DEFAULT_THREAD_TERMINAL_ID),
+  terminalNamesById: {},
 });
 
 function createDefaultThreadTerminalState(): ThreadTerminalState {
@@ -210,6 +241,7 @@ function createDefaultThreadTerminalState(): ThreadTerminalState {
     terminalIds: [...DEFAULT_THREAD_TERMINAL_STATE.terminalIds],
     runningTerminalIds: [...DEFAULT_THREAD_TERMINAL_STATE.runningTerminalIds],
     terminalGroups: copyTerminalGroups(DEFAULT_THREAD_TERMINAL_STATE.terminalGroups),
+    terminalNamesById: { ...DEFAULT_THREAD_TERMINAL_STATE.terminalNamesById },
   };
 }
 
@@ -248,6 +280,7 @@ function normalizeThreadTerminalState(state: ThreadTerminalState): ThreadTermina
       activeGroupIdFromTerminal ??
       terminalGroups[0]?.id ??
       fallbackGroupId(DEFAULT_THREAD_TERMINAL_ID),
+    terminalNamesById: normalizeTerminalNamesById(state.terminalNamesById, nextTerminalIds),
   };
   return threadTerminalStateEqual(state, normalized) ? state : normalized;
 }
@@ -270,10 +303,33 @@ function terminalEventBufferKey(threadRef: ScopedThreadRef, terminalId: string):
 }
 
 function copyTerminalGroups(groups: ThreadTerminalGroup[]): ThreadTerminalGroup[] {
-  return groups.map((group) => ({
-    id: group.id,
-    terminalIds: [...group.terminalIds],
-  }));
+  return groups.map((group) => {
+    const copy: ThreadTerminalGroup = {
+      id: group.id,
+      terminalIds: [...group.terminalIds],
+    };
+    if (typeof group.name === "string" && group.name.length > 0) {
+      copy.name = group.name;
+    }
+    return copy;
+  });
+}
+
+function normalizeTerminalNamesById(
+  terminalNamesById: Record<string, string> | undefined,
+  terminalIds: string[],
+): Record<string, string> {
+  if (!terminalNamesById) return {};
+  const validIds = new Set(terminalIds);
+  const result: Record<string, string> = {};
+  for (const [terminalId, name] of Object.entries(terminalNamesById)) {
+    if (!validIds.has(terminalId)) continue;
+    if (typeof name !== "string") continue;
+    const trimmed = name.trim();
+    if (trimmed.length === 0) continue;
+    result[terminalId] = trimmed;
+  }
+  return result;
 }
 
 function appendTerminalEventEntry(
@@ -445,6 +501,52 @@ function setThreadActiveTerminal(
   };
 }
 
+function renameThreadTerminal(
+  state: ThreadTerminalState,
+  terminalId: string,
+  name: string | null,
+): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  if (!normalized.terminalIds.includes(terminalId)) {
+    return normalized;
+  }
+  const trimmed = typeof name === "string" ? name.trim() : "";
+  const nextNames = { ...normalized.terminalNamesById };
+  if (trimmed.length === 0) {
+    if (!(terminalId in nextNames)) return normalized;
+    delete nextNames[terminalId];
+  } else {
+    if (nextNames[terminalId] === trimmed) return normalized;
+    nextNames[terminalId] = trimmed;
+  }
+  return { ...normalized, terminalNamesById: nextNames };
+}
+
+function renameThreadTerminalGroup(
+  state: ThreadTerminalState,
+  groupId: string,
+  name: string | null,
+): ThreadTerminalState {
+  const normalized = normalizeThreadTerminalState(state);
+  const groupIndex = normalized.terminalGroups.findIndex((group) => group.id === groupId);
+  if (groupIndex < 0) return normalized;
+  const trimmed = typeof name === "string" ? name.trim() : "";
+  const currentName = normalized.terminalGroups[groupIndex]?.name ?? "";
+  if (trimmed === currentName) return normalized;
+  const nextGroups = normalized.terminalGroups.map((group, index) => {
+    if (index !== groupIndex) return group;
+    const nextGroup: ThreadTerminalGroup = {
+      id: group.id,
+      terminalIds: [...group.terminalIds],
+    };
+    if (trimmed.length > 0) {
+      nextGroup.name = trimmed;
+    }
+    return nextGroup;
+  });
+  return { ...normalized, terminalGroups: nextGroups };
+}
+
 function closeThreadTerminal(state: ThreadTerminalState, terminalId: string): ThreadTerminalState {
   const normalized = normalizeThreadTerminalState(state);
   if (!normalized.terminalIds.includes(terminalId)) {
@@ -484,6 +586,7 @@ function closeThreadTerminal(state: ThreadTerminalState, terminalId: string): Th
     activeTerminalId: nextActiveTerminalId,
     terminalGroups,
     activeTerminalGroupId: nextActiveTerminalGroupId,
+    terminalNamesById: normalized.terminalNamesById,
   });
 }
 
@@ -579,6 +682,16 @@ interface TerminalStateStoreState {
   ) => void;
   setActiveTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
   closeTerminal: (threadRef: ScopedThreadRef, terminalId: string) => void;
+  renameTerminal: (
+    threadRef: ScopedThreadRef,
+    terminalId: string,
+    name: string | null,
+  ) => void;
+  renameTerminalGroup: (
+    threadRef: ScopedThreadRef,
+    groupId: string,
+    name: string | null,
+  ) => void;
   setTerminalLaunchContext: (
     threadRef: ScopedThreadRef,
     context: ThreadTerminalLaunchContext,
@@ -656,6 +769,10 @@ export const useTerminalStateStore = create<TerminalStateStoreState>()(
           updateTerminal(threadRef, (state) => setThreadActiveTerminal(state, terminalId)),
         closeTerminal: (threadRef, terminalId) =>
           updateTerminal(threadRef, (state) => closeThreadTerminal(state, terminalId)),
+        renameTerminal: (threadRef, terminalId, name) =>
+          updateTerminal(threadRef, (state) => renameThreadTerminal(state, terminalId, name)),
+        renameTerminalGroup: (threadRef, groupId, name) =>
+          updateTerminal(threadRef, (state) => renameThreadTerminalGroup(state, groupId, name)),
         setTerminalLaunchContext: (threadRef, context) =>
           set((state) => ({
             terminalLaunchContextByThreadKey: {
@@ -836,7 +953,7 @@ export const useTerminalStateStore = create<TerminalStateStoreState>()(
     },
     {
       name: TERMINAL_STATE_STORAGE_KEY,
-      version: 2,
+      version: 3,
       storage: createJSONStorage(createTerminalStateStorage),
       migrate: migratePersistedTerminalStateStoreState,
       partialize: (state) => ({

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -30,6 +30,7 @@ export type ProjectScript = ContractProjectScript;
 export interface ThreadTerminalGroup {
   id: string;
   terminalIds: string[];
+  name?: string;
 }
 
 export interface ChatImageAttachment {


### PR DESCRIPTION
## What Changed

Adds an inline rename affordance to the terminal drawer for individual terminals and split-group headers.

- A pencil (edit) icon appears next to the close (×) button on each terminal row and each group header
- Clicking it renames inline — works for both terminals and split-group headers
- Custom names persist across reloads; clearing the field reverts to the default "Terminal N" / "Split N" label
- The affordance only shows when the sidebar is visible (more than one terminal open), so single-terminal behavior is unchanged

Scope: 6 files, UI + terminal state store only. No server contract changes, no unrelated fixes.

## Why

Once more than one terminal is open, the auto-generated labels ("Terminal 1", "Split 1") make terminals hard to tell apart at a glance. Letting users name them ("dev server", "tests") makes multi-terminal workflows easier to navigate. The names are a pure UI concern, persisted client-side via the existing Zustand persist middleware, so this doesn't touch the terminal contract or server.

Related issue: #<issue-number>

## UI Changes

After 
<img width="282" height="563" alt="Screenshot 2026-05-28 at 12-53-39" src="https://github.com/user-attachments/assets/dcffc99f-4a47-4165-aa36-1097061b106b" />
<img width="290" height="560" alt="Screenshot 2026-05-28 at 12-54-02" src="https://github.com/user-attachments/assets/79ab91f1-16de-4d82-b764-228bf07d5469" />

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and localStorage terminal state; no auth, server contracts, or terminal protocol changes.
> 
> **Overview**
> Adds **inline rename** for terminals and split-group headers in the thread terminal drawer when more than one terminal is open.
> 
> The drawer gains a `TerminalRenameInput` (pencil → edit, Enter/blur commit, Escape cancel). Custom labels live in persisted `terminalNamesById` and optional `ThreadTerminalGroup.name`; clearing the field or matching the default label drops the override back to **Terminal N** / **Split N**. `ChatView` wires new `renameTerminal` / `renameTerminalGroup` store actions into `ThreadTerminalDrawer`.
> 
> `terminalStateStore` bumps persist **version 3** with migration that backfills empty `terminalNamesById` for older saved state; tests cover rename, trim, close cleanup, and group names across splits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7aeef52bbb23c838117b05a98a539774bd3de011. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add inline rename for terminals and terminal groups in the terminal drawer
> - Adds `terminalNamesById` to `ThreadTerminalState` and exposes `renameTerminal`/`renameTerminalGroup` actions in [`terminalStateStore.ts`](https://github.com/pingdotgg/t3code/pull/2839/files#diff-9e98e54d562825d3d06313f14e0c37ba761ec3457248dd98e1e388a6948fcd34); names are trimmed, validated against existing terminal IDs, and cleared when empty.
> - Introduces a `TerminalRenameInput` component in [`ThreadTerminalDrawer.tsx`](https://github.com/pingdotgg/t3code/pull/2839/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) with auto-focus, commit on Enter/blur, and cancel on Escape; a pencil icon button triggers inline editing for both terminals and groups.
> - Group names now survive normalization and splits via an updated `copyTerminalGroups` function, and equality checks for groups and thread state now account for name changes.
> - Bumps the persisted store schema from version 2 to 3; migration initializes `terminalNamesById` as an empty object for older persisted states.
> - Risk: persisted state version bump requires migration on first load for existing users.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7aeef52.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->