### PR TITLE
fix(web): show sidebar new-thread button on iPad Safari and other touch tablets

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -391,7 +391,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
   const threadMetaClassName = isConfirmingArchive
     ? "pointer-events-none opacity-0"
     : !isThreadRunning
-      ? "pointer-events-none transition-opacity duration-150 max-sm:pr-6 group-hover/menu-sub-item:opacity-0 group-focus-within/menu-sub-item:opacity-0"
+      ? "pointer-events-none transition-opacity duration-150 max-sm:pr-6 group-hover/menu-sub-item:opacity-0 group-focus-within/menu-sub-item:opacity-0 sidebar-touch-timestamp"
       : "pointer-events-none";
   const clearConfirmingArchive = useCallback(() => {
     setConfirmingArchiveThreadKey((current) => (current === threadKey ? null : current));
@@ -637,7 +637,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
               </button>
             ) : !isThreadRunning ? (
               appSettingsConfirmThreadArchive ? (
-                <div className="pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100">
+                <div className="pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100 sidebar-touch-visible">
                   <button
                     type="button"
                     data-thread-selection-safe
@@ -654,7 +654,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
                 <Tooltip>
                   <TooltipTrigger
                     render={
-                      <div className="pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100">
+                      <div className="pointer-events-none absolute top-1/2 right-1 -translate-y-1/2 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/menu-sub-item:pointer-events-auto group-hover/menu-sub-item:opacity-100 group-focus-within/menu-sub-item:pointer-events-auto group-focus-within/menu-sub-item:opacity-100 sidebar-touch-visible">
                         <button
                           type="button"
                           data-thread-selection-safe
@@ -2040,7 +2040,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                       ? "Remote project"
                       : "Available in multiple environments"
                   }
-                  className="pointer-events-none absolute top-1 right-1.5 inline-flex size-5 items-center justify-center rounded-md text-muted-foreground/60 transition-opacity duration-150 max-sm:right-7 group-hover/project-header:opacity-0 group-focus-within/project-header:opacity-0 max-sm:group-hover/project-header:opacity-100 max-sm:group-focus-within/project-header:opacity-100"
+                  className="pointer-events-none absolute top-1 right-1.5 inline-flex size-5 items-center justify-center rounded-md text-muted-foreground/60 transition-opacity duration-150 max-sm:right-7 group-hover/project-header:opacity-0 group-focus-within/project-header:opacity-0 max-sm:group-hover/project-header:opacity-100 max-sm:group-focus-within/project-header:opacity-100 sidebar-touch-hidden"
                 />
               }
             >
@@ -2054,7 +2054,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         <Tooltip>
           <TooltipTrigger
             render={
-              <div className="pointer-events-none absolute top-1 right-1.5 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/project-header:pointer-events-auto group-hover/project-header:opacity-100 group-focus-within/project-header:pointer-events-auto group-focus-within/project-header:opacity-100">
+              <div className="pointer-events-none absolute top-1 right-1.5 opacity-0 transition-opacity duration-150 max-sm:pointer-events-auto max-sm:opacity-100 group-hover/project-header:pointer-events-auto group-hover/project-header:opacity-100 group-focus-within/project-header:pointer-events-auto group-focus-within/project-header:opacity-100 sidebar-touch-visible">
                 <button
                   type="button"
                   aria-label={`Create new thread in ${project.displayName}`}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -573,6 +573,23 @@ label:has(> select#reasoning-effort) select {
   animation: ultrathink-rainbow 10s linear infinite;
 }
 
+/* Show sidebar action buttons on touch devices that lack hover capability.
+   iPad Safari and other tablets report viewport widths >640px but cannot
+   hover, so the hover-only reveal pattern breaks. */
+@media (hover: none) {
+  .sidebar-touch-visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .sidebar-touch-hidden {
+    opacity: 0;
+    pointer-events: none;
+  }
+  .sidebar-touch-timestamp {
+    padding-right: 1.5rem;
+  }
+}
+
 /* Thin scrollbar for model picker */
 .model-picker-list::-webkit-scrollbar {
   width: 4px;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -575,8 +575,10 @@ label:has(> select#reasoning-effort) select {
 
 /* Show sidebar action buttons on touch devices that lack hover capability.
    iPad Safari and other tablets report viewport widths >640px but cannot
-   hover, so the hover-only reveal pattern breaks. */
-@media (hover: none) {
+   hover, so the hover-only reveal pattern breaks.
+   We scope to min-width: 640px because below that the max-sm: Tailwind
+   modifiers already handle visibility correctly on phones. */
+@media (hover: none) and (min-width: 640px) {
   .sidebar-touch-visible {
     opacity: 1;
     pointer-events: auto;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only sidebar visibility tweaks; no auth, data, or API changes.
> 
> **Overview**
> Fixes sidebar controls that only appeared on **hover**, which left **iPad Safari and other touch tablets** without a reliable way to start a thread or archive—wide viewports skip `max-sm` overrides but those devices still report **no hover**.
> 
> Adds a **`@media (hover: none)`** block in `index.css` with **`sidebar-touch-visible`**, **`sidebar-touch-hidden`**, and **`sidebar-touch-timestamp`**, and wires them on project headers (new-thread control, remote cloud badge) and thread rows (archive actions, timestamp spacing). Desktop hover behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c02b1ea9c7b39ec31f71fcf79e4ab2c873255ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show sidebar new-thread button and archive actions on iPad Safari and touch tablets
> - Adds a `@media (hover: none) and (min-width: 640px)` block in [index.css](https://github.com/pingdotgg/t3code/pull/2990/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) defining three classes: `sidebar-touch-visible` (opacity 1, pointer-events auto), `sidebar-touch-hidden` (opacity 0, pointer-events none), and `sidebar-touch-timestamp` (extra right padding).
> - Applies `sidebar-touch-visible` to archive action buttons in `SidebarThreadRow` and the new-thread button in `SidebarProjectItem`, so they appear without hover on touch devices.
> - Applies `sidebar-touch-hidden` to the remote-environment Cloud icon in `SidebarProjectItem` on touch devices, and `sidebar-touch-timestamp` to thread row timestamps to prevent overlap with visible action buttons.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 023a1da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->