### PR TITLE
fix(opencode): limit SSE reconnection attempts to prevent infinite hang

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1051,6 +1051,7 @@ export function makeOpenCodeAdapter(
               const client = openCodeRuntime.createOpenCodeSdkClient({
                 baseUrl: server.url,
                 directory,
+                sseMaxRetryAttempts: 1,
                 ...(server.external && serverPassword ? { serverPassword } : {}),
               });
               const openCodeSession = yield* runOpenCodeSdk("session.create", () =>

--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -141,6 +141,7 @@ export interface OpenCodeRuntimeShape {
     readonly baseUrl: string;
     readonly directory: string;
     readonly serverPassword?: string;
+    readonly sseMaxRetryAttempts?: number;
   }) => OpencodeClient;
   readonly loadOpenCodeInventory: (
     client: OpencodeClient,
@@ -504,6 +505,9 @@ const makeOpenCodeRuntime = Effect.gen(function* () {
               Authorization: `Basic ${Buffer.from(`opencode:${input.serverPassword}`, "utf8").toString("base64")}`,
             },
           }
+        : {}),
+      ...(input.sseMaxRetryAttempts !== undefined
+        ? { sseMaxRetryAttempts: input.sseMaxRetryAttempts }
         : {}),
       throwOnError: true,
     });


### PR DESCRIPTION
Fixes infinite hang when sending a message via the OpenCode provider in the web UI.

**Root cause:** The SDK SSE client defaults to infinite reconnection attempts when `sseMaxRetryAttempts` is `undefined` (at `serverSentEvents.gen.js:122`). During reconnection, critical events like `session.status -> idle` are lost, so the code path that calls `emitUnexpectedExit` is never reached and the client hangs forever.

**Fix:** Pass `sseMaxRetryAttempts: 1` through the SDK client creation chain so a single SSE failure terminates and lets the existing error-projection code handle it.

Closes #2691, #2644, #2886, #2579 (same symptom).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Limit SSE reconnection to 1 retry attempt in `OpenCodeAdapter`
> Adds a `sseMaxRetryAttempts: 1` option when creating the OpenCode SDK client to prevent infinite hangs on SSE connection failures. The `createOpenCodeSdkClient` function in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/2908/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) now accepts an optional `sseMaxRetryAttempts` parameter and forwards it to the underlying client. Behavioral Change: SSE connections that previously retried indefinitely will now stop after 1 attempt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a0dd2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->