### PR TITLE
Ensure Electron runtime is installed in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,6 +98,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Ensure Electron runtime is installed
+        run: |
+          if ! node -e "require('./apps/desktop/node_modules/electron')" >/dev/null 2>&1; then
+            rm -rf apps/desktop/node_modules/electron/dist apps/desktop/node_modules/electron/path.txt
+            bun apps/desktop/node_modules/electron/install.js
+          fi
+          node -e "require('./apps/desktop/node_modules/electron')"
+
       - id: release_meta
         name: Resolve release version
         shell: bash


### PR DESCRIPTION
## Summary
- Adds a release-workflow step to verify the Electron runtime is present before packaging.
- Re-runs Electron's install script when the local `apps/desktop/node_modules/electron` runtime is missing or incomplete.
- Fails fast by requiring the Electron package after the check to confirm the runtime is usable.

## Testing
- Not run (workflow-only change).
- Reviewed the release workflow diff for the new Electron runtime bootstrap step.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds a defensive install check; no application runtime or security logic is modified.
> 
> **Overview**
> Adds an **Ensure Electron runtime is installed** step to the release workflow’s **preflight** job, immediately after `bun install --frozen-lockfile`.
> 
> The step mirrors the existing CI workflow: it tries to `require` the desktop Electron package, and if that fails it clears a partial `dist` / `path.txt`, runs Electron’s `install.js`, then requires the package again so preflight fails early when the binary is missing.
> 
> This reduces release failures from an incomplete Electron download after install, before version resolution, lint, typecheck, and test run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76e21592607e8220533abfb3249c76d11c5415d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ensure Electron runtime is installed before building in the release workflow
> Adds a step in [release.yml](.github/workflows/release.yml) that verifies the Electron runtime is loadable after dependencies are installed. If the module cannot be required, it removes the `dist` and `path.txt` artifacts and re-runs `install.js` via `bun`, then confirms the module loads before proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 76e2159.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->