### PR TITLE
fix(ssh): Surface redacted stdout for failed commands

### DIFF
--- a/packages/ssh/src/command.test.ts
+++ b/packages/ssh/src/command.test.ts
@@ -17,6 +17,27 @@ import {
   resolveRemoteT3CliPackageSpec,
   runSshCommand,
 } from "./command.ts";
+import { SshCommandError } from "./errors.ts";
+
+const encoder = new TextEncoder();
+
+const makeFailedProcess = (input: { readonly stdout: string; readonly stderr?: string }) => {
+  const stdoutStream = Stream.make(encoder.encode(input.stdout));
+  const stderrStream = input.stderr ? Stream.make(encoder.encode(input.stderr)) : Stream.empty;
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(123),
+    stdout: stdoutStream,
+    stderr: stderrStream,
+    all: Stream.empty,
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(1)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    stdin: Sink.drain,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+    unref: Effect.succeed(Effect.void),
+  });
+};
 
 const makeNeverFinishingProcess = () => {
   let finish: ((exitCode: ChildProcessSpawner.ExitCode) => void) | null = null;
@@ -123,6 +144,65 @@ describe("ssh command", () => {
       );
     }),
   );
+
+  it.effect("includes stdout in non-zero command failures when stderr is empty", () => {
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(makeFailedProcess({ stdout: "Pairing token creation failed\n" })),
+    );
+    const spawnerLayer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner);
+    const processLayer = Layer.mergeAll(NodeServices.layer, spawnerLayer);
+
+    return Effect.gen(function* () {
+      const result = yield* Effect.result(
+        runSshCommand(
+          {
+            alias: "devbox",
+            hostname: "devbox.example.com",
+            username: "julius",
+            port: 2222,
+          },
+          { remoteCommandArgs: ["sh", "-s"] },
+        ),
+      );
+
+      assert.isTrue(Result.isFailure(result));
+      if (Result.isFailure(result)) {
+        assert.instanceOf(result.failure, SshCommandError);
+        assert.equal(result.failure.message, "Pairing token creation failed");
+        assert.equal(result.failure.stdout, "Pairing token creation failed\n");
+        assert.equal(result.failure.stderr, "");
+      }
+    }).pipe(Effect.provide(processLayer));
+  });
+
+  it.effect("redacts credentials from stdout in non-zero command failures", () => {
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(makeFailedProcess({ stdout: '{"credential":"pairing-secret"}\n' })),
+    );
+    const spawnerLayer = Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner);
+    const processLayer = Layer.mergeAll(NodeServices.layer, spawnerLayer);
+
+    return Effect.gen(function* () {
+      const result = yield* Effect.result(
+        runSshCommand(
+          {
+            alias: "devbox",
+            hostname: "devbox.example.com",
+            username: "julius",
+            port: 2222,
+          },
+          { remoteCommandArgs: ["sh", "-s"] },
+        ),
+      );
+
+      assert.isTrue(Result.isFailure(result));
+      if (Result.isFailure(result)) {
+        assert.instanceOf(result.failure, SshCommandError);
+        assert.equal(result.failure.message, '{"credential":"[redacted]"}');
+        assert.equal(result.failure.stdout, '{"credential":"[redacted]"}\n');
+      }
+    }).pipe(Effect.provide(processLayer));
+  });
 
   it.effect("fails commands that never finish", () => {
     const spawner = ChildProcessSpawner.make(() => Effect.succeed(makeNeverFinishingProcess()));

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -15,6 +15,7 @@ import { SshCommandError, SshInvalidTargetError } from "./errors.ts";
 
 const PUBLISHABLE_T3_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 const DEFAULT_SSH_COMMAND_TIMEOUT_MS = 60_000;
+const MAX_SSH_ERROR_OUTPUT_LENGTH = 4_000;
 
 const encoder = new TextEncoder();
 
@@ -118,9 +119,28 @@ export const collectProcessOutput = <E>(
     ),
   );
 
-function normalizeSshErrorMessage(stderr: string, fallbackMessage: string): string {
-  const cleaned = stderr.trim();
-  return cleaned.length > 0 ? cleaned : fallbackMessage;
+function redactSshErrorOutput(output: string): string {
+  const redacted = output.replace(
+    /("(?:access_token|bearerToken|credential|pairingToken|token)"\s*:\s*")[^"]+(")/giu,
+    "$1[redacted]$2",
+  );
+  return redacted.length > MAX_SSH_ERROR_OUTPUT_LENGTH
+    ? `${redacted.slice(0, MAX_SSH_ERROR_OUTPUT_LENGTH)}\n[truncated]`
+    : redacted;
+}
+
+function normalizeSshErrorMessage(input: {
+  readonly stdout?: string;
+  readonly stderr: string;
+  readonly fallbackMessage: string;
+}): string {
+  const cleanedStderr = input.stderr.trim();
+  if (cleanedStderr.length > 0) {
+    return cleanedStderr;
+  }
+
+  const cleanedStdout = input.stdout?.trim() ?? "";
+  return cleanedStdout.length > 0 ? cleanedStdout : input.fallbackMessage;
 }
 
 function sshTargetLogFields(target: DesktopSshEnvironmentTarget) {
@@ -226,20 +246,24 @@ const runSshCommandInScope = Effect.fn("ssh/command.runSshCommand.inScope")(func
   );
 
   if (exitCode !== 0) {
+    const diagnosticStdout = redactSshErrorOutput(stdout);
     yield* Effect.logWarning("ssh.command.failed", {
       ...sshTargetLogFields(target),
       command: ["ssh", ...args],
       exitCode,
+      stdout: diagnosticStdout,
       stderr,
     });
     return yield* new SshCommandError({
       command: ["ssh", ...args],
       exitCode,
+      stdout: diagnosticStdout,
       stderr,
-      message: normalizeSshErrorMessage(
+      message: normalizeSshErrorMessage({
+        stdout: diagnosticStdout,
         stderr,
-        `SSH command failed for ${hostSpec} (exit ${exitCode}).`,
-      ),
+        fallbackMessage: `SSH command failed for ${hostSpec} (exit ${exitCode}).`,
+      }),
     });
   }
 

--- a/packages/ssh/src/errors.ts
+++ b/packages/ssh/src/errors.ts
@@ -14,6 +14,7 @@ export class SshCommandError extends Data.TaggedError("SshCommandError")<{
   readonly command: readonly string[];
   readonly exitCode: number | null;
   readonly stderr: string;
+  readonly stdout?: string;
   readonly cause?: unknown;
 }> {}
 


### PR DESCRIPTION
## Summary

Fixes #2919.

Failed SSH commands now preserve diagnostic stdout when stderr is empty, so remote setup and pairing failures can surface useful messages instead of only the generic exit-code fallback.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --- | --- |
| `runSshCommand` collected stdout, but non-zero exits only used stderr for logs and error messages. Some remote commands print their useful failure details to stdout. | Use sanitized stdout as a fallback error message source when stderr is empty. |
| Pairing commands can print one-time credentials to stdout, so propagating raw stdout would risk persisting secrets in logs or UI errors. | Redact credential-like JSON fields and truncate stdout before attaching it to `SshCommandError` or failure logs. |

## Validation

- `bun fmt`
- `bun lint` (passes with existing warnings)
- `bun typecheck`
- `bun run --filter @t3tools/ssh test`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface redacted stdout in `SshCommandError` for failed SSH commands with empty stderr
> - When an SSH command exits with a non-zero code and stderr is empty, the error message now falls back to stdout via the updated `normalizeSshErrorMessage` in [command.ts](https://github.com/pingdotgg/t3code/pull/2920/files#diff-4f1aef4b11679d8551404a853942f04f47c3a80c050bc25b784d2b0c48ec9e5e).
> - Stdout is passed through a new `redactSshErrorOutput` function that masks sensitive fields (e.g. `access_token`, `credential`, `token`) as `[redacted]` and truncates output exceeding 4,000 characters with a `[truncated]` marker.
> - The redacted stdout is included in warning logs and as a new `stdout` field on `SshCommandError` in [errors.ts](https://github.com/pingdotgg/t3code/pull/2920/files#diff-8ae37d8d35f60b74c653279b66a9597224de786a68190cdb5e03b9b094059e1f).
> - Behavioral Change: failed SSH commands may now surface stdout-derived error messages where previously only a fallback message was shown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4865f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what appears in logs and user-facing SSH errors; mitigated by credential redaction and truncation, but new stdout exposure paths warrant a careful review.
> 
> **Overview**
> Failed SSH commands now surface **useful error text from stdout** when stderr is empty, instead of only the generic exit-code message—so remote setup/pairing failures are easier to debug.
> 
> On non-zero exits, `runSshCommand` runs stdout through **`redactSshErrorOutput`** (masks JSON fields like `credential` / `token` as `[redacted]`, caps at 4k with `[truncated]`), uses that for the error **message** when stderr is blank, and attaches it as optional **`stdout` on `SshCommandError`** plus failure logs. **Stderr still wins** when present. Tests cover plain stdout failures and redacted credential output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4865f4169bf7e7c91be5be2d70ac6f17b7c7e86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->