### PR TITLE
fix(web): Virtualize model picker

### DIFF
--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -32,6 +32,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
   useTriggerLabel?: boolean;
   showNewBadge?: boolean;
   jumpLabel?: string | null;
+  isLast?: boolean;
   onToggleFavorite: () => void;
 }) {
   const ProviderIcon = PROVIDER_ICON_BY_PROVIDER[props.driverKind] ?? null;
@@ -47,7 +48,8 @@ export const ModelListRow = memo(function ModelListRow(props: {
       contentClassName="flex w-full items-start gap-2"
       className={cn(
         "w-full cursor-pointer rounded px-3 py-2 transition-colors group",
-        "data-highlighted:bg-muted data-selected:bg-accent data-selected:text-foreground",
+        "border-b data-highlighted:bg-muted data-selected:bg-accent data-selected:text-foreground",
+        props.isLast && "border-b-0",
       )}
     >
       <Tooltip>

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -4,13 +4,20 @@ import {
   type ResolvedKeybindingsConfig,
 } from "@t3tools/contracts";
 import { resolveSelectableModel } from "@t3tools/shared/model";
+import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { memo, useMemo, useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { SearchIcon } from "lucide-react";
 import { ModelListRow } from "./ModelListRow";
 import { ModelPickerSidebar } from "./ModelPickerSidebar";
 import { isModelPickerNewModel } from "./modelPickerModelHighlights";
 import { buildModelPickerSearchText, scoreModelPickerSearch } from "./modelPickerSearch";
-import { Combobox, ComboboxEmpty, ComboboxInput, ComboboxList } from "../ui/combobox";
+import {
+  Combobox,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxListVirtualized,
+} from "../ui/combobox";
 import { ModelEsque, PROVIDER_ICON_BY_PROVIDER } from "./providerIconUtils";
 import {
   modelPickerJumpCommandForIndex,
@@ -37,6 +44,10 @@ type ModelPickerItem = {
 };
 
 const EMPTY_MODEL_JUMP_LABELS = new Map<string, string>();
+const MODEL_PICKER_VIRTUALIZATION_THRESHOLD = 60;
+const MODEL_PICKER_ESTIMATED_ROW_HEIGHT = 53;
+const MODEL_PICKER_LIST_MAX_HEIGHT = 335;
+const MODEL_PICKER_LIST_MAX_HEIGHT_NO_SIDEBAR = 289;
 
 // Split a `${instanceId}:${slug}` combobox key back into its pieces. Slugs
 // can contain colons (e.g. some vendor model ids), so we only split on the
@@ -92,6 +103,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   const [searchQuery, setSearchQuery] = useState("");
   const searchInputRef = useRef<HTMLInputElement>(null);
   const listRegionRef = useRef<HTMLDivElement>(null);
+  const modelListRef = useRef<LegendListRef | null>(null);
   const highlightedModelKeyRef = useRef<string | null>(null);
   const favorites = useSettings((s) => s.favorites ?? []);
   const [selectedInstanceId, setSelectedInstanceId] = useState<ProviderInstanceId | "favorites">(
@@ -220,6 +232,9 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   );
   const showLockedInstanceSidebar = isLocked && lockedInstanceEntries.length > 1;
   const showSidebar = !isSearching && (!isLocked || showLockedInstanceSidebar);
+  const modelPickerListMaxHeight = showSidebar
+    ? MODEL_PICKER_LIST_MAX_HEIGHT
+    : MODEL_PICKER_LIST_MAX_HEIGHT_NO_SIDEBAR;
   const sidebarInstanceEntries = showLockedInstanceSidebar
     ? lockedInstanceEntries
     : instanceEntries;
@@ -418,6 +433,8 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       new Map(filteredModels.map((model) => [`${model.instanceId}:${model.slug}`, model] as const)),
     [filteredModels],
   );
+  const shouldVirtualizeModelList =
+    filteredModelKeys.length > MODEL_PICKER_VIRTUALIZATION_THRESHOLD;
   const modelJumpShortcutContext = useMemo(
     () =>
       ({
@@ -478,6 +495,10 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
   }, [handleModelSelect, keybindings, modelJumpModelKeys, modelJumpShortcutContext]);
 
   useLayoutEffect(() => {
+    if (shouldVirtualizeModelList) {
+      return;
+    }
+
     const listRegion = listRegionRef.current;
     if (!listRegion) {
       return;
@@ -518,7 +539,43 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       window.cancelAnimationFrame(nestedFrame);
       window.clearTimeout(timeout);
     };
-  }, [filteredModelKeys]);
+  }, [filteredModelKeys, shouldVirtualizeModelList]);
+
+  const renderModelRow = useCallback(
+    (modelKey: string, index: number) => {
+      const model = filteredModelByKey.get(modelKey);
+      if (!model) {
+        return null;
+      }
+      return (
+        <ModelListRow
+          key={modelKey}
+          index={index}
+          model={model}
+          instanceId={model.instanceId}
+          driverKind={model.driverKind}
+          providerDisplayName={model.instanceDisplayName}
+          providerAccentColor={model.instanceAccentColor}
+          isFavorite={favoritesSet.has(modelKey)}
+          showProvider={!isLocked || showLockedInstanceSidebar}
+          preferShortName={!isLocked}
+          useTriggerLabel={isLocked && !showLockedInstanceSidebar}
+          showNewBadge={isModelPickerNewModel(model.driverKind, model.slug)}
+          jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
+          isLast={index === filteredModelKeys.length - 1}
+          onToggleFavorite={() => toggleFavorite(model.instanceId, model.slug)}
+        />
+      );
+    },
+    [
+      favoritesSet,
+      filteredModelByKey,
+      isLocked,
+      modelJumpLabelByKey,
+      showLockedInstanceSidebar,
+      toggleFavorite,
+    ],
+  );
 
   return (
     <TooltipProvider delay={0}>
@@ -555,9 +612,20 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
           filter={null}
           autoHighlight
           open
+          virtualized={shouldVirtualizeModelList}
           value={`${props.activeInstanceId}:${props.model}`}
-          onItemHighlighted={(modelKey) => {
+          onItemHighlighted={(modelKey, eventDetails) => {
             highlightedModelKeyRef.current = typeof modelKey === "string" ? modelKey : null;
+            if (
+              shouldVirtualizeModelList &&
+              eventDetails.index >= 0 &&
+              eventDetails.reason === "keyboard"
+            ) {
+              modelListRef.current?.scrollIndexIntoView?.({
+                index: eventDetails.index,
+                animated: false,
+              });
+            }
           }}
           onValueChange={(modelKey) => {
             if (typeof modelKey !== "string") {
@@ -616,32 +684,23 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
               ref={listRegionRef}
               className="relative min-h-0 flex-1 before:pointer-events-none before:absolute before:inset-0 before:bg-muted/40"
             >
-              <ComboboxList className="model-picker-list size-full divide-y px-2 py-1">
-                {filteredModelKeys.map((modelKey, index) => {
-                  const model = filteredModelByKey.get(modelKey);
-                  if (!model) {
-                    return null;
-                  }
-                  return (
-                    <ModelListRow
-                      key={modelKey}
-                      index={index}
-                      model={model}
-                      instanceId={model.instanceId}
-                      driverKind={model.driverKind}
-                      providerDisplayName={model.instanceDisplayName}
-                      providerAccentColor={model.instanceAccentColor}
-                      isFavorite={favoritesSet.has(modelKey)}
-                      showProvider={!isLocked || showLockedInstanceSidebar}
-                      preferShortName={!isLocked}
-                      useTriggerLabel={isLocked && !showLockedInstanceSidebar}
-                      showNewBadge={isModelPickerNewModel(model.driverKind, model.slug)}
-                      jumpLabel={modelJumpLabelByKey.get(modelKey) ?? null}
-                      onToggleFavorite={() => toggleFavorite(model.instanceId, model.slug)}
-                    />
-                  );
-                })}
-              </ComboboxList>
+              {shouldVirtualizeModelList ? (
+                <ComboboxListVirtualized className="model-picker-list size-full px-2 py-1">
+                  <LegendList<string>
+                    ref={modelListRef}
+                    data={filteredModelKeys}
+                    keyExtractor={(item) => item}
+                    renderItem={({ item, index }) => renderModelRow(item, index)}
+                    estimatedItemSize={MODEL_PICKER_ESTIMATED_ROW_HEIGHT}
+                    drawDistance={modelPickerListMaxHeight}
+                    style={{ maxHeight: modelPickerListMaxHeight }}
+                  />
+                </ComboboxListVirtualized>
+              ) : (
+                <ComboboxList className="model-picker-list size-full px-2 py-1">
+                  {filteredModelKeys.map((modelKey, index) => renderModelRow(modelKey, index))}
+                </ComboboxList>
+              )}
             </div>
             <ComboboxEmpty className="not-empty:py-6 empty:h-0 text-xs font-normal leading-snug">
               No models found

--- a/apps/web/src/components/chat/ModelPickerSidebar.tsx
+++ b/apps/web/src/components/chat/ModelPickerSidebar.tsx
@@ -80,7 +80,7 @@ export const ModelPickerSidebar = memo(function ModelPickerSidebar(props: {
     <ScrollArea
       hideScrollbars
       scrollFade
-      className="w-12 shrink-0 border-r bg-muted/30"
+      className="w-12 shrink-0 bg-muted/30"
       data-model-picker-sidebar="true"
     >
       <div className="flex min-h-full flex-col gap-1 p-1">

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -61,6 +61,7 @@ function PopoverPopup({
               tooltipStyle
                 ? "py-1 [--viewport-inline-padding:--spacing(2)]"
                 : "not-data-transitioning:overflow-y-auto",
+                'rounded-b-[inherit]'
             )}
             data-slot="popover-viewport"
           >


### PR DESCRIPTION
## What Changed

Virtualized the model picker list for large provider model inventories.

When the picker has more than 60 visible models, it now uses `LegendList` instead of rendering every model row at once. Smaller lists still use the existing non-virtualized `ComboboxList` path.

The virtualized path preserves the existing model picker behavior:

- search still works
- keyboard navigation still works
- highlighted rows scroll into view
- favorites still work
- provider labels, badges, shortcuts, and row styling are unchanged

## Why

OpenCode can expose very large model inventories. In my case, selecting OpenCode caused the picker to try rendering around 199 models into the UI at once.

Each row includes several relatively expensive pieces of UI: combobox item state, tooltip, favorite button, provider icon, shortcut label, model metadata, and badges. Rendering all of that eagerly made opening and interacting with the picker noticeably slow.

Virtualizing the list fixes the performance issue directly by only mounting the visible rows plus a small buffer. This keeps the picker responsive without changing the model data, search logic, or selection behavior.

## UI Changes

The UI should look the same. This is a performance-focused interaction change.

Before: opening OpenCode’s model picker was slow because every model row rendered eagerly.

After: opening and searching the OpenCode model picker is much faster because only visible rows are rendered.

A short before/after interaction video would be useful here if available.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only performance and styling in the model picker; no auth, data, or API changes.
> 
> **Overview**
> **Virtualizes the chat model picker** when more than 60 filtered models are shown, using `LegendList` and `ComboboxListVirtualized` instead of mapping every row. Smaller lists still use the existing `ComboboxList` path; search, favorites, shortcuts, and selection behavior stay the same.
> 
> For the virtualized path, the combobox gets `virtualized={true}`, list height is capped from sidebar layout, keyboard highlight calls `scrollIndexIntoView`, and the old scroll-area measurement layout effect is skipped. Row dividers move from list `divide-y` to per-row `border-b` on `ModelListRow` (with `isLast` dropping the bottom border). Minor polish: model picker sidebar loses `border-r`; popover viewport gets `rounded-b-[inherit]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e723780e1274bc8cfba34bb632d24fb28c6bd6f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Virtualize the model picker list for large model sets
> - Adds list virtualization to [ModelPickerContent](https://github.com/pingdotgg/t3code/pull/2929/files#diff-af6ec8809b715e3718ef62e155f706b7bfc2b5331a509865043ed81e0f10f50c) when more than 60 filtered models are present, constraining the list height and improving scroll performance.
> - Uses `LegendList` with a new `ComboboxListVirtualized` wrapper; keyboard-driven item highlighting calls `scrollIndexIntoView` to keep the focused row visible.
> - Moves row separator borders from list-level `divide-y` to per-row styling in [ModelListRow](https://github.com/pingdotgg/t3code/pull/2929/files#diff-62fe7a1456b0253c1b218f2999690aea3cfa7ab23a472a3dd07e6b6221eece02) via a new `isLast` prop.
> - Minor visual fixes: removes the sidebar's right border and adds `rounded-b-[inherit]` to the popover viewport.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 405e7d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->