### PR TITLE
fix(vcs): reflect external git changes in status via .git watcher

### DIFF
--- a/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
@@ -417,4 +417,69 @@ describe("VcsStatusBroadcaster", () => {
       assert.isTrue(Option.isSome(yield* Deferred.poll(remoteInterrupted)));
     }).pipe(Effect.provide(testLayer));
   });
+
+  // `it.live`, not `it.effect`: this exercises a real `fs.watch` plus
+  // `Stream.debounce`, which need the live clock (TestClock would freeze them).
+  it.live(
+    "pushes a local status update when .git/HEAD changes on disk",
+    () => {
+      const state = {
+        currentLocalStatus: baseLocalStatus,
+        currentRemoteStatus: baseRemoteStatus,
+        localStatusCalls: 0,
+        remoteStatusCalls: 0,
+        localInvalidationCalls: 0,
+        remoteInvalidationCalls: 0,
+      };
+
+      return Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const repoDir = yield* fileSystem.makeTempDirectoryScoped({ prefix: "t3-vcs-watch-" });
+        const gitDir = path.join(repoDir, ".git");
+        yield* fileSystem.makeDirectory(gitDir, { recursive: true });
+        const headPath = path.join(gitDir, "HEAD");
+        yield* fileSystem.writeFileString(headPath, "ref: refs/heads/main\n");
+
+        const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+        const snapshot = yield* Deferred.make<VcsStatusStreamEvent>();
+        const localUpdated = yield* Deferred.make<VcsStatusStreamEvent>();
+        yield* Stream.runForEach(broadcaster.streamStatus({ cwd: repoDir }), (event) => {
+          if (event._tag === "snapshot") {
+            return Deferred.succeed(snapshot, event).pipe(Effect.ignore);
+          }
+          if (event._tag === "localUpdated") {
+            return Deferred.succeed(localUpdated, event).pipe(Effect.ignore);
+          }
+          return Effect.void;
+        }).pipe(Effect.forkScoped);
+
+        // Wait for the initial snapshot so the cached local status is the base ref
+        // before we change what the workflow will report on the next refresh.
+        yield* Deferred.await(snapshot);
+        state.currentLocalStatus = { ...baseLocalStatus, refName: "feature/switched-in-terminal" };
+
+        // Simulate an external `git switch` by rewriting HEAD. The watcher starts
+        // asynchronously, so rewrite on an interval (spaced past the debounce)
+        // until it observes a change — keeps the test deterministic, not racy.
+        yield* Effect.forkScoped(
+          Effect.gen(function* () {
+            let revision = 0;
+            while (true) {
+              revision += 1;
+              yield* fileSystem.writeFileString(headPath, `ref: refs/heads/branch-${revision}\n`);
+              yield* Effect.sleep(Duration.millis(250));
+            }
+          }),
+        );
+
+        const event = yield* Deferred.await(localUpdated);
+        assert.deepStrictEqual(event, {
+          _tag: "localUpdated",
+          local: state.currentLocalStatus,
+        } satisfies VcsStatusStreamEvent);
+      }).pipe(Effect.provide(makeTestLayer(state)));
+    },
+    20_000,
+  );
 });

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -5,6 +5,7 @@ import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as PubSub from "effect/PubSub";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
@@ -24,6 +25,9 @@ import { mergeGitStatusParts } from "@t3tools/shared/git";
 import * as GitWorkflowService from "../git/GitWorkflowService.ts";
 
 const DEFAULT_VCS_STATUS_REFRESH_INTERVAL = Duration.seconds(30);
+// Git writes several files per operation (HEAD, then logs, index, etc.); debounce
+// so one checkout triggers a single local-status refresh rather than a burst.
+const GIT_WATCH_DEBOUNCE = Duration.millis(150);
 const VCS_STATUS_REFRESH_FAILURE_BASE_DELAY = Duration.seconds(30);
 const VCS_STATUS_REFRESH_FAILURE_MAX_DELAY = Duration.minutes(15);
 
@@ -44,6 +48,8 @@ interface CachedVcsStatus {
 
 interface ActiveRemotePoller {
   readonly fiber: Fiber.Fiber<void, never>;
+  /** Watches `.git` (HEAD/packed-refs) so external checkouts refresh local status. */
+  readonly watchFiber: Fiber.Fiber<void, never>;
   readonly subscriberCount: number;
 }
 
@@ -99,6 +105,7 @@ export const layer = Layer.effect(
   Effect.gen(function* () {
     const workflow = yield* GitWorkflowService.GitWorkflowService;
     const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
     const changesPubSub = yield* Effect.acquireRelease(
       PubSub.unbounded<VcsStatusChange>(),
       (pubsub) => PubSub.shutdown(pubsub),
@@ -300,6 +307,44 @@ export const layer = Layer.effect(
       });
     };
 
+    // Resolve the directory that holds this checkout's `HEAD`, so we can watch it.
+    const resolveGitWatchDir = Effect.fn("VcsStatusBroadcaster.resolveGitWatchDir")(function* (
+      cwd: string,
+    ) {
+      const dotGit = path.join(cwd, ".git");
+      const type = yield* fs.stat(dotGit).pipe(
+        Effect.map((info) => info.type),
+        Effect.orElseSucceed(() => null),
+      );
+      // Standard repo: HEAD lives directly inside `<cwd>/.git`.
+      if (type === "Directory") return dotGit;
+      // Linked worktree: `.git` is a file `gitdir: <path>` and HEAD lives there.
+      if (type === "File") {
+        const content = yield* fs.readFileString(dotGit).pipe(Effect.orElseSucceed(() => ""));
+        const target = content.match(/^gitdir:\s*(.+?)\s*$/m)?.[1]?.trim();
+        if (!target) return null;
+        return path.isAbsolute(target) ? target : path.resolve(cwd, target);
+      }
+      return null;
+    });
+
+    // Push a fresh local status whenever HEAD/packed-refs change on disk — e.g. a
+    // `git switch`/`git checkout` run in a terminal outside the app. Without this
+    // the UI only reconciles on window refocus.
+    const makeLocalWatchLoop = (cwd: string) =>
+      Effect.gen(function* () {
+        const watchDir = yield* resolveGitWatchDir(cwd);
+        if (!watchDir) return;
+        yield* fs.watch(watchDir).pipe(
+          Stream.filter((event) => {
+            const base = path.basename(event.path);
+            return base === "HEAD" || base === "packed-refs";
+          }),
+          Stream.debounce(GIT_WATCH_DEBOUNCE),
+          Stream.runForEach(() => refreshLocalStatus(cwd).pipe(Effect.ignore)),
+        );
+      }).pipe(Effect.ignoreCause({ log: true }));
+
     const retainRemotePoller = Effect.fn("VcsStatusBroadcaster.retainRemotePoller")(function* (
       cwd: string,
       automaticRemoteRefreshInterval: Effect.Effect<Duration.Duration, never>,
@@ -315,12 +360,17 @@ export const layer = Layer.effect(
           return Effect.succeed([undefined, nextPollers] as const);
         }
 
-        return makeRemoteRefreshLoop(cwd, automaticRemoteRefreshInterval).pipe(
-          Effect.forkIn(broadcasterScope),
-          Effect.map((fiber) => {
+        return Effect.all([
+          makeRemoteRefreshLoop(cwd, automaticRemoteRefreshInterval).pipe(
+            Effect.forkIn(broadcasterScope),
+          ),
+          makeLocalWatchLoop(cwd).pipe(Effect.forkIn(broadcasterScope)),
+        ]).pipe(
+          Effect.map(([fiber, watchFiber]) => {
             const nextPollers = new Map(activePollers);
             nextPollers.set(cwd, {
               fiber,
+              watchFiber,
               subscriberCount: 1,
             });
             return [undefined, nextPollers] as const;
@@ -349,11 +399,14 @@ export const layer = Layer.effect(
 
         const nextPollers = new Map(activePollers);
         nextPollers.delete(cwd);
-        return [existing.fiber, nextPollers] as const;
+        return [existing, nextPollers] as const;
       });
 
       if (pollerToInterrupt) {
-        yield* Fiber.interrupt(pollerToInterrupt).pipe(Effect.ignore);
+        yield* Effect.all(
+          [Fiber.interrupt(pollerToInterrupt.fiber), Fiber.interrupt(pollerToInterrupt.watchFiber)],
+          { discard: true },
+        ).pipe(Effect.ignore);
       }
     });
 


### PR DESCRIPTION
## What Changed

Added a filesystem watcher on the checkout's git directory in `VcsStatusBroadcaster`. When `HEAD`/`packed-refs` change on disk, it pushes a fresh local status (debounced so one operation = one refresh). It resolves the worktree gitdir when `.git` is a file, and is ref-counted alongside the existing remote-status poller (torn down with the last subscriber). Includes an end-to-end test.

## Why

VCS status was only re-read on window `focus`/`visibilitychange` and after app-initiated git actions. So a branch switch or checkout done in a **terminal** (or another git client) wasn't reflected in the UI until the window regained focus. This is the root cause behind the stale-branch-list symptom in #2926 — the watcher resyncs automatically, so no manual refresh button is needed.

Related to #2926.

## UI Changes

No markup change — behavioral. Observable effect: after a terminal `git switch`, the branch toolbar/list updates on its own instead of only after refocusing the window.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (N/A — no visual change)
- [x] I included a video for animation/interaction changes (to attach)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh VCS local status when `.git` directory changes on disk
> - Adds a filesystem watcher on the repo's `.git` directory (or linked worktree gitdir) in [`VcsStatusBroadcaster`](https://github.com/pingdotgg/t3code/pull/2987/files#diff-1cb99aea20f9603d7de458a7b72df1f1f1dc7c4a0a3424be90cbbbca9ab6f952) that triggers `refreshLocalStatus` when `HEAD` or `packed-refs` change.
> - Debounces watch events by 150ms to coalesce rapid bursts (e.g. during a git checkout).
> - The watch fiber is started alongside the existing remote polling fiber on first subscriber and interrupted when subscriber count reaches zero.
> - Handles linked worktrees by reading the `.git` file to resolve the actual gitdir path.
> - Behavioral Change: `ActiveRemotePoller` now tracks two fibers; both are interrupted on teardown instead of only the remote polling fiber.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9cc0017.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

[vcs-status-live-update-external-git-switch.webm](https://github.com/user-attachments/assets/8d5e1e91-a713-4aad-8aad-bfce1a5ea468)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds long-lived `fs.watch` fibers tied to VCS status streaming lifecycle; incorrect gitdir resolution or watch teardown could miss updates or leak watchers, but scope is limited to local status refresh.
> 
> **Overview**
> **`VcsStatusBroadcaster`** now watches the checkout’s git metadata directory (`.git` or a linked worktree **`gitdir`**) and calls **`refreshLocalStatus`** when **`HEAD`** or **`packed-refs`** change on disk, so terminal **`git switch`** / checkout updates the UI without waiting for window focus.
> 
> Watch events are **debounced (150ms)** to collapse multi-file git writes into one refresh. The watch runs in a second fiber started with the existing remote poller on first **`streamStatus`** subscriber; **both fibers** are interrupted when the last subscriber disconnects.
> 
> Adds a live **`it.live`** test that rewrites **`.git/HEAD`** in a temp repo and asserts a **`localUpdated`** stream event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc001735c9d233c3483e1cb4fb973ff2eb94a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->