### PR TITLE
feat(web): add branch deletion from the branch picker

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -15,6 +15,7 @@ const clientSettings: ClientSettings = {
   autoOpenPlanSidebar: false,
   confirmThreadArchive: true,
   confirmThreadDelete: false,
+  deleteRemoteBranchOnDelete: true,
   dismissedProviderUpdateNotificationKeys: [],
   diffIgnoreWhitespace: true,
   diffWordWrap: true,

--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -9,6 +9,8 @@ import {
   type VcsSwitchRefResult,
   type VcsCreateRefInput,
   type VcsCreateRefResult,
+  type VcsDeleteBranchInput,
+  type VcsDeleteBranchResult,
   type VcsCreateWorktreeInput,
   type VcsCreateWorktreeResult,
   type VcsListRefsInput,
@@ -67,6 +69,9 @@ export interface GitWorkflowServiceShape {
   readonly switchRef: (
     input: VcsSwitchRefInput,
   ) => Effect.Effect<VcsSwitchRefResult, GitCommandError>;
+  readonly deleteBranch: (
+    input: VcsDeleteBranchInput,
+  ) => Effect.Effect<VcsDeleteBranchResult, GitCommandError>;
   readonly renameBranch: (input: {
     readonly cwd: string;
     readonly oldBranch: string;
@@ -305,6 +310,10 @@ export const make = Effect.fn("makeGitWorkflowService")(function* () {
     switchRef: (input) =>
       ensureGitCommand("GitWorkflowService.switchRef", input.cwd).pipe(
         Effect.andThen(Effect.scoped(git.switchRef(input))),
+      ),
+    deleteBranch: (input) =>
+      ensureGitCommand("GitWorkflowService.deleteBranch", input.cwd).pipe(
+        Effect.andThen(git.deleteBranch(input)),
       ),
     renameBranch: (input) =>
       ensureGit("GitWorkflowService.renameBranch", input.cwd).pipe(

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -16,6 +16,8 @@ import {
   type VcsSwitchRefResult,
   type VcsCreateRefInput,
   type VcsCreateRefResult,
+  type VcsDeleteBranchInput,
+  type VcsDeleteBranchResult,
   type VcsCreateWorktreeInput,
   type VcsCreateWorktreeResult,
   type ReviewDiffPreviewInput,
@@ -217,6 +219,9 @@ export interface GitVcsDriverShape {
   readonly switchRef: (
     input: VcsSwitchRefInput,
   ) => Effect.Effect<VcsSwitchRefResult, GitCommandError>;
+  readonly deleteBranch: (
+    input: VcsDeleteBranchInput,
+  ) => Effect.Effect<VcsDeleteBranchResult, GitCommandError>;
   readonly initRepo: (input: VcsInitInput) => Effect.Effect<void, GitCommandError>;
   readonly listLocalBranchNames: (cwd: string) => Effect.Effect<string[], GitCommandError>;
 }

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -316,6 +316,15 @@ function commandLabel(args: readonly string[]): string {
   return `git ${args.join(" ")}`;
 }
 
+function isMissingRemoteBranchError(stderr: string): boolean {
+  const normalized = stderr.toLowerCase();
+  return (
+    normalized.includes("remote ref does not exist") ||
+    normalized.includes("does not exist") ||
+    normalized.includes("unable to delete")
+  );
+}
+
 function parseDefaultBranchFromRemoteHeadRef(value: string, remoteName: string): string | null {
   const trimmed = value.trim();
   const prefix = `refs/remotes/${remoteName}/`;
@@ -2280,6 +2289,59 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     },
   );
 
+  const deleteBranch: GitVcsDriver.GitVcsDriverShape["deleteBranch"] = Effect.fn("deleteBranch")(
+    function* (input) {
+      const isRemoteRef = input.isRemote === true;
+
+      let deletedLocal = false;
+      if (!isRemoteRef) {
+        yield* executeGit(
+          "GitVcsDriver.deleteBranch.local",
+          input.cwd,
+          ["branch", input.force ? "-D" : "-d", "--", input.refName],
+          {
+            timeoutMs: 10_000,
+            fallbackErrorMessage: "git branch delete failed",
+          },
+        );
+        deletedLocal = true;
+      }
+
+      let deletedRemote = false;
+      if (isRemoteRef || input.deleteRemote) {
+        const remoteName = input.remoteName
+          ? input.remoteName
+          : yield* resolvePrimaryRemoteName(input.cwd).pipe(
+              Effect.catch((error) => (isRemoteRef ? Effect.fail(error) : Effect.succeed(null))),
+            );
+        const remoteBranch = isRemoteRef
+          ? deriveLocalBranchNameFromRemoteRef(input.refName)
+          : input.refName;
+        if (remoteName && remoteBranch) {
+          const pushArgs = ["push", remoteName, "--delete", remoteBranch];
+          const result = yield* executeGit(
+            "GitVcsDriver.deleteBranch.remote",
+            input.cwd,
+            pushArgs,
+            { timeoutMs: 30_000, allowNonZeroExit: true },
+          );
+          if (result.exitCode === 0) {
+            deletedRemote = true;
+          } else if (!isMissingRemoteBranchError(result.stderr)) {
+            return yield* createGitCommandError(
+              "GitVcsDriver.deleteBranch.remote",
+              input.cwd,
+              pushArgs,
+              result.stderr.trim() || "git push --delete failed",
+            );
+          }
+        }
+      }
+
+      return { refName: input.refName, deletedLocal, deletedRemote };
+    },
+  );
+
   const initRepo: GitVcsDriver.GitVcsDriverShape["initRepo"] = (input) =>
     executeGit("GitVcsDriver.initRepo", input.cwd, ["init"], {
       timeoutMs: 10_000,
@@ -2329,6 +2391,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     renameBranch,
     createRef,
     switchRef,
+    deleteBranch,
     initRepo,
     listLocalBranchNames,
   });

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1116,6 +1116,12 @@ const makeWsRpcLayer = (currentSessionId: AuthSessionId) =>
             gitWorkflow.switchRef(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
             { "rpc.aggregate": "vcs" },
           ),
+        [WS_METHODS.vcsDeleteBranch]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.vcsDeleteBranch,
+            gitWorkflow.deleteBranch(input).pipe(Effect.tap(() => refreshGitStatus(input.cwd))),
+            { "rpc.aggregate": "vcs" },
+          ),
         [WS_METHODS.vcsInit]: (input) =>
           observeRpcEffect(
             WS_METHODS.vcsInit,

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -1,7 +1,7 @@
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime";
 import type { EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
-import { ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon, Trash2 } from "lucide-react";
 import {
   useCallback,
   useDeferredValue,
@@ -31,6 +31,16 @@ import {
   resolveEffectiveEnvMode,
   shouldIncludeBranchPickerItem,
 } from "./BranchToolbar.logic";
+import { useSettings } from "../hooks/useSettings";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "./ui/alert-dialog";
 import { Button } from "./ui/button";
 import {
   Combobox,
@@ -62,6 +72,15 @@ const EMPTY_REFS: ReadonlyArray<VcsRef> = [];
 
 function toBranchActionErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "An error occurred.";
+}
+
+function isGitCommandError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    (error as { _tag?: unknown })._tag === "GitCommandError"
+  );
 }
 
 function getBranchTriggerLabel(input: {
@@ -200,6 +219,9 @@ export function BranchToolbarBranchSelector({
   const [isBranchMenuOpen, setIsBranchMenuOpen] = useState(false);
   const [branchQuery, setBranchQuery] = useState("");
   const deferredBranchQuery = useDeferredValue(branchQuery);
+  const deleteRemoteBranchOnDelete = useSettings((s) => s.deleteRemoteBranchOnDelete);
+  const [pendingDelete, setPendingDelete] = useState<VcsRef | null>(null);
+  const [forceDeleteTarget, setForceDeleteTarget] = useState<VcsRef | null>(null);
 
   const branchStatusQuery = useVcsStatus({ environmentId, cwd: branchCwd });
   const trimmedBranchQuery = branchQuery.trim();
@@ -392,6 +414,48 @@ export function BranchToolbarBranchSelector({
     });
   };
 
+  const deleteBranch = (ref: VcsRef, force: boolean) => {
+    const api = readEnvironmentApi(environmentId);
+    if (!api || !branchCwd) return;
+
+    runBranchAction(async () => {
+      try {
+        const result = await api.vcs.deleteBranch({
+          cwd: branchCwd,
+          refName: ref.name,
+          isRemote: ref.isRemote,
+          remoteName: ref.remoteName,
+          force,
+          deleteRemote: deleteRemoteBranchOnDelete,
+        });
+        setPendingDelete(null);
+        setForceDeleteTarget(null);
+        toastManager.add(
+          stackedThreadToast({
+            type: "success",
+            title: `Deleted ref "${ref.name}".`,
+            ...(result.deletedRemote ? { description: "Remote branch also deleted." } : {}),
+          }),
+        );
+      } catch (error) {
+        if (!force && isGitCommandError(error)) {
+          setPendingDelete(null);
+          setForceDeleteTarget(ref);
+          return;
+        }
+        setPendingDelete(null);
+        setForceDeleteTarget(null);
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: "Failed to delete ref.",
+            description: toBranchActionErrorMessage(error),
+          }),
+        );
+      }
+    });
+  };
+
   useEffect(() => {
     if (
       effectiveEnvMode !== "worktree" ||
@@ -557,86 +621,170 @@ export function BranchToolbarBranchSelector({
     return (
       <ComboboxItem
         hideIndicator
+        className="group"
         key={itemValue}
         index={index}
         value={itemValue}
         onClick={() => selectBranch(refName)}
       >
         <div className="flex w-full items-center justify-between gap-2">
-          <span className="truncate">{itemValue}</span>
-          {badge && <span className="shrink-0 text-[10px] text-muted-foreground/45">{badge}</span>}
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="truncate">{itemValue}</span>
+            {badge && (
+              <span className="shrink-0 text-[10px] text-muted-foreground/45">{badge}</span>
+            )}
+          </span>
+          <div className="flex shrink-0 items-center gap-1.5">
+            {refName.current ? (
+              <span className="size-7 sm:size-6" aria-hidden />
+            ) : (
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                className="opacity-0 group-hover:opacity-100"
+                aria-label={`Delete ref ${refName.name}`}
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  event.preventDefault();
+                  setForceDeleteTarget(null);
+                  setPendingDelete(refName);
+                }}
+              >
+                <Trash2 />
+              </Button>
+            )}
+          </div>
         </div>
       </ComboboxItem>
     );
   }
 
   return (
-    <Combobox
-      items={branchPickerItems}
-      filteredItems={filteredBranchPickerItems}
-      autoHighlight
-      virtualized={shouldVirtualizeBranchList}
-      onItemHighlighted={(_value, eventDetails) => {
-        if (!isBranchMenuOpen || eventDetails.index < 0 || eventDetails.reason !== "keyboard") {
-          return;
-        }
-        branchListRef.current?.scrollIndexIntoView?.({
-          index: eventDetails.index,
-          animated: false,
-        });
-      }}
-      onOpenChange={handleOpenChange}
-      open={isBranchMenuOpen}
-      value={resolvedActiveBranch}
-    >
-      <ComboboxTrigger
-        render={<Button variant="ghost" size="xs" />}
-        className={cn("min-w-0 text-muted-foreground/70 hover:text-foreground/80", className)}
-        disabled={isInitialBranchesLoadPending || isBranchActionPending}
+    <>
+      <Combobox
+        items={branchPickerItems}
+        filteredItems={filteredBranchPickerItems}
+        autoHighlight
+        virtualized={shouldVirtualizeBranchList}
+        onItemHighlighted={(_value, eventDetails) => {
+          if (!isBranchMenuOpen || eventDetails.index < 0 || eventDetails.reason !== "keyboard") {
+            return;
+          }
+          branchListRef.current?.scrollIndexIntoView?.({
+            index: eventDetails.index,
+            animated: false,
+          });
+        }}
+        onOpenChange={handleOpenChange}
+        open={isBranchMenuOpen}
+        value={resolvedActiveBranch}
       >
-        <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
-        <ChevronDownIcon className="shrink-0" />
-      </ComboboxTrigger>
-      <ComboboxPopup align="end" side="top" className="w-80">
-        <div className="border-b p-1">
-          <ComboboxInput
-            className="[&_input]:font-sans rounded-md"
-            inputClassName="ring-0"
-            placeholder="Search refs..."
-            showTrigger={false}
-            size="sm"
-            value={branchQuery}
-            onChange={(event) => setBranchQuery(event.target.value)}
-          />
-        </div>
-        <ComboboxEmpty>No refs found.</ComboboxEmpty>
-
-        {shouldVirtualizeBranchList ? (
-          <ComboboxListVirtualized>
-            <LegendList<string>
-              ref={branchListRef}
-              data={filteredBranchPickerItems}
-              keyExtractor={(item) => item}
-              renderItem={({ item, index }) => renderPickerItem(item, index)}
-              estimatedItemSize={28}
-              drawDistance={336}
-              onEndReached={() => {
-                if (hasNextPage && !isFetchingNextPage) {
-                  fetchNextBranchPage();
-                }
-              }}
-              style={{ maxHeight: "14rem" }}
+        <ComboboxTrigger
+          render={<Button variant="ghost" size="xs" />}
+          className={cn("min-w-0 text-muted-foreground/70 hover:text-foreground/80", className)}
+          disabled={isInitialBranchesLoadPending || isBranchActionPending}
+        >
+          <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
+          <ChevronDownIcon className="shrink-0" />
+        </ComboboxTrigger>
+        <ComboboxPopup align="end" side="top" className="w-80">
+          <div className="border-b p-1">
+            <ComboboxInput
+              className="[&_input]:font-sans rounded-md"
+              inputClassName="ring-0"
+              placeholder="Search refs..."
+              showTrigger={false}
+              size="sm"
+              value={branchQuery}
+              onChange={(event) => setBranchQuery(event.target.value)}
             />
-          </ComboboxListVirtualized>
-        ) : (
-          <ComboboxList ref={setBranchListRef} className="max-h-56">
-            {filteredBranchPickerItems.map((itemValue, index) =>
-              renderPickerItem(itemValue, index),
-            )}
-          </ComboboxList>
-        )}
-        {branchStatusText ? <ComboboxStatus>{branchStatusText}</ComboboxStatus> : null}
-      </ComboboxPopup>
-    </Combobox>
+          </div>
+          <ComboboxEmpty>No refs found.</ComboboxEmpty>
+
+          {shouldVirtualizeBranchList ? (
+            <ComboboxListVirtualized>
+              <LegendList<string>
+                ref={branchListRef}
+                data={filteredBranchPickerItems}
+                keyExtractor={(item) => item}
+                renderItem={({ item, index }) => renderPickerItem(item, index)}
+                estimatedItemSize={28}
+                drawDistance={336}
+                onEndReached={() => {
+                  if (hasNextPage && !isFetchingNextPage) {
+                    fetchNextBranchPage();
+                  }
+                }}
+                style={{ maxHeight: "14rem" }}
+              />
+            </ComboboxListVirtualized>
+          ) : (
+            <ComboboxList ref={setBranchListRef} className="max-h-56">
+              {filteredBranchPickerItems.map((itemValue, index) =>
+                renderPickerItem(itemValue, index),
+              )}
+            </ComboboxList>
+          )}
+          {branchStatusText ? <ComboboxStatus>{branchStatusText}</ComboboxStatus> : null}
+        </ComboboxPopup>
+      </Combobox>
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete branch &quot;{pendingDelete?.name}&quot;?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteRemoteBranchOnDelete
+                ? "This will delete the branch locally and its remote counterpart."
+                : "This will delete the branch locally."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (pendingDelete) deleteBranch(pendingDelete, false);
+              }}
+            >
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+
+      <AlertDialog
+        open={forceDeleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setForceDeleteTarget(null);
+        }}
+      >
+        <AlertDialogPopup>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Force delete &quot;{forceDeleteTarget?.name}&quot;?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This branch may have unmerged commits that will be lost.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (forceDeleteTarget) deleteBranch(forceDeleteTarget, true);
+              }}
+            >
+              Force delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogPopup>
+      </AlertDialog>
+    </>
   );
 }

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -426,6 +426,10 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
+      ...(settings.deleteRemoteBranchOnDelete !==
+      DEFAULT_UNIFIED_SETTINGS.deleteRemoteBranchOnDelete
+        ? ["Delete remote branch"]
+        : []),
       ...(isGitWritingModelDirty ? ["Git writing model"] : []),
     ],
     [
@@ -433,6 +437,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       settings.autoOpenPlanSidebar,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
+      settings.deleteRemoteBranchOnDelete,
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.diffIgnoreWhitespace,
@@ -468,6 +473,7 @@ export function useSettingsRestore(onRestored?: () => void) {
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+      deleteRemoteBranchOnDelete: DEFAULT_UNIFIED_SETTINGS.deleteRemoteBranchOnDelete,
       textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
     });
     onRestored?.();
@@ -814,6 +820,33 @@ export function GeneralSettingsPanel() {
                 updateSettings({ confirmThreadDelete: Boolean(checked) })
               }
               aria-label="Confirm thread deletion"
+            />
+          }
+        />
+
+        <SettingsRow
+          title="Delete remote branch"
+          description="When deleting a branch, also delete its remote counterpart."
+          resetAction={
+            settings.deleteRemoteBranchOnDelete !==
+            DEFAULT_UNIFIED_SETTINGS.deleteRemoteBranchOnDelete ? (
+              <SettingResetButton
+                label="delete remote branch"
+                onClick={() =>
+                  updateSettings({
+                    deleteRemoteBranchOnDelete: DEFAULT_UNIFIED_SETTINGS.deleteRemoteBranchOnDelete,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Switch
+              checked={settings.deleteRemoteBranchOnDelete}
+              onCheckedChange={(checked) =>
+                updateSettings({ deleteRemoteBranchOnDelete: Boolean(checked) })
+              }
+              aria-label="Delete remote branch on delete"
             />
           }
         />

--- a/apps/web/src/environmentApi.ts
+++ b/apps/web/src/environmentApi.ts
@@ -39,6 +39,7 @@ export function createEnvironmentApi(rpcClient: WsRpcClient): EnvironmentApi {
       removeWorktree: rpcClient.vcs.removeWorktree,
       createRef: rpcClient.vcs.createRef,
       switchRef: rpcClient.vcs.switchRef,
+      deleteBranch: rpcClient.vcs.deleteBranch,
       init: rpcClient.vcs.init,
     },
     git: {

--- a/apps/web/src/environments/runtime/service.threadSubscriptions.test.ts
+++ b/apps/web/src/environments/runtime/service.threadSubscriptions.test.ts
@@ -121,6 +121,7 @@ vi.mock("@t3tools/client-runtime", async (importOriginal) => {
       removeWorktree: vi.fn(),
       createRef: vi.fn(),
       switchRef: vi.fn(),
+      deleteBranch: vi.fn(),
       init: vi.fn(),
     },
     git: {

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -80,6 +80,7 @@ const rpcClientMock = {
     removeWorktree: vi.fn(),
     createRef: vi.fn(),
     switchRef: vi.fn(),
+    deleteBranch: vi.fn(),
     init: vi.fn(),
   },
   git: {
@@ -632,6 +633,7 @@ describe("wsApi", () => {
       autoOpenPlanSidebar: false,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
+      deleteRemoteBranchOnDelete: true,
       dismissedProviderUpdateNotificationKeys: [],
       diffIgnoreWhitespace: true,
       diffWordWrap: true,
@@ -695,6 +697,7 @@ describe("wsApi", () => {
       autoOpenPlanSidebar: false,
       confirmThreadArchive: true,
       confirmThreadDelete: false,
+      deleteRemoteBranchOnDelete: true,
       dismissedProviderUpdateNotificationKeys: [],
       diffIgnoreWhitespace: true,
       diffWordWrap: true,

--- a/packages/client-runtime/src/wsRpcClient.ts
+++ b/packages/client-runtime/src/wsRpcClient.ts
@@ -108,6 +108,7 @@ export interface WsRpcClient {
     readonly removeWorktree: RpcUnaryMethod<typeof WS_METHODS.vcsRemoveWorktree>;
     readonly createRef: RpcUnaryMethod<typeof WS_METHODS.vcsCreateRef>;
     readonly switchRef: RpcUnaryMethod<typeof WS_METHODS.vcsSwitchRef>;
+    readonly deleteBranch: RpcUnaryMethod<typeof WS_METHODS.vcsDeleteBranch>;
     readonly init: RpcUnaryMethod<typeof WS_METHODS.vcsInit>;
   };
   readonly git: {
@@ -247,6 +248,8 @@ export function createWsRpcClient(
         transport.request((client) => client[WS_METHODS.vcsRemoveWorktree](input)),
       createRef: (input) => transport.request((client) => client[WS_METHODS.vcsCreateRef](input)),
       switchRef: (input) => transport.request((client) => client[WS_METHODS.vcsSwitchRef](input)),
+      deleteBranch: (input) =>
+        transport.request((client) => client[WS_METHODS.vcsDeleteBranch](input)),
       init: (input) => transport.request((client) => client[WS_METHODS.vcsInit](input)),
     },
     git: {

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -178,6 +178,23 @@ export const VcsSwitchRefInput = Schema.Struct({
 });
 export type VcsSwitchRefInput = typeof VcsSwitchRefInput.Type;
 
+export const VcsDeleteBranchInput = Schema.Struct({
+  cwd: TrimmedNonEmptyStringSchema,
+  refName: TrimmedNonEmptyStringSchema,
+  isRemote: Schema.optional(Schema.Boolean),
+  remoteName: Schema.optional(TrimmedNonEmptyStringSchema),
+  force: Schema.optional(Schema.Boolean),
+  deleteRemote: Schema.optional(Schema.Boolean),
+});
+export type VcsDeleteBranchInput = typeof VcsDeleteBranchInput.Type;
+
+export const VcsDeleteBranchResult = Schema.Struct({
+  refName: TrimmedNonEmptyStringSchema,
+  deletedLocal: Schema.Boolean,
+  deletedRemote: Schema.Boolean,
+});
+export type VcsDeleteBranchResult = typeof VcsDeleteBranchResult.Type;
+
 export const VcsInitInput = Schema.Struct({
   cwd: TrimmedNonEmptyStringSchema,
   kind: Schema.optional(VcsDriverKind),

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -1,6 +1,8 @@
 import type {
   VcsCreateRefInput,
   VcsCreateRefResult,
+  VcsDeleteBranchInput,
+  VcsDeleteBranchResult,
   VcsCreateWorktreeInput,
   VcsCreateWorktreeResult,
   VcsInitInput,
@@ -542,6 +544,7 @@ export interface EnvironmentApi {
     removeWorktree: (input: VcsRemoveWorktreeInput) => Promise<void>;
     createRef: (input: VcsCreateRefInput) => Promise<VcsCreateRefResult>;
     switchRef: (input: VcsSwitchRefInput) => Promise<VcsSwitchRefResult>;
+    deleteBranch: (input: VcsDeleteBranchInput) => Promise<VcsDeleteBranchResult>;
     init: (input: VcsInitInput) => Promise<void>;
     pull: (input: VcsPullInput) => Promise<VcsPullResult>;
     refreshStatus: (input: VcsStatusInput) => Promise<VcsStatusResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -16,6 +16,8 @@ import {
   GitCommandError,
   VcsCreateRefInput,
   VcsCreateRefResult,
+  VcsDeleteBranchInput,
+  VcsDeleteBranchResult,
   VcsCreateWorktreeInput,
   VcsCreateWorktreeResult,
   VcsInitInput,
@@ -129,6 +131,7 @@ export const WS_METHODS = {
   vcsRemoveWorktree: "vcs.removeWorktree",
   vcsCreateRef: "vcs.createRef",
   vcsSwitchRef: "vcs.switchRef",
+  vcsDeleteBranch: "vcs.deleteBranch",
   vcsInit: "vcs.init",
 
   // Git workflow methods
@@ -367,6 +370,12 @@ export const WsVcsSwitchRefRpc = Rpc.make(WS_METHODS.vcsSwitchRef, {
   error: GitCommandError,
 });
 
+export const WsVcsDeleteBranchRpc = Rpc.make(WS_METHODS.vcsDeleteBranch, {
+  payload: VcsDeleteBranchInput,
+  success: VcsDeleteBranchResult,
+  error: GitCommandError,
+});
+
 export const WsVcsInitRpc = Rpc.make(WS_METHODS.vcsInit, {
   payload: VcsInitInput,
   error: VcsError,
@@ -540,6 +549,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsVcsRemoveWorktreeRpc,
   WsVcsCreateRefRpc,
   WsVcsSwitchRefRpc,
+  WsVcsDeleteBranchRpc,
   WsVcsInitRpc,
   WsReviewGetDiffPreviewRpc,
   WsTerminalOpenRpc,

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -43,6 +43,7 @@ export const ClientSettingsSchema = Schema.Struct({
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  deleteRemoteBranchOnDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
   dismissedProviderUpdateNotificationKeys: Schema.Array(TrimmedNonEmptyString).pipe(
     Schema.withDecodingDefault(Effect.succeed([])),
   ),
@@ -478,6 +479,7 @@ export const ClientSettingsPatch = Schema.Struct({
   autoOpenPlanSidebar: Schema.optionalKey(Schema.Boolean),
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
+  deleteRemoteBranchOnDelete: Schema.optionalKey(Schema.Boolean),
   diffIgnoreWhitespace: Schema.optionalKey(Schema.Boolean),
   diffWordWrap: Schema.optionalKey(Schema.Boolean),
   favorites: Schema.optionalKey(


### PR DESCRIPTION
## What Changed

Adds the ability to delete a git branch directly from the branch picker in the branch toolbar.

- New `vcsDeleteBranch` RPC method wired across contracts, server, and client (`rpc.ts`, `ipc.ts`, `git.ts`, `wsRpcClient.ts`, `ws.ts`).
- Implemented in the Git VCS driver (`GitVcsDriverCore.ts`, `GitVcsDriver.ts`, `GitWorkflowService.ts`).
- Trash icon in the branch picker (`BranchToolbarBranchSelector.tsx`) with a confirmation dialog before deleting.
- Force-delete path for branches that have unmerged commits.
- New `deleteRemoteBranchOnDelete` setting (`settings.ts`, `SettingsPanels.tsx`) that controls whether the matching remote branch is also deleted.

## Why

There was no way to delete a branch from within the app — you had to drop to a terminal. Branches accumulate after merges/abandoned work, and the branch picker is the natural place to clean them up. The optional remote-cleanup setting keeps the destructive remote action opt-in rather than implicit.

## UI Changes
| | |
|---|---|
| Delete button | <img width="319" height="297" alt="image" src="https://github.com/user-attachments/assets/77a6698f-cc55-438a-8f5f-47d5154e7cdb" /> |
| Delete confirmation popup | <img width="572" height="243" alt="image" src="https://github.com/user-attachments/assets/96a9c6c7-fd61-4019-9b4b-8b625b06b862" /> |
| Settings menu | <img width="792" height="116" alt="image" src="https://github.com/user-attachments/assets/0099f87e-3e44-4d34-99b2-96899f1dcee7" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (only after screenshots applicable)
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add branch deletion from the branch picker in the web UI
> - Adds a delete button per branch in `BranchToolbarBranchSelector` that calls a new `vcs.deleteBranch` RPC endpoint; shows a confirmation dialog before proceeding.
> - Supports optional remote branch deletion controlled by a new `deleteRemoteBranchOnDelete` client setting (defaults to `true`), configurable via the General settings panel.
> - If the initial delete fails with a `GitCommandError`, a second dialog offers a force-delete fallback.
> - Implements the full stack: new contract schemas in [`git.ts`](https://github.com/pingdotgg/t3code/pull/2879/files#diff-2282301d92a7a9ddc7e8d88b986c9628fdf70497dc6a09fe80eb8d46d6a769e7), RPC wiring in [`rpc.ts`](https://github.com/pingdotgg/t3code/pull/2879/files#diff-64c16995299d1af309c72e94a298ffcb5c2ee5c65774cf0c73bf997358e9c266), Git driver implementation in [`GitVcsDriverCore.ts`](https://github.com/pingdotgg/t3code/pull/2879/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8), and WS handler in [`ws.ts`](https://github.com/pingdotgg/t3code/pull/2879/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125). Missing remote branches are treated as non-fatal.
> - Risk: `deleteRemoteBranchOnDelete` defaults to `true`, so existing users will have remote deletion enabled by default after upgrade.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30507a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->