### PR TITLE
fix(vcs): prefer fresh refs over cached on branch-list reload

### DIFF
--- a/packages/client-runtime/src/vcsRefState.ts
+++ b/packages/client-runtime/src/vcsRefState.ts
@@ -229,7 +229,12 @@ export function createVcsRefManager(config: VcsRefManagerConfig) {
             : options?.preserveLoadedRefs && current && current.refs.length > result.refs.length
               ? {
                   ...result,
-                  refs: mergeRefs(result.refs, current.refs),
+                  // Fresh server refs must win over previously-loaded ones for
+                  // overlapping names; otherwise a stale `current: true` (e.g. the
+                  // branch you were on before an external checkout) survives and
+                  // you get two refs both badged "current". `mergeRefs` lets the
+                  // second arg overwrite the first, so pass fresh refs last.
+                  refs: mergeRefs(current.refs, result.refs),
                   nextCursor: current.nextCursor,
                   totalCount: Math.max(result.totalCount, current.totalCount),
                 }


### PR DESCRIPTION
## What Changed

In the client ref cache, the `preserveLoadedRefs` merge passed the previously-cached refs **last**, so `mergeRefs` let them overwrite the fresh server entries for overlapping branch names. Reordered the arguments so fresh server refs win, while still retaining previously-paginated entries that aren't in the smaller fresh result.

## Why

A stale `current: true` flag (the branch you had checked out before an external `git switch`) survived the reload, so the branch picker showed **two** refs both badged "current". Git only ever has one current branch, so this is purely a client merge defect. With the fix, server truth always wins for a given branch name.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A — no UI change)
- [x] I included a video for animation/interaction changes (N/A)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line client cache merge behavior change with no auth or server impact; affects branch-picker display correctness only.
> 
> **Overview**
> Fixes incorrect **“current”** badges in the branch picker when a background reload merges a smaller fresh `listRefs` response with a larger paginated cache.
> 
> In `vcsRefState.ts`, the `preserveLoadedRefs` path now calls `mergeRefs(current.refs, result.refs)` instead of the reverse. **`mergeRefs`** gives the second list priority on name collisions, so server refs (including the single true `current` branch) overwrite stale cached entries while extra paginated refs that aren’t in the fresh page are still kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc41ec6ddfbd8db449c26629afa1ded293acacb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale `current` flags in branch list by preferring fresh refs over cached on reload
> When `preserveLoadedRefs` is true and the cached ref list is larger than the fresh result, `mergeRefs` in [vcsRefState.ts](https://github.com/pingdotgg/t3code/pull/2986/files#diff-a3e9bc4bff76abe030707826fa853e4e8b2584918800888e1d7127dc040e2a70) was called with cached refs taking priority over fresh ones. This caused stale `current: true` flags and duplicate 'current' badges for overlapping branch names. The merge argument order is swapped so fresh server refs always win for name collisions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fc41ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->