### PR TITLE
Add Claude Fable 5 model aliases

### DIFF
--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -32,7 +32,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
  */
 const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, string>> = {
   [ProviderDriverKind.make("codex")]: "gpt-6.7-codex-ultra-preview",
-  [ProviderDriverKind.make("claudeAgent")]: "claude-sonnet-5-0",
+  [ProviderDriverKind.make("claudeAgent")]: "claude-fable-5",
   [ProviderDriverKind.make("cursor")]: "claude-sonnet-4-6",
   [ProviderDriverKind.make("opencode")]: "openai/gpt-5",
 };

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -32,7 +32,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
  */
 const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, string>> = {
   [ProviderDriverKind.make("codex")]: "gpt-6.7-codex-ultra-preview",
-  [ProviderDriverKind.make("claudeAgent")]: "claude-fable-5",
+  [ProviderDriverKind.make("claudeAgent")]: "claude-sonnet-4-6",
   [ProviderDriverKind.make("cursor")]: "claude-sonnet-4-6",
   [ProviderDriverKind.make("opencode")]: "openai/gpt-5",
 };

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -32,7 +32,7 @@ import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
  */
 const CUSTOM_MODEL_PLACEHOLDER_BY_KIND: Partial<Record<ProviderDriverKind, string>> = {
   [ProviderDriverKind.make("codex")]: "gpt-6.7-codex-ultra-preview",
-  [ProviderDriverKind.make("claudeAgent")]: "claude-sonnet-4-6",
+  [ProviderDriverKind.make("claudeAgent")]: "claude-sonnet-5-0",
   [ProviderDriverKind.make("cursor")]: "claude-sonnet-4-6",
   [ProviderDriverKind.make("opencode")]: "openai/gpt-5",
 };

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -166,6 +166,9 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "gpt-5.3-spark": "gpt-5.3-codex-spark",
   },
   [CLAUDE_DRIVER_KIND]: {
+    fable: "claude-fable-5",
+    "fable-5": "claude-fable-5",
+    "claude-fable": "claude-fable-5",
     opus: "claude-opus-4-8",
     "opus-4.8": "claude-opus-4-8",
     "claude-opus-4.8": "claude-opus-4-8",

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -75,6 +75,8 @@ describe("normalizeModelSlug", () => {
     const claude = ProviderDriverKind.make("claudeAgent");
     expect(normalizeModelSlug("gpt-5-codex")).toBe("gpt-5.4");
     expect(normalizeModelSlug("5.3")).toBe("gpt-5.3-codex");
+    expect(normalizeModelSlug("fable", claude)).toBe("claude-fable-5");
+    expect(normalizeModelSlug("fable-5", claude)).toBe("claude-fable-5");
     expect(normalizeModelSlug("sonnet", claude)).toBe("claude-sonnet-4-6");
   });
 
@@ -110,6 +112,7 @@ describe("resolveSelectableModel", () => {
   it("resolves exact slugs, labels, and aliases", () => {
     const options = [
       { slug: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+      { slug: "claude-fable-5", name: "Claude Fable 5" },
       { slug: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
     ];
     expect(resolveSelectableModel(ProviderDriverKind.make("codex"), "gpt-5.3-codex", options)).toBe(
@@ -120,6 +123,9 @@ describe("resolveSelectableModel", () => {
     );
     expect(resolveSelectableModel(ProviderDriverKind.make("claudeAgent"), "sonnet", options)).toBe(
       "claude-sonnet-4-6",
+    );
+    expect(resolveSelectableModel(ProviderDriverKind.make("claudeAgent"), "fable", options)).toBe(
+      "claude-fable-5",
     );
   });
 });


### PR DESCRIPTION
## Summary

- Add shorthand aliases that resolve Fable and Fable 5 inputs to `claude-fable-5`.
- Cover the alias behavior in shared model tests.

## Validation

- `bun fmt`
- `bun lint` (passes with existing unrelated unused-disable warnings)
- `bun typecheck`
- `bun run test src/model.test.ts` from `packages/shared`
- Dev server verification: paired locally, opened Settings > Providers, and confirmed Claude v2.1.170 lists Claude Fable 5 first with 7 available models.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small alias-map and test-only changes with no auth, persistence, or routing logic touched.
> 
> **Overview**
> Adds **Claude Fable 5** shorthand to the shared model alias table so user-facing inputs like `fable`, `fable-5`, and `claude-fable` resolve to the canonical slug `claude-fable-5` for the `claudeAgent` provider.
> 
> Shared model tests now assert that normalization and selectable-model resolution pick `claude-fable-5` when those aliases are used alongside the existing selectable options list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ef692e689496ab6a79d7288887b981bbc26e282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'fable', 'fable-5', and 'claude-fable' as aliases for 'claude-fable-5'
> Adds three new entries to `MODEL_SLUG_ALIASES_BY_PROVIDER` in [model.ts](https://github.com/pingdotgg/t3code/pull/3010/files#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959) under the Claude driver, mapping `fable`, `fable-5`, and `claude-fable` to the canonical slug `claude-fable-5`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ef692e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->