### PR TITLE
feat(sidebar): worktree indicator on session rows

### DIFF
--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   resolveThreadPr,
   terminalStatusFromRunningIds,
   ThreadStatusLabel,
+  ThreadWorktreeIndicator,
 } from "./ThreadStatusIndicators";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { useAtomValue } from "@effect/atom-react";
@@ -741,6 +742,7 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
               </TooltipPopup>
             </Tooltip>
           )}
+          <ThreadWorktreeIndicator thread={thread} />
           {terminalStatus && (
             <Tooltip>
               <TooltipTrigger

--- a/apps/web/src/components/ThreadStatusIndicators.test.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.test.tsx
@@ -1,0 +1,39 @@
+import { ThreadId } from "@t3tools/contracts";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ThreadWorktreeIndicator } from "./ThreadStatusIndicators";
+
+describe("ThreadWorktreeIndicator", () => {
+  it("renders the worktree folder and branch in an accessible label", () => {
+    const markup = renderToStaticMarkup(
+      <ThreadWorktreeIndicator
+        thread={{
+          id: ThreadId.make("thread-1"),
+          branch: "feature/sidebar-indicator",
+          worktreePath: "/tmp/worktrees/sidebar-indicator",
+        }}
+      />,
+    );
+
+    expect(markup).toContain('role="img"');
+    expect(markup).toContain(
+      'aria-label="Worktree: sidebar-indicator (feature/sidebar-indicator)"',
+    );
+    expect(markup).toContain('data-testid="thread-worktree-thread-1"');
+  });
+
+  it.each([null, "", "   "])("renders nothing for an absent worktree path", (worktreePath) => {
+    const markup = renderToStaticMarkup(
+      <ThreadWorktreeIndicator
+        thread={{
+          id: ThreadId.make("thread-1"),
+          branch: "main",
+          worktreePath,
+        }}
+      />,
+    );
+
+    expect(markup).toBe("");
+  });
+});

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -4,7 +4,7 @@ import {
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
 import type { VcsStatusResult } from "@t3tools/contracts";
-import { CloudIcon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
+import { CloudIcon, FolderGit2Icon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
 import { useMemo } from "react";
 import { useEnvironment, usePrimaryEnvironmentId } from "../state/environments";
 import { useProject } from "../state/entities";
@@ -15,6 +15,7 @@ import { useUiStateStore } from "../uiStateStore";
 import { resolveChangeRequestPresentation } from "../sourceControlPresentation";
 import { resolveThreadStatusPill, type ThreadStatusPill } from "./Sidebar.logic";
 import type { SidebarThreadSummary } from "../types";
+import { formatWorktreePathForDisplay } from "../worktreeCleanup";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 export interface PrStatusIndicator {
@@ -92,6 +93,40 @@ export function terminalStatusFromRunningIds(
     colorClass: "text-teal-600 dark:text-teal-300/90",
     pulse: true,
   };
+}
+
+export function ThreadWorktreeIndicator({
+  thread,
+}: {
+  thread: Pick<SidebarThreadSummary, "id" | "branch" | "worktreePath">;
+}) {
+  const worktreePath = thread.worktreePath?.trim();
+  if (!worktreePath) {
+    return null;
+  }
+
+  const displayPath = formatWorktreePathForDisplay(worktreePath);
+  const tooltip = thread.branch
+    ? `Worktree: ${displayPath} (${thread.branch})`
+    : `Worktree: ${displayPath}`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            role="img"
+            aria-label={tooltip}
+            data-testid={`thread-worktree-${thread.id}`}
+            className="inline-flex items-center justify-center"
+          />
+        }
+      >
+        <FolderGit2Icon className="size-3 text-muted-foreground/40" />
+      </TooltipTrigger>
+      <TooltipPopup side="top">{tooltip}</TooltipPopup>
+    </Tooltip>
+  );
 }
 
 export function ThreadStatusLabel({


### PR DESCRIPTION
Sessions running in a git worktree now show a small FolderGit2 icon in the sidebar row, next to the terminal-status icon, with a tooltip giving the worktree folder and branch. This makes worktree sessions distinguishable from main-checkout sessions at a glance.

Detection uses the existing `thread.worktreePath`, no extra git calls. The indicator sits in the row's right-side cluster rather than inside the timestamp/meta span, because that span is `pointer-events-none` and fades on row hover, which makes tooltips there unreachable.

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets/before-nohover.png) | ![after](https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets/after-nohover.png) |

Tooltip on hover:

<img src="https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets/after-tooltip.png" width="480" alt="tooltip showing worktree folder and branch" />

Verified in a live session with real worktree threads (screenshots above). `vp check` and typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, read-only UI change driven by existing thread metadata; no new git calls or backend behavior.
> 
> **Overview**
> Sidebar session rows now show a **worktree indicator** when `thread.worktreePath` is set, so worktree sessions are visually distinct from main-checkout sessions.
> 
> A new **`ThreadWorktreeIndicator`** renders a `FolderGit2` icon with a tooltip (formatted folder via `formatWorktreePathForDisplay`, plus branch when present) and an accessible `aria-label`. It is placed in the row’s **right-side icon cluster** in `SidebarThreadRow`—alongside preview port and terminal status—rather than in the timestamp/meta area that uses `pointer-events-none` and fades on hover.
> 
> Coverage is added in **`ThreadStatusIndicators.test.tsx`** for the accessible label and for hiding the indicator when the worktree path is missing or whitespace-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25773fd693f2b7e6144243a36479f987e58057e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add worktree indicator icon to sidebar session rows
> Adds a new `ThreadWorktreeIndicator` component in [ThreadStatusIndicators.tsx](https://github.com/pingdotgg/t3code/pull/3057/files#diff-91746549eb55de0a3ac6a473f89804fbe3db8852968122b4b12cebad10625189) that renders a `FolderGit2Icon` with an accessible tooltip showing the formatted worktree path and branch. The indicator is inserted into the thread row actions area in [Sidebar.tsx](https://github.com/pingdotgg/t3code/pull/3057/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1) and renders nothing when `worktreePath` is absent or whitespace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 25773fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->