### PR TITLE
fix: hydrate devcontainer ssh agent socket

### DIFF
--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -204,6 +204,7 @@ const multiTerminalHistoryLogPath = (
 interface CreateManagerOptions {
   shellResolver?: () => string;
   env?: NodeJS.ProcessEnv;
+  sshAuthSockResolver?: (env: NodeJS.ProcessEnv) => string | undefined;
   subprocessInspector?: (terminalPid: number) => Effect.Effect<{
     readonly hasRunningSubprocess: boolean;
     readonly childCommand: string | null;
@@ -244,6 +245,9 @@ const createManager = (
         ptyAdapter,
         ...(options.shellResolver !== undefined ? { shellResolver: options.shellResolver } : {}),
         ...(options.env !== undefined ? { env: options.env } : {}),
+        ...(options.sshAuthSockResolver !== undefined
+          ? { sshAuthSockResolver: options.sshAuthSockResolver }
+          : {}),
         ...(options.subprocessInspector !== undefined
           ? { subprocessInspector: options.subprocessInspector }
           : {}),
@@ -1353,6 +1357,72 @@ it.layer(
       assert.equal(spawnInput.env.T3CODE_PROJECT_ROOT, "/repo");
       assert.equal(spawnInput.env.T3CODE_WORKTREE_PATH, "/repo/worktree-a");
       assert.equal(spawnInput.env.CUSTOM_FLAG, "1");
+    }),
+  );
+
+  it.effect("hydrates missing SSH_AUTH_SOCK when spawning terminal sessions", () =>
+    Effect.gen(function* () {
+      const resolverInputs: NodeJS.ProcessEnv[] = [];
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: {
+          PATH: "/usr/bin",
+        },
+        sshAuthSockResolver: (env) => {
+          resolverInputs.push(env);
+          return "/tmp/vscode-ssh-auth-forwarded.sock";
+        },
+      });
+
+      yield* manager.open(openInput());
+      const spawnInput = ptyAdapter.spawnInputs[0];
+      expect(spawnInput).toBeDefined();
+      if (!spawnInput) return;
+
+      assert.equal(spawnInput.env.SSH_AUTH_SOCK, "/tmp/vscode-ssh-auth-forwarded.sock");
+      assert.deepEqual(resolverInputs, [{ PATH: "/usr/bin" }]);
+    }),
+  );
+
+  it.effect("drops a stale inherited SSH_AUTH_SOCK when no replacement resolves", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: {
+          PATH: "/usr/bin",
+          SSH_AUTH_SOCK: "/tmp/stale-agent.sock",
+        },
+        sshAuthSockResolver: () => undefined,
+      });
+
+      yield* manager.open(openInput());
+      const spawnInput = ptyAdapter.spawnInputs[0];
+      expect(spawnInput).toBeDefined();
+      if (!spawnInput) return;
+
+      assert.equal(spawnInput.env.SSH_AUTH_SOCK, undefined);
+    }),
+  );
+
+  it.effect("lets runtime env override the resolved SSH_AUTH_SOCK", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager(5, {
+        env: {
+          PATH: "/usr/bin",
+        },
+        sshAuthSockResolver: () => "/tmp/vscode-ssh-auth-forwarded.sock",
+      });
+
+      yield* manager.open(
+        openInput({
+          env: {
+            SSH_AUTH_SOCK: "/tmp/project-specific-agent.sock",
+          },
+        }),
+      );
+      const spawnInput = ptyAdapter.spawnInputs[0];
+      expect(spawnInput).toBeDefined();
+      if (!spawnInput) return;
+
+      assert.equal(spawnInput.env.SSH_AUTH_SOCK, "/tmp/project-specific-agent.sock");
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -34,6 +34,7 @@ import {
 } from "@t3tools/contracts";
 import { makeKeyedCoalescingWorker } from "@t3tools/shared/KeyedCoalescingWorker";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { resolveSshAuthSock } from "@t3tools/shared/sshAgent";
 import { getTerminalLabel } from "@t3tools/shared/terminalLabels";
 import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
@@ -84,6 +85,8 @@ const DEFAULT_OPEN_ROWS = 30;
 const TERMINAL_ENV_BLOCKLIST = new Set(["PORT", "ELECTRON_RENDERER_PORT", "ELECTRON_RUN_AS_NODE"]);
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const MAX_TERMINAL_LABEL_LENGTH = 128;
+
+type SshAuthSockResolver = (env: NodeJS.ProcessEnv) => string | undefined;
 
 class TerminalSubprocessCheckError extends Schema.TaggedErrorClass<TerminalSubprocessCheckError>()(
   "TerminalSubprocessCheckError",
@@ -1068,12 +1071,18 @@ function shouldExcludeTerminalEnvKey(key: string): boolean {
 function createTerminalSpawnEnv(
   baseEnv: NodeJS.ProcessEnv,
   runtimeEnv?: Record<string, string> | null,
+  sshAuthSockResolver?: SshAuthSockResolver,
 ): NodeJS.ProcessEnv {
   const spawnEnv: NodeJS.ProcessEnv = {};
   for (const [key, value] of Object.entries(baseEnv)) {
     if (value === undefined) continue;
     if (shouldExcludeTerminalEnvKey(key)) continue;
+    if (key === "SSH_AUTH_SOCK") continue;
     spawnEnv[key] = value;
+  }
+  const resolvedSshAuthSock = sshAuthSockResolver?.(baseEnv);
+  if (resolvedSshAuthSock) {
+    spawnEnv.SSH_AUTH_SOCK = resolvedSshAuthSock;
   }
   if (runtimeEnv) {
     for (const [key, value] of Object.entries(runtimeEnv)) {
@@ -1098,6 +1107,7 @@ interface TerminalManagerOptions {
   ptyAdapter: PtyAdapter.PtyAdapter["Service"];
   shellResolver?: () => string;
   env?: NodeJS.ProcessEnv;
+  sshAuthSockResolver?: SshAuthSockResolver;
   subprocessInspector?: TerminalSubprocessInspector;
   subprocessPollIntervalMs?: number;
   processKillGraceMs?: number;
@@ -1142,6 +1152,8 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
   // `options.env` is the test seam.
   const baseEnv = options.env ?? process.env;
   const shellResolver = options.shellResolver ?? (() => defaultShellResolver(platform, baseEnv));
+  const sshAuthSockResolver =
+    options.sshAuthSockResolver ?? ((env) => resolveSshAuthSock({ env, platform }));
   const processRunner = yield* ProcessRunner.ProcessRunner;
   const subprocessInspector =
     options.subprocessInspector ??
@@ -1837,7 +1849,11 @@ export const makeWithOptions = Effect.fn("TerminalManager.makeWithOptions")(func
         Effect.andThen(
           Effect.gen(function* () {
             const shellCandidates = resolveShellCandidates(shellResolver, platform, baseEnv);
-            const terminalEnv = createTerminalSpawnEnv(baseEnv, session.runtimeEnv);
+            const terminalEnv = createTerminalSpawnEnv(
+              baseEnv,
+              session.runtimeEnv,
+              sshAuthSockResolver,
+            );
             const spawnResult = yield* trySpawn(shellCandidates, terminalEnv, session);
             ptyProcess = spawnResult.process;
             startedShell = spawnResult.shellLabel;

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -39,6 +39,10 @@
       "types": "./src/shell.ts",
       "import": "./src/shell.ts"
     },
+    "./sshAgent": {
+      "types": "./src/sshAgent.ts",
+      "import": "./src/sshAgent.ts"
+    },
     "./semver": {
       "types": "./src/semver.ts",
       "import": "./src/semver.ts"

--- a/packages/shared/src/sshAgent.test.ts
+++ b/packages/shared/src/sshAgent.test.ts
@@ -62,6 +62,54 @@ describe("resolveSshAuthSock", () => {
     ).toBe("/tmp/vscode-ssh-auth-22222222-2222-2222-2222-222222222222.sock");
   });
 
+  it("finds VS Code forwarded SSH agent sockets that use the sock numeric suffix", () => {
+    const readdir = vi.fn<() => ReadonlyArray<string>>(() => [
+      "vscode-ssh-auth-sock-243591993",
+    ]);
+    const stat = vi.fn<(path: string) => SshAgentSocketStats>(() =>
+      socketStats({ uid: 1000, mtimeMs: 10 }),
+    );
+
+    expect(
+      resolveSshAuthSock({
+        env: {},
+        platform: "linux",
+        tmpDir: "/tmp",
+        currentUid: 1000,
+        readdir,
+        stat,
+      }),
+    ).toBe("/tmp/vscode-ssh-auth-sock-243591993");
+  });
+
+  it("scans /tmp when the process temp directory is somewhere else", () => {
+    const readdir = vi.fn<(path: string) => ReadonlyArray<string>>((path) => {
+      if (path === "/custom-tmp") {
+        return [];
+      }
+      if (path === "/tmp") {
+        return ["vscode-ssh-auth-11111111-1111-1111-1111-111111111111.sock"];
+      }
+      return [];
+    });
+    const stat = vi.fn<(path: string) => SshAgentSocketStats>(() =>
+      socketStats({ uid: 1000, mtimeMs: 10 }),
+    );
+
+    expect(
+      resolveSshAuthSock({
+        env: {},
+        platform: "linux",
+        tmpDir: "/custom-tmp",
+        currentUid: 1000,
+        readdir,
+        stat,
+      }),
+    ).toBe("/tmp/vscode-ssh-auth-11111111-1111-1111-1111-111111111111.sock");
+    expect(readdir).toHaveBeenCalledWith("/custom-tmp");
+    expect(readdir).toHaveBeenCalledWith("/tmp");
+  });
+
   it("falls back from a stale inherited socket to a discovered VS Code socket", () => {
     const readdir = vi.fn<() => ReadonlyArray<string>>(() => [
       "vscode-ssh-auth-11111111-1111-1111-1111-111111111111.sock",
@@ -121,5 +169,32 @@ describe("resolveSshAuthSock", () => {
       }),
     ).toBeUndefined();
     expect(readdir).not.toHaveBeenCalled();
+  });
+
+  it("keeps inherited Windows OpenSSH named pipe sockets", () => {
+    const readdir = vi.fn<() => ReadonlyArray<string>>(() => []);
+    const stat = vi.fn<(path: string) => SshAgentSocketStats>(() =>
+      socketStats({ uid: 1000, mtimeMs: 10 }),
+    );
+
+    expect(
+      resolveSshAuthSock({
+        env: { SSH_AUTH_SOCK: "\\\\.\\pipe\\openssh-ssh-agent" },
+        platform: "win32",
+        readdir,
+        stat,
+      }),
+    ).toBe("\\\\.\\pipe\\openssh-ssh-agent");
+    expect(readdir).not.toHaveBeenCalled();
+    expect(stat).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-pipe inherited SSH_AUTH_SOCK values on Windows", () => {
+    expect(
+      resolveSshAuthSock({
+        env: { SSH_AUTH_SOCK: "/tmp/stale.sock" },
+        platform: "win32",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/shared/src/sshAgent.test.ts
+++ b/packages/shared/src/sshAgent.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { resolveSshAuthSock, type SshAgentSocketStats } from "./sshAgent.ts";
+
+function socketStats(input: {
+  readonly uid?: number;
+  readonly mtimeMs?: number;
+  readonly socket?: boolean;
+}): SshAgentSocketStats {
+  return {
+    isSocket: () => input.socket ?? true,
+    ...(input.mtimeMs !== undefined ? { mtimeMs: input.mtimeMs } : {}),
+    ...(input.uid !== undefined ? { uid: input.uid } : {}),
+  };
+}
+
+describe("resolveSshAuthSock", () => {
+  it("keeps a valid inherited SSH_AUTH_SOCK without scanning temp", () => {
+    const readdir = vi.fn<() => ReadonlyArray<string>>(() => []);
+    const stat = vi.fn<(path: string) => SshAgentSocketStats>(() =>
+      socketStats({ uid: 1000, mtimeMs: 1 }),
+    );
+
+    expect(
+      resolveSshAuthSock({
+        env: { SSH_AUTH_SOCK: "/tmp/inherited.sock" },
+        platform: "linux",
+        currentUid: 1000,
+        readdir,
+        stat,
+      }),
+    ).toBe("/tmp/inherited.sock");
+    expect(stat).toHaveBeenCalledWith("/tmp/inherited.sock");
+    expect(readdir).not.toHaveBeenCalled();
+  });
+
+  it("finds the newest same-user VS Code forwarded SSH agent socket", () => {
+    const readdir = vi.fn<() => ReadonlyArray<string>>(() => [
+      "vscode-ssh-auth-11111111-1111-1111-1111-111111111111.sock",
+      "vscode-ssh-auth-22222222-2222-2222-2222-222222222222.sock",
+      "vscode-ssh-auth-33333333-3333-3333-3333-333333333333.sock",
+      "unrelated.sock",
+    ]);
+    const stat = vi.fn<(path: string) => SshAgentSocketStats>((path) => {
+      if (path.endsWith("111111111111.sock")) {
+        return socketStats({ uid: 1000, mtimeMs: 10 });
+      }
+      if (path.endsWith("222222222222.sock")) {
+        return socketStats({ uid: 1000, mtimeMs: 20 });
+      }
+      return socketStats({ uid: 1000, mtimeMs: 30, socket: false });
+    });
+
+    expect(
+      resolveSshAuthSock({
+        env: {},
+        platform: "linux",
+        tmpDir: "/tmp",
+        currentUid: 1000,
+        readdir,
+        stat,
+      }),
+    ).toBe("/tmp/vscode-ssh-auth-22222222-2222-2222-2222-222222222222.sock");
+  });
+
+  it("falls back from a stale inherited socket to a discovered VS Code socket", () => {
+    const readdir = vi.fn<() => ReadonlyArray<string>>(() => [
+      "vscode-ssh-auth-11111111-1111-1111-1111-111111111111.sock",
+    ]);
+    const stat = vi.fn<(path: string) => SshAgentSocketStats>((path) => {
+      if (path === "/tmp/stale.sock") {
+        throw new Error("missing");
+      }
+      return socketStats({ uid: 1000, mtimeMs: 10 });
+    });
+
+    expect(
+      resolveSshAuthSock({
+        env: { SSH_AUTH_SOCK: "/tmp/stale.sock" },
+        platform: "linux",
+        tmpDir: "/tmp",
+        currentUid: 1000,
+        readdir,
+        stat,
+      }),
+    ).toBe("/tmp/vscode-ssh-auth-11111111-1111-1111-1111-111111111111.sock");
+  });
+
+  it("ignores forwarded sockets owned by another user", () => {
+    const readdir = vi.fn<() => ReadonlyArray<string>>(() => [
+      "vscode-ssh-auth-11111111-1111-1111-1111-111111111111.sock",
+    ]);
+    const stat = vi.fn<(path: string) => SshAgentSocketStats>(() =>
+      socketStats({ uid: 2000, mtimeMs: 10 }),
+    );
+
+    expect(
+      resolveSshAuthSock({
+        env: {},
+        platform: "linux",
+        tmpDir: "/tmp",
+        currentUid: 1000,
+        readdir,
+        stat,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("does not scan for POSIX sockets on Windows", () => {
+    const readdir = vi.fn<() => ReadonlyArray<string>>(() => [
+      "vscode-ssh-auth-11111111-1111-1111-1111-111111111111.sock",
+    ]);
+
+    expect(
+      resolveSshAuthSock({
+        env: {},
+        platform: "win32",
+        tmpDir: "/tmp",
+        currentUid: 1000,
+        readdir,
+        stat: () => socketStats({ uid: 1000, mtimeMs: 10 }),
+      }),
+    ).toBeUndefined();
+    expect(readdir).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/sshAgent.ts
+++ b/packages/shared/src/sshAgent.ts
@@ -18,7 +18,9 @@ export interface SshAuthSockResolverOptions {
   readonly stat?: (path: string) => SshAgentSocketStats;
 }
 
-const VSCODE_SSH_AUTH_SOCK_PATTERN = /^vscode-ssh-auth-[0-9a-fA-F-]+\.sock$/;
+const VSCODE_SSH_AUTH_SOCK_PATTERN = /^vscode-ssh-auth-(?:[0-9a-fA-F-]+\.sock|sock-\d+)$/;
+const VSCODE_SSH_AUTH_SOCK_DIRECTORY = "/tmp";
+const WINDOWS_SSH_AUTH_SOCK_PATTERN = /^\\\\\.\\pipe\\/i;
 
 function trimNonEmpty(value: string | null | undefined): string | undefined {
   const trimmed = value?.trim();
@@ -27,6 +29,10 @@ function trimNonEmpty(value: string | null | undefined): string | undefined {
 
 function processUid(): number | undefined {
   return typeof process.getuid === "function" ? process.getuid() : undefined;
+}
+
+function isWindowsNamedPipe(value: string): boolean {
+  return WINDOWS_SSH_AUTH_SOCK_PATTERN.test(value);
 }
 
 function sameUserSocket(
@@ -61,9 +67,30 @@ function newestSocket(
   return selected?.path;
 }
 
+function listSocketSearchDirectories(primaryDirectory: string): ReadonlyArray<string> {
+  const directories: string[] = [];
+  const seen = new Set<string>();
+
+  for (const candidate of [primaryDirectory, VSCODE_SSH_AUTH_SOCK_DIRECTORY]) {
+    const directory = trimNonEmpty(candidate);
+    if (!directory || seen.has(directory)) continue;
+
+    seen.add(directory);
+    directories.push(directory);
+  }
+
+  return directories;
+}
+
 export function resolveSshAuthSock(options: SshAuthSockResolverOptions = {}): string | undefined {
   const env = options.env ?? process.env;
   const inherited = trimNonEmpty(env.SSH_AUTH_SOCK);
+  const platform = options.platform ?? process.platform;
+
+  if (platform === "win32") {
+    return inherited && isWindowsNamedPipe(inherited) ? inherited : undefined;
+  }
+
   const stat = options.stat ?? ((path: string) => statSync(path));
   const currentUid = options.currentUid ?? processUid();
 
@@ -71,29 +98,26 @@ export function resolveSshAuthSock(options: SshAuthSockResolverOptions = {}): st
     return inherited;
   }
 
-  const platform = options.platform ?? process.platform;
-  if (platform === "win32") {
-    return undefined;
-  }
-
-  const directory = options.tmpDir ?? tmpdir();
+  const directories = listSocketSearchDirectories(options.tmpDir ?? tmpdir());
   const readDirectory = options.readdir ?? ((path: string) => readdirSync(path));
-  let entries: ReadonlyArray<string>;
-  try {
-    entries = readDirectory(directory);
-  } catch {
-    return undefined;
-  }
-
   const sockets: Array<{ path: string; stats: SshAgentSocketStats }> = [];
-  for (const entry of entries) {
-    if (!VSCODE_SSH_AUTH_SOCK_PATTERN.test(entry)) continue;
+  for (const directory of directories) {
+    let entries: ReadonlyArray<string>;
+    try {
+      entries = readDirectory(directory);
+    } catch {
+      continue;
+    }
 
-    const socketPath = join(directory, entry);
-    const socketStats = sameUserSocket(socketPath, stat, currentUid);
-    if (!socketStats) continue;
+    for (const entry of entries) {
+      if (!VSCODE_SSH_AUTH_SOCK_PATTERN.test(entry)) continue;
 
-    sockets.push({ path: socketPath, stats: socketStats });
+      const socketPath = join(directory, entry);
+      const socketStats = sameUserSocket(socketPath, stat, currentUid);
+      if (!socketStats) continue;
+
+      sockets.push({ path: socketPath, stats: socketStats });
+    }
   }
 
   return newestSocket(sockets);

--- a/packages/shared/src/sshAgent.ts
+++ b/packages/shared/src/sshAgent.ts
@@ -1,0 +1,100 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+export interface SshAgentSocketStats {
+  readonly isSocket: () => boolean;
+  readonly mtimeMs?: number;
+  readonly uid?: number;
+}
+
+export interface SshAuthSockResolverOptions {
+  readonly env?: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
+  readonly tmpDir?: string;
+  readonly currentUid?: number;
+  readonly readdir?: (path: string) => ReadonlyArray<string>;
+  readonly stat?: (path: string) => SshAgentSocketStats;
+}
+
+const VSCODE_SSH_AUTH_SOCK_PATTERN = /^vscode-ssh-auth-[0-9a-fA-F-]+\.sock$/;
+
+function trimNonEmpty(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function processUid(): number | undefined {
+  return typeof process.getuid === "function" ? process.getuid() : undefined;
+}
+
+function sameUserSocket(
+  socketPath: string,
+  stat: (path: string) => SshAgentSocketStats,
+  currentUid: number | undefined,
+): SshAgentSocketStats | null {
+  try {
+    const stats = stat(socketPath);
+    if (!stats.isSocket()) return null;
+    if (currentUid !== undefined && stats.uid !== undefined && stats.uid !== currentUid) {
+      return null;
+    }
+    return stats;
+  } catch {
+    return null;
+  }
+}
+
+function newestSocket(
+  candidates: ReadonlyArray<{ readonly path: string; readonly stats: SshAgentSocketStats }>,
+): string | undefined {
+  let selected: { readonly path: string; readonly mtimeMs: number } | null = null;
+
+  for (const candidate of candidates) {
+    const mtimeMs = candidate.stats.mtimeMs ?? 0;
+    if (!selected || mtimeMs > selected.mtimeMs) {
+      selected = { path: candidate.path, mtimeMs };
+    }
+  }
+
+  return selected?.path;
+}
+
+export function resolveSshAuthSock(options: SshAuthSockResolverOptions = {}): string | undefined {
+  const env = options.env ?? process.env;
+  const inherited = trimNonEmpty(env.SSH_AUTH_SOCK);
+  const stat = options.stat ?? ((path: string) => statSync(path));
+  const currentUid = options.currentUid ?? processUid();
+
+  if (inherited && sameUserSocket(inherited, stat, currentUid)) {
+    return inherited;
+  }
+
+  const platform = options.platform ?? process.platform;
+  if (platform === "win32") {
+    return undefined;
+  }
+
+  const directory = options.tmpDir ?? tmpdir();
+  const readDirectory = options.readdir ?? ((path: string) => readdirSync(path));
+  let entries: ReadonlyArray<string>;
+  try {
+    entries = readDirectory(directory);
+  } catch {
+    return undefined;
+  }
+
+  const sockets: Array<{ path: string; stats: SshAgentSocketStats }> = [];
+  for (const entry of entries) {
+    if (!VSCODE_SSH_AUTH_SOCK_PATTERN.test(entry)) continue;
+
+    const socketPath = join(directory, entry);
+    const socketStats = sameUserSocket(socketPath, stat, currentUid);
+    if (!socketStats) continue;
+
+    sockets.push({ path: socketPath, stats: socketStats });
+  }
+
+  return newestSocket(sockets);
+}


### PR DESCRIPTION
## What Changed

Fix terminal PTY environment hydration for devcontainers by resolving a usable `SSH_AUTH_SOCK` when spawning terminal sessions.

The change:
- Keeps a valid inherited `SSH_AUTH_SOCK`
- Falls back to the newest same-user VS Code forwarded socket at `/tmp/vscode-ssh-auth-*.sock`
- Preserves explicit runtime env overrides
- Adds focused tests for resolver behavior and terminal spawn env behavior

## Why

Fixes #3067.

When the T3 Code server starts before VS Code attaches to a devcontainer, the server process does not inherit VS Code’s later-injected forwarded SSH agent environment. Terminals spawned by that server therefore miss `SSH_AUTH_SOCK`, even though the forwarded socket exists and works in normal VS Code terminals.

Resolving the socket at terminal spawn time makes server-started terminals match the attached devcontainer environment without requiring a server restart.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to terminal spawn env and SSH agent socket discovery; behavior change is intentional (stale sockets dropped) with solid unit coverage.
> 
> **Overview**
> **Fixes devcontainer terminals missing SSH agent forwarding** when the server starts before VS Code injects `SSH_AUTH_SOCK`.
> 
> Adds **`resolveSshAuthSock`** in shared (`@t3tools/shared/sshAgent`): on POSIX, reuse a valid same-user inherited socket or pick the newest matching VS Code forwarded socket under temp/`/tmp`; on Windows, only accept OpenSSH named pipes. **`createTerminalSpawnEnv`** no longer copies `SSH_AUTH_SOCK` from the server process—it sets it via the resolver (defaulting to `resolveSshAuthSock`), and **runtime open env** can still override. **`TerminalManager`** wires an injectable `sshAuthSockResolver` for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6042f22cea3aa52155b5351cef5401d7bac2a1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SSH agent socket resolution in devcontainer terminals
> - Adds `resolveSshAuthSock` in [`packages/shared/src/sshAgent.ts`](https://github.com/pingdotgg/t3code/pull/3068/files#diff-08ea2107c7f632738568baf1bc9753ea72754f08d72c07c1e41649a8fd8b1aaa) to compute a valid `SSH_AUTH_SOCK` path: on POSIX it validates the inherited socket by type/uid or falls back to scanning temp directories for VS Code forwarded sockets; on Windows it only accepts named pipe values.
> - `createTerminalSpawnEnv` in [`apps/server/src/terminal/Manager.ts`](https://github.com/pingdotgg/t3code/pull/3068/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) now strips the inherited `SSH_AUTH_SOCK` and replaces it using the resolver, preventing stale or inaccessible socket paths from propagating into terminal processes.
> - `runtimeEnv` values still override the resolved socket, preserving existing override behavior.
> - Behavioral Change: `SSH_AUTH_SOCK` is no longer passed through from the base environment; it is always re-resolved unless explicitly set via `runtimeEnv`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6042f22.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->