### PR TITLE
fix: scope assistant message IDs by turn for Cursor segment reuse

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -61,6 +61,10 @@ const asEventId = (value: string): EventId => EventId.make(value);
 const asMessageId = (value: string): MessageId => MessageId.make(value);
 const asThreadId = (value: string): ThreadId => ThreadId.make(value);
 const asTurnId = (value: string): TurnId => TurnId.make(value);
+const turnScopedAssistantMessageId = (turnId: string, itemId: string, segment?: number): string =>
+  segment === undefined
+    ? `assistant:turn:${turnId}:${itemId}`
+    : `assistant:turn:${turnId}:${itemId}:segment:${segment}`;
 
 type LegacyProviderRuntimeEvent = {
   readonly type: string;
@@ -709,11 +713,12 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-1" && !message.streaming,
+          message.id === turnScopedAssistantMessageId("turn-2", "item-1") && !message.streaming,
       ),
     );
     const message = thread.messages.find(
-      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-1",
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.id === turnScopedAssistantMessageId("turn-2", "item-1"),
     );
     expect(message?.text).toBe("hello world");
     expect(message?.streaming).toBe(false);
@@ -741,11 +746,13 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-no-delta" && !message.streaming,
+          message.id === turnScopedAssistantMessageId("turn-no-delta", "item-no-delta") &&
+          !message.streaming,
       ),
     );
     const message = thread.messages.find(
-      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-no-delta",
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.id === turnScopedAssistantMessageId("turn-no-delta", "item-no-delta"),
     );
     expect(message?.text).toBe("assistant-only final text");
     expect(message?.streaming).toBe(false);
@@ -1529,7 +1536,8 @@ describe("ProviderRuntimeIngestion", () => {
     const midThread = midReadModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
     expect(
       midThread?.messages.some(
-        (message: ProviderRuntimeTestMessage) => message.id === "assistant:item-buffered",
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === turnScopedAssistantMessageId("turn-buffered", "item-buffered"),
       ),
     ).toBe(false);
 
@@ -1550,11 +1558,13 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-buffered" && !message.streaming,
+          message.id === turnScopedAssistantMessageId("turn-buffered", "item-buffered") &&
+          !message.streaming,
       ),
     );
     const message = thread.messages.find(
-      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-buffered",
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.id === turnScopedAssistantMessageId("turn-buffered", "item-buffered"),
     );
     expect(message?.text).toBe("buffer me");
     expect(message?.streaming).toBe(false);
@@ -1609,13 +1619,19 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-buffered-request-flush" &&
+          message.id ===
+            turnScopedAssistantMessageId(
+              "turn-buffered-request-flush",
+              "item-buffered-request-flush",
+            ) &&
           !message.streaming &&
           message.text === "visible before approval",
       ),
     );
     const message = thread.messages.find(
-      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-buffered-request-flush",
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.id ===
+        turnScopedAssistantMessageId("turn-buffered-request-flush", "item-buffered-request-flush"),
     );
     expect(message?.streaming).toBe(false);
   });
@@ -1675,14 +1691,22 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-buffered-user-input-flush" &&
+          message.id ===
+            turnScopedAssistantMessageId(
+              "turn-buffered-user-input-flush",
+              "item-buffered-user-input-flush",
+            ) &&
           !message.streaming &&
           message.text === "visible before user input",
       ),
     );
     const message = thread.messages.find(
       (entry: ProviderRuntimeTestMessage) =>
-        entry.id === "assistant:item-buffered-user-input-flush",
+        entry.id ===
+        turnScopedAssistantMessageId(
+          "turn-buffered-user-input-flush",
+          "item-buffered-user-input-flush",
+        ),
     );
     expect(message?.streaming).toBe(false);
   });
@@ -1742,7 +1766,11 @@ describe("ProviderRuntimeIngestion", () => {
     expect(
       thread.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-buffered-whitespace-request",
+          message.id ===
+          turnScopedAssistantMessageId(
+            "turn-buffered-whitespace-request",
+            "item-buffered-whitespace-request",
+          ),
       ),
     ).toBe(false);
   });
@@ -1799,7 +1827,11 @@ describe("ProviderRuntimeIngestion", () => {
     await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-buffered-request-append" &&
+          message.id ===
+            turnScopedAssistantMessageId(
+              "turn-buffered-request-append",
+              "item-buffered-request-append",
+            ) &&
           !message.streaming &&
           message.text === "first half",
       ),
@@ -1835,17 +1867,32 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-buffered-request-append:segment:1" &&
+          message.id ===
+            turnScopedAssistantMessageId(
+              "turn-buffered-request-append",
+              "item-buffered-request-append",
+              1,
+            ) &&
           !message.streaming &&
           message.text === " second half",
       ),
     );
     const firstMessage = thread.messages.find(
-      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-buffered-request-append",
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.id ===
+        turnScopedAssistantMessageId(
+          "turn-buffered-request-append",
+          "item-buffered-request-append",
+        ),
     );
     const resumedMessage = thread.messages.find(
       (entry: ProviderRuntimeTestMessage) =>
-        entry.id === "assistant:item-buffered-request-append:segment:1",
+        entry.id ===
+        turnScopedAssistantMessageId(
+          "turn-buffered-request-append",
+          "item-buffered-request-append",
+          1,
+        ),
     );
     expect(firstMessage?.text).toBe("first half");
     expect(firstMessage?.streaming).toBe(false);
@@ -1860,7 +1907,12 @@ describe("ProviderRuntimeIngestion", () => {
     const assistantEvents = events.filter(
       (event): event is Extract<(typeof events)[number], { type: "thread.message-sent" }> =>
         event.type === "thread.message-sent" &&
-        event.payload.messageId.startsWith("assistant:item-buffered-request-append"),
+        event.payload.messageId.startsWith(
+          turnScopedAssistantMessageId(
+            "turn-buffered-request-append",
+            "item-buffered-request-append",
+          ).slice(0, "assistant:turn:turn-buffered-request-append:".length),
+        ),
     );
     expect(assistantEvents).toHaveLength(4);
     expect(assistantEvents[0]?.payload.streaming).toBe(true);
@@ -1868,12 +1920,20 @@ describe("ProviderRuntimeIngestion", () => {
     expect(assistantEvents[1]?.payload.streaming).toBe(false);
     expect(assistantEvents[1]?.payload.text).toBe("");
     expect(assistantEvents[2]?.payload.messageId).toBe(
-      "assistant:item-buffered-request-append:segment:1",
+      turnScopedAssistantMessageId(
+        "turn-buffered-request-append",
+        "item-buffered-request-append",
+        1,
+      ),
     );
     expect(assistantEvents[2]?.payload.streaming).toBe(true);
     expect(assistantEvents[2]?.payload.text).toBe(" second half");
     expect(assistantEvents[3]?.payload.messageId).toBe(
-      "assistant:item-buffered-request-append:segment:1",
+      turnScopedAssistantMessageId(
+        "turn-buffered-request-append",
+        "item-buffered-request-append",
+        1,
+      ),
     );
     expect(assistantEvents[3]?.payload.streaming).toBe(false);
     expect(assistantEvents[3]?.payload.text).toBe("");
@@ -1931,7 +1991,11 @@ describe("ProviderRuntimeIngestion", () => {
     await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-streaming-request-segment" &&
+          message.id ===
+            turnScopedAssistantMessageId(
+              "turn-streaming-request-segment",
+              "item-streaming-request-segment",
+            ) &&
           !message.streaming &&
           message.text === "before approval",
       ),
@@ -1967,7 +2031,12 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-streaming-request-segment:segment:1" &&
+          message.id ===
+            turnScopedAssistantMessageId(
+              "turn-streaming-request-segment",
+              "item-streaming-request-segment",
+              1,
+            ) &&
           !message.streaming &&
           message.text === " after approval",
       ),
@@ -1975,15 +2044,104 @@ describe("ProviderRuntimeIngestion", () => {
     expect(
       thread.messages.find(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-streaming-request-segment",
+          message.id ===
+          turnScopedAssistantMessageId(
+            "turn-streaming-request-segment",
+            "item-streaming-request-segment",
+          ),
       )?.text,
     ).toBe("before approval");
     expect(
       thread.messages.find(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-streaming-request-segment:segment:1",
+          message.id ===
+          turnScopedAssistantMessageId(
+            "turn-streaming-request-segment",
+            "item-streaming-request-segment",
+            1,
+          ),
       )?.text,
     ).toBe(" after approval");
+  });
+
+  it("keeps assistant message identities isolated across turns when provider item IDs are reused", async () => {
+    const harness = await createHarness();
+    const now = "2026-01-01T00:00:00.000Z";
+    const reusedItemId = asItemId("assistant:cursor-session:segment:4");
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-reused-item-turn-1"),
+      provider: ProviderDriverKind.make("cursor"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reused-1"),
+      itemId: reusedItemId,
+      payload: {
+        streamKind: "assistant_text",
+        delta: "first turn response",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-reused-item-turn-1-complete"),
+      provider: ProviderDriverKind.make("cursor"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reused-1"),
+      itemId: reusedItemId,
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    harness.emit({
+      type: "content.delta",
+      eventId: asEventId("evt-reused-item-turn-2"),
+      provider: ProviderDriverKind.make("cursor"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reused-2"),
+      itemId: reusedItemId,
+      payload: {
+        streamKind: "assistant_text",
+        delta: "second turn response",
+      },
+    });
+    harness.emit({
+      type: "item.completed",
+      eventId: asEventId("evt-reused-item-turn-2-complete"),
+      provider: ProviderDriverKind.make("cursor"),
+      createdAt: now,
+      threadId: asThreadId("thread-1"),
+      turnId: asTurnId("turn-reused-2"),
+      itemId: reusedItemId,
+      payload: {
+        itemType: "assistant_message",
+        status: "completed",
+      },
+    });
+
+    const thread = await waitForThread(harness.readModel, (entry) =>
+      entry.messages.some(
+        (message: ProviderRuntimeTestMessage) =>
+          message.id === turnScopedAssistantMessageId("turn-reused-2", String(reusedItemId)) &&
+          !message.streaming,
+      ),
+    );
+
+    const firstMessage = thread.messages.find(
+      (message: ProviderRuntimeTestMessage) =>
+        message.id === turnScopedAssistantMessageId("turn-reused-1", String(reusedItemId)),
+    );
+    const secondMessage = thread.messages.find(
+      (message: ProviderRuntimeTestMessage) =>
+        message.id === turnScopedAssistantMessageId("turn-reused-2", String(reusedItemId)),
+    );
+
+    expect(firstMessage?.text).toBe("first turn response");
+    expect(secondMessage?.text).toBe("second turn response");
   });
 
   it("streams assistant deltas when thread.turn.start requests streaming mode", async () => {
@@ -2040,13 +2198,15 @@ describe("ProviderRuntimeIngestion", () => {
     const liveThread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-streaming-mode" &&
+          message.id ===
+            turnScopedAssistantMessageId("turn-streaming-mode", "item-streaming-mode") &&
           message.streaming &&
           message.text === "hello live",
       ),
     );
     const liveMessage = liveThread.messages.find(
-      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-streaming-mode",
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.id === turnScopedAssistantMessageId("turn-streaming-mode", "item-streaming-mode"),
     );
     expect(liveMessage?.streaming).toBe(true);
 
@@ -2068,11 +2228,14 @@ describe("ProviderRuntimeIngestion", () => {
     const finalThread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-streaming-mode" && !message.streaming,
+          message.id ===
+            turnScopedAssistantMessageId("turn-streaming-mode", "item-streaming-mode") &&
+          !message.streaming,
       ),
     );
     const finalMessage = finalThread.messages.find(
-      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-streaming-mode",
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.id === turnScopedAssistantMessageId("turn-streaming-mode", "item-streaming-mode"),
     );
     expect(finalMessage?.text).toBe("hello live");
     expect(finalMessage?.streaming).toBe(false);
@@ -2128,11 +2291,13 @@ describe("ProviderRuntimeIngestion", () => {
     const thread = await waitForThread(harness.readModel, (entry) =>
       entry.messages.some(
         (message: ProviderRuntimeTestMessage) =>
-          message.id === "assistant:item-buffer-spill" && !message.streaming,
+          message.id === turnScopedAssistantMessageId("turn-buffer-spill", "item-buffer-spill") &&
+          !message.streaming,
       ),
     );
     const message = thread.messages.find(
-      (entry: ProviderRuntimeTestMessage) => entry.id === "assistant:item-buffer-spill",
+      (entry: ProviderRuntimeTestMessage) =>
+        entry.id === turnScopedAssistantMessageId("turn-buffer-spill", "item-buffer-spill"),
     );
     expect(message?.text.length).toBe(oversizedText.length);
     expect(message?.text).toBe(oversizedText);
@@ -2204,7 +2369,9 @@ describe("ProviderRuntimeIngestion", () => {
         thread.session?.activeTurnId === null &&
         thread.messages.some(
           (message: ProviderRuntimeTestMessage) =>
-            message.id === "assistant:item-complete-dedup" && !message.streaming,
+            message.id ===
+              turnScopedAssistantMessageId("turn-complete-dedup", "item-complete-dedup") &&
+            !message.streaming,
         ),
     );
 
@@ -2218,7 +2385,8 @@ describe("ProviderRuntimeIngestion", () => {
         return false;
       }
       return (
-        event.payload.messageId === "assistant:item-complete-dedup" &&
+        event.payload.messageId ===
+          turnScopedAssistantMessageId("turn-complete-dedup", "item-complete-dedup") &&
         event.payload.streaming === false
       );
     });
@@ -2575,7 +2743,9 @@ describe("ProviderRuntimeIngestion", () => {
       (entry: ProviderRuntimeTestCheckpoint) => entry.turnId === "turn-p1",
     );
     expect(checkpoint?.status).toBe("missing");
-    expect(checkpoint?.assistantMessageId).toBe("assistant:item-p1-assistant");
+    expect(checkpoint?.assistantMessageId).toBe(
+      turnScopedAssistantMessageId("turn-p1", "item-p1-assistant"),
+    );
     expect(checkpoint?.checkpointRef).toBe("provider-diff:evt-turn-diff-updated");
   });
 

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -193,14 +193,22 @@ function proposedPlanIdFromEvent(event: ProviderRuntimeEvent, threadId: ThreadId
   return `plan:${threadId}:event:${event.eventId}`;
 }
 
-function assistantSegmentBaseKeyFromEvent(event: ProviderRuntimeEvent): string {
-  return String(event.itemId ?? event.turnId ?? event.eventId);
+function assistantSegmentBaseKeyFromEvent(event: ProviderRuntimeEvent, turnId?: TurnId): string {
+  const providerKey = String(event.itemId ?? event.turnId ?? event.eventId);
+  return turnId ? `turn:${turnId}:${providerKey}` : providerKey;
 }
 
 function assistantSegmentMessageId(baseKey: string, segmentIndex: number): MessageId {
   return MessageId.make(
     segmentIndex === 0 ? `assistant:${baseKey}` : `assistant:${baseKey}:segment:${segmentIndex}`,
   );
+}
+
+function runtimeAssistantMessageIdFromEvent(
+  event: ProviderRuntimeEvent,
+  turnId?: TurnId,
+): MessageId {
+  return assistantSegmentMessageId(assistantSegmentBaseKeyFromEvent(event, turnId), 0);
 }
 function buildContextWindowActivityPayload(
   event: ProviderRuntimeEvent,
@@ -781,7 +789,7 @@ const make = Effect.gen(function* () {
   }) =>
     Effect.gen(function* () {
       if (!input.turnId) {
-        return assistantSegmentMessageId(assistantSegmentBaseKeyFromEvent(input.event), 0);
+        return runtimeAssistantMessageIdFromEvent(input.event);
       }
 
       const activeMessageId = yield* getActiveAssistantMessageIdForTurn(
@@ -795,7 +803,7 @@ const make = Effect.gen(function* () {
       return yield* startAssistantSegmentForTurn({
         threadId: input.threadId,
         turnId: input.turnId,
-        baseKey: assistantSegmentBaseKeyFromEvent(input.event),
+        baseKey: assistantSegmentBaseKeyFromEvent(input.event, input.turnId),
       });
     });
 
@@ -1443,9 +1451,7 @@ const make = Effect.gen(function* () {
       const assistantCompletion =
         event.type === "item.completed" && event.payload.itemType === "assistant_message"
           ? {
-              messageId: MessageId.make(
-                `assistant:${event.itemId ?? event.turnId ?? event.eventId}`,
-              ),
+              messageId: runtimeAssistantMessageIdFromEvent(event, toTurnId(event.turnId)),
               fallbackText: event.payload.detail,
             }
           : undefined;
@@ -1618,9 +1624,7 @@ const make = Effect.gen(function* () {
           if (hasCheckpointForTurn(checkpointContext.checkpoints, turnId)) {
             // Already tracked; no-op.
           } else {
-            const assistantMessageId = MessageId.make(
-              `assistant:${event.itemId ?? event.turnId ?? event.eventId}`,
-            );
+            const assistantMessageId = runtimeAssistantMessageIdFromEvent(event, turnId);
             yield* orchestrationEngine.dispatch({
               type: "thread.turn.diff.complete",
               commandId: yield* providerCommandId(event, "thread-turn-diff-complete"),


### PR DESCRIPTION
## Summary
- Include the T3 turn ID when minting runtime assistant message identities so reused Cursor ACP segment item IDs no longer collide in `projection_thread_messages`
- Update provider runtime ingestion tests and add a regression case for same-thread, cross-turn item ID reuse

## Why
Fixes #2426. Cursor can reuse `assistant:<session>:segment:N` item IDs across turns in the same provider session. Projection upserts on `message_id` alone, so later turns overwrote earlier assistant rows and the UI appeared stuck even though orchestration events contained the new responses.

This is distinct from #871 / #882, which address cross-thread collisions and require a schema migration. Turn scoping fixes the within-thread case without changing contracts or persistence schema.

## Test plan
- [x] `vp check`
- [x] `vp run typecheck`
- [x] `vp run --filter t3 test src/orchestration/Layers/ProviderRuntimeIngestion.test.ts`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes projected `message_id` values for assistant messages when a turn is present; fixes UI correctness but alters identity format for ingestion and checkpoints without a DB migration.
> 
> **Overview**
> Fixes **within-thread assistant message collisions** when a provider (notably Cursor) reuses the same `itemId` across turns. Runtime ingestion now **scopes assistant message IDs by turn** when a turn is known, producing IDs like `assistant:turn:<turnId>:<itemId>` (with existing `:segment:N` suffixes unchanged).
> 
> **`ProviderRuntimeIngestion`** introduces `runtimeAssistantMessageIdFromEvent` and extends `assistantSegmentBaseKeyFromEvent` to prefix the provider key with `turn:<turnId>:` for streaming segments, item completion, and diff checkpoint `assistantMessageId` linkage. Events without a turn still use the prior item-only key.
> 
> Tests are updated to the new ID shape and add a regression that two turns with the same reused item ID each retain distinct projected text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2149ba80382640f1d37c40b86cadd5b15f756d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope assistant message IDs by turn to prevent cross-turn collisions when provider item IDs are reused
> - `assistantSegmentBaseKeyFromEvent` now prefixes the base key with `turn:{turnId}:` when a `turnId` is available, scoping message IDs to their originating turn.
> - `runtimeAssistantMessageIdFromEvent` centralizes construction of segment-0 assistant message IDs using the updated turn-scoped base key logic.
> - `getOrCreateAssistantMessageId`, `assistantCompletion` mapping, and `thread.turn.diff.complete` checkpoint dispatch all updated to use turn-scoped IDs when a `turnId` is present.
> - A new test asserts that delta and completion events emitted across two turns with the same provider `itemId` produce isolated texts under distinct turn-scoped message IDs.
> - Behavioral Change: assistant message IDs for any event carrying a `turnId` now have a different format (`assistant:turn:{turnId}:{itemId}` vs `assistant:{itemId}`), which may affect downstream consumers that match on message ID strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2149ba8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->