### PR TITLE
Annotate relay error spans with schema fields

### DIFF
--- a/infra/relay/src/agentActivity/AgentActivityRows.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.ts
@@ -1,7 +1,6 @@
 import type { RelayAgentActivityState } from "@t3tools/contracts/relay";
 import { RelayAgentActivityState as RelayAgentActivityStateSchema } from "@t3tools/contracts/relay";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import { cast } from "effect/Function";
@@ -13,23 +12,32 @@ import { and, desc, eq, isNull } from "drizzle-orm";
 import { RelayDb } from "../db.ts";
 import { relayAgentActivityRows, relayEnvironmentLinks } from "../persistence/schema.ts";
 
-export class AgentActivityRowUpsertPersistenceError extends Data.TaggedError(
+export class AgentActivityRowUpsertPersistenceError extends Schema.TaggedErrorClass<AgentActivityRowUpsertPersistenceError>()(
   "AgentActivityRowUpsertPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to persist agent activity state";
+  }
+}
 
-export class AgentActivityRowDeletePersistenceError extends Data.TaggedError(
+export class AgentActivityRowDeletePersistenceError extends Schema.TaggedErrorClass<AgentActivityRowDeletePersistenceError>()(
   "AgentActivityRowDeletePersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to delete agent activity state";
+  }
+}
 
-export class AgentActivityRowListPersistenceError extends Data.TaggedError(
+export class AgentActivityRowListPersistenceError extends Schema.TaggedErrorClass<AgentActivityRowListPersistenceError>()(
   "AgentActivityRowListPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to list agent activity state";
+  }
+}
 
 export interface AgentActivityRowsShape {
   readonly upsert: (input: {

--- a/infra/relay/src/agentActivity/ApnsClient.ts
+++ b/infra/relay/src/agentActivity/ApnsClient.ts
@@ -2,20 +2,13 @@ import * as NodeCrypto from "node:crypto";
 
 import type { RelayAgentActivityAggregateState } from "@t3tools/contracts/relay";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
-import {
-  Headers,
-  HttpClient,
-  HttpClientRequest,
-  type HttpBody,
-  type HttpClientError,
-} from "effect/unstable/http";
+import { Headers, HttpClient, HttpClientRequest } from "effect/unstable/http";
 import type { ApnsCredentials } from "../Config.ts";
 import type { ApnsNotificationPayload } from "./apnsDeliveryJobs.ts";
 
@@ -45,18 +38,39 @@ export interface ApnsDeliveryResult {
   readonly apnsId: string | null;
 }
 
-export class ApnsSigningError extends Data.TaggedError("ApnsSigningError")<{
-  readonly phase: "encoding" | "signing";
-  readonly cause: unknown;
-}> {}
+export class ApnsSigningError extends Schema.TaggedErrorClass<ApnsSigningError>()(
+  "ApnsSigningError",
+  {
+    phase: Schema.Literals(["encoding", "signing"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed during APNs JWT ${this.phase}`;
+  }
+}
 
-export class ApnsHttpRequestError extends Data.TaggedError("ApnsHttpRequestError")<{
-  readonly cause: HttpClientError.HttpClientError | HttpBody.HttpBodyError;
-}> {}
+export class ApnsHttpRequestError extends Schema.TaggedErrorClass<ApnsHttpRequestError>()(
+  "ApnsHttpRequestError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "APNs HTTP request failed";
+  }
+}
 
-export class ApnsInvalidResponseError extends Data.TaggedError("ApnsInvalidResponseError")<{
-  readonly cause: unknown;
-}> {}
+export class ApnsInvalidResponseError extends Schema.TaggedErrorClass<ApnsInvalidResponseError>()(
+  "ApnsInvalidResponseError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "APNs returned an invalid response";
+  }
+}
 
 export type ApnsError = ApnsSigningError | ApnsHttpRequestError | ApnsInvalidResponseError;
 

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -9,7 +9,6 @@ import {
   RelayAgentAwarenessPreferences as RelayAgentAwarenessPreferencesSchema,
 } from "@t3tools/contracts/relay";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -74,9 +73,16 @@ export type ApnsDeliveryError =
   | LiveActivities.LiveActivityTargetListPersistenceError
   | LiveActivities.LiveActivityDeliveryMarkPersistenceError;
 
-export class ApnsDeliveryJobClaimInFlight extends Data.TaggedError("ApnsDeliveryJobClaimInFlight")<{
-  readonly sourceJobId: string;
-}> {}
+export class ApnsDeliveryJobClaimInFlight extends Schema.TaggedErrorClass<ApnsDeliveryJobClaimInFlight>()(
+  "ApnsDeliveryJobClaimInFlight",
+  {
+    sourceJobId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `APNs delivery job '${this.sourceJobId}' is already in flight`;
+  }
+}
 
 const decodeRelayAgentActivityAggregateStateJson = Schema.decodeUnknownOption(
   Schema.fromJsonString(RelayAgentActivityAggregateStateSchema),

--- a/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
@@ -2,10 +2,10 @@ import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Crypto from "effect/Crypto";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 
 import type { RelayDeliveryResult } from "@t3tools/contracts/relay";
 
@@ -22,9 +22,14 @@ import {
 } from "./apnsDeliveryJobs.ts";
 import * as RelayConfiguration from "../Config.ts";
 
-export class ApnsDeliveryQueueSendError extends Data.TaggedError("ApnsDeliveryQueueSendError")<{
-  readonly cause: unknown;
-}> {}
+export class ApnsDeliveryQueueSendError extends Schema.TaggedErrorClass<ApnsDeliveryQueueSendError>()(
+  "ApnsDeliveryQueueSendError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to enqueue APNs delivery";
+  }
+}
 
 export type ApnsDeliveryQueueError = ApnsDeliveryQueueSendError;
 

--- a/infra/relay/src/agentActivity/DeliveryAttempts.ts
+++ b/infra/relay/src/agentActivity/DeliveryAttempts.ts
@@ -1,20 +1,23 @@
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { and, eq, isNull } from "drizzle-orm";
 import * as Crypto from "effect/Crypto";
+import * as Schema from "effect/Schema";
 
 import { RelayDb } from "../db.ts";
 import { relayDeliveryAttempts } from "../persistence/schema.ts";
 
-export class DeliveryAttemptRecordPersistenceError extends Data.TaggedError(
+export class DeliveryAttemptRecordPersistenceError extends Schema.TaggedErrorClass<DeliveryAttemptRecordPersistenceError>()(
   "DeliveryAttemptRecordPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to persist APNs delivery attempt";
+  }
+}
 
 export interface DeliveryAttemptInput {
   readonly userId: string | null;

--- a/infra/relay/src/agentActivity/Devices.ts
+++ b/infra/relay/src/agentActivity/Devices.ts
@@ -3,31 +3,42 @@ import type {
   RelayDeviceRegistrationRequest,
 } from "@t3tools/contracts/relay";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import { and, eq } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 
 import { RelayDb } from "../db.ts";
 import { relayLiveActivities, relayMobileDevices } from "../persistence/schema.ts";
 
-export class DeviceRegistrationPersistenceError extends Data.TaggedError(
+export class DeviceRegistrationPersistenceError extends Schema.TaggedErrorClass<DeviceRegistrationPersistenceError>()(
   "DeviceRegistrationPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to persist mobile device registration";
+  }
+}
 
-export class DeviceUnregistrationPersistenceError extends Data.TaggedError(
+export class DeviceUnregistrationPersistenceError extends Schema.TaggedErrorClass<DeviceUnregistrationPersistenceError>()(
   "DeviceUnregistrationPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to unregister mobile device";
+  }
+}
 
-export class DeviceListPersistenceError extends Data.TaggedError("DeviceListPersistenceError")<{
-  readonly cause: unknown;
-}> {}
+export class DeviceListPersistenceError extends Schema.TaggedErrorClass<DeviceListPersistenceError>()(
+  "DeviceListPersistenceError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to list mobile devices";
+  }
+}
 
 export interface DevicesShape {
   readonly register: (input: {

--- a/infra/relay/src/agentActivity/LiveActivities.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.ts
@@ -5,7 +5,6 @@ import type {
 } from "@t3tools/contracts/relay";
 import { RelayAgentActivityAggregateState as RelayAgentActivityAggregateStateSchema } from "@t3tools/contracts/relay";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import { cast } from "effect/Function";
@@ -16,23 +15,32 @@ import { and, eq, sql } from "drizzle-orm";
 import { RelayDb } from "../db.ts";
 import { relayLiveActivities, relayMobileDevices } from "../persistence/schema.ts";
 
-export class LiveActivityRegistrationPersistenceError extends Data.TaggedError(
+export class LiveActivityRegistrationPersistenceError extends Schema.TaggedErrorClass<LiveActivityRegistrationPersistenceError>()(
   "LiveActivityRegistrationPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to persist Live Activity registration";
+  }
+}
 
-export class LiveActivityTargetListPersistenceError extends Data.TaggedError(
+export class LiveActivityTargetListPersistenceError extends Schema.TaggedErrorClass<LiveActivityTargetListPersistenceError>()(
   "LiveActivityTargetListPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to list Live Activity delivery targets";
+  }
+}
 
-export class LiveActivityDeliveryMarkPersistenceError extends Data.TaggedError(
+export class LiveActivityDeliveryMarkPersistenceError extends Schema.TaggedErrorClass<LiveActivityDeliveryMarkPersistenceError>()(
   "LiveActivityDeliveryMarkPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to persist Live Activity delivery state";
+  }
+}
 
 export interface DeviceRow {
   readonly user_id: string;

--- a/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
+++ b/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
@@ -2,7 +2,6 @@ import * as NodeCrypto from "node:crypto";
 
 import { RelayAgentActivityAggregateState, type RelayDeliveryKind } from "@t3tools/contracts/relay";
 import { stableStringify } from "@t3tools/shared/relaySigning";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
@@ -50,13 +49,23 @@ export const SignedApnsDeliveryJob = Schema.Struct({
 });
 export type SignedApnsDeliveryJob = typeof SignedApnsDeliveryJob.Type;
 
-export class ApnsDeliveryJobInvalid extends Data.TaggedError("ApnsDeliveryJobInvalid")<{
-  readonly message: string;
-}> {}
+export class ApnsDeliveryJobInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobInvalid>()(
+  "ApnsDeliveryJobInvalid",
+  {
+    message: Schema.String,
+  },
+) {}
 
-export class ApnsDeliveryJobExpired extends Data.TaggedError("ApnsDeliveryJobExpired")<{
-  readonly expiresAt: string;
-}> {}
+export class ApnsDeliveryJobExpired extends Schema.TaggedErrorClass<ApnsDeliveryJobExpired>()(
+  "ApnsDeliveryJobExpired",
+  {
+    expiresAt: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `APNs delivery job expired at ${this.expiresAt}`;
+  }
+}
 
 export type ApnsDeliveryJobVerificationError = ApnsDeliveryJobInvalid | ApnsDeliveryJobExpired;
 

--- a/infra/relay/src/auth/DpopProofs.ts
+++ b/infra/relay/src/auth/DpopProofs.ts
@@ -1,8 +1,8 @@
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as HttpApiError from "effect/unstable/httpapi/HttpApiError";
 import { lt } from "drizzle-orm";
 
@@ -10,11 +10,16 @@ import { verifyDpopProof } from "@t3tools/shared/dpop";
 import { RelayDb } from "../db.ts";
 import { relayDpopProofs } from "../persistence/schema.ts";
 
-export class DpopProofReplayPersistenceError extends Data.TaggedError(
+export class DpopProofReplayPersistenceError extends Schema.TaggedErrorClass<DpopProofReplayPersistenceError>()(
   "DpopProofReplayPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to persist DPoP proof replay state";
+  }
+}
 
 export interface DpopProofReplayShape {
   readonly verifyAndConsume: (input: {

--- a/infra/relay/src/environments/EnvironmentConnector.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.ts
@@ -28,7 +28,6 @@ import {
 import { stableStringify } from "@t3tools/shared/relaySigning";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -42,28 +41,53 @@ import * as EnvironmentLinks from "./EnvironmentLinks.ts";
 import * as ManagedEndpointAllocations from "./ManagedEndpointAllocations.ts";
 import * as RelayConfiguration from "../Config.ts";
 
-export class EnvironmentConnectNotAuthorized extends Data.TaggedError(
+export class EnvironmentConnectNotAuthorized extends Schema.TaggedErrorClass<EnvironmentConnectNotAuthorized>()(
   "EnvironmentConnectNotAuthorized",
-)<{
-  readonly environmentId: string;
-}> {}
+  {
+    environmentId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Environment '${this.environmentId}' is not authorized to connect`;
+  }
+}
 
-export class EnvironmentMintRequestFailed extends Data.TaggedError("EnvironmentMintRequestFailed")<{
-  readonly cause: unknown;
-}> {}
+export class EnvironmentMintRequestFailed extends Schema.TaggedErrorClass<EnvironmentMintRequestFailed>()(
+  "EnvironmentMintRequestFailed",
+  {
+    environmentId: Schema.String,
+    operation: Schema.Literals(["connect", "status"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Environment '${this.environmentId}' ${this.operation} request failed`;
+  }
+}
 
-export class EnvironmentMintRequestTimedOut extends Data.TaggedError(
+export class EnvironmentMintRequestTimedOut extends Schema.TaggedErrorClass<EnvironmentMintRequestTimedOut>()(
   "EnvironmentMintRequestTimedOut",
-)<{
-  readonly environmentId: string;
-  readonly timeoutMs: number;
-}> {}
+  {
+    environmentId: Schema.String,
+    timeoutMs: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Environment '${this.environmentId}' mint request timed out after ${this.timeoutMs}ms`;
+  }
+}
 
-export class EnvironmentMintResponseInvalid extends Data.TaggedError(
+export class EnvironmentMintResponseInvalid extends Schema.TaggedErrorClass<EnvironmentMintResponseInvalid>()(
   "EnvironmentMintResponseInvalid",
-)<{
-  readonly environmentId: string;
-}> {}
+  {
+    environmentId: Schema.String,
+    operation: Schema.Literals(["connect", "status"]),
+  },
+) {
+  override get message(): string {
+    return `Environment '${this.environmentId}' returned an invalid ${this.operation} response`;
+  }
+}
 
 export type EnvironmentConnectorError =
   | EnvironmentConnectNotAuthorized
@@ -277,14 +301,28 @@ const make = Effect.gen(function* () {
       const now = yield* DateTime.now;
       const expiresAt = DateTime.add(now, { minutes: 2 });
       const nonce = yield* crypto.randomUUIDv4.pipe(
-        Effect.mapError((cause) => new EnvironmentMintRequestFailed({ cause })),
+        Effect.mapError(
+          (cause) =>
+            new EnvironmentMintRequestFailed({
+              environmentId: input.environmentId,
+              operation: "status",
+              cause,
+            }),
+        ),
       );
       const payload = {
         iss: relayIssuer,
         aud: `t3-env:${link.environmentId}`,
         sub: input.userId,
         jti: yield* crypto.randomUUIDv4.pipe(
-          Effect.mapError((cause) => new EnvironmentMintRequestFailed({ cause })),
+          Effect.mapError(
+            (cause) =>
+              new EnvironmentMintRequestFailed({
+                environmentId: input.environmentId,
+                operation: "status",
+                cause,
+              }),
+          ),
         ),
         iat: Math.floor(now.epochMilliseconds / 1_000),
         exp: Math.floor(expiresAt.epochMilliseconds / 1_000),
@@ -296,7 +334,16 @@ const make = Effect.gen(function* () {
         privateKey: Redacted.value(settings.cloudMintPrivateKey),
         typ: RELAY_HEALTH_REQUEST_TYP,
         payload,
-      }).pipe(Effect.mapError((cause) => new EnvironmentMintRequestFailed({ cause })));
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new EnvironmentMintRequestFailed({
+              environmentId: input.environmentId,
+              operation: "status",
+              cause,
+            }),
+        ),
+      );
       const checkedAt = DateTime.formatIso(now);
       const environmentClient = yield* makeEnvironmentClient(endpoint.httpBaseUrl);
       const responseOption = yield* environmentClient.cloud.health({ payload: { proof } }).pipe(
@@ -336,7 +383,10 @@ const make = Effect.gen(function* () {
         now: yield* DateTime.now,
       });
       if (!verified) {
-        return yield* new EnvironmentMintResponseInvalid({ environmentId: input.environmentId });
+        return yield* new EnvironmentMintResponseInvalid({
+          environmentId: input.environmentId,
+          operation: "status",
+        });
       }
       return {
         environmentId: link.environmentId,
@@ -364,14 +414,28 @@ const make = Effect.gen(function* () {
       const now = yield* DateTime.now;
       const expiresAt = DateTime.add(now, { minutes: 2 });
       const nonce = yield* crypto.randomUUIDv4.pipe(
-        Effect.mapError((cause) => new EnvironmentMintRequestFailed({ cause })),
+        Effect.mapError(
+          (cause) =>
+            new EnvironmentMintRequestFailed({
+              environmentId: input.environmentId,
+              operation: "connect",
+              cause,
+            }),
+        ),
       );
       const payload = {
         iss: relayIssuer,
         aud: `t3-env:${link.environmentId}`,
         sub: input.userId,
         jti: yield* crypto.randomUUIDv4.pipe(
-          Effect.mapError((cause) => new EnvironmentMintRequestFailed({ cause })),
+          Effect.mapError(
+            (cause) =>
+              new EnvironmentMintRequestFailed({
+                environmentId: input.environmentId,
+                operation: "connect",
+                cause,
+              }),
+          ),
         ),
         iat: Math.floor(now.epochMilliseconds / 1_000),
         exp: Math.floor(expiresAt.epochMilliseconds / 1_000),
@@ -386,11 +450,27 @@ const make = Effect.gen(function* () {
         privateKey: Redacted.value(settings.cloudMintPrivateKey),
         typ: RELAY_MINT_REQUEST_TYP,
         payload,
-      }).pipe(Effect.mapError((cause) => new EnvironmentMintRequestFailed({ cause })));
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new EnvironmentMintRequestFailed({
+              environmentId: input.environmentId,
+              operation: "connect",
+              cause,
+            }),
+        ),
+      );
       const environmentClient = yield* makeEnvironmentClient(endpoint.httpBaseUrl);
       const decoded = yield* environmentClient.cloud.t3MintCredential({ payload: { proof } }).pipe(
         withoutRedirects,
-        Effect.mapError((cause) => new EnvironmentMintRequestFailed({ cause })),
+        Effect.mapError(
+          (cause) =>
+            new EnvironmentMintRequestFailed({
+              environmentId: input.environmentId,
+              operation: "connect",
+              cause,
+            }),
+        ),
         Effect.timeoutOption(Duration.millis(ENVIRONMENT_MINT_REQUEST_TIMEOUT_MS)),
         Effect.flatMap(
           Option.match({
@@ -415,7 +495,10 @@ const make = Effect.gen(function* () {
         nowEpochSeconds: Math.floor(now.epochMilliseconds / 1_000),
       });
       if (!verified) {
-        return yield* new EnvironmentMintResponseInvalid({ environmentId: input.environmentId });
+        return yield* new EnvironmentMintResponseInvalid({
+          environmentId: input.environmentId,
+          operation: "connect",
+        });
       }
       return {
         environmentId: link.environmentId,

--- a/infra/relay/src/environments/EnvironmentCredentials.ts
+++ b/infra/relay/src/environments/EnvironmentCredentials.ts
@@ -1,33 +1,42 @@
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import { and, eq, isNull, ne, notExists } from "drizzle-orm";
 
 import { RelayDb } from "../db.ts";
 import { relayEnvironmentCredentials, relayEnvironmentLinks } from "../persistence/schema.ts";
 
-export class EnvironmentCredentialCreatePersistenceError extends Data.TaggedError(
+export class EnvironmentCredentialCreatePersistenceError extends Schema.TaggedErrorClass<EnvironmentCredentialCreatePersistenceError>()(
   "EnvironmentCredentialCreatePersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to persist environment credential";
+  }
+}
 
-export class EnvironmentCredentialAuthenticatePersistenceError extends Data.TaggedError(
+export class EnvironmentCredentialAuthenticatePersistenceError extends Schema.TaggedErrorClass<EnvironmentCredentialAuthenticatePersistenceError>()(
   "EnvironmentCredentialAuthenticatePersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to authenticate environment credential";
+  }
+}
 
-export class EnvironmentCredentialRevokePersistenceError extends Data.TaggedError(
+export class EnvironmentCredentialRevokePersistenceError extends Schema.TaggedErrorClass<EnvironmentCredentialRevokePersistenceError>()(
   "EnvironmentCredentialRevokePersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to revoke environment credential";
+  }
+}
 
 export interface EnvironmentCredentialPrincipal {
   readonly credentialId: string;

--- a/infra/relay/src/environments/EnvironmentLinker.ts
+++ b/infra/relay/src/environments/EnvironmentLinker.ts
@@ -1,6 +1,6 @@
 import {
   RelayEnvironmentLinkProofPayload,
-  type RelayEnvironmentLinkProofInvalidReason,
+  RelayEnvironmentLinkProofInvalidReason,
   type RelayEnvironmentLinkRequest,
 } from "@t3tools/contracts/relay";
 import {
@@ -10,7 +10,6 @@ import {
   verifyRelayJwt,
 } from "@t3tools/shared/relayJwt";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -23,14 +22,28 @@ import * as EnvironmentLinks from "./EnvironmentLinks.ts";
 import * as ManagedEndpointProvider from "./ManagedEndpointProvider.ts";
 import * as RelayConfiguration from "../Config.ts";
 
-export class EnvironmentLinkProofExpired extends Data.TaggedError("EnvironmentLinkProofExpired")<{
-  readonly expiresAt: string;
-}> {}
+export class EnvironmentLinkProofExpired extends Schema.TaggedErrorClass<EnvironmentLinkProofExpired>()(
+  "EnvironmentLinkProofExpired",
+  {
+    expiresAt: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Environment link proof expired at ${this.expiresAt}`;
+  }
+}
 
-export class EnvironmentLinkProofInvalid extends Data.TaggedError("EnvironmentLinkProofInvalid")<{
-  readonly environmentId: string;
-  readonly reason: RelayEnvironmentLinkProofInvalidReason;
-}> {}
+export class EnvironmentLinkProofInvalid extends Schema.TaggedErrorClass<EnvironmentLinkProofInvalid>()(
+  "EnvironmentLinkProofInvalid",
+  {
+    environmentId: Schema.String,
+    reason: RelayEnvironmentLinkProofInvalidReason,
+  },
+) {
+  override get message(): string {
+    return `Environment '${this.environmentId}' link proof is invalid: ${this.reason}`;
+  }
+}
 
 export type EnvironmentLinkError =
   | EnvironmentLinkProofExpired

--- a/infra/relay/src/environments/EnvironmentLinks.ts
+++ b/infra/relay/src/environments/EnvironmentLinks.ts
@@ -5,10 +5,10 @@ import type {
   RelayManagedEndpoint,
 } from "@t3tools/contracts/relay";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import { and, eq, isNull, or } from "drizzle-orm";
 
 import { RelayDb } from "../db.ts";
@@ -24,41 +24,59 @@ export interface AgentAwarenessDeliveryUserRecord {
   readonly liveActivitiesEnabled: boolean;
 }
 
-export class EnvironmentLinkUpsertPersistenceError extends Data.TaggedError(
+export class EnvironmentLinkUpsertPersistenceError extends Schema.TaggedErrorClass<EnvironmentLinkUpsertPersistenceError>()(
   "EnvironmentLinkUpsertPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to persist environment link";
+  }
+}
 
-export class EnvironmentLinkUserListPersistenceError extends Data.TaggedError(
+export class EnvironmentLinkUserListPersistenceError extends Schema.TaggedErrorClass<EnvironmentLinkUserListPersistenceError>()(
   "EnvironmentLinkUserListPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to list users linked to environment";
+  }
+}
 
-export class EnvironmentPublicKeyListPersistenceError extends Data.TaggedError(
+export class EnvironmentPublicKeyListPersistenceError extends Schema.TaggedErrorClass<EnvironmentPublicKeyListPersistenceError>()(
   "EnvironmentPublicKeyListPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to list environment public keys";
+  }
+}
 
-export class EnvironmentLinkListPersistenceError extends Data.TaggedError(
+export class EnvironmentLinkListPersistenceError extends Schema.TaggedErrorClass<EnvironmentLinkListPersistenceError>()(
   "EnvironmentLinkListPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to list environment links";
+  }
+}
 
-export class EnvironmentLinkLookupPersistenceError extends Data.TaggedError(
+export class EnvironmentLinkLookupPersistenceError extends Schema.TaggedErrorClass<EnvironmentLinkLookupPersistenceError>()(
   "EnvironmentLinkLookupPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to look up environment link";
+  }
+}
 
-export class EnvironmentLinkRevokePersistenceError extends Data.TaggedError(
+export class EnvironmentLinkRevokePersistenceError extends Schema.TaggedErrorClass<EnvironmentLinkRevokePersistenceError>()(
   "EnvironmentLinkRevokePersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to revoke environment link";
+  }
+}
 
 export interface EnvironmentLinksShape {
   readonly upsert: (input: {

--- a/infra/relay/src/environments/EnvironmentPublishSignatures.ts
+++ b/infra/relay/src/environments/EnvironmentPublishSignatures.ts
@@ -11,7 +11,6 @@ import {
 import { stableStringify } from "@t3tools/shared/relaySigning";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
@@ -21,23 +20,38 @@ import * as Schema from "effect/Schema";
 import * as DpopProofs from "../auth/DpopProofs.ts";
 import * as RelayConfiguration from "../Config.ts";
 
-export class EnvironmentPublishSignatureExpired extends Data.TaggedError(
+export class EnvironmentPublishSignatureExpired extends Schema.TaggedErrorClass<EnvironmentPublishSignatureExpired>()(
   "EnvironmentPublishSignatureExpired",
-)<{
-  readonly expiresAt: string;
-}> {}
+  {
+    expiresAt: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Environment publish signature expired at ${this.expiresAt}`;
+  }
+}
 
-export class EnvironmentPublishSignatureInvalid extends Data.TaggedError(
+export class EnvironmentPublishSignatureInvalid extends Schema.TaggedErrorClass<EnvironmentPublishSignatureInvalid>()(
   "EnvironmentPublishSignatureInvalid",
-)<{
-  readonly environmentId: string;
-}> {}
+  {
+    environmentId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Environment '${this.environmentId}' publish signature is invalid`;
+  }
+}
 
-export class EnvironmentPublishPublicKeyMissing extends Data.TaggedError(
+export class EnvironmentPublishPublicKeyMissing extends Schema.TaggedErrorClass<EnvironmentPublishPublicKeyMissing>()(
   "EnvironmentPublishPublicKeyMissing",
-)<{
-  readonly environmentId: string;
-}> {}
+  {
+    environmentId: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Environment '${this.environmentId}' has no publish public key`;
+  }
+}
 
 export type EnvironmentPublishSignatureError =
   | EnvironmentPublishSignatureExpired

--- a/infra/relay/src/environments/ManagedEndpointAllocations.ts
+++ b/infra/relay/src/environments/ManagedEndpointAllocations.ts
@@ -1,10 +1,10 @@
 import type { RelayManagedEndpoint } from "@t3tools/contracts/relay";
 import { and, eq } from "drizzle-orm";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 
 import { RelayDb } from "../db.ts";
 import { isManagedEndpointHostname, managedEndpointForHostname } from "../deploymentConfig.ts";
@@ -36,11 +36,17 @@ export function resolveReadyManagedEndpoint(input: {
   return managedEndpointForHostname(input.allocation.hostname);
 }
 
-export class ManagedEndpointAllocationPersistenceError extends Data.TaggedError(
+export class ManagedEndpointAllocationPersistenceError extends Schema.TaggedErrorClass<ManagedEndpointAllocationPersistenceError>()(
   "ManagedEndpointAllocationPersistenceError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to persist managed endpoint allocation";
+  }
+}
+const isManagedEndpointAllocationPersistenceError = Schema.is(
+  ManagedEndpointAllocationPersistenceError,
+);
 
 interface ManagedEndpointAllocationKey {
   readonly userId: string;
@@ -98,7 +104,7 @@ const whereAllocation = (input: ManagedEndpointAllocationKey) =>
   );
 
 const persistenceError = (cause: unknown) =>
-  cause instanceof ManagedEndpointAllocationPersistenceError
+  isManagedEndpointAllocationPersistenceError(cause)
     ? cause
     : new ManagedEndpointAllocationPersistenceError({ cause });
 

--- a/infra/relay/src/environments/ManagedEndpointProvider.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.ts
@@ -3,12 +3,12 @@ import * as Cloudflare from "alchemy/Cloudflare";
 import * as Arr from "effect/Array";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 
 import type {
   RelayManagedEndpoint,
@@ -25,28 +25,44 @@ import {
 } from "../deploymentConfig.ts";
 import { ManagedEndpointAllocations } from "./ManagedEndpointAllocations.ts";
 
-export class ManagedEndpointProvisioningNotConfigured extends Data.TaggedError(
+export class ManagedEndpointProvisioningNotConfigured extends Schema.TaggedErrorClass<ManagedEndpointProvisioningNotConfigured>()(
   "ManagedEndpointProvisioningNotConfigured",
-)<{}> {}
+  {},
+) {
+  override get message(): string {
+    return "Managed endpoint provisioning is not configured";
+  }
+}
 
-export class ManagedEndpointProvisioningFailed extends Data.TaggedError(
+export class ManagedEndpointProvisioningFailed extends Schema.TaggedErrorClass<ManagedEndpointProvisioningFailed>()(
   "ManagedEndpointProvisioningFailed",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Managed endpoint provisioning failed";
+  }
+}
 
-export class ManagedEndpointDeprovisioningFailed extends Data.TaggedError(
+export class ManagedEndpointDeprovisioningFailed extends Schema.TaggedErrorClass<ManagedEndpointDeprovisioningFailed>()(
   "ManagedEndpointDeprovisioningFailed",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Managed endpoint deprovisioning failed";
+  }
+}
 
-export class ManagedEndpointOriginNotAllowed extends Data.TaggedError(
+export class ManagedEndpointOriginNotAllowed extends Schema.TaggedErrorClass<ManagedEndpointOriginNotAllowed>()(
   "ManagedEndpointOriginNotAllowed",
-)<{
-  readonly host: string;
-  readonly port: number;
-}> {}
+  {
+    host: Schema.String,
+    port: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Managed endpoint origin '${this.host}:${this.port}' is not allowed`;
+  }
+}
 
 export type ManagedEndpointProviderError =
   | ManagedEndpointProvisioningNotConfigured
@@ -80,11 +96,14 @@ interface ManagedEndpointTunnel {
   readonly name?: string | null;
 }
 
-export class ManagedEndpointTunnelClientError extends Data.TaggedError(
+export class ManagedEndpointTunnelClientError extends Schema.TaggedErrorClass<ManagedEndpointTunnelClientError>()(
   "ManagedEndpointTunnelClientError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Managed endpoint tunnel provider request failed";
+  }
+}
 
 export interface ManagedEndpointTunnelClientShape {
   readonly list: (request: {
@@ -124,11 +143,14 @@ interface ManagedEndpointCnameRecordInput {
   readonly proxied: true;
 }
 
-export class ManagedEndpointDnsClientError extends Data.TaggedError(
+export class ManagedEndpointDnsClientError extends Schema.TaggedErrorClass<ManagedEndpointDnsClientError>()(
   "ManagedEndpointDnsClientError",
-)<{
-  readonly cause: unknown;
-}> {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Managed endpoint DNS provider request failed";
+  }
+}
 
 export interface ManagedEndpointDnsClientShape {
   readonly listRecords: (

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -852,16 +852,12 @@ const COMMON_AUTH_INVALID_REASONS = [
   DeliveryAttempts.DeliveryAttemptRecordPersistenceError,
 ] as const;
 type RelayCommonPersistenceError = InstanceType<(typeof COMMON_AUTH_INVALID_REASONS)[number]>;
-const isRelayCommonPersistenceErrorSchema = Schema.is(Schema.Union(COMMON_AUTH_INVALID_REASONS));
+const isRelayCommonPersistenceError = Schema.is(Schema.Union(COMMON_AUTH_INVALID_REASONS));
 
 type MapRelayCommonApiError<E> =
   | Exclude<E, HttpApiError.Unauthorized | RelayCommonPersistenceError>
   | (Extract<E, HttpApiError.Unauthorized> extends never ? never : RelayAuthInvalidError)
   | (Extract<E, RelayCommonPersistenceError> extends never ? never : RelayInternalError);
-
-function isRelayCommonPersistenceError(error: unknown): error is RelayCommonPersistenceError {
-  return isRelayCommonPersistenceErrorSchema(error);
-}
 
 function relayInternalErrorResponse(reason: RelayInternalError["reason"]) {
   return currentTraceId.pipe(

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -1,6 +1,5 @@
 import { createClerkClient, verifyToken } from "@clerk/backend";
 import { sql as drizzleSql } from "drizzle-orm";
-import * as Data from "effect/Data";
 import * as Crypto from "effect/Crypto";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -813,9 +812,16 @@ export const serverApi = HttpApiBuilder.group(
   }),
 );
 
-class ClerkTokenVerificationFailed extends Data.TaggedError("ClerkTokenVerificationFailed")<{
-  readonly cause: unknown;
-}> {}
+class ClerkTokenVerificationFailed extends Schema.TaggedErrorClass<ClerkTokenVerificationFailed>()(
+  "ClerkTokenVerificationFailed",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Clerk token verification failed";
+  }
+}
 
 const isHttpUnauthorized = Schema.is(HttpApiError.Unauthorized);
 
@@ -846,6 +852,7 @@ const COMMON_AUTH_INVALID_REASONS = [
   DeliveryAttempts.DeliveryAttemptRecordPersistenceError,
 ] as const;
 type RelayCommonPersistenceError = InstanceType<(typeof COMMON_AUTH_INVALID_REASONS)[number]>;
+const isRelayCommonPersistenceErrorSchema = Schema.is(Schema.Union(COMMON_AUTH_INVALID_REASONS));
 
 type MapRelayCommonApiError<E> =
   | Exclude<E, HttpApiError.Unauthorized | RelayCommonPersistenceError>
@@ -853,7 +860,7 @@ type MapRelayCommonApiError<E> =
   | (Extract<E, RelayCommonPersistenceError> extends never ? never : RelayInternalError);
 
 function isRelayCommonPersistenceError(error: unknown): error is RelayCommonPersistenceError {
-  return COMMON_AUTH_INVALID_REASONS.some((ErrorType) => error instanceof ErrorType);
+  return isRelayCommonPersistenceErrorSchema(error);
 }
 
 function relayInternalErrorResponse(reason: RelayInternalError["reason"]) {

--- a/infra/relay/src/observability.test.ts
+++ b/infra/relay/src/observability.test.ts
@@ -1,0 +1,119 @@
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as ManagedRuntime from "effect/ManagedRuntime";
+import * as Redacted from "effect/Redacted";
+import { FetchHttpClient } from "effect/unstable/http";
+import type { OtlpTracer } from "effect/unstable/observability";
+import { expect, it } from "vite-plus/test";
+
+import { EnvironmentMintRequestFailed } from "./environments/EnvironmentConnector.ts";
+import { makeRelayTraceLayer } from "./observability.ts";
+
+const otlpAttributeValue = (value: {
+  readonly stringValue?: string | null;
+  readonly boolValue?: boolean | null;
+  readonly intValue?: number | null;
+  readonly doubleValue?: number | null;
+}) => value.stringValue ?? value.boolValue ?? value.intValue ?? value.doubleValue;
+
+it("exports schema error fields as span attributes", async () => {
+  const NodeHttp = await import("node:http");
+  let resolveRequest:
+    | ((request: {
+        readonly body: string;
+        readonly headers: Record<string, string | ReadonlyArray<string> | undefined>;
+      }) => void)
+    | undefined;
+  const firstRequest = new Promise<{
+    readonly body: string;
+    readonly headers: Record<string, string | ReadonlyArray<string> | undefined>;
+  }>((resolve) => {
+    resolveRequest = resolve;
+  });
+  const server = NodeHttp.createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk) => {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    });
+    request.on("end", () => {
+      resolveRequest?.({
+        body: Buffer.concat(chunks).toString("utf8"),
+        headers: request.headers,
+      });
+      resolveRequest = undefined;
+      response.statusCode = 204;
+      response.end();
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("Expected TCP collector address");
+  }
+
+  const runtime = ManagedRuntime.make(
+    makeRelayTraceLayer({
+      tracesEndpoint: `http://127.0.0.1:${address.port}/v1/traces`,
+      tracesDatasetName: "relay-test-traces",
+      ingestToken: Redacted.make("test-token"),
+    }).pipe(Layer.provide(FetchHttpClient.layer)),
+  );
+
+  try {
+    await runtime.runPromise(
+      Effect.fail(
+        new EnvironmentMintRequestFailed({
+          environmentId: "environment-1",
+          operation: "connect",
+          cause: new Error("upstream unavailable"),
+        }),
+      ).pipe(Effect.withSpan("relay.test.schema_error"), Effect.exit),
+    );
+    await runtime.dispose();
+
+    const request = await Effect.runPromise(
+      Effect.raceFirst(
+        Effect.promise(() => firstRequest),
+        Effect.sleep("1 second").pipe(
+          Effect.andThen(Effect.die(new Error("Timed out waiting for OTLP trace export"))),
+        ),
+      ),
+    );
+    const payload = JSON.parse(request.body) as OtlpTracer.TraceData;
+    const span = payload.resourceSpans
+      .flatMap((resourceSpan) => resourceSpan.scopeSpans)
+      .flatMap((scopeSpan) => scopeSpan.spans)
+      .find((candidate) => candidate.name === "relay.test.schema_error");
+    const attributes = Object.fromEntries(
+      (span?.attributes ?? []).map((attribute) => [
+        attribute.key,
+        otlpAttributeValue(attribute.value),
+      ]),
+    );
+
+    expect(request.headers.authorization).toBe("Bearer test-token");
+    expect(request.headers["x-axiom-dataset"]).toBe("relay-test-traces");
+    expect(attributes).toMatchObject({
+      "error.type": "EnvironmentMintRequestFailed",
+      "error.environmentId": "environment-1",
+      "error.operation": "connect",
+      "error.cause.name": "Error",
+      "error.cause.message": "upstream unavailable",
+    });
+  } finally {
+    await runtime.dispose();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+});

--- a/infra/relay/src/observability.test.ts
+++ b/infra/relay/src/observability.test.ts
@@ -1,13 +1,22 @@
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import { expect, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Redacted from "effect/Redacted";
-import { FetchHttpClient } from "effect/unstable/http";
+import * as Schema from "effect/Schema";
+import * as HttpServer from "effect/unstable/http/HttpServer";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type { OtlpTracer } from "effect/unstable/observability";
-import { expect, it } from "vite-plus/test";
 
 import { EnvironmentMintRequestFailed } from "./environments/EnvironmentConnector.ts";
 import { makeRelayTraceLayer } from "./observability.ts";
+
+interface ExportedRequest {
+  readonly authorization: string | undefined;
+  readonly body: string;
+  readonly dataset: string | undefined;
+}
 
 const otlpAttributeValue = (value: {
   readonly stringValue?: string | null;
@@ -16,74 +25,43 @@ const otlpAttributeValue = (value: {
   readonly doubleValue?: number | null;
 }) => value.stringValue ?? value.boolValue ?? value.intValue ?? value.doubleValue;
 
-it("exports schema error fields as span attributes", async () => {
-  const NodeHttp = await import("node:http");
-  let resolveRequest:
-    | ((request: {
-        readonly body: string;
-        readonly headers: Record<string, string | ReadonlyArray<string> | undefined>;
-      }) => void)
-    | undefined;
-  const firstRequest = new Promise<{
-    readonly body: string;
-    readonly headers: Record<string, string | ReadonlyArray<string> | undefined>;
-  }>((resolve) => {
-    resolveRequest = resolve;
-  });
-  const server = NodeHttp.createServer((request, response) => {
-    const chunks: Buffer[] = [];
-    request.on("data", (chunk) => {
-      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
-    });
-    request.on("end", () => {
-      resolveRequest?.({
-        body: Buffer.concat(chunks).toString("utf8"),
-        headers: request.headers,
-      });
-      resolveRequest = undefined;
-      response.statusCode = 204;
-      response.end();
-    });
-  });
+const decodeJson = Schema.decodeUnknownEffect(Schema.UnknownFromJsonString);
 
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("Expected TCP collector address");
-  }
-
-  const runtime = ManagedRuntime.make(
-    makeRelayTraceLayer({
-      tracesEndpoint: `http://127.0.0.1:${address.port}/v1/traces`,
-      tracesDatasetName: "relay-test-traces",
-      ingestToken: Redacted.make("test-token"),
-    }).pipe(Layer.provide(FetchHttpClient.layer)),
-  );
-
-  try {
-    await runtime.runPromise(
-      Effect.fail(
-        new EnvironmentMintRequestFailed({
-          environmentId: "environment-1",
-          operation: "connect",
-          cause: new Error("upstream unavailable"),
-        }),
-      ).pipe(Effect.withSpan("relay.test.schema_error"), Effect.exit),
+it.effect("exports schema error fields as span attributes", () =>
+  Effect.gen(function* () {
+    const exportedRequest = yield* Deferred.make<ExportedRequest>();
+    yield* HttpServer.serveEffect(
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        yield* Deferred.succeed(exportedRequest, {
+          authorization: request.headers.authorization,
+          body: yield* request.text,
+          dataset: request.headers["x-axiom-dataset"],
+        });
+        return HttpServerResponse.empty({ status: 204 });
+      }),
     );
-    await runtime.dispose();
 
-    const request = await Effect.runPromise(
-      Effect.raceFirst(
-        Effect.promise(() => firstRequest),
-        Effect.sleep("1 second").pipe(
-          Effect.andThen(Effect.die(new Error("Timed out waiting for OTLP trace export"))),
-        ),
+    yield* Effect.fail(
+      new EnvironmentMintRequestFailed({
+        environmentId: "environment-1",
+        operation: "connect",
+        cause: new Error("upstream unavailable"),
+      }),
+    ).pipe(
+      Effect.withSpan("relay.test.schema_error"),
+      Effect.exit,
+      Effect.provide(
+        makeRelayTraceLayer({
+          tracesEndpoint: "/v1/traces",
+          tracesDatasetName: "relay-test-traces",
+          ingestToken: Redacted.make("test-token"),
+        }),
       ),
     );
-    const payload = JSON.parse(request.body) as OtlpTracer.TraceData;
+
+    const request = yield* Deferred.await(exportedRequest).pipe(Effect.timeout("1 second"));
+    const payload = (yield* decodeJson(request.body)) as OtlpTracer.TraceData;
     const span = payload.resourceSpans
       .flatMap((resourceSpan) => resourceSpan.scopeSpans)
       .flatMap((scopeSpan) => scopeSpan.spans)
@@ -95,8 +73,8 @@ it("exports schema error fields as span attributes", async () => {
       ]),
     );
 
-    expect(request.headers.authorization).toBe("Bearer test-token");
-    expect(request.headers["x-axiom-dataset"]).toBe("relay-test-traces");
+    expect(request.authorization).toBe("Bearer test-token");
+    expect(request.dataset).toBe("relay-test-traces");
     expect(attributes).toMatchObject({
       "error.type": "EnvironmentMintRequestFailed",
       "error.environmentId": "environment-1",
@@ -104,16 +82,5 @@ it("exports schema error fields as span attributes", async () => {
       "error.cause.name": "Error",
       "error.cause.message": "upstream unavailable",
     });
-  } finally {
-    await runtime.dispose();
-    await new Promise<void>((resolve, reject) => {
-      server.close((error) => {
-        if (error) {
-          reject(error);
-        } else {
-          resolve();
-        }
-      });
-    });
-  }
-});
+  }).pipe(Effect.provide(NodeHttpServer.layerTest), Effect.scoped),
+);

--- a/infra/relay/src/observability.ts
+++ b/infra/relay/src/observability.ts
@@ -1,9 +1,14 @@
 import * as Alchemy from "alchemy";
 import * as Axiom from "alchemy/Axiom";
 import * as Output from "alchemy/Output";
-import * as Layer from "effect/Layer";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
+import * as Tracer from "effect/Tracer";
 import { OtlpSerialization, OtlpTracer } from "effect/unstable/observability";
 
 import { relayResourceNameForStage } from "./deploymentConfig.ts";
@@ -54,23 +59,163 @@ export const withSpanAttributes =
       Effect.andThen(effect.pipe(Effect.annotateSpans(attributes))),
     );
 
+const appendEncodedAttributes = (
+  attributes: Record<string, unknown>,
+  prefix: string,
+  value: unknown,
+): void => {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean" ||
+    typeof value === "bigint" ||
+    Array.isArray(value)
+  ) {
+    attributes[prefix] = value;
+    return;
+  }
+  if (typeof value !== "object") {
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    appendEncodedAttributes(attributes, `${prefix}.${key}`, child);
+  }
+};
+
+const schemaErrorAttributes = (error: unknown): Record<string, unknown> | undefined => {
+  if (typeof error !== "object" || error === null) {
+    return undefined;
+  }
+  const constructor = error.constructor;
+  if (!Schema.isSchema(constructor)) {
+    return undefined;
+  }
+  const encoded = Schema.encodeUnknownOption(constructor as unknown as Schema.Encoder<unknown>)(
+    error,
+  );
+  if (Option.isNone(encoded) || typeof encoded.value !== "object" || encoded.value === null) {
+    return undefined;
+  }
+  const tag = Reflect.get(encoded.value, "_tag");
+  if (typeof tag !== "string") {
+    return undefined;
+  }
+
+  const attributes: Record<string, unknown> = {
+    "error.type": tag,
+  };
+  for (const [key, value] of Object.entries(encoded.value)) {
+    if (key !== "_tag") {
+      appendEncodedAttributes(attributes, `error.${key}`, value);
+    }
+  }
+  return attributes;
+};
+
+const annotateSchemaError = (span: Tracer.Span, exit: Exit.Exit<unknown, unknown>): void => {
+  if (Exit.isSuccess(exit)) {
+    return;
+  }
+  for (const reason of exit.cause.reasons) {
+    const error = Cause.isFailReason(reason)
+      ? reason.error
+      : Cause.isDieReason(reason)
+        ? reason.defect
+        : undefined;
+    const attributes = schemaErrorAttributes(error);
+    if (attributes) {
+      for (const [key, value] of Object.entries(attributes)) {
+        span.attribute(key, value);
+      }
+      return;
+    }
+  }
+};
+
+class RelayTraceSpan implements Tracer.Span {
+  readonly _tag = "Span";
+  private readonly delegate: Tracer.Span;
+
+  constructor(delegate: Tracer.Span) {
+    this.delegate = delegate;
+  }
+
+  get name() {
+    return this.delegate.name;
+  }
+  get spanId() {
+    return this.delegate.spanId;
+  }
+  get traceId() {
+    return this.delegate.traceId;
+  }
+  get parent() {
+    return this.delegate.parent;
+  }
+  get annotations() {
+    return this.delegate.annotations;
+  }
+  get status() {
+    return this.delegate.status;
+  }
+  get attributes() {
+    return this.delegate.attributes;
+  }
+  get links() {
+    return this.delegate.links;
+  }
+  get sampled() {
+    return this.delegate.sampled;
+  }
+  get kind() {
+    return this.delegate.kind;
+  }
+
+  end(endTime: bigint, exit: Exit.Exit<unknown, unknown>): void {
+    annotateSchemaError(this.delegate, exit);
+    this.delegate.end(endTime, exit);
+  }
+
+  attribute(key: string, value: unknown): void {
+    this.delegate.attribute(key, value);
+  }
+
+  event(name: string, startTime: bigint, attributes?: Record<string, unknown>): void {
+    this.delegate.event(name, startTime, attributes);
+  }
+
+  addLinks(links: ReadonlyArray<Tracer.SpanLink>): void {
+    this.delegate.addLinks(links);
+  }
+}
+
+const withSchemaErrorAttributes = (delegate: Tracer.Tracer): Tracer.Tracer =>
+  Tracer.make({
+    span: (options) => new RelayTraceSpan(delegate.span(options)),
+    ...(delegate.context ? { context: delegate.context } : {}),
+  });
+
 export const makeRelayTraceLayer = (input: {
   readonly tracesEndpoint: string;
   readonly tracesDatasetName: string;
   readonly ingestToken: Redacted.Redacted<string>;
 }) =>
-  OtlpTracer.layer({
-    url: input.tracesEndpoint,
-    resource: {
-      serviceName: "t3-code-relay-worker",
-      attributes: {
-        "service.runtime": "cloudflare-worker",
-        "service.component": "relay",
+  Layer.effect(
+    Tracer.Tracer,
+    OtlpTracer.make({
+      url: input.tracesEndpoint,
+      resource: {
+        serviceName: "t3-code-relay-worker",
+        attributes: {
+          "service.runtime": "cloudflare-worker",
+          "service.component": "relay",
+        },
       },
-    },
-    headers: {
-      Authorization: `Bearer ${Redacted.value(input.ingestToken)}`,
-      "X-Axiom-Dataset": input.tracesDatasetName,
-    },
-    exportInterval: "1 second",
-  }).pipe(Layer.provide(OtlpSerialization.layerJson));
+      headers: {
+        Authorization: `Bearer ${Redacted.value(input.ingestToken)}`,
+        "X-Axiom-Dataset": input.tracesDatasetName,
+      },
+      exportInterval: "1 second",
+    }).pipe(Effect.map(withSchemaErrorAttributes)),
+  ).pipe(Layer.provide(OtlpSerialization.layerJson));

--- a/packages/contracts/src/relay.ts
+++ b/packages/contracts/src/relay.ts
@@ -329,7 +329,11 @@ export class RelayAuthInvalidError extends Schema.TaggedErrorClass<RelayAuthInva
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 401 },
-) {}
+) {
+  override get message(): string {
+    return `Relay authentication failed: ${this.reason}`;
+  }
+}
 
 export class RelayEnvironmentLinkProofExpiredError extends Schema.TaggedErrorClass<RelayEnvironmentLinkProofExpiredError>()(
   "RelayEnvironmentLinkProofExpiredError",
@@ -338,7 +342,11 @@ export class RelayEnvironmentLinkProofExpiredError extends Schema.TaggedErrorCla
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 401 },
-) {}
+) {
+  override get message(): string {
+    return "Relay environment link proof expired";
+  }
+}
 
 export class RelayEnvironmentLinkProofInvalidError extends Schema.TaggedErrorClass<RelayEnvironmentLinkProofInvalidError>()(
   "RelayEnvironmentLinkProofInvalidError",
@@ -348,7 +356,11 @@ export class RelayEnvironmentLinkProofInvalidError extends Schema.TaggedErrorCla
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 400 },
-) {}
+) {
+  override get message(): string {
+    return `Relay environment link proof is invalid: ${this.reason}`;
+  }
+}
 
 export class RelayEnvironmentConnectNotAuthorizedError extends Schema.TaggedErrorClass<RelayEnvironmentConnectNotAuthorizedError>()(
   "RelayEnvironmentConnectNotAuthorizedError",
@@ -357,7 +369,11 @@ export class RelayEnvironmentConnectNotAuthorizedError extends Schema.TaggedErro
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 403 },
-) {}
+) {
+  override get message(): string {
+    return "Relay environment connection is not authorized";
+  }
+}
 
 export class RelayEnvironmentEndpointUnavailableError extends Schema.TaggedErrorClass<RelayEnvironmentEndpointUnavailableError>()(
   "RelayEnvironmentEndpointUnavailableError",
@@ -367,7 +383,11 @@ export class RelayEnvironmentEndpointUnavailableError extends Schema.TaggedError
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 502 },
-) {}
+) {
+  override get message(): string {
+    return `Relay environment endpoint is unavailable: ${this.reason}`;
+  }
+}
 
 export class RelayEnvironmentEndpointTimedOutError extends Schema.TaggedErrorClass<RelayEnvironmentEndpointTimedOutError>()(
   "RelayEnvironmentEndpointTimedOutError",
@@ -376,7 +396,11 @@ export class RelayEnvironmentEndpointTimedOutError extends Schema.TaggedErrorCla
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 504 },
-) {}
+) {
+  override get message(): string {
+    return "Relay environment endpoint request timed out";
+  }
+}
 
 export class RelayEnvironmentLinkFailedError extends Schema.TaggedErrorClass<RelayEnvironmentLinkFailedError>()(
   "RelayEnvironmentLinkFailedError",
@@ -386,7 +410,11 @@ export class RelayEnvironmentLinkFailedError extends Schema.TaggedErrorClass<Rel
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 500 },
-) {}
+) {
+  override get message(): string {
+    return `Relay environment link failed: ${this.reason}`;
+  }
+}
 
 export class RelayEnvironmentLinkUnavailableError extends Schema.TaggedErrorClass<RelayEnvironmentLinkUnavailableError>()(
   "RelayEnvironmentLinkUnavailableError",
@@ -396,7 +424,11 @@ export class RelayEnvironmentLinkUnavailableError extends Schema.TaggedErrorClas
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 503 },
-) {}
+) {
+  override get message(): string {
+    return `Relay environment link is unavailable: ${this.reason}`;
+  }
+}
 
 export class RelayAgentActivityPublishProofExpiredError extends Schema.TaggedErrorClass<RelayAgentActivityPublishProofExpiredError>()(
   "RelayAgentActivityPublishProofExpiredError",
@@ -405,7 +437,11 @@ export class RelayAgentActivityPublishProofExpiredError extends Schema.TaggedErr
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 401 },
-) {}
+) {
+  override get message(): string {
+    return "Relay agent activity publish proof expired";
+  }
+}
 
 export class RelayAgentActivityPublishProofInvalidError extends Schema.TaggedErrorClass<RelayAgentActivityPublishProofInvalidError>()(
   "RelayAgentActivityPublishProofInvalidError",
@@ -415,7 +451,11 @@ export class RelayAgentActivityPublishProofInvalidError extends Schema.TaggedErr
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 401 },
-) {}
+) {
+  override get message(): string {
+    return `Relay agent activity publish proof is invalid: ${this.reason}`;
+  }
+}
 
 export class RelayInternalError extends Schema.TaggedErrorClass<RelayInternalError>()(
   "RelayInternalError",
@@ -425,7 +465,11 @@ export class RelayInternalError extends Schema.TaggedErrorClass<RelayInternalErr
     traceId: TrimmedNonEmptyString,
   },
   { httpApiStatus: 500 },
-) {}
+) {
+  override get message(): string {
+    return `Relay internal error: ${this.reason}`;
+  }
+}
 
 export const RelayProtectedError = Schema.Union([
   RelayAuthInvalidError,


### PR DESCRIPTION
## Summary
- Convert relay infra failures from `Data.TaggedError` to `Schema.TaggedErrorClass`
- Add concise message overrides where they add value without overfitting copy
- Teach relay tracing to export schema-backed error fields onto OTLP span attributes
- Replace brittle message assertions with an integration test that inspects the exported span payload

## Testing
- `vp test run infra/relay/src`
- `vp run typecheck`
- `vp check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical error-type migration across auth, environments, and delivery paths; runtime behavior should match but trace payloads and error typing change observability and API mapping.
> 
> **Overview**
> Relay infra errors move from `Data.TaggedError` to **`Schema.TaggedErrorClass`**, with typed fields (often `cause: Schema.Defect()`) and **`message` getters** on relay modules and shared contract API errors. **`EnvironmentConnector`** mint failures now carry **`environmentId`** and **`operation`** (`connect` / `status`) wherever those errors are constructed.
> 
> **Tracing** wraps OTLP spans so that on failure, schema-backed errors are encoded and attached as **`error.*`** attributes (e.g. `error.type`, nested `error.cause.*`). **`makeRelayTraceLayer`** builds the tracer via `OtlpTracer.make` and a **`RelayTraceSpan`** delegate instead of the plain layer helper.
> 
> **API error mapping** replaces `instanceof` checks on common persistence errors with **`Schema.is`**. A new **`observability.test.ts`** asserts exported OTLP spans include those fields for a sample `EnvironmentMintRequestFailed`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1762e6d8763d70d2585ae03a44a57f7ecffa6585. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Annotate relay OTLP spans with schema error fields from `Schema.TaggedErrorClass`
> - Migrates all relay error classes from `Data.TaggedError` to `Schema.TaggedErrorClass`, adding structured fields (e.g. `cause`, `environmentId`, `operation`, `phase`) and deterministic `message` overrides to each.
> - Adds `appendEncodedAttributes`, `schemaErrorAttributes`, and `annotateSchemaError` helpers in [observability.ts](https://github.com/pingdotgg/t3code/pull/2976/files#diff-71653349605bb9ab413273c14a41a47472e1dc49444c20c50ee7125efb0911b0) that flatten schema-encoded error fields into OTLP span attributes prefixed with `error.`.
> - Introduces `RelayTraceSpan` and `withSchemaErrorAttributes` to wrap the tracer so spans closed with a failure automatically attach schema error attributes without call-site changes.
> - Updates `makeRelayTraceLayer` to pipe the OTLP tracer through `withSchemaErrorAttributes`, keeping JSON serialization and a 1-second export interval.
> - Adds a test in [observability.test.ts](https://github.com/pingdotgg/t3code/pull/2976/files#diff-84f7cdc34fc31a1853defca388c21b28620ed34b30f78463f9e0d57459a60c28) verifying that schema error fields appear as span attributes in the exported OTLP payload.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1762e6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->