### PR TITLE
[codex] fix mobile native static analysis source discovery

### DIFF
--- a/scripts/mobile-native-static-check.ts
+++ b/scripts/mobile-native-static-check.ts
@@ -40,14 +40,13 @@ const sourceExtensions = new Set([".swift", ".kt", ".kts"]);
 const excludedDirectories = new Set([
   ".expo",
   ".git",
-  "android",
   "build",
   "DerivedData",
-  "ios",
   "node_modules",
   "Pods",
   "Vendor",
 ]);
+const generatedNativeProjectDirectories = new Set(["android", "ios"]);
 
 const appRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("../apps/mobile", import.meta.url))),
@@ -108,6 +107,7 @@ const runCommand = Effect.fn("runCommand")(function* (
 
 function collectSources(
   directory: string,
+  root: string,
 ): Effect.Effect<
   ReadonlyArray<string>,
   PlatformError.PlatformError,
@@ -120,15 +120,18 @@ function collectSources(
     const sources: Array<string> = [];
 
     for (const entry of entries) {
-      if (excludedDirectories.has(entry)) {
-        continue;
-      }
-
       const entryPath = path.join(directory, entry);
       const stat = yield* fs.stat(entryPath);
 
       if (stat.type === "Directory") {
-        sources.push(...(yield* collectSources(entryPath)));
+        const isGeneratedNativeProjectDirectory =
+          directory === root && generatedNativeProjectDirectories.has(entry);
+
+        if (excludedDirectories.has(entry) || isGeneratedNativeProjectDirectory) {
+          continue;
+        }
+
+        sources.push(...(yield* collectSources(entryPath, root)));
         continue;
       }
 
@@ -144,7 +147,7 @@ function collectSources(
 const runNativeStaticChecks = Effect.fn("runNativeStaticChecks")(function* () {
   const path = yield* Path.Path;
   const root = yield* appRoot;
-  const sources = yield* collectSources(root);
+  const sources = yield* collectSources(root, root);
   const swiftSources = sources.filter((source) => path.extname(source) === ".swift");
   const kotlinSources = sources.filter((source) => {
     const extension = path.extname(source);
@@ -155,6 +158,10 @@ const runNativeStaticChecks = Effect.fn("runNativeStaticChecks")(function* () {
   for (const tool of tools) {
     availableTools.set(tool.command, yield* commandExists(tool.command));
   }
+
+  yield* Console.log(
+    `Found ${swiftSources.length} Swift and ${kotlinSources.length} Kotlin native source files.`,
+  );
 
   if (swiftSources.length > 0) {
     if (availableTools.get("swiftlint")) {


### PR DESCRIPTION
## What changed

- Fixed `scripts/mobile-native-static-check.ts` so native module sources under `apps/mobile/modules/**/ios` and `apps/mobile/modules/**/android` are included in static analysis.
- Kept generated top-level `apps/mobile/ios` and `apps/mobile/android` excluded.
- Added a source-count log so CI makes it obvious when native files are being analyzed.

## Why

The previous directory walker excluded any directory named `ios` or `android` by basename. That unintentionally skipped the checked-in Expo native module sources, so the mobile native static analysis job could succeed while linting no native module files.

## Validation

- `vp check` passed with existing nested-component lint warnings.
- `vp run typecheck` passed.
- `vp run lint:mobile` now reports `Found 4 Swift and 2 Kotlin native source files.`
- `ktlint` and `detekt` ran locally against the Kotlin native module files and passed.

Note: local `swiftlint` validation was skipped because this machine lacks full Xcode, which Homebrew requires to install SwiftLint. CI's macOS image installs the Brewfile tools and should exercise SwiftLint.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix mobile native static analysis to skip only root-level `android/` and `ios/` directories
> - Previously, `android` and `ios` were globally excluded in `collectSources`, causing similarly named subdirectories in other parts of the project to be skipped incorrectly.
> - Moves these two directory names into a new `generatedNativeProjectDirectories` set and only skips them when encountered at the project root.
> - Adds a `root` parameter to `collectSources` in [mobile-native-static-check.ts](https://github.com/pingdotgg/t3code/pull/2942/files#diff-bf82146cd22581df064bfdf7f7976e8ae0ba18a655c5ceedcd0003f978f3d0fc) to track the original root path through recursion.
> - Adds a log of discovered Swift and Kotlin file counts before linters run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c8975c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI script-only change that broadens which native files are linted; no runtime app or auth/data paths affected.
> 
> **Overview**
> Fixes native source discovery in `scripts/mobile-native-static-check.ts` so Swift/Kotlin under Expo native modules (e.g. `modules/**/ios` and `modules/**/android`) are included in static checks again.
> 
> Previously, any folder named `android` or `ios` was skipped everywhere. Those names are now only ignored at the **app root** (`apps/mobile/android` and `apps/mobile/ios`), via `generatedNativeProjectDirectories` and a `root` argument passed through `collectSources`. A log line reports how many Swift and Kotlin files were found before linters run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8975c8c3f6111c14a371707cbc6d9bfbeedc51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->