### PR TITLE
Feat/files panel

### DIFF
--- a/apps/server/src/workspace/Layers/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceEntries.ts
@@ -11,7 +11,11 @@ import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
 
-import { type FilesystemBrowseInput, type ProjectEntry } from "@t3tools/contracts";
+import {
+  type FilesystemBrowseInput,
+  type FilesystemListDirEntry,
+  type ProjectEntry,
+} from "@t3tools/contracts";
 import { isExplicitRelativePath, isWindowsAbsolutePath } from "@t3tools/shared/path";
 import {
   insertRankedSearchResult,
@@ -25,6 +29,7 @@ import {
   WorkspaceEntries,
   WorkspaceEntriesBrowseError,
   WorkspaceEntriesError,
+  WorkspaceEntriesListDirError,
   type WorkspaceEntriesShape,
 } from "../Services/WorkspaceEntries.ts";
 import { WorkspacePaths } from "../Services/WorkspacePaths.ts";
@@ -493,6 +498,104 @@ export const makeWorkspaceEntries = Effect.gen(function* () {
     },
   );
 
+  const listDir: WorkspaceEntriesShape["listDir"] = Effect.fn("WorkspaceEntries.listDir")(
+    function* (input) {
+      const workspaceRoot = yield* workspacePaths.normalizeWorkspaceRoot(input.cwd).pipe(
+        Effect.mapError(
+          (cause) =>
+            new WorkspaceEntriesListDirError({
+              cwd: input.cwd,
+              relativePath: input.relativePath,
+              operation: "workspaceEntries.listDir.normalizeWorkspaceRoot",
+              detail: cause.message,
+              cause,
+            }),
+        ),
+      );
+
+      const trimmedRelativePath = input.relativePath.trim();
+      const absoluteDir = trimmedRelativePath
+        ? path.resolve(workspaceRoot, trimmedRelativePath)
+        : workspaceRoot;
+
+      // Containment: reject paths that escape the workspace root, mirroring the
+      // WorkspacePaths.resolveRelativePathWithinRoot guard.
+      if (path.isAbsolute(trimmedRelativePath)) {
+        return yield* new WorkspaceEntriesListDirError({
+          cwd: input.cwd,
+          relativePath: input.relativePath,
+          operation: "workspaceEntries.listDir.containment",
+          detail: `Directory path must be relative to the project root: ${input.relativePath}`,
+        });
+      }
+      const relativeToRoot = toPosixPath(path.relative(workspaceRoot, absoluteDir));
+      if (
+        relativeToRoot === ".." ||
+        relativeToRoot.startsWith("../") ||
+        path.isAbsolute(relativeToRoot)
+      ) {
+        return yield* new WorkspaceEntriesListDirError({
+          cwd: input.cwd,
+          relativePath: input.relativePath,
+          operation: "workspaceEntries.listDir.containment",
+          detail: `Directory path must be relative to the project root: ${input.relativePath}`,
+        });
+      }
+
+      const dirents = yield* Effect.tryPromise({
+        try: () => fsPromises.readdir(absoluteDir, { withFileTypes: true }),
+        catch: (cause) =>
+          new WorkspaceEntriesListDirError({
+            cwd: input.cwd,
+            relativePath: input.relativePath,
+            operation: "workspaceEntries.listDir.readDirectory",
+            detail: `Unable to list '${absoluteDir}': ${cause instanceof Error ? cause.message : String(cause)}`,
+            cause,
+          }),
+      }).pipe(
+        // The user can deny macOS TCC prompts for the target dir (Documents,
+        // Downloads, Music, etc.); surface an empty listing instead of an
+        // error so the caller doesn't retry-loop the prompt.
+        Effect.catchIf(
+          (error) => {
+            const code = (error.cause as NodeJS.ErrnoException | undefined)?.code;
+            return code === "EACCES" || code === "EPERM";
+          },
+          () => Effect.succeed<Dirent[]>([]),
+        ),
+      );
+
+      const entries: FilesystemListDirEntry[] = [];
+      for (const dirent of dirents) {
+        if (!dirent.name || dirent.name === "." || dirent.name === "..") {
+          continue;
+        }
+        // Skip symlinks/sockets/etc. that aren't plain files or directories.
+        if (!dirent.isDirectory() && !dirent.isFile()) {
+          continue;
+        }
+        const relativePath = toPosixPath(
+          trimmedRelativePath ? path.join(trimmedRelativePath, dirent.name) : dirent.name,
+        );
+        entries.push({
+          name: dirent.name,
+          relativePath,
+          kind: dirent.isDirectory() ? "directory" : "file",
+        });
+      }
+
+      // Directories first, then files, each alphabetical.
+      entries.sort((left, right) => {
+        if (left.kind !== right.kind) {
+          return left.kind === "directory" ? -1 : 1;
+        }
+        return left.name.localeCompare(right.name);
+      });
+
+      return { entries };
+    },
+  );
+
   const search: WorkspaceEntriesShape["search"] = Effect.fn("WorkspaceEntries.search")(
     function* (input) {
       const normalizedCwd = yield* normalizeWorkspaceRoot(input.cwd);
@@ -530,6 +633,7 @@ export const makeWorkspaceEntries = Effect.gen(function* () {
 
   return {
     browse,
+    listDir,
     invalidate,
     search,
   } satisfies WorkspaceEntriesShape;

--- a/apps/server/src/workspace/Layers/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/Layers/WorkspaceFileSystem.ts
@@ -11,11 +11,64 @@ import {
 import { WorkspaceEntries } from "../Services/WorkspaceEntries.ts";
 import { WorkspacePaths } from "../Services/WorkspacePaths.ts";
 
+const MAX_READ_FILE_BYTES = 2 * 1024 * 1024;
+const BINARY_SNIFF_BYTES = 8192;
+
 export const makeWorkspaceFileSystem = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const workspacePaths = yield* WorkspacePaths;
   const workspaceEntries = yield* WorkspaceEntries;
+
+  const readFile: WorkspaceFileSystemShape["readFile"] = Effect.fn(
+    "WorkspaceFileSystem.readFile",
+  )(function* (input) {
+    const target = yield* workspacePaths.resolveRelativePathWithinRoot({
+      workspaceRoot: input.cwd,
+      relativePath: input.relativePath,
+    });
+
+    const stat = yield* fileSystem.stat(target.absolutePath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new WorkspaceFileSystemError({
+            cwd: input.cwd,
+            relativePath: input.relativePath,
+            operation: "workspaceFileSystem.readFile.stat",
+            detail: cause.message,
+            cause,
+          }),
+      ),
+    );
+
+    if (stat.size > BigInt(MAX_READ_FILE_BYTES)) {
+      return { content: "", truncated: false, tooLarge: true, binary: false };
+    }
+
+    const bytes = yield* fileSystem.readFile(target.absolutePath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new WorkspaceFileSystemError({
+            cwd: input.cwd,
+            relativePath: input.relativePath,
+            operation: "workspaceFileSystem.readFile.read",
+            detail: cause.message,
+            cause,
+          }),
+      ),
+    );
+
+    // Binary sniff: a NUL byte within the first chunk indicates non-text content.
+    const sniffLength = Math.min(bytes.length, BINARY_SNIFF_BYTES);
+    for (let index = 0; index < sniffLength; index += 1) {
+      if (bytes[index] === 0) {
+        return { content: "", truncated: false, tooLarge: false, binary: true };
+      }
+    }
+
+    const content = new TextDecoder("utf-8").decode(bytes);
+    return { content, truncated: false, tooLarge: false, binary: false };
+  });
 
   const writeFile: WorkspaceFileSystemShape["writeFile"] = Effect.fn(
     "WorkspaceFileSystem.writeFile",
@@ -52,7 +105,7 @@ export const makeWorkspaceFileSystem = Effect.gen(function* () {
     yield* workspaceEntries.invalidate(input.cwd);
     return { relativePath: target.relativePath };
   });
-  return { writeFile } satisfies WorkspaceFileSystemShape;
+  return { readFile, writeFile } satisfies WorkspaceFileSystemShape;
 });
 
 export const WorkspaceFileSystemLive = Layer.effect(WorkspaceFileSystem, makeWorkspaceFileSystem);

--- a/apps/server/src/workspace/Services/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/Services/WorkspaceEntries.ts
@@ -13,6 +13,8 @@ import type * as Effect from "effect/Effect";
 import type {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
+  FilesystemListDirInput,
+  FilesystemListDirResult,
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
 } from "@t3tools/contracts";
@@ -38,6 +40,17 @@ export class WorkspaceEntriesBrowseError extends Schema.TaggedErrorClass<Workspa
   },
 ) {}
 
+export class WorkspaceEntriesListDirError extends Schema.TaggedErrorClass<WorkspaceEntriesListDirError>()(
+  "WorkspaceEntriesListDirError",
+  {
+    cwd: Schema.String,
+    relativePath: Schema.String,
+    operation: Schema.String,
+    detail: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
 /**
  * WorkspaceEntriesShape - Service API for workspace entry search and cache
  * invalidation.
@@ -49,6 +62,14 @@ export interface WorkspaceEntriesShape {
   readonly browse: (
     input: FilesystemBrowseInput,
   ) => Effect.Effect<FilesystemBrowseResult, WorkspaceEntriesBrowseError>;
+
+  /**
+   * List the immediate files and directories within a workspace-root-relative
+   * directory.
+   */
+  readonly listDir: (
+    input: FilesystemListDirInput,
+  ) => Effect.Effect<FilesystemListDirResult, WorkspaceEntriesListDirError>;
 
   /**
    * Search indexed workspace entries for files and directories matching the

--- a/apps/server/src/workspace/Services/WorkspaceFileSystem.ts
+++ b/apps/server/src/workspace/Services/WorkspaceFileSystem.ts
@@ -10,7 +10,12 @@ import * as Schema from "effect/Schema";
 import * as Context from "effect/Context";
 import type * as Effect from "effect/Effect";
 
-import type { ProjectWriteFileInput, ProjectWriteFileResult } from "@t3tools/contracts";
+import type {
+  FilesystemReadFileInput,
+  FilesystemReadFileResult,
+  ProjectWriteFileInput,
+  ProjectWriteFileResult,
+} from "@t3tools/contracts";
 import { WorkspacePathOutsideRootError } from "./WorkspacePaths.ts";
 
 export class WorkspaceFileSystemError extends Schema.TaggedErrorClass<WorkspaceFileSystemError>()(
@@ -38,6 +43,20 @@ export interface WorkspaceFileSystemShape {
     input: ProjectWriteFileInput,
   ) => Effect.Effect<
     ProjectWriteFileResult,
+    WorkspaceFileSystemError | WorkspacePathOutsideRootError
+  >;
+
+  /**
+   * Read a file relative to the workspace root.
+   *
+   * Rejects paths that escape the workspace root, refuses to read files larger
+   * than the configured limit, and reports binary content instead of returning
+   * it.
+   */
+  readonly readFile: (
+    input: FilesystemReadFileInput,
+  ) => Effect.Effect<
+    FilesystemReadFileResult,
     WorkspaceFileSystemError | WorkspacePathOutsideRootError
   >;
 }

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -39,6 +39,8 @@ import {
   type RelayClientInstallProgressEvent,
   OrchestrationReplayEventsError,
   FilesystemBrowseError,
+  FilesystemListDirError,
+  FilesystemReadFileError,
   EnvironmentAuthorizationError,
   ThreadId,
   type TerminalAttachStreamEvent,
@@ -158,6 +160,8 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.projectsWriteFile, AuthOrchestrationOperateScope],
   [WS_METHODS.shellOpenInEditor, AuthOrchestrationOperateScope],
   [WS_METHODS.filesystemBrowse, AuthOrchestrationReadScope],
+  [WS_METHODS.filesystemListDir, AuthOrchestrationReadScope],
+  [WS_METHODS.filesystemReadFile, AuthOrchestrationReadScope],
   [WS_METHODS.subscribeVcsStatus, AuthOrchestrationReadScope],
   [WS_METHODS.vcsRefreshStatus, AuthOrchestrationReadScope],
   [WS_METHODS.vcsPull, AuthOrchestrationOperateScope],
@@ -1181,6 +1185,36 @@ const makeWsRpcLayer = (currentSession: AuthenticatedSession) =>
                     cause,
                   }),
               ),
+            ),
+            { "rpc.aggregate": "workspace" },
+          ),
+        [WS_METHODS.filesystemListDir]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.filesystemListDir,
+            workspaceEntries.listDir(input).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new FilesystemListDirError({
+                    message: cause.detail,
+                    cause,
+                  }),
+              ),
+            ),
+            { "rpc.aggregate": "workspace" },
+          ),
+        [WS_METHODS.filesystemReadFile]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.filesystemReadFile,
+            workspaceFileSystem.readFile(input).pipe(
+              Effect.mapError((cause) => {
+                const message = isWorkspacePathOutsideRootError(cause)
+                  ? "Workspace file path must stay within the project root."
+                  : cause.detail;
+                return new FilesystemReadFileError({
+                  message,
+                  cause,
+                });
+              }),
             ),
             { "rpc.aggregate": "workspace" },
           ),

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -1,4 +1,3 @@
-import { DiffsHighlighter, getSharedHighlighter, SupportedLanguages } from "@pierre/diffs";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import type { ServerProviderSkill } from "@t3tools/contracts";
 import React, {
@@ -26,6 +25,7 @@ import { stackedThreadToast, toastManager } from "./ui/toast";
 import { openInPreferredEditor } from "../editorPreferences";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
 import { fnv1a32 } from "../lib/diffRendering";
+import { getHighlighterPromise } from "../lib/codeHighlighter";
 import { LRUCache } from "../lib/lruCache";
 import { useTheme } from "../hooks/useTheme";
 import {
@@ -73,8 +73,6 @@ const highlightedCodeCache = new LRUCache<string>(
   MAX_HIGHLIGHT_CACHE_ENTRIES,
   MAX_HIGHLIGHT_CACHE_MEMORY_BYTES,
 );
-const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
-
 function extractFenceLanguage(className: string | undefined): string {
   const match = className?.match(CODE_FENCE_LANGUAGE_REGEX);
   const raw = match?.[1] ?? "text";
@@ -123,27 +121,6 @@ function createHighlightCacheKey(code: string, language: string, themeName: Diff
 
 function estimateHighlightedSize(html: string, code: string): number {
   return Math.max(html.length * 2, code.length * 3);
-}
-
-function getHighlighterPromise(language: string): Promise<DiffsHighlighter> {
-  const cached = highlighterPromiseCache.get(language);
-  if (cached) return cached;
-
-  const promise = getSharedHighlighter({
-    themes: [resolveDiffThemeName("dark"), resolveDiffThemeName("light")],
-    langs: [language as SupportedLanguages],
-    preferredHighlighter: "shiki-js",
-  }).catch((err) => {
-    highlighterPromiseCache.delete(language);
-    if (language === "text") {
-      // "text" itself failed — Shiki cannot initialize at all, surface the error
-      throw err;
-    }
-    // Language not supported by Shiki — fall back to "text"
-    return getHighlighterPromise("text");
-  });
-  highlighterPromiseCache.set(language, promise);
-  return promise;
 }
 
 function MarkdownCodeBlock({ code, children }: { code: string; children: ReactNode }) {

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -248,6 +248,8 @@ function createMockEnvironmentApi(input: {
     projects: {} as EnvironmentApi["projects"],
     filesystem: {
       browse: input.browse,
+      listDir: vi.fn() as unknown as EnvironmentApi["filesystem"]["listDir"],
+      readFile: vi.fn() as unknown as EnvironmentApi["filesystem"]["readFile"],
     },
     sourceControl: {} as EnvironmentApi["sourceControl"],
     vcs: {} as EnvironmentApi["vcs"],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -45,6 +45,7 @@ import { readEnvironmentApi } from "../environmentApi";
 import { isElectron } from "../env";
 import { readLocalApi } from "../localApi";
 import { parseDiffRouteSearch, stripDiffSearchParams } from "../diffRouteSearch";
+import { parseFilesRouteSearch, stripFilesSearchParams } from "../filesRouteSearch";
 import {
   collapseExpandedComposerCursor,
   parseStandaloneComposerSlashCommand,
@@ -803,6 +804,10 @@ export default function ChatView(props: ChatViewProps) {
     strict: false,
     select: (params) => parseDiffRouteSearch(params),
   });
+  const filesSearch = useSearch({
+    strict: false,
+    select: (params) => parseFilesRouteSearch(params),
+  });
   const { resolvedTheme } = useTheme();
   // Granular store selectors — avoid subscribing to prompt changes.
   const composerRuntimeMode = useComposerDraftStore(
@@ -968,6 +973,7 @@ export default function ChatView(props: ChatViewProps) {
   const isLocalDraftThread = !isServerThread && localDraftThread !== undefined;
   const canCheckoutPullRequestIntoThread = isLocalDraftThread;
   const diffOpen = rawSearch.diff === "1";
+  const filesOpen = filesSearch.files === "1";
   const activeThreadId = activeThread?.id ?? null;
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: activeThread?.environmentId ?? null,
@@ -1916,11 +1922,30 @@ export default function ChatView(props: ChatViewProps) {
       },
       replace: true,
       search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
+        // Opening Diff closes Files (they share the one docked right surface).
+        const rest = stripFilesSearchParams(stripDiffSearchParams(previous));
         return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
       },
     });
   }, [diffOpen, environmentId, isServerThread, navigate, onDiffPanelOpen, threadId]);
+  const onToggleFiles = useCallback(() => {
+    if (!isServerThread) {
+      return;
+    }
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: {
+        environmentId,
+        threadId,
+      },
+      replace: true,
+      search: (previous) => {
+        // Opening Files closes Diff (they share the one docked right surface).
+        const rest = stripFilesSearchParams(stripDiffSearchParams(previous));
+        return filesOpen ? { ...rest, files: undefined } : { ...rest, files: "1" };
+      },
+    });
+  }, [environmentId, filesOpen, isServerThread, navigate, threadId]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -3755,12 +3780,14 @@ export default function ChatView(props: ChatViewProps) {
           diffToggleShortcutLabel={diffPanelShortcutLabel}
           gitCwd={gitCwd}
           diffOpen={diffOpen}
+          filesOpen={filesOpen}
           onRunProjectScript={runProjectScript}
           onAddProjectScript={saveProjectScript}
           onUpdateProjectScript={updateProjectScript}
           onDeleteProjectScript={deleteProjectScript}
           onToggleTerminal={toggleTerminalVisibility}
           onToggleDiff={onToggleDiff}
+          onToggleFiles={onToggleFiles}
         />
       </header>
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -973,7 +973,20 @@ export default function ChatView(props: ChatViewProps) {
   const isLocalDraftThread = !isServerThread && localDraftThread !== undefined;
   const canCheckoutPullRequestIntoThread = isLocalDraftThread;
   const diffOpen = rawSearch.diff === "1";
-  const filesOpen = filesSearch.files === "1";
+  // Diff and Files share the one docked right surface; never treat both as open.
+  // Diff takes precedence as a backstop if both params ever coexist.
+  const filesOpen = filesSearch.files === "1" && !diffOpen;
+  const rightPanelOpen = diffOpen || filesOpen;
+  // A single header button opens/closes the docked surface; remember which view
+  // it was last showing so reopening returns to the same one.
+  const [lastRightPanelMode, setLastRightPanelMode] = useState<"diff" | "files">("diff");
+  useEffect(() => {
+    if (diffOpen) {
+      setLastRightPanelMode("diff");
+    } else if (filesOpen) {
+      setLastRightPanelMode("files");
+    }
+  }, [diffOpen, filesOpen]);
   const activeThreadId = activeThread?.id ?? null;
   const runningTerminalIds = useThreadRunningTerminalIds({
     environmentId: activeThread?.environmentId ?? null,
@@ -1923,8 +1936,12 @@ export default function ChatView(props: ChatViewProps) {
       replace: true,
       search: (previous) => {
         // Opening Diff closes Files (they share the one docked right surface).
+        // `files: undefined` is explicit so retainSearchParams clears it rather
+        // than re-injecting its prior value.
         const rest = stripFilesSearchParams(stripDiffSearchParams(previous));
-        return diffOpen ? { ...rest, diff: undefined } : { ...rest, diff: "1" };
+        return diffOpen
+          ? { ...rest, diff: undefined, files: undefined }
+          : { ...rest, diff: "1", files: undefined };
       },
     });
   }, [diffOpen, environmentId, isServerThread, navigate, onDiffPanelOpen, threadId]);
@@ -1941,11 +1958,34 @@ export default function ChatView(props: ChatViewProps) {
       replace: true,
       search: (previous) => {
         // Opening Files closes Diff (they share the one docked right surface).
+        // `diff: undefined` is explicit so retainSearchParams clears it rather
+        // than re-injecting its prior value.
         const rest = stripFilesSearchParams(stripDiffSearchParams(previous));
-        return filesOpen ? { ...rest, files: undefined } : { ...rest, files: "1" };
+        return filesOpen
+          ? { ...rest, files: undefined, diff: undefined }
+          : { ...rest, files: "1", diff: undefined };
       },
     });
   }, [environmentId, filesOpen, isServerThread, navigate, threadId]);
+  // Single open/close control for the docked right surface. Closing closes
+  // whichever view is open; opening restores the last view (falling back to
+  // Files when Diff is unavailable). In-panel tabs switch between the two.
+  const onToggleRightPanel = useCallback(() => {
+    if (diffOpen) {
+      onToggleDiff();
+      return;
+    }
+    if (filesOpen) {
+      onToggleFiles();
+      return;
+    }
+    const mode = lastRightPanelMode === "diff" && !isGitRepo ? "files" : lastRightPanelMode;
+    if (mode === "diff") {
+      onToggleDiff();
+    } else {
+      onToggleFiles();
+    }
+  }, [diffOpen, filesOpen, isGitRepo, lastRightPanelMode, onToggleDiff, onToggleFiles]);
 
   const envLocked = Boolean(
     activeThread &&
@@ -2762,7 +2802,7 @@ export default function ChatView(props: ChatViewProps) {
       if (command === "diff.toggle") {
         event.preventDefault();
         event.stopPropagation();
-        onToggleDiff();
+        onToggleRightPanel();
         return;
       }
 
@@ -2794,7 +2834,7 @@ export default function ChatView(props: ChatViewProps) {
     runProjectScript,
     splitTerminal,
     keybindings,
-    onToggleDiff,
+    onToggleRightPanel,
     toggleTerminalVisibility,
   ]);
 
@@ -3717,10 +3757,12 @@ export default function ChatView(props: ChatViewProps) {
           threadId,
         },
         search: (previous) => {
-          const rest = stripDiffSearchParams(previous);
+          // Opening Diff closes Files (they share the one docked right surface).
+          // `files: undefined` is explicit so retainSearchParams clears it.
+          const rest = stripFilesSearchParams(stripDiffSearchParams(previous));
           return filePath
-            ? { ...rest, diff: "1", diffTurnId: turnId, diffFilePath: filePath }
-            : { ...rest, diff: "1", diffTurnId: turnId };
+            ? { ...rest, diff: "1", diffTurnId: turnId, diffFilePath: filePath, files: undefined }
+            : { ...rest, diff: "1", diffTurnId: turnId, files: undefined };
         },
       });
     },
@@ -3777,17 +3819,15 @@ export default function ChatView(props: ChatViewProps) {
           terminalAvailable={activeProject !== undefined}
           terminalOpen={terminalUiState.terminalOpen}
           terminalToggleShortcutLabel={terminalToggleShortcutLabel}
-          diffToggleShortcutLabel={diffPanelShortcutLabel}
+          rightPanelToggleShortcutLabel={diffPanelShortcutLabel}
           gitCwd={gitCwd}
-          diffOpen={diffOpen}
-          filesOpen={filesOpen}
+          rightPanelOpen={rightPanelOpen}
           onRunProjectScript={runProjectScript}
           onAddProjectScript={saveProjectScript}
           onUpdateProjectScript={updateProjectScript}
           onDeleteProjectScript={deleteProjectScript}
           onToggleTerminal={toggleTerminalVisibility}
-          onToggleDiff={onToggleDiff}
-          onToggleFiles={onToggleFiles}
+          onToggleRightPanel={onToggleRightPanel}
         />
       </header>
 

--- a/apps/web/src/components/DiffPanel.tsx
+++ b/apps/web/src/components/DiffPanel.tsx
@@ -41,6 +41,7 @@ import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { useSettings } from "../hooks/useSettings";
 import { formatShortTimestamp } from "../timestampFormat";
 import { DiffPanelLoadingState, DiffPanelShell, type DiffPanelMode } from "./DiffPanelShell";
+import { RightPanelModeTabs } from "./RightPanelModeTabs";
 import { ToggleGroup, Toggle } from "./ui/toggle-group";
 
 type DiffRenderMode = "stacked" | "split";
@@ -401,6 +402,7 @@ export default function DiffPanel({ mode = "inline" }: DiffPanelProps) {
 
   const headerRow = (
     <>
+      <RightPanelModeTabs />
       <div className="relative min-w-0 flex-1 [-webkit-app-region:no-drag]">
         <button
           type="button"

--- a/apps/web/src/components/FilesPanel.tsx
+++ b/apps/web/src/components/FilesPanel.tsx
@@ -1,0 +1,181 @@
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { useCallback, useMemo, useRef, useState } from "react";
+
+import { type DiffPanelMode, DiffPanelShell } from "./DiffPanelShell";
+import { FileTree } from "./files/FileTree";
+import { FileViewer } from "./files/FileViewer";
+import { parseFilesRouteSearch, stripFilesSearchParams } from "../filesRouteSearch";
+import { useTheme } from "../hooks/useTheme";
+import { selectProjectByRef, useStore } from "../store";
+import { createThreadSelectorByRef } from "../storeSelectors";
+import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
+import { scopeThreadRef } from "@t3tools/client-runtime";
+import { cn } from "~/lib/utils";
+
+function FileTreePlaceholder(props: { label: string }) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-4 text-center">
+      <p className="font-mono text-[11px] text-muted-foreground/70">{props.label}</p>
+    </div>
+  );
+}
+
+const FILES_TREE_WIDTH_STORAGE_KEY = "chat_files_tree_width";
+const MIN_TREE_WIDTH = 160;
+const MAX_TREE_WIDTH = 560;
+const DEFAULT_TREE_WIDTH = 224;
+
+function clampTreeWidth(value: number): number {
+  return Math.min(MAX_TREE_WIDTH, Math.max(MIN_TREE_WIDTH, value));
+}
+
+function readStoredTreeWidth(): number {
+  if (typeof window === "undefined") {
+    return DEFAULT_TREE_WIDTH;
+  }
+  const raw = window.localStorage.getItem(FILES_TREE_WIDTH_STORAGE_KEY);
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isNaN(parsed) ? DEFAULT_TREE_WIDTH : clampTreeWidth(parsed);
+}
+
+export default function FilesPanel(props: { mode: DiffPanelMode }) {
+  const { mode } = props;
+  const navigate = useNavigate();
+  const { resolvedTheme } = useTheme();
+
+  const routeThreadRef = useParams({
+    strict: false,
+    select: (params) => resolveThreadRouteRef(params),
+  });
+  const filesSearch = useSearch({
+    strict: false,
+    select: (search) => parseFilesRouteSearch(search),
+  });
+  const selectedPath = filesSearch.filesPath ?? null;
+
+  const activeThread = useStore(
+    useMemo(() => createThreadSelectorByRef(routeThreadRef), [routeThreadRef]),
+  );
+  const activeProjectId = activeThread?.projectId ?? null;
+  const activeProject = useStore((store) =>
+    activeThread && activeProjectId
+      ? selectProjectByRef(store, {
+          environmentId: activeThread.environmentId,
+          projectId: activeProjectId,
+        })
+      : undefined,
+  );
+  const environmentId = activeThread?.environmentId ?? null;
+  const cwd = activeThread?.worktreePath ?? activeProject?.cwd ?? null;
+
+  const onSelectFile = useCallback(
+    (relativePath: string) => {
+      if (!activeThread) {
+        return;
+      }
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: buildThreadRouteParams(
+          scopeThreadRef(activeThread.environmentId, activeThread.id),
+        ),
+        replace: true,
+        search: (previous) => {
+          const rest = stripFilesSearchParams(previous);
+          return { ...rest, files: "1", filesPath: relativePath };
+        },
+      });
+    },
+    [activeThread, navigate],
+  );
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [treeWidth, setTreeWidth] = useState(readStoredTreeWidth);
+  const treeWidthRef = useRef(treeWidth);
+
+  const onResizeStart = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    event.preventDefault();
+    const onMove = (moveEvent: PointerEvent) => {
+      const rect = container.getBoundingClientRect();
+      // Tree sits on the right edge, so its width grows as the pointer moves left.
+      const next = clampTreeWidth(rect.right - moveEvent.clientX);
+      treeWidthRef.current = next;
+      setTreeWidth(next);
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      window.localStorage.setItem(FILES_TREE_WIDTH_STORAGE_KEY, String(treeWidthRef.current));
+    };
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, []);
+
+  const isSheet = mode === "sheet";
+
+  const header = (
+    <div className="flex min-w-0 flex-1 items-center gap-2">
+      <span className="shrink-0 text-sm font-medium text-foreground">Files</span>
+      {selectedPath ? (
+        <span className="truncate font-mono text-[11px] text-muted-foreground/80">
+          {selectedPath}
+        </span>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <DiffPanelShell mode={mode} header={header}>
+      <div ref={containerRef} className="flex min-h-0 flex-1">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
+          {environmentId && cwd ? (
+            <FileViewer
+              environmentId={environmentId}
+              cwd={cwd}
+              relativePath={selectedPath}
+              theme={resolvedTheme}
+            />
+          ) : null}
+        </div>
+        {isSheet ? null : (
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize file tree"
+            onPointerDown={onResizeStart}
+            className="relative w-px shrink-0 cursor-col-resize bg-border transition-colors hover:bg-primary/50"
+          >
+            {/* Widen the hit area without shifting the visible 1px line. */}
+            <div className="absolute inset-y-0 -left-1.5 -right-1.5" />
+          </div>
+        )}
+        <div
+          className={cn(
+            "flex min-h-0 shrink-0 flex-col overflow-y-auto border-l border-border bg-card/30",
+            isSheet && "w-40",
+          )}
+          style={isSheet ? undefined : { width: treeWidth }}
+        >
+          {environmentId && cwd ? (
+            <FileTree
+              environmentId={environmentId}
+              cwd={cwd}
+              theme={resolvedTheme}
+              selectedPath={selectedPath}
+              onSelectFile={onSelectFile}
+            />
+          ) : (
+            <FileTreePlaceholder label="No project files available." />
+          )}
+        </div>
+      </div>
+    </DiffPanelShell>
+  );
+}

--- a/apps/web/src/components/FilesPanel.tsx
+++ b/apps/web/src/components/FilesPanel.tsx
@@ -2,6 +2,7 @@ import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef, useState } from "react";
 
 import { type DiffPanelMode, DiffPanelShell } from "./DiffPanelShell";
+import { RightPanelModeTabs } from "./RightPanelModeTabs";
 import { FileTree } from "./files/FileTree";
 import { FileViewer } from "./files/FileViewer";
 import { parseFilesRouteSearch, stripFilesSearchParams } from "../filesRouteSearch";
@@ -68,9 +69,20 @@ export default function FilesPanel(props: { mode: DiffPanelMode }) {
   const environmentId = activeThread?.environmentId ?? null;
   const cwd = activeThread?.worktreePath ?? activeProject?.cwd ?? null;
 
+  const hasUnsavedEditsRef = useRef(false);
+  const handleDirtyChange = useCallback((dirty: boolean) => {
+    hasUnsavedEditsRef.current = dirty;
+  }, []);
+
   const onSelectFile = useCallback(
     (relativePath: string) => {
       if (!activeThread) {
+        return;
+      }
+      if (
+        hasUnsavedEditsRef.current &&
+        !window.confirm("Discard unsaved changes to the current file?")
+      ) {
         return;
       }
       void navigate({
@@ -122,7 +134,7 @@ export default function FilesPanel(props: { mode: DiffPanelMode }) {
 
   const header = (
     <div className="flex min-w-0 flex-1 items-center gap-2">
-      <span className="shrink-0 text-sm font-medium text-foreground">Files</span>
+      <RightPanelModeTabs />
       {selectedPath ? (
         <span className="truncate font-mono text-[11px] text-muted-foreground/80">
           {selectedPath}
@@ -141,6 +153,7 @@ export default function FilesPanel(props: { mode: DiffPanelMode }) {
               cwd={cwd}
               relativePath={selectedPath}
               theme={resolvedTheme}
+              onDirtyChange={handleDirtyChange}
             />
           ) : null}
         </div>

--- a/apps/web/src/components/RightPanelModeTabs.tsx
+++ b/apps/web/src/components/RightPanelModeTabs.tsx
@@ -1,0 +1,92 @@
+import { useNavigate, useParams, useSearch } from "@tanstack/react-router";
+import { DiffIcon, FolderTreeIcon } from "lucide-react";
+import { useCallback } from "react";
+
+import { stripDiffSearchParams } from "../diffRouteSearch";
+import { stripFilesSearchParams } from "../filesRouteSearch";
+import { cn } from "~/lib/utils";
+
+type RightPanelMode = "diff" | "files";
+
+// In-panel [Diff | Files] switch. Self-contained: it reads the active mode from
+// the route search and navigates to switch the docked right surface between the
+// diff and files views without closing it. Rendered in both panel headers.
+export function RightPanelModeTabs() {
+  const navigate = useNavigate();
+  const { environmentId, threadId } = useParams({
+    strict: false,
+    select: (params) => ({
+      environmentId: params.environmentId,
+      threadId: params.threadId,
+    }),
+  });
+  const activeMode = useSearch({
+    strict: false,
+    select: (search): RightPanelMode => (search.files === "1" && search.diff !== "1" ? "files" : "diff"),
+  });
+
+  const selectMode = useCallback(
+    (mode: RightPanelMode) => {
+      if (mode === activeMode || !environmentId || !threadId) {
+        return;
+      }
+      void navigate({
+        to: "/$environmentId/$threadId",
+        params: { environmentId, threadId },
+        replace: true,
+        search: (previous) => {
+          // The two views share the one docked surface, so set one and clear the
+          // other. The counterpart must be set to `undefined` (not just omitted):
+          // retainSearchParams(["diff","files"]) re-injects an omitted key's prior
+          // value, which would leave both set and snap the view back.
+          const rest = stripFilesSearchParams(stripDiffSearchParams(previous));
+          return mode === "diff"
+            ? { ...rest, diff: "1", files: undefined }
+            : { ...rest, files: "1", diff: undefined };
+        },
+      });
+    },
+    [activeMode, environmentId, navigate, threadId],
+  );
+
+  return (
+    <div className="flex shrink-0 items-center gap-0.5 rounded-md border border-border/70 p-0.5 [-webkit-app-region:no-drag]">
+      <ModeTabButton
+        active={activeMode === "diff"}
+        label="Diff"
+        icon={<DiffIcon className="size-3" />}
+        onClick={() => selectMode("diff")}
+      />
+      <ModeTabButton
+        active={activeMode === "files"}
+        label="Files"
+        icon={<FolderTreeIcon className="size-3" />}
+        onClick={() => selectMode("files")}
+      />
+    </div>
+  );
+}
+
+function ModeTabButton(props: {
+  active: boolean;
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={props.onClick}
+      aria-pressed={props.active}
+      className={cn(
+        "flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium transition-colors",
+        props.active
+          ? "bg-accent text-foreground"
+          : "text-muted-foreground hover:bg-accent/60 hover:text-foreground",
+      )}
+    >
+      {props.icon}
+      <span>{props.label}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -89,6 +89,7 @@ import {
   type LucideIcon,
   LockIcon,
   LockOpenIcon,
+  PaperclipIcon,
   PenLineIcon,
   XIcon,
 } from "lucide-react";
@@ -816,6 +817,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const mobileComposerExpandReleaseFrameRef = useRef<number | null>(null);
   const mobileComposerExpandInFlightRef = useRef(false);
   const dragDepthRef = useRef(0);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // ------------------------------------------------------------------
   // Derived: composer send state
@@ -1772,6 +1774,22 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     addComposerImages(files);
     focusComposer();
   };
+
+  const openComposerFilePicker = () => {
+    fileInputRef.current?.click();
+  };
+
+  const onComposerFileInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? []);
+    // Reset the input so selecting the same file again still fires onChange.
+    event.target.value = "";
+    if (files.length === 0) {
+      return;
+    }
+    addComposerImages(files);
+    focusComposer();
+  };
+
   const handleInterruptPrimaryAction = useCallback(() => {
     void onInterrupt();
   }, [onInterrupt]);
@@ -1939,6 +1957,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       className="mx-auto w-full min-w-0 max-w-208"
       data-chat-composer-form="true"
     >
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        tabIndex={-1}
+        aria-hidden="true"
+        onChange={onComposerFileInputChange}
+      />
       <div
         className={cn(
           "group rounded-[22px] p-px transition-colors duration-200",
@@ -2330,6 +2358,20 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                   }}
                   onInstanceModelChange={onProviderModelSelect}
                 />
+
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size={isComposerFooterCompact ? "icon-sm" : "sm"}
+                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                  disabled={isComposerApprovalState || pendingUserInputs.length > 0}
+                  onPointerDown={(event) => event.preventDefault()}
+                  onClick={openComposerFilePicker}
+                  aria-label="Attach images"
+                >
+                  <PaperclipIcon className={isComposerFooterCompact ? undefined : "size-4"} />
+                  {isComposerFooterCompact ? null : <span>Attach</span>}
+                </Button>
 
                 {isComposerFooterCompact ? (
                   <CompactComposerControlsMenu

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -9,7 +9,7 @@ import { scopeThreadRef } from "@t3tools/client-runtime";
 import { memo } from "react";
 import GitActionsControl from "../GitActionsControl";
 import { type DraftId } from "~/composerDraftStore";
-import { DiffIcon, TerminalSquareIcon } from "lucide-react";
+import { DiffIcon, FolderTreeIcon, TerminalSquareIcon } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
@@ -36,12 +36,14 @@ interface ChatHeaderProps {
   diffToggleShortcutLabel: string | null;
   gitCwd: string | null;
   diffOpen: boolean;
+  filesOpen: boolean;
   onRunProjectScript: (script: ProjectScript) => void;
   onAddProjectScript: (input: NewProjectScriptInput) => Promise<void>;
   onUpdateProjectScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void>;
   onDeleteProjectScript: (scriptId: string) => Promise<void>;
   onToggleTerminal: () => void;
   onToggleDiff: () => void;
+  onToggleFiles: () => void;
 }
 
 export function shouldShowOpenInPicker(input: {
@@ -74,12 +76,14 @@ export const ChatHeader = memo(function ChatHeader({
   diffToggleShortcutLabel,
   gitCwd,
   diffOpen,
+  filesOpen,
   onRunProjectScript,
   onAddProjectScript,
   onUpdateProjectScript,
   onDeleteProjectScript,
   onToggleTerminal,
   onToggleDiff,
+  onToggleFiles,
 }: ChatHeaderProps) {
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const showOpenInPicker = shouldShowOpenInPicker({
@@ -185,6 +189,23 @@ export const ChatHeader = memo(function ChatHeader({
                 ? `Toggle diff panel (${diffToggleShortcutLabel})`
                 : "Toggle diff panel"}
           </TooltipPopup>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <Toggle
+                className="shrink-0"
+                pressed={filesOpen}
+                onPressedChange={onToggleFiles}
+                aria-label="Toggle files panel"
+                variant="outline"
+                size="xs"
+              >
+                <FolderTreeIcon className="size-3" />
+              </Toggle>
+            }
+          />
+          <TooltipPopup side="bottom">Toggle files panel</TooltipPopup>
         </Tooltip>
       </div>
     </div>

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -9,7 +9,7 @@ import { scopeThreadRef } from "@t3tools/client-runtime";
 import { memo } from "react";
 import GitActionsControl from "../GitActionsControl";
 import { type DraftId } from "~/composerDraftStore";
-import { DiffIcon, FolderTreeIcon, TerminalSquareIcon } from "lucide-react";
+import { PanelRightIcon, TerminalSquareIcon } from "lucide-react";
 import { Badge } from "../ui/badge";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import ProjectScriptsControl, { type NewProjectScriptInput } from "../ProjectScriptsControl";
@@ -33,17 +33,15 @@ interface ChatHeaderProps {
   terminalAvailable: boolean;
   terminalOpen: boolean;
   terminalToggleShortcutLabel: string | null;
-  diffToggleShortcutLabel: string | null;
+  rightPanelToggleShortcutLabel: string | null;
   gitCwd: string | null;
-  diffOpen: boolean;
-  filesOpen: boolean;
+  rightPanelOpen: boolean;
   onRunProjectScript: (script: ProjectScript) => void;
   onAddProjectScript: (input: NewProjectScriptInput) => Promise<void>;
   onUpdateProjectScript: (scriptId: string, input: NewProjectScriptInput) => Promise<void>;
   onDeleteProjectScript: (scriptId: string) => Promise<void>;
   onToggleTerminal: () => void;
-  onToggleDiff: () => void;
-  onToggleFiles: () => void;
+  onToggleRightPanel: () => void;
 }
 
 export function shouldShowOpenInPicker(input: {
@@ -73,17 +71,15 @@ export const ChatHeader = memo(function ChatHeader({
   terminalAvailable,
   terminalOpen,
   terminalToggleShortcutLabel,
-  diffToggleShortcutLabel,
+  rightPanelToggleShortcutLabel,
   gitCwd,
-  diffOpen,
-  filesOpen,
+  rightPanelOpen,
   onRunProjectScript,
   onAddProjectScript,
   onUpdateProjectScript,
   onDeleteProjectScript,
   onToggleTerminal,
-  onToggleDiff,
-  onToggleFiles,
+  onToggleRightPanel,
 }: ChatHeaderProps) {
   const primaryEnvironmentId = usePrimaryEnvironmentId();
   const showOpenInPicker = shouldShowOpenInPicker({
@@ -171,41 +167,21 @@ export const ChatHeader = memo(function ChatHeader({
             render={
               <Toggle
                 className="shrink-0"
-                pressed={diffOpen}
-                onPressedChange={onToggleDiff}
-                aria-label="Toggle diff panel"
+                pressed={rightPanelOpen}
+                onPressedChange={onToggleRightPanel}
+                aria-label={rightPanelOpen ? "Hide side panel" : "Show side panel"}
                 variant="outline"
                 size="xs"
-                disabled={!isGitRepo && !diffOpen}
               >
-                <DiffIcon className="size-3" />
+                <PanelRightIcon className="size-3" />
               </Toggle>
             }
           />
           <TooltipPopup side="bottom">
-            {!isGitRepo && !diffOpen
-              ? "Diff panel is unavailable because this project is not a git repository."
-              : diffToggleShortcutLabel
-                ? `Toggle diff panel (${diffToggleShortcutLabel})`
-                : "Toggle diff panel"}
+            {rightPanelToggleShortcutLabel
+              ? `${rightPanelOpen ? "Hide" : "Show"} side panel (${rightPanelToggleShortcutLabel})`
+              : `${rightPanelOpen ? "Hide" : "Show"} side panel`}
           </TooltipPopup>
-        </Tooltip>
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Toggle
-                className="shrink-0"
-                pressed={filesOpen}
-                onPressedChange={onToggleFiles}
-                aria-label="Toggle files panel"
-                variant="outline"
-                size="xs"
-              >
-                <FolderTreeIcon className="size-3" />
-              </Toggle>
-            }
-          />
-          <TooltipPopup side="bottom">Toggle files panel</TooltipPopup>
         </Tooltip>
       </div>
     </div>

--- a/apps/web/src/components/files/FileTree.tsx
+++ b/apps/web/src/components/files/FileTree.tsx
@@ -1,0 +1,221 @@
+import { type EnvironmentId, type FilesystemListDirEntry } from "@t3tools/contracts";
+import { useQuery } from "@tanstack/react-query";
+import { ChevronRightIcon, FolderClosedIcon, FolderIcon, Loader2Icon } from "lucide-react";
+import { memo, useCallback, useState } from "react";
+
+import { readEnvironmentApi } from "../../environmentApi";
+import { cn } from "~/lib/utils";
+import { VscodeEntryIcon } from "../chat/VscodeEntryIcon";
+
+const FILE_TREE_STALE_TIME_MS = 30_000;
+
+function useListDirQuery(input: {
+  environmentId: EnvironmentId;
+  cwd: string;
+  relativePath: string;
+  enabled: boolean;
+}) {
+  const { environmentId, cwd, relativePath, enabled } = input;
+  return useQuery({
+    queryKey: ["filesystemListDir", environmentId, cwd, relativePath],
+    queryFn: async (): Promise<ReadonlyArray<FilesystemListDirEntry>> => {
+      const api = readEnvironmentApi(environmentId);
+      if (!api) {
+        return [];
+      }
+      const result = await api.filesystem.listDir({ cwd, relativePath });
+      return result.entries;
+    },
+    staleTime: FILE_TREE_STALE_TIME_MS,
+    enabled,
+  });
+}
+
+const TreeRowSpinner = memo(function TreeRowSpinner(props: { depth: number }) {
+  return (
+    <div
+      className="flex items-center gap-1.5 py-1 pr-2 text-muted-foreground/70"
+      style={{ paddingLeft: `${8 + props.depth * 14}px` }}
+    >
+      <span aria-hidden="true" className="size-3.5 shrink-0" />
+      <Loader2Icon className="size-3.5 shrink-0 animate-spin" />
+      <span className="font-mono text-[11px]">Loading…</span>
+    </div>
+  );
+});
+
+const TreeRowEmpty = memo(function TreeRowEmpty(props: { depth: number; label: string }) {
+  return (
+    <div
+      className="flex items-center gap-1.5 py-1 pr-2 font-mono text-[11px] text-muted-foreground/60"
+      style={{ paddingLeft: `${8 + props.depth * 14}px` }}
+    >
+      <span aria-hidden="true" className="size-3.5 shrink-0" />
+      {props.label}
+    </div>
+  );
+});
+
+const DirectoryNode = memo(function DirectoryNode(props: {
+  environmentId: EnvironmentId;
+  cwd: string;
+  entry: FilesystemListDirEntry;
+  depth: number;
+  theme: "light" | "dark";
+  selectedPath: string | null;
+  onSelectFile: (relativePath: string) => void;
+}) {
+  const { cwd, depth, entry, environmentId, onSelectFile, selectedPath, theme } = props;
+  const [expanded, setExpanded] = useState(false);
+  const toggle = useCallback(() => setExpanded((value) => !value), []);
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80"
+        style={{ paddingLeft: `${8 + depth * 14}px` }}
+        onClick={toggle}
+      >
+        <ChevronRightIcon
+          aria-hidden="true"
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground/70 transition-transform group-hover:text-foreground/80",
+            expanded && "rotate-90",
+          )}
+        />
+        {expanded ? (
+          <FolderIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
+        ) : (
+          <FolderClosedIcon className="size-3.5 shrink-0 text-muted-foreground/75" />
+        )}
+        <span className="truncate font-mono text-[11px] text-muted-foreground/90 group-hover:text-foreground/90">
+          {entry.name}
+        </span>
+      </button>
+      {expanded ? (
+        <DirectoryChildren
+          environmentId={environmentId}
+          cwd={cwd}
+          relativePath={entry.relativePath}
+          depth={depth + 1}
+          theme={theme}
+          selectedPath={selectedPath}
+          onSelectFile={onSelectFile}
+        />
+      ) : null}
+    </div>
+  );
+});
+
+const FileNode = memo(function FileNode(props: {
+  entry: FilesystemListDirEntry;
+  depth: number;
+  theme: "light" | "dark";
+  selectedPath: string | null;
+  onSelectFile: (relativePath: string) => void;
+}) {
+  const { depth, entry, onSelectFile, selectedPath, theme } = props;
+  const isSelected = selectedPath === entry.relativePath;
+  return (
+    <button
+      type="button"
+      aria-current={isSelected ? "true" : undefined}
+      className={cn(
+        "group flex w-full items-center gap-1.5 rounded-md py-1 pr-2 text-left hover:bg-background/80",
+        isSelected && "bg-accent/60 hover:bg-accent/60",
+      )}
+      style={{ paddingLeft: `${8 + depth * 14}px` }}
+      onClick={() => onSelectFile(entry.relativePath)}
+    >
+      <span aria-hidden="true" className="size-3.5 shrink-0" />
+      <VscodeEntryIcon
+        pathValue={entry.relativePath}
+        kind="file"
+        theme={theme}
+        className="size-3.5 text-muted-foreground/70"
+      />
+      <span
+        className={cn(
+          "truncate font-mono text-[11px] text-muted-foreground/80 group-hover:text-foreground/90",
+          isSelected && "text-foreground",
+        )}
+      >
+        {entry.name}
+      </span>
+    </button>
+  );
+});
+
+function DirectoryChildren(props: {
+  environmentId: EnvironmentId;
+  cwd: string;
+  relativePath: string;
+  depth: number;
+  theme: "light" | "dark";
+  selectedPath: string | null;
+  onSelectFile: (relativePath: string) => void;
+}) {
+  const { cwd, depth, environmentId, onSelectFile, relativePath, selectedPath, theme } = props;
+  const query = useListDirQuery({ environmentId, cwd, relativePath, enabled: true });
+
+  if (query.isPending) {
+    return <TreeRowSpinner depth={depth} />;
+  }
+
+  const entries = query.data ?? [];
+  if (entries.length === 0) {
+    return <TreeRowEmpty depth={depth} label="Empty" />;
+  }
+
+  return (
+    <div className="space-y-0.5">
+      {entries.map((entry) =>
+        entry.kind === "directory" ? (
+          <DirectoryNode
+            key={`dir:${entry.relativePath}`}
+            environmentId={environmentId}
+            cwd={cwd}
+            entry={entry}
+            depth={depth}
+            theme={theme}
+            selectedPath={selectedPath}
+            onSelectFile={onSelectFile}
+          />
+        ) : (
+          <FileNode
+            key={`file:${entry.relativePath}`}
+            entry={entry}
+            depth={depth}
+            theme={theme}
+            selectedPath={selectedPath}
+            onSelectFile={onSelectFile}
+          />
+        ),
+      )}
+    </div>
+  );
+}
+
+export function FileTree(props: {
+  environmentId: EnvironmentId;
+  cwd: string;
+  theme: "light" | "dark";
+  selectedPath: string | null;
+  onSelectFile: (relativePath: string) => void;
+}) {
+  const { cwd, environmentId, onSelectFile, selectedPath, theme } = props;
+  return (
+    <div className="space-y-0.5 py-1">
+      <DirectoryChildren
+        environmentId={environmentId}
+        cwd={cwd}
+        relativePath=""
+        depth={0}
+        theme={theme}
+        selectedPath={selectedPath}
+        onSelectFile={onSelectFile}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/files/FileViewer.tsx
+++ b/apps/web/src/components/files/FileViewer.tsx
@@ -1,0 +1,195 @@
+import { type EnvironmentId, type FilesystemReadFileResult } from "@t3tools/contracts";
+import { useQuery } from "@tanstack/react-query";
+import { Loader2Icon } from "lucide-react";
+import { Suspense, use, useMemo } from "react";
+
+import { readEnvironmentApi } from "../../environmentApi";
+import { getHighlighterPromise } from "../../lib/codeHighlighter";
+import { resolveDiffThemeName } from "../../lib/diffRendering";
+
+const FILE_VIEWER_STALE_TIME_MS = 15_000;
+
+// Maps file extensions / well-known filenames to a shiki language id. Anything
+// not listed falls back to "text" (and getHighlighterPromise degrades further
+// if shiki has no grammar for the resolved language).
+const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
+  ts: "typescript",
+  tsx: "tsx",
+  mts: "typescript",
+  cts: "typescript",
+  js: "javascript",
+  jsx: "jsx",
+  mjs: "javascript",
+  cjs: "javascript",
+  json: "json",
+  jsonc: "jsonc",
+  json5: "json5",
+  md: "markdown",
+  mdx: "mdx",
+  css: "css",
+  scss: "scss",
+  less: "less",
+  html: "html",
+  htm: "html",
+  xml: "xml",
+  svg: "xml",
+  yml: "yaml",
+  yaml: "yaml",
+  toml: "toml",
+  ini: "ini",
+  sh: "shellscript",
+  bash: "shellscript",
+  zsh: "shellscript",
+  fish: "fish",
+  py: "python",
+  rb: "ruby",
+  rs: "rust",
+  go: "go",
+  java: "java",
+  kt: "kotlin",
+  kts: "kotlin",
+  swift: "swift",
+  c: "c",
+  h: "c",
+  cc: "cpp",
+  cpp: "cpp",
+  cxx: "cpp",
+  hpp: "cpp",
+  cs: "csharp",
+  php: "php",
+  sql: "sql",
+  graphql: "graphql",
+  gql: "graphql",
+  vue: "vue",
+  svelte: "svelte",
+  astro: "astro",
+  dockerfile: "docker",
+  lua: "lua",
+  dart: "dart",
+  // Shiki doesn't bundle a gitignore grammar; ini is a close match (#685)
+  gitignore: "ini",
+};
+
+const FILENAME_LANGUAGE_MAP: Record<string, string> = {
+  dockerfile: "docker",
+  makefile: "make",
+  ".gitignore": "ini",
+  ".npmrc": "ini",
+  ".env": "dotenv",
+};
+
+function inferLanguageFromPath(relativePath: string): string {
+  const segments = relativePath.replaceAll("\\", "/").split("/");
+  const basename = (segments[segments.length - 1] ?? "").toLowerCase();
+  const byFilename = FILENAME_LANGUAGE_MAP[basename];
+  if (byFilename) {
+    return byFilename;
+  }
+  const dotIndex = basename.lastIndexOf(".");
+  if (dotIndex <= 0) {
+    return "text";
+  }
+  const extension = basename.slice(dotIndex + 1);
+  return EXTENSION_LANGUAGE_MAP[extension] ?? "text";
+}
+
+function FileViewerMessage(props: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-center">
+      <p className="font-mono text-xs text-muted-foreground/80">{props.children}</p>
+    </div>
+  );
+}
+
+function HighlightedFileContent(props: {
+  content: string;
+  language: string;
+  theme: "light" | "dark";
+}) {
+  const { content, language, theme } = props;
+  const themeName = resolveDiffThemeName(theme);
+  const highlighter = use(getHighlighterPromise(language));
+  const highlightedHtml = useMemo(() => {
+    try {
+      return highlighter.codeToHtml(content, { lang: language, theme: themeName });
+    } catch (error) {
+      console.warn(
+        `File highlighting failed for language "${language}", falling back to plain text.`,
+        error instanceof Error ? error.message : error,
+      );
+      return highlighter.codeToHtml(content, { lang: "text", theme: themeName });
+    }
+  }, [content, highlighter, language, themeName]);
+
+  return (
+    <div
+      className="file-viewer-shiki min-h-0 flex-1 overflow-auto text-[12px] leading-[1.6]"
+      dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+    />
+  );
+}
+
+export function FileViewer(props: {
+  environmentId: EnvironmentId;
+  cwd: string;
+  relativePath: string | null;
+  theme: "light" | "dark";
+}) {
+  const { cwd, environmentId, relativePath, theme } = props;
+  const query = useQuery({
+    queryKey: ["filesystemReadFile", environmentId, cwd, relativePath],
+    queryFn: async (): Promise<FilesystemReadFileResult> => {
+      const api = readEnvironmentApi(environmentId);
+      if (!api || relativePath === null) {
+        return { content: "", truncated: false, tooLarge: false, binary: false };
+      }
+      return api.filesystem.readFile({ cwd, relativePath });
+    },
+    staleTime: FILE_VIEWER_STALE_TIME_MS,
+    enabled: relativePath !== null,
+  });
+
+  const language = useMemo(
+    () => (relativePath ? inferLanguageFromPath(relativePath) : "text"),
+    [relativePath],
+  );
+
+  if (relativePath === null) {
+    return <FileViewerMessage>Select a file to preview its contents.</FileViewerMessage>;
+  }
+
+  if (query.isPending) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-muted-foreground/70">
+        <Loader2Icon className="size-4 animate-spin" />
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return <FileViewerMessage>Could not read this file.</FileViewerMessage>;
+  }
+
+  const result = query.data;
+  if (result.binary) {
+    return <FileViewerMessage>Binary file not shown.</FileViewerMessage>;
+  }
+  if (result.tooLarge) {
+    return <FileViewerMessage>File too large to preview.</FileViewerMessage>;
+  }
+  if (result.content.length === 0) {
+    return <FileViewerMessage>This file is empty.</FileViewerMessage>;
+  }
+
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-muted-foreground/70">
+          <Loader2Icon className="size-4 animate-spin" />
+        </div>
+      }
+    >
+      <HighlightedFileContent content={result.content} language={language} theme={theme} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/files/FileViewer.tsx
+++ b/apps/web/src/components/files/FileViewer.tsx
@@ -1,11 +1,12 @@
 import { type EnvironmentId, type FilesystemReadFileResult } from "@t3tools/contracts";
-import { useQuery } from "@tanstack/react-query";
-import { Loader2Icon } from "lucide-react";
-import { Suspense, use, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { CheckIcon, Loader2Icon, PencilIcon, XIcon } from "lucide-react";
+import { Suspense, use, useCallback, useEffect, useMemo, useState } from "react";
 
 import { readEnvironmentApi } from "../../environmentApi";
 import { getHighlighterPromise } from "../../lib/codeHighlighter";
 import { resolveDiffThemeName } from "../../lib/diffRendering";
+import { cn } from "~/lib/utils";
 
 const FILE_VIEWER_STALE_TIME_MS = 15_000;
 
@@ -129,15 +130,216 @@ function HighlightedFileContent(props: {
   );
 }
 
+const READ_FILE_QUERY_KEY = "filesystemReadFile";
+
+function ViewerSpinner() {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-muted-foreground/70">
+      <Loader2Icon className="size-4 animate-spin" />
+    </div>
+  );
+}
+
+// Holds all edit state. Keyed by relativePath in the parent so switching files
+// remounts this with a clean slate (no stale draft leaking across files).
+function EditableFileView(props: {
+  environmentId: EnvironmentId;
+  cwd: string;
+  relativePath: string;
+  diskContent: string;
+  language: string;
+  theme: "light" | "dark";
+  onDirtyChange?: (dirty: boolean) => void;
+}) {
+  const { cwd, diskContent, environmentId, language, onDirtyChange, relativePath, theme } = props;
+  const queryClient = useQueryClient();
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(diskContent);
+  // The content we last loaded or saved; the save concurrency-check compares
+  // the on-disk content against this to detect external (agent) edits.
+  const [baseline, setBaseline] = useState(diskContent);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [justSaved, setJustSaved] = useState(false);
+
+  // While not editing, keep the draft in sync with refetched disk content.
+  useEffect(() => {
+    if (!isEditing) {
+      setDraft(diskContent);
+      setBaseline(diskContent);
+    }
+  }, [diskContent, isEditing]);
+
+  const dirty = isEditing && draft !== baseline;
+
+  // Report dirty state up so the panel can guard file switches, and clear it on unmount.
+  useEffect(() => {
+    onDirtyChange?.(dirty);
+  }, [dirty, onDirtyChange]);
+  useEffect(() => () => onDirtyChange?.(false), [onDirtyChange]);
+
+  // Warn before closing/reloading the app with unsaved edits.
+  useEffect(() => {
+    if (!dirty) {
+      return;
+    }
+    const handler = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [dirty]);
+
+  const handleSave = useCallback(async () => {
+    if (isSaving) {
+      return;
+    }
+    const api = readEnvironmentApi(environmentId);
+    if (!api) {
+      setSaveError("This environment is not connected.");
+      return;
+    }
+    setSaveError(null);
+    setIsSaving(true);
+    try {
+      // Concurrency guard: refuse to silently clobber edits made on disk
+      // (e.g. by the agent) since we opened the file.
+      const latest = await api.filesystem.readFile({ cwd, relativePath });
+      if (!latest.binary && !latest.tooLarge && latest.content !== baseline) {
+        const overwrite = window.confirm(
+          "This file changed on disk since you opened it. Overwrite those changes?",
+        );
+        if (!overwrite) {
+          setIsSaving(false);
+          return;
+        }
+      }
+      await api.projects.writeFile({ cwd, relativePath, contents: draft });
+      setBaseline(draft);
+      setJustSaved(true);
+      await queryClient.invalidateQueries({
+        queryKey: [READ_FILE_QUERY_KEY, environmentId, cwd, relativePath],
+      });
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : "Could not save this file.");
+    } finally {
+      setIsSaving(false);
+    }
+  }, [baseline, cwd, draft, environmentId, isSaving, queryClient, relativePath]);
+
+  const handleCancel = useCallback(() => {
+    if (dirty && !window.confirm("Discard unsaved changes?")) {
+      return;
+    }
+    setDraft(baseline);
+    setSaveError(null);
+    setIsEditing(false);
+  }, [baseline, dirty]);
+
+  const onTextareaKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((event.metaKey || event.ctrlKey) && event.key === "s") {
+        event.preventDefault();
+        if (dirty) {
+          void handleSave();
+        }
+      }
+    },
+    [dirty, handleSave],
+  );
+
+  const isEmpty = diskContent.length === 0;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-8 shrink-0 items-center justify-end gap-2 border-b border-border/60 px-2">
+        {saveError ? (
+          <span className="truncate font-mono text-[11px] text-destructive" title={saveError}>
+            {saveError}
+          </span>
+        ) : null}
+        {isEditing ? (
+          <>
+            {dirty ? (
+              <span
+                className="size-1.5 rounded-full bg-amber-500"
+                aria-label="Unsaved changes"
+                title="Unsaved changes"
+              />
+            ) : justSaved ? (
+              <span className="flex items-center gap-1 text-[11px] text-muted-foreground/80">
+                <CheckIcon className="size-3" /> Saved
+              </span>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!dirty || isSaving}
+              className="flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium text-foreground hover:bg-accent disabled:opacity-40"
+            >
+              {isSaving ? <Loader2Icon className="size-3 animate-spin" /> : null}
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={handleCancel}
+              disabled={isSaving}
+              className="flex items-center gap-1 rounded px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-accent disabled:opacity-40"
+            >
+              <XIcon className="size-3" /> Cancel
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => {
+              setJustSaved(false);
+              setDraft(baseline);
+              setIsEditing(true);
+            }}
+            className="flex items-center gap-1 rounded px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground"
+          >
+            <PencilIcon className="size-3" /> Edit
+          </button>
+        )}
+      </div>
+
+      {isEditing ? (
+        <textarea
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onKeyDown={onTextareaKeyDown}
+          spellCheck={false}
+          autoCorrect="off"
+          autoCapitalize="off"
+          className={cn(
+            "min-h-0 flex-1 resize-none bg-background p-3 font-mono text-[12px] leading-[1.6]",
+            "text-foreground outline-none",
+          )}
+        />
+      ) : isEmpty ? (
+        <FileViewerMessage>This file is empty.</FileViewerMessage>
+      ) : (
+        <Suspense fallback={<ViewerSpinner />}>
+          <HighlightedFileContent content={diskContent} language={language} theme={theme} />
+        </Suspense>
+      )}
+    </div>
+  );
+}
+
 export function FileViewer(props: {
   environmentId: EnvironmentId;
   cwd: string;
   relativePath: string | null;
   theme: "light" | "dark";
+  onDirtyChange?: (dirty: boolean) => void;
 }) {
-  const { cwd, environmentId, relativePath, theme } = props;
+  const { cwd, environmentId, onDirtyChange, relativePath, theme } = props;
   const query = useQuery({
-    queryKey: ["filesystemReadFile", environmentId, cwd, relativePath],
+    queryKey: [READ_FILE_QUERY_KEY, environmentId, cwd, relativePath],
     queryFn: async (): Promise<FilesystemReadFileResult> => {
       const api = readEnvironmentApi(environmentId);
       if (!api || relativePath === null) {
@@ -159,11 +361,7 @@ export function FileViewer(props: {
   }
 
   if (query.isPending) {
-    return (
-      <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-muted-foreground/70">
-        <Loader2Icon className="size-4 animate-spin" />
-      </div>
-    );
+    return <ViewerSpinner />;
   }
 
   if (query.isError) {
@@ -177,19 +375,17 @@ export function FileViewer(props: {
   if (result.tooLarge) {
     return <FileViewerMessage>File too large to preview.</FileViewerMessage>;
   }
-  if (result.content.length === 0) {
-    return <FileViewerMessage>This file is empty.</FileViewerMessage>;
-  }
 
   return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-0 flex-1 items-center justify-center p-6 text-muted-foreground/70">
-          <Loader2Icon className="size-4 animate-spin" />
-        </div>
-      }
-    >
-      <HighlightedFileContent content={result.content} language={language} theme={theme} />
-    </Suspense>
+    <EditableFileView
+      key={relativePath}
+      environmentId={environmentId}
+      cwd={cwd}
+      relativePath={relativePath}
+      diskContent={result.content}
+      language={language}
+      theme={theme}
+      {...(onDirtyChange ? { onDirtyChange } : {})}
+    />
   );
 }

--- a/apps/web/src/environmentApi.ts
+++ b/apps/web/src/environmentApi.ts
@@ -24,6 +24,8 @@ export function createEnvironmentApi(rpcClient: WsRpcClient): EnvironmentApi {
     },
     filesystem: {
       browse: rpcClient.filesystem.browse,
+      listDir: rpcClient.filesystem.listDir,
+      readFile: rpcClient.filesystem.readFile,
     },
     sourceControl: {
       lookupRepository: rpcClient.sourceControl.lookupRepository,

--- a/apps/web/src/environments/runtime/service.threadSubscriptions.test.ts
+++ b/apps/web/src/environments/runtime/service.threadSubscriptions.test.ts
@@ -110,6 +110,8 @@ vi.mock("@t3tools/client-runtime", async (importOriginal) => {
     },
     filesystem: {
       browse: vi.fn(),
+      listDir: vi.fn(),
+      readFile: vi.fn(),
     },
     sourceControl: {
       lookupRepository: vi.fn(),

--- a/apps/web/src/filesRouteSearch.ts
+++ b/apps/web/src/filesRouteSearch.ts
@@ -1,0 +1,33 @@
+export interface FilesRouteSearch {
+  files?: "1" | undefined;
+  filesPath?: string | undefined;
+}
+
+function isFilesOpenValue(value: unknown): boolean {
+  return value === "1" || value === 1 || value === true;
+}
+
+function normalizeSearchString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+export function stripFilesSearchParams<T extends Record<string, unknown>>(
+  params: T,
+): Omit<T, "files" | "filesPath"> {
+  const { files: _files, filesPath: _filesPath, ...rest } = params;
+  return rest as Omit<T, "files" | "filesPath">;
+}
+
+export function parseFilesRouteSearch(search: Record<string, unknown>): FilesRouteSearch {
+  const files = isFilesOpenValue(search.files) ? "1" : undefined;
+  const filesPath = files ? normalizeSearchString(search.filesPath) : undefined;
+
+  return {
+    ...(files ? { files } : {}),
+    ...(filesPath ? { filesPath } : {}),
+  };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -473,6 +473,41 @@ label:has(> select#reasoning-effort) select {
   background: color-mix(in srgb, var(--muted) 78%, var(--background)) !important;
 }
 
+/* Read-only file viewer (Files panel): shiki output with gutter line numbers. */
+.file-viewer-shiki .shiki {
+  margin: 0;
+  padding: 0.5rem 0;
+  background: var(--background) !important;
+  counter-reset: file-viewer-line;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  tab-size: 2;
+}
+
+.file-viewer-shiki .shiki code {
+  display: block;
+  width: fit-content;
+  min-width: 100%;
+}
+
+.file-viewer-shiki .shiki .line {
+  display: inline-block;
+  width: 100%;
+  padding-right: 1rem;
+}
+
+.file-viewer-shiki .shiki .line::before {
+  counter-increment: file-viewer-line;
+  content: counter(file-viewer-line);
+  display: inline-block;
+  width: 3rem;
+  margin-right: 1rem;
+  padding-right: 0.75rem;
+  text-align: right;
+  color: color-mix(in srgb, var(--muted-foreground) 70%, transparent);
+  border-right: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  user-select: none;
+}
+
 .chat-markdown table {
   width: 100%;
   border-collapse: collapse;

--- a/apps/web/src/lib/codeHighlighter.ts
+++ b/apps/web/src/lib/codeHighlighter.ts
@@ -1,0 +1,33 @@
+import { type DiffsHighlighter, getSharedHighlighter, type SupportedLanguages } from "@pierre/diffs";
+
+import { resolveDiffThemeName } from "./diffRendering";
+
+const highlighterPromiseCache = new Map<string, Promise<DiffsHighlighter>>();
+
+/**
+ * Returns a shared shiki highlighter promise for the given language, caching by
+ * language. If the language is not supported by shiki, falls back to "text".
+ *
+ * Shared between ChatMarkdown's code fences and the Files panel's read-only
+ * viewer so both stay in sync on highlighter configuration.
+ */
+export function getHighlighterPromise(language: string): Promise<DiffsHighlighter> {
+  const cached = highlighterPromiseCache.get(language);
+  if (cached) return cached;
+
+  const promise = getSharedHighlighter({
+    themes: [resolveDiffThemeName("dark"), resolveDiffThemeName("light")],
+    langs: [language as SupportedLanguages],
+    preferredHighlighter: "shiki-js",
+  }).catch((err) => {
+    highlighterPromiseCache.delete(language);
+    if (language === "text") {
+      // "text" itself failed — Shiki cannot initialize at all, surface the error
+      throw err;
+    }
+    // Language not supported by Shiki — fall back to "text"
+    return getHighlighterPromise("text");
+  });
+  highlighterPromiseCache.set(language, promise);
+  return promise;
+}

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -60,6 +60,8 @@ const rpcClientMock = {
   },
   filesystem: {
     browse: vi.fn(),
+    listDir: vi.fn(),
+    readFile: vi.fn(),
   },
   sourceControl: {
     lookupRepository: vi.fn(),
@@ -522,6 +524,45 @@ describe("wsApi", () => {
     expect(rpcClientMock.filesystem.browse).toHaveBeenCalledWith({
       partialPath: "/tmp/project/",
       cwd: "/tmp/project",
+    });
+  });
+
+  it("forwards filesystem listDir requests to the RPC client", async () => {
+    rpcClientMock.filesystem.listDir.mockResolvedValue({
+      entries: [],
+    });
+    const { createEnvironmentApi } = await import("./environmentApi");
+
+    const api = createEnvironmentApi(rpcClientMock as never);
+    await api.filesystem.listDir({
+      cwd: "/tmp/project",
+      relativePath: "src",
+    });
+
+    expect(rpcClientMock.filesystem.listDir).toHaveBeenCalledWith({
+      cwd: "/tmp/project",
+      relativePath: "src",
+    });
+  });
+
+  it("forwards filesystem readFile requests to the RPC client", async () => {
+    rpcClientMock.filesystem.readFile.mockResolvedValue({
+      content: "hello",
+      truncated: false,
+      tooLarge: false,
+      binary: false,
+    });
+    const { createEnvironmentApi } = await import("./environmentApi");
+
+    const api = createEnvironmentApi(rpcClientMock as never);
+    await api.filesystem.readFile({
+      cwd: "/tmp/project",
+      relativePath: "src/main.ts",
+    });
+
+    expect(rpcClientMock.filesystem.readFile).toHaveBeenCalledWith({
+      cwd: "/tmp/project",
+      relativePath: "src/main.ts",
     });
   });
 

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -16,6 +16,11 @@ import {
   parseDiffRouteSearch,
   stripDiffSearchParams,
 } from "../diffRouteSearch";
+import {
+  type FilesRouteSearch,
+  parseFilesRouteSearch,
+  stripFilesSearchParams,
+} from "../filesRouteSearch";
 import { useMediaQuery } from "../hooks/useMediaQuery";
 import { RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY } from "../rightPanelLayout";
 import { selectEnvironmentState, selectThreadExistsByRef, useStore } from "../store";
@@ -25,7 +30,9 @@ import { RightPanelSheet } from "../components/RightPanelSheet";
 import { Sidebar, SidebarInset, SidebarProvider, SidebarRail } from "~/components/ui/sidebar";
 
 const DiffPanel = lazy(() => import("../components/DiffPanel"));
+const FilesPanel = lazy(() => import("../components/FilesPanel"));
 const DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_diff_sidebar_width";
+const FILES_INLINE_SIDEBAR_WIDTH_STORAGE_KEY = "chat_files_sidebar_width";
 const DIFF_INLINE_DEFAULT_WIDTH = "clamp(24rem,34vw,36rem)";
 const DIFF_INLINE_SIDEBAR_MIN_WIDTH = 22 * 16;
 const DIFF_INLINE_SIDEBAR_MAX_WIDTH = 256 * 16;
@@ -49,24 +56,24 @@ const LazyDiffPanel = (props: { mode: DiffPanelMode }) => {
   );
 };
 
-const DiffPanelInlineSidebar = (props: {
-  diffOpen: boolean;
-  onCloseDiff: () => void;
-  onOpenDiff: () => void;
-  renderDiffContent: boolean;
-}) => {
-  const { diffOpen, onCloseDiff, onOpenDiff, renderDiffContent } = props;
-  const onOpenChange = useCallback(
-    (open: boolean) => {
-      if (open) {
-        onOpenDiff();
-        return;
-      }
-      onCloseDiff();
-    },
-    [onCloseDiff, onOpenDiff],
+const FilesLoadingFallback = (props: { mode: DiffPanelMode }) => {
+  return (
+    <DiffPanelShell mode={props.mode} header={<DiffPanelHeaderSkeleton />}>
+      <DiffPanelLoadingState label="Loading files viewer..." />
+    </DiffPanelShell>
   );
-  const shouldAcceptInlineSidebarWidth = useCallback(
+};
+
+const LazyFilesPanel = (props: { mode: DiffPanelMode }) => {
+  return (
+    <Suspense fallback={<FilesLoadingFallback mode={props.mode} />}>
+      <FilesPanel mode={props.mode} />
+    </Suspense>
+  );
+};
+
+function useShouldAcceptInlineSidebarWidth() {
+  return useCallback(
     ({ nextWidth, wrapper }: { nextWidth: number; wrapper: HTMLElement }) => {
       const composerForm = document.querySelector<HTMLElement>("[data-chat-composer-form='true']");
       if (!composerForm) return true;
@@ -111,11 +118,32 @@ const DiffPanelInlineSidebar = (props: {
     },
     [],
   );
+}
+
+const RightPanelInlineSidebar = (props: {
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+  storageKey: string;
+  children: React.ReactNode;
+}) => {
+  const { children, onClose, onOpen, open, storageKey } = props;
+  const onOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        onOpen();
+        return;
+      }
+      onClose();
+    },
+    [onClose, onOpen],
+  );
+  const shouldAcceptInlineSidebarWidth = useShouldAcceptInlineSidebarWidth();
 
   return (
     <SidebarProvider
       defaultOpen={false}
-      open={diffOpen}
+      open={open}
       onOpenChange={onOpenChange}
       className="w-auto min-h-0 flex-none bg-transparent"
       style={{ "--sidebar-width": DIFF_INLINE_DEFAULT_WIDTH } as React.CSSProperties}
@@ -128,13 +156,49 @@ const DiffPanelInlineSidebar = (props: {
           maxWidth: DIFF_INLINE_SIDEBAR_MAX_WIDTH,
           minWidth: DIFF_INLINE_SIDEBAR_MIN_WIDTH,
           shouldAcceptWidth: shouldAcceptInlineSidebarWidth,
-          storageKey: DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY,
+          storageKey,
         }}
       >
-        {renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
+        {children}
         <SidebarRail />
       </Sidebar>
     </SidebarProvider>
+  );
+};
+
+const DiffPanelInlineSidebar = (props: {
+  diffOpen: boolean;
+  onCloseDiff: () => void;
+  onOpenDiff: () => void;
+  renderDiffContent: boolean;
+}) => {
+  return (
+    <RightPanelInlineSidebar
+      open={props.diffOpen}
+      onOpen={props.onOpenDiff}
+      onClose={props.onCloseDiff}
+      storageKey={DIFF_INLINE_SIDEBAR_WIDTH_STORAGE_KEY}
+    >
+      {props.renderDiffContent ? <LazyDiffPanel mode="sidebar" /> : null}
+    </RightPanelInlineSidebar>
+  );
+};
+
+const FilesPanelInlineSidebar = (props: {
+  filesOpen: boolean;
+  onCloseFiles: () => void;
+  onOpenFiles: () => void;
+  renderFilesContent: boolean;
+}) => {
+  return (
+    <RightPanelInlineSidebar
+      open={props.filesOpen}
+      onOpen={props.onOpenFiles}
+      onClose={props.onCloseFiles}
+      storageKey={FILES_INLINE_SIDEBAR_WIDTH_STORAGE_KEY}
+    >
+      {props.renderFilesContent ? <LazyFilesPanel mode="sidebar" /> : null}
+    </RightPanelInlineSidebar>
   );
 };
 
@@ -168,6 +232,7 @@ function ChatThreadRouteView() {
   const serverThreadStarted = threadHasStarted(serverThread);
   const environmentHasAnyThreads = environmentHasServerThreads || environmentHasDraftThreads;
   const diffOpen = search.diff === "1";
+  const filesOpen = search.files === "1";
   const shouldUseDiffSheet = useMediaQuery(RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY);
   const currentThreadKey = threadRef ? `${threadRef.environmentId}:${threadRef.threadId}` : null;
   const [diffPanelMountState, setDiffPanelMountState] = useState(() => ({
@@ -186,6 +251,25 @@ function ChatThreadRouteView() {
       return {
         threadKey: currentThreadKey,
         hasOpenedDiff: true,
+      };
+    });
+  }, [currentThreadKey]);
+  const [filesPanelMountState, setFilesPanelMountState] = useState(() => ({
+    threadKey: currentThreadKey,
+    hasOpenedFiles: filesOpen,
+  }));
+  const hasOpenedFiles =
+    filesPanelMountState.threadKey === currentThreadKey
+      ? filesPanelMountState.hasOpenedFiles
+      : filesOpen;
+  const markFilesOpened = useCallback(() => {
+    setFilesPanelMountState((previous) => {
+      if (previous.threadKey === currentThreadKey && previous.hasOpenedFiles) {
+        return previous;
+      }
+      return {
+        threadKey: currentThreadKey,
+        hasOpenedFiles: true,
       };
     });
   }, [currentThreadKey]);
@@ -208,11 +292,37 @@ function ChatThreadRouteView() {
       to: "/$environmentId/$threadId",
       params: buildThreadRouteParams(threadRef),
       search: (previous) => {
-        const rest = stripDiffSearchParams(previous);
+        // Opening Diff closes Files (they share the one docked right surface).
+        const rest = stripFilesSearchParams(stripDiffSearchParams(previous));
         return { ...rest, diff: "1" };
       },
     });
   }, [markDiffOpened, navigate, threadRef]);
+  const closeFiles = useCallback(() => {
+    if (!threadRef) {
+      return;
+    }
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: buildThreadRouteParams(threadRef),
+      search: (previous) => stripFilesSearchParams(previous),
+    });
+  }, [navigate, threadRef]);
+  const openFiles = useCallback(() => {
+    if (!threadRef) {
+      return;
+    }
+    markFilesOpened();
+    void navigate({
+      to: "/$environmentId/$threadId",
+      params: buildThreadRouteParams(threadRef),
+      search: (previous) => {
+        // Opening Files closes Diff (they share the one docked right surface).
+        const rest = stripFilesSearchParams(stripDiffSearchParams(previous));
+        return { ...rest, files: "1" };
+      },
+    });
+  }, [markFilesOpened, navigate, threadRef]);
 
   useEffect(() => {
     if (!threadRef || !bootstrapComplete) {
@@ -236,6 +346,7 @@ function ChatThreadRouteView() {
   }
 
   const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
+  const shouldRenderFilesContent = filesOpen || hasOpenedFiles;
 
   if (!shouldUseDiffSheet) {
     return (
@@ -245,7 +356,7 @@ function ChatThreadRouteView() {
             environmentId={threadRef.environmentId}
             threadId={threadRef.threadId}
             onDiffPanelOpen={markDiffOpened}
-            reserveTitleBarControlInset={!diffOpen}
+            reserveTitleBarControlInset={!diffOpen && !filesOpen}
             routeKind="server"
           />
         </SidebarInset>
@@ -254,6 +365,12 @@ function ChatThreadRouteView() {
           onCloseDiff={closeDiff}
           onOpenDiff={openDiff}
           renderDiffContent={shouldRenderDiffContent}
+        />
+        <FilesPanelInlineSidebar
+          filesOpen={filesOpen}
+          onCloseFiles={closeFiles}
+          onOpenFiles={openFiles}
+          renderFilesContent={shouldRenderFilesContent}
         />
       </>
     );
@@ -272,14 +389,20 @@ function ChatThreadRouteView() {
       <RightPanelSheet open={diffOpen} onClose={closeDiff}>
         {shouldRenderDiffContent ? <LazyDiffPanel mode="sheet" /> : null}
       </RightPanelSheet>
+      <RightPanelSheet open={filesOpen} onClose={closeFiles}>
+        {shouldRenderFilesContent ? <LazyFilesPanel mode="sheet" /> : null}
+      </RightPanelSheet>
     </>
   );
 }
 
 export const Route = createFileRoute("/_chat/$environmentId/$threadId")({
-  validateSearch: (search) => parseDiffRouteSearch(search),
+  validateSearch: (search) => ({
+    ...parseDiffRouteSearch(search),
+    ...parseFilesRouteSearch(search),
+  }),
   search: {
-    middlewares: [retainSearchParams<DiffRouteSearch>(["diff"])],
+    middlewares: [retainSearchParams<DiffRouteSearch & FilesRouteSearch>(["diff", "files"])],
   },
   component: ChatThreadRouteView,
 });

--- a/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
+++ b/apps/web/src/routes/_chat.$environmentId.$threadId.tsx
@@ -232,7 +232,9 @@ function ChatThreadRouteView() {
   const serverThreadStarted = threadHasStarted(serverThread);
   const environmentHasAnyThreads = environmentHasServerThreads || environmentHasDraftThreads;
   const diffOpen = search.diff === "1";
-  const filesOpen = search.files === "1";
+  // Diff and Files share the one docked right surface; never render both. Diff
+  // takes precedence as a backstop if both params ever coexist.
+  const filesOpen = search.files === "1" && !diffOpen;
   const shouldUseDiffSheet = useMediaQuery(RIGHT_PANEL_INLINE_LAYOUT_MEDIA_QUERY);
   const currentThreadKey = threadRef ? `${threadRef.environmentId}:${threadRef.threadId}` : null;
   const [diffPanelMountState, setDiffPanelMountState] = useState(() => ({
@@ -345,8 +347,11 @@ function ChatThreadRouteView() {
     return null;
   }
 
-  const shouldRenderDiffContent = diffOpen || hasOpenedDiff;
-  const shouldRenderFilesContent = filesOpen || hasOpenedFiles;
+  // Only keep the active surface's content mounted. The two are mutually
+  // exclusive, and a still-mounted DiffPanel re-asserts its diff URL params,
+  // which would otherwise snap the view back when switching to Files.
+  const shouldRenderDiffContent = (diffOpen || hasOpenedDiff) && !filesOpen;
+  const shouldRenderFilesContent = (filesOpen || hasOpenedFiles) && !diffOpen;
 
   if (!shouldUseDiffSheet) {
     return (

--- a/packages/client-runtime/src/wsRpcClient.ts
+++ b/packages/client-runtime/src/wsRpcClient.ts
@@ -85,6 +85,8 @@ export interface WsRpcClient {
   };
   readonly filesystem: {
     readonly browse: RpcUnaryMethod<typeof WS_METHODS.filesystemBrowse>;
+    readonly listDir: RpcUnaryMethod<typeof WS_METHODS.filesystemListDir>;
+    readonly readFile: RpcUnaryMethod<typeof WS_METHODS.filesystemReadFile>;
   };
   readonly sourceControl: {
     readonly lookupRepository: RpcUnaryMethod<typeof WS_METHODS.sourceControlLookupRepository>;
@@ -220,6 +222,10 @@ export function createWsRpcClient(
     },
     filesystem: {
       browse: (input) => transport.request((client) => client[WS_METHODS.filesystemBrowse](input)),
+      listDir: (input) =>
+        transport.request((client) => client[WS_METHODS.filesystemListDir](input)),
+      readFile: (input) =>
+        transport.request((client) => client[WS_METHODS.filesystemReadFile](input)),
     },
     sourceControl: {
       lookupRepository: (input) =>

--- a/packages/contracts/src/filesystem.ts
+++ b/packages/contracts/src/filesystem.ts
@@ -28,3 +28,54 @@ export class FilesystemBrowseError extends Schema.TaggedErrorClass<FilesystemBro
     cause: Schema.optional(Schema.Defect()),
   },
 ) {}
+
+// --- listDir ---
+export const FilesystemListDirInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
+  // relativePath is "" for the workspace root, hence Schema.String (not TrimmedNonEmptyString)
+  relativePath: Schema.String.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
+});
+export type FilesystemListDirInput = typeof FilesystemListDirInput.Type;
+
+export const FilesystemListDirEntry = Schema.Struct({
+  name: TrimmedNonEmptyString,
+  relativePath: TrimmedNonEmptyString,
+  kind: Schema.Literals(["file", "directory"]),
+});
+export type FilesystemListDirEntry = typeof FilesystemListDirEntry.Type;
+
+export const FilesystemListDirResult = Schema.Struct({
+  entries: Schema.Array(FilesystemListDirEntry),
+});
+export type FilesystemListDirResult = typeof FilesystemListDirResult.Type;
+
+export class FilesystemListDirError extends Schema.TaggedErrorClass<FilesystemListDirError>()(
+  "FilesystemListDirError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+// --- readFile ---
+export const FilesystemReadFileInput = Schema.Struct({
+  cwd: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
+  relativePath: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
+});
+export type FilesystemReadFileInput = typeof FilesystemReadFileInput.Type;
+
+export const FilesystemReadFileResult = Schema.Struct({
+  content: Schema.String,
+  truncated: Schema.Boolean,
+  tooLarge: Schema.Boolean,
+  binary: Schema.Boolean,
+});
+export type FilesystemReadFileResult = typeof FilesystemReadFileResult.Type;
+
+export class FilesystemReadFileError extends Schema.TaggedErrorClass<FilesystemReadFileError>()(
+  "FilesystemReadFileError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -19,7 +19,14 @@ import type {
   VcsStatusResult,
 } from "./git.ts";
 import type { ReviewDiffPreviewInput, ReviewDiffPreviewResult } from "./review.ts";
-import type { FilesystemBrowseInput, FilesystemBrowseResult } from "./filesystem.ts";
+import type {
+  FilesystemBrowseInput,
+  FilesystemBrowseResult,
+  FilesystemListDirInput,
+  FilesystemListDirResult,
+  FilesystemReadFileInput,
+  FilesystemReadFileResult,
+} from "./filesystem.ts";
 import type {
   ProjectSearchEntriesInput,
   ProjectSearchEntriesResult,
@@ -552,6 +559,8 @@ export interface EnvironmentApi {
   };
   filesystem: {
     browse: (input: FilesystemBrowseInput) => Promise<FilesystemBrowseResult>;
+    listDir: (input: FilesystemListDirInput) => Promise<FilesystemListDirResult>;
+    readFile: (input: FilesystemReadFileInput) => Promise<FilesystemReadFileResult>;
   };
   sourceControl: {
     lookupRepository: (

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -12,6 +12,12 @@ import {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
   FilesystemBrowseError,
+  FilesystemListDirInput,
+  FilesystemListDirResult,
+  FilesystemListDirError,
+  FilesystemReadFileInput,
+  FilesystemReadFileResult,
+  FilesystemReadFileError,
 } from "./filesystem.ts";
 import {
   GitActionProgressEvent,
@@ -129,6 +135,8 @@ export const WS_METHODS = {
 
   // Filesystem methods
   filesystemBrowse: "filesystem.browse",
+  filesystemListDir: "filesystem.listDir",
+  filesystemReadFile: "filesystem.readFile",
 
   // VCS methods
   vcsPull: "vcs.pull",
@@ -330,6 +338,18 @@ export const WsFilesystemBrowseRpc = Rpc.make(WS_METHODS.filesystemBrowse, {
   payload: FilesystemBrowseInput,
   success: FilesystemBrowseResult,
   error: Schema.Union([FilesystemBrowseError, EnvironmentAuthorizationError]),
+});
+
+export const WsFilesystemListDirRpc = Rpc.make(WS_METHODS.filesystemListDir, {
+  payload: FilesystemListDirInput,
+  success: FilesystemListDirResult,
+  error: Schema.Union([FilesystemListDirError, EnvironmentAuthorizationError]),
+});
+
+export const WsFilesystemReadFileRpc = Rpc.make(WS_METHODS.filesystemReadFile, {
+  payload: FilesystemReadFileInput,
+  success: FilesystemReadFileResult,
+  error: Schema.Union([FilesystemReadFileError, EnvironmentAuthorizationError]),
 });
 
 export const WsSubscribeVcsStatusRpc = Rpc.make(WS_METHODS.subscribeVcsStatus, {
@@ -567,6 +587,8 @@ export const WsRpcGroup = RpcGroup.make(
   WsProjectsWriteFileRpc,
   WsShellOpenInEditorRpc,
   WsFilesystemBrowseRpc,
+  WsFilesystemListDirRpc,
+  WsFilesystemReadFileRpc,
   WsSubscribeVcsStatusRpc,
   WsVcsPullRpc,
   WsVcsRefreshStatusRpc,


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces authenticated filesystem read/list over the workspace with path containment; in-app file editing reuses write RPC with concurrency prompts—moderate scope but not auth changes.
> 
> **Overview**
> Adds a **Files** view alongside **Diff** in the thread’s docked right panel, driven by URL search params (`files`, `filesPath`) and in-panel **Diff | Files** tabs. The header shortcut now toggles whichever side panel was last open (Files when Diff isn’t available).
> 
> **Backend:** New workspace RPCs **`filesystem.listDir`** and **`filesystem.readFile`** (contracts, WS, client). `listDir` lists immediate children under a root-relative path with root containment and empty listings on macOS permission denials. `readFile` resolves paths within the workspace, caps reads at 2MB, and flags binary content via NUL sniffing instead of returning bytes.
> 
> **Web:** `FilesPanel` with lazy-loaded tree (`listDir`) and viewer (syntax highlight via shared `codeHighlighter`, optional edit/save through existing `projects.writeFile` with on-disk change prompts). Diff and Files are mutually exclusive in routing and mounting so URL state doesn’t fight. Markdown code fences reuse the extracted highlighter helper.
> 
> **Also:** Composer **Attach** control for image files (picker + existing drag-drop path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550b35b5515d887001c82b1c6a5a75947ca13d76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Files panel to the chat thread right-side surface
> - Adds a new Files panel (alongside the existing Diff panel) with a navigable `FileTree` and syntax-highlighted `FileViewer` that supports editing, saving, and concurrency checks.
> - The right-side surface is now unified: opening Files closes Diff and vice versa; the header toggle and keyboard shortcut control whichever panel is currently active.
> - Adds `filesystem.listDir` and `filesystem.readFile` RPC endpoints (contracts, server handlers, client bindings, and `EnvironmentApi` pass-throughs) to power the tree and viewer.
> - The file tree is resizable with width persisted to `localStorage`; the viewer supports edit mode with a dirty-state guard and `Cmd/Ctrl+S` to save.
> - Adds an image attach button (file picker) to `ChatComposer` as a separate small improvement in this PR.
> - Risk: `readFile` returns binary/tooLarge flags instead of an error; callers must check these flags or the viewer will silently show nothing for large or binary files.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 550b35b. 24 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->