### PR TITLE
feat: add Hermes Agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # T3 Code
 
-T3 Code is a minimal web GUI for coding agents (currently Codex, Claude, and OpenCode, more coming soon).
+T3 Code is a minimal web GUI for coding agents (currently Codex, Claude, OpenCode, and Hermes, more coming soon).
 
 ## Installation
 
 > [!WARNING]
-> T3 Code currently supports Codex, Claude, and OpenCode.
+> T3 Code currently supports Codex, Claude, OpenCode, and Hermes.
 > Install and authenticate at least one provider before use:
 >
 > - Codex: install [Codex CLI](https://developers.openai.com/codex/cli) and run `codex login`
 > - Claude: install [Claude Code](https://claude.com/product/claude-code) and run `claude auth login`
 > - OpenCode: install [OpenCode](https://opencode.ai) and run `opencode auth login`
+> - Hermes: install [Hermes Agent](https://github.com/nousresearch/hermes-agent) and run `hermes model`
+
+Hermes setup notes: [docs/providers/hermes.md](./docs/providers/hermes.md)
 
 ### Run without installing
 

--- a/apps/server/src/provider/Drivers/HermesDriver.ts
+++ b/apps/server/src/provider/Drivers/HermesDriver.ts
@@ -1,0 +1,177 @@
+/**
+ * HermesDriver — `ProviderDriver` for the Hermes Agent (`hermes`) runtime.
+ *
+ * Hermes exposes an ACP-based CLI. The driver is still a plain value, but
+ * its snapshot uses `makeManagedServerProvider`'s optional `enrichSnapshot`
+ * hook to run the slow ACP model-capability probe in the background without
+ * blocking the initial `ready`-state publish.
+ *
+ * Text generation is supported via the ACP runtime — `makeHermesTextGeneration`
+ * drives `runtime.prompt` with a structured-output schema and collects the
+ * agent's `agent_message_chunk` stream into a single JSON blob.
+ *
+ * @module provider/Drivers/HermesDriver
+ */
+import { HermesSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { ServerConfig } from "../../config.ts";
+import { makeHermesTextGeneration } from "../../textGeneration/HermesTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeHermesAdapter } from "../Layers/HermesAdapter.ts";
+import {
+  buildInitialHermesProviderSnapshot,
+  checkHermesProviderStatus,
+  enrichHermesSnapshot,
+} from "../Layers/HermesProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+const decodeHermesSettings = Schema.decodeSync(HermesSettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("hermes");
+const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+    updateExecutable: "hermes",
+    updateArgs: ["update"],
+    updateLockKey: "hermes-agent",
+  }),
+);
+
+export type HermesDriverEnv =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const HermesDriver: ProviderDriver<HermesSettings, HermesDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Hermes",
+    supportsMultipleInstances: true,
+  },
+  configSchema: HermesSettings,
+  defaultConfig: (): HermesSettings => decodeHermesSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const httpClient = yield* HttpClient.HttpClient;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies HermesSettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+
+      const adapter = yield* makeHermesAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+      const textGeneration = yield* makeHermesTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkHermesProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
+
+      const snapshot = yield* makeManagedServerProvider<HermesSettings>({
+        maintenanceCapabilities,
+        getSettings: Effect.succeed(effectiveConfig),
+        streamSettings: Stream.never,
+        haveSettingsChanged: () => false,
+        initialSnapshot: (settings) =>
+          buildInitialHermesProviderSnapshot(settings).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+        // Keep version-advisory enrichment off the initial provider snapshot
+        // so Hermes never blocks server startup or settings rendering.
+        enrichSnapshot: ({ settings: _settings, snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichHermesSnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            publishSnapshot,
+            stampIdentity,
+            httpClient,
+          }),
+        refreshInterval: SNAPSHOT_REFRESH_INTERVAL,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Hermes snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/HermesAdapter.ts
+++ b/apps/server/src/provider/Layers/HermesAdapter.ts
@@ -1,0 +1,986 @@
+/**
+ * HermesAdapterLive — Hermes CLI (`hermes acp`) via ACP.
+ *
+ * @module HermesAdapterLive
+ */
+
+import {
+  ApprovalRequestId,
+  type HermesSettings,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderInteractionMode,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderUserInputAnswers,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeRequestId,
+  type RuntimeMode,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { acpPermissionOutcome, mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import { type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import {
+  type AcpSessionMode,
+  type AcpSessionModeState,
+  parsePermissionRequest,
+} from "../acp/AcpRuntimeModel.ts";
+import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import { makeHermesAcpRuntime } from "../acp/HermesAcpSupport.ts";
+import { type HermesAdapterShape } from "../Services/HermesAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.UnknownFromJsonString);
+
+const PROVIDER = ProviderDriverKind.make("hermes");
+const HERMES_RESUME_VERSION = 1 as const;
+const ACP_PLAN_MODE_ALIASES = ["plan", "architect"];
+const ACP_IMPLEMENT_MODE_ALIASES = ["code", "agent", "default", "chat", "implement"];
+const ACP_APPROVAL_MODE_ALIASES = ["ask"];
+
+function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
+  const result = encodeUnknownJsonStringExit(input);
+  return Exit.isSuccess(result) ? result.value : undefined;
+}
+
+export interface HermesAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  /**
+   * Selections are honored when `modelSelection.instanceId` matches this value.
+   * Defaults to the legacy built-in instance id (`hermes`).
+   */
+  readonly instanceId?: ProviderInstanceId;
+  /**
+   * Optional per-session settings resolver. When provided the adapter yields
+   * this effect at the start of every session and uses the result instead of
+   * the `hermesSettings` captured at construction.
+   *
+   * Production instances bind settings to the instance scope (the hydration
+   * layer rebuilds the adapter on config change) and leave this undefined.
+   * Test suites that mutate `ServerSettingsService` mid-flight — e.g. to
+   * swap `binaryPath` to a mock ACP wrapper — pass a resolver that reads
+   * the latest snapshot so the closure isn't stale.
+   */
+  readonly resolveSettings?: Effect.Effect<HermesSettings>;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  readonly kind: string | "unknown";
+}
+
+interface PendingUserInput {
+  readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
+}
+
+interface HermesSessionContext {
+  readonly threadId: ThreadId;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntimeShape;
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
+  readonly turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  lastPlanFingerprint: string | undefined;
+  activeTurnId: TurnId | undefined;
+  stopped: boolean;
+}
+
+function settlePendingApprovalsAsCancelled(
+  pendingApprovals: ReadonlyMap<ApprovalRequestId, PendingApproval>,
+): Effect.Effect<void> {
+  const pendingEntries = Array.from(pendingApprovals.values());
+  return Effect.forEach(
+    pendingEntries,
+    (pending) => Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore),
+    {
+      discard: true,
+    },
+  );
+}
+
+function settlePendingUserInputsAsEmptyAnswers(
+  pendingUserInputs: ReadonlyMap<ApprovalRequestId, PendingUserInput>,
+): Effect.Effect<void> {
+  const pendingEntries = Array.from(pendingUserInputs.values());
+  return Effect.forEach(
+    pendingEntries,
+    (pending) => Deferred.succeed(pending.answers, {}).pipe(Effect.ignore),
+    {
+      discard: true,
+    },
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseHermesResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== HERMES_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+function normalizeModeSearchText(mode: AcpSessionMode): string {
+  return [mode.id, mode.name, mode.description]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function findModeByAliases(
+  modes: ReadonlyArray<AcpSessionMode>,
+  aliases: ReadonlyArray<string>,
+): AcpSessionMode | undefined {
+  const normalizedAliases = aliases.map((alias) => alias.toLowerCase());
+  for (const alias of normalizedAliases) {
+    const exact = modes.find((mode) => {
+      const id = mode.id.toLowerCase();
+      const name = mode.name.toLowerCase();
+      return id === alias || name === alias;
+    });
+    if (exact) {
+      return exact;
+    }
+  }
+  for (const alias of normalizedAliases) {
+    const partial = modes.find((mode) => normalizeModeSearchText(mode).includes(alias));
+    if (partial) {
+      return partial;
+    }
+  }
+  return undefined;
+}
+
+function isPlanMode(mode: AcpSessionMode): boolean {
+  return findModeByAliases([mode], ACP_PLAN_MODE_ALIASES) !== undefined;
+}
+
+function resolveRequestedModeId(input: {
+  readonly interactionMode: ProviderInteractionMode | undefined;
+  readonly runtimeMode: RuntimeMode;
+  readonly modeState: AcpSessionModeState | undefined;
+}): string | undefined {
+  const modeState = input.modeState;
+  if (!modeState) {
+    return undefined;
+  }
+
+  if (input.interactionMode === "plan") {
+    return findModeByAliases(modeState.availableModes, ACP_PLAN_MODE_ALIASES)?.id;
+  }
+
+  if (input.runtimeMode === "approval-required") {
+    return (
+      findModeByAliases(modeState.availableModes, ACP_APPROVAL_MODE_ALIASES)?.id ??
+      findModeByAliases(modeState.availableModes, ACP_IMPLEMENT_MODE_ALIASES)?.id ??
+      modeState.availableModes.find((mode) => !isPlanMode(mode))?.id ??
+      modeState.currentModeId
+    );
+  }
+
+  return (
+    findModeByAliases(modeState.availableModes, ACP_IMPLEMENT_MODE_ALIASES)?.id ??
+    findModeByAliases(modeState.availableModes, ACP_APPROVAL_MODE_ALIASES)?.id ??
+    modeState.availableModes.find((mode) => !isPlanMode(mode))?.id ??
+    modeState.currentModeId
+  );
+}
+
+function applyRequestedSessionConfiguration<E>(input: {
+  readonly runtime: AcpSessionRuntimeShape;
+  readonly runtimeMode: RuntimeMode;
+  readonly interactionMode: ProviderInteractionMode | undefined;
+  readonly mapError: (context: {
+    readonly cause: import("effect-acp/errors").AcpError;
+    readonly method: "session/set_mode";
+  }) => E;
+}): Effect.Effect<void, E> {
+  return Effect.gen(function* () {
+    const requestedModeId = resolveRequestedModeId({
+      interactionMode: input.interactionMode,
+      runtimeMode: input.runtimeMode,
+      modeState: yield* input.runtime.getModeState,
+    });
+    if (!requestedModeId) {
+      return;
+    }
+
+    yield* input.runtime.setMode(requestedModeId).pipe(
+      Effect.mapError((cause) =>
+        input.mapError({
+          cause,
+          method: "session/set_mode",
+        }),
+      ),
+    );
+  });
+}
+
+function selectAutoApprovedPermissionOption(
+  request: EffectAcpSchema.RequestPermissionRequest,
+): string | undefined {
+  const allowAlwaysOption = request.options.find((option) => option.kind === "allow_always");
+  if (typeof allowAlwaysOption?.optionId === "string" && allowAlwaysOption.optionId.trim()) {
+    return allowAlwaysOption.optionId.trim();
+  }
+
+  const allowOnceOption = request.options.find((option) => option.kind === "allow_once");
+  if (typeof allowOnceOption?.optionId === "string" && allowOnceOption.optionId.trim()) {
+    return allowOnceOption.optionId.trim();
+  }
+
+  return undefined;
+}
+
+export function makeHermesAdapter(
+  hermesSettings: HermesSettings,
+  options?: HermesAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("hermes");
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const crypto = yield* Crypto.Crypto;
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, {
+            stream: "native",
+          })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+    const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
+
+    const sessions = new Map<ThreadId, HermesSessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate Hermes runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const mapExtensionFailure = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new EffectAcpErrors.AcpTransportError({
+              detail: "Failed to process Hermes ACP event.",
+              cause,
+            }),
+        ),
+      );
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
+          current.get(threadId),
+        );
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const logNative = (
+      threadId: ThreadId,
+      method: string,
+      payload: unknown,
+      _source: "acp.jsonrpc" | "acp.hermes.extension",
+    ) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      });
+
+    const emitPlanUpdate = (
+      ctx: HermesSessionContext,
+      payload: {
+        readonly explanation?: string | null;
+        readonly plan: ReadonlyArray<{
+          readonly step: string;
+          readonly status: "pending" | "inProgress" | "completed";
+        }>;
+      },
+      rawPayload: unknown,
+      source: "acp.jsonrpc" | "acp.hermes.extension",
+      method: string,
+    ) =>
+      Effect.gen(function* () {
+        const fingerprint = `${ctx.activeTurnId ?? "no-turn"}:${encodeJsonStringForDiagnostics(payload) ?? "[unserializable payload]"}`;
+        if (ctx.lastPlanFingerprint === fingerprint) {
+          return;
+        }
+        ctx.lastPlanFingerprint = fingerprint;
+        yield* offerRuntimeEvent(
+          makeAcpPlanUpdatedEvent({
+            stamp: yield* makeEventStamp(),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId: ctx.activeTurnId,
+            payload,
+            source,
+            method,
+            rawPayload,
+          }),
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<HermesSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: HermesSessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: HermesAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+          let ctx!: HermesSessionContext;
+
+          const resumeSessionId = parseHermesResume(input.resumeCursor)?.sessionId;
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+
+          // Resolve the HermesSettings used to spawn the ACP child. Production
+          // leaves `options.resolveSettings` undefined so we use the value
+          // captured at adapter construction — per-instance isolation is
+          // enforced by the hydration layer rebuilding this adapter whenever
+          // its config changes. Tests set `resolveSettings` to pull the latest
+          // snapshot from `ServerSettingsService` so that mid-suite
+          // `updateSettings({ providers: { hermes: { binaryPath } } })` calls
+          // actually take effect when the next session spawns.
+          const effectiveHermesSettings = options?.resolveSettings
+            ? yield* options.resolveSettings
+            : hermesSettings;
+
+          const acp = yield* makeHermesAcpRuntime({
+            hermesSettings: effectiveHermesSettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...acpNativeLoggers,
+          }).pipe(
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+          const started = yield* Effect.gen(function* () {
+            yield* acp.handleRequestPermission((params) =>
+              mapExtensionFailure(
+                Effect.gen(function* () {
+                  yield* logNative(
+                    input.threadId,
+                    "session/request_permission",
+                    params,
+                    "acp.jsonrpc",
+                  );
+                  if (input.runtimeMode === "full-access") {
+                    const autoApprovedOptionId = selectAutoApprovedPermissionOption(params);
+                    if (autoApprovedOptionId !== undefined) {
+                      return {
+                        outcome: {
+                          outcome: "selected" as const,
+                          optionId: autoApprovedOptionId,
+                        },
+                      };
+                    }
+                  }
+                  const permissionRequest = parsePermissionRequest(params);
+                  const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                  const runtimeRequestId = RuntimeRequestId.make(requestId);
+                  const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                  pendingApprovals.set(requestId, {
+                    decision,
+                    kind: permissionRequest.kind,
+                  });
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestOpenedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      detail:
+                        permissionRequest.detail ??
+                        encodeJsonStringForDiagnostics(params)?.slice(0, 2000) ??
+                        "[unserializable params]",
+                      args: params,
+                      source: "acp.jsonrpc",
+                      method: "session/request_permission",
+                      rawPayload: params,
+                    }),
+                  );
+                  const resolved = yield* Deferred.await(decision);
+                  pendingApprovals.delete(requestId);
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestResolvedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      decision: resolved,
+                    }),
+                  );
+                  return {
+                    outcome:
+                      resolved === "cancel"
+                        ? ({ outcome: "cancelled" } as const)
+                        : {
+                            outcome: "selected" as const,
+                            optionId: acpPermissionOutcome(resolved),
+                          },
+                  };
+                }),
+              ),
+            );
+            return yield* acp.start();
+          }).pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+            ),
+          );
+
+          yield* applyRequestedSessionConfiguration({
+            runtime: acp,
+            runtimeMode: input.runtimeMode,
+            interactionMode: undefined,
+            mapError: ({ cause, method }) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+          });
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: HERMES_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          ctx = {
+            threadId: input.threadId,
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            pendingApprovals,
+            pendingUserInputs,
+            turns: [],
+            lastPlanFingerprint: undefined,
+            activeTurnId: undefined,
+            stopped: false,
+          };
+
+          const nf = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                switch (event._tag) {
+                  case "ModeChanged":
+                    return;
+                  case "AssistantItemStarted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.started",
+                      }),
+                    );
+                    return;
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* logNative(
+                      ctx.threadId,
+                      "session/update",
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                    );
+                    yield* emitPlanUpdate(
+                      ctx,
+                      event.payload,
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                      "session/update",
+                    );
+                    return;
+                  case "ToolCallUpdated":
+                    yield* logNative(
+                      ctx.threadId,
+                      "session/update",
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                    );
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* logNative(
+                      ctx.threadId,
+                      "session/update",
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                    );
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to process Hermes runtime notification.", { cause }),
+            ),
+            Effect.forkChild,
+          );
+
+          ctx.notificationFiber = nf;
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Hermes ACP session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: HermesAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(input.threadId);
+        const turnId = TurnId.make(yield* randomUUIDv4);
+        yield* applyRequestedSessionConfiguration({
+          runtime: ctx.acp,
+          runtimeMode: ctx.session.runtimeMode,
+          interactionMode: input.interactionMode,
+          mapError: ({ cause, method }) =>
+            mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+        });
+        ctx.activeTurnId = turnId;
+        ctx.lastPlanFingerprint = undefined;
+        ctx.session = {
+          ...ctx.session,
+          activeTurnId: turnId,
+          updatedAt: yield* nowIso,
+        };
+
+        yield* offerRuntimeEvent({
+          type: "turn.started",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: input.threadId,
+          turnId,
+          payload: { model: ctx.session.model ?? "hermes-default" },
+        });
+
+        const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
+        if (input.input?.trim()) {
+          promptParts.push({ type: "text", text: input.input.trim() });
+        }
+        if (input.attachments && input.attachments.length > 0) {
+          for (const attachment of input.attachments) {
+            const attachmentPath = resolveAttachmentPath({
+              attachmentsDir: serverConfig.attachmentsDir,
+              attachment,
+            });
+            if (!attachmentPath) {
+              return yield* new ProviderAdapterRequestError({
+                provider: PROVIDER,
+                method: "session/prompt",
+                detail: `Invalid attachment id '${attachment.id}'.`,
+              });
+            }
+            const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "session/prompt",
+                    detail: cause.message,
+                    cause,
+                  }),
+              ),
+            );
+            promptParts.push({
+              type: "image",
+              data: Buffer.from(bytes).toString("base64"),
+              mimeType: attachment.mimeType,
+            });
+          }
+        }
+
+        if (promptParts.length === 0) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "sendTurn",
+            issue: "Turn requires non-empty text or attachments.",
+          });
+        }
+
+        const result = yield* ctx.acp
+          .prompt({
+            prompt: promptParts,
+          })
+          .pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+            ),
+          );
+
+        ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
+        ctx.session = {
+          ...ctx.session,
+          activeTurnId: turnId,
+          updatedAt: yield* nowIso,
+        };
+
+        yield* offerRuntimeEvent({
+          type: "turn.completed",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: input.threadId,
+          turnId,
+          payload: {
+            state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+            stopReason: result.stopReason ?? null,
+          },
+        });
+
+        return {
+          threadId: input.threadId,
+          turnId,
+          resumeCursor: ctx.session.resumeCursor,
+        };
+      });
+
+    const interruptTurn: HermesAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        yield* Effect.ignore(
+          ctx.acp.cancel.pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+            ),
+          ),
+        );
+      });
+
+    const respondToRequest: HermesAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: HermesAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingUserInputs.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "hermes/ask_question",
+            detail: `Unknown pending user-input request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.answers, answers);
+      });
+
+    const readThread: HermesAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: HermesAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        const nextLength = Math.max(0, ctx.turns.length - numTurns);
+        ctx.turns.splice(nextLength);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const stopSession: HermesAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions: HermesAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (c) => ({ ...c.session })));
+
+    const hasSession: HermesAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const c = sessions.get(threadId);
+        return c !== undefined && !c.stopped;
+      });
+
+    const stopAll: HermesAdapterShape["stopAll"] = () =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to emit Hermes session shutdown event.", { cause }),
+        ),
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
+
+    return {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents,
+    } satisfies HermesAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/HermesProvider.test.ts
+++ b/apps/server/src/provider/Layers/HermesProvider.test.ts
@@ -1,0 +1,258 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { HermesSettings } from "@t3tools/contracts";
+import {
+  checkHermesProviderStatus,
+  getHermesFallbackModels,
+  parseHermesConfigModelDefaults,
+  resolveHermesBinary,
+} from "./HermesProvider.ts";
+
+const encoder = new TextEncoder();
+const decodeHermesSettings = Schema.decodeSync(HermesSettings);
+
+function mockHandle(result: { stdout?: string; stderr?: string; code?: number }) {
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(result.code ?? 0)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(result.stdout ?? "")),
+    stderr: Stream.make(encoder.encode(result.stderr ?? "")),
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
+}
+
+function mockSpawnerLayer(
+  handler: (
+    command: string,
+    args: ReadonlyArray<string>,
+  ) => { stdout?: string; stderr?: string; code?: number },
+) {
+  return Layer.succeed(
+    ChildProcessSpawner.ChildProcessSpawner,
+    ChildProcessSpawner.make((command) => {
+      const childProcess = command as unknown as {
+        readonly command: string;
+        readonly args: ReadonlyArray<string>;
+      };
+      return Effect.succeed(mockHandle(handler(childProcess.command, childProcess.args)));
+    }),
+  );
+}
+
+const makeHermesSettings = (overrides?: Partial<HermesSettings>): HermesSettings =>
+  decodeHermesSettings({
+    enabled: true,
+    binaryPath: "hermes",
+    customModels: [],
+    ...overrides,
+  });
+
+const makeTempHome = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  return yield* fs.makeTempDirectoryScoped({ prefix: "t3-hermes-test-" });
+});
+
+const writeTestFile = (filePath: string, contents: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    yield* fs.makeDirectory(path.dirname(filePath), { recursive: true });
+    yield* fs.writeFileString(filePath, contents);
+  });
+
+describe("parseHermesConfigModelDefaults", () => {
+  it("reads the model.default value from Hermes config.yaml", () => {
+    assert.deepEqual(
+      parseHermesConfigModelDefaults(`
+model:
+  provider: openai-codex
+  base_url: https://chatgpt.com/backend-api/codex
+  default: gpt-5.5
+`),
+      { defaultModel: "gpt-5.5", malformed: false },
+    );
+  });
+
+  it("ignores unrelated default keys outside the model block", () => {
+    assert.deepEqual(
+      parseHermesConfigModelDefaults(`
+default: wrong
+model:
+  provider: openai-codex
+tools:
+  default: also-wrong
+`),
+      { defaultModel: null, malformed: true },
+    );
+  });
+
+  it("parses quoted model defaults and strips inline comments", () => {
+    assert.deepEqual(
+      parseHermesConfigModelDefaults(`
+model:
+  default: "gpt-5.5" # selected in hermes model
+`),
+      { defaultModel: "gpt-5.5", malformed: false },
+    );
+  });
+});
+
+describe("getHermesFallbackModels", () => {
+  it("keeps a built-in fallback model plus configured custom models", () => {
+    const models = getHermesFallbackModels(
+      makeHermesSettings({ customModels: ["nous/hermes-4", "hermes-default"] }),
+    );
+
+    assert.deepEqual(
+      models.map((model) => [model.slug, model.name, model.isCustom]),
+      [
+        ["hermes-default", "Hermes Default", false],
+        ["nous/hermes-4", "nous/hermes-4", true],
+      ],
+    );
+  });
+});
+
+describe("checkHermesProviderStatus", () => {
+  it.effect("reports ready status and parses --version output", () =>
+    Effect.gen(function* () {
+      const layer = Layer.merge(
+        NodeServices.layer,
+        mockSpawnerLayer((command, args) => {
+          if (args[0] === "-lc") {
+            assert.equal(command, "/bin/zsh");
+            return { stdout: "", code: 1 };
+          }
+          assert.deepEqual(args, ["--version"]);
+          return { stdout: "Hermes Agent v0.11.0\n", code: 0 };
+        }),
+      );
+      const snapshot = yield* checkHermesProviderStatus(makeHermesSettings(), {
+        HOME: "/tmp/no-hermes-config",
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(snapshot.status, "ready");
+      assert.equal(snapshot.installed, true);
+      assert.equal(snapshot.version, "0.11.0");
+      assert.equal(snapshot.models[0]?.slug, "hermes-default");
+    }),
+  );
+
+  it.effect("uses the detected common macOS binary path for the default hermes command", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const home = yield* makeTempHome;
+      const binaryPath = path.join(home, ".local/bin/hermes");
+      yield* writeTestFile(binaryPath, "");
+
+      const resolution = yield* resolveHermesBinary(makeHermesSettings(), {
+        HOME: home,
+      });
+
+      assert.equal(resolution.binaryPath, binaryPath);
+      assert.equal(resolution.suggestedBinaryPath, binaryPath);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("suggests a detected path when an explicit binary path is invalid", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const home = yield* makeTempHome;
+      const binaryPath = path.join(home, ".local/bin/hermes");
+      yield* writeTestFile(binaryPath, "");
+
+      const snapshot = yield* checkHermesProviderStatus(
+        makeHermesSettings({ binaryPath: path.join(home, "missing/hermes") }),
+        { HOME: home },
+      );
+
+      assert.equal(snapshot.status, "error");
+      assert.equal(snapshot.installed, false);
+      assert.equal(snapshot.suggestedBinaryPath, binaryPath);
+      assert.match(snapshot.message ?? "", /Detected Hermes/);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("shows the configured Hermes model from config.yaml", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const home = yield* makeTempHome;
+      yield* writeTestFile(
+        path.join(home, ".hermes/config.yaml"),
+        `
+model:
+  provider: openai-codex
+  default: gpt-5.5
+`,
+      );
+      const layer = mockSpawnerLayer((command, args) => {
+        if (args[0] === "-lc") return { stdout: "", code: 1 };
+        assert.equal(command, "hermes");
+        return { stdout: "Hermes Agent v0.11.0\n", code: 0 };
+      });
+
+      const snapshot = yield* checkHermesProviderStatus(makeHermesSettings(), {
+        HOME: home,
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(snapshot.models[0]?.slug, "gpt-5.5");
+      assert.equal(snapshot.models[0]?.name, "GPT 5.5");
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("guides setup when Hermes config has no model.default", () =>
+    Effect.gen(function* () {
+      const path = yield* Path.Path;
+      const home = yield* makeTempHome;
+      yield* writeTestFile(
+        path.join(home, ".hermes/config.yaml"),
+        "model:\n  provider: openai-codex\n",
+      );
+      const layer = mockSpawnerLayer((_command, args) => {
+        if (args[0] === "-lc") return { stdout: "", code: 1 };
+        return { stdout: "Hermes Agent v0.11.0\n", code: 0 };
+      });
+
+      const snapshot = yield* checkHermesProviderStatus(makeHermesSettings(), {
+        HOME: home,
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(snapshot.status, "ready");
+      assert.match(snapshot.message ?? "", /hermes model/);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("surfaces stderr when the Hermes CLI health check exits nonzero", () =>
+    Effect.gen(function* () {
+      const layer = Layer.merge(
+        NodeServices.layer,
+        mockSpawnerLayer((_command, args) => {
+          if (args[0] === "-lc") return { stdout: "", code: 1 };
+          return { stderr: "ACP failed to start: missing provider credentials", code: 2 };
+        }),
+      );
+
+      const snapshot = yield* checkHermesProviderStatus(makeHermesSettings(), {
+        HOME: "/tmp/no-hermes-config",
+      }).pipe(Effect.provide(layer));
+
+      assert.equal(snapshot.status, "warning");
+      assert.match(snapshot.message ?? "", /ACP failed to start/);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/HermesProvider.ts
+++ b/apps/server/src/provider/Layers/HermesProvider.ts
@@ -1,0 +1,506 @@
+import type {
+  HermesSettings,
+  ServerProvider,
+  ServerProviderAuth,
+  ServerProviderModel,
+  ServerProviderState,
+} from "@t3tools/contracts";
+import { ProviderDriverKind } from "@t3tools/contracts";
+import * as NodeOS from "node:os";
+import * as Cause from "effect/Cause";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+
+import {
+  buildServerProvider,
+  collectStreamAsString,
+  isCommandMissingCause,
+  providerModelsFromSettings,
+  type CommandResult,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+
+const PROVIDER = ProviderDriverKind.make("hermes");
+const HERMES_PRESENTATION = {
+  displayName: "Hermes",
+  badgeLabel: "Early Access",
+  showInteractionModeToggle: true,
+} as const;
+const EMPTY_CAPABILITIES = createModelCapabilities({ optionDescriptors: [] });
+const HERMES_FALLBACK_MODEL: ServerProviderModel = {
+  slug: "hermes-default",
+  name: "Hermes Default",
+  isCustom: false,
+  capabilities: EMPTY_CAPABILITIES,
+};
+const HERMES_DEFAULT_MODELS: ReadonlyArray<ServerProviderModel> = [HERMES_FALLBACK_MODEL];
+const ABOUT_TIMEOUT_MS = 4_000;
+const LOGIN_SHELL_TIMEOUT_MS = 2_000;
+
+export interface HermesConfigModelDefaults {
+  readonly defaultModel: string | null;
+  readonly malformed: boolean;
+}
+
+export interface HermesBinaryResolution {
+  readonly binaryPath: string;
+  readonly suggestedBinaryPath: string | null;
+}
+
+function stripQuotes(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+export function parseHermesConfigModelDefaults(raw: string): HermesConfigModelDefaults {
+  const lines = raw.replace(/\r\n?/g, "\n").split("\n");
+  let inModelBlock = false;
+  let modelIndent = 0;
+  let sawModelBlock = false;
+
+  for (const line of lines) {
+    const withoutComment = line.replace(/\s+#.*$/, "");
+    if (withoutComment.trim().length === 0) continue;
+
+    const indent = withoutComment.length - withoutComment.trimStart().length;
+    const trimmed = withoutComment.trim();
+    const topLevelModelMatch = /^model\s*:\s*$/.exec(trimmed);
+    if (topLevelModelMatch && indent === 0) {
+      inModelBlock = true;
+      sawModelBlock = true;
+      modelIndent = indent;
+      continue;
+    }
+
+    if (inModelBlock && indent <= modelIndent) {
+      inModelBlock = false;
+    }
+
+    if (!inModelBlock) continue;
+    const defaultMatch = /^default\s*:\s*(.+?)\s*$/.exec(trimmed);
+    if (!defaultMatch?.[1]) continue;
+
+    const value = stripQuotes(defaultMatch[1]);
+    return { defaultModel: value.length > 0 ? value : null, malformed: false };
+  }
+
+  return { defaultModel: null, malformed: sawModelBlock };
+}
+
+function formatHermesModelName(slug: string): string {
+  return slug
+    .split(/[/-]/g)
+    .filter((segment) => segment.length > 0)
+    .map((segment) => {
+      if (/^gpt$/i.test(segment)) return "GPT";
+      if (/^\d/.test(segment)) return segment;
+      return segment[0]!.toUpperCase() + segment.slice(1);
+    })
+    .join(" ");
+}
+
+function modelFromHermesDefault(defaultModel: string | null): ServerProviderModel {
+  const slug = defaultModel?.trim();
+  if (!slug) return HERMES_FALLBACK_MODEL;
+  return {
+    slug,
+    name: formatHermesModelName(slug),
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  };
+}
+
+function readHermesConfigModelDefaults(
+  environment: NodeJS.ProcessEnv,
+): Effect.Effect<HermesConfigModelDefaults, never, FileSystem.FileSystem | Path.Path> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const home =
+      environment.HERMES_HOME?.trim() || path.join(environment.HOME || NodeOS.homedir(), ".hermes");
+    const raw = yield* fs
+      .readFileString(path.join(home, "config.yaml"))
+      .pipe(Effect.catch(() => Effect.succeed(null)));
+    return raw ? parseHermesConfigModelDefaults(raw) : { defaultModel: null, malformed: false };
+  });
+}
+
+function isExplicitBinaryPath(binaryPath: string): boolean {
+  return binaryPath.includes("/") || binaryPath.includes("\\") || binaryPath.startsWith("~");
+}
+
+function commonHermesBinaryCandidates(
+  environment: NodeJS.ProcessEnv,
+): Effect.Effect<ReadonlyArray<string>, never, Path.Path> {
+  return Effect.gen(function* () {
+    const path = yield* Path.Path;
+    const home = environment.HOME || NodeOS.homedir();
+    return [
+      path.join(home, ".local/bin/hermes"),
+      path.join(home, "Projects/hermes-agent/venv/bin/hermes"),
+      "/opt/homebrew/bin/hermes",
+      "/usr/local/bin/hermes",
+    ];
+  });
+}
+
+function expandHomePath(input: string, environment: NodeJS.ProcessEnv): string {
+  const home = environment.HOME || NodeOS.homedir();
+  if (input === "~") return home;
+  if (input.startsWith("~/") || input.startsWith("~\\")) return `${home}${input.slice(1)}`;
+  return input;
+}
+
+function firstExistingPath(
+  candidates: ReadonlyArray<string>,
+): Effect.Effect<string | null, never, FileSystem.FileSystem> {
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    for (const candidate of candidates) {
+      const exists = yield* fs.exists(candidate).pipe(Effect.catch(() => Effect.succeed(false)));
+      if (exists) return candidate;
+    }
+    return null;
+  });
+}
+
+function detectHermesFromLoginShell(
+  environment: NodeJS.ProcessEnv,
+): Effect.Effect<string | null, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const shell = environment.SHELL?.trim() || "/bin/zsh";
+  return runRawCommand(shell, ["-lc", "command -v hermes"], environment).pipe(
+    Effect.timeoutOption(LOGIN_SHELL_TIMEOUT_MS),
+    Effect.map((result) => {
+      if (Option.isNone(result) || result.value.code !== 0) return null;
+      const candidate = result.value.stdout.trim().split(/\r?\n/u)[0]?.trim();
+      return candidate && candidate.length > 0 ? candidate : null;
+    }),
+    Effect.catch(() => Effect.succeed(null)),
+  );
+}
+
+export function resolveHermesBinary(
+  hermesSettings: Pick<HermesSettings, "binaryPath">,
+  environment: NodeJS.ProcessEnv = process.env,
+): Effect.Effect<
+  HermesBinaryResolution,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> {
+  return Effect.gen(function* () {
+    const configured = hermesSettings.binaryPath.trim() || "hermes";
+    const explicitConfigured = isExplicitBinaryPath(configured);
+    const expandedConfigured = explicitConfigured
+      ? expandHomePath(configured, environment)
+      : configured;
+    const candidates = yield* commonHermesBinaryCandidates(environment);
+    const detected =
+      (yield* firstExistingPath(candidates)) ?? (yield* detectHermesFromLoginShell(environment));
+
+    if (!explicitConfigured && configured === "hermes" && detected) {
+      return { binaryPath: detected, suggestedBinaryPath: detected };
+    }
+
+    return {
+      binaryPath: expandedConfigured,
+      suggestedBinaryPath: detected && detected !== expandedConfigured ? detected : null,
+    };
+  });
+}
+
+function getHermesModels(
+  hermesSettings: Pick<HermesSettings, "customModels">,
+  defaults: HermesConfigModelDefaults,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(
+    [modelFromHermesDefault(defaults.defaultModel)],
+    PROVIDER,
+    hermesSettings.customModels,
+    EMPTY_CAPABILITIES,
+  );
+}
+
+export function getHermesFallbackModels(
+  hermesSettings: Pick<HermesSettings, "customModels">,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(
+    HERMES_DEFAULT_MODELS,
+    PROVIDER,
+    hermesSettings.customModels,
+    EMPTY_CAPABILITIES,
+  );
+}
+
+export function buildInitialHermesProviderSnapshot(
+  hermesSettings: HermesSettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = getHermesFallbackModels(hermesSettings);
+
+    if (!hermesSettings.enabled) {
+      return buildServerProvider({
+        presentation: HERMES_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Hermes is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: HERMES_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking Hermes Agent availability...",
+      },
+    });
+  });
+}
+
+interface HermesAboutResult {
+  readonly version: string | null;
+  readonly status: Exclude<ServerProviderState, "disabled">;
+  readonly auth: ServerProviderAuth;
+  readonly message?: string;
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07/g, "");
+}
+
+function extractVersion(raw: string): string | null {
+  const plain = stripAnsi(raw);
+  const aboutMatch = /^CLI Version\s{2,}(.+)$/im.exec(plain);
+  if (aboutMatch?.[1]) return aboutMatch[1].trim();
+  const versionMatch = /\b(?:hermes(?:-agent)?\s+)?v?(\d+\.\d+\.\d+(?:[-+][\w.-]+)?)/i.exec(plain);
+  return versionMatch?.[1]?.trim() ?? null;
+}
+
+function parseHermesAboutOutput(result: CommandResult): HermesAboutResult {
+  const combined = `${result.stdout}\n${result.stderr}`;
+  const lower = combined.toLowerCase();
+  const version = extractVersion(combined);
+  const detail = stripAnsi(combined).trim();
+
+  if (lower.includes("not logged in") || lower.includes("authentication required")) {
+    return {
+      version,
+      status: "error",
+      auth: { status: "unauthenticated" },
+      message: "Hermes Agent is not authenticated. Run `hermes setup` or `hermes model`.",
+    };
+  }
+
+  if (result.code === 0) {
+    return {
+      version,
+      status: "ready",
+      auth: { status: "unknown" },
+    };
+  }
+
+  return {
+    version,
+    status: "warning",
+    auth: { status: "unknown" },
+    message: detail
+      ? `Hermes Agent CLI health check exited with code ${result.code}: ${detail}`
+      : "Hermes Agent is installed, but T3 Code could not verify its auth status.",
+  };
+}
+
+const runRawCommand = (
+  binaryPath: string,
+  args: ReadonlyArray<string>,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const command = ChildProcess.make(binaryPath, [...args], {
+      env: environment,
+      shell: process.platform === "win32",
+    });
+    const child = yield* spawner.spawn(command);
+    const [stdout, stderr, exitCode] = yield* Effect.all(
+      [
+        collectStreamAsString(child.stdout),
+        collectStreamAsString(child.stderr),
+        child.exitCode.pipe(Effect.map(Number)),
+      ],
+      { concurrency: "unbounded" },
+    );
+    return { stdout, stderr, code: exitCode } satisfies CommandResult;
+  }).pipe(Effect.scoped);
+
+const runHermesCommand = (
+  binaryPath: string,
+  args: ReadonlyArray<string>,
+  environment: NodeJS.ProcessEnv = process.env,
+) => runRawCommand(binaryPath, args, environment);
+
+const runHermesAboutCommand = (binaryPath: string, environment: NodeJS.ProcessEnv = process.env) =>
+  runHermesCommand(binaryPath, ["--version"], environment).pipe(
+    Effect.catch(() => runHermesCommand(binaryPath, ["about"], environment)),
+  );
+
+export const checkHermesProviderStatus = Effect.fn("checkHermesProviderStatus")(function* (
+  hermesSettings: HermesSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+): Effect.fn.Return<
+  ServerProviderDraft,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> {
+  const checkedAt = DateTime.formatIso(yield* DateTime.now);
+  const configDefaults = yield* readHermesConfigModelDefaults(environment);
+  const models = getHermesModels(hermesSettings, configDefaults);
+  const binaryResolution = yield* resolveHermesBinary(hermesSettings, environment);
+  const withHermesHints = (snapshot: ServerProviderDraft): ServerProviderDraft => ({
+    ...snapshot,
+    ...(binaryResolution.suggestedBinaryPath
+      ? { suggestedBinaryPath: binaryResolution.suggestedBinaryPath }
+      : {}),
+  });
+
+  if (!hermesSettings.enabled) {
+    return withHermesHints(
+      buildServerProvider({
+        presentation: HERMES_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Hermes is disabled in T3 Code settings.",
+        },
+      }),
+    );
+  }
+
+  const probe = yield* runHermesAboutCommand(binaryResolution.binaryPath, environment).pipe(
+    Effect.timeoutOption(ABOUT_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  if (Result.isFailure(probe)) {
+    const error =
+      probe.failure instanceof Error
+        ? probe.failure
+        : new Error(typeof probe.failure === "string" ? probe.failure : String(probe.failure));
+    const isMissing = isCommandMissingCause(error);
+    const missingMessage = binaryResolution.suggestedBinaryPath
+      ? `Hermes Agent CLI was not found at \`${binaryResolution.binaryPath}\`. Detected Hermes at \`${binaryResolution.suggestedBinaryPath}\`; use the detected path or update Binary path.`
+      : "Hermes Agent CLI (`hermes`) is not installed or not on PATH.";
+    return withHermesHints(
+      buildServerProvider({
+        presentation: HERMES_PRESENTATION,
+        enabled: true,
+        checkedAt,
+        models,
+        probe: {
+          installed: !isMissing,
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: isMissing
+            ? missingMessage
+            : `Failed to execute Hermes Agent CLI health check: ${error instanceof Error ? error.message : String(error)}.`,
+        },
+      }),
+    );
+  }
+
+  if (Option.isNone(probe.success)) {
+    return withHermesHints(
+      buildServerProvider({
+        presentation: HERMES_PRESENTATION,
+        enabled: true,
+        checkedAt,
+        models,
+        probe: {
+          installed: true,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Hermes Agent CLI is installed but timed out during the health check.",
+        },
+      }),
+    );
+  }
+
+  const parsed = parseHermesAboutOutput(probe.success.value);
+  const configMessage =
+    parsed.status === "ready" && configDefaults.malformed
+      ? "Hermes Agent is ready, but `~/.hermes/config.yaml` has no `model.default`; run `hermes model` to choose the model T3 Code should display."
+      : parsed.message;
+  return withHermesHints(
+    buildServerProvider({
+      presentation: HERMES_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: parsed.version,
+        status: parsed.status,
+        auth: parsed.auth,
+        ...(configMessage ? { message: configMessage } : {}),
+      },
+    }),
+  );
+});
+
+export const enrichHermesSnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly stampIdentity?: (snapshot: ServerProvider) => ServerProvider;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void, never> => {
+  const stampIdentity = input.stampIdentity ?? ((value) => value);
+  return enrichProviderSnapshotWithVersionAdvisory(
+    input.snapshot,
+    input.maintenanceCapabilities,
+  ).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((snapshot) => input.publishSnapshot(stampIdentity(snapshot))),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Hermes version advisory enrichment failed", {
+        cause: Cause.pretty(cause),
+      }),
+    ),
+  );
+};

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1305,6 +1305,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
                 "claudeAgent",
                 "codex",
                 "cursor",
+                "hermes",
                 "opencode",
               ]);
               assert.strictEqual(cursorProvider?.enabled, false);

--- a/apps/server/src/provider/Services/HermesAdapter.ts
+++ b/apps/server/src/provider/Services/HermesAdapter.ts
@@ -1,0 +1,19 @@
+/**
+ * HermesAdapter — shape type for the Hermes provider adapter.
+ *
+ * Historically this module exposed a `Context.Service` tag so consumers
+ * could inject the adapter through the Effect layer graph. The driver
+ * model ({@link ../Drivers/HermesDriver}) bundles one adapter per
+ * instance as a captured closure instead, so the tag is gone — we only
+ * retain the shape interface as a naming anchor for the driver bundle.
+ *
+ * @module HermesAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * HermesAdapterShape — per-instance Hermes adapter contract. Carries
+ * a branded driver kind as the nominal discriminant.
+ */
+export interface HermesAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/acp/HermesAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/HermesAcpSupport.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { buildHermesAcpSpawnInput } from "./HermesAcpSupport.ts";
+
+describe("buildHermesAcpSpawnInput", () => {
+  it("builds the default Hermes ACP command", () => {
+    expect(buildHermesAcpSpawnInput(undefined, "/tmp/project")).toEqual({
+      command: "hermes",
+      args: ["acp"],
+      cwd: "/tmp/project",
+    });
+  });
+
+  it("uses the configured Hermes binary path and environment", () => {
+    const env = { HOME: "/tmp/hermes-home", PATH: "/usr/bin" };
+
+    expect(
+      buildHermesAcpSpawnInput(
+        {
+          binaryPath: "/Users/me/.local/bin/hermes",
+        },
+        "/tmp/project",
+        env,
+      ),
+    ).toEqual({
+      command: "/Users/me/.local/bin/hermes",
+      args: ["acp"],
+      cwd: "/tmp/project",
+      env,
+    });
+  });
+});

--- a/apps/server/src/provider/acp/HermesAcpSupport.ts
+++ b/apps/server/src/provider/acp/HermesAcpSupport.ts
@@ -1,0 +1,54 @@
+import { type HermesSettings } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import type * as EffectAcpErrors from "effect-acp/errors";
+import {
+  AcpSessionRuntime,
+  type AcpSessionRuntimeOptions,
+  type AcpSessionRuntimeShape,
+  type AcpSpawnInput,
+} from "./AcpSessionRuntime.ts";
+
+type HermesAcpRuntimeHermesSettings = Pick<HermesSettings, "binaryPath">;
+
+export interface HermesAcpRuntimeInput extends Omit<
+  AcpSessionRuntimeOptions,
+  "authMethodId" | "clientCapabilities" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly hermesSettings: HermesAcpRuntimeHermesSettings | null | undefined;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+export function buildHermesAcpSpawnInput(
+  hermesSettings: HermesAcpRuntimeHermesSettings | null | undefined,
+  cwd: string,
+  environment?: NodeJS.ProcessEnv,
+): AcpSpawnInput {
+  return {
+    command: hermesSettings?.binaryPath || "hermes",
+    args: ["acp"],
+    cwd,
+    ...(environment ? { env: environment } : {}),
+  };
+}
+
+export const makeHermesAcpRuntime = (
+  input: HermesAcpRuntimeInput,
+): Effect.Effect<AcpSessionRuntimeShape, EffectAcpErrors.AcpError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildHermesAcpSpawnInput(input.hermesSettings, input.cwd, input.environment),
+        authMethodId: "terminal_setup",
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return yield* Effect.service(AcpSessionRuntime).pipe(Effect.provide(acpContext));
+  });

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -23,6 +23,7 @@
 import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
+import { HermesDriver, type HermesDriverEnv } from "./Drivers/HermesDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
@@ -35,6 +36,7 @@ export type BuiltInDriversEnv =
   | ClaudeDriverEnv
   | CodexDriverEnv
   | CursorDriverEnv
+  | HermesDriverEnv
   | OpenCodeDriverEnv;
 
 /**
@@ -46,5 +48,6 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   CodexDriver,
   ClaudeDriver,
   CursorDriver,
+  HermesDriver,
   OpenCodeDriver,
 ];

--- a/apps/server/src/textGeneration/HermesTextGeneration.ts
+++ b/apps/server/src/textGeneration/HermesTextGeneration.ts
@@ -1,0 +1,256 @@
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { type HermesSettings } from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import { TextGenerationError } from "@t3tools/contracts";
+import { type ThreadTitleGenerationResult, type TextGenerationShape } from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import { makeHermesAcpRuntime } from "../provider/acp/HermesAcpSupport.ts";
+
+const HERMES_TIMEOUT_MS = 180_000;
+
+function mapHermesAcpError(
+  operation:
+    | "generateCommitMessage"
+    | "generatePrContent"
+    | "generateBranchName"
+    | "generateThreadTitle",
+  detail: string,
+  cause: unknown,
+): TextGenerationError {
+  return new TextGenerationError({
+    operation,
+    detail,
+    ...(cause !== undefined ? { cause } : {}),
+  });
+}
+
+function isTextGenerationError(error: unknown): error is TextGenerationError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    error._tag === "TextGenerationError"
+  );
+}
+
+/**
+ * Build a Hermes text-generation closure bound to a specific `HermesSettings`
+ * payload. See `makeCodexAdapter` for the overall per-instance rationale.
+ */
+export const makeHermesTextGeneration = Effect.fn("makeHermesTextGeneration")(function* (
+  hermesSettings: HermesSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+  const runHermesJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const outputRef = yield* Ref.make("");
+      const runtime = yield* makeHermesAcpRuntime({
+        hermesSettings,
+        environment,
+        childProcessSpawner: commandSpawner,
+        cwd,
+        clientInfo: { name: "t3-code-git-text", version: "0.0.0" },
+      });
+
+      yield* runtime.handleSessionUpdate((notification) => {
+        const update = notification.update;
+        if (update.sessionUpdate !== "agent_message_chunk") {
+          return Effect.void;
+        }
+        const content = update.content;
+        if (content.type !== "text") {
+          return Effect.void;
+        }
+        return Ref.update(outputRef, (current) => current + content.text);
+      });
+
+      const promptResult = yield* Effect.gen(function* () {
+        yield* runtime.start();
+        yield* Effect.ignore(runtime.setMode("ask"));
+
+        return yield* runtime.prompt({
+          prompt: [{ type: "text", text: prompt }],
+        });
+      }).pipe(
+        Effect.timeoutOption(HERMES_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({
+                  operation,
+                  detail: "Hermes Agent request timed out.",
+                }),
+              ),
+            onSome: (value) => Effect.succeed(value),
+          }),
+        ),
+        Effect.mapError((cause) =>
+          isTextGenerationError(cause)
+            ? cause
+            : mapHermesAcpError(operation, "Hermes ACP request failed.", cause),
+        ),
+      );
+
+      const rawResult = (yield* Ref.get(outputRef)).trim();
+      if (!rawResult) {
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            promptResult.stopReason === "cancelled"
+              ? "Hermes ACP request was cancelled."
+              : "Hermes Agent returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(rawResult)).pipe(
+        Effect.catchTag("SchemaError", (cause) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation,
+              detail: "Hermes Agent returned invalid structured output.",
+              cause,
+            }),
+          ),
+        ),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : mapHermesAcpError(operation, "Hermes ACP text generation failed.", cause),
+      ),
+      Effect.scoped,
+    );
+
+  const generateCommitMessage: TextGenerationShape["generateCommitMessage"] = Effect.fn(
+    "HermesTextGeneration.generateCommitMessage",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildCommitMessagePrompt({
+      branch: input.branch,
+      stagedSummary: input.stagedSummary,
+      stagedPatch: input.stagedPatch,
+      includeBranch: input.includeBranch === true,
+    });
+
+    const generated = yield* runHermesJson({
+      operation: "generateCommitMessage",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+    });
+
+    return {
+      subject: sanitizeCommitSubject(generated.subject),
+      body: generated.body.trim(),
+      ...("branch" in generated && typeof generated.branch === "string"
+        ? { branch: sanitizeFeatureBranchName(generated.branch) }
+        : {}),
+    };
+  });
+
+  const generatePrContent: TextGenerationShape["generatePrContent"] = Effect.fn(
+    "HermesTextGeneration.generatePrContent",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildPrContentPrompt({
+      baseBranch: input.baseBranch,
+      headBranch: input.headBranch,
+      commitSummary: input.commitSummary,
+      diffSummary: input.diffSummary,
+      diffPatch: input.diffPatch,
+    });
+
+    const generated = yield* runHermesJson({
+      operation: "generatePrContent",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+    });
+
+    return {
+      title: sanitizePrTitle(generated.title),
+      body: generated.body.trim(),
+    };
+  });
+
+  const generateBranchName: TextGenerationShape["generateBranchName"] = Effect.fn(
+    "HermesTextGeneration.generateBranchName",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildBranchNamePrompt({
+      message: input.message,
+      attachments: input.attachments,
+    });
+
+    const generated = yield* runHermesJson({
+      operation: "generateBranchName",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+    });
+
+    return {
+      branch: sanitizeBranchFragment(generated.branch),
+    };
+  });
+
+  const generateThreadTitle: TextGenerationShape["generateThreadTitle"] = Effect.fn(
+    "HermesTextGeneration.generateThreadTitle",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildThreadTitlePrompt({
+      message: input.message,
+      attachments: input.attachments,
+    });
+
+    const generated = yield* runHermesJson({
+      operation: "generateThreadTitle",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+    });
+
+    return {
+      title: sanitizeThreadTitle(generated.title),
+    } satisfies ThreadTitleGenerationResult;
+  });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGenerationShape;
+});

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1856,6 +1856,7 @@ export default function ChatView(props: ChatViewProps) {
     const defaultInstanceId = defaultInstanceIdForDriver(selectedProvider);
     return providerStatuses.find((status) => status.instanceId === defaultInstanceId) ?? null;
   }, [activeProviderInstanceId, providerStatuses, selectedProvider]);
+  const isHermesSelected = String(selectedProvider) === "hermes";
   const activeProjectCwd = activeProject?.cwd ?? null;
   const activeThreadWorktreePath = activeThread?.worktreePath ?? null;
   const activeWorkspaceRoot = activeThreadWorktreePath ?? activeProjectCwd ?? undefined;
@@ -3775,7 +3776,13 @@ export default function ChatView(props: ChatViewProps) {
         {/* Chat column */}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {/* Messages Wrapper */}
-          <div className="relative flex min-h-0 flex-1 flex-col">
+          <div
+            className={cn(
+              "relative flex min-h-0 flex-1 flex-col transition-colors duration-300",
+              isHermesSelected && "chat-surface-hermes",
+            )}
+            data-chat-provider-surface={isHermesSelected ? "hermes" : "default"}
+          >
             {/* Messages — LegendList handles virtualization and scrolling internally */}
             <MessagesTimeline
               key={activeThread.id}

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -165,6 +165,11 @@ function createBaseServerConfig(): ServerConfig {
           serverPassword: "",
           customModels: [],
         },
+        hermes: {
+          enabled: false,
+          binaryPath: "",
+          customModels: [],
+        },
       },
     },
   };

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -95,6 +95,7 @@ import { proposedPlanTitle } from "../../proposedPlan";
 import { getProviderInteractionModeToggle } from "../../providerModels";
 import {
   deriveProviderInstanceEntries,
+  isSelectableProviderInstance,
   resolveProviderDriverKindForInstanceSelection,
   sortProviderInstanceEntries,
   type ProviderInstanceEntry,
@@ -644,7 +645,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     for (const candidate of candidates) {
       if (!candidate) continue;
       const match = providerInstanceEntries.find(
-        (entry) => entry.instanceId === candidate && entry.enabled,
+        (entry) => entry.instanceId === candidate && isSelectableProviderInstance(entry),
       );
       if (match) {
         // When locked to a specific driver kind, ignore persisted instance
@@ -664,12 +665,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     }
     const byKind = providerInstanceEntries.find(
       (entry) =>
-        entry.enabled &&
+        isSelectableProviderInstance(entry) &&
         entry.driverKind === selectedProvider &&
         (!lockedContinuationGroupKey || entry.continuationGroupKey === lockedContinuationGroupKey),
     );
     if (byKind) return byKind.instanceId;
-    const anyEnabled = providerInstanceEntries.find((entry) => entry.enabled);
+    const anyEnabled = providerInstanceEntries.find(isSelectableProviderInstance);
     return (
       anyEnabled?.instanceId ??
       providerInstanceEntries[0]?.instanceId ??

--- a/apps/web/src/components/chat/ModelPickerContent.tsx
+++ b/apps/web/src/components/chat/ModelPickerContent.tsx
@@ -21,7 +21,7 @@ import {
 import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
 import { cn } from "~/lib/utils";
 import { TooltipProvider } from "../ui/tooltip";
-import type { ProviderInstanceEntry } from "../../providerInstances";
+import { isSelectableProviderInstance, type ProviderInstanceEntry } from "../../providerInstances";
 import { providerModelKey, sortProviderModelItems } from "../../modelOrdering";
 
 type ModelPickerItem = {
@@ -166,15 +166,16 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
     [props.lockedContinuationGroupKey, props.lockedProvider],
   );
 
-  const readyInstanceSet = useMemo(() => {
-    const ready = new Set<ProviderInstanceId>();
+  const selectableInstanceSet = useMemo(() => {
+    const selectable = new Set<ProviderInstanceId>();
     for (const entry of instanceEntries) {
-      if (entry.status === "ready") {
-        ready.add(entry.instanceId);
+      const models = modelOptionsByInstance.get(entry.instanceId) ?? [];
+      if (isSelectableProviderInstance(entry) && models.length > 0) {
+        selectable.add(entry.instanceId);
       }
     }
-    return ready;
-  }, [instanceEntries]);
+    return selectable;
+  }, [instanceEntries, modelOptionsByInstance]);
 
   // Flatten models into a searchable array. One pass over the
   // instance-keyed map; each model carries its instance id + driver kind
@@ -189,7 +190,7 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
         // its models — stale options shouldn't appear in the picker.
         continue;
       }
-      if (!readyInstanceSet.has(instanceId)) {
+      if (!selectableInstanceSet.has(instanceId)) {
         continue;
       }
       for (const model of models) {
@@ -209,20 +210,24 @@ export const ModelPickerContent = memo(function ModelPickerContent(props: {
       }
     }
     return out;
-  }, [modelOptionsByInstance, entryByInstanceId, readyInstanceSet]);
+  }, [modelOptionsByInstance, entryByInstanceId, selectableInstanceSet]);
 
   const isLocked = props.lockedProvider !== null;
   const isSearching = searchQuery.trim().length > 0;
   const lockedInstanceEntries = useMemo(
     () =>
-      props.lockedProvider ? instanceEntries.filter((entry) => matchesLockedProvider(entry)) : [],
-    [instanceEntries, matchesLockedProvider, props.lockedProvider],
+      props.lockedProvider
+        ? instanceEntries.filter(
+            (entry) => selectableInstanceSet.has(entry.instanceId) && matchesLockedProvider(entry),
+          )
+        : [],
+    [instanceEntries, matchesLockedProvider, props.lockedProvider, selectableInstanceSet],
   );
   const showLockedInstanceSidebar = isLocked && lockedInstanceEntries.length > 1;
   const showSidebar = !isSearching && (!isLocked || showLockedInstanceSidebar);
   const sidebarInstanceEntries = showLockedInstanceSidebar
     ? lockedInstanceEntries
-    : instanceEntries;
+    : instanceEntries.filter((entry) => selectableInstanceSet.has(entry.instanceId));
   const instanceOrder = useMemo(
     () => instanceEntries.map((entry) => entry.instanceId),
     [instanceEntries],

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import {
   isProviderDriverKind,
   type ProviderInstanceConfig,
@@ -61,6 +61,13 @@ const ENVIRONMENT_VARIABLE_NAME_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 let environmentVariableDraftId = 0;
 const nextEnvironmentVariableDraftId = () => `provider-env-${environmentVariableDraftId++}`;
+
+function isInteractiveEventTarget(target: EventTarget | null): boolean {
+  return (
+    target instanceof Element &&
+    target.closest("a,button,input,select,textarea,[role='switch']") !== null
+  );
+}
 
 type EnvironmentDraftRow = {
   readonly id: string;
@@ -392,6 +399,39 @@ function ProviderEnvironmentSection(props: {
   );
 }
 
+function ProviderSetupCommandRow(props: {
+  readonly command: string;
+  readonly label: string;
+  readonly onCopy: (command: string, label: string) => void;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-1 rounded-md border border-border/70 bg-muted/30 py-0.5 pr-0.5 pl-2">
+      <ScrollArea scrollFade className="h-8 min-w-0 flex-1 rounded-none">
+        <code className="flex h-full w-max items-center whitespace-nowrap pr-3 font-mono text-[11px] text-foreground">
+          {props.command}
+        </code>
+      </ScrollArea>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              type="button"
+              size="icon-xs"
+              variant="ghost"
+              className="size-6 shrink-0 rounded-sm p-0 text-muted-foreground hover:text-foreground"
+              onClick={() => props.onCopy(props.command, props.label)}
+              aria-label={`Copy ${props.label}`}
+            >
+              <CopyIcon className="size-3" />
+            </Button>
+          }
+        />
+        <TooltipPopup side="top">Copy command</TooltipPopup>
+      </Tooltip>
+    </div>
+  );
+}
+
 interface ProviderInstanceCardProps {
   readonly instanceId: ProviderInstanceId;
   readonly instance: ProviderInstanceConfig;
@@ -486,6 +526,8 @@ export function ProviderInstanceCard({
   const versionLabel = getProviderVersionLabel(liveProvider?.version);
   const versionAdvisory = getProviderVersionAdvisoryPresentation(liveProvider?.versionAdvisory);
   const updateCommand = versionAdvisory?.updateCommand ?? null;
+  const suggestedBinaryPath = liveProvider?.suggestedBinaryPath?.trim();
+  const isHermesDriver = String(instance.driver) === "hermes";
   const FallbackIconComponent = driverOption?.icon;
   const displayName =
     instance.displayName?.trim() || driverOption?.label || String(instance.driver);
@@ -565,6 +607,12 @@ export function ProviderInstanceCard({
     onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
   };
 
+  const applySuggestedBinaryPath = (binaryPath: string) => {
+    const nextConfig = nextConfigBlobWithValue(instance.config, "binaryPath", binaryPath);
+    const { config: _omit, ...rest } = instance;
+    onUpdate({ ...rest, config: nextConfig } as ProviderInstanceConfig);
+  };
+
   const updateEnvironment = (environment: ReadonlyArray<ProviderInstanceEnvironmentVariable>) => {
     const cleaned = environment.filter((variable) => variable.name.trim().length > 0);
     const { environment: _omit, ...rest } = instance;
@@ -573,6 +621,20 @@ export function ProviderInstanceCard({
         ? ({ ...rest, environment: cleaned } as ProviderInstanceConfig)
         : (rest as ProviderInstanceConfig),
     );
+  };
+
+  const toggleExpanded = () => onExpandedChange(!isExpanded);
+
+  const handleHeaderClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (isInteractiveEventTarget(event.target)) return;
+    toggleExpanded();
+  };
+
+  const handleHeaderKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.currentTarget !== event.target) return;
+    if (event.key !== "Enter" && event.key !== " ") return;
+    event.preventDefault();
+    toggleExpanded();
   };
 
   const titleIconNode = driverKind ? (
@@ -672,9 +734,68 @@ export function ProviderInstanceCard({
     <code className="text-xs text-muted-foreground">{versionLabel}</code>
   ) : null;
 
+  const hermesSetupNode = isHermesDriver ? (
+    <div className="border-t border-border/60 px-4 py-3 sm:px-5">
+      <div className="grid gap-3">
+        <div className="grid gap-1">
+          <span className="text-xs font-medium text-foreground">Hermes setup</span>
+          <p className="text-xs leading-snug text-muted-foreground">
+            T3 Code starts Hermes through ACP. Configure Hermes once, then verify the ACP command
+            before sending a turn.
+          </p>
+        </div>
+        {suggestedBinaryPath ? (
+          <div className="grid gap-2 rounded-md border border-border/70 bg-muted/20 p-2">
+            <span className="text-xs text-muted-foreground">
+              Detected Hermes at <code className="text-foreground">{suggestedBinaryPath}</code>
+            </span>
+            <Button
+              type="button"
+              size="xs"
+              variant="outline"
+              className="w-fit"
+              onClick={() => applySuggestedBinaryPath(suggestedBinaryPath)}
+              aria-label="Use detected Hermes path"
+            >
+              Use detected path
+            </Button>
+          </div>
+        ) : null}
+        <div className="grid gap-2">
+          <ProviderSetupCommandRow
+            command="hermes model"
+            label="Hermes setup command"
+            onCopy={(command, label) => copyToClipboard(command, { providerName: label })}
+          />
+          <ProviderSetupCommandRow
+            command="hermes acp"
+            label="Hermes ACP verification command"
+            onCopy={(command, label) => copyToClipboard(command, { providerName: label })}
+          />
+        </div>
+        <a
+          href="docs/providers/hermes.md"
+          target="_blank"
+          rel="noreferrer"
+          className="w-fit text-xs font-medium text-primary hover:underline"
+        >
+          Hermes setup docs
+        </a>
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div className="border-t border-border/60 first:border-t-0">
-      <div className="px-4 py-3.5 sm:px-5">
+      <div
+        className="cursor-pointer px-4 py-3.5 outline-none transition-colors hover:bg-muted/25 focus-visible:bg-muted/25 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset sm:px-5"
+        role="button"
+        tabIndex={0}
+        aria-expanded={isExpanded}
+        aria-label={`${isExpanded ? "Collapse" : "Expand"} ${displayName} provider details`}
+        onClick={handleHeaderClick}
+        onKeyDown={handleHeaderKeyDown}
+      >
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="min-w-0 flex-1 space-y-1">
             <div className="flex min-w-0 flex-wrap items-center gap-2">
@@ -784,7 +905,7 @@ export function ProviderInstanceCard({
               size="sm"
               variant="ghost"
               className="h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
-              onClick={() => onExpandedChange(!isExpanded)}
+              onClick={toggleExpanded}
               aria-label={`Toggle ${displayName} details`}
             >
               <ChevronDownIcon
@@ -834,6 +955,8 @@ export function ProviderInstanceCard({
                 onChange={updateEnvironment}
               />
             </div>
+
+            {hermesSetupNode}
 
             {driverOption ? (
               <ProviderSettingsForm

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -2,6 +2,7 @@ import {
   ClaudeSettings,
   CodexSettings,
   CursorSettings,
+  HermesSettings,
   OpenCodeSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
@@ -58,6 +59,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     label: "OpenCode",
     icon: OpenCodeIcon,
     settingsSchema: OpenCodeSettings,
+  },
+  {
+    value: ProviderDriverKind.make("hermes"),
+    label: "Hermes",
+    icon: OpenCodeIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: HermesSettings,
   },
 ];
 

--- a/apps/web/src/components/settings/providerStatus.ts
+++ b/apps/web/src/components/settings/providerStatus.ts
@@ -21,6 +21,10 @@ export const PROVIDER_STATUS_STYLES = {
 
 export type ProviderStatusKey = keyof typeof PROVIDER_STATUS_STYLES;
 
+function isHermesProvider(provider: ServerProvider): boolean {
+  return String(provider.driver) === "hermes";
+}
+
 /**
  * Derive the headline + detail copy shown under a provider's name in the
  * settings page. Prefers `provider.message` for server-supplied detail and
@@ -76,7 +80,11 @@ export function getProviderSummary(provider: ServerProvider | undefined) {
   }
   return {
     headline: "Available",
-    detail: provider.message ?? "Installed and ready, but authentication could not be verified.",
+    detail:
+      provider.message ??
+      (isHermesProvider(provider)
+        ? "Installed and ready. Hermes manages authentication through its own CLI and local config."
+        : "Installed and ready, but authentication could not be verified."),
   };
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -83,6 +83,99 @@
   animation-duration: 0s !important;
 }
 
+.chat-surface-hermes {
+  isolation: isolate;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, #f5c542 16%, transparent) 0 2px, transparent 2px) 0
+      0 / 42px 42px,
+    linear-gradient(0deg, color-mix(in srgb, #d4961c 12%, transparent) 0 2px, transparent 2px) 0 0 /
+      42px 42px,
+    radial-gradient(
+        circle at 12% 10%,
+        color-mix(in srgb, #f5c542 18%, transparent) 0 5px,
+        transparent 6px
+      )
+      0 0 / 96px 96px,
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--background) 90%, #f5c542) 0%,
+      color-mix(in srgb, var(--background) 94%, #d4961c) 34%,
+      color-mix(in srgb, var(--background) 97%, #0f172a) 68%,
+      var(--background) 100%
+    );
+}
+
+.chat-surface-hermes::before,
+.chat-surface-hermes::after {
+  position: absolute;
+  pointer-events: none;
+  z-index: -1;
+  content: "";
+}
+
+.chat-surface-hermes::before {
+  top: max(2rem, 8%);
+  right: max(1.5rem, 5%);
+  width: min(32rem, 58vw);
+  aspect-ratio: 1;
+  opacity: 0.13;
+  background:
+    linear-gradient(#f5c542, #d4961c) 50% 12% / 3% 58% no-repeat,
+    radial-gradient(circle at 50% 12%, #fff8e1 0 2.5%, #f5c542 2.75% 6%, transparent 6.25%),
+    conic-gradient(from 300deg at 50% 28%, transparent 0 17%, #f5c542 17% 22%, transparent 22%),
+    conic-gradient(from 120deg at 50% 28%, transparent 0 17%, #f5c542 17% 22%, transparent 22%),
+    radial-gradient(ellipse at 38% 26%, transparent 0 42%, #f5c542 43% 47%, transparent 48%),
+    radial-gradient(ellipse at 62% 26%, transparent 0 42%, #d4961c 43% 47%, transparent 48%),
+    repeating-linear-gradient(
+      90deg,
+      color-mix(in srgb, #f5c542 40%, transparent) 0 8px,
+      transparent 8px 16px
+    );
+  clip-path: polygon(50% 0, 83% 22%, 67% 100%, 50% 80%, 33% 100%, 17% 22%);
+  filter: saturate(1.15);
+}
+
+.chat-surface-hermes::after {
+  inset: 0;
+  opacity: 0.1;
+  background:
+    linear-gradient(90deg, transparent 0 18px, #f5c542 18px 24px, transparent 24px 42px) right 9%
+      top 8% / 252px 54px no-repeat,
+    linear-gradient(90deg, transparent 0 12px, #d4961c 12px 18px, transparent 18px 36px) right 6%
+      top calc(8% + 54px) / 216px 42px no-repeat,
+    repeating-linear-gradient(
+      0deg,
+      color-mix(in srgb, var(--foreground) 5%, transparent) 0 1px,
+      transparent 1px 4px
+    );
+  mix-blend-mode: multiply;
+}
+
+.dark .chat-surface-hermes {
+  background:
+    linear-gradient(90deg, color-mix(in srgb, #f5c542 16%, transparent) 0 2px, transparent 2px) 0
+      0 / 42px 42px,
+    linear-gradient(0deg, color-mix(in srgb, #d4961c 12%, transparent) 0 2px, transparent 2px) 0 0 /
+      42px 42px,
+    radial-gradient(
+        circle at 12% 10%,
+        color-mix(in srgb, #f5c542 16%, transparent) 0 5px,
+        transparent 6px
+      )
+      0 0 / 96px 96px,
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--background) 80%, #f5c542) 0%,
+      color-mix(in srgb, var(--background) 88%, #d4961c) 34%,
+      color-mix(in srgb, var(--background) 96%, #0f172a) 68%,
+      var(--background) 100%
+    );
+}
+
+.dark .chat-surface-hermes::after {
+  mix-blend-mode: screen;
+}
+
 :root {
   color-scheme: light;
   --radius: 0.625rem;

--- a/apps/web/src/providerInstances.test.ts
+++ b/apps/web/src/providerInstances.test.ts
@@ -12,6 +12,7 @@ function provider(input: {
   enabled?: boolean;
   availability?: ServerProvider["availability"];
   displayName?: string;
+  models?: ServerProvider["models"];
 }): ServerProvider {
   return {
     instanceId: ProviderInstanceId.make(input.instanceId),
@@ -24,7 +25,9 @@ function provider(input: {
     ...(input.availability ? { availability: input.availability } : {}),
     auth: { status: "authenticated" },
     checkedAt: "2026-01-01T00:00:00.000Z",
-    models: [],
+    models: input.models ?? [
+      { slug: "default", name: "Default", isCustom: false, capabilities: {} },
+    ],
     slashCommands: [],
     skills: [],
   };

--- a/apps/web/src/providerInstances.ts
+++ b/apps/web/src/providerInstances.ts
@@ -87,6 +87,10 @@ export function normalizeProviderAccentColor(value: string | undefined): string 
   return /^#[0-9a-fA-F]{6}$/u.test(trimmed) ? trimmed : undefined;
 }
 
+export function isSelectableProviderInstance(entry: ProviderInstanceEntry): boolean {
+  return entry.enabled && entry.isAvailable && entry.status === "ready" && entry.models.length > 0;
+}
+
 /**
  * Resolve an entry's displayName with a tiered priority:
  *
@@ -219,16 +223,14 @@ export function resolveSelectableProviderInstance(
   instanceId: ProviderInstanceId | undefined,
 ): ProviderInstanceId | undefined {
   if (instanceId === undefined) {
-    return deriveProviderInstanceEntries(providers).find(
-      (entry) => entry.enabled && entry.isAvailable,
-    )?.instanceId;
+    return deriveProviderInstanceEntries(providers).find(isSelectableProviderInstance)?.instanceId;
   }
   const entries = deriveProviderInstanceEntries(providers);
   const requested = entries.find((entry) => entry.instanceId === instanceId);
-  if (requested && requested.enabled && requested.isAvailable) {
+  if (requested && isSelectableProviderInstance(requested)) {
     return instanceId;
   }
-  return entries.find((entry) => entry.enabled && entry.isAvailable)?.instanceId;
+  return entries.find(isSelectableProviderInstance)?.instanceId;
 }
 
 /**

--- a/docs/providers/hermes.md
+++ b/docs/providers/hermes.md
@@ -1,0 +1,84 @@
+# Hermes
+
+This guide is for people who want to use Hermes Agent from T3 Code.
+
+Hermes runs as a local CLI process through ACP. T3 Code only starts `hermes acp` when a Hermes
+conversation needs it, so provider refreshes stay fast.
+
+## Install Hermes
+
+Install and configure Hermes Agent from the upstream project:
+
+```bash
+git clone https://github.com/nousresearch/hermes-agent.git ~/Projects/hermes-agent
+cd ~/Projects/hermes-agent
+python3 -m venv venv
+./venv/bin/pip install -e .
+```
+
+Create a stable binary path that GUI apps can find:
+
+```bash
+mkdir -p ~/.local/bin
+ln -sf ~/Projects/hermes-agent/venv/bin/hermes ~/.local/bin/hermes
+~/.local/bin/hermes --version
+```
+
+Then run Hermes setup:
+
+```bash
+~/.local/bin/hermes model
+```
+
+Hermes stores its model configuration in:
+
+```text
+~/.hermes/config.yaml
+```
+
+T3 Code reads `model.default` from that file and shows it in the model picker. If the config file is
+missing or unreadable, T3 Code falls back to `Hermes Default`.
+
+## Configure T3 Code
+
+In Settings, enable Hermes and set:
+
+```text
+Binary path: /Users/you/.local/bin/hermes
+```
+
+Using the full path is recommended on macOS because apps launched from the Dock or a desktop shell
+may not inherit your terminal `PATH`.
+
+T3 Code also checks common Hermes locations such as `~/.local/bin/hermes`,
+`~/Projects/hermes-agent/venv/bin/hermes`, Homebrew paths, and your login-shell `PATH`. If it finds
+Hermes somewhere else, the provider card shows a detected path you can apply from Settings.
+
+## Verify
+
+Run:
+
+```bash
+/Users/you/.local/bin/hermes --version
+/Users/you/.local/bin/hermes acp
+```
+
+The ACP command should stay running and print a startup message. Stop it with `Ctrl-C`.
+
+In T3 Code, select Hermes in the model picker and send a small prompt. If Hermes has a configured
+default model, the picker should show that model name rather than only `Hermes Default`.
+
+## Troubleshooting
+
+If T3 Code says Hermes is not installed, use an absolute binary path instead of `hermes`.
+
+If Settings shows a detected Hermes path, click **Use detected path** and refresh provider status.
+
+If the model picker says no models were found, refresh provider status and confirm that Hermes is
+enabled. Disabled, missing, or not-ready providers are not treated as selectable model sources.
+
+If Hermes asks for auth or model setup, run:
+
+```bash
+~/.local/bin/hermes model
+```

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -131,6 +131,7 @@ const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const HERMES_DRIVER_KIND = ProviderDriverKind.make("hermes");
 
 export const DEFAULT_MODEL = "gpt-5.4";
 export const DEFAULT_GIT_TEXT_GENERATION_MODEL = "gpt-5.4-mini";
@@ -140,6 +141,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CLAUDE_DRIVER_KIND]: "claude-sonnet-4-6",
   [CURSOR_DRIVER_KIND]: "auto",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [HERMES_DRIVER_KIND]: "hermes-default",
 };
 
 /** Per-provider text generation model defaults. */
@@ -150,6 +152,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [HERMES_DRIVER_KIND]: "hermes-default",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -193,6 +196,7 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [HERMES_DRIVER_KIND]: {},
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -202,4 +206,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CLAUDE_DRIVER_KIND]: "Claude",
   [CURSOR_DRIVER_KIND]: "Cursor",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [HERMES_DRIVER_KIND]: "Hermes",
 };

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -172,6 +172,7 @@ export const ServerProvider = Schema.Struct({
   auth: ServerProviderAuth,
   checkedAt: IsoDateTime,
   message: Schema.optional(TrimmedNonEmptyString),
+  suggestedBinaryPath: Schema.optional(TrimmedNonEmptyString),
   // Optional for back-compat: every legacy producer omits this field and
   // an absent value is interpreted as `"available"` by consumers (see
   // `isProviderAvailable`). New `ProviderInstanceRegistry` outputs set it

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -331,6 +331,33 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const HermesSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("hermes").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Hermes Agent binary.",
+        providerSettingsForm: {
+          placeholder: "hermes",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath"],
+  },
+);
+export type HermesSettings = typeof HermesSettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -370,6 +397,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    hermes: HermesSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -445,6 +473,12 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const HermesSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
@@ -464,6 +498,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      hermes: Schema.optionalKey(HermesSettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual


### PR DESCRIPTION
## Summary

Ports the Hermes Agent provider from [joeynyc/t3code](https://github.com/joeynyc/t3code) fork.

- Adds full Hermes provider support (driver, adapter, ACP runtime, text generation)
- Adds Hermes settings schema and configuration UI
- Adds themed chat surface for Hermes (golden/amber color scheme)
- Adds `isSelectableProviderInstance` helper to consolidate filtering logic
- Adds provider documentation

## Sources

- Fork: [joeynyc/t3code](https://github.com/joeynyc/t3code) (13 commits ahead)
- Reference quality verdict: **good** (port the design as-is)
- Port strategy: **adapt** (same design, mechanical conflicts)

## Changes

### Server
- `HermesDriver.ts`: Provider driver following CursorDriver pattern
- `HermesAdapter.ts`: ACP adapter for session management (952 lines)
- `HermesProvider.ts`: Status checking and snapshot building
- `HermesAcpSupport.ts`: ACP runtime factory
- `HermesTextGeneration.ts`: Text generation via ACP
- Tests for provider and ACP support

### Web
- `providerDriverMeta.ts`: Hermes client definition
- `ProviderInstanceCard.tsx`: Hermes setup section with binary path detection
- `providerStatus.ts`: Hermes-specific status copy
- `providerInstances.ts`: `isSelectableProviderInstance` helper
- `ChatView.tsx`: Hermes surface detection
- `index.css`: Hermes themed chat surface CSS

### Contracts
- `settings.ts`: HermesSettings schema
- `model.ts`: HERMES_DRIVER_KIND and defaults
- `server.ts`: suggestedBinaryPath field

## Test plan

- [x] All 1058 tests pass
- [x] Typecheck passes
- [x] Lint passes (only pre-existing warnings)
- [ ] Manual: Enable Hermes in settings
- [ ] Manual: Verify provider card expands with setup instructions
- [ ] Manual: Verify themed chat surface when Hermes selected

## Validation evidence

Provider appears in settings with "Early Access" badge and expandable configuration.

## Scope exclusions

The following changes from the reference fork were excluded (separate PRs):
- `dev-watch.mjs` utility (orthogonal DX improvement)
- `VITE_HTTP_URL` handling (orthogonal DX improvement)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Hermes as a built-in AI agent provider
> - Adds a full Hermes provider driver ([HermesDriver.ts](https://github.com/pingdotgg/t3code/pull/2965/files#diff-8dc41680682e5ae63a0756804864ecfa44d46d3104a200dcb0af98f6456e02ef)) with binary auto-detection, CLI health checks, auth status parsing, and snapshot enrichment via version advisory.
> - Adds a Hermes adapter ([HermesAdapter.ts](https://github.com/pingdotgg/t3code/pull/2965/files#diff-7536a65ca59c99c8448dead22cdb29e8ceb2f5bb197fa2f1c59e4a1b996d7f7b)) that manages ACP sessions, turn prompting with image attachments, permission mediation, cancellation, and rollback.
> - Adds Hermes-backed text generation ([HermesTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/2965/files#diff-138cf3ab9580745cbc53702dc6b61942cb0bf83601fddd43701f43da9141d5a6)) for commit messages, PR content, branch names, and thread titles via structured JSON output over ACP.
> - Adds settings schema for `binaryPath` and `customModels`, and registers Hermes in the contracts layer with default model slugs and display name.
> - Adds a Hermes-specific chat surface theme and setup UI in [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/2965/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9), including a suggested binary path control and CLI command copy rows.
> - `resolveSelectableProviderInstance` now requires `status === 'ready'` and `models.length > 0` in addition to enabled/available; provider selection in `ChatComposer` and `ModelPickerContent` is updated accordingly.
> - Risk: the new `isSelectableProviderInstance` requirement may cause previously selectable provider instances (ready but with no models) to silently fall through to the next candidate.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a1b1604. 21 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->