### PR TITLE
[codex] split ci workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,61 @@ on:
       - main
 
 jobs:
-  quality:
-    name: Format, Lint, Typecheck, Test, Browser Test, Build
+  check:
+    name: Check
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: true
+
+      - name: Ensure Electron runtime is installed
+        run: vp run --filter @t3tools/desktop ensure:electron
+
+      - name: Check
+        run: vp check
+
+      - name: Typecheck
+        run: vpr typecheck
+
+      - name: Build desktop pipeline
+        run: vp run build:desktop
+
+      - name: Verify preload bundle output
+        run: |
+          test -f apps/desktop/dist-electron/preload.cjs
+          grep -nE "desktopBridge|getLocalEnvironmentBootstrap|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.cjs
+
+  test:
+    name: Test
+    runs-on: blacksmith-8vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
+        with:
+          node-version-file: package.json
+          cache: true
+          run-install: true
+
+      - name: Ensure Electron runtime is installed
+        run: vp run --filter @t3tools/desktop ensure:electron
+
+      - name: Test
+        run: vp run test
+
+  test_browser:
+    name: Test Browser
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 10
     steps:
@@ -29,18 +82,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
-
-      - name: Ensure Electron runtime is installed
-        run: vp run --filter @t3tools/desktop ensure:electron
-
-      - name: Check
-        run: vp check
-
-      - name: Typecheck
-        run: vp run typecheck
-
-      - name: Test
-        run: vp run test
 
       - name: Install browser test runtime
         run: vp run --filter @t3tools/web test:browser:install
@@ -64,14 +105,6 @@ jobs:
             src/components/chat/ProviderModelPicker.browser.tsx \
             src/components/chat/CompactComposerControlsMenu.browser.tsx \
             src/components/settings/SettingsPanels.browser.tsx
-
-      - name: Build desktop pipeline
-        run: vp run build:desktop
-
-      - name: Verify preload bundle output
-        run: |
-          test -f apps/desktop/dist-electron/preload.cjs
-          grep -nE "desktopBridge|getLocalEnvironmentBootstrap|PICK_FOLDER_CHANNEL|wsUrl" apps/desktop/dist-electron/preload.cjs
 
   mobile_native_static_analysis:
     name: Mobile Native Static Analysis

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -752,6 +752,9 @@ importers:
       effect:
         specifier: 4.0.0-beta.73
         version: 4.0.0-beta.73(patch_hash=a28d840fa97ffebabe628e5562837c537d83c40cfdad8049de73c38086f2fb01)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@effect/vitest':
         specifier: 4.0.0-beta.73

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,7 +11,8 @@
     "@effect/platform-node": "catalog:",
     "@t3tools/contracts": "workspace:*",
     "@t3tools/shared": "workspace:*",
-    "effect": "catalog:"
+    "effect": "catalog:",
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@effect/vitest": "catalog:",


### PR DESCRIPTION
## What changed

- Split the main CI workflow into separate `Check`, `Test`, and `Test Browser` jobs so they can run in parallel.
- Kept desktop build and preload verification in the `Check` lane with `vp check` and `vpr typecheck`.
- Moved Playwright browser cache/runtime setup into the browser-test lane.
- Declared the missing `yaml` dependency for `@t3tools/scripts`, which is required by `scripts/build-desktop-artifact.ts` during typecheck.

## Why

The previous `quality` job serialized formatting/linting, typechecking, tests, browser tests, and desktop build work in one CI lane. Splitting these into independent jobs reduces PR feedback time while keeping the same validation coverage.

The `yaml` dependency declaration keeps workspace package metadata accurate and prevents package-scoped type resolution failures.

## Validation

- `vp check` passed with existing nested-component lint warnings.
- `vp run typecheck` passed.
- Parsed `.github/workflows/ci.yml` with the `yaml` package.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split CI workflow into separate check, test, and browser test jobs
> - Renames the top-level `quality` job to `check` and adds a desktop build step (`vp run build:desktop`) plus a preload bundle verification step for `apps/desktop/dist-electron/preload.cjs`
> - Adds a new `test` job that sets up the Electron runtime and runs unit tests via `vp run test`
> - Adds a new `test_browser` job that restores a Playwright browser cache and runs browser tests in `apps/web`
> - Changes the typecheck command from `vp run typecheck` to `vpr typecheck` in the `check` job
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7525999.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI orchestration and package metadata only; no runtime product or security logic changes.
> 
> **Overview**
> Replaces the monolithic **`quality`** CI job with three parallel jobs—**`check`**, **`test`**, and **`test_browser`**—so formatting/lint, unit tests, and Playwright runs can finish sooner without dropping coverage.
> 
> The **`check`** job still runs `vp check`, desktop build, and preload bundle assertions; typecheck is now **`vpr typecheck`** instead of `vp run typecheck`. Playwright browser caching and install steps live only under **`test_browser`**. **`@t3tools/scripts`** declares **`yaml`** as a dependency (used when parsing workspace YAML during desktop build/typecheck).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7525999a9db916030f4e8d696b88ffdfe7d74733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->