### PR TITLE
[codex] Avoid shell for system executables

### DIFF
--- a/apps/server/src/diagnostics/ProcessDiagnostics.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.ts
@@ -280,7 +280,6 @@ const runProcess = Effect.fn("runProcess")(
     const child = yield* spawner.spawn(
       ChildProcess.make(input.command, input.args, {
         cwd: process.cwd(),
-        shell: process.platform === "win32",
       }),
     );
     const [stdout, stderr, exitCode] = yield* Effect.all(

--- a/apps/server/src/environment/Layers/ServerEnvironmentLabel.ts
+++ b/apps/server/src/environment/Layers/ServerEnvironmentLabel.ts
@@ -59,7 +59,6 @@ const runFriendlyLabelCommand = Effect.fn("runFriendlyLabelCommand")(function* (
       command,
       args,
       timeoutBehavior: "timedOutResult",
-      shell: process.platform === "win32",
     })
     .pipe(Effect.option);
 

--- a/apps/server/src/project/Layers/RepositoryIdentityResolver.test.ts
+++ b/apps/server/src/project/Layers/RepositoryIdentityResolver.test.ts
@@ -23,7 +23,6 @@ const git = (cwd: string, args: ReadonlyArray<string>) =>
     return yield* processRunner.run({
       command: "git",
       args: ["-C", cwd, ...args],
-      shell: process.platform === "win32",
     });
   }).pipe(Effect.provide(ProcessRunner.layer));
 

--- a/apps/server/src/project/Layers/RepositoryIdentityResolver.ts
+++ b/apps/server/src/project/Layers/RepositoryIdentityResolver.ts
@@ -94,7 +94,6 @@ const resolveRepositoryIdentityCacheKey = Effect.fn("resolveRepositoryIdentityCa
       command: "git",
       args: ["-C", cwd, "rev-parse", "--show-toplevel"],
       timeoutBehavior: "timedOutResult",
-      shell: process.platform === "win32",
     })
     .pipe(Effect.option);
   if (topLevelResult._tag === "None" || topLevelResult.value.code !== 0) {
@@ -119,7 +118,6 @@ const resolveRepositoryIdentityFromCacheKey = Effect.fn("resolveRepositoryIdenti
         command: "git",
         args: ["-C", cacheKey, "remote", "-v"],
         timeoutBehavior: "timedOutResult",
-        shell: process.platform === "win32",
       })
       .pipe(Effect.option);
     if (remoteResult._tag === "None" || remoteResult.value.code !== 0) {

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -519,7 +519,6 @@ function windowsInspectSubprocess(
       timeout: "1500 millis",
       maxOutputBytes: 32_768,
       outputMode: "truncate",
-      shell: process.platform === "win32",
       timeoutBehavior: "timedOutResult",
     });
   }).pipe(

--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -16,6 +16,7 @@ import { SshCommandError, SshInvalidTargetError } from "./errors.ts";
 const PUBLISHABLE_T3_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/u;
 const DEFAULT_SSH_COMMAND_TIMEOUT_MS = 60_000;
 const MAX_SSH_ERROR_OUTPUT_LENGTH = 4_000;
+export const SSH_COMMAND = process.platform === "win32" ? "ssh.exe" : "ssh";
 
 const encoder = new TextEncoder();
 
@@ -192,15 +193,14 @@ const runSshCommandInScope = Effect.fn("ssh/command.runSshCommand.inScope")(func
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   yield* Effect.logDebug("ssh.command.start", {
     ...sshTargetLogFields(target),
-    command: ["ssh", ...args],
+    command: [SSH_COMMAND, ...args],
     hasStdin: input.stdin !== undefined,
     timeoutMs: input.timeoutMs ?? DEFAULT_SSH_COMMAND_TIMEOUT_MS,
   });
   const child = yield* spawner
     .spawn(
-      ChildProcess.make("ssh", args, {
+      ChildProcess.make(SSH_COMMAND, args, {
         env: environment,
-        shell: process.platform === "win32",
         stdin: {
           stream: stdinStream(input.stdin),
           endOnDone: true,
@@ -212,7 +212,7 @@ const runSshCommandInScope = Effect.fn("ssh/command.runSshCommand.inScope")(func
       Effect.mapError(
         (cause) =>
           new SshCommandError({
-            command: ["ssh", ...args],
+            command: [SSH_COMMAND, ...args],
             exitCode: null,
             stderr: "",
             message:

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -36,6 +36,7 @@ import {
   remoteStateKey,
   resolveSshTarget,
   runSshCommand,
+  SSH_COMMAND,
   targetConnectionKey,
 } from "./command.ts";
 import {
@@ -1068,7 +1069,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     `${input.localPort}:127.0.0.1:${input.remotePort}`,
     hostSpec,
   ];
-  const tunnelCommand = ["ssh", ...args];
+  const tunnelCommand = [SSH_COMMAND, ...args];
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const scope = yield* Scope.Scope;
   yield* Effect.logDebug("ssh.tunnel.spawn.start", {
@@ -1081,9 +1082,8 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
   });
   const child = yield* spawner
     .spawn(
-      ChildProcess.make("ssh", args, {
+      ChildProcess.make(SSH_COMMAND, args, {
         env: childEnvironment,
-        shell: process.platform === "win32",
         stdin: {
           stream: Stream.empty,
           endOnDone: true,

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -10,6 +10,7 @@ export const DEFAULT_TAILSCALE_SERVE_PORT = 443;
 export const TAILSCALE_STATUS_TIMEOUT_MS = 1_500;
 export const TAILSCALE_SERVE_TIMEOUT_MS = 10_000;
 export const TAILSCALE_PROBE_TIMEOUT_MS = 2_500;
+const TAILSCALE_COMMAND = process.platform === "win32" ? "tailscale.exe" : "tailscale";
 
 export class TailscaleCommandError extends Data.TaggedError("TailscaleCommandError")<{
   readonly command: readonly string[];
@@ -136,11 +137,7 @@ export const readTailscaleStatus: Effect.Effect<
   const args = ["status", "--json"];
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const child = yield* spawner
-    .spawn(
-      ChildProcess.make("tailscale", args, {
-        shell: process.platform === "win32",
-      }),
-    )
+    .spawn(ChildProcess.make(TAILSCALE_COMMAND, args))
     .pipe(
       Effect.mapError((cause) =>
         tailscaleCommandError(
@@ -215,11 +212,7 @@ const runTailscaleCommand = (
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const child = yield* spawner
-      .spawn(
-        ChildProcess.make("tailscale", args, {
-          shell: process.platform === "win32",
-        }),
-      )
+      .spawn(ChildProcess.make(TAILSCALE_COMMAND, args))
       .pipe(
         Effect.mapError((cause) =>
           tailscaleCommandError(


### PR DESCRIPTION
## Summary

Removes `shell: process.platform === "win32"` from direct system executable launches where the command is not a package-manager or user-installed `.cmd` shim.

## Details

- Runs Git repository identity probes without shell mode.
- Runs process diagnostics and terminal subprocess PowerShell probes directly via `powershell.exe` argv.
- Uses `ssh.exe` and `tailscale.exe` on Windows so those executable launches can avoid `cmd.exe` while still resolving the Windows binary name.
- Leaves package-manager/provider/editor command paths untouched because those may legitimately be `.cmd` shims.

## Validation

- `vp check` passed. It reported existing `react(no-unstable-nested-components)` warnings outside this change.
- `vp run typecheck` passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Avoid shell when spawning system executables for SSH, Tailscale, and git commands
> - Removes the `shell: true` option from all `ChildProcess.make` and `ProcessRunner.run` calls across the server and packages, so processes are spawned directly rather than via a shell.
> - Introduces `SSH_COMMAND` in [`packages/ssh/src/command.ts`](https://github.com/pingdotgg/t3code/pull/2950/files#diff-4f1aef4b11679d8551404a853942f04f47c3a80c050bc25b784d2b0c48ec9e5e) and `TAILSCALE_COMMAND` in [`packages/tailscale/src/tailscale.ts`](https://github.com/pingdotgg/t3code/pull/2950/files#diff-580f62662917cf32d498487b66719be157805c6a8b3cd04d84bb278fef541e43), each selecting the `.exe` variant on Windows and the plain name elsewhere.
> - Updates SSH tunnel, Tailscale status/command runners, git identity resolution, diagnostics, and environment label commands to use the platform-specific executable names.
> - Behavioral Change: on Windows, these processes no longer run through `cmd.exe`; the executable must be on `PATH` directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1fbde6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Related issues

Refs #2537. This removes the SSH/Tailscale shell-wrapped executable launches called out there, but does not close the issue because OpenCode/provider process cleanup and shim-resolution work remains.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows process launch semantics for SSH, Tailscale, git, and diagnostics; failures are possible if executables are not on PATH without cmd.exe resolution.
> 
> **Overview**
> Stops wrapping **known system executables** in a Windows shell when spawning child processes. **`shell: process.platform === "win32"`** is removed from diagnostics (`ps` / **`powershell.exe`**), **`ProcessRunner`** git and host-label probes, terminal subprocess inspection, and SSH/Tailscale **`ChildProcess`** spawns.
> 
> SSH and Tailscale now use platform constants (**`SSH_COMMAND`**, **`TAILSCALE_COMMAND`**) so Windows launches **`ssh.exe`** / **`tailscale.exe`** directly while Unix keeps **`ssh`** / **`tailscale`**. Package-manager or `.cmd` shim paths are intentionally unchanged per the PR description.
> 
> On Windows, these calls no longer go through **`cmd.exe`**; the binary must be resolvable on **`PATH`** without shell indirection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fbde6efe2f0b94538fd55547668cba1884e8cc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->