### PR TITLE
Preserve diff surface when toggling right panel

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -1545,6 +1545,18 @@ function dispatchChatNewShortcut(): void {
   );
 }
 
+function dispatchConfiguredDiffToggleShortcut(): void {
+  window.dispatchEvent(
+    new KeyboardEvent("keydown", {
+      key: "g",
+      shiftKey: true,
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    }),
+  );
+}
+
 function releaseModShortcut(key?: string): void {
   window.dispatchEvent(
     new KeyboardEvent("keyup", {
@@ -3377,6 +3389,76 @@ describe("ChatView timeline estimator parity (full app)", () => {
         },
         { timeout: 8_000, interval: 16 },
       );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
+  it("uses the configured diff toggle binding without discarding its surface", async () => {
+    const mounted = await mountChatView({
+      viewport: DEFAULT_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-target-diff-hotkey" as MessageId,
+        targetText: "diff hotkey target",
+      }),
+      configureFixture: (nextFixture) => {
+        nextFixture.serverConfig = {
+          ...nextFixture.serverConfig,
+          keybindings: [
+            {
+              command: "diff.toggle",
+              shortcut: {
+                key: "g",
+                metaKey: false,
+                ctrlKey: false,
+                shiftKey: true,
+                altKey: true,
+                modKey: false,
+              },
+              whenAst: {
+                type: "not",
+                node: { type: "identifier", name: "terminalFocus" },
+              },
+            },
+          ],
+        };
+      },
+    });
+
+    try {
+      await waitForServerConfigToApply();
+      dispatchConfiguredDiffToggleShortcut();
+      await vi.waitFor(() => {
+        expect(
+          selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF),
+        ).toEqual({
+          isOpen: true,
+          activeSurfaceId: "diff",
+          surfaces: [{ id: "diff", kind: "diff" }],
+        });
+      });
+
+      dispatchConfiguredDiffToggleShortcut();
+      await vi.waitFor(() => {
+        expect(
+          selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF),
+        ).toEqual({
+          isOpen: false,
+          activeSurfaceId: "diff",
+          surfaces: [{ id: "diff", kind: "diff" }],
+        });
+      });
+
+      dispatchConfiguredDiffToggleShortcut();
+      await vi.waitFor(() => {
+        expect(
+          selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF),
+        ).toEqual({
+          isOpen: true,
+          activeSurfaceId: "diff",
+          surfaces: [{ id: "diff", kind: "diff" }],
+        });
+      });
     } finally {
       await mounted.cleanup();
     }

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2263,9 +2263,9 @@ export default function ChatView(props: ChatViewProps) {
   //     openness; when both fight, `selectActiveRightPanelKindWithUrl` lets
   //     diff win (URL is truth).
   //   - The two toggles below treat the panels as mutually exclusive: opening
-  //     one always tears down the other in BOTH the URL and the store. Without
-  //     this, e.g. clicking the browser button while diff is URL-pinned would
-  //     just toggle the (overridden) store value and look like a no-op.
+  //     one updates BOTH the URL and the store. Without this, e.g. clicking the
+  //     browser button while diff is URL-pinned would just toggle the
+  //     (overridden) store value and look like a no-op.
   const onTogglePreview = useCallback(() => {
     if (!activeThreadRef) return;
     if (previewPanelOpen) {
@@ -2303,11 +2303,9 @@ export default function ChatView(props: ChatViewProps) {
     const diffPanelOpen = activeRightPanelKind === "diff";
     if (!diffPanelOpen) {
       onDiffPanelOpen?.();
-      if (activeThreadRef) {
-        useRightPanelStore.getState().open(activeThreadRef, "diff");
-      }
-    } else if (activeThreadRef) {
-      useRightPanelStore.getState().closeSurface(activeThreadRef, "diff");
+    }
+    if (activeThreadRef) {
+      useRightPanelStore.getState().toggle(activeThreadRef, "diff");
     }
     void navigate({
       to: "/$environmentId/$threadId",

--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -111,11 +111,16 @@ describe("rightPanelStore", () => {
     expect(useRightPanelStore.getState().byThreadKey).toEqual({});
   });
 
-  it("toggle opens then closes the same kind", () => {
-    useRightPanelStore.getState().toggle(refA, "preview");
-    expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBe("preview");
-    useRightPanelStore.getState().toggle(refA, "preview");
+  it("toggle hides the panel without discarding the active surface", () => {
+    useRightPanelStore.getState().toggle(refA, "diff");
+    expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBe("diff");
+    useRightPanelStore.getState().toggle(refA, "diff");
     expect(selectActiveRightPanel(useRightPanelStore.getState().byThreadKey, refA)).toBeNull();
+    expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
+      isOpen: false,
+      activeSurfaceId: "diff",
+      surfaces: [{ id: "diff", kind: "diff" }],
+    });
   });
 
   it("toggle to a different kind switches active", () => {


### PR DESCRIPTION
## Summary
- Update diff panel toggling so it hides and reopens the same `diff` surface instead of discarding it from state.
- Keep URL and store state aligned when opening the diff panel from chat view.
- Extend browser and store tests to cover the configured diff hotkey flow and surface retention.

## Testing
- `vp check`
- `vp run typecheck`
- `vp run lint`
- `vp test apps/web/src/rightPanelStore.test.ts`
- `vp test apps/web/src/components/ChatView.browser.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized right-panel UI state and URL sync for diff; no auth, data, or server changes.
> 
> **Overview**
> **Diff panel toggling** now hides and reopens the same `diff` surface instead of removing it from right-panel state. In `ChatView`, `onToggleDiff` calls `useRightPanelStore.toggle(..., "diff")` rather than `open` plus `closeSurface`, while still syncing the `?diff=1` URL when opening or closing.
> 
> A **browser test** covers the configured `diff.toggle` shortcut (Shift+Alt+G): repeated toggles flip `isOpen` but keep `activeSurfaceId: "diff"` and the diff surface in `surfaces`. The **store unit test** asserts the same hide-without-discard behavior for `toggle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ee8bed23d989796469cbfcf2753b9d973facc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve diff surface when toggling the right panel
> - Previously, closing the diff panel via `onToggleDiff` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/3083/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) discarded the active diff surface; now it calls `rightPanelStore.toggle()` unconditionally, hiding the panel while keeping `activeSurfaceId` and the diff surface intact.
> - On re-open, the panel returns to the same diff surface rather than starting fresh.
> - Behavioral Change: the diff surface is no longer torn down on close, which changes observable store state when the panel is hidden.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0ee8be.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->