### PR TITLE
Expandable File Change and Command activity boxes

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -219,9 +219,11 @@ describe("hasRenderableCommandOutput", () => {
     expect(hasRenderableCommandOutput("\n\t\n")).toBe(false);
   });
 
-  it("removes empty and whitespace-only command output lines", () => {
+  it("preserves intentional blank command output lines", () => {
     expect(getRenderableCommandOutputLines("\nstdout\n   \n\t\nstderr\n")).toEqual([
       "stdout",
+      "   ",
+      "\t",
       "stderr",
     ]);
   });

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -3,6 +3,8 @@ import {
   computeStableMessagesTimelineRows,
   computeMessageDurationStart,
   deriveMessagesTimelineRows,
+  getRenderableCommandOutputLines,
+  hasRenderableCommandOutput,
   normalizeCompactToolLabel,
   resolveAssistantMessageCopyState,
 } from "./MessagesTimeline.logic";
@@ -201,6 +203,27 @@ describe("resolveAssistantMessageCopyState", () => {
       text: "Interim thought",
       visible: false,
     });
+  });
+});
+
+describe("hasRenderableCommandOutput", () => {
+  it("hides nullish and empty command output streams", () => {
+    expect(hasRenderableCommandOutput(undefined)).toBe(false);
+    expect(hasRenderableCommandOutput(null)).toBe(false);
+    expect(hasRenderableCommandOutput("")).toBe(false);
+  });
+
+  it("renders command output streams when the provider emitted content", () => {
+    expect(hasRenderableCommandOutput("stdout\n")).toBe(true);
+    expect(hasRenderableCommandOutput("   ")).toBe(false);
+    expect(hasRenderableCommandOutput("\n\t\n")).toBe(false);
+  });
+
+  it("removes empty and whitespace-only command output lines", () => {
+    expect(getRenderableCommandOutputLines("\nstdout\n   \n\t\nstderr\n")).toEqual([
+      "stdout",
+      "stderr",
+    ]);
   });
 });
 

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -92,7 +92,16 @@ export function getRenderableCommandOutputLines(value: string | null | undefined
   if (typeof value !== "string" || value.length === 0) {
     return [];
   }
-  return value.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+  const lines = value.split(/\r?\n/u);
+  let startIndex = 0;
+  let endIndex = lines.length;
+  while (startIndex < endIndex && (lines[startIndex]?.trim().length ?? 0) === 0) {
+    startIndex += 1;
+  }
+  while (endIndex > startIndex && (lines[endIndex - 1]?.trim().length ?? 0) === 0) {
+    endIndex -= 1;
+  }
+  return lines.slice(startIndex, endIndex);
 }
 
 function deriveTerminalAssistantMessageIds(timelineEntries: ReadonlyArray<TimelineEntry>) {

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -84,6 +84,17 @@ export function resolveAssistantMessageCopyState({
   };
 }
 
+export function hasRenderableCommandOutput(value: string | null | undefined): value is string {
+  return getRenderableCommandOutputLines(value).length > 0;
+}
+
+export function getRenderableCommandOutputLines(value: string | null | undefined): string[] {
+  if (typeof value !== "string" || value.length === 0) {
+    return [];
+  }
+  return value.split(/\r?\n/u).filter((line) => line.trim().length > 0);
+}
+
 function deriveTerminalAssistantMessageIds(timelineEntries: ReadonlyArray<TimelineEntry>) {
   const lastAssistantMessageIdByResponseKey = new Map<string, string>();
   let nullTurnResponseIndex = 0;

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -447,6 +447,39 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Expand Dynamic patch tool"');
   });
 
+  it("renders mixed dynamic tool command and patch metadata", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Dynamic edit tool",
+              tone: "tool",
+              itemType: "dynamic_tool_call",
+              command: "apply_patch",
+              stdout: "updated files",
+              changedFiles: ["apps/web/src/session-logic.ts"],
+              patch:
+                "diff --git a/apps/web/src/session-logic.ts b/apps/web/src/session-logic.ts\n--- a/apps/web/src/session-logic.ts\n+++ b/apps/web/src/session-logic.ts\n@@ -1 +1 @@\n-old\n+new\n",
+              exitCode: 0,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("apply_patch");
+    expect(markup).toContain("apps/web/src/session-logic.ts");
+    expect(markup).toContain('aria-label="Expand Dynamic edit tool"');
+  });
+
   it("renders review comment contexts as structured cards instead of raw tags", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -258,6 +258,71 @@ describe("MessagesTimeline", () => {
     expect(markup).not.toContain("C:/Users/mike/dev-stuff/t3code/apps/web/src/session-logic.ts");
   });
 
+  it("renders command work entries as expandable rows", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const stdout = Array.from({ length: 45 }, (_, index) => `stdout ${index + 1}`).join("\n");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Ran command",
+              tone: "tool",
+              itemType: "command_execution",
+              command: "vp test",
+              stdout,
+              stderr: "warning",
+              exitCode: 0,
+              durationMs: 1234,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Ran command");
+    expect(markup).toContain("vp test");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-label="Expand Ran command"');
+  });
+
+  it("renders file-change work entries as expandable rows", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Changed files",
+              tone: "tool",
+              itemType: "file_change",
+              changedFiles: ["apps/web/src/session-logic.ts"],
+              patch:
+                "diff --git a/apps/web/src/session-logic.ts b/apps/web/src/session-logic.ts\n--- a/apps/web/src/session-logic.ts\n+++ b/apps/web/src/session-logic.ts\n@@ -1 +1 @@\n-old\n+new\n",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Changed files");
+    expect(markup).toContain("apps/web/src/session-logic.ts");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-label="Expand Changed files"');
+  });
+
   it("renders review comment contexts as structured cards instead of raw tags", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -447,6 +447,66 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Expand Dynamic patch tool"');
   });
 
+  it("renders dynamic tool output metadata as expandable command rows without a command", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Dynamic output tool",
+              tone: "tool",
+              itemType: "dynamic_tool_call",
+              stdout: "updated files",
+              exitCode: 0,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Dynamic output tool");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-label="Expand Dynamic output tool"');
+  });
+
+  it("renders command execution patch metadata as expandable file-change rows", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Ran command",
+              tone: "tool",
+              itemType: "command_execution",
+              changedFiles: ["apps/web/src/session-logic.ts"],
+              patch:
+                "diff --git a/apps/web/src/session-logic.ts b/apps/web/src/session-logic.ts\n--- a/apps/web/src/session-logic.ts\n+++ b/apps/web/src/session-logic.ts\n@@ -1 +1 @@\n-old\n+new\n",
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Ran command");
+    expect(markup).toContain("apps/web/src/session-logic.ts");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-label="Expand Ran command"');
+  });
+
   it("renders mixed dynamic tool command and patch metadata", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -292,6 +292,98 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain('aria-label="Expand Ran command"');
   });
 
+  it("renders dynamic tool command metadata as expandable command rows", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Dynamic tool",
+              tone: "tool",
+              itemType: "dynamic_tool_call",
+              command: "vp test",
+              stdout: "passed",
+              exitCode: 0,
+              durationMs: 1234,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Dynamic tool");
+    expect(markup).toContain("vp test");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-label="Expand Dynamic tool"');
+  });
+
+  it("renders MCP tool command metadata as expandable command rows", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "MCP tool",
+              tone: "tool",
+              itemType: "mcp_tool_call",
+              command: "rg TODO",
+              stdout: "apps/web/src/session-logic.ts:1:TODO",
+              exitCode: 0,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("MCP tool");
+    expect(markup).toContain("rg TODO");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-label="Expand MCP tool"');
+  });
+
+  it("does not render typed non-command stdout as command details", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Web search",
+              tone: "tool",
+              itemType: "web_search",
+              stdout: "search results",
+              durationMs: 1234,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Web search");
+    expect(markup).not.toContain('aria-expanded="false"');
+    expect(markup).not.toContain('aria-label="Expand Web search"');
+  });
+
   it("renders file-change work entries as expandable rows", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(
@@ -321,6 +413,38 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("apps/web/src/session-logic.ts");
     expect(markup).toContain('aria-expanded="false"');
     expect(markup).toContain('aria-label="Expand Changed files"');
+  });
+
+  it("renders dynamic tool patch metadata as expandable file-change rows", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          {
+            id: "entry-1",
+            kind: "work",
+            createdAt: "2026-03-17T19:12:28.000Z",
+            entry: {
+              id: "work-1",
+              createdAt: "2026-03-17T19:12:28.000Z",
+              label: "Dynamic patch tool",
+              tone: "tool",
+              itemType: "dynamic_tool_call",
+              patch:
+                "diff --git a/apps/web/src/session-logic.ts b/apps/web/src/session-logic.ts\n--- a/apps/web/src/session-logic.ts\n+++ b/apps/web/src/session-logic.ts\n@@ -1 +1 @@\n-old\n+new\n",
+              stdout: "applied patch",
+              exitCode: 0,
+              durationMs: 1234,
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("Dynamic patch tool");
+    expect(markup).toContain('aria-expanded="false"');
+    expect(markup).toContain('aria-label="Expand Dynamic patch tool"');
   });
 
   it("renders review comment contexts as structured cards instead of raw tags", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1209,13 +1209,17 @@ function hasExpandableWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
 }
 
 function ToolEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {
-  if (hasCommandWorkEntryDetails(workEntry)) {
-    return <CommandEntryDetails workEntry={workEntry} />;
+  const hasCommandDetails = hasCommandWorkEntryDetails(workEntry);
+  const hasFileChangeDetails = hasFileChangeWorkEntryDetails(workEntry);
+  if (!hasCommandDetails && !hasFileChangeDetails) {
+    return null;
   }
-  if (hasFileChangeWorkEntryDetails(workEntry)) {
-    return <FileChangeEntryDetails workEntry={workEntry} />;
-  }
-  return null;
+  return (
+    <>
+      {hasCommandDetails ? <CommandEntryDetails workEntry={workEntry} /> : null}
+      {hasFileChangeDetails ? <FileChangeEntryDetails workEntry={workEntry} /> : null}
+    </>
+  );
 }
 
 function hasCommandWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1419,7 +1419,7 @@ function FileChangeEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry })
               />
             )}
             options={{
-              collapsed: false,
+              collapsed: true,
               diffStyle: "unified",
               theme: resolveDiffThemeName(ctx.resolvedTheme),
             }}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1209,17 +1209,13 @@ function hasExpandableWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
 }
 
 function ToolEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {
-  const showCommandDetails = hasCommandWorkEntryDetails(workEntry);
-  const showFileChangeDetails = hasFileChangeWorkEntryDetails(workEntry);
-  if (!showCommandDetails && !showFileChangeDetails) {
-    return null;
+  if (hasCommandWorkEntryDetails(workEntry)) {
+    return <CommandEntryDetails workEntry={workEntry} />;
   }
-  return (
-    <>
-      {showCommandDetails && <CommandEntryDetails workEntry={workEntry} />}
-      {showFileChangeDetails && <FileChangeEntryDetails workEntry={workEntry} />}
-    </>
-  );
+  if (hasFileChangeWorkEntryDetails(workEntry)) {
+    return <FileChangeEntryDetails workEntry={workEntry} />;
+  }
+  return null;
 }
 
 function hasCommandWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
@@ -1237,7 +1233,10 @@ function hasCommandWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
     return false;
   }
   if (workEntry.itemType || workEntry.requestKind) {
-    return workEntry.itemType === "dynamic_tool_call" || workEntry.itemType === "mcp_tool_call";
+    return (
+      (workEntry.itemType === "dynamic_tool_call" || workEntry.itemType === "mcp_tool_call") &&
+      hasCommandWorkEntryCommand(workEntry)
+    );
   }
   return hasCommandWorkEntryCommand(workEntry);
 }
@@ -1259,6 +1258,16 @@ function hasCommandWorkEntryCommand(workEntry: TimelineWorkEntry): boolean {
 }
 
 function hasFileChangeWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
+  if (workEntry.itemType === "file_change" || workEntry.requestKind === "file-change") {
+    return Boolean(workEntry.patch || (workEntry.changedFiles?.length ?? 0) > 0);
+  }
+  if (
+    workEntry.itemType === "command_execution" ||
+    workEntry.itemType === "collab_agent_tool_call" ||
+    workEntry.requestKind === "command"
+  ) {
+    return false;
+  }
   return Boolean(workEntry.patch || (workEntry.changedFiles?.length ?? 0) > 0);
 }
 

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -13,11 +13,13 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent,
   type ReactNode,
 } from "react";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { FileDiff } from "@pierre/diffs/react";
-import { deriveTimelineEntries, formatElapsed } from "../../session-logic";
+import type { FileDiffMetadata, Hunk } from "@pierre/diffs/types";
+import { deriveTimelineEntries, formatDuration, formatElapsed } from "../../session-logic";
 import { type TurnDiffSummary } from "../../types";
 import { summarizeTurnDiffStats } from "../../lib/turnDiffTree";
 import {
@@ -29,6 +31,8 @@ import ChatMarkdown from "../ChatMarkdown";
 import {
   BotIcon,
   CheckIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
   CircleAlertIcon,
   EyeIcon,
   GlobeIcon,
@@ -48,6 +52,8 @@ import { DiffStatLabel, hasNonZeroStat } from "./DiffStatLabel";
 import { MessageCopyButton } from "./MessageCopyButton";
 import {
   computeStableMessagesTimelineRows,
+  getRenderableCommandOutputLines,
+  hasRenderableCommandOutput,
   MAX_VISIBLE_WORK_LOG_ENTRIES,
   deriveMessagesTimelineRows,
   normalizeCompactToolLabel,
@@ -109,6 +115,7 @@ const TimelineRowActivityCtx = createContext<TimelineRowActivityState>(null!);
 const TIMELINE_LIST_HEADER = <div className="h-3 sm:h-4" />;
 const TIMELINE_LIST_FOOTER = <div className="h-3 sm:h-4" />;
 const EMPTY_TIMELINE_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
+const COMMAND_OUTPUT_TAIL_LINES = 40;
 
 // ---------------------------------------------------------------------------
 // Props (public API)
@@ -1172,11 +1179,322 @@ function toolWorkEntryHeading(workEntry: TimelineWorkEntry): string {
   return capitalizePhrase(normalizeCompactToolLabel(workEntry.toolTitle));
 }
 
+function ToolDetailBlock(props: {
+  title: string;
+  children: ReactNode;
+  mono?: boolean;
+  tone?: "default" | "error";
+}) {
+  return (
+    <div className="space-y-1">
+      <p className="text-[9px] font-medium uppercase tracking-[0.14em] text-muted-foreground/55">
+        {props.title}
+      </p>
+      <div
+        className={cn(
+          "max-h-80 overflow-auto rounded-md border border-border/55 bg-background/80 px-2 py-1.5 text-[11px] leading-5 text-foreground/78",
+          props.mono && "font-mono whitespace-pre-wrap wrap-break-word",
+          props.tone === "error" &&
+            "border-rose-500/20 bg-rose-500/5 text-rose-800 dark:text-rose-200",
+        )}
+      >
+        {props.children}
+      </div>
+    </div>
+  );
+}
+
+function hasExpandableWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
+  if (isCommandWorkEntry(workEntry)) {
+    return Boolean(
+      workEntry.command ||
+      workEntry.rawCommand ||
+      workEntry.output ||
+      workEntry.stdout ||
+      workEntry.stderr ||
+      workEntry.exitCode !== undefined ||
+      workEntry.durationMs !== undefined,
+    );
+  }
+  if (isFileChangeWorkEntry(workEntry)) {
+    return Boolean(workEntry.patch || (workEntry.changedFiles?.length ?? 0) > 0);
+  }
+  return false;
+}
+
+function ToolEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {
+  if (isCommandWorkEntry(workEntry)) {
+    return <CommandEntryDetails workEntry={workEntry} />;
+  }
+  if (isFileChangeWorkEntry(workEntry)) {
+    return <FileChangeEntryDetails workEntry={workEntry} />;
+  }
+  return null;
+}
+
+function isCommandWorkEntry(workEntry: TimelineWorkEntry): boolean {
+  if (workEntry.itemType === "command_execution" || workEntry.requestKind === "command") {
+    return true;
+  }
+  if (workEntry.itemType === "file_change" || workEntry.requestKind === "file-change") {
+    return false;
+  }
+  if (workEntry.itemType || workEntry.requestKind) {
+    return (
+      (workEntry.itemType === "dynamic_tool_call" || workEntry.itemType === "mcp_tool_call") &&
+      hasCommandWorkEntryCommand(workEntry)
+    );
+  }
+  return hasCommandWorkEntryCommand(workEntry);
+}
+
+function hasCommandWorkEntryCommand(workEntry: TimelineWorkEntry): boolean {
+  return Boolean(workEntry.command || workEntry.rawCommand);
+}
+
+function isFileChangeWorkEntry(workEntry: TimelineWorkEntry): boolean {
+  if (workEntry.itemType === "file_change" || workEntry.requestKind === "file-change") {
+    return true;
+  }
+  if (workEntry.itemType === "command_execution" || workEntry.requestKind === "command") {
+    return false;
+  }
+  return Boolean(workEntry.patch);
+}
+
+function CommandEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {
+  const command = workEntry.command ?? workEntry.rawCommand ?? null;
+  const rawCommand =
+    workEntry.rawCommand && workEntry.rawCommand !== command ? workEntry.rawCommand : null;
+  const hasStreamOutput =
+    hasRenderableCommandOutput(workEntry.stdout) || hasRenderableCommandOutput(workEntry.stderr);
+
+  return (
+    <div className="mt-2 space-y-2 pl-7">
+      {command && (
+        <ToolDetailBlock title="Command" mono>
+          {command}
+        </ToolDetailBlock>
+      )}
+      {rawCommand && <CollapsedRawCommandBlock value={rawCommand} />}
+      <div className="flex flex-wrap gap-1.5 text-[10px] text-muted-foreground/70">
+        <span className="rounded-md border border-border/55 bg-background/75 px-1.5 py-0.5">
+          Exit code {workEntry.exitCode ?? "unknown"}
+        </span>
+        <span className="rounded-md border border-border/55 bg-background/75 px-1.5 py-0.5">
+          Duration{" "}
+          {workEntry.durationMs !== undefined ? formatDuration(workEntry.durationMs) : "unknown"}
+        </span>
+      </div>
+      {hasRenderableCommandOutput(workEntry.stdout) ? (
+        <CommandOutputBlock title="Stdout" value={workEntry.stdout} />
+      ) : null}
+      {hasRenderableCommandOutput(workEntry.stderr) ? (
+        <CommandOutputBlock title="Stderr" value={workEntry.stderr} tone="error" />
+      ) : null}
+      {!hasStreamOutput && hasRenderableCommandOutput(workEntry.output) ? (
+        <CommandOutputBlock title="Output" value={workEntry.output} />
+      ) : null}
+    </div>
+  );
+}
+
+function CollapsedRawCommandBlock({ value }: { value: string }) {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="space-y-1">
+      <button
+        type="button"
+        className="flex items-center gap-1 text-[9px] font-medium uppercase tracking-[0.14em] text-muted-foreground/55 transition-colors hover:text-foreground/75 focus-visible:outline-2 focus-visible:outline-ring"
+        onClick={() => setExpanded((current) => !current)}
+        aria-expanded={expanded}
+      >
+        <span>Raw command</span>
+        <span className="normal-case tracking-normal">({expanded ? "hide" : "show"})</span>
+      </button>
+      {expanded ? (
+        <div className="max-h-80 overflow-auto rounded-md border border-border/55 bg-background/80 px-2 py-1.5 font-mono text-[11px] leading-5 whitespace-pre-wrap wrap-break-word text-foreground/78">
+          {value}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function CommandOutputBlock(props: { title: string; value: string; tone?: "default" | "error" }) {
+  const [showFull, setShowFull] = useState(false);
+  const lines = useMemo(() => getRenderableCommandOutputLines(props.value), [props.value]);
+  const isTruncated = lines.length > COMMAND_OUTPUT_TAIL_LINES;
+  const toggleLabel = `${showFull ? "Collapse" : "Expand"} ${props.title}`;
+  const visibleValue =
+    showFull || !isTruncated
+      ? lines.join("\n")
+      : lines.slice(-COMMAND_OUTPUT_TAIL_LINES).join("\n");
+  const suffix = isTruncated
+    ? showFull
+      ? `${lines.length.toLocaleString()} lines`
+      : `last ${COMMAND_OUTPUT_TAIL_LINES} of ${lines.length.toLocaleString()} lines`
+    : `${lines.length.toLocaleString()} line${lines.length === 1 ? "" : "s"}`;
+
+  return (
+    <div className="space-y-1">
+      <button
+        type="button"
+        className={cn(
+          "flex items-center gap-1 text-[9px] font-medium uppercase tracking-[0.14em] text-muted-foreground/55 transition-colors focus-visible:outline-2 focus-visible:outline-ring",
+          isTruncated ? "cursor-pointer hover:text-foreground/75" : "cursor-default",
+        )}
+        disabled={!isTruncated}
+        aria-expanded={isTruncated ? showFull : undefined}
+        aria-label={isTruncated ? toggleLabel : `${props.title} output`}
+        onClick={() => {
+          if (isTruncated) {
+            setShowFull((value) => !value);
+          }
+        }}
+      >
+        <span>{props.title}</span>
+        <span className="normal-case tracking-normal">({suffix})</span>
+      </button>
+      <button
+        type="button"
+        className={cn(
+          "block max-h-80 w-full overflow-auto rounded-md border border-border/55 bg-background/80 px-2 py-1.5 text-left font-mono text-[11px] leading-5 whitespace-pre-wrap wrap-break-word text-foreground/78",
+          props.tone === "error" &&
+            "border-rose-500/20 bg-rose-500/5 text-rose-800 dark:text-rose-200",
+          isTruncated ? "cursor-pointer" : "cursor-default",
+        )}
+        disabled={!isTruncated}
+        aria-expanded={isTruncated ? showFull : undefined}
+        aria-label={isTruncated ? toggleLabel : `${props.title} output`}
+        onClick={() => {
+          if (isTruncated) {
+            setShowFull((value) => !value);
+          }
+        }}
+      >
+        {visibleValue}
+      </button>
+    </div>
+  );
+}
+
+function FileChangeEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {
+  const ctx = use(TimelineRowCtx);
+  const renderablePatch = getRenderablePatch(
+    workEntry.patch,
+    `tool-file-change:${workEntry.id}:${ctx.resolvedTheme}`,
+  );
+  const hasInlineDiff = renderablePatch?.kind === "files";
+
+  return (
+    <div className="mt-2 space-y-2 pl-7">
+      {!hasInlineDiff && (workEntry.changedFiles?.length ?? 0) > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {workEntry.changedFiles?.map((filePath) => {
+            const displayPath = formatWorkspaceRelativePath(filePath, ctx.workspaceRoot);
+            return (
+              <span
+                key={`${workEntry.id}:expanded-file:${filePath}`}
+                className="rounded-md border border-border/55 bg-background/75 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground/75"
+                title={displayPath}
+              >
+                {displayPath}
+              </span>
+            );
+          })}
+        </div>
+      )}
+      {hasInlineDiff &&
+        renderablePatch.files.map((fileDiff) => (
+          <FileDiff
+            key={resolveFileDiffPath(fileDiff)}
+            fileDiff={fileDiff}
+            renderCustomHeader={(renderedFileDiff) => (
+              <InlineFileDiffHeader
+                fileDiff={renderedFileDiff}
+                changedFiles={workEntry.changedFiles}
+                workspaceRoot={ctx.workspaceRoot}
+              />
+            )}
+            options={{
+              collapsed: false,
+              diffStyle: "unified",
+              theme: resolveDiffThemeName(ctx.resolvedTheme),
+            }}
+          />
+        ))}
+      {renderablePatch?.kind === "raw" && (
+        <ToolDetailBlock title={renderablePatch.reason} mono>
+          {renderablePatch.text}
+        </ToolDetailBlock>
+      )}
+    </div>
+  );
+}
+
+function InlineFileDiffHeader({
+  fileDiff,
+  changedFiles,
+  workspaceRoot,
+}: {
+  fileDiff: FileDiffMetadata;
+  changedFiles: ReadonlyArray<string> | undefined;
+  workspaceRoot: string | undefined;
+}) {
+  const displayPath = resolveInlineFileDiffDisplayPath(fileDiff, changedFiles, workspaceRoot);
+  const additions = countDiffHunkChangedLines(fileDiff.hunks, "additionLines");
+  const deletions = countDiffHunkChangedLines(fileDiff.hunks, "deletionLines");
+
+  return (
+    <div className="flex min-w-0 items-center justify-between gap-3 border-b border-border/55 bg-background/80 px-2 py-1 text-[11px]">
+      <span className="min-w-0 truncate font-mono text-foreground/85" title={displayPath}>
+        {displayPath}
+      </span>
+      <span className="shrink-0">
+        <DiffStatLabel additions={additions} deletions={deletions} />
+      </span>
+    </div>
+  );
+}
+
+function resolveInlineFileDiffDisplayPath(
+  fileDiff: FileDiffMetadata,
+  changedFiles: ReadonlyArray<string> | undefined,
+  workspaceRoot: string | undefined,
+): string {
+  const rawPath = resolveFileDiffPath(fileDiff);
+  const normalizedRawPath = rawPath.replace(/\\/gu, "/");
+  const matchedChangedFile = changedFiles?.find((filePath) => {
+    const normalizedChangedFile = filePath.replace(/\\/gu, "/");
+    return (
+      normalizedChangedFile === normalizedRawPath ||
+      normalizedChangedFile.endsWith(`/${normalizedRawPath}`) ||
+      normalizedRawPath.endsWith(`/${normalizedChangedFile.replace(/^\/+/u, "")}`)
+    );
+  });
+
+  return formatWorkspaceRelativePath(matchedChangedFile ?? rawPath, workspaceRoot);
+}
+
+function countDiffHunkChangedLines(
+  hunks: ReadonlyArray<Hunk>,
+  lineCountKey: "additionLines" | "deletionLines",
+): number {
+  let count = 0;
+  for (const hunk of hunks) {
+    count += hunk[lineCountKey];
+  }
+  return count;
+}
+
 const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   workEntry: TimelineWorkEntry;
   workspaceRoot: string | undefined;
 }) {
   const { workEntry, workspaceRoot } = props;
+  const [expanded, setExpanded] = useState(false);
   const iconConfig = workToneIcon(workEntry.tone);
   const EntryIcon = workEntryIcon(workEntry);
   const heading = toolWorkEntryHeading(workEntry);
@@ -1191,10 +1509,45 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
   const displayText = preview ? `${heading} - ${preview}` : heading;
   const hasChangedFiles = (workEntry.changedFiles?.length ?? 0) > 0;
   const previewIsChangedFiles = hasChangedFiles && !workEntry.command && !workEntry.detail;
+  const canExpand = hasExpandableWorkEntryDetails(workEntry);
+  const ToggleIcon = expanded ? ChevronDownIcon : ChevronRightIcon;
+  const toggleExpanded = useCallback(() => {
+    if (!canExpand) {
+      return;
+    }
+    setExpanded((value) => !value);
+  }, [canExpand]);
+  const handleSummaryKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (!canExpand || (event.key !== "Enter" && event.key !== " ")) {
+        return;
+      }
+      event.preventDefault();
+      toggleExpanded();
+    },
+    [canExpand, toggleExpanded],
+  );
 
   return (
-    <div className="rounded-lg px-1 py-1">
-      <div className="flex items-center gap-2 transition-[opacity,translate] duration-200">
+    <div
+      className={cn(
+        "rounded-lg px-1 py-1 transition-colors duration-150",
+        expanded && "bg-background/45",
+      )}
+      data-tool-entry-expanded={expanded ? "true" : "false"}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-md transition-[opacity,translate] duration-200",
+          canExpand &&
+            "cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+        )}
+        role={canExpand ? "button" : undefined}
+        tabIndex={canExpand ? 0 : undefined}
+        aria-expanded={canExpand ? expanded : undefined}
+        onClick={toggleExpanded}
+        onKeyDown={handleSummaryKeyDown}
+      >
         <span
           className={cn("flex size-5 shrink-0 items-center justify-center", iconConfig.className)}
         >
@@ -1267,6 +1620,20 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
             </Tooltip>
           )}
         </div>
+        {canExpand && (
+          <button
+            type="button"
+            className="flex size-5 shrink-0 items-center justify-center rounded-md text-muted-foreground/55 transition-colors hover:bg-muted/70 hover:text-foreground/80 focus-visible:outline-2 focus-visible:outline-ring"
+            aria-expanded={expanded}
+            aria-label={expanded ? `Collapse ${heading}` : `Expand ${heading}`}
+            onClick={(event) => {
+              event.stopPropagation();
+              toggleExpanded();
+            }}
+          >
+            <ToggleIcon className="size-3" />
+          </button>
+        )}
       </div>
       {hasChangedFiles && !previewIsChangedFiles && (
         <div className="mt-1 flex flex-wrap gap-1 pl-6">
@@ -1289,6 +1656,7 @@ const SimpleWorkEntryRow = memo(function SimpleWorkEntryRow(props: {
           )}
         </div>
       )}
+      {canExpand && expanded && <ToolEntryDetails workEntry={workEntry} />}
     </div>
   );
 });

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1205,34 +1205,27 @@ function ToolDetailBlock(props: {
 }
 
 function hasExpandableWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
-  if (isCommandWorkEntry(workEntry)) {
-    return Boolean(
-      workEntry.command ||
-      workEntry.rawCommand ||
-      workEntry.output ||
-      workEntry.stdout ||
-      workEntry.stderr ||
-      workEntry.exitCode !== undefined ||
-      workEntry.durationMs !== undefined,
-    );
-  }
-  if (isFileChangeWorkEntry(workEntry)) {
-    return Boolean(workEntry.patch || (workEntry.changedFiles?.length ?? 0) > 0);
-  }
-  return false;
+  return hasCommandWorkEntryDetails(workEntry) || hasFileChangeWorkEntryDetails(workEntry);
 }
 
 function ToolEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {
-  if (isCommandWorkEntry(workEntry)) {
-    return <CommandEntryDetails workEntry={workEntry} />;
+  const showCommandDetails = hasCommandWorkEntryDetails(workEntry);
+  const showFileChangeDetails = hasFileChangeWorkEntryDetails(workEntry);
+  if (!showCommandDetails && !showFileChangeDetails) {
+    return null;
   }
-  if (isFileChangeWorkEntry(workEntry)) {
-    return <FileChangeEntryDetails workEntry={workEntry} />;
-  }
-  return null;
+  return (
+    <>
+      {showCommandDetails && <CommandEntryDetails workEntry={workEntry} />}
+      {showFileChangeDetails && <FileChangeEntryDetails workEntry={workEntry} />}
+    </>
+  );
 }
 
-function isCommandWorkEntry(workEntry: TimelineWorkEntry): boolean {
+function hasCommandWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
+  if (!hasCommandWorkEntryMetadata(workEntry)) {
+    return false;
+  }
   if (workEntry.itemType === "command_execution" || workEntry.requestKind === "command") {
     return true;
   }
@@ -1244,33 +1237,29 @@ function isCommandWorkEntry(workEntry: TimelineWorkEntry): boolean {
     return false;
   }
   if (workEntry.itemType || workEntry.requestKind) {
-    return (
-      (workEntry.itemType === "dynamic_tool_call" || workEntry.itemType === "mcp_tool_call") &&
-      hasCommandWorkEntryCommand(workEntry)
-    );
+    return workEntry.itemType === "dynamic_tool_call" || workEntry.itemType === "mcp_tool_call";
   }
   return hasCommandWorkEntryCommand(workEntry);
+}
+
+function hasCommandWorkEntryMetadata(workEntry: TimelineWorkEntry): boolean {
+  return Boolean(
+    workEntry.command ||
+    workEntry.rawCommand ||
+    workEntry.output ||
+    workEntry.stdout ||
+    workEntry.stderr ||
+    workEntry.exitCode !== undefined ||
+    workEntry.durationMs !== undefined,
+  );
 }
 
 function hasCommandWorkEntryCommand(workEntry: TimelineWorkEntry): boolean {
   return Boolean(workEntry.command || workEntry.rawCommand);
 }
 
-function isFileChangeWorkEntry(workEntry: TimelineWorkEntry): boolean {
-  if (workEntry.itemType === "file_change" || workEntry.requestKind === "file-change") {
-    return true;
-  }
-  if (
-    workEntry.itemType === "command_execution" ||
-    workEntry.itemType === "collab_agent_tool_call" ||
-    workEntry.requestKind === "command"
-  ) {
-    return false;
-  }
-  if (workEntry.patch) {
-    return true;
-  }
-  return false;
+function hasFileChangeWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
+  return Boolean(workEntry.patch || (workEntry.changedFiles?.length ?? 0) > 0);
 }
 
 function CommandEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1237,10 +1237,7 @@ function hasCommandWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
     return false;
   }
   if (workEntry.itemType || workEntry.requestKind) {
-    return (
-      (workEntry.itemType === "dynamic_tool_call" || workEntry.itemType === "mcp_tool_call") &&
-      hasCommandWorkEntryCommand(workEntry)
-    );
+    return workEntry.itemType === "dynamic_tool_call" || workEntry.itemType === "mcp_tool_call";
   }
   return hasCommandWorkEntryCommand(workEntry);
 }
@@ -1265,11 +1262,7 @@ function hasFileChangeWorkEntryDetails(workEntry: TimelineWorkEntry): boolean {
   if (workEntry.itemType === "file_change" || workEntry.requestKind === "file-change") {
     return Boolean(workEntry.patch || (workEntry.changedFiles?.length ?? 0) > 0);
   }
-  if (
-    workEntry.itemType === "command_execution" ||
-    workEntry.itemType === "collab_agent_tool_call" ||
-    workEntry.requestKind === "command"
-  ) {
+  if (workEntry.itemType === "collab_agent_tool_call") {
     return false;
   }
   return Boolean(workEntry.patch || (workEntry.changedFiles?.length ?? 0) > 0);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1430,7 +1430,7 @@ function FileChangeEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry })
               />
             )}
             options={{
-              collapsed: true,
+              collapsed: false,
               diffStyle: "unified",
               theme: resolveDiffThemeName(ctx.resolvedTheme),
             }}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -1236,7 +1236,11 @@ function isCommandWorkEntry(workEntry: TimelineWorkEntry): boolean {
   if (workEntry.itemType === "command_execution" || workEntry.requestKind === "command") {
     return true;
   }
-  if (workEntry.itemType === "file_change" || workEntry.requestKind === "file-change") {
+  if (
+    workEntry.itemType === "file_change" ||
+    workEntry.itemType === "collab_agent_tool_call" ||
+    workEntry.requestKind === "file-change"
+  ) {
     return false;
   }
   if (workEntry.itemType || workEntry.requestKind) {
@@ -1256,10 +1260,17 @@ function isFileChangeWorkEntry(workEntry: TimelineWorkEntry): boolean {
   if (workEntry.itemType === "file_change" || workEntry.requestKind === "file-change") {
     return true;
   }
-  if (workEntry.itemType === "command_execution" || workEntry.requestKind === "command") {
+  if (
+    workEntry.itemType === "command_execution" ||
+    workEntry.itemType === "collab_agent_tool_call" ||
+    workEntry.requestKind === "command"
+  ) {
     return false;
   }
-  return Boolean(workEntry.patch);
+  if (workEntry.patch) {
+    return true;
+  }
+  return false;
 }
 
 function CommandEntryDetails({ workEntry }: { workEntry: TimelineWorkEntry }) {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -1059,7 +1059,7 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.stdout).toBe("line 1\nline 2");
   });
 
-  it("deduplicates suffix-overlapping incremental command output chunks", () => {
+  it("keeps distinct suffix-overlapping command output chunks", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "command-tool-output-update",
@@ -1098,7 +1098,7 @@ describe("deriveWorkLogEntries", () => {
     ];
 
     const [entry] = deriveWorkLogEntries(activities, undefined);
-    expect(entry?.stdout).toBe("foobar");
+    expect(entry?.stdout).toBe("foo\noobar");
   });
 
   it("preserves existing newlines between incremental command output chunks", () => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -929,6 +929,52 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("uses completed cumulative command output instead of duplicating updated output", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-output-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "line 1\n",
+              stderr: "warning 1\n",
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-tool-output-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "line 1\nline 2\n",
+              stderr: "warning 1\nwarning 2\n",
+              exitCode: 0,
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.stdout).toBe("line 1\nline 2\n");
+    expect(entry?.stderr).toBe("warning 1\nwarning 2\n");
+  });
+
   it("strips fallback stdout exit-code metadata", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -1118,6 +1164,31 @@ describe("deriveWorkLogEntries", () => {
           itemType: "file_change",
           patch,
         },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.patch).toBe(patch);
+  });
+
+  it("does not traverse nested patch keys when extracting top-level array patches", () => {
+    const patch =
+      "diff --git a/app.ts b/app.ts\n--- a/app.ts\n+++ b/app.ts\n@@ -1 +1 @@\n-old\n+new\n";
+    const nestedPatch =
+      "diff --git a/nested.ts b/nested.ts\n--- a/nested.ts\n+++ b/nested.ts\n@@ -1 +1 @@\n-old\n+nested\n";
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "top-level-array-file-tool-patch",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: [
+          {
+            patch,
+            item: {
+              patch: nestedPatch,
+            },
+          },
+        ] as unknown as Record<string, unknown>,
       }),
     ];
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -929,6 +929,34 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("strips fallback stdout exit-code metadata", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-result-stdout-exit-code",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          data: {
+            item: {
+              command: "node script.js",
+              result: {
+                stdout: "done\n<exited with exit code 7>",
+              },
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry).toMatchObject({
+      command: "node script.js",
+      stdout: "done",
+      exitCode: 7,
+    });
+  });
+
   it("keeps Codex command execution item output, exit code, and duration", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -1070,6 +1098,38 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.patch).toContain("+Smoke test file-change row.");
   });
 
+  it("keeps nested result file-change patches within the traversal budget", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-file-tool-result-patch",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            item: {
+              result: {
+                changes: [
+                  {
+                    path: "apps/web/src/session-logic.ts",
+                    diff: "@@ -1 +1 @@\n-old\n+new",
+                  },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.changedFiles).toEqual(["apps/web/src/session-logic.ts"]);
+    expect(entry?.patch).toContain(
+      "diff --git a/apps/web/src/session-logic.ts b/apps/web/src/session-logic.ts",
+    );
+    expect(entry?.patch).toContain("+new");
+  });
+
   it("extracts top-level tool patches", () => {
     const patch =
       "diff --git a/app.ts b/app.ts\n--- a/app.ts\n+++ b/app.ts\n@@ -1 +1 @@\n-old\n+new\n";
@@ -1087,6 +1147,28 @@ describe("deriveWorkLogEntries", () => {
 
     const [entry] = deriveWorkLogEntries(activities, undefined);
     expect(entry?.patch).toBe(patch);
+  });
+
+  it("normalizes top-level hunk-only diffs with sibling path metadata", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "top-level-file-tool-hunk",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          path: "apps/web/src/session-logic.ts",
+          diff: "@@ -1 +1 @@\n-old\n+new",
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.patch).toContain(
+      "diff --git a/apps/web/src/session-logic.ts b/apps/web/src/session-logic.ts",
+    );
+    expect(entry?.patch).toContain("--- a/apps/web/src/session-logic.ts");
+    expect(entry?.patch).toContain("+++ b/apps/web/src/session-logic.ts");
   });
 
   it("keeps add hunk-only diffs rooted at dev null", () => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -30,7 +30,7 @@ function makeActivity(overrides: {
   kind?: string;
   summary?: string;
   tone?: OrchestrationThreadActivity["tone"];
-  payload?: Record<string, unknown>;
+  payload?: OrchestrationThreadActivity["payload"];
   turnId?: string;
   sequence?: number;
 }): OrchestrationThreadActivity {
@@ -975,7 +975,7 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.stderr).toBe("warning 1\nwarning 2\n");
   });
 
-  it("preserves overlapping incremental command output chunks", () => {
+  it("concatenates non-matching incremental command output chunks", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
         id: "command-tool-output-update",
@@ -1015,6 +1015,135 @@ describe("deriveWorkLogEntries", () => {
 
     const [entry] = deriveWorkLogEntries(activities, undefined);
     expect(entry?.stdout).toBe("Error\nretrying");
+  });
+
+  it("keeps accumulated command output when a later chunk repeats its prefix", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-output-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "line 1\nline 2",
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-tool-output-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "line 1",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.stdout).toBe("line 1\nline 2");
+  });
+
+  it("deduplicates suffix-overlapping incremental command output chunks", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-output-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "foo",
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-tool-output-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "oobar",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.stdout).toBe("foobar");
+  });
+
+  it("preserves existing newlines between incremental command output chunks", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-output-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "Error",
+              stderr: "warning\n",
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-tool-output-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "\nretrying",
+              stderr: "done",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.stdout).toBe("Error\nretrying");
+    expect(entry?.stderr).toBe("warning\ndone");
   });
 
   it("strips fallback stdout exit-code metadata", () => {
@@ -1230,7 +1359,7 @@ describe("deriveWorkLogEntries", () => {
               patch: nestedPatch,
             },
           },
-        ] as unknown as Record<string, unknown>,
+        ],
       }),
     ];
 

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -962,6 +962,30 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
+  it("does not overwrite subagent output with command result fallbacks", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "subagent-with-output",
+        kind: "tool.completed",
+        summary: "Subagent",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          data: {
+            rawOutput: {
+              content: "Subagent result",
+            },
+            item: {
+              aggregatedOutput: "Command-like fallback",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.output).toBe("Subagent result");
+  });
+
   it("extracts changed file paths for file-change tool activities", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({
@@ -1040,10 +1064,57 @@ describe("deriveWorkLogEntries", () => {
     const [entry] = deriveWorkLogEntries(activities, undefined);
     expect(entry?.changedFiles).toEqual(["/Users/example/t3code/SMOKE_TEST_CHANGE.md"]);
     expect(entry?.patch).toContain(
-      "diff --git a/Users/example/t3code/SMOKE_TEST_CHANGE.md b/Users/example/t3code/SMOKE_TEST_CHANGE.md",
+      "diff --git a//Users/example/t3code/SMOKE_TEST_CHANGE.md b//Users/example/t3code/SMOKE_TEST_CHANGE.md",
     );
     expect(entry?.patch).toContain("--- /dev/null");
     expect(entry?.patch).toContain("+Smoke test file-change row.");
+  });
+
+  it("extracts top-level tool patches", () => {
+    const patch =
+      "diff --git a/app.ts b/app.ts\n--- a/app.ts\n+++ b/app.ts\n@@ -1 +1 @@\n-old\n+new\n";
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "top-level-file-tool-patch",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          patch,
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.patch).toBe(patch);
+  });
+
+  it("keeps add hunk-only diffs rooted at dev null", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-file-tool-add-hunk",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            item: {
+              changes: [
+                {
+                  path: "SMOKE_TEST_ADD.md",
+                  kind: { type: "add" },
+                  diff: "@@ -0,0 +1 @@\n+Smoke test file-change row.",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.patch).toContain("--- /dev/null");
+    expect(entry?.patch).toContain("+++ b/SMOKE_TEST_ADD.md");
   });
 
   it("normalizes Codex file-change diffs for gitignored paths when the provider emits a patch", () => {

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -975,6 +975,48 @@ describe("deriveWorkLogEntries", () => {
     expect(entry?.stderr).toBe("warning 1\nwarning 2\n");
   });
 
+  it("preserves overlapping incremental command output chunks", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-output-update",
+        createdAt: "2026-02-23T00:00:01.000Z",
+        kind: "tool.updated",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "Error",
+            },
+          },
+        },
+      }),
+      makeActivity({
+        id: "command-tool-output-complete",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            toolCallId: "command-1",
+            command: "vp test",
+            rawOutput: {
+              stdout: "retrying",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.stdout).toBe("Error\nretrying");
+  });
+
   it("strips fallback stdout exit-code metadata", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -990,30 +990,6 @@ describe("deriveWorkLogEntries", () => {
     });
   });
 
-  it("does not overwrite subagent output with command result fallbacks", () => {
-    const activities: OrchestrationThreadActivity[] = [
-      makeActivity({
-        id: "subagent-with-output",
-        kind: "tool.completed",
-        summary: "Subagent",
-        payload: {
-          itemType: "collab_agent_tool_call",
-          data: {
-            rawOutput: {
-              content: "Subagent result",
-            },
-            item: {
-              aggregatedOutput: "Command-like fallback",
-            },
-          },
-        },
-      }),
-    ];
-
-    const [entry] = deriveWorkLogEntries(activities, undefined);
-    expect(entry?.output).toBe("Subagent result");
-  });
-
   it("extracts changed file paths for file-change tool activities", () => {
     const activities: OrchestrationThreadActivity[] = [
       makeActivity({

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -890,8 +890,75 @@ describe("deriveWorkLogEntries", () => {
     expect(entry).toMatchObject({
       command: "bun run dev",
       detail: '{ "dev": "vite dev --port 3000" }',
+      output: '{ "dev": "vite dev --port 3000" }',
+      exitCode: 0,
       itemType: "command_execution",
       toolTitle: "bash",
+    });
+  });
+
+  it("keeps command stdout, stderr, exit code, and duration for expanded command details", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "command-tool-output",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          title: "Ran command",
+          data: {
+            command: "vp test",
+            rawOutput: {
+              stdout: "line 1\nline 2\n",
+              stderr: "warning\n",
+              exitCode: 1,
+              durationMs: 1250,
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry).toMatchObject({
+      command: "vp test",
+      stdout: "line 1\nline 2\n",
+      stderr: "warning\n",
+      exitCode: 1,
+      durationMs: 1250,
+    });
+  });
+
+  it("keeps Codex command execution item output, exit code, and duration", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-command-tool-output",
+        kind: "tool.completed",
+        summary: "Ran command",
+        payload: {
+          itemType: "command_execution",
+          detail: `/opt/homebrew/bin/bash -lc "printf 'stdout ui smoke test\\\\n'"`,
+          data: {
+            item: {
+              aggregatedOutput: "stdout ui smoke test\n",
+              command: `/opt/homebrew/bin/bash -lc "printf 'stdout ui smoke test\\\\n'"`,
+              commandActions: [{ command: "printf 'stdout ui smoke test\\n'", type: "unknown" }],
+              durationMs: 0,
+              exitCode: 0,
+              type: "commandExecution",
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry).toMatchObject({
+      command: "printf 'stdout ui smoke test\\\\n'",
+      rawCommand: `/opt/homebrew/bin/bash -lc "printf 'stdout ui smoke test\\\\n'"`,
+      output: "stdout ui smoke test\n",
+      exitCode: 0,
+      durationMs: 0,
     });
   });
 
@@ -920,6 +987,122 @@ describe("deriveWorkLogEntries", () => {
       "apps/web/src/components/ChatView.tsx",
       "apps/web/src/session-logic.ts",
     ]);
+  });
+
+  it("keeps file-change patches for inline expanded diff rendering", () => {
+    const patch =
+      "diff --git a/app.ts b/app.ts\n--- a/app.ts\n+++ b/app.ts\n@@ -1 +1 @@\n-old\n+new\n";
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "file-tool-patch",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            item: {
+              path: "app.ts",
+              patch,
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.changedFiles).toEqual(["app.ts"]);
+    expect(entry?.patch).toBe(patch);
+  });
+
+  it("normalizes Codex file-change content diffs into unified patches", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-file-tool-patch",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            item: {
+              changes: [
+                {
+                  path: "/Users/example/t3code/SMOKE_TEST_CHANGE.md",
+                  kind: { type: "add" },
+                  diff: "Smoke test file-change row.\n",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.changedFiles).toEqual(["/Users/example/t3code/SMOKE_TEST_CHANGE.md"]);
+    expect(entry?.patch).toContain(
+      "diff --git a/Users/example/t3code/SMOKE_TEST_CHANGE.md b/Users/example/t3code/SMOKE_TEST_CHANGE.md",
+    );
+    expect(entry?.patch).toContain("--- /dev/null");
+    expect(entry?.patch).toContain("+Smoke test file-change row.");
+  });
+
+  it("normalizes Codex file-change diffs for gitignored paths when the provider emits a patch", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-file-tool-ignored-patch",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            item: {
+              changes: [
+                {
+                  path: "apps/web/dist/ignored.txt",
+                  kind: { type: "add" },
+                  diff: "ignored file content\n",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.changedFiles).toEqual(["apps/web/dist/ignored.txt"]);
+    expect(entry?.patch).toContain(
+      "diff --git a/apps/web/dist/ignored.txt b/apps/web/dist/ignored.txt",
+    );
+    expect(entry?.patch).toContain("+ignored file content");
+  });
+
+  it("normalizes Codex hunk-only diffs into unified patches", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "codex-file-tool-hunk",
+        kind: "tool.completed",
+        summary: "File change",
+        payload: {
+          itemType: "file_change",
+          data: {
+            item: {
+              changes: [
+                {
+                  path: "SMOKE_TEST_CHANGE.md",
+                  diff: "@@ -1 +1,2 @@\n Smoke test file-change row.\n+Smoke test file-change row rerun.",
+                },
+              ],
+            },
+          },
+        },
+      }),
+    ];
+
+    const [entry] = deriveWorkLogEntries(activities, undefined);
+    expect(entry?.patch).toContain("diff --git a/SMOKE_TEST_CHANGE.md b/SMOKE_TEST_CHANGE.md");
+    expect(entry?.patch).toContain("--- a/SMOKE_TEST_CHANGE.md");
+    expect(entry?.patch).toContain("+++ b/SMOKE_TEST_CHANGE.md");
   });
 
   it("drops duplicated tool detail when it only repeats the title", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -729,7 +729,35 @@ function mergeTextOutput(
   if (previous === next) {
     return next;
   }
-  return `${previous}${previous.endsWith("\n") ? "" : "\n"}${next}`;
+  if (next.startsWith(previous)) {
+    return next;
+  }
+  if (previous.startsWith(next)) {
+    return previous;
+  }
+  const overlap = findSuffixPrefixOverlap(previous, next);
+  if (overlap > 0) {
+    return `${previous}${next.slice(overlap)}`;
+  }
+  const separator = previous.endsWith("\n") || next.startsWith("\n") ? "" : "\n";
+  return `${previous}${separator}${next}`;
+}
+
+function findSuffixPrefixOverlap(previous: string, next: string): number {
+  const maxLength = Math.min(previous.length, next.length);
+  const candidate = `${next.slice(0, maxLength)}\u0000${previous.slice(-maxLength)}`;
+  const prefixLengths = Array.from({ length: candidate.length }, () => 0);
+  for (let index = 1; index < candidate.length; index += 1) {
+    let fallbackIndex = prefixLengths[index - 1] ?? 0;
+    while (fallbackIndex > 0 && candidate[index] !== candidate[fallbackIndex]) {
+      fallbackIndex = prefixLengths[fallbackIndex - 1] ?? 0;
+    }
+    if (candidate[index] === candidate[fallbackIndex]) {
+      fallbackIndex += 1;
+    }
+    prefixLengths[index] = fallbackIndex;
+  }
+  return Math.min(prefixLengths.at(-1) ?? 0, maxLength);
 }
 
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {
@@ -1282,7 +1310,7 @@ function collectPatchStrings(
   }
   if (Array.isArray(value)) {
     for (const entry of value) {
-      collectPatchStrings(entry, patches, seen, depth + 1);
+      collectPatchStrings(entry, patches, seen, depth + 1, includeNested);
       if (patches.length >= MAX_PATCH_STRINGS) {
         return;
       }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -54,12 +54,23 @@ export interface WorkLogEntry {
   detail?: string;
   command?: string;
   rawCommand?: string;
+  output?: string;
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number;
+  durationMs?: number;
+  patch?: string;
   changedFiles?: ReadonlyArray<string>;
   tone: "thinking" | "tool" | "info" | "error";
   toolTitle?: string;
   itemType?: ToolLifecycleItemType;
   requestKind?: PendingApproval["requestKind"];
 }
+
+const MAX_PATCH_SEARCH_DEPTH = 4;
+const MAX_PATCH_STRINGS = 4;
+const MAX_INLINE_PATCH_CHARS = 200_000;
+const PATCH_TOO_LARGE_MESSAGE = `[patch omitted: exceeds ${MAX_INLINE_PATCH_CHARS} characters]`;
 
 interface DerivedWorkLogEntry extends WorkLogEntry {
   activityKind: OrchestrationThreadActivity["kind"];
@@ -515,7 +526,9 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
       ? (activity.payload as Record<string, unknown>)
       : null;
   const commandPreview = extractToolCommand(payload);
+  const commandResult = extractCommandResult(payload);
   const changedFiles = extractChangedFiles(payload);
+  const patch = extractToolPatch(payload);
   const title = extractToolTitle(payload);
   const isTaskActivity = activity.kind === "task.progress" || activity.kind === "task.completed";
   const taskSummary =
@@ -561,6 +574,28 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
   }
   if (commandPreview.rawCommand) {
     entry.rawCommand = commandPreview.rawCommand;
+  }
+  const isCommandEntry =
+    itemType === "command_execution" ||
+    requestKind === "command" ||
+    Boolean(commandPreview.command || commandPreview.rawCommand);
+  if (commandResult.output && !commandResult.stdout && !commandResult.stderr && isCommandEntry) {
+    entry.output = commandResult.output;
+  }
+  if (commandResult.stdout) {
+    entry.stdout = commandResult.stdout;
+  }
+  if (commandResult.stderr) {
+    entry.stderr = commandResult.stderr;
+  }
+  if (commandResult.exitCode !== null) {
+    entry.exitCode = commandResult.exitCode;
+  }
+  if (commandResult.durationMs !== null) {
+    entry.durationMs = commandResult.durationMs;
+  }
+  if (patch) {
+    entry.patch = patch;
   }
   if (changedFiles.length > 0) {
     entry.changedFiles = changedFiles;
@@ -632,6 +667,12 @@ function mergeDerivedWorkLogEntries(
   const detail = next.detail ?? previous.detail;
   const command = next.command ?? previous.command;
   const rawCommand = next.rawCommand ?? previous.rawCommand;
+  const output = mergeTextOutput(previous.output, next.output);
+  const stdout = mergeTextOutput(previous.stdout, next.stdout);
+  const stderr = mergeTextOutput(previous.stderr, next.stderr);
+  const exitCode = next.exitCode ?? previous.exitCode;
+  const durationMs = next.durationMs ?? previous.durationMs;
+  const patch = next.patch ?? previous.patch;
   const toolTitle = next.toolTitle ?? previous.toolTitle;
   const itemType = next.itemType ?? previous.itemType;
   const requestKind = next.requestKind ?? previous.requestKind;
@@ -643,6 +684,12 @@ function mergeDerivedWorkLogEntries(
     ...(detail ? { detail } : {}),
     ...(command ? { command } : {}),
     ...(rawCommand ? { rawCommand } : {}),
+    ...(output ? { output } : {}),
+    ...(stdout ? { stdout } : {}),
+    ...(stderr ? { stderr } : {}),
+    ...(exitCode !== undefined ? { exitCode } : {}),
+    ...(durationMs !== undefined ? { durationMs } : {}),
+    ...(patch ? { patch } : {}),
     ...(changedFiles.length > 0 ? { changedFiles } : {}),
     ...(toolTitle ? { toolTitle } : {}),
     ...(itemType ? { itemType } : {}),
@@ -661,6 +708,22 @@ function mergeChangedFiles(
     return [];
   }
   return [...new Set(merged)];
+}
+
+function mergeTextOutput(
+  previous: string | undefined,
+  next: string | undefined,
+): string | undefined {
+  if (!previous) {
+    return next;
+  }
+  if (!next) {
+    return previous;
+  }
+  if (previous === next) {
+    return next;
+  }
+  return `${previous}${previous.endsWith("\n") ? "" : "\n"}${next}`;
 }
 
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {
@@ -894,6 +957,94 @@ function extractToolCommand(payload: Record<string, unknown> | null): {
   };
 }
 
+function firstNumberFromRecord(
+  record: Record<string, unknown> | null,
+  keys: ReadonlyArray<string>,
+): number | null {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = asNumber(record[key]);
+    if (value !== null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function firstIntegerFromRecord(
+  record: Record<string, unknown> | null,
+  keys: ReadonlyArray<string>,
+): number | null {
+  const value = firstNumberFromRecord(record, keys);
+  return value !== null && Number.isInteger(value) ? value : null;
+}
+
+function extractCommandResult(payload: Record<string, unknown> | null): {
+  output: string | null;
+  stdout: string | null;
+  stderr: string | null;
+  exitCode: number | null;
+  durationMs: number | null;
+} {
+  const data = asRecord(payload?.data);
+  const item = asRecord(data?.item);
+  const itemResult = asRecord(item?.result);
+  const rawOutput = asRecord(data?.rawOutput);
+  const stdout =
+    firstRawStringFromRecord(rawOutput, ["stdout"]) ??
+    firstRawStringFromRecord(itemResult, ["stdout"]) ??
+    firstRawStringFromRecord(data, ["stdout"]) ??
+    firstRawStringFromRecord(payload, ["stdout"]);
+  const stderr =
+    firstRawStringFromRecord(rawOutput, ["stderr"]) ??
+    firstRawStringFromRecord(itemResult, ["stderr"]) ??
+    firstRawStringFromRecord(data, ["stderr"]) ??
+    firstRawStringFromRecord(payload, ["stderr"]);
+  const content =
+    stdout ??
+    firstRawStringFromRecord(rawOutput, ["content", "output", "text", "result"]) ??
+    firstRawStringFromRecord(itemResult, ["content", "output", "text", "result"]) ??
+    firstRawStringFromRecord(item, ["aggregatedOutput", "output", "text", "result"]);
+  const strippedContent = content ? stripTrailingExitCode(content) : null;
+  const detailExit =
+    typeof payload?.detail === "string" ? stripTrailingExitCode(payload.detail) : null;
+  const exitCode =
+    firstIntegerFromRecord(rawOutput, ["exitCode", "code"]) ??
+    firstIntegerFromRecord(itemResult, ["exitCode", "code"]) ??
+    firstIntegerFromRecord(item, ["exitCode", "code"]) ??
+    firstIntegerFromRecord(data, ["exitCode", "code"]) ??
+    firstIntegerFromRecord(payload, ["exitCode", "code"]) ??
+    strippedContent?.exitCode ??
+    detailExit?.exitCode ??
+    null;
+  const elapsedSeconds =
+    firstNumberFromRecord(rawOutput, ["elapsedSeconds"]) ??
+    firstNumberFromRecord(itemResult, ["elapsedSeconds"]) ??
+    firstNumberFromRecord(item, ["elapsedSeconds"]) ??
+    firstNumberFromRecord(data, ["elapsedSeconds"]) ??
+    firstNumberFromRecord(payload, ["elapsedSeconds"]);
+  const durationMs =
+    firstNumberFromRecord(rawOutput, ["durationMs", "elapsedMs"]) ??
+    firstNumberFromRecord(itemResult, ["durationMs", "elapsedMs"]) ??
+    firstNumberFromRecord(item, ["durationMs", "elapsedMs"]) ??
+    firstNumberFromRecord(data, ["durationMs", "elapsedMs"]) ??
+    firstNumberFromRecord(payload, ["durationMs", "elapsedMs"]) ??
+    (elapsedSeconds !== null ? elapsedSeconds * 1000 : null);
+  const strippedStdout = stdout ? stripTrailingExitCode(stdout) : null;
+  const normalizedOutput =
+    strippedContent?.exitCode !== undefined ? strippedContent.output : (content ?? null);
+
+  return {
+    output: normalizedOutput,
+    stdout: strippedStdout?.exitCode !== undefined ? strippedStdout.output : stdout,
+    stderr,
+    exitCode,
+    durationMs,
+  };
+}
+
 function extractToolTitle(payload: Record<string, unknown> | null): string | null {
   return asTrimmedString(payload?.title);
 }
@@ -1027,6 +1178,151 @@ function stripTrailingExitCode(value: string): {
   };
 }
 
+function firstRawStringFromRecord(
+  record: Record<string, unknown> | null,
+  keys: ReadonlyArray<string>,
+): string | null {
+  if (!record) {
+    return null;
+  }
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.length > 0) {
+      return value;
+    }
+  }
+  return null;
+}
+
+function looksLikeUnifiedDiff(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("diff --git ") ||
+    trimmed.startsWith("--- ") ||
+    trimmed.startsWith("@@ ") ||
+    /^@@\s+-\d+(?:,\d+)?\s+\+\d+(?:,\d+)?\s+@@/u.test(trimmed)
+  );
+}
+
+function codexChangeKindType(record: Record<string, unknown>): string | null {
+  const kind = record.kind;
+  if (typeof kind === "string") {
+    return kind;
+  }
+  const kindRecord = asRecord(kind);
+  return asTrimmedString(kindRecord?.type);
+}
+
+function patchPathFromRecord(record: Record<string, unknown>): string | null {
+  return (
+    asTrimmedString(record.path) ??
+    asTrimmedString(record.filePath) ??
+    asTrimmedString(record.relativePath) ??
+    asTrimmedString(record.filename) ??
+    asTrimmedString(record.newPath) ??
+    asTrimmedString(record.oldPath)
+  );
+}
+
+function normalizeDiffHeaderPath(path: string): string {
+  return path.replace(/\\/gu, "/");
+}
+
+function toUnifiedPatchFromRecordDiff(
+  record: Record<string, unknown>,
+  diff: string,
+): string | null {
+  if (diff.startsWith("diff --git ") || diff.startsWith("--- ")) {
+    return diff;
+  }
+  const trimmed = diff.trimEnd();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  const rawPath = patchPathFromRecord(record);
+  if (!rawPath) {
+    return looksLikeUnifiedDiff(trimmed) ? trimmed : null;
+  }
+  const path = normalizeDiffHeaderPath(rawPath);
+
+  if (codexChangeKindType(record) === "add") {
+    if (trimmed.startsWith("@@ ")) {
+      return `diff --git a/${path} b/${path}\nnew file mode 100644\n--- /dev/null\n+++ b/${path}\n${trimmed}`;
+    }
+    const lines = trimmed.length > 0 ? trimmed.split(/\r?\n/u) : [];
+    const addedLines = lines.map((line) => `+${line}`).join("\n");
+    return `diff --git a/${path} b/${path}\nnew file mode 100644\n--- /dev/null\n+++ b/${path}\n@@ -0,0 +1,${lines.length} @@\n${addedLines}`;
+  }
+
+  if (trimmed.startsWith("@@ ")) {
+    return `diff --git a/${path} b/${path}\n--- a/${path}\n+++ b/${path}\n${trimmed}`;
+  }
+
+  return null;
+}
+
+function collectPatchStrings(
+  value: unknown,
+  patches: string[],
+  seen: Set<string>,
+  depth: number,
+  includeNested = true,
+): void {
+  if (depth > MAX_PATCH_SEARCH_DEPTH || patches.length >= MAX_PATCH_STRINGS) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectPatchStrings(entry, patches, seen, depth + 1);
+      if (patches.length >= MAX_PATCH_STRINGS) {
+        return;
+      }
+    }
+    return;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return;
+  }
+  for (const key of ["patch", "diff", "unifiedDiff"]) {
+    const rawCandidate = typeof record[key] === "string" ? record[key] : null;
+    const candidate = rawCandidate ? toUnifiedPatchFromRecordDiff(record, rawCandidate) : null;
+    if (!candidate || seen.has(candidate)) {
+      continue;
+    }
+    if (candidate.length > MAX_INLINE_PATCH_CHARS) {
+      seen.add(candidate);
+      patches.push(PATCH_TOO_LARGE_MESSAGE);
+      continue;
+    }
+    if (!looksLikeUnifiedDiff(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    patches.push(candidate);
+  }
+  if (!includeNested) {
+    return;
+  }
+  for (const nestedKey of ["item", "result", "input", "data", "changes", "files", "edits"]) {
+    if (!(nestedKey in record)) {
+      continue;
+    }
+    collectPatchStrings(record[nestedKey], patches, seen, depth + 1);
+    if (patches.length >= MAX_PATCH_STRINGS) {
+      return;
+    }
+  }
+}
+
+function extractToolPatch(payload: Record<string, unknown> | null): string | null {
+  const patches: string[] = [];
+  const data = asRecord(payload?.data);
+  collectPatchStrings(data, patches, new Set<string>(), 0, false);
+  collectPatchStrings(asRecord(data?.item), patches, new Set<string>(patches), 0);
+  return patches.length > 0 ? patches.join("\n\n") : null;
+}
 function extractWorkLogItemType(
   payload: Record<string, unknown> | null,
 ): WorkLogEntry["itemType"] | undefined {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -735,15 +735,6 @@ function mergeTextOutput(
   if (previous.startsWith(next)) {
     return previous;
   }
-  for (
-    let overlapLength = Math.min(previous.length, next.length);
-    overlapLength > 1;
-    overlapLength -= 1
-  ) {
-    if (previous.endsWith(next.slice(0, overlapLength))) {
-      return `${previous}${next.slice(overlapLength)}`;
-    }
-  }
   const separator = previous.endsWith("\n") || next.startsWith("\n") ? "" : "\n";
   return `${previous}${separator}${next}`;
 }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -579,7 +579,13 @@ function toDerivedWorkLogEntry(activity: OrchestrationThreadActivity): DerivedWo
     itemType === "command_execution" ||
     requestKind === "command" ||
     Boolean(commandPreview.command || commandPreview.rawCommand);
-  if (commandResult.output && !commandResult.stdout && !commandResult.stderr && isCommandEntry) {
+  if (
+    commandResult.output &&
+    !commandResult.stdout &&
+    !commandResult.stderr &&
+    !entry.output &&
+    isCommandEntry
+  ) {
     entry.output = commandResult.output;
   }
   if (commandResult.stdout) {
@@ -992,8 +998,9 @@ function extractCommandResult(payload: Record<string, unknown> | null): {
   const item = asRecord(data?.item);
   const itemResult = asRecord(item?.result);
   const rawOutput = asRecord(data?.rawOutput);
+  const rawOutputStdout = firstRawStringFromRecord(rawOutput, ["stdout"]);
   const stdout =
-    firstRawStringFromRecord(rawOutput, ["stdout"]) ??
+    rawOutputStdout ??
     firstRawStringFromRecord(itemResult, ["stdout"]) ??
     firstRawStringFromRecord(data, ["stdout"]) ??
     firstRawStringFromRecord(payload, ["stdout"]);
@@ -1032,11 +1039,12 @@ function extractCommandResult(payload: Record<string, unknown> | null): {
     firstNumberFromRecord(data, ["durationMs", "elapsedMs"]) ??
     firstNumberFromRecord(payload, ["durationMs", "elapsedMs"]) ??
     (elapsedSeconds !== null ? elapsedSeconds * 1000 : null);
-  const strippedStdout = stdout ? stripTrailingExitCode(stdout) : null;
+  const strippedStdout = rawOutputStdout ? stripTrailingExitCode(rawOutputStdout) : null;
   const normalizedOutput =
     strippedContent?.exitCode !== undefined ? strippedContent.output : (content ?? null);
 
   return {
+    // `output` is the legacy fallback stream; callers should prefer stdout/stderr when present.
     output: normalizedOutput,
     stdout: strippedStdout?.exitCode !== undefined ? strippedStdout.output : stdout,
     stderr,
@@ -1318,9 +1326,13 @@ function collectPatchStrings(
 
 function extractToolPatch(payload: Record<string, unknown> | null): string | null {
   const patches: string[] = [];
+  const seen = new Set<string>();
+  if (payload) {
+    collectPatchStrings(payload, patches, seen, 0, false);
+  }
   const data = asRecord(payload?.data);
-  collectPatchStrings(data, patches, new Set<string>(), 0, false);
-  collectPatchStrings(asRecord(data?.item), patches, new Set<string>(patches), 0);
+  // Keep traversal bounded; provider payloads can nest raw tool data deeply.
+  collectPatchStrings(data, patches, seen, 0);
   return patches.length > 0 ? patches.join("\n\n") : null;
 }
 function extractWorkLogItemType(

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -735,6 +735,15 @@ function mergeTextOutput(
   if (previous.startsWith(next)) {
     return previous;
   }
+  for (
+    let overlapLength = Math.min(previous.length, next.length);
+    overlapLength > 1;
+    overlapLength -= 1
+  ) {
+    if (previous.endsWith(next.slice(0, overlapLength))) {
+      return `${previous}${next.slice(overlapLength)}`;
+    }
+  }
   const separator = previous.endsWith("\n") || next.startsWith("\n") ? "" : "\n";
   return `${previous}${separator}${next}`;
 }
@@ -1324,7 +1333,7 @@ function collectPatchStrings(
     if (!(nestedKey in record)) {
       continue;
     }
-    collectPatchStrings(record[nestedKey], patches, seen, depth + 1);
+    collectPatchStrings(record[nestedKey], patches, seen, depth + 1, includeNested);
     if (patches.length >= MAX_PATCH_STRINGS) {
       return;
     }

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -735,29 +735,8 @@ function mergeTextOutput(
   if (previous.startsWith(next)) {
     return previous;
   }
-  const overlap = findSuffixPrefixOverlap(previous, next);
-  if (overlap > 0) {
-    return `${previous}${next.slice(overlap)}`;
-  }
   const separator = previous.endsWith("\n") || next.startsWith("\n") ? "" : "\n";
   return `${previous}${separator}${next}`;
-}
-
-function findSuffixPrefixOverlap(previous: string, next: string): number {
-  const maxLength = Math.min(previous.length, next.length);
-  const candidate = `${next.slice(0, maxLength)}\u0000${previous.slice(-maxLength)}`;
-  const prefixLengths = Array.from({ length: candidate.length }, () => 0);
-  for (let index = 1; index < candidate.length; index += 1) {
-    let fallbackIndex = prefixLengths[index - 1] ?? 0;
-    while (fallbackIndex > 0 && candidate[index] !== candidate[fallbackIndex]) {
-      fallbackIndex = prefixLengths[fallbackIndex - 1] ?? 0;
-    }
-    if (candidate[index] === candidate[fallbackIndex]) {
-      fallbackIndex += 1;
-    }
-    prefixLengths[index] = fallbackIndex;
-  }
-  return Math.min(prefixLengths.at(-1) ?? 0, maxLength);
 }
 
 function deriveToolLifecycleCollapseKey(entry: DerivedWorkLogEntry): string | undefined {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -1039,7 +1039,7 @@ function extractCommandResult(payload: Record<string, unknown> | null): {
     firstNumberFromRecord(data, ["durationMs", "elapsedMs"]) ??
     firstNumberFromRecord(payload, ["durationMs", "elapsedMs"]) ??
     (elapsedSeconds !== null ? elapsedSeconds * 1000 : null);
-  const strippedStdout = rawOutputStdout ? stripTrailingExitCode(rawOutputStdout) : null;
+  const strippedStdout = stdout ? stripTrailingExitCode(stdout) : null;
   const normalizedOutput =
     strippedContent?.exitCode !== undefined ? strippedContent.output : (content ?? null);
 


### PR DESCRIPTION
## Summary

Adds inline expandable work-log details for file-change and command activities in the conversation timeline.

## What Changed

- Render command activity rows as clickable expandable rows.
  - Goal: keep the collapsed `Ran command - <command>` preview compact while making command details available inline.
  - Expanded rows show command, differing raw command, exit code, duration, and any stdout/stderr/output streams.

- Add command output rendering helpers.
  - Goal: hide empty output blocks and keep long command output readable.
  - Output streams trim only outer empty lines, preserve intentional blank lines inside output, show the last 40 lines by default, and toggle to the full stream when clicked.

- Render file-change activity rows as clickable expandable rows.
  - Goal: keep the collapsed `Changed files - <path>` preview compact while avoiding a jump to the full turn diff panel.
  - Expanded rows render available patches through the existing `FileDiff` viewer.
  - If no patch is available, expanded rows list changed paths inline.

- Extract richer command and patch metadata from tool activity payloads.
  - Goal: support Codex/provider payload shapes that include stdout, stderr, exit code, duration, shell-wrapped raw commands, hunk-only diffs, content-only add diffs, nested patch data, and gitignored file patches when the provider emits patch data.

- Add coverage for timeline rendering and session activity derivation.
  - Goal: lock in expandable command/file-change behavior, output trimming/toggling rules, command metadata extraction, and inline patch normalization.

## Why

Individual command and diff events are mostly opaque currently. We can somewhat see what the agent is doing, but we don't have a clear picture of what each command actually outputs, or what each file change actually produced.

Usually that's fine, most times we inspect the end result and trust the agent. Sometimes it's good to inspect a little deeper. For commands we can help steer by debugging their output, or just compare the results with manual runs. For diffs we can see better follow along the multiple changes an agent makes, or even inspect changes to git-ignored files (which don't appear on the main diff panel).

## UI Changes

<img width="1322" height="876" alt="Screenshot 2026-06-09 at 09 34 06" src="https://github.com/user-attachments/assets/f923529b-d254-422d-ad27-4e6af9e8e5e0" />
<img width="1319" height="613" alt="Screenshot 2026-06-09 at 09 32 11" src="https://github.com/user-attachments/assets/02dd660d-9801-4a5e-af67-1a794ca215fa" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI and payload-parsing changes in the chat timeline and session-logic derivation; behavior is heavily tested but provider payload edge cases and rendering large diffs/output could affect performance or display correctness.
> 
> **Overview**
> Adds **inline expandable details** for command and file-change work-log rows in the messages timeline, so collapsed previews stay compact while stdout/stderr, exit metadata, and patches are available without opening the turn diff panel.
> 
> **Timeline UI** — `SimpleWorkEntryRow` gains expand/collapse (keyboard + chevron, `aria-expanded`). Expanded command rows show command/raw command, exit code, duration, and output streams via new helpers that hide whitespace-only output, preserve intentional blank lines, and default long stdout/stderr to the **last 40 lines** with expand/collapse. File-change rows render inline `FileDiff` when a patch exists, otherwise changed-file chips.
> 
> **Activity derivation** — `WorkLogEntry` and `deriveWorkLogEntries` now populate `stdout`, `stderr`, `output`, `exitCode`, `durationMs`, and `patch` from varied provider payloads (including incremental `tool.updated` merging, Codex command/file shapes, hunk-only diffs normalized to unified patches, and bounded patch extraction with size limits). Expandability is gated by item type so non-command tools (e.g. web search) do not pick up stray stdout as command UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8883b9022392ea5db1fb1e438a4cc0e466405b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add expandable command output and file diff sections to work entry rows in the chat timeline
> - `SimpleWorkEntryRow` in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/3005/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) now supports expand/collapse with chevron icons, keyboard handling (Enter/Space), and aria attributes for accessibility.
> - New `CommandEntryDetails` component renders command metadata, stdout/stderr (truncated to last 40 lines with an expand toggle), exit code, and duration; `FileChangeEntryDetails` renders inline unified diffs with a path/stats header or falls back to file badges and raw patch text.
> - [session-logic.ts](https://github.com/pingdotgg/t3code/pull/3005/files#diff-9f1f9f19555f14c3c47d4ce52e1b7dcec7e968e54f400820085376797a7223d6) adds `output`, `stdout`, `stderr`, `exitCode`, `durationMs`, and `patch` fields to `WorkLogEntry`, extracted and normalized from heterogeneous provider payloads (including Codex and legacy shapes) via new `extractCommandResult` and `extractToolPatch` helpers.
> - Streaming tool updates are coalesced via `mergeTextOutput`, which handles prefix/suffix overlap and newline boundaries across `tool.updated` and `tool.completed` events.
> - Behavioral Change: partial or non-unified diffs in payloads are now synthesized into proper unified patch format before rendering; patch extraction is bounded by depth and total size guards to prevent excessive traversal.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8883b90.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->