### PR TITLE
[codex] Avoid shell for Node executable spawns

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -175,8 +175,6 @@ const buildCmd = Command.make(
           cwd: serverDir,
           stdout: config.verbose ? "inherit" : "ignore",
           stderr: "inherit",
-          // Windows needs shell mode to resolve `.cmd` shims on PATH.
-          shell: process.platform === "win32",
         }),
       );
 

--- a/packages/effect-acp/src/client.test.ts
+++ b/packages/effect-acp/src/client.test.ts
@@ -34,9 +34,8 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const path = yield* Path.Path;
-      const command = ChildProcess.make("node", mockPeerArgs(yield* mockPeerPath), {
+      const command = ChildProcess.make(process.execPath, mockPeerArgs(yield* mockPeerPath), {
         cwd: path.join(import.meta.dirname, ".."),
-        shell: process.platform === "win32",
         ...(env ? { env: { ...process.env, ...env } } : {}),
       });
       return yield* spawner.spawn(command);

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -57,9 +57,8 @@ const makeHandle = (env?: Record<string, string>) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     const path = yield* Path.Path;
-    const command = ChildProcess.make("node", mockPeerArgs(yield* mockPeerPath), {
+    const command = ChildProcess.make(process.execPath, mockPeerArgs(yield* mockPeerPath), {
       cwd: path.join(import.meta.dirname, ".."),
-      shell: process.platform === "win32",
       ...(env ? { env: { ...process.env, ...env } } : {}),
     });
     return yield* spawner.spawn(command);

--- a/packages/effect-codex-app-server/src/client.test.ts
+++ b/packages/effect-codex-app-server/src/client.test.ts
@@ -22,9 +22,8 @@ it.layer(NodeServices.layer)("effect-codex-app-server client", (it) => {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const path = yield* Path.Path;
       const peerCwd = path.join(import.meta.dirname, "..");
-      const command = ChildProcess.make("node", mockPeerArgs(yield* mockPeerPath), {
+      const command = ChildProcess.make(process.execPath, mockPeerArgs(yield* mockPeerPath), {
         cwd: peerCwd,
-        shell: process.platform === "win32",
       });
       return yield* spawner.spawn(command);
     });


### PR DESCRIPTION
## Summary

Removes Windows shell mode from launches that execute Node itself.

## Details

- Test peers now spawn through `process.execPath`, which is the current Node executable path and does not require shell lookup.
- The server CLI build step already used `process.execPath`; this removes the stale shell flag/comment from that direct Node invocation.
- Nearby `npm` and provider/agent command launches are intentionally left shell-backed because they may resolve through `.cmd` shims on Windows.

## Validation

- `vp check` passed. It reported existing `react(no-unstable-nested-components)` warnings outside this change.
- `vp run typecheck` passed.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace hardcoded `node` string with `process.execPath` for child process spawns
> Replaces the string `"node"` with `process.execPath` and removes the Windows-only shell mode option in all `ChildProcess.make` calls across the build script and test utilities. This ensures the correct Node binary is used at runtime rather than relying on PATH resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a8ff34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and build-only spawn options; no auth, data, or production runtime behavior beyond more reliable Node invocation on Windows.
> 
> **Overview**
> Child process spawns that run **Node directly** now use `process.execPath` instead of the `node` command and no longer pass `shell: true` on Windows.
> 
> The server **build** CLI already invoked Node via `process.execPath`; this drops the leftover Windows shell option and comment from that `ChildProcess.make` call. **ACP** and **Codex app-server** integration tests spawn mock peers the same way, so tests use the current Node binary without shell-based PATH lookup.
> 
> **npm publish** and other launches that may resolve `.cmd` shims on Windows are unchanged and still use shell mode where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8ff345018c9edd2e773b729823526485786ece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->