### PR TITLE
fix(desktop): Preserve SSH HTTP auth status

### DIFF
--- a/apps/desktop/src/ipc/methods/sshEnvironment.test.ts
+++ b/apps/desktop/src/ipc/methods/sshEnvironment.test.ts
@@ -10,7 +10,6 @@ import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstab
 import {
   DesktopSshEnvironmentRequestError,
   fetchSshEnvironmentDescriptor,
-  fetchSshSessionState,
 } from "./sshEnvironment.ts";
 
 function jsonResponse(request: HttpClientRequest.HttpClientRequest, body: unknown, status = 200) {
@@ -111,41 +110,6 @@ describe("SSH environment IPC", () => {
       assert.instanceOf(error, DesktopSshEnvironmentRequestError);
       assert.instanceOf(error.cause, SshHttpBridgeError);
       assert.equal(requestCount, 0);
-    }).pipe(Effect.provide(layer));
-  });
-
-  it.effect("preserves SSH HTTP status in top-level request error messages", () => {
-    const layer = makeHttpClientLayer((request) =>
-      Effect.succeed(
-        jsonResponse(
-          request,
-          {
-            _tag: "EnvironmentAuthInvalidError",
-            code: "auth_invalid",
-            reason: "invalid_credential",
-            traceId: "11111111111111111111111111111111",
-          },
-          401,
-        ),
-      ),
-    );
-
-    return Effect.gen(function* () {
-      const exit = yield* Effect.exit(
-        fetchSshSessionState.handler({
-          bearerToken: "stale-bearer-token",
-          httpBaseUrl: "http://127.0.0.1:41773/",
-        }),
-      );
-      assert(Exit.isFailure(exit));
-      const failure = Cause.findErrorOption(exit.cause);
-      assert(Option.isSome(failure));
-      const error = failure.value;
-
-      assert.instanceOf(error, DesktopSshEnvironmentRequestError);
-      assert.equal(error.operation, "fetch-session-state");
-      assert.equal(error.sshHttpStatus, 401);
-      assert.match(error.message, /^\[ssh_http:401\] /u);
     }).pipe(Effect.provide(layer));
   });
 });

--- a/apps/desktop/src/ipc/methods/sshEnvironment.test.ts
+++ b/apps/desktop/src/ipc/methods/sshEnvironment.test.ts
@@ -10,6 +10,7 @@ import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstab
 import {
   DesktopSshEnvironmentRequestError,
   fetchSshEnvironmentDescriptor,
+  fetchSshSessionState,
 } from "./sshEnvironment.ts";
 
 function jsonResponse(request: HttpClientRequest.HttpClientRequest, body: unknown, status = 200) {
@@ -110,6 +111,41 @@ describe("SSH environment IPC", () => {
       assert.instanceOf(error, DesktopSshEnvironmentRequestError);
       assert.instanceOf(error.cause, SshHttpBridgeError);
       assert.equal(requestCount, 0);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect("preserves SSH HTTP status in top-level request error messages", () => {
+    const layer = makeHttpClientLayer((request) =>
+      Effect.succeed(
+        jsonResponse(
+          request,
+          {
+            _tag: "EnvironmentAuthInvalidError",
+            code: "auth_invalid",
+            reason: "invalid_credential",
+            traceId: "11111111111111111111111111111111",
+          },
+          401,
+        ),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(
+        fetchSshSessionState.handler({
+          bearerToken: "stale-bearer-token",
+          httpBaseUrl: "http://127.0.0.1:41773/",
+        }),
+      );
+      assert(Exit.isFailure(exit));
+      const failure = Cause.findErrorOption(exit.cause);
+      assert(Option.isSome(failure));
+      const error = failure.value;
+
+      assert.instanceOf(error, DesktopSshEnvironmentRequestError);
+      assert.equal(error.operation, "fetch-session-state");
+      assert.equal(error.sshHttpStatus, 401);
+      assert.match(error.message, /^\[ssh_http:401\] /u);
     }).pipe(Effect.provide(layer));
   });
 });

--- a/apps/desktop/src/ipc/methods/sshEnvironment.ts
+++ b/apps/desktop/src/ipc/methods/sshEnvironment.ts
@@ -3,8 +3,11 @@ import {
   fetchRemoteEnvironmentDescriptor,
   fetchRemoteSessionState,
   issueRemoteWebSocketTicket,
+  RemoteEnvironmentAuthUndeclaredStatusError,
+  type RemoteEnvironmentAuthError,
 } from "@t3tools/client-runtime";
 import {
+  EnvironmentAuthInvalidError,
   DesktopDiscoveredSshHostSchema,
   DesktopSshBearerBootstrapInputSchema,
   DesktopSshBearerRequestInputSchema,
@@ -15,10 +18,15 @@ import {
   DesktopSshPasswordPromptCancelledType,
   DesktopSshPasswordPromptResolutionInputSchema,
   ExecutionEnvironmentDescriptor,
+  EnvironmentInternalError,
+  EnvironmentOperationForbiddenError,
+  EnvironmentRequestInvalidError,
+  EnvironmentScopeRequiredError,
   AuthAccessTokenResult,
   AuthSessionState,
   AuthWebSocketTicketResult,
 } from "@t3tools/contracts";
+import { SshHttpBridgeError } from "@t3tools/ssh/errors";
 import { resolveLoopbackSshHttpBaseUrl } from "@t3tools/ssh/tunnel";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
@@ -35,26 +43,68 @@ type DesktopSshEnvironmentRequestOperation =
   | "fetch-session-state"
   | "issue-websocket-ticket";
 
+type DesktopSshEnvironmentRequestCause = RemoteEnvironmentAuthError | SshHttpBridgeError;
+
+const isEnvironmentAuthInvalidError = Schema.is(EnvironmentAuthInvalidError);
+const isEnvironmentInternalError = Schema.is(EnvironmentInternalError);
+const isEnvironmentOperationForbiddenError = Schema.is(EnvironmentOperationForbiddenError);
+const isEnvironmentRequestInvalidError = Schema.is(EnvironmentRequestInvalidError);
+const isEnvironmentScopeRequiredError = Schema.is(EnvironmentScopeRequiredError);
+
+function readSshHttpStatus(cause: DesktopSshEnvironmentRequestCause): number | null {
+  if (
+    cause instanceof RemoteEnvironmentAuthUndeclaredStatusError ||
+    cause instanceof SshHttpBridgeError
+  ) {
+    return cause.status ?? null;
+  }
+  if (isEnvironmentRequestInvalidError(cause)) {
+    return 400;
+  }
+  if (isEnvironmentAuthInvalidError(cause)) {
+    return 401;
+  }
+  if (isEnvironmentScopeRequiredError(cause)) {
+    return 403;
+  }
+  if (isEnvironmentOperationForbiddenError(cause)) {
+    return 403;
+  }
+  if (isEnvironmentInternalError(cause)) {
+    return 500;
+  }
+  return null;
+}
+
 export class DesktopSshEnvironmentRequestError extends Data.TaggedError(
   "DesktopSshEnvironmentRequestError",
 )<{
   readonly operation: DesktopSshEnvironmentRequestOperation;
-  readonly cause: unknown;
+  readonly cause: DesktopSshEnvironmentRequestCause;
+  readonly sshHttpStatus: number | null;
 }> {
   override get message() {
-    return `SSH remote API request failed during ${this.operation}.`;
+    const prefix = this.sshHttpStatus === null ? "" : `[ssh_http:${this.sshHttpStatus}] `;
+    return `${prefix}SSH remote API request failed during ${this.operation}.`;
   }
 }
 
 const withLoopbackSshApi =
-  <A, E, R>(
+  <A, R>(
     operation: DesktopSshEnvironmentRequestOperation,
-    use: (httpBaseUrl: string) => Effect.Effect<A, E, R>,
+    use: (httpBaseUrl: string) => Effect.Effect<A, RemoteEnvironmentAuthError, R>,
   ) =>
   (httpBaseUrl: string): Effect.Effect<A, DesktopSshEnvironmentRequestError, R> =>
     resolveLoopbackSshHttpBaseUrl(httpBaseUrl).pipe(
       Effect.flatMap(use),
-      Effect.mapError((cause) => new DesktopSshEnvironmentRequestError({ operation, cause })),
+      Effect.mapError(
+        (cause) =>
+          new DesktopSshEnvironmentRequestError({
+            operation,
+            cause,
+            sshHttpStatus: readSshHttpStatus(cause),
+          }),
+      ),
     );
 
 export const discoverSshHosts = makeIpcMethod({


### PR DESCRIPTION
## Summary

Fixes #2922.

Preserve SSH HTTP status markers through desktop IPC request errors so the web runtime can detect `401` responses and refresh stale desktop SSH bearer sessions.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --- | --- |
| Desktop SSH IPC wrapped remote HTTP failures in `DesktopSshEnvironmentRequestError`, which replaced the original HTTP status-bearing message with a generic request failure. | Read the status from the wrapped Effect cause and prefix the top-level desktop IPC error message with `[ssh_http:<status>]` when one is available. |
| Remote auth failures can be represented as tagged API errors such as `EnvironmentAuthInvalidError`, not always as a direct numeric status on the outer cause. | Map known environment API error tags back to their HTTP status codes and walk nested causes defensively. |

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --cwd apps/desktop test src/ipc/methods/sshEnvironment.test.ts`
- `bun run --cwd apps/web test src/environments/runtime/service.addSavedEnvironment.test.ts`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve SSH HTTP auth status in `DesktopSshEnvironmentRequestError`
> - Adds a `sshHttpStatus` field to `DesktopSshEnvironmentRequestError` derived from the underlying environment or bridge error type.
> - Maps known error types (auth invalid, scope required, operation forbidden, internal, request invalid) to standard HTTP status codes; passes through the raw status for `RemoteEnvironmentAuthUndeclaredStatusError` and `SshHttpBridgeError`.
> - Updates `withLoopbackSshApi` in [sshEnvironment.ts](https://github.com/pingdotgg/t3code/pull/2923/files#diff-a2fd3cb3211dc8dca34f2cd51cd517b9ccb23e3d0af817e0f24b97f04c3e6cb4) to attach the derived status when constructing the error.
> - Prefixes the error message with `[ssh_http:<status>]` when a status is available, making the HTTP status visible in logs and error surfaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbb95c7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop IPC error shaping for SSH environment calls; no auth logic changes, only surfacing status codes the web runtime already expects.
> 
> **Overview**
> Desktop SSH remote API failures were wrapped in `DesktopSshEnvironmentRequestError` with a generic message, so the web app could not see that the tunneled HTTP call returned **401** and retry bearer refresh.
> 
> **`sshEnvironment.ts`** now derives an HTTP status from the wrapped cause (`SshHttpBridgeError`, `RemoteEnvironmentAuthUndeclaredStatusError`, and tagged environment API errors mapped to 400/401/403/500), stores it on `sshHttpStatus`, and prefixes the IPC error message with **`[ssh_http:<status>]`** when known—matching what `apps/web` already parses to refresh stale desktop SSH sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bbb95c70eb0f5d4be00243f2ef3ede010a6bd4cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->