### PR TITLE
fix(web): restore sidebar access in zoomed empty state

### DIFF
--- a/apps/web/src/components/AppSidebarLayout.test.ts
+++ b/apps/web/src/components/AppSidebarLayout.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldAcceptThreadSidebarWidth } from "./AppSidebarLayout";
+
+describe("shouldAcceptThreadSidebarWidth", () => {
+  it("allows shrinking even when the sidebar is wider than the available content area", () => {
+    expect(
+      shouldAcceptThreadSidebarWidth({
+        currentWidth: 900,
+        nextWidth: 800,
+        wrapperClientWidth: 700,
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects expansion that would leave less than the minimum main content width", () => {
+    expect(
+      shouldAcceptThreadSidebarWidth({
+        currentWidth: 500,
+        nextWidth: 600,
+        wrapperClientWidth: 1_000,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows expansion when the main content minimum remains available", () => {
+    expect(
+      shouldAcceptThreadSidebarWidth({
+        currentWidth: 300,
+        nextWidth: 340,
+        wrapperClientWidth: 1_000,
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -11,6 +11,21 @@ import {
 const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
 const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
+
+export function shouldAcceptThreadSidebarWidth({
+  currentWidth,
+  nextWidth,
+  wrapperClientWidth,
+}: {
+  currentWidth: number;
+  nextWidth: number;
+  wrapperClientWidth: number;
+}): boolean {
+  return (
+    nextWidth <= currentWidth || wrapperClientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH
+  );
+}
+
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
 
@@ -61,8 +76,12 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
         className="border-r border-border bg-card text-foreground"
         resizable={{
           minWidth: THREAD_SIDEBAR_MIN_WIDTH,
-          shouldAcceptWidth: ({ nextWidth, wrapper }) =>
-            wrapper.clientWidth - nextWidth >= THREAD_MAIN_CONTENT_MIN_WIDTH,
+          shouldAcceptWidth: ({ currentWidth, nextWidth, wrapper }) =>
+            shouldAcceptThreadSidebarWidth({
+              currentWidth,
+              nextWidth,
+              wrapperClientWidth: wrapper.clientWidth,
+            }),
           storageKey: THREAD_SIDEBAR_WIDTH_STORAGE_KEY,
         }}
       >

--- a/apps/web/src/components/NoActiveThreadState.test.ts
+++ b/apps/web/src/components/NoActiveThreadState.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowNoActiveThreadSidebarTrigger } from "./NoActiveThreadState";
+
+describe("shouldShowNoActiveThreadSidebarTrigger", () => {
+  it("shows the trigger when the mobile sidebar sheet is closed", () => {
+    expect(
+      shouldShowNoActiveThreadSidebarTrigger({
+        isMobile: true,
+        open: true,
+        openMobile: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the trigger when the mobile sidebar sheet is already open", () => {
+    expect(
+      shouldShowNoActiveThreadSidebarTrigger({
+        isMobile: true,
+        open: true,
+        openMobile: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("shows the trigger when the desktop sidebar is collapsed", () => {
+    expect(
+      shouldShowNoActiveThreadSidebarTrigger({
+        isMobile: false,
+        open: false,
+        openMobile: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the trigger when the desktop sidebar is expanded", () => {
+    expect(
+      shouldShowNoActiveThreadSidebarTrigger({
+        isMobile: false,
+        open: true,
+        openMobile: false,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/NoActiveThreadState.tsx
+++ b/apps/web/src/components/NoActiveThreadState.tsx
@@ -1,9 +1,28 @@
 import { Empty, EmptyDescription, EmptyHeader, EmptyTitle } from "./ui/empty";
-import { SidebarInset, SidebarTrigger } from "./ui/sidebar";
+import { SidebarInset, SidebarTrigger, useSidebar } from "./ui/sidebar";
 import { isElectron } from "../env";
 import { cn } from "~/lib/utils";
 
+export function shouldShowNoActiveThreadSidebarTrigger({
+  isMobile,
+  open,
+  openMobile,
+}: {
+  isMobile: boolean;
+  open: boolean;
+  openMobile: boolean;
+}): boolean {
+  return isMobile ? !openMobile : !open;
+}
+
 export function NoActiveThreadState() {
+  const { isMobile, open, openMobile } = useSidebar();
+  const showSidebarTrigger = shouldShowNoActiveThreadSidebarTrigger({
+    isMobile,
+    open,
+    openMobile,
+  });
+
   return (
     <SidebarInset className="h-dvh min-h-0 overflow-hidden overscroll-y-none bg-background text-foreground">
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-x-hidden bg-background">
@@ -16,12 +35,13 @@ export function NoActiveThreadState() {
           )}
         >
           {isElectron ? (
-            <span className="text-xs text-muted-foreground/50 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]">
-              No active thread
-            </span>
+            <div className="flex min-w-0 items-center gap-2 wco:pr-[calc(100vw-env(titlebar-area-width)-env(titlebar-area-x)+1em)]">
+              {showSidebarTrigger ? <SidebarTrigger className="size-7 shrink-0" /> : null}
+              <span className="truncate text-xs text-muted-foreground/50">No active thread</span>
+            </div>
           ) : (
             <div className="flex items-center gap-2">
-              <SidebarTrigger className="size-7 shrink-0 md:hidden" />
+              {showSidebarTrigger ? <SidebarTrigger className="size-7 shrink-0" /> : null}
               <span className="text-sm font-medium text-foreground md:text-muted-foreground/60">
                 No active thread
               </span>


### PR DESCRIPTION
## Summary
- Allow the thread sidebar resize guard to accept shrinking even when the stored sidebar width is wider than the viewport/main content area.
- Show the no-active-thread sidebar trigger whenever the sidebar is currently hidden, including Electron/mobile-sheet mode after zooming in.
- Add focused tests for the sidebar width predicate and no-active-thread trigger visibility predicate.

## Why
When the app is zoomed in enough to enter the mobile sidebar layout and no thread is selected, the sidebar becomes a closed sheet. The Electron no-active-thread header did not render `SidebarTrigger`, leaving only "Pick a thread to continue" with no visible way to reopen the sidebar and select a thread.

The existing width guard also rejected every drag when the sidebar width exceeded the wrapper width, so users could not shrink back out of a bad persisted/resized sidebar state.

## Checks
- [x] `bun fmt`
- [x] `bun lint` (passes with existing warnings)
- [x] `bun typecheck`
- [x] `bun run test -- src/components/AppSidebarLayout.test.ts src/components/NoActiveThreadState.test.ts`

## Test Notes
- `bun run test` currently fails outside this change in `scripts/mock-update-server.test.ts` with a timeout in `serves files from the configured root`.
- `bun run test --filter=@t3tools/web` currently fails outside this change in `src/environments/runtime/service.addSavedEnvironment.test.ts` with a timeout in `rolls back persisted metadata when bearer token persistence fails`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore sidebar access in the 'No active thread' empty state when sidebar is collapsed
> - The `NoActiveThreadState` component now conditionally renders `SidebarTrigger` only when needed: on desktop when the sidebar is collapsed, and on mobile when the sheet is closed. Previously the trigger was always shown on non-Electron and never shown on Electron.
> - A `shouldShowNoActiveThreadSidebarTrigger` helper encapsulates this visibility logic, with tests added in [NoActiveThreadState.test.ts](https://github.com/pingdotgg/t3code/pull/2841/files#diff-e277c3d0c2f875d8cdeeaa770175407c52213f536d0f0deede17108f9b29ca3d).
> - `shouldAcceptThreadSidebarWidth` in [AppSidebarLayout.tsx](https://github.com/pingdotgg/t3code/pull/2841/files#diff-b580a936d60a70bebcccf38ac9a82ca5f4440c99445dbccb0c176ebe5dc1d301) is updated to allow all shrink operations unconditionally, while still enforcing the minimum main content width on expansion.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized caf8c4f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->