### PR TITLE
[codex] fix release finalize install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -705,6 +705,7 @@ jobs:
           run-install: |
             args:
               - --filter=@t3tools/scripts...
+              - --filter=@t3tools/oxlint-plugin-t3code...
 
       - id: update_versions
         name: Update version strings


### PR DESCRIPTION
## What changed

- Added the `@t3tools/oxlint-plugin-t3code...` workspace closure to the `finalize` release job's `setup-vp` install filters.

## Why

The stable release failed in the final version-bump commit step because the pre-commit hook runs `vp check --fix`, which loads the repo-wide local oxlint JS plugin. That finalize job only installed `@t3tools/scripts...`, so the plugin's `effect` dependency was missing and oxlint failed before linting started.

## Validation

- `vp check`
- `vp run typecheck`
- Local commit hook ran `vp check --fix` successfully while committing this workflow change


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `@t3tools/oxlint-plugin-t3code` to release workflow install filter
> Updates the `run-install` args in the 'Setup Vite+' step of [release.yml](.github/workflows/release.yml) to include `@t3tools/oxlint-plugin-t3code` as a filtered package, fixing the release finalize install step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bf6073.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line workflow install filter change with no runtime or application logic impact.
> 
> **Overview**
> The **Finalize release** job’s `setup-vp` install step now includes `--filter=@t3tools/oxlint-plugin-t3code...` alongside `@t3tools/scripts...`.
> 
> That job commits version bumps on `main`, and staged commits run `vp check --fix`, which loads the repo’s local oxlint plugin. Without installing that workspace package (and its deps such as `effect`), oxlint failed before the stable release could finish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bf6073cc91cfab0e2a9a6663a5552e82e0cc063. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->