### PR TITLE
[codex] Filter staged desktop patched dependencies

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -65,19 +65,37 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     );
   });
 
-  it("carries workspace patch metadata into staged desktop installs", () => {
+  it("carries only staged dependency patch metadata into staged desktop installs", () => {
     assert.deepStrictEqual(
-      createStagePnpmConfig({
-        "@pierre/diffs@1.1.20": "patches/@pierre%2Fdiffs@1.1.20.patch",
-      }),
+      createStagePnpmConfig(
+        {
+          "@expo/metro-config@56.0.13": "patches/@expo%2Fmetro-config@56.0.13.patch",
+          "@pierre/diffs@1.1.20": "patches/@pierre%2Fdiffs@1.1.20.patch",
+          "alchemy@2.0.0-beta.49": "patches/alchemy@2.0.0-beta.49.patch",
+          "effect@4.0.0-beta.73": "patches/effect@4.0.0-beta.73.patch",
+        },
+        {
+          "@pierre/diffs": "1.1.20",
+          effect: "4.0.0-beta.73",
+        },
+      ),
       {
         patchedDependencies: {
           "@pierre/diffs@1.1.20": "patches/@pierre%2Fdiffs@1.1.20.patch",
+          "effect@4.0.0-beta.73": "patches/effect@4.0.0-beta.73.patch",
         },
       },
     );
 
-    assert.equal(createStagePnpmConfig({}), undefined);
+    assert.equal(
+      createStagePnpmConfig(
+        {
+          "@expo/metro-config@56.0.13": "patches/@expo%2Fmetro-config@56.0.13.patch",
+        },
+        { effect: "4.0.0-beta.73" },
+      ),
+      undefined,
+    );
   });
 
   it("falls back to the default mock update port when the configured port is blank", () => {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -278,8 +278,22 @@ interface StagePackageJson {
 
 export function createStagePnpmConfig(
   patchedDependencies: Record<string, string>,
+  dependencies: Record<string, unknown>,
 ): StagePackageJson["pnpm"] | undefined {
-  return Object.keys(patchedDependencies).length > 0 ? { patchedDependencies } : undefined;
+  const stagePatchedDependencies = Object.fromEntries(
+    Object.entries(patchedDependencies).filter(([patchKey]) =>
+      Object.hasOwn(dependencies, getPatchedDependencyPackageName(patchKey)),
+    ),
+  );
+
+  return Object.keys(stagePatchedDependencies).length > 0
+    ? { patchedDependencies: stagePatchedDependencies }
+    : undefined;
+}
+
+function getPatchedDependencyPackageName(patchKey: string): string {
+  const versionSeparator = patchKey.lastIndexOf("@");
+  return versionSeparator > 0 ? patchKey.slice(0, versionSeparator) : patchKey;
 }
 
 const AzureTrustedSigningOptionsConfig = Config.all({
@@ -878,7 +892,11 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   // electron-builder is filtering out stageResourcesDir directory in the AppImage for production
   yield* fs.copy(stageResourcesDir, path.join(stageAppDir, "apps/desktop/prod-resources"));
 
-  const stagePnpmConfig = createStagePnpmConfig(workspacePatchedDependencies);
+  const stageDependencies = {
+    ...resolvedServerDependencies,
+    ...resolvedDesktopRuntimeDependencies,
+  };
+  const stagePnpmConfig = createStagePnpmConfig(workspacePatchedDependencies, stageDependencies);
   const stagePackageJson: StagePackageJson = {
     name: "t3code",
     version: appVersion,
@@ -897,10 +915,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
       options.mockUpdates,
       options.mockUpdateServerPort,
     ),
-    dependencies: {
-      ...resolvedServerDependencies,
-      ...resolvedDesktopRuntimeDependencies,
-    },
+    dependencies: stageDependencies,
     devDependencies: {
       electron: electronVersion,
     },


### PR DESCRIPTION
## Summary

Filters workspace `patchedDependencies` before writing the staged desktop app `package.json`, keeping only patches for packages that are actually installed in the staged production app.

## Root cause

The previous desktop packaging fix copied all workspace patch metadata into the staged app. The staged desktop app needs patches for packages like `@pierre/diffs` and `effect`, but it does not install unrelated workspace dependencies like Expo Metro, Nitro modules, or Alchemy. `pnpm install --prod --no-optional` correctly rejected those as unused patches with `ERR_PNPM_UNUSED_PATCH`.

## Validation

- `vp run --filter scripts test -- build-desktop-artifact.test.ts`
- `vp run dist:desktop:dmg`
- `vp check`
- `vp run typecheck`

The DMG build completed and produced:
- `release/T3-Code-0.0.24-arm64.dmg`
- `release/T3-Code-0.0.24-arm64.zip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change to which patch metadata is written for staged desktop installs; low blast radius outside the desktop build script.
> 
> **Overview**
> Staged desktop packaging no longer copies the full workspace `patchedDependencies` list into the staged app `package.json`. **`createStagePnpmConfig`** now takes the merged staged production dependencies and keeps only patches whose package name is actually installed there (via **`getPatchedDependencyPackageName`** on keys like `effect@4.0.0-beta.73`).
> 
> The desktop artifact script builds **`stageDependencies`** from resolved server + desktop runtime deps, passes that into **`createStagePnpmConfig`**, and reuses the same object for **`dependencies`** in the staged manifest. Unrelated workspace patches (e.g. Expo Metro, Alchemy) are omitted so **`pnpm install --prod --no-optional`** no longer fails with unused-patch errors.
> 
> Tests assert filtered patch metadata and that a workspace with no matching staged packages yields no `pnpm` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ebef980ade7867c15c15ce6431f0675819d039. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter staged desktop patched dependencies to only include packages in the staged dependency set
> - `createStagePnpmConfig` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/2945/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) now accepts a `dependencies` parameter and filters `patchedDependencies` to only include entries whose package name exists in that set.
> - Returns `undefined` when no patches match, omitting the `pnpm` section from the staged `package.json` entirely.
> - `buildDesktopArtifact` computes a combined `stageDependencies` object from resolved server and desktop runtime deps and passes it to `createStagePnpmConfig`.
> - Behavioral Change: previously all workspace patches were included in the staged `package.json`; now only patches for staged dependencies are included.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1ebef9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->