### PR TITLE
fix(web): Remove saved environments atomically

### DIFF
--- a/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
+++ b/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
@@ -272,6 +272,26 @@ describe("DesktopSavedEnvironments", () => {
     ),
   );
 
+  it.effect("removes saved environment metadata and its embedded secret atomically", () =>
+    withSavedEnvironments(
+      Effect.gen(function* () {
+        const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
+        yield* savedEnvironments.setRegistry([savedRegistryRecord]);
+        yield* savedEnvironments.setSecret({
+          environmentId: savedRegistryRecord.environmentId,
+          secret: "bearer-token",
+        });
+
+        yield* savedEnvironments.removeEnvironment(savedRegistryRecord.environmentId);
+
+        assert.deepEqual(yield* savedEnvironments.getRegistry, []);
+        assert.isTrue(
+          Option.isNone(yield* savedEnvironments.getSecret(savedRegistryRecord.environmentId)),
+        );
+      }),
+    ),
+  );
+
   it.effect("treats empty saved environment documents as empty", () =>
     withSavedEnvironments(
       Effect.gen(function* () {

--- a/apps/desktop/src/settings/DesktopSavedEnvironments.ts
+++ b/apps/desktop/src/settings/DesktopSavedEnvironments.ts
@@ -121,6 +121,9 @@ export interface DesktopSavedEnvironmentsShape {
   readonly setRegistry: (
     records: readonly PersistedSavedEnvironmentRecord[],
   ) => Effect.Effect<void, DesktopSavedEnvironmentsWriteError>;
+  readonly removeEnvironment: (
+    environmentId: string,
+  ) => Effect.Effect<void, DesktopSavedEnvironmentsWriteError>;
   readonly getSecret: (
     environmentId: string,
   ) => Effect.Effect<Option.Option<string>, DesktopSavedEnvironmentsGetSecretError>;
@@ -293,6 +296,23 @@ export const layer = Layer.effect(
         ).pipe(Effect.mapError((cause) => new DesktopSavedEnvironmentsWriteError({ cause })));
         yield* writeDocument(preserveExistingSecrets(currentDocument, records));
       }),
+      removeEnvironment: Effect.fn("desktop.savedEnvironments.removeEnvironment")(
+        function* (environmentId) {
+          yield* Effect.annotateCurrentSpan({ environmentId });
+          const document = yield* readRegistryDocument(
+            fileSystem,
+            environment.savedEnvironmentRegistryPath,
+          ).pipe(Effect.mapError((cause) => new DesktopSavedEnvironmentsWriteError({ cause })));
+          if (!document.records.some((record) => record.environmentId === environmentId)) {
+            return;
+          }
+
+          yield* writeDocument({
+            version: document.version,
+            records: document.records.filter((record) => record.environmentId !== environmentId),
+          });
+        },
+      ),
       getSecret: Effect.fn("desktop.savedEnvironments.getSecret")(function* (environmentId) {
         yield* Effect.annotateCurrentSpan({ environmentId });
         const document = yield* readRegistryDocument(
@@ -385,6 +405,18 @@ export const layerTest = (input?: {
       return DesktopSavedEnvironments.of({
         getRegistry: Ref.get(recordsRef),
         setRegistry: (records) => Ref.set(recordsRef, records),
+        removeEnvironment: (environmentId) =>
+          Ref.update(recordsRef, (records) =>
+            records.filter((record) => record.environmentId !== environmentId),
+          ).pipe(
+            Effect.andThen(
+              Ref.update(secretsRef, (secrets) => {
+                const nextSecrets = new Map(secrets);
+                nextSecrets.delete(environmentId);
+                return nextSecrets;
+              }),
+            ),
+          ),
         getSecret: (environmentId) =>
           Ref.get(secretsRef).pipe(
             Effect.map((secrets) => Option.fromNullishOr(secrets.get(environmentId))),


### PR DESCRIPTION
## Summary

Closes #2914.

This makes saved-environment removal use a single persistence operation that removes metadata and embedded credentials together, and tightens rollback behavior when replacing stale desktop SSH records.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --- | --- |
| Removing a saved environment updated persisted metadata and bearer-token state separately, so SSH cleanup could race with deletion and stale records could reappear. | Add `removeSavedEnvironment` to the local persistence API and desktop IPC bridge so metadata and embedded secrets are removed atomically. |
| The UI cleared saved-environment state before durable removal finished. | Persist removal first, then clear registry/runtime/UI state, while still awaiting SSH cleanup before returning. |
| Browser fallback persistence did not have an equivalent atomic saved-environment removal path. | Add browser-storage removal alongside the desktop bridge implementation. |
| Replacing a stale desktop SSH record only snapshotted the new environment id. | Snapshot both the new id and stale SSH record so rollback can restore the previous saved record if credential persistence fails. |

## Defensive Fixes

| Problem and Why it Happened | Fix |
| --- | --- |
| Rollback errors could hide the original credential persistence error. | Preserve and rethrow the primary credential persistence failure after best-effort rollback. |
| SSH cleanup errors during removal could block state cleanup in the wrong order. | Remove persisted saved-environment state first, then await SSH cleanup and log cleanup failures without restoring stale persistence. |

## Validation

- [x] `bun fmt`
- [x] `bun lint`
- [x] `bun typecheck`
- [x] `bun run --filter @t3tools/desktop test -- DesktopSavedEnvironments`
- [x] `bun run --filter @t3tools/web test -- localApi catalog service.addSavedEnvironment service.savedEnvironments`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes: N/A, persistence behavior only
- [x] I included a video for animation/interaction changes: N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-disk saved-environment and credential persistence, but the scope is narrow and covered by a new atomic-removal test.
> 
> **Overview**
> Adds **`removeEnvironment(environmentId)`** to desktop saved-environment persistence so registry metadata and the embedded **`encryptedBearerToken`** are dropped in **one registry write**, instead of relying on separate metadata vs secret updates.
> 
> The file-backed implementation filters the matching record out of the persisted document (no-op if missing). The in-memory test layer clears both the records ref and secrets ref together. A new test asserts the registry is empty and **`getSecret`** is none after removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01dee9c04f65c48dff061909c3d38c633a93e447. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `removeEnvironment` to `DesktopSavedEnvironments` to delete registry records and secrets atomically
> - Adds `removeEnvironment(environmentId)` to [`DesktopSavedEnvironmentsShape`](https://github.com/pingdotgg/t3code/pull/2917/files#diff-8c5e156b438cdca8b80aa299e0a70831bcbc67ffc702ca46ebde33c900570cf4), which removes the matching record from the registry document and its embedded `encryptedBearerToken` in a single write.
> - The production layer reads the current registry, filters out the matching record, and writes the updated document preserving the version field.
> - The test layer removes the record from `recordsRef` and the secret from `secretsRef` together, with a new test asserting both are cleared after calling `removeEnvironment`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized da654c7. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->