### PR TITLE
ci: let setup-vp install dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
+          run-install: true
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -29,9 +29,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile
 
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
@@ -89,10 +86,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile
+          run-install: true
 
       - name: Install mobile native static analysis tools
         run: brew bundle install --file apps/mobile/Brewfile
@@ -113,10 +107,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile
+          run-install: true
 
       - name: Exercise release-only workflow steps
         run: node scripts/release-smoke.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,10 +90,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile
+          run-install: true
 
       - name: Ensure Electron runtime is installed
         run: vp run --filter @t3tools/desktop ensure:electron
@@ -216,10 +213,7 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile
+          run-install: true
 
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
@@ -446,15 +440,16 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
+          run-install: |
+            args:
+              - --filter=t3
+              - --filter=@t3tools/web
+              - --filter=@t3tools/scripts
 
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
           registry-url: https://registry.npmjs.org
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile --filter=t3 --filter=@t3tools/web --filter=@t3tools/scripts
 
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
@@ -493,10 +488,9 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile --filter=@t3tools/scripts
+          run-install: |
+            args:
+              - --filter=@t3tools/scripts
 
       - name: Download all desktop artifacts
         uses: actions/download-artifact@v8
@@ -611,10 +605,10 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
-
-      - name: Install release tooling dependencies
-        run: vp install --frozen-lockfile --filter=@t3tools/scripts --filter=@t3tools/web
+          run-install: |
+            args:
+              - --filter=@t3tools/scripts
+              - --filter=@t3tools/web
 
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
@@ -713,10 +707,9 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile --filter=@t3tools/scripts
+          run-install: |
+            args:
+              - --filter=@t3tools/scripts
 
       - id: update_versions
         name: Update version strings
@@ -772,10 +765,9 @@ jobs:
         with:
           node-version-file: package.json
           cache: true
-          run-install: false
-
-      - name: Install dependencies
-        run: vp install --frozen-lockfile --filter=@t3tools/scripts
+          run-install: |
+            args:
+              - --filter=@t3tools/scripts
 
       - name: Announce prerelease on Discord
         if: needs.preflight.outputs.is_prerelease == 'true'


### PR DESCRIPTION
## Summary

- let `voidzero-dev/setup-vp` run dependency installs directly in CI and release workflows
- remove duplicated `vp install` steps that immediately followed setup
- keep scoped release installs scoped by passing only the existing `--filter` args through `run-install`
- leave lockfile refresh installs separate because they run after release version updates

## Checks

- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change; install scope and timing are preserved except for consolidating into the setup action.
> 
> **Overview**
> **CI and release workflows** now install dependencies inside `voidzero-dev/setup-vp` instead of a separate `vp install --frozen-lockfile` step right after setup.
> 
> Jobs that only needed a subset of packages pass the same `--filter` values through `run-install`’s `args` block (CLI publish, GitHub release, web deploy, finalize, Discord announce). Full-repo jobs use `run-install: true`.
> 
> **Unchanged:** post–version-bump `vp install --lockfile-only` steps in deploy/finalize still run on their own, since they happen after release version alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf0cafbf2df962829eb1afd963ebab7dca1aa164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move dependency installation into the `setup-vp` action across CI and release workflows
> Replaces standalone `vp install --frozen-lockfile` steps in [ci.yml](.github/workflows/ci.yml) and [release.yml](.github/workflows/release.yml) with `run-install: true` on the existing `setup-vp` step. Release jobs that only need a subset of the monorepo pass workspace filters (e.g. `--filter=t3`, `--filter=@t3tools/web`) via the `run-install` block. Risk: the `--frozen-lockfile` flag is no longer explicitly passed, so lockfile enforcement depends on the `setup-vp` action's internal behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cf0cafb. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->