### PR TITLE
fix: closing a terminal on Windows never kills its processes

### DIFF
--- a/apps/server/src/terminal/Layers/Manager.test.ts
+++ b/apps/server/src/terminal/Layers/Manager.test.ts
@@ -991,7 +991,9 @@ it.layer(
 
   it.effect("escalates terminal shutdown to SIGKILL when process does not exit in time", () =>
     Effect.gen(function* () {
-      const { manager, ptyAdapter } = yield* createManager(5, { processKillGraceMs: 10 });
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        processKillGraceMs: 10,
+      }).pipe(Effect.provide(withHostPlatform("linux")));
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();
@@ -1005,6 +1007,24 @@ it.layer(
       assert.equal(process.killSignals[0], "SIGTERM");
       expect(process.killSignals).toContain("SIGKILL");
     }).pipe(Effect.provide(TestClock.layer())),
+  );
+
+  it.effect("kills the terminal without a signal on Windows", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        subprocessInspector: () =>
+          Effect.succeed({ hasRunningSubprocess: false, childCommand: null, processIds: [] }),
+      }).pipe(Effect.provide(withHostPlatform("win32")));
+      yield* manager.open(openInput());
+      const process = ptyAdapter.processes[0];
+      expect(process).toBeDefined();
+      if (!process) return;
+
+      yield* manager.close({ threadId: "thread-1" });
+      yield* waitFor(Effect.sync(() => process.killed));
+
+      expect(process.killSignals).toEqual([undefined]);
+    }),
   );
 
   it.effect("publishes closed events when terminals are explicitly closed", () =>
@@ -1488,7 +1508,10 @@ it.layer(
       const scope = yield* Scope.make("sequential");
       const { manager, ptyAdapter } = yield* createManager(5, {
         processKillGraceMs: 10,
-      }).pipe(Effect.provideService(Scope.Scope, scope));
+      }).pipe(
+        Effect.provide(withHostPlatform("linux")),
+        Effect.provideService(Scope.Scope, scope),
+      );
       yield* manager.open(openInput());
       const process = ptyAdapter.processes[0];
       expect(process).toBeDefined();

--- a/apps/server/src/terminal/Layers/Manager.ts
+++ b/apps/server/src/terminal/Layers/Manager.ts
@@ -77,7 +77,7 @@ class TerminalProcessSignalError extends Schema.TaggedErrorClass<TerminalProcess
   {
     message: Schema.String,
     cause: Schema.optional(Schema.Defect()),
-    signal: Schema.Literals(["SIGTERM", "SIGKILL"]),
+    signal: Schema.optional(Schema.Literals(["SIGTERM", "SIGKILL"])),
   },
 ) {}
 
@@ -1143,6 +1143,29 @@ export const makeTerminalManagerWithOptions = Effect.fn("makeTerminalManagerWith
       threadId: string,
       terminalId: string,
     ) {
+      if (platform === "win32") {
+        // node-pty throws on Windows whenever a signal is passed; a signal-less
+        // kill terminates every process attached to the pty's console
+        // (shell and child processes such as dev servers), so no escalation step.
+        yield* Effect.try({
+          try: () => process.kill(),
+          catch: (cause) =>
+            new TerminalProcessSignalError({
+              message: "Failed to kill terminal console process tree.",
+              cause,
+            }),
+        }).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("failed to kill terminal process", {
+              threadId,
+              terminalId,
+              error: error.message,
+            }),
+          ),
+        );
+        return;
+      }
+
       const terminated = yield* Effect.try({
         try: () => process.kill("SIGTERM"),
         catch: (cause) =>


### PR DESCRIPTION
## What changed

On Windows, closing a terminal (trash can, or closing its thread) never kills the terminal's processes. `runKillEscalation` in `apps/server/src/terminal/Layers/Manager.ts` always passes a signal to `PtyProcess.kill` (SIGTERM, then SIGKILL after the grace period), and node-pty's `WindowsTerminal.kill(signal)` throws `'Signals not supported on windows.'` whenever a signal is provided. Both attempts are caught and logged as `failed to kill terminal process`, and nothing is killed.

The result on win32: the shell and everything started in it (dev servers, watchers) keep running detached until the whole app exits, still holding their ports. Since closing also removes the session and deletes its history, the orphans are invisible afterwards; reopening spawns a fresh pty next to the still-running old one.

**Repro** (Windows): open a thread terminal, run anything that binds a port (`npm run dev`), close the terminal from the UI, then check the process list or the port. The dev server is still running.

## The fix

On `win32`, call `kill()` with no signal and skip the SIGTERM/SIGKILL escalation. node-pty's signal-less Windows kill enumerates the console process list and terminates every process attached to the pty's console; that code path exists in node-pty precisely so node servers don't outlive the terminal (its source references microsoft/vscode#26807). POSIX behavior is unchanged.

`TerminalProcessSignalError.signal` becomes optional because the Windows failure case has no signal to report.

## Tests

- New: `kills the terminal without a signal on Windows` (manager pinned to `platform: "win32"`, asserts exactly one signal-less kill).
- The two existing kill-escalation tests used the host platform, so with this change they would exercise the win32 path when run on a Windows machine; they now pin `platform: "linux"` and deterministically test the POSIX escalation everywhere.

`vp check` (0 errors), `vp run typecheck`, and the terminal Manager suite (43 passed) all pass.

Found and verified in a downstream fork running on Windows 11; the diff here is built against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes process teardown on Windows only; incorrect kill behavior could still leave processes running or affect shutdown paths, but scope is limited to terminal manager kill escalation.
> 
> **Overview**
> **Fixes terminal close on Windows** so closing a thread or trashing a terminal actually tears down the shell and child processes (e.g. dev servers) instead of leaving orphans.
> 
> `runKillEscalation` in `Manager.ts` now branches on `win32`: it calls `process.kill()` with **no signal** and skips the SIGTERM → grace → SIGKILL path, because node-pty throws when a signal is passed on Windows. POSIX behavior is unchanged.
> 
> `TerminalProcessSignalError.signal` is **optional** for failures on the signal-less Windows kill path.
> 
> Tests pin **linux** for the two escalation tests so they stay deterministic on Windows hosts, and add **`kills the terminal without a signal on Windows`** asserting a single signal-less kill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c50cf96c8bbfecf6f2ac962bed5bc65cc72dbbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal process kill on Windows to use signal-less `process.kill()`
> On Windows, `SIGTERM`/`SIGKILL` signals are not supported, so closing a terminal never actually killed its processes. The `runKillEscalation` function in [Manager.ts](https://github.com/pingdotgg/t3code/pull/3063/files#diff-51f9668a4493e7cf6ec7c836a4af9946110091ee50cd822c9c4a4d5bdcedf496) now checks for `win32` and performs a signal-less `process.kill()` instead of the SIGTERM→SIGKILL escalation used on other platforms. The `signal` field on `TerminalProcessSignalError` is made optional to accommodate signal-less kills.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c50cf9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->