### PR TITLE
feat: add Kimi Code provider support

### DIFF
--- a/apps/server/src/provider/Drivers/KimiCodeDriver.test.ts
+++ b/apps/server/src/provider/Drivers/KimiCodeDriver.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Schema from "effect/Schema";
+
+import { KimiCodeSettings, ProviderDriverKind } from "@t3tools/contracts";
+
+import { KimiCodeDriver } from "./KimiCodeDriver.ts";
+
+const decodeKimiCodeSettings = Schema.decodeSync(KimiCodeSettings);
+
+describe("KimiCodeDriver", () => {
+  it("advertises the correct driver kind and metadata", () => {
+    expect(KimiCodeDriver.driverKind).toBe(ProviderDriverKind.make("kimiCode"));
+    expect(KimiCodeDriver.metadata.displayName).toBe("Kimi Code");
+    expect(KimiCodeDriver.metadata.supportsMultipleInstances).toBe(true);
+  });
+
+  it("provides a default config with the standard binary path", () => {
+    const defaults = KimiCodeDriver.defaultConfig();
+    expect(defaults.enabled).toBe(true);
+    expect(defaults.binaryPath).toBe("kimi");
+    expect(defaults.customModels).toEqual([]);
+  });
+
+  it("accepts settings with a custom binary path", () => {
+    const decoded = decodeKimiCodeSettings({
+      enabled: false,
+      binaryPath: "/usr/local/bin/kimi",
+      customModels: ["kimi-code/custom"],
+    });
+    expect(decoded.enabled).toBe(false);
+    expect(decoded.binaryPath).toBe("/usr/local/bin/kimi");
+    expect(decoded.customModels).toEqual(["kimi-code/custom"]);
+  });
+});

--- a/apps/server/src/provider/Drivers/KimiCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/KimiCodeDriver.ts
@@ -1,0 +1,168 @@
+/**
+ * KimiCodeDriver — `ProviderDriver` for the Kimi Code CLI (`kimi acp`) runtime.
+ *
+ * Kimi exposes an ACP-based CLI. Model catalog and capability refreshes happen
+ * during the managed provider status check via the ACP session setup response.
+ *
+ * Text generation is supported via the ACP runtime — `makeKimiCodeTextGeneration`
+ * drives `runtime.prompt` with a structured-output schema.
+ *
+ * @module provider/Drivers/KimiCodeDriver
+ */
+import { KimiCodeSettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { ServerConfig } from "../../config.ts";
+import { makeKimiCodeTextGeneration } from "../../textGeneration/KimiCodeTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeKimiCodeAdapter } from "../Layers/KimiCodeAdapter.ts";
+import {
+  buildInitialKimiCodeProviderSnapshot,
+  checkKimiCodeProviderStatus,
+  enrichKimiCodeSnapshot,
+} from "../Layers/KimiCodeProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeManualOnlyProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+const decodeKimiCodeSettings = Schema.decodeSync(KimiCodeSettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("kimiCode");
+const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeManualOnlyProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+  }),
+);
+
+export type KimiCodeDriverEnv =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const KimiCodeDriver: ProviderDriver<KimiCodeSettings, KimiCodeDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Kimi Code",
+    supportsMultipleInstances: true,
+  },
+  configSchema: KimiCodeSettings,
+  defaultConfig: (): KimiCodeSettings => decodeKimiCodeSettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const httpClient = yield* HttpClient.HttpClient;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies KimiCodeSettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+
+      const adapter = yield* makeKimiCodeAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+      const textGeneration = yield* makeKimiCodeTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkKimiCodeProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
+
+      const snapshot = yield* makeManagedServerProvider<KimiCodeSettings>({
+        maintenanceCapabilities,
+        getSettings: Effect.succeed(effectiveConfig),
+        streamSettings: Stream.never,
+        haveSettingsChanged: () => false,
+        initialSnapshot: (settings) =>
+          buildInitialKimiCodeProviderSnapshot(settings).pipe(Effect.map(stampIdentity)),
+        checkProvider,
+        enrichSnapshot: ({ snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichKimiCodeSnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            publishSnapshot,
+            httpClient,
+          }),
+        refreshInterval: SNAPSHOT_REFRESH_INTERVAL,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Kimi Code snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/KimiCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/KimiCodeAdapter.test.ts
@@ -1,0 +1,177 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as path from "node:path";
+import * as os from "node:os";
+import { chmod, mkdtemp, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+
+import {
+  KimiCodeSettings,
+  ProviderDriverKind,
+  ThreadId,
+  ProviderInstanceId,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+
+import { ServerConfig } from "../../config.ts";
+import { makeKimiCodeAdapter } from "./KimiCodeAdapter.ts";
+const decodeKimiCodeSettings = Schema.decodeSync(KimiCodeSettings);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const mockAgentPath = path.join(__dirname, "../../../scripts/acp-mock-agent.ts");
+const mockAgentCommand = process.execPath;
+
+async function makeMockKimiCodeWrapper(extraEnv?: Record<string, string>) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "kimi-code-acp-mock-"));
+  const wrapperPath = path.join(dir, "fake-kimi.sh");
+  const envExports = Object.entries(extraEnv ?? {})
+    .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
+    .join("\n");
+  const script = `#!/bin/sh
+${envExports}
+exec ${JSON.stringify(mockAgentCommand)} ${JSON.stringify(mockAgentPath)} "$@"
+`;
+  await writeFile(wrapperPath, script, "utf8");
+  await chmod(wrapperPath, 0o755);
+  return wrapperPath;
+}
+
+const kimiCodeAdapterTestLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3code-kimi-code-adapter-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+const makeTestAdapter = (binaryPath: string, options?: Parameters<typeof makeKimiCodeAdapter>[1]) =>
+  makeKimiCodeAdapter(decodeKimiCodeSettings({ binaryPath }), options).pipe(Effect.orDie);
+
+it.layer(kimiCodeAdapterTestLayer)("KimiCodeAdapterLive", (it) => {
+  it.effect("starts a session and maps mock ACP prompt flow to runtime events", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("kimi-code-mock-thread");
+      const wrapperPath = yield* Effect.promise(() => makeMockKimiCodeWrapper());
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "turn.completed"
+              ? Deferred.succeed(turnCompleted, undefined)
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("kimiCode"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("kimiCode"),
+          model: "grok-build",
+        },
+      });
+
+      assert.equal(session.provider, "kimiCode");
+      assert.equal(session.model, "grok-build");
+      assert.deepStrictEqual(session.resumeCursor, {
+        schemaVersion: 1,
+        sessionId: "mock-session-1",
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "hello kimi",
+        attachments: [],
+      });
+
+      yield* Deferred.await(turnCompleted);
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      const types = runtimeEvents.map((e) => e.type);
+
+      assert.includeMembers(types, [
+        "session.started",
+        "session.state.changed",
+        "thread.started",
+        "turn.started",
+        "item.started",
+        "content.delta",
+        "turn.completed",
+      ] as const);
+
+      const delta = runtimeEvents.find((e) => e.type === "content.delta");
+      assert.isDefined(delta);
+      if (delta?.type === "content.delta") {
+        assert.equal(delta.payload.delta, "hello from mock");
+      }
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("rejects startSession when provider mismatches", () =>
+    Effect.gen(function* () {
+      const wrapperPath = yield* Effect.promise(() => makeMockKimiCodeWrapper());
+      const adapter = yield* makeTestAdapter(wrapperPath);
+      const threadId = ThreadId.make("kimi-code-provider-mismatch");
+
+      const error = yield* Effect.flip(
+        adapter.startSession({
+          threadId,
+          provider: ProviderDriverKind.make("cursor"),
+          cwd: process.cwd(),
+          runtimeMode: "full-access",
+          modelSelection: {
+            instanceId: ProviderInstanceId.make("kimiCode"),
+            model: "kimi-code/kimi-for-coding",
+          },
+        }),
+      );
+
+      assert.equal(error._tag, "ProviderAdapterValidationError");
+    }),
+  );
+
+  it.effect("rejects sendTurn with empty input and no attachments", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("kimi-code-empty-turn");
+
+      const wrapperPath = yield* Effect.promise(() => makeMockKimiCodeWrapper());
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("kimiCode"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("kimiCode"),
+          model: "grok-build",
+        },
+      });
+
+      const error = yield* Effect.flip(
+        adapter.sendTurn({
+          threadId,
+          input: "   ",
+          attachments: [],
+        }),
+      );
+
+      assert.equal(error._tag, "ProviderAdapterValidationError");
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/KimiCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/KimiCodeAdapter.ts
@@ -1,0 +1,975 @@
+/**
+ * KimiCodeAdapterLive — Kimi Code CLI (`kimi acp`) via ACP.
+ *
+ * @module KimiCodeAdapterLive
+ */
+
+import {
+  ApprovalRequestId,
+  type KimiCodeSettings,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderUserInputAnswers,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  type RuntimeMode,
+  type ProviderInteractionMode,
+  RuntimeRequestId,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import { type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import { parsePermissionRequest } from "../acp/AcpRuntimeModel.ts";
+import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import {
+  applyKimiCodeAcpModelSelection,
+  currentKimiCodeModelIdFromSessionSetup,
+  makeKimiCodeAcpRuntime,
+  resolveKimiCodeAcpBaseModelId,
+  resolveKimiCodeAcpModeId,
+} from "../acp/KimiCodeAcpSupport.ts";
+import { type KimiCodeAdapterShape } from "../Services/KimiCodeAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.UnknownFromJsonString);
+
+const PROVIDER = ProviderDriverKind.make("kimiCode");
+const KIMI_CODE_RESUME_VERSION = 1 as const;
+
+function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
+  const result = encodeUnknownJsonStringExit(input);
+  return Exit.isSuccess(result) ? result.value : undefined;
+}
+
+export interface KimiCodeAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  readonly instanceId?: ProviderInstanceId;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+}
+
+interface PendingUserInput {
+  readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
+}
+
+interface KimiCodeSessionContext {
+  readonly threadId: ThreadId;
+  readonly acpSessionId: string;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntimeShape;
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
+  turns: Array<{ id: TurnId; items: Array<unknown> }>;
+  lastPlanFingerprint: string | undefined;
+  activeTurnId: TurnId | undefined;
+  /** Number of sendTurn prompts currently in flight or being prepared. */
+  promptsInFlight: number;
+  currentModelId: string | undefined;
+  stopped: boolean;
+}
+
+function settlePendingApprovalsAsCancelled(
+  pendingApprovals: ReadonlyMap<ApprovalRequestId, PendingApproval>,
+): Effect.Effect<void> {
+  return Effect.forEach(
+    Array.from(pendingApprovals.values()),
+    (pending) => Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore),
+    { discard: true },
+  );
+}
+
+function settlePendingUserInputsAsEmptyAnswers(
+  pendingUserInputs: ReadonlyMap<ApprovalRequestId, PendingUserInput>,
+): Effect.Effect<void> {
+  return Effect.forEach(
+    Array.from(pendingUserInputs.values()),
+    (pending) => Deferred.succeed(pending.answers, {}).pipe(Effect.ignore),
+    { discard: true },
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseKimiCodeResume(raw: unknown): { sessionId: string } | undefined {
+  if (!isRecord(raw)) return undefined;
+  if (raw.schemaVersion !== KIMI_CODE_RESUME_VERSION) return undefined;
+  if (typeof raw.sessionId !== "string" || !raw.sessionId.trim()) return undefined;
+  return { sessionId: raw.sessionId.trim() };
+}
+
+function selectPermissionOptionId(
+  request: EffectAcpSchema.RequestPermissionRequest,
+  decision: Exclude<ProviderApprovalDecision, "cancel">,
+): string | undefined {
+  const kind =
+    decision === "acceptForSession"
+      ? "allow_always"
+      : decision === "accept"
+        ? "allow_once"
+        : "reject_once";
+  const option = request.options.find((entry) => entry.kind === kind);
+  return option?.optionId.trim() || undefined;
+}
+
+function selectAutoApprovedPermissionOption(
+  request: EffectAcpSchema.RequestPermissionRequest,
+): string | undefined {
+  return (
+    selectPermissionOptionId(request, "acceptForSession") ??
+    selectPermissionOptionId(request, "accept")
+  );
+}
+
+export function makeKimiCodeAdapter(
+  kimiCodeSettings: KimiCodeSettings,
+  options?: KimiCodeAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("kimiCode");
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const crypto = yield* Crypto.Crypto;
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, { stream: "native" })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+    const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
+
+    const sessions = new Map<ThreadId, KimiCodeSessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate Kimi Code runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const mapAcpCallbackFailure = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new EffectAcpErrors.AcpTransportError({
+              detail: "Failed to process Kimi Code ACP callback.",
+              cause,
+            }),
+        ),
+      );
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
+          current.get(threadId),
+        );
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const logNative = (threadId: ThreadId, method: string, payload: unknown) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("Failed to write native Kimi Code notification log.", {
+            cause,
+            threadId,
+            method,
+          }),
+        ),
+      );
+
+    const emitPlanUpdate = (
+      ctx: KimiCodeSessionContext,
+      payload: {
+        readonly explanation?: string | null;
+        readonly plan: ReadonlyArray<{
+          readonly step: string;
+          readonly status: "pending" | "inProgress" | "completed";
+        }>;
+      },
+      rawPayload: unknown,
+      method: string,
+    ) =>
+      Effect.gen(function* () {
+        const fingerprint = `${ctx.activeTurnId ?? "no-turn"}:${encodeJsonStringForDiagnostics(payload) ?? "[unserializable payload]"}`;
+        if (ctx.lastPlanFingerprint === fingerprint) {
+          return;
+        }
+        ctx.lastPlanFingerprint = fingerprint;
+        yield* offerRuntimeEvent(
+          makeAcpPlanUpdatedEvent({
+            stamp: yield* makeEventStamp(),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId: ctx.activeTurnId,
+            payload,
+            source: "acp.jsonrpc",
+            method,
+            rawPayload,
+          }),
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<KimiCodeSessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: KimiCodeSessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const applyRequestedSessionConfiguration = <E>(input: {
+      readonly acp: AcpSessionRuntimeShape;
+      readonly runtimeMode: RuntimeMode;
+      readonly interactionMode: ProviderInteractionMode | undefined;
+      readonly modelSelection:
+        | {
+            readonly model: string;
+          }
+        | undefined;
+      readonly currentModelId: string | undefined;
+      readonly mapError: (context: {
+        readonly cause: EffectAcpErrors.AcpError;
+        readonly method: string;
+      }) => E;
+    }): Effect.Effect<string | undefined, E> =>
+      Effect.gen(function* () {
+        const requestedModelId = input.modelSelection?.model
+          ? resolveKimiCodeAcpBaseModelId(input.modelSelection.model)
+          : undefined;
+        const newModelId = yield* applyKimiCodeAcpModelSelection({
+          runtime: input.acp,
+          currentModelId: input.currentModelId,
+          requestedModelId,
+          mapError: (cause) => input.mapError({ cause, method: "session/set_model" }),
+        });
+
+        const modeState = yield* input.acp.getModeState;
+        const requestedModeId = resolveKimiCodeAcpModeId({
+          interactionMode: input.interactionMode,
+          runtimeMode: input.runtimeMode,
+          availableModes: modeState?.availableModes,
+          currentModeId: modeState?.currentModeId,
+        });
+        if (requestedModeId && requestedModeId !== modeState?.currentModeId) {
+          yield* input.acp
+            .setMode(requestedModeId)
+            .pipe(
+              Effect.mapError((cause) => input.mapError({ cause, method: "session/set_mode" })),
+            );
+        }
+
+        return newModelId;
+      });
+
+    const startSession: KimiCodeAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const kimiCodeModelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+
+          const resumeSessionId = parseKimiCodeResume(input.resumeCursor)?.sessionId;
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+
+          const acp = yield* makeKimiCodeAcpRuntime({
+            kimiCodeSettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...acpNativeLoggers,
+          }).pipe(
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+
+          const started = yield* Effect.gen(function* () {
+            yield* acp.handleRequestPermission((params) =>
+              mapAcpCallbackFailure(
+                Effect.gen(function* () {
+                  yield* logNative(input.threadId, "session/request_permission", params);
+                  if (input.runtimeMode === "full-access") {
+                    const autoApprovedOptionId = selectAutoApprovedPermissionOption(params);
+                    if (autoApprovedOptionId !== undefined) {
+                      return {
+                        outcome: {
+                          outcome: "selected" as const,
+                          optionId: autoApprovedOptionId,
+                        },
+                      };
+                    }
+                  }
+                  const permissionRequest = parsePermissionRequest(params);
+                  const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                  const runtimeRequestId = RuntimeRequestId.make(requestId);
+                  const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                  pendingApprovals.set(requestId, { decision });
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestOpenedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: sessions.get(input.threadId)?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      detail:
+                        permissionRequest.detail ??
+                        encodeJsonStringForDiagnostics(params)?.slice(0, 2000) ??
+                        "[unserializable params]",
+                      args: params,
+                      source: "acp.jsonrpc",
+                      method: "session/request_permission",
+                      rawPayload: params,
+                    }),
+                  );
+                  const resolved = yield* Deferred.await(decision);
+                  pendingApprovals.delete(requestId);
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestResolvedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: sessions.get(input.threadId)?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      decision: resolved,
+                    }),
+                  );
+                  const selectedOptionId =
+                    resolved === "cancel" ? undefined : selectPermissionOptionId(params, resolved);
+                  return {
+                    outcome: selectedOptionId
+                      ? {
+                          outcome: "selected" as const,
+                          optionId: selectedOptionId,
+                        }
+                      : ({ outcome: "cancelled" } as const),
+                  };
+                }),
+              ),
+            );
+            return yield* acp.start();
+          }).pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+            ),
+          );
+
+          const boundModelId = yield* applyRequestedSessionConfiguration({
+            acp,
+            runtimeMode: input.runtimeMode,
+            interactionMode: undefined,
+            modelSelection: kimiCodeModelSelection?.model
+              ? { model: kimiCodeModelSelection.model }
+              : undefined,
+            currentModelId: currentKimiCodeModelIdFromSessionSetup(started.sessionSetupResult),
+            mapError: ({ cause, method }) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+          });
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            ...(boundModelId ? { model: resolveKimiCodeAcpBaseModelId(boundModelId) } : {}),
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: KIMI_CODE_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          const ctx: KimiCodeSessionContext = {
+            threadId: input.threadId,
+            acpSessionId: started.sessionId,
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            pendingApprovals,
+            pendingUserInputs,
+            turns: [],
+            lastPlanFingerprint: undefined,
+            activeTurnId: undefined,
+            promptsInFlight: 0,
+            currentModelId: boundModelId,
+            stopped: false,
+          };
+
+          const nf = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                switch (event._tag) {
+                  case "ModeChanged":
+                    return;
+                  case "AssistantItemStarted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.started",
+                      }),
+                    );
+                    return;
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* emitPlanUpdate(ctx, event.payload, event.rawPayload, "session/update");
+                    return;
+                  case "ToolCallUpdated":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* logNative(ctx.threadId, "session/update", event.rawPayload);
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to process Kimi Code runtime notification.", { cause }),
+            ),
+            Effect.forkChild,
+          );
+
+          ctx.notificationFiber = nf;
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Kimi Code ACP session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: KimiCodeAdapterShape["sendTurn"] = (input) =>
+      Effect.gen(function* () {
+        const prepared = yield* withThreadLock(
+          input.threadId,
+          Effect.gen(function* () {
+            const ctx = yield* requireSession(input.threadId);
+            const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+            const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+            ctx.promptsInFlight += 1;
+
+            return yield* Effect.gen(function* () {
+              const turnModelSelection =
+                input.modelSelection?.instanceId === boundInstanceId
+                  ? input.modelSelection
+                  : undefined;
+              const currentModelId = yield* applyRequestedSessionConfiguration({
+                acp: ctx.acp,
+                runtimeMode: ctx.session.runtimeMode,
+                interactionMode: input.interactionMode,
+                modelSelection: turnModelSelection?.model
+                  ? { model: turnModelSelection.model }
+                  : undefined,
+                currentModelId: ctx.currentModelId,
+                mapError: ({ cause, method }) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+              });
+
+              const text = input.input?.trim();
+              const imagePromptParts = yield* Effect.forEach(
+                input.attachments ?? [],
+                (attachment) =>
+                  Effect.gen(function* () {
+                    const attachmentPath = resolveAttachmentPath({
+                      attachmentsDir: serverConfig.attachmentsDir,
+                      attachment,
+                    });
+                    if (!attachmentPath) {
+                      return yield* new ProviderAdapterRequestError({
+                        provider: PROVIDER,
+                        method: "session/prompt",
+                        detail: `Invalid attachment id '${attachment.id}'.`,
+                      });
+                    }
+                    const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+                      Effect.mapError(
+                        (cause) =>
+                          new ProviderAdapterRequestError({
+                            provider: PROVIDER,
+                            method: "session/prompt",
+                            detail: cause.message,
+                            cause,
+                          }),
+                      ),
+                    );
+                    return {
+                      type: "image",
+                      data: Buffer.from(bytes).toString("base64"),
+                      mimeType: attachment.mimeType,
+                    } satisfies EffectAcpSchema.ContentBlock;
+                  }),
+              );
+              const promptParts: Array<EffectAcpSchema.ContentBlock> = [
+                ...(text ? [{ type: "text" as const, text }] : []),
+                ...imagePromptParts,
+              ];
+
+              if (promptParts.length === 0) {
+                return yield* new ProviderAdapterValidationError({
+                  provider: PROVIDER,
+                  operation: "sendTurn",
+                  issue: "Turn requires non-empty text or attachments.",
+                });
+              }
+
+              ctx.currentModelId = currentModelId;
+              const displayModel = currentModelId
+                ? resolveKimiCodeAcpBaseModelId(currentModelId)
+                : undefined;
+              ctx.activeTurnId = turnId;
+              if (steeringTurnId === undefined) {
+                ctx.lastPlanFingerprint = undefined;
+              }
+              ctx.session = {
+                ...ctx.session,
+                activeTurnId: turnId,
+                updatedAt: yield* nowIso,
+                ...(displayModel ? { model: displayModel } : {}),
+              };
+
+              if (steeringTurnId === undefined) {
+                yield* offerRuntimeEvent({
+                  type: "turn.started",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId,
+                  payload: displayModel ? { model: displayModel } : {},
+                });
+              }
+
+              return {
+                acp: ctx.acp,
+                acpSessionId: ctx.acpSessionId,
+                displayModel,
+                promptParts,
+                turnId,
+              };
+            }).pipe(
+              Effect.tapCause(() =>
+                Effect.sync(() => {
+                  ctx.promptsInFlight = Math.max(0, ctx.promptsInFlight - 1);
+                }),
+              ),
+            );
+          }),
+        );
+
+        return yield* Effect.gen(function* () {
+          const result = yield* prepared.acp
+            .prompt({
+              prompt: prepared.promptParts,
+            })
+            .pipe(
+              Effect.mapError((error) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+              ),
+            );
+
+          return yield* withThreadLock(
+            input.threadId,
+            Effect.gen(function* () {
+              const ctx = yield* requireSession(input.threadId);
+              if (ctx.acpSessionId !== prepared.acpSessionId) {
+                return yield* new ProviderAdapterRequestError({
+                  provider: PROVIDER,
+                  method: "session/prompt",
+                  detail: "Kimi Code session changed before the turn completed.",
+                });
+              }
+
+              const existingTurnRecord = ctx.turns.find((turn) => turn.id === prepared.turnId);
+              ctx.turns = existingTurnRecord
+                ? ctx.turns.map((turn) =>
+                    turn.id === prepared.turnId
+                      ? {
+                          ...turn,
+                          items: [...turn.items, { prompt: prepared.promptParts, result }],
+                        }
+                      : turn,
+                  )
+                : [
+                    ...ctx.turns,
+                    { id: prepared.turnId, items: [{ prompt: prepared.promptParts, result }] },
+                  ];
+              ctx.session = {
+                ...ctx.session,
+                activeTurnId: prepared.turnId,
+                updatedAt: yield* nowIso,
+                ...(prepared.displayModel ? { model: prepared.displayModel } : {}),
+              };
+
+              if (ctx.promptsInFlight === 1) {
+                yield* offerRuntimeEvent({
+                  type: "turn.completed",
+                  ...(yield* makeEventStamp()),
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  turnId: prepared.turnId,
+                  payload: {
+                    state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                    stopReason: result.stopReason ?? null,
+                  },
+                });
+              }
+
+              return {
+                threadId: input.threadId,
+                turnId: prepared.turnId,
+                resumeCursor: ctx.session.resumeCursor,
+              };
+            }),
+          );
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              const liveCtx = sessions.get(input.threadId);
+              if (liveCtx) {
+                liveCtx.promptsInFlight = Math.max(0, liveCtx.promptsInFlight - 1);
+              }
+            }),
+          ),
+        );
+      });
+
+    const interruptTurn: KimiCodeAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        yield* Effect.ignore(
+          ctx.acp.cancel.pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+            ),
+          ),
+        );
+      });
+
+    const respondToRequest: KimiCodeAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: KimiCodeAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingUserInputs.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_user_input",
+            detail: `Unknown pending user-input request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.answers, answers);
+      });
+
+    const readThread: KimiCodeAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: KimiCodeAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      Effect.gen(function* () {
+        yield* requireSession(threadId);
+        if (!Number.isInteger(numTurns) || numTurns < 1) {
+          return yield* new ProviderAdapterValidationError({
+            provider: PROVIDER,
+            operation: "rollbackThread",
+            issue: "numTurns must be an integer >= 1.",
+          });
+        }
+        return yield* new ProviderAdapterRequestError({
+          provider: PROVIDER,
+          method: "thread/rollback",
+          detail: "Kimi Code ACP sessions do not support provider-side rollback yet.",
+        });
+      });
+
+    const stopSession: KimiCodeAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions: KimiCodeAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (c) => ({ ...c.session })));
+
+    const hasSession: KimiCodeAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const c = sessions.get(threadId);
+        return c !== undefined && !c.stopped;
+      });
+
+    const stopAll: KimiCodeAdapterShape["stopAll"] = () =>
+      Effect.forEach(Array.from(sessions.values()), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.ignore(stopAll()).pipe(
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
+
+    return {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents,
+    } satisfies KimiCodeAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/KimiCodeProvider.test.ts
+++ b/apps/server/src/provider/Layers/KimiCodeProvider.test.ts
@@ -1,0 +1,118 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { KimiCodeSettings } from "@t3tools/contracts";
+
+import {
+  buildInitialKimiCodeProviderSnapshot,
+  checkKimiCodeProviderStatus,
+} from "./KimiCodeProvider.ts";
+
+const decodeKimiCodeSettings = Schema.decodeSync(KimiCodeSettings);
+
+describe("buildInitialKimiCodeProviderSnapshot", () => {
+  it.effect("returns a disabled snapshot when settings.enabled is false", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialKimiCodeProviderSnapshot(
+        decodeKimiCodeSettings({ enabled: false }),
+      );
+      expect(snapshot.enabled).toBe(false);
+      expect(snapshot.status).toBe("disabled");
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.message).toContain("disabled");
+    }),
+  );
+
+  it.effect("returns a pending snapshot by default", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialKimiCodeProviderSnapshot(decodeKimiCodeSettings({}));
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.status).toBe("warning");
+      expect(snapshot.version).toBeNull();
+      expect(snapshot.message).toContain("Checking Kimi Code");
+      expect(snapshot.showInteractionModeToggle).toBe(true);
+    }),
+  );
+
+  it.effect("includes the default built-in model", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* buildInitialKimiCodeProviderSnapshot(decodeKimiCodeSettings({}));
+      expect(snapshot.models.map((model) => model.slug)).toContain("kimi-code/kimi-for-coding");
+    }),
+  );
+});
+
+it.layer(NodeServices.layer)("checkKimiCodeProviderStatus", (it) => {
+  it.effect("reports the binary as missing when the binary path does not resolve", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* checkKimiCodeProviderStatus(
+        decodeKimiCodeSettings({
+          enabled: true,
+          binaryPath: "/definitely/not/installed/kimi-binary",
+        }),
+      );
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(false);
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.message).toMatch(/not installed|not on PATH|Failed to execute/);
+    }),
+  );
+
+  it.effect("reports an installed CLI as unhealthy when --version exits non-zero", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-kimi-version-" });
+          const kimiPath = path.join(dir, "kimi");
+          yield* fs.writeFileString(
+            kimiPath,
+            ["#!/bin/sh", 'printf "%s\\n" "broken kimi install" >&2', "exit 2", ""].join("\n"),
+          );
+          yield* fs.chmod(kimiPath, 0o755);
+
+          return yield* checkKimiCodeProviderStatus(
+            decodeKimiCodeSettings({ enabled: true, binaryPath: kimiPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.enabled).toBe(true);
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.message).toContain("broken kimi install");
+    }),
+  );
+
+  it.effect("reports an error when ACP startup is unavailable", () =>
+    Effect.gen(function* () {
+      const snapshot = yield* Effect.scoped(
+        Effect.gen(function* () {
+          const fs = yield* FileSystem.FileSystem;
+          const path = yield* Path.Path;
+          const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-kimi-success-" });
+          const kimiPath = path.join(dir, "kimi");
+          yield* fs.writeFileString(
+            kimiPath,
+            ["#!/bin/sh", 'printf "kimi-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
+          );
+          yield* fs.chmod(kimiPath, 0o755);
+
+          return yield* checkKimiCodeProviderStatus(
+            decodeKimiCodeSettings({ enabled: true, binaryPath: kimiPath }),
+          );
+        }),
+      );
+
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.models.map((model) => model.slug)).toEqual(["kimi-code/kimi-for-coding"]);
+      expect(snapshot.message).toContain("ACP startup failed");
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/KimiCodeProvider.ts
+++ b/apps/server/src/provider/Layers/KimiCodeProvider.ts
@@ -1,0 +1,346 @@
+import {
+  type KimiCodeSettings,
+  type ModelCapabilities,
+  ProviderDriverKind,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import type * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+import * as Cause from "effect/Cause";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+
+import {
+  buildServerProvider,
+  detailFromResult,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+import {
+  makeKimiCodeAcpRuntime,
+  resolveKimiCodeAcpBaseModelId,
+} from "../acp/KimiCodeAcpSupport.ts";
+
+const KIMI_CODE_PRESENTATION = {
+  displayName: "Kimi Code",
+  badgeLabel: "Early Access",
+  showInteractionModeToggle: true,
+} as const;
+const PROVIDER = ProviderDriverKind.make("kimiCode");
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [],
+});
+
+const VERSION_PROBE_TIMEOUT_MS = 4_000;
+const KIMI_CODE_ACP_PROBE_TIMEOUT_MS = 15_000;
+
+const KIMI_CODE_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "kimi-code/kimi-for-coding",
+    name: "Kimi K2.7 Code",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+];
+
+function kimiCodeModelsFromSettings(
+  customModels: ReadonlyArray<string> | undefined,
+  builtInModels: ReadonlyArray<ServerProviderModel> = KIMI_CODE_BUILT_IN_MODELS,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(
+    builtInModels,
+    PROVIDER,
+    customModels ?? [],
+    EMPTY_CAPABILITIES,
+  );
+}
+
+function buildKimiCodeDiscoveredModelsFromSessionModelState(
+  modelState: EffectAcpSchema.SessionModelState | null | undefined,
+): ReadonlyArray<ServerProviderModel> {
+  if (!modelState || modelState.availableModels.length === 0) {
+    return [];
+  }
+  const seen = new Set<string>();
+  return modelState.availableModels
+    .map((model): ServerProviderModel | undefined => {
+      const slug = resolveKimiCodeAcpBaseModelId(model.modelId);
+      if (!slug || seen.has(slug)) {
+        return undefined;
+      }
+      seen.add(slug);
+      return {
+        slug,
+        name: model.name.trim() || slug,
+        isCustom: false,
+        capabilities: EMPTY_CAPABILITIES,
+      };
+    })
+    .filter((model): model is ServerProviderModel => model !== undefined);
+}
+
+function isAcpAuthRequiredError(error: EffectAcpErrors.AcpError): boolean {
+  if (error._tag === "AcpRequestError") {
+    return (
+      error.code === -32000 || /auth|login|unauthenticated|not logged in/i.test(error.errorMessage)
+    );
+  }
+  return false;
+}
+
+const discoverKimiCodeModelsViaAcp = (
+  kimiCodeSettings: KimiCodeSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const acp = yield* makeKimiCodeAcpRuntime({
+      kimiCodeSettings,
+      environment,
+      childProcessSpawner,
+      cwd: process.cwd(),
+      clientInfo: { name: "t3-code-provider-probe", version: "0.0.0" },
+    });
+    const started = yield* acp.start();
+    return buildKimiCodeDiscoveredModelsFromSessionModelState(started.sessionSetupResult.models);
+  }).pipe(Effect.scoped);
+
+const runKimiCodeVersionCommand = (
+  kimiCodeSettings: KimiCodeSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) => {
+  const command = kimiCodeSettings.binaryPath || "kimi";
+  return spawnAndCollect(
+    command,
+    ChildProcess.make(command, ["--version"], {
+      env: environment,
+      shell: process.platform === "win32",
+    }),
+  );
+};
+
+export function buildInitialKimiCodeProviderSnapshot(
+  kimiCodeSettings: KimiCodeSettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = kimiCodeModelsFromSettings(kimiCodeSettings.customModels);
+
+    if (!kimiCodeSettings.enabled) {
+      return buildServerProvider({
+        presentation: KIMI_CODE_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Kimi Code is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: KIMI_CODE_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking Kimi Code CLI availability...",
+      },
+    });
+  });
+}
+
+export const checkKimiCodeProviderStatus = Effect.fn("checkKimiCodeProviderStatus")(function* (
+  kimiCodeSettings: KimiCodeSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
+  const checkedAt = DateTime.formatIso(yield* DateTime.now);
+  const fallbackModels = kimiCodeModelsFromSettings(kimiCodeSettings.customModels);
+
+  if (!kimiCodeSettings.enabled) {
+    return buildServerProvider({
+      presentation: KIMI_CODE_PRESENTATION,
+      enabled: false,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: false,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Kimi Code is disabled in T3 Code settings.",
+      },
+    });
+  }
+
+  const versionResult = yield* runKimiCodeVersionCommand(kimiCodeSettings, environment).pipe(
+    Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
+    Effect.result,
+  );
+
+  if (Result.isFailure(versionResult)) {
+    const error = versionResult.failure;
+    return buildServerProvider({
+      presentation: KIMI_CODE_PRESENTATION,
+      enabled: kimiCodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: !isCommandMissingCause(error),
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: isCommandMissingCause(error)
+          ? "Kimi Code CLI (`kimi`) is not installed or not on PATH."
+          : `Failed to execute Kimi Code CLI health check: ${error instanceof Error ? error.message : String(error)}.`,
+      },
+    });
+  }
+
+  if (Option.isNone(versionResult.success)) {
+    return buildServerProvider({
+      presentation: KIMI_CODE_PRESENTATION,
+      enabled: kimiCodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version: null,
+        status: "error",
+        auth: { status: "unknown" },
+        message: "Kimi Code CLI is installed but timed out while running `kimi --version`.",
+      },
+    });
+  }
+
+  const versionOutput = versionResult.success.value;
+  const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+  if (versionOutput.code !== 0) {
+    const detail = detailFromResult(versionOutput);
+    return buildServerProvider({
+      presentation: KIMI_CODE_PRESENTATION,
+      enabled: kimiCodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unknown" },
+        message: detail
+          ? `Kimi Code CLI is installed but failed to run. ${detail}`
+          : "Kimi Code CLI is installed but failed to run.",
+      },
+    });
+  }
+
+  const discoveryExit = yield* discoverKimiCodeModelsViaAcp(kimiCodeSettings, environment).pipe(
+    Effect.timeoutOption(KIMI_CODE_ACP_PROBE_TIMEOUT_MS),
+    Effect.exit,
+  );
+
+  if (Exit.isFailure(discoveryExit)) {
+    const cause = discoveryExit.cause;
+    const detail = Cause.pretty(cause);
+    const failReason = cause.reasons.find(Cause.isFailReason);
+    const error = failReason?.error;
+    const isAuthError = error && isAcpAuthRequiredError(error);
+
+    yield* Effect.logWarning("Kimi Code ACP probe failed", { cause: detail });
+    return buildServerProvider({
+      presentation: KIMI_CODE_PRESENTATION,
+      enabled: kimiCodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: isAuthError ? { status: "unauthenticated" } : { status: "unknown" },
+        message: isAuthError
+          ? "Kimi Code is not authenticated. Run `kimi login` and try again."
+          : `Kimi Code CLI is installed but ACP startup failed. ${detail}`,
+      },
+    });
+  }
+
+  if (Option.isNone(discoveryExit.value)) {
+    yield* Effect.logWarning(
+      `Kimi Code ACP probe timed out after ${KIMI_CODE_ACP_PROBE_TIMEOUT_MS}ms.`,
+    );
+    return buildServerProvider({
+      presentation: KIMI_CODE_PRESENTATION,
+      enabled: kimiCodeSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unknown" },
+        message: `Kimi Code CLI is installed but ACP startup timed out after ${KIMI_CODE_ACP_PROBE_TIMEOUT_MS}ms.`,
+      },
+    });
+  }
+
+  const discoveredModels = discoveryExit.value.value;
+  const models =
+    discoveredModels.length > 0
+      ? kimiCodeModelsFromSettings(kimiCodeSettings.customModels, discoveredModels)
+      : fallbackModels;
+
+  return buildServerProvider({
+    presentation: KIMI_CODE_PRESENTATION,
+    enabled: kimiCodeSettings.enabled,
+    checkedAt,
+    models,
+    probe: {
+      installed: true,
+      version,
+      status: "ready",
+      auth: { status: "authenticated" },
+    },
+  });
+});
+
+export const enrichKimiCodeSnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> => {
+  const { snapshot, publishSnapshot } = input;
+
+  return enrichProviderSnapshotWithVersionAdvisory(snapshot, input.maintenanceCapabilities).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Kimi Code version advisory enrichment failed", {
+        cause: Cause.pretty(cause),
+      }),
+    ),
+    Effect.asVoid,
+  );
+};

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1406,6 +1406,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsService.layerTest(), T
                 "codex",
                 "cursor",
                 "grok",
+                "kimiCode",
                 "opencode",
               ]);
               assert.strictEqual(cursorProvider?.enabled, false);

--- a/apps/server/src/provider/Services/KimiCodeAdapter.ts
+++ b/apps/server/src/provider/Services/KimiCodeAdapter.ts
@@ -1,0 +1,15 @@
+/**
+ * KimiCodeAdapter — shape type for the Kimi Code provider adapter.
+ *
+ * The driver model bundles one adapter per instance as a captured closure, so
+ * this module only retains the shape interface as a naming anchor.
+ *
+ * @module KimiCodeAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * KimiCodeAdapterShape — per-instance Kimi Code adapter contract.
+ */
+export interface KimiCodeAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/acp/KimiCodeAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/KimiCodeAcpSupport.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as EffectAcpErrors from "effect-acp/errors";
+
+import {
+  applyKimiCodeAcpModelSelection,
+  buildKimiCodeAcpSpawnInput,
+  resolveKimiCodeAcpBaseModelId,
+  resolveKimiCodeAcpModeId,
+} from "./KimiCodeAcpSupport.ts";
+
+describe("resolveKimiCodeAcpBaseModelId", () => {
+  it("normalizes empty and custom Kimi Code model ids", () => {
+    expect(resolveKimiCodeAcpBaseModelId(undefined)).toBe("kimi-code/kimi-for-coding");
+    expect(resolveKimiCodeAcpBaseModelId("   ")).toBe("kimi-code/kimi-for-coding");
+    expect(resolveKimiCodeAcpBaseModelId("  kimi-code/custom  ")).toBe("kimi-code/custom");
+  });
+});
+
+describe("buildKimiCodeAcpSpawnInput", () => {
+  it("builds the spawn input for kimi acp", () => {
+    const spawn = buildKimiCodeAcpSpawnInput(
+      { binaryPath: "/usr/local/bin/kimi" },
+      "/tmp/project",
+      { CUSTOM_ENV: "value" },
+    );
+
+    expect(spawn).toEqual({
+      command: "/usr/local/bin/kimi",
+      args: ["acp"],
+      cwd: "/tmp/project",
+      env: { CUSTOM_ENV: "value" },
+    });
+  });
+
+  it("falls back to 'kimi' when binary path is empty", () => {
+    const spawn = buildKimiCodeAcpSpawnInput({ binaryPath: "" }, "/tmp/project");
+    expect(spawn.command).toBe("kimi");
+  });
+});
+
+describe("resolveKimiCodeAcpModeId", () => {
+  const modes = [
+    { id: "default", name: "Default" },
+    { id: "plan", name: "Plan" },
+    { id: "auto", name: "Auto" },
+    { id: "yolo", name: "YOLO" },
+  ];
+
+  it("selects plan mode for interactionMode plan", () => {
+    expect(
+      resolveKimiCodeAcpModeId({
+        interactionMode: "plan",
+        runtimeMode: "full-access",
+        availableModes: modes,
+        currentModeId: "default",
+      }),
+    ).toBe("plan");
+  });
+
+  it("selects yolo mode for full-access runtime", () => {
+    expect(
+      resolveKimiCodeAcpModeId({
+        interactionMode: "default",
+        runtimeMode: "full-access",
+        availableModes: modes,
+        currentModeId: "default",
+      }),
+    ).toBe("auto");
+  });
+
+  it("selects default mode for approval-required runtime", () => {
+    expect(
+      resolveKimiCodeAcpModeId({
+        interactionMode: "default",
+        runtimeMode: "approval-required",
+        availableModes: modes,
+        currentModeId: "auto",
+      }),
+    ).toBe("default");
+  });
+
+  it("falls back to current mode when no match is found", () => {
+    expect(
+      resolveKimiCodeAcpModeId({
+        interactionMode: "default",
+        runtimeMode: "full-access",
+        availableModes: [{ id: "default", name: "Default" }],
+        currentModeId: "default",
+      }),
+    ).toBe("default");
+  });
+});
+
+describe("applyKimiCodeAcpModelSelection", () => {
+  const makeRecordingRuntime = (failure?: EffectAcpErrors.AcpError) => {
+    const modelCalls: Array<string> = [];
+    const runtime = {
+      setSessionModel: (modelId: string) =>
+        Effect.gen(function* () {
+          modelCalls.push(modelId);
+          if (failure) return yield* failure;
+          return {};
+        }),
+    };
+    return { runtime, modelCalls };
+  };
+
+  it.effect("calls session/set_model when the requested model differs from current", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyKimiCodeAcpModelSelection({
+        runtime,
+        currentModelId: "kimi-code/kimi-for-coding",
+        requestedModelId: "kimi-code/custom",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual(["kimi-code/custom"]);
+      expect(result).toBe("kimi-code/custom");
+    }),
+  );
+
+  it.effect("skips set_model when requested matches current", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyKimiCodeAcpModelSelection({
+        runtime,
+        currentModelId: "kimi-code/kimi-for-coding",
+        requestedModelId: "kimi-code/kimi-for-coding",
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([]);
+      expect(result).toBe("kimi-code/kimi-for-coding");
+    }),
+  );
+
+  it.effect("skips set_model when no model is requested", () =>
+    Effect.gen(function* () {
+      const { runtime, modelCalls } = makeRecordingRuntime();
+      const result = yield* applyKimiCodeAcpModelSelection({
+        runtime,
+        currentModelId: "kimi-code/kimi-for-coding",
+        requestedModelId: undefined,
+        mapError: (cause) => cause.message,
+      });
+      expect(modelCalls).toEqual([]);
+      expect(result).toBe("kimi-code/kimi-for-coding");
+    }),
+  );
+
+  it.effect("propagates session/set_model failures via mapError", () =>
+    Effect.gen(function* () {
+      const failure = EffectAcpErrors.AcpRequestError.invalidParams("session id not known");
+      const { runtime } = makeRecordingRuntime(failure);
+      const error = yield* Effect.flip(
+        applyKimiCodeAcpModelSelection({
+          runtime,
+          currentModelId: "kimi-code/kimi-for-coding",
+          requestedModelId: "kimi-code/custom",
+          mapError: (cause) => cause.message,
+        }),
+      );
+      expect(error).toBe(failure.message);
+    }),
+  );
+});

--- a/apps/server/src/provider/acp/KimiCodeAcpSupport.ts
+++ b/apps/server/src/provider/acp/KimiCodeAcpSupport.ts
@@ -1,0 +1,167 @@
+/**
+ * KimiCodeAcpSupport — spawn and configuration helpers for Kimi Code CLI's
+ * ACP stdio server (`kimi acp`).
+ *
+ * Kimi exposes a minimal ACP surface: auth method `"login"`, config options
+ * for `model`, `thinking`, and `mode`, and modes `default`/`plan`/`auto`/`yolo`.
+ *
+ * @module provider/acp/KimiCodeAcpSupport
+ */
+import {
+  type KimiCodeSettings,
+  ProviderDriverKind,
+  type ProviderInteractionMode,
+  type RuntimeMode,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+import { normalizeModelSlug } from "@t3tools/shared/model";
+
+import {
+  AcpSessionRuntime,
+  type AcpSessionRuntimeOptions,
+  type AcpSessionRuntimeShape,
+  type AcpSpawnInput,
+} from "./AcpSessionRuntime.ts";
+
+const KIMI_CODE_AUTH_METHOD_ID = "login";
+const KIMI_CODE_DRIVER_KIND = ProviderDriverKind.make("kimiCode");
+const KIMI_CODE_DEFAULT_MODEL = "kimi-code/kimi-for-coding";
+
+const KIMI_CODE_MODE_ALIASES = {
+  plan: ["plan"],
+  implement: ["auto", "yolo", "default"],
+  approval: ["default", "auto"],
+} as const;
+
+type KimiCodeAcpRuntimeKimiCodeSettings = Pick<KimiCodeSettings, "binaryPath">;
+
+interface KimiCodeAcpRuntimeInput extends Omit<
+  AcpSessionRuntimeOptions,
+  "authMethodId" | "clientCapabilities" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly kimiCodeSettings: KimiCodeAcpRuntimeKimiCodeSettings | null | undefined;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+export function buildKimiCodeAcpSpawnInput(
+  kimiCodeSettings: KimiCodeAcpRuntimeKimiCodeSettings | null | undefined,
+  cwd: string,
+  environment?: NodeJS.ProcessEnv,
+): AcpSpawnInput {
+  return {
+    command: kimiCodeSettings?.binaryPath || "kimi",
+    args: ["acp"],
+    cwd,
+    ...(environment ? { env: environment } : {}),
+  };
+}
+
+export const makeKimiCodeAcpRuntime = (
+  input: KimiCodeAcpRuntimeInput,
+): Effect.Effect<AcpSessionRuntimeShape, EffectAcpErrors.AcpError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildKimiCodeAcpSpawnInput(input.kimiCodeSettings, input.cwd, input.environment),
+        authMethodId: KIMI_CODE_AUTH_METHOD_ID,
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return yield* Effect.service(AcpSessionRuntime).pipe(Effect.provide(acpContext));
+  });
+
+export function resolveKimiCodeAcpBaseModelId(model: string | null | undefined): string {
+  const trimmed = model?.trim();
+  const base = trimmed && trimmed.length > 0 ? trimmed : KIMI_CODE_DEFAULT_MODEL;
+  return normalizeModelSlug(base, KIMI_CODE_DRIVER_KIND) ?? KIMI_CODE_DEFAULT_MODEL;
+}
+
+export function currentKimiCodeModelIdFromSessionSetup(
+  sessionSetupResult:
+    | EffectAcpSchema.LoadSessionResponse
+    | EffectAcpSchema.NewSessionResponse
+    | EffectAcpSchema.ResumeSessionResponse,
+): string | undefined {
+  return sessionSetupResult.models?.currentModelId?.trim() || undefined;
+}
+
+export function applyKimiCodeAcpModelSelection<E>(input: {
+  readonly runtime: Pick<AcpSessionRuntimeShape, "setSessionModel">;
+  readonly currentModelId: string | undefined;
+  readonly requestedModelId: string | undefined;
+  readonly mapError: (cause: EffectAcpErrors.AcpError) => E;
+}): Effect.Effect<string | undefined, E> {
+  const shouldSwitchModel =
+    input.requestedModelId !== undefined && input.requestedModelId !== input.currentModelId;
+  if (!shouldSwitchModel) {
+    return Effect.succeed(input.currentModelId);
+  }
+  return input.runtime
+    .setSessionModel(input.requestedModelId)
+    .pipe(Effect.mapError(input.mapError), Effect.as(input.requestedModelId));
+}
+
+function findKimiCodeModeId(
+  modes: ReadonlyArray<EffectAcpSchema.SessionMode> | null | undefined,
+  aliases: ReadonlyArray<string>,
+): string | undefined {
+  if (!modes || modes.length === 0) {
+    return undefined;
+  }
+  const normalizedAliases = aliases.map((alias) => alias.toLowerCase());
+  for (const alias of normalizedAliases) {
+    const exact = modes.find((mode) => mode.id.toLowerCase() === alias);
+    if (exact) {
+      return exact.id;
+    }
+  }
+  for (const alias of normalizedAliases) {
+    const partial = modes.find((mode) => {
+      const name = mode.name?.toLowerCase() ?? "";
+      const description = mode.description?.toLowerCase() ?? "";
+      return (
+        mode.id.toLowerCase().includes(alias) || name.includes(alias) || description.includes(alias)
+      );
+    });
+    if (partial) {
+      return partial.id;
+    }
+  }
+  return undefined;
+}
+
+export function resolveKimiCodeAcpModeId(input: {
+  readonly interactionMode: ProviderInteractionMode | undefined;
+  readonly runtimeMode: RuntimeMode | undefined;
+  readonly availableModes: ReadonlyArray<EffectAcpSchema.SessionMode> | null | undefined;
+  readonly currentModeId: string | undefined;
+}): string | undefined {
+  if (input.interactionMode === "plan") {
+    return (
+      findKimiCodeModeId(input.availableModes, [...KIMI_CODE_MODE_ALIASES.plan]) ??
+      input.currentModeId
+    );
+  }
+  if (input.runtimeMode === "approval-required") {
+    return (
+      findKimiCodeModeId(input.availableModes, [...KIMI_CODE_MODE_ALIASES.approval]) ??
+      findKimiCodeModeId(input.availableModes, [...KIMI_CODE_MODE_ALIASES.implement]) ??
+      input.currentModeId
+    );
+  }
+  return (
+    findKimiCodeModeId(input.availableModes, [...KIMI_CODE_MODE_ALIASES.implement]) ??
+    findKimiCodeModeId(input.availableModes, [...KIMI_CODE_MODE_ALIASES.approval]) ??
+    input.currentModeId
+  );
+}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -24,6 +24,7 @@ import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
+import { KimiCodeDriver, type KimiCodeDriverEnv } from "./Drivers/KimiCodeDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
@@ -37,6 +38,7 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
+  | KimiCodeDriverEnv
   | OpenCodeDriverEnv;
 
 /**
@@ -49,5 +51,6 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   ClaudeDriver,
   CursorDriver,
   GrokDriver,
+  KimiCodeDriver,
   OpenCodeDriver,
 ];

--- a/apps/server/src/textGeneration/KimiCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/KimiCodeTextGeneration.ts
@@ -1,0 +1,280 @@
+/**
+ * KimiCodeTextGeneration — commit/PR/branch/title generation via Kimi Code ACP.
+ *
+ * @module textGeneration/KimiCodeTextGeneration
+ */
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+import type * as EffectAcpErrors from "effect-acp/errors";
+
+import {
+  type KimiCodeSettings,
+  type ModelSelection,
+  TextGenerationError,
+} from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import { type TextGenerationShape } from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import {
+  applyKimiCodeAcpModelSelection,
+  currentKimiCodeModelIdFromSessionSetup,
+  makeKimiCodeAcpRuntime,
+  resolveKimiCodeAcpBaseModelId,
+} from "../provider/acp/KimiCodeAcpSupport.ts";
+
+const KIMI_CODE_TIMEOUT_MS = 180_000;
+
+function mapKimiCodeAcpError(
+  operation:
+    | "generateCommitMessage"
+    | "generatePrContent"
+    | "generateBranchName"
+    | "generateThreadTitle",
+  detail: string,
+  cause: unknown,
+): TextGenerationError {
+  return new TextGenerationError({
+    operation,
+    detail,
+    ...(cause !== undefined ? { cause } : {}),
+  });
+}
+
+function isTextGenerationError(error: unknown): error is TextGenerationError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    error._tag === "TextGenerationError"
+  );
+}
+
+export const makeKimiCodeTextGeneration = Effect.fn("makeKimiCodeTextGeneration")(function* (
+  kimiCodeSettings: KimiCodeSettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) {
+  const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+
+  const runKimiCodeJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const resolvedModel = resolveKimiCodeAcpBaseModelId(modelSelection.model);
+      const outputRef = yield* Ref.make("");
+      const runtime = yield* makeKimiCodeAcpRuntime({
+        kimiCodeSettings,
+        environment,
+        childProcessSpawner: commandSpawner,
+        cwd,
+        clientInfo: { name: "t3-code-git-text", version: "0.0.0" },
+      });
+
+      yield* runtime.handleSessionUpdate((notification) => {
+        const update = notification.update;
+        if (update.sessionUpdate !== "agent_message_chunk") {
+          return Effect.void;
+        }
+        const content = update.content;
+        if (content.type !== "text") {
+          return Effect.void;
+        }
+        return Ref.update(outputRef, (current) => current + content.text);
+      });
+
+      const promptResult = yield* Effect.gen(function* () {
+        const started = yield* runtime.start();
+        yield* applyKimiCodeAcpModelSelection({
+          runtime,
+          currentModelId: currentKimiCodeModelIdFromSessionSetup(started.sessionSetupResult),
+          requestedModelId: resolvedModel,
+          mapError: (cause) =>
+            mapKimiCodeAcpError(
+              operation,
+              "Failed to set Kimi Code ACP base model for text generation.",
+              cause,
+            ),
+        });
+
+        return yield* runtime.prompt({
+          prompt: [{ type: "text", text: prompt }],
+        });
+      }).pipe(
+        Effect.timeoutOption(KIMI_CODE_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({ operation, detail: "Kimi Code ACP request timed out." }),
+              ),
+            onSome: (value) => Effect.succeed(value),
+          }),
+        ),
+        Effect.mapError((cause: EffectAcpErrors.AcpError | TextGenerationError) =>
+          isTextGenerationError(cause)
+            ? cause
+            : mapKimiCodeAcpError(operation, "Kimi Code ACP request failed.", cause),
+        ),
+      );
+
+      const trimmed = (yield* Ref.get(outputRef)).trim();
+      if (!trimmed) {
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            promptResult.stopReason === "cancelled"
+              ? "Kimi Code ACP request was cancelled."
+              : "Kimi Code Agent returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(trimmed)).pipe(
+        Effect.catchTag("SchemaError", (cause) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation,
+              detail: "Kimi Code Agent returned invalid structured output.",
+              cause,
+            }),
+          ),
+        ),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : mapKimiCodeAcpError(operation, "Kimi Code ACP text generation failed.", cause),
+      ),
+      Effect.scoped,
+    );
+
+  const generateCommitMessage: TextGenerationShape["generateCommitMessage"] = Effect.fn(
+    "KimiCodeTextGeneration.generateCommitMessage",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildCommitMessagePrompt({
+      branch: input.branch,
+      stagedSummary: input.stagedSummary,
+      stagedPatch: input.stagedPatch,
+      includeBranch: input.includeBranch === true,
+    });
+
+    const generated = yield* runKimiCodeJson({
+      operation: "generateCommitMessage",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+
+    return {
+      subject: sanitizeCommitSubject(generated.subject),
+      body: generated.body.trim(),
+      ...("branch" in generated && typeof generated.branch === "string"
+        ? { branch: sanitizeFeatureBranchName(generated.branch) }
+        : {}),
+    };
+  });
+
+  const generatePrContent: TextGenerationShape["generatePrContent"] = Effect.fn(
+    "KimiCodeTextGeneration.generatePrContent",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildPrContentPrompt({
+      baseBranch: input.baseBranch,
+      headBranch: input.headBranch,
+      commitSummary: input.commitSummary,
+      diffSummary: input.diffSummary,
+      diffPatch: input.diffPatch,
+    });
+
+    const generated = yield* runKimiCodeJson({
+      operation: "generatePrContent",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+
+    return {
+      title: sanitizePrTitle(generated.title),
+      body: generated.body.trim(),
+    };
+  });
+
+  const generateBranchName: TextGenerationShape["generateBranchName"] = Effect.fn(
+    "KimiCodeTextGeneration.generateBranchName",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildBranchNamePrompt({
+      message: input.message,
+      attachments: input.attachments,
+    });
+
+    const generated = yield* runKimiCodeJson({
+      operation: "generateBranchName",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+
+    return {
+      branch: sanitizeBranchFragment(generated.branch),
+    };
+  });
+
+  const generateThreadTitle: TextGenerationShape["generateThreadTitle"] = Effect.fn(
+    "KimiCodeTextGeneration.generateThreadTitle",
+  )(function* (input) {
+    const { prompt, outputSchema } = buildThreadTitlePrompt({
+      message: input.message,
+      attachments: input.attachments,
+    });
+
+    const generated = yield* runKimiCodeJson({
+      operation: "generateThreadTitle",
+      cwd: input.cwd,
+      prompt,
+      outputSchemaJson: outputSchema,
+      modelSelection: input.modelSelection,
+    });
+
+    return {
+      title: sanitizeThreadTitle(generated.title),
+    };
+  });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGenerationShape;
+});

--- a/apps/web/src/components/Icons.tsx
+++ b/apps/web/src/components/Icons.tsx
@@ -211,6 +211,17 @@ export const GrokIcon: Icon = ({ className, ...props }) => (
   </svg>
 );
 
+export const KimiCodeIcon: Icon = ({ className, ...props }) => (
+  <svg
+    {...props}
+    viewBox="0 0 24 24"
+    fill="none"
+    className={cn("fill-[#7C3AED] dark:fill-[#A78BFA]", className)}
+  >
+    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm3.5 14.5h-2.25l-2.5-3.5-1.25 1.5v2H8v-7h1.5v3.25l3-3.25h2.25l-3 3.25 3.75 3.75Z" />
+  </svg>
+);
+
 export const TraeIcon: Icon = (props) => (
   <svg {...props} viewBox="0 0 24 24" fill="currentColor">
     {/* Back rectangle: left strip + bottom strip drawn separately — empty bottom-left corner is the gap between them */}

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -159,6 +159,7 @@ function createBaseServerConfig(): ServerConfig {
         },
         cursor: { enabled: true, binaryPath: "", apiEndpoint: "", customModels: [] },
         grok: { enabled: true, binaryPath: "", customModels: [] },
+        kimiCode: { enabled: true, binaryPath: "", customModels: [] },
         opencode: {
           enabled: true,
           binaryPath: "",

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -3,11 +3,20 @@ import {
   CodexSettings,
   CursorSettings,
   GrokSettings,
+  KimiCodeSettings,
   OpenCodeSettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import {
+  ClaudeAI,
+  CursorIcon,
+  GrokIcon,
+  KimiCodeIcon,
+  type Icon,
+  OpenAI,
+  OpenCodeIcon,
+} from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -60,6 +69,13 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     icon: GrokIcon,
     badgeLabel: "Early Access",
     settingsSchema: GrokSettings,
+  },
+  {
+    value: ProviderDriverKind.make("kimiCode"),
+    label: "Kimi Code",
+    icon: KimiCodeIcon,
+    badgeLabel: "Early Access",
+    settingsSchema: KimiCodeSettings,
   },
   {
     value: ProviderDriverKind.make("opencode"),

--- a/docs/providers/kimi-code.md
+++ b/docs/providers/kimi-code.md
@@ -1,0 +1,133 @@
+# Kimi Code
+
+This guide is for people who want to use Kimi Code in T3 Code.
+
+## What is Kimi Code?
+
+Kimi Code is the command-line interface for Moonshot AI's Kimi coding assistant. T3 Code talks to
+Kimi Code through its `kimi acp` stdio server, which exposes a small ACP (Agent Communication
+Protocol) surface for sessions, models, and modes.
+
+## I Only Use One Kimi Account
+
+Use the default provider.
+
+Log in with Kimi Code normally:
+
+```bash
+kimi login
+```
+
+In T3 Code Settings, your Kimi Code provider can stay like this:
+
+```text
+Display name: Kimi Code
+Binary path: kimi
+```
+
+An empty or default `Binary path` means T3 Code looks for `kimi` on your PATH.
+
+## I Want Work And Personal Kimi Accounts
+
+Kimi Code stores login state under its own config directory, and T3 Code spawns a fresh `kimi acp`
+process for each session. To use multiple accounts, add one Kimi Code provider per account and
+configure the environment so each provider's process uses the intended credentials.
+
+The simplest approach is to set account-specific environment variables on each provider instance.
+Kimi Code usually respects the standard `KIMI_API_KEY` variable, or you can point each provider at a
+separate Kimi config directory.
+
+Example setup:
+
+```text
+Display name: Kimi Code Work
+Binary path: kimi
+Environment variables:
+  KIMI_API_KEY  sk-work-...   Sensitive
+```
+
+```text
+Display name: Kimi Code Personal
+Binary path: kimi
+Environment variables:
+  KIMI_API_KEY  sk-personal-...   Sensitive
+```
+
+Mark API keys as sensitive. T3 Code stores the values as server secrets and does not send them back
+to the app after saving.
+
+## I Need A Different Binary Or Working Directory
+
+Use the provider's settings in T3 Code:
+
+- `Binary path` — path to the `kimi` executable, or `kimi` to use PATH.
+- `Environment variables` — extra variables passed to every `kimi acp` process spawned by this
+  provider.
+
+## Picking Models
+
+T3 Code asks `kimi acp` for the list of available models when it probes provider status. The model
+picker shows those models. If Kimi Code reports only one model, the picker locks to it.
+
+You can type a model slug directly in the model picker if you know Kimi supports it but does not
+advertise it in the current session.
+
+## Modes And Runtime Modes
+
+T3 Code maps T3 runtime modes to Kimi Code ACP modes:
+
+- `full-access` / YOLO mode → `auto` or `yolo`, whichever Kimi advertises
+- `approval-required` → `default` or `auto`, whichever Kimi advertises
+- `plan` mode → `plan`, if Kimi advertises it
+
+Kimi Code does not implement a separate permissions prompt protocol, so T3 Code treats the selected
+mode as the authority for what actions Kimi may take.
+
+## Can I Switch Accounts In An Existing Thread?
+
+Yes, as long as both Kimi Code providers use the same binary and only differ in credentials or
+environment variables. T3 Code considers them the same continuation identity for Kimi Code threads.
+
+## Troubleshooting
+
+### Kimi Code is not installed
+
+T3 Code shows `installed: false` for the provider and a message like:
+
+```text
+Kimi Code CLI (`kimi`) is not installed or not on PATH.
+```
+
+Install Kimi Code and make sure `kimi` is on the PATH used by the T3 Code server, or set the
+provider's `Binary path` to the absolute path of the `kimi` executable.
+
+### Not authenticated
+
+T3 Code shows `auth.status: unauthenticated` and a message like:
+
+```text
+Kimi Code CLI is not authenticated. Run `kimi login` and try again.
+```
+
+Run:
+
+```bash
+kimi login
+```
+
+If you are using a custom binary path or environment variables, make sure the same binary and
+environment can authenticate.
+
+### Model picker is empty
+
+1. Refresh provider status in T3 Code Settings.
+2. Check that `kimi acp` reports models by running `kimi acp` manually and sending a
+   `session/get_models` request.
+3. If Kimi Code does not advertise models through ACP, type a known model slug directly in the
+   model picker.
+
+### Changes not taking effect
+
+Provider settings are saved per instance. Make sure you edited the correct Kimi Code provider row,
+not a different provider. If you added environment variables, the next new session uses them;
+existing sessions keep their original environment.

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -131,6 +131,7 @@ const CODEX_DRIVER_KIND = ProviderDriverKind.make("codex");
 const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
+const KIMI_CODE_DRIVER_KIND = ProviderDriverKind.make("kimiCode");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
 
 export const DEFAULT_MODEL = "gpt-5.4";
@@ -141,6 +142,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CLAUDE_DRIVER_KIND]: "claude-sonnet-4-6",
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
+  [KIMI_CODE_DRIVER_KIND]: "kimi-code/kimi-for-coding",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
 };
 
@@ -151,6 +153,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CODEX_DRIVER_KIND]: DEFAULT_GIT_TEXT_GENERATION_MODEL,
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
+  [KIMI_CODE_DRIVER_KIND]: "kimi-code/kimi-for-coding",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
 };
 
@@ -204,5 +207,6 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CLAUDE_DRIVER_KIND]: "Claude",
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
+  [KIMI_CODE_DRIVER_KIND]: "Kimi Code",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
 };

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -305,6 +305,30 @@ export const GrokSettings = makeProviderSettingsSchema(
 );
 export type GrokSettings = typeof GrokSettings.Type;
 
+export const KimiCodeSettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(true)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("kimi").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Kimi Code CLI binary.",
+        providerSettingsForm: { placeholder: "kimi", clearWhenEmpty: "omit" },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath"],
+  },
+);
+export type KimiCodeSettings = typeof KimiCodeSettings.Type;
+
 export const OpenCodeSettings = makeProviderSettingsSchema(
   {
     enabled: Schema.Boolean.pipe(
@@ -394,6 +418,7 @@ export const ServerSettings = Schema.Struct({
     claudeAgent: ClaudeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    kimiCode: KimiCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
@@ -468,6 +493,12 @@ const GrokSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const KimiCodeSettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 const OpenCodeSettingsPatch = Schema.Struct({
   enabled: Schema.optionalKey(Schema.Boolean),
   binaryPath: Schema.optionalKey(TrimmedString),
@@ -495,6 +526,7 @@ export const ServerSettingsPatch = Schema.Struct({
       claudeAgent: Schema.optionalKey(ClaudeSettingsPatch),
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
+      kimiCode: Schema.optionalKey(KimiCodeSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
     }),
   ),


### PR DESCRIPTION
This PR adds a full [Kimi Code](https://www.moonshot.cn/) provider to T3 Code, using Kimi's ACP stdio server (`kimi acp`).

## What's included

- **Contracts** — `KimiCodeSettings` schema and provider constants in `@t3tools/contracts`.
- **ACP support layer** — `KimiCodeAcpSupport.ts` handles spawning `kimi acp`, model resolution, and T3 runtime-mode → Kimi mode mapping (`auto` / `yolo` / `default` / `plan`).
- **Provider snapshot** — `KimiCodeProvider.ts` probes `kimi --version` and runs a short ACP handshake to report version, auth status, and available models.
- **Adapter** — `KimiCodeAdapter.ts` implements the full provider adapter interface: session lifecycle, turn streaming, runtime event mapping, and plan/approval flow.
- **Driver** — `KimiCodeDriver.ts` wires adapter, snapshot, and text generation together and registers with `builtInDrivers`.
- **Text generation** — `KimiCodeTextGeneration.ts` provides commit messages, branch names, PR titles, etc. via Kimi ACP.
- **Web UI** — settings card, provider icon, and keybindings fixture.
- **Tests** — unit/integration coverage for ACP support, provider, adapter, and driver.
- **Docs** — new provider guide at `docs/providers/kimi-code.md`.

## How to try it

1. Install and authenticate Kimi Code: `kimi login`
2. Start T3 Code: `bun run dev`
3. Create a thread and select **Kimi Code** in the model picker.

## Notes

- Kimi ACP auth method is `login`, matching Kimi's terminal-based authentication.
- Kimi ACP does not implement `session/close`, so session teardown relies on process scope closure.
- All server tests pass (1208 passed, 7 skipped). `fmt:check`, `lint`, and `typecheck` are clean for the new code.

I know the project currently says "not accepting contributions yet" — I'm offering this anyway in case it's useful. Happy to adjust based on feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new provider surface area (subprocess ACP, permissions, sessions) but mirrors existing ACP drivers; main risk is operational edge cases around CLI auth, probes, and long-running child processes rather than core app security refactors.
> 
> **Overview**
> Adds **Kimi Code** as a first-class built-in provider, wired through the same driver → adapter → snapshot → text-generation stack as other ACP CLIs.
> 
> **Contracts & settings** introduce `KimiCodeSettings` (`enabled`, `binaryPath`, `customModels`), register `kimiCode` in server settings/patches, and set default models (`kimi-code/kimi-for-coding`) for chat and git text generation.
> 
> **Server** spawns `kimi acp` via `KimiCodeAcpSupport` (model normalization, runtime/plan mode mapping). `KimiCodeProvider` health-checks with `kimi --version` plus a timed ACP probe for models and auth. `KimiCodeAdapter` implements full session/turn streaming (permissions, plans, tool calls, image attachments, resume cursors) and maps ACP events to provider runtime events. `KimiCodeDriver` registers in `builtInDrivers` with managed snapshots and manual-only maintenance. `KimiCodeTextGeneration` runs structured JSON prompts for commits, PRs, branches, and thread titles.
> 
> **Web** adds the Kimi settings card (Early Access), icon, and test fixtures.
> 
> **Docs** add `docs/providers/kimi-code.md` (login, multi-account env, troubleshooting). Tests cover driver metadata, ACP helpers, provider probes, and adapter flows against the mock ACP agent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61775c3e96b25ec362e507d72552935987f0f870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Kimi Code as a built-in provider with ACP-based adapter and text generation
> - Adds a new `kimiCode` provider driver, adapter, and text generation layer backed by the Kimi ACP protocol, covering session lifecycle, event streaming, model/mode selection, and structured output for commit messages, PR content, branch names, and thread titles.
> - Registers `KIMI_CODE_DRIVER_KIND` in contracts, extends `ServerSettings` and `KimiCodeSettings` schema with `enabled`, `binaryPath`, and `customModels` fields, and adds the driver to the built-in driver registry after `GrokDriver`.
> - Adds provider health-check logic that probes the `kimi --version` CLI, runs ACP model discovery with timeouts, classifies auth errors, and emits enriched snapshots via version advisory.
> - Adds a `KimiCodeIcon` SVG component and registers the provider in the settings UI with an Early Access badge.
> - Adds documentation in [docs/providers/kimi-code.md](https://github.com/pingdotgg/t3code/pull/3066/files#diff-55373d10ef4a13c6516319ab8a7016583ac017e3786c48581e9f911e50bdc393) covering installation, multi-account setup, model/mode selection, and troubleshooting.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 61775c3. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->