### PR TITLE
[RFC] Plan review annotations

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -85,11 +85,17 @@ import {
   resolvePlanFollowUpSubmission,
 } from "../proposedPlan";
 import {
+  appendPlanReviewFeedbackToDraft,
+  formatPlanReviewFeedback,
+  type PlanReviewAnnotation,
+} from "../proposedPlanReview";
+import {
   DEFAULT_INTERACTION_MODE,
   DEFAULT_RUNTIME_MODE,
   DEFAULT_THREAD_TERMINAL_ID,
   MAX_TERMINALS_PER_GROUP,
   type ChatMessage,
+  type ProposedPlan,
   type SessionPhase,
   type Thread,
   type TurnDiffSummary,
@@ -146,6 +152,7 @@ import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
+import { PlanReviewPanel } from "./PlanReviewPanel";
 import { ChatHeader } from "./chat/ChatHeader";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
@@ -704,9 +711,14 @@ export default function ChatView(props: ChatViewProps) {
   const [pendingUserInputQuestionIndexByRequestId, setPendingUserInputQuestionIndexByRequestId] =
     useState<Record<string, number>>({});
   const [planSidebarOpen, setPlanSidebarOpen] = useState(false);
+  const [reviewingProposedPlan, setReviewingProposedPlan] = useState<ProposedPlan | null>(null);
+  const [planReviewAnnotationsByPlanId, setPlanReviewAnnotationsByPlanId] = useState<
+    Record<string, PlanReviewAnnotation[]>
+  >({});
   const shouldUsePlanSidebarSheet = useMediaQuery(RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY);
   // Tracks whether the user explicitly dismissed the sidebar for the active turn.
   const planSidebarDismissedForTurnRef = useRef<string | null>(null);
+  const planSidebarWasOpenBeforeReviewRef = useRef(false);
   // When set, the thread-change reset effect will open the sidebar instead of closing it.
   // Used by "Implement in a new thread" to carry the sidebar-open intent across navigation.
   const planSidebarOpenOnNextThreadRef = useRef(false);
@@ -2135,6 +2147,7 @@ export default function ChatView(props: ChatViewProps) {
   const togglePlanSidebar = useCallback(() => {
     setPlanSidebarOpen((open) => {
       if (open) {
+        setReviewingProposedPlan(null);
         planSidebarDismissedForTurnRef.current =
           activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
       } else {
@@ -2144,10 +2157,61 @@ export default function ChatView(props: ChatViewProps) {
     });
   }, [activePlan?.turnId, sidebarProposedPlan?.turnId]);
   const closePlanSidebar = useCallback(() => {
+    setReviewingProposedPlan(null);
     setPlanSidebarOpen(false);
     planSidebarDismissedForTurnRef.current =
       activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
   }, [activePlan?.turnId, sidebarProposedPlan?.turnId]);
+  const openPlanReview = useCallback(
+    (proposedPlan: ProposedPlan) => {
+      planSidebarWasOpenBeforeReviewRef.current = planSidebarOpen;
+      setReviewingProposedPlan(proposedPlan);
+      planSidebarDismissedForTurnRef.current = null;
+      setPlanSidebarOpen(true);
+    },
+    [planSidebarOpen],
+  );
+  const closePlanReview = useCallback(() => {
+    setReviewingProposedPlan(null);
+    setPlanSidebarOpen(planSidebarWasOpenBeforeReviewRef.current);
+  }, []);
+  const updatePlanReviewAnnotations = useCallback(
+    (annotations: PlanReviewAnnotation[]) => {
+      if (!reviewingProposedPlan) return;
+      setPlanReviewAnnotationsByPlanId((existing) => ({
+        ...existing,
+        [reviewingProposedPlan.id]: annotations,
+      }));
+    },
+    [reviewingProposedPlan],
+  );
+  const finishPlanReview = useCallback(() => {
+    if (!reviewingProposedPlan) return;
+    const annotations = planReviewAnnotationsByPlanId[reviewingProposedPlan.id] ?? [];
+    const feedback = formatPlanReviewFeedback(annotations);
+    if (feedback.trim().length === 0) return;
+
+    const nextPrompt = appendPlanReviewFeedbackToDraft(promptRef.current, feedback);
+    const nextCursor = collapseExpandedComposerCursor(nextPrompt, nextPrompt.length);
+    promptRef.current = nextPrompt;
+    setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+    composerRef.current?.resetCursorState({
+      cursor: nextCursor,
+      prompt: nextPrompt,
+      detectTrigger: true,
+    });
+    setReviewingProposedPlan(null);
+    setPlanSidebarOpen(planSidebarWasOpenBeforeReviewRef.current);
+    window.requestAnimationFrame(() => {
+      composerRef.current?.focusAt(nextCursor);
+    });
+  }, [
+    composerDraftTarget,
+    composerRef,
+    planReviewAnnotationsByPlanId,
+    reviewingProposedPlan,
+    setComposerDraftPrompt,
+  ]);
 
   const persistThreadSettingsForNextTurn = useCallback(
     async (input: {
@@ -2227,6 +2291,9 @@ export default function ChatView(props: ChatViewProps) {
 
   useEffect(() => {
     setPullRequestDialogState(null);
+    setReviewingProposedPlan(null);
+    setPlanReviewAnnotationsByPlanId({});
+    planSidebarWasOpenBeforeReviewRef.current = false;
     isAtEndRef.current = true;
     showScrollDebouncer.current.cancel();
     setShowScrollToBottom(false);
@@ -3568,6 +3635,7 @@ export default function ChatView(props: ChatViewProps) {
               activeThreadEnvironmentId={activeThread.environmentId}
               routeThreadKey={routeThreadKey}
               onOpenTurnDiff={onOpenTurnDiff}
+              onReviewProposedPlan={openPlanReview}
               revertTurnCountByUserMessageId={revertTurnCountByUserMessageId}
               onRevertUserMessage={onRevertUserMessage}
               isRevertingCheckpoint={isRevertingCheckpoint}
@@ -3725,17 +3793,31 @@ export default function ChatView(props: ChatViewProps) {
 
         {/* Plan sidebar */}
         {planSidebarOpen && !shouldUsePlanSidebarSheet ? (
-          <PlanSidebar
-            activePlan={activePlan}
-            activeProposedPlan={sidebarProposedPlan}
-            label={planSidebarLabel}
-            environmentId={environmentId}
-            markdownCwd={gitCwd ?? undefined}
-            workspaceRoot={activeWorkspaceRoot}
-            timestampFormat={timestampFormat}
-            mode="sidebar"
-            onClose={closePlanSidebar}
-          />
+          reviewingProposedPlan ? (
+            <div className="h-full w-[min(760px,50vw)] min-w-[420px] shrink-0 border-l border-border/70">
+              <PlanReviewPanel
+                proposedPlan={reviewingProposedPlan}
+                markdownCwd={gitCwd ?? undefined}
+                annotations={planReviewAnnotationsByPlanId[reviewingProposedPlan.id] ?? []}
+                onAnnotationsChange={updatePlanReviewAnnotations}
+                onDone={finishPlanReview}
+                onBack={closePlanReview}
+              />
+            </div>
+          ) : (
+            <PlanSidebar
+              activePlan={activePlan}
+              activeProposedPlan={sidebarProposedPlan}
+              label={planSidebarLabel}
+              environmentId={environmentId}
+              markdownCwd={gitCwd ?? undefined}
+              workspaceRoot={activeWorkspaceRoot}
+              timestampFormat={timestampFormat}
+              mode="sidebar"
+              onClose={closePlanSidebar}
+              onReviewPlan={openPlanReview}
+            />
+          )
         ) : null}
       </div>
       {/* end horizontal flex container */}
@@ -3758,18 +3840,33 @@ export default function ChatView(props: ChatViewProps) {
         />
       ))}
       {shouldUsePlanSidebarSheet ? (
-        <RightPanelSheet open={planSidebarOpen} onClose={closePlanSidebar}>
-          <PlanSidebar
-            activePlan={activePlan}
-            activeProposedPlan={sidebarProposedPlan}
-            label={planSidebarLabel}
-            environmentId={environmentId}
-            markdownCwd={gitCwd ?? undefined}
-            workspaceRoot={activeWorkspaceRoot}
-            timestampFormat={timestampFormat}
-            mode="sheet"
-            onClose={closePlanSidebar}
-          />
+        <RightPanelSheet
+          open={planSidebarOpen}
+          onClose={reviewingProposedPlan ? closePlanReview : closePlanSidebar}
+        >
+          {reviewingProposedPlan ? (
+            <PlanReviewPanel
+              proposedPlan={reviewingProposedPlan}
+              markdownCwd={gitCwd ?? undefined}
+              annotations={planReviewAnnotationsByPlanId[reviewingProposedPlan.id] ?? []}
+              onAnnotationsChange={updatePlanReviewAnnotations}
+              onDone={finishPlanReview}
+              onBack={closePlanReview}
+            />
+          ) : (
+            <PlanSidebar
+              activePlan={activePlan}
+              activeProposedPlan={sidebarProposedPlan}
+              label={planSidebarLabel}
+              environmentId={environmentId}
+              markdownCwd={gitCwd ?? undefined}
+              workspaceRoot={activeWorkspaceRoot}
+              timestampFormat={timestampFormat}
+              mode="sheet"
+              onClose={closePlanSidebar}
+              onReviewPlan={openPlanReview}
+            />
+          )}
         </RightPanelSheet>
       ) : null}
 

--- a/apps/web/src/components/PlanReviewPanel.browser.tsx
+++ b/apps/web/src/components/PlanReviewPanel.browser.tsx
@@ -1,0 +1,92 @@
+import "../index.css";
+
+import { useState } from "react";
+import { page } from "vitest/browser";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render } from "vitest-browser-react";
+
+import type { ProposedPlan } from "../types";
+import type { PlanReviewAnnotation } from "../proposedPlanReview";
+import { PlanReviewPanel } from "./PlanReviewPanel";
+
+const PROPOSED_PLAN: ProposedPlan = {
+  id: "plan-review-browser-test" as never,
+  turnId: null,
+  planMarkdown: "# Reviewable plan\n\n- Keep composer stable.\n- Add success criteria.",
+  implementedAt: null,
+  implementationThreadId: null,
+  createdAt: "2026-05-29T00:00:00.000Z",
+  updatedAt: "2026-05-29T00:00:00.000Z",
+};
+
+function findTextNode(root: Node, text: string): Text {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let node = walker.nextNode();
+  while (node) {
+    if (node.textContent?.includes(text)) {
+      return node as Text;
+    }
+    node = walker.nextNode();
+  }
+  throw new Error(`Unable to find text node containing "${text}".`);
+}
+
+function selectText(root: HTMLElement, text: string) {
+  const textNode = findTextNode(root, text);
+  const start = textNode.textContent?.indexOf(text) ?? -1;
+  if (start < 0) {
+    throw new Error(`Unable to find selection text "${text}".`);
+  }
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, start + text.length);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+  root.dispatchEvent(new MouseEvent("mouseup", { bubbles: true }));
+}
+
+function Harness(props: { onDone: () => void }) {
+  const [annotations, setAnnotations] = useState<PlanReviewAnnotation[]>([]);
+  return (
+    <div className="h-[720px] w-[720px]">
+      <PlanReviewPanel
+        proposedPlan={PROPOSED_PLAN}
+        markdownCwd={undefined}
+        annotations={annotations}
+        onAnnotationsChange={setAnnotations}
+        onDone={props.onDone}
+        onBack={vi.fn()}
+      />
+    </div>
+  );
+}
+
+describe("PlanReviewPanel", () => {
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+    document.body.innerHTML = "";
+  });
+
+  it("creates a visual comment from selected plan text and enables done", async () => {
+    const onDone = vi.fn();
+    await render(<Harness onDone={onDone} />);
+
+    let reviewRoot: HTMLElement | null = null;
+    await vi.waitFor(() => {
+      reviewRoot = document.querySelector<HTMLElement>('[data-testid="plan-review-markdown"]');
+      expect(reviewRoot).toBeTruthy();
+    });
+    selectText(reviewRoot!, "Add success criteria.");
+
+    await page.getByText("Comment", { exact: true }).click();
+    await page.getByPlaceholder("Add a comment").fill("Needs acceptance coverage.");
+    await page.getByText("Save", { exact: true }).click();
+
+    await expect.element(page.getByText("Needs acceptance coverage.")).toBeInTheDocument();
+    await expect.element(page.getByText("Add success criteria.").first()).toBeInTheDocument();
+
+    await page.getByText("Done", { exact: true }).click();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/PlanReviewPanel.tsx
+++ b/apps/web/src/components/PlanReviewPanel.tsx
@@ -1,0 +1,363 @@
+import { memo, useCallback, useMemo, useRef, useState } from "react";
+import {
+  ArrowLeftIcon,
+  CheckIcon,
+  MessageSquarePlusIcon,
+  PencilIcon,
+  Trash2Icon,
+} from "lucide-react";
+
+import type { ProposedPlan } from "../types";
+import { proposedPlanTitle, stripDisplayedPlanMarkdown } from "../proposedPlan";
+import { normalizePlanReviewSelectionText, type PlanReviewAnnotation } from "../proposedPlanReview";
+import { randomUUID } from "../lib/utils";
+import ChatMarkdown from "./ChatMarkdown";
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import { ScrollArea } from "./ui/scroll-area";
+import { Textarea } from "./ui/textarea";
+import { stackedThreadToast, toastManager } from "./ui/toast";
+
+const MAX_PLAN_REVIEW_QUOTE_LENGTH = 8_000;
+
+interface SelectionActionState {
+  quote: string;
+  x: number;
+  y: number;
+}
+
+interface CommentEditorState {
+  mode: "create" | "edit";
+  quote: string;
+  annotationId?: string;
+  comment: string;
+}
+
+interface PlanReviewPanelProps {
+  proposedPlan: ProposedPlan;
+  markdownCwd: string | undefined;
+  annotations: readonly PlanReviewAnnotation[];
+  onAnnotationsChange: (annotations: PlanReviewAnnotation[]) => void;
+  onDone: () => void;
+  onBack: () => void;
+}
+
+function isSelectionInsideRoot(selection: Selection, root: HTMLElement): boolean {
+  const { anchorNode, focusNode } = selection;
+  if (!anchorNode || !focusNode) {
+    return false;
+  }
+
+  const range = selection.getRangeAt(0);
+  const commonAncestor =
+    range.commonAncestorContainer instanceof Element
+      ? range.commonAncestorContainer
+      : range.commonAncestorContainer.parentElement;
+
+  return (
+    root.contains(anchorNode) &&
+    root.contains(focusNode) &&
+    commonAncestor !== null &&
+    root.contains(commonAncestor)
+  );
+}
+
+function getSelectionActionPosition(range: Range): { x: number; y: number } | null {
+  const primaryRect = range.getBoundingClientRect();
+  const rect =
+    primaryRect.width > 0 || primaryRect.height > 0
+      ? primaryRect
+      : (Array.from(range.getClientRects())[0] ?? null);
+  if (!rect) {
+    return null;
+  }
+
+  return {
+    x: Math.min(window.innerWidth - 96, Math.max(12, rect.right - 16)),
+    y: Math.min(window.innerHeight - 52, Math.max(12, rect.bottom + 8)),
+  };
+}
+
+export const PlanReviewPanel = memo(function PlanReviewPanel({
+  proposedPlan,
+  markdownCwd,
+  annotations,
+  onAnnotationsChange,
+  onDone,
+  onBack,
+}: PlanReviewPanelProps) {
+  const markdownRootRef = useRef<HTMLDivElement>(null);
+  const [selectionAction, setSelectionAction] = useState<SelectionActionState | null>(null);
+  const [commentEditor, setCommentEditor] = useState<CommentEditorState | null>(null);
+  const displayedPlanMarkdown = useMemo(
+    () => stripDisplayedPlanMarkdown(proposedPlan.planMarkdown),
+    [proposedPlan.planMarkdown],
+  );
+  const title = proposedPlanTitle(proposedPlan.planMarkdown) ?? "Proposed plan";
+
+  const readSelection = useCallback(() => {
+    const root = markdownRootRef.current;
+    const selection = window.getSelection();
+    if (!root || !selection || selection.rangeCount === 0 || selection.isCollapsed) {
+      setSelectionAction(null);
+      return;
+    }
+    if (!isSelectionInsideRoot(selection, root)) {
+      setSelectionAction(null);
+      return;
+    }
+
+    const quote = normalizePlanReviewSelectionText(selection.toString());
+    if (quote.length === 0) {
+      setSelectionAction(null);
+      return;
+    }
+
+    const range = selection.getRangeAt(0);
+    const position = getSelectionActionPosition(range);
+    if (!position) {
+      setSelectionAction(null);
+      return;
+    }
+
+    const cappedQuote =
+      quote.length > MAX_PLAN_REVIEW_QUOTE_LENGTH
+        ? quote.slice(0, MAX_PLAN_REVIEW_QUOTE_LENGTH).trimEnd()
+        : quote;
+    if (cappedQuote.length !== quote.length) {
+      toastManager.add(
+        stackedThreadToast({
+          type: "warning",
+          title: "Selection shortened",
+          description: "Plan review quotes are limited to 8,000 characters.",
+        }),
+      );
+    }
+
+    setSelectionAction({
+      quote: cappedQuote,
+      x: position.x,
+      y: position.y,
+    });
+  }, []);
+
+  const scheduleSelectionRead = useCallback(() => {
+    window.setTimeout(readSelection, 0);
+  }, [readSelection]);
+
+  const handleStartComment = useCallback(() => {
+    if (!selectionAction) {
+      return;
+    }
+    setCommentEditor({
+      mode: "create",
+      quote: selectionAction.quote,
+      comment: "",
+    });
+    setSelectionAction(null);
+    window.getSelection()?.removeAllRanges();
+  }, [selectionAction]);
+
+  const handleSaveComment = useCallback(() => {
+    if (!commentEditor) {
+      return;
+    }
+    const quote = normalizePlanReviewSelectionText(commentEditor.quote);
+    const comment = commentEditor.comment.trim();
+    if (quote.length === 0 || comment.length === 0) {
+      return;
+    }
+
+    const now = new Date().toISOString();
+    if (commentEditor.mode === "edit" && commentEditor.annotationId) {
+      onAnnotationsChange(
+        annotations.map((annotation) =>
+          annotation.id === commentEditor.annotationId
+            ? {
+                ...annotation,
+                comment,
+                updatedAt: now,
+              }
+            : annotation,
+        ),
+      );
+    } else {
+      onAnnotationsChange([
+        ...annotations,
+        {
+          id: randomUUID(),
+          quote,
+          comment,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ]);
+    }
+    setCommentEditor(null);
+  }, [annotations, commentEditor, onAnnotationsChange]);
+
+  const handleEditAnnotation = useCallback((annotation: PlanReviewAnnotation) => {
+    setSelectionAction(null);
+    setCommentEditor({
+      mode: "edit",
+      annotationId: annotation.id,
+      quote: annotation.quote,
+      comment: annotation.comment,
+    });
+  }, []);
+
+  const handleDeleteAnnotation = useCallback(
+    (annotationId: string) => {
+      onAnnotationsChange(annotations.filter((annotation) => annotation.id !== annotationId));
+      if (commentEditor?.annotationId === annotationId) {
+        setCommentEditor(null);
+      }
+    },
+    [annotations, commentEditor?.annotationId, onAnnotationsChange],
+  );
+
+  return (
+    <div className="flex h-full w-full min-w-0 flex-col bg-card/50">
+      <div className="flex min-h-12 shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            onClick={onBack}
+            aria-label="Back to plan sidebar"
+            className="text-muted-foreground/60 hover:text-foreground"
+          >
+            <ArrowLeftIcon className="size-3.5" />
+          </Button>
+          <Badge
+            variant="secondary"
+            className="rounded-md bg-blue-500/10 px-1.5 py-0 text-[10px] font-semibold tracking-wide text-blue-400 uppercase"
+          >
+            Review
+          </Badge>
+          <span className="truncate text-xs font-medium text-foreground/80">{title}</span>
+        </div>
+        <Button size="xs" onClick={onDone} disabled={annotations.length === 0}>
+          <CheckIcon className="size-3.5" />
+          Done
+        </Button>
+      </div>
+
+      <ScrollArea className="min-h-0 flex-1">
+        <div className="grid min-w-0 grid-cols-1 gap-3 p-3 2xl:grid-cols-[minmax(0,1fr)_18rem]">
+          <div className="min-w-0 space-y-3">
+            {commentEditor ? (
+              <div className="rounded-lg border border-border/70 bg-background/80 p-3 shadow-xs">
+                <div className="mb-2 rounded-md border-l-2 border-blue-400/70 bg-blue-500/5 px-2.5 py-2 text-[12px] leading-relaxed text-muted-foreground">
+                  {commentEditor.quote}
+                </div>
+                <Textarea
+                  value={commentEditor.comment}
+                  onChange={(event) =>
+                    setCommentEditor((existing) =>
+                      existing ? { ...existing, comment: event.target.value } : existing,
+                    )
+                  }
+                  placeholder="Add a comment"
+                  size="sm"
+                />
+                <div className="mt-2 flex justify-end gap-2">
+                  <Button size="xs" variant="outline" onClick={() => setCommentEditor(null)}>
+                    Cancel
+                  </Button>
+                  <Button
+                    size="xs"
+                    onClick={handleSaveComment}
+                    disabled={commentEditor.comment.trim().length === 0}
+                  >
+                    Save
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+
+            <div
+              ref={markdownRootRef}
+              data-testid="plan-review-markdown"
+              className="rounded-lg border border-border/50 bg-background/50 p-3 selection:bg-blue-400/25"
+              onMouseUp={scheduleSelectionRead}
+              onKeyUp={scheduleSelectionRead}
+            >
+              <ChatMarkdown text={displayedPlanMarkdown} cwd={markdownCwd} isStreaming={false} />
+            </div>
+          </div>
+
+          <div className="min-w-0 space-y-2 2xl:sticky 2xl:top-3 2xl:self-start">
+            <div className="flex items-center justify-between">
+              <p className="text-[10px] font-semibold tracking-widest text-muted-foreground/40 uppercase">
+                Comments
+              </p>
+              <span className="text-[11px] text-muted-foreground/45">{annotations.length}</span>
+            </div>
+            {annotations.length > 0 ? (
+              <div className="space-y-2">
+                {annotations.map((annotation, index) => (
+                  <div
+                    key={annotation.id}
+                    className="rounded-lg border border-border/60 bg-background/65 p-2.5"
+                  >
+                    <div className="mb-2 flex items-start justify-between gap-2">
+                      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-blue-500/12 text-[11px] font-semibold text-blue-400">
+                        {index + 1}
+                      </span>
+                      <div className="flex items-center gap-1">
+                        <Button
+                          size="icon-xs"
+                          variant="ghost"
+                          aria-label="Edit comment"
+                          onClick={() => handleEditAnnotation(annotation)}
+                          className="text-muted-foreground/50 hover:text-foreground"
+                        >
+                          <PencilIcon className="size-3.5" />
+                        </Button>
+                        <Button
+                          size="icon-xs"
+                          variant="ghost"
+                          aria-label="Delete comment"
+                          onClick={() => handleDeleteAnnotation(annotation.id)}
+                          className="text-muted-foreground/50 hover:text-destructive-foreground"
+                        >
+                          <Trash2Icon className="size-3.5" />
+                        </Button>
+                      </div>
+                    </div>
+                    <blockquote className="border-l-2 border-blue-400/60 pl-2 text-[12px] leading-relaxed text-muted-foreground">
+                      {annotation.quote}
+                    </blockquote>
+                    <p className="mt-2 whitespace-pre-wrap text-[13px] leading-relaxed text-foreground/85">
+                      {annotation.comment}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed border-border/60 bg-background/35 p-3 text-center text-[12px] text-muted-foreground/45">
+                No comments yet.
+              </div>
+            )}
+          </div>
+        </div>
+      </ScrollArea>
+
+      {selectionAction ? (
+        <Button
+          size="xs"
+          className="fixed z-50 shadow-lg"
+          style={{ left: selectionAction.x, top: selectionAction.y }}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={handleStartComment}
+        >
+          <MessageSquarePlusIcon className="size-3.5" />
+          Comment
+        </Button>
+      ) : null}
+    </div>
+  );
+});
+
+export type { PlanReviewPanelProps };

--- a/apps/web/src/components/PlanReviewPanel.tsx
+++ b/apps/web/src/components/PlanReviewPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type Ref } from "react";
 import {
   ArrowLeftIcon,
   CheckIcon,
@@ -31,6 +31,10 @@ interface CommentEditorState {
   quote: string;
   annotationId?: string;
   comment: string;
+  position?: {
+    x: number;
+    y: number;
+  };
 }
 
 interface PlanReviewPanelProps {
@@ -78,6 +82,13 @@ function getSelectionActionPosition(range: Range): { x: number; y: number } | nu
   };
 }
 
+function getCommentEditorPosition(position: { x: number; y: number }): { x: number; y: number } {
+  return {
+    x: Math.max(12, Math.min(window.innerWidth - 372, position.x - 272)),
+    y: Math.max(12, Math.min(window.innerHeight - 260, position.y)),
+  };
+}
+
 export const PlanReviewPanel = memo(function PlanReviewPanel({
   proposedPlan,
   markdownCwd,
@@ -87,6 +98,7 @@ export const PlanReviewPanel = memo(function PlanReviewPanel({
   onBack,
 }: PlanReviewPanelProps) {
   const markdownRootRef = useRef<HTMLDivElement>(null);
+  const commentTextareaRef = useRef<HTMLTextAreaElement>(null);
   const [selectionAction, setSelectionAction] = useState<SelectionActionState | null>(null);
   const [commentEditor, setCommentEditor] = useState<CommentEditorState | null>(null);
   const displayedPlanMarkdown = useMemo(
@@ -153,10 +165,20 @@ export const PlanReviewPanel = memo(function PlanReviewPanel({
       mode: "create",
       quote: selectionAction.quote,
       comment: "",
+      position: getCommentEditorPosition(selectionAction),
     });
     setSelectionAction(null);
     window.getSelection()?.removeAllRanges();
   }, [selectionAction]);
+
+  useEffect(() => {
+    if (!commentEditor) {
+      return;
+    }
+    window.requestAnimationFrame(() => {
+      commentTextareaRef.current?.focus();
+    });
+  }, [commentEditor?.annotationId, commentEditor?.mode]);
 
   const handleSaveComment = useCallback(() => {
     if (!commentEditor) {
@@ -216,6 +238,37 @@ export const PlanReviewPanel = memo(function PlanReviewPanel({
     [annotations, commentEditor?.annotationId, onAnnotationsChange],
   );
 
+  const commentEditorPanel = commentEditor ? (
+    <div className="rounded-lg border border-border/70 bg-background/95 p-3 shadow-lg">
+      <div className="mb-2 max-h-32 overflow-y-auto rounded-md border-l-2 border-blue-400/70 bg-blue-500/5 px-2.5 py-2 text-[12px] leading-relaxed text-muted-foreground">
+        {commentEditor.quote}
+      </div>
+      <Textarea
+        ref={commentTextareaRef}
+        value={commentEditor.comment}
+        onChange={(event) =>
+          setCommentEditor((existing) =>
+            existing ? { ...existing, comment: event.target.value } : existing,
+          )
+        }
+        placeholder="Add a comment"
+        size="sm"
+      />
+      <div className="mt-2 flex justify-end gap-2">
+        <Button size="xs" variant="outline" onClick={() => setCommentEditor(null)}>
+          Cancel
+        </Button>
+        <Button
+          size="xs"
+          onClick={handleSaveComment}
+          disabled={commentEditor.comment.trim().length === 0}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div className="flex h-full w-full min-w-0 flex-col bg-card/50">
       <div className="flex min-h-12 shrink-0 items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
@@ -246,36 +299,6 @@ export const PlanReviewPanel = memo(function PlanReviewPanel({
       <ScrollArea className="min-h-0 flex-1">
         <div className="grid min-w-0 grid-cols-1 gap-3 p-3 2xl:grid-cols-[minmax(0,1fr)_18rem]">
           <div className="min-w-0 space-y-3">
-            {commentEditor ? (
-              <div className="rounded-lg border border-border/70 bg-background/80 p-3 shadow-xs">
-                <div className="mb-2 rounded-md border-l-2 border-blue-400/70 bg-blue-500/5 px-2.5 py-2 text-[12px] leading-relaxed text-muted-foreground">
-                  {commentEditor.quote}
-                </div>
-                <Textarea
-                  value={commentEditor.comment}
-                  onChange={(event) =>
-                    setCommentEditor((existing) =>
-                      existing ? { ...existing, comment: event.target.value } : existing,
-                    )
-                  }
-                  placeholder="Add a comment"
-                  size="sm"
-                />
-                <div className="mt-2 flex justify-end gap-2">
-                  <Button size="xs" variant="outline" onClick={() => setCommentEditor(null)}>
-                    Cancel
-                  </Button>
-                  <Button
-                    size="xs"
-                    onClick={handleSaveComment}
-                    disabled={commentEditor.comment.trim().length === 0}
-                  >
-                    Save
-                  </Button>
-                </div>
-              </div>
-            ) : null}
-
             <div
               ref={markdownRootRef}
               data-testid="plan-review-markdown"
@@ -297,42 +320,27 @@ export const PlanReviewPanel = memo(function PlanReviewPanel({
             {annotations.length > 0 ? (
               <div className="space-y-2">
                 {annotations.map((annotation, index) => (
-                  <div
+                  <AnnotationCard
                     key={annotation.id}
-                    className="rounded-lg border border-border/60 bg-background/65 p-2.5"
-                  >
-                    <div className="mb-2 flex items-start justify-between gap-2">
-                      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-blue-500/12 text-[11px] font-semibold text-blue-400">
-                        {index + 1}
-                      </span>
-                      <div className="flex items-center gap-1">
-                        <Button
-                          size="icon-xs"
-                          variant="ghost"
-                          aria-label="Edit comment"
-                          onClick={() => handleEditAnnotation(annotation)}
-                          className="text-muted-foreground/50 hover:text-foreground"
-                        >
-                          <PencilIcon className="size-3.5" />
-                        </Button>
-                        <Button
-                          size="icon-xs"
-                          variant="ghost"
-                          aria-label="Delete comment"
-                          onClick={() => handleDeleteAnnotation(annotation.id)}
-                          className="text-muted-foreground/50 hover:text-destructive-foreground"
-                        >
-                          <Trash2Icon className="size-3.5" />
-                        </Button>
-                      </div>
-                    </div>
-                    <blockquote className="border-l-2 border-blue-400/60 pl-2 text-[12px] leading-relaxed text-muted-foreground">
-                      {annotation.quote}
-                    </blockquote>
-                    <p className="mt-2 whitespace-pre-wrap text-[13px] leading-relaxed text-foreground/85">
-                      {annotation.comment}
-                    </p>
-                  </div>
+                    annotation={annotation}
+                    index={index}
+                    editing={commentEditor?.annotationId === annotation.id}
+                    commentValue={
+                      commentEditor?.annotationId === annotation.id ? commentEditor.comment : ""
+                    }
+                    textareaRef={commentTextareaRef}
+                    onCommentChange={(comment) =>
+                      setCommentEditor((existing) =>
+                        existing?.annotationId === annotation.id
+                          ? { ...existing, comment }
+                          : existing,
+                      )
+                    }
+                    onCancelEdit={() => setCommentEditor(null)}
+                    onSaveEdit={handleSaveComment}
+                    onEdit={() => handleEditAnnotation(annotation)}
+                    onDelete={() => handleDeleteAnnotation(annotation.id)}
+                  />
                 ))}
               </div>
             ) : (
@@ -356,8 +364,100 @@ export const PlanReviewPanel = memo(function PlanReviewPanel({
           Comment
         </Button>
       ) : null}
+      {commentEditor?.position ? (
+        <div
+          className="fixed z-50 w-[min(22rem,calc(100vw-1.5rem))]"
+          style={{ left: commentEditor.position.x, top: commentEditor.position.y }}
+        >
+          {commentEditorPanel}
+        </div>
+      ) : null}
     </div>
   );
 });
+
+interface AnnotationCardProps {
+  annotation: PlanReviewAnnotation;
+  index: number;
+  editing: boolean;
+  commentValue: string;
+  textareaRef: Ref<HTMLTextAreaElement>;
+  onCommentChange: (comment: string) => void;
+  onCancelEdit: () => void;
+  onSaveEdit: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+function AnnotationCard({
+  annotation,
+  index,
+  editing,
+  commentValue,
+  textareaRef,
+  onCommentChange,
+  onCancelEdit,
+  onSaveEdit,
+  onEdit,
+  onDelete,
+}: AnnotationCardProps) {
+  return (
+    <div className="rounded-lg border border-border/60 bg-background/65 p-2.5">
+      <div className="mb-2 flex items-start justify-between gap-2">
+        <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-blue-500/12 text-[11px] font-semibold text-blue-400">
+          {index + 1}
+        </span>
+        {editing ? null : (
+          <div className="flex items-center gap-1">
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              aria-label="Edit comment"
+              onClick={onEdit}
+              className="text-muted-foreground/50 hover:text-foreground"
+            >
+              <PencilIcon className="size-3.5" />
+            </Button>
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              aria-label="Delete comment"
+              onClick={onDelete}
+              className="text-muted-foreground/50 hover:text-destructive-foreground"
+            >
+              <Trash2Icon className="size-3.5" />
+            </Button>
+          </div>
+        )}
+      </div>
+      <blockquote className="border-l-2 border-blue-400/60 pl-2 text-[12px] leading-relaxed text-muted-foreground">
+        {annotation.quote}
+      </blockquote>
+      {editing ? (
+        <div className="mt-2">
+          <Textarea
+            ref={textareaRef}
+            value={commentValue}
+            onChange={(event) => onCommentChange(event.target.value)}
+            placeholder="Add a comment"
+            size="sm"
+          />
+          <div className="mt-2 flex justify-end gap-2">
+            <Button size="xs" variant="outline" onClick={onCancelEdit}>
+              Cancel
+            </Button>
+            <Button size="xs" onClick={onSaveEdit} disabled={commentValue.trim().length === 0}>
+              Save
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <p className="mt-2 whitespace-pre-wrap text-[13px] leading-relaxed text-foreground/85">
+          {annotation.comment}
+        </p>
+      )}
+    </div>
+  );
+}
 
 export type { PlanReviewPanelProps };

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -11,6 +11,7 @@ import {
   ChevronRightIcon,
   EllipsisIcon,
   LoaderIcon,
+  MessageSquarePlusIcon,
   PanelRightCloseIcon,
 } from "lucide-react";
 import { cn } from "~/lib/utils";
@@ -61,6 +62,7 @@ interface PlanSidebarProps {
   timestampFormat: TimestampFormat;
   mode?: "sheet" | "sidebar";
   onClose: () => void;
+  onReviewPlan?: (proposedPlan: LatestProposedPlanState) => void;
 }
 
 const PlanSidebar = memo(function PlanSidebar({
@@ -73,6 +75,7 @@ const PlanSidebar = memo(function PlanSidebar({
   timestampFormat,
   mode = "sidebar",
   onClose,
+  onReviewPlan,
 }: PlanSidebarProps) {
   const [proposedPlanExpanded, setProposedPlanExpanded] = useState(false);
   const [isSavingToWorkspace, setIsSavingToWorkspace] = useState(false);
@@ -126,6 +129,11 @@ const PlanSidebar = memo(function PlanSidebar({
       );
   }, [environmentId, planMarkdown, workspaceRoot]);
 
+  const handleReviewPlan = useCallback(() => {
+    if (!activeProposedPlan || !onReviewPlan) return;
+    onReviewPlan(activeProposedPlan);
+  }, [activeProposedPlan, onReviewPlan]);
+
   return (
     <div
       className={cn(
@@ -151,6 +159,17 @@ const PlanSidebar = memo(function PlanSidebar({
           ) : null}
         </div>
         <div className="flex items-center gap-1">
+          {activeProposedPlan && onReviewPlan ? (
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              onClick={handleReviewPlan}
+              aria-label="Review plan"
+              className="text-muted-foreground/50 hover:text-foreground/70"
+            >
+              <MessageSquarePlusIcon className="size-3.5" />
+            </Button>
+          ) : null}
           {planMarkdown ? (
             <Menu>
               <MenuTrigger
@@ -166,6 +185,9 @@ const PlanSidebar = memo(function PlanSidebar({
                 <EllipsisIcon className="size-3.5" />
               </MenuTrigger>
               <MenuPopup align="end">
+                {activeProposedPlan && onReviewPlan ? (
+                  <MenuItem onClick={handleReviewPlan}>Review plan</MenuItem>
+                ) : null}
                 <MenuItem onClick={handleCopyPlan}>
                   {isCopied ? "Copied!" : "Copy to clipboard"}
                 </MenuItem>

--- a/apps/web/src/components/chat/MessagesTimeline.browser.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.browser.tsx
@@ -60,6 +60,7 @@ function buildProps() {
     turnDiffSummaryByAssistantMessageId: new Map(),
     routeThreadKey: "environment-local:thread-1",
     onOpenTurnDiff: vi.fn(),
+    onReviewProposedPlan: vi.fn(),
     revertTurnCountByUserMessageId: new Map(),
     onRevertUserMessage: vi.fn(),
     isRevertingCheckpoint: false,

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -83,6 +83,7 @@ function buildProps() {
     turnDiffSummaryByAssistantMessageId: new Map(),
     routeThreadKey: "environment-local:thread-1",
     onOpenTurnDiff: () => {},
+    onReviewProposedPlan: () => {},
     revertTurnCountByUserMessageId: new Map(),
     onRevertUserMessage: () => {},
     isRevertingCheckpoint: false,

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { deriveTimelineEntries, formatElapsed } from "../../session-logic";
-import { type TurnDiffSummary } from "../../types";
+import { type ProposedPlan, type TurnDiffSummary } from "../../types";
 import { summarizeTurnDiffStats } from "../../lib/turnDiffTree";
 import ChatMarkdown from "../ChatMarkdown";
 import {
@@ -86,6 +86,7 @@ interface TimelineRowSharedState {
   onRevertUserMessage: (messageId: MessageId) => void;
   onImageExpand: (preview: ExpandedImagePreview) => void;
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
+  onReviewProposedPlan: (proposedPlan: ProposedPlan) => void;
 }
 
 interface TimelineRowActivityState {
@@ -119,6 +120,7 @@ interface MessagesTimelineProps {
   onRevertUserMessage: (messageId: MessageId) => void;
   isRevertingCheckpoint: boolean;
   onImageExpand: (preview: ExpandedImagePreview) => void;
+  onReviewProposedPlan: (proposedPlan: ProposedPlan) => void;
   activeThreadEnvironmentId: EnvironmentId;
   markdownCwd: string | undefined;
   resolvedTheme: "light" | "dark";
@@ -148,6 +150,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   onRevertUserMessage,
   isRevertingCheckpoint,
   onImageExpand,
+  onReviewProposedPlan,
   activeThreadEnvironmentId,
   markdownCwd,
   resolvedTheme,
@@ -220,6 +223,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onRevertUserMessage,
       onImageExpand,
       onOpenTurnDiff,
+      onReviewProposedPlan,
     }),
     [
       timestampFormat,
@@ -232,6 +236,7 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onRevertUserMessage,
       onImageExpand,
       onOpenTurnDiff,
+      onReviewProposedPlan,
     ],
   );
   const activityState = useMemo<TimelineRowActivityState>(
@@ -500,6 +505,7 @@ function ProposedPlanTimelineRow({
         environmentId={ctx.activeThreadEnvironmentId}
         cwd={ctx.markdownCwd}
         workspaceRoot={ctx.workspaceRoot}
+        onReviewPlan={() => ctx.onReviewProposedPlan(row.proposedPlan)}
       />
     </div>
   );

--- a/apps/web/src/components/chat/ProposedPlanCard.tsx
+++ b/apps/web/src/components/chat/ProposedPlanCard.tsx
@@ -9,7 +9,7 @@ import {
   stripDisplayedPlanMarkdown,
 } from "../../proposedPlan";
 import ChatMarkdown from "../ChatMarkdown";
-import { EllipsisIcon } from "lucide-react";
+import { EllipsisIcon, MessageSquarePlusIcon } from "lucide-react";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
@@ -33,11 +33,13 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
   environmentId,
   cwd,
   workspaceRoot,
+  onReviewPlan,
 }: {
   planMarkdown: string;
   environmentId: EnvironmentId;
   cwd: string | undefined;
   workspaceRoot: string | undefined;
+  onReviewPlan?: () => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
@@ -143,22 +145,31 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
           <Badge variant="secondary">Plan</Badge>
           <p className="truncate text-sm font-medium text-foreground">{title}</p>
         </div>
-        <Menu>
-          <MenuTrigger
-            render={<Button aria-label="Plan actions" size="icon-xs" variant="outline" />}
-          >
-            <EllipsisIcon aria-hidden="true" className="size-4" />
-          </MenuTrigger>
-          <MenuPopup align="end">
-            <MenuItem onClick={handleCopyPlan}>
-              {isCopied ? "Copied!" : "Copy to clipboard"}
-            </MenuItem>
-            <MenuItem onClick={handleDownload}>Download as markdown</MenuItem>
-            <MenuItem onClick={openSaveDialog} disabled={!workspaceRoot || isSavingToWorkspace}>
-              Save to workspace
-            </MenuItem>
-          </MenuPopup>
-        </Menu>
+        <div className="flex items-center gap-2">
+          {onReviewPlan ? (
+            <Button size="xs" variant="outline" onClick={onReviewPlan}>
+              <MessageSquarePlusIcon className="size-3.5" />
+              Review
+            </Button>
+          ) : null}
+          <Menu>
+            <MenuTrigger
+              render={<Button aria-label="Plan actions" size="icon-xs" variant="outline" />}
+            >
+              <EllipsisIcon aria-hidden="true" className="size-4" />
+            </MenuTrigger>
+            <MenuPopup align="end">
+              {onReviewPlan ? <MenuItem onClick={onReviewPlan}>Review plan</MenuItem> : null}
+              <MenuItem onClick={handleCopyPlan}>
+                {isCopied ? "Copied!" : "Copy to clipboard"}
+              </MenuItem>
+              <MenuItem onClick={handleDownload}>Download as markdown</MenuItem>
+              <MenuItem onClick={openSaveDialog} disabled={!workspaceRoot || isSavingToWorkspace}>
+                Save to workspace
+              </MenuItem>
+            </MenuPopup>
+          </Menu>
+        </div>
       </div>
       <div className="mt-4">
         <div className={cn("relative", canCollapse && !expanded && "max-h-104 overflow-hidden")}>

--- a/apps/web/src/proposedPlanReview.test.ts
+++ b/apps/web/src/proposedPlanReview.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  appendPlanReviewFeedbackToDraft,
+  formatPlanReviewFeedback,
+  formatPlanReviewQuote,
+  normalizePlanReviewSelectionText,
+  type PlanReviewAnnotation,
+} from "./proposedPlanReview";
+
+function annotation(
+  input: Partial<PlanReviewAnnotation> & Pick<PlanReviewAnnotation, "quote" | "comment">,
+): PlanReviewAnnotation {
+  return {
+    id: input.id ?? "annotation-1",
+    quote: input.quote,
+    comment: input.comment,
+    createdAt: input.createdAt ?? "2026-05-29T00:00:00.000Z",
+    updatedAt: input.updatedAt ?? "2026-05-29T00:00:00.000Z",
+  };
+}
+
+describe("normalizePlanReviewSelectionText", () => {
+  it("trims outer whitespace and normalizes newlines", () => {
+    expect(normalizePlanReviewSelectionText(" \r\n selected\r\ntext \n")).toBe("selected\ntext");
+  });
+});
+
+describe("formatPlanReviewQuote", () => {
+  it("formats a single-line quote", () => {
+    expect(formatPlanReviewQuote("selected quote")).toBe("> selected quote");
+  });
+
+  it("formats multiline quotes with blank lines", () => {
+    expect(formatPlanReviewQuote("line 1\n\nline 2")).toBe("> line 1\n>\n> line 2");
+  });
+});
+
+describe("formatPlanReviewFeedback", () => {
+  it("formats quote/comment feedback", () => {
+    expect(
+      formatPlanReviewFeedback([
+        annotation({
+          quote: "selected quote",
+          comment: "This needs more detail.",
+        }),
+      ]),
+    ).toBe("> selected quote\n\nThis needs more detail.");
+  });
+
+  it("filters annotations with empty quotes or comments", () => {
+    expect(
+      formatPlanReviewFeedback([
+        annotation({ id: "empty-quote", quote: " ", comment: "comment" }),
+        annotation({ id: "empty-comment", quote: "quote", comment: " " }),
+        annotation({ id: "valid", quote: "keep this", comment: "keep comment" }),
+      ]),
+    ).toBe("> keep this\n\nkeep comment");
+  });
+});
+
+describe("appendPlanReviewFeedbackToDraft", () => {
+  it("appends to an empty composer draft", () => {
+    expect(appendPlanReviewFeedbackToDraft("", "> quote\n\ncomment")).toBe("> quote\n\ncomment");
+  });
+
+  it("appends to non-empty composer draft with exactly two blank lines", () => {
+    expect(appendPlanReviewFeedbackToDraft("Existing feedback\n\n", "> quote\n\ncomment")).toBe(
+      "Existing feedback\n\n> quote\n\ncomment",
+    );
+  });
+});

--- a/apps/web/src/proposedPlanReview.ts
+++ b/apps/web/src/proposedPlanReview.ts
@@ -1,0 +1,59 @@
+export interface PlanReviewAnnotation {
+  id: string;
+  quote: string;
+  comment: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PlanReviewAnnotationDraft {
+  quote: string;
+  comment: string;
+}
+
+function normalizePlanReviewText(text: string): string {
+  return text.replace(/\r\n?/g, "\n").trim();
+}
+
+export function normalizePlanReviewSelectionText(text: string): string {
+  return normalizePlanReviewText(text);
+}
+
+export function formatPlanReviewQuote(quote: string): string {
+  const normalizedQuote = normalizePlanReviewSelectionText(quote);
+  if (normalizedQuote.length === 0) {
+    return "";
+  }
+
+  return normalizedQuote
+    .split("\n")
+    .map((line) => (line.length > 0 ? `> ${line}` : ">"))
+    .join("\n");
+}
+
+export function formatPlanReviewFeedback(annotations: readonly PlanReviewAnnotation[]): string {
+  return annotations
+    .flatMap((annotation) => {
+      const quote = formatPlanReviewQuote(annotation.quote);
+      const comment = normalizePlanReviewText(annotation.comment);
+      if (quote.length === 0 || comment.length === 0) {
+        return [];
+      }
+      return [`${quote}\n\n${comment}`];
+    })
+    .join("\n\n");
+}
+
+export function appendPlanReviewFeedbackToDraft(existingDraft: string, feedback: string): string {
+  const normalizedFeedback = normalizePlanReviewText(feedback);
+  if (normalizedFeedback.length === 0) {
+    return existingDraft;
+  }
+
+  const trimmedDraft = existingDraft.trimEnd();
+  if (trimmedDraft.length === 0) {
+    return normalizedFeedback;
+  }
+
+  return `${trimmedDraft}\n\n${normalizedFeedback}`;
+}


### PR DESCRIPTION
## What Changed

- Added a dedicated proposed-plan review view in the existing right panel/sheet flow.
- Added plan review entry points from proposed plan cards and the plan sidebar.
- Added text-selection comments for proposed plans, including visual annotation cards with edit/delete support.
- Added “Done” review flow that appends annotations into the composer as quote/comment markdown for plan refinement.
- Kept review annotations client-side only and scoped to the mounted thread/session.
- Added pure formatting helpers and tests for quote/comment markdown generation.

> Sorry if too disruptive, I guess that with the new guidelines it would probably be too much. Just keeping it open as a RFC and food for thought

## Why

### Original prompt to Claude:

> I'm not happy by how the plan's review experience is like. I believe that we should make this better in the following ways:

> 1. Option to show the proposed plan in its own view
> 2. That within that render it's possible to select text and "comment" about it. What this will do is that it will create a visual annotation like if you were making inline comments on any code review platform or similar
> 3. When the user is done reviewing, we will "inline" those values so that we follow the quotation -> comment format. Eg

```markdown
> quotation

comment
```

### Additional context

Right now my main issue when going through the plan is that I think of edit as an editorial process in which you read what's there and you just want to inline on it or check some of the other details. The problem as of now is that it continues to feel like a simple text chat experience instead of an improvement of a review process which the planning phase should also be

## UI Changes
 

https://github.com/user-attachments/assets/e33ff7a3-92ec-44e7-8d2e-1b74617aaf34

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UI and composer draft formatting; no server persistence or auth changes.
> 
> **Overview**
> Adds an **inline plan review** flow in the existing plan right panel (desktop sidebar and mobile sheet): users open review from proposed-plan cards, the plan sidebar, or timeline cards, select plan text, attach comments, then **Done** merges feedback into the composer as blockquoted excerpts plus comments for plan refinement.
> 
> Introduces **`PlanReviewPanel`** with selection-based commenting, a comments list (edit/delete), and **`proposedPlanReview`** helpers to normalize selections and format/append that markdown. Review state and annotations stay **client-side** and reset when the thread changes; sidebar open/close is preserved when entering and leaving review.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f5740d8c3cff0b86d9a278824594436746c3d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add plan review annotations flow to proposed plan cards
> - Adds a `PlanReviewPanel` component that renders plan markdown with text-selection-driven comment creation, allowing users to quote sections and attach comments as annotations.
> - Adds a 'Review' button to `ProposedPlanCard` and `PlanSidebar` that opens the review panel in place of the plan sidebar in `ChatView`.
> - When the user clicks 'Done', formatted quote/comment blocks are appended to the composer draft and the composer is focused.
> - Adds `proposedPlanReview.ts` with utilities for normalizing selection text, formatting quoted comments, and appending feedback to an existing draft.
> - The 'Done' button is disabled until at least one annotation exists; selections are capped at 8,000 characters with a warning toast.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 52f5740. 8 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->