### PR TITLE
Use blue check for selected state in runtime mode and workspace menus

### DIFF
--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -25,6 +25,7 @@ import {
 import { BranchToolbarBranchSelector } from "./BranchToolbarBranchSelector";
 import { BranchToolbarEnvironmentSelector } from "./BranchToolbarEnvironmentSelector";
 import { BranchToolbarEnvModeSelector } from "./BranchToolbarEnvModeSelector";
+import { SelectedModelBadge } from "./chat/SelectedModelBadge";
 import { Button } from "./ui/button";
 import {
   Menu,
@@ -164,23 +165,39 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
             value={effectiveEnvMode}
             onValueChange={(value) => onEnvModeChange(value as EnvMode)}
           >
-            <MenuRadioItem disabled={envModeLocked} value="local">
-              <span className="flex min-w-0 items-center gap-1.5">
-                {activeWorktreePath ? (
-                  <FolderGitIcon className="size-3" />
-                ) : (
-                  <FolderIcon className="size-3" />
-                )}
-                <span className="min-w-0 truncate">
-                  {resolveCurrentWorkspaceLabel(activeWorktreePath)}
+            <MenuRadioItem
+              disabled={envModeLocked}
+              value="local"
+              hideIndicator
+              className="ps-2 pe-2"
+            >
+              <div className="flex w-full min-w-0 items-center justify-between gap-2">
+                <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                  {activeWorktreePath ? (
+                    <FolderGitIcon className="size-3 shrink-0" />
+                  ) : (
+                    <FolderIcon className="size-3 shrink-0" />
+                  )}
+                  <span className="min-w-0 truncate">
+                    {resolveCurrentWorkspaceLabel(activeWorktreePath)}
+                  </span>
                 </span>
-              </span>
+                {effectiveEnvMode === "local" ? <SelectedModelBadge /> : null}
+              </div>
             </MenuRadioItem>
-            <MenuRadioItem disabled={envModeLocked} value="worktree">
-              <span className="flex min-w-0 items-center gap-1.5">
-                <FolderGit2Icon className="size-3" />
-                <span className="min-w-0 truncate">{resolveEnvModeLabel("worktree")}</span>
-              </span>
+            <MenuRadioItem
+              disabled={envModeLocked}
+              value="worktree"
+              hideIndicator
+              className="ps-2 pe-2"
+            >
+              <div className="flex w-full min-w-0 items-center justify-between gap-2">
+                <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                  <FolderGit2Icon className="size-3 shrink-0" />
+                  <span className="min-w-0 truncate">{resolveEnvModeLabel("worktree")}</span>
+                </span>
+                {effectiveEnvMode === "worktree" ? <SelectedModelBadge /> : null}
+              </div>
             </MenuRadioItem>
           </MenuRadioGroup>
         </MenuGroup>

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -7,6 +7,7 @@ import {
   resolveLockedWorkspaceLabel,
   type EnvMode,
 } from "./BranchToolbar.logic";
+import { SelectedModelBadge } from "./chat/SelectedModelBadge";
 import {
   Select,
   SelectGroup,
@@ -43,13 +44,13 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
       <span className="inline-flex items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
         {activeWorktreePath ? (
           <>
-            <FolderGitIcon className="size-3" />
-            {resolveLockedWorkspaceLabel(activeWorktreePath)}
+            <FolderGitIcon className="size-3 shrink-0" />
+            <span>{resolveLockedWorkspaceLabel(activeWorktreePath)}</span>
           </>
         ) : (
           <>
-            <FolderIcon className="size-3" />
-            {resolveLockedWorkspaceLabel(activeWorktreePath)}
+            <FolderIcon className="size-3 shrink-0" />
+            <span>{resolveLockedWorkspaceLabel(activeWorktreePath)}</span>
           </>
         )}
       </span>
@@ -65,32 +66,40 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
     >
       <SelectTrigger variant="ghost" size="xs" className="font-medium" aria-label="Workspace">
         {effectiveEnvMode === "worktree" ? (
-          <FolderGit2Icon className="size-3" />
+          <FolderGit2Icon className="size-3 shrink-0" />
         ) : activeWorktreePath ? (
-          <FolderGitIcon className="size-3" />
+          <FolderGitIcon className="size-3 shrink-0" />
         ) : (
-          <FolderIcon className="size-3" />
+          <FolderIcon className="size-3 shrink-0" />
         )}
         <SelectValue />
       </SelectTrigger>
       <SelectPopup>
         <SelectGroup>
           <SelectGroupLabel>Workspace</SelectGroupLabel>
-          <SelectItem value="local">
-            <span className="inline-flex items-center gap-1.5">
-              {activeWorktreePath ? (
-                <FolderGitIcon className="size-3" />
-              ) : (
-                <FolderIcon className="size-3" />
-              )}
-              {resolveCurrentWorkspaceLabel(activeWorktreePath)}
-            </span>
+          <SelectItem value="local" hideIndicator className="ps-2 pe-2">
+            <div className="flex w-full min-w-0 items-center justify-between gap-2">
+              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                {activeWorktreePath ? (
+                  <FolderGitIcon className="size-3 shrink-0" />
+                ) : (
+                  <FolderIcon className="size-3 shrink-0" />
+                )}
+                <span className="min-w-0 truncate">
+                  {resolveCurrentWorkspaceLabel(activeWorktreePath)}
+                </span>
+              </span>
+              {effectiveEnvMode === "local" ? <SelectedModelBadge /> : null}
+            </div>
           </SelectItem>
-          <SelectItem value="worktree">
-            <span className="inline-flex items-center gap-1.5">
-              <FolderGit2Icon className="size-3" />
-              {resolveEnvModeLabel("worktree")}
-            </span>
+          <SelectItem value="worktree" hideIndicator className="ps-2 pe-2">
+            <div className="flex w-full min-w-0 items-center justify-between gap-2">
+              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+                <FolderGit2Icon className="size-3 shrink-0" />
+                <span className="min-w-0 truncate">{resolveEnvModeLabel("worktree")}</span>
+              </span>
+              {effectiveEnvMode === "worktree" ? <SelectedModelBadge /> : null}
+            </div>
           </SelectItem>
         </SelectGroup>
       </SelectPopup>

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -59,6 +59,7 @@ import {
 } from "../composerFooterLayout";
 import { type ComposerPromptEditorHandle, ComposerPromptEditor } from "../ComposerPromptEditor";
 import { ProviderModelPicker } from "./ProviderModelPicker";
+import { SelectedModelBadge } from "./SelectedModelBadge";
 import { type ComposerCommandItem, ComposerCommandMenu } from "./ComposerCommandMenu";
 import { ComposerPendingApprovalActions } from "./ComposerPendingApprovalActions";
 import { CompactComposerControlsMenu } from "./CompactComposerControlsMenu";
@@ -231,15 +232,17 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
           <SelectValue>{runtimeModeOption.label}</SelectValue>
         </SelectTrigger>
         <SelectPopup alignItemWithTrigger={false}>
+          <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">Permissions</div>
           {runtimeModeOptions.map((mode) => {
             const option = runtimeModeConfig[mode];
             const OptionIcon = option.icon;
             return (
-              <SelectItem key={mode} value={mode} className="min-w-64 py-2">
+              <SelectItem key={mode} value={mode} className="min-w-64 py-2" hideIndicator>
                 <div className="grid min-w-0 gap-0.5">
                   <span className="inline-flex items-center gap-1.5 font-medium text-foreground">
                     <OptionIcon className="size-3.5 shrink-0 text-muted-foreground" />
                     {option.label}
+                    {mode === props.runtimeMode ? <SelectedModelBadge /> : null}
                   </span>
                   <span className="text-muted-foreground text-xs leading-4">
                     {option.description}

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -11,6 +11,15 @@ import {
   MenuSeparator as MenuDivider,
   MenuTrigger,
 } from "../ui/menu";
+import { SelectedModelBadge } from "./SelectedModelBadge";
+
+const runtimeModeLabels: Record<RuntimeMode, string> = {
+  "approval-required": "Supervised",
+  "auto-accept-edits": "Auto-accept edits",
+  "full-access": "Full access",
+};
+
+const runtimeModeOptions = Object.keys(runtimeModeLabels) as RuntimeMode[];
 
 export const CompactComposerControlsMenu = memo(function CompactComposerControlsMenu(props: {
   activePlan: boolean;
@@ -69,9 +78,14 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             props.onRuntimeModeChange(value as RuntimeMode);
           }}
         >
-          <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
-          <MenuRadioItem value="auto-accept-edits">Auto-accept edits</MenuRadioItem>
-          <MenuRadioItem value="full-access">Full access</MenuRadioItem>
+          {runtimeModeOptions.map((mode) => (
+            <MenuRadioItem key={mode} value={mode} hideIndicator>
+              <span className="inline-flex items-center gap-1.5">
+                {runtimeModeLabels[mode]}
+                {mode === props.runtimeMode ? <SelectedModelBadge /> : null}
+              </span>
+            </MenuRadioItem>
+          ))}
         </MenuRadioGroup>
         {props.activePlan ? (
           <>

--- a/apps/web/src/components/chat/SelectedModelBadge.tsx
+++ b/apps/web/src/components/chat/SelectedModelBadge.tsx
@@ -1,0 +1,18 @@
+import { CheckIcon } from "lucide-react";
+
+import { Badge } from "../ui/badge";
+
+export function SelectedModelBadge() {
+  return <CheckIcon className="size-3.5 shrink-0 text-blue-400" />;
+}
+
+export function DefaultBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="inline-flex h-4 w-fit min-w-0 items-center justify-center gap-0 ps-1.5 pe-1.5 py-0 text-[10px] font-semibold leading-none border-border/70 bg-muted/60 text-muted-foreground sm:h-4"
+    >
+      Default
+    </Badge>
+  );
+}

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -147,32 +147,42 @@ function MenuRadioGroup(props: MenuPrimitive.RadioGroup.Props) {
   return <MenuPrimitive.RadioGroup data-slot="menu-radio-group" {...props} />;
 }
 
-function MenuRadioItem({ className, children, ...props }: MenuPrimitive.RadioItem.Props) {
+function MenuRadioItem({
+  className,
+  children,
+  hideIndicator = false,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  hideIndicator?: boolean;
+}) {
   return (
     <MenuPrimitive.RadioItem
       className={cn(
-        "grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-sm py-1 ps-2 pe-4 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default items-center gap-2 rounded-sm py-1 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        hideIndicator ? "grid-cols-[1fr] ps-3 pe-3" : "grid-cols-[1rem_1fr] ps-2 pe-4",
         className,
       )}
       data-slot="menu-radio-item"
       {...props}
     >
-      <MenuPrimitive.RadioItemIndicator className="col-start-1">
-        <svg
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
-        </svg>
-      </MenuPrimitive.RadioItemIndicator>
-      <span className="col-start-2">{children}</span>
+      {hideIndicator ? null : (
+        <MenuPrimitive.RadioItemIndicator className="col-start-1">
+          <svg
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
+          </svg>
+        </MenuPrimitive.RadioItemIndicator>
+      )}
+      <span className={hideIndicator ? "col-start-1" : "col-start-2"}>{children}</span>
     </MenuPrimitive.RadioItem>
   );
 }


### PR DESCRIPTION
Ports the selected-state part of #2451 by @sandersonstabo, rebased onto current main.

- New shared `SelectedModelBadge` (blue check) and `DefaultBadge` components
- `MenuRadioItem` gains a `hideIndicator` prop matching `SelectItem`'s
- Runtime mode (Supervised/Auto-accept/Full access) select gets a "Permissions" group header and shows the blue check on the active option instead of the leading radio indicator — same treatment in the compact composer controls menu
- Workspace (local/worktree) selectors on desktop and mobile show the blue check on the active option; icons get `shrink-0` so they no longer squish

Per the review discussion in #2451, this uses checkmarks rather than the earlier "Selected" badges.

Part of splitting #2451 into reviewable frontend-only pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to composer and branch toolbar menus; no behavior, auth, or data-path changes.
> 
> **Overview**
> Unifies **selected** styling across workspace and permissions menus: the default leading radio/check indicator is hidden, and the active row shows a shared **blue check** (`SelectedModelBadge`) instead.
> 
> **`MenuRadioItem`** now supports **`hideIndicator`**, aligned with **`SelectItem`**, so list rows can use inline selection affordances. Workspace pickers (desktop select, mobile menu, env mode selector) and runtime mode controls (composer permissions select and compact “Access” menu) adopt this pattern, with row layouts adjusted so the check sits on the trailing side. The runtime permissions dropdown also adds a **Permissions** section label; compact access options are generated from a shared label map.
> 
> Adds **`SelectedModelBadge`** (check icon) and **`DefaultBadge`** for reuse in follow-up UI; workspace icons get **`shrink-0`** so labels truncate cleanly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7839aa9ce4305d46c6c4d52091bcab6282345e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use blue check indicator for selected state in runtime mode and workspace menus
> - Adds a `SelectedModelBadge` component ([SelectedModelBadge.tsx](https://github.com/pingdotgg/t3code/pull/3019/files#diff-376144777959e27ca4358936ae0117c508fde92b01ef5ee8e18a089706e754cf)) that renders a small blue check icon to indicate the active selection.
> - Replaces the default radio/select indicators in runtime mode and workspace menus with this check badge, shown inline to the right of the selected item's label.
> - Affects `BranchToolbar`, `BranchToolbarEnvModeSelector`, `ChatComposer`, and `CompactComposerControlsMenu` components.
> - Extends `MenuRadioItem` with a `hideIndicator` prop to suppress the built-in radio indicator and adjust item layout; default behavior is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7839aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->