### PR TITLE
feat: integrate Grok Build CLI ACP provider with custom branding icons

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -160,8 +160,6 @@ const buildCmd = Command.make(
           cwd: serverDir,
           stdout: config.verbose ? "inherit" : "ignore",
           stderr: "inherit",
-          // Windows needs shell mode to resolve `.cmd` shims on PATH.
-          shell: process.platform === "win32",
         }),
       );
 

--- a/apps/server/src/provider/Drivers/GrokBuildDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokBuildDriver.ts
@@ -1,0 +1,154 @@
+import {
+  GrokBuildSettings,
+  ProviderDriverKind,
+  type ServerProvider,
+  TextGenerationError,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Crypto from "effect/Crypto";
+import * as Stream from "effect/Stream";
+import * as Duration from "effect/Duration";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { ProviderDriverError } from "../Errors.ts";
+import { makeGrokBuildAdapter } from "../Layers/GrokBuildAdapter.ts";
+import {
+  buildInitialGrokBuildProviderSnapshot,
+  checkGrokBuildProviderStatus,
+} from "../Layers/GrokBuildProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import { ServerConfig } from "../../config.ts";
+import { type TextGenerationShape } from "../../textGeneration/TextGeneration.ts";
+
+const DRIVER_KIND = ProviderDriverKind.make("grok-build");
+const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
+
+export type GrokBuildDriverEnv =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig;
+
+export const GrokBuildDriver: ProviderDriver<GrokBuildSettings, GrokBuildDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Grok Build",
+    supportsMultipleInstances: true,
+  },
+  configSchema: GrokBuildSettings,
+  defaultConfig: () => ({
+    enabled: false,
+    command: "grok",
+    args: ["agent", "stdio"],
+    envJson: "{}",
+    customModels: [],
+  }),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+
+      const effectiveConfig = { ...config, enabled } as GrokBuildSettings;
+
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+
+      const stampIdentity = (snapshot: any): ServerProvider => ({
+        ...snapshot,
+        instanceId,
+        driver: DRIVER_KIND,
+        ...(displayName ? { displayName } : {}),
+        ...(accentColor ? { accentColor } : {}),
+        continuation: { groupKey: continuationIdentity.continuationKey },
+      });
+
+      const adapter = yield* makeGrokBuildAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+
+      const textGeneration: TextGenerationShape = {
+        generateCommitMessage: (_input) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: "generateCommitMessage",
+              detail: "Text generation is not supported by Grok Build.",
+            }),
+          ),
+        generatePrContent: (_input) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: "generatePrContent",
+              detail: "Text generation is not supported by Grok Build.",
+            }),
+          ),
+        generateBranchName: (_input) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: "generateBranchName",
+              detail: "Text generation is not supported by Grok Build.",
+            }),
+          ),
+        generateThreadTitle: (_input) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: "generateThreadTitle",
+              detail: "Text generation is not supported by Grok Build.",
+            }),
+          ),
+      };
+
+      const checkProvider = checkGrokBuildProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      );
+
+      const snapshot = yield* makeManagedServerProvider<GrokBuildSettings>({
+        getSettings: Effect.succeed(effectiveConfig),
+        streamSettings: Stream.never,
+        haveSettingsChanged: () => false,
+        initialSnapshot: (settings) =>
+          buildInitialGrokBuildProviderSnapshot(settings).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+        refreshInterval: SNAPSHOT_REFRESH_INTERVAL,
+        maintenanceCapabilities: { provider: DRIVER_KIND, packageName: null, update: null },
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Grok Build snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/GrokBuildAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokBuildAdapter.ts
@@ -1,0 +1,757 @@
+import {
+  ApprovalRequestId,
+  type GrokBuildSettings,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as Layer from "effect/Layer";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+import { type ProviderAdapterShape } from "../Services/ProviderAdapter.ts";
+
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import type { ProviderAdapterError } from "../Errors.ts";
+import { acpPermissionOutcome, mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import { AcpSessionRuntime, type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
+import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const PROVIDER = ProviderDriverKind.make("grok-build");
+
+export interface GrokBuildAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly instanceId?: ProviderInstanceId;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  readonly kind: string | "unknown";
+}
+
+interface GrokBuildSessionContext {
+  readonly threadId: ThreadId;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntimeShape;
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  activeTurnId: TurnId | undefined;
+  stopped: boolean;
+}
+
+function settlePendingApprovalsAsCancelled(
+  pendingApprovals: ReadonlyMap<ApprovalRequestId, PendingApproval>,
+): Effect.Effect<void> {
+  const pendingEntries = Array.from(pendingApprovals.values());
+  return Effect.forEach(
+    pendingEntries,
+    (pending) => Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore),
+    { discard: true },
+  );
+}
+
+const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.UnknownFromJsonString);
+function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
+  const result = encodeUnknownJsonStringExit(input);
+  return Exit.isSuccess(result) ? result.value : undefined;
+}
+
+function parseEnvJson(json: string): Record<string, string> {
+  if (!json || !json.trim()) return {};
+  const parsed = JSON.parse(json);
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error('Environment overrides must be a JSON object, e.g. {"XAI_LOG_LEVEL":"debug"}');
+  }
+  const result: Record<string, string> = {};
+  for (const [k, v] of Object.entries(parsed)) {
+    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+      result[k] = String(v);
+    } else {
+      throw new Error(
+        `Environment override for key '${k}' has invalid type. Expected string, number, or boolean.`,
+      );
+    }
+  }
+  return result;
+}
+
+export function resolveGrokBuildAcpBaseModelId(model: string | undefined): string {
+  if (!model) {
+    return "grok-build";
+  }
+  if (model === "composer-2.5" || model === "grok-composer-2.5-fast") {
+    return "grok-composer-2.5-fast";
+  }
+  return model;
+}
+
+export function applyGrokBuildModelSelection<E>(input: {
+  readonly runtime: AcpSessionRuntimeShape;
+  readonly model: string | undefined;
+  readonly mapError: (cause: import("effect-acp/errors").AcpError) => E;
+}): Effect.Effect<void, E> {
+  return Effect.gen(function* () {
+    if (!input.model) return;
+    const resolvedModel = resolveGrokBuildAcpBaseModelId(input.model);
+    yield* input.runtime.setModel(resolvedModel).pipe(Effect.mapError(input.mapError));
+  });
+}
+
+export function makeGrokBuildAdapter(
+  settings: GrokBuildSettings,
+  options?: GrokBuildAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("grok-build");
+    const path = yield* Path.Path;
+    const fileSystem = yield* FileSystem.FileSystem;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const crypto = yield* Crypto.Crypto;
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, {
+            stream: "native",
+          })
+        : undefined);
+    const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
+
+    const sessions = new Map<ThreadId, GrokBuildSessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate Grok runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logError("Failed to emit Grok Build session shutdown event.", { cause }),
+        ),
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => nativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing = current.get(threadId);
+        if (existing) return Effect.succeed([existing, current] as const);
+        return Semaphore.make(1).pipe(
+          Effect.map((semaphore) => {
+            const next = new Map(current);
+            next.set(threadId, semaphore);
+            return [semaphore, next] as const;
+          }),
+        );
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const logNative = (
+      threadId: ThreadId,
+      method: string,
+      payload: unknown,
+      _source: "acp.jsonrpc",
+    ) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<GrokBuildSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: GrokBuildSessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const adapter: ProviderAdapterShape<ProviderAdapterError> = {
+      provider: PROVIDER,
+      capabilities: {
+        sessionModelSwitch: "in-session" as const,
+      },
+      startSession: (input) =>
+        withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            if (input.provider !== undefined && input.provider !== PROVIDER) {
+              return yield* new ProviderAdapterValidationError({
+                provider: PROVIDER,
+                operation: "startSession",
+                issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+              });
+            }
+            if (!input.cwd?.trim()) {
+              return yield* new ProviderAdapterValidationError({
+                provider: PROVIDER,
+                operation: "startSession",
+                issue: "cwd is required and must be non-empty.",
+              });
+            }
+
+            const cwd = path.resolve(input.cwd.trim());
+            const cwdExists = yield* fileSystem.exists(cwd).pipe(
+              Effect.mapError(
+                (error) =>
+                  new ProviderAdapterValidationError({
+                    provider: PROVIDER,
+                    operation: "startSession",
+                    issue: `Failed to access project root: ${error.message}`,
+                  }),
+              ),
+            );
+            if (!cwdExists) {
+              return yield* new ProviderAdapterValidationError({
+                provider: PROVIDER,
+                operation: "startSession",
+                issue: `Project root directory does not exist: ${cwd}`,
+              });
+            }
+
+            const envOverrides = yield* Effect.try({
+              try: () => parseEnvJson(settings.envJson),
+              catch: (err: any) =>
+                new ProviderAdapterValidationError({
+                  provider: PROVIDER,
+                  operation: "startSession",
+                  issue: err.message || "Invalid environment overrides.",
+                }),
+            });
+
+            const existing = sessions.get(input.threadId);
+            if (existing && !existing.stopped) {
+              yield* stopSessionInternal(existing);
+            }
+
+            const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+            const sessionScope = yield* Scope.make("sequential");
+            let sessionScopeTransferred = false;
+            yield* Effect.addFinalizer(() =>
+              sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+            );
+
+            const acpNativeLoggers = makeAcpNativeLoggers({
+              nativeEventLogger,
+              provider: PROVIDER,
+              threadId: input.threadId,
+            });
+
+            const command = settings.command || "grok";
+            const args = settings.args || ["agent", "stdio"];
+
+            const processEnv = { ...process.env, ...options?.environment, ...envOverrides };
+
+            const acp = yield* Effect.gen(function* () {
+              const acpContext = yield* Layer.build(
+                AcpSessionRuntime.layer({
+                  spawn: {
+                    command,
+                    args,
+                    cwd,
+                    env: processEnv,
+                  },
+                  cwd,
+                  clientInfo: { name: "t3-code", version: "0.0.0" },
+                  authMethodId: "cached_token",
+                  ...acpNativeLoggers,
+                }).pipe(
+                  Layer.provide(
+                    Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, childProcessSpawner),
+                  ),
+                ),
+              );
+              return yield* Effect.service(AcpSessionRuntime).pipe(Effect.provide(acpContext));
+            }).pipe(
+              Effect.provideService(Scope.Scope, sessionScope),
+              Effect.mapError(
+                (error) =>
+                  new ProviderAdapterProcessError({
+                    provider: PROVIDER,
+                    threadId: input.threadId,
+                    detail: error.message ?? String(error),
+                    cause: error,
+                  }),
+              ),
+            );
+
+            let ctx!: GrokBuildSessionContext;
+
+            const started = yield* Effect.gen(function* () {
+              yield* acp.handleRequestPermission((params) =>
+                Effect.gen(function* () {
+                  yield* logNative(
+                    input.threadId,
+                    "session/request_permission",
+                    params,
+                    "acp.jsonrpc",
+                  );
+                  const permissionRequest = parsePermissionRequest(params);
+                  const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                  const runtimeRequestId = RuntimeRequestId.make(requestId);
+                  const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                  pendingApprovals.set(requestId, {
+                    decision,
+                    kind: permissionRequest.kind,
+                  });
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestOpenedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      detail:
+                        permissionRequest.detail ??
+                        encodeJsonStringForDiagnostics(params)?.slice(0, 2000) ??
+                        "[unserializable params]",
+                      args: params,
+                      source: "acp.jsonrpc",
+                      method: "session/request_permission",
+                      rawPayload: params,
+                    }),
+                  );
+                  const resolved = yield* Deferred.await(decision);
+                  pendingApprovals.delete(requestId);
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestResolvedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      decision: resolved,
+                    }),
+                  );
+                  return {
+                    outcome:
+                      resolved === "cancel"
+                        ? ({ outcome: "cancelled" } as const)
+                        : {
+                            outcome: "selected" as const,
+                            optionId: acpPermissionOutcome(resolved),
+                          },
+                  };
+                }).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new EffectAcpErrors.AcpTransportError({
+                        detail: "Failed to process Grok ACP permission event.",
+                        cause,
+                      }),
+                  ),
+                ),
+              );
+              return yield* acp.start();
+            }).pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+              ),
+            );
+
+            if (input.modelSelection) {
+              yield* applyGrokBuildModelSelection({
+                runtime: acp,
+                model: input.modelSelection.model,
+                mapError: (cause) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+              });
+            }
+
+            const now = yield* nowIso;
+            const session: ProviderSession = {
+              provider: PROVIDER,
+              providerInstanceId: boundInstanceId,
+              status: "ready",
+              runtimeMode: input.runtimeMode,
+              cwd,
+              model: input.modelSelection?.model ?? "grok-build",
+              threadId: input.threadId,
+              createdAt: now,
+              updatedAt: now,
+            };
+
+            ctx = {
+              threadId: input.threadId,
+              session,
+              scope: sessionScope,
+              acp,
+              notificationFiber: undefined,
+              pendingApprovals,
+              activeTurnId: undefined,
+              stopped: false,
+            };
+
+            yield* offerRuntimeEvent({
+              type: "session.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { resume: started.initializeResult },
+            });
+            yield* offerRuntimeEvent({
+              type: "session.state.changed",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { state: "ready", reason: "Grok Build ACP session ready" },
+            });
+            yield* offerRuntimeEvent({
+              type: "thread.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              payload: { providerThreadId: started.sessionId },
+            });
+
+            const nf = yield* Stream.runDrain(
+              Stream.mapEffect(acp.getEvents(), (event) =>
+                Effect.gen(function* () {
+                  switch (event._tag) {
+                    case "ModeChanged":
+                      return;
+                    case "AssistantItemStarted":
+                      yield* offerRuntimeEvent(
+                        makeAcpAssistantItemEvent({
+                          stamp: yield* makeEventStamp(),
+                          provider: PROVIDER,
+                          threadId: ctx.threadId,
+                          turnId: ctx.activeTurnId,
+                          itemId: event.itemId,
+                          lifecycle: "item.started",
+                        }),
+                      );
+                      return;
+                    case "AssistantItemCompleted":
+                      yield* offerRuntimeEvent(
+                        makeAcpAssistantItemEvent({
+                          stamp: yield* makeEventStamp(),
+                          provider: PROVIDER,
+                          threadId: ctx.threadId,
+                          turnId: ctx.activeTurnId,
+                          itemId: event.itemId,
+                          lifecycle: "item.completed",
+                        }),
+                      );
+                      return;
+                    case "ContentDelta":
+                      yield* offerRuntimeEvent(
+                        makeAcpContentDeltaEvent({
+                          stamp: yield* makeEventStamp(),
+                          provider: PROVIDER,
+                          threadId: ctx.threadId,
+                          turnId: ctx.activeTurnId,
+                          ...(event.itemId ? { itemId: event.itemId } : {}),
+                          text: event.text,
+                          rawPayload: event.rawPayload,
+                        }),
+                      );
+                      return;
+                    case "ToolCallUpdated":
+                      yield* logNative(
+                        ctx.threadId,
+                        "session/update",
+                        event.rawPayload,
+                        "acp.jsonrpc",
+                      );
+                      yield* offerRuntimeEvent(
+                        makeAcpToolCallEvent({
+                          stamp: yield* makeEventStamp(),
+                          provider: PROVIDER,
+                          threadId: ctx.threadId,
+                          turnId: ctx.activeTurnId,
+                          toolCall: event.toolCall,
+                          rawPayload: event.rawPayload,
+                        }),
+                      );
+                      return;
+                    default:
+                      return;
+                  }
+                }),
+              ),
+            ).pipe(
+              Effect.catchCause((_cause) => {
+                if (ctx.stopped) return Effect.void;
+                return makeEventStamp().pipe(
+                  Effect.flatMap((stamp) =>
+                    offerRuntimeEvent({
+                      type: "runtime.error",
+                      ...stamp,
+                      provider: PROVIDER,
+                      threadId: ctx.threadId,
+                      payload: {
+                        message: "ACP session event stream closed unexpectedly.",
+                        class: "transport_error",
+                        detail: { errorCode: "StreamClosed" },
+                      },
+                    }),
+                  ),
+                  Effect.asVoid,
+                );
+              }),
+              Effect.forkIn(sessionScope),
+            );
+            ctx.notificationFiber = nf as Fiber.Fiber<void, never>;
+            sessions.set(input.threadId, ctx);
+            sessionScopeTransferred = true;
+
+            return session;
+          }).pipe(Effect.scoped),
+        ),
+
+      sendTurn: (input) =>
+        withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(input.threadId);
+            const turnId = TurnId.make(yield* randomUUIDv4);
+            const turnModelSelection =
+              input.modelSelection?.instanceId === boundInstanceId
+                ? input.modelSelection
+                : undefined;
+            const model = turnModelSelection?.model ?? ctx.session.model;
+            const resolvedModel = resolveGrokBuildAcpBaseModelId(model);
+
+            if (model !== undefined) {
+              yield* applyGrokBuildModelSelection({
+                runtime: ctx.acp,
+                model,
+                mapError: (cause) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/set_model", cause),
+              });
+            }
+
+            ctx.activeTurnId = turnId;
+            ctx.session = {
+              ...ctx.session,
+              activeTurnId: turnId,
+              updatedAt: yield* nowIso,
+              model: resolvedModel,
+            };
+
+            yield* offerRuntimeEvent({
+              type: "turn.started",
+              ...(yield* makeEventStamp()),
+              provider: PROVIDER,
+              threadId: input.threadId,
+              turnId,
+              payload: { model: resolvedModel },
+            });
+
+            const promptText = input.input?.trim() ?? "";
+            const payload: Omit<EffectAcpSchema.PromptRequest, "sessionId"> = {
+              prompt: [
+                {
+                  type: "text",
+                  text: promptText,
+                },
+              ],
+            };
+            yield* logNative(input.threadId, "session/prompt", payload, "acp.jsonrpc");
+
+            // Fork the prompt so we don't block `sendTurn`
+            yield* ctx.acp.prompt(payload).pipe(
+              Effect.tap((result) =>
+                logNative(input.threadId, "session/prompt(response)", result, "acp.jsonrpc"),
+              ),
+              Effect.flatMap((result) =>
+                makeEventStamp().pipe(
+                  Effect.flatMap((stamp) =>
+                    offerRuntimeEvent({
+                      type: "turn.completed",
+                      ...stamp,
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId,
+                      payload: {
+                        state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                        stopReason: result.stopReason ?? null,
+                      },
+                    }),
+                  ),
+                ),
+              ),
+              Effect.catchCause((_cause) => {
+                if (ctx.stopped) return Effect.void;
+                return makeEventStamp().pipe(
+                  Effect.flatMap((stamp) =>
+                    offerRuntimeEvent({
+                      type: "runtime.error",
+                      ...stamp,
+                      provider: PROVIDER,
+                      threadId: ctx.threadId,
+                      turnId: ctx.activeTurnId,
+                      payload: {
+                        message: "Failed to send prompt to Grok Build CLI.",
+                        class: "provider_error",
+                        detail: { errorCode: "PromptFailed" },
+                      },
+                    }),
+                  ),
+                  Effect.asVoid,
+                );
+              }),
+              Effect.forkIn(ctx.scope),
+            );
+
+            return {
+              threadId: input.threadId,
+              turnId,
+            };
+          }),
+        ),
+
+      interruptTurn: (threadId) =>
+        withThreadLock(
+          threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(threadId);
+            yield* ctx.acp.cancel.pipe(Effect.ignore);
+          }),
+        ),
+
+      respondToRequest: (threadId, requestId, decision) =>
+        withThreadLock(
+          threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(threadId);
+            const pending = ctx.pendingApprovals.get(requestId);
+            if (!pending) {
+              return yield* new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "respondToRequest",
+                detail: `No pending approval request found for ID '${requestId}'.`,
+              });
+            }
+            yield* Deferred.succeed(pending.decision, decision);
+          }),
+        ),
+
+      stopSession: (threadId) =>
+        withThreadLock(
+          threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(threadId);
+            yield* stopSessionInternal(ctx);
+          }),
+        ),
+
+      hasSession: (threadId) =>
+        Effect.sync(() => {
+          const ctx = sessions.get(threadId);
+          return ctx !== undefined && !ctx.stopped;
+        }),
+
+      streamEvents: Stream.fromPubSub(runtimeEventPubSub),
+
+      respondToUserInput: () =>
+        Effect.die(new Error("respondToUserInput not implemented for Grok Build")),
+      listSessions: () =>
+        Effect.succeed(
+          Array.from(sessions.values())
+            .filter((s) => !s.stopped)
+            .map((s) => s.session),
+        ),
+      readThread: () => Effect.die(new Error("readThread not implemented")),
+      rollbackThread: () => Effect.die(new Error("rollbackThread not implemented")),
+      stopAll: () => Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }),
+    };
+
+    return adapter;
+  });
+}

--- a/apps/server/src/provider/Layers/GrokBuildProvider.ts
+++ b/apps/server/src/provider/Layers/GrokBuildProvider.ts
@@ -1,0 +1,129 @@
+import {
+  type GrokBuildSettings,
+  ProviderDriverKind,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as DateTime from "effect/DateTime";
+import { ChildProcessSpawner, ChildProcess } from "effect/unstable/process";
+import {
+  buildServerProvider,
+  providerModelsFromSettings,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+
+const DRIVER_KIND = ProviderDriverKind.make("grok-build");
+
+const GROK_BUILD_PRESENTATION = {
+  displayName: "Grok Build",
+  showInteractionModeToggle: true,
+} as const;
+
+const BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "grok-build",
+    name: "Grok Build",
+    shortName: "Grok Build",
+    isCustom: false,
+    capabilities: null,
+  },
+  {
+    slug: "composer-2.5",
+    name: "Composer 2.5",
+    shortName: "Composer 2.5",
+    isCustom: false,
+    capabilities: null,
+  },
+];
+
+export const buildInitialGrokBuildProviderSnapshot = (
+  settings: GrokBuildSettings,
+): Effect.Effect<ServerProviderDraft> =>
+  Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    return buildServerProvider({
+      driver: DRIVER_KIND,
+      presentation: GROK_BUILD_PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt,
+      models: providerModelsFromSettings(
+        BUILT_IN_MODELS,
+        DRIVER_KIND,
+        settings.customModels ?? [],
+        { optionDescriptors: [] },
+      ),
+      probe: {
+        installed: false,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking for Grok Build CLI...",
+      },
+    });
+  });
+
+export const checkGrokBuildProviderStatus = (
+  settings: GrokBuildSettings,
+  env: NodeJS.ProcessEnv,
+): Effect.Effect<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const command = settings.command || "grok";
+
+    // Fast check: grok --version
+    const versionCheck = yield* spawner
+      .spawn(
+        ChildProcess.make(command, ["--version"], {
+          env: { ...process.env, ...env },
+          shell: process.platform === "win32",
+        }),
+      )
+      .pipe(
+        Effect.andThen((process) => process.exitCode),
+        Effect.scoped,
+        Effect.exit,
+      );
+
+    if (versionCheck._tag === "Failure") {
+      return buildServerProvider({
+        driver: DRIVER_KIND,
+        presentation: GROK_BUILD_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: providerModelsFromSettings(
+          BUILT_IN_MODELS,
+          DRIVER_KIND,
+          settings.customModels ?? [],
+          { optionDescriptors: [] },
+        ),
+        probe: {
+          installed: false,
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message:
+            "Grok Build CLI not found.\nWindows: irm https://x.ai/cli/install.ps1 | iex\nmacOS/Linux: curl -fsSL https://x.ai/cli/install.sh | bash",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      driver: DRIVER_KIND,
+      presentation: GROK_BUILD_PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt,
+      models: providerModelsFromSettings(
+        BUILT_IN_MODELS,
+        DRIVER_KIND,
+        settings.customModels ?? [],
+        { optionDescriptors: [] },
+      ),
+      probe: {
+        installed: true,
+        version: "available",
+        status: "ready",
+        auth: { status: "authenticated" },
+      },
+    });
+  });

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -543,8 +543,23 @@ const makeAcpSessionRuntime = (
       setConfigOption,
       setModel: (model) =>
         getStartedState.pipe(
-          Effect.flatMap((started) => setConfigOption(started.modelConfigId ?? "model", model)),
-          Effect.asVoid,
+          Effect.flatMap((started) => {
+            if (started.modelConfigId) {
+              return setConfigOption(started.modelConfigId, model);
+            } else {
+              return runLoggedRequest(
+                "session/set_model",
+                {
+                  sessionId: started.sessionId,
+                  modelId: model,
+                },
+                acp.agent.setSessionModel({
+                  sessionId: started.sessionId,
+                  modelId: model,
+                }),
+              ).pipe(Effect.asVoid);
+            }
+          }),
         ),
       request: (method, payload) =>
         runLoggedRequest(method, payload, acp.raw.request(method, payload)),

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -24,6 +24,7 @@ import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
+import { GrokBuildDriver, type GrokBuildDriverEnv } from "./Drivers/GrokBuildDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
 /**
@@ -35,7 +36,8 @@ export type BuiltInDriversEnv =
   | ClaudeDriverEnv
   | CodexDriverEnv
   | CursorDriverEnv
-  | OpenCodeDriverEnv;
+  | OpenCodeDriverEnv
+  | GrokBuildDriverEnv;
 
 /**
  * Ordered list of built-in drivers. Order matters only for tie-breaking in
@@ -47,4 +49,5 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   ClaudeDriver,
   CursorDriver,
   OpenCodeDriver,
+  GrokBuildDriver,
 ];

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -673,6 +673,24 @@ export const ACPRegistryIcon: Icon = ({ className, ...props }) => (
   </svg>
 );
 
+export const XaiIcon: Icon = ({ className, ...props }) => (
+  <svg {...props} viewBox="0 0 24 24" className={cn("fill-black dark:fill-white", className)}>
+    <path
+      fill="currentColor"
+      d="M3.8 21h3.8l1.9-2.71l-1.9-2.71zm0-12.2L12.34 21h3.8L7.6 8.8zM17.4 21h2.49l.31-16.64l-3.11 4.44zm-6.96-9.49l1.9 2.71L20.2 3h-3.8z"
+    />
+  </svg>
+);
+
+export const GrokIcon: Icon = ({ className, ...props }) => (
+  <svg {...props} viewBox="0 0 256 256" className={cn("fill-black dark:fill-white", className)}>
+    <path
+      fill="currentColor"
+      d="M63.83 56.843c27.469-27.48 67.635-34.865 101.712-21.87l2.314.917c7.645 2.844 14.309 6.89 19.507 10.651l-28.857 13.342c-26.869-11.286-57.649-3.609-76.435 15.2c-25.405 25.414-30.539 69.484-.764 97.96L0 245.764c4.296-5.923 9.457-11.573 14.75-17.178l5.815-6.13l2.608-2.774c15.53-16.655 28.81-33.77 20.496-56.709l-.766-1.98c-14.592-35.497-6.094-77.096 20.928-104.15m156.956-21.587L256 0l-10.128 14.069c-21.094 29.716-30.456 48.424-21.11 88.659l-.065-.065c7.23 30.728-.503 64.803-25.472 89.802c-31.478 31.538-81.852 38.558-123.336 10.17l28.923-13.407c26.476 10.41 55.442 5.839 76.26-15.003c20.818-20.844 25.493-51.2 15.03-76.462c-1.989-4.79-7.952-5.992-12.125-2.909L98.87 157.755L220.786 35.147z"
+    />
+  </svg>
+);
+
 export const PiAgentIcon: Icon = ({ className, ...props }) => (
   <svg {...props} viewBox="0 0 800 800" className={cn("fill-none", className)}>
     <rect width="800" height="800" rx="160" fill="#000" />

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -156,6 +156,13 @@ function createBaseServerConfig(): ServerConfig {
           serverPassword: "",
           customModels: [],
         },
+        "grok-build": {
+          enabled: true,
+          command: "",
+          args: [],
+          envJson: "",
+          customModels: [],
+        },
       },
     },
   };

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -618,16 +618,53 @@ const WorkGroupSection = memo(function WorkGroupSection({
       : groupedEntries;
   const hiddenCount = groupedEntries.length - visibleEntries.length;
   const onlyToolEntries = groupedEntries.every((entry) => entry.tone === "tool");
-  const showHeader = hasOverflow || !onlyToolEntries;
+  const showHeader = true;
   const groupLabel = onlyToolEntries ? "Tool calls" : "Work log";
+
+  const copyText = useMemo(() => {
+    return groupedEntries
+      .map((entry) => {
+        const heading = toolWorkEntryHeading(entry);
+        const rawPreview = workEntryPreview(entry, workspaceRoot);
+        const preview =
+          rawPreview &&
+          normalizeCompactToolLabel(rawPreview).toLowerCase() ===
+            normalizeCompactToolLabel(heading).toLowerCase()
+            ? null
+            : rawPreview;
+        const mainText = preview ? `${heading} - ${preview}` : heading;
+
+        const rawCommand = workEntryRawCommand(entry);
+        const commandPart = rawCommand ? `\n  Command: ${rawCommand}` : "";
+
+        const detailPart =
+          entry.detail && entry.detail !== rawPreview ? `\n  Detail: ${entry.detail}` : "";
+
+        const fileList =
+          entry.changedFiles && entry.changedFiles.length > 0
+            ? `\n  Files:\n${entry.changedFiles.map((f) => `    - ${f}`).join("\n")}`
+            : "";
+        const prefix = entry.tone === "error" ? "❌ " : "";
+        return `- ${prefix}${mainText}${commandPart}${detailPart}${fileList}`;
+      })
+      .join("\n");
+  }, [groupedEntries, workspaceRoot]);
 
   return (
     <div className="rounded-xl border border-border/45 bg-card/25 px-2 py-1.5">
       {showHeader && (
         <div className="mb-1.5 flex items-center justify-between gap-2 px-0.5">
-          <p className="text-[9px] uppercase tracking-[0.16em] text-muted-foreground/55">
-            {groupLabel} ({groupedEntries.length})
-          </p>
+          <div className="flex items-center gap-1.5">
+            <p className="text-[9px] uppercase tracking-[0.16em] text-muted-foreground/55">
+              {groupLabel} ({groupedEntries.length})
+            </p>
+            <MessageCopyButton
+              text={copyText}
+              size="icon-xs"
+              variant="ghost"
+              className="h-4 w-4 text-muted-foreground/45 hover:text-foreground/75"
+            />
+          </div>
           {hasOverflow && (
             <button
               type="button"

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,5 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, Icon, OpenAI, OpenCodeIcon, GrokIcon } from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -7,6 +7,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("claudeAgent")]: ClaudeAI,
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
+  [ProviderDriverKind.make("grok-build")]: GrokIcon,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1052,8 +1052,10 @@ export function ProviderSettingsPanel() {
     const driver = providerSettings.provider;
     const defaultInstanceId = defaultInstanceIdForDriver(driver);
     const explicitInstance = settings.providerInstances?.[defaultInstanceId];
-    const legacyConfig = legacyProviders[providerSettings.provider]!;
-    const defaultLegacyConfig = defaultLegacyProviders[providerSettings.provider]!;
+    const defaultLegacyConfig = defaultLegacyProviders[providerSettings.provider] ?? {
+      enabled: false,
+    };
+    const legacyConfig = legacyProviders[providerSettings.provider] ?? defaultLegacyConfig;
     const effectiveInstance: ProviderInstanceConfig =
       explicitInstance ??
       ({

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -3,10 +3,11 @@ import {
   CodexSettings,
   CursorSettings,
   OpenCodeSettings,
+  GrokBuildSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, type Icon, OpenAI, OpenCodeIcon, GrokIcon } from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -58,6 +59,12 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("grok-build"),
+    label: "Grok Build",
+    icon: GrokIcon,
+    settingsSchema: GrokBuildSettings,
   },
 ];
 

--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,9 @@
   "workspaces": {
     "": {
       "name": "@t3tools/monorepo",
+      "dependencies": {
+        "@t3tools/monorepo": ".",
+      },
       "devDependencies": {
         "@effect/tsgo": "catalog:",
         "@oxlint/plugins": "^1.63.0",
@@ -1138,6 +1141,8 @@
     "@t3tools/marketing": ["@t3tools/marketing@workspace:apps/marketing"],
 
     "@t3tools/mobile": ["@t3tools/mobile@workspace:apps/mobile"],
+
+    "@t3tools/monorepo": ["@t3tools/monorepo@root:", {}],
 
     "@t3tools/oxlint-plugin-t3code": ["@t3tools/oxlint-plugin-t3code@workspace:oxlint-plugin-t3code"],
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "sync:vscode-icons": "node scripts/sync-vscode-icons.mjs",
     "sync:repos": "node scripts/sync-reference-repos.ts"
   },
+  "dependencies": {
+    "@t3tools/monorepo": "."
+  },
   "devDependencies": {
     "@effect/tsgo": "catalog:",
     "@oxlint/plugins": "^1.63.0",

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -131,6 +131,7 @@ const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const GROK_BUILD_DRIVER_KIND = ProviderDriverKind.make("grok-build");
 
 export const DEFAULT_MODEL = "gpt-5.4";
 export const DEFAULT_GIT_TEXT_GENERATION_MODEL = "gpt-5.4-mini";
@@ -140,6 +141,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CLAUDE_DRIVER_KIND]: "claude-sonnet-4-6",
   [CURSOR_DRIVER_KIND]: "auto",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [GROK_BUILD_DRIVER_KIND]: "grok-build",
 };
 
 /** Per-provider text generation model defaults. */
@@ -150,6 +152,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [GROK_BUILD_DRIVER_KIND]: "grok-build",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -193,6 +196,10 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [GROK_BUILD_DRIVER_KIND]: {
+    "grok-build": "grok-build",
+    "composer-2.5": "composer-2.5",
+  },
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -202,4 +209,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CLAUDE_DRIVER_KIND]: "Claude",
   [CURSOR_DRIVER_KIND]: "Cursor",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [GROK_BUILD_DRIVER_KIND]: "Grok Build",
 };

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -331,6 +331,51 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const GrokBuildSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    command: makeBinaryPathSetting("grok").pipe(
+      Schema.annotateKey({
+        title: "Command path",
+        description: "Path to the Grok Build CLI.",
+        providerSettingsForm: {
+          placeholder: "grok",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    args: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed(["agent", "stdio"])),
+      Schema.annotateKey({
+        title: "Arguments",
+        description: "Arguments to pass to the Grok Build CLI.",
+      }),
+    ),
+    envJson: Schema.String.pipe(
+      Schema.withDecodingDefault(Effect.succeed("{}")),
+      Schema.annotateKey({
+        title: "Environment Overrides (JSON)",
+        description: "JSON string containing environment variables.",
+        providerSettingsForm: {
+          control: "textarea",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["command", "args", "envJson"],
+  },
+);
+export type GrokBuildSettings = typeof GrokBuildSettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -370,6 +415,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    "grok-build": GrokBuildSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -445,6 +491,14 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const GrokBuildSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  command: Schema.optionalKey(TrimmedString),
+  args: Schema.optionalKey(Schema.Array(Schema.String)),
+  envJson: Schema.optionalKey(Schema.String),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
@@ -464,6 +518,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      "grok-build": Schema.optionalKey(GrokBuildSettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual


### PR DESCRIPTION
## Summary

This PR integrates the new **Grok Build CLI provider** (xAI's coding assistant) as a first-class local agent session provider using the stdio-based Agent Communication Protocol (ACP). It also introduces custom branding SVG icons for xAI and Grok Build, replacing generic terminal icons and placeholder text.

---

## Key Changes

### 1. Contracts & Configuration (`packages/contracts`)
- **`model.ts`:**
  - Added `grok-build` provider definition with `GROK_BUILD_DRIVER_KIND`.
  - Configured supported models (`grok-build` and `composer-2.5`) with default display metadata.
- **`settings.ts`:**
  - Defined strict Effect Schemas for Grok Build CLI config options (`GrokBuildSettings`, `GrokBuildSettingsPatch`).

### 2. Server Implementation (`apps/server`)
- **Grok Build Driver (`GrokBuildDriver.ts`, `GrokBuildProvider.ts`):**
  - Added CLI runner driver supporting custom command overrides, arguments, and custom environment JSON.
  - Performs health checks by validating CLI installation/presence on startup.
- **AcpSessionRuntime Set-Model Fallback (`AcpSessionRuntime.ts`):**
  - Grok Build CLI ACP does not support standard custom `model_picker` config options.
  - Implemented standard ACP `session/set_model` fallback method so model swaps work correctly out of the box.
- **Grok Build ACP Adapter (`GrokBuildAdapter.ts`):**
  - Wrapped grok stdio ACP lifecycle and authentication (`cached_token`).
  - Added turn lifecycle hook logic to translate streaming tokens into standard turn lifecycle events.
  - Handles base model mapping for Composer 2.5.

### 3. Web & Branding Improvements (`apps/web`)
- **Branding Icons (`Icons.tsx`):**
  - Added proper vector SVG brand icons for `XaiIcon` (xAI company) and `GrokIcon` (Grok looping X symbol).
- **Icons Wiring (`providerDriverMeta.ts`, `providerIconUtils.ts`):**
  - Configured `GrokIcon` as the primary logo for `grok-build` instead of fallback `Terminal` or initial placeholders ("GB").

---

## Verification

The following verification steps have been executed and verified on a Windows machine:
1. **Compilation:** `bun run typecheck` passes 100% cleanly across all 14 workspace packages.
2. **Linting & Formatting:** `bun lint` and `bun run fmt` ran with zero lint errors and correct code formatting.
3. **Automated Unit Tests:**
   - Web application test suites pass successfully (988 tests passing).
   - Server-side ACP integration test suite passes successfully.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/2909" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7dca963875d913721c07898797acf52fd4faeb79. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Grok Build CLI ACP provider with custom branding icons
> - Adds a new `grok-build` provider driver ([GrokBuildDriver.ts](https://github.com/pingdotgg/t3code/pull/2909/files#diff-11ee674ba3dbe130831dae204537983e3fe5856b3552460887eedde790f2ede1)) that spawns the Grok CLI as an ACP subprocess, manages session lifecycle, and streams runtime events.
> - Implements the full adapter in [GrokBuildAdapter.ts](https://github.com/pingdotgg/t3code/pull/2909/files#diff-c40339567c7f8134c316e5506a12e64f332ff8ea1323a3547cc0588cd02c4cc3): start/stop sessions, send turns, handle approval workflows, interrupt turns, and resolve model aliases (`composer-2.5` → `grok-composer-2.5-fast`).
> - Probes for the `grok` CLI via `--version` at startup to set provider status; shows install instructions if missing ([GrokBuildProvider.ts](https://github.com/pingdotgg/t3code/pull/2909/files#diff-6a0483f8b76a237360bb73e3440c7c50370de6a1c5bcaf4856c6099829770a9f)).
> - Adds `GrokIcon` and `XaiIcon` SVG components and wires `grok-build` into the provider icon map and settings UI.
> - Adds `GrokBuildSettings` schema (command, args, envJson, customModels) to contracts and registers the driver in the built-in driver registry.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7dca963. 14 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->