### PR TITLE
[codex] Fix desktop packaging patched dependencies

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 
 import {
+  createStagePnpmConfig,
   resolveDesktopRuntimeDependencies,
   resolveBuildOptions,
   resolveDesktopBuildIconAssets,
@@ -62,6 +63,21 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         effect: "4.0.0-beta.59",
       },
     );
+  });
+
+  it("carries workspace patch metadata into staged desktop installs", () => {
+    assert.deepStrictEqual(
+      createStagePnpmConfig({
+        "@pierre/diffs@1.1.20": "patches/@pierre%2Fdiffs@1.1.20.patch",
+      }),
+      {
+        patchedDependencies: {
+          "@pierre/diffs@1.1.20": "patches/@pierre%2Fdiffs@1.1.20.patch",
+        },
+      },
+    );
+
+    assert.equal(createStagePnpmConfig({}), undefined);
   });
 
   it("falls back to the default mock update port when the configured port is blank", () => {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -32,6 +32,7 @@ const BuildArch = Schema.Literals(["arm64", "x64", "universal"]);
 const WorkspaceConfig = Schema.Struct({
   catalog: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   overrides: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  patchedDependencies: Schema.optional(Schema.Record(Schema.String, Schema.String)),
 });
 type WorkspaceConfig = typeof WorkspaceConfig.Type;
 
@@ -270,6 +271,15 @@ interface StagePackageJson {
     readonly electron: string;
   };
   readonly overrides: Record<string, unknown>;
+  readonly pnpm?: {
+    readonly patchedDependencies?: Record<string, string>;
+  };
+}
+
+export function createStagePnpmConfig(
+  patchedDependencies: Record<string, string>,
+): StagePackageJson["pnpm"] | undefined {
+  return Object.keys(patchedDependencies).length > 0 ? { patchedDependencies } : undefined;
 }
 
 const AzureTrustedSigningOptionsConfig = Config.all({
@@ -757,6 +767,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const workspaceConfig = yield* readWorkspaceConfig();
   const workspaceCatalog = workspaceConfig.catalog ?? {};
   const workspaceOverrides = workspaceConfig.overrides ?? {};
+  const workspacePatchedDependencies = workspaceConfig.patchedDependencies ?? {};
 
   const platformConfig = PLATFORM_CONFIG[options.platform];
   if (!platformConfig) {
@@ -867,6 +878,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   // electron-builder is filtering out stageResourcesDir directory in the AppImage for production
   yield* fs.copy(stageResourcesDir, path.join(stageAppDir, "apps/desktop/prod-resources"));
 
+  const stagePnpmConfig = createStagePnpmConfig(workspacePatchedDependencies);
   const stagePackageJson: StagePackageJson = {
     name: "t3code",
     version: appVersion,
@@ -893,10 +905,15 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       electron: electronVersion,
     },
     overrides: resolvedOverrides,
+    ...(stagePnpmConfig ? { pnpm: stagePnpmConfig } : {}),
   };
 
   const stagePackageJsonString = yield* encodeJsonString(stagePackageJson);
   yield* fs.writeFileString(path.join(stageAppDir, "package.json"), `${stagePackageJsonString}\n`);
+
+  if (Object.keys(workspacePatchedDependencies).length > 0) {
+    yield* fs.copy(path.join(repoRoot, "patches"), path.join(stageAppDir, "patches"));
+  }
 
   yield* Effect.log("[desktop-artifact] Installing staged production dependencies...");
   yield* runCommand(


### PR DESCRIPTION
## Summary

Fixes desktop artifact packaging so staged production installs preserve pnpm patched dependency metadata and patch files from the workspace.

## Root cause

The source workspace correctly patches `@pierre/diffs` to export `@pierre/diffs/utils/parsePatchFiles`, but `scripts/build-desktop-artifact.ts` creates a standalone staged app install. That generated `package.json` carried catalog-resolved dependencies and overrides, but dropped `pnpm.patchedDependencies` and did not copy the `patches/` directory. The packaged app therefore installed an unpatched `@pierre/diffs`, causing server startup to fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Validation

- `vp run --filter scripts test -- build-desktop-artifact.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-script change with targeted tests; no auth or runtime logic beyond ensuring patched deps install correctly.
> 
> **Overview**
> Desktop artifact staging now mirrors the workspace’s **pnpm patched dependencies** so production installs inside the packaged app apply the same patches (e.g. `@pierre/diffs`) instead of pulling unpatched packages.
> 
> `build-desktop-artifact.ts` reads `patchedDependencies` from `pnpm-workspace.yaml`, writes `pnpm.patchedDependencies` on the staged `package.json` when non-empty, and copies the repo `patches/` folder into the stage before `vp install --prod`. A small `createStagePnpmConfig` helper and unit tests cover the metadata shape and empty-map behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ead87aa7194438bb24c75c7f0b0b0acd0f837beb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop packaging to carry patched dependencies into staged installs
> - Adds an optional `patchedDependencies` field to the `WorkspaceConfig` schema in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/2944/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d), read from the root workspace config.
> - Introduces `createStagePnpmConfig`, which returns a `pnpm.patchedDependencies` config object when patches are present, or `undefined` when none are specified.
> - When `patchedDependencies` are present, the staged `package.json` is updated with the `pnpm` config section and the top-level `patches/` directory is copied into the stage app directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ead87aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->