### PR TITLE
feat(cloud): add headless cloud CLI control plane

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,10 @@
 # Release builds inject their public values at build time. Do not add server-side
 # secrets to this file.
 
-# Get these from the Clerk Dashboard under API keys and JWT templates.
+# Get these from the Clerk Dashboard under API keys, JWT templates, and OAuth applications.
 # T3CODE_CLERK_PUBLISHABLE_KEY=pk_test_...
 # T3CODE_CLERK_JWT_TEMPLATE=t3-relay
+# T3CODE_CLERK_CLI_OAUTH_CLIENT_ID=oauthapp_...
 
 # Get this from your relay deployment. `infra/relay` deploys update it automatically.
 # T3CODE_RELAY_URL=https://relay.example.com

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,11 +180,13 @@ jobs:
     outputs:
       clerk_publishable_key: ${{ steps.public_config.outputs.clerk_publishable_key }}
       clerk_jwt_template: ${{ steps.public_config.outputs.clerk_jwt_template }}
+      clerk_cli_oauth_client_id: ${{ steps.public_config.outputs.clerk_cli_oauth_client_id }}
       relay_url: ${{ steps.public_config.outputs.relay_url }}
     env:
       RELAY_DOMAIN: ${{ vars.RELAY_DOMAIN }}
       CLERK_PUBLISHABLE_KEY: ${{ vars.CLERK_PUBLISHABLE_KEY }}
       CLERK_JWT_TEMPLATE: ${{ vars.CLERK_JWT_TEMPLATE }}
+      CLERK_CLI_OAUTH_CLIENT_ID: ${{ vars.CLERK_CLI_OAUTH_CLIENT_ID }}
     steps:
       - id: public_config
         name: Resolve production relay public config
@@ -196,6 +198,7 @@ jobs:
             RELAY_DOMAIN
             CLERK_PUBLISHABLE_KEY
             CLERK_JWT_TEMPLATE
+            CLERK_CLI_OAUTH_CLIENT_ID
           )
           missing=()
           for name in "${required[@]}"; do
@@ -210,6 +213,7 @@ jobs:
 
           echo "clerk_publishable_key=$CLERK_PUBLISHABLE_KEY" >> "$GITHUB_OUTPUT"
           echo "clerk_jwt_template=$CLERK_JWT_TEMPLATE" >> "$GITHUB_OUTPUT"
+          echo "clerk_cli_oauth_client_id=$CLERK_CLI_OAUTH_CLIENT_ID" >> "$GITHUB_OUTPUT"
           echo "relay_url=https://$RELAY_DOMAIN" >> "$GITHUB_OUTPUT"
 
   build:
@@ -221,6 +225,7 @@ jobs:
     env:
       T3CODE_CLERK_PUBLISHABLE_KEY: ${{ needs.relay_public_config.outputs.clerk_publishable_key }}
       T3CODE_CLERK_JWT_TEMPLATE: ${{ needs.relay_public_config.outputs.clerk_jwt_template }}
+      T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: ${{ needs.relay_public_config.outputs.clerk_cli_oauth_client_id }}
       T3CODE_RELAY_URL: ${{ needs.relay_public_config.outputs.relay_url }}
     strategy:
       fail-fast: false
@@ -485,6 +490,7 @@ jobs:
     env:
       T3CODE_CLERK_PUBLISHABLE_KEY: ${{ needs.relay_public_config.outputs.clerk_publishable_key }}
       T3CODE_CLERK_JWT_TEMPLATE: ${{ needs.relay_public_config.outputs.clerk_jwt_template }}
+      T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: ${{ needs.relay_public_config.outputs.clerk_cli_oauth_client_id }}
       T3CODE_RELAY_URL: ${{ needs.relay_public_config.outputs.relay_url }}
     steps:
       - name: Checkout

--- a/apps/desktop/src/ipc/methods/cloudAuth.test.ts
+++ b/apps/desktop/src/ipc/methods/cloudAuth.test.ts
@@ -2,8 +2,14 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import { afterEach } from "vitest";
 
-import { fetchCloudAuth } from "./cloudAuth.ts";
+import { fetchCloudAuth, validateClerkFrontendApiUrl } from "./cloudAuth.ts";
+
+const originalClerkPublishableKey = process.env.T3CODE_CLERK_PUBLISHABLE_KEY;
+
+const clerkPublishableKey = (hostname: string): string =>
+  `pk_test_${Buffer.from(`${hostname}$`).toString("base64")}`;
 
 function makeHttpClientLayer(
   handler: (
@@ -17,6 +23,14 @@ function makeHttpClientLayer(
 }
 
 describe("Desktop cloud auth IPC", () => {
+  afterEach(() => {
+    if (originalClerkPublishableKey === undefined) {
+      delete process.env.T3CODE_CLERK_PUBLISHABLE_KEY;
+    } else {
+      process.env.T3CODE_CLERK_PUBLISHABLE_KEY = originalClerkPublishableKey;
+    }
+  });
+
   it.effect("preserves Clerk's URL-encoded OAuth form content type", () => {
     const body = "strategy=oauth_google&redirect_url=t3code%3A%2F%2Fauth%2Fcallback";
     let forwardedRequest: HttpClientRequest.HttpClientRequest | null = null;
@@ -51,5 +65,41 @@ describe("Desktop cloud auth IPC", () => {
         assert.equal(new TextDecoder().decode(forwardedRequest.body.body), body);
       }
     }).pipe(Effect.provide(layer));
+  });
+
+  it.effect(
+    "allows the custom Clerk Frontend API host encoded by the configured publishable key",
+    () => {
+      process.env.T3CODE_CLERK_PUBLISHABLE_KEY = clerkPublishableKey("clerk.t3.codes");
+      let forwardedRequest: HttpClientRequest.HttpClientRequest | null = null;
+      const layer = makeHttpClientLayer((request) =>
+        Effect.sync(() => {
+          forwardedRequest = request;
+          return HttpClientResponse.fromWeb(
+            request,
+            Response.json({ response: { object: "client" } }),
+          );
+        }),
+      );
+
+      return Effect.gen(function* () {
+        yield* fetchCloudAuth.handler({
+          url: "https://clerk.t3.codes/v1/client",
+          method: "GET",
+          headers: {},
+        });
+
+        assert(forwardedRequest !== null);
+        assert.equal(forwardedRequest.url.toString(), "https://clerk.t3.codes/v1/client");
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it("rejects arbitrary HTTPS hosts that are not configured Clerk Frontend API hosts", () => {
+    process.env.T3CODE_CLERK_PUBLISHABLE_KEY = clerkPublishableKey("clerk.t3.codes");
+    assert.throws(
+      () => validateClerkFrontendApiUrl("https://attacker.example/v1/client"),
+      /restricted to Clerk Frontend API HTTPS hosts/u,
+    );
   });
 });

--- a/apps/desktop/src/ipc/methods/cloudAuth.ts
+++ b/apps/desktop/src/ipc/methods/cloudAuth.ts
@@ -2,6 +2,10 @@ import {
   DesktopCloudAuthFetchInputSchema,
   DesktopCloudAuthFetchResultSchema,
 } from "@t3tools/contracts";
+import {
+  clerkFrontendApiHostnameFromPublishableKey,
+  isAllowedClerkFrontendApiHostname,
+} from "@t3tools/shared/relayAuth";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
@@ -13,6 +17,8 @@ import * as DesktopCloudAuthTokenStore from "../../app/DesktopCloudAuthTokenStor
 import * as IpcChannels from "../channels.ts";
 import { makeIpcMethod } from "../DesktopIpc.ts";
 
+declare const __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: string | undefined;
+
 export class DesktopCloudAuthFetchError extends Data.TaggedError("DesktopCloudAuthFetchError")<{
   readonly reason: string;
   readonly cause?: unknown;
@@ -22,10 +28,21 @@ export class DesktopCloudAuthFetchError extends Data.TaggedError("DesktopCloudAu
   }
 }
 
-const allowedClerkFrontendApiHosts = (hostname: string): boolean =>
-  hostname.endsWith(".clerk.accounts.dev") || hostname.endsWith(".clerk.accounts.com");
+function configuredClerkFrontendApiHostname(): string | null {
+  const publishableKey =
+    process.env.T3CODE_CLERK_PUBLISHABLE_KEY?.trim() ||
+    (typeof __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__ === "undefined"
+      ? ""
+      : __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__.trim());
+  if (!publishableKey) return null;
 
-function validateClerkFrontendApiUrl(rawUrl: string): URL {
+  return clerkFrontendApiHostnameFromPublishableKey(publishableKey);
+}
+
+const allowedClerkFrontendApiHosts = (hostname: string): boolean =>
+  isAllowedClerkFrontendApiHostname(hostname, configuredClerkFrontendApiHostname());
+
+export function validateClerkFrontendApiUrl(rawUrl: string): URL {
   const url = new URL(rawUrl);
   if (url.protocol !== "https:" || !allowedClerkFrontendApiHosts(url.hostname)) {
     throw new DesktopCloudAuthFetchError({

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -32,10 +32,13 @@ const environmentInput = {
 } satisfies DesktopEnvironment.MakeDesktopEnvironmentInput;
 
 function makeFakeBrowserWindow() {
+  const webContentsListeners = new Map<string, (...args: readonly unknown[]) => void>();
   const webContents = {
     copyImageAt: vi.fn(),
     isLoadingMainFrame: vi.fn(() => false),
-    on: vi.fn(),
+    on: vi.fn((eventName: string, listener: (...args: readonly unknown[]) => void) => {
+      webContentsListeners.set(eventName, listener);
+    }),
     once: vi.fn(),
     openDevTools: vi.fn(),
     replaceMisspelling: vi.fn(),
@@ -63,6 +66,7 @@ function makeFakeBrowserWindow() {
     window: window as unknown as Electron.BrowserWindow,
     loadURL: window.loadURL,
     openDevTools: webContents.openDevTools,
+    webContentsListeners,
   };
 }
 
@@ -96,11 +100,6 @@ const electronMenuLayer = Layer.succeed(ElectronMenu.ElectronMenu, {
   showContextMenu: () => Effect.succeed(Option.none()),
 } satisfies ElectronMenu.ElectronMenuShape);
 
-const electronShellLayer = Layer.succeed(ElectronShell.ElectronShell, {
-  openExternal: () => Effect.succeed(true),
-  copyText: () => Effect.void,
-} satisfies ElectronShell.ElectronShellShape);
-
 const electronThemeLayer = Layer.succeed(ElectronTheme.ElectronTheme, {
   shouldUseDarkColors: Effect.succeed(false),
   setSource: () => Effect.void,
@@ -123,6 +122,7 @@ function makeTestLayer(input: {
   readonly window: Electron.BrowserWindow;
   readonly createCount: Ref.Ref<number>;
   readonly mainWindow: Ref.Ref<Option.Option<Electron.BrowserWindow>>;
+  readonly openedExternalUrls?: unknown[];
 }) {
   const electronWindowLayer = Layer.succeed(ElectronWindow.ElectronWindow, {
     create: () => Ref.update(input.createCount, (count) => count + 1).pipe(Effect.as(input.window)),
@@ -145,7 +145,14 @@ function makeTestLayer(input: {
         desktopServerExposureLayer,
         DesktopState.layer,
         electronMenuLayer,
-        electronShellLayer,
+        Layer.succeed(ElectronShell.ElectronShell, {
+          openExternal: (url) =>
+            Effect.sync(() => {
+              input.openedExternalUrls?.push(url);
+              return true;
+            }),
+          copyText: () => Effect.void,
+        } satisfies ElectronShell.ElectronShellShape),
         electronThemeLayer,
         electronWindowLayer,
       ),
@@ -154,6 +161,27 @@ function makeTestLayer(input: {
 }
 
 describe("DesktopWindow", () => {
+  it("recognizes only same-origin renderer navigations", () => {
+    assert.isTrue(
+      DesktopWindow.isSameOriginRendererNavigation({
+        applicationUrl: "http://127.0.0.1:3773/",
+        navigationUrl: "http://127.0.0.1:3773/settings/cloud",
+      }),
+    );
+    assert.isFalse(
+      DesktopWindow.isSameOriginRendererNavigation({
+        applicationUrl: "http://127.0.0.1:3773/",
+        navigationUrl: "https://accounts.microsoft.com/oauth",
+      }),
+    );
+    assert.isFalse(
+      DesktopWindow.isSameOriginRendererNavigation({
+        applicationUrl: "http://127.0.0.1:3773/",
+        navigationUrl: "not a url",
+      }),
+    );
+  });
+
   it.effect("does not open a development window until the backend is ready", () =>
     Effect.gen(function* () {
       const fakeWindow = makeFakeBrowserWindow();
@@ -174,6 +202,44 @@ describe("DesktopWindow", () => {
         assert.equal(yield* Ref.get(createCount), 1);
         assert.deepEqual(fakeWindow.loadURL.mock.calls[0], ["http://127.0.0.1:5733/"]);
         assert.equal(fakeWindow.openDevTools.mock.calls.length, 1);
+      }).pipe(Effect.provide(layer));
+    }),
+  );
+
+  it.effect("opens safe off-origin renderer navigations in the system browser", () =>
+    Effect.gen(function* () {
+      const fakeWindow = makeFakeBrowserWindow();
+      const createCount = yield* Ref.make(0);
+      const mainWindow = yield* Ref.make<Option.Option<Electron.BrowserWindow>>(Option.none());
+      const openedExternalUrls: unknown[] = [];
+      const layer = makeTestLayer({
+        window: fakeWindow.window,
+        createCount,
+        mainWindow,
+        openedExternalUrls,
+      });
+
+      yield* Effect.gen(function* () {
+        const desktopWindow = yield* DesktopWindow.DesktopWindow;
+        yield* desktopWindow.handleBackendReady;
+
+        const willNavigate = fakeWindow.webContentsListeners.get("will-navigate");
+        if (!willNavigate) {
+          return yield* Effect.die("will-navigate listener was not registered");
+        }
+        let prevented = false;
+        willNavigate(
+          {
+            preventDefault: () => {
+              prevented = true;
+            },
+          },
+          "https://accounts.microsoft.com/oauth",
+        );
+        yield* Effect.promise(() => Promise.resolve());
+
+        assert.isTrue(prevented);
+        assert.deepEqual(openedExternalUrls, ["https://accounts.microsoft.com/oauth"]);
       }).pipe(Effect.provide(layer));
     }),
   );

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -92,6 +92,17 @@ function getInitialWindowBackgroundColor(shouldUseDarkColors: boolean): string {
   return shouldUseDarkColors ? "#0a0a0a" : "#ffffff";
 }
 
+export function isSameOriginRendererNavigation(input: {
+  readonly applicationUrl: string;
+  readonly navigationUrl: string;
+}): boolean {
+  try {
+    return new URL(input.applicationUrl).origin === new URL(input.navigationUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
 function getWindowTitleBarOptions(shouldUseDarkColors: boolean): WindowTitleBarOptions {
   if (process.platform === "darwin") {
     return {
@@ -159,6 +170,9 @@ const make = Effect.gen(function* () {
   const createWindow = Effect.fn("desktop.window.createWindow")(function* (
     backendHttpUrl: URL,
   ): Effect.fn.Return<Electron.BrowserWindow, DesktopWindowError> {
+    const applicationUrl = environment.isDevelopment
+      ? yield* resolveDesktopDevServerUrl(environment)
+      : backendHttpUrl.href;
     const iconPaths = yield* assets.iconPaths;
     const iconOption = getIconOption(iconPaths);
     const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
@@ -235,6 +249,21 @@ const make = Effect.gen(function* () {
       }
       return { action: "deny" };
     });
+    window.webContents.on("will-navigate", (event, url) => {
+      if (
+        isSameOriginRendererNavigation({
+          applicationUrl,
+          navigationUrl: url,
+        })
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      if (Option.isSome(ElectronShell.parseSafeExternalUrl(url))) {
+        void runPromise(electronShell.openExternal(url));
+      }
+    });
 
     window.on("page-title-updated", (event) => {
       event.preventDefault();
@@ -276,11 +305,10 @@ const make = Effect.gen(function* () {
     });
 
     if (environment.isDevelopment) {
-      const devServerUrl = yield* resolveDesktopDevServerUrl(environment);
-      void window.loadURL(devServerUrl);
+      void window.loadURL(applicationUrl);
       window.webContents.openDevTools({ mode: "detach" });
     } else {
-      void window.loadURL(backendHttpUrl.href);
+      void window.loadURL(applicationUrl);
     }
 
     window.on("closed", () => {

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -5,5 +5,5 @@
     "types": ["node", "electron"],
     "lib": ["ESNext", "DOM", "esnext.disposable"]
   },
-  "include": ["src", "vite.config.ts"]
+  "include": ["src", "vite.config.ts", "../../scripts/lib"]
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,6 +1,14 @@
 import { defineConfig } from "vite-plus";
 
+import { loadRepoEnv } from "../../scripts/lib/public-config.ts";
+
+const repoEnv = loadRepoEnv();
 const shouldLaunchElectronAfterPack = process.env.T3CODE_DESKTOP_DEV === "1";
+const publicConfigDefine = {
+  __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: JSON.stringify(
+    repoEnv.T3CODE_CLERK_PUBLISHABLE_KEY?.trim() ?? "",
+  ),
+};
 
 export default defineConfig({
   run: {
@@ -27,6 +35,7 @@ export default defineConfig({
       outDir: "dist-electron",
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
+      define: publicConfigDefine,
       entry: ["src/main.ts"],
       clean: true,
       deps: {
@@ -39,6 +48,7 @@ export default defineConfig({
       outDir: "dist-electron",
       sourcemap: true,
       outExtensions: () => ({ js: ".cjs" }),
+      define: publicConfigDefine,
       entry: ["src/preload.ts"],
     },
   ],

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig } from "expo/config";
 
-import { loadRepoEnv } from "../../scripts/lib/public-config";
+import { loadRepoEnv } from "../../scripts/lib/public-config.ts";
 
 type AppVariant = "development" | "preview" | "production";
 

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -175,6 +175,29 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     }),
   );
 
+  it.effect("reports fresh headless cloud state without requiring local configuration", () =>
+    Effect.gen(function* () {
+      const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-status-test-"));
+      const { output } = yield* captureStdout(
+        runCli(["cloud", "status", "--base-dir", baseDir, "--json"]),
+      );
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - CLI JSON output is decoded as a presentation DTO.
+      const status = JSON.parse(output) as {
+        readonly desired: boolean;
+        readonly authenticated: boolean;
+        readonly linked: boolean;
+        readonly cloudUserId: string | null;
+        readonly relayUrl: string | null;
+      };
+
+      assert.equal(status.desired, false);
+      assert.equal(status.authenticated, false);
+      assert.equal(status.linked, false);
+      assert.equal(status.cloudUserId, null);
+      assert.equal(status.relayUrl, null);
+    }),
+  );
+
   it.effect("executes auth pairing subcommands and redacts secrets from list output", () =>
     Effect.gen(function* () {
       const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-auth-pairing-test-"));

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -198,6 +198,15 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     }),
   );
 
+  it.effect("disables headless cloud exposure without a running server", () =>
+    Effect.gen(function* () {
+      const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-unlink-test-"));
+      const { output } = yield* captureStdout(runCli(["cloud", "unlink", "--base-dir", baseDir]));
+
+      assert.equal(output, "T3 Cloud exposure is disabled locally.");
+    }),
+  );
+
   it.effect("executes auth pairing subcommands and redacts secrets from list output", () =>
     Effect.gen(function* () {
       const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-auth-pairing-test-"));

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -210,6 +210,37 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     }),
   );
 
+  it.effect("logs in to headless cloud without enabling exposure", () =>
+    Effect.gen(function* () {
+      const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-login-test-"));
+      const { secretsDir } = yield* deriveServerPaths(baseDir, undefined);
+      mkdirSync(secretsDir, { recursive: true });
+      writeFileSync(
+        join(secretsDir, "cloud-cli-oauth-token.bin"),
+        // @effect-diagnostics-next-line preferSchemaOverJson:off - Test fixture matches the persisted CLI token representation.
+        JSON.stringify({
+          accessToken: "access-token",
+          refreshToken: "refresh-token",
+          expiresAtEpochMs: Number.MAX_SAFE_INTEGER,
+        }),
+      );
+
+      const login = yield* captureStdout(runCli(["cloud", "login", "--base-dir", baseDir]));
+      const status = yield* captureStdout(
+        runCli(["cloud", "status", "--base-dir", baseDir, "--json"]),
+      );
+      // @effect-diagnostics-next-line preferSchemaOverJson:off - CLI JSON output is decoded as a presentation DTO.
+      const decoded = JSON.parse(status.output) as {
+        readonly desired: boolean;
+        readonly authenticated: boolean;
+      };
+
+      assert.equal(login.output, "Signed in to T3 Cloud.");
+      assert.isFalse(decoded.desired);
+      assert.isTrue(decoded.authenticated);
+    }),
+  );
+
   it.effect("disables headless cloud exposure without a running server", () =>
     Effect.gen(function* () {
       const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-unlink-test-"));

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -1,6 +1,6 @@
 // @effect-diagnostics nodeBuiltinImport:off - CLI integration exercises Node HTTP and filesystem boundaries.
 import * as NodeHttp from "node:http";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -198,12 +198,39 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     }),
   );
 
+  it.effect("reports actionable human-readable headless cloud state", () =>
+    Effect.gen(function* () {
+      const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-status-human-test-"));
+      const { output } = yield* captureStdout(runCli(["cloud", "status", "--base-dir", baseDir]));
+
+      assert.include(output, "T3 Cloud\n  Exposure: disabled");
+      assert.include(output, "  Authorization: missing");
+      assert.include(output, "  Environment link: not provisioned");
+      assert.include(output, "Next: Run `t3 cloud link` to authorize and enable cloud exposure.");
+    }),
+  );
+
   it.effect("disables headless cloud exposure without a running server", () =>
     Effect.gen(function* () {
       const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-unlink-test-"));
       const { output } = yield* captureStdout(runCli(["cloud", "unlink", "--base-dir", baseDir]));
 
       assert.equal(output, "T3 Cloud exposure is disabled locally.");
+    }),
+  );
+
+  it.effect("logs out of headless cloud and removes the stored CLI authorization", () =>
+    Effect.gen(function* () {
+      const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-logout-test-"));
+      const { secretsDir } = yield* deriveServerPaths(baseDir, undefined);
+      const tokenPath = join(secretsDir, "cloud-cli-oauth-token.bin");
+      mkdirSync(secretsDir, { recursive: true });
+      writeFileSync(tokenPath, "invalid persisted token");
+
+      const { output } = yield* captureStdout(runCli(["cloud", "logout", "--base-dir", baseDir]));
+
+      assert.equal(output, "Signed out of T3 Cloud locally.");
+      assert.isFalse(existsSync(tokenPath));
     }),
   );
 

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -181,22 +181,21 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
 
   it.effect("rejects cloud commands when public cloud configuration is missing", () =>
     Effect.gen(function* () {
-      const error = yield* runCli(["cloud", "status"], noCloudCli).pipe(
-        Effect.provide(CliRuntimeLayer),
-        Effect.flip,
-      );
+      const error = yield* runCli(["cloud", "status"], noCloudCli).pipe(Effect.flip);
 
       if (!CliError.isCliError(error)) {
         assert.fail(`Expected CliError, got ${String(error)}`);
       }
-      if (error._tag !== "UserError") {
-        assert.fail(`Expected UserError, got ${error._tag}`);
+      if (error._tag !== "ShowHelp") {
+        assert.fail(`Expected ShowHelp, got ${error._tag}`);
       }
-      if (!(error.cause instanceof Error)) {
-        assert.fail(`Expected Error cause, got ${String(error.cause)}`);
-      }
-      assert.include(error.cause.message, "missing T3 Cloud public configuration");
-    }),
+      assert.deepEqual(error.commandPath, ["t3", "cloud"]);
+      assert.include(error.errors[0]?.message ?? "", "missing T3 Cloud public configuration");
+
+      const output = (yield* TestConsole.errorLines).join("\n");
+      assert.include(output, "ERROR");
+      assert.include(output, "missing T3 Cloud public configuration");
+    }).pipe(Effect.provide(Layer.mergeAll(CliRuntimeLayer, TestConsole.layer))),
   );
 
   it.effect("reports fresh headless cloud state without requiring local configuration", () =>

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -19,7 +19,7 @@ import * as CliError from "effect/unstable/cli/CliError";
 import * as TestConsole from "effect/testing/TestConsole";
 import { Command } from "effect/unstable/cli";
 
-import { cli } from "./bin.ts";
+import { cli, makeCli } from "./bin.ts";
 import { deriveServerPaths, ServerConfig, type ServerConfigShape } from "./config.ts";
 import { ProjectionSnapshotQuery } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
@@ -38,7 +38,10 @@ import { environmentAuthenticatedAuthLayer } from "./auth/http.ts";
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 class ProjectCliHttpApi extends HttpApi.make("environment").add(EnvironmentOrchestrationHttpApi) {}
 
-const runCli = (args: ReadonlyArray<string>) => Command.runWith(cli, { version: "0.0.0" })(args);
+const cloudCli = makeCli({ cloudEnabled: true });
+const runCli = (args: ReadonlyArray<string>, command = cli) =>
+  Command.runWith(command, { version: "0.0.0" })(args);
+const runCloudCli = (args: ReadonlyArray<string>) => runCli(args, cloudCli);
 const runCliWithRuntime = (args: ReadonlyArray<string>) =>
   runCli(args).pipe(Effect.provide(CliRuntimeLayer));
 
@@ -179,7 +182,7 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
     Effect.gen(function* () {
       const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-status-test-"));
       const { output } = yield* captureStdout(
-        runCli(["cloud", "status", "--base-dir", baseDir, "--json"]),
+        runCloudCli(["cloud", "status", "--base-dir", baseDir, "--json"]),
       );
       // @effect-diagnostics-next-line preferSchemaOverJson:off - CLI JSON output is decoded as a presentation DTO.
       const status = JSON.parse(output) as {
@@ -201,7 +204,9 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
   it.effect("reports actionable human-readable headless cloud state", () =>
     Effect.gen(function* () {
       const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-status-human-test-"));
-      const { output } = yield* captureStdout(runCli(["cloud", "status", "--base-dir", baseDir]));
+      const { output } = yield* captureStdout(
+        runCloudCli(["cloud", "status", "--base-dir", baseDir]),
+      );
 
       assert.include(output, "T3 Cloud\n  Exposure: disabled");
       assert.include(output, "  Authorization: missing");
@@ -225,9 +230,9 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
         }),
       );
 
-      const login = yield* captureStdout(runCli(["cloud", "login", "--base-dir", baseDir]));
+      const login = yield* captureStdout(runCloudCli(["cloud", "login", "--base-dir", baseDir]));
       const status = yield* captureStdout(
-        runCli(["cloud", "status", "--base-dir", baseDir, "--json"]),
+        runCloudCli(["cloud", "status", "--base-dir", baseDir, "--json"]),
       );
       // @effect-diagnostics-next-line preferSchemaOverJson:off - CLI JSON output is decoded as a presentation DTO.
       const decoded = JSON.parse(status.output) as {
@@ -244,7 +249,9 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
   it.effect("disables headless cloud exposure without a running server", () =>
     Effect.gen(function* () {
       const baseDir = mkdtempSync(join(tmpdir(), "t3-cli-cloud-unlink-test-"));
-      const { output } = yield* captureStdout(runCli(["cloud", "unlink", "--base-dir", baseDir]));
+      const { output } = yield* captureStdout(
+        runCloudCli(["cloud", "unlink", "--base-dir", baseDir]),
+      );
 
       assert.equal(output, "T3 Cloud exposure is disabled locally.");
     }),
@@ -258,7 +265,9 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
       mkdirSync(secretsDir, { recursive: true });
       writeFileSync(tokenPath, "invalid persisted token");
 
-      const { output } = yield* captureStdout(runCli(["cloud", "logout", "--base-dir", baseDir]));
+      const { output } = yield* captureStdout(
+        runCloudCli(["cloud", "logout", "--base-dir", baseDir]),
+      );
 
       assert.equal(output, "Signed out of T3 Cloud locally.");
       assert.isFalse(existsSync(tokenPath));

--- a/apps/server/src/bin.test.ts
+++ b/apps/server/src/bin.test.ts
@@ -39,6 +39,7 @@ const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 class ProjectCliHttpApi extends HttpApi.make("environment").add(EnvironmentOrchestrationHttpApi) {}
 
 const cloudCli = makeCli({ cloudEnabled: true });
+const noCloudCli = makeCli({ cloudEnabled: false });
 const runCli = (args: ReadonlyArray<string>, command = cli) =>
   Command.runWith(command, { version: "0.0.0" })(args);
 const runCloudCli = (args: ReadonlyArray<string>) => runCli(args, cloudCli);
@@ -175,6 +176,26 @@ it.layer(NodeServices.layer)("bin cli parsing", (it) => {
       }
       assert.equal(error.option, "log-level");
       assert.equal(error.value, "Debug");
+    }),
+  );
+
+  it.effect("rejects cloud commands when public cloud configuration is missing", () =>
+    Effect.gen(function* () {
+      const error = yield* runCli(["cloud", "status"], noCloudCli).pipe(
+        Effect.provide(CliRuntimeLayer),
+        Effect.flip,
+      );
+
+      if (!CliError.isCliError(error)) {
+        assert.fail(`Expected CliError, got ${String(error)}`);
+      }
+      if (error._tag !== "UserError") {
+        assert.fail(`Expected UserError, got ${error._tag}`);
+      }
+      if (!(error.cause instanceof Error)) {
+        assert.fail(`Expected Error cause, got ${String(error.cause)}`);
+      }
+      assert.include(error.cause.message, "missing T3 Cloud public configuration");
     }),
   );
 

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -16,15 +16,23 @@ import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
+const cloudPublicConfigMissingMessage =
+  "T3 Cloud commands are unavailable: this build is missing T3 Cloud public configuration.";
+
+class CloudPublicConfigMissingError extends CliError.UserError {
+  override get message() {
+    return cloudPublicConfigMissingMessage;
+  }
+}
+
 const cloudUnavailableCommand = Command.make("cloud").pipe(
   Command.withDescription("T3 Cloud is unavailable in builds without public cloud configuration."),
   Command.withHidden,
   Command.withHandler(() =>
     Effect.fail(
-      new CliError.UserError({
-        cause: new Error(
-          "T3 Cloud commands are unavailable: this build is missing T3 Cloud public configuration.",
-        ),
+      new CliError.ShowHelp({
+        commandPath: ["t3", "cloud"],
+        errors: [new CloudPublicConfigMissingError({ cause: cloudPublicConfigMissingMessage })],
       }),
     ),
   ),

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -8,14 +8,14 @@ import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
 import { cloudCommand } from "./cli/cloud.ts";
-import { hasRelayPublicConfig } from "./cloud/publicConfig.ts";
+import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
-export const makeCli = ({ cloudEnabled = hasRelayPublicConfig } = {}) =>
+export const makeCli = ({ cloudEnabled = hasCloudPublicConfig } = {}) =>
   Command.make("t3", { ...sharedServerCommandFlags }).pipe(
     Command.withDescription("Run the T3 Code server."),
     Command.withHandler((flags) => runServerCommand(flags)),

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -7,6 +7,7 @@ import { Command } from "effect/unstable/cli";
 import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
+import { cloudCommand } from "./cli/cloud.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
@@ -16,7 +17,7 @@ const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
   Command.withDescription("Run the T3 Code server."),
   Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand]),
+  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand, cloudCommand]),
 );
 
 if (import.meta.main) {

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -8,17 +8,27 @@ import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
 import { authCommand } from "./cli/auth.ts";
 import { cloudCommand } from "./cli/cloud.ts";
+import { hasRelayPublicConfig } from "./cloud/publicConfig.ts";
 import { sharedServerCommandFlags } from "./cli/config.ts";
 import { projectCommand } from "./cli/project.ts";
 import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
-export const cli = Command.make("t3", { ...sharedServerCommandFlags }).pipe(
-  Command.withDescription("Run the T3 Code server."),
-  Command.withHandler((flags) => runServerCommand(flags)),
-  Command.withSubcommands([startCommand, serveCommand, authCommand, projectCommand, cloudCommand]),
-);
+export const makeCli = ({ cloudEnabled = hasRelayPublicConfig } = {}) =>
+  Command.make("t3", { ...sharedServerCommandFlags }).pipe(
+    Command.withDescription("Run the T3 Code server."),
+    Command.withHandler((flags) => runServerCommand(flags)),
+    Command.withSubcommands([
+      startCommand,
+      serveCommand,
+      authCommand,
+      projectCommand,
+      ...(cloudEnabled ? [cloudCommand] : []),
+    ]),
+  );
+
+export const cli = makeCli();
 
 if (import.meta.main) {
   Command.run(cli, { version: packageJson.version }).pipe(

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -3,6 +3,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { Command } from "effect/unstable/cli";
+import * as CliError from "effect/unstable/cli/CliError";
 
 import * as NetService from "@t3tools/shared/Net";
 import packageJson from "../package.json" with { type: "json" };
@@ -15,6 +16,20 @@ import { runServerCommand, serveCommand, startCommand } from "./cli/server.ts";
 
 const CliRuntimeLayer = Layer.mergeAll(NodeServices.layer, NetService.layer);
 
+const cloudUnavailableCommand = Command.make("cloud").pipe(
+  Command.withDescription("T3 Cloud is unavailable in builds without public cloud configuration."),
+  Command.withHidden,
+  Command.withHandler(() =>
+    Effect.fail(
+      new CliError.UserError({
+        cause: new Error(
+          "T3 Cloud commands are unavailable: this build is missing T3 Cloud public configuration.",
+        ),
+      }),
+    ),
+  ),
+);
+
 export const makeCli = ({ cloudEnabled = hasCloudPublicConfig } = {}) =>
   Command.make("t3", { ...sharedServerCommandFlags }).pipe(
     Command.withDescription("Run the T3 Code server."),
@@ -24,7 +39,7 @@ export const makeCli = ({ cloudEnabled = hasCloudPublicConfig } = {}) =>
       serveCommand,
       authCommand,
       projectCommand,
-      ...(cloudEnabled ? [cloudCommand] : []),
+      cloudEnabled ? cloudCommand : cloudUnavailableCommand,
     ]),
   );
 

--- a/apps/server/src/cli/cloud.test.ts
+++ b/apps/server/src/cli/cloud.test.ts
@@ -25,8 +25,14 @@ it.effect("does not install the relay client when the user declines the managed 
           installCalls += 1;
           return managedExecutable;
         }),
+        installWithProgress: () =>
+          Effect.sync(() => {
+            installCalls += 1;
+            return managedExecutable;
+          }),
       },
       () => Effect.succeed(false),
+      () => Effect.void,
     );
 
     assert.isTrue(Option.isNone(result));
@@ -37,6 +43,7 @@ it.effect("does not install the relay client when the user declines the managed 
 it.effect("installs the relay client after the user accepts the managed download", () =>
   Effect.gen(function* () {
     let installCalls = 0;
+    const progress: Array<string> = [];
     const result = yield* acquireRelayClientForLink(
       {
         resolve: Effect.succeed({
@@ -47,12 +54,28 @@ it.effect("installs the relay client after the user accepts the managed download
           installCalls += 1;
           return managedExecutable;
         }),
+        installWithProgress: (report) =>
+          report({ type: "progress", stage: "downloading" }).pipe(
+            Effect.andThen(
+              Effect.sync(() => {
+                installCalls += 1;
+                return managedExecutable;
+              }),
+            ),
+          ),
       },
       () => Effect.succeed(true),
+      (event) =>
+        Effect.sync(() => {
+          if (event.type === "progress") {
+            progress.push(event.stage);
+          }
+        }),
     );
 
     assert.deepEqual(Option.getOrThrow(result), managedExecutable);
     assert.equal(installCalls, 1);
+    assert.deepEqual(progress, ["downloading"]);
   }),
 );
 
@@ -63,12 +86,14 @@ it.effect("reuses an available relay client executable without prompting", () =>
       {
         resolve: Effect.succeed(managedExecutable),
         install: Effect.die("unexpected install"),
+        installWithProgress: () => Effect.die("unexpected install"),
       },
       () =>
         Effect.sync(() => {
           promptCalls += 1;
           return false;
         }),
+      () => Effect.void,
     );
 
     assert.deepEqual(Option.getOrThrow(result), managedExecutable);

--- a/apps/server/src/cli/cloud.test.ts
+++ b/apps/server/src/cli/cloud.test.ts
@@ -1,0 +1,77 @@
+import * as RelayClient from "@t3tools/shared/relayClient";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import { acquireRelayClientForLink } from "./cloud.ts";
+
+const managedExecutable = {
+  status: "available",
+  executablePath: "/tmp/cloudflared",
+  source: "managed",
+  version: RelayClient.CLOUDFLARED_VERSION,
+} as const;
+
+it.effect("does not install the relay client when the user declines the managed download", () =>
+  Effect.gen(function* () {
+    let installCalls = 0;
+    const result = yield* acquireRelayClientForLink(
+      {
+        resolve: Effect.succeed({
+          status: "missing",
+          version: RelayClient.CLOUDFLARED_VERSION,
+        }),
+        install: Effect.sync(() => {
+          installCalls += 1;
+          return managedExecutable;
+        }),
+      },
+      () => Effect.succeed(false),
+    );
+
+    assert.isTrue(Option.isNone(result));
+    assert.equal(installCalls, 0);
+  }),
+);
+
+it.effect("installs the relay client after the user accepts the managed download", () =>
+  Effect.gen(function* () {
+    let installCalls = 0;
+    const result = yield* acquireRelayClientForLink(
+      {
+        resolve: Effect.succeed({
+          status: "missing",
+          version: RelayClient.CLOUDFLARED_VERSION,
+        }),
+        install: Effect.sync(() => {
+          installCalls += 1;
+          return managedExecutable;
+        }),
+      },
+      () => Effect.succeed(true),
+    );
+
+    assert.deepEqual(Option.getOrThrow(result), managedExecutable);
+    assert.equal(installCalls, 1);
+  }),
+);
+
+it.effect("reuses an available relay client executable without prompting", () =>
+  Effect.gen(function* () {
+    let promptCalls = 0;
+    const result = yield* acquireRelayClientForLink(
+      {
+        resolve: Effect.succeed(managedExecutable),
+        install: Effect.die("unexpected install"),
+      },
+      () =>
+        Effect.sync(() => {
+          promptCalls += 1;
+          return false;
+        }),
+    );
+
+    assert.deepEqual(Option.getOrThrow(result), managedExecutable);
+    assert.equal(promptCalls, 0);
+  }),
+);

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -1,0 +1,281 @@
+import { AuthRelayWriteScope, EnvironmentHttpApi } from "@t3tools/contracts";
+import { RelayOkResponse } from "@t3tools/contracts/relay";
+import * as Cloudflared from "@t3tools/shared/cloudflared";
+import { DEFAULT_T3_RELAY_URL } from "@t3tools/shared/relayAuth";
+import * as Config from "effect/Config";
+import * as Console from "effect/Console";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as References from "effect/References";
+import { Command, Flag, GlobalFlag } from "effect/unstable/cli";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http";
+import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
+
+import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
+import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import * as CliState from "../cloud/CliState.ts";
+import * as CliTokenManager from "../cloud/CliTokenManager.ts";
+import { CLOUD_LINKED_USER_ID, RELAY_URL_SECRET } from "../cloud/config.ts";
+import { ServerConfig } from "../config.ts";
+import { ServerEnvironmentLive } from "../environment/Layers/ServerEnvironment.ts";
+import { ServerEnvironment } from "../environment/Services/ServerEnvironment.ts";
+import { readPersistedServerRuntimeState } from "../serverRuntimeState.ts";
+import { projectLocationFlags, resolveCliAuthConfig } from "./config.ts";
+
+const jsonFlag = Flag.boolean("json").pipe(
+  Flag.withDescription("Emit JSON instead of human-readable output."),
+  Flag.withDefault(false),
+);
+
+function bytesToString(value: Uint8Array): string {
+  return new TextDecoder().decode(value);
+}
+
+const CLOUD_CLI_LIVE_SERVER_TIMEOUT = Duration.seconds(5);
+
+const withCloudCliSessionToken = <A, E, R>(
+  environmentAuth: EnvironmentAuth.EnvironmentAuthShape,
+  run: (token: string) => Effect.Effect<A, E, R>,
+) =>
+  Effect.acquireUseRelease(
+    environmentAuth.issueSession({
+      scopes: [AuthRelayWriteScope],
+      subject: "cloud-cli",
+      label: "t3 cloud cli",
+    }),
+    (issued) => run(issued.token),
+    (issued) => environmentAuth.revokeSession(issued.sessionId).pipe(Effect.ignore({ log: true })),
+  );
+
+type LiveCloudActionResult =
+  | { readonly status: "not-running" }
+  | { readonly status: "succeeded" }
+  | { readonly status: "failed"; readonly cause: unknown };
+
+const runLiveCloudAction = Effect.fn("cloud.cli.run_live_action")(function* (
+  action: "reconcile" | "unlink",
+) {
+  const config = yield* ServerConfig;
+  const runtimeState = yield* readPersistedServerRuntimeState(config.serverRuntimeStatePath);
+  if (Option.isNone(runtimeState)) {
+    return { status: "not-running" } satisfies LiveCloudActionResult;
+  }
+
+  const environmentAuth = yield* EnvironmentAuth.EnvironmentAuth;
+  const result = yield* Effect.exit(
+    withCloudCliSessionToken(environmentAuth, (token) =>
+      Effect.gen(function* () {
+        const httpClient = yield* HttpClient.HttpClient;
+        const client = yield* HttpApiClient.makeWith(EnvironmentHttpApi, {
+          baseUrl: runtimeState.value.origin,
+          httpClient,
+        });
+        return yield* action === "reconcile"
+          ? client.cloud.reconcile({ headers: { authorization: `Bearer ${token}` } })
+          : client.cloud.unlink({ headers: { authorization: `Bearer ${token}` } });
+      }).pipe(Effect.timeout(CLOUD_CLI_LIVE_SERVER_TIMEOUT)),
+    ),
+  );
+  return Exit.isSuccess(result)
+    ? ({ status: "succeeded" } satisfies LiveCloudActionResult)
+    : ({ status: "failed", cause: result.cause } satisfies LiveCloudActionResult);
+});
+
+type RelayUnlinkResult =
+  | { readonly status: "not-authenticated" }
+  | { readonly status: "revoked" }
+  | { readonly status: "not-linked" };
+
+const unlinkRelayEnvironment = Effect.fn("cloud.cli.unlink_relay_environment")(function* () {
+  const tokens = yield* CliTokenManager.CloudCliTokenManager;
+  const token = yield* tokens.getExisting;
+  if (Option.isNone(token)) {
+    return { status: "not-authenticated" } satisfies RelayUnlinkResult;
+  }
+
+  const environment = yield* ServerEnvironment;
+  const environmentId = yield* environment.getEnvironmentId;
+  const relayUrl = (yield* Config.string("T3_RELAY_URL").pipe(
+    Config.withDefault(DEFAULT_T3_RELAY_URL),
+    Effect.orDie,
+  )).replace(/\/+$/u, "");
+  const httpClient = yield* HttpClient.HttpClient;
+  const response = yield* HttpClientRequest.delete(
+    `${relayUrl}/v1/client/environment-links/${encodeURIComponent(environmentId)}`,
+  ).pipe(
+    HttpClientRequest.bearerToken(token.value.accessToken),
+    httpClient.execute,
+    Effect.flatMap(HttpClientResponse.filterStatusOk),
+    Effect.flatMap(HttpClientResponse.schemaBodyJson(RelayOkResponse)),
+  );
+  return response.ok
+    ? ({ status: "revoked" } satisfies RelayUnlinkResult)
+    : ({ status: "not-linked" } satisfies RelayUnlinkResult);
+});
+
+const runCloudCommand = <A, E>(
+  flags: { readonly baseDir: Option.Option<string> },
+  run: Effect.Effect<
+    A,
+    E,
+    | ServerSecretStore.ServerSecretStore
+    | CliTokenManager.CloudCliTokenManager
+    | Cloudflared.CloudflaredExecutable
+    | EnvironmentAuth.EnvironmentAuth
+    | FileSystem.FileSystem
+    | HttpClient.HttpClient
+    | ServerConfig
+    | ServerEnvironment
+  >,
+) =>
+  Effect.gen(function* () {
+    const logLevel = yield* GlobalFlag.LogLevel;
+    const config = yield* resolveCliAuthConfig(flags, logLevel);
+    const runtimeLayer = Layer.mergeAll(
+      ServerSecretStore.layer,
+      CliTokenManager.layer.pipe(Layer.provide(ServerSecretStore.layer)),
+      Cloudflared.layer({ baseDir: config.baseDir }),
+      EnvironmentAuth.runtimeLayer,
+      ServerEnvironmentLive,
+    ).pipe(
+      Layer.provideMerge(FetchHttpClient.layer),
+      Layer.provide(Layer.succeed(ServerConfig, config)),
+      Layer.provide(Layer.succeed(References.MinimumLogLevel, config.logLevel)),
+    );
+    return yield* run.pipe(Effect.provide(runtimeLayer));
+  });
+
+const cloudLinkCommand = Command.make("link", {
+  ...projectLocationFlags,
+}).pipe(
+  Command.withDescription("Authorize this environment for T3 Cloud and expose it on next start."),
+  Command.withHandler((flags) =>
+    runCloudCommand(
+      flags,
+      Effect.gen(function* () {
+        const cloudflared = yield* Cloudflared.CloudflaredExecutable;
+        const executable = yield* cloudflared.resolve;
+        const installed =
+          executable.status === "available" ? executable : yield* cloudflared.install;
+        yield* Console.log(
+          `Using cloudflared ${installed.version} from ${installed.executablePath}.`,
+        );
+
+        const tokens = yield* CliTokenManager.CloudCliTokenManager;
+        yield* tokens.get;
+        yield* CliState.setCliDesiredCloudLink(true);
+
+        const liveResult = yield* runLiveCloudAction("reconcile");
+        if (liveResult.status === "succeeded") {
+          yield* Console.log("T3 Cloud is linked and the running server is exposing its tunnel.");
+        } else if (liveResult.status === "failed") {
+          yield* Console.warn(
+            `T3 Cloud is linked, but the running server could not expose its tunnel yet: ${String(liveResult.cause)}\nThe server will retry the next time it starts.`,
+          );
+        } else {
+          yield* Console.log(
+            "T3 Cloud is linked. The next time T3 starts, it will expose a managed tunnel.",
+          );
+        }
+      }),
+    ),
+  ),
+);
+
+const cloudStatusCommand = Command.make("status", {
+  ...projectLocationFlags,
+  json: jsonFlag,
+}).pipe(
+  Command.withDescription("Show persisted T3 Cloud and cloudflared state."),
+  Command.withHandler((flags) =>
+    runCloudCommand(
+      flags,
+      Effect.gen(function* () {
+        const secrets = yield* ServerSecretStore.ServerSecretStore;
+        const cloudflared = yield* Cloudflared.CloudflaredExecutable;
+        const tokens = yield* CliTokenManager.CloudCliTokenManager;
+        const [desired, authenticated, cloudUserId, relayUrl, executable] = yield* Effect.all(
+          [
+            CliState.readCliDesiredCloudLink,
+            tokens.hasCredential,
+            secrets.get(CLOUD_LINKED_USER_ID),
+            secrets.get(RELAY_URL_SECRET),
+            cloudflared.resolve,
+          ],
+          { concurrency: "unbounded" },
+        );
+        const status = {
+          desired,
+          authenticated,
+          linked: cloudUserId !== null,
+          cloudUserId: cloudUserId ? bytesToString(cloudUserId) : null,
+          relayUrl: relayUrl ? bytesToString(relayUrl) : null,
+          cloudflared: executable,
+        };
+        yield* Console.log(
+          flags.json
+            ? // @effect-diagnostics-next-line preferSchemaOverJson:off - CLI JSON output intentionally encodes a presentation DTO.
+              JSON.stringify(status)
+            : [
+                `Desired cloud exposure: ${status.desired ? "enabled" : "disabled"}`,
+                `T3 Cloud CLI authorization: ${status.authenticated ? "stored" : "missing"}`,
+                `Provisioned cloud link: ${status.linked ? "yes" : "no"}`,
+                `Relay URL: ${status.relayUrl ?? "not provisioned"}`,
+                `cloudflared: ${
+                  executable.status === "available"
+                    ? `${executable.source} (${executable.executablePath})`
+                    : executable.status
+                }`,
+              ].join("\n"),
+        );
+      }),
+    ),
+  ),
+);
+
+const cloudUnlinkCommand = Command.make("unlink", {
+  ...projectLocationFlags,
+}).pipe(
+  Command.withDescription("Disable T3 Cloud exposure and remove persisted local cloud state."),
+  Command.withHandler((flags) =>
+    runCloudCommand(
+      flags,
+      Effect.gen(function* () {
+        yield* CliState.setCliDesiredCloudLink(false);
+        const liveResult = yield* runLiveCloudAction("unlink");
+        const relayResult = yield* Effect.exit(unlinkRelayEnvironment());
+        yield* CliState.clearPersistedCloudLink;
+
+        if (liveResult.status === "failed") {
+          yield* Console.warn(
+            `T3 Cloud exposure is disabled, but the running server could not stop its tunnel: ${String(liveResult.cause)}\nRestart that server to stop the connector.`,
+          );
+        } else {
+          yield* Console.log("T3 Cloud exposure is disabled locally.");
+        }
+
+        if (Exit.isFailure(relayResult)) {
+          yield* Console.warn(
+            `Could not revoke the relay-side environment record yet: ${String(relayResult.cause)}\nRun \`t3 cloud unlink\` again when the relay is reachable.`,
+          );
+        } else if (relayResult.value.status === "revoked") {
+          yield* Console.log("Revoked the relay-side environment record.");
+        }
+      }),
+    ),
+  ),
+);
+
+export const cloudCommand = Command.make("cloud").pipe(
+  Command.withDescription("Manage headless T3 Cloud exposure."),
+  Command.withSubcommands([cloudLinkCommand, cloudStatusCommand, cloudUnlinkCommand]),
+);

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -1,8 +1,6 @@
 import { AuthRelayWriteScope, EnvironmentHttpApi } from "@t3tools/contracts";
 import { RelayOkResponse } from "@t3tools/contracts/relay";
 import * as Cloudflared from "@t3tools/shared/cloudflared";
-import { DEFAULT_T3_RELAY_URL } from "@t3tools/shared/relayAuth";
-import * as Config from "effect/Config";
 import * as Console from "effect/Console";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -25,6 +23,7 @@ import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import * as CliState from "../cloud/CliState.ts";
 import * as CliTokenManager from "../cloud/CliTokenManager.ts";
 import { CLOUD_LINKED_USER_ID, RELAY_URL_SECRET } from "../cloud/config.ts";
+import { relayUrlConfig } from "../cloud/publicConfig.ts";
 import { ServerConfig } from "../config.ts";
 import { ServerEnvironmentLive } from "../environment/Layers/ServerEnvironment.ts";
 import { ServerEnvironment } from "../environment/Services/ServerEnvironment.ts";
@@ -169,10 +168,7 @@ const unlinkRelayEnvironment = Effect.fn("cloud.cli.unlink_relay_environment")(f
 
   const environment = yield* ServerEnvironment;
   const environmentId = yield* environment.getEnvironmentId;
-  const relayUrl = (yield* Config.string("T3_RELAY_URL").pipe(
-    Config.withDefault(DEFAULT_T3_RELAY_URL),
-    Effect.orDie,
-  )).replace(/\/+$/u, "");
+  const relayUrl = yield* relayUrlConfig;
   const httpClient = yield* HttpClient.HttpClient;
   const response = yield* HttpClientRequest.delete(
     `${relayUrl}/v1/client/environment-links/${encodeURIComponent(environmentId)}`,

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -40,6 +40,71 @@ function bytesToString(value: Uint8Array): string {
   return new TextDecoder().decode(value);
 }
 
+interface CloudCliStatus {
+  readonly desired: boolean;
+  readonly authenticated: boolean;
+  readonly linked: boolean;
+  readonly cloudUserId: string | null;
+  readonly relayUrl: string | null;
+  readonly cloudflared: Cloudflared.CloudflaredExecutableStatus;
+}
+
+function formatCloudflaredStatus(
+  executable: Cloudflared.CloudflaredExecutableStatus,
+): ReadonlyArray<string> {
+  switch (executable.status) {
+    case "available": {
+      const source =
+        executable.source === "path"
+          ? "PATH"
+          : executable.source === "managed"
+            ? "managed install"
+            : "configured override";
+      return [
+        `  cloudflared: available via ${source}`,
+        `    Path: ${executable.executablePath}`,
+        `    Version: ${executable.version}`,
+      ];
+    }
+    case "missing":
+      return [`  cloudflared: not installed (managed version ${executable.version})`];
+    case "unsupported":
+      return [
+        `  cloudflared: unsupported on ${executable.platform}-${executable.arch}`,
+        `    Managed version: ${executable.version}`,
+      ];
+  }
+}
+
+function formatCloudStatus(status: CloudCliStatus, options?: { readonly json?: boolean }): string {
+  if (options?.json) {
+    return JSON.stringify(status, null, 2);
+  }
+
+  const provisioned = status.linked
+    ? "provisioned"
+    : status.desired && status.authenticated
+      ? "pending server startup"
+      : "not provisioned";
+  const nextStep = !status.authenticated
+    ? "Run `t3 cloud link` to authorize and enable cloud exposure."
+    : !status.desired
+      ? "Run `t3 cloud link` to enable cloud exposure."
+      : !status.linked
+        ? "Start T3 to provision the environment link and launch its managed tunnel."
+        : undefined;
+
+  return [
+    "T3 Cloud",
+    `  Exposure: ${status.desired ? "enabled" : "disabled"}`,
+    `  Authorization: ${status.authenticated ? "stored credential" : "missing"}`,
+    `  Environment link: ${provisioned}`,
+    `  Relay: ${status.relayUrl ?? "not provisioned"}`,
+    ...formatCloudflaredStatus(status.cloudflared),
+    ...(nextStep ? ["", `Next: ${nextStep}`] : []),
+  ].join("\n");
+}
+
 const CLOUD_CLI_LIVE_SERVER_TIMEOUT = Duration.seconds(5);
 
 const withCloudCliSessionToken = <A, E, R>(
@@ -122,6 +187,42 @@ const unlinkRelayEnvironment = Effect.fn("cloud.cli.unlink_relay_environment")(f
     : ({ status: "not-linked" } satisfies RelayUnlinkResult);
 });
 
+const disconnectCloud = Effect.fn("cloud.cli.disconnect")(function* (options: {
+  readonly clearAuthorization: boolean;
+}) {
+  yield* CliState.setCliDesiredCloudLink(false);
+  const liveResult = yield* runLiveCloudAction("unlink");
+  const relayResult = yield* Effect.exit(unlinkRelayEnvironment());
+  yield* CliState.clearPersistedCloudLink;
+
+  if (options.clearAuthorization) {
+    const tokens = yield* CliTokenManager.CloudCliTokenManager;
+    yield* tokens.clear;
+  }
+
+  if (liveResult.status === "failed") {
+    yield* Console.warn(
+      `T3 Cloud exposure is disabled, but the running server could not stop its tunnel: ${String(liveResult.cause)}\nRestart that server to stop the connector.`,
+    );
+  } else {
+    yield* Console.log("T3 Cloud exposure is disabled locally.");
+  }
+
+  if (Exit.isFailure(relayResult)) {
+    yield* Console.warn(
+      options.clearAuthorization
+        ? `Could not revoke the relay-side environment record before signing out: ${String(relayResult.cause)}\nThe stored CLI authorization was still removed locally.`
+        : `Could not revoke the relay-side environment record yet: ${String(relayResult.cause)}\nRun \`t3 cloud unlink\` again when the relay is reachable.`,
+    );
+  } else if (relayResult.value.status === "revoked") {
+    yield* Console.log("Revoked the relay-side environment record.");
+  }
+
+  if (options.clearAuthorization) {
+    yield* Console.log("Signed out of T3 Cloud locally.");
+  }
+});
+
 const runCloudCommand = <A, E>(
   flags: { readonly baseDir: Option.Option<string> },
   run: Effect.Effect<
@@ -136,10 +237,14 @@ const runCloudCommand = <A, E>(
     | ServerConfig
     | ServerEnvironment
   >,
+  options?: {
+    readonly quietLogs?: boolean;
+  },
 ) =>
   Effect.gen(function* () {
     const logLevel = yield* GlobalFlag.LogLevel;
     const config = yield* resolveCliAuthConfig(flags, logLevel);
+    const minimumLogLevel = options?.quietLogs ? "Error" : config.logLevel;
     const runtimeLayer = Layer.mergeAll(
       ServerSecretStore.layer,
       CliTokenManager.layer.pipe(Layer.provide(ServerSecretStore.layer)),
@@ -149,7 +254,7 @@ const runCloudCommand = <A, E>(
     ).pipe(
       Layer.provideMerge(FetchHttpClient.layer),
       Layer.provideMerge(Layer.succeed(ServerConfig, config)),
-      Layer.provide(Layer.succeed(References.MinimumLogLevel, config.logLevel)),
+      Layer.provide(Layer.succeed(References.MinimumLogLevel, minimumLogLevel)),
     );
     return yield* run.pipe(Effect.provide(runtimeLayer));
   });
@@ -213,7 +318,7 @@ const cloudStatusCommand = Command.make("status", {
           ],
           { concurrency: "unbounded" },
         );
-        const status = {
+        const status: CloudCliStatus = {
           desired,
           authenticated,
           linked: cloudUserId !== null,
@@ -221,23 +326,11 @@ const cloudStatusCommand = Command.make("status", {
           relayUrl: relayUrl ? bytesToString(relayUrl) : null,
           cloudflared: executable,
         };
-        yield* Console.log(
-          flags.json
-            ? // @effect-diagnostics-next-line preferSchemaOverJson:off - CLI JSON output intentionally encodes a presentation DTO.
-              JSON.stringify(status)
-            : [
-                `Desired cloud exposure: ${status.desired ? "enabled" : "disabled"}`,
-                `T3 Cloud CLI authorization: ${status.authenticated ? "stored" : "missing"}`,
-                `Provisioned cloud link: ${status.linked ? "yes" : "no"}`,
-                `Relay URL: ${status.relayUrl ?? "not provisioned"}`,
-                `cloudflared: ${
-                  executable.status === "available"
-                    ? `${executable.source} (${executable.executablePath})`
-                    : executable.status
-                }`,
-              ].join("\n"),
-        );
+        yield* Console.log(formatCloudStatus(status, { json: flags.json }));
       }),
+      {
+        quietLogs: flags.json,
+      },
     ),
   ),
 );
@@ -245,37 +338,27 @@ const cloudStatusCommand = Command.make("status", {
 const cloudUnlinkCommand = Command.make("unlink", {
   ...projectLocationFlags,
 }).pipe(
-  Command.withDescription("Disable T3 Cloud exposure and remove persisted local cloud state."),
+  Command.withDescription("Disable T3 Cloud exposure while retaining the stored authorization."),
   Command.withHandler((flags) =>
-    runCloudCommand(
-      flags,
-      Effect.gen(function* () {
-        yield* CliState.setCliDesiredCloudLink(false);
-        const liveResult = yield* runLiveCloudAction("unlink");
-        const relayResult = yield* Effect.exit(unlinkRelayEnvironment());
-        yield* CliState.clearPersistedCloudLink;
+    runCloudCommand(flags, disconnectCloud({ clearAuthorization: false })),
+  ),
+);
 
-        if (liveResult.status === "failed") {
-          yield* Console.warn(
-            `T3 Cloud exposure is disabled, but the running server could not stop its tunnel: ${String(liveResult.cause)}\nRestart that server to stop the connector.`,
-          );
-        } else {
-          yield* Console.log("T3 Cloud exposure is disabled locally.");
-        }
-
-        if (Exit.isFailure(relayResult)) {
-          yield* Console.warn(
-            `Could not revoke the relay-side environment record yet: ${String(relayResult.cause)}\nRun \`t3 cloud unlink\` again when the relay is reachable.`,
-          );
-        } else if (relayResult.value.status === "revoked") {
-          yield* Console.log("Revoked the relay-side environment record.");
-        }
-      }),
-    ),
+const cloudLogoutCommand = Command.make("logout", {
+  ...projectLocationFlags,
+}).pipe(
+  Command.withDescription("Disable T3 Cloud exposure and clear the stored CLI authorization."),
+  Command.withHandler((flags) =>
+    runCloudCommand(flags, disconnectCloud({ clearAuthorization: true })),
   ),
 );
 
 export const cloudCommand = Command.make("cloud").pipe(
   Command.withDescription("Manage headless T3 Cloud exposure."),
-  Command.withSubcommands([cloudLinkCommand, cloudStatusCommand, cloudUnlinkCommand]),
+  Command.withSubcommands([
+    cloudLinkCommand,
+    cloudStatusCommand,
+    cloudUnlinkCommand,
+    cloudLogoutCommand,
+  ]),
 );

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -148,7 +148,7 @@ const runCloudCommand = <A, E>(
       ServerEnvironmentLive,
     ).pipe(
       Layer.provideMerge(FetchHttpClient.layer),
-      Layer.provide(Layer.succeed(ServerConfig, config)),
+      Layer.provideMerge(Layer.succeed(ServerConfig, config)),
       Layer.provide(Layer.succeed(References.MinimumLogLevel, config.logLevel)),
     );
     return yield* run.pipe(Effect.provide(runtimeLayer));

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -125,9 +125,7 @@ type LiveCloudActionResult =
   | { readonly status: "succeeded" }
   | { readonly status: "failed"; readonly cause: unknown };
 
-const runLiveCloudAction = Effect.fn("cloud.cli.run_live_action")(function* (
-  action: "reconcile" | "unlink",
-) {
+const runLiveCloudUnlink = Effect.fn("cloud.cli.run_live_unlink")(function* () {
   const config = yield* ServerConfig;
   const runtimeState = yield* readPersistedServerRuntimeState(config.serverRuntimeStatePath);
   if (Option.isNone(runtimeState)) {
@@ -143,9 +141,7 @@ const runLiveCloudAction = Effect.fn("cloud.cli.run_live_action")(function* (
           baseUrl: runtimeState.value.origin,
           httpClient,
         });
-        return yield* action === "reconcile"
-          ? client.cloud.reconcile({ headers: { authorization: `Bearer ${token}` } })
-          : client.cloud.unlink({ headers: { authorization: `Bearer ${token}` } });
+        return yield* client.cloud.unlink({ headers: { authorization: `Bearer ${token}` } });
       }).pipe(Effect.timeout(CLOUD_CLI_LIVE_SERVER_TIMEOUT)),
     ),
   );
@@ -187,7 +183,7 @@ const disconnectCloud = Effect.fn("cloud.cli.disconnect")(function* (options: {
   readonly clearAuthorization: boolean;
 }) {
   yield* CliState.setCliDesiredCloudLink(false);
-  const liveResult = yield* runLiveCloudAction("unlink");
+  const liveResult = yield* runLiveCloudUnlink();
   const relayResult = yield* Effect.exit(unlinkRelayEnvironment());
   yield* CliState.clearPersistedCloudLink;
 
@@ -290,19 +286,9 @@ const cloudLinkCommand = Command.make("link", {
         const tokens = yield* CliTokenManager.CloudCliTokenManager;
         yield* tokens.get;
         yield* CliState.setCliDesiredCloudLink(true);
-
-        const liveResult = yield* runLiveCloudAction("reconcile");
-        if (liveResult.status === "succeeded") {
-          yield* Console.log("T3 Cloud is linked and the running server is exposing its tunnel.");
-        } else if (liveResult.status === "failed") {
-          yield* Console.warn(
-            `T3 Cloud is linked, but the running server could not expose its tunnel yet: ${String(liveResult.cause)}\nThe server will retry the next time it starts.`,
-          );
-        } else {
-          yield* Console.log(
-            "T3 Cloud is linked. The next time T3 starts, it will expose a managed tunnel.",
-          );
-        }
+        yield* Console.log(
+          "This T3 environment will be available over T3 Cloud the next time T3 starts.",
+        );
       }),
     ),
   ),

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -1,6 +1,6 @@
 import { AuthRelayWriteScope, EnvironmentHttpApi } from "@t3tools/contracts";
 import { RelayOkResponse } from "@t3tools/contracts/relay";
-import * as Cloudflared from "@t3tools/shared/cloudflared";
+import * as RelayClient from "@t3tools/shared/relayClient";
 import * as Console from "effect/Console";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -9,7 +9,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as References from "effect/References";
-import { Command, Flag, GlobalFlag } from "effect/unstable/cli";
+import { Command, Flag, GlobalFlag, Prompt } from "effect/unstable/cli";
 import {
   FetchHttpClient,
   HttpClient,
@@ -45,12 +45,10 @@ interface CloudCliStatus {
   readonly linked: boolean;
   readonly cloudUserId: string | null;
   readonly relayUrl: string | null;
-  readonly cloudflared: Cloudflared.CloudflaredExecutableStatus;
+  readonly relayClient: RelayClient.RelayClientStatus;
 }
 
-function formatCloudflaredStatus(
-  executable: Cloudflared.CloudflaredExecutableStatus,
-): ReadonlyArray<string> {
+function formatRelayClientStatus(executable: RelayClient.RelayClientStatus): ReadonlyArray<string> {
   switch (executable.status) {
     case "available": {
       const source =
@@ -60,16 +58,16 @@ function formatCloudflaredStatus(
             ? "managed install"
             : "configured override";
       return [
-        `  cloudflared: available via ${source}`,
+        `  Relay client: available via ${source}`,
         `    Path: ${executable.executablePath}`,
         `    Version: ${executable.version}`,
       ];
     }
     case "missing":
-      return [`  cloudflared: not installed (managed version ${executable.version})`];
+      return ["  Relay client: not installed"];
     case "unsupported":
       return [
-        `  cloudflared: unsupported on ${executable.platform}-${executable.arch}`,
+        `  Relay client: unsupported on ${executable.platform}-${executable.arch}`,
         `    Managed version: ${executable.version}`,
       ];
   }
@@ -99,12 +97,39 @@ function formatCloudStatus(status: CloudCliStatus, options?: { readonly json?: b
     `  Authorization: ${status.authenticated ? "stored credential" : "missing"}`,
     `  Environment link: ${provisioned}`,
     `  Relay: ${status.relayUrl ?? "not provisioned"}`,
-    ...formatCloudflaredStatus(status.cloudflared),
+    ...formatRelayClientStatus(status.relayClient),
     ...(nextStep ? ["", `Next: ${nextStep}`] : []),
   ].join("\n");
 }
 
 const CLOUD_CLI_LIVE_SERVER_TIMEOUT = Duration.seconds(5);
+
+const confirmRelayClientInstall = (version: string) =>
+  Prompt.run(
+    Prompt.confirm({
+      message: `The T3 relay client is required for T3 Cloud exposure. Download and install version ${version}?`,
+      initial: false,
+    }),
+  );
+
+export const acquireRelayClientForLink = Effect.fn("cloud.cli.acquire_relay_client_for_link")(
+  function* <E, R>(
+    relayClient: RelayClient.RelayClientShape,
+    confirmInstall: (version: string) => Effect.Effect<boolean, E, R>,
+  ) {
+    const executable = yield* relayClient.resolve;
+    if (executable.status === "available") {
+      return Option.some(executable);
+    }
+    if (executable.status === "unsupported") {
+      return Option.some(yield* relayClient.install);
+    }
+    if (!(yield* confirmInstall(executable.version))) {
+      return Option.none();
+    }
+    return Option.some(yield* relayClient.install);
+  },
+);
 
 const withCloudCliSessionToken = <A, E, R>(
   environmentAuth: EnvironmentAuth.EnvironmentAuthShape,
@@ -222,10 +247,11 @@ const runCloudCommand = <A, E>(
     E,
     | ServerSecretStore.ServerSecretStore
     | CliTokenManager.CloudCliTokenManager
-    | Cloudflared.CloudflaredExecutable
+    | RelayClient.RelayClient
     | EnvironmentAuth.EnvironmentAuth
     | FileSystem.FileSystem
     | HttpClient.HttpClient
+    | Prompt.Environment
     | ServerConfig
     | ServerEnvironment
   >,
@@ -240,7 +266,7 @@ const runCloudCommand = <A, E>(
     const runtimeLayer = Layer.mergeAll(
       ServerSecretStore.layer,
       CliTokenManager.layer.pipe(Layer.provide(ServerSecretStore.layer)),
-      Cloudflared.layer({ baseDir: config.baseDir }),
+      RelayClient.layerCloudflared({ baseDir: config.baseDir }),
       EnvironmentAuth.runtimeLayer,
       ServerEnvironmentLive,
     ).pipe(
@@ -275,12 +301,14 @@ const cloudLinkCommand = Command.make("link", {
     runCloudCommand(
       flags,
       Effect.gen(function* () {
-        const cloudflared = yield* Cloudflared.CloudflaredExecutable;
-        const executable = yield* cloudflared.resolve;
-        const installed =
-          executable.status === "available" ? executable : yield* cloudflared.install;
+        const relayClient = yield* RelayClient.RelayClient;
+        const installed = yield* acquireRelayClientForLink(relayClient, confirmRelayClientInstall);
+        if (Option.isNone(installed)) {
+          yield* Console.log("T3 Cloud link cancelled. The relay client was not installed.");
+          return;
+        }
         yield* Console.log(
-          `Using cloudflared ${installed.version} from ${installed.executablePath}.`,
+          `Using relay client ${installed.value.version} from ${installed.value.executablePath}.`,
         );
 
         const tokens = yield* CliTokenManager.CloudCliTokenManager;
@@ -298,13 +326,13 @@ const cloudStatusCommand = Command.make("status", {
   ...projectLocationFlags,
   json: jsonFlag,
 }).pipe(
-  Command.withDescription("Show persisted T3 Cloud and cloudflared state."),
+  Command.withDescription("Show persisted T3 Cloud and relay client state."),
   Command.withHandler((flags) =>
     runCloudCommand(
       flags,
       Effect.gen(function* () {
         const secrets = yield* ServerSecretStore.ServerSecretStore;
-        const cloudflared = yield* Cloudflared.CloudflaredExecutable;
+        const relayClient = yield* RelayClient.RelayClient;
         const tokens = yield* CliTokenManager.CloudCliTokenManager;
         const [desired, authenticated, cloudUserId, relayUrl, executable] = yield* Effect.all(
           [
@@ -312,7 +340,7 @@ const cloudStatusCommand = Command.make("status", {
             tokens.hasCredential,
             secrets.get(CLOUD_LINKED_USER_ID),
             secrets.get(RELAY_URL_SECRET),
-            cloudflared.resolve,
+            relayClient.resolve,
           ],
           { concurrency: "unbounded" },
         );
@@ -322,7 +350,7 @@ const cloudStatusCommand = Command.make("status", {
           linked: cloudUserId !== null,
           cloudUserId: cloudUserId ? bytesToString(cloudUserId) : null,
           relayUrl: relayUrl ? bytesToString(relayUrl) : null,
-          cloudflared: executable,
+          relayClient: executable,
         };
         yield* Console.log(formatCloudStatus(status, { json: flags.json }));
       }),

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -1,4 +1,9 @@
-import { AuthRelayWriteScope, EnvironmentHttpApi } from "@t3tools/contracts";
+import {
+  AuthRelayWriteScope,
+  EnvironmentHttpApi,
+  type RelayClientInstallProgressEvent,
+  type RelayClientInstallProgressStage,
+} from "@t3tools/contracts";
 import { RelayOkResponse } from "@t3tools/contracts/relay";
 import * as RelayClient from "@t3tools/shared/relayClient";
 import * as Console from "effect/Console";
@@ -112,22 +117,47 @@ const confirmRelayClientInstall = (version: string) =>
     }),
   );
 
+function relayClientInstallProgressMessage(stage: RelayClientInstallProgressStage): string {
+  switch (stage) {
+    case "checking":
+      return "Checking existing installation";
+    case "waiting_for_lock":
+      return "Waiting for installation lock";
+    case "downloading":
+      return "Downloading";
+    case "verifying":
+      return "Verifying download";
+    case "installing":
+      return "Installing";
+    case "validating":
+      return "Validating executable";
+    case "activating":
+      return "Activating installation";
+  }
+}
+
+const reportRelayClientInstallProgress = (event: RelayClientInstallProgressEvent) =>
+  event.type === "progress"
+    ? Console.log(`Relay client: ${relayClientInstallProgressMessage(event.stage)}...`)
+    : Effect.void;
+
 export const acquireRelayClientForLink = Effect.fn("cloud.cli.acquire_relay_client_for_link")(
-  function* <E, R>(
+  function* <ConfirmError, ConfirmContext>(
     relayClient: RelayClient.RelayClientShape,
-    confirmInstall: (version: string) => Effect.Effect<boolean, E, R>,
+    confirmInstall: (version: string) => Effect.Effect<boolean, ConfirmError, ConfirmContext>,
+    reportProgress: (event: RelayClientInstallProgressEvent) => Effect.Effect<void>,
   ) {
     const executable = yield* relayClient.resolve;
     if (executable.status === "available") {
       return Option.some(executable);
     }
     if (executable.status === "unsupported") {
-      return Option.some(yield* relayClient.install);
+      return Option.some(yield* relayClient.installWithProgress(reportProgress));
     }
     if (!(yield* confirmInstall(executable.version))) {
       return Option.none();
     }
-    return Option.some(yield* relayClient.install);
+    return Option.some(yield* relayClient.installWithProgress(reportProgress));
   },
 );
 
@@ -302,7 +332,11 @@ const cloudLinkCommand = Command.make("link", {
       flags,
       Effect.gen(function* () {
         const relayClient = yield* RelayClient.RelayClient;
-        const installed = yield* acquireRelayClientForLink(relayClient, confirmRelayClientInstall);
+        const installed = yield* acquireRelayClientForLink(
+          relayClient,
+          confirmRelayClientInstall,
+          reportRelayClientInstallProgress,
+        );
         if (Option.isNone(installed)) {
           yield* Console.log("T3 Cloud link cancelled. The relay client was not installed.");
           return;

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -259,6 +259,22 @@ const runCloudCommand = <A, E>(
     return yield* run.pipe(Effect.provide(runtimeLayer));
   });
 
+const cloudLoginCommand = Command.make("login", {
+  ...projectLocationFlags,
+}).pipe(
+  Command.withDescription("Authorize the T3 Cloud CLI without enabling cloud exposure."),
+  Command.withHandler((flags) =>
+    runCloudCommand(
+      flags,
+      Effect.gen(function* () {
+        const tokens = yield* CliTokenManager.CloudCliTokenManager;
+        yield* tokens.get;
+        yield* Console.log("Signed in to T3 Cloud.");
+      }),
+    ),
+  ),
+);
+
 const cloudLinkCommand = Command.make("link", {
   ...projectLocationFlags,
 }).pipe(
@@ -356,6 +372,7 @@ const cloudLogoutCommand = Command.make("logout", {
 export const cloudCommand = Command.make("cloud").pipe(
   Command.withDescription("Manage headless T3 Cloud exposure."),
   Command.withSubcommands([
+    cloudLoginCommand,
     cloudLinkCommand,
     cloudStatusCommand,
     cloudUnlinkCommand,

--- a/apps/server/src/cli/cloud.ts
+++ b/apps/server/src/cli/cloud.ts
@@ -135,14 +135,14 @@ const runLiveCloudUnlink = Effect.fn("cloud.cli.run_live_unlink")(function* () {
   const environmentAuth = yield* EnvironmentAuth.EnvironmentAuth;
   const result = yield* Effect.exit(
     withCloudCliSessionToken(environmentAuth, (token) =>
-      Effect.gen(function* () {
-        const httpClient = yield* HttpClient.HttpClient;
-        const client = yield* HttpApiClient.makeWith(EnvironmentHttpApi, {
-          baseUrl: runtimeState.value.origin,
-          httpClient,
-        });
-        return yield* client.cloud.unlink({ headers: { authorization: `Bearer ${token}` } });
-      }).pipe(Effect.timeout(CLOUD_CLI_LIVE_SERVER_TIMEOUT)),
+      HttpApiClient.make(EnvironmentHttpApi, {
+        baseUrl: runtimeState.value.origin,
+      }).pipe(
+        Effect.flatMap((client) =>
+          client.cloud.unlink({ headers: { authorization: `Bearer ${token}` } }),
+        ),
+        Effect.timeout(CLOUD_CLI_LIVE_SERVER_TIMEOUT),
+      ),
     ),
   );
   return Exit.isSuccess(result)

--- a/apps/server/src/cloud/CliState.test.ts
+++ b/apps/server/src/cloud/CliState.test.ts
@@ -1,0 +1,58 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import { ServerConfig } from "../config.ts";
+import * as CliState from "./CliState.ts";
+import {
+  CLOUD_ENDPOINT_RUNTIME_CONFIG,
+  CLOUD_LINKED_USER_ID,
+  CLOUD_MINT_PUBLIC_KEY,
+  PUBLISH_AGENT_ACTIVITY_SECRET,
+  RELAY_ENVIRONMENT_CREDENTIAL_SECRET,
+  RELAY_ISSUER_SECRET,
+  RELAY_URL_SECRET,
+} from "./config.ts";
+
+const persistedCloudLinkSecrets = [
+  CLOUD_LINKED_USER_ID,
+  RELAY_URL_SECRET,
+  RELAY_ISSUER_SECRET,
+  RELAY_ENVIRONMENT_CREDENTIAL_SECRET,
+  CLOUD_MINT_PUBLIC_KEY,
+  CLOUD_ENDPOINT_RUNTIME_CONFIG,
+  PUBLISH_AGENT_ACTIVITY_SECRET,
+] as const;
+
+const makeTestLayer = () =>
+  ServerSecretStore.layer.pipe(
+    Layer.provide(
+      ServerConfig.layerTest(process.cwd(), {
+        prefix: "t3-cloud-cli-state-test-",
+      }),
+    ),
+  );
+
+it.layer(NodeServices.layer)("CliState", (it) => {
+  it.effect("persists desired exposure and clears provisioned relay state", () =>
+    Effect.gen(function* () {
+      const secrets = yield* ServerSecretStore.ServerSecretStore;
+
+      expect(yield* CliState.readCliDesiredCloudLink).toBe(false);
+      yield* CliState.setCliDesiredCloudLink(true);
+      expect(yield* CliState.readCliDesiredCloudLink).toBe(true);
+
+      for (const name of persistedCloudLinkSecrets) {
+        yield* secrets.set(name, new TextEncoder().encode(name));
+      }
+      yield* CliState.clearPersistedCloudLink;
+
+      expect(yield* CliState.readCliDesiredCloudLink).toBe(false);
+      for (const name of persistedCloudLinkSecrets) {
+        expect(yield* secrets.get(name)).toBe(null);
+      }
+    }).pipe(Effect.provide(makeTestLayer())),
+  );
+});

--- a/apps/server/src/cloud/CliState.ts
+++ b/apps/server/src/cloud/CliState.ts
@@ -1,0 +1,49 @@
+import * as Effect from "effect/Effect";
+
+import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import {
+  CLOUD_ENDPOINT_RUNTIME_CONFIG,
+  CLOUD_LINKED_USER_ID,
+  CLOUD_MINT_PUBLIC_KEY,
+  PUBLISH_AGENT_ACTIVITY_SECRET,
+  RELAY_ENVIRONMENT_CREDENTIAL_SECRET,
+  RELAY_ISSUER_SECRET,
+  RELAY_URL_SECRET,
+} from "./config.ts";
+
+export const CLOUD_CLI_DESIRED_LINK_SECRET = "cloud-cli-desired-link";
+
+const TRUE_BYTES = new TextEncoder().encode("true");
+
+export const readCliDesiredCloudLink = Effect.gen(function* () {
+  const secrets = yield* ServerSecretStore.ServerSecretStore;
+  return (yield* secrets.get(CLOUD_CLI_DESIRED_LINK_SECRET)) !== null;
+});
+
+export const setCliDesiredCloudLink = Effect.fn("cloud.cli_state.set_desired")(function* (
+  desired: boolean,
+) {
+  const secrets = yield* ServerSecretStore.ServerSecretStore;
+  if (desired) {
+    yield* secrets.set(CLOUD_CLI_DESIRED_LINK_SECRET, TRUE_BYTES);
+  } else {
+    yield* secrets.remove(CLOUD_CLI_DESIRED_LINK_SECRET);
+  }
+});
+
+export const clearPersistedCloudLink = Effect.gen(function* () {
+  const secrets = yield* ServerSecretStore.ServerSecretStore;
+  yield* Effect.all(
+    [
+      secrets.remove(CLOUD_CLI_DESIRED_LINK_SECRET),
+      secrets.remove(CLOUD_LINKED_USER_ID),
+      secrets.remove(RELAY_URL_SECRET),
+      secrets.remove(RELAY_ISSUER_SECRET),
+      secrets.remove(RELAY_ENVIRONMENT_CREDENTIAL_SECRET),
+      secrets.remove(CLOUD_MINT_PUBLIC_KEY),
+      secrets.remove(CLOUD_ENDPOINT_RUNTIME_CONFIG),
+      secrets.remove(PUBLISH_AGENT_ACTIVITY_SECRET),
+    ],
+    { concurrency: "unbounded" },
+  );
+});

--- a/apps/server/src/cloud/CliTokenManager.ts
+++ b/apps/server/src/cloud/CliTokenManager.ts
@@ -1,0 +1,249 @@
+// @effect-diagnostics nodeBuiltinImport:off - The CLI loopback OAuth callback is a Node HTTP boundary.
+import { createServer } from "node:http";
+
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import { DEFAULT_T3_RELAY_URL } from "@t3tools/shared/relayAuth";
+import { RelayCliOAuthMetadata } from "@t3tools/contracts/relay";
+import * as Clock from "effect/Clock";
+import * as Config from "effect/Config";
+import * as Console from "effect/Console";
+import * as Context from "effect/Context";
+import * as Crypto from "effect/Crypto";
+import * as Data from "effect/Data";
+import * as Deferred from "effect/Deferred";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Encoding from "effect/Encoding";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+import * as HttpRouter from "effect/unstable/http/HttpRouter";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+
+import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+
+const CLOUD_CLI_OAUTH_TOKEN_SECRET = "cloud-cli-oauth-token";
+const CLOUD_CLI_OAUTH_CALLBACK_TIMEOUT = Duration.minutes(10);
+const CLOUD_CLI_OAUTH_REFRESH_EARLY_MS = Duration.toMillis(Duration.minutes(5));
+
+const PersistedToken = Schema.Struct({
+  accessToken: Schema.String,
+  refreshToken: Schema.String,
+  expiresAtEpochMs: Schema.Number,
+});
+type PersistedToken = typeof PersistedToken.Type;
+
+const PersistedTokenJson = Schema.fromJsonString(PersistedToken);
+const decodePersistedToken = Schema.decodeUnknownEffect(PersistedTokenJson);
+const encodePersistedToken = Schema.encodeEffect(PersistedTokenJson);
+
+const OAuthTokenResponse = Schema.Struct({
+  access_token: Schema.String,
+  refresh_token: Schema.optional(Schema.String),
+  expires_in: Schema.Number,
+  token_type: Schema.String,
+});
+
+export class CloudCliTokenManagerError extends Data.TaggedError("CloudCliTokenManagerError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {}
+
+export interface CloudCliTokenManagerShape {
+  readonly get: Effect.Effect<PersistedToken, CloudCliTokenManagerError>;
+  readonly getExisting: Effect.Effect<Option.Option<PersistedToken>, CloudCliTokenManagerError>;
+  readonly hasCredential: Effect.Effect<boolean, CloudCliTokenManagerError>;
+  readonly clear: Effect.Effect<void, CloudCliTokenManagerError>;
+}
+
+export class CloudCliTokenManager extends Context.Service<
+  CloudCliTokenManager,
+  CloudCliTokenManagerShape
+>()("t3/cloud/CliTokenManager/CloudCliTokenManager") {}
+
+const wrapError =
+  (message: string) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, CloudCliTokenManagerError, R> =>
+    effect.pipe(
+      Effect.mapError(
+        (cause) =>
+          new CloudCliTokenManagerError({
+            message,
+            cause,
+          }),
+      ),
+    );
+
+function stringToBytes(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
+}
+
+function bytesToString(value: Uint8Array): string {
+  return new TextDecoder().decode(value);
+}
+
+const make = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const httpClient = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
+  const secrets = yield* ServerSecretStore.ServerSecretStore;
+  const semaphore = yield* Semaphore.make(1);
+  const relayUrl = yield* Config.string("T3_RELAY_URL").pipe(
+    Config.withDefault(DEFAULT_T3_RELAY_URL),
+    Effect.map((value) => value.replace(/\/+$/u, "")),
+    Effect.orDie,
+  );
+
+  const persist = Effect.fn("cloud.cli_token.persist")(function* (token: PersistedToken) {
+    const encoded = yield* encodePersistedToken(token);
+    yield* secrets.set(CLOUD_CLI_OAUTH_TOKEN_SECRET, stringToBytes(encoded));
+    return token;
+  });
+
+  const clear = secrets
+    .remove(CLOUD_CLI_OAUTH_TOKEN_SECRET)
+    .pipe(wrapError("Could not remove the stored T3 Cloud CLI credential."));
+
+  const read = Effect.fn("cloud.cli_token.read")(function* () {
+    const encoded = yield* secrets.get(CLOUD_CLI_OAUTH_TOKEN_SECRET);
+    if (!encoded) return Option.none<PersistedToken>();
+    return Option.some(yield* decodePersistedToken(bytesToString(encoded)));
+  });
+
+  const readMetadata = HttpClientRequest.get(`${relayUrl}/.well-known/t3-cloud-cli`).pipe(
+    httpClient.execute,
+    Effect.flatMap(HttpClientResponse.schemaBodyJson(RelayCliOAuthMetadata)),
+  );
+
+  const exchangeToken = Effect.fn("cloud.cli_token.exchange")(function* (
+    metadata: RelayCliOAuthMetadata,
+    params: Record<string, string>,
+  ) {
+    const response = yield* HttpClientRequest.post(metadata.tokenEndpoint).pipe(
+      HttpClientRequest.bodyUrlParams(params),
+      httpClient.execute,
+      Effect.flatMap(HttpClientResponse.schemaBodyJson(OAuthTokenResponse)),
+    );
+    const now = yield* Clock.currentTimeMillis;
+    return {
+      accessToken: response.access_token,
+      refreshToken: response.refresh_token ?? params.refresh_token ?? "",
+      expiresAtEpochMs: now + response.expires_in * 1_000,
+    } satisfies PersistedToken;
+  });
+
+  const refresh = Effect.fn("cloud.cli_token.refresh")(function* (token: PersistedToken) {
+    const metadata = yield* readMetadata;
+    return yield* exchangeToken(metadata, {
+      grant_type: "refresh_token",
+      refresh_token: token.refreshToken,
+      client_id: metadata.clientId,
+    });
+  });
+
+  const login = Effect.fn("cloud.cli_token.login")(function* () {
+    const metadata = yield* readMetadata;
+    const verifier = Encoding.encodeBase64Url(yield* crypto.randomBytes(32));
+    const challenge = Encoding.encodeBase64Url(
+      yield* crypto.digest("SHA-256", new TextEncoder().encode(verifier)),
+    );
+    const state = yield* crypto.randomUUIDv4;
+    const callback = yield* Deferred.make<string>();
+    const callbackRoute = HttpRouter.add(
+      "GET",
+      "/callback",
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const url = new URL(request.originalUrl, metadata.redirectUri);
+        const code = url.searchParams.get("code");
+        if (url.searchParams.get("state") !== state || !code) {
+          return HttpServerResponse.text("Invalid T3 Cloud authorization callback.", {
+            status: 400,
+          });
+        }
+        yield* Deferred.succeed(callback, code);
+        return yield* HttpServerResponse.html`
+<html>
+  <body style="font-family: sans-serif; text-align: center; margin-top: 50px;">
+    <h1>T3 Cloud authorization complete</h1>
+    <p>You can close this window and return to your terminal.</p>
+  </body>
+</html>
+`;
+      }),
+    );
+    yield* HttpRouter.serve(callbackRoute, {
+      disableListenLog: true,
+      disableLogger: true,
+    }).pipe(
+      Layer.provide(
+        NodeHttpServer.layer(createServer, {
+          host: "127.0.0.1",
+          port: 34338,
+          disablePreemptiveShutdown: true,
+        }),
+      ),
+      Layer.build,
+    );
+    const authorizationUrl = new URL(metadata.authorizationEndpoint);
+    authorizationUrl.searchParams.set("client_id", metadata.clientId);
+    authorizationUrl.searchParams.set("redirect_uri", metadata.redirectUri);
+    authorizationUrl.searchParams.set("response_type", "code");
+    authorizationUrl.searchParams.set("scope", metadata.scopes.join(" "));
+    authorizationUrl.searchParams.set("state", state);
+    authorizationUrl.searchParams.set("code_challenge", challenge);
+    authorizationUrl.searchParams.set("code_challenge_method", "S256");
+    yield* Console.log(`Open this URL to authorize T3 Cloud:\n${authorizationUrl.toString()}\n`);
+    const code = yield* Deferred.await(callback).pipe(
+      Effect.timeout(CLOUD_CLI_OAUTH_CALLBACK_TIMEOUT),
+      Effect.catchTag("TimeoutError", () =>
+        Effect.fail(
+          new CloudCliTokenManagerError({
+            message: "Timed out waiting for T3 Cloud authorization.",
+          }),
+        ),
+      ),
+    );
+    return yield* exchangeToken(metadata, {
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: metadata.redirectUri,
+      client_id: metadata.clientId,
+      code_verifier: verifier,
+    });
+  });
+
+  const getExistingNoLock = Effect.fn("cloud.cli_token.get_existing_no_lock")(function* () {
+    const token = yield* read();
+    if (Option.isNone(token)) return token;
+    const now = yield* Clock.currentTimeMillis;
+    if (token.value.expiresAtEpochMs - CLOUD_CLI_OAUTH_REFRESH_EARLY_MS > now) {
+      return token;
+    }
+    return Option.some(yield* refresh(token.value).pipe(Effect.flatMap(persist)));
+  });
+
+  const getExisting = semaphore.withPermits(1)(
+    getExistingNoLock().pipe(wrapError("Could not refresh the T3 Cloud CLI credential.")),
+  );
+  const hasCredential = semaphore.withPermits(1)(
+    read().pipe(
+      Effect.map(Option.isSome),
+      wrapError("Could not read the stored T3 Cloud CLI credential."),
+    ),
+  );
+  const get = semaphore.withPermits(1)(
+    Effect.gen(function* () {
+      const token = yield* getExistingNoLock();
+      return Option.isSome(token)
+        ? token.value
+        : yield* Effect.scoped(login()).pipe(Effect.flatMap(persist));
+    }).pipe(wrapError("Could not authorize the T3 Cloud CLI.")),
+  );
+
+  return CloudCliTokenManager.of({ get, getExisting, hasCredential, clear });
+});
+
+export const layer = Layer.effect(CloudCliTokenManager, make);

--- a/apps/server/src/cloud/CliTokenManager.ts
+++ b/apps/server/src/cloud/CliTokenManager.ts
@@ -2,10 +2,8 @@
 import { createServer } from "node:http";
 
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import { DEFAULT_T3_RELAY_URL } from "@t3tools/shared/relayAuth";
 import { RelayCliOAuthMetadata } from "@t3tools/contracts/relay";
 import * as Clock from "effect/Clock";
-import * as Config from "effect/Config";
 import * as Console from "effect/Console";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
@@ -24,6 +22,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import { relayUrlConfig } from "./publicConfig.ts";
 
 const CLOUD_CLI_OAUTH_TOKEN_SECRET = "cloud-cli-oauth-token";
 const CLOUD_CLI_OAUTH_CALLBACK_TIMEOUT = Duration.minutes(10);
@@ -90,12 +89,6 @@ const make = Effect.gen(function* () {
   const httpClient = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
   const secrets = yield* ServerSecretStore.ServerSecretStore;
   const semaphore = yield* Semaphore.make(1);
-  const relayUrl = yield* Config.string("T3_RELAY_URL").pipe(
-    Config.withDefault(DEFAULT_T3_RELAY_URL),
-    Effect.map((value) => value.replace(/\/+$/u, "")),
-    Effect.orDie,
-  );
-
   const persist = Effect.fn("cloud.cli_token.persist")(function* (token: PersistedToken) {
     const encoded = yield* encodePersistedToken(token);
     yield* secrets.set(CLOUD_CLI_OAUTH_TOKEN_SECRET, stringToBytes(encoded));
@@ -112,9 +105,13 @@ const make = Effect.gen(function* () {
     return Option.some(yield* decodePersistedToken(bytesToString(encoded)));
   });
 
-  const readMetadata = HttpClientRequest.get(`${relayUrl}/.well-known/t3-cloud-cli`).pipe(
-    httpClient.execute,
-    Effect.flatMap(HttpClientResponse.schemaBodyJson(RelayCliOAuthMetadata)),
+  const readMetadata = relayUrlConfig.pipe(
+    Effect.flatMap((relayUrl) =>
+      HttpClientRequest.get(`${relayUrl}/.well-known/t3-cloud-cli`).pipe(
+        httpClient.execute,
+        Effect.flatMap(HttpClientResponse.schemaBodyJson(RelayCliOAuthMetadata)),
+      ),
+    ),
   );
 
   const exchangeToken = Effect.fn("cloud.cli_token.exchange")(function* (

--- a/apps/server/src/cloud/CliTokenManager.ts
+++ b/apps/server/src/cloud/CliTokenManager.ts
@@ -2,7 +2,6 @@
 import { createServer } from "node:http";
 
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import { RelayCliOAuthMetadata } from "@t3tools/contracts/relay";
 import * as Clock from "effect/Clock";
 import * as Console from "effect/Console";
 import * as Context from "effect/Context";
@@ -22,7 +21,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
-import { relayUrlConfig } from "./publicConfig.ts";
+import { cloudCliOAuthConfig, type CloudCliOAuthConfig } from "./publicConfig.ts";
 
 const CLOUD_CLI_OAUTH_TOKEN_SECRET = "cloud-cli-oauth-token";
 const CLOUD_CLI_OAUTH_CALLBACK_TIMEOUT = Duration.minutes(10);
@@ -105,17 +104,8 @@ const make = Effect.gen(function* () {
     return Option.some(yield* decodePersistedToken(bytesToString(encoded)));
   });
 
-  const readMetadata = relayUrlConfig.pipe(
-    Effect.flatMap((relayUrl) =>
-      HttpClientRequest.get(`${relayUrl}/.well-known/t3-cloud-cli`).pipe(
-        httpClient.execute,
-        Effect.flatMap(HttpClientResponse.schemaBodyJson(RelayCliOAuthMetadata)),
-      ),
-    ),
-  );
-
   const exchangeToken = Effect.fn("cloud.cli_token.exchange")(function* (
-    metadata: RelayCliOAuthMetadata,
+    metadata: CloudCliOAuthConfig,
     params: Record<string, string>,
   ) {
     const response = yield* HttpClientRequest.post(metadata.tokenEndpoint).pipe(
@@ -132,7 +122,7 @@ const make = Effect.gen(function* () {
   });
 
   const refresh = Effect.fn("cloud.cli_token.refresh")(function* (token: PersistedToken) {
-    const metadata = yield* readMetadata;
+    const metadata = yield* cloudCliOAuthConfig;
     return yield* exchangeToken(metadata, {
       grant_type: "refresh_token",
       refresh_token: token.refreshToken,
@@ -141,7 +131,7 @@ const make = Effect.gen(function* () {
   });
 
   const login = Effect.fn("cloud.cli_token.login")(function* () {
-    const metadata = yield* readMetadata;
+    const metadata = yield* cloudCliOAuthConfig;
     const verifier = Encoding.encodeBase64Url(yield* crypto.randomBytes(32));
     const challenge = Encoding.encodeBase64Url(
       yield* crypto.digest("SHA-256", new TextEncoder().encode(verifier)),

--- a/apps/server/src/cloud/http.test.ts
+++ b/apps/server/src/cloud/http.test.ts
@@ -1,9 +1,19 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
+import { HttpClient } from "effect/unstable/http";
 
+import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
-import { consumeCloudReplayGuards } from "./http.ts";
+import { ServerEnvironment } from "../environment/Services/ServerEnvironment.ts";
+import * as CliTokenManager from "./CliTokenManager.ts";
+import { consumeCloudReplayGuards, reconcileDesiredCloudLink } from "./http.ts";
+import {
+  CloudManagedEndpointRuntime,
+  type CloudManagedEndpointRuntimeShape,
+} from "./ManagedEndpointRuntime.ts";
 
 const storeFailure = (tag: "AlreadyExists" | "PermissionDenied") =>
   new ServerSecretStore.SecretStoreError({
@@ -56,5 +66,54 @@ describe("consumeCloudReplayGuards", () => {
 
       expect(error).toBe(failure);
     }),
+  );
+});
+
+describe("reconcileDesiredCloudLink", () => {
+  it.effect("requires stored CLI authorization without exposing an HTTP endpoint", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(reconcileDesiredCloudLink("http://127.0.0.1:3774"));
+
+      expect(error).toMatchObject({
+        _tag: "EnvironmentHttpUnauthorizedError",
+        message: "Run `t3 cloud link` to authorize this environment.",
+      });
+    }).pipe(
+      Effect.provideService(
+        ServerSecretStore.ServerSecretStore,
+        makeSecretStore(unusedSecretStoreOperation),
+      ),
+      Effect.provideService(
+        ServerEnvironment,
+        ServerEnvironment.of({
+          getEnvironmentId: unusedSecretStoreOperation(),
+          getDescriptor: unusedSecretStoreOperation(),
+        }),
+      ),
+      Effect.provideService(
+        CloudManagedEndpointRuntime,
+        CloudManagedEndpointRuntime.of({
+          applyConfig: unusedSecretStoreOperation,
+        } satisfies CloudManagedEndpointRuntimeShape),
+      ),
+      Effect.provideService(
+        EnvironmentAuth.EnvironmentAuth,
+        EnvironmentAuth.EnvironmentAuth.of({} as EnvironmentAuth.EnvironmentAuthShape),
+      ),
+      Effect.provideService(
+        CliTokenManager.CloudCliTokenManager,
+        CliTokenManager.CloudCliTokenManager.of({
+          get: unusedSecretStoreOperation(),
+          getExisting: Effect.succeed(Option.none()),
+          hasCredential: unusedSecretStoreOperation(),
+          clear: unusedSecretStoreOperation(),
+        }),
+      ),
+      Effect.provideService(
+        HttpClient.HttpClient,
+        HttpClient.make(() => unusedSecretStoreOperation()),
+      ),
+      Effect.provide(NodeServices.layer),
+    ),
   );
 });

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -341,57 +341,79 @@ interface CloudHttpDependencies {
   readonly httpClient: HttpClient.HttpClient;
 }
 
+const cloudHttpDependencies = Effect.gen(function* () {
+  return {
+    secrets: yield* ServerSecretStore.ServerSecretStore,
+    environment: yield* ServerEnvironment,
+    endpointRuntime: yield* CloudManagedEndpointRuntime,
+    environmentAuth: yield* EnvironmentAuth.EnvironmentAuth,
+    cliTokenManager: yield* CliTokenManager.CloudCliTokenManager,
+    httpClient: yield* HttpClient.HttpClient,
+  } satisfies CloudHttpDependencies;
+});
+
+const makeCloudLinkProof = Effect.fn("environment.cloud.makeLinkProof")(function* (
+  dependencies: CloudHttpDependencies,
+  request: RelayLinkProofRequest,
+  requestUrl: string,
+) {
+  const keyPair = yield* getOrCreateEnvironmentKeyPairFromSecretStore(dependencies.secrets);
+  if (
+    !providerKindMatchesRequestedLinkScopes(request) ||
+    !isAllowedEndpointOrigin({
+      origin: request.origin,
+      requestUrl,
+    })
+  ) {
+    return yield* new EnvironmentHttpBadRequestError({
+      message: "Invalid managed endpoint origin.",
+    });
+  }
+  const now = yield* DateTime.now;
+  const expiresAt = DateTime.add(now, { minutes: 5 });
+  const nowSeconds = Math.floor(now.epochMilliseconds / 1_000);
+  const descriptor = yield* dependencies.environment.getDescriptor;
+  const payload = {
+    iss: `t3-env:${descriptor.environmentId}`,
+    aud: normalizeRelayIssuer(request.relayIssuer),
+    sub: descriptor.environmentId,
+    jti: yield* Crypto.Crypto.pipe(Effect.flatMap((crypto) => crypto.randomUUIDv4)),
+    iat: nowSeconds,
+    exp: Math.floor(expiresAt.epochMilliseconds / 1_000),
+    challenge: request.challenge,
+    descriptor,
+    environmentId: descriptor.environmentId,
+    environmentPublicKey: normalizePemForSignedPayload(keyPair.publicKey),
+    endpoint: request.endpoint,
+    origin: request.origin,
+    scopes: ["agent_activity_notifications", "managed_tunnels"],
+  } satisfies RelayEnvironmentLinkProofPayload;
+  return yield* signRelayJwt({
+    privateKey: keyPair.privateKey,
+    typ: RELAY_LINK_PROOF_TYP,
+    payload,
+  }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new EnvironmentAuth.ServerAuthInternalError({
+          message: "Failed to sign cloud link JWT.",
+          cause,
+        }),
+    ),
+  );
+});
+
 const cloudLinkProofHandler = Effect.fn("environment.cloud.linkProof")(
   function* (dependencies: CloudHttpDependencies, request: RelayLinkProofRequest) {
     yield* requireEnvironmentScope(AuthRelayWriteScope);
     const httpRequest = yield* HttpServerRequest.HttpServerRequest;
-    const keyPair = yield* getOrCreateEnvironmentKeyPairFromSecretStore(dependencies.secrets);
     const requestUrl = requestAbsoluteUrl(httpRequest);
-    if (
-      requestUrl === null ||
-      hasForwardedAuthorityHeaders(httpRequest) ||
-      !providerKindMatchesRequestedLinkScopes(request) ||
-      !isAllowedEndpointOrigin({
-        origin: request.origin,
-        requestUrl,
-      })
-    ) {
+    if (requestUrl === null || hasForwardedAuthorityHeaders(httpRequest)) {
       return yield* new EnvironmentHttpBadRequestError({
         message: "Invalid managed endpoint origin.",
       });
     }
-    const now = yield* DateTime.now;
-    const expiresAt = DateTime.add(now, { minutes: 5 });
-    const nowSeconds = Math.floor(now.epochMilliseconds / 1_000);
-    const descriptor = yield* dependencies.environment.getDescriptor;
-    const payload = {
-      iss: `t3-env:${descriptor.environmentId}`,
-      aud: normalizeRelayIssuer(request.relayIssuer),
-      sub: descriptor.environmentId,
-      jti: yield* Crypto.Crypto.pipe(Effect.flatMap((crypto) => crypto.randomUUIDv4)),
-      iat: nowSeconds,
-      exp: Math.floor(expiresAt.epochMilliseconds / 1_000),
-      challenge: request.challenge,
-      descriptor,
-      environmentId: descriptor.environmentId,
-      environmentPublicKey: normalizePemForSignedPayload(keyPair.publicKey),
-      endpoint: request.endpoint,
-      origin: request.origin,
-      scopes: ["agent_activity_notifications", "managed_tunnels"],
-    } satisfies RelayEnvironmentLinkProofPayload;
-    const proof = yield* signRelayJwt({
-      privateKey: keyPair.privateKey,
-      typ: RELAY_LINK_PROOF_TYP,
-      payload,
-    }).pipe(
-      Effect.mapError(
-        (cause) =>
-          new EnvironmentAuth.ServerAuthInternalError({
-            message: "Failed to sign cloud link JWT.",
-            cause,
-          }),
-      ),
-    );
+    const proof = yield* makeCloudLinkProof(dependencies, request, requestUrl);
     yield* appendCloudCredentialResponseHeaders;
     return proof satisfies RelayEnvironmentLinkProof;
   },
@@ -406,51 +428,55 @@ const cloudLinkProofHandler = Effect.fn("environment.cloud.linkProof")(
   }),
 );
 
+const applyCloudRelayConfig = Effect.fn("environment.cloud.applyRelayConfig")(function* (
+  dependencies: CloudHttpDependencies,
+  payload: RelayEnvironmentConfigRequest,
+) {
+  yield* validateRelayConfigPayload(payload);
+  yield* validateLinkedCloudUser({
+    secrets: dependencies.secrets,
+    cloudUserId: payload.cloudUserId,
+  });
+  yield* validateCloudMintPublicKey(payload.cloudMintPublicKey);
+  const endpointRuntimeStatus = yield* dependencies.endpointRuntime.applyConfig(
+    payload.endpointRuntime,
+  );
+  const ok =
+    endpointRuntimeStatus.status === "disabled" || endpointRuntimeStatus.status === "running";
+  if (!ok) {
+    return yield* new EnvironmentCloudEndpointUnavailableError({
+      message: "Managed endpoint runtime could not be started.",
+      endpointRuntimeStatus,
+    });
+  }
+
+  yield* dependencies.secrets.set(RELAY_URL_SECRET, stringToBytes(payload.relayUrl));
+  yield* dependencies.secrets.set(
+    RELAY_ISSUER_SECRET,
+    stringToBytes(payload.relayIssuer ?? payload.relayUrl),
+  );
+  yield* dependencies.secrets.set(CLOUD_LINKED_USER_ID, stringToBytes(payload.cloudUserId));
+  yield* dependencies.secrets.set(
+    RELAY_ENVIRONMENT_CREDENTIAL_SECRET,
+    stringToBytes(payload.environmentCredential),
+  );
+  yield* dependencies.secrets.set(CLOUD_MINT_PUBLIC_KEY, stringToBytes(payload.cloudMintPublicKey));
+  if (payload.endpointRuntime) {
+    const endpointRuntimeJson = yield* encodeEndpointRuntimeConfigJson(payload.endpointRuntime);
+    yield* dependencies.secrets.set(
+      CLOUD_ENDPOINT_RUNTIME_CONFIG,
+      stringToBytes(endpointRuntimeJson),
+    );
+  } else {
+    yield* dependencies.secrets.remove(CLOUD_ENDPOINT_RUNTIME_CONFIG);
+  }
+  return { ok, endpointRuntimeStatus } satisfies EnvironmentCloudRelayConfigResult;
+});
+
 const cloudRelayConfigHandler = Effect.fn("environment.cloud.relayConfig")(
   function* (dependencies: CloudHttpDependencies, payload: RelayEnvironmentConfigRequest) {
     yield* requireEnvironmentScope(AuthRelayWriteScope);
-    yield* validateRelayConfigPayload(payload);
-    yield* validateLinkedCloudUser({
-      secrets: dependencies.secrets,
-      cloudUserId: payload.cloudUserId,
-    });
-    yield* validateCloudMintPublicKey(payload.cloudMintPublicKey);
-    const endpointRuntimeStatus = yield* dependencies.endpointRuntime.applyConfig(
-      payload.endpointRuntime,
-    );
-    const ok =
-      endpointRuntimeStatus.status === "disabled" || endpointRuntimeStatus.status === "running";
-    if (!ok) {
-      return yield* new EnvironmentCloudEndpointUnavailableError({
-        message: "Managed endpoint runtime could not be started.",
-        endpointRuntimeStatus,
-      });
-    }
-
-    yield* dependencies.secrets.set(RELAY_URL_SECRET, stringToBytes(payload.relayUrl));
-    yield* dependencies.secrets.set(
-      RELAY_ISSUER_SECRET,
-      stringToBytes(payload.relayIssuer ?? payload.relayUrl),
-    );
-    yield* dependencies.secrets.set(CLOUD_LINKED_USER_ID, stringToBytes(payload.cloudUserId));
-    yield* dependencies.secrets.set(
-      RELAY_ENVIRONMENT_CREDENTIAL_SECRET,
-      stringToBytes(payload.environmentCredential),
-    );
-    yield* dependencies.secrets.set(
-      CLOUD_MINT_PUBLIC_KEY,
-      stringToBytes(payload.cloudMintPublicKey),
-    );
-    if (payload.endpointRuntime) {
-      const endpointRuntimeJson = yield* encodeEndpointRuntimeConfigJson(payload.endpointRuntime);
-      yield* dependencies.secrets.set(
-        CLOUD_ENDPOINT_RUNTIME_CONFIG,
-        stringToBytes(endpointRuntimeJson),
-      );
-    } else {
-      yield* dependencies.secrets.remove(CLOUD_ENDPOINT_RUNTIME_CONFIG);
-    }
-    return { ok, endpointRuntimeStatus } satisfies EnvironmentCloudRelayConfigResult;
+    return yield* applyCloudRelayConfig(dependencies, payload);
   },
   Effect.catchTag("ServerAuthInternalError", (error) =>
     failEnvironmentCloudInternalError(error.message)(error.cause),
@@ -488,17 +514,20 @@ const relayClientRequest = <A>(
     ),
   );
 
-const cloudReconcileHandler = Effect.fn("environment.cloud.reconcile")(
-  function* (dependencies: CloudHttpDependencies) {
-    yield* requireEnvironmentScope(AuthRelayWriteScope);
-    const httpRequest = yield* HttpServerRequest.HttpServerRequest;
-    const requestUrl = requestAbsoluteUrl(httpRequest);
-    if (!requestUrl) {
+const reconcileDesiredCloudLinkWith = Effect.fn("environment.cloud.reconcileDesiredLinkWith")(
+  function* (dependencies: CloudHttpDependencies, localOrigin: string) {
+    const localUrl = yield* Effect.try({
+      try: () => new URL(localOrigin),
+      catch: () =>
+        new EnvironmentHttpBadRequestError({
+          message: "Could not resolve local environment origin.",
+        }),
+    });
+    if (localUrl.origin !== localOrigin) {
       return yield* new EnvironmentHttpBadRequestError({
         message: "Could not resolve local environment origin.",
       });
     }
-    const localOrigin = new URL(requestUrl).origin;
     const localWsOrigin = localOrigin.replace(/^http/u, "ws");
     const token = yield* dependencies.cliTokenManager.getExisting.pipe(
       Effect.flatMap(
@@ -524,19 +553,23 @@ const cloudReconcileHandler = Effect.fn("environment.cloud.reconcile")(
       },
       schema: RelayEnvironmentLinkChallengeResponse,
     });
-    const proof = yield* cloudLinkProofHandler(dependencies, {
-      challenge: challenge.challenge,
-      relayIssuer: relayUrl,
-      endpoint: {
-        httpBaseUrl: localOrigin,
-        wsBaseUrl: localWsOrigin,
-        providerKind: "cloudflare_tunnel",
+    const proof = yield* makeCloudLinkProof(
+      dependencies,
+      {
+        challenge: challenge.challenge,
+        relayIssuer: relayUrl,
+        endpoint: {
+          httpBaseUrl: localOrigin,
+          wsBaseUrl: localWsOrigin,
+          providerKind: "cloudflare_tunnel",
+        },
+        origin: {
+          localHttpHost: localUrl.hostname,
+          localHttpPort: endpointRequestPort(localUrl),
+        },
       },
-      origin: {
-        localHttpHost: new URL(localOrigin).hostname,
-        localHttpPort: endpointRequestPort(new URL(localOrigin)),
-      },
-    });
+      localOrigin,
+    );
     const link = yield* relayClientRequest(dependencies, {
       url: `${relayUrl}/v1/client/environment-links`,
       token: token.accessToken,
@@ -549,7 +582,7 @@ const cloudReconcileHandler = Effect.fn("environment.cloud.reconcile")(
       schema: RelayEnvironmentLinkResponse,
     });
     yield* CliState.setCliDesiredCloudLink(true);
-    return yield* cloudRelayConfigHandler(dependencies, {
+    return yield* applyCloudRelayConfig(dependencies, {
       relayUrl,
       relayIssuer: link.relayIssuer,
       cloudUserId: link.cloudUserId,
@@ -565,6 +598,12 @@ const cloudReconcileHandler = Effect.fn("environment.cloud.reconcile")(
       "Could not persist desired T3 Cloud link state.",
     ),
   }),
+);
+
+export const reconcileDesiredCloudLink = Effect.fn("environment.cloud.reconcileDesiredLink")(
+  function* (localOrigin: string) {
+    return yield* reconcileDesiredCloudLinkWith(yield* cloudHttpDependencies, localOrigin);
+  },
 );
 
 const readCloudLinkState = Effect.fn("environment.cloud.readLinkState")(function* (
@@ -889,18 +928,10 @@ export const cloudHttpApiLayer = HttpApiBuilder.group(
   EnvironmentHttpApi,
   "cloud",
   Effect.fnUntraced(function* (handlers) {
-    const dependencies: CloudHttpDependencies = {
-      secrets: yield* ServerSecretStore.ServerSecretStore,
-      environment: yield* ServerEnvironment,
-      endpointRuntime: yield* CloudManagedEndpointRuntime,
-      environmentAuth: yield* EnvironmentAuth.EnvironmentAuth,
-      cliTokenManager: yield* CliTokenManager.CloudCliTokenManager,
-      httpClient: yield* HttpClient.HttpClient,
-    };
+    const dependencies = yield* cloudHttpDependencies;
     return handlers
       .handle("linkProof", ({ payload }) => cloudLinkProofHandler(dependencies, payload))
       .handle("relayConfig", ({ payload }) => cloudRelayConfigHandler(dependencies, payload))
-      .handle("reconcile", () => cloudReconcileHandler(dependencies))
       .handle("linkState", () => cloudLinkStateHandler(dependencies))
       .handle("unlink", () => cloudUnlinkHandler(dependencies))
       .handle("preferences", ({ payload }) => cloudPreferencesHandler(dependencies, payload))

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -20,6 +20,8 @@ import {
   RelayEnvironmentHealthResponseProofPayload,
   type RelayEnvironmentHealthResponse as RelayEnvironmentHealthResponseShape,
   RelayEnvironmentConfigRequest,
+  RelayEnvironmentLinkChallengeResponse,
+  RelayEnvironmentLinkResponse,
   RelayEnvironmentMintResponseProofPayload,
   type RelayEnvironmentMintResponse as RelayEnvironmentMintResponseShape,
   RelayEnvironmentLinkProof,
@@ -37,7 +39,9 @@ import {
   signRelayJwt,
   verifyRelayJwt,
 } from "@t3tools/shared/relayJwt";
+import { DEFAULT_T3_RELAY_URL } from "@t3tools/shared/relayAuth";
 import { isSecureRelayUrl } from "@t3tools/shared/relayUrl";
+import * as Config from "effect/Config";
 import * as DateTime from "effect/DateTime";
 import * as Crypto from "effect/Crypto";
 import * as Duration from "effect/Duration";
@@ -46,6 +50,7 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as HttpEffect from "effect/unstable/http/HttpEffect";
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http";
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 
 import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
@@ -69,6 +74,8 @@ import {
   RELAY_ISSUER_SECRET,
   RELAY_URL_SECRET,
 } from "./config.ts";
+import * as CliState from "./CliState.ts";
+import * as CliTokenManager from "./CliTokenManager.ts";
 import { getOrCreateEnvironmentKeyPairFromSecretStore } from "./environmentKeys.ts";
 
 const CLOUD_MINT_NONCE_PREFIX = "cloud-mint-nonce-";
@@ -322,6 +329,8 @@ interface CloudHttpDependencies {
   readonly environment: ServerEnvironmentShape;
   readonly endpointRuntime: CloudManagedEndpointRuntimeShape;
   readonly environmentAuth: EnvironmentAuth.EnvironmentAuthShape;
+  readonly cliTokenManager: CliTokenManager.CloudCliTokenManagerShape;
+  readonly httpClient: HttpClient.HttpClient;
 }
 
 const cloudLinkProofHandler = Effect.fn("environment.cloud.linkProof")(
@@ -448,6 +457,111 @@ const cloudRelayConfigHandler = Effect.fn("environment.cloud.relayConfig")(
   }),
 );
 
+const relayClientRequest = <A>(
+  dependencies: CloudHttpDependencies,
+  input: {
+    readonly url: string;
+    readonly token: string;
+    readonly payload: unknown;
+    readonly schema: Schema.Decoder<A>;
+  },
+) =>
+  HttpClientRequest.post(input.url).pipe(
+    HttpClientRequest.bearerToken(input.token),
+    HttpClientRequest.bodyJson(input.payload),
+    Effect.flatMap(dependencies.httpClient.execute),
+    Effect.flatMap(HttpClientResponse.filterStatusOk),
+    Effect.flatMap(HttpClientResponse.schemaBodyJson(input.schema)),
+    Effect.mapError(
+      (cause) =>
+        new EnvironmentHttpInternalServerError({
+          message: `T3 Cloud relay request failed: ${String(cause)}`,
+        }),
+    ),
+  );
+
+const cloudReconcileHandler = Effect.fn("environment.cloud.reconcile")(
+  function* (dependencies: CloudHttpDependencies) {
+    yield* requireEnvironmentScope(AuthRelayWriteScope);
+    const httpRequest = yield* HttpServerRequest.HttpServerRequest;
+    const requestUrl = requestAbsoluteUrl(httpRequest);
+    if (!requestUrl) {
+      return yield* new EnvironmentHttpBadRequestError({
+        message: "Could not resolve local environment origin.",
+      });
+    }
+    const localOrigin = new URL(requestUrl).origin;
+    const localWsOrigin = localOrigin.replace(/^http/u, "ws");
+    const relayUrl = (yield* Config.string("T3_RELAY_URL").pipe(
+      Config.withDefault(DEFAULT_T3_RELAY_URL),
+      Effect.orDie,
+    )).replace(/\/+$/u, "");
+    const token = yield* dependencies.cliTokenManager.getExisting.pipe(
+      Effect.flatMap(
+        Option.match({
+          onNone: () =>
+            Effect.fail(
+              new EnvironmentHttpUnauthorizedError({
+                message: "Run `t3 cloud link` to authorize this environment.",
+              }),
+            ),
+          onSome: Effect.succeed,
+        }),
+      ),
+    );
+    const challenge = yield* relayClientRequest(dependencies, {
+      url: `${relayUrl}/v1/client/environment-link-challenges`,
+      token: token.accessToken,
+      payload: {
+        notificationsEnabled: true,
+        liveActivitiesEnabled: true,
+        managedTunnelsEnabled: true,
+      },
+      schema: RelayEnvironmentLinkChallengeResponse,
+    });
+    const proof = yield* cloudLinkProofHandler(dependencies, {
+      challenge: challenge.challenge,
+      relayIssuer: relayUrl,
+      endpoint: {
+        httpBaseUrl: localOrigin,
+        wsBaseUrl: localWsOrigin,
+        providerKind: "cloudflare_tunnel",
+      },
+      origin: {
+        localHttpHost: new URL(localOrigin).hostname,
+        localHttpPort: endpointRequestPort(new URL(localOrigin)),
+      },
+    });
+    const link = yield* relayClientRequest(dependencies, {
+      url: `${relayUrl}/v1/client/environment-links`,
+      token: token.accessToken,
+      payload: {
+        proof,
+        notificationsEnabled: true,
+        liveActivitiesEnabled: true,
+        managedTunnelsEnabled: true,
+      },
+      schema: RelayEnvironmentLinkResponse,
+    });
+    yield* CliState.setCliDesiredCloudLink(true);
+    return yield* cloudRelayConfigHandler(dependencies, {
+      relayUrl,
+      relayIssuer: link.relayIssuer,
+      cloudUserId: link.cloudUserId,
+      environmentCredential: link.environmentCredential,
+      cloudMintPublicKey: link.cloudMintPublicKey,
+      endpointRuntime: link.endpointRuntime,
+    });
+  },
+  Effect.catchTags({
+    CloudCliTokenManagerError: (error) =>
+      failEnvironmentCloudInternalError(error.message)(error.cause),
+    SecretStoreError: failEnvironmentCloudInternalError(
+      "Could not persist desired T3 Cloud link state.",
+    ),
+  }),
+);
+
 const readCloudLinkState = Effect.fn("environment.cloud.readLinkState")(function* (
   dependencies: CloudHttpDependencies,
 ) {
@@ -498,6 +612,7 @@ const cloudUnlinkHandler = Effect.fn("environment.cloud.unlink")(
       ],
       { concurrency: 7 },
     );
+    yield* CliState.setCliDesiredCloudLink(false);
     return { ok: true, endpointRuntimeStatus } satisfies EnvironmentCloudRelayConfigResult;
   },
   Effect.catchTag(
@@ -774,10 +889,13 @@ export const cloudHttpApiLayer = HttpApiBuilder.group(
       environment: yield* ServerEnvironment,
       endpointRuntime: yield* CloudManagedEndpointRuntime,
       environmentAuth: yield* EnvironmentAuth.EnvironmentAuth,
+      cliTokenManager: yield* CliTokenManager.CloudCliTokenManager,
+      httpClient: yield* HttpClient.HttpClient,
     };
     return handlers
       .handle("linkProof", ({ payload }) => cloudLinkProofHandler(dependencies, payload))
       .handle("relayConfig", ({ payload }) => cloudRelayConfigHandler(dependencies, payload))
+      .handle("reconcile", () => cloudReconcileHandler(dependencies))
       .handle("linkState", () => cloudLinkStateHandler(dependencies))
       .handle("unlink", () => cloudUnlinkHandler(dependencies))
       .handle("preferences", ({ payload }) => cloudPreferencesHandler(dependencies, payload))

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -105,7 +105,7 @@ const requireRelayUrl = relayUrlConfig.pipe(
   Effect.mapError(
     () =>
       new EnvironmentHttpInternalServerError({
-        message: "T3CODE_RELAY_URL is not configured.",
+        message: "T3CODE_RELAY_URL must be configured as a secure absolute HTTPS origin.",
       }),
   ),
 );

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -39,9 +39,7 @@ import {
   signRelayJwt,
   verifyRelayJwt,
 } from "@t3tools/shared/relayJwt";
-import { DEFAULT_T3_RELAY_URL } from "@t3tools/shared/relayAuth";
 import { isSecureRelayUrl } from "@t3tools/shared/relayUrl";
-import * as Config from "effect/Config";
 import * as DateTime from "effect/DateTime";
 import * as Crypto from "effect/Crypto";
 import * as Duration from "effect/Duration";
@@ -74,6 +72,7 @@ import {
   RELAY_ISSUER_SECRET,
   RELAY_URL_SECRET,
 } from "./config.ts";
+import { relayUrlConfig } from "./publicConfig.ts";
 import * as CliState from "./CliState.ts";
 import * as CliTokenManager from "./CliTokenManager.ts";
 import { getOrCreateEnvironmentKeyPairFromSecretStore } from "./environmentKeys.ts";
@@ -101,6 +100,15 @@ const failEnvironmentCloudInternalError =
     Effect.logError(message, { cause }).pipe(
       Effect.flatMap(() => Effect.fail(new EnvironmentHttpInternalServerError({ message }))),
     );
+
+const requireRelayUrl = relayUrlConfig.pipe(
+  Effect.mapError(
+    () =>
+      new EnvironmentHttpInternalServerError({
+        message: "T3_RELAY_URL is not configured.",
+      }),
+  ),
+);
 
 function bytesToString(bytes: Uint8Array): string {
   return new TextDecoder().decode(bytes);
@@ -492,10 +500,6 @@ const cloudReconcileHandler = Effect.fn("environment.cloud.reconcile")(
     }
     const localOrigin = new URL(requestUrl).origin;
     const localWsOrigin = localOrigin.replace(/^http/u, "ws");
-    const relayUrl = (yield* Config.string("T3_RELAY_URL").pipe(
-      Config.withDefault(DEFAULT_T3_RELAY_URL),
-      Effect.orDie,
-    )).replace(/\/+$/u, "");
     const token = yield* dependencies.cliTokenManager.getExisting.pipe(
       Effect.flatMap(
         Option.match({
@@ -509,6 +513,7 @@ const cloudReconcileHandler = Effect.fn("environment.cloud.reconcile")(
         }),
       ),
     );
+    const relayUrl = yield* requireRelayUrl;
     const challenge = yield* relayClientRequest(dependencies, {
       url: `${relayUrl}/v1/client/environment-link-challenges`,
       token: token.accessToken,

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -105,7 +105,7 @@ const requireRelayUrl = relayUrlConfig.pipe(
   Effect.mapError(
     () =>
       new EnvironmentHttpInternalServerError({
-        message: "T3_RELAY_URL is not configured.",
+        message: "T3CODE_RELAY_URL is not configured.",
       }),
   ),
 );

--- a/apps/server/src/cloud/publicConfig.test.ts
+++ b/apps/server/src/cloud/publicConfig.test.ts
@@ -2,7 +2,7 @@ import { assert, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 
-import { makeRelayUrlConfig } from "./publicConfig.ts";
+import { makeCloudCliOAuthConfig, makeRelayUrlConfig } from "./publicConfig.ts";
 
 const provideEnv = (env: Readonly<Record<string, string>>) =>
   Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env })));
@@ -20,7 +20,7 @@ it.effect("uses the statically injected relay URL when no runtime override exist
 it.effect("prefers a runtime relay URL override over the statically injected value", () =>
   Effect.gen(function* () {
     const relayUrl = yield* makeRelayUrlConfig("https://embedded.example.test").pipe(
-      provideEnv({ T3_RELAY_URL: "https://runtime.example.test///" }),
+      provideEnv({ T3CODE_RELAY_URL: "https://runtime.example.test///" }),
     );
 
     assert.equal(relayUrl, "https://runtime.example.test");
@@ -29,4 +29,46 @@ it.effect("prefers a runtime relay URL override over the statically injected val
 
 it.effect("requires a relay URL when the server bundle has no injected value", () =>
   makeRelayUrlConfig("").pipe(provideEnv({}), Effect.flip),
+);
+
+it.effect("derives direct Clerk OAuth endpoints from statically injected public config", () =>
+  Effect.gen(function* () {
+    const config = yield* makeCloudCliOAuthConfig({
+      clerkPublishableKeyFallback: "pk_test_Y2xlcmsuZXhhbXBsZS50ZXN0JA==",
+      clerkCliOAuthClientIdFallback: "oauth_client_embedded",
+    }).pipe(provideEnv({}));
+
+    assert.deepEqual(config, {
+      authorizationEndpoint: "https://clerk.example.test/oauth/authorize",
+      tokenEndpoint: "https://clerk.example.test/oauth/token",
+      clientId: "oauth_client_embedded",
+      redirectUri: "http://127.0.0.1:34338/callback",
+      scopes: ["openid", "profile", "email"],
+    });
+  }),
+);
+
+it.effect("prefers runtime Clerk OAuth config overrides over statically injected values", () =>
+  Effect.gen(function* () {
+    const config = yield* makeCloudCliOAuthConfig({
+      clerkPublishableKeyFallback: "pk_test_ZW1iZWRkZWQuZXhhbXBsZS50ZXN0JA==",
+      clerkCliOAuthClientIdFallback: "oauth_client_embedded",
+    }).pipe(
+      provideEnv({
+        T3CODE_CLERK_PUBLISHABLE_KEY: "pk_test_cnVudGltZS5leGFtcGxlLnRlc3Qk",
+        T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: "oauth_client_runtime",
+      }),
+    );
+
+    assert.equal(config.authorizationEndpoint, "https://runtime.example.test/oauth/authorize");
+    assert.equal(config.tokenEndpoint, "https://runtime.example.test/oauth/token");
+    assert.equal(config.clientId, "oauth_client_runtime");
+  }),
+);
+
+it.effect("requires Clerk OAuth config when the server bundle has no injected values", () =>
+  makeCloudCliOAuthConfig({
+    clerkPublishableKeyFallback: "",
+    clerkCliOAuthClientIdFallback: "",
+  }).pipe(provideEnv({}), Effect.flip),
 );

--- a/apps/server/src/cloud/publicConfig.test.ts
+++ b/apps/server/src/cloud/publicConfig.test.ts
@@ -1,0 +1,32 @@
+import { assert, it } from "@effect/vitest";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+
+import { makeRelayUrlConfig } from "./publicConfig.ts";
+
+const provideEnv = (env: Readonly<Record<string, string>>) =>
+  Effect.provide(ConfigProvider.layer(ConfigProvider.fromEnv({ env })));
+
+it.effect("uses the statically injected relay URL when no runtime override exists", () =>
+  Effect.gen(function* () {
+    const relayUrl = yield* makeRelayUrlConfig("https://embedded.example.test///").pipe(
+      provideEnv({}),
+    );
+
+    assert.equal(relayUrl, "https://embedded.example.test");
+  }),
+);
+
+it.effect("prefers a runtime relay URL override over the statically injected value", () =>
+  Effect.gen(function* () {
+    const relayUrl = yield* makeRelayUrlConfig("https://embedded.example.test").pipe(
+      provideEnv({ T3_RELAY_URL: "https://runtime.example.test///" }),
+    );
+
+    assert.equal(relayUrl, "https://runtime.example.test");
+  }),
+);
+
+it.effect("requires a relay URL when the server bundle has no injected value", () =>
+  makeRelayUrlConfig("").pipe(provideEnv({}), Effect.flip),
+);

--- a/apps/server/src/cloud/publicConfig.test.ts
+++ b/apps/server/src/cloud/publicConfig.test.ts
@@ -31,6 +31,17 @@ it.effect("requires a relay URL when the server bundle has no injected value", (
   makeRelayUrlConfig("").pipe(provideEnv({}), Effect.flip),
 );
 
+it.effect("rejects an insecure runtime relay URL override", () =>
+  makeRelayUrlConfig("https://embedded.example.test").pipe(
+    provideEnv({ T3CODE_RELAY_URL: "http://runtime.example.test" }),
+    Effect.flip,
+  ),
+);
+
+it.effect("rejects an injected relay URL with a non-origin path", () =>
+  makeRelayUrlConfig("https://embedded.example.test/path").pipe(provideEnv({}), Effect.flip),
+);
+
 it.effect("derives direct Clerk OAuth endpoints from statically injected public config", () =>
   Effect.gen(function* () {
     const config = yield* makeCloudCliOAuthConfig({

--- a/apps/server/src/cloud/publicConfig.ts
+++ b/apps/server/src/cloud/publicConfig.ts
@@ -1,0 +1,25 @@
+import * as Config from "effect/Config";
+
+declare const __T3CODE_BUILD_T3_RELAY_URL__: string | undefined;
+
+function normalizeRelayUrl(value: string): string {
+  return value.trim().replace(/\/+$/u, "");
+}
+
+export const buildTimeRelayUrl =
+  typeof __T3CODE_BUILD_T3_RELAY_URL__ === "undefined"
+    ? ""
+    : normalizeRelayUrl(__T3CODE_BUILD_T3_RELAY_URL__);
+
+export function makeRelayUrlConfig(fallback = buildTimeRelayUrl) {
+  const runtimeConfig = Config.nonEmptyString("T3_RELAY_URL");
+  return (fallback ? runtimeConfig.pipe(Config.withDefault(fallback)) : runtimeConfig).pipe(
+    Config.map(normalizeRelayUrl),
+  );
+}
+
+export const relayUrlConfig = makeRelayUrlConfig();
+
+export const hasRelayPublicConfig = Boolean(
+  normalizeRelayUrl(process.env.T3_RELAY_URL ?? "") || buildTimeRelayUrl,
+);

--- a/apps/server/src/cloud/publicConfig.ts
+++ b/apps/server/src/cloud/publicConfig.ts
@@ -1,18 +1,38 @@
+import { clerkFrontendApiUrlFromPublishableKey } from "@t3tools/shared/relayAuth";
 import * as Config from "effect/Config";
 
-declare const __T3CODE_BUILD_T3_RELAY_URL__: string | undefined;
+declare const __T3CODE_BUILD_RELAY_URL__: string | undefined;
+declare const __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: string | undefined;
+declare const __T3CODE_BUILD_CLERK_CLI_OAUTH_CLIENT_ID__: string | undefined;
+
+const CLOUD_CLI_OAUTH_REDIRECT_URI = "http://127.0.0.1:34338/callback";
+const CLOUD_CLI_OAUTH_SCOPES = ["openid", "profile", "email"] as const;
 
 function normalizeRelayUrl(value: string): string {
   return value.trim().replace(/\/+$/u, "");
 }
 
+function readBuildTimeValue(value: string | undefined): string {
+  return typeof value === "undefined" ? "" : value.trim();
+}
+
 export const buildTimeRelayUrl =
-  typeof __T3CODE_BUILD_T3_RELAY_URL__ === "undefined"
+  typeof __T3CODE_BUILD_RELAY_URL__ === "undefined"
     ? ""
-    : normalizeRelayUrl(__T3CODE_BUILD_T3_RELAY_URL__);
+    : normalizeRelayUrl(__T3CODE_BUILD_RELAY_URL__);
+export const buildTimeClerkPublishableKey = readBuildTimeValue(
+  typeof __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__ === "undefined"
+    ? undefined
+    : __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__,
+);
+export const buildTimeClerkCliOAuthClientId = readBuildTimeValue(
+  typeof __T3CODE_BUILD_CLERK_CLI_OAUTH_CLIENT_ID__ === "undefined"
+    ? undefined
+    : __T3CODE_BUILD_CLERK_CLI_OAUTH_CLIENT_ID__,
+);
 
 export function makeRelayUrlConfig(fallback = buildTimeRelayUrl) {
-  const runtimeConfig = Config.nonEmptyString("T3_RELAY_URL");
+  const runtimeConfig = Config.nonEmptyString("T3CODE_RELAY_URL");
   return (fallback ? runtimeConfig.pipe(Config.withDefault(fallback)) : runtimeConfig).pipe(
     Config.map(normalizeRelayUrl),
   );
@@ -20,6 +40,55 @@ export function makeRelayUrlConfig(fallback = buildTimeRelayUrl) {
 
 export const relayUrlConfig = makeRelayUrlConfig();
 
-export const hasRelayPublicConfig = Boolean(
-  normalizeRelayUrl(process.env.T3_RELAY_URL ?? "") || buildTimeRelayUrl,
+function makePublicValueConfig(name: string, fallback: string) {
+  const runtimeConfig = Config.nonEmptyString(name);
+  return (fallback ? runtimeConfig.pipe(Config.withDefault(fallback)) : runtimeConfig).pipe(
+    Config.map((value) => value.trim()),
+  );
+}
+
+export interface CloudCliOAuthConfig {
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly scopes: typeof CLOUD_CLI_OAUTH_SCOPES;
+}
+
+export function makeCloudCliOAuthConfig({
+  clerkPublishableKeyFallback = buildTimeClerkPublishableKey,
+  clerkCliOAuthClientIdFallback = buildTimeClerkCliOAuthClientId,
+}: {
+  readonly clerkPublishableKeyFallback?: string;
+  readonly clerkCliOAuthClientIdFallback?: string;
+} = {}) {
+  return Config.all({
+    clerkPublishableKey: makePublicValueConfig(
+      "T3CODE_CLERK_PUBLISHABLE_KEY",
+      clerkPublishableKeyFallback,
+    ),
+    clientId: makePublicValueConfig(
+      "T3CODE_CLERK_CLI_OAUTH_CLIENT_ID",
+      clerkCliOAuthClientIdFallback,
+    ),
+  }).pipe(
+    Config.map(({ clerkPublishableKey, clientId }) => {
+      const clerkFrontendApiUrl = clerkFrontendApiUrlFromPublishableKey(clerkPublishableKey);
+      return {
+        authorizationEndpoint: `${clerkFrontendApiUrl}/oauth/authorize`,
+        tokenEndpoint: `${clerkFrontendApiUrl}/oauth/token`,
+        clientId,
+        redirectUri: CLOUD_CLI_OAUTH_REDIRECT_URI,
+        scopes: CLOUD_CLI_OAUTH_SCOPES,
+      } satisfies CloudCliOAuthConfig;
+    }),
+  );
+}
+
+export const cloudCliOAuthConfig = makeCloudCliOAuthConfig();
+
+export const hasCloudPublicConfig = Boolean(
+  (normalizeRelayUrl(process.env.T3CODE_RELAY_URL ?? "") || buildTimeRelayUrl) &&
+  (process.env.T3CODE_CLERK_PUBLISHABLE_KEY?.trim() || buildTimeClerkPublishableKey) &&
+  (process.env.T3CODE_CLERK_CLI_OAUTH_CLIENT_ID?.trim() || buildTimeClerkCliOAuthClientId),
 );

--- a/apps/server/src/cloud/publicConfig.ts
+++ b/apps/server/src/cloud/publicConfig.ts
@@ -1,5 +1,10 @@
 import { clerkFrontendApiUrlFromPublishableKey } from "@t3tools/shared/relayAuth";
+import { normalizeSecureRelayUrl } from "@t3tools/shared/relayUrl";
 import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as SchemaIssue from "effect/SchemaIssue";
 
 declare const __T3CODE_BUILD_RELAY_URL__: string | undefined;
 declare const __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: string | undefined;
@@ -8,8 +13,19 @@ declare const __T3CODE_BUILD_CLERK_CLI_OAUTH_CLIENT_ID__: string | undefined;
 const CLOUD_CLI_OAUTH_REDIRECT_URI = "http://127.0.0.1:34338/callback";
 const CLOUD_CLI_OAUTH_SCOPES = ["openid", "profile", "email"] as const;
 
-function normalizeRelayUrl(value: string): string {
-  return value.trim().replace(/\/+$/u, "");
+function validateRelayUrl(value: string) {
+  const relayUrl = normalizeSecureRelayUrl(value);
+  return relayUrl === null
+    ? Effect.fail(
+        new Config.ConfigError(
+          new Schema.SchemaError(
+            new SchemaIssue.InvalidValue(Option.some(value), {
+              message: "Relay URL must be a secure absolute HTTPS origin.",
+            }),
+          ),
+        ),
+      )
+    : Effect.succeed(relayUrl);
 }
 
 function readBuildTimeValue(value: string | undefined): string {
@@ -19,7 +35,7 @@ function readBuildTimeValue(value: string | undefined): string {
 export const buildTimeRelayUrl =
   typeof __T3CODE_BUILD_RELAY_URL__ === "undefined"
     ? ""
-    : normalizeRelayUrl(__T3CODE_BUILD_RELAY_URL__);
+    : (normalizeSecureRelayUrl(__T3CODE_BUILD_RELAY_URL__) ?? "");
 export const buildTimeClerkPublishableKey = readBuildTimeValue(
   typeof __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__ === "undefined"
     ? undefined
@@ -34,7 +50,7 @@ export const buildTimeClerkCliOAuthClientId = readBuildTimeValue(
 export function makeRelayUrlConfig(fallback = buildTimeRelayUrl) {
   const runtimeConfig = Config.nonEmptyString("T3CODE_RELAY_URL");
   return (fallback ? runtimeConfig.pipe(Config.withDefault(fallback)) : runtimeConfig).pipe(
-    Config.map(normalizeRelayUrl),
+    Config.mapOrFail(validateRelayUrl),
   );
 }
 
@@ -88,7 +104,7 @@ export function makeCloudCliOAuthConfig({
 export const cloudCliOAuthConfig = makeCloudCliOAuthConfig();
 
 export const hasCloudPublicConfig = Boolean(
-  (normalizeRelayUrl(process.env.T3CODE_RELAY_URL ?? "") || buildTimeRelayUrl) &&
+  (normalizeSecureRelayUrl(process.env.T3CODE_RELAY_URL ?? "") ?? buildTimeRelayUrl) &&
   (process.env.T3CODE_CLERK_PUBLISHABLE_KEY?.trim() || buildTimeClerkPublishableKey) &&
   (process.env.T3CODE_CLERK_CLI_OAUTH_CLIENT_ID?.trim() || buildTimeClerkCliOAuthClientId),
 );

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -2280,26 +2280,16 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
-  it.effect("rejects cloud reconciliation before the headless CLI is authorized", () =>
+  it.effect("does not expose internal cloud reconciliation over HTTP", () =>
     Effect.gen(function* () {
       yield* buildAppUnderTest();
 
-      const ownerCookie = yield* getAuthenticatedSessionCookieHeader();
       const reconcileUrl = yield* getHttpServerUrl("/api/cloud/reconcile");
       const response = yield* fetchEffect(reconcileUrl, {
         method: "POST",
-        headers: {
-          cookie: ownerCookie,
-        },
       });
-      const body = yield* responseJsonEffect<{
-        readonly _tag?: string;
-        readonly message?: string;
-      }>(response);
 
-      assert.equal(response.status, 401);
-      assert.equal(body._tag, "EnvironmentHttpUnauthorizedError");
-      assert.equal(body.message, "Run `t3 cloud link` to authorize this environment.");
+      assert.equal(response.status, 404);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -132,6 +132,7 @@ import {
   CloudManagedEndpointRuntime,
   type CloudManagedEndpointRuntimeShape,
 } from "./cloud/ManagedEndpointRuntime.ts";
+import * as CloudCliTokenManager from "./cloud/CliTokenManager.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
@@ -361,6 +362,7 @@ const buildAppUnderTest = (options?: {
     repositoryIdentityResolver?: Partial<RepositoryIdentityResolverShape>;
     cloudManagedEndpointRuntime?: Partial<CloudManagedEndpointRuntimeShape>;
     relayClient?: Partial<RelayClient.RelayClientShape>;
+    cloudCliTokenManager?: Partial<CloudCliTokenManager.CloudCliTokenManagerShape>;
   };
 }) =>
   Effect.gen(function* () {
@@ -777,6 +779,15 @@ const buildAppUnderTest = (options?: {
             ...options?.layers?.relayClient,
           }),
         ),
+      ),
+      Layer.provide(
+        Layer.mock(CloudCliTokenManager.CloudCliTokenManager)({
+          get: Effect.die(new Error("Unexpected T3 Cloud CLI authorization request.")),
+          getExisting: Effect.succeed(Option.none()),
+          hasCredential: Effect.succeed(false),
+          clear: Effect.void,
+          ...options?.layers?.cloudCliTokenManager,
+        }),
       ),
       Layer.provideMerge(makeAuthTestLayer()),
       Layer.provideMerge(ServerSecretStore.layer),
@@ -2266,6 +2277,29 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(linkedBody.cloudUserId, "user_123");
       assert.equal(linkedBody.relayUrl, "https://transport.example.test");
       assert.equal(linkedBody.relayIssuer, "https://relay.example.test");
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("rejects cloud reconciliation before the headless CLI is authorized", () =>
+    Effect.gen(function* () {
+      yield* buildAppUnderTest();
+
+      const ownerCookie = yield* getAuthenticatedSessionCookieHeader();
+      const reconcileUrl = yield* getHttpServerUrl("/api/cloud/reconcile");
+      const response = yield* fetchEffect(reconcileUrl, {
+        method: "POST",
+        headers: {
+          cookie: ownerCookie,
+        },
+      });
+      const body = yield* responseJsonEffect<{
+        readonly _tag?: string;
+        readonly message?: string;
+      }>(response);
+
+      assert.equal(response.status, 401);
+      assert.equal(body._tag, "EnvironmentHttpUnauthorizedError");
+      assert.equal(body.message, "Run `t3 cloud link` to authorize this environment.");
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,7 +1,14 @@
-import { EnvironmentHttpApi } from "@t3tools/contracts";
+import { AuthRelayWriteScope, EnvironmentHttpApi } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
+import {
+  FetchHttpClient,
+  HttpClient,
+  HttpClientRequest,
+  HttpClientResponse,
+  HttpRouter,
+  HttpServer,
+} from "effect/unstable/http";
 import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 
 import { ServerConfig } from "./config.ts";
@@ -70,6 +77,8 @@ import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import { cloudHttpApiLayer } from "./cloud/http.ts";
 import * as CloudManagedEndpointRuntime from "./cloud/ManagedEndpointRuntime.ts";
+import * as CloudCliTokenManager from "./cloud/CliTokenManager.ts";
+import * as CloudCliState from "./cloud/CliState.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
@@ -292,7 +301,12 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   Layer.provideMerge(ServerEnvironmentLive),
   Layer.provideMerge(AuthLayerLive),
   Layer.provideMerge(ServerSecretStore.layer),
-  Layer.provideMerge(CloudManagedEndpointRuntimeLive),
+  Layer.provideMerge(
+    Layer.mergeAll(
+      CloudCliTokenManager.layer.pipe(Layer.provide(ServerSecretStore.layer)),
+      CloudManagedEndpointRuntimeLive,
+    ),
+  ),
 );
 
 const RuntimeDependenciesLive = RuntimeCoreDependenciesLive.pipe(
@@ -410,6 +424,40 @@ export const makeServerLayer = Layer.unwrap(
           ),
         )
       : Layer.empty;
+    const cloudDesiredLinkReconcileLayer = Layer.effectDiscard(
+      Effect.gen(function* () {
+        if (!(yield* CloudCliState.readCliDesiredCloudLink)) return;
+        const server = yield* HttpServer.HttpServer;
+        const address = server.address;
+        if (typeof address === "string" || !("port" in address)) return;
+        const environmentAuth = yield* EnvironmentAuth.EnvironmentAuth;
+        const issued = yield* environmentAuth.issueSession({
+          scopes: [AuthRelayWriteScope],
+          subject: "cloud-cli-startup-reconcile",
+          label: "T3 Cloud startup reconcile",
+        });
+        const httpClient = yield* HttpClient.HttpClient;
+        yield* Effect.forkScoped(
+          Effect.sleep("250 millis").pipe(
+            Effect.andThen(
+              HttpClientRequest.post(`http://127.0.0.1:${address.port}/api/cloud/reconcile`).pipe(
+                HttpClientRequest.bearerToken(issued.token),
+                httpClient.execute,
+                Effect.flatMap(HttpClientResponse.filterStatusOk),
+              ),
+            ),
+            Effect.retry({ times: 4 }),
+            Effect.tap(() => Effect.logInfo("T3 Cloud desired link reconciled on startup")),
+            Effect.catch((cause) =>
+              Effect.logWarning("Failed to reconcile T3 Cloud desired link on startup", {
+                cause,
+              }),
+            ),
+            Effect.ensuring(environmentAuth.revokeSession(issued.sessionId).pipe(Effect.ignore)),
+          ),
+        );
+      }),
+    );
 
     const serverApplicationLayer = Layer.mergeAll(
       HttpRouter.serve(makeRoutesLayer, {
@@ -418,6 +466,7 @@ export const makeServerLayer = Layer.unwrap(
       httpListeningLayer,
       runtimeStateLayer,
       tailscaleServeLayer,
+      cloudDesiredLinkReconcileLayer,
     );
 
     return serverApplicationLayer.pipe(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,14 +1,7 @@
-import { AuthRelayWriteScope, EnvironmentHttpApi } from "@t3tools/contracts";
+import { EnvironmentHttpApi } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import {
-  FetchHttpClient,
-  HttpClient,
-  HttpClientRequest,
-  HttpClientResponse,
-  HttpRouter,
-  HttpServer,
-} from "effect/unstable/http";
+import { FetchHttpClient, HttpRouter, HttpServer } from "effect/unstable/http";
 import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 
 import { ServerConfig } from "./config.ts";
@@ -76,7 +69,7 @@ import { ServerEnvironmentLive } from "./environment/Layers/ServerEnvironment.ts
 import { authHttpApiLayer, environmentAuthenticatedAuthLayer } from "./auth/http.ts";
 import * as ServerSecretStore from "./auth/ServerSecretStore.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
-import { cloudHttpApiLayer } from "./cloud/http.ts";
+import { cloudHttpApiLayer, reconcileDesiredCloudLink } from "./cloud/http.ts";
 import * as CloudManagedEndpointRuntime from "./cloud/ManagedEndpointRuntime.ts";
 import * as CloudCliTokenManager from "./cloud/CliTokenManager.ts";
 import * as CloudCliState from "./cloud/CliState.ts";
@@ -432,22 +425,9 @@ export const makeServerLayer = Layer.unwrap(
         const server = yield* HttpServer.HttpServer;
         const address = server.address;
         if (typeof address === "string" || !("port" in address)) return;
-        const environmentAuth = yield* EnvironmentAuth.EnvironmentAuth;
-        const issued = yield* environmentAuth.issueSession({
-          scopes: [AuthRelayWriteScope],
-          subject: "cloud-cli-startup-reconcile",
-          label: "T3 Cloud startup reconcile",
-        });
-        const httpClient = yield* HttpClient.HttpClient;
         yield* Effect.forkScoped(
           Effect.sleep("250 millis").pipe(
-            Effect.andThen(
-              HttpClientRequest.post(`http://127.0.0.1:${address.port}/api/cloud/reconcile`).pipe(
-                HttpClientRequest.bearerToken(issued.token),
-                httpClient.execute,
-                Effect.flatMap(HttpClientResponse.filterStatusOk),
-              ),
-            ),
+            Effect.andThen(reconcileDesiredCloudLink(`http://127.0.0.1:${address.port}`)),
             Effect.retry({ times: 4 }),
             Effect.tap(() => Effect.logInfo("T3 Cloud desired link reconciled on startup")),
             Effect.catch((cause) =>
@@ -455,7 +435,6 @@ export const makeServerLayer = Layer.unwrap(
                 cause,
               }),
             ),
-            Effect.ensuring(environmentAuth.revokeSession(issued.sessionId).pipe(Effect.ignore)),
           ),
         );
       }),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -45,7 +45,7 @@ import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderComma
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
 import * as AgentAwarenessRelay from "./relay/AgentAwarenessRelay.ts";
-import { hasRelayPublicConfig } from "./cloud/publicConfig.ts";
+import { hasCloudPublicConfig } from "./cloud/publicConfig.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
 import { ServerSettingsLive } from "./serverSettings.ts";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver.ts";
@@ -420,7 +420,7 @@ export const makeServerLayer = Layer.unwrap(
       : Layer.empty;
     const cloudDesiredLinkReconcileLayer = Layer.effectDiscard(
       Effect.gen(function* () {
-        if (!hasRelayPublicConfig) return;
+        if (!hasCloudPublicConfig) return;
         if (!(yield* CloudCliState.readCliDesiredCloudLink)) return;
         const server = yield* HttpServer.HttpServer;
         const address = server.address;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -52,6 +52,7 @@ import { ProviderCommandReactorLive } from "./orchestration/Layers/ProviderComma
 import { CheckpointReactorLive } from "./orchestration/Layers/CheckpointReactor.ts";
 import { ThreadDeletionReactorLive } from "./orchestration/Layers/ThreadDeletionReactor.ts";
 import * as AgentAwarenessRelay from "./relay/AgentAwarenessRelay.ts";
+import { hasRelayPublicConfig } from "./cloud/publicConfig.ts";
 import { ProviderRegistryLive } from "./provider/Layers/ProviderRegistry.ts";
 import { ServerSettingsLive } from "./serverSettings.ts";
 import { ProjectFaviconResolverLive } from "./project/Layers/ProjectFaviconResolver.ts";
@@ -426,6 +427,7 @@ export const makeServerLayer = Layer.unwrap(
       : Layer.empty;
     const cloudDesiredLinkReconcileLayer = Layer.effectDiscard(
       Effect.gen(function* () {
+        if (!hasRelayPublicConfig) return;
         if (!(yield* CloudCliState.readCliDesiredCloudLink)) return;
         const server = yield* HttpServer.HttpServer;
         const address = server.address;

--- a/apps/server/vite.config.ts
+++ b/apps/server/vite.config.ts
@@ -2,8 +2,10 @@ import "vite-plus/test/config";
 import { defineConfig, mergeConfig } from "vite-plus";
 
 import baseConfig from "../../vite.config.ts";
+import { loadRepoEnv } from "../../scripts/lib/public-config.ts";
 
 const internalPackagePrefixes = ["@t3tools/", "effect-acp", "effect-codex-app-server"];
+const repoEnv = loadRepoEnv();
 
 export default mergeConfig(
   baseConfig,
@@ -20,6 +22,15 @@ export default mergeConfig(
       },
       banner: {
         js: "#!/usr/bin/env node\n",
+      },
+      define: {
+        __T3CODE_BUILD_RELAY_URL__: JSON.stringify(repoEnv.T3CODE_RELAY_URL?.trim() ?? ""),
+        __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: JSON.stringify(
+          repoEnv.T3CODE_CLERK_PUBLISHABLE_KEY?.trim() ?? "",
+        ),
+        __T3CODE_BUILD_CLERK_CLI_OAUTH_CLIENT_ID__: JSON.stringify(
+          repoEnv.T3CODE_CLERK_CLI_OAUTH_CLIENT_ID?.trim() ?? "",
+        ),
       },
     },
     test: {

--- a/apps/web/src/cloud/desktopClerk.tsx
+++ b/apps/web/src/cloud/desktopClerk.tsx
@@ -5,6 +5,10 @@ import {
   InternalClerkProvider,
 } from "@clerk/react/internal";
 import type { ClerkProviderProps } from "@clerk/react";
+import {
+  clerkFrontendApiHostnameFromPublishableKey,
+  isAllowedClerkFrontendApiHostname,
+} from "@t3tools/shared/relayAuth";
 import React, { useEffect, useState } from "react";
 
 type DesktopClerkUiCtor = NonNullable<Window["__internal_ClerkUICtor"]>;
@@ -54,6 +58,7 @@ interface DesktopClerkProviderProps {
 let desktopClerk: Clerk | null = null;
 let desktopClerkFetchInstalled = false;
 let desktopClerkUiLoad: Promise<DesktopClerkUiCtor> | null = null;
+let desktopClerkFrontendApiHostname: string | null = null;
 
 const isNativeRequestClerk = (value: unknown): value is NativeRequestClerk => {
   if (typeof value !== "object" || value === null) return false;
@@ -82,7 +87,7 @@ const clearStoredClientJwt = (): Promise<void> =>
 
 const isClerkFrontendApiUrl = (url: URL): boolean =>
   url.protocol === "https:" &&
-  (url.hostname.endsWith(".clerk.accounts.dev") || url.hostname.endsWith(".clerk.accounts.com"));
+  isAllowedClerkFrontendApiHostname(url.hostname, desktopClerkFrontendApiHostname);
 
 const headersToRecord = (headers: Headers): Record<string, string> => {
   const record: Record<string, string> = {};
@@ -92,7 +97,8 @@ const headersToRecord = (headers: Headers): Record<string, string> => {
   return record;
 };
 
-function installDesktopClerkFetchProxy(): void {
+function installDesktopClerkFetchProxy(publishableKey: string): void {
+  desktopClerkFrontendApiHostname = clerkFrontendApiHostnameFromPublishableKey(publishableKey);
   if (desktopClerkFetchInstalled) return;
   const bridge = window.desktopBridge;
   if (!bridge) return;
@@ -187,7 +193,7 @@ function loadDesktopClerkUi(publishableKey: string): Promise<DesktopClerkUiCtor>
 }
 
 function getDesktopClerkInstance(publishableKey: string): Clerk {
-  installDesktopClerkFetchProxy();
+  installDesktopClerkFetchProxy(publishableKey);
 
   const hasKeyChanged = desktopClerk !== null && desktopClerk.publishableKey !== publishableKey;
   if (hasKeyChanged) {

--- a/apps/web/src/cloud/desktopClerk.tsx
+++ b/apps/web/src/cloud/desktopClerk.tsx
@@ -11,6 +11,11 @@ import {
 } from "@t3tools/shared/relayAuth";
 import React, { useEffect, useState } from "react";
 
+import {
+  makeDesktopClerkExternalAccountAdapter,
+  type DesktopClerkUser,
+} from "./desktopClerkExternalAccounts";
+
 type DesktopClerkUiCtor = NonNullable<Window["__internal_ClerkUICtor"]>;
 
 interface ClerkFrontendApiRequest {
@@ -59,6 +64,7 @@ let desktopClerk: Clerk | null = null;
 let desktopClerkFetchInstalled = false;
 let desktopClerkUiLoad: Promise<DesktopClerkUiCtor> | null = null;
 let desktopClerkFrontendApiHostname: string | null = null;
+let desktopClerkExternalAccountCleanup: (() => void) | null = null;
 
 const isNativeRequestClerk = (value: unknown): value is NativeRequestClerk => {
   if (typeof value !== "object" || value === null) return false;
@@ -131,6 +137,25 @@ function installDesktopClerkFetchProxy(publishableKey: string): void {
   desktopClerkFetchInstalled = true;
 }
 
+function installDesktopClerkExternalAccounts(clerk: Clerk): void {
+  desktopClerkExternalAccountCleanup?.();
+  desktopClerkExternalAccountCleanup = null;
+
+  const bridge = window.desktopBridge;
+  if (!bridge) return;
+
+  const adapter = makeDesktopClerkExternalAccountAdapter({ bridge });
+  const unsubscribe = clerk.addListener(({ user }) => {
+    if (user) {
+      adapter.installUser(user as DesktopClerkUser);
+    }
+  });
+  desktopClerkExternalAccountCleanup = () => {
+    unsubscribe();
+    adapter.dispose();
+  };
+}
+
 function loadDesktopClerkUi(publishableKey: string): Promise<DesktopClerkUiCtor> {
   if (window.__internal_ClerkUICtor) {
     return Promise.resolve(window.__internal_ClerkUICtor);
@@ -198,6 +223,8 @@ function getDesktopClerkInstance(publishableKey: string): Clerk {
   const hasKeyChanged = desktopClerk !== null && desktopClerk.publishableKey !== publishableKey;
   if (hasKeyChanged) {
     void clearStoredClientJwt();
+    desktopClerkExternalAccountCleanup?.();
+    desktopClerkExternalAccountCleanup = null;
     desktopClerk = null;
   }
 
@@ -206,6 +233,7 @@ function getDesktopClerkInstance(publishableKey: string): Clerk {
   }
 
   const nextClerk = new Clerk(publishableKey);
+  installDesktopClerkExternalAccounts(nextClerk);
   if (!isNativeRequestClerk(nextClerk)) {
     desktopClerk = nextClerk;
     return nextClerk;

--- a/apps/web/src/cloud/desktopClerkExternalAccounts.test.ts
+++ b/apps/web/src/cloud/desktopClerkExternalAccounts.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  makeDesktopClerkExternalAccountAdapter,
+  type DesktopClerkUser,
+} from "./desktopClerkExternalAccounts";
+
+describe("desktop Clerk external account adapter", () => {
+  it("replaces renderer redirects with native callbacks and reloads the user on return", async () => {
+    const callbacks: ((rawUrl: string) => void)[] = [];
+    const callbackCleanup = vi.fn();
+    const bridge = {
+      createCloudAuthRequest: vi
+        .fn()
+        .mockResolvedValueOnce("t3code://auth/callback?t3_state=add")
+        .mockResolvedValueOnce("t3code://auth/callback?t3_state=reconnect"),
+      onCloudAuthCallback: vi.fn((listener: (rawUrl: string) => void) => {
+        callbacks.push(listener);
+        return callbackCleanup;
+      }),
+    };
+    const reauthorize = vi.fn(async (_params: Record<string, unknown>) => account);
+    const account = { reauthorize };
+    const createExternalAccount = vi.fn(async (_params: Record<string, unknown>) => account);
+    const reload = vi.fn(async () => undefined);
+    const user = {
+      externalAccounts: [],
+      createExternalAccount,
+      reload,
+    } satisfies DesktopClerkUser;
+    const adapter = makeDesktopClerkExternalAccountAdapter({ bridge });
+    adapter.installUser(user);
+
+    await user.createExternalAccount({
+      redirectUrl: "http://127.0.0.1:3773/?__clerk_modal_state=state",
+      strategy: "oauth_microsoft",
+    });
+
+    expect(createExternalAccount).toHaveBeenCalledWith({
+      redirectUrl: "t3code://auth/callback?t3_state=add",
+      strategy: "oauth_microsoft",
+    });
+
+    callbacks[0]?.("t3code://auth/callback?t3_state=add");
+    await Promise.resolve();
+    expect(reload).toHaveBeenCalledOnce();
+
+    await account.reauthorize({
+      redirectUrl: "http://127.0.0.1:3773/?__clerk_modal_state=state",
+    });
+    expect(reauthorize).toHaveBeenCalledWith({
+      redirectUrl: "t3code://auth/callback?t3_state=reconnect",
+    });
+  });
+
+  it("cleans up the pending callback when Clerk rejects account creation", async () => {
+    const callbackCleanup = vi.fn();
+    const bridge = {
+      createCloudAuthRequest: vi.fn().mockResolvedValue("t3code://auth/callback?t3_state=failed"),
+      onCloudAuthCallback: vi.fn(() => callbackCleanup),
+    };
+    const createError = new Error("oauth provider unavailable");
+    const user = {
+      externalAccounts: [],
+      createExternalAccount: vi.fn(async (_params: Record<string, unknown>) => {
+        throw createError;
+      }),
+      reload: vi.fn(async () => undefined),
+    } satisfies DesktopClerkUser;
+    const adapter = makeDesktopClerkExternalAccountAdapter({ bridge });
+    adapter.installUser(user);
+
+    await expect(user.createExternalAccount({ strategy: "oauth_microsoft" })).rejects.toBe(
+      createError,
+    );
+    expect(callbackCleanup).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/cloud/desktopClerkExternalAccounts.ts
+++ b/apps/web/src/cloud/desktopClerkExternalAccounts.ts
@@ -1,0 +1,112 @@
+interface DesktopClerkExternalAccountParams {
+  readonly redirectUrl?: string;
+  readonly [key: string]: unknown;
+}
+
+interface DesktopClerkExternalAccount {
+  reauthorize: (params: DesktopClerkExternalAccountParams) => Promise<DesktopClerkExternalAccount>;
+}
+
+interface DesktopClerkUser {
+  readonly externalAccounts: readonly DesktopClerkExternalAccount[];
+  createExternalAccount: (
+    params: DesktopClerkExternalAccountParams,
+  ) => Promise<DesktopClerkExternalAccount>;
+  reload: () => Promise<unknown>;
+}
+
+interface DesktopClerkExternalAccountBridge {
+  readonly createCloudAuthRequest: () => Promise<string>;
+  readonly onCloudAuthCallback: (listener: (rawUrl: string) => void) => () => void;
+}
+
+interface DesktopClerkExternalAccountAdapter {
+  readonly dispose: () => void;
+  readonly installUser: (user: DesktopClerkUser) => void;
+}
+
+interface MakeDesktopClerkExternalAccountAdapterInput {
+  readonly bridge: DesktopClerkExternalAccountBridge;
+  readonly reportError?: (message: string, error: unknown) => void;
+}
+
+// Clerk's profile component uses window.location.href as the OAuth callback and navigates the
+// current window to the provider. Keep the upstream component intact while adapting its resource
+// calls to the native callback bridge:
+// https://github.com/clerk/javascript/blob/52861184477bee99c71552000311a289e91d3b59/packages/ui/src/components/UserProfile/ConnectedAccountsMenu.tsx
+// https://github.com/clerk/javascript/blob/52861184477bee99c71552000311a289e91d3b59/packages/ui/src/components/UserProfile/ConnectedAccountsSection.tsx
+export function makeDesktopClerkExternalAccountAdapter({
+  bridge,
+  reportError = console.error,
+}: MakeDesktopClerkExternalAccountAdapterInput): DesktopClerkExternalAccountAdapter {
+  const installedAccounts = new WeakSet<object>();
+  const installedUsers = new WeakSet<object>();
+  let callbackGeneration = 0;
+  let callbackCleanup: (() => void) | null = null;
+
+  const clearCallback = () => {
+    callbackGeneration += 1;
+    callbackCleanup?.();
+    callbackCleanup = null;
+  };
+
+  const createRedirectUrl = async (user: DesktopClerkUser): Promise<string> => {
+    clearCallback();
+    const redirectUrl = await bridge.createCloudAuthRequest();
+    const generation = callbackGeneration;
+    callbackCleanup = bridge.onCloudAuthCallback(() => {
+      if (generation !== callbackGeneration) return;
+      clearCallback();
+      void user.reload().catch((error: unknown) => {
+        reportError("Failed to reload Clerk after desktop account linking.", error);
+      });
+    });
+    return redirectUrl;
+  };
+
+  const installAccount = (user: DesktopClerkUser, account: DesktopClerkExternalAccount): void => {
+    if (installedAccounts.has(account)) return;
+    installedAccounts.add(account);
+
+    const reauthorize = account.reauthorize.bind(account);
+    account.reauthorize = async (params) => {
+      const redirectUrl = await createRedirectUrl(user);
+      try {
+        const nextAccount = await reauthorize({ ...params, redirectUrl });
+        installAccount(user, nextAccount);
+        return nextAccount;
+      } catch (error) {
+        clearCallback();
+        throw error;
+      }
+    };
+  };
+
+  const installUser = (user: DesktopClerkUser): void => {
+    for (const account of user.externalAccounts) {
+      installAccount(user, account);
+    }
+    if (installedUsers.has(user)) return;
+    installedUsers.add(user);
+
+    const createExternalAccount = user.createExternalAccount.bind(user);
+    user.createExternalAccount = async (params) => {
+      const redirectUrl = await createRedirectUrl(user);
+      try {
+        const account = await createExternalAccount({ ...params, redirectUrl });
+        installAccount(user, account);
+        return account;
+      } catch (error) {
+        clearCallback();
+        throw error;
+      }
+    };
+  };
+
+  return {
+    dispose: clearCallback,
+    installUser,
+  };
+}
+
+export type { DesktopClerkExternalAccountAdapter, DesktopClerkUser };

--- a/docs/t3-cloud-clerk.md
+++ b/docs/t3-cloud-clerk.md
@@ -47,6 +47,44 @@ The `prod` Alchemy stage owns the retained PlanetScale database. Non-production 
 that database and provision isolated PlanetScale branches, so deploy `prod` before creating a
 preview or developer stage.
 
+## Headless CLI OAuth Application
+
+The `t3 cloud` commands authorize a headless environment with a separate Clerk OAuth application.
+This uses an OAuth public client with PKCE, so the CLI stores no client secret.
+
+In **Clerk Dashboard > OAuth applications**:
+
+1. Create an OAuth application for the T3 CLI.
+2. Enable the **Public** option so authorization-code exchange uses PKCE.
+3. Add `http://127.0.0.1:34338/callback` as an allowed redirect URI.
+4. Enable the `openid`, `profile`, and `email` scopes.
+5. Set the relay deployment's `CLERK_CLI_OAUTH_CLIENT_ID` to the generated public client ID.
+
+The CLI supports these headless operations:
+
+```sh
+t3 cloud link
+t3 cloud status
+t3 cloud unlink
+t3 serve
+```
+
+`t3 cloud link` installs the pinned managed `cloudflared` binary when needed, opens the Clerk
+authorization flow, and records durable intent to expose the environment. It works without a
+running T3 server. If no server is running, the next `t3 serve` or `t3 start` reconciles the relay
+link and launches the managed tunnel. `t3 cloud unlink` records disabled intent immediately,
+stops a reachable running connector, and attempts to revoke the relay-side environment record.
+
+The current OAuth callback listener binds to loopback port `34338`. When running the CLI over SSH,
+forward that port before running `t3 cloud link`:
+
+```sh
+ssh -L 34338:127.0.0.1:34338 <host>
+```
+
+A relay-hosted callback broker can remove this port-forward requirement later without changing the
+stored PKCE token model.
+
 ## JWT Template
 
 In **Clerk Dashboard > JWT templates**, create a template with:

--- a/docs/t3-cloud-clerk.md
+++ b/docs/t3-cloud-clerk.md
@@ -48,7 +48,7 @@ environment or commit it to the repository.
 
 The `prod` Alchemy stage owns the retained PlanetScale database. Non-production stages reference
 that database and provision isolated PlanetScale branches, so deploy `prod` before creating a
-preview or developer stage.
+personal developer stage.
 
 ## Headless CLI OAuth Application
 
@@ -77,11 +77,11 @@ t3 serve
 `t3 cloud login` opens the Clerk authorization flow and stores the CLI credential without enabling
 cloud exposure. `t3 cloud link` installs the pinned managed `cloudflared` binary when needed,
 authorizes when needed, and records durable intent to expose the environment. It works without a
-running T3 server. If no server is running, the next `t3 serve` or `t3 start` reconciles the relay
-link and launches the managed tunnel. `t3 cloud unlink` records disabled intent immediately, stops
-a reachable running connector, and attempts to revoke the relay-side environment record. It retains
-the stored CLI authorization so `t3 cloud link` can re-enable exposure without another browser
-flow. `t3 cloud logout` performs the same cleanup and removes the stored CLI authorization.
+running T3 server. The next `t3 serve` or `t3 start` reconciles the relay link and launches the
+managed tunnel. `t3 cloud unlink` records disabled intent immediately, stops a reachable running
+connector, and attempts to revoke the relay-side environment record. It retains the stored CLI
+authorization so `t3 cloud link` can re-enable exposure without another browser flow. `t3 cloud
+logout` performs the same cleanup and removes the stored CLI authorization.
 
 The current OAuth callback listener binds to loopback port `34338`. When running the CLI over SSH,
 forward that port before running `t3 cloud login` or `t3 cloud link`:

--- a/docs/t3-cloud-clerk.md
+++ b/docs/t3-cloud-clerk.md
@@ -66,6 +66,7 @@ The CLI supports these headless operations:
 t3 cloud link
 t3 cloud status
 t3 cloud unlink
+t3 cloud logout
 t3 serve
 ```
 
@@ -73,7 +74,9 @@ t3 serve
 authorization flow, and records durable intent to expose the environment. It works without a
 running T3 server. If no server is running, the next `t3 serve` or `t3 start` reconciles the relay
 link and launches the managed tunnel. `t3 cloud unlink` records disabled intent immediately,
-stops a reachable running connector, and attempts to revoke the relay-side environment record.
+stops a reachable running connector, and attempts to revoke the relay-side environment record. It
+retains the stored CLI authorization so `t3 cloud link` can re-enable exposure without another
+browser flow. `t3 cloud logout` performs the same cleanup and removes the stored CLI authorization.
 
 The current OAuth callback listener binds to loopback port `34338`. When running the CLI over SSH,
 forward that port before running `t3 cloud link`:

--- a/docs/t3-cloud-clerk.md
+++ b/docs/t3-cloud-clerk.md
@@ -63,6 +63,7 @@ In **Clerk Dashboard > OAuth applications**:
 The CLI supports these headless operations:
 
 ```sh
+t3 cloud login
 t3 cloud link
 t3 cloud status
 t3 cloud unlink
@@ -70,16 +71,17 @@ t3 cloud logout
 t3 serve
 ```
 
-`t3 cloud link` installs the pinned managed `cloudflared` binary when needed, opens the Clerk
-authorization flow, and records durable intent to expose the environment. It works without a
+`t3 cloud login` opens the Clerk authorization flow and stores the CLI credential without enabling
+cloud exposure. `t3 cloud link` installs the pinned managed `cloudflared` binary when needed,
+authorizes when needed, and records durable intent to expose the environment. It works without a
 running T3 server. If no server is running, the next `t3 serve` or `t3 start` reconciles the relay
-link and launches the managed tunnel. `t3 cloud unlink` records disabled intent immediately,
-stops a reachable running connector, and attempts to revoke the relay-side environment record. It
-retains the stored CLI authorization so `t3 cloud link` can re-enable exposure without another
-browser flow. `t3 cloud logout` performs the same cleanup and removes the stored CLI authorization.
+link and launches the managed tunnel. `t3 cloud unlink` records disabled intent immediately, stops
+a reachable running connector, and attempts to revoke the relay-side environment record. It retains
+the stored CLI authorization so `t3 cloud link` can re-enable exposure without another browser
+flow. `t3 cloud logout` performs the same cleanup and removes the stored CLI authorization.
 
 The current OAuth callback listener binds to loopback port `34338`. When running the CLI over SSH,
-forward that port before running `t3 cloud link`:
+forward that port before running `t3 cloud login` or `t3 cloud link`:
 
 ```sh
 ssh -L 34338:127.0.0.1:34338 <host>

--- a/docs/t3-cloud-clerk.md
+++ b/docs/t3-cloud-clerk.md
@@ -12,6 +12,7 @@ or `.env.local` file:
 ```dotenv
 T3CODE_CLERK_PUBLISHABLE_KEY=<publishable key>
 T3CODE_CLERK_JWT_TEMPLATE=<JWT template name>
+T3CODE_CLERK_CLI_OAUTH_CLIENT_ID=<public OAuth application client ID>
 T3CODE_RELAY_URL=https://relay.example.com
 ```
 
@@ -25,16 +26,18 @@ Configuration precedence is:
 2. Repository-root `.env.local`.
 3. Repository-root `.env`.
 
-The Clerk publishable key, JWT template name, and relay URL are public identifiers, not secrets.
-Web, desktop, mobile, and bundled server builds statically inject their public values during the
-build step. A built artifact does not need an environment file at runtime. CI release builds should
-set `T3CODE_CLERK_PUBLISHABLE_KEY`, `T3CODE_CLERK_JWT_TEMPLATE`, and `T3CODE_RELAY_URL` before
-building. EAS preview and production builds should define the same client-facing values in their
-EAS environment.
+The Clerk publishable key, JWT template name, CLI OAuth client ID, and relay URL are public
+identifiers, not secrets.
+Web, desktop, mobile, and bundled server builds statically inject the values they consume during
+their build step. A built artifact does not need an environment file at runtime. CI release builds
+should set `T3CODE_CLERK_PUBLISHABLE_KEY`, `T3CODE_CLERK_JWT_TEMPLATE`,
+`T3CODE_CLERK_CLI_OAUTH_CLIENT_ID`, and `T3CODE_RELAY_URL` before building. EAS preview and
+production builds only need the Clerk publishable key, JWT template name, and relay URL in their EAS
+environment.
 
 When any client-facing public value is absent, cloud UI is omitted. When the CLI public values are
-absent, the `t3 cloud` CLI command group is omitted. The
-bundled server still accepts a runtime `T3CODE_RELAY_URL` override for self-hosted or operator-managed
+absent, the `t3 cloud` CLI command group is omitted. The bundled server still accepts runtime
+overrides for self-hosted or operator-managed
 deployments.
 
 For a hosted relay deployment, copy `infra/relay/.env.example` to `infra/relay/.env`. The relay
@@ -61,7 +64,12 @@ In **Clerk Dashboard > OAuth applications**:
 2. Enable the **Public** option so authorization-code exchange uses PKCE.
 3. Add `http://127.0.0.1:34338/callback` as an allowed redirect URI.
 4. Enable the `openid`, `profile`, and `email` scopes.
-5. Set the relay deployment's `CLERK_CLI_OAUTH_CLIENT_ID` to the generated public client ID.
+5. Set `T3CODE_CLERK_CLI_OAUTH_CLIENT_ID` in the repository-root `.env` file and release build
+   environment to the generated public client ID.
+
+The CLI derives Clerk's frontend API URL from the publishable key and calls Clerk's
+`/oauth/authorize` and `/oauth/token` endpoints directly. The relay is not involved in the OAuth
+handshake; it only validates the issued Clerk bearer token when the CLI manages an environment link.
 
 The CLI supports these headless operations:
 

--- a/docs/t3-cloud-clerk.md
+++ b/docs/t3-cloud-clerk.md
@@ -26,13 +26,16 @@ Configuration precedence is:
 3. Repository-root `.env`.
 
 The Clerk publishable key, JWT template name, and relay URL are public identifiers, not secrets.
-Web, desktop, and mobile builds statically inject them during their build step. A built artifact
-does not need an environment file at runtime. CI release builds should set
-`T3CODE_CLERK_PUBLISHABLE_KEY`, `T3CODE_CLERK_JWT_TEMPLATE`, and `T3CODE_RELAY_URL` before building.
-EAS preview and production builds should define the same client-facing values in their EAS
-environment.
+Web, desktop, mobile, and bundled server builds statically inject their public values during the
+build step. A built artifact does not need an environment file at runtime. CI release builds should
+set `T3CODE_CLERK_PUBLISHABLE_KEY`, `T3CODE_CLERK_JWT_TEMPLATE`, and `T3CODE_RELAY_URL` before
+building. EAS preview and production builds should define the same client-facing values in their
+EAS environment.
 
-When any client-facing public value is absent, cloud UI is omitted.
+When any client-facing public value is absent, cloud UI is omitted. When the CLI public values are
+absent, the `t3 cloud` CLI command group is omitted. The
+bundled server still accepts a runtime `T3CODE_RELAY_URL` override for self-hosted or operator-managed
+deployments.
 
 For a hosted relay deployment, copy `infra/relay/.env.example` to `infra/relay/.env`. The relay
 deployment reads `RELAY_DOMAIN`, `RELAY_ZONE_NAME`, `CLERK_PUBLISHABLE_KEY`, and

--- a/docs/t3-cloud-clerk.md
+++ b/docs/t3-cloud-clerk.md
@@ -128,7 +128,11 @@ t3code://auth/callback
 ```
 
 The first entry is for local desktop development. The second is for packaged desktop builds.
-The app also adds a request-scoped `t3_state` query parameter and validates it on callback.
+The app also adds a request-scoped `t3_state` query parameter and validates it on callback. Initial
+sign-in and linked-account OAuth flows both return through this bridge. The desktop provider keeps
+Clerk's stock profile component, replaces its renderer-page callback with the custom-scheme callback,
+and opens the provider URL in the system browser. Do not add the local renderer URL as an OAuth
+redirect: an external browser cannot use it to reopen the packaged app.
 
 The current mobile UI uses Clerk's native authentication view. If a future mobile browser OAuth
 flow uses a custom redirect URI, add that exact URI to the same allowlist.

--- a/docs/t3-code-cloud-auth-flow.html
+++ b/docs/t3-code-cloud-auth-flow.html
@@ -289,6 +289,33 @@
             The relay cannot mint an environment access token by itself. It can only ask the local
             environment to mint a short-lived bootstrap credential for an authorized cloud user.
           </div>
+          <p>During an honest connection flow, the relay cannot act as the remote client:</p>
+          <ul>
+            <li>
+              Normal environment API traffic goes directly from the remote client through the
+              managed endpoint. The relay does not receive the resulting environment access token.
+            </li>
+            <li>
+              The one-time bootstrap credential and resulting environment access token are bound to
+              the remote client's DPoP public-key thumbprint. Redeeming or using them requires
+              request proofs signed by the corresponding private key, which stays on the client.
+            </li>
+            <li>
+              Relay-signed health and mint proofs are short-lived, audience-bound, scoped, and
+              replay-guarded. They are accepted only by the narrow cloud endpoints, not as normal
+              environment API credentials.
+            </li>
+            <li>
+              Environment health and mint responses are signed by the linked environment and bound
+              to the request nonce, so a different process behind the tunnel cannot impersonate the
+              linked environment.
+            </li>
+          </ul>
+          <div class="callout warning">
+            The hosted relay remains a trusted mint broker: it holds the cloud-mint signing key.
+            DPoP prevents credential reuse by the relay or tunnel transport during an honest flow,
+            but it does not make compromise of the relay signing authority harmless.
+          </div>
         </article>
 
         <article class="panel half">
@@ -697,6 +724,47 @@ sequenceDiagram
             config, and agent-activity preference.
           </p>
         </article>
+      </section>
+
+      <section class="panel" aria-label="Cloudflare tunnel operational profile">
+        <h2>Cloudflare Tunnel Operational Profile</h2>
+        <p>
+          Managed tunnels are private application backends, not general-purpose public hosting. The
+          relay provisions one named Cloudflare tunnel and one DNS record per active
+          <code>(userId, environmentId)</code> allocation.
+        </p>
+        <ul>
+          <li>
+            <strong>Lifecycle:</strong> the tunnel is created when an environment is linked, reused
+            across retry-safe reconciliation, kept for the lifetime of that link, and deleted on
+            unlink. If teardown fails, the allocation checkpoint remains so cleanup can be retried.
+          </li>
+          <li>
+            <strong>Origin:</strong> tunnel ingress is restricted to the linked environment server's
+            validated loopback HTTP origin. Arbitrary upstream hosts and raw TCP origins are
+            rejected.
+          </li>
+          <li>
+            <strong>Protocols:</strong> managed endpoints carry HTTPS request/response traffic and
+            WSS connections only. Remote clients use the normal environment HTTP APIs and
+            authenticated WebSocket RPC transport through the tunnel.
+          </li>
+          <li>
+            <strong>Relay-generated traffic:</strong> the hosted relay sends sparse HTTPS health
+            checks and credential-mint requests during status checks and remote connection
+            bootstrap. It does not proxy steady-state remote sessions.
+          </li>
+          <li>
+            <strong>Traffic shape:</strong> expected load is interactive and user-driven. Active
+            remote sessions may keep WebSockets open and exchange terminal, agent, and UI updates;
+            inactive linked environments should carry little or no tunnel traffic.
+          </li>
+          <li>
+            <strong>Capacity planning:</strong> the project is pre-launch, so there is not yet a
+            production bandwidth baseline. Tunnel count grows with active linked user/environment
+            allocations, while bandwidth and concurrent WebSockets grow with active remote use.
+          </li>
+        </ul>
       </section>
 
       <section class="panel" aria-label="SSRF and tunnel hardening">

--- a/docs/t3-code-cloud-auth-flow.html
+++ b/docs/t3-code-cloud-auth-flow.html
@@ -327,15 +327,15 @@ flowchart LR
   Clerk["Clerk<br/>user identity and OAuth"]
 
   subgraph Relay["T3 Code Relay on Cloudflare"]
-    Worker["Relay Worker<br/>HTTP API + Scalar docs"]
+    Worker["Relay Worker<br/>HTTP API"]
     Queue["APNs delivery queue<br/>with dead-letter queue"]
     Hyperdrive["Hyperdrive"]
-    Traces["Axiom OTLP traces"]
   end
 
   DB["PlanetScale Postgres<br/>prod database + stage branches"]
   CF["Cloudflare tunnel + DNS APIs"]
   APNs["Apple Push Notification service"]
+  Traces["Axiom OTLP traces"]
 
   subgraph Local["Linked T3 environment"]
     Env["Environment server<br/>local auth authority"]
@@ -355,7 +355,7 @@ flowchart LR
   Worker --> Traces
   Worker --> CF
   Worker --> Queue --> APNs
-  Worker -->|"signed health + mint requests"| Endpoint
+  Worker --> Endpoint
   Endpoint --> RelayClient -->|"http://127.0.0.1:port"| Env
   Env --> Secrets
   Web -->|"environment token + DPoP<br/>HTTPS / WSS"| Endpoint
@@ -770,8 +770,8 @@ sequenceDiagram
       <section class="panel" aria-label="Relay HTTP API">
         <h2>Relay HTTP API</h2>
         <p>
-          The relay publishes an OpenAPI document at <code>/openapi.json</code>, Scalar docs at
-          <code>/docs</code>, and redirects <code>/</code> to the docs.
+          The relay publishes an OpenAPI document at <code>/openapi.json</code>, interactive API
+          docs at <code>/docs</code>, and redirects <code>/</code> to the docs.
         </p>
         <table>
           <thead>

--- a/docs/t3-code-cloud-auth-flow.html
+++ b/docs/t3-code-cloud-auth-flow.html
@@ -357,10 +357,10 @@ flowchart LR
     Worker["Relay Worker<br/>HTTP API"]
     Queue["APNs delivery queue<br/>with dead-letter queue"]
     Hyperdrive["Hyperdrive"]
+    CF["Cloudflare tunnel + DNS APIs"]
   end
 
   DB["PlanetScale Postgres<br/>prod database + stage branches"]
-  CF["Cloudflare tunnel + DNS APIs"]
   APNs["Apple Push Notification service"]
   Traces["Axiom OTLP traces"]
 

--- a/docs/t3-code-cloud-auth-flow.html
+++ b/docs/t3-code-cloud-auth-flow.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>T3 Code Cloud Control Plane and Managed Endpoint Flow</title>
+    <title>T3 Code Cloud Architecture</title>
     <style>
       :root {
         color-scheme: light;
@@ -53,11 +53,11 @@
       }
 
       .eyebrow {
+        color: var(--blue);
         font-size: 12px;
         font-weight: 800;
         letter-spacing: 0.08em;
         text-transform: uppercase;
-        color: var(--blue);
       }
 
       h1 {
@@ -65,14 +65,6 @@
         margin: 8px 0 12px;
         font-size: clamp(34px, 5vw, 66px);
         line-height: 0.98;
-        letter-spacing: 0;
-      }
-
-      .lede {
-        max-width: 930px;
-        margin: 0;
-        color: var(--muted);
-        font-size: 18px;
       }
 
       h2 {
@@ -96,6 +88,20 @@
           ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
       }
 
+      code {
+        border-radius: 4px;
+        background: #f0f0ed;
+        padding: 1px 4px;
+        font-size: 0.92em;
+      }
+
+      .lede {
+        max-width: 1000px;
+        margin: 0;
+        color: var(--muted);
+        font-size: 18px;
+      }
+
       .grid {
         display: grid;
         grid-template-columns: repeat(12, 1fr);
@@ -104,15 +110,11 @@
 
       .panel {
         grid-column: span 12;
-        background: var(--panel);
         border: 1px solid var(--hairline);
         border-radius: 10px;
+        background: var(--panel);
         box-shadow: var(--shadow);
         padding: 22px;
-      }
-
-      .panel.compact {
-        padding: 18px;
       }
 
       .half {
@@ -123,17 +125,12 @@
         border-left: 5px solid var(--blue);
         background: #eef4ff;
         padding: 14px 16px;
-        margin: 14px 0 0;
+        margin-top: 14px;
       }
 
       .callout.warning {
         border-left-color: var(--amber);
         background: #fff6e6;
-      }
-
-      .callout.danger {
-        border-left-color: var(--red);
-        background: #fff1f1;
       }
 
       .badge-row {
@@ -170,8 +167,8 @@
       .diagram {
         overflow-x: auto;
         margin: 12px 0 0;
-        border-radius: 8px;
         border: 1px solid var(--hairline);
+        border-radius: 8px;
         background: #fbfbf8;
         color: var(--ink);
         padding: 18px;
@@ -184,162 +181,6 @@
         max-width: none !important;
         height: auto;
         margin: 0 auto;
-      }
-
-      .diagram.mermaid {
-        min-height: 120px;
-        text-align: center;
-      }
-
-      .actor-diagram {
-        max-height: none;
-        overflow: auto;
-        padding: 14px;
-        background: #fbfbf8;
-      }
-
-      .architecture-svg {
-        display: block;
-        height: auto;
-        min-width: 1260px;
-        width: 100%;
-      }
-
-      .architecture-svg .cluster {
-        fill-opacity: 0.5;
-        stroke-dasharray: 7 5;
-        stroke-width: 1.4;
-      }
-
-      .architecture-svg .cluster-label {
-        fill: var(--ink);
-        font-size: 15px;
-        font-weight: 800;
-      }
-
-      .architecture-svg .node {
-        fill: #f7f7f3;
-        rx: 9;
-        stroke: #62646b;
-        stroke-width: 2;
-      }
-
-      .architecture-svg .node.user {
-        fill: #eef4ff;
-        stroke: var(--blue);
-      }
-
-      .architecture-svg .node.control {
-        fill: #fff7e8;
-        stroke: var(--amber);
-      }
-
-      .architecture-svg .node.data {
-        fill: #f4f2ff;
-        stroke: var(--violet);
-      }
-
-      .architecture-svg .node.local {
-        fill: #effaf3;
-        stroke: var(--green);
-      }
-
-      .architecture-svg .svg-label {
-        align-items: center;
-        display: flex;
-        height: 100%;
-        justify-content: center;
-        line-height: 1.16;
-        padding: 8px;
-        text-align: center;
-      }
-
-      .architecture-svg .svg-label strong {
-        display: block;
-        font-size: 16px;
-      }
-
-      .architecture-svg .svg-label span {
-        color: var(--muted);
-        display: block;
-        font-size: 12px;
-        font-weight: 700;
-        margin-top: 3px;
-      }
-
-      .architecture-svg .edge {
-        fill: none;
-        stroke: #62646b;
-        stroke-width: 2.1;
-      }
-
-      .architecture-svg .edge.user-edge {
-        stroke: var(--blue);
-      }
-
-      .architecture-svg .edge.control-edge {
-        stroke: var(--amber);
-      }
-
-      .architecture-svg .edge.data-edge {
-        stroke: var(--violet);
-      }
-
-      .architecture-svg .edge.local-edge {
-        stroke: var(--green);
-      }
-
-      .architecture-svg .edge.private-edge {
-        stroke-dasharray: 8 6;
-      }
-
-      .architecture-svg .edge-label rect {
-        fill: #fbfbf8;
-        stroke: rgba(0, 0, 0, 0.08);
-      }
-
-      .architecture-svg .edge-label text {
-        font-size: 12px;
-        font-weight: 800;
-      }
-
-      .architecture-svg .user-label text {
-        fill: var(--blue);
-      }
-
-      .architecture-svg .control-label text {
-        fill: var(--amber);
-      }
-
-      .architecture-svg .data-label text {
-        fill: var(--violet);
-      }
-
-      .architecture-svg .local-label text {
-        fill: var(--green);
-      }
-
-      .architecture-svg .private-label text {
-        fill: #42444a;
-      }
-
-      .legend {
-        display: grid;
-        grid-template-columns: repeat(4, minmax(0, 1fr));
-        gap: 12px;
-        margin-top: 14px;
-      }
-
-      .legend-item {
-        border: 1px solid var(--hairline);
-        border-radius: 8px;
-        padding: 12px;
-        background: #fafafa;
-      }
-
-      .legend-item strong {
-        display: block;
-        margin-bottom: 4px;
       }
 
       table {
@@ -357,26 +198,25 @@
       }
 
       th {
+        color: var(--muted);
         font-size: 12px;
         letter-spacing: 0.05em;
         text-transform: uppercase;
-        color: var(--muted);
+      }
+
+      ul {
+        margin: 8px 0 0;
+        padding-left: 20px;
+      }
+
+      li + li {
+        margin-top: 6px;
       }
 
       .flow {
         display: grid;
         gap: 10px;
         margin-top: 12px;
-      }
-
-      .grid[aria-label="Core setup flows"] > .panel,
-      .grid[aria-label="Hosted web and mismatch handling"] > .panel {
-        grid-column: 1 / -1;
-      }
-
-      .grid[aria-label="Core setup flows"] .diagram,
-      .grid[aria-label="Hosted web and mismatch handling"] .diagram {
-        width: 100%;
       }
 
       .step {
@@ -392,22 +232,6 @@
         margin-bottom: 3px;
       }
 
-      .split-title {
-        display: flex;
-        align-items: baseline;
-        justify-content: space-between;
-        gap: 16px;
-        border-bottom: 1px solid var(--hairline);
-        padding-bottom: 10px;
-        margin-bottom: 14px;
-      }
-
-      .split-title span {
-        color: var(--muted);
-        font-size: 13px;
-        font-weight: 700;
-      }
-
       .source-list a {
         color: var(--blue);
         font-weight: 700;
@@ -416,10 +240,6 @@
       @media (max-width: 860px) {
         .half {
           grid-column: span 12;
-        }
-
-        .legend {
-          grid-template-columns: 1fr;
         }
 
         .shell {
@@ -432,1342 +252,793 @@
   <body>
     <main class="shell">
       <header>
-        <div class="eyebrow">Draft architecture</div>
+        <div class="eyebrow">Implemented architecture</div>
         <h1>T3 Code Cloud Control Plane and Managed Endpoint Flow</h1>
         <p class="lede">
-          A concrete topology for one user with a MacBook Pro desktop environment, a headless Mac
-          mini environment, the T3 Code mobile app, and the hosted web UI. The control plane owns
-          identity, grants, provisioning, endpoint records, and connection tickets. The managed
-          endpoint carries both normal environment HTTP/WebSocket traffic and short signed
-          control-over-data-plane requests such as credential minting.
+          T3 Cloud links a locally authorized T3 environment to a signed-in cloud user, provisions a
+          managed HTTPS/WSS endpoint for that environment, and brokers proof-bound remote
+          connections. The local environment remains the authority that issues environment access
+          credentials. The hosted relay stores links, reconciles managed endpoint resources,
+          validates signed proofs, and delivers agent-activity notifications.
         </p>
-        <div class="badge-row" aria-label="Key implementation boundaries">
-          <span class="badge user">Client -> Cloud: HTTPS + IdP JWT</span>
-          <span class="badge env">Cloud -> Env: HTTPS + cloud-signed request</span>
-          <span class="badge env">Env -> Cloud: env-signed response</span>
-          <span class="badge local">Client -> Env: HTTPS/WSS + local T3 auth</span>
+        <div class="badge-row">
+          <span class="badge user">Client -> Relay: Clerk bearer or relay DPoP</span>
+          <span class="badge env">Relay -> Environment: relay-signed health and mint proofs</span>
+          <span class="badge env"
+            >Environment -> Relay: environment bearer plus signed activity proof</span
+          >
+          <span class="badge local">Client -> Environment: environment access token plus DPoP</span>
         </div>
       </header>
 
-      <section class="grid" aria-label="Security invariant">
+      <section class="grid" aria-label="Architecture summary">
         <article class="panel half">
           <h2>Security Invariant</h2>
           <p>
-            A cloud user session is not environment authority. Remote access requires an authorized
-            IdP user, a linked environment authenticated by its registered cloud-link key, and a
-            one-time local bootstrap credential minted by the target T3 server.
+            A cloud identity is not an environment login. Remote access requires all of the
+            following:
           </p>
-          <div class="callout danger">
-            T3 Cloud must not proxy normal app traffic. It brokers identity, provisioning, grants,
-            endpoint records, and connect tickets. To connect a client, T3 Cloud sends a short-lived
-            signed mint request through the managed endpoint to the target local T3 server. After
-            token exchange, clients talk directly to
-            <code>https://env_abc.tunnels.t3code.com</code> and
-            <code>wss://env_abc.tunnels.t3code.com/ws</code>.
+          <ul>
+            <li>a Clerk-authenticated T3 Cloud user;</li>
+            <li>an active relay link for that user and environment;</li>
+            <li>a DPoP proof key held by the remote client;</li>
+            <li>a relay-signed mint request accepted by the linked local environment; and</li>
+            <li>an environment-issued credential bound to the remote client's DPoP thumbprint.</li>
+          </ul>
+          <div class="callout">
+            The relay cannot mint an environment access token by itself. It can only ask the local
+            environment to mint a short-lived bootstrap credential for an authorized cloud user.
           </div>
         </article>
 
         <article class="panel half">
-          <h2>Minimal Credential Set</h2>
-          <p><strong>1. User session</strong><br />Hosted IdP session/JWT on clients.</p>
+          <h2>Product Boundaries</h2>
           <p>
-            <strong>2. Cloud signing key</strong><br />Private key controlled by T3 Cloud; public
-            issuer metadata installed into linked environments.
+            The generic local connector is called the <strong>relay client</strong>. The current
+            implementation layer uses <code>cloudflared</code>, but that is an internal transport
+            detail rather than the product contract.
           </p>
-          <p>
-            <strong>3. Environment cloud-link keypair</strong><br />Private key stored in
-            Keychain/state dir; public key registered with T3 Cloud.
-          </p>
-          <p>
-            <strong>4. Local server authority</strong><br />Local tokens carrying
-            <code>relay:write</code> mint single-use bootstrap credentials.
-          </p>
-          <p>
-            <strong>5. Managed endpoint runtime credential</strong><br />Endpoint runtime credential
-            used only to expose the environment's managed endpoint.
-          </p>
+          <ul>
+            <li>
+              The relay Worker owns cloud links, managed endpoint allocations, and notifications.
+            </li>
+            <li>
+              The environment server owns local sessions, environment keys, and access tokens.
+            </li>
+            <li>The relay client exposes only the environment's loopback HTTP server.</li>
+            <li>
+              Web and mobile clients connect directly to the managed environment endpoint after
+              bootstrap.
+            </li>
+          </ul>
         </article>
       </section>
 
-      <section class="panel" aria-label="Implementation auth and transport matrix">
-        <h2>Implementation Auth and Transport Matrix</h2>
-        <p>
-          This table is the contract to implement and validate against. The managed endpoint
-          transport forwards bytes; it does not authorize T3 sessions.
-        </p>
+      <section class="panel" aria-label="Topology">
+        <h2>Current Topology</h2>
+        <pre class="diagram mermaid">
+flowchart LR
+  subgraph Clients["User-facing clients"]
+    Web["Desktop / hosted web UI"]
+    Mobile["Mobile app"]
+    CLI["Headless CLI"]
+  end
+
+  Clerk["Clerk<br/>user identity and OAuth"]
+
+  subgraph Relay["T3 Code Relay on Cloudflare"]
+    Worker["Relay Worker<br/>HTTP API + Scalar docs"]
+    Queue["APNs delivery queue<br/>with dead-letter queue"]
+    Hyperdrive["Hyperdrive"]
+    Traces["Axiom OTLP traces"]
+  end
+
+  DB["PlanetScale Postgres<br/>prod database + stage branches"]
+  CF["Cloudflare tunnel + DNS APIs"]
+  APNs["Apple Push Notification service"]
+
+  subgraph Local["Linked T3 environment"]
+    Env["Environment server<br/>local auth authority"]
+    RelayClient["Relay client<br/>cloudflared implementation"]
+    Secrets["Server secret store<br/>keys + relay config"]
+  end
+
+  Endpoint["Managed HTTPS/WSS endpoint"]
+
+  Web -->|"Clerk bearer / relay DPoP"| Worker
+  Mobile -->|"Clerk bearer / relay DPoP"| Worker
+  CLI -->|"Clerk OAuth bearer"| Worker
+  Web --> Clerk
+  Mobile --> Clerk
+  CLI -->|"PKCE authorization code flow"| Clerk
+  Worker --> Hyperdrive --> DB
+  Worker --> Traces
+  Worker --> CF
+  Worker --> Queue --> APNs
+  Worker -->|"signed health + mint requests"| Endpoint
+  Endpoint --> RelayClient -->|"http://127.0.0.1:port"| Env
+  Env --> Secrets
+  Web -->|"environment token + DPoP<br/>HTTPS / WSS"| Endpoint
+  Mobile -->|"environment token + DPoP<br/>HTTPS / WSS"| Endpoint
+  Env -->|"environment bearer + signed activity proof"| Worker
+        </pre>
+      </section>
+
+      <section class="panel" aria-label="Authentication matrix">
+        <h2>Authentication and Transport Matrix</h2>
         <table>
           <thead>
             <tr>
-              <th>Path</th>
+              <th>Boundary</th>
               <th>Transport</th>
-              <th>Auth Material</th>
-              <th>Verifier</th>
+              <th>Authentication</th>
               <th>Purpose</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>Client -> T3 Cloud</td>
+              <td>Web or mobile -> relay link management</td>
               <td>HTTPS</td>
-              <td>Hosted IdP session/JWT</td>
-              <td>T3 Cloud</td>
-              <td>List environments, manage grants, request connect.</td>
+              <td>Clerk session-template bearer token</td>
+              <td>Create a link challenge, submit an environment proof, list links, or unlink.</td>
             </tr>
             <tr>
-              <td>T3 Cloud -> local T3 server</td>
-              <td>HTTPS through managed endpoint</td>
-              <td>Cloud-signed mint or health request with nonce, audience, expiry, and scope.</td>
-              <td>Local T3 server</td>
-              <td>Ask the linked environment to mint a one-time bootstrap credential.</td>
+              <td>CLI -> relay link management</td>
+              <td>HTTPS</td>
+              <td>Clerk OAuth access token obtained with PKCE</td>
+              <td>Reconcile the desired headless cloud link when the server starts.</td>
             </tr>
             <tr>
-              <td>Local T3 server -> T3 Cloud</td>
+              <td>Web or mobile -> relay protected client endpoints</td>
+              <td>HTTPS</td>
+              <td>Relay-issued DPoP token plus per-request DPoP proof</td>
               <td>
-                HTTPS response through managed endpoint, or direct HTTPS cloud API for status.
+                Check environment status, request a remote connection, and register mobile devices.
               </td>
-              <td>Environment cloud-link signature.</td>
-              <td>T3 Cloud</td>
-              <td>Prove the real linked environment responded or reported status.</td>
             </tr>
             <tr>
-              <td>Client -> local T3 token exchange</td>
-              <td>HTTPS through managed endpoint</td>
-              <td>Single-use bootstrap credential minted by the local T3 server.</td>
-              <td>Local T3 server</td>
-              <td>Mint a scoped proof-bound environment access token.</td>
+              <td>Relay -> managed environment endpoint</td>
+              <td>HTTPS over the managed tunnel</td>
+              <td>Short-lived relay-signed JWT request proof</td>
+              <td>
+                Request a signed health response or ask the local environment to mint a credential.
+              </td>
             </tr>
             <tr>
-              <td>Client -> local T3 WebSocket ticket API</td>
-              <td>HTTPS through managed endpoint</td>
-              <td>Scoped environment access token plus DPoP proof.</td>
-              <td>Local T3 server</td>
-              <td>Mint a short-lived ticket for one WebSocket connection.</td>
+              <td>Environment -> relay activity publication</td>
+              <td>HTTPS</td>
+              <td>Relay-issued environment bearer credential plus environment-signed JWT proof</td>
+              <td>
+                Publish redacted agent-activity state for push notifications and Live Activities.
+              </td>
             </tr>
             <tr>
-              <td>Client -> local T3 WebSocket</td>
-              <td>WSS through managed endpoint</td>
-              <td><code>wsTicket</code> query parameter.</td>
-              <td>Local T3 server</td>
-              <td>Run the existing app RPC protocol.</td>
-            </tr>
-            <tr>
-              <td>Endpoint runtime -> endpoint provider</td>
-              <td>Provider-specific outbound tunnel connection</td>
-              <td>Cloudflare tunnel token today; T3 relay connector token later.</td>
-              <td>Cloudflare Tunnel or T3 Relay</td>
-              <td>Expose the loopback T3 server as a stable public HTTPS/WSS endpoint.</td>
-            </tr>
-            <tr>
-              <td>APNs -> mobile app</td>
-              <td>APNs push transport</td>
-              <td>Apple push token and APNs provider auth.</td>
-              <td>Apple APNs and mobile app.</td>
-              <td>Wake or update mobile UI with minimal status, not full agent traffic.</td>
+              <td>Remote client -> environment</td>
+              <td>HTTPS and WSS over the managed tunnel</td>
+              <td>Environment-issued access token bound to the client DPoP key</td>
+              <td>Use the normal environment HTTP APIs and request a one-time WebSocket ticket.</td>
             </tr>
           </tbody>
         </table>
-        <div class="callout warning">
-          Do not add an app-session authorization dependency to Cloudflare Tunnel or T3 Relay. The
-          endpoint provider may authenticate the connector, but local T3 auth remains the only
-          verifier for bootstrap credentials, scoped access tokens, WebSocket tickets, and commands.
-          The endpoint runtime credential authenticates the connector to the endpoint provider; it
-          is not a client-facing access gate for the public hostname.
-        </div>
       </section>
 
-      <section class="panel" aria-label="Overall actor diagram">
-        <div class="split-title">
-          <h2>Overall Actor Diagram</h2>
-          <span>Service-level auth/control/data lanes</span>
-        </div>
-        <div class="diagram actor-diagram">
-          <div
-            id="actorGraph"
-            class="architecture-diagram"
-            role="img"
-            aria-label="T3 Cloud actor graph showing user identity, clients, control plane, data plane, MacBook environment, and Mac mini environment."
-          >
-            <svg
-              class="architecture-svg"
-              viewBox="0 0 1500 760"
-              role="presentation"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <defs>
-                <marker
-                  id="arrow-blue"
-                  markerHeight="9"
-                  markerWidth="9"
-                  orient="auto"
-                  refX="8"
-                  refY="4.5"
-                >
-                  <path d="M0,0 L9,4.5 L0,9 Z" fill="#1457d9" />
-                </marker>
-                <marker
-                  id="arrow-green"
-                  markerHeight="9"
-                  markerWidth="9"
-                  orient="auto"
-                  refX="8"
-                  refY="4.5"
-                >
-                  <path d="M0,0 L9,4.5 L0,9 Z" fill="#1d7d4d" />
-                </marker>
-                <marker
-                  id="arrow-amber"
-                  markerHeight="9"
-                  markerWidth="9"
-                  orient="auto"
-                  refX="8"
-                  refY="4.5"
-                >
-                  <path d="M0,0 L9,4.5 L0,9 Z" fill="#a65f00" />
-                </marker>
-                <marker
-                  id="arrow-violet"
-                  markerHeight="9"
-                  markerWidth="9"
-                  orient="auto"
-                  refX="8"
-                  refY="4.5"
-                >
-                  <path d="M0,0 L9,4.5 L0,9 Z" fill="#6150b8" />
-                </marker>
-                <marker
-                  id="arrow-gray"
-                  markerHeight="9"
-                  markerWidth="9"
-                  orient="auto"
-                  refX="8"
-                  refY="4.5"
-                >
-                  <path d="M0,0 L9,4.5 L0,9 Z" fill="#62646b" />
-                </marker>
-              </defs>
-
-              <rect
-                class="cluster"
-                x="45"
-                y="60"
-                width="250"
-                height="125"
-                rx="14"
-                fill="#eef4ff"
-                stroke="#1457d9"
-              />
-              <text class="cluster-label" x="68" y="88">Identity Provider</text>
-              <rect
-                class="cluster"
-                x="45"
-                y="245"
-                width="300"
-                height="315"
-                rx="14"
-                fill="#eef4ff"
-                stroke="#1457d9"
-              />
-              <text class="cluster-label" x="68" y="273">User Clients</text>
-              <rect
-                class="cluster"
-                x="445"
-                y="210"
-                width="280"
-                height="230"
-                rx="14"
-                fill="#fff7e8"
-                stroke="#a65f00"
-              />
-              <text class="cluster-label" x="468" y="238">T3 Cloud</text>
-              <rect
-                class="cluster"
-                x="445"
-                y="520"
-                width="280"
-                height="160"
-                rx="14"
-                fill="#f4f2ff"
-                stroke="#6150b8"
-              />
-              <text class="cluster-label" x="468" y="548">Managed Endpoint</text>
-              <rect
-                class="cluster"
-                x="870"
-                y="80"
-                width="520"
-                height="245"
-                rx="14"
-                fill="#effaf3"
-                stroke="#1d7d4d"
-              />
-              <text class="cluster-label" x="895" y="108">MacBook Pro</text>
-              <rect
-                class="cluster"
-                x="870"
-                y="405"
-                width="520"
-                height="245"
-                rx="14"
-                fill="#effaf3"
-                stroke="#1d7d4d"
-              />
-              <text class="cluster-label" x="895" y="433">Mac mini</text>
-
-              <rect class="node user" x="85" y="105" width="170" height="70" />
-              <foreignObject x="85" y="105" width="170" height="70">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div><strong>IdP</strong><span>hosted user auth</span></div>
-                </div>
-              </foreignObject>
-
-              <rect class="node user" x="85" y="295" width="220" height="70" />
-              <foreignObject x="85" y="295" width="220" height="70">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div><strong>Desktop app</strong><span>MacBook user interface</span></div>
-                </div>
-              </foreignObject>
-              <rect class="node user" x="85" y="380" width="220" height="70" />
-              <foreignObject x="85" y="380" width="220" height="70">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div><strong>Mobile app</strong><span>IdP session, APNs token</span></div>
-                </div>
-              </foreignObject>
-              <rect class="node user" x="85" y="465" width="220" height="70" />
-              <foreignObject x="85" y="465" width="220" height="70">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div><strong>Hosted web UI</strong><span>app.t3.codes</span></div>
-                </div>
-              </foreignObject>
-
-              <rect class="node control" x="485" y="270" width="200" height="95" />
-              <foreignObject x="485" y="270" width="200" height="95">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div>
-                    <strong>T3 Cloud control plane</strong
-                    ><span>grants, links, endpoint records, connect tickets</span>
-                  </div>
-                </div>
-              </foreignObject>
-              <rect class="node data" x="485" y="575" width="200" height="75" />
-              <foreignObject x="485" y="575" width="200" height="75">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div>
-                    <strong>Public environment endpoint</strong><span>HTTPS + WebSocket</span>
-                  </div>
-                </div>
-              </foreignObject>
-              <rect class="node control" x="485" y="80" width="200" height="75" />
-              <foreignObject x="485" y="80" width="200" height="75">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div><strong>APNs</strong><span>push transport</span></div>
-                </div>
-              </foreignObject>
-
-              <rect class="node local" x="930" y="145" width="210" height="95" />
-              <foreignObject x="930" y="145" width="210" height="95">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div>
-                    <strong>env_mbp</strong><span>local T3 server, terminal authority</span>
-                  </div>
-                </div>
-              </foreignObject>
-              <rect class="node" x="1165" y="145" width="170" height="95" />
-              <foreignObject x="1165" y="145" width="170" height="95">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div>
-                    <strong>Local cloud link</strong><span>cloud-link key + endpoint runtime</span>
-                  </div>
-                </div>
-              </foreignObject>
-
-              <rect class="node local" x="930" y="470" width="210" height="95" />
-              <foreignObject x="930" y="470" width="210" height="95">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div>
-                    <strong>env_mini</strong><span>headless T3 server, terminal authority</span>
-                  </div>
-                </div>
-              </foreignObject>
-              <rect class="node" x="1165" y="470" width="170" height="95" />
-              <foreignObject x="1165" y="470" width="170" height="95">
-                <div xmlns="http://www.w3.org/1999/xhtml" class="svg-label">
-                  <div>
-                    <strong>Local cloud link</strong><span>cloud-link key + endpoint runtime</span>
-                  </div>
-                </div>
-              </foreignObject>
-
-              <!-- User auth and cloud API lanes. These stay above the data-plane tracks. -->
-              <path
-                class="edge user-edge"
-                d="M305 330 L455 330 L455 305 L485 305"
-                marker-end="url(#arrow-blue)"
-              />
-              <path
-                class="edge user-edge"
-                d="M305 415 L435 415 L435 330 L485 330"
-                marker-end="url(#arrow-blue)"
-              />
-              <path
-                class="edge user-edge"
-                d="M305 500 L415 500 L415 355 L485 355"
-                marker-end="url(#arrow-blue)"
-              />
-              <path
-                class="edge user-edge"
-                d="M150 295 L150 235 L170 235 L170 175"
-                marker-end="url(#arrow-blue)"
-              />
-              <path
-                class="edge user-edge"
-                d="M195 380 L195 225 L185 225 L185 175"
-                marker-end="url(#arrow-blue)"
-              />
-              <path
-                class="edge user-edge"
-                d="M240 465 L240 235 L200 235 L200 175"
-                marker-end="url(#arrow-blue)"
-              />
-
-              <!-- Local owner authority from the desktop shell to its colocated environment. -->
-              <path
-                class="edge local-edge"
-                d="M305 330 L370 330 L370 205 L930 205"
-                marker-end="url(#arrow-green)"
-              />
-              <path
-                class="edge local-edge"
-                d="M1165 192 L1140 192"
-                marker-end="url(#arrow-green)"
-              />
-              <path
-                class="edge local-edge"
-                d="M1165 518 L1140 518"
-                marker-end="url(#arrow-green)"
-              />
-
-              <!-- Cloud control: provisioning and signed mint requests. -->
-              <path
-                class="edge control-edge"
-                d="M585 365 L585 575"
-                marker-end="url(#arrow-amber)"
-              />
-              <path
-                class="edge control-edge"
-                d="M685 320 L755 320 L755 560 L650 560 L650 575"
-                marker-end="url(#arrow-amber)"
-              />
-              <path
-                class="edge control-edge private-edge"
-                d="M685 590 L785 590 L785 225 L930 225"
-                marker-end="url(#arrow-amber)"
-              />
-              <path
-                class="edge control-edge private-edge"
-                d="M685 625 L805 625 L805 542 L930 542"
-                marker-end="url(#arrow-amber)"
-              />
-
-              <!-- Data plane: clients connect to endpoint, endpoint traffic reaches local link. -->
-              <path
-                class="edge data-edge"
-                d="M305 352 L382 352 L382 586 L485 586"
-                marker-end="url(#arrow-violet)"
-              />
-              <path
-                class="edge data-edge"
-                d="M305 430 L400 430 L400 612 L485 612"
-                marker-end="url(#arrow-violet)"
-              />
-              <path
-                class="edge data-edge"
-                d="M305 515 L420 515 L420 638 L485 638"
-                marker-end="url(#arrow-violet)"
-              />
-              <path
-                class="edge data-edge"
-                d="M685 600 L865 600 L865 252 L1165 252"
-                marker-end="url(#arrow-violet)"
-              />
-              <path
-                class="edge data-edge"
-                d="M685 640 L885 640 L885 545 L1165 545"
-                marker-end="url(#arrow-violet)"
-              />
-
-              <!-- Existing private-network relationship between environments. -->
-              <path
-                class="edge private-edge"
-                d="M1035 240 L1035 390 L1035 470"
-                marker-end="url(#arrow-gray)"
-              />
-
-              <!-- Minimal notification/status path. Kept on its own upper control lane. -->
-              <path
-                class="edge control-edge"
-                d="M930 180 L760 180 L760 285 L685 285"
-                marker-end="url(#arrow-amber)"
-              />
-              <path
-                class="edge control-edge"
-                d="M930 500 L775 500 L775 350 L685 350"
-                marker-end="url(#arrow-amber)"
-              />
-              <path
-                class="edge control-edge"
-                d="M585 270 L585 155"
-                marker-end="url(#arrow-amber)"
-              />
-              <path
-                class="edge control-edge"
-                d="M485 118 L355 118 L355 415 L305 415"
-                marker-end="url(#arrow-amber)"
-              />
-
-              <g class="edge-label user-label">
-                <rect x="45" y="205" width="198" height="28" rx="14" />
-                <text x="144" y="224" text-anchor="middle">browser IdP sign-in</text>
-              </g>
-              <g class="edge-label user-label">
-                <rect x="322" y="262" width="168" height="28" rx="14" />
-                <text x="406" y="281" text-anchor="middle">HTTPS + IdP JWT</text>
-              </g>
-              <g class="edge-label control-label">
-                <rect x="676" y="392" width="238" height="28" rx="14" />
-                <text x="795" y="411" text-anchor="middle">HTTPS + cloud-signed mint</text>
-              </g>
-              <g class="edge-label data-label">
-                <rect x="300" y="650" width="210" height="28" rx="14" />
-                <text x="405" y="669" text-anchor="middle">HTTPS/WSS + local T3 auth</text>
-              </g>
-              <g class="edge-label local-label">
-                <rect x="703" y="162" width="190" height="28" rx="14" />
-                <text x="798" y="181" text-anchor="middle">local owner authority</text>
-              </g>
-              <g class="edge-label private-label">
-                <rect x="940" y="348" width="190" height="28" rx="14" />
-                <text x="1035" y="367" text-anchor="middle">existing SSH/private auth</text>
-              </g>
-            </svg>
-          </div>
-        </div>
-
-        <div class="legend">
-          <div class="legend-item">
-            <strong>User path</strong>
-            The hosted IdP authenticates the human. Desktop, mobile, and hosted web present IdP
-            sessions to T3 Cloud for account-scoped API calls.
-          </div>
-          <div class="legend-item">
-            <strong>Control plane</strong>
-            T3 Cloud stores links, grants, endpoint records, audit events, and short-lived connect
-            tickets. It reaches environments through signed requests over their managed endpoints,
-            not through a persistent per-environment control channel.
-          </div>
-          <div class="legend-item">
-            <strong>Data plane</strong>
-            Cloudflare Tunnel is the first managed endpoint transport. Later T3 Relay keeps the same
-            <code>httpBaseUrl</code>/<code>wsBaseUrl</code> client contract.
-          </div>
-          <div class="legend-item">
-            <strong>Local authority</strong>
-            The loopback T3 server remains the execution boundary and mints the one-time credential
-            required before remote clients can open a normal session.
-          </div>
-        </div>
-      </section>
-
-      <section class="panel" aria-label="Credential ownership table">
+      <section class="panel" aria-label="Credential ownership">
         <h2>Credential Ownership</h2>
         <table>
           <thead>
             <tr>
               <th>Credential</th>
-              <th>Stored By</th>
-              <th>Presented To</th>
-              <th>What It Proves</th>
-              <th>Implementation Rule</th>
+              <th>Created by</th>
+              <th>Stored by</th>
+              <th>Use</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>Hosted IdP session/JWT</td>
-              <td>Desktop renderer, mobile app, hosted web browser.</td>
-              <td>T3 Cloud control plane.</td>
-              <td>The human user and account identity.</td>
-              <td>Never treat this as local environment authority.</td>
-            </tr>
-            <tr>
-              <td>Cloud signing key</td>
-              <td>T3 Cloud secret storage or signing service.</td>
-              <td>Linked local T3 servers.</td>
-              <td>The request came from T3 Cloud and was authorized by cloud policy.</td>
-              <td>Use short expiries, nonce/jti replay protection, audience, and scoped claims.</td>
-            </tr>
-            <tr>
-              <td>Environment cloud-link private key</td>
-              <td>Local T3 server on MacBook or Mac mini.</td>
-              <td>T3 Cloud.</td>
-              <td>The response/status came from the linked environment.</td>
+              <td>Clerk session-template JWT</td>
+              <td>Clerk</td>
+              <td>Web or mobile client</td>
               <td>
-                Private key never leaves the environment; public key is registered in T3 Cloud.
+                Authenticate cloud-user relay requests and bootstrap relay DPoP token exchange.
               </td>
             </tr>
             <tr>
-              <td>Managed endpoint runtime credential</td>
-              <td>Local environment sidecar/runtime.</td>
-              <td>Cloudflare Tunnel today; T3 Relay later.</td>
-              <td>The connector may expose this loopback origin through the endpoint provider.</td>
+              <td>CLI OAuth access and refresh token</td>
+              <td>Clerk OAuth</td>
+              <td>Local server secret store</td>
+              <td>Authorize headless CLI link reconciliation.</td>
+            </tr>
+            <tr>
+              <td>Environment Ed25519 key pair</td>
+              <td>Local environment server</td>
+              <td>Local server secret store</td>
               <td>
-                Do not use this as T3 app authorization; rotate on unlink or suspected compromise.
+                Sign link proofs, health responses, mint responses, and activity publication proofs.
               </td>
             </tr>
             <tr>
-              <td>Single-use bootstrap credential</td>
-              <td>Minted by local T3 server; returned to the requesting client via T3 Cloud.</td>
-              <td>Local T3 server over managed endpoint.</td>
-              <td>The client completed cloud authorization and environment minting.</td>
-              <td>Single use, short TTL, bound to environment and cloud request nonce.</td>
+              <td>Relay cloud-mint key pair</td>
+              <td>Relay deployment</td>
+              <td>Private key in relay Worker config; public key installed into the environment</td>
+              <td>Sign relay-to-environment health and mint requests.</td>
+            </tr>
+            <tr>
+              <td>Relay environment bearer credential</td>
+              <td>Relay</td>
+              <td>Hashed in relay Postgres; plaintext in local server secret store</td>
+              <td>Authenticate environment-to-relay agent-activity publication.</td>
+            </tr>
+            <tr>
+              <td>Relay DPoP access token</td>
+              <td>Relay</td>
+              <td>Remote client memory cache</td>
+              <td>
+                Authorize status, connect, and mobile registration endpoints with proof of
+                possession.
+              </td>
+            </tr>
+            <tr>
+              <td>Environment bootstrap credential</td>
+              <td>Local environment server</td>
+              <td>Passed relay -> remote client</td>
+              <td>One-time exchange at the environment <code>/oauth/token</code> endpoint.</td>
             </tr>
             <tr>
               <td>Environment access token</td>
-              <td>Remote client after token exchange.</td>
-              <td>Local T3 server over managed endpoint.</td>
-              <td>The client has the granted environment scopes and proof key.</td>
-              <td>Issued and revoked only by the local T3 server.</td>
+              <td>Local environment server</td>
+              <td>Remote client</td>
+              <td>Authorize environment HTTP operations and WebSocket ticket issuance.</td>
             </tr>
             <tr>
               <td>WebSocket ticket</td>
-              <td>Remote client, briefly.</td>
-              <td>Local T3 WebSocket endpoint.</td>
-              <td>The WebSocket was opened by a client with a valid scoped access token.</td>
-              <td>Short-lived, one connection, verified by existing T3 WebSocket auth.</td>
+              <td>Local environment server</td>
+              <td>Remote client until consumed</td>
+              <td>Short-lived one-time credential for the WSS upgrade.</td>
             </tr>
             <tr>
-              <td>APNs token</td>
-              <td>Mobile app and T3 Cloud.</td>
-              <td>Apple APNs.</td>
-              <td>User/device notification and Live Activity delivery target.</td>
+              <td>Relay client connector token</td>
+              <td>Cloudflare tunnel API</td>
+              <td>Local server secret store</td>
               <td>
-                Account-scoped token. Environment links and preferences decide which environment
-                updates fan out to that user's devices. Never include full agent traffic or secrets
-                in push payloads.
+                Start the local relay client. It is passed through <code>TUNNEL_TOKEN</code>, not a
+                shell argument.
               </td>
             </tr>
           </tbody>
         </table>
       </section>
 
-      <section class="panel compact" aria-label="Sequence diagram reading key">
-        <h2>How To Read The Sequence Diagrams</h2>
-        <p>
-          Each participant name includes where it runs. Arrows are concrete service boundaries:
-          hosted IdP auth, local app-to-environment calls, T3 Cloud API calls, signed
-          control-over-data-plane requests, managed endpoint traffic, or APNs delivery.
-        </p>
-        <div class="callout warning">
-          The hosted IdP never calls into a MacBook or Mac mini. An IdP arrow back to a client means
-          the client-side auth SDK or hosted auth page finished sign-in and the client now has an
-          IdP session/JWT.
-        </div>
-      </section>
-
-      <section class="panel" aria-label="Endpoint contracts">
-        <h2>Endpoint Contracts</h2>
-        <p>
-          Names are draft, but these contracts are the behavioral boundary. All timestamps are ISO
-          strings. All nonces and token ids must be replay-protected until their expiry window has
-          passed.
-        </p>
-        <h3>Cloud API: Request Remote Connect</h3>
-        <pre class="diagram"><code>POST /v1/environments/:environmentId/connect
-Authorization: Bearer &lt;idp-jwt&gt;
-DPoP: &lt;client-proof-jwt&gt;
-
-Request body
-{
-  "clientKeyThumbprint": "jkt_..."
-}
-
-Response 200
-{
-  "environmentId": "env_mbp",
-  "httpBaseUrl": "https://env_mbp.tunnels.t3code.com/",
-  "wsBaseUrl": "wss://env_mbp.tunnels.t3code.com/ws",
-  "credential": "one_time_bootstrap_...",
-  "expiresAt": "2026-05-25T12:00:30.000Z"
-}</code></pre>
-
-        <h3>Cloud -> Environment: Mint Credential</h3>
-        <pre
-          class="diagram"
-        ><code>POST https://env_mbp.tunnels.t3code.com/api/t3-cloud/mint-credential
-Authorization: T3Cloud &lt;cloud-signed-jwt&gt;
-Content-Type: application/json
-
-Cloud-signed claims
-{
-  "iss": "https://cloud.t3code.com",
-  "aud": "t3-env:env_mbp",
-  "sub": "user_123",
-  "deviceId": "device_456",
-  "cnf": { "jkt": "jkt_..." },
-  "scope": ["environment:connect"],
-  "nonce": "nonce_...",
-  "jti": "mint_request_...",
-  "exp": 1780000030
-}
-
-Environment-signed response 200
-{
-  "environmentId": "env_mbp",
-  "nonce": "nonce_...",
-  "credential": "one_time_bootstrap_...",
-  "expiresAt": "2026-05-25T12:00:30.000Z",
-  "signature": "env_signature_..."
-}</code></pre>
-
-        <h3>Client -> Environment: Exchange Proof-Bound Bootstrap Grant</h3>
-        <pre class="diagram"><code>POST https://env_mbp.tunnels.t3code.com/oauth/token
-DPoP: &lt;client-proof-jwt-for-token-url&gt;
-Content-Type: application/x-www-form-urlencoded
-
-grant_type=urn:ietf:params:oauth:grant-type:token-exchange
-&amp;subject_token=one_time_bootstrap_...
-&amp;subject_token_type=urn:t3:params:oauth:token-type:environment-bootstrap
-&amp;requested_token_type=urn:ietf:params:oauth:token-type:access_token
-&amp;scope=orchestration:read%20orchestration:operate%20terminal:operate%20review:write
-
-Response 200
-{
-  "access_token": "env_access_...",
-  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
-  "token_type": "DPoP",
-  "expires_in": 3600,
-  "scope": "orchestration:read orchestration:operate terminal:operate review:write"
-}</code></pre>
-        <div class="callout">
-          The client generates an ephemeral proof key before requesting connect. T3 Cloud includes
-          the key thumbprint in the signed mint request, and the local T3 server binds the one-time
-          bootstrap credential to that thumbprint. A cloud service that can see the minted
-          credential still cannot redeem it without the client's private proof key.
-        </div>
-
-        <h3>Client -> Environment: Existing WebSocket Flow</h3>
-        <pre class="diagram"><code>POST https://env_mbp.tunnels.t3code.com/api/auth/websocket-ticket
-Authorization: DPoP &lt;env_access_token&gt;
-DPoP: &lt;client-proof-jwt-for-ticket-url&gt;
-
-Response 200
-{ "ticket": "ws_ticket_...", "expiresAt": "2026-05-25T12:01:00.000Z" }
-
-GET wss://env_mbp.tunnels.t3code.com/ws?wsTicket=ws_ticket_...</code></pre>
-
-        <h3>Environment -> Cloud: Status For Notifications</h3>
-        <pre class="diagram"><code>POST /v1/environments/:environmentId/status
-Authorization: T3Environment &lt;env-signed-jwt-or-dpop-proof&gt;
-
-{
-  "environmentId": "env_mbp",
-  "status": "online",
-  "summary": {
-    "activeThreadId": "thread_123",
-    "state": "agent_running"
-  },
-  "issuedAt": "2026-05-25T12:00:00.000Z",
-  "nonce": "nonce_..."
-}</code></pre>
-        <div class="callout">
-          These contracts preserve the current app protocol. Only the cloud connect flow and the
-          local <code>/api/t3-cloud/mint-credential</code> endpoint are new. Bootstrap grants,
-          scoped access tokens, and WebSocket tickets stay owned by the local T3 server.
-        </div>
-      </section>
-
-      <section class="grid" aria-label="Core setup flows">
+      <section class="grid" aria-label="Core flows">
         <article class="panel">
-          <h2>Flow 1: Link MacBook Desktop Environment</h2>
+          <h2>Flow 1: Link From the Desktop Web UI</h2>
           <pre class="diagram mermaid">
 sequenceDiagram
-  actor User as User on MacBook
-  participant Desktop as Desktop app on MacBook
-  participant IdP as Hosted IdP
-  participant Env as T3 server env_mbp on MacBook
-  participant Cloud as T3 Cloud control plane
-  participant Endpoint as Managed endpoint platform
+  participant U as Signed-in user
+  participant C as Desktop web UI
+  participant E as Local environment
+  participant R as Relay Worker
+  participant CF as Cloudflare APIs
+  participant RC as Local relay client
 
-  Note over Desktop,Env: Both run on the MacBook. The IdP never calls into the MacBook directly.
-  User->>Desktop: Click Link cloud account
-  Desktop->>IdP: Official hosted IdP sign-in flow
-  IdP-->>Desktop: IdP session and JWT
-  Desktop->>Env: Local owner-authorized link request with IdP JWT
-  Env->>Env: Get or create cloud-link keypair
-  Note right of Env: Private key stays local.
-  Env->>Cloud: Link env_mbp with IdP JWT + descriptor + public key
-  Cloud->>Cloud: Verify IdP user and store env grant/link record
-  Cloud->>Endpoint: Create managed endpoint for env_mbp
-  Endpoint-->>Cloud: Endpoint URLs and local runtime config
-  Cloud-->>Env: Link accepted with endpoint config
-  Env->>Env: Persist cloud link, cloud issuer metadata, and endpoint runtime config
-  Env->>Endpoint: Maintain managed endpoint to loopback origin
-  Cloud->>Endpoint: Optional signed health check through managed endpoint
-  Endpoint->>Env: Forward health check to loopback origin
-  Env-->>Endpoint: Signed environment health response
-  Endpoint-->>Cloud: Environment health response
-  Env-->>Desktop: Linked account and endpoint status
+  U->>C: Enable T3 Cloud for a locally paired environment
+  C->>E: Check relay client availability
+  alt relay client is missing
+    C->>U: Prompt before download and install
+    U->>C: Confirm
+    C->>E: Stream relay-client install RPC
+    E-->>C: Progress stages
+  end
+  C->>R: POST /v1/client/environment-link-challenges (Clerk bearer)
+  R-->>C: Short-lived challenge
+  C->>E: POST /api/cloud/link-proof (local relay:write bearer)
+  E->>E: Authenticate, reject forwarded authority, get or create key pair, validate loopback origin
+  E-->>C: Environment-signed link proof
+  C->>R: POST /v1/client/environment-links (Clerk bearer + proof)
+  R->>R: Verify challenge, proof, capabilities, nonce, and loopback origin
+  R->>CF: Reconcile tunnel, ingress, and CNAME
+  R->>R: Upsert user/environment link and issue environment bearer
+  R-->>C: Managed endpoint, relay config, and connector token
+  C->>E: POST /api/cloud/relay-config (local relay:write bearer)
+  E->>RC: Start relay client with TUNNEL_TOKEN
           </pre>
           <div class="callout">
-            Flow 1 has three service boundaries: the hosted IdP proves the human user, the local T3
-            environment proves local machine authority, and T3 Cloud creates the cloud link plus
-            managed endpoint. Health and credential-mint requests use the endpoint instead of a
-            persistent environment control channel.
+            The local link-proof endpoint requires <code>relay:write</code>, rejects forwarded
+            authority headers, and accepts only an exact loopback origin. Environment keypair
+            persistence is atomic across concurrent link attempts.
           </div>
+          <p>
+            A locally paired mobile client uses the same relay challenge, local proof, relay link,
+            and local relay-config endpoints. The desktop web UI is the surface that checks relay
+            client availability and offers the managed install dialog.
+          </p>
         </article>
 
         <article class="panel">
-          <h2>Flow 2: Link Headless Mac Mini</h2>
+          <h2>Flow 2: Headless CLI Link</h2>
           <pre class="diagram mermaid">
 sequenceDiagram
-  actor Admin as User in browser
-  participant IdP as Hosted IdP
-  participant CLI as t3 cloud login on Mac mini
-  participant Env as T3 server env_mini on Mac mini
-  participant Cloud as T3 Cloud control plane
-  participant Endpoint as Managed endpoint platform
+  participant U as Operator
+  participant CLI as t3 cloud CLI
+  participant Clerk as Clerk OAuth
+  participant S as Environment server on next start
+  participant R as Relay Worker
+  participant RC as Local relay client
 
-  CLI->>Env: Local owner-authorized headless link request
-  Env->>Env: Get or create cloud-link keypair
-  Env-->>CLI: Environment descriptor and public cloud-link key
-  Note right of Env: Private key stays local.
-  CLI->>Cloud: Start device-link request with descriptor and public key
-  Cloud-->>CLI: Browser URL and short code
-  CLI-->>Admin: Print URL and code
-  Admin->>IdP: Open URL and sign in
-  IdP-->>Admin: IdP session and JWT
-  Admin->>Cloud: Approve device-link request with IdP JWT and code
-  Cloud->>Cloud: Verify IdP user and store env grant/link record
-  CLI->>Cloud: Poll until device-link request is approved
-  Cloud->>Endpoint: Create managed endpoint for env_mini
-  Endpoint-->>Cloud: Endpoint URLs and local runtime config
-  Cloud-->>CLI: Link accepted with endpoint config
-  CLI->>Env: Install endpoint config, cloud issuer metadata, and enable cloud link
-  Env->>Env: Persist cloud link and endpoint runtime config
-  Env->>Endpoint: Maintain managed endpoint to loopback origin
-  Cloud->>Endpoint: Optional signed health check through managed endpoint
-  Endpoint->>Env: Forward health check to loopback origin
-  Env-->>Endpoint: Signed environment health response
-  Endpoint-->>Cloud: Environment health response
+  U->>CLI: t3 cloud link
+  CLI->>CLI: Resolve relay client
+  alt relay client is missing
+    CLI->>U: Confirm managed relay-client install
+    U->>CLI: Confirm
+    CLI->>CLI: Install with terminal progress updates
+  end
+  CLI->>Clerk: Browser PKCE authorization-code flow
+  Clerk-->>CLI: OAuth access and refresh tokens
+  CLI->>CLI: Persist desired cloud-link state
+  U->>S: Start T3 environment server
+  S->>R: Create challenge and submit local signed proof
+  R-->>S: Managed endpoint config and connector token
+  S->>RC: Start relay client
           </pre>
-          <div class="callout">
-            This is the headless equivalent of desktop setup. The end state is identical:
-            <code>env_mini</code> has a local cloud-link key, a managed endpoint connection, and a
-            local endpoint that can verify signed cloud requests. The browser only approves the
-            login; it never talks to the Mac mini directly.
-          </div>
+          <p>
+            <code>t3 cloud login</code> stores authorization without enabling exposure.
+            <code>t3 cloud unlink</code> disables exposure while retaining authorization.
+            <code>t3 cloud logout</code> also removes the stored CLI authorization.
+          </p>
         </article>
 
         <article class="panel">
           <h2>Flow 3: Remote Connect Bootstrap</h2>
           <pre class="diagram mermaid">
 sequenceDiagram
-  participant Client as Mobile or hosted web client
-  participant Cloud as T3 Cloud control plane
-  participant Endpoint as Managed endpoint data plane
-  participant Env as Target T3 server on loopback
+  participant C as Web or mobile client
+  participant Clerk as Clerk
+  participant R as Relay Worker
+  participant E as Managed environment endpoint
 
-  Client->>Client: Generate ephemeral proof key
-  Client->>Cloud: POST /v1/environments/:id/connect with IdP JWT + DPoP proof
-  Cloud->>Cloud: Verify IdP user, grant, endpoint record, and connect policy
-  Cloud->>Cloud: Create short-lived signed mint request bound to client key thumbprint
-  Cloud->>Endpoint: POST /api/t3-cloud/mint-credential with signed request
-  Endpoint->>Env: Forward signed mint request to loopback origin
-  Env->>Env: Verify cloud signature, audience, expiry, nonce, link state, and key binding
-  Env-->>Endpoint: Single-use proof-bound bootstrap credential and signed response
-  Endpoint-->>Cloud: Single-use bootstrap credential and signed response
-  Cloud->>Cloud: Verify environment signature and consume connect ticket
-  Cloud-->>Client: httpBaseUrl, wsBaseUrl, one-time credential
-  Client->>Endpoint: POST /oauth/token with credential, scopes, and DPoP proof
-  Endpoint->>Env: Forward request to loopback origin
-  Env->>Env: Verify proof matches credential key binding
-  Env-->>Endpoint: Scoped DPoP access token response
-  Endpoint-->>Client: Scoped DPoP access token response
-  Client->>Endpoint: POST /api/auth/websocket-ticket using DPoP access token
-  Endpoint-->>Client: Short-lived wsTicket
-  Client->>Endpoint: Open WebSocket with wsTicket
-          </pre>
-          <div class="callout warning">
-            T3 Cloud authorizes the account, but the environment still decides whether to mint the
-            credential. The request reaches the local server through the managed endpoint, so the
-            first implementation can infer reachability at connect time instead of maintaining a
-            separate cloud-side presence service.
-          </div>
-        </article>
-
-        <article class="panel">
-          <h2>Flow 4: Mobile and Hosted Web Discover Environments</h2>
-          <pre class="diagram mermaid">
-sequenceDiagram
-  participant Client as Mobile app or hosted web UI
-  participant IdP as Hosted IdP
-  participant Cloud as T3 Cloud control plane
-  participant Endpoint as Managed endpoint data plane
-  participant Env as Target T3 server
-
-  Client->>IdP: Official hosted IdP sign-in flow
-  IdP-->>Client: IdP session and JWT
-  Client->>Cloud: GET /v1/environments with IdP JWT
-  Cloud->>Cloud: Verify user and lookup grants and endpoint records
-  Cloud-->>Client: Environment list and endpoint records
-  Client->>Cloud: POST /v1/environments/:id/connect with DPoP proof
-  Cloud->>Endpoint: Signed proof-bound mint request over managed endpoint
-  Endpoint->>Env: Forward signed mint request to loopback server
-  Env-->>Endpoint: Single-use proof-bound bootstrap credential
-  Endpoint-->>Cloud: Single-use bootstrap credential
-  Cloud-->>Client: Endpoint URLs and one-time credential
-  Client->>Endpoint: Exchange grant for scoped DPoP token and open WebSocket with ticket
-  Endpoint->>Env: Forward app protocol to loopback server
+  C->>Clerk: Get Clerk session-template JWT
+  C->>R: POST /v1/client/dpop-token (Clerk JWT + DPoP proof)
+  R-->>C: Relay DPoP access token
+  C->>R: POST /v1/environments/:id/connect (relay DPoP)
+  R->>E: POST /api/t3-cloud/mint-credential (relay-signed proof)
+  E->>E: Verify relay signer, linked user, scope, lifetime, cnf, and replay guards
+  E-->>R: Bootstrap credential + environment-signed proof
+  R->>R: Verify environment signature, nonce, endpoint, and DPoP binding
+  R-->>C: Managed endpoint + bootstrap credential
+  C->>E: POST /oauth/token (bootstrap credential + DPoP proof)
+  E-->>C: Environment DPoP-bound access token
+  C->>E: POST /api/auth/websocket-ticket
+  E-->>C: One-time WebSocket ticket
+  C->>E: WSS /ws with ticket
           </pre>
           <div class="callout">
-            Discovery stays cloud-mediated. Normal session traffic is direct to the managed endpoint
-            after connect, not streamed through T3 Cloud.
+            Relay-to-environment control requests disable redirects, use only a reconciled managed
+            endpoint allocation, and require a signed environment response before the relay returns
+            data to the client.
           </div>
         </article>
-      </section>
 
-      <section class="panel" aria-label="Managed endpoint data flow">
-        <div class="split-title">
-          <h2>Agent Traffic Over Managed Endpoint</h2>
-          <span>App protocol stays HTTP + WebSocket</span>
-        </div>
-        <pre class="diagram mermaid">
-sequenceDiagram
-  participant Client as Mobile or hosted web client
-  participant Cloud as T3 Cloud control plane
-  participant Endpoint as Cloudflare Tunnel or T3 Relay edge
-  participant Env as T3 server loopback origin
-
-  Client->>Cloud: Connect request with IdP JWT + DPoP proof
-  Cloud->>Endpoint: Signed proof-bound mint request over managed endpoint
-  Endpoint->>Env: Forward signed mint request to loopback origin
-  Env-->>Endpoint: One-time proof-bound bootstrap credential
-  Endpoint-->>Cloud: One-time bootstrap credential
-  Cloud-->>Client: Endpoint URLs and one-time bootstrap credential
-  Client->>Endpoint: HTTPS token exchange with requested scopes and DPoP proof
-  Endpoint->>Env: Forward request over managed endpoint to loopback origin
-  Env-->>Endpoint: Scoped DPoP access token response
-  Endpoint-->>Client: Scoped DPoP access token established
-  Client->>Endpoint: WebSocket RPC stream
-  Endpoint->>Env: Forward WebSocket frames to existing T3 protocol
-  Env-->>Endpoint: Agent chunks, status, command results
-  Endpoint-->>Client: Agent chunks, status, command results
-        </pre>
-        <div class="flow">
-          <div class="step">
-            <strong>Cloud before traffic</strong>
-            The control plane authorizes the user, checks grants, creates a short-lived signed mint
-            request, and sends it through the managed endpoint to the target environment.
-          </div>
-          <div class="step">
-            <strong>Data plane during traffic</strong>
-            Normal agent chunks and command RPC use the existing environment HTTP/WebSocket protocol
-            through the managed endpoint. T3 Cloud is not in this hot path.
-          </div>
-          <div class="step">
-            <strong>Environment remains the boundary</strong>
-            The local T3 server authenticates the bootstrap credential, mints WebSocket tickets, and
-            can reject commands based on local policy or approval state.
-          </div>
-        </div>
-      </section>
-
-      <section class="panel" aria-label="Push notifications and live activities">
-        <div class="split-title">
-          <h2>Push Notifications and Live Activities</h2>
-          <span>Minimal payloads, control-plane state</span>
-        </div>
-        <pre class="diagram mermaid">
-sequenceDiagram
-  participant Mobile as T3 mobile app
-  participant IdP as Hosted IdP
-  participant Cloud as T3 Cloud control plane
-  participant APNs as Apple APNs
-  participant Env as Local T3 server
-
-  Mobile->>IdP: Sign in with hosted IdP
-  IdP-->>Mobile: IdP session and JWT
-  Mobile->>Cloud: Register APNs and Live Activity tokens with IdP JWT
-  Cloud->>Cloud: Store token per user/device with agent-awareness preferences
-  Env->>Cloud: Publish minimal status via cloud API or webhook with cloud-link signature
-  Cloud->>Cloud: Select linked users for the publishing environment
-  Cloud->>Cloud: Store latest summary and notification state
-  Cloud->>APNs: Send minimal notification or Live Activity payload
-  APNs-->>Mobile: Deliver push or Live Activity update
-  Mobile->>Cloud: App foregrounds and requests connect
-  Cloud-->>Mobile: Endpoint URLs and bootstrap credential
-        </pre>
-        <div class="callout">
-          Push payloads should be summaries: environment id, thread id, status, counters, and a
-          short title if product policy allows. Full agent chunks are fetched from the environment
-          over the managed endpoint after authentication.
-        </div>
-      </section>
-
-      <section class="grid" aria-label="Hosted web and mismatch handling">
         <article class="panel">
-          <h2>Hosted Web UI Monitoring</h2>
+          <h2>Flow 4: Agent Activity Notifications</h2>
           <pre class="diagram mermaid">
 sequenceDiagram
-  participant Browser as Browser on other device
-  participant IdP as Hosted IdP
-  participant Cloud as T3 Cloud control plane
-  participant Endpoint as Managed endpoint data plane
-  participant Env as env_mbp or env_mini
+  participant E as Local environment
+  participant R as Relay Worker
+  participant DB as Relay Postgres
+  participant Q as APNs queue
+  participant APNs as Apple Push Notification service
+  participant M as Mobile app
 
-  Browser->>IdP: Open app.t3.codes and sign in
-  IdP-->>Browser: IdP session and JWT
-  Browser->>Cloud: GET linked environments with IdP JWT
-  Cloud-->>Browser: env_mbp and env_mini metadata
-  Browser->>Cloud: Connect to selected environment
-  Cloud->>Endpoint: Signed mint request over managed endpoint
-  Endpoint->>Env: Forward signed mint request to loopback local server
-  Env-->>Endpoint: One-time bootstrap credential
-  Endpoint-->>Cloud: One-time bootstrap credential
-  Cloud-->>Browser: Endpoint URLs and one-time credential
-  Browser->>Endpoint: Exchange bootstrap grant for scoped DPoP access token
-  Endpoint->>Env: Forward to loopback local server
-  Browser->>Endpoint: Open WebSocket RPC stream
-  Env-->>Endpoint: Live chunks and status
-  Endpoint-->>Browser: Live chunks and status
-  opt User starts an agent remotely
-    Browser->>Endpoint: Command request over existing WebSocket
-    Env->>Env: Local policy check
-    Env-->>Endpoint: Accept or reject
-    Endpoint-->>Browser: Accept or reject
-  end
+  E->>E: Project publishable thread state and redact failure detail
+  E->>R: POST /v1/environments/:environmentId/threads/:threadId/agent-activity
+  Note over E,R: Environment bearer credential + environment-signed per-state proof
+  R->>R: Verify credential, signature, scope, expiry, and nonce
+  R->>DB: Store current activity row
+  R->>Q: Enqueue push or Live Activity delivery jobs
+  Q->>APNs: Deliver signed APNs request
+  APNs-->>M: Push notification or Live Activity update
           </pre>
+          <p>
+            The local server publishes a deliberately narrow projection. Failed runs use a fixed
+            redacted summary, and detail strings are capped before publication.
+          </p>
         </article>
+      </section>
 
-        <article class="panel">
-          <h2>Account Mismatch Rule</h2>
+      <section class="grid" aria-label="Managed endpoint lifecycle">
+        <article class="panel half">
+          <h2>Managed Endpoint Reconciliation</h2>
+          <p>
+            Managed endpoint resources are keyed by <code>(userId, environmentId)</code>. The relay
+            reserves a stable hostname and tunnel name before provisioning, then checkpoints the
+            tunnel ID, DNS record ID, and ready state in Postgres.
+          </p>
           <div class="flow">
             <div class="step">
-              <strong>Compare two identities</strong>
-              The environment link state says <code>env_mbp</code> is linked to User A. The renderer
-              IdP browser session may currently be User B.
+              <strong>1. Reserve deterministic allocation</strong>
+              Hostname and tunnel name derive from relay stage, cloud user, and environment ID.
             </div>
             <div class="step">
-              <strong>Match</strong>
-              If the renderer user and environment link match, show normal cloud management: refresh
-              endpoint, unlink, rotate, and configure.
+              <strong>2. Reuse or create tunnel</strong>
+              Existing named tunnels are reused. Tunnel ingress is rewritten to the validated
+              loopback origin.
             </div>
             <div class="step">
-              <strong>Mismatch</strong>
-              If they differ, show linked-as User A and signed-in-as User B. Allow sign out, sign in
-              as the linked user, or an explicit unlink/switch flow.
+              <strong>3. Reconcile DNS</strong>
+              Existing CNAMEs are updated and duplicate records are removed. Create conflicts are
+              recovered by listing and reconciling the winning record.
             </div>
             <div class="step">
-              <strong>Never allowed</strong>
-              Do not silently replace the linked account, treat the renderer cookie as environment
-              authority, or issue connect credentials unless that cloud user is explicitly granted.
+              <strong>4. Mark ready</strong>
+              Connect and status requests use only ready allocations whose hostname still matches
+              the relay-managed namespace.
             </div>
           </div>
-          <div class="callout warning">
-            The displayed cloud account for an environment comes from the environment link state,
-            not from whatever IdP session currently exists in the renderer.
-          </div>
+        </article>
+
+        <article class="panel half">
+          <h2>Unlink Cleanup</h2>
+          <p>
+            Relay unlink removes the user's managed endpoint allocation before revoking the
+            user/environment link:
+          </p>
+          <ul>
+            <li>delete the managed DNS record if present;</li>
+            <li>delete the Cloudflare tunnel if present;</li>
+            <li>remove the allocation row;</li>
+            <li>revoke the user's environment link; and</li>
+            <li>
+              revoke the environment publication credential only after the final active link for
+              that environment key disappears.
+            </li>
+          </ul>
+          <p>
+            Local unlink stops the relay client and removes the locally persisted relay URL, issuer,
+            linked user, environment publication credential, cloud-mint public key, connector
+            config, and agent-activity preference.
+          </p>
         </article>
       </section>
 
-      <section class="panel" aria-label="Setup checklist">
-        <h2>End-to-End Setup Checklist For This Use Case</h2>
-        <div class="flow">
-          <div class="step">
-            <strong>1. MacBook Pro desktop</strong>
-            Start desktop app. User signs in with the hosted IdP. <code>env_mbp</code> registers its
-            descriptor and cloud-link public key, receives a managed endpoint, enables the managed
-            endpoint runtime, and accepts signed cloud mint requests through that endpoint.
-          </div>
-          <div class="step">
-            <strong>2. Mac mini headless server</strong>
-            Run <code>t3 cloud login</code>. Complete device/browser login as the same T3 user or
-            org. <code>env_mini</code> registers its own cloud-link key, receives its own managed
-            endpoint, enables the managed endpoint runtime, and accepts signed cloud mint requests
-            through that endpoint.
-          </div>
-          <div class="step">
-            <strong>3. MacBook remote environment entry</strong>
-            Add Mac mini as a remote environment using existing direct auth such as SSH, pairing, or
-            private network. This is for direct local/private management; the cloud link is a
-            separate managed endpoint record.
-          </div>
-          <div class="step">
-            <strong>4. Mobile app</strong>
-            Sign into the T3 Code mobile app with the hosted IdP. Register APNs and Live Activity
-            tokens. The app lists <code>env_mbp</code> and <code>env_mini</code>, asks T3 Cloud to
-            connect, then opens HTTP/WebSocket traffic directly against the selected endpoint.
-          </div>
-          <div class="step">
-            <strong>5. Hosted web</strong>
-            Sign into <code>app.t3.codes</code>. It lists the same linked environments and exchanges
-            for a direct managed-endpoint access token the same way mobile does.
-          </div>
-        </div>
-      </section>
-
-      <section class="panel" aria-label="Managed endpoint boundary">
-        <div class="split-title">
-          <h2>Managed Endpoint Boundary</h2>
-          <span>Cloudflare Tunnel is a transport choice, not the product architecture</span>
-        </div>
-        <div class="flow">
-          <div class="step">
-            <strong>Stable client contract</strong>
-            T3 Cloud returns <code>httpBaseUrl</code>, <code>wsBaseUrl</code>, and a one-time
-            credential. Clients do not know whether the endpoint is backed by Cloudflare Tunnel or a
-            future T3 relay.
-          </div>
-          <div class="step">
-            <strong>Cloudflare Tunnel today</strong>
-            Provision one tunnel per environment, configure ingress to
-            <code>http://127.0.0.1:&lt;serverPort&gt;</code>, create the public hostname, and give
-            the linked environment only the endpoint credential it needs to expose that endpoint. T3
-            Cloud reaches the environment through signed HTTPS requests to that endpoint.
-          </div>
-          <div class="step">
-            <strong>Request-time reachability</strong>
-            V1 does not maintain authoritative online presence for each environment. The control
-            plane infers reachability when it attempts a signed health or credential-mint request
-            over the managed endpoint, then returns a concrete connect result or a timeout/failure.
-          </div>
-          <div class="step">
-            <strong>T3 Relay later</strong>
-            Replace the endpoint runtime with <code>t3-relayd connect ...</code> and keep the same
-            managed endpoint, control-plane, and local credential semantics. The relay can add
-            purpose-built stateful behavior later without changing client bootstrap semantics.
-          </div>
-        </div>
-      </section>
-
-      <section class="panel" aria-label="Implementation validation checklist">
-        <h2>Implementation Validation Checklist</h2>
-        <div class="flow">
-          <div class="step">
-            <strong>Cloud user auth is isolated</strong>
-            A valid IdP JWT can list cloud environments and request connect, but cannot call local
-            T3 app APIs directly without a local bootstrap credential.
-          </div>
-          <div class="step">
-            <strong>Cloud-signed mint requests are strict</strong>
-            The local T3 server rejects mint requests with the wrong issuer, audience, environment
-            id, scope, expiry, nonce, replayed <code>jti</code>, or client key binding.
-          </div>
-          <div class="step">
-            <strong>Environment responses are authenticated</strong>
-            T3 Cloud rejects credential and health responses that are missing the environment
-            cloud-link signature or are signed by a key other than the registered environment key.
-          </div>
-          <div class="step">
-            <strong>Endpoint runtime auth is not app auth</strong>
-            Stealing or rotating the Cloudflare tunnel token or future relay connector token does
-            not create a valid T3 access token, WebSocket ticket, or environment-signed response.
-          </div>
-          <div class="step">
-            <strong>Bootstrap credentials are one-shot</strong>
-            The local T3 server rejects expired, replayed, wrong-environment, or wrong-nonce
-            bootstrap credentials, and rejects proof-bound credentials unless the bootstrap request
-            proves possession of the bound client key.
-          </div>
-          <div class="step">
-            <strong>Existing WebSocket protocol stays unchanged</strong>
-            After token exchange, remote clients use scoped access tokens and the
-            <code>wsTicket</code> flow used for remote environments.
-          </div>
-          <div class="step">
-            <strong>T3 Cloud is not in the hot path</strong>
-            Agent chunks, command RPC, terminal traffic, and session WebSocket frames flow from
-            client to managed endpoint to local T3 server, not through T3 Cloud.
-          </div>
-          <div class="step">
-            <strong>Provider swap is observable only in endpoint metadata</strong>
-            Replacing Cloudflare Tunnel with T3 Relay changes endpoint runtime provisioning and
-            provider refs, but not client token exchange, scoped authorization, or WebSocket
-            behavior.
-          </div>
-        </div>
-      </section>
-
-      <section class="panel" aria-label="V1 infrastructure primitives">
-        <div class="split-title">
-          <h2>V1 Infrastructure Primitives</h2>
-          <span>Concrete stack for the first managed endpoint implementation</span>
-        </div>
+      <section class="panel" aria-label="SSRF and tunnel hardening">
+        <h2>SSRF and Tunnel Hardening</h2>
         <table>
           <thead>
             <tr>
-              <th>Concern</th>
-              <th>V1 Primitive</th>
-              <th>Source Of Truth?</th>
-              <th>Implementation Notes</th>
+              <th>Risk</th>
+              <th>Implemented control</th>
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>Control plane runtime</td>
-              <td>Cloudflare Workers</td>
-              <td>No, stateless runtime.</td>
+              <td>A client asks the relay to tunnel an arbitrary host.</td>
               <td>
-                Hosts T3 Cloud APIs, verifies IdP JWTs, provisions endpoint records, signs mint
-                requests, receives status updates, and enqueues async work.
+                The environment and relay both accept managed tunnel origins only for loopback hosts
+                and valid ports.
               </td>
             </tr>
             <tr>
-              <td>Hosted user identity</td>
-              <td>Hosted IdP, v1 implementation: Clerk</td>
-              <td>No, external identity authority.</td>
+              <td>A forwarded request tricks local origin validation.</td>
               <td>
-                T3 Cloud verifies IdP JWTs and consumes IdP webhooks. Local T3 servers do not trust
-                hosted IdP sessions directly.
+                The local link-proof handler requires an exact loopback request URL and rejects
+                forwarded host or protocol headers.
               </td>
             </tr>
             <tr>
-              <td>Relational database</td>
-              <td>PlanetScale Postgres via Cloudflare Hyperdrive</td>
-              <td>Yes.</td>
+              <td>A stored endpoint is replaced with an arbitrary external URL.</td>
               <td>
-                Stores accounts, users, devices, environments, grants, cloud links, endpoint
-                records, public environment keys, connect requests, notification targets, status
-                snapshots, and audit events.
+                Connect and status resolve a ready allocation from Postgres and require a hostname
+                under the configured managed endpoint zone.
               </td>
             </tr>
             <tr>
-              <td>Database connection layer</td>
-              <td>Cloudflare Hyperdrive</td>
-              <td>No, connection/pooling layer.</td>
+              <td>A managed endpoint redirects relay egress elsewhere.</td>
               <td>
-                Workers connect to PlanetScale Postgres through Hyperdrive. Hyperdrive is never used
-                as application state.
+                Relay-to-environment status and mint requests set redirect handling to
+                <code>manual</code>.
               </td>
             </tr>
             <tr>
-              <td>Cloud secrets</td>
-              <td>Cloudflare Worker secret bindings</td>
-              <td>No, secret source for Worker runtime.</td>
+              <td>A process behind the tunnel returns attacker-controlled data.</td>
               <td>
-                Use for IdP secrets, IdP webhook secret, Cloudflare API token, cloud mint signing
-                private key, APNs provider credentials, and optional app encryption key. Do not use
-                Secrets Store for v1 unless multiple independently deployed Workers need shared
-                account-level secrets.
+                The relay verifies environment-signed health and mint responses against the linked
+                environment public key, expected nonce, and request binding.
               </td>
             </tr>
             <tr>
-              <td>Environment private keys</td>
-              <td>Local Keychain or local state directory</td>
-              <td>Yes, for environment identity.</td>
+              <td>A stolen remote access token is replayed.</td>
               <td>
-                Environment cloud-link private keys remain local only. T3 Cloud stores only the
-                public key in PlanetScale.
+                Relay and environment access tokens are DPoP-bound; per-request proofs and replay
+                guards are required.
               </td>
             </tr>
             <tr>
-              <td>Managed endpoint data plane</td>
-              <td>Cloudflare Tunnel</td>
-              <td>No, transport provider.</td>
+              <td>The relay client token leaks through process listings or shell parsing.</td>
               <td>
-                First <code>ManagedEndpointProvider</code>. T3 Cloud provisions tunnels, DNS
-                records, endpoint metadata, and one-time runtime config for the local environment.
-              </td>
-            </tr>
-            <tr>
-              <td>Future data plane</td>
-              <td>T3 Relay</td>
-              <td>No, transport provider.</td>
-              <td>
-                Implements the same provider interface and client contract:
-                <code>httpBaseUrl</code>, <code>wsBaseUrl</code>, and local T3 auth.
-              </td>
-            </tr>
-            <tr>
-              <td>Async jobs</td>
-              <td>Cloudflare Queues with dead-letter queues</td>
-              <td>No, delivery mechanism.</td>
-              <td>
-                Use for endpoint provisioning, endpoint reconciliation, IdP webhook processing,
-                unlink/rotate workflows, audit event fanout, and APNs delivery.
-              </td>
-            </tr>
-            <tr>
-              <td>Push delivery</td>
-              <td>Cloudflare Queues consumer -> Apple APNs</td>
-              <td>No, delivery mechanism.</td>
-              <td>
-                Queue APNs jobs after status updates. Payloads are minimal and must not include full
-                agent chunks, access tokens, bootstrap credentials, or WebSocket tickets.
-              </td>
-            </tr>
-            <tr>
-              <td>Scheduled reconciliation</td>
-              <td>Cloudflare Cron Triggers</td>
-              <td>No, scheduler.</td>
-              <td>
-                Expire connect requests, reconcile pending tunnel provisioning, expire stale health
-                observations, audit dangling tunnel/DNS records, and clean old link codes.
-              </td>
-            </tr>
-            <tr>
-              <td>Blob/object storage</td>
-              <td>Cloudflare R2, optional</td>
-              <td>No for core auth/control state.</td>
-              <td>
-                Use only for diagnostics, exports, large redacted logs, or archived webhook
-                payloads. PlanetScale remains the source of truth.
-              </td>
-            </tr>
-            <tr>
-              <td>Coordination</td>
-              <td>Database constraints, idempotency keys, queues</td>
-              <td>PlanetScale is authoritative.</td>
-              <td>
-                Use explicit idempotency keys for link, provisioning, connect, notification, and
-                rotation workflows. Keep the database as the durable coordination point for v1.
-              </td>
-            </tr>
-            <tr>
-              <td>Observability</td>
-              <td>Workers Observability, Analytics Engine, PlanetScale audit rows</td>
-              <td>PlanetScale for durable audit events.</td>
-              <td>
-                Use Analytics Engine for high-cardinality operational/product metrics. Keep durable
-                audit history in PlanetScale, with optional R2 exports.
+                The relay client is spawned without a shell and receives its connector token in
+                <code>TUNNEL_TOKEN</code>.
               </td>
             </tr>
           </tbody>
         </table>
-        <div class="callout">
-          Worker secret bindings are enough for the initial cloud secrets, and
-          control-over-data-plane requests avoid persistent environment control sockets.
+        <div class="callout warning">
+          Managed tunnel hostnames currently live under the configured relay DNS zone. Serving them
+          from a dedicated registrable domain with a Public Suffix List entry remains an operational
+          isolation requirement before broad untrusted use.
         </div>
       </section>
 
-      <section class="panel" aria-label="Design anchors">
-        <h2>Design Anchors</h2>
+      <section class="panel" aria-label="Relay HTTP API">
+        <h2>Relay HTTP API</h2>
         <p>
-          These references are the standards this shape should align with. They are not product
-          requirements by themselves, but they describe the secure patterns we should avoid
-          reinventing badly.
+          The relay publishes an OpenAPI document at <code>/openapi.json</code>, Scalar docs at
+          <code>/docs</code>, and redirects <code>/</code> to the docs.
         </p>
+        <table>
+          <thead>
+            <tr>
+              <th>Endpoint</th>
+              <th>Authentication</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>GET /health</code></td>
+              <td>None</td>
+              <td>Relay health check.</td>
+            </tr>
+            <tr>
+              <td><code>GET /.well-known/oauth-authorization-server</code></td>
+              <td>None</td>
+              <td>Relay OAuth token-exchange discovery metadata.</td>
+            </tr>
+            <tr>
+              <td><code>GET /.well-known/oauth-protected-resource</code></td>
+              <td>None</td>
+              <td>Relay DPoP protected-resource discovery metadata.</td>
+            </tr>
+            <tr>
+              <td><code>GET /v1/environments</code></td>
+              <td>Clerk bearer</td>
+              <td>List environments linked to the signed-in user.</td>
+            </tr>
+            <tr>
+              <td><code>POST /v1/client/environment-link-challenges</code></td>
+              <td>Clerk bearer</td>
+              <td>Create a short-lived user-bound environment link challenge.</td>
+            </tr>
+            <tr>
+              <td><code>POST /v1/client/environment-links</code></td>
+              <td>Clerk bearer</td>
+              <td>
+                Verify a local environment proof, reconcile a managed endpoint, and upsert the user
+                link.
+              </td>
+            </tr>
+            <tr>
+              <td><code>DELETE /v1/client/environment-links/:environmentId</code></td>
+              <td>Clerk bearer</td>
+              <td>Remove managed endpoint resources and revoke the user's link.</td>
+            </tr>
+            <tr>
+              <td><code>POST /v1/client/dpop-token</code></td>
+              <td>Clerk token in token-exchange payload plus DPoP proof</td>
+              <td>Issue a relay DPoP access token for the requested supported scopes.</td>
+            </tr>
+            <tr>
+              <td><code>POST /v1/environments/:environmentId/status</code></td>
+              <td>Relay DPoP</td>
+              <td>Request and validate a signed environment health response.</td>
+            </tr>
+            <tr>
+              <td><code>POST /v1/environments/:environmentId/connect</code></td>
+              <td>Relay DPoP</td>
+              <td>Request and validate an environment bootstrap credential.</td>
+            </tr>
+            <tr>
+              <td><code>POST /v1/mobile/devices</code></td>
+              <td>Relay DPoP</td>
+              <td>Register or update a mobile device for notifications.</td>
+            </tr>
+            <tr>
+              <td><code>POST /v1/mobile/live-activities</code></td>
+              <td>Relay DPoP</td>
+              <td>Register a Live Activity push token.</td>
+            </tr>
+            <tr>
+              <td><code>DELETE /v1/mobile/devices/:deviceId</code></td>
+              <td>Relay DPoP</td>
+              <td>Unregister a mobile device.</td>
+            </tr>
+            <tr>
+              <td>
+                <code>POST /v1/environments/:environmentId/threads/:threadId/agent-activity</code>
+              </td>
+              <td>Environment bearer plus signed publish proof</td>
+              <td>Publish redacted current agent activity for notification delivery.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="panel" aria-label="Environment HTTP API">
+        <h2>Environment Cloud HTTP API</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Endpoint</th>
+              <th>Authentication</th>
+              <th>Purpose</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>POST /api/cloud/link-proof</code></td>
+              <td>Local environment token with <code>relay:write</code></td>
+              <td>Validate local origin and sign an environment link proof.</td>
+            </tr>
+            <tr>
+              <td><code>POST /api/cloud/relay-config</code></td>
+              <td>Local environment token with <code>relay:write</code></td>
+              <td>Persist linked relay configuration and start the relay client.</td>
+            </tr>
+            <tr>
+              <td><code>GET /api/cloud/link-state</code></td>
+              <td>Local environment token with <code>relay:read</code></td>
+              <td>Read the environment's current T3 Cloud link state.</td>
+            </tr>
+            <tr>
+              <td><code>POST /api/cloud/preferences</code></td>
+              <td>Local environment token with <code>relay:write</code></td>
+              <td>Enable or disable agent-activity publication.</td>
+            </tr>
+            <tr>
+              <td><code>POST /api/cloud/unlink</code></td>
+              <td>Local environment token with <code>relay:write</code></td>
+              <td>Stop the relay client and clear local T3 Cloud configuration.</td>
+            </tr>
+            <tr>
+              <td><code>POST /api/t3-cloud/health</code></td>
+              <td>Relay-signed proof</td>
+              <td>Return a signed environment health response.</td>
+            </tr>
+            <tr>
+              <td><code>POST /api/t3-cloud/mint-credential</code></td>
+              <td>Relay-signed proof</td>
+              <td>Mint a DPoP-bound one-time bootstrap credential for a remote client.</td>
+            </tr>
+            <tr>
+              <td><code>POST /oauth/token</code></td>
+              <td>Bootstrap credential plus DPoP proof</td>
+              <td>Exchange a bootstrap credential for an environment access token.</td>
+            </tr>
+            <tr>
+              <td><code>POST /api/auth/websocket-ticket</code></td>
+              <td>Environment access token</td>
+              <td>Issue a one-time ticket for the WSS upgrade.</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="grid" aria-label="Runtime and infrastructure">
+        <article class="panel half">
+          <h2>Relay Client Installation</h2>
+          <p>
+            Desktop web UI availability checks and installs are local WebSocket RPC methods:
+            <code>cloud.getRelayClientStatus</code> and streaming
+            <code>cloud.installRelayClient</code>. The install stream emits the current stage:
+            checking, waiting for lock, downloading, verifying, installing, validating, and
+            activating.
+          </p>
+          <p>
+            The web UI asks for confirmation before installation and displays a custom progress
+            dialog. The CLI invokes the same local relay-client service directly and reports the
+            same progress stages in the terminal.
+          </p>
+        </article>
+
+        <article class="panel half">
+          <h2>Relay Infrastructure</h2>
+          <ul>
+            <li>Cloudflare Worker for the hosted relay HTTP API.</li>
+            <li>PlanetScale Postgres database named <code>t3coderelay</code>.</li>
+            <li>
+              Production uses the shared database; non-production stages use database branches.
+            </li>
+            <li>
+              Cloudflare Hyperdrive with caching disabled and a constrained origin connection limit.
+            </li>
+            <li>Cloudflare tunnel and DNS bindings for managed endpoint reconciliation.</li>
+            <li>Cloudflare APNs delivery queue plus dead-letter queue.</li>
+            <li>A five-minute cron job that prunes expired DPoP replay rows.</li>
+            <li>Axiom OTLP trace dataset, scoped ingest token, and recent-spans view per stage.</li>
+          </ul>
+        </article>
+      </section>
+
+      <section class="panel" aria-label="Deployment configuration">
+        <h2>Deployment Configuration</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>Boundary</th>
+              <th>Configuration</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Relay infrastructure</td>
+              <td>
+                <code>RELAY_ZONE_NAME</code>, optional <code>RELAY_DOMAIN</code>,
+                <code>CLERK_PUBLISHABLE_KEY</code>, <code>CLERK_SECRET_KEY</code>,
+                <code>CLERK_JWT_AUDIENCE</code>, and APNs credentials.
+              </td>
+            </tr>
+            <tr>
+              <td>Source-built desktop/server cloud features</td>
+              <td>
+                Optional <code>T3CODE_RELAY_URL</code>, <code>T3CODE_CLERK_PUBLISHABLE_KEY</code>,
+                and <code>T3CODE_CLERK_CLI_OAUTH_CLIENT_ID</code>. Release builds inject public
+                values at build time.
+              </td>
+            </tr>
+            <tr>
+              <td>Web and mobile cloud clients</td>
+              <td>
+                Public Clerk publishable key, Clerk JWT template name, and relay URL. Relay URLs
+                must normalize to an absolute HTTPS origin without credentials, query, fragment, or
+                non-root path.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <section class="panel" aria-label="Implementation checklist">
+        <h2>Implementation Checklist</h2>
+        <ul>
+          <li>
+            Keep the relay cloud-mint private key hosted-only; install only its public key into
+            environments.
+          </li>
+          <li>
+            Keep environment signing private keys local and persist keypair creation atomically.
+          </li>
+          <li>
+            Require a local <code>relay:write</code> session before linking or changing relay
+            config.
+          </li>
+          <li>Validate relay URLs as secure absolute HTTPS origins before sending credentials.</li>
+          <li>Require loopback-only tunnel origins on both sides of the link-proof boundary.</li>
+          <li>
+            Resolve managed endpoint egress from ready allocation rows, not client-supplied URLs.
+          </li>
+          <li>Disable redirects on relay-to-environment requests.</li>
+          <li>Validate environment-signed response proofs before consuming tunneled responses.</li>
+          <li>Keep tunnel and DNS provisioning retry-safe and deprovision them on unlink.</li>
+          <li>
+            Revoke shared environment publication credentials only after the final active link
+            disappears.
+          </li>
+          <li>Redact and cap local agent failure details before publishing them externally.</li>
+        </ul>
+      </section>
+
+      <section class="panel" aria-label="Standards references">
+        <h2>Standards References</h2>
         <ul class="source-list">
           <li>
-            <a href="https://www.rfc-editor.org/rfc/rfc8252">RFC 8252</a>: OAuth 2.0 for native
-            apps. Use browser-based user auth instead of collecting credentials inside the app.
+            <a href="https://www.rfc-editor.org/rfc/rfc8252">RFC 8252</a>: browser-based OAuth for
+            native apps, used by the CLI PKCE authorization flow.
           </li>
           <li>
-            <a href="https://www.rfc-editor.org/rfc/rfc8628">RFC 8628</a>: Device authorization
-            grant. Good fit for headless <code>t3 cloud login</code>.
+            <a href="https://www.rfc-editor.org/rfc/rfc8693">RFC 8693</a>: OAuth token exchange,
+            used for Clerk-token to relay-DPoP-token exchange.
           </li>
           <li>
-            <a href="https://www.rfc-editor.org/rfc/rfc9449">RFC 9449</a>: DPoP /
-            proof-of-possession. Useful model for making stolen bearer tokens insufficient without
-            the environment key.
+            <a href="https://www.rfc-editor.org/rfc/rfc9449">RFC 9449</a>: DPoP proof of possession,
+            used for relay and environment access tokens.
           </li>
         </ul>
       </section>

--- a/packages/contracts/src/environmentHttp.ts
+++ b/packages/contracts/src/environmentHttp.ts
@@ -457,13 +457,6 @@ export class EnvironmentCloudHttpApi extends HttpApiGroup.make("cloud")
     }).middleware(EnvironmentAuthenticatedAuth),
   )
   .add(
-    HttpApiEndpoint.post("reconcile", "/api/cloud/reconcile", {
-      headers: OptionalBearerHeaders,
-      success: EnvironmentCloudRelayConfigResult,
-      error: [...EnvironmentHttpCloudErrors, EnvironmentCloudEndpointUnavailableError],
-    }).middleware(EnvironmentAuthenticatedAuth),
-  )
-  .add(
     HttpApiEndpoint.get("linkState", "/api/cloud/link-state", {
       headers: OptionalBearerHeaders,
       success: EnvironmentCloudLinkStateResult,

--- a/packages/contracts/src/environmentHttp.ts
+++ b/packages/contracts/src/environmentHttp.ts
@@ -457,6 +457,13 @@ export class EnvironmentCloudHttpApi extends HttpApiGroup.make("cloud")
     }).middleware(EnvironmentAuthenticatedAuth),
   )
   .add(
+    HttpApiEndpoint.post("reconcile", "/api/cloud/reconcile", {
+      headers: OptionalBearerHeaders,
+      success: EnvironmentCloudRelayConfigResult,
+      error: [...EnvironmentHttpCloudErrors, EnvironmentCloudEndpointUnavailableError],
+    }).middleware(EnvironmentAuthenticatedAuth),
+  )
+  .add(
     HttpApiEndpoint.get("linkState", "/api/cloud/link-state", {
       headers: OptionalBearerHeaders,
       success: EnvironmentCloudLinkStateResult,

--- a/packages/shared/src/relayAuth.test.ts
+++ b/packages/shared/src/relayAuth.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clerkFrontendApiHostnameFromPublishableKey,
+  isAllowedClerkFrontendApiHostname,
+} from "./relayAuth.ts";
+
+const clerkPublishableKey = (hostname: string): string => `pk_test_${btoa(`${hostname}$`)}`;
+
+describe("Clerk relay auth", () => {
+  it("derives a custom Frontend API hostname from a Clerk publishable key", () => {
+    expect(clerkFrontendApiHostnameFromPublishableKey(clerkPublishableKey("clerk.t3.codes"))).toBe(
+      "clerk.t3.codes",
+    );
+  });
+
+  it("allows standard Clerk hosts and an exact configured custom hostname", () => {
+    expect(isAllowedClerkFrontendApiHostname("example.clerk.accounts.dev", null)).toBe(true);
+    expect(isAllowedClerkFrontendApiHostname("example.clerk.accounts.com", null)).toBe(true);
+    expect(isAllowedClerkFrontendApiHostname("clerk.t3.codes", "clerk.t3.codes")).toBe(true);
+    expect(isAllowedClerkFrontendApiHostname("attacker.example", "clerk.t3.codes")).toBe(false);
+    expect(isAllowedClerkFrontendApiHostname("nested.clerk.t3.codes", "clerk.t3.codes")).toBe(
+      false,
+    );
+  });
+});

--- a/packages/shared/src/relayAuth.ts
+++ b/packages/shared/src/relayAuth.ts
@@ -1,3 +1,12 @@
+export function clerkFrontendApiUrlFromPublishableKey(publishableKey: string): string {
+  const encodedFrontendApi = publishableKey.split("_").slice(2).join("_");
+  const frontendApi = globalThis.atob(encodedFrontendApi).replace(/\$$/u, "");
+  if (frontendApi.length === 0 || frontendApi.includes("/")) {
+    throw new Error("Invalid Clerk publishable key.");
+  }
+  return `https://${frontendApi}`;
+}
+
 export function relayClerkTokenOptions(template: string) {
   return {
     template,

--- a/packages/shared/src/relayAuth.ts
+++ b/packages/shared/src/relayAuth.ts
@@ -7,6 +7,21 @@ export function clerkFrontendApiUrlFromPublishableKey(publishableKey: string): s
   return `https://${frontendApi}`;
 }
 
+export function clerkFrontendApiHostnameFromPublishableKey(publishableKey: string): string {
+  return new URL(clerkFrontendApiUrlFromPublishableKey(publishableKey)).hostname;
+}
+
+export function isAllowedClerkFrontendApiHostname(
+  hostname: string,
+  configuredHostname: string | null,
+): boolean {
+  return (
+    hostname.endsWith(".clerk.accounts.dev") ||
+    hostname.endsWith(".clerk.accounts.com") ||
+    hostname === configuredHostname
+  );
+}
+
 export function relayClerkTokenOptions(template: string) {
   return {
     template,

--- a/scripts/lib/public-config.test.ts
+++ b/scripts/lib/public-config.test.ts
@@ -19,6 +19,7 @@ describe("loadRepoEnv", () => {
     const env = loadRepoEnv({ baseEnv: {}, repoRoot: makeTemporaryDirectory() });
 
     expect(env.T3CODE_CLERK_PUBLISHABLE_KEY).toBeUndefined();
+    expect(env.T3CODE_CLERK_CLI_OAUTH_CLIENT_ID).toBeUndefined();
     expect(env.VITE_CLERK_PUBLISHABLE_KEY).toBeUndefined();
     expect(env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY).toBeUndefined();
     expect(env.T3CODE_CLERK_JWT_TEMPLATE).toBeUndefined();
@@ -32,11 +33,11 @@ describe("loadRepoEnv", () => {
     const repoRoot = makeTemporaryDirectory();
     writeFileSync(
       join(repoRoot, ".env"),
-      "T3CODE_CLERK_PUBLISHABLE_KEY=pk_root\nT3CODE_CLERK_JWT_TEMPLATE=template_root\nT3CODE_RELAY_URL=https://root.example.test\n",
+      "T3CODE_CLERK_PUBLISHABLE_KEY=pk_root\nT3CODE_CLERK_JWT_TEMPLATE=template_root\nT3CODE_CLERK_CLI_OAUTH_CLIENT_ID=oauth_root\nT3CODE_RELAY_URL=https://root.example.test\n",
     );
     writeFileSync(
       join(repoRoot, ".env.local"),
-      "T3CODE_CLERK_PUBLISHABLE_KEY=pk_local\nT3CODE_CLERK_JWT_TEMPLATE=template_local\nT3CODE_RELAY_URL=https://local.example.test\n",
+      "T3CODE_CLERK_PUBLISHABLE_KEY=pk_local\nT3CODE_CLERK_JWT_TEMPLATE=template_local\nT3CODE_CLERK_CLI_OAUTH_CLIENT_ID=oauth_local\nT3CODE_RELAY_URL=https://local.example.test\n",
     );
 
     expect(loadRepoEnv({ baseEnv: {}, repoRoot }).T3CODE_RELAY_URL).toBe(
@@ -47,12 +48,14 @@ describe("loadRepoEnv", () => {
         baseEnv: {
           T3CODE_CLERK_PUBLISHABLE_KEY: "pk_ci",
           T3CODE_CLERK_JWT_TEMPLATE: "template_ci",
+          T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: "oauth_ci",
           T3CODE_RELAY_URL: "https://ci.example.test",
         },
         repoRoot,
       }),
     ).toMatchObject({
       T3CODE_CLERK_PUBLISHABLE_KEY: "pk_ci",
+      T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: "oauth_ci",
       VITE_CLERK_PUBLISHABLE_KEY: "pk_ci",
       EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY: "pk_ci",
       T3CODE_CLERK_JWT_TEMPLATE: "template_ci",
@@ -73,6 +76,7 @@ describe("loadRepoEnv", () => {
     ).toEqual({
       clerkPublishableKey: "pk_legacy",
       clerkJwtTemplate: "template_legacy",
+      clerkCliOAuthClientId: undefined,
       relayUrl: "https://legacy.example.test",
     });
   });

--- a/scripts/lib/public-config.test.ts
+++ b/scripts/lib/public-config.test.ts
@@ -71,12 +71,13 @@ describe("loadRepoEnv", () => {
       resolvePublicConfig({
         VITE_CLERK_PUBLISHABLE_KEY: "pk_legacy",
         VITE_CLERK_JWT_TEMPLATE: "template_legacy",
+        T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: "oauth_canonical",
         VITE_T3CODE_RELAY_URL: "https://legacy.example.test",
       }),
     ).toEqual({
       clerkPublishableKey: "pk_legacy",
       clerkJwtTemplate: "template_legacy",
-      clerkCliOAuthClientId: undefined,
+      clerkCliOAuthClientId: "oauth_canonical",
       relayUrl: "https://legacy.example.test",
     });
   });

--- a/scripts/lib/public-config.ts
+++ b/scripts/lib/public-config.ts
@@ -7,6 +7,7 @@ import * as NodeUtil from "node:util";
 export interface T3CodePublicConfig {
   readonly clerkPublishableKey: string | undefined;
   readonly clerkJwtTemplate: string | undefined;
+  readonly clerkCliOAuthClientId: string | undefined;
   readonly relayUrl: string | undefined;
 }
 
@@ -45,6 +46,11 @@ export function loadRepoEnv({
           EXPO_PUBLIC_CLERK_JWT_TEMPLATE: config.clerkJwtTemplate,
         }
       : {}),
+    ...(config.clerkCliOAuthClientId
+      ? {
+          T3CODE_CLERK_CLI_OAUTH_CLIENT_ID: config.clerkCliOAuthClientId,
+        }
+      : {}),
     ...(config.relayUrl
       ? {
           T3CODE_RELAY_URL: config.relayUrl,
@@ -68,6 +74,7 @@ export function resolvePublicConfig(...sources: readonly Environment[]): T3CodeP
       "VITE_CLERK_JWT_TEMPLATE",
       "EXPO_PUBLIC_CLERK_JWT_TEMPLATE",
     ),
+    clerkCliOAuthClientId: firstNonEmpty(sources, "T3CODE_CLERK_CLI_OAUTH_CLIENT_ID"),
     relayUrl: firstNonEmpty(sources, "T3CODE_RELAY_URL", "VITE_T3CODE_RELAY_URL"),
   };
 }


### PR DESCRIPTION
## Summary

- add `t3 cloud link`, `t3 cloud status`, and `t3 cloud unlink` for headless T3 Cloud management
- persist desired cloud exposure independently of a running server and reconcile the managed tunnel on the next server startup
- authorize the CLI through a Clerk public OAuth PKCE client with refresh-token persistence and relay OAuth bearer verification fallback
- document relay OAuth application setup and the current SSH loopback callback forwarding requirement

## Behavior

`t3 cloud link` works when no T3 server is running. It installs the managed `cloudflared` binary, completes Clerk OAuth authorization, stores desired exposure, and tells the user that the next `t3 serve` or `t3 start` will expose the tunnel. When a server is already reachable, it reconciles immediately.

`t3 cloud unlink` disables desired exposure first, asks a reachable server to stop its managed connector, and best-effort revokes the relay-side environment record.

## Testing

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run test`

## Stack

Stacked on #2837.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, persisted credentials, relay linking, and automatic outbound reconciliation on server startup; misconfiguration could affect exposure or startup behavior.
> 
> **Overview**
> Adds a **headless `t3 cloud` CLI** (`login`, `link`, `status`, `unlink`, `logout`) gated on build-time public config (`T3CODE_CLERK_CLI_OAUTH_CLIENT_ID`, relay URL, Clerk publishable key). The CLI uses **Clerk PKCE OAuth** with tokens in the secret store, persists **desired exposure** separately from a running server, and can install **managed `cloudflared`** before linking.
> 
> On **server startup**, if exposure was requested, **`reconcileDesiredCloudLink`** completes the relay environment link using the stored CLI credential (no new HTTP reconcile route). Release builds and **`.env.example`** now require the CLI OAuth client ID; **release workflow** passes it into desktop/CLI builds.
> 
> **Desktop/web** Clerk API calls allow only hosts derived from the publishable key (replacing hardcoded suffix checks). The desktop app **opens off-origin navigations** (e.g. OAuth) in the system browser and adapts Clerk **connected-account** flows to the native `t3code://` callback bridge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8989d679dccc48f12c5fd024a74bf0bd09ab926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add headless CLI OAuth control plane for T3 Cloud link and relay management
> - Adds a `t3 cloud` CLI subcommand that is conditionally available based on build-time public config (`T3CODE_CLERK_CLI_OAUTH_CLIENT_ID`, relay URL, Clerk publishable key); when config is absent the subcommand exits with a help error
> - Introduces `CloudCliTokenManager` to store, retrieve, and exchange CLI OAuth (PKCE) credentials in `ServerSecretStore`, and `CliState` to track and clear the desired-cloud-link flag and all persisted relay secrets
> - Adds `reconcileDesiredCloudLink` in [cloud/http.ts](https://github.com/pingdotgg/t3code/pull/2905/files#diff-b79881a5b259327afb0e64d68ef93d9a259516a2f6b2d58322bf4ee2d8402c61): on server startup, if a desired-link flag is set, the server automatically completes the relay link using the stored CLI credential without requiring an HTTP endpoint
> - Adds a `makeDesktopClerkExternalAccountAdapter` in [desktopClerkExternalAccounts.ts](https://github.com/pingdotgg/t3code/pull/2905/files#diff-14baf4d07ff0fe93cd87e7b1d24a4bb4d93ffd1ec12b983a55b0e0257fc6cae3) that intercepts `createExternalAccount` and `reauthorize` calls to use a native bridge callback URL and reloads the user on completion
> - Hardens Clerk Frontend API hostname validation across desktop and web by deriving allowed hosts from the publishable key via new `relayAuth` utilities (`clerkFrontendApiHostnameFromPublishableKey`, `isAllowedClerkFrontendApiHostname`) instead of hardcoded suffix checks
> - Risk: server startup now attempts an outbound relay HTTP request when the desired-link flag is set; failures are logged as warnings but may slow startup or produce noise in misconfigured environments
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8989d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->