### PR TITLE
Wrap authorized clients in fading scroll area

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -3007,7 +3007,13 @@ export function ConnectionsSettings() {
                 />
               }
             >
-              {renderAuthorizedClients("current")}
+              <ScrollArea
+                scrollFade
+                className="max-h-[22.5rem]"
+                data-testid="authorized-clients-scroll-area"
+              >
+                {renderAuthorizedClients("current")}
+              </ScrollArea>
             </SettingsSection>
           ) : null}
           <AlertDialog

--- a/apps/web/src/components/settings/SettingsPanels.browser.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.browser.tsx
@@ -917,6 +917,59 @@ describe("GeneralSettingsPanel observability", () => {
     await expect.element(page.getByText("Revoke others")).toBeInTheDocument();
   });
 
+  it("keeps authorized clients within a five-row fading scroll area", async () => {
+    window.desktopBridge = createDesktopBridgeStub({
+      serverExposureState: {
+        mode: "network-accessible",
+        endpointUrl: "http://192.168.1.44:3773",
+        advertisedHost: "192.168.1.44",
+        tailscaleServeEnabled: false,
+        tailscaleServePort: 443,
+      },
+    });
+    authAccessHarness.setSnapshot({
+      pairingLinks: [],
+      clientSessions: Array.from({ length: 7 }, (_, index) =>
+        makeClientSession({
+          sessionId: `session-client-${index}`,
+          subject: `client-${index}`,
+          scopes: ["orchestration:read"],
+          method: "browser-session-cookie",
+          client: {
+            label: `Client ${index + 1}`,
+            deviceType: "desktop",
+            os: "macOS",
+            browser: "Electron",
+            ipAddress: `192.168.1.${index + 10}`,
+          },
+          issuedAt: "2036-04-07T00:00:00.000Z",
+          expiresAt: "2036-05-07T00:00:00.000Z",
+          connected: index === 0,
+          current: index === 0,
+        }),
+      ),
+    });
+    setServerConfigSnapshot(createBaseServerConfig());
+
+    mounted = await render(
+      <AppAtomRegistryProvider>
+        <ConnectionsSettings />
+      </AppAtomRegistryProvider>,
+    );
+
+    await expect.element(page.getByText("Client 7")).toBeInTheDocument();
+    const scrollArea = document.querySelector<HTMLElement>(
+      '[data-testid="authorized-clients-scroll-area"]',
+    );
+    const viewport = scrollArea?.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]');
+
+    expect(scrollArea).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    expect(scrollArea?.clientHeight).toBe(360);
+    expect(viewport?.scrollHeight).toBeGreaterThan(viewport?.clientHeight ?? 0);
+    expect(viewport?.className).toContain("mask-b-from");
+  });
+
   it("revokes all other paired clients from settings", async () => {
     window.desktopBridge = createDesktopBridgeStub({
       serverExposureState: {


### PR DESCRIPTION
## Summary
- Wraps the authorized clients list in a bounded `ScrollArea` with fade masking in Settings.
- Adds a browser test covering the new scroll area behavior and verifying overflow/fade styling.
- Keeps the authorized clients section constrained to about five visible rows for better readability.

## Testing
- `Not run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change in settings UI; revoke/create pairing behavior is unchanged.
> 
> **Overview**
> The **Authorized clients** section in Connections settings no longer grows without limit when many paired clients exist. The list is wrapped in a `ScrollArea` with **scroll fade** and **`max-h-[22.5rem]`** (~five visible rows), plus `data-testid="authorized-clients-scroll-area"` for tests.
> 
> A browser test seeds seven client sessions and asserts the scroll container height (360px), that content overflows the viewport, and that fade masking (`mask-b-from`) is applied—matching the pattern already used elsewhere (e.g. SSH suggested hosts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f8df4e5a97bc85bc9dbfadd1980b3ed9e353183. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wrap authorized clients list in a fading scroll area with a max height
> Wraps the authorized clients list in [ConnectionsSettings](https://github.com/pingdotgg/t3code/pull/3085/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) with a `ScrollArea` that has a maximum height and a fading edge mask, preventing the list from growing unbounded. A `data-testid` is added to the wrapper, and a browser test verifies the scroll and fade behavior with seven client sessions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f8df4e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->