### PR TITLE
fix(release): install dependency closures in partial jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -442,14 +442,9 @@ jobs:
           cache: true
           run-install: |
             args:
-              - --filter=t3
-              - --filter=@t3tools/web
-              - --filter=@t3tools/scripts
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          registry-url: https://registry.npmjs.org
+              - --filter=t3...
+              - --filter=@t3tools/web...
+              - --filter=@t3tools/scripts...
 
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
@@ -490,7 +485,7 @@ jobs:
           cache: true
           run-install: |
             args:
-              - --filter=@t3tools/scripts
+              - --filter=@t3tools/scripts...
 
       - name: Download all desktop artifacts
         uses: actions/download-artifact@v8
@@ -607,8 +602,8 @@ jobs:
           cache: true
           run-install: |
             args:
-              - --filter=@t3tools/scripts
-              - --filter=@t3tools/web
+              - --filter=@t3tools/scripts...
+              - --filter=@t3tools/web...
 
       - name: Align package versions to release version
         run: node scripts/update-release-package-versions.ts "${{ needs.preflight.outputs.version }}"
@@ -709,7 +704,7 @@ jobs:
           cache: true
           run-install: |
             args:
-              - --filter=@t3tools/scripts
+              - --filter=@t3tools/scripts...
 
       - id: update_versions
         name: Update version strings
@@ -767,7 +762,7 @@ jobs:
           cache: true
           run-install: |
             args:
-              - --filter=@t3tools/scripts
+              - --filter=@t3tools/scripts...
 
       - name: Announce prerelease on Discord
         if: needs.preflight.outputs.is_prerelease == 'true'


### PR DESCRIPTION
## Summary

- Use dependency-closure filters (`pkg...`) for release jobs that run repo scripts after partial installs.
- Remove the redundant `actions/setup-node` step from `Publish CLI to npm`; `setup-vp` already resolves Node from `package.json` and sets it up.

## Why

The latest release run got all desktop builds green, including Windows, then failed in `Publish CLI to npm` while running `scripts/update-release-package-versions.ts`:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'effect' imported from packages/shared/src/schemaJson.ts
```

The job had installed `@t3tools/scripts` and linked `@t3tools/shared`, but the partial install did not include `@t3tools/shared`'s own dependency links. Installing the selected package dependency closure fixes that class of partial-install runtime failure for publish/release/deploy/finalize/announce jobs.

## Validation

- confirmed `.github/workflows` no longer references `actions/setup-node`
- `vp pm list --filter '@t3tools/scripts...' --depth=0` includes `@t3tools/shared` and `effect`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only install filter and redundant Node setup changes; no runtime app or auth logic touched.
> 
> **Overview**
> Release workflow **partial installs** now use **dependency-closure** filters (`--filter=pkg...`) instead of single-package filters, so jobs that run repo scripts (e.g. `update-release-package-versions.ts`) get transitive deps like `effect` for `@t3tools/shared`. This applies across **publish CLI**, **GitHub release**, **deploy web**, **finalize**, and **Discord announce** steps.
> 
> **Publish CLI to npm** drops the extra **`actions/setup-node`** step; **`setup-vp`** already provisions Node from `package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 932b0dea5ebc3a555bef611aa81996127bf62c26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Install dependency closures in partial release jobs by appending `...` to pnpm filter selectors
> Updates [release.yml](.github/workflows/release.yml) to append `...` to package filter selectors (e.g. `--filter=t3...`) so that pnpm installs the full dependency closure, not just the named package. Also removes a redundant `actions/setup-node@v6` step with an npm registry URL from the affected job.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 932b0de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->