### PR TITLE
fix(desktop): Niri/Hyprland - Linux secret storage backend

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -9,6 +9,7 @@ import * as Crypto from "effect/Crypto";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronDialog from "../electron/ElectronDialog.ts";
 import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
+import * as ElectronSafeStorage from "../electron/ElectronSafeStorage.ts";
 import { installDesktopIpcHandlers } from "../ipc/DesktopIpcHandlers.ts";
 import * as DesktopAppIdentity from "./DesktopAppIdentity.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
@@ -18,6 +19,7 @@ import * as DesktopBackendPool from "../backend/DesktopBackendPool.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./DesktopLifecycle.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
+import * as DesktopPreReadyPlatform from "./DesktopPreReadyPlatform.ts";
 import * as DesktopShutdown from "./DesktopShutdown.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
@@ -223,17 +225,45 @@ const startup = Effect.gen(function* () {
   const clerk = yield* DesktopClerk.DesktopClerk;
   const shellEnvironment = yield* DesktopShellEnvironment.DesktopShellEnvironment;
   const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
+  const preReadyElectronOptions = yield* DesktopPreReadyPlatform.DesktopPreReadyElectronOptions;
+  const safeStorage = yield* ElectronSafeStorage.ElectronSafeStorage;
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
 
   yield* shellEnvironment.installIntoProcess;
+  const hasCommandLinePasswordStore =
+    preReadyElectronOptions.linuxPasswordStoreCommandLine !== null;
+  const linuxElectronOptions =
+    environment.platform === "linux" && !hasCommandLinePasswordStore
+      ? DesktopPreReadyPlatform.resolveEarlyLinuxElectronOptionsFromProcess()
+      : preReadyElectronOptions.linux;
+  if (linuxElectronOptions !== null && !hasCommandLinePasswordStore) {
+    if (
+      linuxElectronOptions.passwordStore !== null ||
+      preReadyElectronOptions.linux?.passwordStore !== null
+    ) {
+      yield* electronApp.removeCommandLineSwitch("password-store");
+    }
+    if (linuxElectronOptions.passwordStore !== null) {
+      yield* electronApp.appendCommandLineSwitch(
+        "password-store",
+        linuxElectronOptions.passwordStore,
+      );
+    }
+  }
   const userDataPath = yield* appIdentity.resolveUserDataPath;
   yield* electronApp.setPath("userData", userDataPath);
   yield* logStartupInfo("runtime logging configured", { logDir: environment.logDir });
   yield* desktopSettings.load;
 
-  if (environment.platform === "linux") {
-    yield* electronApp.appendCommandLineSwitch("class", environment.linuxWmClass);
+  if (linuxElectronOptions !== null) {
+    yield* logStartupInfo("linux password store configured", {
+      passwordStore: hasCommandLinePasswordStore
+        ? "command-line"
+        : (linuxElectronOptions.passwordStore ?? "electron-default"),
+      xdgCurrentDesktop: process.env.XDG_CURRENT_DESKTOP ?? null,
+      xdgSessionDesktop: process.env.XDG_SESSION_DESKTOP ?? null,
+    });
   }
 
   yield* appIdentity.configure;
@@ -245,6 +275,12 @@ const startup = Effect.gen(function* () {
     Effect.catchCause((cause) => fatalStartupCause("whenReady", cause)),
   );
   yield* logStartupInfo("app ready");
+  if (environment.platform === "linux") {
+    const selectedBackend = yield* safeStorage.selectedStorageBackend;
+    yield* logStartupInfo("safe storage ready", {
+      backend: Option.getOrElse(selectedBackend, () => "unknown"),
+    });
+  }
   yield* appIdentity.configure;
   yield* applicationMenu.configure;
   yield* updates.configure;

--- a/apps/desktop/src/app/DesktopAppIdentity.test.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.test.ts
@@ -64,6 +64,7 @@ const makeElectronAppLayer = (calls: ElectronAppCalls) =>
       }),
     appendCommandLineSwitch: () => Effect.void,
     onBeforeQuitForUpdate: () => Effect.void,
+    removeCommandLineSwitch: () => Effect.void,
     on: () => Effect.void,
   } satisfies ElectronApp.ElectronApp["Service"]);
 

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
@@ -39,6 +39,7 @@ function makeSafeStorageLayer(available: boolean, failDecrypt: Ref.Ref<boolean> 
         return decoded.slice("encrypted:".length);
       });
     },
+    selectedStorageBackend: Effect.succeed(Option.none()),
   } satisfies ElectronSafeStorage.ElectronSafeStorage["Service"]);
 }
 

--- a/apps/desktop/src/app/DesktopEarlyElectronStartup.test.ts
+++ b/apps/desktop/src/app/DesktopEarlyElectronStartup.test.ts
@@ -1,0 +1,121 @@
+// @effect-diagnostics nodeBuiltinImport:off - tests use POSIX path joining to match the Linux startup boundary.
+import * as NodePath from "node:path";
+import { assert, describe, it } from "@effect/vitest";
+
+import {
+  resolveEarlyLinuxElectronOptions,
+  resolveEarlyLinuxPasswordStorePreference,
+} from "./DesktopEarlyElectronStartup.ts";
+
+describe("DesktopEarlyElectronStartup", () => {
+  const joinPath = NodePath.posix.join;
+
+  it("reads the persisted linux password-store preference before Electron is ready", () => {
+    const preference = resolveEarlyLinuxPasswordStorePreference({
+      env: { T3CODE_HOME: "/home/user/.t3-test" },
+      homeDirectory: "/home/user",
+      joinPath,
+      readFileString: (path) => {
+        assert.equal(path, "/home/user/.t3-test/userdata/desktop-settings.json");
+        return JSON.stringify({ linuxPasswordStore: "kwallet6" });
+      },
+    });
+
+    assert.equal(preference, "kwallet6");
+  });
+
+  it("accepts JSONC in the early desktop settings file", () => {
+    const preference = resolveEarlyLinuxPasswordStorePreference({
+      env: { T3CODE_HOME: "/home/user/.t3-test" },
+      homeDirectory: "/home/user",
+      joinPath,
+      readFileString: () => `{
+        // manually edited setting
+        "linuxPasswordStore": "gnome-libsecret",
+      }`,
+    });
+
+    assert.equal(preference, "gnome-libsecret");
+  });
+
+  it("falls back to auto when the early settings document is missing or invalid", () => {
+    const preference = resolveEarlyLinuxPasswordStorePreference({
+      env: {},
+      homeDirectory: "/home/user",
+      joinPath,
+      readFileString: () => {
+        throw new Error("missing");
+      },
+    });
+
+    assert.equal(preference, "auto");
+  });
+
+  it("preserves absolute root paths when resolving early settings", () => {
+    const preference = resolveEarlyLinuxPasswordStorePreference({
+      env: { T3CODE_HOME: "/" },
+      homeDirectory: "/home/user",
+      joinPath,
+      readFileString: (path) => {
+        assert.equal(path, "/userdata/desktop-settings.json");
+        return JSON.stringify({ linuxPasswordStore: "kwallet6" });
+      },
+    });
+
+    assert.equal(preference, "kwallet6");
+  });
+
+  it("resolves the early linux Electron switches", () => {
+    const options = resolveEarlyLinuxElectronOptions({
+      env: {
+        T3CODE_HOME: "/home/user/.t3-test",
+        XDG_CURRENT_DESKTOP: "niri",
+        VITE_DEV_SERVER_URL: "http://127.0.0.1:5173",
+      },
+      homeDirectory: "/home/user",
+      joinPath,
+      readFileString: (path) => {
+        assert.equal(path, "/home/user/.t3-test/userdata/desktop-settings.json");
+        return JSON.stringify({ linuxPasswordStore: "auto" });
+      },
+    });
+
+    assert.deepEqual(options, {
+      linuxWmClass: "t3code-dev",
+      passwordStore: "gnome-libsecret",
+    });
+  });
+
+  it("keeps implicit development state under ~/.t3/dev when T3CODE_HOME is unset", () => {
+    const preference = resolveEarlyLinuxPasswordStorePreference({
+      env: {
+        VITE_DEV_SERVER_URL: "http://127.0.0.1:5173",
+      },
+      homeDirectory: "/home/user",
+      joinPath,
+      readFileString: (path) => {
+        assert.equal(path, "/home/user/.t3/dev/desktop-settings.json");
+        return JSON.stringify({ linuxPasswordStore: "kwallet" });
+      },
+    });
+
+    assert.equal(preference, "kwallet");
+  });
+
+  it("treats whitespace-only T3CODE_HOME as unconfigured in development", () => {
+    const preference = resolveEarlyLinuxPasswordStorePreference({
+      env: {
+        T3CODE_HOME: "   ",
+        VITE_DEV_SERVER_URL: "http://127.0.0.1:5173",
+      },
+      homeDirectory: "/home/user",
+      joinPath,
+      readFileString: (path) => {
+        assert.equal(path, "/home/user/.t3/dev/desktop-settings.json");
+        return JSON.stringify({ linuxPasswordStore: "gnome-libsecret" });
+      },
+    });
+
+    assert.equal(preference, "gnome-libsecret");
+  });
+});

--- a/apps/desktop/src/app/DesktopEarlyElectronStartup.ts
+++ b/apps/desktop/src/app/DesktopEarlyElectronStartup.ts
@@ -1,0 +1,90 @@
+import { fromLenientJson } from "@t3tools/shared/schemaJson";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import {
+  DEFAULT_LINUX_PASSWORD_STORE,
+  normalizeLinuxPasswordStorePreference,
+  resolveLinuxPasswordStoreSwitch,
+  type LinuxPasswordStoreSwitch,
+  type LinuxPasswordStorePreference,
+} from "../linuxSecretStorage.ts";
+import {
+  resolveDesktopBaseDir,
+  resolveDesktopStateDir,
+  type JoinPath,
+} from "./DesktopStatePaths.ts";
+
+interface EarlyDesktopSettingsInput {
+  readonly env: NodeJS.ProcessEnv;
+  readonly homeDirectory: string;
+  readonly joinPath: JoinPath;
+  readonly readFileString: (path: string) => string;
+}
+
+type EarlyLinuxElectronOptionsInput = EarlyDesktopSettingsInput;
+
+export interface EarlyLinuxElectronOptions {
+  readonly linuxWmClass: string;
+  readonly passwordStore: LinuxPasswordStoreSwitch | null;
+}
+
+const trimNonEmpty = (value: string | undefined): string | null => {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+};
+
+const EarlyDesktopSettingsJson = fromLenientJson(
+  Schema.Struct({
+    linuxPasswordStore: Schema.optionalKey(Schema.Unknown),
+  }),
+);
+const decodeEarlyDesktopSettingsJson = Schema.decodeSync(EarlyDesktopSettingsJson);
+
+const isDevelopmentEnvironment = (env: NodeJS.ProcessEnv): boolean =>
+  trimNonEmpty(env.VITE_DEV_SERVER_URL) !== null;
+
+function resolveEarlyDesktopSettingsPath(input: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly homeDirectory: string;
+  readonly joinPath: JoinPath;
+}): string {
+  const t3Home = Option.fromUndefinedOr(input.env.T3CODE_HOME);
+  const baseDir = resolveDesktopBaseDir({
+    homeDirectory: input.homeDirectory,
+    joinPath: input.joinPath,
+    t3Home,
+  });
+  const stateDir = resolveDesktopStateDir({
+    baseDir,
+    isDevelopment: isDevelopmentEnvironment(input.env),
+    joinPath: input.joinPath,
+    t3Home,
+  });
+  return input.joinPath(stateDir, "desktop-settings.json");
+}
+
+export function resolveEarlyLinuxPasswordStorePreference(
+  input: EarlyDesktopSettingsInput,
+): LinuxPasswordStorePreference {
+  const settingsPath = resolveEarlyDesktopSettingsPath(input);
+  try {
+    const parsed = decodeEarlyDesktopSettingsJson(input.readFileString(settingsPath));
+    return normalizeLinuxPasswordStorePreference(parsed.linuxPasswordStore);
+  } catch {
+    return DEFAULT_LINUX_PASSWORD_STORE;
+  }
+}
+
+export function resolveEarlyLinuxElectronOptions(
+  input: EarlyLinuxElectronOptionsInput,
+): EarlyLinuxElectronOptions {
+  const preference = resolveEarlyLinuxPasswordStorePreference(input);
+  return {
+    linuxWmClass: isDevelopmentEnvironment(input.env) ? "t3code-dev" : "t3code",
+    passwordStore: resolveLinuxPasswordStoreSwitch({
+      preference,
+      env: input.env,
+    }),
+  };
+}

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -13,6 +13,7 @@ import * as Path from "effect/Path";
 
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopConfig from "./DesktopConfig.ts";
+import { resolveDesktopBaseDir, resolveDesktopStateDir } from "./DesktopStatePaths.ts";
 import { isNightlyDesktopVersion } from "../updates/updateChannels.ts";
 
 export interface MakeDesktopEnvironmentInput {
@@ -147,8 +148,11 @@ const make = Effect.fn("desktop.environment.make")(function* (
       : input.platform === "darwin"
         ? path.join(homeDirectory, "Library", "Application Support")
         : Option.getOrElse(config.xdgConfigHome, () => path.join(homeDirectory, ".config"));
-  const configuredBaseDir = config.t3Home;
-  const baseDir = Option.getOrElse(configuredBaseDir, () => path.join(homeDirectory, ".t3"));
+  const baseDir = resolveDesktopBaseDir({
+    homeDirectory,
+    joinPath: path.join,
+    t3Home: config.t3Home,
+  });
   const rootDir = path.resolve(input.dirname, "../../..");
   const appRoot = input.isPackaged ? input.appPath : rootDir;
   const branding = resolveDesktopAppBranding({
@@ -156,10 +160,12 @@ const make = Effect.fn("desktop.environment.make")(function* (
     appVersion: input.appVersion,
   });
   const displayName = branding.displayName;
-  const stateDir = path.join(
+  const stateDir = resolveDesktopStateDir({
     baseDir,
-    isDevelopment && Option.isNone(configuredBaseDir) ? "dev" : "userdata",
-  );
+    isDevelopment,
+    joinPath: path.join,
+    t3Home: config.t3Home,
+  });
   const userDataDirName = isDevelopment ? "t3code-dev" : "t3code";
   const legacyUserDataDirName = isDevelopment ? "T3 Code (Dev)" : "T3 Code (Alpha)";
   const resourcesPath = input.resourcesPath;

--- a/apps/desktop/src/app/DesktopLifecycle.test.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.test.ts
@@ -35,6 +35,7 @@ describe("DesktopLifecycle", () => {
         setDesktopName: () => Effect.void,
         setDockIcon: () => Effect.void,
         appendCommandLineSwitch: () => Effect.void,
+        removeCommandLineSwitch: () => Effect.void,
         onBeforeQuitForUpdate: (listener) =>
           Effect.acquireRelease(
             Effect.sync(() => {

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
@@ -1,19 +1,44 @@
 import { assert, describe, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Context from "effect/Context";
-import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
+import { beforeEach, vi } from "vite-plus/test";
 
-import {
-  DesktopPreReadyElectronOptions,
-  makeDesktopElectronPreReadyLayer,
-  readCommandLineSwitchValue,
-} from "./DesktopPreReadyPlatform.ts";
+const { appendSwitchMock, getSwitchValueMock, hasSwitchMock, registerSchemesMock } = vi.hoisted(
+  () => ({
+    appendSwitchMock: vi.fn(),
+    getSwitchValueMock: vi.fn(),
+    hasSwitchMock: vi.fn(),
+    registerSchemesMock: vi.fn(),
+  }),
+);
+
+vi.mock("electron", () => ({
+  app: {
+    commandLine: {
+      appendSwitch: appendSwitchMock,
+      getSwitchValue: getSwitchValueMock,
+      hasSwitch: hasSwitchMock,
+    },
+  },
+  protocol: {
+    registerSchemesAsPrivileged: registerSchemesMock,
+  },
+}));
+
+import * as DesktopPreReadyPlatform from "./DesktopPreReadyPlatform.ts";
 
 describe("DesktopPreReadyPlatform", () => {
+  beforeEach(() => {
+    appendSwitchMock.mockReset();
+    getSwitchValueMock.mockReset();
+    hasSwitchMock.mockReset();
+    registerSchemesMock.mockReset();
+  });
+
   it("reads an explicit Electron command-line switch value", () => {
-    const value = readCommandLineSwitchValue(
+    const value = DesktopPreReadyPlatform.readCommandLineSwitchValue(
       {
         hasSwitch: (switchName) => switchName === "password-store",
         getSwitchValue: (switchName) => {
@@ -28,7 +53,7 @@ describe("DesktopPreReadyPlatform", () => {
   });
 
   it("treats valueless Electron command-line switches as absent", () => {
-    const value = readCommandLineSwitchValue(
+    const value = DesktopPreReadyPlatform.readCommandLineSwitchValue(
       {
         hasSwitch: () => true,
         getSwitchValue: () => "",
@@ -40,7 +65,7 @@ describe("DesktopPreReadyPlatform", () => {
   });
 
   it("returns null for missing Electron command-line switches", () => {
-    const value = readCommandLineSwitchValue(
+    const value = DesktopPreReadyPlatform.readCommandLineSwitchValue(
       {
         hasSwitch: () => false,
         getSwitchValue: () => {
@@ -53,38 +78,6 @@ describe("DesktopPreReadyPlatform", () => {
     assert.isNull(value);
   });
 
-  it.effect("builds scheme privileges and command-line setup as sibling pre-ready effects", () =>
-    Effect.gen(function* () {
-      const schemeStarted = yield* Deferred.make<void>();
-      const configureStarted = yield* Deferred.make<void>();
-
-      const layer = makeDesktopElectronPreReadyLayer({
-        schemePrivilegesLayer: Layer.effectDiscard(
-          Deferred.succeed(schemeStarted, undefined).pipe(
-            Effect.andThen(Deferred.await(configureStarted)),
-          ),
-        ),
-        configureElectronBeforeReady: Deferred.succeed(configureStarted, undefined).pipe(
-          Effect.andThen(Deferred.await(schemeStarted)),
-          Effect.as({
-            linux: null,
-            linuxPasswordStoreCommandLine: null,
-          }),
-        ),
-      });
-
-      const options = yield* DesktopPreReadyElectronOptions.pipe(
-        Effect.provide(layer),
-        Effect.timeoutOption("50 millis"),
-      );
-
-      assert.deepEqual(Option.getOrNull(options), {
-        linux: null,
-        linuxPasswordStoreCommandLine: null,
-      });
-    }),
-  );
-
   it.effect(
     "acquires a synchronous pre-ready layer before an asynchronous Clerk-shaped layer",
     () =>
@@ -94,14 +87,13 @@ describe("DesktopPreReadyPlatform", () => {
         ) {}
 
         const events: Array<string> = [];
-
-        const preReadyLayer = Layer.sync(DesktopPreReadyElectronOptions, () => {
+        registerSchemesMock.mockImplementation(() => {
           events.push("pre-ready");
-          return {
-            linux: null,
-            linuxPasswordStoreCommandLine: null,
-          };
         });
+
+        const preReadyLayer = DesktopPreReadyPlatform.layer.pipe(
+          Layer.provide(Layer.succeed(HostProcessPlatform, "darwin")),
+        );
 
         const clerkShapedLayer = Layer.effect(
           ClerkShaped,
@@ -120,7 +112,7 @@ describe("DesktopPreReadyPlatform", () => {
 
         const result = yield* Effect.all({
           clerk: ClerkShaped,
-          preReady: DesktopPreReadyElectronOptions,
+          preReady: DesktopPreReadyPlatform.DesktopPreReadyElectronOptions,
         }).pipe(Effect.provide(runtimeLayer));
 
         assert.deepEqual(result, {
@@ -131,6 +123,8 @@ describe("DesktopPreReadyPlatform", () => {
           },
         });
         assert.deepEqual(events, ["pre-ready", "clerk"]);
+        assert.equal(registerSchemesMock.mock.calls.length, 1);
+        assert.equal(appendSwitchMock.mock.calls.length, 0);
       }),
   );
 });

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.test.ts
@@ -1,0 +1,136 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+import {
+  DesktopPreReadyElectronOptions,
+  makeDesktopElectronPreReadyLayer,
+  readCommandLineSwitchValue,
+} from "./DesktopPreReadyPlatform.ts";
+
+describe("DesktopPreReadyPlatform", () => {
+  it("reads an explicit Electron command-line switch value", () => {
+    const value = readCommandLineSwitchValue(
+      {
+        hasSwitch: (switchName) => switchName === "password-store",
+        getSwitchValue: (switchName) => {
+          assert.equal(switchName, "password-store");
+          return "basic";
+        },
+      },
+      "password-store",
+    );
+
+    assert.equal(value, "basic");
+  });
+
+  it("treats valueless Electron command-line switches as absent", () => {
+    const value = readCommandLineSwitchValue(
+      {
+        hasSwitch: () => true,
+        getSwitchValue: () => "",
+      },
+      "password-store",
+    );
+
+    assert.isNull(value);
+  });
+
+  it("returns null for missing Electron command-line switches", () => {
+    const value = readCommandLineSwitchValue(
+      {
+        hasSwitch: () => false,
+        getSwitchValue: () => {
+          throw new Error("Unexpected switch value read.");
+        },
+      },
+      "password-store",
+    );
+
+    assert.isNull(value);
+  });
+
+  it.effect("builds scheme privileges and command-line setup as sibling pre-ready effects", () =>
+    Effect.gen(function* () {
+      const schemeStarted = yield* Deferred.make<void>();
+      const configureStarted = yield* Deferred.make<void>();
+
+      const layer = makeDesktopElectronPreReadyLayer({
+        schemePrivilegesLayer: Layer.effectDiscard(
+          Deferred.succeed(schemeStarted, undefined).pipe(
+            Effect.andThen(Deferred.await(configureStarted)),
+          ),
+        ),
+        configureElectronBeforeReady: Deferred.succeed(configureStarted, undefined).pipe(
+          Effect.andThen(Deferred.await(schemeStarted)),
+          Effect.as({
+            linux: null,
+            linuxPasswordStoreCommandLine: null,
+          }),
+        ),
+      });
+
+      const options = yield* DesktopPreReadyElectronOptions.pipe(
+        Effect.provide(layer),
+        Effect.timeoutOption("50 millis"),
+      );
+
+      assert.deepEqual(Option.getOrNull(options), {
+        linux: null,
+        linuxPasswordStoreCommandLine: null,
+      });
+    }),
+  );
+
+  it.effect(
+    "acquires a synchronous pre-ready layer before an asynchronous Clerk-shaped layer",
+    () =>
+      Effect.gen(function* () {
+        class ClerkShaped extends Context.Service<ClerkShaped, { readonly ready: true }>()(
+          "@t3tools/desktop/app/DesktopPreReadyPlatform.test/ClerkShaped",
+        ) {}
+
+        const events: Array<string> = [];
+
+        const preReadyLayer = Layer.sync(DesktopPreReadyElectronOptions, () => {
+          events.push("pre-ready");
+          return {
+            linux: null,
+            linuxPasswordStoreCommandLine: null,
+          };
+        });
+
+        const clerkShapedLayer = Layer.effect(
+          ClerkShaped,
+          Effect.promise(() => Promise.resolve()).pipe(
+            Effect.map(() => {
+              events.push("clerk");
+              return { ready: true as const };
+            }),
+          ),
+        );
+
+        const runtimeLayer = clerkShapedLayer.pipe(
+          Layer.flatMap((clerkContext) => Layer.succeedContext(clerkContext)),
+          Layer.provideMerge(preReadyLayer),
+        );
+
+        const result = yield* Effect.all({
+          clerk: ClerkShaped,
+          preReady: DesktopPreReadyElectronOptions,
+        }).pipe(Effect.provide(runtimeLayer));
+
+        assert.deepEqual(result, {
+          clerk: { ready: true },
+          preReady: {
+            linux: null,
+            linuxPasswordStoreCommandLine: null,
+          },
+        });
+        assert.deepEqual(events, ["pre-ready", "clerk"]);
+      }),
+  );
+});

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.ts
@@ -1,0 +1,57 @@
+// @effect-diagnostics nodeBuiltinImport:off - pre-ready Electron setup reads persisted settings synchronously before app services are available.
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as DesktopEarlyElectronStartup from "./DesktopEarlyElectronStartup.ts";
+
+export class DesktopPreReadyElectronOptions extends Context.Service<
+  DesktopPreReadyElectronOptions,
+  {
+    readonly linux: DesktopEarlyElectronStartup.EarlyLinuxElectronOptions | null;
+    readonly linuxPasswordStoreCommandLine: string | null;
+  }
+>()("@t3tools/desktop/app/DesktopPreReadyPlatform/DesktopPreReadyElectronOptions") {}
+
+export interface DesktopPreReadyCommandLineReader {
+  readonly hasSwitch: (switchName: string) => boolean;
+  readonly getSwitchValue: (switchName: string) => string;
+}
+
+export function readCommandLineSwitchValue(
+  commandLine: DesktopPreReadyCommandLineReader,
+  switchName: string,
+): string | null {
+  if (!commandLine.hasSwitch(switchName)) {
+    return null;
+  }
+
+  const value = commandLine.getSwitchValue(switchName).trim();
+  return value.length > 0 ? value : null;
+}
+
+export function makeDesktopElectronPreReadyLayer<E, R, E2, R2>(input: {
+  readonly schemePrivilegesLayer: Layer.Layer<never, E, R>;
+  readonly configureElectronBeforeReady: Effect.Effect<
+    DesktopPreReadyElectronOptions["Service"],
+    E2,
+    R2
+  >;
+}): Layer.Layer<DesktopPreReadyElectronOptions, E | E2, R | R2> {
+  return Layer.mergeAll(
+    input.schemePrivilegesLayer,
+    Layer.effect(DesktopPreReadyElectronOptions, input.configureElectronBeforeReady),
+  );
+}
+
+export const resolveEarlyLinuxElectronOptionsFromProcess =
+  (): DesktopEarlyElectronStartup.EarlyLinuxElectronOptions =>
+    DesktopEarlyElectronStartup.resolveEarlyLinuxElectronOptions({
+      env: process.env,
+      homeDirectory: NodeOS.homedir(),
+      joinPath: NodePath.posix.join,
+      readFileString: (path) => NodeFS.readFileSync(path, "utf8"),
+    });

--- a/apps/desktop/src/app/DesktopPreReadyPlatform.ts
+++ b/apps/desktop/src/app/DesktopPreReadyPlatform.ts
@@ -6,15 +6,11 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import * as DesktopEarlyElectronStartup from "./DesktopEarlyElectronStartup.ts";
+import * as Electron from "electron";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
-export class DesktopPreReadyElectronOptions extends Context.Service<
-  DesktopPreReadyElectronOptions,
-  {
-    readonly linux: DesktopEarlyElectronStartup.EarlyLinuxElectronOptions | null;
-    readonly linuxPasswordStoreCommandLine: string | null;
-  }
->()("@t3tools/desktop/app/DesktopPreReadyPlatform/DesktopPreReadyElectronOptions") {}
+import * as DesktopEarlyElectronStartup from "./DesktopEarlyElectronStartup.ts";
+import * as ElectronProtocol from "../electron/ElectronProtocol.ts";
 
 export interface DesktopPreReadyCommandLineReader {
   readonly hasSwitch: (switchName: string) => boolean;
@@ -33,20 +29,6 @@ export function readCommandLineSwitchValue(
   return value.length > 0 ? value : null;
 }
 
-export function makeDesktopElectronPreReadyLayer<E, R, E2, R2>(input: {
-  readonly schemePrivilegesLayer: Layer.Layer<never, E, R>;
-  readonly configureElectronBeforeReady: Effect.Effect<
-    DesktopPreReadyElectronOptions["Service"],
-    E2,
-    R2
-  >;
-}): Layer.Layer<DesktopPreReadyElectronOptions, E | E2, R | R2> {
-  return Layer.mergeAll(
-    input.schemePrivilegesLayer,
-    Layer.effect(DesktopPreReadyElectronOptions, input.configureElectronBeforeReady),
-  );
-}
-
 export const resolveEarlyLinuxElectronOptionsFromProcess =
   (): DesktopEarlyElectronStartup.EarlyLinuxElectronOptions =>
     DesktopEarlyElectronStartup.resolveEarlyLinuxElectronOptions({
@@ -55,3 +37,38 @@ export const resolveEarlyLinuxElectronOptionsFromProcess =
       joinPath: NodePath.posix.join,
       readFileString: (path) => NodeFS.readFileSync(path, "utf8"),
     });
+
+export class DesktopPreReadyElectronOptions extends Context.Service<
+  DesktopPreReadyElectronOptions,
+  {
+    readonly linux: DesktopEarlyElectronStartup.EarlyLinuxElectronOptions | null;
+    readonly linuxPasswordStoreCommandLine: string | null;
+  }
+>()("@t3tools/desktop/app/DesktopPreReadyPlatform/DesktopPreReadyElectronOptions") {}
+
+export const make = Effect.gen(function* () {
+  const platform = yield* HostProcessPlatform;
+  return yield* Effect.sync((): DesktopPreReadyElectronOptions["Service"] => {
+    const linuxPasswordStoreCommandLine =
+      platform === "linux"
+        ? readCommandLineSwitchValue(Electron.app.commandLine, "password-store")
+        : null;
+    const linux = platform === "linux" ? resolveEarlyLinuxElectronOptionsFromProcess() : null;
+
+    if (linux !== null) {
+      Electron.app.commandLine.appendSwitch("class", linux.linuxWmClass);
+      if (linux.passwordStore !== null && linuxPasswordStoreCommandLine === null) {
+        Electron.app.commandLine.appendSwitch("password-store", linux.passwordStore);
+      }
+    }
+
+    return { linux, linuxPasswordStoreCommandLine };
+  });
+}).pipe(Effect.withSpan("desktop.electron.configureBeforeReady"));
+
+// Keep Electron's strict pre-ready setup isolated so later runtime layers cannot
+// observe app readiness before scheme privileges and command-line switches exist.
+export const layer = Layer.mergeAll(
+  ElectronProtocol.layerSchemePrivileges,
+  Layer.effect(DesktopPreReadyElectronOptions, make),
+);

--- a/apps/desktop/src/app/DesktopStatePaths.ts
+++ b/apps/desktop/src/app/DesktopStatePaths.ts
@@ -1,0 +1,32 @@
+import * as Option from "effect/Option";
+
+export type JoinPath = (first: string, ...segments: string[]) => string;
+
+function normalizeConfiguredBaseDir(t3Home: Option.Option<string>): Option.Option<string> {
+  if (Option.isNone(t3Home)) {
+    return Option.none();
+  }
+  const trimmed = t3Home.value.trim();
+  return trimmed.length > 0 ? Option.some(trimmed) : Option.none();
+}
+
+export function resolveDesktopBaseDir(input: {
+  readonly homeDirectory: string;
+  readonly joinPath: JoinPath;
+  readonly t3Home: Option.Option<string>;
+}): string {
+  return Option.getOrElse(normalizeConfiguredBaseDir(input.t3Home), () =>
+    input.joinPath(input.homeDirectory, ".t3"),
+  );
+}
+
+export function resolveDesktopStateDir(input: {
+  readonly baseDir: string;
+  readonly isDevelopment: boolean;
+  readonly joinPath: JoinPath;
+  readonly t3Home: Option.Option<string>;
+}): string {
+  const useDevSubdir =
+    input.isDevelopment && Option.isNone(normalizeConfiguredBaseDir(input.t3Home));
+  return input.joinPath(input.baseDir, useDevSubdir ? "dev" : "userdata");
+}

--- a/apps/desktop/src/electron/ElectronApp.test.ts
+++ b/apps/desktop/src/electron/ElectronApp.test.ts
@@ -14,6 +14,7 @@ const {
   quitMock,
   relaunchMock,
   removeListenerMock,
+  removeSwitchMock,
   setAboutPanelOptionsMock,
   setAppUserModelIdMock,
   setAsDefaultProtocolClientMock,
@@ -34,6 +35,7 @@ const {
   quitMock: vi.fn(),
   relaunchMock: vi.fn(),
   removeListenerMock: vi.fn(),
+  removeSwitchMock: vi.fn(),
   setAboutPanelOptionsMock: vi.fn(),
   setAppUserModelIdMock: vi.fn(),
   setAsDefaultProtocolClientMock: vi.fn(() => true),
@@ -52,6 +54,7 @@ vi.mock("electron", () => ({
   app: {
     commandLine: {
       appendSwitch: appendSwitchMock,
+      removeSwitch: removeSwitchMock,
     },
     dock: {
       setIcon: setDockIconMock,
@@ -89,6 +92,7 @@ describe("ElectronApp", () => {
     quitMock.mockClear();
     relaunchMock.mockClear();
     removeListenerMock.mockClear();
+    removeSwitchMock.mockClear();
     setPathMock.mockClear();
   });
 
@@ -176,6 +180,15 @@ describe("ElectronApp", () => {
       assert.deepEqual(autoUpdaterRemoveListenerMock.mock.calls, [
         ["before-quit-for-update", listener],
       ]);
+    }).pipe(Effect.provide(ElectronApp.layer)),
+  );
+
+  it.effect("removes command-line switches through the service", () =>
+    Effect.gen(function* () {
+      const electronApp = yield* ElectronApp.ElectronApp;
+      yield* electronApp.removeCommandLineSwitch("password-store");
+
+      assert.deepEqual(removeSwitchMock.mock.calls, [["password-store"]]);
     }).pipe(Effect.provide(ElectronApp.layer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronApp.ts
+++ b/apps/desktop/src/electron/ElectronApp.ts
@@ -69,6 +69,7 @@ export class ElectronApp extends Context.Service<
     readonly onBeforeQuitForUpdate: (
       listener: () => void,
     ) => Effect.Effect<void, never, Scope.Scope>;
+    readonly removeCommandLineSwitch: (switchName: string) => Effect.Effect<void>;
     readonly on: <Args extends ReadonlyArray<unknown>>(
       eventName: string,
       listener: (...args: Args) => void,
@@ -191,6 +192,10 @@ export const make = ElectronApp.of({
           Electron.autoUpdater.removeListener("before-quit-for-update", listener);
         }),
     ).pipe(Effect.asVoid),
+  removeCommandLineSwitch: (switchName) =>
+    Effect.sync(() => {
+      Electron.app.commandLine.removeSwitch(switchName);
+    }),
   on: addScopedAppListener,
 });
 

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -105,6 +105,38 @@ function withContentSecurityPolicy(response: Response, policy: string): Response
   });
 }
 
+/**
+ * Must run synchronously during process bootstrap, before Electron emits `ready`.
+ */
+export function registerDesktopSchemePrivilegesSync(): void {
+  Electron.protocol.registerSchemesAsPrivileged([
+    {
+      scheme: DESKTOP_PRODUCTION_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+      },
+    },
+    {
+      scheme: DESKTOP_DEVELOPMENT_SCHEME,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        corsEnabled: true,
+      },
+    },
+  ]);
+}
+
+const registerDesktopSchemePrivileges = Effect.sync(registerDesktopSchemePrivilegesSync).pipe(
+  Effect.withSpan("desktop.electron.protocol.registerSchemePrivileges"),
+);
+
+export const layerSchemePrivileges = Layer.effectDiscard(registerDesktopSchemePrivileges);
+
 async function proxyRequest(
   request: Request,
   targetOrigin: URL,

--- a/apps/desktop/src/electron/ElectronSafeStorage.ts
+++ b/apps/desktop/src/electron/ElectronSafeStorage.ts
@@ -1,9 +1,11 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as Electron from "electron";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 const electronSafeStorageErrorFields = {
   cause: Schema.Defect(),
@@ -60,24 +62,39 @@ export class ElectronSafeStorage extends Context.Service<
     readonly decryptString: (
       value: Uint8Array,
     ) => Effect.Effect<string, ElectronSafeStorageDecryptError>;
+    readonly selectedStorageBackend: Effect.Effect<Option.Option<string>>;
   }
 >()("@t3tools/desktop/electron/ElectronSafeStorage") {}
 
-export const make = ElectronSafeStorage.of({
-  isEncryptionAvailable: Effect.try({
-    try: () => Electron.safeStorage.isEncryptionAvailable(),
-    catch: (cause) => new ElectronSafeStorageAvailabilityError({ cause }),
-  }),
-  encryptString: (value) =>
-    Effect.try({
-      try: () => Electron.safeStorage.encryptString(value),
-      catch: (cause) => new ElectronSafeStorageEncryptError({ cause }),
+export const make = Effect.gen(function* () {
+  const platform = yield* HostProcessPlatform;
+
+  return ElectronSafeStorage.of({
+    isEncryptionAvailable: Effect.try({
+      try: () => Electron.safeStorage.isEncryptionAvailable(),
+      catch: (cause) => new ElectronSafeStorageAvailabilityError({ cause }),
     }),
-  decryptString: (value) =>
-    Effect.try({
-      try: () => Electron.safeStorage.decryptString(Buffer.from(value)),
-      catch: (cause) => new ElectronSafeStorageDecryptError({ cause }),
+    encryptString: (value) =>
+      Effect.try({
+        try: () => Electron.safeStorage.encryptString(value),
+        catch: (cause) => new ElectronSafeStorageEncryptError({ cause }),
+      }),
+    decryptString: (value) =>
+      Effect.try({
+        try: () => Electron.safeStorage.decryptString(Buffer.from(value)),
+        catch: (cause) => new ElectronSafeStorageDecryptError({ cause }),
+      }),
+    selectedStorageBackend: Effect.sync(() => {
+      if (platform !== "linux") {
+        return Option.none();
+      }
+      try {
+        return Option.fromNullishOr(Electron.safeStorage.getSelectedStorageBackend());
+      } catch {
+        return Option.none();
+      }
     }),
+  });
 });
 
-export const layer = Layer.succeed(ElectronSafeStorage, make);
+export const layer = Layer.effect(ElectronSafeStorage, make);

--- a/apps/desktop/src/linuxSecretStorage.test.ts
+++ b/apps/desktop/src/linuxSecretStorage.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  normalizeLinuxPasswordStorePreference,
+  resolveLinuxPasswordStoreSwitch,
+  resolveLinuxSecretStorageUnavailableMessage,
+} from "./linuxSecretStorage.ts";
+
+const autoSwitch = (env: NodeJS.ProcessEnv) =>
+  resolveLinuxPasswordStoreSwitch({ preference: "auto", env });
+
+describe("linuxSecretStorage", () => {
+  it("preserves explicit supported password-store preferences", () => {
+    expect(normalizeLinuxPasswordStorePreference("gnome-libsecret")).toBe("gnome-libsecret");
+    expect(normalizeLinuxPasswordStorePreference("kwallet")).toBe("kwallet");
+    expect(normalizeLinuxPasswordStorePreference("kwallet5")).toBe("kwallet5");
+    expect(normalizeLinuxPasswordStorePreference("kwallet6")).toBe("kwallet6");
+  });
+
+  it("falls back to auto for missing or unsupported preferences", () => {
+    expect(normalizeLinuxPasswordStorePreference(undefined)).toBe("auto");
+    expect(normalizeLinuxPasswordStorePreference("basic")).toBe("auto");
+  });
+
+  it("uses explicit preferences instead of the auto heuristic", () => {
+    for (const preference of ["gnome-libsecret", "kwallet", "kwallet5", "kwallet6"] as const) {
+      expect(
+        resolveLinuxPasswordStoreSwitch({ preference, env: { XDG_CURRENT_DESKTOP: "niri" } }),
+      ).toBe(preference);
+      // An explicit preference also wins where auto would have stayed out of the way.
+      expect(
+        resolveLinuxPasswordStoreSwitch({ preference, env: { XDG_CURRENT_DESKTOP: "KDE" } }),
+      ).toBe(preference);
+    }
+  });
+
+  it("leaves canonical KDE sessions to Electron's own wallet selection", () => {
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "KDE" })).toBeNull();
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "KDE", KDE_SESSION_VERSION: "6" })).toBeNull();
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "KDE", KDE_SESSION_VERSION: "5" })).toBeNull();
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "KDE:plasma" })).toBeNull();
+  });
+
+  it("does not force a password-store for desktops Electron already recognizes", () => {
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "GNOME" })).toBeNull();
+    for (const desktop of ["Deepin", "Pantheon", "UKUI", "Unity", "X-Cinnamon", "XFCE"]) {
+      expect(autoSwitch({ XDG_CURRENT_DESKTOP: desktop })).toBeNull();
+    }
+  });
+
+  it("recognizes a known desktop later in a colon-separated XDG_CURRENT_DESKTOP list", () => {
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "niri:GNOME" })).toBeNull();
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "ubuntu:GNOME" })).toBeNull();
+  });
+
+  it("forces gnome-libsecret for unrecognized Linux desktop sessions", () => {
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "niri" })).toBe("gnome-libsecret");
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "Hyprland" })).toBe("gnome-libsecret");
+    expect(autoSwitch({})).toBe("gnome-libsecret");
+  });
+
+  it("forces gnome-libsecret for desktops Electron recognizes but leaves on basic text", () => {
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "LXQt" })).toBe("gnome-libsecret");
+    // Chromium stops at the first recognized value, so a later name cannot rescue the session.
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "LXQt:GNOME" })).toBe("gnome-libsecret");
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "LXQt:KDE" })).toBe("gnome-libsecret");
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "LXQt:plasma" })).toBe("gnome-libsecret");
+  });
+
+  it("does not treat lowercase desktop names as ones Electron recognizes", () => {
+    // Chromium matches these case-sensitively, so lowercase spellings reach basic text.
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "gnome" })).toBe("gnome-libsecret");
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "xfce" })).toBe("gnome-libsecret");
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "kde", KDE_SESSION_VERSION: "6" })).toBe(
+      "gnome-libsecret",
+    );
+  });
+
+  it("overrides KDE sessions identified only by legacy variables", () => {
+    // Chromium reaches KWallet4 for some of these, such as DESKTOP_SESSION=kde with a version, and
+    // basic text for the rest. Either way these are the variables a previous session leaves behind,
+    // so they are treated as unproven and forced to a real keyring rather than a guessed wallet.
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "plasma" })).toBe("gnome-libsecret");
+    for (const session of [
+      "kde",
+      "kde-plasma",
+      "kde4",
+      "plasma",
+      "plasmawayland",
+      "plasmawayland-dev",
+      "plasmax11",
+      "plasmax11-dev",
+    ]) {
+      expect(autoSwitch({ DESKTOP_SESSION: session })).toBe("gnome-libsecret");
+      expect(autoSwitch({ XDG_SESSION_DESKTOP: session })).toBe("gnome-libsecret");
+      expect(autoSwitch({ GDMSESSION: session })).toBe("gnome-libsecret");
+    }
+    expect(autoSwitch({ DESKTOP_SESSION: "kde", KDE_SESSION_VERSION: "6" })).toBe(
+      "gnome-libsecret",
+    );
+    expect(autoSwitch({ KDE_SESSION_VERSION: "6" })).toBe("gnome-libsecret");
+    expect(autoSwitch({ KDE_FULL_SESSION: "true", KDE_SESSION_VERSION: "6" })).toBe(
+      "gnome-libsecret",
+    );
+  });
+
+  it("ignores stale session hints when XDG_CURRENT_DESKTOP is authoritative", () => {
+    expect(
+      autoSwitch({ XDG_CURRENT_DESKTOP: "niri", DESKTOP_SESSION: "gnome", GDMSESSION: "gnome" }),
+    ).toBe("gnome-libsecret");
+    // A previous KDE session left these behind; the compositor running now is not KDE.
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "niri", KDE_SESSION_VERSION: "6" })).toBe(
+      "gnome-libsecret",
+    );
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "niri", XDG_SESSION_DESKTOP: "GNOME" })).toBe(
+      "gnome-libsecret",
+    );
+    expect(autoSwitch({ XDG_CURRENT_DESKTOP: "niri:plasma" })).toBe("gnome-libsecret");
+    expect(
+      autoSwitch({
+        XDG_CURRENT_DESKTOP: "Hyprland",
+        XDG_SESSION_DESKTOP: "KDE",
+        KDE_SESSION_VERSION: "6",
+      }),
+    ).toBe("gnome-libsecret");
+  });
+
+  it("uses GNOME Keyring remediation for libsecret and unknown backends", () => {
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "auto",
+        selectedBackend: "gnome_libsecret",
+        env: { XDG_CURRENT_DESKTOP: "niri" },
+      }),
+    ).toContain("GNOME Keyring");
+  });
+
+  it("prefers explicit libsecret selection over KDE desktop heuristics", () => {
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "gnome-libsecret",
+        selectedBackend: "unknown",
+        env: { XDG_CURRENT_DESKTOP: "KDE" },
+      }),
+    ).toContain("GNOME Keyring");
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "auto",
+        selectedBackend: "gnome_libsecret",
+        env: { XDG_CURRENT_DESKTOP: "KDE" },
+      }),
+    ).toContain("GNOME Keyring");
+  });
+
+  it("prefers explicit KWallet preference over selected gnome-libsecret backend", () => {
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "kwallet6",
+        selectedBackend: "gnome_libsecret",
+        env: { XDG_CURRENT_DESKTOP: "niri" },
+      }),
+    ).toContain("KWallet");
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "kwallet",
+        selectedBackend: "gnome-libsecret",
+        env: {},
+      }),
+    ).toContain("KWallet");
+  });
+
+  it("uses KWallet remediation wording for KDE-looking sessions", () => {
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "auto",
+        selectedBackend: "kwallet6",
+        env: {},
+      }),
+    ).toContain("KWallet");
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "auto",
+        selectedBackend: "unknown",
+        env: { XDG_CURRENT_DESKTOP: "KDE" },
+      }),
+    ).toContain("KWallet");
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "auto",
+        selectedBackend: "unknown",
+        env: { DESKTOP_SESSION: "plasmawayland" },
+      }),
+    ).toContain("KWallet");
+    // A desktop name outranks a bare KDE marker when choosing the wording.
+    expect(
+      resolveLinuxSecretStorageUnavailableMessage({
+        configuredPreference: "auto",
+        selectedBackend: "unknown",
+        env: { GDMSESSION: "gnome", KDE_FULL_SESSION: "true" },
+      }),
+    ).toContain("GNOME Keyring");
+  });
+});

--- a/apps/desktop/src/linuxSecretStorage.ts
+++ b/apps/desktop/src/linuxSecretStorage.ts
@@ -1,0 +1,178 @@
+export type LinuxPasswordStorePreference =
+  | "auto"
+  | "gnome-libsecret"
+  | "kwallet"
+  | "kwallet5"
+  | "kwallet6";
+export type LinuxPasswordStoreSwitch = Exclude<LinuxPasswordStorePreference, "auto">;
+
+export const DEFAULT_LINUX_PASSWORD_STORE: LinuxPasswordStorePreference = "auto";
+
+// Chromium matches XDG_CURRENT_DESKTOP values case-sensitively and returns on the first value it
+// recognizes, so these stay exact literals and are scanned in order. Omitting a real desktop fails
+// safe: we force gnome-libsecret, which is the backend Chromium selects for all of these anyway.
+const ELECTRON_LIBSECRET_DESKTOPS = new Set([
+  "Deepin",
+  "GNOME",
+  "Pantheon",
+  "UKUI",
+  "Unity",
+  "X-Cinnamon",
+  "XFCE",
+]);
+// Chromium selects a KWallet generation for KDE from KDE_SESSION_VERSION, so it needs no help.
+const ELECTRON_KDE_DESKTOP = "KDE";
+// Chromium recognizes LXQt and still selects basic text for it, so it does need a forced backend.
+const ELECTRON_UNPROTECTED_DESKTOPS = new Set(["LXQt"]);
+
+const KDE_NAME_PREFIXES = ["kde", "plasma"];
+const NEGATIVE_FLAG_VALUES = new Set(["0", "false", "no", "off"]);
+
+export function normalizeLinuxPasswordStorePreference(
+  value: unknown,
+): LinuxPasswordStorePreference {
+  return value === "gnome-libsecret" ||
+    value === "kwallet" ||
+    value === "kwallet5" ||
+    value === "kwallet6"
+    ? value
+    : DEFAULT_LINUX_PASSWORD_STORE;
+}
+
+// Auto mode asks one question: will Electron select a real keyring on its own? If so, stay out of
+// the way, which is how canonical KDE sessions keep the KWallet generation Chromium picks for them.
+// Otherwise force gnome-libsecret, because the alternative is basic text, which is barely
+// encryption at all. Forcing never guesses a KWallet generation; a KDE session that needs a
+// specific one sets linuxPasswordStore explicitly.
+export function resolveLinuxPasswordStoreSwitch(input: {
+  readonly preference: LinuxPasswordStorePreference;
+  readonly env: NodeJS.ProcessEnv;
+}): LinuxPasswordStoreSwitch | null {
+  if (input.preference !== "auto") {
+    return input.preference;
+  }
+
+  return electronSelectsProtectedBackend(input.env) ? null : "gnome-libsecret";
+}
+
+// Only an exact XDG_CURRENT_DESKTOP literal proves Electron will protect the session. Chromium can
+// also reach a real backend through DESKTOP_SESSION and the legacy KDE markers, but those are the
+// variables a previous session leaves behind, and trusting them is what let stale hints suppress
+// the forced backend before. Forcing where Chromium would have chosen libsecret is harmless, since
+// it lands on the same backend.
+function electronSelectsProtectedBackend(env: NodeJS.ProcessEnv): boolean {
+  for (const name of splitDesktopNameList(env.XDG_CURRENT_DESKTOP)) {
+    const trimmed = name.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    if (trimmed === ELECTRON_KDE_DESKTOP || ELECTRON_LIBSECRET_DESKTOPS.has(trimmed)) {
+      return true;
+    }
+    if (ELECTRON_UNPROTECTED_DESKTOPS.has(trimmed)) {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+export function resolveLinuxSecretStorageUnavailableMessage(input: {
+  readonly configuredPreference: LinuxPasswordStorePreference;
+  readonly selectedBackend: string | null;
+  readonly env: NodeJS.ProcessEnv;
+}): string {
+  if (input.configuredPreference === "gnome-libsecret") {
+    return getGnomeKeyringRemediationMessage();
+  }
+
+  if (
+    input.configuredPreference === "kwallet" ||
+    input.configuredPreference === "kwallet5" ||
+    input.configuredPreference === "kwallet6"
+  ) {
+    return getKWalletRemediationMessage();
+  }
+
+  const backend = normalizeSelectedStorageBackend(input.selectedBackend);
+  if (backend === "gnome-libsecret") {
+    return getGnomeKeyringRemediationMessage();
+  }
+
+  if (
+    backend === "kwallet" ||
+    backend === "kwallet5" ||
+    backend === "kwallet6" ||
+    looksLikeKdeSession(input.env)
+  ) {
+    return getKWalletRemediationMessage();
+  }
+
+  return getGnomeKeyringRemediationMessage();
+}
+
+function getGnomeKeyringRemediationMessage(): string {
+  return "T3 Code could not access GNOME Keyring to save this environment credential. Install and start GNOME Keyring, then restart T3 Code.";
+}
+
+function getKWalletRemediationMessage(): string {
+  return "T3 Code could not access KWallet to save this environment credential. Enable the KDE wallet subsystem in System Settings, then restart T3 Code.";
+}
+
+// Advisory only: this picks between the GNOME Keyring and KWallet wording in the failure notice. It
+// never decides which backend to select, so a loose match costs a user slightly wrong instructions
+// rather than an unprotected credential store.
+function looksLikeKdeSession(env: NodeJS.ProcessEnv): boolean {
+  const currentDesktopNames = nonEmptyDesktopNames(env.XDG_CURRENT_DESKTOP);
+  if (currentDesktopNames.length > 0) {
+    return currentDesktopNames.some(isKdeDesktopName);
+  }
+
+  const legacyNames = legacyDesktopNames(env);
+  if (legacyNames.length > 0) {
+    return legacyNames.some(isKdeDesktopName);
+  }
+
+  return isSet(env.KDE_SESSION_VERSION) || isAffirmativeFlag(env.KDE_FULL_SESSION);
+}
+
+function isKdeDesktopName(name: string): boolean {
+  return KDE_NAME_PREFIXES.some((prefix) => name.startsWith(prefix));
+}
+
+function legacyDesktopNames(env: NodeJS.ProcessEnv): string[] {
+  return [env.XDG_SESSION_DESKTOP, env.DESKTOP_SESSION, env.GDMSESSION].flatMap((entry) => {
+    const normalized = normalizeDesktopName(entry);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function nonEmptyDesktopNames(value: string | undefined): string[] {
+  return splitDesktopNameList(value).flatMap((entry) => {
+    const normalized = normalizeDesktopName(entry);
+    return normalized ? [normalized] : [];
+  });
+}
+
+function isSet(value: string | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+function isAffirmativeFlag(value: string | undefined): boolean {
+  const normalized = value?.trim().toLowerCase();
+  return normalized ? !NEGATIVE_FLAG_VALUES.has(normalized) : false;
+}
+
+function splitDesktopNameList(value: string | undefined): string[] {
+  return value?.split(":") ?? [];
+}
+
+function normalizeDesktopName(value: string | undefined): string | null {
+  const normalized = value?.trim().toLowerCase();
+  return normalized && normalized.length > 0 ? normalized : null;
+}
+
+function normalizeSelectedStorageBackend(value: string | null): string | null {
+  const normalized = value?.trim().toLowerCase().replace(/_/gu, "-");
+  return normalized && normalized.length > 0 ? normalized : null;
+}

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -62,41 +62,6 @@ import * as DesktopWindow from "./window/DesktopWindow.ts";
 import * as DesktopWslBackend from "./wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "./wsl/DesktopWslEnvironment.ts";
 
-const configureElectronBeforeReady = Effect.gen(function* () {
-  const platform = yield* HostProcessPlatform;
-  return yield* Effect.sync(
-    (): DesktopPreReadyPlatform.DesktopPreReadyElectronOptions["Service"] => {
-      const linuxPasswordStoreCommandLine =
-        platform === "linux"
-          ? DesktopPreReadyPlatform.readCommandLineSwitchValue(
-              Electron.app.commandLine,
-              "password-store",
-            )
-          : null;
-      const linux =
-        platform === "linux"
-          ? DesktopPreReadyPlatform.resolveEarlyLinuxElectronOptionsFromProcess()
-          : null;
-
-      if (linux !== null) {
-        Electron.app.commandLine.appendSwitch("class", linux.linuxWmClass);
-        if (linux.passwordStore !== null && linuxPasswordStoreCommandLine === null) {
-          Electron.app.commandLine.appendSwitch("password-store", linux.passwordStore);
-        }
-      }
-
-      return { linux, linuxPasswordStoreCommandLine };
-    },
-  );
-}).pipe(Effect.withSpan("desktop.electron.configureBeforeReady"));
-
-// Keep Electron's strict pre-ready setup isolated so later runtime layers cannot
-// observe app readiness before scheme privileges and command-line switches exist.
-const desktopElectronPreReadyLayer = DesktopPreReadyPlatform.makeDesktopElectronPreReadyLayer({
-  schemePrivilegesLayer: ElectronProtocol.layerSchemePrivileges,
-  configureElectronBeforeReady,
-});
-
 const desktopEnvironmentLayer = Layer.unwrap(
   Effect.gen(function* () {
     const metadata = yield* Effect.service(ElectronApp.ElectronApp).pipe(
@@ -244,7 +209,7 @@ const desktopRuntimeLayer = desktopClerkLayer.pipe(
   Layer.flatMap((clerkContext) =>
     desktopApplicationRuntimeLayer.pipe(Layer.provideMerge(Layer.succeedContext(clerkContext))),
   ),
-  Layer.provideMerge(desktopElectronPreReadyLayer),
+  Layer.provideMerge(DesktopPreReadyPlatform.layer),
 );
 
 DesktopApp.program.pipe(Effect.provide(desktopRuntimeLayer), NodeRuntime.runMain);

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -49,6 +49,7 @@ import * as DesktopServerExposure from "./backend/DesktopServerExposure.ts";
 import * as DesktopClientSettings from "./settings/DesktopClientSettings.ts";
 import * as DesktopSavedEnvironments from "./settings/DesktopSavedEnvironments.ts";
 import * as DesktopAppSettings from "./settings/DesktopAppSettings.ts";
+import * as DesktopPreReadyPlatform from "./app/DesktopPreReadyPlatform.ts";
 import * as DesktopShellEnvironment from "./shell/DesktopShellEnvironment.ts";
 import * as DesktopSshEnvironment from "./ssh/DesktopSshEnvironment.ts";
 import * as DesktopSshPasswordPrompts from "./ssh/DesktopSshPasswordPrompts.ts";
@@ -60,6 +61,41 @@ import * as PreviewManager from "./preview/Manager.ts";
 import * as DesktopWindow from "./window/DesktopWindow.ts";
 import * as DesktopWslBackend from "./wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "./wsl/DesktopWslEnvironment.ts";
+
+const configureElectronBeforeReady = Effect.gen(function* () {
+  const platform = yield* HostProcessPlatform;
+  return yield* Effect.sync(
+    (): DesktopPreReadyPlatform.DesktopPreReadyElectronOptions["Service"] => {
+      const linuxPasswordStoreCommandLine =
+        platform === "linux"
+          ? DesktopPreReadyPlatform.readCommandLineSwitchValue(
+              Electron.app.commandLine,
+              "password-store",
+            )
+          : null;
+      const linux =
+        platform === "linux"
+          ? DesktopPreReadyPlatform.resolveEarlyLinuxElectronOptionsFromProcess()
+          : null;
+
+      if (linux !== null) {
+        Electron.app.commandLine.appendSwitch("class", linux.linuxWmClass);
+        if (linux.passwordStore !== null && linuxPasswordStoreCommandLine === null) {
+          Electron.app.commandLine.appendSwitch("password-store", linux.passwordStore);
+        }
+      }
+
+      return { linux, linuxPasswordStoreCommandLine };
+    },
+  );
+}).pipe(Effect.withSpan("desktop.electron.configureBeforeReady"));
+
+// Keep Electron's strict pre-ready setup isolated so later runtime layers cannot
+// observe app readiness before scheme privileges and command-line switches exist.
+const desktopElectronPreReadyLayer = DesktopPreReadyPlatform.makeDesktopElectronPreReadyLayer({
+  schemePrivilegesLayer: ElectronProtocol.layerSchemePrivileges,
+  configureElectronBeforeReady,
+});
 
 const desktopEnvironmentLayer = Layer.unwrap(
   Effect.gen(function* () {
@@ -195,16 +231,20 @@ const desktopClerkLayer = DesktopClerk.layer.pipe(
   Layer.provideMerge(ElectronApp.layer),
 );
 
+const desktopApplicationRuntimeLayer = desktopApplicationLayer.pipe(
+  Layer.provideMerge(NodeServices.layer),
+  Layer.provideMerge(NodeHttpClient.layerUndici),
+  Layer.provideMerge(NetService.layer),
+  Layer.provideMerge(electronLayer),
+);
+
+// Acquire strict pre-ready setup before Clerk, whose userData resolution can
+// yield and let Electron emit ready.
 const desktopRuntimeLayer = desktopClerkLayer.pipe(
   Layer.flatMap((clerkContext) =>
-    desktopApplicationLayer.pipe(
-      Layer.provideMerge(Layer.succeedContext(clerkContext)),
-      Layer.provideMerge(NodeServices.layer),
-      Layer.provideMerge(NodeHttpClient.layerUndici),
-      Layer.provideMerge(NetService.layer),
-      Layer.provideMerge(electronLayer),
-    ),
+    desktopApplicationRuntimeLayer.pipe(Layer.provideMerge(Layer.succeedContext(clerkContext))),
   ),
+  Layer.provideMerge(desktopElectronPreReadyLayer),
 );
 
 DesktopApp.program.pipe(Effect.provide(desktopRuntimeLayer), NodeRuntime.runMain);

--- a/apps/desktop/src/settings/DesktopAppSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.test.ts
@@ -11,6 +11,9 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopAppSettings from "./DesktopAppSettings.ts";
 
 const DesktopSettingsPatch = Schema.Struct({
+  linuxPasswordStore: Schema.optionalKey(
+    Schema.Literals(["auto", "gnome-libsecret", "kwallet", "kwallet5", "kwallet6"]),
+  ),
   mainWindowBounds: Schema.optionalKey(
     Schema.NullOr(
       Schema.Struct({
@@ -102,6 +105,7 @@ describe("DesktopSettings", () => {
     assert.deepEqual(
       DesktopAppSettings.resolveDefaultDesktopSettings("0.0.17-nightly.20260415.1"),
       {
+        linuxPasswordStore: "auto",
         mainWindowBounds: null,
         mainWindowMaximized: false,
         serverExposureMode: "local-only",
@@ -121,6 +125,7 @@ describe("DesktopSettings", () => {
       Effect.gen(function* () {
         const settings = yield* DesktopAppSettings.DesktopAppSettings;
         yield* writeSettingsPatch({
+          linuxPasswordStore: "gnome-libsecret",
           serverExposureMode: "network-accessible",
           tailscaleServeEnabled: true,
           tailscaleServePort: 8443,
@@ -129,6 +134,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          linuxPasswordStore: "gnome-libsecret",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "network-accessible",
@@ -235,6 +241,7 @@ describe("DesktopSettings", () => {
         );
 
         assert.deepEqual(yield* settings.load, {
+          linuxPasswordStore: "auto",
           mainWindowBounds: { x: 120, y: 80, width: 1280, height: 900 },
           mainWindowMaximized: false,
           serverExposureMode: "network-accessible",
@@ -266,6 +273,44 @@ describe("DesktopSettings", () => {
         assert.equal(loaded.serverExposureMode, "network-accessible");
       }),
     ),
+  );
+
+  it.effect(
+    "normalizes unsupported linux password-store values without dropping other settings",
+    () =>
+      withSettings(
+        Effect.gen(function* () {
+          const environment = yield* DesktopEnvironment.DesktopEnvironment;
+          const fileSystem = yield* FileSystem.FileSystem;
+          const settings = yield* DesktopAppSettings.DesktopAppSettings;
+          yield* fileSystem.makeDirectory(environment.stateDir, { recursive: true });
+          yield* fileSystem.writeFileString(
+            environment.desktopSettingsPath,
+            `{
+            "linuxPasswordStore": "unsupported-store",
+            "serverExposureMode": "network-accessible",
+            "tailscaleServeEnabled": true,
+            "tailscaleServePort": 8443,
+            "updateChannel": "nightly",
+            "updateChannelConfiguredByUser": true
+          }\n`,
+          );
+
+          assert.deepEqual(yield* settings.load, {
+            linuxPasswordStore: "auto",
+            mainWindowBounds: null,
+            mainWindowMaximized: false,
+            serverExposureMode: "network-accessible",
+            tailscaleServeEnabled: true,
+            tailscaleServePort: 8443,
+            updateChannel: "nightly",
+            updateChannelConfiguredByUser: true,
+            wslBackendEnabled: false,
+            wslOnly: false,
+            wslDistro: null,
+          } satisfies DesktopAppSettings.DesktopSettings);
+        }),
+      ),
   );
 
   it.effect("persists sparse desktop settings documents", () =>
@@ -300,6 +345,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          linuxPasswordStore: "auto",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
@@ -327,6 +373,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          linuxPasswordStore: "auto",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",
@@ -353,6 +400,7 @@ describe("DesktopSettings", () => {
         });
 
         assert.deepEqual(yield* settings.load, {
+          linuxPasswordStore: "auto",
           mainWindowBounds: null,
           mainWindowMaximized: false,
           serverExposureMode: "local-only",

--- a/apps/desktop/src/settings/DesktopAppSettings.ts
+++ b/apps/desktop/src/settings/DesktopAppSettings.ts
@@ -16,10 +16,16 @@ import * as Schema from "effect/Schema";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import {
+  DEFAULT_LINUX_PASSWORD_STORE,
+  normalizeLinuxPasswordStorePreference,
+  type LinuxPasswordStorePreference,
+} from "../linuxSecretStorage.ts";
 import { resolveDefaultDesktopUpdateChannel } from "../updates/updateChannels.ts";
 import { isValidDistroName } from "../wsl/wslPathParsing.ts";
 
 export interface DesktopSettings {
+  readonly linuxPasswordStore: LinuxPasswordStorePreference;
   readonly mainWindowBounds: DesktopWindowBounds | null;
   readonly mainWindowMaximized: boolean;
   readonly serverExposureMode: DesktopServerExposureMode;
@@ -67,6 +73,7 @@ export const DEFAULT_MAIN_WINDOW_SIZE = {
 } as const;
 
 export const DEFAULT_DESKTOP_SETTINGS: DesktopSettings = {
+  linuxPasswordStore: DEFAULT_LINUX_PASSWORD_STORE,
   mainWindowBounds: null,
   mainWindowMaximized: false,
   serverExposureMode: "local-only",
@@ -87,6 +94,7 @@ const DesktopWindowBoundsDocument = Schema.Struct({
 });
 
 const DesktopSettingsDocument = Schema.Struct({
+  linuxPasswordStore: Schema.optionalKey(Schema.Unknown),
   mainWindowBounds: Schema.optionalKey(Schema.NullOr(DesktopWindowBoundsDocument)),
   mainWindowMaximized: Schema.optionalKey(Schema.Boolean),
   serverExposureMode: Schema.optionalKey(DesktopServerExposureModeSchema),
@@ -216,6 +224,7 @@ function normalizeDesktopSettingsDocument(
     (parsed.wslBackendEnabled === undefined && parsed.wslMode === "wsl");
 
   return {
+    linuxPasswordStore: normalizeLinuxPasswordStorePreference(parsed.linuxPasswordStore),
     mainWindowBounds,
     mainWindowMaximized: mainWindowBounds !== null && parsed.mainWindowMaximized === true,
     serverExposureMode:
@@ -238,6 +247,9 @@ function toDesktopSettingsDocument(
 ): DesktopSettingsDocument {
   const document: Mutable<DesktopSettingsDocument> = {};
 
+  if (settings.linuxPasswordStore !== defaults.linuxPasswordStore) {
+    document.linuxPasswordStore = settings.linuxPasswordStore;
+  }
   if (settings.mainWindowBounds !== null) {
     document.mainWindowBounds = settings.mainWindowBounds;
   }

--- a/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
+++ b/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
@@ -86,6 +86,7 @@ function makeSafeStorageLayer(input: {
       }
       return Effect.succeed(decoded.slice("enc:".length));
     },
+    selectedStorageBackend: Effect.succeed(Option.none()),
   } satisfies ElectronSafeStorage.ElectronSafeStorage["Service"]);
 }
 

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -1,3 +1,4 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -90,7 +91,7 @@ function runShellEnvironment(input: {
   }).pipe(
     Effect.provide(
       DesktopShellEnvironment.layer.pipe(
-        Layer.provide(Layer.mergeAll(environmentLayer, spawnerLayer)),
+        Layer.provide(Layer.mergeAll(environmentLayer, NodeServices.layer, spawnerLayer)),
       ),
     ),
   );
@@ -242,6 +243,65 @@ describe("DesktopShellEnvironment", () => {
       );
     }),
   );
+
+  it.effect("prefers login-shell desktop session hints over inherited values on linux", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        XDG_CURRENT_DESKTOP: "wrong-launcher",
+        XDG_SESSION_DESKTOP: "wrong-launcher",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        handler: () =>
+          envOutput({
+            PATH: "/home/linuxbrew/.linuxbrew/bin:/usr/bin",
+            XDG_CURRENT_DESKTOP: "KDE",
+            XDG_SESSION_DESKTOP: "KDE",
+            XDG_SESSION_TYPE: "wayland",
+          }),
+      });
+
+      assert.equal(env.XDG_CURRENT_DESKTOP, "KDE");
+      assert.equal(env.XDG_SESSION_DESKTOP, "KDE");
+      assert.equal(env.XDG_SESSION_TYPE, "wayland");
+    }),
+  );
+
+  it.effect("overrides stale dbus session addresses from the login shell", () =>
+    Effect.gen(function* () {
+      const env: NodeJS.ProcessEnv = {
+        SHELL: "/bin/zsh",
+        PATH: "/usr/bin",
+        DBUS_SESSION_BUS_ADDRESS: "unix:path=/tmp/stale-bus",
+      };
+
+      yield* runShellEnvironment({
+        env,
+        platform: "linux",
+        handler: () =>
+          envOutput({
+            PATH: "/usr/bin",
+            DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/1000/bus",
+          }),
+      });
+
+      assert.equal(env.DBUS_SESSION_BUS_ADDRESS, "unix:path=/run/user/1000/bus");
+    }),
+  );
+
+  it("resolves dbus runtime dir candidates with existence checks", () => {
+    const busPath = DesktopShellEnvironment.resolveDefaultLinuxDbusSessionBusAddress({
+      env: { XDG_RUNTIME_DIR: "/tmp/stale-runtime" },
+      uid: 1000,
+      exists: (path) => path === "/run/user/1000/bus",
+    });
+
+    assert.equal(busPath, "unix:path=/run/user/1000/bus");
+  });
 
   it.effect("logs command failures with safe probe context and the exact cause", () => {
     const env: NodeJS.ProcessEnv = {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
@@ -13,6 +14,7 @@ type EnvironmentPatch = Record<string, string>;
 
 interface ShellEnvironmentConfig {
   readonly env: NodeJS.ProcessEnv;
+  readonly fileSystem: FileSystem.FileSystem;
   readonly platform: NodeJS.Platform;
   readonly userShell: Option.Option<string>;
 }
@@ -68,12 +70,19 @@ export class DesktopShellEnvironment extends Context.Service<
 
 const LOGIN_SHELL_ENV_NAMES = [
   "PATH",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "DISPLAY",
   "SSH_AUTH_SOCK",
   "HOMEBREW_PREFIX",
   "HOMEBREW_CELLAR",
   "HOMEBREW_REPOSITORY",
   "XDG_CONFIG_HOME",
+  "XDG_CURRENT_DESKTOP",
   "XDG_DATA_HOME",
+  "XDG_RUNTIME_DIR",
+  "XDG_SESSION_DESKTOP",
+  "XDG_SESSION_TYPE",
+  "WAYLAND_DISPLAY",
 ] as const;
 const WINDOWS_PROFILE_ENV_NAMES = ["PATH", "FNM_DIR", "FNM_MULTISHELL_PATH"] as const;
 const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
@@ -91,6 +100,47 @@ const pathDelimiter = (platform: NodeJS.Platform) => (platform === "win32" ? ";"
 
 const readEnvPath = (env: NodeJS.ProcessEnv): Option.Option<string> =>
   trimNonEmpty(env.PATH ?? env.Path ?? env.path);
+
+const normalizeRuntimeDir = (value: string): string => value.replace(/\/+$/u, "");
+
+const linuxRuntimeDirCandidates = (
+  env: NodeJS.ProcessEnv,
+  uid: number | undefined,
+): ReadonlyArray<string> => {
+  const candidates: string[] = [];
+  const fromEnv = trimNonEmpty(env.XDG_RUNTIME_DIR);
+  if (Option.isSome(fromEnv)) {
+    candidates.push(normalizeRuntimeDir(fromEnv.value));
+  }
+  if (uid !== undefined) {
+    candidates.push(`/run/user/${uid}`);
+  }
+  return candidates.filter((candidate) => candidate.length > 0);
+};
+
+function resolveDefaultLinuxDbusSessionBusPath(input: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly uid: number | undefined;
+  readonly exists?: (path: string) => boolean;
+}): string | null {
+  for (const runtimeDir of linuxRuntimeDirCandidates(input.env, input.uid)) {
+    const busPath = `${runtimeDir}/bus`;
+    if (input.exists === undefined || input.exists(busPath)) {
+      return busPath;
+    }
+  }
+
+  return null;
+}
+
+export function resolveDefaultLinuxDbusSessionBusAddress(input: {
+  readonly env: NodeJS.ProcessEnv;
+  readonly exists: (path: string) => boolean;
+  readonly uid: number | undefined;
+}): string | null {
+  const busPath = resolveDefaultLinuxDbusSessionBusPath(input);
+  return busPath !== null && input.exists(busPath) ? `unix:path=${busPath}` : null;
+}
 
 const pathComparisonKey = (entry: string, platform: NodeJS.Platform) => {
   const normalized = entry.trim().replace(/^"+|"+$/g, "");
@@ -383,15 +433,46 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
       config.env.SSH_AUTH_SOCK = shellEnvironment.SSH_AUTH_SOCK;
     }
 
+    const shellPreferredEnvNames = [
+      "DBUS_SESSION_BUS_ADDRESS",
+      "XDG_CURRENT_DESKTOP",
+      "XDG_SESSION_DESKTOP",
+      "XDG_SESSION_TYPE",
+    ] as const;
+    for (const name of shellPreferredEnvNames) {
+      if (shellEnvironment[name]) {
+        config.env[name] = shellEnvironment[name];
+      }
+    }
+
     for (const name of [
+      "DISPLAY",
       "HOMEBREW_PREFIX",
       "HOMEBREW_CELLAR",
       "HOMEBREW_REPOSITORY",
       "XDG_CONFIG_HOME",
       "XDG_DATA_HOME",
+      "XDG_RUNTIME_DIR",
+      "WAYLAND_DISPLAY",
     ] as const) {
       if (!config.env[name] && shellEnvironment[name]) {
         config.env[name] = shellEnvironment[name];
+      }
+    }
+
+    if (
+      config.platform === "linux" &&
+      Option.isNone(trimNonEmpty(config.env.DBUS_SESSION_BUS_ADDRESS))
+    ) {
+      for (const runtimeDir of linuxRuntimeDirCandidates(config.env, process.getuid?.())) {
+        const dbusSessionBusPath = `${runtimeDir}/bus`;
+        const busExists = yield* config.fileSystem
+          .exists(dbusSessionBusPath)
+          .pipe(Effect.orElseSucceed(() => false));
+        if (busExists) {
+          config.env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${dbusSessionBusPath}`;
+          break;
+        }
       }
     }
   },
@@ -411,10 +492,12 @@ const installShellEnvironment = (
 
 export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const fileSystem = yield* FileSystem.FileSystem;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const installIntoProcess: DesktopShellEnvironment["Service"]["installIntoProcess"] =
     installShellEnvironment({
       env: process.env,
+      fileSystem,
       platform: environment.platform,
       userShell: Option.none(),
     }).pipe(

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -14,7 +14,6 @@ type EnvironmentPatch = Record<string, string>;
 
 interface ShellEnvironmentConfig {
   readonly env: NodeJS.ProcessEnv;
-  readonly fileSystem: FileSystem.FileSystem;
   readonly platform: NodeJS.Platform;
   readonly userShell: Option.Option<string>;
 }
@@ -406,7 +405,12 @@ const installWindowsEnvironment = Effect.fn("desktop.shellEnvironment.installWin
 const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosixEnvironment")(
   function* (
     config: ShellEnvironmentConfig,
-  ): Effect.fn.Return<void, never, ChildProcessSpawner.ChildProcessSpawner> {
+  ): Effect.fn.Return<
+    void,
+    never,
+    ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem
+  > {
+    const fileSystem = yield* FileSystem.FileSystem;
     const shellEnvironment: EnvironmentPatch = {};
 
     for (const shell of listLoginShellCandidates(config)) {
@@ -466,7 +470,7 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
     ) {
       for (const runtimeDir of linuxRuntimeDirCandidates(config.env, process.getuid?.())) {
         const dbusSessionBusPath = `${runtimeDir}/bus`;
-        const busExists = yield* config.fileSystem
+        const busExists = yield* fileSystem
           .exists(dbusSessionBusPath)
           .pipe(Effect.orElseSucceed(() => false));
         if (busExists) {
@@ -480,7 +484,7 @@ const installPosixEnvironment = Effect.fn("desktop.shellEnvironment.installPosix
 
 const installShellEnvironment = (
   config: ShellEnvironmentConfig,
-): Effect.Effect<void, never, ChildProcessSpawner.ChildProcessSpawner> => {
+): Effect.Effect<void, never, ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem> => {
   if (config.platform === "win32") {
     return installWindowsEnvironment(config);
   }
@@ -497,10 +501,10 @@ export const make = Effect.gen(function* () {
   const installIntoProcess: DesktopShellEnvironment["Service"]["installIntoProcess"] =
     installShellEnvironment({
       env: process.env,
-      fileSystem,
       platform: environment.platform,
       userShell: Option.none(),
     }).pipe(
+      Effect.provideService(FileSystem.FileSystem, fileSystem),
       Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
       Effect.withSpan("desktop.shellEnvironment.installIntoProcess"),
     );

--- a/apps/desktop/src/telemetry/DesktopTelemetryPublisher.test.ts
+++ b/apps/desktop/src/telemetry/DesktopTelemetryPublisher.test.ts
@@ -43,6 +43,7 @@ function makeElectronAppLayer(
     setDesktopName: () => Effect.void,
     setDockIcon: () => Effect.void,
     appendCommandLineSwitch: () => Effect.void,
+    removeCommandLineSwitch: () => Effect.void,
     onBeforeQuitForUpdate: () => Effect.void,
     on: () => Effect.void,
   } satisfies ElectronApp.ElectronApp["Service"]);

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -46,6 +46,7 @@ const electronAppLayer = Layer.succeed(ElectronApp.ElectronApp, {
   setDockIcon: () => Effect.void,
   appendCommandLineSwitch: () => Effect.void,
   onBeforeQuitForUpdate: () => Effect.void,
+  removeCommandLineSwitch: () => Effect.void,
   on: () => Effect.void,
 } satisfies ElectronApp.ElectronApp["Service"]);
 


### PR DESCRIPTION
## Summary

Closes #2880 Linux/Hyprland safeStorage.

This selects an encrypted Linux `safeStorage` backend before Electron is ready, so desktop SSH environment credentials and the encrypted connection catalog can be persisted on Linux sessions Electron does not recognize automatically.

The #3092 clerk-bridge-migration replaced T3 Code's custom `safeStorage`-backed cloud-auth token store with Clerk's Electron storage adapter, which also uses Electron `safeStorage`. Clerk session tokens, desktop SSH environment credentials, and the encrypted connection catalog therefore all depend on selecting a working Linux password-store backend.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --- | --- |
| Electron 41 can fall back to `basic_text` on Linux sessions such as Niri or Hyprland, because the desktop name is not one of Electron's recognized backend selectors. | Resolve a Linux `password-store` switch before `app.ready`, forcing `gnome-libsecret` for any session Electron would otherwise leave on `basic_text`. Sessions Electron does recognize, KDE included, keep the backend it selects for them. |
| The desktop app did not have a pre-ready settings path for a user-selected Linux password-store override. | Read the persisted `linuxPasswordStore` setting synchronously during early Electron startup, with unsupported values normalized to `auto` without dropping unrelated settings. |
| AppImage sessions can start without the session bus and desktop environment variables needed by Linux secret stores. | Hydrate Linux session environment values from the login shell before re-resolving the runtime `password-store` switch. |

## Defensive Fixes

| Problem and Why it Happened | Fix |
| --- | --- |
| Upstream no longer registers privileged custom protocol schemes before `ready`; Electron requires that registration synchronously at bootstrap. | Add `ElectronProtocol.layerSchemePrivileges` for both `t3code` and `t3code-dev`, then acquire the complete pre-ready layer before Clerk or the broader desktop runtime can build. |
| Safe-storage failures were hard to diagnose on Linux. | Log the configured password-store decision before `ready` and the selected backend after `ready`, without probing keyring availability during startup. |

## Application Startup Sequence

Before this change, `main.ts` built the desktop runtime directly from the Clerk layer. Linux password-store selection and privileged scheme registration did not happen before `app.ready`, and `DesktopApp.startup` only applied a WM `class` switch after shell hydration:

```text
DesktopApp.program
  │
  ▼
desktopClerkLayer
  │
  ▼
desktopApplicationLayer + electronLayer + Node/HTTP services
  │
  ▼
DesktopApp.startup
  ├─ shellEnvironment.installIntoProcess
  ├─ append Linux WM class switch (no password-store selection)
  ├─ clerk.configure → whenReady
  └─ bootstrap
```

After this change, `main.ts` acquires all pre-ready Electron setup before Clerk can build. Clerk then resolves the user-data path and creates its bridge, after which the broader desktop runtime and `DesktopApp.startup` can proceed:

```text
DesktopApp.program
  │
  ▼
desktopElectronPreReadyLayer
  ├─ ElectronProtocol.layerSchemePrivileges
  │    └─ register t3code + t3code-dev before ready
  └─ configureElectronBeforeReady
       ├─ read existing --password-store
       ├─ read early Linux settings from desktop-settings.json
       ├─ append pre-ready switches (class, password-store)
       └─ provide DesktopPreReadyElectronOptions
  │
  │ strict pre-ready barrier
  ▼
desktopClerkLayer
  ├─ resolve userData path
  └─ create Clerk bridge and acquire the single-instance lock
  │
  ▼
desktopApplicationRuntimeLayer
  │
  ▼
DesktopApp.startup
  ├─ shellEnvironment.installIntoProcess
  ├─ re-resolve password-store if shell changed XDG_* / DBUS
  ├─ clerk.configure → whenReady
  └─ log selected safeStorage backend
```

## What `auto` does, and what it deliberately does not

`auto` answers one question: will Electron select a real keyring on its own? Only an exact `XDG_CURRENT_DESKTOP` literal proves that, because Chromium matches those case-sensitively and returns on the first value it recognizes. `KDE` and the libsecret desktops are left alone; `LXQt` is recognized by Chromium but still mapped to basic text, so it is forced like an unknown session.

`auto` never selects a KWallet generation. Earlier revisions tried, and guessing one from `KDE_SESSION_VERSION` or a `plasma*` session name repeatedly picked a wallet service the session does not run. A KDE user who needs a specific generation sets `linuxPasswordStore` explicitly.

## Known Limitations

- `auto` never guesses a KWallet generation itself. For canonical KDE sessions that Electron recognizes, T3 Code leaves `password-store` unset and relies on Electron's built-in detection to select the matching KWallet generation. Ambiguous legacy hints such as `KDE_SESSION_VERSION` or a `plasma*` session name are not trusted on their own because stale values repeatedly selected a wallet service the active session did not run. Those sessions use `gnome-libsecret` unless the user explicitly selects a KWallet generation with `linuxPasswordStore`.
- Plasma sessions whose only hint is a `plasma*` session name get `gnome-libsecret` rather than KWallet. On current Plasma, KWallet exposes the Secret Service API, so libsecret generally resolves; where it does not, it fails loudly rather than silently storing near-plaintext.
- The first pre-ready decision uses `process.env` before login-shell hydration, and post-shell re-resolution in `DesktopApp.startup` covers the common AppImage case but not every desktop session ordering.

## Out of scope (follow-up PRs or issues)

| Topic | Why deferred |
| --- | --- |
| Shell hydration clearing a forced pre-ready `--password-store` when re-resolution returns `null` | Requires a contradictory login-shell profile (e.g. shell exports GNOME `XDG_CURRENT_DESKTOP` on a Niri session). Uncommon for target users; Bugbot thread replied, not blocking this fix. |
| Unconditional DBus / `XDG_RUNTIME_DIR` override when launcher sets stale values | AppImage edge cases; separate hardening from the core password-store selection path. |
| Precedence among `XDG_SESSION_DESKTOP`, `DESKTOP_SESSION`, and `GDMSESSION` when they conflict | None of them influence backend selection any more, so this only affects the wording of the failure notice. |

## Validation

- [x] `vp check`
- [x] `vp run typecheck`
- [x] `vp run build:desktop`
- [x] `vp run --filter @t3tools/desktop test` on the current tip: 56 files, 437 tests
- [x] Packaged AppImage launched on a Niri session and exercised end to end, on the revision before `auto` was narrowed. The narrowing changes which switch that session receives only for KDE-identified sessions, and Niri resolves to `gnome-libsecret` on both revisions.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes: N/A, desktop startup and persistence behavior
- [x] I included a video for animation/interaction changes: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes Electron startup ordering and Linux credential encryption backend selection before `app.ready`; mis-selection or stale env could leave secrets unencrypted or break persistence on Linux.
> 
> **Overview**
> Fixes Linux sessions (e.g. Niri/Hyprland) where Electron would otherwise use weak `basic_text` for `safeStorage`, which breaks encrypted SSH credentials, the connection catalog, and Clerk-backed token storage.
> 
> **Pre-ready bootstrap** adds `DesktopPreReadyPlatform` so privileged `t3code` / `t3code-dev` scheme registration and Linux `class` + `password-store` switches run **before** Clerk or other async layers can reach `app.ready`. Persisted `linuxPasswordStore` is read synchronously from `desktop-settings.json` (JSONC), with `auto` forcing `gnome-libsecret` only when `XDG_CURRENT_DESKTOP` does not prove Electron will pick a real keyring (canonical KDE/GNOME/etc. stay on Electron defaults).
> 
> **After login-shell hydration**, startup re-reads early Linux options and can **remove/re-append** `password-store` when session env changes (typical AppImage case), respects an explicit CLI `--password-store`, and logs the chosen store plus `safeStorage.getSelectedStorageBackend()` on Linux.
> 
> **Supporting changes**: shared `DesktopStatePaths` (trimmed `T3CODE_HOME` treated as unset), `ElectronApp.removeCommandLineSwitch`, `linuxSecretStorage` heuristics and failure messaging, and broader Linux shell env hydration (`DBUS_SESSION_BUS_ADDRESS`, `XDG_*`, display/Wayland) with a runtime DBus bus path fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454eb3ddc14f83f9049d9a41684f6f23ab0b2eed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux secret storage backend selection for Niri/Hyprland window managers
> - Adds pre-ready resolution of the Electron `password-store` command-line switch on Linux, reading a persisted `linuxPasswordStore` setting from `desktop-settings.json` before Electron emits `ready`
> - Introduces `DesktopPreReadyElectronOptions` to synchronously append `class` and `password-store` switches before any async layer can yield control, ensuring Electron sees the correct values at startup
> - Expands login-shell environment hydration to include `DBUS_SESSION_BUS_ADDRESS`, `DISPLAY`, `XDG_CURRENT_DESKTOP`, `XDG_RUNTIME_DIR`, and Wayland/session vars; falls back to a derived DBUS bus path when the address is missing
> - Adds `selectedStorageBackend` to `ElectronSafeStorage` and `removeCommandLineSwitch` to `ElectronApp` to support querying and modifying Electron state at runtime
> - Behavioral Change: whitespace-only `T3CODE_HOME` values are now treated as unset, which changes whether the `dev` or `userdata` subdirectory is used for state storage
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 454eb3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->