### PR TITLE
fix(release): preserve desktop artifact arch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -373,7 +373,7 @@ jobs:
             echo "Signing disabled for ${{ matrix.platform }}."
           fi
 
-          vp run dist:desktop:artifact -- "${args[@]}"
+          vp run dist:desktop:artifact "${args[@]}"
 
       - name: Collect release assets
         shell: bash


### PR DESCRIPTION
## Summary
- remove the extra standalone `--` before the desktop artifact args in the release workflow

## Why
`vp run` forwards args after the script name. The release workflow was invoking `vp run dist:desktop:artifact -- "${args[@]}"`, which made the artifact script itself receive a literal standalone `--`. Effect CLI then stopped parsing flags after that separator, so the macOS x64 job ignored `--arch x64`, defaulted to the arm64 host arch, and uploaded arm64 artifacts as the x64 artifact. The GitHub release manifest merge later failed on duplicate arm64 entries.

## Validation
- `vp run dist:desktop:artifact --help` shows the script help
- `vp run dist:desktop:artifact -- --help` reproduces the broken behavior by ignoring `--help` and running the default build
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI invocation fix; no runtime app or auth changes.
> 
> **Overview**
> Fixes the release workflow **Build desktop artifact** step so platform/target/arch flags are actually passed through to `dist:desktop:artifact`.
> 
> The step previously ran `vp run dist:desktop:artifact -- "${args[@]}"`, which forwarded options after a bare `--` into `node scripts/build-desktop-artifact.ts` in a way the Effect CLI did not apply. Matrix values like `--arch x64` were ignored, so macOS x64 jobs could build the host default (arm64) and mislabel release assets.
> 
> It now invokes `vp run dist:desktop:artifact "${args[@]}"` without the extra `--`, so signing and verbose flags in the same `args` array reach the build script as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfea9d58384776a789b08d7f1da2c7495c01366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop artifact architecture preservation in release workflow
> Removes the standalone `--` argument separator from the `vp run dist:desktop:artifact` command in [release.yml](.github/workflows/release.yml). The separator was causing the arch args to be passed incorrectly, preventing the desktop artifact architecture from being preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cfea9d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->