### PR TITLE
Handle unborn branches in VCS status

### DIFF
--- a/.repos/alchemy-effect/packages/alchemy/src/Telemetry/Attributes.ts
+++ b/.repos/alchemy-effect/packages/alchemy/src/Telemetry/Attributes.ts
@@ -84,7 +84,7 @@ const getGitOriginUrl: Effect.Effect<string | null> = execCapture(
 );
 
 const getBranchName: Effect.Effect<string | null> = execCapture(
-  "git rev-parse --abbrev-ref HEAD",
+  "git symbolic-ref --quiet --short HEAD",
 );
 
 const getRuntime = (): { name: string; version: string } => {

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -155,6 +155,26 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
+    it.effect("reports remote status for an unborn branch", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+        yield* driver.initRepo({ cwd });
+
+        const status = yield* driver.statusDetailsRemote(cwd);
+
+        assert.equal(status.isRepo, true);
+        assert.equal(
+          status.branch,
+          yield* git(cwd, ["symbolic-ref", "--quiet", "--short", "HEAD"]),
+        );
+        assert.equal(status.hasUpstream, false);
+        assert.equal(status.aheadCount, 0);
+        assert.equal(status.behindCount, 0);
+        assert.equal(status.aheadOfDefaultCount, 0);
+      }),
+    );
+
     it.effect("reports remote divergence without reading working-tree details", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1168,7 +1168,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     const branchResult = yield* executeGit(
       "GitVcsDriver.statusDetailsRemote.branch",
       cwd,
-      ["rev-parse", "--abbrev-ref", "HEAD"],
+      ["symbolic-ref", "--quiet", "--short", "HEAD"],
       { allowNonZeroExit: true },
     ).pipe(Effect.catchIf(isMissingGitCwdError, () => Effect.succeed(null)));
 
@@ -1176,17 +1176,25 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       return NON_REPOSITORY_REMOTE_STATUS_DETAILS;
     }
     if (branchResult.exitCode !== 0) {
-      const stderr = branchResult.stderr.trim();
-      return yield* createGitCommandError(
-        "GitVcsDriver.statusDetailsRemote.branch",
+      const headResult = yield* executeGit(
+        "GitVcsDriver.statusDetailsRemote.head",
         cwd,
-        ["rev-parse", "--abbrev-ref", "HEAD"],
-        stderr || "git branch lookup failed",
+        ["rev-parse", "--verify", "--quiet", "HEAD"],
+        { allowNonZeroExit: true },
       );
+      if (headResult.exitCode !== 0) {
+        const stderr = branchResult.stderr.trim() || headResult.stderr.trim();
+        return yield* createGitCommandError(
+          "GitVcsDriver.statusDetailsRemote.branch",
+          cwd,
+          ["symbolic-ref", "--quiet", "--short", "HEAD"],
+          stderr || "git branch lookup failed",
+        );
+      }
     }
 
     const branchValue = branchResult.stdout.trim();
-    const branch = branchValue.length > 0 && branchValue !== "HEAD" ? branchValue : null;
+    const branch = branchResult.exitCode === 0 && branchValue.length > 0 ? branchValue : null;
     const upstream = yield* resolveCurrentUpstream(cwd);
     const upstreamRef = upstream?.upstreamRef ?? null;
     let aheadCount = 0;


### PR DESCRIPTION
## Summary

- read the current branch for remote status with git symbolic-ref so newly initialized repositories without commits are supported
- preserve detached HEAD handling by treating it as no branch instead of turning the commit hash into a branch name
- update telemetry branch collection to tolerate unborn branches and detached HEADs

Closes #3045.

## Testing

- pnpm fmt:check
- pnpm --filter t3 test -- GitVcsDriverCore.test.ts

Note: local verification emitted the repository's existing unsupported-engine warning because this environment uses Node v26.1.0 while the root package requests Node ^24.13.1.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/3046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `branch` is derived for remote status (null on detached HEAD vs `"HEAD"`) and alters git failure paths; limited scope but may affect UI or consumers of `statusDetailsRemote`.
> 
> **Overview**
> **Remote VCS status** and **Alchemy telemetry** now resolve the current branch with `git symbolic-ref --quiet --short HEAD` instead of `git rev-parse --abbrev-ref HEAD`, so freshly initialized repos with no commits (unborn branches) still report a branch name.
> 
> In `readStatusDetailsRemote`, when symbolic-ref fails, the driver checks `git rev-parse --verify --quiet HEAD` and only errors if both fail; otherwise it treats the repo as valid (e.g. unborn). **Detached HEAD** is reported as `branch: null` rather than the string `"HEAD"`.
> 
> A new integration test covers `statusDetailsRemote` on an initialized repo with no commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a53c8a01696a11f92c07622d1e2707d6c2e2e920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle unborn branches in VCS status by switching to `git symbolic-ref`
> - Replaces `git rev-parse --abbrev-ref HEAD` with `git symbolic-ref --quiet --short HEAD` in [`GitVcsDriverCore.ts`](https://github.com/pingdotgg/t3code/pull/3046/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) for branch discovery, which correctly handles unborn branches (repos with no commits).
> - When `symbolic-ref` fails (e.g. detached HEAD), a fallback `git rev-parse --verify --quiet HEAD` check runs; only if both fail does the function return an error. Branch is set to `null` when `symbolic-ref` fails but HEAD is still valid.
> - Adds a test case for empty repositories in [`GitVcsDriverCore.test.ts`](https://github.com/pingdotgg/t3code/pull/3046/files#diff-ac30488287dac9aa8d4cb819c508d77d2e47267d4aae35819e6fa24b86312c26) asserting `isRepo: true`, `branch` equals the `symbolic-ref` output, and `hasUpstream: false`.
> - Behavioral Change: `statusDetailsRemote` no longer errors on detached HEAD or unborn branches; it now returns `branch: null` in those cases instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a53c8a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->