### PR TITLE
Prevent settings layout shifts with scrollbar gutters

### DIFF
--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -127,7 +127,7 @@ export function SettingsPageContainer({
   className?: string;
 }) {
   return (
-    <div className="flex-1 overflow-y-auto p-6 sm:p-8">
+    <div className="scrollbar-gutter-both flex-1 overflow-y-auto p-6 sm:p-8">
       <div className={cn("mx-auto flex w-full max-w-3xl flex-col gap-8", className)}>
         {children}
       </div>

--- a/apps/web/src/components/ui/scroll-area.tsx
+++ b/apps/web/src/components/ui/scroll-area.tsx
@@ -29,7 +29,7 @@ function ScrollArea({
           chainVerticalScroll && "overscroll-y-auto",
           scrollFade &&
             "mask-t-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-start)))] mask-b-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-y-end)))] mask-l-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-start)))] mask-r-from-[calc(100%-min(var(--fade-size),var(--scroll-area-overflow-x-end)))] [--fade-size:1.5rem]",
-          scrollbarGutter && "[scrollbar-gutter:stable]",
+          scrollbarGutter && "scrollbar-gutter-stable",
           hideScrollbars &&
             "[-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
         )}


### PR DESCRIPTION
## Summary
- Add `scrollbar-gutter-both` to the shared settings page container so centered settings content stays visually centered when the scrollbar appears.
- Switch the reusable scroll area helper to the Tailwind 4.3 `scrollbar-gutter-stable` utility.

## Testing
- `vp check`
- `pnpm lint`
- `vp run typecheck`
- `vp run --filter @t3tools/web build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks on settings and scroll components with no security or data impact.
> 
> **Overview**
> Reserves horizontal space for scrollbars so settings pages and scroll areas do not **jump horizontally** when overflow scrollbars appear.
> 
> `SettingsPageContainer` now uses **`scrollbar-gutter-both`** on its main scroll column so the centered `max-w-3xl` block stays visually centered. The shared **`ScrollArea`** viewport swaps the old arbitrary `[scrollbar-gutter:stable]` class for the Tailwind **4.3** `scrollbar-gutter-stable` utility when `scrollbarGutter` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3598646a3d083ce220681cbe1e1a6ca63a7ff0e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->