### PR TITLE
fix(desktop): mac start:desktop crash from rewritten framework symlinks

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -30,7 +30,7 @@ export const APP_BUNDLE_ID = isDevelopment
   ? `com.t3tools.t3code.dev.${devBundleIdSuffix || "local"}`
   : "com.t3tools.t3code";
 const APP_PROTOCOL_SCHEMES = isDevelopment ? ["t3code-dev"] : ["t3code"];
-const LAUNCHER_VERSION = 10;
+const LAUNCHER_VERSION = 11;
 const defaultIconPath = join(desktopDir, "resources", "icon.icns");
 const developmentMacIconPngPath = join(repoRoot, "assets", "dev", "blueprint-macos-1024.png");
 
@@ -295,7 +295,11 @@ function buildMacLauncher(electronBinaryPath) {
   }
 
   rmSync(targetAppBundlePath, { recursive: true, force: true });
-  cpSync(sourceAppBundlePath, targetAppBundlePath, { recursive: true });
+  // verbatimSymlinks keeps the framework's relative symlinks intact
+  // (e.g. Resources -> Versions/Current/Resources). Without it cpSync
+  // rewrites them to absolute paths into node_modules, which escape the
+  // bundle and crash sandboxed helper processes (icudtl.dat not found).
+  cpSync(sourceAppBundlePath, targetAppBundlePath, { recursive: true, verbatimSymlinks: true });
   patchMainBundleInfoPlist(targetAppBundlePath, iconPath);
   patchHelperBundleInfoPlists(targetAppBundlePath);
   if (isDevelopment) {


### PR DESCRIPTION
`pnpm start:desktop` crashed at launch on macOS with repeated "icudtl.dat not found in bundle" and a fatal unusable GPU process.

Root cause: `buildMacLauncher` copies `Electron.app` into `.electron-runtime/` with `cpSync`, which by default rewrites the framework's relative symlinks (such as `Resources -> Versions/Current/Resources`) into absolute paths pointing back into `node_modules`. Electron's sandboxed helper processes cannot follow symlinks that escape the app bundle, so ICU data lookup fails and every helper crashes. Dev mode is unaffected because it execs the original bundle; only the production start path runs the copy.

Fix: pass `verbatimSymlinks: true` so the staged bundle stays self-contained, and bump `LAUNCHER_VERSION` so previously staged bundles with rewritten symlinks are invalidated and re-copied instead of being reused by the metadata check.

Verified by reproducing the crash with a minimal Electron app against the broken copied bundle, then confirming `pnpm build && pnpm start:desktop` launches cleanly after the fix (window up, GPU and network helpers alive, no ICU errors). Also verified the version bump re-stages an existing stale bundle without manual deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
