### PR TITLE
Fix Bitbucket source control availability toggle

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -1360,6 +1360,50 @@ describe("SourceControlSettingsPanel discovery states", () => {
     await expect.element(page.getByText("Nothing detected yet")).not.toBeInTheDocument();
   });
 
+  it("shows unauthenticated API providers as available but not enabled", async () => {
+    setSourceControlDiscoveryStub(async () => ({
+      versionControlSystems: [],
+      sourceControlProviders: [
+        {
+          kind: "bitbucket",
+          label: "Bitbucket",
+          status: "available",
+          version: Option.none(),
+          installHint:
+            "Set T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN, or T3CODE_BITBUCKET_ACCESS_TOKEN.",
+          detail: Option.none(),
+          auth: {
+            status: "unauthenticated",
+            account: Option.none(),
+            host: Option.some("bitbucket.org"),
+            detail: Option.some(
+              "Set T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN, or T3CODE_BITBUCKET_ACCESS_TOKEN.",
+            ),
+          },
+        },
+      ],
+    }));
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <SourceControlSettingsPanel />
+      </AppAtomRegistryProvider>,
+    );
+
+    const bitbucketSwitch = page.getByRole("switch", { name: "Bitbucket availability" });
+
+    await expect.element(page.getByText("Not authenticated")).toBeInTheDocument();
+    await expect
+      .element(
+        page.getByText(
+          "Available. Set T3CODE_BITBUCKET_EMAIL and T3CODE_BITBUCKET_API_TOKEN, or T3CODE_BITBUCKET_ACCESS_TOKEN.",
+        ),
+      )
+      .toBeInTheDocument();
+    await expect.element(bitbucketSwitch).toBeDisabled();
+    await expect.element(bitbucketSwitch).not.toBeChecked();
+  });
+
   it("shows Git fetch interval settings inside the Git details dropdown", async () => {
     setSourceControlDiscoveryStub(async () => ({
       versionControlSystems: [

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -188,7 +188,7 @@ function itemSummary({
     }
 
     if (!item.executable) {
-      return <span>{item.installHint}</span>;
+      return <span>Available. {item.installHint}</span>;
     }
 
     if (auth.status === "unauthenticated") {
@@ -218,8 +218,9 @@ function DiscoveryItemRow({
   readonly children?: ReactNode;
 }) {
   const version = optionLabel(item.version);
-  const enabled =
-    item.status === "available" && (isProviderDiscoveryItem(item) || item.implemented);
+  const enabled = isProviderDiscoveryItem(item)
+    ? item.status === "available" && item.auth.status === "authenticated"
+    : item.status === "available" && item.implemented;
   const auth = isProviderDiscoveryItem(item) ? item.auth : null;
   const authStatus = auth ? authPresentation(auth) : null;
   const authAccount = auth ? optionLabel(auth.account) : null;


### PR DESCRIPTION
## What Changed

Updated the Source Control settings UI so source control provider toggles are only shown as enabled when the provider is both available and authenticated.

For unauthenticated API-based providers like Bitbucket, the row now keeps the provider marked as available, shows the existing setup instructions, and leaves the disabled toggle off.

Added browser coverage for the Bitbucket `available` + `unauthenticated` state.

## Why

Bitbucket was shown with its disabled toggle already selected even when no Bitbucket credentials were configured. That made it look like the provider was installed/authenticated or user-enabled, even though pull request features could not actually work.

This keeps the existing discovery model intact: provider availability still means the integration exists in T3 Code, while the toggle now reflects whether the provider is actually usable through authenticated credentials.

## UI Changes
Before:
<img width="2559" height="1439" alt="Screenshot 2026-06-14 162513" src="https://github.com/user-attachments/assets/f1e28b1f-1d5c-4f70-bed0-27497f790e15" />

After:
<img width="2559" height="1439" alt="Screenshot 2026-06-14 163311" src="https://github.com/user-attachments/assets/3d1574ad-0d7a-43dd-b791-d2db59d25281" />

## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI and display logic only; discovery contracts unchanged and no server auth behavior is modified.
> 
> **Overview**
> Fixes **Source Control** settings so provider availability toggles no longer appear **on** when the integration is discovered but **not authenticated** (e.g. Bitbucket with env vars unset).
> 
> Provider rows now treat **enabled** as *available and authenticated* for API providers; VCS rows still use *available and implemented*. Unauthenticated API providers without a CLI executable show **Available.** plus the existing credential **installHint** instead of only the hint text.
> 
> Adds a browser test that stubs Bitbucket as `available` + `unauthenticated` and asserts **Not authenticated**, the prefixed availability copy, and a **disabled, unchecked** toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3213244294214a052f883f8eafdb6874d90bfd4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Bitbucket availability toggle to require authentication before enabling
> - Provider rows in `SourceControlSettingsPanel` are now disabled unless the provider's `auth.status` is `'authenticated'`, even when `status` is `'available'`.
> - The `itemSummary` util now prefixes the install hint with `'Available. '` when a provider has auth info but no executable present.
> - A new browser test covers the unauthenticated-but-available state, asserting the switch is disabled and the summary shows the prefixed hint.
> - Behavioral Change: unauthenticated Bitbucket providers can no longer be toggled on via the settings UI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3213244.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->