### PR TITLE
Guard VCS status updates against stale targets

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -100,6 +100,7 @@ vi.mock("../lib/vcsStatusState", () => {
   };
 
   return {
+    getVcsStatusDataForTarget: (state: typeof status) => state.data,
     getVcsStatusSnapshot: () => status,
     useVcsStatus: () => status,
     useVcsStatuses: () => new Map(),

--- a/apps/web/src/components/GitActionsControl.browser.tsx
+++ b/apps/web/src/components/GitActionsControl.browser.tsx
@@ -94,6 +94,7 @@ vi.mock("~/lib/sourceControlActions", () => ({
 }));
 
 vi.mock("~/lib/vcsStatusState", () => ({
+  getVcsStatusDataForTarget: (state: { data: unknown }) => state.data,
   refreshVcsStatus: refreshVcsStatusSpy,
   resetVcsStatusStateForTests: () => undefined,
   useVcsStatus: vi.fn(() => ({

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1100,6 +1100,15 @@ describe("resolveLiveThreadBranchUpdate", () => {
 
     assert.equal(update, null);
   });
+
+  it("allows a temporary worktree ref to reconcile to a semantic branch", () => {
+    const update = resolveLiveThreadBranchUpdate({
+      threadBranch: "t3code/a9628676",
+      gitStatus: status({ refName: "feature/diff-panel-toggle" }),
+    });
+
+    assert.deepEqual(update, { branch: "feature/diff-panel-toggle" });
+  });
 });
 
 describe("resolveAutoFeatureBranchName", () => {

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -71,7 +71,7 @@ import {
   useVcsInitAction,
   useVcsPullAction,
 } from "~/lib/sourceControlActions";
-import { refreshVcsStatus, useVcsStatus } from "~/lib/vcsStatusState";
+import { getVcsStatusDataForTarget, refreshVcsStatus, useVcsStatus } from "~/lib/vcsStatusState";
 import { useSourceControlDiscovery } from "~/lib/sourceControlDiscoveryState";
 import { newCommandId, randomUUID } from "~/lib/utils";
 import { resolvePathLinkTarget } from "~/terminal-links";
@@ -1058,10 +1058,13 @@ export default function GitActionsControl({
     [persistThreadBranchSync],
   );
 
-  const { data: gitStatus, error: gitStatusError } = useVcsStatus({
-    environmentId: activeEnvironmentId,
-    cwd: gitCwd,
-  });
+  const vcsStatusTarget = useMemo(
+    () => ({ environmentId: activeEnvironmentId, cwd: gitCwd }),
+    [activeEnvironmentId, gitCwd],
+  );
+  const gitStatusQuery = useVcsStatus(vcsStatusTarget);
+  const { error: gitStatusError } = gitStatusQuery;
+  const gitStatus = getVcsStatusDataForTarget(gitStatusQuery, vcsStatusTarget);
   const sourceControlPresentation = useMemo(
     () => getSourceControlPresentation(gitStatus?.sourceControlProvider),
     [gitStatus?.sourceControlProvider],

--- a/apps/web/src/components/KeybindingsToast.browser.tsx
+++ b/apps/web/src/components/KeybindingsToast.browser.tsx
@@ -67,6 +67,7 @@ vi.mock("../lib/vcsStatusState", () => {
   };
 
   return {
+    getVcsStatusDataForTarget: (state: typeof status) => state.data,
     getVcsStatusSnapshot: () => status,
     useVcsStatus: () => status,
     useVcsStatuses: () => new Map(),

--- a/apps/web/src/lib/vcsStatusState.ts
+++ b/apps/web/src/lib/vcsStatusState.ts
@@ -6,6 +6,7 @@ import {
   EMPTY_VCS_STATUS_ATOM,
   EMPTY_VCS_STATUS_STATE,
   createVcsStatusManager,
+  getVcsStatusDataForTarget,
   getVcsStatusTargetKey,
   vcsStatusStateAtom,
 } from "@t3tools/client-runtime";
@@ -19,6 +20,7 @@ import {
 import { appAtomRegistry } from "../rpc/atomRegistry";
 
 export type { VcsStatusState, VcsStatusTarget };
+export { getVcsStatusDataForTarget };
 
 const manager = createVcsStatusManager({
   getRegistry: () => appAtomRegistry,

--- a/packages/client-runtime/src/gitActions.test.ts
+++ b/packages/client-runtime/src/gitActions.test.ts
@@ -1,0 +1,43 @@
+import type { VcsStatusResult } from "@t3tools/contracts";
+import { assert, describe, it } from "vite-plus/test";
+
+import { resolveLiveThreadBranchUpdate } from "./gitActions.js";
+
+function status(refName: string): VcsStatusResult {
+  return {
+    isRepo: true,
+    hasPrimaryRemote: true,
+    isDefaultRef: refName === "main",
+    refName,
+    hasWorkingTreeChanges: false,
+    workingTree: {
+      files: [],
+      insertions: 0,
+      deletions: 0,
+    },
+    hasUpstream: true,
+    aheadCount: 0,
+    behindCount: 0,
+    pr: null,
+  };
+}
+
+describe("resolveLiveThreadBranchUpdate", () => {
+  it("allows a temporary worktree ref to reconcile to a semantic branch", () => {
+    const update = resolveLiveThreadBranchUpdate({
+      threadBranch: "t3code/a9628676",
+      gitStatus: status("feature/diff-panel-toggle"),
+    });
+
+    assert.deepEqual(update, { branch: "feature/diff-panel-toggle" });
+  });
+
+  it("still reconciles ordinary semantic branch changes", () => {
+    const update = resolveLiveThreadBranchUpdate({
+      threadBranch: "feature/old",
+      gitStatus: status("feature/new"),
+    });
+
+    assert.deepEqual(update, { branch: "feature/new" });
+  });
+});

--- a/packages/client-runtime/src/vcsStatusState.test.ts
+++ b/packages/client-runtime/src/vcsStatusState.test.ts
@@ -2,7 +2,11 @@ import { EnvironmentId, type VcsStatusResult } from "@t3tools/contracts";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { type VcsStatusClient, createVcsStatusManager } from "./vcsStatusState.ts";
+import {
+  type VcsStatusClient,
+  createVcsStatusManager,
+  getVcsStatusDataForTarget,
+} from "./vcsStatusState.ts";
 
 /* ─── Test helpers ──────────────────────────────────────────────────── */
 
@@ -57,12 +61,24 @@ function createMockClient(): {
   };
 }
 
-const PENDING = { data: null, error: null, cause: null, isPending: true };
-const EMPTY = { data: null, error: null, cause: null, isPending: false };
-
 const TARGET = { environmentId: EnvironmentId.make("env-local"), cwd: "/repo" } as const;
 const FRESH_TARGET = { environmentId: EnvironmentId.make("env-local"), cwd: "/fresh" } as const;
 const OTHER_ENV_TARGET = { environmentId: EnvironmentId.make("env-remote"), cwd: "/repo" } as const;
+const TARGET_KEY = "env-local:/repo";
+const PENDING = {
+  targetKey: TARGET_KEY,
+  data: null,
+  error: null,
+  cause: null,
+  isPending: true,
+};
+const EMPTY = {
+  targetKey: null,
+  data: null,
+  error: null,
+  cause: null,
+  isPending: false,
+};
 
 /* ─── Tests ─────────────────────────────────────────────────────────── */
 
@@ -99,6 +115,7 @@ describe("createVcsStatusManager", () => {
 
       emit(BASE_STATUS);
       expect(manager.getSnapshot(TARGET)).toEqual({
+        targetKey: TARGET_KEY,
         data: BASE_STATUS,
         error: null,
         cause: null,
@@ -130,6 +147,7 @@ describe("createVcsStatusManager", () => {
 
       // Snapshot still reflects stream data, not the refresh response
       expect(manager.getSnapshot(TARGET)).toEqual({
+        targetKey: TARGET_KEY,
         data: BASE_STATUS,
         error: null,
         cause: null,
@@ -158,6 +176,19 @@ describe("createVcsStatusManager", () => {
 
       releaseLocal();
       releaseRemote();
+    });
+
+    it("rejects status data from a previous cwd during target transitions", () => {
+      const staleState = {
+        targetKey: TARGET_KEY,
+        data: BASE_STATUS,
+        error: null,
+        cause: null,
+        isPending: false,
+      };
+
+      expect(getVcsStatusDataForTarget(staleState, FRESH_TARGET)).toBeNull();
+      expect(getVcsStatusDataForTarget(staleState, TARGET)).toBe(BASE_STATUS);
     });
 
     it("returns null from refresh when no client is available", async () => {
@@ -204,6 +235,7 @@ describe("createVcsStatusManager", () => {
 
       mock.emit(BASE_STATUS);
       expect(manager.getSnapshot(TARGET)).toEqual({
+        targetKey: TARGET_KEY,
         data: BASE_STATUS,
         error: null,
         cause: null,
@@ -241,6 +273,7 @@ describe("createVcsStatusManager", () => {
       for (const listener of connectionListeners) listener();
 
       expect(manager.getSnapshot(TARGET)).toEqual({
+        targetKey: TARGET_KEY,
         data: BASE_STATUS,
         error: null,
         cause: null,

--- a/packages/client-runtime/src/vcsStatusState.ts
+++ b/packages/client-runtime/src/vcsStatusState.ts
@@ -7,6 +7,7 @@ import type { WsRpcClient } from "./wsRpcClient.ts";
 /* ─── Types ─────────────────────────────────────────────────────────── */
 
 export interface VcsStatusState {
+  readonly targetKey: string | null;
   readonly data: VcsStatusResult | null;
   readonly error: GitManagerServiceError | null;
   readonly cause: Cause.Cause<GitManagerServiceError> | null;
@@ -30,18 +31,22 @@ interface WatchedEntry {
 const NOOP: () => void = () => undefined;
 
 export const EMPTY_VCS_STATUS_STATE = Object.freeze<VcsStatusState>({
+  targetKey: null,
   data: null,
   error: null,
   cause: null,
   isPending: false,
 });
 
-const INITIAL_VCS_STATUS_STATE = Object.freeze<VcsStatusState>({
-  data: null,
-  error: null,
-  cause: null,
-  isPending: true,
-});
+function initialVcsStatusState(targetKey: string): VcsStatusState {
+  return {
+    targetKey,
+    data: null,
+    error: null,
+    cause: null,
+    isPending: true,
+  };
+}
 
 /* ─── Atoms ─────────────────────────────────────────────────────────── */
 
@@ -49,7 +54,7 @@ const knownVcsStatusKeys = new Set<string>();
 
 export const vcsStatusStateAtom = Atom.family((key: string) => {
   knownVcsStatusKeys.add(key);
-  return Atom.make(INITIAL_VCS_STATUS_STATE).pipe(
+  return Atom.make(initialVcsStatusState(key)).pipe(
     Atom.keepAlive,
     Atom.withLabel(`vcs-status:${key}`),
   );
@@ -67,6 +72,14 @@ export function getVcsStatusTargetKey(target: VcsStatusTarget): string | null {
     return null;
   }
   return `${target.environmentId}:${target.cwd}`;
+}
+
+export function getVcsStatusDataForTarget(
+  state: VcsStatusState,
+  target: VcsStatusTarget,
+): VcsStatusResult | null {
+  const targetKey = getVcsStatusTargetKey(target);
+  return targetKey !== null && state.targetKey === targetKey ? state.data : null;
 }
 
 /* ─── Subscription manager ──────────────────────────────────────────── */
@@ -107,7 +120,7 @@ export function createVcsStatusManager(config: VcsStatusManagerConfig) {
     const current = config.getRegistry().get(atom);
     const next: VcsStatusState =
       current.data === null
-        ? INITIAL_VCS_STATUS_STATE
+        ? initialVcsStatusState(targetKey)
         : { ...current, error: null, cause: null, isPending: true };
     if (
       current.data === next.data &&
@@ -122,6 +135,7 @@ export function createVcsStatusManager(config: VcsStatusManagerConfig) {
 
   function setData(targetKey: string, status: VcsStatusResult): void {
     config.getRegistry().set(vcsStatusStateAtom(targetKey), {
+      targetKey,
       data: status,
       error: null,
       cause: null,
@@ -283,7 +297,7 @@ export function createVcsStatusManager(config: VcsStatusManagerConfig) {
     refreshInFlight.clear();
     lastRefreshAt.clear();
     for (const key of knownVcsStatusKeys) {
-      config.getRegistry().set(vcsStatusStateAtom(key), INITIAL_VCS_STATUS_STATE);
+      config.getRegistry().set(vcsStatusStateAtom(key), initialVcsStatusState(key));
     }
     knownVcsStatusKeys.clear();
   }


### PR DESCRIPTION
## Summary
- Track the active VCS target key alongside each cached status snapshot.
- Ignore status data when the current query target no longer matches the snapshot, preventing stale cwd data from leaking into the UI.
- Update Git actions branch reconciliation to accept a temporary worktree ref when the live branch has already resolved to a semantic branch.
- Add coverage for target transitions and branch reconciliation behavior.

## Testing
- Not run (not requested in this review task).
- Existing tests added/updated in `packages/client-runtime/src/vcsStatusState.test.ts` and `packages/client-runtime/src/gitActions.test.ts` cover stale-target filtering and branch reconciliation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how git status is read during cwd/target transitions and thread branch sync; incorrect filtering could briefly hide status or block branch updates, but scope is limited to VCS UI state.
> 
> **Overview**
> VCS status snapshots now carry a **target key** (`environmentId:cwd`), and consumers read status through **`getVcsStatusDataForTarget`** so cached data from a previous cwd is not shown after the UI switches worktrees or paths.
> 
> **`GitActionsControl`** uses that helper for git actions and live thread-branch sync, which avoids wrong branch/ref driving commits, pushes, and metadata updates during fast target changes.
> 
> Tests cover **stale-target rejection** in `vcsStatusState` and **live branch reconciliation** when a thread still has a temporary `t3code/…` ref but git reports a real feature branch (without regressing a semantic ref back to another temp ref).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4da3870788eda7c92cc7200e5138421075aac814. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard VCS status reads against stale targets in `GitActionsControl`
> - Adds a `targetKey` field to `VcsStatusState` in [`vcsStatusState.ts`](https://github.com/pingdotgg/t3code/pull/3084/files#diff-008353f38c5e7198b87cb16aa13eccd946c7e6258bbf9a55b6bb04c42423192d) so each atom tracks which target its data belongs to.
> - Adds `getVcsStatusDataForTarget`, which returns `state.data` only when the caller's target key matches `state.targetKey`, returning `null` otherwise.
> - Updates `GitActionsControl` to derive `gitStatus` via `getVcsStatusDataForTarget` so stale data from a previous target is not consumed during target transitions.
> - Re-exports `getVcsStatusDataForTarget` from [`vcsStatusState.ts`](https://github.com/pingdotgg/t3code/pull/3084/files#diff-169ebdf4d49e3c8c1c686816a00437eb3ba34f79a817a9b17bbe818991f81f86) and updates browser test mocks to expose it.
> - Behavioral Change: components using `getVcsStatusDataForTarget` will see `null` instead of stale data while a new target's status is loading.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d314b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->