### PR TITLE
fix: special characters in markdown links

### DIFF
--- a/apps/web/src/components/ChatMarkdown.browser.tsx
+++ b/apps/web/src/components/ChatMarkdown.browser.tsx
@@ -34,8 +34,7 @@ describe("ChatMarkdown", () => {
   });
 
   it("rewrites file uri hrefs into direct paths before rendering", async () => {
-    const filePath =
-      "/Users/yashsingh/p/sco/claude-code-extract/src/utils/permissions/PermissionRule.ts";
+    const filePath = "/Users/lol/p/sco/claude-code-extract/src/utils/permissions/PermissionRule.ts";
     const screen = await render(
       <ChatMarkdown text={`[PermissionRule.ts](file://${filePath})`} cwd="/repo/project" />,
     );
@@ -56,8 +55,7 @@ describe("ChatMarkdown", () => {
   });
 
   it("keeps line anchors working after rewriting file uri hrefs", async () => {
-    const filePath =
-      "/Users/yashsingh/p/sco/claude-code-extract/src/utils/permissions/PermissionRule.ts";
+    const filePath = "/Users/lol/p/sco/claude-code-extract/src/utils/permissions/PermissionRule.ts";
     const screen = await render(
       <ChatMarkdown text={`[PermissionRule.ts:1](file://${filePath}#L1)`} cwd="/repo/project" />,
     );
@@ -77,9 +75,89 @@ describe("ChatMarkdown", () => {
     }
   });
 
+  it("opens markdown file links containing parentheses and square brackets", async () => {
+    const filePath = "/Users/lol/p/t3code/apps/web/src/routes/(chat)/[threadId].tsx";
+    const screen = await render(<ChatMarkdown text={`[route](${filePath})`} cwd="/repo/project" />);
+
+    try {
+      const link = page.getByRole("link", { name: "[threadId].tsx" });
+      await expect.element(link).toBeInTheDocument();
+
+      await link.click();
+
+      await vi.waitFor(() => {
+        expect(openInPreferredEditorMock).toHaveBeenCalledWith(expect.anything(), filePath);
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("opens encoded markdown file links containing parentheses and square brackets", async () => {
+    const targetPath = "/repo/project/apps/web/src/routes/(chat)/[threadId].tsx";
+    const screen = await render(
+      <ChatMarkdown
+        text="[route](apps/web/src/routes/%28chat%29/%5BthreadId%5D.tsx)"
+        cwd="/repo/project"
+      />,
+    );
+
+    try {
+      const link = page.getByRole("link", { name: "[threadId].tsx" });
+      await expect.element(link).toBeInTheDocument();
+
+      await link.click();
+
+      await vi.waitFor(() => {
+        expect(openInPreferredEditorMock).toHaveBeenCalledWith(expect.anything(), targetPath);
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("opens angle-bracketed markdown file links", async () => {
+    const filePath = "/Users/lol/p/t3code/apps/web/src/routes/(chat)/My Route [thread].tsx";
+    const screen = await render(
+      <ChatMarkdown text={`[route](<${filePath}>)`} cwd="/repo/project" />,
+    );
+
+    try {
+      const link = page.getByRole("link", { name: "My Route [thread].tsx" });
+      await expect.element(link).toBeInTheDocument();
+
+      await link.click();
+
+      await vi.waitFor(() => {
+        expect(openInPreferredEditorMock).toHaveBeenCalledWith(expect.anything(), filePath);
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("opens Windows drive markdown file links", async () => {
+    const targetPath = "D:/Users/lol/t3code/apps/web/src/routes/(chat)/[threadId].tsx:42";
+    const screen = await render(
+      <ChatMarkdown text={`[route](${targetPath})`} cwd="/repo/project" />,
+    );
+
+    try {
+      const link = page.getByRole("link", { name: "[threadId].tsx · L42" });
+      await expect.element(link).toBeInTheDocument();
+
+      await link.click();
+
+      await vi.waitFor(() => {
+        expect(openInPreferredEditorMock).toHaveBeenCalledWith(expect.anything(), targetPath);
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
   it("shows column information inline when present", async () => {
-    const filePath =
-      "/Users/yashsingh/p/sco/claude-code-extract/src/utils/permissions/PermissionRule.ts";
+    const filePath = "/Users/lol/p/sco/claude-code-extract/src/utils/permissions/PermissionRule.ts";
     const screen = await render(
       <ChatMarkdown text={`[PermissionRule.ts](file://${filePath}#L1C7)`} cwd="/repo/project" />,
     );
@@ -103,8 +181,8 @@ describe("ChatMarkdown", () => {
   });
 
   it("disambiguates duplicate file basenames inline", async () => {
-    const firstPath = "/Users/yashsingh/p/t3code/apps/web/src/components/chat/MessagesTimeline.tsx";
-    const secondPath = "/Users/yashsingh/p/t3code/apps/web/src/components/MessagesTimeline.tsx";
+    const firstPath = "/Users/lol/p/t3code/apps/web/src/components/chat/MessagesTimeline.tsx";
+    const secondPath = "/Users/lol/p/t3code/apps/web/src/components/MessagesTimeline.tsx";
     const screen = await render(
       <ChatMarkdown
         text={`See [MessagesTimeline.tsx](file://${firstPath}) and [MessagesTimeline.tsx](file://${secondPath}).`}

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -29,8 +29,8 @@ import { fnv1a32 } from "../lib/diffRendering";
 import { LRUCache } from "../lib/lruCache";
 import { useTheme } from "../hooks/useTheme";
 import {
-  normalizeMarkdownLinkDestination,
   resolveMarkdownFileLinkMeta,
+  resolveMarkdownFileLinkTarget,
   rewriteMarkdownFileUriHref,
 } from "../markdown-links";
 import { readLocalApi } from "../localApi";
@@ -286,11 +286,20 @@ interface MarkdownFileLinkProps {
   className?: string | undefined;
 }
 
-const MARKDOWN_LINK_HREF_PATTERN = /\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
 const MARKDOWN_FILE_LINK_CLASS_NAME =
   "chat-markdown-file-link relative top-[2px] max-w-full no-underline";
 const MARKDOWN_FILE_LINK_ICON_CLASS_NAME = "chat-markdown-file-link-icon size-3.5 shrink-0";
 const MARKDOWN_FILE_LINK_LABEL_CLASS_NAME = "chat-markdown-file-link-label truncate";
+const FILE_LINK_PARENT_SUFFIX_DATA_ATTR = "data-file-link-parent-suffix";
+
+interface MarkdownAstNode {
+  type?: string;
+  url?: string;
+  children?: MarkdownAstNode[];
+  data?: {
+    hProperties?: Record<string, unknown>;
+  };
+}
 
 function pathParentSegments(path: string): string[] {
   const normalized = path.replaceAll("\\", "/");
@@ -352,19 +361,42 @@ function buildFileLinkParentSuffixByPath(filePaths: ReadonlyArray<string>): Map<
   return suffixByPath;
 }
 
-function extractMarkdownLinkHrefs(text: string): string[] {
-  const hrefs: string[] = [];
-  for (const match of text.matchAll(MARKDOWN_LINK_HREF_PATTERN)) {
-    const href = match[1]?.trim();
-    if (!href) continue;
-    hrefs.push(href);
-  }
-  return hrefs;
-}
+function createFileLinkDisambiguationPlugin(cwd: string | undefined) {
+  return () => (tree: MarkdownAstNode) => {
+    const fileLinks: Array<{
+      node: MarkdownAstNode;
+      meta: NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>;
+    }> = [];
 
-function normalizeMarkdownLinkHrefKey(href: string): string {
-  const normalizedHref = normalizeMarkdownLinkDestination(href);
-  return rewriteMarkdownFileUriHref(normalizedHref) ?? normalizedHref;
+    const visit = (node: MarkdownAstNode) => {
+      if (node.type === "link" && typeof node.url === "string") {
+        const meta = resolveMarkdownFileLinkMeta(node.url, cwd);
+        if (meta) {
+          fileLinks.push({ node, meta });
+        }
+      }
+      for (const child of node.children ?? []) {
+        visit(child);
+      }
+    };
+
+    visit(tree);
+
+    const suffixByPath = buildFileLinkParentSuffixByPath(
+      fileLinks.map((fileLink) => fileLink.meta.filePath),
+    );
+    for (const { node, meta } of fileLinks) {
+      const parentSuffix = suffixByPath.get(meta.filePath);
+      if (!parentSuffix) continue;
+      node.data = {
+        ...node.data,
+        hProperties: {
+          ...node.data?.hProperties,
+          [FILE_LINK_PARENT_SUFFIX_DATA_ATTR]: parentSuffix,
+        },
+      };
+    }
+  };
 }
 
 const MarkdownFileLink = memo(function MarkdownFileLink({
@@ -520,28 +552,16 @@ function ChatMarkdown({
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
-  const markdownFileLinkMetaByHref = useMemo(() => {
-    const metaByHref = new Map<
-      string,
-      NonNullable<ReturnType<typeof resolveMarkdownFileLinkMeta>>
-    >();
-    for (const href of extractMarkdownLinkHrefs(text)) {
-      const normalizedHref = normalizeMarkdownLinkHrefKey(href);
-      if (metaByHref.has(normalizedHref)) continue;
-      const meta = resolveMarkdownFileLinkMeta(normalizedHref, cwd);
-      if (meta) {
-        metaByHref.set(normalizedHref, meta);
-      }
-    }
-    return metaByHref;
-  }, [cwd, text]);
-  const fileLinkParentSuffixByPath = useMemo(() => {
-    const filePaths = [...markdownFileLinkMetaByHref.values()].map((meta) => meta.filePath);
-    return buildFileLinkParentSuffixByPath(filePaths);
-  }, [markdownFileLinkMetaByHref]);
-  const markdownUrlTransform = useCallback((href: string) => {
-    return rewriteMarkdownFileUriHref(href) ?? defaultUrlTransform(href);
-  }, []);
+  const remarkPlugins = useMemo(() => [remarkGfm, createFileLinkDisambiguationPlugin(cwd)], [cwd]);
+  const markdownUrlTransform = useCallback(
+    (href: string) => {
+      return (
+        rewriteMarkdownFileUriHref(href) ??
+        (resolveMarkdownFileLinkTarget(href, cwd) ? href : defaultUrlTransform(href))
+      );
+    },
+    [cwd],
+  );
   const markdownComponents = useMemo<Components>(
     () => ({
       p({ node: _node, children, ...props }) {
@@ -551,15 +571,18 @@ function ChatMarkdown({
         return <li {...props}>{renderSkillInlineMarkdownChildren(children, skills)}</li>;
       },
       a({ node: _node, href, ...props }) {
-        const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
+        const fileLinkMeta = href ? resolveMarkdownFileLinkMeta(href, cwd) : null;
         if (!fileLinkMeta) {
           return <a {...props} href={href} target="_blank" rel="noopener noreferrer" />;
         }
 
-        const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
+        const anchorProps = props as typeof props & Record<string, unknown>;
+        const parentSuffix =
+          typeof anchorProps[FILE_LINK_PARENT_SUFFIX_DATA_ATTR] === "string"
+            ? anchorProps[FILE_LINK_PARENT_SUFFIX_DATA_ATTR]
+            : undefined;
         const labelParts = [fileLinkMeta.basename];
-        if (typeof parentSuffix === "string" && parentSuffix.length > 0) {
+        if (parentSuffix) {
           labelParts.push(parentSuffix);
         }
         if (fileLinkMeta.line) {
@@ -602,20 +625,13 @@ function ChatMarkdown({
         );
       },
     }),
-    [
-      diffThemeName,
-      fileLinkParentSuffixByPath,
-      isStreaming,
-      markdownFileLinkMetaByHref,
-      resolvedTheme,
-      skills,
-    ],
+    [diffThemeName, cwd, isStreaming, resolvedTheme, skills],
   );
 
   return (
     <div className="chat-markdown w-full min-w-0 text-sm leading-relaxed text-foreground/80">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={remarkPlugins}
         components={markdownComponents}
         urlTransform={markdownUrlTransform}
       >

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -6,6 +6,14 @@ import {
   rewriteMarkdownFileUriHref,
 } from "./markdown-links";
 
+describe("normalizeMarkdownLinkDestination", () => {
+  it("unescapes markdown punctuation when normalizing destinations", () => {
+    expect(
+      resolveMarkdownFileLinkTarget("apps/web/src/routes/\\(chat\\)/\\[id\\].tsx", "/repo"),
+    ).toBe("/repo/apps/web/src/routes/(chat)/[id].tsx");
+  });
+});
+
 describe("rewriteMarkdownFileUriHref", () => {
   it("rewrites file uri hrefs into direct path hrefs", () => {
     expect(rewriteMarkdownFileUriHref("file:///Users/julius/project/src/main.ts#L42")).toBe(
@@ -25,12 +33,6 @@ describe("rewriteMarkdownFileUriHref", () => {
         "file:///D:/Programme/t3code/apps/web/src/components/chat/OpenInPicker.tsx#L69",
       ),
     ).toBe("D:/Programme/t3code/apps/web/src/components/chat/OpenInPicker.tsx#L69");
-  });
-
-  it("unwraps angle-bracketed file uri hrefs", () => {
-    expect(
-      rewriteMarkdownFileUriHref(" <file:///D:/Programme/t3code/apps/web/src/markdown-links.ts> "),
-    ).toBe("D:/Programme/t3code/apps/web/src/markdown-links.ts");
   });
 });
 
@@ -57,6 +59,21 @@ describe("resolveMarkdownFileLinkTarget", () => {
     expect(resolveMarkdownFileLinkTarget("AGENTS.md", "/Users/julius/project")).toBe(
       "/Users/julius/project/AGENTS.md",
     );
+  });
+
+  it("resolves relative paths with route group and dynamic segment characters", () => {
+    expect(
+      resolveMarkdownFileLinkTarget("apps/web/src/routes/(chat)/[threadId].tsx", "/repo/project"),
+    ).toBe("/repo/project/apps/web/src/routes/(chat)/[threadId].tsx");
+  });
+
+  it("resolves encoded route group and dynamic segment characters", () => {
+    expect(
+      resolveMarkdownFileLinkTarget(
+        "apps/web/src/routes/%28chat%29/%5BthreadId%5D.tsx",
+        "/repo/project",
+      ),
+    ).toBe("/repo/project/apps/web/src/routes/(chat)/[threadId].tsx");
   });
 
   it("maps #L line anchors to editor line suffixes", () => {
@@ -104,14 +121,6 @@ describe("resolveMarkdownFileLinkTarget", () => {
         "/D:/Programme/t3code/apps/web/src/components/chat/OpenInPicker.tsx#L69",
       ),
     ).toBe("D:/Programme/t3code/apps/web/src/components/chat/OpenInPicker.tsx:69");
-  });
-
-  it("resolves angle-bracketed windows drive paths", () => {
-    expect(
-      resolveMarkdownFileLinkTarget(
-        "</D:/Programme/t3code/apps/web/src/components/ChatMarkdown.tsx:1>",
-      ),
-    ).toBe("D:/Programme/t3code/apps/web/src/components/ChatMarkdown.tsx:1");
   });
 
   it("does not treat app routes as file links", () => {

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -5,8 +5,6 @@ const WINDOWS_DRIVE_PATH_PATTERN = /^[A-Za-z]:[\\/]/;
 const WINDOWS_UNC_PATH_PATTERN = /^\\\\/;
 const EXTERNAL_SCHEME_PATTERN = /^([A-Za-z][A-Za-z0-9+.-]*):(.*)$/;
 const RELATIVE_PATH_PREFIX_PATTERN = /^(~\/|\.{1,2}\/)/;
-const RELATIVE_FILE_PATH_PATTERN = /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)+(?::\d+){0,2}$/;
-const RELATIVE_FILE_NAME_PATTERN = /^[A-Za-z0-9._-]+\.[A-Za-z0-9_-]+(?::\d+){0,2}$/;
 const POSITION_SUFFIX_PATTERN = /:\d+(?::\d+)?$/;
 const POSITION_ONLY_PATTERN = /^\d+(?::\d+)?$/;
 const POSIX_FILE_ROOT_PREFIXES = [
@@ -39,12 +37,10 @@ function safeDecode(value: string): string {
   }
 }
 
-function unwrapMarkdownLinkDestination(value: string): string {
-  return value.startsWith("<") && value.endsWith(">") ? value.slice(1, -1) : value;
-}
+const MARKDOWN_ESCAPE_PATTERN = /\\([!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~])/g;
 
 export function normalizeMarkdownLinkDestination(value: string): string {
-  return unwrapMarkdownLinkDestination(value.trim());
+  return value.trim().replace(MARKDOWN_ESCAPE_PATTERN, "$1");
 }
 
 function stripSearchAndHash(value: string): { path: string; hash: string } {
@@ -112,7 +108,19 @@ function isLikelyPathCandidate(path: string): boolean {
   if (WINDOWS_DRIVE_PATH_PATTERN.test(path) || WINDOWS_UNC_PATH_PATTERN.test(path)) return true;
   if (RELATIVE_PATH_PREFIX_PATTERN.test(path)) return true;
   if (path.startsWith("/")) return looksLikePosixFilesystemPath(path);
-  return RELATIVE_FILE_PATH_PATTERN.test(path) || RELATIVE_FILE_NAME_PATTERN.test(path);
+  const { path: actualPath } = splitPathAndPosition(path);
+  if (actualPath.length === 0) return false;
+  if (["\0", "\r", "\n", '"', "'", "`", "<", ">"].some((char) => actualPath.includes(char))) {
+    return false;
+  }
+
+  const normalizedPath = actualPath.replaceAll("\\", "/");
+  const segments = normalizedPath.split("/");
+  if (segments.length > 1) {
+    return segments.every((segment) => segment.length > 0);
+  }
+
+  return /\.[A-Za-z0-9_-]+$/.test(actualPath);
 }
 
 function isRelativePath(path: string): boolean {


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Better relative path detection
- Used a remark plugin to handle same filenames in different subdirectories instead of raw markdown parsing w/ regex
- Fixed links w/ special characters in them

## Why

Filenames with square brackets or parenthesis or other special characters in them (param route files, route group folders) were unlinkable to, this pr fixes that

## UI Changes

N/A

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat markdown link parsing and open-in-editor behavior; no auth, data, or API surface changes beyond richer path matching.
> 
> **Overview**
> Chat markdown **file links** now resolve and open paths that include **parentheses, square brackets, spaces, and encoded segments** (e.g. route groups and `[param]` files), which previously failed strict path-regex checks.
> 
> In `markdown-links`, link destinations are **unescaped** for standard markdown punctuation, and **path detection** is relaxed so multi-segment relative paths with special characters count as files while obvious non-paths (quotes, angle brackets in the raw path, etc.) are still rejected. **`urlTransform`** keeps resolved file destinations intact instead of running them through the default sanitizer, so encoded and relative paths survive rendering.
> 
> In `ChatMarkdown`, duplicate-basename disambiguation moves from a **regex pre-scan** to a **remark AST plugin** that annotates link nodes; anchors resolve file metadata from the parsed `href` at render time. Browser and unit tests cover escaped, encoded, angle-bracketed, and Windows drive links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69f1adb306e1054a3e084fbcf01088c170dbf1ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix markdown link handling for special characters in file paths
> - Updates `isLikelyPathCandidate` in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/2846/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) to accept paths containing parentheses and square brackets (e.g. route group and dynamic segment characters), while rejecting paths with control characters or invalid quoting.
> - Adds markdown escape unescaping in `normalizeMarkdownLinkDestination` so escaped punctuation in link destinations resolves to the correct file path.
> - Replaces pre-scan href parsing with a remark AST plugin (`createFileLinkDisambiguationPlugin`) that annotates file link nodes with disambiguation suffixes via a data attribute, removing the need for a global href-to-meta map.
> - Fixes `markdownUrlTransform` to preserve non-URI file link destinations as-is instead of passing them through `defaultUrlTransform`, enabling encoded characters and plain relative paths to resolve correctly.
> - Behavioral Change: angle-bracket unwrapping for file link destinations is removed from `markdown-links.ts`; angle-bracketed destinations are now handled upstream by the markdown parser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69f1adb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->