### PR TITLE
Show remote host label in sidebar projects

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1357,6 +1357,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     threadLastVisitedAts,
     visibleProjectThreads,
   ]);
+  const remoteProjectEnvironmentLabel =
+    project.environmentPresence === "remote-only"
+      ? project.remoteEnvironmentLabels.join(", ") || "Remote"
+      : null;
 
   const handleProjectButtonClick = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -2249,6 +2253,26 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
             <span className="truncate text-xs font-medium text-foreground/90">
               {project.displayName}
             </span>
+            {remoteProjectEnvironmentLabel ? (
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <span
+                      aria-label={`Remote project: ${remoteProjectEnvironmentLabel}`}
+                      className="inline-flex h-5 min-w-0 shrink items-center gap-1 rounded-md text-muted-foreground/60"
+                    />
+                  }
+                >
+                  <span className="max-w-[7rem] truncate text-[10px] leading-none max-sm:max-w-[5.5rem]">
+                    {remoteProjectEnvironmentLabel}
+                  </span>
+                  <CloudIcon className="size-3 shrink-0" />
+                </TooltipTrigger>
+                <TooltipPopup side="top">
+                  Remote environment: {remoteProjectEnvironmentLabel}
+                </TooltipPopup>
+              </Tooltip>
+            ) : null}
             {project.groupedProjectCount > 1 ? (
               <span className="shrink-0 text-[10px] text-muted-foreground/60">
                 {project.groupedProjectCount} projects
@@ -2256,30 +2280,6 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
             ) : null}
           </span>
         </SidebarMenuButton>
-        {/* Environment badge – visible by default, crossfades with the
-            "new thread" button on hover using the same pointer-events +
-            opacity pattern as the thread row archive/timestamp swap. */}
-        {project.environmentPresence === "remote-only" && (
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <span
-                  aria-label={
-                    project.environmentPresence === "remote-only"
-                      ? "Remote project"
-                      : "Available in multiple environments"
-                  }
-                  className="pointer-events-none absolute top-1 right-1.5 inline-flex size-5 items-center justify-center rounded-md text-muted-foreground/60 transition-opacity duration-150 max-sm:right-7 group-hover/project-header:opacity-0 group-focus-within/project-header:opacity-0 max-sm:group-hover/project-header:opacity-100 max-sm:group-focus-within/project-header:opacity-100"
-                />
-              }
-            >
-              <CloudIcon className="size-3" />
-            </TooltipTrigger>
-            <TooltipPopup side="top">
-              Remote environment: {project.remoteEnvironmentLabels.join(", ")}
-            </TooltipPopup>
-          </Tooltip>
-        )}
         <Tooltip>
           <TooltipTrigger
             render={


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Added a remote host label ot the project label in the sidebar. Also moved the cloud icon to be left aligned instead of right aligned. 

## Why
 - If you have multiple projects, you can't tell which project is on which host
 - The cloud icon gets covered up by the new thread on hover

## UI Changes

Added below

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar presentation only in `Sidebar.tsx`; no auth, data, or routing changes.
> 
> **Overview**
> For sidebar projects with **`environmentPresence === "remote-only"`**, the PR shows which host they live on by rendering an **inline** truncated label (from `remoteEnvironmentLabels`, or **Remote**) plus a cloud icon next to the project name, with tooltip **Remote environment: …**.
> 
> It **removes** the old **top-right** cloud-only badge that faded out on project-row hover so it no longer conflicts with the **new thread** control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a5741672f6f784d10a8b5ba30c90b71f6f045a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show remote host label inline next to project name in sidebar
> Replaces the top-right corner cloud icon badge on sidebar project items with an inline cloud icon and label next to the project name. For `remote-only` projects, the label is drawn from `project.remoteEnvironmentLabels` (comma-joined) or falls back to 'Remote', with a tooltip showing 'Remote environment: <labels>'.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59a5741.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->