### PR TITLE
Store sidebar width relative to container

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -53,6 +53,16 @@ type SidebarResizableOptions = {
   storageKey?: string;
 };
 
+const SidebarStoredWidthSchema = Schema.Union([
+  Schema.Finite,
+  Schema.Struct({
+    unit: Schema.Literal("fraction"),
+    value: Schema.Finite,
+  }),
+]);
+
+type SidebarStoredWidth = typeof SidebarStoredWidthSchema.Type;
+
 type SidebarResolvedResizableOptions = {
   maxWidth: number;
   minWidth: number;
@@ -335,6 +345,26 @@ function clampSidebarWidth(width: number, options: SidebarResolvedResizableOptio
   return Math.max(options.minWidth, Math.min(width, options.maxWidth));
 }
 
+function getSidebarWidthStorageBasis(wrapper: HTMLElement): number {
+  return wrapper.parentElement?.clientWidth || window.innerWidth;
+}
+
+function getStoredSidebarWidth(
+  storedWidth: SidebarStoredWidth,
+  wrapper: HTMLElement,
+): number | null {
+  if (typeof storedWidth === "number") {
+    return null;
+  }
+
+  return storedWidth.value * getSidebarWidthStorageBasis(wrapper);
+}
+
+function createStoredSidebarWidth(width: number, wrapper: HTMLElement): SidebarStoredWidth {
+  const basis = getSidebarWidthStorageBasis(wrapper);
+  return { unit: "fraction", value: basis > 0 ? width / basis : 0 };
+}
+
 function SidebarRail({
   className,
   onClick,
@@ -380,7 +410,11 @@ function SidebarRail({
         element.style.removeProperty("transition-duration");
       });
       if (resolvedResizable?.storageKey && typeof window !== "undefined") {
-        setLocalStorageItem(resolvedResizable.storageKey, resizeState.width, Schema.Finite);
+        setLocalStorageItem(
+          resolvedResizable.storageKey,
+          createStoredSidebarWidth(resizeState.width, resizeState.wrapper),
+          SidebarStoredWidthSchema,
+        );
       }
       resolvedResizable?.onResize?.(resizeState.width);
       resizeStateRef.current = null;
@@ -545,16 +579,34 @@ function SidebarRail({
 
   React.useEffect(() => {
     if (!resolvedResizable?.storageKey || typeof window === "undefined") return;
+    const storageKey = resolvedResizable.storageKey;
     const rail = railRef.current;
     if (!rail) return;
     const wrapper = rail.closest<HTMLElement>("[data-slot='sidebar-wrapper']");
     if (!wrapper) return;
+    const storageBasisElement = wrapper.parentElement;
 
-    const storedWidth = getLocalStorageItem(resolvedResizable.storageKey, Schema.Finite);
-    if (storedWidth === null) return;
-    const clampedWidth = clampSidebarWidth(storedWidth, resolvedResizable);
-    wrapper.style.setProperty("--sidebar-width", `${clampedWidth}px`);
-    resolvedResizable.onResize?.(clampedWidth);
+    const applyStoredWidth = () => {
+      const storedWidth = getLocalStorageItem(storageKey, SidebarStoredWidthSchema);
+      if (storedWidth === null) return;
+      const width = getStoredSidebarWidth(storedWidth, wrapper);
+      if (width === null) return;
+      const clampedWidth = clampSidebarWidth(width, resolvedResizable);
+      wrapper.style.setProperty("--sidebar-width", `${clampedWidth}px`);
+      resolvedResizable.onResize?.(clampedWidth);
+    };
+
+    applyStoredWidth();
+    window.addEventListener("resize", applyStoredWidth);
+    const resizeObserver = new ResizeObserver(applyStoredWidth);
+    if (storageBasisElement) {
+      resizeObserver.observe(storageBasisElement);
+    }
+
+    return () => {
+      window.removeEventListener("resize", applyStoredWidth);
+      resizeObserver?.disconnect();
+    };
   }, [resolvedResizable]);
 
   React.useEffect(() => {


### PR DESCRIPTION
- Persist resizable sidebar width as a fraction of its parent
- Reapply stored width on window and container resizes

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Diff sidebar width is now stored as a fraction instead of a fixed width

## Why

When switching between monitor sizes the diff bar is very unmanageable.

## UI Changes

before:
https://github.com/user-attachments/assets/899eee18-96f3-407c-971e-2ecf3efb2a3e

after:
https://github.com/user-attachments/assets/de740f72-6fb0-4d71-a972-7170284b6ea1

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI persistence and resize behavior in the shared sidebar component; no auth, data, or API impact. Legacy pixel prefs are dropped until the user resizes once.
> 
> **Overview**
> Resizable sidebar width in `sidebar.tsx` is **persisted as a fraction** of the sidebar wrapper’s parent width (or viewport fallback) instead of a fixed pixel value, so the panel scales when monitors or layout containers change size.
> 
> On drag end, storage uses a new `{ unit: "fraction", value }` shape validated by `SidebarStoredWidthSchema`. **Restore** recomputes pixel width from that fraction, still clamped to min/max, and **`onResize` runs** after apply.
> 
> **Re-application** no longer runs only on mount: a shared `applyStoredWidth` runs on initial load, **`window` resize**, and a **`ResizeObserver`** on the parent element, keeping `--sidebar-width` in sync when the basis changes.
> 
> Legacy **plain numeric** localStorage entries still parse but are **ignored** for width restore (`getStoredSidebarWidth` returns null); users re-save on the next resize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce3f903c4e643737a35a7c7dff443114fb8736c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Store sidebar width as a fraction of its container width
> - The `SidebarRail` component in [sidebar.tsx](https://github.com/pingdotgg/t3code/pull/2946/files#diff-224383fe35d78f69b89d11dbdf0c045779e7ba45ca023f26abc828cd88e309cd) now saves width as a fraction of the wrapper's parent element width instead of an absolute pixel value.
> - On load and during window or container resize events, the stored fraction is converted back to pixels, clamped, and applied via the CSS width variable.
> - A `ResizeObserver` on the parent element and a `window` resize listener both trigger recomputation, keeping the sidebar proportionally sized as the container changes.
> - Behavioral Change: previously stored absolute widths (bare numbers) are ignored on load; only the new fraction-based format is restored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce3f903.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->