### PR TITLE
fix(release): install hosted web workspace closure

### DIFF
--- a/apps/web/vercel.ts
+++ b/apps/web/vercel.ts
@@ -30,7 +30,7 @@ export const config: VercelConfig = {
     deploymentEnabled: false,
   },
   installCommand:
-    "npm install -g vite-plus && vp install --filter '@t3tools/contracts' --filter '@t3tools/client-runtime' --filter '@t3tools/scripts' --filter '@t3tools/web'",
+    "npm install -g vite-plus && vp install --filter '@t3tools/scripts...' --filter '@t3tools/web...'",
   routes: [
     {
       src: "/__t3code/channel",


### PR DESCRIPTION
## Summary
- update hosted web Vercel install command to use pnpm/Vite+ dependency-closure filters
- install the web app and scripts roots via `@t3tools/web...` and `@t3tools/scripts...` instead of a hand-written workspace package list

## Why
The release failed in Vercel remote build because the install command did not include the full workspace dependency closure. Vercel installed `@t3tools/contracts`, `@t3tools/client-runtime`, `@t3tools/scripts`, and `@t3tools/web`, but the web build also resolves `@t3tools/shared`; `packages/shared/src/model.ts` then failed to resolve `@t3tools/contracts` in the remote build graph.

Using the `...` filters matches the working GitHub partial install shape and lets pnpm/Vite+ keep the closure current as workspace deps change.

## Validation
- `vp run --filter @t3tools/web build`
- `vp check`
- `vp run typecheck`
- `vp install --filter '@t3tools/scripts...' --filter '@t3tools/web...' --lockfile-only --ignore-scripts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to Vercel installCommand only; no runtime, auth, or application logic changes.
> 
> **Overview**
> **Fixes hosted web Vercel installs** by replacing a hand-picked list of workspace packages with **pnpm/Vite+ `...` closure filters** on `@t3tools/scripts` and `@t3tools/web`.
> 
> Remote builds were failing because packages such as `@t3tools/shared` (pulled in by the web app) were never installed, so nested workspace deps like `@t3tools/contracts` could not resolve at build time. The new install shape matches the **release workflow** partial install and stays correct as workspace dependencies change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0301f2e03432f19edba4db554d8f8dda6648f0a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Vercel install command to use wildcarded workspace scopes for web deployment
> Updates the `installCommand` in [vercel.ts](https://github.com/pingdotgg/t3code/pull/2949/files#diff-1a4d1119041bfb6fb5a4ce82060d10113bf5a2236b3c00ff3e2df8f83ae5de88) to replace four explicit package filters with two wildcard scopes (`@t3tools/scripts...` and `@t3tools/web...`), removing the `@t3tools/contracts` and `@t3tools/client-runtime` filters. Behavioral Change: the Vercel deployment install step now installs a different set of workspace packages than before.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0301f2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->