### PR TITLE
[codex] remove duplicated pnpm root config

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -17,8 +17,8 @@ import {
 } from "../../../scripts/lib/brand-assets.ts";
 import { resolveCatalogDependencies } from "../../../scripts/lib/resolve-catalog.ts";
 import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
+import { fromYaml } from "@t3tools/shared/schemaYaml";
 import serverPackageJson from "../package.json" with { type: "json" };
-import { parse as parseYaml } from "yaml";
 
 interface PackageJson {
   name: string;
@@ -39,10 +39,12 @@ interface PackageJson {
 const PackageJsonPrettyJson = fromJsonStringPretty(Schema.Unknown);
 const encodePackageJson = Schema.encodeEffect(PackageJsonPrettyJson);
 
-interface WorkspaceConfig {
-  readonly catalog?: Record<string, string>;
-  readonly overrides?: Record<string, string>;
-}
+const WorkspaceConfig = Schema.Struct({
+  catalog: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  overrides: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+});
+type WorkspaceConfig = typeof WorkspaceConfig.Type;
+const decodeWorkspaceConfig = Schema.decodeEffect(fromYaml(WorkspaceConfig));
 
 class CliError extends Data.TaggedError("CliError")<{
   readonly message: string;
@@ -58,7 +60,7 @@ const readWorkspaceConfig = Effect.fn("readWorkspaceConfig")(function* () {
   const fs = yield* FileSystem.FileSystem;
   const repoRoot = yield* RepoRoot;
   const workspaceYaml = yield* fs.readFileString(path.join(repoRoot, "pnpm-workspace.yaml"));
-  return parseYaml(workspaceYaml) as WorkspaceConfig;
+  return yield* decodeWorkspaceConfig(workspaceYaml);
 });
 
 const runCommand = Effect.fn("runCommand")(function* (command: ChildProcess.Command) {

--- a/package.json
+++ b/package.json
@@ -1,35 +1,6 @@
 {
   "name": "@t3tools/monorepo",
   "private": true,
-  "workspaces": {
-    "packages": [
-      "apps/*",
-      "oxlint-plugin-t3code",
-      "packages/*",
-      "scripts"
-    ],
-    "catalog": {
-      "effect": "4.0.0-beta.73",
-      "@effect/atom-react": "4.0.0-beta.73",
-      "@effect/openapi-generator": "4.0.0-beta.73",
-      "@effect/platform-bun": "4.0.0-beta.73",
-      "@effect/platform-node": "4.0.0-beta.73",
-      "@effect/platform-node-shared": "4.0.0-beta.73",
-      "@effect/sql-sqlite-bun": "4.0.0-beta.73",
-      "@effect/vitest": "4.0.0-beta.73",
-      "@effect/tsgo": "0.11.4",
-      "@pierre/diffs": "1.1.20",
-      "@vitest/runner": "^4.1.8",
-      "@types/bun": "^1.3.11",
-      "@types/node": "24.12.4",
-      "@typescript/native-preview": "7.0.0-dev.20260527.2",
-      "typescript": "~6.0.3",
-      "vitest": "npm:@voidzero-dev/vite-plus-test@latest",
-      "vite": "npm:@voidzero-dev/vite-plus-core@latest",
-      "vite-plus": "latest",
-      "yaml": "^2.9.0"
-    }
-  },
   "type": "module",
   "scripts": {
     "prepare": "vp config && effect-tsgo patch",
@@ -75,19 +46,6 @@
     "@vitest/runner": "catalog:",
     "vite": "catalog:",
     "vite-plus": "catalog:",
-    "vitest": "catalog:",
-    "yaml": "catalog:"
-  },
-  "overrides": {
-    "@effect/atom-react": "catalog:",
-    "@effect/platform-bun": "catalog:",
-    "@effect/platform-node": "catalog:",
-    "@effect/platform-node-shared": "catalog:",
-    "@effect/sql-sqlite-bun": "catalog:",
-    "@effect/vitest": "catalog:",
-    "@types/node": "catalog:",
-    "effect": "catalog:",
-    "vite": "catalog:",
     "vitest": "catalog:"
   },
   "engines": {
@@ -98,11 +56,5 @@
     "workerDirectory": [
       "apps/web/public"
     ]
-  },
-  "patchedDependencies": {
-    "@expo/metro-config@56.0.13": "patches/@expo%2Fmetro-config@56.0.13.patch",
-    "@pierre/diffs@1.1.20@1.1.20": "patches/@pierre%2Fdiffs@1.1.20.patch",
-    "effect@4.0.0-beta.73@4.0.0-beta.73": "patches/effect@4.0.0-beta.73.patch",
-    "react-native-nitro-modules@0.35.9@0.35.9": "patches/react-native-nitro-modules@0.35.9.patch"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -51,6 +51,10 @@
       "types": "./src/schemaJson.ts",
       "import": "./src/schemaJson.ts"
     },
+    "./schemaYaml": {
+      "types": "./src/schemaYaml.ts",
+      "import": "./src/schemaYaml.ts"
+    },
     "./toolActivity": {
       "types": "./src/toolActivity.ts",
       "import": "./src/toolActivity.ts"
@@ -118,7 +122,8 @@
   },
   "dependencies": {
     "@t3tools/contracts": "workspace:*",
-    "effect": "catalog:"
+    "effect": "catalog:",
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@effect/platform-node": "catalog:",

--- a/packages/shared/src/schemaYaml.test.ts
+++ b/packages/shared/src/schemaYaml.test.ts
@@ -1,0 +1,58 @@
+import * as Schema from "effect/Schema";
+import { describe, expect, it } from "vite-plus/test";
+
+import { fromYaml, fromYamlString } from "./schemaYaml.ts";
+
+const ProjectConfig = Schema.Struct({
+  name: Schema.String,
+  enabled: Schema.Boolean,
+  tags: Schema.Array(Schema.String),
+});
+
+describe("schemaYaml helpers", () => {
+  it("decodes YAML through a schema", () => {
+    const decodeConfig = Schema.decodeUnknownSync(fromYaml(ProjectConfig));
+
+    expect(
+      decodeConfig(`name: t3code
+enabled: true
+tags:
+  - codex
+  - effect
+`),
+    ).toEqual({
+      name: "t3code",
+      enabled: true,
+      tags: ["codex", "effect"],
+    });
+  });
+
+  it("encodes values as YAML text", () => {
+    const encodeConfig = Schema.encodeSync(fromYaml(ProjectConfig));
+
+    expect(
+      encodeConfig({
+        name: "t3code",
+        enabled: true,
+        tags: ["codex"],
+      }),
+    ).toBe(`name: t3code
+enabled: true
+tags:
+  - codex
+`);
+  });
+
+  it("can be used as a schema transformation directly", () => {
+    const schema = Schema.String.pipe(Schema.decodeTo(Schema.Unknown, fromYamlString));
+    const decodeYaml = Schema.decodeUnknownSync(schema);
+
+    expect(decodeYaml("answer: 42\n")).toEqual({ answer: 42 });
+  });
+
+  it("rejects malformed YAML", () => {
+    const decodeYaml = Schema.decodeUnknownSync(fromYaml(Schema.Unknown));
+
+    expect(() => decodeYaml("name: ok\n  bad-indent: nope\n")).toThrow();
+  });
+});

--- a/packages/shared/src/schemaYaml.ts
+++ b/packages/shared/src/schemaYaml.ts
@@ -1,0 +1,132 @@
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import * as SchemaGetter from "effect/SchemaGetter";
+import * as SchemaIssue from "effect/SchemaIssue";
+import * as SchemaTransformation from "effect/SchemaTransformation";
+import {
+  parse as parseYamlString,
+  stringify as stringifyYamlValue,
+  type CreateNodeOptions,
+  type DocumentOptions,
+  type ParseOptions,
+  type SchemaOptions,
+  type ToJSOptions,
+  type ToStringOptions,
+} from "yaml";
+
+export type YamlParseOptions = ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions;
+export type YamlStringifyOptions = DocumentOptions &
+  SchemaOptions &
+  ParseOptions &
+  CreateNodeOptions &
+  ToStringOptions;
+
+function formatYamlError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Parses a YAML string into a value.
+ *
+ * **When to use**
+ *
+ * Use when you need a schema getter to parse a present encoded YAML string
+ * during decoding.
+ *
+ * **Details**
+ *
+ * Parse failures become `SchemaIssue.InvalidValue` values.
+ *
+ * **Example** (Parse YAML)
+ *
+ * ```ts
+ * import { parseYaml } from "@t3tools/shared/schemaYaml"
+ *
+ * const parse = parseYaml<string>()
+ * // Getter<unknown, string>
+ * ```
+ *
+ * @see {@link stringifyYaml} for the inverse operation
+ */
+export function parseYaml<E extends string>(
+  options?: YamlParseOptions,
+): SchemaGetter.Getter<unknown, E> {
+  return SchemaGetter.transformOrFail((input: E) =>
+    Effect.try({
+      try: () => parseYamlString(input, options) as unknown,
+      catch: (error) =>
+        new SchemaIssue.InvalidValue(Option.some(input), { message: formatYamlError(error) }),
+    }),
+  );
+}
+
+/**
+ * Stringifies a present value as YAML.
+ *
+ * **When to use**
+ *
+ * Use when you need a schema getter to serialize a present decoded value to
+ * YAML text during encoding.
+ *
+ * **Details**
+ *
+ * Stringify failures become `SchemaIssue.InvalidValue` values.
+ *
+ * **Example** (Stringify YAML)
+ *
+ * ```ts
+ * import { stringifyYaml } from "@t3tools/shared/schemaYaml"
+ *
+ * const stringify = stringifyYaml()
+ * // Getter<string, unknown>
+ * ```
+ *
+ * @see {@link parseYaml} for the inverse operation
+ */
+export function stringifyYaml(
+  options?: YamlStringifyOptions,
+): SchemaGetter.Getter<string, unknown> {
+  return SchemaGetter.transformOrFail((input: unknown) =>
+    Effect.try({
+      try: () => stringifyYamlValue(input, options),
+      catch: (error) =>
+        new SchemaIssue.InvalidValue(Option.some(input), { message: formatYamlError(error) }),
+    }),
+  );
+}
+
+/**
+ * Decodes a YAML string and encodes a value as YAML text.
+ *
+ * **When to use**
+ *
+ * Use when you need a schema transformation to decode YAML stored or
+ * transmitted as a string before validating the parsed structure.
+ *
+ * **Details**
+ *
+ * Decode and encode failures become `InvalidValue` schema issues.
+ *
+ * **Example** (Parsing YAML)
+ *
+ * ```ts
+ * import * as Schema from "effect/Schema"
+ * import { fromYamlString } from "@t3tools/shared/schemaYaml"
+ *
+ * const schema = Schema.String.pipe(Schema.decodeTo(Schema.Unknown, fromYamlString))
+ * ```
+ */
+export const fromYamlString = new SchemaTransformation.Transformation<unknown, string>(
+  parseYaml(),
+  stringifyYaml(),
+);
+
+/**
+ * Build a schema that decodes a YAML string into `A`.
+ *
+ * Decode parses the input as YAML before validating the parsed value with the
+ * provided schema. Encode validates the value and serializes it as YAML text.
+ */
+export const fromYaml = <S extends Schema.Top>(schema: S) =>
+  Schema.String.pipe(Schema.decodeTo(schema, fromYamlString));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,9 +30,6 @@ catalogs:
     vite-plus:
       specifier: latest
       version: 0.1.24
-    yaml:
-      specifier: ^2.9.0
-      version: 2.9.0
 
 overrides:
   '@effect/atom-react': 4.0.0-beta.73
@@ -45,6 +42,7 @@ overrides:
   effect: 4.0.0-beta.73
   vite: npm:@voidzero-dev/vite-plus-core@latest
   vitest: npm:@voidzero-dev/vite-plus-test@latest
+  yaml: ^2.9.0
 
 packageExtensionsChecksum: sha256-MDpMSm2Rk8Y7FDIbaAgFkT45PZBPV7JBzjTAft+noEM=
 
@@ -93,9 +91,6 @@ importers:
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@latest
         version: '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.4)(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.4)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'
-      yaml:
-        specifier: 'catalog:'
-        version: 2.9.0
 
   apps/desktop:
     dependencies:
@@ -670,6 +665,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.73
         version: 4.0.0-beta.73(patch_hash=a28d840fa97ffebabe628e5562837c537d83c40cfdad8049de73c38086f2fb01)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@effect/platform-node':
         specifier: 4.0.0-beta.73
@@ -3808,7 +3806,7 @@ packages:
       typescript: ^5.0.0 || ^6.0.0
       unplugin-unused: ^0.5.0
       unrun: '*'
-      yaml: ^2.4.2
+      yaml: ^2.9.0
     peerDependenciesMeta:
       '@arethetypeswrong/core':
         optional: true
@@ -8041,11 +8039,6 @@ packages:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
     hasBin: true
 
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
-    hasBin: true
-
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
@@ -10525,7 +10518,9 @@ snapshots:
       metro-runtime: 0.84.4
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
 
   '@react-native/normalize-colors@0.85.3': {}
 
@@ -16274,9 +16269,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.9.0
 
   yaml@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,7 @@ overrides:
   effect: "catalog:"
   vite: "catalog:"
   vitest: "catalog:"
+  yaml: "catalog:"
 peerDependencyRules:
   allowAny:
     - vite

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { parse as parseYaml } from "yaml";
+import { fromYaml } from "@t3tools/shared/schemaYaml";
 import rootPackageJson from "../package.json" with { type: "json" };
 import desktopPackageJson from "../apps/desktop/package.json" with { type: "json" };
 import serverPackageJson from "../apps/server/package.json" with { type: "json" };
@@ -29,22 +29,24 @@ const LINUX_ICON_SIZES = [16, 22, 24, 32, 48, 64, 128, 256, 512] as const;
 const BuildPlatform = Schema.Literals(["mac", "linux", "win"]);
 const BuildArch = Schema.Literals(["arm64", "x64", "universal"]);
 
-interface WorkspaceConfig {
-  readonly catalog?: Record<string, string>;
-  readonly overrides?: Record<string, string>;
-}
+const WorkspaceConfig = Schema.Struct({
+  catalog: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  overrides: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+});
+type WorkspaceConfig = typeof WorkspaceConfig.Type;
 
 const RepoRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("..", import.meta.url))),
 );
 const encodeJsonString = Schema.encodeEffect(Schema.UnknownFromJsonString);
+const decodeWorkspaceConfig = Schema.decodeEffect(fromYaml(WorkspaceConfig));
 
 const readWorkspaceConfig = Effect.fn("readWorkspaceConfig")(function* () {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const repoRoot = yield* RepoRoot;
   const workspaceYaml = yield* fs.readFileString(path.join(repoRoot, "pnpm-workspace.yaml"));
-  return parseYaml(workspaceYaml) as WorkspaceConfig;
+  return yield* decodeWorkspaceConfig(workspaceYaml);
 });
 
 interface DesktopBuildIconAssets {
@@ -776,7 +778,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
     try: () => resolveCatalogDependencies(workspaceOverrides, workspaceCatalog, "apps/desktop"),
     catch: (cause) =>
       new BuildScriptError({
-        message: "Could not resolve overrides from package.json.",
+        message: "Could not resolve overrides from pnpm-workspace.yaml.",
         cause,
       }),
   });

--- a/scripts/lib/reference-repos.ts
+++ b/scripts/lib/reference-repos.ts
@@ -3,7 +3,7 @@ export interface ReferenceRepo {
   readonly prefix: string;
   readonly repository: string;
   readonly latestRef: string;
-  readonly packageJsonPath: string;
+  readonly versionSourcePath: string;
   readonly packageVersionPath: ReadonlyArray<string>;
   readonly versionTagPrefix: string;
 }
@@ -14,8 +14,8 @@ export const referenceRepos: ReadonlyArray<ReferenceRepo> = [
     prefix: ".repos/effect-smol",
     repository: "https://github.com/Effect-TS/effect-smol.git",
     latestRef: "main",
-    packageJsonPath: "package.json",
-    packageVersionPath: ["workspaces", "catalog", "effect"],
+    versionSourcePath: "pnpm-workspace.yaml",
+    packageVersionPath: ["catalog", "effect"],
     versionTagPrefix: "effect@",
   },
   {
@@ -23,7 +23,7 @@ export const referenceRepos: ReadonlyArray<ReferenceRepo> = [
     prefix: ".repos/alchemy-effect",
     repository: "https://github.com/alchemy-run/alchemy-effect.git",
     latestRef: "main",
-    packageJsonPath: "infra/relay/package.json",
+    versionSourcePath: "infra/relay/package.json",
     packageVersionPath: ["dependencies", "alchemy"],
     versionTagPrefix: "v",
   },

--- a/scripts/sync-reference-repos.test.ts
+++ b/scripts/sync-reference-repos.test.ts
@@ -63,8 +63,8 @@ it.layer(NodeServices.layer)("sync-reference-repos", (it) => {
         prefix: "sync-reference-repos-version-",
       });
       yield* fs.writeFileString(
-        path.join(rootDir, "package.json"),
-        '{"workspaces":{"catalog":{"effect":"4.0.0-beta.73"}}}',
+        path.join(rootDir, "pnpm-workspace.yaml"),
+        "catalog:\n  effect: 4.0.0-beta.73\n",
       );
 
       assert.equal(
@@ -110,8 +110,8 @@ it.layer(NodeServices.layer)("sync-reference-repos", (it) => {
         prefix: "sync-reference-repos-plan-",
       });
       yield* fs.writeFileString(
-        path.join(rootDir, "package.json"),
-        '{"workspaces":{"catalog":{"effect":"4.0.0-beta.73"}}}',
+        path.join(rootDir, "pnpm-workspace.yaml"),
+        "catalog:\n  effect: 4.0.0-beta.73\n",
       );
 
       const addPlan = yield* planReferenceRepoSync(effectSmol, rootDir, false);
@@ -140,8 +140,8 @@ it.layer(NodeServices.layer)("sync-reference-repos", (it) => {
         prefix: "sync-reference-repos-run-",
       });
       yield* fs.writeFileString(
-        path.join(rootDir, "package.json"),
-        '{"workspaces":{"catalog":{"effect":"4.0.0-beta.73"}}}',
+        path.join(rootDir, "pnpm-workspace.yaml"),
+        "catalog:\n  effect: 4.0.0-beta.73\n",
       );
 
       yield* syncReferenceRepos({ rootDir, repoId: "effect-smol" }).pipe(

--- a/scripts/sync-reference-repos.ts
+++ b/scripts/sync-reference-repos.ts
@@ -12,6 +12,7 @@ import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { Command, Flag } from "effect/unstable/cli";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { fromYaml } from "@t3tools/shared/schemaYaml";
 
 import { referenceRepos, type ReferenceRepo } from "./lib/reference-repos.ts";
 
@@ -36,7 +37,8 @@ export class ReferenceRepoSyncError extends Data.TaggedError("ReferenceRepoSyncE
   readonly cause?: unknown;
 }> {}
 
-const decodePackageJson = Schema.decodeUnknownEffect(Schema.UnknownFromJsonString);
+const decodeJsonSource = Schema.decodeUnknownEffect(Schema.UnknownFromJsonString);
+const decodeYamlSource = Schema.decodeEffect(fromYaml(Schema.Unknown));
 
 const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
   stream.pipe(
@@ -56,6 +58,33 @@ function readNestedString(input: unknown, keys: ReadonlyArray<string>): string |
     value = (value as Record<string, unknown>)[key];
   }
   return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function decodeVersionSource(
+  sourcePath: string,
+  content: string,
+): Effect.Effect<unknown, ReferenceRepoSyncError> {
+  if (sourcePath.endsWith(".yaml") || sourcePath.endsWith(".yml")) {
+    return decodeYamlSource(content).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ReferenceRepoSyncError({
+            message: `Unable to parse version source ${sourcePath}.`,
+            cause,
+          }),
+      ),
+    );
+  }
+
+  return decodeJsonSource(content).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ReferenceRepoSyncError({
+          message: `Unable to parse version source ${sourcePath}.`,
+          cause,
+        }),
+    ),
+  );
 }
 
 function getSelectedRepos(
@@ -88,22 +117,22 @@ export const resolveReferenceRepoRef = Effect.fn("resolveReferenceRepoRef")(func
 
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const packageJsonPath = path.join(rootDir, repo.packageJsonPath);
-  const packageJson = yield* fs.readFileString(packageJsonPath).pipe(
-    Effect.flatMap(decodePackageJson),
+  const versionSourcePath = path.join(rootDir, repo.versionSourcePath);
+  const versionSourceContent = yield* fs.readFileString(versionSourcePath).pipe(
     Effect.mapError(
       (cause) =>
         new ReferenceRepoSyncError({
-          message: `Unable to read package version for '${repo.id}' from ${packageJsonPath}.`,
+          message: `Unable to read package version for '${repo.id}' from ${versionSourcePath}.`,
           cause,
         }),
     ),
   );
-  const version = readNestedString(packageJson, repo.packageVersionPath);
+  const versionSource = yield* decodeVersionSource(repo.versionSourcePath, versionSourceContent);
+  const version = readNestedString(versionSource, repo.packageVersionPath);
 
   if (!version) {
     return yield* new ReferenceRepoSyncError({
-      message: `Unable to resolve package version for '${repo.id}' at ${repo.packageJsonPath}:${repo.packageVersionPath.join(
+      message: `Unable to resolve package version for '${repo.id}' at ${repo.versionSourcePath}:${repo.packageVersionPath.join(
         ".",
       )}.`,
     });


### PR DESCRIPTION
## What changed

- Removed pnpm workspace configuration duplicated in the root `package.json` (`workspaces`, `overrides`, and `patchedDependencies`).
- Added `@t3tools/shared/schemaYaml`, a single-file SchemaGetter/SchemaTransformation-based YAML helper with parse/stringify getters and schema decoding support.
- Updated all repo-local YAML parsing of `pnpm-workspace.yaml` to use the shared schema helper.
- Added a workspace override for `yaml: "catalog:"` so Effect and the rest of the workspace resolve the same `yaml` version.
- Adjusted sync tests and a stale desktop build diagnostic message to point at the workspace YAML config.

## Why

The pnpm workspace config now lives in `pnpm-workspace.yaml`, so keeping duplicate root `package.json` fields risks drift. The sync/build scripts also needed to stop depending on local ad hoc YAML parsing and use a reusable schema-based parser.

## Validation

- `vp test run packages/shared/src/schemaYaml.test.ts scripts/sync-reference-repos.test.ts`
- `vp check` (passes with existing lint warnings)
- `vp run typecheck`
- `corepack pnpm install`
- `corepack pnpm list yaml -r --depth 20` reports only `yaml 2.9.0`
- `find node_modules/.pnpm -maxdepth 1 -type d -name 'yaml@*'` reports only `yaml@2.9.0`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove duplicated pnpm root config and add YAML schema decoding support
> - Removes `workspaces`, `catalog`, `overrides`, and `patchedDependencies` from the root [package.json](https://github.com/pingdotgg/t3code/pull/2939/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), consolidating these into [pnpm-workspace.yaml](https://github.com/pingdotgg/t3code/pull/2939/files#diff-18ae0a0fab29a7db7aded913fd05f30a2c8f6c104fadae86c9d217091709794c).
> - Adds a new `@t3tools/shared/schemaYaml` module ([schemaYaml.ts](https://github.com/pingdotgg/t3code/pull/2939/files#diff-5a65dba8f89100a6af26bde8d05f9b407facf71bda02ce3e0b69bbca5b6255b2)) with `fromYaml` and `fromYamlString` schema constructors that decode/encode YAML strings with structured error mapping.
> - Updates `readWorkspaceConfig` in both [apps/server/scripts/cli.ts](https://github.com/pingdotgg/t3code/pull/2939/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) and [scripts/build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/2939/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to validate parsed YAML against a `Schema.Struct` instead of casting the raw parse result.
> - Updates `effect-smol` in [scripts/lib/reference-repos.ts](https://github.com/pingdotgg/t3code/pull/2939/files#diff-f1c46c0377949ec9439b6bb1b552e9c524ec590577f6cf7fcfe31b742de92ca4) to read its version from `pnpm-workspace.yaml` via the new YAML decoder rather than from a `package.json`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e58544b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->