### PR TITLE
test(web): CI stability - prebundle react-dom client for browser tests

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -117,6 +117,7 @@ export default defineConfig(() => {
         "@pierre/diffs/worker/worker.js",
         "effect/Array",
         "effect/Order",
+        "react-dom/client",
       ],
     },
     define: {


### PR DESCRIPTION
## Summary

Fixes #2927.

Prebundle `react-dom/client` in the web Vitest browser config so Vite does not optimize it after tests have already started and reload the browser test session mid-run.

## Problems Addressed

* `apps/web test:browser` can discover `react-dom/client` during the running browser test session, causing Vite to optimize the dependency and reload Vitest mid-run.
* The reload can make unrelated browser test modules fail to import, for example `ChatView.browser.tsx` failing to fetch `test/wsRpcHarness.ts`.

## Validation

- `bun fmt`
- `bun lint`
- `bun typecheck`
- `bun run --cwd apps/web test:browser`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pre-bundle `react-dom/client` in Vite config to improve CI browser test stability
> Adds `react-dom/client` to `optimizeDeps.include` in [vite.config.ts](https://github.com/pingdotgg/t3code/pull/2928/files#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786) so Vite pre-bundles it at startup rather than discovering it lazily during tests, reducing flakiness in CI browser test runs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcc67ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Vite `optimizeDeps` tweak for test/CI stability; no runtime app or security behavior changes.
> 
> **Overview**
> Adds **`react-dom/client`** to **`optimizeDeps.include`** in the web app’s Vite config so it is pre-bundled up front with the other listed deps.
> 
> This targets flaky **`apps/web test:browser`** runs where Vite would otherwise optimize **`react-dom/client`** after the browser session had already started, reload Vitest mid-run, and break unrelated module loads (e.g. harness imports).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcc67ca0186e2a2d59cc63144380298501664278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->