### PR TITLE
[codex] Fix Codex workspace skill autocomplete

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -170,7 +170,7 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         haveSettingsChanged: () => false,
         initialSnapshot: (settings) =>
           makePendingClaudeProvider(settings).pipe(Effect.map(stampIdentity)),
-        checkProvider,
+        checkProvider: () => checkProvider,
         enrichSnapshot: ({ snapshot, publishSnapshot }) =>
           enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities).pipe(
             Effect.provideService(HttpClient.HttpClient, httpClient),

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -112,6 +112,7 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
       const httpClient = yield* HttpClient.HttpClient;
       const eventLoggers = yield* ProviderEventLoggers;
+      const serverConfig = yield* ServerConfig;
       const processEnv = mergeProviderInstanceEnvironment(environment);
       const homeLayout = yield* resolveCodexHomeLayout(config);
       const continuationIdentity = codexContinuationIdentity(homeLayout);
@@ -159,10 +160,16 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
       // in as instance rebuilds from the registry rather than in-place
       // updates. Pre-provide `ChildProcessSpawner` so the check fits
       // `makeManagedServerProvider.checkProvider`'s `R = never`.
-      const checkProvider = checkCodexProviderStatus(effectiveConfig, undefined, processEnv).pipe(
-        Effect.map(stampIdentity),
-        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
-      );
+      const checkProvider = (refreshInput?: { readonly cwd?: string | undefined }) =>
+        checkCodexProviderStatus(
+          effectiveConfig,
+          undefined,
+          processEnv,
+          refreshInput?.cwd ?? serverConfig.cwd,
+        ).pipe(
+          Effect.map(stampIdentity),
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        );
       const snapshot = yield* makeManagedServerProvider<CodexSettings>({
         maintenanceCapabilities,
         getSettings: Effect.succeed(effectiveConfig),

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -137,7 +137,7 @@ export const CursorDriver: ProviderDriver<CursorSettings, CursorDriverEnv> = {
         haveSettingsChanged: () => false,
         initialSnapshot: (settings) =>
           buildInitialCursorProviderSnapshot(settings).pipe(Effect.map(stampIdentity)),
-        checkProvider,
+        checkProvider: () => checkProvider,
         // Model catalog and capabilities come exclusively from Cursor's
         // list_available_models extension method during provider checks.
         enrichSnapshot: ({ settings, snapshot: currentSnapshot, publishSnapshot }) =>

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -149,7 +149,7 @@ export const OpenCodeDriver: ProviderDriver<OpenCodeSettings, OpenCodeDriverEnv>
         haveSettingsChanged: () => false,
         initialSnapshot: (settings) =>
           makePendingOpenCodeProvider(settings).pipe(Effect.map(stampIdentity)),
-        checkProvider,
+        checkProvider: () => checkProvider,
         enrichSnapshot: ({ snapshot, publishSnapshot }) =>
           enrichProviderSnapshotWithVersionAdvisory(snapshot, maintenanceCapabilities).pipe(
             Effect.provideService(HttpClient.HttpClient, httpClient),

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -418,6 +418,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
     ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
   > = probeCodexAppServerProvider,
   environment: NodeJS.ProcessEnv = process.env,
+  cwd: string = process.cwd(),
 ): Effect.fn.Return<
   ServerProviderDraft,
   ServerSettingsError,
@@ -446,7 +447,7 @@ export const checkCodexProviderStatus = Effect.fn("checkCodexProviderStatus")(fu
   const probeResult = yield* probe({
     binaryPath: codexSettings.binaryPath,
     homePath: codexSettings.homePath,
-    cwd: process.cwd(),
+    cwd,
     customModels: codexSettings.customModels,
     environment,
   }).pipe(

--- a/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderAdapterRegistry.test.ts
@@ -120,7 +120,7 @@ const makeFakeInstance = (
         packageName: null,
       }),
       getSnapshot: Effect.succeed({} as unknown as ServerProvider),
-      refresh: Effect.succeed({} as unknown as ServerProvider),
+      refresh: () => Effect.succeed({} as unknown as ServerProvider),
       streamChanges: Stream.empty,
     },
     adapter,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -48,6 +48,7 @@ import { readProviderStatusCache, resolveProviderStatusCachePath } from "../prov
 import type { ProviderInstance } from "../ProviderDriver.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry } from "../Services/ProviderRegistry.ts";
+import type { ProviderSnapshotRefreshInput } from "../Services/ServerProvider.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
 const decodeServerSettings = Schema.decodeSync(ServerSettings);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
@@ -365,6 +366,23 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
             status.message,
             "Codex CLI is not authenticated. Run `codex login` and try again.",
           );
+        }),
+      );
+
+      it.effect("passes the supplied cwd to the app-server probe", () =>
+        Effect.gen(function* () {
+          let capturedCwd: string | null = null;
+          yield* checkCodexProviderStatus(
+            defaultCodexSettings,
+            (input) => {
+              capturedCwd = input.cwd;
+              return Effect.succeed(makeCodexProbeSnapshot());
+            },
+            process.env,
+            "/workspace/project",
+          );
+
+          assert.strictEqual(capturedCwd, "/workspace/project");
         }),
       );
 
@@ -709,7 +727,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
                 packageName: null,
               }),
               getSnapshot: Effect.succeed(initialProvider),
-              refresh: Effect.succeed(refreshedProvider),
+              refresh: () => Effect.succeed(refreshedProvider),
               streamChanges: Stream.fromPubSub(changes),
             },
             adapter: {} as ProviderInstance["adapter"],
@@ -803,7 +821,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
                 packageName: null,
               }),
               getSnapshot: Effect.succeed(cachedProvider),
-              refresh: Effect.die(new Error("simulated refresh failure")),
+              refresh: () => Effect.die(new Error("simulated refresh failure")),
               streamChanges: Stream.empty,
             },
             adapter: {} as ProviderInstance["adapter"],
@@ -841,6 +859,81 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
             assert.deepStrictEqual(yield* registry.refreshInstance(codexInstanceId), [
               cachedProvider,
             ]);
+          }).pipe(Effect.provide(runtimeServices));
+        }),
+      );
+
+      it.effect("forwards manual refresh input to the targeted provider instance", () =>
+        Effect.gen(function* () {
+          const codexDriver = ProviderDriverKind.make("codex");
+          const codexInstanceId = ProviderInstanceId.make("codex");
+          const refreshInputs = yield* Ref.make<Array<string | undefined>>([]);
+          const provider = {
+            instanceId: codexInstanceId,
+            driver: codexDriver,
+            status: "ready",
+            enabled: true,
+            installed: true,
+            auth: { status: "authenticated" },
+            checkedAt: "2026-04-29T10:00:00.000Z",
+            version: "1.0.0",
+            models: [],
+            slashCommands: [],
+            skills: [],
+          } as const satisfies ServerProvider;
+          const instance = {
+            instanceId: codexInstanceId,
+            driverKind: codexDriver,
+            continuationIdentity: {
+              driverKind: codexDriver,
+              continuationKey: "codex:instance:codex",
+            },
+            displayName: undefined,
+            enabled: true,
+            snapshot: {
+              maintenanceCapabilities: makeManualOnlyProviderMaintenanceCapabilities({
+                provider: codexDriver,
+                packageName: null,
+              }),
+              getSnapshot: Effect.succeed(provider),
+              refresh: (input?: ProviderSnapshotRefreshInput) =>
+                Ref.update(refreshInputs, (inputs) => [...inputs, input?.cwd]).pipe(
+                  Effect.as(provider),
+                ),
+              streamChanges: Stream.empty,
+            },
+            adapter: {} as ProviderInstance["adapter"],
+            textGeneration: {} as ProviderInstance["textGeneration"],
+          } satisfies ProviderInstance;
+          const instanceRegistryLayer = Layer.succeed(ProviderInstanceRegistry, {
+            getInstance: (instanceId) =>
+              Effect.succeed(instanceId === codexInstanceId ? instance : undefined),
+            listInstances: Effect.succeed([instance]),
+            listUnavailable: Effect.succeed([]),
+            streamChanges: Stream.empty,
+            subscribeChanges: Effect.flatMap(PubSub.unbounded<void>(), (pubsub) =>
+              PubSub.subscribe(pubsub),
+            ),
+          });
+          const scope = yield* Scope.make();
+          yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+          const runtimeServices = yield* Layer.build(
+            ProviderRegistryLive.pipe(
+              Layer.provideMerge(instanceRegistryLayer),
+              Layer.provideMerge(
+                ServerConfig.layerTest(process.cwd(), {
+                  prefix: "t3-provider-registry-refresh-input-",
+                }),
+              ),
+              Layer.provideMerge(NodeServices.layer),
+            ),
+          ).pipe(Scope.provide(scope));
+
+          yield* Effect.gen(function* () {
+            const registry = yield* ProviderRegistry;
+            yield* registry.refreshInstance(codexInstanceId, { cwd: "/workspace/project" });
+
+            assert.strictEqual((yield* Ref.get(refreshInputs)).at(-1), "/workspace/project");
           }).pipe(Effect.provide(runtimeServices));
         }),
       );
@@ -892,7 +985,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
                 packageName: null,
               }),
               getSnapshot: Effect.succeed(provider),
-              refresh: Effect.succeed(provider),
+              refresh: () => Effect.succeed(provider),
               streamChanges: Stream.empty,
             },
             adapter: {} as ProviderInstance["adapter"],

--- a/apps/server/src/provider/Layers/ProviderRegistry.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.ts
@@ -43,6 +43,7 @@ import * as Semaphore from "effect/Semaphore";
 import { ServerConfig } from "../../config.ts";
 import { ProviderInstanceRegistry } from "../Services/ProviderInstanceRegistry.ts";
 import { ProviderRegistry, type ProviderRegistryShape } from "../Services/ProviderRegistry.ts";
+import type { ProviderSnapshotRefreshInput } from "../Services/ServerProvider.ts";
 import {
   hydrateCachedProvider,
   isCachedProviderCorrelated,
@@ -429,27 +430,33 @@ export const ProviderRegistryLive = Layer.effect(
 
     const refreshOneSource = Effect.fn("refreshOneSource")(function* (
       providerSource: ProviderSnapshotSource,
+      input?: ProviderSnapshotRefreshInput,
     ) {
-      return yield* providerSource.refresh.pipe(
-        Effect.flatMap((nextProvider) =>
-          correlateSnapshotWithSource(providerSource, nextProvider).pipe(
-            Effect.flatMap(syncProvider),
+      return yield* providerSource
+        .refresh(input)
+        .pipe(
+          Effect.flatMap((nextProvider) =>
+            correlateSnapshotWithSource(providerSource, nextProvider).pipe(
+              Effect.flatMap(syncProvider),
+            ),
           ),
-        ),
-      );
+        );
     });
 
-    const refreshAll = Effect.fn("refreshAll")(function* () {
+    const refreshAll = Effect.fn("refreshAll")(function* (input?: ProviderSnapshotRefreshInput) {
       const sources = yield* getLiveSources;
-      return yield* Effect.forEach(sources, (source) => refreshOneSource(source), {
+      return yield* Effect.forEach(sources, (source) => refreshOneSource(source, input), {
         concurrency: "unbounded",
         discard: true,
       }).pipe(Effect.andThen(Ref.get(providersRef)));
     });
 
-    const refresh = Effect.fn("refresh")(function* (provider?: ProviderDriverKind) {
+    const refresh = Effect.fn("refresh")(function* (
+      provider?: ProviderDriverKind,
+      input?: ProviderSnapshotRefreshInput,
+    ) {
       if (provider === undefined) {
-        return yield* refreshAll();
+        return yield* refreshAll(input);
       }
       // Kind-scoped refreshes target the default instance for that driver.
       const defaultInstanceId = defaultInstanceIdForDriver(provider);
@@ -460,18 +467,19 @@ export const ProviderRegistryLive = Layer.effect(
       if (!providerSource) {
         return yield* Ref.get(providersRef);
       }
-      return yield* refreshOneSource(providerSource);
+      return yield* refreshOneSource(providerSource, input);
     });
 
     const refreshInstance = Effect.fn("refreshInstance")(function* (
       instanceId: ProviderInstanceId,
+      input?: ProviderSnapshotRefreshInput,
     ) {
       const sources = yield* getLiveSources;
       const providerSource = sources.find((candidate) => candidate.instanceId === instanceId);
       if (!providerSource) {
         return yield* Ref.get(providersRef);
       }
-      return yield* refreshOneSource(providerSource);
+      return yield* refreshOneSource(providerSource, input);
     });
 
     const getProviderMaintenanceCapabilitiesForInstance = Effect.fn(
@@ -681,10 +689,10 @@ export const ProviderRegistryLive = Layer.effect(
 
     return {
       getProviders: Ref.get(providersRef),
-      refresh: (provider?: ProviderDriverKind) =>
-        refresh(provider).pipe(Effect.catchCause(recoverRefreshFailure)),
-      refreshInstance: (instanceId: ProviderInstanceId) =>
-        refreshInstance(instanceId).pipe(Effect.catchCause(recoverRefreshFailure)),
+      refresh: (provider?: ProviderDriverKind, input?: ProviderSnapshotRefreshInput) =>
+        refresh(provider, input).pipe(Effect.catchCause(recoverRefreshFailure)),
+      refreshInstance: (instanceId: ProviderInstanceId, input?: ProviderSnapshotRefreshInput) =>
+        refreshInstance(instanceId, input).pipe(Effect.catchCause(recoverRefreshFailure)),
       getProviderMaintenanceCapabilitiesForInstance,
       setProviderMaintenanceActionState,
       get streamChanges() {

--- a/apps/server/src/provider/Services/ProviderRegistry.ts
+++ b/apps/server/src/provider/Services/ProviderRegistry.ts
@@ -16,6 +16,7 @@ import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 import type * as Stream from "effect/Stream";
 import type { ProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import type { ProviderSnapshotRefreshInput } from "./ServerProvider.ts";
 
 export type ProviderMaintenanceActionKind = "update";
 
@@ -36,7 +37,10 @@ export interface ProviderRegistryShape {
    *
    * @deprecated prefer `refreshInstance` for new call sites.
    */
-  readonly refresh: (provider?: ProviderDriverKind) => Effect.Effect<ReadonlyArray<ServerProvider>>;
+  readonly refresh: (
+    provider?: ProviderDriverKind,
+    input?: ProviderSnapshotRefreshInput,
+  ) => Effect.Effect<ReadonlyArray<ServerProvider>>;
 
   /**
    * Refresh the specific configured instance. Returns the updated snapshot
@@ -46,6 +50,7 @@ export interface ProviderRegistryShape {
    */
   readonly refreshInstance: (
     instanceId: ProviderInstanceId,
+    input?: ProviderSnapshotRefreshInput,
   ) => Effect.Effect<ReadonlyArray<ServerProvider>>;
 
   /**

--- a/apps/server/src/provider/Services/ServerProvider.ts
+++ b/apps/server/src/provider/Services/ServerProvider.ts
@@ -3,9 +3,13 @@ import type * as Effect from "effect/Effect";
 import type * as Stream from "effect/Stream";
 import type { ProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
 
+export interface ProviderSnapshotRefreshInput {
+  readonly cwd?: string | undefined;
+}
+
 export interface ServerProviderShape {
   readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
   readonly getSnapshot: Effect.Effect<ServerProvider>;
-  readonly refresh: Effect.Effect<ServerProvider>;
+  readonly refresh: (input?: ProviderSnapshotRefreshInput) => Effect.Effect<ServerProvider>;
   readonly streamChanges: Stream.Stream<ServerProvider>;
 }

--- a/apps/server/src/provider/makeManagedServerProvider.test.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.test.ts
@@ -114,10 +114,11 @@ describe("makeManagedServerProvider", () => {
             streamSettings: Stream.empty,
             haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
             initialSnapshot: () => Effect.succeed(initialSnapshot),
-            checkProvider: Ref.update(checkCalls, (count) => count + 1).pipe(
-              Effect.flatMap(() => Deferred.await(releaseCheck)),
-              Effect.as(refreshedSnapshot),
-            ),
+            checkProvider: () =>
+              Ref.update(checkCalls, (count) => count + 1).pipe(
+                Effect.flatMap(() => Deferred.await(releaseCheck)),
+                Effect.as(refreshedSnapshot),
+              ),
             refreshInterval: "1 hour",
           });
 
@@ -156,13 +157,14 @@ describe("makeManagedServerProvider", () => {
           streamSettings: Stream.fromPubSub(settingsChanges),
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
           initialSnapshot: () => Effect.succeed(initialSnapshot),
-          checkProvider: Ref.updateAndGet(checkCalls, (count) => count + 1).pipe(
-            Effect.flatMap((count) =>
-              count === 1
-                ? Deferred.await(releaseInitialCheck).pipe(Effect.as(refreshedSnapshot))
-                : Deferred.await(releaseSettingsCheck).pipe(Effect.as(refreshedSnapshotSecond)),
+          checkProvider: () =>
+            Ref.updateAndGet(checkCalls, (count) => count + 1).pipe(
+              Effect.flatMap((count) =>
+                count === 1
+                  ? Deferred.await(releaseInitialCheck).pipe(Effect.as(refreshedSnapshot))
+                  : Deferred.await(releaseSettingsCheck).pipe(Effect.as(refreshedSnapshotSecond)),
+              ),
             ),
-          ),
           refreshInterval: "1 hour",
         });
 
@@ -198,7 +200,7 @@ describe("makeManagedServerProvider", () => {
           streamSettings: Stream.empty,
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
           initialSnapshot: () => Effect.succeed(initialSnapshot),
-          checkProvider: Deferred.await(releaseCheck).pipe(Effect.as(refreshedSnapshot)),
+          checkProvider: () => Deferred.await(releaseCheck).pipe(Effect.as(refreshedSnapshot)),
           enrichSnapshot: ({ publishSnapshot }) =>
             Deferred.await(releaseEnrichment).pipe(
               Effect.flatMap(() => publishSnapshot(enrichedSnapshot)),
@@ -239,13 +241,14 @@ describe("makeManagedServerProvider", () => {
           streamSettings: Stream.empty,
           haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
           initialSnapshot: () => Effect.succeed(initialSnapshot),
-          checkProvider: Ref.updateAndGet(refreshCount, (count) => count + 1).pipe(
-            Effect.flatMap((count) =>
-              count === 1
-                ? Deferred.await(allowFirstRefresh).pipe(Effect.as(refreshedSnapshot))
-                : Effect.succeed(refreshedSnapshotSecond),
+          checkProvider: () =>
+            Ref.updateAndGet(refreshCount, (count) => count + 1).pipe(
+              Effect.flatMap((count) =>
+                count === 1
+                  ? Deferred.await(allowFirstRefresh).pipe(Effect.as(refreshedSnapshot))
+                  : Effect.succeed(refreshedSnapshotSecond),
+              ),
             ),
-          ),
           enrichSnapshot: ({ publishSnapshot }) =>
             Effect.gen(function* () {
               publishCallbacks.push(publishSnapshot);
@@ -267,7 +270,7 @@ describe("makeManagedServerProvider", () => {
         yield* Deferred.succeed(allowFirstRefresh, undefined);
         yield* Deferred.await(firstCallbackReady);
 
-        yield* provider.refresh;
+        yield* provider.refresh();
         yield* Deferred.await(secondCallbackReady);
 
         yield* publishCallbacks[0]!(enrichedSnapshot);
@@ -282,6 +285,34 @@ describe("makeManagedServerProvider", () => {
           enrichedSnapshotSecond,
         ]);
         assert.deepStrictEqual(latest, enrichedSnapshotSecond);
+      }),
+    ),
+  );
+
+  it.effect("remembers explicit refresh input for later background checks", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const refreshInputs = yield* Ref.make<Array<string | undefined>>([]);
+        const provider = yield* makeManagedServerProvider<TestSettings>({
+          maintenanceCapabilities,
+          getSettings: Effect.succeed({ enabled: true }),
+          streamSettings: Stream.empty,
+          haveSettingsChanged: (previous, next) => previous.enabled !== next.enabled,
+          initialSnapshot: () => Effect.succeed(initialSnapshot),
+          checkProvider: (input) =>
+            Ref.update(refreshInputs, (inputs) => [...inputs, input?.cwd]).pipe(
+              Effect.as(refreshedSnapshot),
+            ),
+          refreshInterval: "1 hour",
+        });
+
+        yield* provider.refresh({ cwd: "/workspace/project" });
+        yield* provider.refresh();
+
+        assert.deepStrictEqual((yield* Ref.get(refreshInputs)).slice(-2), [
+          "/workspace/project",
+          "/workspace/project",
+        ]);
       }),
     ),
   );

--- a/apps/server/src/provider/makeManagedServerProvider.ts
+++ b/apps/server/src/provider/makeManagedServerProvider.ts
@@ -9,7 +9,10 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as Semaphore from "effect/Semaphore";
 
-import type { ServerProviderShape } from "./Services/ServerProvider.ts";
+import type {
+  ProviderSnapshotRefreshInput,
+  ServerProviderShape,
+} from "./Services/ServerProvider.ts";
 import { ServerSettingsError } from "@t3tools/contracts";
 
 interface ProviderSnapshotState {
@@ -25,7 +28,9 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
   readonly streamSettings: Stream.Stream<Settings>;
   readonly haveSettingsChanged: (previous: Settings, next: Settings) => boolean;
   readonly initialSnapshot: (settings: Settings) => Effect.Effect<ServerProvider>;
-  readonly checkProvider: Effect.Effect<ServerProvider, ServerSettingsError>;
+  readonly checkProvider: (
+    input?: ProviderSnapshotRefreshInput,
+  ) => Effect.Effect<ServerProvider, ServerSettingsError>;
   readonly enrichSnapshot?: (input: {
     readonly settings: Settings;
     readonly snapshot: ServerProvider;
@@ -46,6 +51,7 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     enrichmentGeneration: 0,
   });
   const settingsRef = yield* Ref.make(initialSettings);
+  const refreshInputRef = yield* Ref.make<ProviderSnapshotRefreshInput | undefined>(undefined);
   const enrichmentFiberRef = yield* Ref.make<Fiber.Fiber<void, unknown> | null>(null);
   const scope = yield* Effect.scope;
 
@@ -97,9 +103,22 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     yield* Ref.set(enrichmentFiberRef, fiber);
   });
 
+  const resolveRefreshInput = Effect.fn("resolveRefreshInput")(function* (
+    nextInput: ProviderSnapshotRefreshInput | undefined,
+  ) {
+    if (nextInput !== undefined) {
+      yield* Ref.set(refreshInputRef, nextInput);
+      return nextInput;
+    }
+    return yield* Ref.get(refreshInputRef);
+  });
+
   const applySnapshotBase = Effect.fn("applySnapshot")(function* (
     nextSettings: Settings,
-    options?: { readonly forceRefresh?: boolean },
+    options?: {
+      readonly forceRefresh?: boolean;
+      readonly refreshInput?: ProviderSnapshotRefreshInput | undefined;
+    },
   ) {
     const forceRefresh = options?.forceRefresh === true;
     const previousSettings = yield* Ref.get(settingsRef);
@@ -108,7 +127,8 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
       return yield* Ref.get(snapshotStateRef).pipe(Effect.map((state) => state.snapshot));
     }
 
-    const nextSnapshot = yield* input.checkProvider;
+    const refreshInput = yield* resolveRefreshInput(options?.refreshInput);
+    const nextSnapshot = yield* input.checkProvider(refreshInput);
     const nextGeneration = yield* Ref.modify(snapshotStateRef, (state) => {
       const generation = input.enrichSnapshot
         ? state.enrichmentGeneration + 1
@@ -126,12 +146,19 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
     yield* restartSnapshotEnrichment(nextSettings, nextSnapshot, nextGeneration);
     return nextSnapshot;
   });
-  const applySnapshot = (nextSettings: Settings, options?: { readonly forceRefresh?: boolean }) =>
-    refreshSemaphore.withPermits(1)(applySnapshotBase(nextSettings, options));
+  const applySnapshot = (
+    nextSettings: Settings,
+    options?: {
+      readonly forceRefresh?: boolean;
+      readonly refreshInput?: ProviderSnapshotRefreshInput | undefined;
+    },
+  ) => refreshSemaphore.withPermits(1)(applySnapshotBase(nextSettings, options));
 
-  const refreshSnapshot = Effect.fn("refreshSnapshot")(function* () {
+  const refreshSnapshot = Effect.fn("refreshSnapshot")(function* (
+    refreshInput?: ProviderSnapshotRefreshInput,
+  ) {
     const nextSettings = yield* input.getSettings;
-    return yield* applySnapshot(nextSettings, { forceRefresh: true });
+    return yield* applySnapshot(nextSettings, { forceRefresh: true, refreshInput });
   });
 
   yield* Stream.runForEach(input.streamSettings, (nextSettings) =>
@@ -157,7 +184,8 @@ export const makeManagedServerProvider = Effect.fn("makeManagedServerProvider")(
       Effect.tapError(Effect.logError),
       Effect.orDie,
     ),
-    refresh: refreshSnapshot().pipe(Effect.tapError(Effect.logError), Effect.orDie),
+    refresh: (refreshInput) =>
+      refreshSnapshot(refreshInput).pipe(Effect.tapError(Effect.logError), Effect.orDie),
     get streamChanges() {
       return Stream.fromPubSub(changesPubSub);
     },

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -987,10 +987,14 @@ const makeWsRpcLayer = (currentSession: AuthenticatedSession) =>
         [WS_METHODS.serverRefreshProviders]: (input) =>
           observeRpcEffect(
             WS_METHODS.serverRefreshProviders,
-            (input.instanceId !== undefined
-              ? providerRegistry.refreshInstance(input.instanceId)
-              : providerRegistry.refresh()
-            ).pipe(Effect.map((providers) => ({ providers }))),
+            Effect.gen(function* () {
+              const refreshInput = input.cwd !== undefined ? { cwd: input.cwd } : undefined;
+              const providers =
+                input.instanceId !== undefined
+                  ? yield* providerRegistry.refreshInstance(input.instanceId, refreshInput)
+                  : yield* providerRegistry.refresh(undefined, refreshInput);
+              return { providers };
+            }),
             { "rpc.aggregate": "server" },
           ),
         [WS_METHODS.serverUpdateProvider]: (input) =>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -202,6 +202,7 @@ const EMPTY_PROPOSED_PLANS: Thread["proposedPlans"] = [];
 const EMPTY_PROVIDERS: ServerProvider[] = [];
 const EMPTY_PROVIDER_SKILLS: ServerProvider["skills"] = [];
 const EMPTY_PENDING_USER_INPUT_ANSWERS: Record<string, PendingUserInputDraftAnswer> = {};
+const CODEX_PROVIDER_DRIVER = ProviderDriverKind.make("codex");
 type EnvironmentUnavailableState = {
   readonly environmentId: EnvironmentId;
   readonly label: string;
@@ -844,6 +845,7 @@ export default function ChatView(props: ChatViewProps) {
   const composerImagesRef = useRef<ComposerImageAttachment[]>([]);
   const composerTerminalContextsRef = useRef<TerminalContextDraft[]>([]);
   const localComposerRef = useRef<ChatComposerHandle | null>(null);
+  const codexWorkspaceProviderRefreshKeyRef = useRef<string | null>(null);
   const composerRef = useComposerHandleContext() ?? localComposerRef;
   const [showScrollToBottom, setShowScrollToBottom] = useState(false);
   const [expandedImage, setExpandedImage] = useState<ExpandedImagePreview | null>(null);
@@ -1859,6 +1861,34 @@ export default function ChatView(props: ChatViewProps) {
   const activeProjectCwd = activeProject?.cwd ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
+  useEffect(() => {
+    if (!activeWorkspaceRoot) return;
+    const refreshProviderInstanceId =
+      activeProviderInstanceId ?? defaultInstanceIdForDriver(selectedProvider);
+    const refreshProviderDriver = activeProviderStatus?.driver ?? selectedProvider;
+    if (refreshProviderDriver !== CODEX_PROVIDER_DRIVER) return;
+
+    const refreshKey = `${environmentId}\u0000${refreshProviderInstanceId}\u0000${activeWorkspaceRoot}`;
+    if (codexWorkspaceProviderRefreshKeyRef.current === refreshKey) return;
+
+    const api = readLocalApi();
+    if (!api) return;
+    codexWorkspaceProviderRefreshKeyRef.current = refreshKey;
+    void api.server
+      .refreshProviders({
+        instanceId: refreshProviderInstanceId,
+        cwd: activeWorkspaceRoot,
+      })
+      .catch((error: unknown) => {
+        console.warn("Failed to refresh Codex provider for active workspace", error);
+      });
+  }, [
+    activeProviderInstanceId,
+    activeProviderStatus?.driver,
+    activeWorkspaceRoot,
+    environmentId,
+    selectedProvider,
+  ]);
   const activeTerminalLaunchContext =
     terminalUiLaunchContext?.threadId === activeThreadId ? terminalUiLaunchContext : null;
   // Default true while loading to avoid toolbar flicker.

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -542,7 +542,18 @@ describe("wsApi", () => {
     const api = createLocalApi(rpcClientMock as never);
 
     await expect(api.server.refreshProviders()).resolves.toEqual({ providers: nextProviders });
-    expect(rpcClientMock.server.refreshProviders).toHaveBeenCalledWith();
+    expect(rpcClientMock.server.refreshProviders).toHaveBeenCalledWith(undefined);
+
+    await expect(
+      api.server.refreshProviders({
+        instanceId: defaultProviders[0]!.instanceId,
+        cwd: "/workspace/project",
+      }),
+    ).resolves.toEqual({ providers: nextProviders });
+    expect(rpcClientMock.server.refreshProviders).toHaveBeenLastCalledWith({
+      instanceId: defaultProviders[0]!.instanceId,
+      cwd: "/workspace/project",
+    });
   });
 
   it("forwards provider updates directly to the RPC client", async () => {

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -121,9 +121,9 @@ function createBrowserLocalApi(rpcClient?: WsRpcClient): LocalApi {
     server: {
       getConfig: () =>
         rpcClient ? rpcClient.server.getConfig() : Promise.reject(unavailableLocalBackendError()),
-      refreshProviders: () =>
+      refreshProviders: (input) =>
         rpcClient
-          ? rpcClient.server.refreshProviders()
+          ? rpcClient.server.refreshProviders(input)
           : Promise.reject(unavailableLocalBackendError()),
       updateProvider: (input) =>
         rpcClient

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -471,6 +471,7 @@ export interface LocalApi {
      */
     refreshProviders: (input?: {
       readonly instanceId?: ProviderInstanceId;
+      readonly cwd?: string;
     }) => Promise<ServerProviderUpdatedPayload>;
     updateProvider: (input: ServerProviderUpdateInput) => Promise<ServerProviderUpdatedPayload>;
     upsertKeybinding: (input: ServerUpsertKeybindingInput) => Promise<ServerUpsertKeybindingResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -207,6 +207,11 @@ export const WsServerRefreshProvidersRpc = Rpc.make(WS_METHODS.serverRefreshProv
      * refreshes.
      */
     instanceId: Schema.optional(ProviderInstanceId),
+    /**
+     * Workspace directory to use for provider probes that expose project-local
+     * metadata, such as Codex skills.
+     */
+    cwd: Schema.optional(Schema.String),
   }),
   success: ServerProviderUpdatedPayload,
   error: EnvironmentAuthorizationError,


### PR DESCRIPTION
## Summary
Fix Codex `$skill` autocomplete for project/worktree-local skills.

## Root cause
Codex provider status was probed from the server process cwd, so `codex app-server skills/list` did not receive the active project or worktree cwd. Project-local `.agents/skills` entries could be parsed by Codex, but T3 Code's provider snapshot did not include them for the active workspace, leaving `$create-st` and similar skill queries with no matches.

## Changes
- Thread optional `cwd` context through `server.refreshProviders`, the WebSocket contract, provider registry refreshes, and managed provider snapshots.
- Make managed providers remember an explicit refresh context so later background refreshes keep using the active workspace cwd.
- Probe Codex provider status with the active project/worktree cwd, falling back to the configured server cwd.
- Refresh the active Codex provider when the active workspace root changes so the existing `$` skill autocomplete has the right skill list.
- Add regression coverage for Codex cwd forwarding, registry refresh context, managed-provider context reuse, and local API forwarding.

## Related
Related to #2637, but this PR intentionally does not change `/` command suggestions or close that issue.
Related to #2048, but this PR only wires the cwd consumer for Codex; Claude project skill discovery remains separate.
Builds on the closed stale approach from #2330, with the cwd coming from the active workspace rather than only the server config cwd.
Supersedes draft #2953 with a narrower `$` autocomplete-only scope.

## Validation
- `mise exec -- pnpm exec vp check`
- `mise exec -- pnpm exec vp test run apps/server/src/provider/makeManagedServerProvider.test.ts apps/server/src/provider/Layers/ProviderRegistry.test.ts apps/web/src/localApi.test.ts`
- `mise exec -- pnpm exec vp run --filter t3 --filter @t3tools/web --filter @t3tools/contracts typecheck`

Note: full `mise exec -- pnpm exec vp run typecheck` currently fails on fresh `origin/main` in unrelated `apps/desktop` Effect diagnostics (`effect/Scope` resolution and any-in-requirements errors), before any changed package fails.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex workspace skill autocomplete by passing cwd through provider refresh
> - Adds an optional `cwd` field to the `ProviderSnapshotRefreshInput` type and threads it through the refresh call chain: RPC schema → `ProviderRegistry` → `makeManagedServerProvider` → `checkCodexProviderStatus`.
> - `makeManagedServerProvider` now accepts `checkProvider` as a function (instead of a plain Effect) and persists the last explicit refresh input so background rechecks reuse the same `cwd`.
> - `ChatView` gains a `useEffect` that triggers a one-time Codex provider refresh with the active workspace `cwd` whenever the active provider is Codex and a workspace root is set, ensuring project-local skills are resolved correctly.
> - Behavioral Change: `ServerProviderShape.refresh` changes from a plain Effect to a function accepting optional input; all driver and test call sites are updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 957ecf6. 14 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->