### PR TITLE
Use pnpm for server publish workflow

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -195,6 +195,31 @@ const buildCmd = Command.make(
 // publish subcommand
 // ---------------------------------------------------------------------------
 
+interface PublishCommandConfig {
+  readonly access: string;
+  readonly tag: string;
+  readonly provenance: boolean;
+  readonly dryRun: boolean;
+}
+
+const createPnpmPublishArgs = (config: PublishCommandConfig): ReadonlyArray<string> => {
+  const args = [
+    "--filter",
+    "t3",
+    "publish",
+    "--access",
+    config.access,
+    "--tag",
+    config.tag,
+    "--no-git-checks",
+  ];
+
+  if (config.provenance) args.push("--provenance");
+  if (config.dryRun) args.push("--dry-run");
+
+  return args;
+};
+
 const publishCmd = Command.make(
   "publish",
   {
@@ -260,17 +285,16 @@ const publishCmd = Command.make(
           const iconBackups = yield* applyPublishIconOverrides(repoRoot, serverDir);
           return { iconBackups };
         }),
-        // Use: npm publish
+        // Use: pnpm publish from the workspace root so pnpm-only workspace
+        // config, including override selectors, is interpreted correctly.
         () =>
           Effect.gen(function* () {
-            const args = ["publish", "--access", config.access, "--tag", config.tag];
-            if (config.provenance) args.push("--provenance");
-            if (config.dryRun) args.push("--dry-run");
+            const args = createPnpmPublishArgs(config);
 
-            yield* Effect.log(`[cli] Running: npm ${args.join(" ")}`);
+            yield* Effect.log(`[cli] Running: pnpm ${args.join(" ")}`);
             yield* runCommand(
-              ChildProcess.make("npm", [...args], {
-                cwd: serverDir,
+              ChildProcess.make("pnpm", [...args], {
+                cwd: repoRoot,
                 stdout: config.verbose ? "inherit" : "ignore",
                 stderr: "inherit",
                 // Windows needs shell mode to resolve .cmd shims.


### PR DESCRIPTION
## Summary
- Switched the server publish script from `npm publish` to `pnpm publish` so workspace-level pnpm configuration is applied correctly.
- Added a small helper to build publish arguments in one place, including `--provenance` and `--dry-run` handling.
- Changed the publish command to run from the repository root with `--filter t3`, matching the workspace publish target.

## Testing
- Not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Publishing is release-critical; changing the tool, cwd, and flags could alter what gets published or fail in CI if pnpm behavior differs from npm.
> 
> **Overview**
> The server **publish** CLI now runs **`pnpm publish`** from the **repository root** with **`--filter t3`** instead of **`npm publish`** from `apps/server`, so workspace-level **pnpm** settings (including override selectors in `pnpm-workspace.yaml`) apply during publish.
> 
> A **`createPnpmPublishArgs`** helper centralizes publish flags: **`--access`**, **`--tag`**, **`--no-git-checks`**, and optional **`--provenance`** / **`--dry-run`**. Log output reflects the new **`pnpm`** invocation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a88b094a2634f4d766bc307d57b0baa2102e4fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use pnpm instead of npm for the server publish workflow
> - Replaces the `npm publish` call in [cli.ts](https://github.com/pingdotgg/t3code/pull/2966/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) with a `pnpm publish` call using a new `createPnpmPublishArgs` helper.
> - The command now runs from the repository root with `--filter t3` instead of from the server package directory.
> - Adds `--no-git-checks` to skip git state validation during publish.
> - Behavioral Change: working directory and package manager change may affect CI environments that assume npm or a package-local working directory.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6a88b09.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->