### PR TITLE
Fix PR action controls

### DIFF
--- a/apps/web/src/components/GitActionsControl.browser.tsx
+++ b/apps/web/src/components/GitActionsControl.browser.tsx
@@ -25,12 +25,17 @@ function createDeferredPromise<T>() {
 const {
   activeRunStackedActionDeferredRef,
   activeDraftThreadRef,
+  composerDraftsByKeyRef,
   hasServerThreadRef,
+  vcsStatusOverrideRef,
+  archiveThreadSpy,
   invalidateSourceControlStateSpy,
   refreshVcsStatusSpy,
   runStackedActionSpy,
+  setComposerDraftPromptSpy,
   setDraftThreadContextSpy,
   setThreadBranchSpy,
+  submitPromptSpy,
   toastAddSpy,
   toastCloseSpy,
   toastPromiseSpy,
@@ -38,12 +43,17 @@ const {
 } = vi.hoisted(() => ({
   activeRunStackedActionDeferredRef: { current: createDeferredPromise<never>() },
   activeDraftThreadRef: { current: null as unknown },
+  composerDraftsByKeyRef: { current: {} as Record<string, { prompt: string }> },
   hasServerThreadRef: { current: true },
+  vcsStatusOverrideRef: { current: null as unknown },
+  archiveThreadSpy: vi.fn(() => Promise.resolve()),
   invalidateSourceControlStateSpy: vi.fn(() => Promise.resolve()),
   refreshVcsStatusSpy: vi.fn(() => Promise.resolve(null)),
   runStackedActionSpy: vi.fn(() => activeRunStackedActionDeferredRef.current.promise),
+  setComposerDraftPromptSpy: vi.fn(),
   setDraftThreadContextSpy: vi.fn(),
   setThreadBranchSpy: vi.fn(),
+  submitPromptSpy: vi.fn(() => true),
   toastAddSpy: vi.fn(() => "toast-1"),
   toastCloseSpy: vi.fn(),
   toastPromiseSpy: vi.fn(),
@@ -96,26 +106,36 @@ vi.mock("~/lib/sourceControlActions", () => ({
 vi.mock("~/lib/vcsStatusState", () => ({
   refreshVcsStatus: refreshVcsStatusSpy,
   resetVcsStatusStateForTests: () => undefined,
-  useVcsStatus: vi.fn(() => ({
-    data: {
-      isRepo: true,
-      sourceControlProvider: {
-        kind: "github",
-        name: "GitHub",
-        baseUrl: "https://github.com",
+  useVcsStatus: vi.fn(
+    () =>
+      vcsStatusOverrideRef.current ?? {
+        data: {
+          isRepo: true,
+          sourceControlProvider: {
+            kind: "github",
+            name: "GitHub",
+            baseUrl: "https://github.com",
+          },
+          hasPrimaryRemote: true,
+          isDefaultRef: false,
+          refName: BRANCH_NAME,
+          hasWorkingTreeChanges: false,
+          workingTree: { files: [], insertions: 0, deletions: 0 },
+          hasUpstream: true,
+          aheadCount: 1,
+          behindCount: 0,
+          pr: null,
+        },
+        error: null,
+        cause: null,
+        isPending: false,
       },
-      hasPrimaryRemote: true,
-      isDefaultRef: false,
-      refName: BRANCH_NAME,
-      hasWorkingTreeChanges: false,
-      workingTree: { files: [], insertions: 0, deletions: 0 },
-      hasUpstream: true,
-      aheadCount: 1,
-      behindCount: 0,
-      pr: null,
-    },
-    error: null,
-    isPending: false,
+  ),
+}));
+
+vi.mock("~/hooks/useThreadActions", () => ({
+  useThreadActions: vi.fn(() => ({
+    archiveThread: archiveThreadSpy,
   })),
 }));
 
@@ -126,13 +146,23 @@ vi.mock("~/localApi", () => ({
   readLocalApi: vi.fn(() => null),
 }));
 
+function composerDraftKey(target: string | { environmentId: string; threadId: string }) {
+  return typeof target === "string" ? target : `${target.environmentId}:${target.threadId}`;
+}
+
 vi.mock("~/composerDraftStore", async () => {
   const draftStoreState = {
+    getComposerDraft: (target: string | { environmentId: string; threadId: string }) =>
+      composerDraftsByKeyRef.current[composerDraftKey(target)] ?? null,
     getDraftThreadByRef: () => activeDraftThreadRef.current,
     getDraftSession: () => activeDraftThreadRef.current,
     getDraftThread: () => activeDraftThreadRef.current,
     getDraftSessionByLogicalProjectKey: () => null,
     setDraftThreadContext: setDraftThreadContextSpy,
+    setPrompt: (target: string | { environmentId: string; threadId: string }, prompt: string) => {
+      setComposerDraftPromptSpy(target, prompt);
+      composerDraftsByKeyRef.current[composerDraftKey(target)] = { prompt };
+    },
     setLogicalProjectDraftThreadId: vi.fn(),
     setProjectDraftThreadId: vi.fn(),
     hasDraftThreadsInEnvironment: () => false,
@@ -269,7 +299,10 @@ describe("GitActionsControl thread-scoped progress toast", () => {
     vi.clearAllMocks();
     activeRunStackedActionDeferredRef.current = createDeferredPromise<never>();
     activeDraftThreadRef.current = null;
+    composerDraftsByKeyRef.current = {};
     hasServerThreadRef.current = true;
+    vcsStatusOverrideRef.current = null;
+    archiveThreadSpy.mockClear();
     document.body.innerHTML = "";
   });
 
@@ -448,6 +481,152 @@ describe("GitActionsControl thread-scoped progress toast", () => {
 
       expect(setDraftThreadContextSpy).not.toHaveBeenCalled();
       expect(setThreadBranchSpy).not.toHaveBeenCalled();
+    } finally {
+      await screen.unmount();
+      host.remove();
+    }
+  });
+
+  it("submits a conflicting pull request prompt", async () => {
+    vcsStatusOverrideRef.current = {
+      data: {
+        isRepo: true,
+        sourceControlProvider: {
+          kind: "github",
+          name: "GitHub",
+          baseUrl: "https://github.com",
+        },
+        hasPrimaryRemote: true,
+        isDefaultRef: false,
+        refName: BRANCH_NAME,
+        hasWorkingTreeChanges: false,
+        workingTree: { files: [], insertions: 0, deletions: 0 },
+        hasUpstream: true,
+        aheadCount: 0,
+        behindCount: 0,
+        pr: {
+          number: 43,
+          title: "Conflict PR",
+          url: "https://github.com/example/repo/pull/43",
+          baseRef: "main",
+          headRef: BRANCH_NAME,
+          state: "open",
+          mergeStatus: "conflicting",
+        },
+      },
+      error: null,
+      cause: null,
+      isPending: false,
+    };
+
+    const threadRef = scopeThreadRef(ENVIRONMENT_A, SHARED_THREAD_ID);
+    const host = document.createElement("div");
+    document.body.append(host);
+    const screen = await render(
+      <GitActionsControl
+        gitCwd={GIT_CWD}
+        activeThreadRef={threadRef}
+        onSubmitPrompt={submitPromptSpy}
+      />,
+      {
+        container: host,
+      },
+    );
+
+    try {
+      const resolveConflictsButton = findButtonByText("Resolve conflicts");
+      expect(
+        resolveConflictsButton,
+        'Unable to find button containing "Resolve conflicts"',
+      ).toBeTruthy();
+      if (!(resolveConflictsButton instanceof HTMLButtonElement)) {
+        throw new Error('Unable to find button containing "Resolve conflicts"');
+      }
+
+      resolveConflictsButton.click();
+
+      expect(submitPromptSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Resolve the merge conflicts for PR #43 (Conflict PR)."),
+      );
+      expect(setComposerDraftPromptSpy).not.toHaveBeenCalled();
+      expect(toastAddSpy).not.toHaveBeenCalled();
+    } finally {
+      await screen.unmount();
+      host.remove();
+    }
+  });
+
+  it("requires a second click before archiving a merged pull request thread", async () => {
+    vcsStatusOverrideRef.current = {
+      data: {
+        isRepo: true,
+        sourceControlProvider: {
+          kind: "github",
+          name: "GitHub",
+          baseUrl: "https://github.com",
+        },
+        hasPrimaryRemote: true,
+        isDefaultRef: false,
+        refName: BRANCH_NAME,
+        hasWorkingTreeChanges: false,
+        workingTree: { files: [], insertions: 0, deletions: 0 },
+        hasUpstream: true,
+        aheadCount: 0,
+        behindCount: 0,
+        pr: {
+          number: 42,
+          title: "Merged PR",
+          url: "https://github.com/example/repo/pull/42",
+          baseRef: "main",
+          headRef: BRANCH_NAME,
+          state: "merged",
+        },
+      },
+      error: null,
+      cause: null,
+      isPending: false,
+    };
+
+    const host = document.createElement("div");
+    document.body.append(host);
+    const screen = await render(
+      <GitActionsControl
+        gitCwd={GIT_CWD}
+        activeThreadRef={scopeThreadRef(ENVIRONMENT_A, SHARED_THREAD_ID)}
+      />,
+      {
+        container: host,
+      },
+    );
+
+    try {
+      const mergedButton = findButtonByText("Merged");
+      expect(mergedButton, 'Unable to find button containing "Merged"').toBeTruthy();
+      if (!(mergedButton instanceof HTMLButtonElement)) {
+        throw new Error('Unable to find button containing "Merged"');
+      }
+
+      mergedButton.click();
+
+      await vi.waitFor(() => {
+        expect(findButtonByText("Archive")).toBeTruthy();
+      });
+      expect(archiveThreadSpy).not.toHaveBeenCalled();
+
+      const archiveButton = findButtonByText("Archive");
+      expect(archiveButton, 'Unable to find button containing "Archive"').toBeTruthy();
+      if (!(archiveButton instanceof HTMLButtonElement)) {
+        throw new Error('Unable to find button containing "Archive"');
+      }
+      expect(archiveButton.className).toContain("border-destructive");
+
+      archiveButton.click();
+
+      await vi.waitFor(() => {
+        expect(archiveThreadSpy).toHaveBeenCalledWith(
+          scopeThreadRef(ENVIRONMENT_A, SHARED_THREAD_ID),
+        );
+      });
     } finally {
       await screen.unmount();
       host.remove();

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1,6 +1,7 @@
-import type { VcsStatusResult } from "@t3tools/contracts";
+import { EnvironmentId, ThreadId, type VcsStatusResult } from "@t3tools/contracts";
 import { assert, describe, it } from "vitest";
 import {
+  buildGitAgentPrompt,
   buildGitActionProgressStages,
   buildMenuItems,
   requiresDefaultBranchConfirmation,
@@ -30,6 +31,73 @@ function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
     ...overrides,
   };
 }
+
+describe("buildGitAgentPrompt", () => {
+  it("includes workspace, repo, branch, PR, and selected file context", () => {
+    const prompt = buildGitAgentPrompt({
+      intent: "commit_push_pr",
+      cwd: "/repo/t3code",
+      threadRef: {
+        environmentId: EnvironmentId.make("env-1"),
+        threadId: ThreadId.make("thread-1"),
+      },
+      commitMessage: "feat: route github actions through prompts",
+      filePaths: ["apps/web/src/components/GitActionsControl.tsx"],
+      gitStatus: status({
+        refName: "feature/prompt-github-actions",
+        hasWorkingTreeChanges: true,
+        aheadCount: 2,
+        behindCount: 0,
+        aheadOfDefaultCount: 3,
+        behindOfDefaultCount: 1,
+        sourceControlProvider: {
+          kind: "github",
+          name: "GitHub",
+          baseUrl: "https://github.com",
+        },
+        workingTree: {
+          files: [
+            {
+              path: "apps/web/src/components/GitActionsControl.tsx",
+              insertions: 120,
+              deletions: 20,
+            },
+          ],
+          insertions: 120,
+          deletions: 20,
+        },
+        pr: {
+          number: 42,
+          title: "Prompt GitHub actions",
+          url: "https://github.com/pingdotgg/t3code/pull/42",
+          baseRef: "main",
+          headRef: "feature/prompt-github-actions",
+          state: "open",
+          mergeStatus: "behind",
+          checks: {
+            total: 3,
+            completed: 2,
+            successful: 2,
+            failed: 0,
+            pending: 1,
+          },
+        },
+      }),
+    });
+
+    assert.include(prompt, "Workspace path: /repo/t3code");
+    assert.include(prompt, "Repository: pingdotgg/t3code");
+    assert.include(prompt, "Source control provider: GitHub (github, https://github.com)");
+    assert.include(prompt, "Current ref: feature/prompt-github-actions");
+    assert.include(prompt, "Ahead/behind base: 3 ahead / 1 behind");
+    assert.include(prompt, "apps/web/src/components/GitActionsControl.tsx (+120 / -20)");
+    assert.include(prompt, "User-selected file scope");
+    assert.include(prompt, "Pull request: #42 Prompt GitHub actions");
+    assert.include(prompt, "Checks: 2/3 complete, 2 successful, 0 failed, 1 pending");
+    assert.include(prompt, "git status --short --branch");
+    assert.include(prompt, "git remote -v");
+  });
+});
 
 describe("when: ref is clean and has an open PR", () => {
   it("resolveQuickAction opens the existing PR", () => {
@@ -91,6 +159,176 @@ describe("when: ref is clean and has an open PR", () => {
   });
 });
 
+describe("when: PR status has merge metadata", () => {
+  it("resolveQuickAction shows merged PRs as merged", () => {
+    const quick = resolveQuickAction(
+      status({
+        pr: {
+          number: 20,
+          title: "Merged PR",
+          url: "https://example.com/pr/20",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "merged",
+        },
+      }),
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "open_pr",
+      label: "Merged",
+      tone: "merged",
+      disabled: false,
+    });
+  });
+
+  it("resolveQuickAction disables while checks are still running", () => {
+    const quick = resolveQuickAction(
+      status({
+        pr: {
+          number: 21,
+          title: "Pending checks",
+          url: "https://example.com/pr/21",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "open",
+          mergeStatus: "mergeable",
+          checks: {
+            total: 4,
+            completed: 2,
+            successful: 2,
+            failed: 0,
+            pending: 2,
+          },
+        },
+      }),
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "show_hint",
+      label: "2 / 4 Checks",
+      tone: "warning",
+      disabled: true,
+    });
+  });
+
+  it("buildMenuItems keeps View PR available while checks are still running", () => {
+    const items = buildMenuItems(
+      status({
+        pr: {
+          number: 21,
+          title: "Pending checks",
+          url: "https://example.com/pr/21",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "open",
+          mergeStatus: "mergeable",
+          checks: {
+            total: 4,
+            completed: 2,
+            successful: 2,
+            failed: 0,
+            pending: 2,
+          },
+        },
+      }),
+      false,
+    );
+
+    assert.deepInclude(items[2] ?? {}, {
+      id: "pr",
+      kind: "open_pr",
+      label: "View PR",
+      disabled: false,
+    });
+  });
+
+  it("resolveQuickAction prompts the agent for conflicts", () => {
+    const quick = resolveQuickAction(
+      status({
+        pr: {
+          number: 22,
+          title: "Conflict PR",
+          url: "https://example.com/pr/22",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "open",
+          mergeStatus: "conflicting",
+        },
+      }),
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "prompt_ai",
+      label: "Resolve conflicts",
+      tone: "destructive",
+      disabled: false,
+    });
+    assert.include(quick.prompt ?? "", "Resolve the merge conflicts");
+  });
+
+  it("resolveQuickAction prefers conflicts over running checks", () => {
+    const quick = resolveQuickAction(
+      status({
+        pr: {
+          number: 22,
+          title: "Conflict PR",
+          url: "https://example.com/pr/22",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "open",
+          mergeStatus: "conflicting",
+          checks: {
+            total: 4,
+            completed: 2,
+            successful: 2,
+            failed: 0,
+            pending: 2,
+          },
+        },
+      }),
+      false,
+    );
+
+    assert.deepInclude(quick, {
+      kind: "prompt_ai",
+      label: "Resolve conflicts",
+      tone: "destructive",
+      disabled: false,
+    });
+  });
+
+  it("resolveQuickAction shows merge when a clean PR is mergeable", () => {
+    const quick = resolveQuickAction(
+      status({
+        pr: {
+          number: 23,
+          title: "Mergeable PR",
+          url: "https://example.com/pr/23",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "open",
+          mergeStatus: "mergeable",
+          checks: {
+            total: 2,
+            completed: 2,
+            successful: 2,
+            failed: 0,
+            pending: 0,
+          },
+        },
+      }),
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "open_pr",
+      label: "Merge",
+      tone: "success",
+      disabled: false,
+    });
+  });
+});
+
 describe("when: actions are busy", () => {
   it("resolveQuickAction returns running disabled state", () => {
     const quick = resolveQuickAction(status(), true);
@@ -130,6 +368,29 @@ describe("when: actions are busy", () => {
         dialogAction: "create_pr",
       },
     ]);
+  });
+
+  it("buildMenuItems keeps existing PR links enabled while actions are busy", () => {
+    const items = buildMenuItems(
+      status({
+        pr: {
+          number: 24,
+          title: "Open PR",
+          url: "https://example.com/pr/24",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "open",
+        },
+      }),
+      true,
+    );
+
+    assert.deepInclude(items[2] ?? {}, {
+      id: "pr",
+      label: "View PR",
+      disabled: false,
+      kind: "open_pr",
+    });
   });
 });
 
@@ -342,7 +603,7 @@ describe("when: ref is clean, up to date, and has no open PR", () => {
 describe("when: ref is behind upstream", () => {
   it("resolveQuickAction returns pull", () => {
     const quick = resolveQuickAction(status({ behindCount: 2 }), false);
-    assert.deepInclude(quick, { kind: "run_pull", label: "Pull", disabled: false });
+    assert.deepInclude(quick, { kind: "run_pull", label: "Rebase / pull", disabled: false });
   });
 
   it("buildMenuItems disables push and create PR", () => {
@@ -376,14 +637,53 @@ describe("when: ref is behind upstream", () => {
   });
 });
 
+describe("when: ref is behind its base branch", () => {
+  it("resolveQuickAction returns update from base", () => {
+    const quick = resolveQuickAction(
+      status({ aheadOfDefaultCount: 1, behindOfDefaultCount: 2 }),
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "run_sync_base",
+      label: "Update from base",
+      disabled: false,
+      tone: "warning",
+    });
+  });
+
+  it("resolveQuickAction asks for a clean tree before updating from base", () => {
+    const quick = resolveQuickAction(
+      status({ hasWorkingTreeChanges: true, behindOfDefaultCount: 1 }),
+      false,
+    );
+    assert.deepEqual(quick, {
+      label: "Update from base",
+      disabled: true,
+      kind: "show_hint",
+      hint: "Commit or stash local changes before updating from the base branch.",
+      tone: "warning",
+    });
+  });
+
+  it("buildMenuItems disables push and create PR", () => {
+    const items = buildMenuItems(
+      status({ aheadCount: 1, aheadOfDefaultCount: 1, behindOfDefaultCount: 1, pr: null }),
+      false,
+    );
+    assert.equal(items.find((item) => item.id === "push")?.disabled, true);
+    assert.equal(items.find((item) => item.id === "pr")?.disabled, true);
+  });
+});
+
 describe("when: ref has diverged from upstream", () => {
   it("resolveQuickAction returns a disabled sync hint", () => {
     const quick = resolveQuickAction(status({ aheadCount: 2, behindCount: 1 }), false);
     assert.deepEqual(quick, {
-      label: "Sync ref",
+      label: "Rebase / pull",
       disabled: true,
       kind: "show_hint",
       hint: "Branch has diverged from upstream. Rebase/merge first.",
+      tone: "warning",
     });
   });
 });
@@ -431,7 +731,37 @@ describe("when: working tree has local changes", () => {
     assert.deepInclude(quick, {
       kind: "run_action",
       action: "commit_push",
-      label: "Commit & push",
+      label: "Commit and push",
+    });
+  });
+
+  it("resolveQuickAction returns commit and push when open PR checks are pending", () => {
+    const quick = resolveQuickAction(
+      status({
+        hasWorkingTreeChanges: true,
+        pr: {
+          number: 16,
+          title: "Existing PR",
+          url: "https://example.com/pr/16",
+          baseRef: "main",
+          headRef: "feature/test",
+          state: "open",
+          mergeStatus: "mergeable",
+          checks: {
+            total: 2,
+            completed: 1,
+            successful: 1,
+            failed: 0,
+            pending: 1,
+          },
+        },
+      }),
+      false,
+    );
+    assert.deepInclude(quick, {
+      kind: "run_action",
+      action: "commit_push",
+      label: "Commit and push",
     });
   });
 
@@ -518,7 +848,7 @@ describe("when: on default ref without open PR", () => {
     assert.deepInclude(quick, {
       kind: "run_action",
       action: "commit_push",
-      label: "Commit & push",
+      label: "Commit and push",
       disabled: false,
     });
   });
@@ -539,15 +869,15 @@ describe("when: on default ref without open PR", () => {
 });
 
 describe("when: working tree has local changes and ref is behind upstream", () => {
-  it("resolveQuickAction still prefers commit, push, and create PR", () => {
+  it("resolveQuickAction prefers pull over commit, push, and create PR", () => {
     const quick = resolveQuickAction(
       status({ hasWorkingTreeChanges: true, behindCount: 1 }),
       false,
     );
     assert.deepInclude(quick, {
-      kind: "run_action",
-      action: "commit_push_pr",
-      label: "Commit, push & PR",
+      kind: "run_pull",
+      label: "Rebase / pull",
+      disabled: false,
     });
   });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -1,6 +1,7 @@
 import type {
   GitRunStackedActionResult,
   GitStackedAction,
+  ScopedThreadRef,
   VcsStatusResult,
 } from "@t3tools/contracts";
 import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
@@ -19,16 +20,26 @@ export interface GitActionMenuItem {
   label: string;
   disabled: boolean;
   icon: GitActionIconName;
-  kind: "open_dialog" | "open_pr";
+  kind: "open_dialog" | "open_pr" | "prompt_ai";
   dialogAction?: GitDialogAction;
+  prompt?: string;
 }
 
 export interface GitQuickAction {
   label: string;
   disabled: boolean;
-  kind: "run_action" | "run_pull" | "open_pr" | "open_publish" | "show_hint";
+  kind:
+    | "run_action"
+    | "run_pull"
+    | "run_sync_base"
+    | "open_pr"
+    | "open_publish"
+    | "prompt_ai"
+    | "show_hint";
   action?: GitStackedAction;
   hint?: string;
+  tone?: "default" | "success" | "merged" | "warning" | "destructive";
+  prompt?: string;
 }
 
 export interface DefaultBranchActionDialogCopy {
@@ -43,12 +54,298 @@ export type DefaultBranchConfirmableAction =
   | "commit_push"
   | "commit_push_pr";
 
+export type GitAgentPromptIntent =
+  | "initialize"
+  | "commit"
+  | "push"
+  | "create_pr"
+  | "commit_push"
+  | "commit_push_pr"
+  | "pull"
+  | "sync_base"
+  | "publish_repository"
+  | "inspect_pr"
+  | "merge_pr"
+  | "resolve_conflicts"
+  | "review_pr_comments"
+  | "archive_merged_thread"
+  | "recover_status";
+
+export interface BuildGitAgentPromptInput {
+  readonly intent: GitAgentPromptIntent;
+  readonly cwd: string | null;
+  readonly gitStatus: VcsStatusResult | null;
+  readonly threadRef: ScopedThreadRef | null;
+  readonly commitMessage?: string;
+  readonly filePaths?: readonly string[];
+  readonly promptHint?: string;
+  readonly unreadCommentCount?: number;
+}
+
 function resolveChangeRequestTerminology(
   gitStatus: VcsStatusResult | null,
 ): ChangeRequestTerminology {
   return gitStatus?.sourceControlProvider
     ? getChangeRequestTerminology(gitStatus.sourceControlProvider)
     : DEFAULT_CHANGE_REQUEST_TERMINOLOGY;
+}
+
+function formatChecksLabel(
+  checks: NonNullable<NonNullable<VcsStatusResult["pr"]>["checks"]>,
+): string {
+  return `${checks.completed} / ${checks.total} Checks`;
+}
+
+function resolveChangeRequestPrompt(input: {
+  action: "resolve_conflicts" | "sync_base";
+  gitStatus: VcsStatusResult;
+}): string {
+  const pr = input.gitStatus.pr;
+  const branch = input.gitStatus.refName ?? pr?.headRef ?? "the current branch";
+  const baseRef = pr?.baseRef ?? "the base branch";
+
+  if (input.action === "resolve_conflicts") {
+    return [
+      `Resolve the merge conflicts for ${pr ? `PR #${pr.number} (${pr.title})` : "the current pull request"}.`,
+      `Current branch: ${branch}`,
+      `Base branch: ${baseRef}`,
+      "Update the branch safely, resolve conflicts, run the relevant checks, and commit the conflict resolution.",
+    ].join("\n");
+  }
+
+  return [
+    `Update ${branch} against ${baseRef}${pr ? ` for PR #${pr.number} (${pr.title})` : ""}.`,
+    "Prefer a rebase when it is safe for this branch; otherwise pull/merge according to the repository's conventions.",
+    "Resolve any conflicts, run the relevant checks, and push the updated branch if needed.",
+  ].join("\n");
+}
+
+function isPrMergeable(pr: NonNullable<VcsStatusResult["pr"]>): boolean {
+  return (
+    pr.state === "open" &&
+    pr.mergeStatus === "mergeable" &&
+    (pr.checks === undefined || (pr.checks.pending === 0 && pr.checks.failed === 0))
+  );
+}
+
+function isPrWaitingOnChecks(pr: NonNullable<VcsStatusResult["pr"]>): boolean {
+  return (
+    pr.state === "open" &&
+    pr.mergeStatus === "mergeable" &&
+    pr.checks !== undefined &&
+    pr.checks.pending > 0 &&
+    pr.checks.failed === 0
+  );
+}
+
+function formatYesNo(value: boolean): string {
+  return value ? "yes" : "no";
+}
+
+function formatOptional(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "unknown";
+  if (typeof value === "boolean") return formatYesNo(value);
+  return String(value);
+}
+
+function inferRepositoryLabel(gitStatus: VcsStatusResult | null): string {
+  const prUrl = gitStatus?.pr?.url;
+  if (prUrl) {
+    try {
+      const url = new URL(prUrl);
+      const pathParts = url.pathname.split("/").filter(Boolean);
+      if (url.hostname === "github.com" && pathParts.length >= 2) {
+        return `${pathParts[0]}/${pathParts[1]}`;
+      }
+      const mergeRequestMarker = pathParts.indexOf("-");
+      if (mergeRequestMarker > 0) {
+        return `${url.hostname}/${pathParts.slice(0, mergeRequestMarker).join("/")}`;
+      }
+      if (pathParts.length >= 2) {
+        return `${url.hostname}/${pathParts.slice(0, 2).join("/")}`;
+      }
+      return url.hostname;
+    } catch {
+      return "inspect with `git remote -v`";
+    }
+  }
+  return "inspect with `git remote -v`";
+}
+
+function formatWorkingTree(gitStatus: VcsStatusResult | null): string[] {
+  if (!gitStatus) return ["- Working tree: unknown"];
+  const files = gitStatus.workingTree.files;
+  const lines = [
+    `- Working tree: ${gitStatus.hasWorkingTreeChanges ? "has local changes" : "clean"}`,
+    `- Working tree totals: +${gitStatus.workingTree.insertions} / -${gitStatus.workingTree.deletions}`,
+  ];
+  if (files.length === 0) {
+    lines.push("- Changed files: none reported");
+    return lines;
+  }
+  lines.push("- Changed files:");
+  for (const file of files.slice(0, 20)) {
+    lines.push(`  - ${file.path} (+${file.insertions} / -${file.deletions})`);
+  }
+  if (files.length > 20) {
+    lines.push(`  - ...and ${files.length - 20} more`);
+  }
+  return lines;
+}
+
+function formatPullRequest(gitStatus: VcsStatusResult | null): string[] {
+  const pr = gitStatus?.pr;
+  if (!pr) return ["- Pull request: none detected"];
+  return [
+    `- Pull request: #${pr.number} ${pr.title}`,
+    `- Pull request URL: ${pr.url}`,
+    `- Pull request state: ${pr.state}`,
+    `- Pull request refs: ${pr.headRef} -> ${pr.baseRef}`,
+    `- Merge status: ${formatOptional(pr.mergeStatus)}`,
+    `- Checks: ${
+      pr.checks
+        ? `${pr.checks.completed}/${pr.checks.total} complete, ${pr.checks.successful} successful, ${pr.checks.failed} failed, ${pr.checks.pending} pending`
+        : "unknown"
+    }`,
+  ];
+}
+
+function resolveAgentTask(input: BuildGitAgentPromptInput): string[] {
+  const terms = resolveChangeRequestTerminology(input.gitStatus);
+  switch (input.intent) {
+    case "initialize":
+      return [
+        "Initialize git for this workspace.",
+        "Create an initial commit only if it is appropriate after inspecting the project and repository expectations.",
+      ];
+    case "commit":
+      return [
+        "Commit the relevant local changes.",
+        input.commitMessage
+          ? `Use this commit message unless the diff clearly requires a safer correction: ${input.commitMessage}`
+          : "Generate a concise, conventional commit message from the actual diff.",
+      ];
+    case "push":
+      return ["Push the current branch to the correct remote/upstream."];
+    case "create_pr":
+      return [
+        `Create a ${terms.singular} for the current branch.`,
+        "Push the branch first if it has unpublished commits or no upstream.",
+        `Generate a clear ${terms.shortLabel} title and body from the commits and diff.`,
+      ];
+    case "commit_push":
+      return [
+        "Commit the relevant local changes, then push the branch.",
+        input.commitMessage
+          ? `Use this commit message unless the diff clearly requires a safer correction: ${input.commitMessage}`
+          : "Generate a concise, conventional commit message from the actual diff.",
+      ];
+    case "commit_push_pr":
+      return [
+        `Commit the relevant local changes, push the branch, and create a ${terms.singular}.`,
+        input.commitMessage
+          ? `Use this commit message unless the diff clearly requires a safer correction: ${input.commitMessage}`
+          : "Generate a concise, conventional commit message from the actual diff.",
+        `Generate a clear ${terms.shortLabel} title and body from the commits and diff.`,
+      ];
+    case "pull":
+      return [
+        "Update the current branch from upstream.",
+        "Prefer a rebase when it is safe for this branch; otherwise follow this repository's conventions.",
+      ];
+    case "sync_base":
+      return [
+        "Update the current branch against its base/default branch.",
+        "Prefer a rebase when it is safe; resolve conflicts carefully and push the updated branch if needed.",
+      ];
+    case "publish_repository":
+      return [
+        "Publish this local repository to GitHub or the configured source control provider.",
+        "Inspect remotes first, create or select the correct remote repository, add the remote, and push the current branch.",
+      ];
+    case "inspect_pr":
+      return [
+        `Inspect the current ${terms.singular}.`,
+        "Summarize state, checks, review comments, and any required follow-up work.",
+      ];
+    case "merge_pr":
+      return [
+        `Verify the current ${terms.singular} is safe to merge, then merge it if appropriate.`,
+        "Confirm checks, review state, base/head refs, and repository policy before merging.",
+      ];
+    case "resolve_conflicts":
+      return [
+        `Resolve merge conflicts for the current ${terms.singular}.`,
+        "Update from the base branch, resolve conflicts, run relevant checks, commit the conflict resolution, and push.",
+      ];
+    case "review_pr_comments":
+      return [
+        `Review and address ${input.unreadCommentCount ? `${input.unreadCommentCount} unread ` : ""}${terms.shortLabel} comments.`,
+        "Fetch review comments, identify actionable feedback, implement fixes, run relevant checks, commit, and push.",
+      ];
+    case "archive_merged_thread":
+      return [
+        `The ${terms.singular} appears to be merged. Verify final GitHub state and clean up anything appropriate.`,
+        "If the work is complete, summarize whether this T3 Code thread can be archived.",
+      ];
+    case "recover_status":
+      return [
+        "Inspect and recover the git/source-control state for this workspace.",
+        "Report what is blocking the normal GitHub workflow and fix it when safe.",
+      ];
+  }
+}
+
+export function buildGitAgentPrompt(input: BuildGitAgentPromptInput): string {
+  const gitStatus = input.gitStatus;
+  const provider = gitStatus?.sourceControlProvider;
+  const selectedFiles = input.filePaths?.filter((path) => path.trim().length > 0) ?? [];
+  const taskLines = resolveAgentTask(input);
+  const lines = [
+    "Handle this Git/GitHub workflow from the current workspace.",
+    "",
+    "Task:",
+    ...taskLines.map((line) => `- ${line}`),
+    "",
+    "Workspace and repo context:",
+    `- Workspace path: ${formatOptional(input.cwd)}`,
+    `- Environment id: ${formatOptional(input.threadRef?.environmentId)}`,
+    `- Thread id: ${formatOptional(input.threadRef?.threadId)}`,
+    `- Repository: ${inferRepositoryLabel(gitStatus)}`,
+    `- Source control provider: ${provider ? `${provider.name} (${provider.kind}, ${provider.baseUrl})` : "unknown"}`,
+    `- Is git repository: ${gitStatus ? formatYesNo(gitStatus.isRepo) : "unknown"}`,
+    `- Has primary remote: ${gitStatus ? formatYesNo(gitStatus.hasPrimaryRemote) : "unknown"}`,
+    "",
+    "Branch context:",
+    `- Current ref: ${formatOptional(gitStatus?.refName)}`,
+    `- Default ref: ${gitStatus ? formatYesNo(gitStatus.isDefaultRef) : "unknown"}`,
+    `- Has upstream: ${gitStatus ? formatYesNo(gitStatus.hasUpstream) : "unknown"}`,
+    `- Ahead/behind upstream: ${formatOptional(gitStatus?.aheadCount)} ahead / ${formatOptional(gitStatus?.behindCount)} behind`,
+    `- Ahead/behind base: ${formatOptional(gitStatus?.aheadOfDefaultCount)} ahead / ${formatOptional(gitStatus?.behindOfDefaultCount)} behind`,
+    "",
+    "Local changes:",
+    ...formatWorkingTree(gitStatus),
+    ...(selectedFiles.length > 0
+      ? ["- User-selected file scope:", ...selectedFiles.map((path) => `  - ${path}`)]
+      : []),
+    "",
+    "Pull request context:",
+    ...formatPullRequest(gitStatus),
+    "",
+    "Operational requirements:",
+    "- Start by inspecting `git status --short --branch`, `git remote -v`, and the relevant branch/upstream configuration.",
+    "- Use GitHub CLI or the configured source-control tooling for provider interactions when available.",
+    "- Do not force-push unless it is clearly required and safe; explain before doing it.",
+    "- Keep commits focused. Do not include unrelated files.",
+    "- Run the relevant lightweight checks for the touched code before reporting completion.",
+    "- Report exactly what changed, what was pushed, and any pull request URL or remaining blocker.",
+  ];
+
+  if (input.promptHint?.trim()) {
+    lines.push("", "Additional context:", input.promptHint.trim());
+  }
+
+  return lines.join("\n");
 }
 
 export function buildGitActionProgressStages(input: {
@@ -103,6 +400,7 @@ export function buildMenuItems(
   const hasChanges = gitStatus.hasWorkingTreeChanges;
   const hasOpenPr = gitStatus.pr?.state === "open";
   const isBehind = gitStatus.behindCount > 0;
+  const isBehindBase = (gitStatus.behindOfDefaultCount ?? 0) > 0 && !gitStatus.isDefaultRef;
   const hasDefaultBranchDelta = (gitStatus.aheadOfDefaultCount ?? gitStatus.aheadCount) > 0;
   const canPushWithoutUpstream = hasPrimaryRemote && !gitStatus.hasUpstream;
   const canCommit = !isBusy && hasChanges;
@@ -110,6 +408,7 @@ export function buildMenuItems(
     !isBusy &&
     hasBranch &&
     !isBehind &&
+    !isBehindBase &&
     gitStatus.aheadCount > 0 &&
     (gitStatus.hasUpstream || canPushWithoutUpstream);
   const canCreatePr =
@@ -119,8 +418,14 @@ export function buildMenuItems(
     !hasOpenPr &&
     hasDefaultBranchDelta &&
     !isBehind &&
+    !isBehindBase &&
     (gitStatus.hasUpstream || canPushWithoutUpstream);
-  const canOpenPr = !isBusy && hasOpenPr;
+  const prItemLabel = (() => {
+    const pr = gitStatus.pr;
+    if (!pr) return `Create ${terminology.shortLabel}`;
+    if (pr.state === "merged") return "Merged";
+    return `View ${terminology.shortLabel}`;
+  })();
 
   const commitItem: GitActionMenuItem = {
     id: "commit",
@@ -145,11 +450,11 @@ export function buildMenuItems(
       kind: "open_dialog",
       dialogAction: "push",
     },
-    hasOpenPr
+    gitStatus.pr
       ? {
           id: "pr",
-          label: `View ${terminology.shortLabel}`,
-          disabled: !canOpenPr,
+          label: prItemLabel,
+          disabled: false,
           icon: "pr",
           kind: "open_pr",
         }
@@ -185,10 +490,12 @@ export function resolveQuickAction(
 
   const hasBranch = gitStatus.refName !== null;
   const hasChanges = gitStatus.hasWorkingTreeChanges;
-  const hasOpenPr = gitStatus.pr?.state === "open";
+  const pr = gitStatus.pr;
+  const hasOpenPr = pr?.state === "open";
   const isAhead = gitStatus.aheadCount > 0;
   const hasDefaultBranchDelta = (gitStatus.aheadOfDefaultCount ?? gitStatus.aheadCount) > 0;
   const isBehind = gitStatus.behindCount > 0;
+  const isBehindBase = (gitStatus.behindOfDefaultCount ?? 0) > 0 && !isDefaultRef;
   const isDiverged = isAhead && isBehind;
   const terminology = resolveChangeRequestTerminology(gitStatus);
 
@@ -201,12 +508,78 @@ export function resolveQuickAction(
     };
   }
 
+  if (pr?.state === "merged") {
+    return { label: "Merged", disabled: false, kind: "open_pr", tone: "merged" };
+  }
+
+  if (isDiverged) {
+    return {
+      label: "Rebase / pull",
+      disabled: true,
+      kind: "show_hint",
+      hint: "Branch has diverged from upstream. Rebase/merge first.",
+      tone: "warning",
+    };
+  }
+
+  if (isBehind) {
+    return {
+      label: "Rebase / pull",
+      disabled: false,
+      kind: "run_pull",
+      tone: "warning",
+    };
+  }
+
+  if (hasOpenPr && pr?.mergeStatus === "conflicting") {
+    return {
+      label: "Resolve conflicts",
+      disabled: false,
+      kind: "prompt_ai",
+      prompt: resolveChangeRequestPrompt({ action: "resolve_conflicts", gitStatus }),
+      tone: "destructive",
+    };
+  }
+
+  if (hasOpenPr && pr?.mergeStatus === "behind") {
+    return {
+      label: "Rebase / pull",
+      disabled: false,
+      kind: "prompt_ai",
+      prompt: resolveChangeRequestPrompt({ action: "sync_base", gitStatus }),
+      tone: "warning",
+    };
+  }
+
+  if (isBehindBase) {
+    if (hasChanges) {
+      return {
+        label: "Update from base",
+        disabled: true,
+        kind: "show_hint",
+        hint: "Commit or stash local changes before updating from the base branch.",
+        tone: "warning",
+      };
+    }
+    return {
+      label: "Update from base",
+      disabled: false,
+      kind: "run_sync_base",
+      tone: "warning",
+    };
+  }
+
   if (hasChanges) {
     if (!gitStatus.hasUpstream && !hasPrimaryRemote) {
       return { label: "Commit", disabled: false, kind: "run_action", action: "commit" };
     }
     if (hasOpenPr || isDefaultRef) {
-      return { label: "Commit & push", disabled: false, kind: "run_action", action: "commit_push" };
+      return {
+        label: "Commit and push",
+        disabled: false,
+        kind: "run_action",
+        action: "commit_push",
+      };
     }
     return {
       label: `Commit, push & ${terminology.shortLabel}`,
@@ -216,9 +589,22 @@ export function resolveQuickAction(
     };
   }
 
+  if (hasOpenPr && pr?.checks && pr.checks.pending > 0) {
+    return {
+      label: formatChecksLabel(pr.checks),
+      disabled: !isPrWaitingOnChecks(pr),
+      kind: isPrWaitingOnChecks(pr) ? "open_pr" : "show_hint",
+      hint: "Checks are still running.",
+      tone: "warning",
+    };
+  }
+
   if (!gitStatus.hasUpstream) {
     if (!hasPrimaryRemote) {
       if (hasOpenPr && !isAhead) {
+        if (pr && isPrMergeable(pr)) {
+          return { label: "Merge", disabled: false, kind: "open_pr", tone: "success" };
+        }
         return { label: `View ${terminology.shortLabel}`, disabled: false, kind: "open_pr" };
       }
       return {
@@ -229,6 +615,9 @@ export function resolveQuickAction(
     }
     if (!isAhead) {
       if (hasOpenPr) {
+        if (pr && isPrMergeable(pr)) {
+          return { label: "Merge", disabled: false, kind: "open_pr", tone: "success" };
+        }
         return { label: `View ${terminology.shortLabel}`, disabled: false, kind: "open_pr" };
       }
       return {
@@ -254,23 +643,6 @@ export function resolveQuickAction(
     };
   }
 
-  if (isDiverged) {
-    return {
-      label: "Sync ref",
-      disabled: true,
-      kind: "show_hint",
-      hint: "Branch has diverged from upstream. Rebase/merge first.",
-    };
-  }
-
-  if (isBehind) {
-    return {
-      label: "Pull",
-      disabled: false,
-      kind: "run_pull",
-    };
-  }
-
   if (isAhead) {
     if (hasOpenPr || isDefaultRef) {
       return {
@@ -289,6 +661,9 @@ export function resolveQuickAction(
   }
 
   if (hasOpenPr && gitStatus.hasUpstream) {
+    if (pr && isPrMergeable(pr)) {
+      return { label: "Merge", disabled: false, kind: "open_pr", tone: "success" };
+    }
     return { label: `View ${terminology.shortLabel}`, disabled: false, kind: "open_pr" };
   }
 

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1,3 +1,4 @@
+import { scopedThreadKey } from "@t3tools/client-runtime";
 import { type ScopedThreadRef } from "@t3tools/contracts";
 import type {
   GitActionProgressEvent,
@@ -23,6 +24,9 @@ import {
   InfoIcon,
   LockIcon,
   GlobeIcon,
+  ArchiveIcon,
+  MessageSquareTextIcon,
+  RefreshCwIcon,
 } from "lucide-react";
 import { Radio as RadioPrimitive } from "@base-ui/react/radio";
 import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "~/components/Icons";
@@ -30,8 +34,10 @@ import { RadioGroup } from "~/components/ui/radio-group";
 import { Spinner } from "~/components/ui/spinner";
 import { cn } from "~/lib/utils";
 import {
+  buildGitAgentPrompt,
   buildGitActionProgressStages,
   buildMenuItems,
+  type GitAgentPromptIntent,
   type GitActionIconName,
   type GitActionMenuItem,
   type GitQuickAction,
@@ -56,7 +62,7 @@ import {
 } from "~/components/ui/dialog";
 import { Group, GroupSeparator } from "~/components/ui/group";
 import { Input } from "~/components/ui/input";
-import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
+import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from "~/components/ui/menu";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { Textarea } from "~/components/ui/textarea";
@@ -69,22 +75,34 @@ import {
   useSourceControlPublishRepositoryAction,
   useVcsInitAction,
   useVcsPullAction,
+  useVcsSyncBaseAction,
 } from "~/lib/sourceControlActions";
 import { refreshVcsStatus, useVcsStatus } from "~/lib/vcsStatusState";
 import { useSourceControlDiscovery } from "~/lib/sourceControlDiscoveryState";
 import { newCommandId, randomUUID } from "~/lib/utils";
 import { resolvePathLinkTarget } from "~/terminal-links";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
+import { useComposerHandleContext } from "~/composerHandleContext";
 import { readEnvironmentApi } from "~/environmentApi";
 import { readLocalApi } from "~/localApi";
 import { getSourceControlPresentation } from "~/sourceControlPresentation";
 import { useStore } from "~/store";
 import { createThreadSelectorByRef } from "~/storeSelectors";
+import { useThreadActions } from "~/hooks/useThreadActions";
 
 interface GitActionsControlProps {
   gitCwd: string | null;
   activeThreadRef: ScopedThreadRef | null;
   draftId?: DraftId;
+  pullRequestCommentsAction?: GitPullRequestCommentsAction;
+  onSubmitPrompt?: (prompt: string) => boolean | Promise<boolean>;
+}
+
+export interface GitPullRequestCommentsAction {
+  readonly unreadCount: number;
+  readonly isFetching: boolean;
+  readonly hasError: boolean;
+  readonly onOpen: () => void;
 }
 
 interface PendingDefaultBranchAction {
@@ -127,7 +145,15 @@ interface RunGitActionWithToastInput {
 }
 
 const GIT_STATUS_WINDOW_REFRESH_DEBOUNCE_MS = 250;
-const RUNNING_SOURCE_CONTROL_ACTIONS = ["runStackedAction", "pull", "publishRepository"] as const;
+const RUNNING_SOURCE_CONTROL_ACTIONS = [
+  "runStackedAction",
+  "pull",
+  "syncBase",
+  "publishRepository",
+] as const;
+const USE_AGENT_PROMPTS_FOR_GIT_ACTIONS = true;
+const PULL_QUICK_ACTION_CLASS_NAME =
+  "border-cyan-500/50 bg-cyan-500/12 text-cyan-700 shadow-cyan-500/20 shadow-sm [:hover,[data-pressed]]:bg-cyan-500/18 dark:border-cyan-300/45 dark:bg-cyan-300/12 dark:text-cyan-100 dark:shadow-cyan-300/20 dark:[:hover,[data-pressed]]:bg-cyan-300/18";
 
 const PUBLISH_PROVIDER_OPTIONS = [
   {
@@ -251,6 +277,7 @@ function getMenuActionDisabledReason({
   const hasOpenPr = gitStatus.pr?.state === "open";
   const isAhead = gitStatus.aheadCount > 0;
   const isBehind = gitStatus.behindCount > 0;
+  const isBehindBase = (gitStatus.behindOfDefaultCount ?? 0) > 0 && !gitStatus.isDefaultRef;
   const terminology = getSourceControlPresentation(gitStatus.sourceControlProvider).terminology;
 
   if (item.id === "commit") {
@@ -270,6 +297,9 @@ function getMenuActionDisabledReason({
     if (isBehind) {
       return "Branch is behind upstream. Pull/rebase before pushing.";
     }
+    if (isBehindBase) {
+      return "Branch is behind base. Update from base before pushing.";
+    }
     if (!gitStatus.hasUpstream && !hasPrimaryRemote) {
       return 'Add an "origin" remote before pushing.';
     }
@@ -280,6 +310,9 @@ function getMenuActionDisabledReason({
   }
 
   if (hasOpenPr) {
+    if (gitStatus.pr?.checks && gitStatus.pr.checks.pending > 0) {
+      return "Checks are still running.";
+    }
     return `View ${terminology.singular} is currently unavailable.`;
   }
   if (!hasBranch) {
@@ -296,6 +329,9 @@ function getMenuActionDisabledReason({
   }
   if (isBehind) {
     return `Branch is behind upstream. Pull/rebase before creating a ${terminology.singular}.`;
+  }
+  if (isBehindBase) {
+    return `Branch is behind base. Update from base before creating a ${terminology.singular}.`;
   }
   return `Create ${terminology.singular} is currently unavailable.`;
 }
@@ -324,9 +360,12 @@ function GitQuickActionIcon({
   SourceControlIcon: ReturnType<typeof getSourceControlPresentation>["Icon"];
 }) {
   const iconClassName = "size-3.5";
+  if (quickAction.label === "Archive") return <ArchiveIcon className={iconClassName} />;
   if (quickAction.kind === "open_pr") return <SourceControlIcon className={iconClassName} />;
+  if (quickAction.kind === "prompt_ai") return <SourceControlIcon className={iconClassName} />;
   if (quickAction.kind === "open_publish") return <CloudUploadIcon className={iconClassName} />;
   if (quickAction.kind === "run_pull") return <InfoIcon className={iconClassName} />;
+  if (quickAction.kind === "run_sync_base") return <RefreshCwIcon className={iconClassName} />;
   if (quickAction.kind === "run_action") {
     if (quickAction.action === "commit") return <GitCommitIcon className={iconClassName} />;
     if (quickAction.action === "push" || quickAction.action === "commit_push") {
@@ -336,6 +375,70 @@ function GitQuickActionIcon({
   }
   if (quickAction.label === "Commit") return <GitCommitIcon className={iconClassName} />;
   return <InfoIcon className={iconClassName} />;
+}
+
+function gitStackedActionToPromptIntent(action: GitStackedAction): GitAgentPromptIntent {
+  switch (action) {
+    case "commit":
+      return "commit";
+    case "push":
+      return "push";
+    case "create_pr":
+      return "create_pr";
+    case "commit_push":
+      return "commit_push";
+    case "commit_push_pr":
+      return "commit_push_pr";
+  }
+}
+
+function quickActionPromptIntent(quickAction: GitQuickAction): GitAgentPromptIntent | null {
+  if (quickAction.label === "Archive") return "archive_merged_thread";
+  if (quickAction.kind === "prompt_ai") {
+    if (quickAction.label === "Resolve conflicts") return "resolve_conflicts";
+    return "sync_base";
+  }
+  if (quickAction.kind === "open_pr") {
+    if (quickAction.label === "Merge") return "merge_pr";
+    if (quickAction.label === "Merged") return "archive_merged_thread";
+    return "inspect_pr";
+  }
+  if (quickAction.kind === "open_publish") return "publish_repository";
+  if (quickAction.kind === "run_pull") return "pull";
+  if (quickAction.kind === "run_sync_base") return "sync_base";
+  if (quickAction.kind === "run_action" && quickAction.action) {
+    return gitStackedActionToPromptIntent(quickAction.action);
+  }
+  return null;
+}
+
+function menuItemPromptIntent(item: GitActionMenuItem): GitAgentPromptIntent | null {
+  if (item.id === "commit") return "commit";
+  if (item.id === "push") return "push";
+  if (item.id === "pr") {
+    if (item.kind === "open_pr") {
+      if (item.label === "Merged") return "archive_merged_thread";
+      return "inspect_pr";
+    }
+    return "create_pr";
+  }
+  return null;
+}
+
+function gitQuickActionToneClassName(tone: GitQuickAction["tone"]): string | undefined {
+  if (tone === "success") {
+    return "border-success/45 bg-success/10 text-success-foreground hover:bg-success/16 dark:text-success";
+  }
+  if (tone === "merged") {
+    return "border-violet-500/40 bg-violet-500/10 text-violet-700 hover:bg-violet-500/16 dark:text-violet-300";
+  }
+  if (tone === "warning") {
+    return "border-warning/40 bg-warning/10 text-warning-foreground hover:bg-warning/16 dark:text-warning";
+  }
+  if (tone === "destructive") {
+    return "border-destructive/40 bg-destructive/8 text-destructive-foreground hover:bg-destructive/12 dark:text-destructive";
+  }
+  return undefined;
 }
 
 interface PublishRepositoryDialogProps {
@@ -949,6 +1052,8 @@ export default function GitActionsControl({
   gitCwd,
   activeThreadRef,
   draftId,
+  pullRequestCommentsAction,
+  onSubmitPrompt,
 }: GitActionsControlProps) {
   const activeEnvironmentId = activeThreadRef?.environmentId ?? null;
   const threadToastData = useMemo(
@@ -967,19 +1072,31 @@ export default function GitActionsControl({
         ? store.getDraftThreadByRef(activeThreadRef)
         : null,
   );
+  const getComposerDraft = useComposerDraftStore((store) => store.getComposerDraft);
   const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const setComposerDraftPrompt = useComposerDraftStore((store) => store.setPrompt);
+  const composerRef = useComposerHandleContext();
   const setThreadBranch = useStore((store) => store.setThreadBranch);
   const [isCommitDialogOpen, setIsCommitDialogOpen] = useState(false);
   const [dialogCommitMessage, setDialogCommitMessage] = useState("");
   const [excludedFiles, setExcludedFiles] = useState<ReadonlySet<string>>(new Set());
   const [isEditingFiles, setIsEditingFiles] = useState(false);
   const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
+  const [mergedArchiveArmedThreadKey, setMergedArchiveArmedThreadKey] = useState<string | null>(
+    null,
+  );
+  const [isArchivingMergedThread, setIsArchivingMergedThread] = useState(false);
   const [pendingDefaultBranchAction, setPendingDefaultBranchAction] =
     useState<PendingDefaultBranchAction | null>(null);
   const activeGitActionProgressRef = useRef<ActiveGitActionProgress | null>(null);
+  const { archiveThread } = useThreadActions();
   const sourceControlScope = useMemo(
     () => ({ environmentId: activeEnvironmentId, cwd: gitCwd }),
     [activeEnvironmentId, gitCwd],
+  );
+  const activeThreadKey = useMemo(
+    () => (activeThreadRef ? scopedThreadKey(activeThreadRef) : null),
+    [activeThreadRef],
   );
   let runGitActionWithToast: (input: RunGitActionWithToastInput) => Promise<void>;
 
@@ -1080,6 +1197,7 @@ export default function GitActionsControl({
   const initAction = useVcsInitAction(sourceControlScope);
   const runImmediateGitAction = useGitStackedAction(sourceControlScope);
   const pullAction = useVcsPullAction(sourceControlScope);
+  const syncBaseAction = useVcsSyncBaseAction(sourceControlScope);
   const isGitActionRunning = useSourceControlActionRunning(
     sourceControlScope,
     RUNNING_SOURCE_CONTROL_ACTIONS,
@@ -1125,8 +1243,21 @@ export default function GitActionsControl({
       resolveQuickAction(gitStatusForActions, isGitActionRunning, isDefaultRef, hasPrimaryRemote),
     [gitStatusForActions, hasPrimaryRemote, isDefaultRef, isGitActionRunning],
   );
-  const quickActionDisabledReason = quickAction.disabled
-    ? (quickAction.hint ?? "This action is currently unavailable.")
+  const isMergedQuickAction =
+    gitStatusForActions?.pr?.state === "merged" && quickAction.tone === "merged";
+  const isMergedArchiveArmed =
+    isMergedQuickAction &&
+    activeThreadKey !== null &&
+    mergedArchiveArmedThreadKey === activeThreadKey;
+  const renderedQuickAction: GitQuickAction = isMergedArchiveArmed
+    ? { ...quickAction, label: "Archive", tone: "destructive" }
+    : quickAction;
+  const quickActionToneClassName = gitQuickActionToneClassName(renderedQuickAction.tone);
+  const quickActionClassName =
+    quickActionToneClassName ??
+    (renderedQuickAction.kind === "run_pull" ? PULL_QUICK_ACTION_CLASS_NAME : undefined);
+  const quickActionDisabledReason = renderedQuickAction.disabled
+    ? (renderedQuickAction.hint ?? "This action is currently unavailable.")
     : null;
   const pendingDefaultBranchActionCopy = pendingDefaultBranchAction
     ? resolveDefaultBranchActionDialogCopy({
@@ -1149,6 +1280,16 @@ export default function GitActionsControl({
       window.clearInterval(interval);
     };
   }, [updateActiveProgressToast]);
+
+  useEffect(() => {
+    setMergedArchiveArmedThreadKey(null);
+  }, [activeThreadKey]);
+
+  useEffect(() => {
+    if (!isMergedQuickAction) {
+      setMergedArchiveArmedThreadKey(null);
+    }
+  }, [isMergedQuickAction]);
 
   useEffect(() => {
     if (gitCwd === null) {
@@ -1195,11 +1336,11 @@ export default function GitActionsControl({
       });
       return;
     }
-    const prUrl = gitStatusForActions?.pr?.state === "open" ? gitStatusForActions.pr.url : null;
+    const prUrl = gitStatusForActions?.pr?.url ?? null;
     if (!prUrl) {
       toastManager.add({
         type: "error",
-        title: "No open pull request found.",
+        title: "No pull request found.",
         data: threadToastData,
       });
       return;
@@ -1215,6 +1356,99 @@ export default function GitActionsControl({
       );
     });
   }, [gitStatusForActions, threadToastData]);
+
+  const promptAi = useCallback(
+    (prompt: string | undefined) => {
+      const nextPrompt = prompt?.trim();
+      if (!nextPrompt) {
+        return;
+      }
+      const composerDraftTarget = draftId ?? activeThreadRef;
+      if (!composerDraftTarget) {
+        toastManager.add({
+          type: "error",
+          title: "Composer is unavailable.",
+          data: threadToastData,
+        });
+        return;
+      }
+      if (onSubmitPrompt) {
+        void Promise.resolve(onSubmitPrompt(nextPrompt))
+          .then((submitted) => {
+            if (submitted) {
+              return;
+            }
+            toastManager.add({
+              type: "error",
+              title: "Unable to send prompt.",
+              description: "The thread is busy or unavailable.",
+              data: threadToastData,
+            });
+          })
+          .catch((err: unknown) => {
+            toastManager.add({
+              type: "error",
+              title: "Unable to send prompt.",
+              description: err instanceof Error ? err.message : "An error occurred.",
+              data: threadToastData,
+            });
+          });
+        return;
+      }
+      setComposerDraftPrompt(composerDraftTarget, nextPrompt);
+      const stagedDraft = getComposerDraft(composerDraftTarget);
+      if (stagedDraft?.prompt !== nextPrompt) {
+        toastManager.add({
+          type: "error",
+          title: "Unable to add prompt to composer.",
+          data: threadToastData,
+        });
+        return;
+      }
+      composerRef?.current?.resetCursorState({ cursor: nextPrompt.length, prompt: nextPrompt });
+      composerRef?.current?.focusAtEnd();
+      toastManager.add({
+        type: "success",
+        title: "Prompt added to composer.",
+        description: "Review and send it to start the AI action.",
+        data: threadToastData,
+      });
+    },
+    [
+      activeThreadRef,
+      composerRef,
+      draftId,
+      getComposerDraft,
+      onSubmitPrompt,
+      setComposerDraftPrompt,
+      threadToastData,
+    ],
+  );
+
+  const buildAgentPrompt = useCallback(
+    (
+      intent: GitAgentPromptIntent,
+      options?: {
+        readonly commitMessage?: string;
+        readonly filePaths?: readonly string[];
+        readonly promptHint?: string;
+        readonly unreadCommentCount?: number;
+      },
+    ) =>
+      buildGitAgentPrompt({
+        intent,
+        cwd: gitCwd,
+        gitStatus: gitStatusForActions,
+        threadRef: activeThreadRef,
+        ...(options?.commitMessage ? { commitMessage: options.commitMessage } : {}),
+        ...(options?.filePaths ? { filePaths: options.filePaths } : {}),
+        ...(options?.promptHint ? { promptHint: options.promptHint } : {}),
+        ...(options?.unreadCommentCount !== undefined
+          ? { unreadCommentCount: options.unreadCommentCount }
+          : {}),
+      }),
+    [activeThreadRef, gitCwd, gitStatusForActions],
+  );
 
   runGitActionWithToast = useEffectEvent(
     async ({
@@ -1475,28 +1709,91 @@ export default function GitActionsControl({
   const runDialogActionOnNewBranch = () => {
     if (!isCommitDialogOpen) return;
     const commitMessage = dialogCommitMessage.trim();
+    const filePaths = !allSelected ? selectedFiles.map((f) => f.path) : undefined;
 
     setIsCommitDialogOpen(false);
     setDialogCommitMessage("");
     setExcludedFiles(new Set());
     setIsEditingFiles(false);
 
+    if (USE_AGENT_PROMPTS_FOR_GIT_ACTIONS) {
+      promptAi(
+        buildAgentPrompt("commit", {
+          ...(commitMessage ? { commitMessage } : {}),
+          ...(filePaths ? { filePaths } : {}),
+          promptHint:
+            "Create a new feature ref before committing. Pick a descriptive branch name from the actual change.",
+        }),
+      );
+      return;
+    }
+
     void runGitActionWithToast({
       action: "commit",
       ...(commitMessage ? { commitMessage } : {}),
-      ...(!allSelected ? { filePaths: selectedFiles.map((f) => f.path) } : {}),
+      ...(filePaths ? { filePaths } : {}),
       featureBranch: true,
       skipDefaultBranchPrompt: true,
     });
   };
 
   const runQuickAction = () => {
+    if (USE_AGENT_PROMPTS_FOR_GIT_ACTIONS) {
+      const promptIntent = quickActionPromptIntent(renderedQuickAction);
+      if (promptIntent) {
+        promptAi(
+          buildAgentPrompt(
+            promptIntent,
+            renderedQuickAction.prompt ? { promptHint: renderedQuickAction.prompt } : undefined,
+          ),
+        );
+        return;
+      }
+    }
+
+    if (isMergedQuickAction) {
+      if (!activeThreadRef || !activeThreadKey) {
+        toastManager.add({
+          type: "error",
+          title: "No active thread to archive.",
+          data: threadToastData,
+        });
+        return;
+      }
+      if (!isMergedArchiveArmed) {
+        setMergedArchiveArmedThreadKey(activeThreadKey);
+        return;
+      }
+      setIsArchivingMergedThread(true);
+      void archiveThread(activeThreadRef)
+        .then(() => {
+          setMergedArchiveArmedThreadKey(null);
+        })
+        .catch((err: unknown) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Failed to archive thread",
+              description: err instanceof Error ? err.message : "An error occurred.",
+              ...(threadToastData !== undefined ? { data: threadToastData } : {}),
+            }),
+          );
+        })
+        .finally(() => {
+          setIsArchivingMergedThread(false);
+        });
+      return;
+    }
     if (quickAction.kind === "open_pr") {
       void openExistingPr();
       return;
     }
     if (quickAction.kind === "open_publish") {
       setIsPublishDialogOpen(true);
+      return;
+    }
+    if (quickAction.kind === "prompt_ai") {
+      promptAi(quickAction.prompt);
       return;
     }
     if (quickAction.kind === "run_pull") {
@@ -1523,6 +1820,30 @@ export default function GitActionsControl({
       void promise.catch(() => undefined);
       return;
     }
+    if (quickAction.kind === "run_sync_base") {
+      const promise = syncBaseAction.run();
+      void toastManager.promise<Awaited<ReturnType<typeof syncBaseAction.run>>, ThreadToastData>(
+        promise,
+        {
+          loading: { title: "Updating from base...", data: threadToastData },
+          success: (result) => ({
+            title: result.status === "rebased" ? "Updated from base" : "Already up to date",
+            description:
+              result.status === "rebased"
+                ? `Rebased ${result.refName} onto ${result.baseRef}.`
+                : `${result.refName} already includes ${result.baseRef}.`,
+            data: threadToastData,
+          }),
+          error: (err) => ({
+            title: "Base update failed",
+            description: err instanceof Error ? err.message : "An error occurred.",
+            data: threadToastData,
+          }),
+        },
+      );
+      void promise.catch(() => undefined);
+      return;
+    }
     if (quickAction.kind === "show_hint") {
       toastManager.add({
         type: "info",
@@ -1539,8 +1860,21 @@ export default function GitActionsControl({
 
   const openDialogForMenuItem = (item: GitActionMenuItem) => {
     if (item.disabled) return;
+    if (USE_AGENT_PROMPTS_FOR_GIT_ACTIONS) {
+      const promptIntent = menuItemPromptIntent(item);
+      if (promptIntent) {
+        promptAi(
+          buildAgentPrompt(promptIntent, item.prompt ? { promptHint: item.prompt } : undefined),
+        );
+        return;
+      }
+    }
     if (item.kind === "open_pr") {
       void openExistingPr();
+      return;
+    }
+    if (item.kind === "prompt_ai") {
+      promptAi(item.prompt);
       return;
     }
     if (item.dialogAction === "push") {
@@ -1559,14 +1893,26 @@ export default function GitActionsControl({
   const runDialogAction = () => {
     if (!isCommitDialogOpen) return;
     const commitMessage = dialogCommitMessage.trim();
+    const filePaths = !allSelected ? selectedFiles.map((f) => f.path) : undefined;
     setIsCommitDialogOpen(false);
     setDialogCommitMessage("");
     setExcludedFiles(new Set());
     setIsEditingFiles(false);
+
+    if (USE_AGENT_PROMPTS_FOR_GIT_ACTIONS) {
+      promptAi(
+        buildAgentPrompt("commit", {
+          ...(commitMessage ? { commitMessage } : {}),
+          ...(filePaths ? { filePaths } : {}),
+        }),
+      );
+      return;
+    }
+
     void runGitActionWithToast({
       action: "commit",
       ...(commitMessage ? { commitMessage } : {}),
-      ...(!allSelected ? { filePaths: selectedFiles.map((f) => f.path) } : {}),
+      ...(filePaths ? { filePaths } : {}),
     });
   };
 
@@ -1608,6 +1954,10 @@ export default function GitActionsControl({
           size="xs"
           disabled={initAction.isPending}
           onClick={() => {
+            if (USE_AGENT_PROMPTS_FOR_GIT_ACTIONS) {
+              promptAi(buildAgentPrompt("initialize"));
+              return;
+            }
             void initAction.run();
           }}
         >
@@ -1622,19 +1972,20 @@ export default function GitActionsControl({
                 render={
                   <Button
                     aria-disabled="true"
-                    className="cursor-not-allowed rounded-e-none border-e-0 opacity-64 before:rounded-e-none"
+                    className={cn(
+                      "min-w-0 max-w-56 cursor-not-allowed rounded-e-none border-e-0 opacity-64 before:rounded-e-none",
+                      quickActionClassName,
+                    )}
                     size="xs"
                     variant="outline"
                   />
                 }
               >
                 <GitQuickActionIcon
-                  quickAction={quickAction}
+                  quickAction={renderedQuickAction}
                   SourceControlIcon={SourceControlIcon}
                 />
-                <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">
-                  {quickAction.label}
-                </span>
+                <span className="ml-0.5 min-w-0 truncate">{renderedQuickAction.label}</span>
               </PopoverTrigger>
               <PopoverPopup tooltipStyle side="bottom" align="start">
                 {quickActionDisabledReason}
@@ -1644,13 +1995,17 @@ export default function GitActionsControl({
             <Button
               variant="outline"
               size="xs"
-              disabled={isGitActionRunning || quickAction.disabled}
+              className={cn("min-w-0 max-w-56", quickActionClassName)}
+              disabled={
+                isGitActionRunning || renderedQuickAction.disabled || isArchivingMergedThread
+              }
               onClick={runQuickAction}
             >
-              <GitQuickActionIcon quickAction={quickAction} SourceControlIcon={SourceControlIcon} />
-              <span className="sr-only @3xl/header-actions:not-sr-only @3xl/header-actions:ml-0.5">
-                {quickAction.label}
-              </span>
+              <GitQuickActionIcon
+                quickAction={renderedQuickAction}
+                SourceControlIcon={SourceControlIcon}
+              />
+              <span className="ml-0.5 min-w-0 truncate">{renderedQuickAction.label}</span>
             </Button>
           )}
           <GroupSeparator className="hidden @3xl/header-actions:block" />
@@ -1665,8 +2020,14 @@ export default function GitActionsControl({
             }}
           >
             <MenuTrigger
-              render={<Button aria-label="Git action options" size="icon-xs" variant="outline" />}
-              disabled={isGitActionRunning}
+              render={
+                <Button
+                  aria-label="Git action options"
+                  className={quickActionClassName}
+                  size="icon-xs"
+                  variant="outline"
+                />
+              }
             >
               <ChevronDownIcon aria-hidden="true" className="size-4" />
             </MenuTrigger>
@@ -1714,10 +2075,53 @@ export default function GitActionsControl({
                   </MenuItem>
                 );
               })}
+              {pullRequestCommentsAction ? (
+                <>
+                  <MenuSeparator />
+                  <MenuItem
+                    aria-label={
+                      pullRequestCommentsAction.unreadCount > 0
+                        ? `PR comments, ${pullRequestCommentsAction.unreadCount} unread`
+                        : "PR comments"
+                    }
+                    onClick={() => {
+                      if (USE_AGENT_PROMPTS_FOR_GIT_ACTIONS) {
+                        promptAi(
+                          buildAgentPrompt("review_pr_comments", {
+                            unreadCommentCount: pullRequestCommentsAction.unreadCount,
+                          }),
+                        );
+                        return;
+                      }
+                      pullRequestCommentsAction.onOpen();
+                    }}
+                  >
+                    {pullRequestCommentsAction.isFetching ? (
+                      <Spinner className="size-4" />
+                    ) : (
+                      <MessageSquareTextIcon />
+                    )}
+                    <span className="min-w-0 flex-1 truncate">PR comments</span>
+                    {pullRequestCommentsAction.hasError ? (
+                      <span className="ms-auto rounded-sm bg-destructive/10 px-1.5 py-0.5 text-[10px] text-destructive">
+                        Error
+                      </span>
+                    ) : pullRequestCommentsAction.unreadCount > 0 ? (
+                      <span className="ms-auto rounded-sm bg-primary/10 px-1.5 py-0.5 text-[10px] text-primary">
+                        {pullRequestCommentsAction.unreadCount} unread
+                      </span>
+                    ) : null}
+                  </MenuItem>
+                </>
+              ) : null}
               {canPublishRepository ? (
                 <MenuItem
                   disabled={isGitActionRunning}
                   onClick={() => {
+                    if (USE_AGENT_PROMPTS_FOR_GIT_ACTIONS) {
+                      promptAi(buildAgentPrompt("publish_repository"));
+                      return;
+                    }
                     setIsPublishDialogOpen(true);
                   }}
                 >
@@ -1738,6 +2142,16 @@ export default function GitActionsControl({
                 gitStatusForActions.aheadCount === 0 && (
                   <p className="px-2 py-1.5 text-xs text-warning">
                     Behind upstream. Pull/rebase first.
+                  </p>
+                )}
+              {gitStatusForActions &&
+                gitStatusForActions.refName !== null &&
+                !gitStatusForActions.isDefaultRef &&
+                !gitStatusForActions.hasWorkingTreeChanges &&
+                gitStatusForActions.behindCount === 0 &&
+                (gitStatusForActions.behindOfDefaultCount ?? 0) > 0 && (
+                  <p className="px-2 py-1.5 text-xs text-warning">
+                    Behind base. Update from base first.
                   </p>
                 )}
               {gitStatusError && (


### PR DESCRIPTION
## Summary
- Open View PR actions directly in the browser.
- Let mergeable PRs with pending checks arm the quick action as Merge, then send the merge prompt on the next click.
- Archive merged PR threads immediately from the Merged quick action.

## Checks
- bun fmt
- bun lint
- bun typecheck
- bun run test src/components/GitActionsControl.logic.test.ts
- bun run test:browser src/components/GitActionsControl.browser.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible git/PR behavior and thread archiving in the header; mistakes could send wrong prompts or archive threads unexpectedly, though logic is heavily unit/browser tested.
> 
> **Overview**
> **Git/PR controls** now derive quick actions and menu state from richer VCS/PR metadata (merged, conflicting, behind base, checks, mergeable), with new paths like **Rebase / pull**, **Update from base**, **Resolve conflicts**, and **Merge** plus visual tones.
> 
> **`GitActionsControl`** routes most git/PR actions through **`buildGitAgentPrompt`** and the composer (`onSubmitPrompt` or draft staging) instead of only running stacked git commands; conflicting PRs submit merge-resolution prompts directly when a submit handler is provided.
> 
> **Merged PR threads** use a two-step quick action (**Merged** → **Archive**) that calls **`archiveThread`**; browser and logic tests cover conflict prompts, archive arming, and the updated action matrix (including preferring pull when dirty and behind upstream).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a5f3a8d2ba424321e910b4659922deadf264283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PR action controls to handle merged, conflicting, and behind-base states
> - `resolveQuickAction` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/2898/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) now covers merged PRs ('Merged'), conflicting PRs ('Resolve conflicts' via AI prompt), behind-base branches ('Rebase / pull' or 'Update from base'), and check-pending states with progress labels.
> - `buildMenuItems` enables 'View PR' even while busy, shows 'Merged' for merged PRs, and disables 'Push' and 'Create PR' when the branch is behind its base.
> - [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/2898/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) routes most git workflow actions (commit, push, create PR, pull, conflict resolution) through AI-generated prompts when `USE_AGENT_PROMPTS_FOR_GIT_ACTIONS` is true, and adds a two-click safety for the 'Archive' button on merged PRs.
> - A new `buildGitAgentPrompt` function assembles structured AI prompts from current git status, PR state, checks, and selected files.
> - Behavioral Change: labels change from 'Commit & push' to 'Commit and push' and from 'Sync ref' to 'Rebase / pull'; many actions now submit AI prompts instead of executing git commands directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a5f3a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->