### PR TITLE
"claude system message" instead of "runtime warning" when using 4.8 from claude code

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -351,7 +351,9 @@ function runtimeEventToActivities(
           createdAt: event.createdAt,
           tone: "info",
           kind: "runtime.warning",
-          summary: "Runtime warning",
+          // Use the adapter-supplied message as the row label so the work log
+          // shows what the warning was about, not a generic "Runtime warning".
+          summary: truncateDetail(event.payload.message, 120),
           payload: {
             message: truncateDetail(event.payload.message),
             ...(event.payload.detail !== undefined ? { detail: event.payload.detail } : {}),

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -972,6 +972,52 @@ function sdkNativeMethod(message: SDKMessage): string {
   return `claude/${message.type}`;
 }
 
+// Discriminator/identity keys carry no human-readable content; everything else
+// on an unmodeled SDK message is potentially worth surfacing in the work log.
+const SDK_MESSAGE_NOISE_KEYS = new Set([
+  "type",
+  "subtype",
+  "uuid",
+  "parent_uuid",
+  "session_id",
+  "parent_tool_use_id",
+  "request_id",
+]);
+
+// Pull the salient scalar content out of a message the adapter doesn't model
+// yet, so the work-log row shows what actually arrived (e.g. a notification's
+// text) instead of an opaque "unhandled subtype" placeholder. Nested structures
+// are left to the full payload retained in the event's `detail`.
+function previewUnknownSdkContent(message: unknown): string | undefined {
+  if (!message || typeof message !== "object") {
+    return undefined;
+  }
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(message as Record<string, unknown>)) {
+    if (SDK_MESSAGE_NOISE_KEYS.has(key)) {
+      continue;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        parts.push(`${key}: ${trimmed}`);
+      }
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      parts.push(`${key}: ${String(value)}`);
+    }
+  }
+  if (parts.length === 0) {
+    return undefined;
+  }
+  const joined = parts.join(" · ");
+  return joined.length > 280 ? `${joined.slice(0, 279)}…` : joined;
+}
+
+function describeUnknownSdkMessage(kind: string, message: unknown): string {
+  const preview = previewUnknownSdkContent(message);
+  return preview ? `${kind} — ${preview}` : `${kind} (no displayable text content)`;
+}
+
 function sdkNativeItemId(message: SDKMessage): string | undefined {
   if (message.type === "assistant") {
     const maybeId = (message.message as { id?: unknown }).id;
@@ -2270,7 +2316,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       default:
         yield* emitRuntimeWarning(
           context,
-          `Unhandled Claude system message subtype '${message.subtype}'.`,
+          describeUnknownSdkMessage(`Claude system message '${message.subtype}'`, message),
           message,
         );
         return;
@@ -2384,7 +2430,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       default:
         yield* emitRuntimeWarning(
           context,
-          `Unhandled Claude SDK message type '${message.type}'.`,
+          describeUnknownSdkMessage(`Claude SDK message '${message.type}'`, message),
           message,
         );
         return;


### PR DESCRIPTION
## What Changed

when using claude code from inside WSL2 (cc and t3code running on ubuntu, browser inside win 11, I used `pnpm dev` on main branch), I was getting too many Runtime warnings so I asked opus to modify t3code to show something more useful, now seeing claude system messages => no need to merge this PR, just a prompt to find real solution in some future release please 🙏

## Why

..the warnings were very annoying?

## UI Changes

|before|after|
|---|---|
|<img width="1582" height="1377" alt="Screenshot 2026-06-04 130119" src="https://github.com/user-attachments/assets/78590c44-f426-48aa-92e7-ee694a0034ac" />|<img width="2296" height="1973" alt="image" src="https://github.com/user-attachments/assets/7f0000e6-f2da-4145-bb3b-bdebc2e14dd4" />|

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] ❌ I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only changes to warning messages and activity summaries; no changes to auth, permissions, or turn lifecycle.
> 
> **Overview**
> Improves **work log** readability for Claude runtime warnings instead of flooding the UI with identical “Runtime warning” rows.
> 
> **Orchestration ingestion** now uses the adapter’s `payload.message` (truncated to 120 chars) as the activity **summary**, so each row describes what happened.
> 
> **Claude adapter** builds richer warning text for unhandled SDK `system` subtypes and unknown message types: scalar fields are extracted (skipping identity keys like `type`, `uuid`, `session_id`) and appended as a short preview, with the full message still in `detail`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eff2c0b0c29ba05ff7bf5f7d94b48c117d09ca82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show Claude system message subtype in runtime warnings instead of generic label
> - In [ClaudeAdapter.ts](https://github.com/pingdotgg/t3code/pull/2972/files#diff-e696bea66caf21d357bea5ea814bcbb18d1816288cc94247c855823f50fce6dc), unhandled Claude system message subtypes and SDK message types now emit runtime warnings that include a preview of meaningful fields from the raw SDK message, extracted by the new `previewUnknownSdkContent` helper.
> - The helper skips noise keys (e.g. `uuid`, `session_id`, `request_id`) and joins scalar values with ` · `, truncated to 280 characters.
> - In [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/2972/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7), the summary label for `runtime.warning` activities now uses the adapter-supplied message text (truncated to 120 chars) instead of the fixed string `'Runtime warning'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eff2c0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->