### PR TITLE
feat(sidebar): drag-and-drop reordering of threads within a project

### DIFF
--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -80,6 +80,7 @@ import {
   useStore,
 } from "../store";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
+import { useUiStateStore } from "../uiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
 import {
   ADDON_ICON_CLASS,
@@ -406,6 +407,14 @@ function OpenCommandPaletteDialog() {
     useHandleNewThread();
   const projects = useStore(useShallow(selectProjectsAcrossEnvironments));
   const threads = useStore(useShallow(selectSidebarThreadsAcrossEnvironments));
+  const threadOrderByProject = useUiStateStore((state) => state.threadOrderByProject);
+  // Flattened manual thread order so "open project" navigates to the thread
+  // that is first in the sidebar under manual sort; the per-project filter in
+  // getLatestThreadForProject means only the target project's keys match.
+  const manualThreadOrder = useMemo(
+    () => Object.values(threadOrderByProject).flat(),
+    [threadOrderByProject],
+  );
   const keybindings = useServerKeybindings();
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
@@ -601,6 +610,7 @@ function OpenCommandPaletteDialog() {
         threads.filter((thread) => thread.environmentId === project.environmentId),
         project.id,
         settings.sidebarThreadSortOrder,
+        manualThreadOrder,
       );
       if (latestThread) {
         await navigate({
@@ -618,6 +628,7 @@ function OpenCommandPaletteDialog() {
     },
     [
       handleNewThread,
+      manualThreadOrder,
       navigate,
       settings.defaultThreadEnvMode,
       settings.sidebarThreadSortOrder,
@@ -1099,6 +1110,7 @@ function OpenCommandPaletteDialog() {
           threads.filter((thread) => thread.environmentId === existing.environmentId),
           existing.id,
           settings.sidebarThreadSortOrder,
+          manualThreadOrder,
         );
         if (latestThread) {
           await navigate({
@@ -1150,6 +1162,7 @@ function OpenCommandPaletteDialog() {
       browseEnvironmentPlatform,
       currentProjectCwdForBrowse,
       handleNewThread,
+      manualThreadOrder,
       navigate,
       projects,
       setOpen,

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { ProviderDriverKind } from "@t3tools/contracts";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime";
 
 import {
   createThreadJumpHintVisibilityController,
@@ -810,6 +811,26 @@ describe("getFallbackThreadIdAfterDelete", () => {
     });
 
     expect(fallbackThreadId).toBe(ThreadId.make("thread-next"));
+  });
+
+  it("falls back to the first thread in manual order, not raw store order", () => {
+    const threads = [
+      makeThread({ id: ThreadId.make("thread-a"), projectId: ProjectId.make("project-1") }),
+      makeThread({ id: ThreadId.make("thread-active"), projectId: ProjectId.make("project-1") }),
+      makeThread({ id: ThreadId.make("thread-c"), projectId: ProjectId.make("project-1") }),
+    ];
+    const keyFor = (id: string) =>
+      scopedThreadKey(scopeThreadRef(localEnvironmentId, ThreadId.make(id)));
+
+    const fallbackThreadId = getFallbackThreadIdAfterDelete({
+      threads,
+      deletedThreadId: ThreadId.make("thread-active"),
+      sortOrder: "manual",
+      // Manual order puts thread-c first, ahead of thread-a in store order.
+      manualThreadOrder: [keyFor("thread-c"), keyFor("thread-active"), keyFor("thread-a")],
+    });
+
+    expect(fallbackThreadId).toBe(ThreadId.make("thread-c"));
   });
 });
 describe("sortProjectsForSidebar", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -2,11 +2,17 @@ import * as React from "react";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
 import {
   getThreadSortTimestamp,
+  orderItemsByPreferredIds,
   sortThreads,
   toSortableTimestamp,
   type ThreadSortInput,
 } from "../lib/threadSort";
+import { scopeThreadRef, scopedThreadKey } from "@t3tools/client-runtime";
 import type { SidebarThreadSummary, Thread } from "../types";
+
+// Re-exported from lib/threadSort so existing importers keep using this path;
+// it lives in the sort lib to stay reusable without an import cycle.
+export { orderItemsByPreferredIds };
 import { cn } from "../lib/utils";
 import { isLatestTurnSettled } from "../session-logic";
 
@@ -211,34 +217,6 @@ export function resolveSidebarNewThreadSeedContext(input: {
   return {
     envMode: input.defaultEnvMode,
   };
-}
-
-export function orderItemsByPreferredIds<TItem, TId>(input: {
-  items: readonly TItem[];
-  preferredIds: readonly TId[];
-  getId: (item: TItem) => TId;
-}): TItem[] {
-  const { getId, items, preferredIds } = input;
-  if (preferredIds.length === 0) {
-    return [...items];
-  }
-
-  const itemsById = new Map(items.map((item) => [getId(item), item] as const));
-  const preferredIdSet = new Set(preferredIds);
-  const emittedPreferredIds = new Set<TId>();
-  const ordered = preferredIds.flatMap((id) => {
-    if (emittedPreferredIds.has(id)) {
-      return [];
-    }
-    const item = itemsById.get(id);
-    if (!item) {
-      return [];
-    }
-    emittedPreferredIds.add(id);
-    return [item];
-  });
-  const remaining = items.filter((item) => !preferredIdSet.has(getId(item)));
-  return [...ordered, ...remaining];
 }
 
 export function getVisibleSidebarThreadIds<TThreadId>(
@@ -460,30 +438,41 @@ export function getVisibleThreadsForProject<T extends Pick<Thread, "id">>(input:
 }
 
 export function getFallbackThreadIdAfterDelete<
-  T extends Pick<Thread, "id" | "projectId" | "createdAt" | "updatedAt"> & ThreadSortInput,
+  T extends Pick<Thread, "id" | "projectId" | "createdAt" | "updatedAt" | "environmentId"> &
+    ThreadSortInput,
 >(input: {
   threads: readonly T[];
   deletedThreadId: T["id"];
   sortOrder: SidebarThreadSortOrder;
   deletedThreadIds?: ReadonlySet<T["id"]>;
+  // Manual order (scoped thread keys) so the fallback matches the thread that
+  // is actually first in the sidebar under manual sort, not raw store order.
+  manualThreadOrder?: readonly string[];
 }): T["id"] | null {
-  const { deletedThreadId, deletedThreadIds, sortOrder, threads } = input;
+  const { deletedThreadId, deletedThreadIds, manualThreadOrder, sortOrder, threads } = input;
   const deletedThread = threads.find((thread) => thread.id === deletedThreadId);
   if (!deletedThread) {
     return null;
   }
 
-  return (
-    sortThreads(
-      threads.filter(
-        (thread) =>
-          thread.projectId === deletedThread.projectId &&
-          thread.id !== deletedThreadId &&
-          !deletedThreadIds?.has(thread.id),
-      ),
-      sortOrder,
-    )[0]?.id ?? null
+  const candidates = sortThreads(
+    threads.filter(
+      (thread) =>
+        thread.projectId === deletedThread.projectId &&
+        thread.id !== deletedThreadId &&
+        !deletedThreadIds?.has(thread.id),
+    ),
+    sortOrder,
   );
+  const ordered =
+    sortOrder === "manual" && manualThreadOrder && manualThreadOrder.length > 0
+      ? orderItemsByPreferredIds({
+          items: candidates,
+          preferredIds: manualThreadOrder,
+          getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        })
+      : candidates;
+  return ordered[0]?.id ?? null;
 }
 export function getProjectSortTimestamp(
   project: SidebarProject,

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -206,7 +206,9 @@ const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
 const SIDEBAR_THREAD_SORT_LABELS: Record<SidebarThreadSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
+  manual: "Manual",
 };
+const EMPTY_THREAD_ORDER: readonly string[] = [];
 const SIDEBAR_LIST_ANIMATION_OPTIONS = {
   duration: 180,
   easing: "ease-out",
@@ -279,10 +281,16 @@ function buildThreadJumpLabelMap(input: {
   return mapping.size > 0 ? mapping : EMPTY_THREAD_JUMP_LABELS;
 }
 
+type SortableThreadHandleProps = Pick<
+  ReturnType<typeof useSortable>,
+  "attributes" | "listeners" | "setActivatorNodeRef" | "setNodeRef" | "isDragging" | "isOver"
+> & { style: React.CSSProperties };
+
 interface SidebarThreadRowProps {
   thread: SidebarThreadSummary;
   projectCwd: string | null;
   orderedProjectThreadKeys: readonly string[];
+  dragHandleProps: SortableThreadHandleProps | null;
   isActive: boolean;
   jumpLabel: string | null;
   appSettingsConfirmThreadArchive: boolean;
@@ -340,6 +348,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
     attemptArchiveThread,
     openPrLink,
     thread,
+    dragHandleProps,
   } = props;
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
@@ -495,6 +504,14 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
   const handleRenameInputClick = useCallback((event: React.MouseEvent<HTMLInputElement>) => {
     event.stopPropagation();
   }, []);
+  // Keep drag listeners on the row button from hijacking pointer-down while the
+  // inline rename input is focused (manual sort mode attaches them to the row).
+  const handleRenameInputPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLInputElement>) => {
+      event.stopPropagation();
+    },
+    [],
+  );
   const handleConfirmArchiveRef = useCallback(
     (element: HTMLButtonElement | null) => {
       if (element) {
@@ -543,12 +560,19 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
 
   return (
     <SidebarMenuSubItem
-      className="w-full"
+      ref={dragHandleProps?.setNodeRef}
+      style={dragHandleProps?.style}
+      className={`w-full ${dragHandleProps?.isDragging ? "z-20 opacity-80" : ""} ${
+        dragHandleProps?.isOver && !dragHandleProps?.isDragging
+          ? "rounded-md ring-1 ring-primary/40"
+          : ""
+      }`}
       data-thread-item
       onMouseLeave={handleMouseLeave}
       onBlurCapture={handleBlurCapture}
     >
       <SidebarMenuSubButton
+        ref={dragHandleProps?.setActivatorNodeRef}
         render={rowButtonRender}
         size="sm"
         isActive={isActive}
@@ -556,10 +580,12 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
         className={`${resolveThreadRowClassName({
           isActive,
           isSelected,
-        })} relative isolate`}
+        })} relative isolate ${dragHandleProps ? "cursor-grab active:cursor-grabbing" : ""}`}
         onClick={handleRowClick}
         onKeyDown={handleRowKeyDown}
         onContextMenu={handleRowContextMenu}
+        {...(dragHandleProps ? dragHandleProps.attributes : {})}
+        {...(dragHandleProps ? dragHandleProps.listeners : {})}
       >
         <div className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
           {prStatus && (
@@ -589,6 +615,7 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
               onKeyDown={handleRenameInputKeyDown}
               onBlur={handleRenameInputBlur}
               onClick={handleRenameInputClick}
+              onPointerDown={handleRenameInputPointerDown}
             />
           ) : (
             <Tooltip>
@@ -734,9 +761,47 @@ const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThreadRowP
   );
 });
 
+function SortableThreadItem({
+  threadKey,
+  children,
+}: {
+  threadKey: string;
+  children: (handleProps: SortableThreadHandleProps) => React.ReactNode;
+}) {
+  const {
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+    isOver,
+  } = useSortable({ id: threadKey });
+  const style: React.CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+    transition,
+  };
+  return children({
+    attributes,
+    listeners,
+    setActivatorNodeRef,
+    setNodeRef,
+    isDragging,
+    isOver,
+    style,
+  });
+}
+
 interface SidebarProjectThreadListProps {
   projectKey: string;
   projectExpanded: boolean;
+  isManualThreadSorting: boolean;
+  threadDnDSensors: ReturnType<typeof useSensors>;
+  threadCollisionDetection: CollisionDetection;
+  handleThreadDragStart: (event: DragStartEvent) => void;
+  handleThreadDragEnd: (event: DragEndEvent) => void;
+  handleThreadDragCancel: (event: DragCancelEvent) => void;
   hasOverflowingThreads: boolean;
   hiddenThreadStatus: ThreadStatusPill | null;
   orderedProjectThreadKeys: readonly string[];
@@ -787,6 +852,12 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
   const {
     projectKey,
     projectExpanded,
+    isManualThreadSorting,
+    threadDnDSensors,
+    threadCollisionDetection,
+    handleThreadDragStart,
+    handleThreadDragEnd,
+    handleThreadDragCancel,
     hasOverflowingThreads,
     hiddenThreadStatus,
     orderedProjectThreadKeys,
@@ -838,37 +909,92 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
         </SidebarMenuSubItem>
       ) : null}
       {shouldShowThreadPanel &&
-        renderedThreads.map((thread) => {
-          const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-          return (
-            <SidebarThreadRow
-              key={threadKey}
-              thread={thread}
-              projectCwd={projectCwd}
-              orderedProjectThreadKeys={orderedProjectThreadKeys}
-              isActive={activeRouteThreadKey === threadKey}
-              jumpLabel={threadJumpLabelByKey.get(threadKey) ?? null}
-              appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}
-              renamingThreadKey={renamingThreadKey}
-              renamingTitle={renamingTitle}
-              setRenamingTitle={setRenamingTitle}
-              renamingInputRef={renamingInputRef}
-              renamingCommittedRef={renamingCommittedRef}
-              confirmingArchiveThreadKey={confirmingArchiveThreadKey}
-              setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
-              confirmArchiveButtonRefs={confirmArchiveButtonRefs}
-              handleThreadClick={handleThreadClick}
-              navigateToThread={navigateToThread}
-              handleMultiSelectContextMenu={handleMultiSelectContextMenu}
-              handleThreadContextMenu={handleThreadContextMenu}
-              clearSelection={clearSelection}
-              commitRename={commitRename}
-              cancelRename={cancelRename}
-              attemptArchiveThread={attemptArchiveThread}
-              openPrLink={openPrLink}
-            />
-          );
-        })}
+        (isManualThreadSorting ? (
+          <DndContext
+            sensors={threadDnDSensors}
+            collisionDetection={threadCollisionDetection}
+            modifiers={[restrictToVerticalAxis, restrictToFirstScrollableAncestor]}
+            onDragStart={handleThreadDragStart}
+            onDragEnd={handleThreadDragEnd}
+            onDragCancel={handleThreadDragCancel}
+          >
+            <SortableContext
+              items={renderedThreads.map((thread) =>
+                scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+              )}
+              strategy={verticalListSortingStrategy}
+            >
+              {renderedThreads.map((thread) => {
+                const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+                return (
+                  <SortableThreadItem key={threadKey} threadKey={threadKey}>
+                    {(dragHandleProps) => (
+                      <SidebarThreadRow
+                        thread={thread}
+                        projectCwd={projectCwd}
+                        orderedProjectThreadKeys={orderedProjectThreadKeys}
+                        dragHandleProps={dragHandleProps}
+                        isActive={activeRouteThreadKey === threadKey}
+                        jumpLabel={threadJumpLabelByKey.get(threadKey) ?? null}
+                        appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}
+                        renamingThreadKey={renamingThreadKey}
+                        renamingTitle={renamingTitle}
+                        setRenamingTitle={setRenamingTitle}
+                        renamingInputRef={renamingInputRef}
+                        renamingCommittedRef={renamingCommittedRef}
+                        confirmingArchiveThreadKey={confirmingArchiveThreadKey}
+                        setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
+                        confirmArchiveButtonRefs={confirmArchiveButtonRefs}
+                        handleThreadClick={handleThreadClick}
+                        navigateToThread={navigateToThread}
+                        handleMultiSelectContextMenu={handleMultiSelectContextMenu}
+                        handleThreadContextMenu={handleThreadContextMenu}
+                        clearSelection={clearSelection}
+                        commitRename={commitRename}
+                        cancelRename={cancelRename}
+                        attemptArchiveThread={attemptArchiveThread}
+                        openPrLink={openPrLink}
+                      />
+                    )}
+                  </SortableThreadItem>
+                );
+              })}
+            </SortableContext>
+          </DndContext>
+        ) : (
+          renderedThreads.map((thread) => {
+            const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+            return (
+              <SidebarThreadRow
+                key={threadKey}
+                thread={thread}
+                projectCwd={projectCwd}
+                orderedProjectThreadKeys={orderedProjectThreadKeys}
+                dragHandleProps={null}
+                isActive={activeRouteThreadKey === threadKey}
+                jumpLabel={threadJumpLabelByKey.get(threadKey) ?? null}
+                appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}
+                renamingThreadKey={renamingThreadKey}
+                renamingTitle={renamingTitle}
+                setRenamingTitle={setRenamingTitle}
+                renamingInputRef={renamingInputRef}
+                renamingCommittedRef={renamingCommittedRef}
+                confirmingArchiveThreadKey={confirmingArchiveThreadKey}
+                setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
+                confirmArchiveButtonRefs={confirmArchiveButtonRefs}
+                handleThreadClick={handleThreadClick}
+                navigateToThread={navigateToThread}
+                handleMultiSelectContextMenu={handleMultiSelectContextMenu}
+                handleThreadContextMenu={handleThreadContextMenu}
+                clearSelection={clearSelection}
+                commitRename={commitRename}
+                cancelRename={cancelRename}
+                attemptArchiveThread={attemptArchiveThread}
+                openPrLink={openPrLink}
+              />
+            );
+          })
+        ))}
 
       {projectExpanded && hasOverflowingThreads && !isThreadListExpanded && (
         <SidebarMenuSubItem className="w-full">
@@ -948,6 +1074,25 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const threadSortOrder = useSettings<SidebarThreadSortOrder>(
     (settings) => settings.sidebarThreadSortOrder,
   );
+  const isManualThreadSorting = threadSortOrder === "manual";
+  const reorderThreads = useUiStateStore((state) => state.reorderThreads);
+  const threadOrder = useUiStateStore(
+    useShallow((state) => state.threadOrderByProject[project.projectKey] ?? EMPTY_THREAD_ORDER),
+  );
+  const threadDragInProgressRef = useRef(false);
+  const suppressThreadClickAfterDragRef = useRef(false);
+  const threadDnDSensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+  );
+  const threadCollisionDetection = useCallback<CollisionDetection>((args) => {
+    const pointerCollisions = pointerWithin(args);
+    if (pointerCollisions.length > 0) {
+      return pointerCollisions;
+    }
+    return closestCorners(args);
+  }, []);
   const appSettingsConfirmThreadDelete = useSettings<boolean>(
     (settings) => settings.confirmThreadDelete,
   );
@@ -1131,10 +1276,18 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         },
       });
     };
-    const visibleProjectThreads = sortThreads(
+    const sortedProjectThreads = sortThreads(
       projectThreads.filter((thread) => thread.archivedAt === null),
       threadSortOrder,
     );
+    const visibleProjectThreads =
+      threadSortOrder === "manual"
+        ? orderItemsByPreferredIds({
+            items: sortedProjectThreads,
+            preferredIds: threadOrder,
+            getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+          })
+        : sortedProjectThreads;
     const projectStatus = resolveProjectStatusIndicator(
       visibleProjectThreads.map((thread) => resolveProjectThreadStatus(thread)),
     );
@@ -1145,7 +1298,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       projectStatus,
       visibleProjectThreads,
     };
-  }, [projectThreads, threadLastVisitedAts, threadSortOrder]);
+  }, [projectThreads, threadLastVisitedAts, threadSortOrder, threadOrder]);
 
   const pinnedCollapsedThread = useMemo(() => {
     const activeThreadKey = activeRouteThreadKey ?? undefined;
@@ -1184,7 +1337,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         },
       });
     };
-    const hasOverflowingThreads = visibleProjectThreads.length > sidebarThreadPreviewCount;
+    // Manual sort makes the whole list reorderable, so never hide rows behind
+    // "Show more" — render every thread and suppress the overflow controls.
+    const hasOverflowingThreads =
+      !isManualThreadSorting && visibleProjectThreads.length > sidebarThreadPreviewCount;
     const previewThreads =
       isThreadListExpanded || !hasOverflowingThreads
         ? visibleProjectThreads
@@ -1213,6 +1369,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       shouldShowThreadPanel: projectExpanded || pinnedCollapsedThread !== null,
     };
   }, [
+    isManualThreadSorting,
     isThreadListExpanded,
     pinnedCollapsedThread,
     projectExpanded,
@@ -1570,6 +1727,19 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       threadRef: ScopedThreadRef,
       orderedProjectThreadKeys: readonly string[],
     ) => {
+      // A drag in flight (or one that just finished) must not fall through to a
+      // navigate / multi-select; mirror the project drag suppression pattern.
+      if (threadDragInProgressRef.current) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      if (suppressThreadClickAfterDragRef.current) {
+        suppressThreadClickAfterDragRef.current = false;
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       const isMac = isMacPlatform(navigator.platform);
       const isModClick = isMac ? event.metaKey : event.ctrlKey;
       const isShiftClick = event.shiftKey;
@@ -1610,6 +1780,41 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       toggleThreadSelection,
     ],
   );
+
+  const handleThreadDragStart = useCallback(
+    (_event: DragStartEvent) => {
+      if (!isManualThreadSorting) {
+        return;
+      }
+      threadDragInProgressRef.current = true;
+      suppressThreadClickAfterDragRef.current = true;
+    },
+    [isManualThreadSorting],
+  );
+
+  const handleThreadDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      threadDragInProgressRef.current = false;
+      if (!isManualThreadSorting) {
+        return;
+      }
+      const { active, over } = event;
+      if (!over || active.id === over.id) {
+        return;
+      }
+      reorderThreads(
+        project.projectKey,
+        orderedProjectThreadKeys,
+        [String(active.id)],
+        String(over.id),
+      );
+    },
+    [isManualThreadSorting, orderedProjectThreadKeys, project.projectKey, reorderThreads],
+  );
+
+  const handleThreadDragCancel = useCallback((_event: DragCancelEvent) => {
+    threadDragInProgressRef.current = false;
+  }, []);
 
   const handleMultiSelectContextMenu = useCallback(
     async (position: { x: number; y: number }) => {
@@ -2099,6 +2304,12 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       <SidebarProjectThreadList
         projectKey={project.projectKey}
         projectExpanded={projectExpanded}
+        isManualThreadSorting={isManualThreadSorting}
+        threadDnDSensors={threadDnDSensors}
+        threadCollisionDetection={threadCollisionDetection}
+        handleThreadDragStart={handleThreadDragStart}
+        handleThreadDragEnd={handleThreadDragEnd}
+        handleThreadDragCancel={handleThreadDragCancel}
         hasOverflowingThreads={hasOverflowingThreads}
         hiddenThreadStatus={hiddenThreadStatus}
         orderedProjectThreadKeys={orderedProjectThreadKeys}
@@ -2815,6 +3026,7 @@ export default function Sidebar() {
   const sidebarThreads = useStore(useShallow(selectSidebarThreadsAcrossEnvironments));
   const projectExpandedById = useUiStateStore((store) => store.projectExpandedById);
   const projectOrder = useUiStateStore((store) => store.projectOrder);
+  const threadOrderByProject = useUiStateStore((store) => store.threadOrderByProject);
   const reorderProjects = useUiStateStore((store) => store.reorderProjects);
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
@@ -3094,15 +3306,25 @@ export default function Sidebar() {
     visibleThreads,
   ]);
   const isManualProjectSorting = sidebarProjectSortOrder === "manual";
+  const isManualThreadSorting = sidebarThreadSortOrder === "manual";
   const visibleSidebarThreadKeys = useMemo(
     () =>
       sortedProjects.flatMap((project) => {
-        const projectThreads = sortThreads(
+        const sortedProjectThreads = sortThreads(
           (threadsByProjectKey.get(project.projectKey) ?? []).filter(
             (thread) => thread.archivedAt === null,
           ),
           sidebarThreadSortOrder,
         );
+        // Keep this in lockstep with SidebarProjectItem so thread-jump indices
+        // and prewarm targets match the on-screen order under manual sort.
+        const projectThreads = isManualThreadSorting
+          ? orderItemsByPreferredIds({
+              items: sortedProjectThreads,
+              preferredIds: threadOrderByProject[project.projectKey] ?? EMPTY_THREAD_ORDER,
+              getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+            })
+          : sortedProjectThreads;
         const projectExpanded = projectExpandedById[project.projectKey] ?? true;
         const activeThreadKey = routeThreadKey ?? undefined;
         const pinnedCollapsedThread =
@@ -3118,7 +3340,8 @@ export default function Sidebar() {
           return [];
         }
         const isThreadListExpanded = expandedThreadListsByProject.has(project.projectKey);
-        const hasOverflowingThreads = projectThreads.length > sidebarThreadPreviewCount;
+        const hasOverflowingThreads =
+          !isManualThreadSorting && projectThreads.length > sidebarThreadPreviewCount;
         const previewThreads =
           isThreadListExpanded || !hasOverflowingThreads
             ? projectThreads
@@ -3129,6 +3352,7 @@ export default function Sidebar() {
         );
       }),
     [
+      isManualThreadSorting,
       sidebarThreadSortOrder,
       sidebarThreadPreviewCount,
       expandedThreadListsByProject,
@@ -3136,6 +3360,7 @@ export default function Sidebar() {
       routeThreadKey,
       sortedProjects,
       threadsByProjectKey,
+      threadOrderByProject,
     ],
   );
   const threadJumpCommandByKey = useMemo(() => {

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -18,6 +18,7 @@ import {
   useStore,
 } from "../store";
 import { useTerminalUiStateStore } from "../terminalUiStateStore";
+import { useUiStateStore } from "../uiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
 import { formatWorktreePathForDisplay, getOrphanedWorktreePathForThread } from "../worktreeCleanup";
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
@@ -181,6 +182,9 @@ export function useThreadActions() {
         deletedThreadId: threadRef.threadId,
         deletedThreadIds,
         sortOrder: sidebarThreadSortOrder,
+        // Flatten every project's manual order; the per-project filter inside
+        // the helper means only the deleted thread's siblings actually match.
+        manualThreadOrder: Object.values(useUiStateStore.getState().threadOrderByProject).flat(),
       });
       await api.orchestration.dispatchCommand({
         type: "thread.delete",

--- a/apps/web/src/lib/threadSort.test.ts
+++ b/apps/web/src/lib/threadSort.test.ts
@@ -6,6 +6,7 @@ import {
   ProviderInstanceId,
   ThreadId,
 } from "@t3tools/contracts";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime";
 import type { Thread } from "../types";
 import { getLatestThreadForProject, sortThreads } from "./threadSort";
 
@@ -237,5 +238,22 @@ describe("sortThreads", () => {
     );
 
     expect(latestThread?.id).toBe(ThreadId.make("thread-3"));
+  });
+
+  it("returns the first thread in manual order when sort is manual", () => {
+    const keyFor = (id: string) =>
+      scopedThreadKey(scopeThreadRef(LOCAL_ENVIRONMENT_ID, ThreadId.make(id)));
+    const latestThread = getLatestThreadForProject(
+      [
+        makeThread({ id: ThreadId.make("thread-1"), archivedAt: null }),
+        makeThread({ id: ThreadId.make("thread-2"), archivedAt: null }),
+        makeThread({ id: ThreadId.make("thread-3"), archivedAt: null }),
+      ],
+      PROJECT_ID,
+      "manual",
+      [keyFor("thread-2"), keyFor("thread-1"), keyFor("thread-3")],
+    );
+
+    expect(latestThread?.id).toBe(ThreadId.make("thread-2"));
   });
 });

--- a/apps/web/src/lib/threadSort.ts
+++ b/apps/web/src/lib/threadSort.ts
@@ -1,6 +1,40 @@
 import type { ProjectId } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import { scopeThreadRef, scopedThreadKey } from "@t3tools/client-runtime";
 import type { Thread } from "../types";
+
+/**
+ * Reorders `items` to match `preferredIds` first, then appends any items not
+ * listed in `preferredIds` in their original order. Duplicates and unknown ids
+ * are ignored. Generic so it can order projects, threads, or anything keyed.
+ */
+export function orderItemsByPreferredIds<TItem, TId>(input: {
+  items: readonly TItem[];
+  preferredIds: readonly TId[];
+  getId: (item: TItem) => TId;
+}): TItem[] {
+  const { getId, items, preferredIds } = input;
+  if (preferredIds.length === 0) {
+    return [...items];
+  }
+
+  const itemsById = new Map(items.map((item) => [getId(item), item] as const));
+  const preferredIdSet = new Set(preferredIds);
+  const emittedPreferredIds = new Set<TId>();
+  const ordered = preferredIds.flatMap((id) => {
+    if (emittedPreferredIds.has(id)) {
+      return [];
+    }
+    const item = itemsById.get(id);
+    if (!item) {
+      return [];
+    }
+    emittedPreferredIds.add(id);
+    return [item];
+  });
+  const remaining = items.filter((item) => !preferredIdSet.has(getId(item)));
+  return [...ordered, ...remaining];
+}
 
 export type ThreadSortInput = Pick<Thread, "createdAt" | "updatedAt"> & {
   latestUserMessageAt?: string | null;
@@ -80,12 +114,26 @@ export function sortThreads<T extends Pick<Thread, "id"> & ThreadSortInput>(
 }
 
 export function getLatestThreadForProject<
-  T extends Pick<Thread, "id" | "projectId" | "archivedAt"> & ThreadSortInput,
->(threads: readonly T[], projectId: ProjectId, sortOrder: SidebarThreadSortOrder): T | null {
-  return (
-    sortThreads(
-      threads.filter((thread) => thread.projectId === projectId && thread.archivedAt === null),
-      sortOrder,
-    )[0] ?? null
+  T extends Pick<Thread, "id" | "projectId" | "archivedAt" | "environmentId"> & ThreadSortInput,
+>(
+  threads: readonly T[],
+  projectId: ProjectId,
+  sortOrder: SidebarThreadSortOrder,
+  // Manual order (scoped thread keys) so "latest" matches the sidebar's
+  // user-defined order rather than raw store order under manual sort.
+  manualThreadOrder: readonly string[] = [],
+): T | null {
+  const sorted = sortThreads(
+    threads.filter((thread) => thread.projectId === projectId && thread.archivedAt === null),
+    sortOrder,
   );
+  const ordered =
+    sortOrder === "manual" && manualThreadOrder.length > 0
+      ? orderItemsByPreferredIds({
+          items: sorted,
+          preferredIds: manualThreadOrder,
+          getId: (thread) => scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
+        })
+      : sorted;
+  return ordered[0] ?? null;
 }

--- a/apps/web/src/lib/threadSort.ts
+++ b/apps/web/src/lib/threadSort.ts
@@ -64,6 +64,11 @@ export function sortThreads<T extends Pick<Thread, "id"> & ThreadSortInput>(
   threads: readonly T[],
   sortOrder: SidebarThreadSortOrder,
 ): T[] {
+  // Manual sort preserves the incoming order; the caller layers the
+  // user-defined order on top via `orderItemsByPreferredIds`.
+  if (sortOrder === "manual") {
+    return [...threads];
+  }
   return threads.toSorted((left, right) => {
     const rightTimestamp = getThreadSortTimestamp(right, sortOrder);
     const leftTimestamp = getThreadSortTimestamp(left, sortOrder);

--- a/apps/web/src/uiStateStore.test.ts
+++ b/apps/web/src/uiStateStore.test.ts
@@ -10,6 +10,7 @@ import {
   type PersistedUiState,
   persistState,
   reorderProjects,
+  reorderThreads,
   setDefaultAdvertisedEndpointKey,
   setProjectExpanded,
   setThreadChangedFilesExpanded,
@@ -24,6 +25,7 @@ function makeUiState(overrides: Partial<UiState> = {}): UiState {
     projectOrder: [],
     threadLastVisitedAtById: {},
     threadChangedFilesExpandedById: {},
+    threadOrderByProject: {},
     defaultAdvertisedEndpointKey: null,
     ...overrides,
   };
@@ -366,6 +368,98 @@ describe("uiStateStore pure functions", () => {
     });
   });
 
+  it("syncThreads prunes stale thread keys and empty projects from manual order", () => {
+    const thread1 = ThreadId.make("thread-1");
+    const thread2 = ThreadId.make("thread-2");
+    const thread3 = ThreadId.make("thread-3");
+    const initialState = makeUiState({
+      threadOrderByProject: {
+        "env-local:proj-a": [thread1, thread2],
+        "env-local:proj-b": [thread3],
+      },
+    });
+
+    const next = syncThreads(initialState, [{ key: thread1 }]);
+
+    expect(next.threadOrderByProject).toEqual({
+      "env-local:proj-a": [thread1],
+    });
+  });
+
+  it("syncThreads leaves manual order untouched when every thread is retained", () => {
+    const thread1 = ThreadId.make("thread-1");
+    const thread2 = ThreadId.make("thread-2");
+    const initialState = makeUiState({
+      threadOrderByProject: {
+        "env-local:proj-a": [thread1, thread2],
+      },
+    });
+
+    const next = syncThreads(initialState, [{ key: thread1 }, { key: thread2 }]);
+
+    expect(next.threadOrderByProject).toBe(initialState.threadOrderByProject);
+  });
+
+  it("reorderThreads moves a thread down past its target within a project", () => {
+    const initialState = makeUiState();
+
+    const next = reorderThreads(
+      initialState,
+      "env-local:proj-a",
+      ["t-1", "t-2", "t-3"],
+      ["t-1"],
+      "t-3",
+    );
+
+    expect(next.threadOrderByProject["env-local:proj-a"]).toEqual(["t-2", "t-3", "t-1"]);
+  });
+
+  it("reorderThreads moves a thread up before its target within a project", () => {
+    const initialState = makeUiState();
+
+    const next = reorderThreads(
+      initialState,
+      "env-local:proj-a",
+      ["t-1", "t-2", "t-3"],
+      ["t-3"],
+      "t-1",
+    );
+
+    expect(next.threadOrderByProject["env-local:proj-a"]).toEqual(["t-3", "t-1", "t-2"]);
+  });
+
+  it("reorderThreads seeds order from the live list on first drag", () => {
+    const initialState = makeUiState();
+
+    const next = reorderThreads(initialState, "env-local:proj-a", ["t-1", "t-2"], ["t-2"], "t-1");
+
+    expect(next.threadOrderByProject["env-local:proj-a"]).toEqual(["t-2", "t-1"]);
+  });
+
+  it("reorderThreads is a no-op when dragging onto itself", () => {
+    const initialState = makeUiState({
+      threadOrderByProject: { "env-local:proj-a": ["t-1", "t-2"] },
+    });
+
+    const next = reorderThreads(initialState, "env-local:proj-a", ["t-1", "t-2"], ["t-1"], "t-1");
+
+    expect(next).toBe(initialState);
+  });
+
+  it("reorderThreads is a no-op when the target is not in the live list", () => {
+    const initialState = makeUiState();
+
+    const next = reorderThreads(
+      initialState,
+      "env-local:proj-a",
+      ["t-1", "t-2"],
+      ["t-1"],
+      "missing",
+    );
+
+    expect(next).toBe(initialState);
+  });
+
   it("syncThreads seeds visit state for unseen snapshot threads", () => {
     const thread1 = ThreadId.make("thread-1");
     const initialState = makeUiState();
@@ -566,6 +660,28 @@ describe("uiStateStore persistence round-trip", () => {
     const rehydrated = syncProjects(makeUiState(), [projectA, projectB, projectC]);
 
     expect(rehydrated.projectOrder).toEqual([projectC.key, projectA.key, projectB.key]);
+  });
+
+  it("persists manual thread order verbatim across restart", () => {
+    // Thread keys are stable, so unlike project order this round-trips with no
+    // id→cwd remapping: what reorderThreads stores is exactly what reloads.
+    const state = reorderThreads(
+      makeUiState(),
+      "env-local:proj-a",
+      ["t-1", "t-2", "t-3"],
+      ["t-3"],
+      "t-1",
+    );
+    expect(state.threadOrderByProject["env-local:proj-a"]).toEqual(["t-3", "t-1", "t-2"]);
+
+    persistState(state);
+
+    const persisted = JSON.parse(
+      localStorageStub.getItem(PERSISTED_STATE_KEY) ?? "{}",
+    ) as PersistedUiState;
+    expect(persisted.threadOrderByProject).toEqual({
+      "env-local:proj-a": ["t-3", "t-1", "t-2"],
+    });
   });
 
   it("persists the default advertised endpoint preference", () => {

--- a/apps/web/src/uiStateStore.ts
+++ b/apps/web/src/uiStateStore.ts
@@ -21,6 +21,10 @@ export interface PersistedUiState {
   projectOrderCwds?: string[];
   defaultAdvertisedEndpointKey?: string | null;
   threadChangedFilesExpandedById?: Record<string, Record<string, boolean>>;
+  // Manual thread order, keyed by sidebar project (logical) key. Thread keys are
+  // stable (env + threadId), so unlike `projectOrderCwds` this persists directly
+  // without any id→cwd remapping.
+  threadOrderByProject?: Record<string, string[]>;
 }
 
 export interface UiProjectState {
@@ -31,6 +35,8 @@ export interface UiProjectState {
 export interface UiThreadState {
   threadLastVisitedAtById: Record<string, string>;
   threadChangedFilesExpandedById: Record<string, Record<string, boolean>>;
+  /** Manual thread order per sidebar project (logical) key. */
+  threadOrderByProject: Record<string, string[]>;
 }
 
 export interface UiEndpointState {
@@ -57,6 +63,7 @@ const initialState: UiState = {
   projectOrder: [],
   threadLastVisitedAtById: {},
   threadChangedFilesExpandedById: {},
+  threadOrderByProject: {},
   defaultAdvertisedEndpointKey: null,
 };
 
@@ -103,10 +110,41 @@ function readPersistedState(): UiState {
       threadChangedFilesExpandedById: sanitizePersistedThreadChangedFilesExpanded(
         parsed.threadChangedFilesExpandedById,
       ),
+      threadOrderByProject: sanitizePersistedThreadOrderByProject(parsed.threadOrderByProject),
     };
   } catch {
     return initialState;
   }
+}
+
+function sanitizePersistedThreadOrderByProject(
+  value: PersistedUiState["threadOrderByProject"],
+): Record<string, string[]> {
+  if (!value || typeof value !== "object") {
+    return {};
+  }
+
+  const nextState: Record<string, string[]> = {};
+  for (const [projectKey, threadKeys] of Object.entries(value)) {
+    if (!projectKey || !Array.isArray(threadKeys)) {
+      continue;
+    }
+
+    const seen = new Set<string>();
+    const nextThreadKeys: string[] = [];
+    for (const threadKey of threadKeys) {
+      if (typeof threadKey === "string" && threadKey.length > 0 && !seen.has(threadKey)) {
+        seen.add(threadKey);
+        nextThreadKeys.push(threadKey);
+      }
+    }
+
+    if (nextThreadKeys.length > 0) {
+      nextState[projectKey] = nextThreadKeys;
+    }
+  }
+
+  return nextState;
 }
 
 function sanitizePersistedThreadChangedFilesExpanded(
@@ -195,6 +233,7 @@ export function persistState(state: UiState): void {
         projectOrderCwds,
         defaultAdvertisedEndpointKey: state.defaultAdvertisedEndpointKey,
         threadChangedFilesExpandedById,
+        threadOrderByProject: state.threadOrderByProject,
       } satisfies PersistedUiState),
     );
     if (!legacyKeysCleanedUp) {
@@ -224,10 +263,29 @@ function recordsEqual<T>(left: Record<string, T>, right: Record<string, T>): boo
   return true;
 }
 
+function stringListsEqual(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
 function projectOrdersEqual(left: readonly string[], right: readonly string[]): boolean {
-  return (
-    left.length === right.length && left.every((projectId, index) => projectId === right[index])
-  );
+  return stringListsEqual(left, right);
+}
+
+function threadOrderByProjectEqual(
+  left: Record<string, string[]>,
+  right: Record<string, string[]>,
+): boolean {
+  const leftKeys = Object.keys(left);
+  if (leftKeys.length !== Object.keys(right).length) {
+    return false;
+  }
+  for (const key of leftKeys) {
+    const rightValue = right[key];
+    if (!rightValue || !stringListsEqual(left[key]!, rightValue)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function nestedBooleanRecordsEqual(
@@ -427,12 +485,22 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
       retainedThreadIds.has(threadId),
     ),
   );
+  // Drop manual order entries for threads that no longer exist; a project whose
+  // every thread is gone (or that was removed entirely) collapses to no entry.
+  const nextThreadOrderByProject: Record<string, string[]> = {};
+  for (const [projectKey, threadKeys] of Object.entries(state.threadOrderByProject)) {
+    const retained = threadKeys.filter((threadKey) => retainedThreadIds.has(threadKey));
+    if (retained.length > 0) {
+      nextThreadOrderByProject[projectKey] = retained;
+    }
+  }
   if (
     recordsEqual(state.threadLastVisitedAtById, nextThreadLastVisitedAtById) &&
     nestedBooleanRecordsEqual(
       state.threadChangedFilesExpandedById,
       nextThreadChangedFilesExpandedById,
-    )
+    ) &&
+    threadOrderByProjectEqual(state.threadOrderByProject, nextThreadOrderByProject)
   ) {
     return state;
   }
@@ -440,6 +508,7 @@ export function syncThreads(state: UiState, threads: readonly SyncThreadInput[])
     ...state,
     threadLastVisitedAtById: nextThreadLastVisitedAtById,
     threadChangedFilesExpandedById: nextThreadChangedFilesExpandedById,
+    threadOrderByProject: nextThreadOrderByProject,
   };
 }
 
@@ -633,6 +702,65 @@ export function reorderProjects(
   };
 }
 
+/**
+ * Reorder threads within a single sidebar project (or group). `orderedThreadKeys`
+ * is the full, currently-displayed order — it seeds the persisted order even when
+ * the user has never dragged this project before. Mirrors `reorderProjects`, but
+ * operates on the live order rather than a pre-existing persisted array so it
+ * works the first time a thread is dragged.
+ */
+export function reorderThreads(
+  state: UiState,
+  projectKey: string,
+  orderedThreadKeys: readonly string[],
+  draggedThreadKeys: readonly string[],
+  targetThreadKey: string,
+): UiState {
+  if (draggedThreadKeys.length === 0) {
+    return state;
+  }
+  const draggedSet = new Set(draggedThreadKeys);
+  if (draggedSet.has(targetThreadKey)) {
+    return state;
+  }
+
+  const nextOrder = [...orderedThreadKeys];
+  const originalTargetIndex = nextOrder.indexOf(targetThreadKey);
+  if (originalTargetIndex < 0) {
+    return state;
+  }
+
+  const removed: string[] = [];
+  let draggedBeforeTarget = 0;
+  for (let i = nextOrder.length - 1; i >= 0; i--) {
+    if (draggedSet.has(nextOrder[i]!)) {
+      removed.unshift(nextOrder.splice(i, 1)[0]!);
+      if (i < originalTargetIndex) {
+        draggedBeforeTarget++;
+      }
+    }
+  }
+  if (removed.length === 0) {
+    return state;
+  }
+
+  const insertIndex = originalTargetIndex - Math.max(0, draggedBeforeTarget - 1);
+  nextOrder.splice(insertIndex, 0, ...removed);
+
+  const previousOrder = state.threadOrderByProject[projectKey];
+  if (previousOrder && stringListsEqual(previousOrder, nextOrder)) {
+    return state;
+  }
+
+  return {
+    ...state,
+    threadOrderByProject: {
+      ...state.threadOrderByProject,
+      [projectKey]: nextOrder,
+    },
+  };
+}
+
 interface UiStateStore extends UiState {
   syncProjects: (projects: readonly SyncProjectInput[]) => void;
   syncThreads: (threads: readonly SyncThreadInput[]) => void;
@@ -646,6 +774,12 @@ interface UiStateStore extends UiState {
   reorderProjects: (
     draggedProjectIds: readonly string[],
     targetProjectIds: readonly string[],
+  ) => void;
+  reorderThreads: (
+    projectKey: string,
+    orderedThreadKeys: readonly string[],
+    draggedThreadKeys: readonly string[],
+    targetThreadKey: string,
   ) => void;
 }
 
@@ -667,6 +801,10 @@ export const useUiStateStore = create<UiStateStore>((set) => ({
     set((state) => setProjectExpanded(state, projectId, expanded)),
   reorderProjects: (draggedProjectIds, targetProjectIds) =>
     set((state) => reorderProjects(state, draggedProjectIds, targetProjectIds)),
+  reorderThreads: (projectKey, orderedThreadKeys, draggedThreadKeys, targetThreadKey) =>
+    set((state) =>
+      reorderThreads(state, projectKey, orderedThreadKeys, draggedThreadKeys, targetThreadKey),
+    ),
 }));
 
 useUiStateStore.subscribe((state) => debouncedPersistState.maybeExecute(state));

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -17,7 +17,7 @@ export const SidebarProjectSortOrder = Schema.Literals(["updated_at", "created_a
 export type SidebarProjectSortOrder = typeof SidebarProjectSortOrder.Type;
 export const DEFAULT_SIDEBAR_PROJECT_SORT_ORDER: SidebarProjectSortOrder = "updated_at";
 
-export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at"]);
+export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at", "manual"]);
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 


### PR DESCRIPTION
## What

Adds drag-and-drop reordering of threads **within their project** in the sidebar — grab a thread row and move it among the other threads in the same project. This is reordering within one project, not moving threads between projects. It mirrors the existing project-reorder pattern (same `@dnd-kit` setup, same client-side persistence model).

## Demo

Enable **Sort threads → Manual**, then drag a thread row to reorder it within its project. The list auto-expands so the whole project is reorderable, and the order persists across reloads.

![Thread drag-and-drop reorder demo](https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets-thread-drag-reorder/assets/thread-reorder.gif)

<table>
<tr>
<td align="center"><b>New "Manual" thread sort</b></td>
<td align="center"><b>Before</b></td>
<td align="center"><b>After (persists on reload)</b></td>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets-thread-drag-reorder/assets/sort-menu.png" width="260"></td>
<td><img src="https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets-thread-drag-reorder/assets/before.png" width="260"></td>
<td><img src="https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets-thread-drag-reorder/assets/after-reload.png" width="260"></td>
</tr>
</table>

## Changes

- **contracts**: add `"manual"` to `SidebarThreadSortOrder` (alongside `updated_at`/`created_at`), matching `SidebarProjectSortOrder`. New "Manual" option in the "Sort threads" menu.
- **threadSort**: `sortThreads` returns input order for `"manual"`, so the user-defined order is layered on top via `orderItemsByPreferredIds` (same shape as `sortProjectsForSidebar`).
- **uiStateStore**: new `threadOrderByProject: Record<projectKey, threadKey[]>`. Because `scopedThreadKey` is stable, it persists **directly** to `localStorage` (no id→cwd remapping like projects need). New `reorderThreads` action; `syncThreads` prunes stale thread keys and drops emptied projects.
- **Sidebar**: per-project `DndContext` + `SortableContext` + `SortableThreadItem` rendered only when manual sort is active (non-DnD fallback otherwise). `dragInProgress` / `suppressClickAfterDrag` refs guard click, cmd/shift multi-select and rename so they don't fire on a drag. Manual mode auto-expands the full list (skips preview slicing / "Show more") so the whole list is reorderable; auto-animate stays attached.

The order map is keyed per project now but keyed so it extends naturally to user-defined groups once folders land.

## Verification

- `tsgo --noEmit` passes (web + contracts).
- Full web unit suite green (1057 tests); contracts 148. Added store tests (reorder up/down, first-drag seeding, no-ops, sync pruning, persistence round-trip) plus manual-order coverage for the delete-fallback and command-palette navigation helpers.
- Manually tested on localhost: enabled Manual thread sort, dragged a thread within a project, confirmed the new order persists across reload, and that click / rename / multi-select still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only sidebar ordering and localStorage persistence; navigation/delete fallbacks are aligned with manual order but do not touch server auth or data.
> 
> **Overview**
> Adds **manual thread sort** so users can drag thread rows within a project to define sidebar order, with the same persistence model as manual project reorder.
> 
> **Contracts & sorting:** `SidebarThreadSortOrder` gains `"manual"`. `orderItemsByPreferredIds` moves to `threadSort.ts`; manual mode keeps store order and callers apply persisted scoped thread keys. `getLatestThreadForProject` and post-delete fallback navigation use that order so “open project” and delete routing match the first visible thread.
> 
> **Persistence:** `uiStateStore` adds `threadOrderByProject` and `reorderThreads`, saved to `localStorage`; `syncThreads` prunes removed threads.
> 
> **Sidebar UX:** When sort is manual, per-project `DndContext`/`SortableContext` enables vertical drag on rows (grab cursor, drop highlight), suppresses clicks during/after drag, and shows the full thread list (no “Show more” truncation). Thread-jump indices and prewarm lists follow the same manual ordering.
> 
> **Call sites:** Command palette project open paths pass flattened manual order into `getLatestThreadForProject`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ed1189b323d88655eb724a450df36a83442d307. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add drag-and-drop manual reordering of threads within sidebar projects
> - Adds a new `'manual'` sort mode to `SidebarThreadSortOrder` and a `reorderThreads` reducer in [`uiStateStore.ts`](https://github.com/pingdotgg/t3code/pull/3069/files#diff-605fd32a90753e51ac329e924c51be2b2ce46a7ce8b6d02117aee02489c8acd8) that persists per-project thread order to localStorage.
> - Wraps sidebar thread rows in a `SortableThreadItem` component using `@dnd-kit`, enabling vertical drag-and-drop reordering within each project in [`Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/3069/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1).
> - Extends `sortThreads` and `getLatestThreadForProject` in [`threadSort.ts`](https://github.com/pingdotgg/t3code/pull/3069/files#diff-0e3be39caf95414e9d9732e11f3ec3b6436f9854f257d442f5bd2b5d783a1a4e) so manual mode preserves input order and resolves "latest" thread by manual position rather than timestamp.
> - Fallback navigation after thread deletion and command palette project opening both respect manual order when active.
> - `syncThreads` prunes stale thread keys from the saved order automatically when threads are removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ed1189.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
