### PR TITLE
Fix auth JSON datetime decoding

### DIFF
--- a/packages/contracts/src/auth.test.ts
+++ b/packages/contracts/src/auth.test.ts
@@ -1,0 +1,89 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vitest";
+
+import {
+  AuthAccessSnapshot,
+  AuthBearerBootstrapResult,
+  AuthSessionState,
+  AuthWebSocketTokenResult,
+} from "./auth.ts";
+
+const decodeBearerBootstrap = Schema.decodeUnknownSync(AuthBearerBootstrapResult);
+const encodeBearerBootstrap = Schema.encodeUnknownSync(AuthBearerBootstrapResult);
+const decodeSessionState = Schema.decodeUnknownSync(AuthSessionState);
+const decodeWebSocketToken = Schema.decodeUnknownSync(AuthWebSocketTokenResult);
+const decodeAccessSnapshot = Schema.decodeUnknownSync(AuthAccessSnapshot);
+
+describe("auth contracts", () => {
+  it("decodes bearer bootstrap JSON timestamps from remote HTTP responses", () => {
+    const payload = {
+      authenticated: true,
+      role: "client",
+      sessionMethod: "bearer-session-token",
+      expiresAt: "2026-06-29T04:36:01.577Z",
+      sessionToken: "session-token",
+    };
+
+    const decoded = decodeBearerBootstrap(payload);
+    const encoded = encodeBearerBootstrap(decoded);
+
+    expect(encoded).toEqual(payload);
+  });
+
+  it("decodes auth JSON timestamps across session and access payloads", () => {
+    const expiresAt = "2026-06-29T04:36:01.577Z";
+
+    expect(
+      decodeSessionState({
+        authenticated: true,
+        auth: {
+          policy: "remote-reachable",
+          bootstrapMethods: ["one-time-token"],
+          sessionMethods: ["bearer-session-token"],
+          sessionCookieName: "t3_session_3773",
+        },
+        role: "client",
+        sessionMethod: "bearer-session-token",
+        expiresAt,
+      }).authenticated,
+    ).toBe(true);
+
+    expect(
+      decodeWebSocketToken({
+        token: "ws-token",
+        expiresAt,
+      }),
+    ).toBeDefined();
+
+    expect(
+      decodeAccessSnapshot({
+        pairingLinks: [
+          {
+            id: "pairing-link",
+            credential: "pairing-credential",
+            role: "client",
+            subject: "pairing-subject",
+            createdAt: "2026-05-29T04:36:01.577Z",
+            expiresAt,
+          },
+        ],
+        clientSessions: [
+          {
+            sessionId: "session-id",
+            subject: "client-subject",
+            role: "client",
+            method: "bearer-session-token",
+            client: {
+              deviceType: "desktop",
+            },
+            issuedAt: "2026-05-29T04:36:01.577Z",
+            expiresAt,
+            lastConnectedAt: null,
+            connected: false,
+            current: false,
+          },
+        ],
+      }).clientSessions,
+    ).toHaveLength(1);
+  });
+});

--- a/packages/contracts/src/auth.ts
+++ b/packages/contracts/src/auth.ts
@@ -2,6 +2,8 @@ import * as Schema from "effect/Schema";
 
 import { AuthSessionId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
+const AuthDateTimeUtc = Schema.DateTimeUtcFromString;
+
 /**
  * Declares the server's overall authentication posture.
  *
@@ -109,7 +111,7 @@ export const AuthBootstrapResult = Schema.Struct({
   authenticated: Schema.Literal(true),
   role: AuthSessionRole,
   sessionMethod: ServerAuthSessionMethod,
-  expiresAt: Schema.DateTimeUtc,
+  expiresAt: AuthDateTimeUtc,
 });
 export type AuthBootstrapResult = typeof AuthBootstrapResult.Type;
 
@@ -117,14 +119,14 @@ export const AuthBearerBootstrapResult = Schema.Struct({
   authenticated: Schema.Literal(true),
   role: AuthSessionRole,
   sessionMethod: Schema.Literal("bearer-session-token"),
-  expiresAt: Schema.DateTimeUtc,
+  expiresAt: AuthDateTimeUtc,
   sessionToken: TrimmedNonEmptyString,
 });
 export type AuthBearerBootstrapResult = typeof AuthBearerBootstrapResult.Type;
 
 export const AuthWebSocketTokenResult = Schema.Struct({
   token: TrimmedNonEmptyString,
-  expiresAt: Schema.DateTimeUtc,
+  expiresAt: AuthDateTimeUtc,
 });
 export type AuthWebSocketTokenResult = typeof AuthWebSocketTokenResult.Type;
 
@@ -132,7 +134,7 @@ export const AuthPairingCredentialResult = Schema.Struct({
   id: TrimmedNonEmptyString,
   credential: TrimmedNonEmptyString,
   label: Schema.optionalKey(TrimmedNonEmptyString),
-  expiresAt: Schema.DateTimeUtc,
+  expiresAt: AuthDateTimeUtc,
 });
 export type AuthPairingCredentialResult = typeof AuthPairingCredentialResult.Type;
 
@@ -142,8 +144,8 @@ export const AuthPairingLink = Schema.Struct({
   role: AuthSessionRole,
   subject: TrimmedNonEmptyString,
   label: Schema.optionalKey(TrimmedNonEmptyString),
-  createdAt: Schema.DateTimeUtc,
-  expiresAt: Schema.DateTimeUtc,
+  createdAt: AuthDateTimeUtc,
+  expiresAt: AuthDateTimeUtc,
 });
 export type AuthPairingLink = typeof AuthPairingLink.Type;
 
@@ -172,9 +174,9 @@ export const AuthClientSession = Schema.Struct({
   role: AuthSessionRole,
   method: ServerAuthSessionMethod,
   client: AuthClientMetadata,
-  issuedAt: Schema.DateTimeUtc,
-  expiresAt: Schema.DateTimeUtc,
-  lastConnectedAt: Schema.NullOr(Schema.DateTimeUtc),
+  issuedAt: AuthDateTimeUtc,
+  expiresAt: AuthDateTimeUtc,
+  lastConnectedAt: Schema.NullOr(AuthDateTimeUtc),
   connected: Schema.Boolean,
   current: Schema.Boolean,
 });
@@ -261,6 +263,6 @@ export const AuthSessionState = Schema.Struct({
   auth: ServerAuthDescriptor,
   role: Schema.optionalKey(AuthSessionRole),
   sessionMethod: Schema.optionalKey(ServerAuthSessionMethod),
-  expiresAt: Schema.optionalKey(Schema.DateTimeUtc),
+  expiresAt: Schema.optionalKey(AuthDateTimeUtc),
 });
 export type AuthSessionState = typeof AuthSessionState.Type;


### PR DESCRIPTION
## Summary
- Decode auth contract timestamp fields from JSON ISO strings using `Schema.DateTimeUtcFromString`
- Add regression coverage for remote bearer bootstrap/session/auth access payloads

## Testing
- `bun run --filter @t3tools/contracts test -- auth.test.ts`
- `bun run --filter @t3tools/contracts test`
- `bun run --filter @t3tools/contracts typecheck`
- `bun fmt`
- `bun lint`
- `bun typecheck`

## Context
Desktop SSH environment bootstrap can receive a successful `/api/auth/bootstrap/bearer` response with an ISO string `expiresAt`, then fail local schema decoding with `Expected DateTime.Utc`. The auth response contracts are JSON boundaries, so these timestamp fields should use the string codec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Contract-layer codec alignment for JSON timestamps; low risk with targeted tests and no auth logic changes.
> 
> **Overview**
> Auth contract schemas now decode and encode UTC timestamps from **ISO 8601 strings** at JSON boundaries, fixing failures (e.g. bearer bootstrap `expiresAt`) where remote HTTP responses were valid but local decoding expected `DateTime.Utc` objects.
> 
> A shared `AuthDateTimeUtc` codec replaces direct `Schema.DateTimeUtc` on bootstrap, session, WebSocket token, pairing, and access snapshot fields. **Regression tests** cover bearer bootstrap round-trip encoding and session/access payloads with string timestamps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0d60ed84efa561b9ca469fd42fa24c75674c2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix auth JSON datetime decoding by using `Schema.DateTimeUtcFromString` for all timestamp fields
> All datetime fields in the auth contract schemas (`expiresAt`, `createdAt`, `issuedAt`, `lastConnectedAt`) now decode from and encode to ISO-8601 strings instead of requiring `Date` instances. A shared `AuthDateTimeUtc` alias for `Schema.DateTimeUtcFromString` is introduced in [auth.ts](https://github.com/pingdotgg/t3code/pull/2871/files#diff-ff0457cc1ebe1a7b4a4a5c946a6d6725020e9dcb88aa053aad376b5dac686046) and applied across `AuthBootstrapResult`, `AuthBearerBootstrapResult`, `AuthWebSocketTokenResult`, `AuthPairingLink`, `AuthClientSession`, and `AuthSessionState`. Tests in [auth.test.ts](https://github.com/pingdotgg/t3code/pull/2871/files#diff-31a8fe91d6c3e4f9a023ebdc8ab7933a150aa326d182a8d13afa20c14e4d2232) cover round-trip encode/decode for all affected schemas.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c0d60ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->