### PR TITLE
Rename function for publishing arguments to vp pm

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -202,7 +202,7 @@ interface PublishCommandConfig {
   readonly dryRun: boolean;
 }
 
-const createPnpmPublishArgs = (config: PublishCommandConfig): ReadonlyArray<string> => {
+const createVpPmPublishArgs = (config: PublishCommandConfig): ReadonlyArray<string> => {
   const args = [
     "--filter",
     "t3",
@@ -289,11 +289,11 @@ const publishCmd = Command.make(
         // config, including override selectors, is interpreted correctly.
         () =>
           Effect.gen(function* () {
-            const args = createPnpmPublishArgs(config);
+            const args = createVpPmPublishArgs(config);
 
-            yield* Effect.log(`[cli] Running: pnpm ${args.join(" ")}`);
+            yield* Effect.log(`[cli] Running: vp pm ${args.join(" ")}`);
             yield* runCommand(
-              ChildProcess.make("pnpm", [...args], {
+              ChildProcess.make("vp", ["pm", ...args], {
                 cwd: repoRoot,
                 stdout: config.verbose ? "inherit" : "ignore",
                 stderr: "inherit",


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release publishing depends on `vp` being installed and correctly forwarding to the workspace package manager; a misconfiguration would break the publish subcommand only.
> 
> **Overview**
> The server **publish** CLI subcommand now runs **`vp pm`** (with the same `--filter t3 publish …` arguments) instead of invoking **`pnpm`** directly.
> 
> The publish-args helper is renamed to **`createVpPmPublishArgs`**, and verbose logging reflects the new command line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9d8c6f65306db0459f415518dc577ce996367b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `pnpm` with `vp pm` in the publish command invocation
> Renames `createPnpmPublishArgs` to `createVpPmPublishArgs` in [cli.ts](https://github.com/pingdotgg/t3code/pull/2967/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) and updates the publish command to run `vp pm` instead of `pnpm`. The logged command prefix is also updated to `vp pm`. Publish arguments remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9d8c6f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->