### PR TITLE
[codex] Avoid shell for Windows environment probe

### DIFF
--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -241,7 +241,6 @@ const readWindowsEnvironment = Effect.fn("desktop.shellEnvironment.readWindowsEn
       const output = yield* runCommandOutput({
         command,
         args,
-        shell: true,
         timeout: LOGIN_SHELL_TIMEOUT,
       });
       const environment = extractEnvironment(output, names);


### PR DESCRIPTION
## Summary

Removes shell mode from the desktop Windows shell-environment probe.

## Details

The probe already iterates explicit PowerShell executable candidates (`pwsh.exe`, `powershell.exe`) and passes all flags as argv, so `cmd.exe` does not add command discovery value here and can only add quoting/shell interpretation risk.

## Validation

- `vp check` passed. It reported existing `react(no-unstable-nested-components)` warnings outside this change.
- `vp run typecheck` passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `shell: true` option from Windows environment probe subprocesses
> In `readWindowsEnvironment` within [DesktopShellEnvironment.ts](https://github.com/pingdotgg/t3code/pull/2951/files#diff-ed26aa44c93ddc9fedab8bc7cf7aa64c7b0b8fc0e22a3960d5c02c30c940dabd), the `shell: true` option is dropped from the `runCommandOutput` call when probing `WINDOWS_SHELL_CANDIDATES`. Subprocesses are now invoked directly without a shell wrapper.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2cd38e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line subprocess option change in desktop shell setup; no auth, data, or API surface changes.
> 
> **Overview**
> The Windows login-shell environment probe in `DesktopShellEnvironment.ts` no longer spawns PowerShell through a shell wrapper when calling `runCommandOutput`.
> 
> The probe already tries `pwsh.exe` and `powershell.exe` with full argv (`-NoLogo`, profile flags, `-Command`, etc.), so **`shell: true` is removed** so the child runs directly instead of via `cmd.exe`, avoiding extra quoting and shell interpretation while behavior stays the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd38e3c4fd60c2b53c46e4aaf4a7e0650e8e785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->