### PR TITLE
Keep new provider models in provider order

### DIFF
--- a/apps/web/src/modelOrdering.ts
+++ b/apps/web/src/modelOrdering.ts
@@ -32,6 +32,25 @@ function byTrueFirst<T>(predicate: (item: T) => boolean): Order.Order<T> {
   return Order.mapInput(Order.flip(Order.Boolean), predicate);
 }
 
+function hydrateModelOrderFromProviderOrder(
+  providerOrder: ReadonlyArray<string>,
+  modelOrder: ReadonlyArray<string>,
+): ReadonlyArray<string> {
+  const providerSlugs = new Set(providerOrder);
+  const hydratedOrder = modelOrder.filter((slug) => providerSlugs.has(slug));
+  const orderedSlugs = new Set(hydratedOrder);
+  const firstOrderedProviderIndex = providerOrder.findIndex((slug) => orderedSlugs.has(slug));
+
+  if (firstOrderedProviderIndex <= 0) {
+    return hydratedOrder;
+  }
+
+  return [
+    ...providerOrder.slice(0, firstOrderedProviderIndex).filter((slug) => !orderedSlugs.has(slug)),
+    ...hydratedOrder,
+  ];
+}
+
 export function sortModelsForProviderInstance<T extends ModelSlugItem>(
   models: ReadonlyArray<T>,
   options?: {
@@ -42,8 +61,13 @@ export function sortModelsForProviderInstance<T extends ModelSlugItem>(
 ): T[] {
   const modelOrder = options?.modelOrder ?? [];
   const favoriteModels = toSet(options?.favoriteModels);
-  const orderBySlug = rankByValue(modelOrder);
   const originalOrder = rankByValue(Arr.map(models, (model) => model.slug));
+  const orderBySlug = rankByValue(
+    hydrateModelOrderFromProviderOrder(
+      Arr.map(models, (model) => model.slug),
+      modelOrder,
+    ),
+  );
   const orders: Array<Order.Order<T>> = [
     ...(options?.groupFavorites === true
       ? [byTrueFirst<T>((model) => favoriteModels.has(model.slug))]


### PR DESCRIPTION
Sorry @Julius

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sort logic in provider model settings; no auth, data, or API changes.
> 
> **Overview**
> Fixes provider model list ordering when the provider adds models that are not yet in the user’s saved `modelOrder`.
> 
> A new `hydrateModelOrderFromProviderOrder` helper merges the saved order with the current provider slug list: it keeps ranked slugs in preference order and inserts unranked slugs ahead of the first ranked entry using the provider’s native order. `sortModelsForProviderInstance` ranks models from this hydrated list instead of raw `modelOrder`, so new models no longer sink to the end via the `originalOrder` fallback.
> 
> **Impact:** Provider settings model lists (`ProviderModelsSection`) should show newly available models in provider order while still respecting favorites grouping and explicit reordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0c22b3bcb8d065f920d5f3eb74d5a91079976f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Keep new provider models in provider order when sorting model instances
> When sorting models for a provider instance, new models (not yet in the saved order) were not being placed relative to the provider's own ordering. The new `hydrateModelOrderFromProviderOrder` helper in [modelOrdering.ts](https://github.com/pingdotgg/t3code/pull/2850/files#diff-39bf4c4bf3c63927041e2b0e9824ba2aa30ee0d55cddf85d9f5906592fde93f4) filters the saved model order to slugs available in the provider, then prepends any provider slugs that appear before the first ordered slug. `sortModelsForProviderInstance` now uses this hydrated order instead of the raw saved order, so provider-native ordering is respected for unranked models.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0c22b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->