### PR TITLE
Split composer traits into per-descriptor pickers, rename Fast Mode to Speed

### DIFF
--- a/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.browser.tsx
@@ -100,7 +100,7 @@ async function mountMenu(props?: { modelSelection?: ModelSelection; prompt?: str
             ],
             ["ultrathink"],
           ),
-          booleanDescriptor("fastMode", "Fast Mode"),
+          booleanDescriptor("fastMode", "Speed"),
         ],
       }),
     },
@@ -181,7 +181,7 @@ describe("CompactComposerControlsMenu", () => {
     });
   });
 
-  it("shows fast mode controls for Opus", async () => {
+  it("shows speed controls for Opus", async () => {
     await using _ = await mountMenu({
       modelSelection: createModelSelection(
         ProviderInstanceId.make("claudeAgent"),
@@ -193,13 +193,13 @@ describe("CompactComposerControlsMenu", () => {
 
     await vi.waitFor(() => {
       const text = document.body.textContent ?? "";
-      expect(text).toContain("Fast Mode");
-      expect(text).toContain("On");
-      expect(text).toContain("Off");
+      expect(text).toContain("Speed");
+      expect(text).toContain("Normal");
+      expect(text).toContain("Fast");
     });
   });
 
-  it("hides fast mode controls for non-Opus Claude models", async () => {
+  it("hides speed controls for non-Opus Claude models", async () => {
     await using _ = await mountMenu({
       modelSelection: createModelSelection(
         ProviderInstanceId.make("claudeAgent"),
@@ -210,7 +210,7 @@ describe("CompactComposerControlsMenu", () => {
     await page.getByLabelText("More composer controls").click();
 
     await vi.waitFor(() => {
-      expect(document.body.textContent ?? "").not.toContain("Fast Mode");
+      expect(document.body.textContent ?? "").not.toContain("Speed");
     });
   });
 

--- a/apps/web/src/components/chat/SelectedModelBadge.tsx
+++ b/apps/web/src/components/chat/SelectedModelBadge.tsx
@@ -1,0 +1,18 @@
+import { CheckIcon } from "lucide-react";
+
+import { Badge } from "../ui/badge";
+
+export function SelectedModelBadge() {
+  return <CheckIcon className="size-3.5 shrink-0 text-blue-400" />;
+}
+
+export function DefaultBadge() {
+  return (
+    <Badge
+      variant="outline"
+      className="inline-flex h-4 w-fit min-w-0 items-center justify-center gap-0 ps-1.5 pe-1.5 py-0 text-[10px] font-semibold leading-none border-border/70 bg-muted/60 text-muted-foreground sm:h-4"
+    >
+      Default
+    </Badge>
+  );
+}

--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -14,9 +14,16 @@ import {
   getProviderOptionDescriptors,
   isClaudeUltrathinkPrompt,
 } from "@t3tools/shared/model";
-import { memo, useCallback, useState } from "react";
+import { Fragment, memo, useCallback, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
-import { ChevronDownIcon } from "lucide-react";
+import {
+  BookOpenIcon,
+  BrainIcon,
+  ChevronDownIcon,
+  RabbitIcon,
+  TurtleIcon,
+  ZapIcon,
+} from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
 import {
   Menu,
@@ -30,6 +37,8 @@ import {
 import { useComposerDraftStore, DraftId } from "../../composerDraftStore";
 import { getProviderModelCapabilities } from "../../providerModels";
 import { cn } from "~/lib/utils";
+import { Separator } from "../ui/separator";
+import { DefaultBadge, SelectedModelBadge } from "./SelectedModelBadge";
 
 type ProviderOptions = ReadonlyArray<ProviderOptionSelection>;
 
@@ -45,6 +54,50 @@ type TraitsPersistence =
     };
 
 const ULTRATHINK_PROMPT_PREFIX = "Ultrathink:\n";
+
+function getBooleanDescriptorLabel(
+  descriptor: Extract<ProviderOptionDescriptor, { type: "boolean" }>,
+): string {
+  return descriptor.id === "fastMode" ? "Speed" : descriptor.label;
+}
+
+function getBooleanDescriptorOptionLabel(
+  descriptor: Extract<ProviderOptionDescriptor, { type: "boolean" }>,
+  value: "on" | "off",
+): string {
+  if (descriptor.id === "fastMode") {
+    return value === "on" ? "Fast" : "Normal";
+  }
+  return value === "on" ? "On" : "Off";
+}
+
+function getSpeedOptionDescription(input: {
+  provider: ProviderDriverKind;
+  model: string | null | undefined;
+  value: "on" | "off";
+}): string {
+  if (input.value === "off") {
+    return "Uses standard speed and normal usage.";
+  }
+  if (input.provider === "claudeAgent") {
+    return "Works up to 2.5x faster, but uses 6x more usage than normal.";
+  }
+  if (input.model === "gpt-5.5") {
+    return "Works up to 1.5x faster, but uses 2.5x more usage than normal.";
+  }
+  return "Works up to 1.5x faster, but uses 2x more usage than normal.";
+}
+
+function BooleanDescriptorOptionIcon(props: {
+  descriptor: Extract<ProviderOptionDescriptor, { type: "boolean" }>;
+  value: "on" | "off";
+}) {
+  if (props.descriptor.id !== "fastMode") {
+    return null;
+  }
+  const Icon = props.value === "on" ? RabbitIcon : TurtleIcon;
+  return <Icon aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />;
+}
 
 function replaceDescriptorCurrentValue(
   descriptors: ReadonlyArray<ProviderOptionDescriptor>,
@@ -191,8 +244,13 @@ export function shouldRenderTraitsControls(input: {
   prompt: string;
   modelOptions: ProviderOptions | null | undefined;
   allowPromptInjectedEffort?: boolean;
+  hiddenDescriptorIds?: ReadonlyArray<string>;
 }): boolean {
-  return getTraitsSectionVisibility(input).hasAnyControls;
+  const visibility = getTraitsSectionVisibility(input);
+  if (!visibility.hasAnyControls) return false;
+  const hidden = new Set(input.hiddenDescriptorIds ?? []);
+  if (hidden.size === 0) return true;
+  return visibility.descriptors.some((descriptor) => !hidden.has(descriptor.id));
 }
 
 export interface TraitsMenuContentProps {
@@ -204,8 +262,11 @@ export interface TraitsMenuContentProps {
   onPromptChange: (prompt: string) => void;
   modelOptions?: ProviderOptions | null | undefined;
   allowPromptInjectedEffort?: boolean;
+  hiddenDescriptorIds?: ReadonlyArray<string>;
+  showTriggerSeparators?: boolean;
   triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   triggerClassName?: string;
+  onRequestClose?: () => void;
 }
 
 export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
@@ -217,6 +278,8 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   onPromptChange,
   modelOptions,
   allowPromptInjectedEffort = true,
+  hiddenDescriptorIds,
+  onRequestClose,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
@@ -254,6 +317,16 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     modelOptions,
     allowPromptInjectedEffort,
   });
+  const hiddenDescriptorIdSet = new Set(hiddenDescriptorIds ?? []);
+  const visibleDescriptors = descriptors.filter(
+    (descriptor) => !hiddenDescriptorIdSet.has(descriptor.id),
+  );
+  const visibleSelectDescriptors = selectDescriptors.filter(
+    (descriptor) => !hiddenDescriptorIdSet.has(descriptor.id),
+  );
+  const visibleBooleanDescriptors = booleanDescriptors.filter(
+    (descriptor) => !hiddenDescriptorIdSet.has(descriptor.id),
+  );
   const updateDescriptors = (nextDescriptors: ReadonlyArray<ProviderOptionDescriptor>) => {
     updateModelOptions(buildProviderOptionSelectionsFromDescriptors(nextDescriptors));
   };
@@ -277,15 +350,16 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       onPromptChange(stripped);
     }
     updateDescriptors(replaceDescriptorCurrentValue(descriptors, descriptor.id, value));
+    onRequestClose?.();
   };
 
-  if (!hasAnyControls) {
+  if (!hasAnyControls || visibleDescriptors.length === 0) {
     return null;
   }
 
   return (
     <>
-      {selectDescriptors.map((descriptor, index) => (
+      {visibleSelectDescriptors.map((descriptor, index) => (
         <div key={descriptor.id}>
           {index > 0 ? <MenuDivider /> : null}
           <MenuGroup>
@@ -298,46 +372,81 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                 option.
               </div>
             ) : null}
-            <MenuRadioGroup
-              value={
+            {(() => {
+              const selectedValue =
                 ultrathinkPromptControlled && descriptor.id === primarySelectDescriptor?.id
                   ? "ultrathink"
-                  : (getDescriptorStringValue(descriptor) ?? "")
-              }
-              onValueChange={(value) => handleSelectChange(descriptor, value)}
-            >
-              {descriptor.options.map((option) => (
-                <MenuRadioItem
-                  key={option.id}
-                  value={option.id}
-                  disabled={ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id}
+                  : (getDescriptorStringValue(descriptor) ?? "");
+              return (
+                <MenuRadioGroup
+                  value={selectedValue}
+                  onValueChange={(value) => handleSelectChange(descriptor, value)}
                 >
-                  {option.label}
-                  {option.isDefault ? " (default)" : ""}
-                </MenuRadioItem>
-              ))}
-            </MenuRadioGroup>
+                  {descriptor.options.map((option) => (
+                    <MenuRadioItem
+                      key={option.id}
+                      value={option.id}
+                      hideIndicator
+                      disabled={
+                        ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id
+                      }
+                    >
+                      <span className="inline-flex items-center gap-1.5">
+                        {option.label}
+                        {option.isDefault ? <DefaultBadge /> : null}
+                        {option.id === selectedValue ? <SelectedModelBadge /> : null}
+                      </span>
+                    </MenuRadioItem>
+                  ))}
+                </MenuRadioGroup>
+              );
+            })()}
           </MenuGroup>
         </div>
       ))}
-      {booleanDescriptors.map((descriptor, index) => (
+      {visibleBooleanDescriptors.map((descriptor, index) => (
         <div key={descriptor.id}>
-          {index > 0 || selectDescriptors.length > 0 ? <MenuDivider /> : null}
+          {index > 0 || visibleSelectDescriptors.length > 0 ? <MenuDivider /> : null}
           <MenuGroup>
             <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">
-              {descriptor.label}
+              {getBooleanDescriptorLabel(descriptor)}
             </div>
-            <MenuRadioGroup
-              value={descriptor.currentValue === true ? "on" : "off"}
-              onValueChange={(value) => {
-                updateDescriptors(
-                  replaceDescriptorCurrentValue(descriptors, descriptor.id, value === "on"),
-                );
-              }}
-            >
-              <MenuRadioItem value="on">On</MenuRadioItem>
-              <MenuRadioItem value="off">Off</MenuRadioItem>
-            </MenuRadioGroup>
+            {(() => {
+              const selectedValue = descriptor.currentValue === true ? "on" : "off";
+              return (
+                <MenuRadioGroup
+                  value={selectedValue}
+                  onValueChange={(value) => {
+                    updateDescriptors(
+                      replaceDescriptorCurrentValue(descriptors, descriptor.id, value === "on"),
+                    );
+                    onRequestClose?.();
+                  }}
+                >
+                  {(["on", "off"] as const).map((value) => (
+                    <MenuRadioItem
+                      key={value}
+                      value={value}
+                      hideIndicator
+                      className={descriptor.id === "fastMode" ? "min-w-72 items-start py-2" : ""}
+                    >
+                      <span className="grid min-w-0 gap-0.5">
+                        <span className="inline-flex items-center gap-1.5">
+                          <BooleanDescriptorOptionIcon descriptor={descriptor} value={value} />
+                          {getBooleanDescriptorOptionLabel(descriptor, value)}
+                          {value === selectedValue ? <SelectedModelBadge /> : null}
+                        </span>
+                        {descriptor.id === "fastMode" ? (
+                          <span className="text-muted-foreground text-xs leading-4">
+                            {getSpeedOptionDescription({ provider, model, value })}
+                          </span>
+                        ) : null}
+                      </span>
+                    </MenuRadioItem>
+                  ))}
+                </MenuRadioGroup>
+              );
+            })()}
           </MenuGroup>
         </div>
       ))}
@@ -354,11 +463,12 @@ export const TraitsPicker = memo(function TraitsPicker({
   onPromptChange,
   modelOptions,
   allowPromptInjectedEffort = true,
+  hiddenDescriptorIds,
+  showTriggerSeparators = true,
   triggerVariant,
   triggerClassName,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled } =
     getTraitsSectionVisibility({
       provider,
@@ -368,6 +478,33 @@ export const TraitsPicker = memo(function TraitsPicker({
       modelOptions,
       allowPromptInjectedEffort,
     });
+  const hiddenDescriptorIdSet = new Set(hiddenDescriptorIds ?? []);
+  const visibleDescriptors = descriptors.filter(
+    (descriptor) => !hiddenDescriptorIdSet.has(descriptor.id),
+  );
+  const isCodexStyle = provider === "codex";
+  const [openDescriptorId, setOpenDescriptorId] = useState<string | null>(null);
+
+  const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
+  const updateModelOptions = useCallback(
+    (nextOptions: ProviderOptions | undefined) => {
+      if ("onModelOptionsChange" in persistence) {
+        persistence.onModelOptionsChange(nextOptions);
+        return;
+      }
+      const threadTarget = persistence.threadRef ?? persistence.draftId;
+      if (!threadTarget) {
+        return;
+      }
+      setProviderModelOptions(threadTarget, provider, nextOptions, {
+        ...(instanceId ? { instanceId } : {}),
+        model,
+        persistSticky: true,
+      });
+    },
+    [instanceId, model, persistence, provider, setProviderModelOptions],
+  );
+
   if (
     !shouldRenderTraitsControls({
       provider,
@@ -376,77 +513,154 @@ export const TraitsPicker = memo(function TraitsPicker({
       prompt,
       modelOptions,
       allowPromptInjectedEffort,
-    })
+    }) ||
+    visibleDescriptors.length === 0
   ) {
     return null;
   }
 
-  const triggerLabels: Array<string> = [];
-  for (const descriptor of descriptors) {
-    const label =
-      ultrathinkPromptControlled && descriptor.id === primarySelectDescriptor?.id
-        ? "Ultrathink"
-        : descriptor.type === "boolean"
-          ? descriptor.id === "fastMode"
-            ? descriptor.currentValue === true
-              ? "Fast"
-              : "Normal"
-            : `${descriptor.label} ${descriptor.currentValue === true ? "On" : "Off"}`
-          : getProviderOptionCurrentLabel(descriptor);
-    if (typeof label === "string" && label.length > 0) {
-      triggerLabels.push(label);
-    }
-  }
-  const triggerLabel = triggerLabels.join(" · ");
-
-  const isCodexStyle = provider === "codex";
-
   return (
-    <Menu
-      open={isMenuOpen}
-      onOpenChange={(open) => {
-        setIsMenuOpen(open);
-      }}
-    >
-      <MenuTrigger
-        render={
-          <Button
-            size="sm"
-            variant={triggerVariant ?? "ghost"}
-            className={cn(
-              isCodexStyle
-                ? "min-w-0 max-w-40 shrink justify-start overflow-hidden whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:max-w-48 sm:px-3 [&_svg]:mx-0"
-                : "shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3",
-              triggerClassName,
+    <>
+      {visibleDescriptors.map((descriptor, descriptorIndex) => {
+        const resolvedSelectLabel = getProviderOptionCurrentLabel(descriptor);
+        const descriptorIdLower = descriptor.id.toLowerCase();
+        const descriptorLabelLower = descriptor.label.toLowerCase();
+        const isThinkingLike =
+          descriptorIdLower.includes("reason") ||
+          descriptorLabelLower.includes("reason") ||
+          descriptorIdLower === "variant" ||
+          descriptorLabelLower === "variant" ||
+          descriptorIdLower.includes("thinking") ||
+          descriptorLabelLower.includes("thinking");
+        const triggerLabel =
+          ultrathinkPromptControlled && descriptor.id === primarySelectDescriptor?.id
+            ? "Ultrathink"
+            : descriptor.type === "boolean"
+              ? descriptor.id === "fastMode"
+                ? descriptor.currentValue === true
+                  ? "Fast"
+                  : "Normal"
+                : isThinkingLike
+                  ? descriptor.currentValue === true
+                    ? "On"
+                    : "Off"
+                  : `${descriptor.label} ${descriptor.currentValue === true ? "On" : "Off"}`
+              : resolvedSelectLabel && resolvedSelectLabel.length > 0
+                ? resolvedSelectLabel
+                : descriptor.label;
+        const isContextWindow =
+          descriptorIdLower === "contextwindow" ||
+          descriptorIdLower === "context_window" ||
+          descriptorIdLower.includes("contextwindow") ||
+          descriptorLabelLower.includes("context window");
+        const TriggerIcon =
+          descriptor.id === "fastMode"
+            ? ZapIcon
+            : isThinkingLike
+              ? BrainIcon
+              : isContextWindow
+                ? BookOpenIcon
+                : null;
+        const popupHiddenDescriptorIds = [
+          ...(hiddenDescriptorIds ?? []),
+          ...visibleDescriptors
+            .filter((visibleDescriptor) => visibleDescriptor.id !== descriptor.id)
+            .map((visibleDescriptor) => visibleDescriptor.id),
+        ];
+
+        const isBooleanToggle = descriptor.type === "boolean" && isThinkingLike;
+        const toggleOn = isBooleanToggle && descriptor.currentValue === true;
+        const toggleLabel = toggleOn ? "Thinking" : "Instant";
+
+        return (
+          <Fragment key={descriptor.id}>
+            {showTriggerSeparators && descriptorIndex > 0 ? (
+              <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
+            ) : null}
+            {isBooleanToggle ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                aria-pressed={toggleOn}
+                title={
+                  toggleOn
+                    ? "Thinking enabled - click to switch to instant responses"
+                    : "Instant responses - click to enable thinking"
+                }
+                onClick={() => {
+                  updateModelOptions(
+                    buildProviderOptionSelectionsFromDescriptors(
+                      replaceDescriptorCurrentValue(descriptors, descriptor.id, !toggleOn),
+                    ),
+                  );
+                }}
+                className={cn(
+                  "shrink-0 whitespace-nowrap px-2 sm:px-3",
+                  toggleOn
+                    ? "bg-blue-500/10 text-blue-400 hover:bg-blue-500/15 hover:text-blue-300"
+                    : "text-muted-foreground/70 hover:text-foreground/80",
+                  triggerClassName,
+                )}
+              >
+                <BrainIcon
+                  aria-hidden="true"
+                  className={cn("size-3.5", toggleOn ? "text-current opacity-100" : "opacity-70")}
+                />
+                <span className="sr-only sm:not-sr-only">{toggleLabel}</span>
+              </Button>
+            ) : (
+              <Menu
+                open={openDescriptorId === descriptor.id}
+                onOpenChange={(open) => setOpenDescriptorId(open ? descriptor.id : null)}
+              >
+                <MenuTrigger
+                  render={
+                    <Button
+                      size="sm"
+                      variant={triggerVariant ?? "ghost"}
+                      className={cn(
+                        isCodexStyle
+                          ? "min-w-0 max-w-40 shrink justify-between whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:max-w-48 sm:px-3"
+                          : "shrink-0 justify-between whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3",
+                        triggerClassName,
+                      )}
+                    />
+                  }
+                >
+                  <span className="flex min-w-0 flex-1 justify-center items-center gap-1.5 overflow-hidden">
+                    {TriggerIcon ? (
+                      <TriggerIcon aria-hidden="true" className="ps-[2px] opacity-70" />
+                    ) : null}
+                    <span className="min-w-0 truncate">{triggerLabel}</span>
+                  </span>
+                  <span aria-hidden="true" className="flex items-center">
+                    <ChevronDownIcon
+                      aria-hidden="true"
+                      className="!ms-0 !-me-1 size-3 shrink-0 opacity-60"
+                    />
+                  </span>
+                </MenuTrigger>
+                <MenuPopup align="start">
+                  <TraitsMenuContent
+                    provider={provider}
+                    {...(instanceId ? { instanceId } : {})}
+                    models={models}
+                    model={model}
+                    prompt={prompt}
+                    onPromptChange={onPromptChange}
+                    modelOptions={modelOptions}
+                    allowPromptInjectedEffort={allowPromptInjectedEffort}
+                    hiddenDescriptorIds={popupHiddenDescriptorIds}
+                    onRequestClose={() => setOpenDescriptorId(null)}
+                    {...persistence}
+                  />
+                </MenuPopup>
+              </Menu>
             )}
-          />
-        }
-      >
-        {isCodexStyle ? (
-          <span className="flex min-w-0 w-full items-center gap-2 overflow-hidden">
-            {triggerLabel}
-            <ChevronDownIcon aria-hidden="true" className="size-3 shrink-0 opacity-60" />
-          </span>
-        ) : (
-          <>
-            <span>{triggerLabel}</span>
-            <ChevronDownIcon aria-hidden="true" className="size-3 opacity-60" />
-          </>
-        )}
-      </MenuTrigger>
-      <MenuPopup align="start">
-        <TraitsMenuContent
-          provider={provider}
-          {...(instanceId ? { instanceId } : {})}
-          models={models}
-          model={model}
-          prompt={prompt}
-          onPromptChange={onPromptChange}
-          modelOptions={modelOptions}
-          allowPromptInjectedEffort={allowPromptInjectedEffort}
-          {...persistence}
-        />
-      </MenuPopup>
-    </Menu>
+          </Fragment>
+        );
+      })}
+    </>
   );
 });

--- a/apps/web/src/components/settings/ProviderModelsSection.tsx
+++ b/apps/web/src/components/settings/ProviderModelsSection.tsx
@@ -204,7 +204,7 @@ export function ProviderModelsSection({
             nextModel !== undefined && favoriteModelSet.has(nextModel.slug) === isFavorite;
           const descriptors = caps?.optionDescriptors ?? [];
           if (descriptors.some((descriptor) => descriptor.id === "fastMode")) {
-            capLabels.push("Fast mode");
+            capLabels.push("Speed");
           }
           if (descriptors.some((descriptor) => descriptor.id === "thinking")) {
             capLabels.push("Thinking");

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -821,6 +821,7 @@ export function GeneralSettingsPanel() {
         <SettingsRow
           title="Text generation model"
           description="Configure the model used for generated commit messages, PR titles, and similar Git text."
+          descriptionMinLines={2}
           resetAction={
             isGitWritingModelDirty ? (
               <SettingResetButton
@@ -870,6 +871,8 @@ export function GeneralSettingsPanel() {
                 onPromptChange={() => {}}
                 modelOptions={textGenModelOptions}
                 allowPromptInjectedEffort={false}
+                hiddenDescriptorIds={["agent"]}
+                showTriggerSeparators={false}
                 triggerVariant="outline"
                 triggerClassName="min-w-0 max-w-none shrink-0 text-foreground/90 hover:text-foreground"
                 onModelOptionsChange={(nextOptions) => {

--- a/apps/web/src/components/settings/settingsLayout.tsx
+++ b/apps/web/src/components/settings/settingsLayout.tsx
@@ -48,6 +48,7 @@ export function SettingsSection({
 export function SettingsRow({
   title,
   description,
+  descriptionMinLines,
   status,
   resetAction,
   control,
@@ -57,6 +58,7 @@ export function SettingsRow({
 }: Omit<ComponentPropsWithoutRef<"div">, "title"> & {
   title: ReactNode;
   description: ReactNode;
+  descriptionMinLines?: 2;
   status?: ReactNode;
   resetAction?: ReactNode;
   control?: ReactNode;
@@ -81,7 +83,14 @@ export function SettingsRow({
               {resetAction}
             </span>
           </div>
-          <p className="text-xs text-muted-foreground/80">{description}</p>
+          <p
+            className={cn(
+              "text-xs leading-relaxed text-muted-foreground/80",
+              descriptionMinLines === 2 ? "min-h-[2lh]" : null,
+            )}
+          >
+            {description}
+          </p>
           {status ? <div className="pt-0.5 text-[11px] text-muted-foreground">{status}</div> : null}
         </div>
         {control ? (

--- a/apps/web/src/components/ui/menu.tsx
+++ b/apps/web/src/components/ui/menu.tsx
@@ -147,32 +147,42 @@ function MenuRadioGroup(props: MenuPrimitive.RadioGroup.Props) {
   return <MenuPrimitive.RadioGroup data-slot="menu-radio-group" {...props} />;
 }
 
-function MenuRadioItem({ className, children, ...props }: MenuPrimitive.RadioItem.Props) {
+function MenuRadioItem({
+  className,
+  children,
+  hideIndicator = false,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  hideIndicator?: boolean;
+}) {
   return (
     <MenuPrimitive.RadioItem
       className={cn(
-        "grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default grid-cols-[1rem_1fr] items-center gap-2 rounded-sm py-1 ps-2 pe-4 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "grid min-h-8 in-data-[side=none]:min-w-[calc(var(--anchor-width)+1.25rem)] cursor-default items-center gap-2 rounded-sm py-1 text-base text-foreground outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-highlighted:text-accent-foreground data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        hideIndicator ? "grid-cols-[1fr] ps-3 pe-3" : "grid-cols-[1rem_1fr] ps-2 pe-4",
         className,
       )}
       data-slot="menu-radio-item"
       {...props}
     >
-      <MenuPrimitive.RadioItemIndicator className="col-start-1">
-        <svg
-          fill="none"
-          height="24"
-          stroke="currentColor"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          strokeWidth="2"
-          viewBox="0 0 24 24"
-          width="24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
-        </svg>
-      </MenuPrimitive.RadioItemIndicator>
-      <span className="col-start-2">{children}</span>
+      {hideIndicator ? null : (
+        <MenuPrimitive.RadioItemIndicator className="col-start-1">
+          <svg
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M5.252 12.7 10.2 18.63 18.748 5.37" />
+          </svg>
+        </MenuPrimitive.RadioItemIndicator>
+      )}
+      <span className={hideIndicator ? "col-start-1" : "col-start-2"}>{children}</span>
     </MenuPrimitive.RadioItem>
   );
 }

--- a/packages/shared/src/model.test.ts
+++ b/packages/shared/src/model.test.ts
@@ -37,7 +37,7 @@ const codexCaps: ModelCapabilities = createModelCapabilities({
     },
     {
       id: "fastMode",
-      label: "Fast Mode",
+      label: "Speed",
       type: "boolean",
     },
   ],


### PR DESCRIPTION
Ports the traits-picker part of #2451 by @sandersonstabo, rebased onto current main.

- The combined traits dropdown (`Medium · Fast`) becomes one trigger per descriptor, each with its own popup and an icon (brain for reasoning, lightning/rabbit/turtle for speed, book for context window)
- `fastMode` is presented as **Speed** with Fast/Normal options and usage descriptions (e.g. Claude fast mode "works up to 2.5x faster, but uses 6x more usage")
- Thinking-like boolean descriptors render as a direct toggle button (Instant ⇄ Thinking) with a blue active state instead of a dropdown
- Trait dropdowns auto-close after a value change; active option shows the blue check, provider defaults show a neutral `Default` badge (both can show together)
- The settings "Text generation model" row hides the `agent` descriptor, drops the trigger separators, and reserves a stable two-line description height

Note: changing one descriptor rebuilds options from the full descriptor list, so the hidden-descriptor reset issue flagged by Codex review on #2451 doesn't apply here. The composer keeps the `agent` descriptor visible (OpenCode still uses it for plan/build since the backend toggle change wasn't ported).

Part of splitting #2451 into reviewable frontend-only pieces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only composer and settings UI; model option persistence behavior is unchanged aside from presentation and menu structure.
> 
> **Overview**
> Replaces the single combined traits menu with **one control per model option** (reasoning, speed, context window, etc.), each opening its own popup with descriptor-specific icons and labels.
> 
> **Speed** replaces **Fast Mode**: options are **Fast** / **Normal** with provider-specific usage copy and rabbit/turtle icons in menus; the composer trigger uses a zap icon. Thinking-like booleans become a direct **Instant ⇄ Thinking** toggle (blue when on) instead of an On/Off submenu.
> 
> Trait menus use custom selection UI: blue check for the active choice, **Default** badge for provider defaults, optional `hideIndicator` on radio items, and menus close after a change. `hiddenDescriptorIds` and `showTriggerSeparators` tailor embedded use (e.g. text generation settings hides **agent** and drops separators). Settings copy and model capability chips say **Speed**; the text generation row gets a two-line minimum description height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea45f447cbf9b8db2ce7e9bcae9f3dd8134e9e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split composer trait controls into per-descriptor pickers and rename Fast Mode to Speed
> - Refactors [TraitsPicker.tsx](https://github.com/pingdotgg/t3code/pull/3020/files#diff-acec26af7ec4bf39e06038a3af2abfa9fd60b86d283ee7015aea33c8f7b92d45) from a single combined menu into per-descriptor trigger buttons, each opening a scoped menu for that descriptor only.
> - Renames the `fastMode` descriptor label from 'Fast Mode' to 'Speed' across the UI, with option labels changing from 'On/Off' to 'Fast/Normal' and rabbit/turtle icons added.
> - Adds provider/model-aware descriptions to the Speed option (e.g. up to 2.5x faster at 6x usage for Claude agent).
> - Thinking-like boolean descriptors (e.g. `thinking`) get a direct toggle button instead of a dropdown menu.
> - Adds `hiddenDescriptorIds` and `showTriggerSeparators` props to `TraitsPicker`, used in settings to hide the `agent` descriptor.
> - Adds `SelectedModelBadge` and `DefaultBadge` components and a `hideIndicator` prop to `MenuRadioItem` for custom selection affordances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ea45f4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->