### PR TITLE
s

### DIFF
--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -5,6 +5,7 @@ import { useThemeColor } from "../lib/useThemeColor";
 
 /* ─── Favicon cache (matches web pattern) ────────────────────────────── */
 const loadedFaviconUrls = new Set<string>();
+const PROJECT_FAVICON_URL_VERSION = "github-repo-image-v1";
 
 /* ─── Component ──────────────────────────────────────────────────────── */
 export function ProjectFavicon(props: {
@@ -19,7 +20,7 @@ export function ProjectFavicon(props: {
 
   const faviconUrl =
     props.httpBaseUrl && props.workspaceRoot
-      ? `${props.httpBaseUrl}/api/project-favicon?cwd=${encodeURIComponent(props.workspaceRoot)}`
+      ? `${props.httpBaseUrl}/api/project-favicon?cwd=${encodeURIComponent(props.workspaceRoot)}&v=${PROJECT_FAVICON_URL_VERSION}`
       : null;
 
   const [status, setStatus] = useState<"loading" | "loaded" | "error">(() =>

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -1,6 +1,7 @@
 import Mime from "@effect/platform-node/Mime";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
 import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
@@ -24,7 +25,17 @@ import {
 import { resolveAttachmentPathById } from "./attachmentStore.ts";
 import { resolveStaticDir, ServerConfig } from "./config.ts";
 import { BrowserTraceCollector } from "./observability/Services/BrowserTraceCollector.ts";
+import { ProcessRunner, type ProcessRunnerShape } from "./processRunner.ts";
+import {
+  buildGitHubProjectImageCandidateUrls,
+  buildGitHubRepositoryPageUrl,
+  parseGitHubRepositoryImageGraphqlResponse,
+  resolveGitHubRepositoryRef,
+  type GitHubRepositoryRef,
+  type GitHubRepositoryImageMetadata,
+} from "./project/githubProjectImage.ts";
 import { ProjectFaviconResolver } from "./project/Services/ProjectFaviconResolver.ts";
+import { RepositoryIdentityResolver } from "./project/Services/RepositoryIdentityResolver.ts";
 import { ServerAuth } from "./auth/Services/ServerAuth.ts";
 import { respondToAuthError } from "./auth/http.ts";
 import { ServerEnvironment } from "./environment/Services/ServerEnvironment.ts";
@@ -35,6 +46,21 @@ import {
 } from "./httpCors.ts";
 
 const PROJECT_FAVICON_CACHE_CONTROL = "public, max-age=3600";
+const PROJECT_FAVICON_REMOTE_FETCH_TIMEOUT_MS = 5_000;
+const PROJECT_FAVICON_REMOTE_IMAGE_MAX_BYTES = 2 * 1024 * 1024;
+const PROJECT_FAVICON_REMOTE_USER_AGENT = "T3 Code project favicon resolver";
+const PROJECT_FAVICON_GITHUB_CLI_TIMEOUT_MS = 2_500;
+const PROJECT_FAVICON_GITHUB_CLI_MAX_OUTPUT_BYTES = 128 * 1024;
+const PROJECT_FAVICON_GITHUB_GRAPHQL_QUERY = `
+  query RepositoryProjectImage($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      openGraphImageUrl
+      owner {
+        avatarUrl(size: 64)
+      }
+    }
+  }
+`;
 const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
 const OTLP_TRACES_PROXY_PATH = "/api/observability/v1/traces";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "::1", "localhost"]);
@@ -66,6 +92,127 @@ const requireAuthenticatedRequest = Effect.gen(function* () {
   const serverAuth = yield* ServerAuth;
   yield* serverAuth.authenticateHttpRequest(request);
 });
+
+const fetchGitHubProjectImageMetadataWithCli = (
+  processRunner: ProcessRunnerShape,
+  repository: GitHubRepositoryRef,
+): Effect.Effect<GitHubRepositoryImageMetadata | null> =>
+  processRunner
+    .run({
+      command: "gh",
+      args: [
+        "api",
+        "graphql",
+        "-f",
+        `query=${PROJECT_FAVICON_GITHUB_GRAPHQL_QUERY}`,
+        "-F",
+        `owner=${repository.owner}`,
+        "-F",
+        `name=${repository.name}`,
+      ],
+      env: { GH_PROMPT_DISABLED: "1" },
+      maxOutputBytes: PROJECT_FAVICON_GITHUB_CLI_MAX_OUTPUT_BYTES,
+      outputMode: "truncate",
+      timeout: Duration.millis(PROJECT_FAVICON_GITHUB_CLI_TIMEOUT_MS),
+      timeoutBehavior: "timedOutResult",
+    })
+    .pipe(
+      Effect.map((result) =>
+        result.code === 0 && !result.timedOut
+          ? parseGitHubRepositoryImageGraphqlResponse(result.stdout)
+          : null,
+      ),
+      Effect.catch(() => Effect.succeed(null)),
+    );
+
+const fetchProjectFaviconText = (
+  httpClient: HttpClient.HttpClient,
+  url: string,
+): Effect.Effect<string | null> =>
+  httpClient
+    .get(url, {
+      headers: { "User-Agent": PROJECT_FAVICON_REMOTE_USER_AGENT },
+    })
+    .pipe(
+      Effect.flatMap((response) =>
+        response.status >= 200 && response.status < 300 ? response.text : Effect.succeed(null),
+      ),
+      Effect.timeoutOption(PROJECT_FAVICON_REMOTE_FETCH_TIMEOUT_MS),
+      Effect.map((result) => (Option.isSome(result) ? result.value : null)),
+      Effect.catch(() => Effect.succeed(null)),
+    );
+
+const fetchProjectFaviconRemoteImage = (
+  httpClient: HttpClient.HttpClient,
+  url: string,
+): Effect.Effect<{ readonly body: Uint8Array; readonly contentType: string } | null> =>
+  httpClient
+    .get(url, {
+      headers: { "User-Agent": PROJECT_FAVICON_REMOTE_USER_AGENT },
+    })
+    .pipe(
+      Effect.flatMap((response) =>
+        Effect.gen(function* () {
+          if (response.status < 200 || response.status >= 300) {
+            return null;
+          }
+
+          const contentType = response.headers["content-type"]?.split(";")[0]?.trim() ?? "";
+          if (!contentType.toLowerCase().startsWith("image/")) {
+            return null;
+          }
+
+          const contentLength = Number(response.headers["content-length"] ?? "0");
+          if (contentLength > PROJECT_FAVICON_REMOTE_IMAGE_MAX_BYTES) {
+            return null;
+          }
+
+          const body = new Uint8Array(yield* response.arrayBuffer);
+          if (body.byteLength > PROJECT_FAVICON_REMOTE_IMAGE_MAX_BYTES) {
+            return null;
+          }
+
+          return { body, contentType };
+        }),
+      ),
+      Effect.timeoutOption(PROJECT_FAVICON_REMOTE_FETCH_TIMEOUT_MS),
+      Effect.map((result) => (Option.isSome(result) ? result.value : null)),
+      Effect.catch(() => Effect.succeed(null)),
+    );
+
+const resolveGitHubProjectFavicon = (projectCwd: string) =>
+  Effect.gen(function* () {
+    const httpClient = (yield* HttpClient.HttpClient).pipe(HttpClient.followRedirects(3));
+    const processRunner = yield* ProcessRunner;
+    const repositoryIdentityResolver = yield* RepositoryIdentityResolver;
+    const repositoryIdentity = yield* repositoryIdentityResolver.resolve(projectCwd);
+    const githubRepository = resolveGitHubRepositoryRef(repositoryIdentity);
+    if (!githubRepository) {
+      return null;
+    }
+
+    const repositoryImageMetadata = yield* fetchGitHubProjectImageMetadataWithCli(
+      processRunner,
+      githubRepository,
+    );
+    const repositoryHtml = repositoryImageMetadata
+      ? null
+      : yield* fetchProjectFaviconText(httpClient, buildGitHubRepositoryPageUrl(githubRepository));
+    const imageUrls = buildGitHubProjectImageCandidateUrls({
+      repository: githubRepository,
+      repositoryImageMetadata,
+      repositoryHtml,
+    });
+
+    for (const imageUrl of imageUrls) {
+      const image = yield* fetchProjectFaviconRemoteImage(httpClient, imageUrl);
+      if (image) {
+        return image;
+      }
+    }
+
+    return null;
+  });
 
 export const serverEnvironmentRouteLayer = HttpRouter.add(
   "GET",
@@ -205,6 +352,17 @@ export const projectFaviconRouteLayer = HttpRouter.add(
     const projectCwd = url.value.searchParams.get("cwd");
     if (!projectCwd) {
       return HttpServerResponse.text("Missing cwd parameter", { status: 400 });
+    }
+
+    const githubProjectFavicon = yield* resolveGitHubProjectFavicon(projectCwd);
+    if (githubProjectFavicon) {
+      return HttpServerResponse.uint8Array(githubProjectFavicon.body, {
+        status: 200,
+        contentType: githubProjectFavicon.contentType,
+        headers: {
+          "Cache-Control": PROJECT_FAVICON_CACHE_CONTROL,
+        },
+      });
     }
 
     const faviconResolver = yield* ProjectFaviconResolver;

--- a/apps/server/src/project/githubProjectImage.test.ts
+++ b/apps/server/src/project/githubProjectImage.test.ts
@@ -1,0 +1,156 @@
+import type { RepositoryIdentity } from "@t3tools/contracts";
+import { describe, expect, it } from "vitest";
+import {
+  buildGitHubOwnerAvatarUrl,
+  buildGitHubProjectImageCandidateUrls,
+  buildGitHubRepositoryPageUrl,
+  extractGitHubCustomRepositoryImageUrl,
+  parseGitHubRepositoryImageGraphqlResponse,
+  resolveGitHubRepositoryRef,
+} from "./githubProjectImage.ts";
+
+function makeRepositoryIdentity(overrides: Partial<RepositoryIdentity> = {}): RepositoryIdentity {
+  return {
+    canonicalKey: "github.com/t3tools/t3code",
+    locator: {
+      source: "git-remote",
+      remoteName: "origin",
+      remoteUrl: "git@github.com:T3Tools/t3code.git",
+    },
+    provider: "github",
+    owner: "T3Tools",
+    name: "t3code",
+    ...overrides,
+  } as RepositoryIdentity;
+}
+
+describe("github project image helpers", () => {
+  it("resolves GitHub repository fields from repository identity metadata", () => {
+    expect(resolveGitHubRepositoryRef(makeRepositoryIdentity())).toEqual({
+      owner: "T3Tools",
+      name: "t3code",
+    });
+  });
+
+  it("falls back to canonical key and remote URL when explicit fields are missing", () => {
+    const {
+      provider: _provider,
+      owner: _owner,
+      name: _name,
+      ...canonicalIdentity
+    } = makeRepositoryIdentity();
+    expect(resolveGitHubRepositoryRef(canonicalIdentity)).toEqual({
+      owner: "t3tools",
+      name: "t3code",
+    });
+
+    const {
+      provider: _remoteProvider,
+      owner: _remoteOwner,
+      name: _remoteName,
+      ...remoteIdentity
+    } = makeRepositoryIdentity({
+      canonicalKey: "example.com/t3tools/t3code",
+    });
+    expect(resolveGitHubRepositoryRef(remoteIdentity)).toEqual({
+      owner: "T3Tools",
+      name: "t3code",
+    });
+  });
+
+  it("builds stable GitHub page and owner avatar URLs", () => {
+    const repository = { owner: "T3Tools", name: "t3code" };
+
+    expect(buildGitHubRepositoryPageUrl(repository)).toBe("https://github.com/T3Tools/t3code");
+    expect(buildGitHubOwnerAvatarUrl(repository)).toBe("https://github.com/T3Tools.png?size=64");
+  });
+
+  it("extracts only custom repository images, not GitHub generated OpenGraph cards", () => {
+    expect(
+      extractGitHubCustomRepositoryImageUrl(
+        '<meta property="og:image" content="https://repository-images.githubusercontent.com/123/preview">',
+      ),
+    ).toBe("https://repository-images.githubusercontent.com/123/preview");
+
+    expect(
+      extractGitHubCustomRepositoryImageUrl(
+        '<meta property="og:image" content="https://opengraph.githubassets.com/hash/owner/repo">',
+      ),
+    ).toBeNull();
+  });
+
+  it("parses GitHub GraphQL repository image metadata", () => {
+    expect(
+      parseGitHubRepositoryImageGraphqlResponse(
+        JSON.stringify({
+          data: {
+            repository: {
+              openGraphImageUrl: "https://repository-images.githubusercontent.com/70107786/preview",
+              owner: {
+                avatarUrl: "https://avatars.githubusercontent.com/u/14985020?s=64&v=4",
+              },
+            },
+          },
+        }),
+      ),
+    ).toEqual({
+      openGraphImageUrl: "https://repository-images.githubusercontent.com/70107786/preview",
+      ownerAvatarUrl: "https://avatars.githubusercontent.com/u/14985020?s=64&v=4",
+    });
+
+    expect(parseGitHubRepositoryImageGraphqlResponse("{not-json")).toBeNull();
+    expect(parseGitHubRepositoryImageGraphqlResponse(JSON.stringify({ data: {} }))).toBeNull();
+  });
+
+  it("uses GitHub API metadata before falling back to public GitHub URLs", () => {
+    expect(
+      buildGitHubProjectImageCandidateUrls({
+        repository: { owner: "vercel", name: "next.js" },
+        repositoryImageMetadata: {
+          openGraphImageUrl: "https://repository-images.githubusercontent.com/70107786/preview",
+          ownerAvatarUrl: "https://avatars.githubusercontent.com/u/14985020?s=64&v=4",
+        },
+        repositoryHtml: null,
+      }),
+    ).toEqual([
+      "https://repository-images.githubusercontent.com/70107786/preview",
+      "https://avatars.githubusercontent.com/u/14985020?s=64&v=4",
+      "https://github.com/vercel.png?size=64",
+    ]);
+
+    expect(
+      buildGitHubProjectImageCandidateUrls({
+        repository: { owner: "pingdotgg", name: "t3code" },
+        repositoryImageMetadata: {
+          openGraphImageUrl: "https://opengraph.githubassets.com/hash/pingdotgg/t3code",
+          ownerAvatarUrl: "https://avatars.githubusercontent.com/u/89191727?s=64&v=4",
+        },
+        repositoryHtml: null,
+      }),
+    ).toEqual([
+      "https://avatars.githubusercontent.com/u/89191727?s=64&v=4",
+      "https://github.com/pingdotgg.png?size=64",
+    ]);
+  });
+
+  it("uses custom repository image before falling back to owner avatar", () => {
+    expect(
+      buildGitHubProjectImageCandidateUrls({
+        repository: { owner: "T3Tools", name: "t3code" },
+        repositoryHtml:
+          '<meta property="og:image" content="https://repository-images.githubusercontent.com/123/preview">',
+      }),
+    ).toEqual([
+      "https://repository-images.githubusercontent.com/123/preview",
+      "https://github.com/T3Tools.png?size=64",
+    ]);
+
+    expect(
+      buildGitHubProjectImageCandidateUrls({
+        repository: { owner: "T3Tools", name: "t3code" },
+        repositoryHtml:
+          '<meta property="og:image" content="https://opengraph.githubassets.com/hash/owner/repo">',
+      }),
+    ).toEqual(["https://github.com/T3Tools.png?size=64"]);
+  });
+});

--- a/apps/server/src/project/githubProjectImage.ts
+++ b/apps/server/src/project/githubProjectImage.ts
@@ -1,0 +1,212 @@
+import type { RepositoryIdentity } from "@t3tools/contracts";
+import { parseGitHubRepositoryNameWithOwnerFromRemoteUrl } from "@t3tools/shared/git";
+
+export interface GitHubRepositoryRef {
+  readonly owner: string;
+  readonly name: string;
+}
+
+export interface GitHubRepositoryImageMetadata {
+  readonly openGraphImageUrl: string | null;
+  readonly ownerAvatarUrl: string | null;
+}
+
+const GITHUB_REPOSITORY_PAGE_ORIGIN = "https://github.com";
+const GITHUB_GENERATED_OPEN_GRAPH_HOST = "opengraph.githubassets.com";
+const GITHUB_CUSTOM_REPOSITORY_IMAGE_HOST = "repository-images.githubusercontent.com";
+const GITHUB_OWNER_AVATAR_SIZE = 64;
+
+const META_TAG_RE = /<meta\b[^>]*>/gi;
+const META_ATTR_RE = /([a-zA-Z_:][-a-zA-Z0-9_:.]*)\s*=\s*["']([^"']*)["']/g;
+
+function normalizeGitHubPathSegment(value: string | null | undefined): string | null {
+  const trimmed = value?.trim().replace(/\.git$/i, "") ?? "";
+  if (trimmed.length === 0 || trimmed.includes("/") || trimmed.includes("\\")) {
+    return null;
+  }
+  return trimmed;
+}
+
+function parseGitHubRepositoryPath(value: string | null | undefined): GitHubRepositoryRef | null {
+  const trimmed = value?.trim() ?? "";
+  const match = /^github\.com\/([^/\s]+)\/([^/\s]+)$/i.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+
+  const owner = normalizeGitHubPathSegment(match[1]);
+  const name = normalizeGitHubPathSegment(match[2]);
+  return owner && name ? { owner, name } : null;
+}
+
+function parseGitHubRepositoryRemoteUrl(
+  value: string | null | undefined,
+): GitHubRepositoryRef | null {
+  const nameWithOwner = parseGitHubRepositoryNameWithOwnerFromRemoteUrl(value ?? null);
+  if (!nameWithOwner) {
+    return null;
+  }
+
+  const [rawOwner, rawName] = nameWithOwner.split("/");
+  const owner = normalizeGitHubPathSegment(rawOwner);
+  const name = normalizeGitHubPathSegment(rawName);
+  return owner && name ? { owner, name } : null;
+}
+
+function readMetaAttributes(tag: string): ReadonlyMap<string, string> {
+  const attrs = new Map<string, string>();
+  for (const match of tag.matchAll(META_ATTR_RE)) {
+    const name = match[1]?.toLowerCase();
+    const value = match[2];
+    if (name && value !== undefined) {
+      attrs.set(name, value);
+    }
+  }
+  return attrs;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizeHttpUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "https:" || url.protocol === "http:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+function isGitHubGeneratedOpenGraphImageUrl(value: string): boolean {
+  try {
+    return new URL(value).hostname === GITHUB_GENERATED_OPEN_GRAPH_HOST;
+  } catch {
+    return false;
+  }
+}
+
+function isGitHubCustomRepositoryImageUrl(value: string): boolean {
+  try {
+    return new URL(value).hostname === GITHUB_CUSTOM_REPOSITORY_IMAGE_HOST;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeGitHubCustomRepositoryImageUrl(value: string | null | undefined): string | null {
+  const url = normalizeHttpUrl(value);
+  if (!url || !isGitHubCustomRepositoryImageUrl(url) || isGitHubGeneratedOpenGraphImageUrl(url)) {
+    return null;
+  }
+  return url;
+}
+
+function pushUnique(urls: string[], value: string | null | undefined): void {
+  const url = normalizeHttpUrl(value);
+  if (url && !urls.includes(url)) {
+    urls.push(url);
+  }
+}
+
+export function resolveGitHubRepositoryRef(
+  repositoryIdentity: RepositoryIdentity | null | undefined,
+): GitHubRepositoryRef | null {
+  if (!repositoryIdentity) {
+    return null;
+  }
+
+  if (repositoryIdentity.provider?.toLowerCase() === "github") {
+    const owner = normalizeGitHubPathSegment(repositoryIdentity.owner);
+    const name = normalizeGitHubPathSegment(repositoryIdentity.name);
+    if (owner && name) {
+      return { owner, name };
+    }
+  }
+
+  return (
+    parseGitHubRepositoryPath(repositoryIdentity.canonicalKey) ??
+    parseGitHubRepositoryRemoteUrl(repositoryIdentity.locator.remoteUrl)
+  );
+}
+
+export function buildGitHubRepositoryPageUrl(repository: GitHubRepositoryRef): string {
+  const url = new URL(GITHUB_REPOSITORY_PAGE_ORIGIN);
+  url.pathname = `/${repository.owner}/${repository.name}`;
+  return url.toString();
+}
+
+export function buildGitHubOwnerAvatarUrl(repository: GitHubRepositoryRef): string {
+  const url = new URL(`${GITHUB_REPOSITORY_PAGE_ORIGIN}/${repository.owner}.png`);
+  url.searchParams.set("size", String(GITHUB_OWNER_AVATAR_SIZE));
+  return url.toString();
+}
+
+export function extractGitHubCustomRepositoryImageUrl(html: string): string | null {
+  for (const match of html.matchAll(META_TAG_RE)) {
+    const attrs = readMetaAttributes(match[0]);
+    if (attrs.get("property") !== "og:image") {
+      continue;
+    }
+
+    const content = attrs.get("content")?.trim();
+    const customRepositoryImageUrl = normalizeGitHubCustomRepositoryImageUrl(content);
+    if (customRepositoryImageUrl) {
+      return customRepositoryImageUrl;
+    }
+  }
+  return null;
+}
+
+export function parseGitHubRepositoryImageGraphqlResponse(
+  stdout: string,
+): GitHubRepositoryImageMetadata | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+
+  const root = asRecord(parsed);
+  const data = asRecord(root?.data);
+  const repository = asRecord(data?.repository);
+  if (!repository) {
+    return null;
+  }
+
+  const owner = asRecord(repository.owner);
+  return {
+    openGraphImageUrl:
+      typeof repository.openGraphImageUrl === "string" ? repository.openGraphImageUrl : null,
+    ownerAvatarUrl: typeof owner?.avatarUrl === "string" ? owner.avatarUrl : null,
+  };
+}
+
+export function buildGitHubProjectImageCandidateUrls(input: {
+  readonly repository: GitHubRepositoryRef;
+  readonly repositoryImageMetadata?: GitHubRepositoryImageMetadata | null;
+  readonly repositoryHtml: string | null;
+}): ReadonlyArray<string> {
+  const urls: string[] = [];
+  pushUnique(
+    urls,
+    normalizeGitHubCustomRepositoryImageUrl(input.repositoryImageMetadata?.openGraphImageUrl),
+  );
+  pushUnique(
+    urls,
+    input.repositoryHtml ? extractGitHubCustomRepositoryImageUrl(input.repositoryHtml) : null,
+  );
+  pushUnique(urls, input.repositoryImageMetadata?.ownerAvatarUrl);
+  const ownerAvatarUrl = buildGitHubOwnerAvatarUrl(input.repository);
+  pushUnique(urls, ownerAvatarUrl);
+
+  return urls;
+}

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -116,6 +116,11 @@ import * as ReviewService from "./review/ReviewService.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
 import { ServerSecretStoreLive } from "./auth/Layers/ServerSecretStore.ts";
 import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
+import {
+  ProcessRunner,
+  layer as ProcessRunnerLive,
+  type ProcessRunnerShape,
+} from "./processRunner.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
@@ -340,6 +345,7 @@ const buildAppUnderTest = (options?: {
     serverRuntimeStartup?: Partial<ServerRuntimeStartupShape>;
     serverEnvironment?: Partial<ServerEnvironmentShape>;
     repositoryIdentityResolver?: Partial<RepositoryIdentityResolverShape>;
+    processRunner?: Partial<ProcessRunnerShape>;
   };
 }) =>
   Effect.gen(function* () {
@@ -737,6 +743,13 @@ const buildAppUnderTest = (options?: {
       Layer.provideMerge(makeAuthTestLayer()),
       Layer.provide(workspaceAndProjectServicesLayer),
       Layer.provideMerge(FetchHttpClient.layer),
+      Layer.provideMerge(
+        options?.layers?.processRunner
+          ? Layer.mock(ProcessRunner)({
+              ...options.layers.processRunner,
+            })
+          : ProcessRunnerLive,
+      ),
       Layer.provide(layerConfig),
     );
 
@@ -1012,6 +1025,111 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
 
       assert.equal(response.status, 200);
       assert.include(yield* response.text, 'data-fallback="project-favicon"');
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("serves GitHub owner avatar metadata resolved through gh", () =>
+    Effect.gen(function* () {
+      const imageBytes = new Uint8Array([137, 80, 78, 71]);
+      const imageServer = yield* Effect.acquireRelease(
+        Effect.promise(async () => {
+          const NodeHttp = await import("node:http");
+
+          return await new Promise<{
+            readonly close: () => Promise<void>;
+            readonly url: string;
+          }>((resolve, reject) => {
+            const server = NodeHttp.createServer((_request, response) => {
+              response.statusCode = 200;
+              response.setHeader("content-type", "image/png");
+              response.setHeader("content-length", String(imageBytes.byteLength));
+              response.end(Buffer.from(imageBytes));
+            });
+
+            server.on("error", reject);
+            server.listen(0, "127.0.0.1", () => {
+              const address = server.address();
+              if (!address || typeof address === "string") {
+                reject(new Error("Expected TCP image server address"));
+                return;
+              }
+
+              resolve({
+                url: `http://127.0.0.1:${address.port}/avatar.png`,
+                close: () =>
+                  new Promise<void>((resolveClose, rejectClose) => {
+                    server.close((error) => {
+                      if (error) {
+                        rejectClose(error);
+                        return;
+                      }
+                      resolveClose();
+                    });
+                  }),
+              });
+            });
+          });
+        }),
+        ({ close }) => Effect.promise(close),
+      );
+
+      const fileSystem = yield* FileSystem.FileSystem;
+      const projectDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-router-project-favicon-github-",
+      });
+
+      yield* buildAppUnderTest({
+        layers: {
+          repositoryIdentityResolver: {
+            resolve: () =>
+              Effect.succeed({
+                canonicalKey: "github.com/pingdotgg/t3code",
+                locator: {
+                  source: "git-remote",
+                  remoteName: "origin",
+                  remoteUrl: "git@github.com:pingdotgg/t3code.git",
+                },
+                provider: "github",
+                owner: "pingdotgg",
+                name: "t3code",
+                rootPath: projectDir,
+              }),
+          },
+          processRunner: {
+            run: () =>
+              Effect.succeed({
+                stdout: JSON.stringify({
+                  data: {
+                    repository: {
+                      openGraphImageUrl: "https://opengraph.githubassets.com/hash/pingdotgg/t3code",
+                      owner: {
+                        avatarUrl: imageServer.url,
+                      },
+                    },
+                  },
+                }),
+                stderr: "",
+                code: ChildProcessSpawner.ExitCode(0),
+                timedOut: false,
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              }),
+          },
+        },
+      });
+
+      const response = yield* HttpClient.get(
+        `/api/project-favicon?cwd=${encodeURIComponent(projectDir)}&v=github-repo-image-v1`,
+        {
+          headers: {
+            cookie: yield* getAuthenticatedSessionCookieHeader(),
+          },
+        },
+      );
+
+      assert.equal(response.status, 200);
+      assert.equal(response.headers["content-type"], "image/png");
+      assert.deepEqual(Array.from(new Uint8Array(yield* response.arrayBuffer)), [...imageBytes]);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -79,6 +79,7 @@ import { ServerAuthLive } from "./auth/Layers/ServerAuth.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
+import { layer as ProcessRunnerLive } from "./processRunner.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
 import {
   clearPersistedServerRuntimeState,
@@ -281,6 +282,7 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(WorkspaceLayerLive),
   Layer.provideMerge(ProjectFaviconResolverLive),
   Layer.provideMerge(RepositoryIdentityResolverLive),
+  Layer.provideMerge(ProcessRunnerLive),
   Layer.provideMerge(ServerEnvironmentLive),
   Layer.provideMerge(AuthLayerLive),
 );

--- a/apps/web/src/components/ProjectFavicon.tsx
+++ b/apps/web/src/components/ProjectFavicon.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { resolveEnvironmentHttpUrl } from "../environments/runtime";
 
 const loadedProjectFaviconSrcs = new Set<string>();
+const PROJECT_FAVICON_URL_VERSION = "github-repo-image-v1";
 
 export function ProjectFavicon(input: {
   environmentId: EnvironmentId;
@@ -15,7 +16,7 @@ export function ProjectFavicon(input: {
       return resolveEnvironmentHttpUrl({
         environmentId: input.environmentId,
         pathname: "/api/project-favicon",
-        searchParams: { cwd: input.cwd },
+        searchParams: { cwd: input.cwd, v: PROJECT_FAVICON_URL_VERSION },
       });
     } catch {
       return null;


### PR DESCRIPTION
- Prefer GitHub open graph images and owner avatars for repository projects
- Add server-side GitHub image resolution with fallback favicon handling
- Bump favicon URL version in web and mobile clients

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The favicon route now runs `gh`, performs outbound fetches to GitHub, and proxies image bytes—bounded but new failure/SSRF-adjacent surface on an authenticated API; existing fallbacks limit user impact.
> 
> **Overview**
> **GitHub-backed project icons** now resolve before local favicon files on `/api/project-favicon`: the server maps the project `cwd` to a GitHub repo, tries `gh api graphql` for Open Graph / owner avatar URLs, optionally scrapes the repo page for a custom `repository-images` OG image (skipping generated Open Graph cards), then downloads the first valid remote image with timeouts and a 2MB cap. If that fails, behavior stays the same (local favicon path or SVG fallback).
> 
> **Web and mobile** append `v=github-repo-image-v1` on favicon requests so clients bust caches after this behavior change.
> 
> **Runtime wiring** adds `ProcessRunner` to the server stack; helper logic lives in `githubProjectImage.ts` with unit and HTTP integration coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 818e5612cff94027337ddab97b04a0b11a288499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add GitHub repository image resolution to project favicon API
> - The `/api/project-favicon` endpoint now attempts to fetch a GitHub-hosted repository image (custom OpenGraph image or owner avatar) when the project `cwd` corresponds to a GitHub repo, before falling back to local favicon resolution.
> - Resolution uses the `gh` CLI to query repository `openGraphImageUrl` and `ownerAvatarUrl` via GraphQL, with an HTML scrape fallback. Candidate URLs are prioritized by [buildGitHubProjectImageCandidateUrls](https://github.com/pingdotgg/t3code/pull/2881/files#diff-dc9ae4718cd475f8638309514b5962659a198b4adbfe359dcf8588171cf62117).
> - Remote image fetching enforces a size cap, content-type validation (`image/*`), and a timeout per request.
> - Both the mobile and web `ProjectFavicon` components append a `v=github-repo-image-v1` version query parameter to bust existing favicon caches.
> - `ProcessRunnerLive` is added to the live server runtime and exposed to route handlers via the dependency layer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 818e561.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->