### PR TITLE
Fix Clerk browser test mock

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -149,11 +149,15 @@ const authAccessHarness = vi.hoisted(() => {
 
 const mockConnectDesktopSshEnvironment = vi.hoisted(() => vi.fn());
 const mockGetClerkToken = vi.hoisted(() => vi.fn(async () => null));
+const mockOpenClerkWaitlist = vi.hoisted(() => vi.fn());
 
 vi.mock("@clerk/react", () => ({
   useAuth: () => ({
     getToken: mockGetClerkToken,
     isSignedIn: false,
+  }),
+  useClerk: () => ({
+    openWaitlist: mockOpenClerkWaitlist,
   }),
 }));
 


### PR DESCRIPTION
## Summary
- add the missing `useClerk` export to the Settings panels browser-test Clerk mock
- provide a mocked `openWaitlist` implementation used by the T3 Connect auth prompt

## Root cause
The T3 Connect auth prompt introduced a static `useClerk` import. The Settings panels browser suite fully mocks `@clerk/react` but only exported `useAuth`, causing module collection to fail before tests ran.

## Validation
- exact `Browser test / Components` CI command: 7 files, 66 tests passed
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock change with no production runtime or auth behavior impact.
> 
> **Overview**
> Extends the **`@clerk/react` mock** in `SettingsPanels.browser.tsx` so Settings browser tests can load modules that depend on Clerk beyond `useAuth`.
> 
> Adds a hoisted **`mockOpenClerkWaitlist`** and exports **`useClerk`** returning `{ openWaitlist: mockOpenClerkWaitlist }`, matching what **`useT3ConnectAuthPrompt`** (used by **`ConnectionsSettings`**) expects after it started importing `useClerk` for the T3 Connect auth flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d67b295a4e4316b7b433a08ca14e923dc869fe69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `useClerk` mock in Clerk browser tests to include `openWaitlist`
> Extends the `@clerk/react` mock in [SettingsPanels.browser.tsx](https://github.com/pingdotgg/t3code/pull/3013/files#diff-f7196539183cad0998dcae73e40b74bed7c5d5b555ef3e5a3354f59310edac45) to return a `useClerk` hook with `openWaitlist` mapped to a hoisted mock function. Previously only `useAuth` was mocked, causing `useClerk().openWaitlist` calls to fail in tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d67b295.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->