### PR TITLE
Bundle DM Sans and JetBrains Mono fonts instead of Google Fonts

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -48,6 +48,7 @@
         background: #ffffff;
         color: #262626;
         font-family:
+          "DM Sans Variable",
           "DM Sans",
           -apple-system,
           BlinkMacSystemFont,
@@ -83,12 +84,6 @@
         object-fit: contain;
       }
     </style>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300..800;1,9..40,300..800&display=swap"
-      rel="stylesheet"
-    />
     <title>T3 Code (Alpha)</title>
   </head>
   <body>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,6 +21,8 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@effect/atom-react": "catalog:",
+    "@fontsource-variable/dm-sans": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@formkit/auto-animate": "^0.9.0",
     "@legendapp/list": "3.0.0-beta.44",
     "@lexical/react": "^0.41.0",

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -329,7 +329,8 @@ export function TerminalViewport({
       lineHeight: 1.2,
       fontSize: 12,
       scrollback: 5_000,
-      fontFamily: '"SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace',
+      fontFamily:
+        '"SF Mono", "SFMono-Regular", "JetBrains Mono", Consolas, "Liberation Mono", Menlo, monospace',
       theme: terminalThemeFromApp(mount),
     });
     terminal.loadAddon(fitAddon);

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6,6 +6,11 @@
 
 @theme inline {
   --animate-skeleton: skeleton 2s -1s infinite linear;
+  --font-sans:
+    "DM Sans Variable", "DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
+    sans-serif;
+  --font-mono:
+    "SF Mono", "SFMono-Regular", "JetBrains Mono", Consolas, "Liberation Mono", Menlo, monospace;
   --color-warning-foreground: var(--warning-foreground);
   --color-warning: var(--warning);
   --color-success-foreground: var(--success-foreground);
@@ -146,6 +151,7 @@
 
 body {
   font-family:
+    "DM Sans Variable",
     "DM Sans",
     -apple-system,
     BlinkMacSystemFont,
@@ -191,7 +197,8 @@ body::after {
 
 pre,
 code {
-  font-family: "SF Mono", "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-family:
+    "SF Mono", "SFMono-Regular", "JetBrains Mono", Consolas, "Liberation Mono", Menlo, monospace;
 }
 
 /* Window drag region (frameless titlebar) */

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,9 @@ import { ClerkProvider } from "@clerk/react";
 import { RouterProvider } from "@tanstack/react-router";
 import { createHashHistory, createBrowserHistory } from "@tanstack/react-router";
 
+import "@fontsource-variable/dm-sans/index.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
 import "@xterm/xterm/css/xterm.css";
 import "./index.css";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,12 @@ importers:
       '@effect/atom-react':
         specifier: 4.0.0-beta.78
         version: 4.0.0-beta.78(effect@4.0.0-beta.78(patch_hash=883249d8efbb462e928e21fefef96027b66aec50751178cafdce45f08eee3754))(react@19.2.6)(scheduler@0.27.0)
+      '@fontsource-variable/dm-sans':
+        specifier: ^5.2.8
+        version: 5.2.8
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@formkit/auto-animate':
         specifier: ^0.9.0
         version: 0.9.0
@@ -2363,6 +2369,12 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource-variable/dm-sans@5.2.8':
+    resolution: {integrity: sha512-AxkvMTvNWgfrmlyjiV05vlHYJa+nRQCf1EfvIrQAPBpFJW0O9VTz7oAFr9S3lvbWdmnFoBk7yFqQL86u64nl2g==}
+
+  '@fontsource/jetbrains-mono@5.2.8':
+    resolution: {integrity: sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==}
 
   '@formkit/auto-animate@0.9.0':
     resolution: {integrity: sha512-VhP4zEAacXS3dfTpJpJ88QdLqMTcabMg0jwpOSxZ/VzfQVfl3GkZSCZThhGC5uhq/TxPHPzW0dzr4H9Bb1OgKA==}
@@ -11566,6 +11578,10 @@ snapshots:
       tabbable: 6.4.0
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource-variable/dm-sans@5.2.8': {}
+
+  '@fontsource/jetbrains-mono@5.2.8': {}
 
   '@formkit/auto-animate@0.9.0': {}
 


### PR DESCRIPTION
Ports the bundled-fonts part of #2451 by @sandersonstabo, rebased onto current main.

- Adds `@fontsource-variable/dm-sans` and `@fontsource/jetbrains-mono`, imported from `main.tsx`, removing the runtime Google Fonts dependency (more reliable for packaged desktop/offline usage)
- Adds `DM Sans Variable` / `JetBrains Mono` to the app and Tailwind font stacks (`--font-sans`, `--font-mono`, `body`, `pre/code`)
- Adds JetBrains Mono to the terminal (xterm) font stack

Part of splitting #2451 into reviewable frontend-only pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only font loading and stack updates with no auth, data, or business-logic changes; main tradeoff is slightly larger JS/CSS bundle size.
> 
> **Overview**
> **Bundles DM Sans and JetBrains Mono** via `@fontsource` instead of loading them from Google Fonts at runtime, which should improve reliability for packaged desktop and offline use.
> 
> Google Fonts `<link>` tags are removed from `index.html`; font CSS is imported from `main.tsx`. **DM Sans Variable** is wired into the boot splash, global `body`, and Tailwind `--font-sans`. **JetBrains Mono** is added to `--font-mono`, `pre`/`code`, and the xterm terminal `fontFamily` stack (still behind system mono fonts where present).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de91706c8ffb890c1184e3ed9cc9b5929d077b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bundle DM Sans and JetBrains Mono fonts instead of loading from Google Fonts
> - Adds `@fontsource-variable/dm-sans` and `@fontsource/jetbrains-mono` as dependencies, importing them in [main.tsx](https://github.com/pingdotgg/t3code/pull/3014/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b) so fonts are served from the bundle.
> - Removes Google Fonts preconnect and stylesheet links from [index.html](https://github.com/pingdotgg/t3code/pull/3014/files#diff-6954645055c39fbf3050b489306101f727465101a1172683088448035dc8463f).
> - Updates CSS custom properties in [index.css](https://github.com/pingdotgg/t3code/pull/3014/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to reference "DM Sans Variable" for body text and "JetBrains Mono" for `pre`/`code` elements.
> - Updates the xterm.js terminal font stack in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/3014/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) to prefer JetBrains Mono.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized de91706.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->