### PR TITLE
feat(composer): show CI status next to the PR pill

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -546,7 +546,7 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
             "--limit",
             String(input.limit ?? 1),
             "--json",
-            "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+            "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner,statusCheckRollup",
           ],
         }).pipe(
           Effect.map((result) => JSON.parse(result.stdout) as unknown[]),
@@ -590,7 +590,7 @@ function createGitHubCliWithFakeGh(scenario: FakeGhScenario = {}): {
             "view",
             input.reference,
             "--json",
-            "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+            "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner,statusCheckRollup",
           ],
         }).pipe(Effect.map((result) => JSON.parse(result.stdout) as GitHubPullRequestSummary)),
       getRepositoryCloneUrls: (input) =>
@@ -1084,7 +1084,7 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           state: "open",
         });
         expect(ghCalls).toContain(
-          "pr list --head jasonLaster:statemachine --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "pr list --head jasonLaster:statemachine --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner,statusCheckRollup",
         );
       }),
     20_000,

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -49,7 +49,7 @@ import { ServerSettingsService } from "../serverSettings.ts";
 import type { GitManagerServiceError } from "@t3tools/contracts";
 import { GitVcsDriver, type GitStatusDetails } from "../vcs/GitVcsDriver.ts";
 import { SourceControlProviderRegistry } from "../sourceControl/SourceControlProviderRegistry.ts";
-import type { ChangeRequest } from "@t3tools/contracts";
+import type { ChangeRequest, ChangeRequestChecks } from "@t3tools/contracts";
 
 export interface GitActionProgressReporter {
   readonly publish: (event: GitActionProgressEvent) => Effect.Effect<void, never>;
@@ -114,6 +114,7 @@ interface OpenPrInfo {
 interface PullRequestInfo extends OpenPrInfo, PullRequestHeadRemoteInfo {
   state: "open" | "closed" | "merged";
   updatedAt: Option.Option<DateTime.Utc>;
+  checks?: ChangeRequestChecks | null;
 }
 
 const pullRequestUpdatedAtDescOrder: Order.Order<PullRequestInfo> = Order.mapInput(
@@ -317,6 +318,7 @@ function toPullRequestInfo(summary: ChangeRequest): PullRequestInfo {
     ...(summary.headRepositoryOwnerLogin !== undefined
       ? { headRepositoryOwnerLogin: summary.headRepositoryOwnerLogin }
       : {}),
+    ...(summary.checks !== undefined ? { checks: summary.checks } : {}),
   };
 }
 
@@ -469,6 +471,7 @@ function toStatusPr(pr: PullRequestInfo): {
   baseRef: string;
   headRef: string;
   state: "open" | "closed" | "merged";
+  checks?: ChangeRequestChecks | null;
 } {
   return {
     number: pr.number,
@@ -477,6 +480,7 @@ function toStatusPr(pr: PullRequestInfo): {
     baseRef: pr.baseRefName,
     headRef: pr.headRefName,
     state: pr.state,
+    ...(pr.checks !== undefined ? { checks: pr.checks } : {}),
   };
 }
 

--- a/apps/server/src/sourceControl/GitHubCli.test.ts
+++ b/apps/server/src/sourceControl/GitHubCli.test.ts
@@ -81,11 +81,100 @@ describe("GitHubCli.layer", () => {
           "view",
           "#42",
           "--json",
-          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner,statusCheckRollup",
         ],
         cwd: "/repo",
         timeoutMs: 30_000,
       });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("derives a failing checks summary from statusCheckRollup", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              number: 42,
+              title: "Add PR thread creation",
+              url: "https://github.com/pingdotgg/codething-mvp/pull/42",
+              baseRefName: "main",
+              headRefName: "feature/pr-threads",
+              state: "OPEN",
+              mergedAt: null,
+              statusCheckRollup: [
+                { __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" },
+                { __typename: "CheckRun", status: "COMPLETED", conclusion: "FAILURE" },
+                { __typename: "StatusContext", state: "ERROR" },
+                { __typename: "CheckRun", status: "IN_PROGRESS", conclusion: null },
+              ],
+            }),
+          ),
+        ),
+      );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.getPullRequest({ cwd: "/repo", reference: "#42" });
+
+      assert.deepStrictEqual(result.checks, { state: "failing", failingCount: 2 });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("derives a pending checks summary when a run is still in progress", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              number: 42,
+              title: "Add PR thread creation",
+              url: "https://github.com/pingdotgg/codething-mvp/pull/42",
+              baseRefName: "main",
+              headRefName: "feature/pr-threads",
+              state: "OPEN",
+              mergedAt: null,
+              statusCheckRollup: [
+                { __typename: "CheckRun", status: "COMPLETED", conclusion: "SUCCESS" },
+                { __typename: "CheckRun", status: "IN_PROGRESS", conclusion: null },
+              ],
+            }),
+          ),
+        ),
+      );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.getPullRequest({ cwd: "/repo", reference: "#42" });
+
+      assert.deepStrictEqual(result.checks, { state: "pending", failingCount: 0 });
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("omits checks when statusCheckRollup is empty", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(
+        Effect.succeed(
+          processOutput(
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify({
+              number: 42,
+              title: "Add PR thread creation",
+              url: "https://github.com/pingdotgg/codething-mvp/pull/42",
+              baseRefName: "main",
+              headRefName: "feature/pr-threads",
+              state: "OPEN",
+              mergedAt: null,
+              statusCheckRollup: [],
+            }),
+          ),
+        ),
+      );
+
+      const gh = yield* GitHubCli.GitHubCli;
+      const result = yield* gh.getPullRequest({ cwd: "/repo", reference: "#42" });
+
+      expect(result.checks).toBeUndefined();
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/GitHubCli.ts
+++ b/apps/server/src/sourceControl/GitHubCli.ts
@@ -7,6 +7,7 @@ import * as SchemaIssue from "effect/SchemaIssue";
 
 import {
   TrimmedNonEmptyString,
+  type ChangeRequestChecks,
   type SourceControlRepositoryVisibility,
   type VcsError,
 } from "@t3tools/contracts";
@@ -36,6 +37,7 @@ export interface GitHubPullRequestSummary {
   readonly isCrossRepository?: boolean;
   readonly headRepositoryNameWithOwner?: string | null;
   readonly headRepositoryOwnerLogin?: string | null;
+  readonly checks?: ChangeRequestChecks | null;
 }
 
 export interface GitHubRepositoryCloneUrls {
@@ -255,7 +257,7 @@ export const make = Effect.fn("makeGitHubCli")(function* () {
           "--limit",
           String(input.limit ?? 1),
           "--json",
-          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner,statusCheckRollup",
         ],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
@@ -289,7 +291,7 @@ export const make = Effect.fn("makeGitHubCli")(function* () {
           "view",
           input.reference,
           "--json",
-          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner",
+          "number,title,url,baseRefName,headRefName,state,mergedAt,isCrossRepository,headRepository,headRepositoryOwner,statusCheckRollup",
         ],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -109,7 +109,7 @@ it.effect("uses gh json listing for non-open change request state queries", () =
       "--limit",
       "10",
       "--json",
-      "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+      "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner,statusCheckRollup",
     ]);
     assert.strictEqual(changeRequests[0]?.provider, "github");
     assert.strictEqual(changeRequests[0]?.state, "merged");

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -47,6 +47,7 @@ function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeReq
     ...(summary.headRepositoryOwnerLogin !== undefined
       ? { headRepositoryOwnerLogin: summary.headRepositoryOwnerLogin }
       : {}),
+    ...(summary.checks !== undefined ? { checks: summary.checks } : {}),
   };
 }
 
@@ -138,7 +139,7 @@ export const make = Effect.fn("makeGitHubSourceControlProvider")(function* () {
             "--limit",
             String(input.limit ?? 20),
             "--json",
-            "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+            "number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner,statusCheckRollup",
           ],
         })
         .pipe(

--- a/apps/server/src/sourceControl/gitHubPullRequests.ts
+++ b/apps/server/src/sourceControl/gitHubPullRequests.ts
@@ -4,7 +4,7 @@ import * as Exit from "effect/Exit";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
-import { PositiveInt, TrimmedNonEmptyString } from "@t3tools/contracts";
+import { PositiveInt, TrimmedNonEmptyString, type ChangeRequestChecks } from "@t3tools/contracts";
 import { decodeJsonResult, formatSchemaError } from "@t3tools/shared/schemaJson";
 
 export interface NormalizedGitHubPullRequestRecord {
@@ -18,6 +18,7 @@ export interface NormalizedGitHubPullRequestRecord {
   readonly isCrossRepository?: boolean;
   readonly headRepositoryNameWithOwner?: string | null;
   readonly headRepositoryOwnerLogin?: string | null;
+  readonly checks?: ChangeRequestChecks | null;
 }
 
 const GitHubPullRequestSchema = Schema.Struct({
@@ -44,7 +45,77 @@ const GitHubPullRequestSchema = Schema.Struct({
       }),
     ),
   ),
+  statusCheckRollup: Schema.optional(Schema.NullOr(Schema.Array(Schema.Unknown))),
 });
+
+const FAILING_CHECK_CONCLUSIONS = new Set([
+  "FAILURE",
+  "ERROR",
+  "CANCELLED",
+  "TIMED_OUT",
+  "ACTION_REQUIRED",
+  "STARTUP_FAILURE",
+]);
+const PENDING_CHECK_STATUSES = new Set([
+  "QUEUED",
+  "IN_PROGRESS",
+  "PENDING",
+  "WAITING",
+  "REQUESTED",
+]);
+
+function readUpperString(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value.trim().toUpperCase() : "";
+}
+
+/**
+ * Classify a single `statusCheckRollup` entry. Entries are either GitHub Actions
+ * `CheckRun`s (status + conclusion) or legacy `StatusContext`s (state).
+ */
+function classifyCheckRollupEntry(entry: unknown): "passing" | "failing" | "pending" {
+  if (typeof entry !== "object" || entry === null) {
+    return "pending";
+  }
+  const record = entry as Record<string, unknown>;
+  const state = readUpperString(record, "state");
+  if (state.length > 0) {
+    if (state === "FAILURE" || state === "ERROR") return "failing";
+    if (state === "SUCCESS") return "passing";
+    return "pending";
+  }
+  const conclusion = readUpperString(record, "conclusion");
+  if (FAILING_CHECK_CONCLUSIONS.has(conclusion)) return "failing";
+  const status = readUpperString(record, "status");
+  if (PENDING_CHECK_STATUSES.has(status)) return "pending";
+  if (conclusion.length === 0) return "pending";
+  return "passing";
+}
+
+/**
+ * Derive an overall CI summary from a `statusCheckRollup` array. Returns null
+ * when there are no checks (no CI configured), so the UI renders nothing.
+ */
+function deriveChecksSummary(
+  rollup: ReadonlyArray<unknown> | null | undefined,
+): ChangeRequestChecks | null {
+  if (!rollup || rollup.length === 0) {
+    return null;
+  }
+  let failingCount = 0;
+  let anyPending = false;
+  for (const entry of rollup) {
+    const classification = classifyCheckRollupEntry(entry);
+    if (classification === "failing") {
+      failingCount += 1;
+    } else if (classification === "pending") {
+      anyPending = true;
+    }
+  }
+  if (failingCount > 0) return { state: "failing", failingCount };
+  if (anyPending) return { state: "pending", failingCount: 0 };
+  return { state: "passing", failingCount: 0 };
+}
 
 function trimOptionalString(value: string | null | undefined): string | null {
   const trimmed = value?.trim() ?? "";
@@ -77,6 +148,7 @@ function normalizeGitHubPullRequestRecord(
     (typeof headRepositoryNameWithOwner === "string" && headRepositoryNameWithOwner.includes("/")
       ? (headRepositoryNameWithOwner.split("/")[0] ?? null)
       : null);
+  const checks = deriveChecksSummary(raw.statusCheckRollup);
 
   return {
     number: raw.number,
@@ -91,6 +163,7 @@ function normalizeGitHubPullRequestRecord(
       : {}),
     ...(headRepositoryNameWithOwner ? { headRepositoryNameWithOwner } : {}),
     ...(headRepositoryOwnerLogin ? { headRepositoryOwnerLogin } : {}),
+    ...(checks ? { checks } : {}),
   };
 }
 

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -3,7 +3,6 @@ import type { EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { ChevronDownIcon, GitBranchIcon, SearchIcon } from "lucide-react";
 import {
-  type MouseEvent,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -17,7 +16,7 @@ import {
 
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
 import { readEnvironmentApi } from "../environmentApi";
-import { readLocalApi } from "../localApi";
+import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { useVcsStatus } from "../lib/vcsStatusState";
 import { useVcsRefs, vcsRefManager } from "../lib/vcsRefState";
 import { newCommandId } from "../lib/utils";
@@ -524,38 +523,13 @@ export function BranchToolbarBranchSelector({
 
   // PR pill shown next to the branch selector when the active branch has one.
   const branchPr = resolveThreadPr(resolvedActiveBranch, branchStatusQuery.data ?? null);
-  const branchPrStatus = prStatusIndicator(
-    branchPr,
-    branchStatusQuery.data?.sourceControlProvider,
-  );
+  const branchPrStatus = prStatusIndicator(branchPr, branchStatusQuery.data?.sourceControlProvider);
   // Action-oriented tooltip (the pill opens the PR), distinct from the sidebar's
   // state-description tooltip.
   const branchPrTooltip = branchPr
     ? `Open ${sourceControlPresentation.terminology.singular} #${branchPr.number} (${branchPr.state}) in browser`
     : "";
-  const openPrLink = useCallback((event: MouseEvent<HTMLElement>, prUrl: string) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    const api = readLocalApi();
-    if (!api) {
-      toastManager.add({
-        type: "error",
-        title: "Link opening is unavailable.",
-      });
-      return;
-    }
-
-    void api.shell.openExternal(prUrl).catch((error) => {
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Unable to open pull request link",
-          description: error instanceof Error ? error.message : "An error occurred.",
-        }),
-      );
-    });
-  }, []);
+  const openPrLink = useOpenPrLink();
 
   function renderPickerItem(itemValue: string, index: number) {
     if (checkoutPullRequestItemValue && itemValue === checkoutPullRequestItemValue) {

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -35,6 +35,8 @@ import {
 } from "./BranchToolbar.logic";
 import {
   ChangeRequestStatusIcon,
+  ChecksStatusIcon,
+  checksStatusIndicator,
   prStatusIndicator,
   resolveThreadPr,
 } from "./ThreadStatusIndicators";
@@ -529,6 +531,16 @@ export function BranchToolbarBranchSelector({
   const branchPrTooltip = branchPr
     ? `Open ${sourceControlPresentation.terminology.singular} #${branchPr.number} (${branchPr.state}) in browser`
     : "";
+  // CI status chip shown next to the PR pill when the PR has checks.
+  const branchPrChecks = checksStatusIndicator(branchPr?.checks);
+  const branchPrChecksUrl = branchPr ? `${branchPr.url}/checks` : "";
+  // For an open PR with CI, color the pill by the check status too (red/amber/green)
+  // so the whole PR cluster reflects health at a glance. Otherwise keep the PR
+  // state color (merged = violet, closed = gray).
+  const branchPrPillColorClass =
+    branchPr?.state === "open" && branchPrChecks
+      ? branchPrChecks.colorClass
+      : branchPrStatus?.colorClass;
   const openPrLink = useOpenPrLink();
 
   function renderPickerItem(itemValue: string, index: number) {
@@ -638,7 +650,7 @@ export function BranchToolbarBranchSelector({
                   onClick={(event) => openPrLink(event, branchPrStatus.url)}
                   className={cn(
                     "inline-flex shrink-0 items-center gap-0.5 rounded px-1 py-0.5 text-[11px] font-medium tabular-nums transition-colors hover:bg-muted/60",
-                    branchPrStatus.colorClass,
+                    branchPrPillColorClass,
                   )}
                 />
               }
@@ -647,6 +659,26 @@ export function BranchToolbarBranchSelector({
               <span>#{branchPr.number}</span>
             </TooltipTrigger>
             <TooltipPopup side="top">{branchPrTooltip}</TooltipPopup>
+          </Tooltip>
+        ) : null}
+        {branchPr && branchPrChecks ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  aria-label={branchPrChecks.tooltip}
+                  onClick={(event) => openPrLink(event, branchPrChecksUrl)}
+                  className={cn(
+                    "inline-flex shrink-0 items-center rounded px-1 py-0.5 transition-colors hover:bg-muted/60",
+                    branchPrChecks.colorClass,
+                  )}
+                />
+              }
+            >
+              <ChecksStatusIcon state={branchPrChecks.state} className="size-3" />
+            </TooltipTrigger>
+            <TooltipPopup side="top">{branchPrChecks.tooltip}</TooltipPopup>
           </Tooltip>
         ) : null}
         <ComboboxTrigger

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -3,6 +3,7 @@ import type { EnvironmentId, VcsRef, ThreadId } from "@t3tools/contracts";
 import { LegendList, type LegendListRef } from "@legendapp/list/react";
 import { ChevronDownIcon, GitBranchIcon, SearchIcon } from "lucide-react";
 import {
+  type MouseEvent,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -16,6 +17,7 @@ import {
 
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
 import { readEnvironmentApi } from "../environmentApi";
+import { readLocalApi } from "../localApi";
 import { useVcsStatus } from "../lib/vcsStatusState";
 import { useVcsRefs, vcsRefManager } from "../lib/vcsRefState";
 import { newCommandId } from "../lib/utils";
@@ -32,6 +34,11 @@ import {
   resolveEffectiveEnvMode,
   shouldIncludeBranchPickerItem,
 } from "./BranchToolbar.logic";
+import {
+  ChangeRequestStatusIcon,
+  prStatusIndicator,
+  resolveThreadPr,
+} from "./ThreadStatusIndicators";
 import { Button } from "./ui/button";
 import {
   Combobox,
@@ -44,6 +51,7 @@ import {
   ComboboxTrigger,
 } from "./ui/combobox";
 import { stackedThreadToast, toastManager } from "./ui/toast";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 
 interface BranchToolbarBranchSelectorProps {
   className?: string;
@@ -514,6 +522,41 @@ export function BranchToolbarBranchSelector({
     resolvedActiveBranch,
   });
 
+  // PR pill shown next to the branch selector when the active branch has one.
+  const branchPr = resolveThreadPr(resolvedActiveBranch, branchStatusQuery.data ?? null);
+  const branchPrStatus = prStatusIndicator(
+    branchPr,
+    branchStatusQuery.data?.sourceControlProvider,
+  );
+  // Action-oriented tooltip (the pill opens the PR), distinct from the sidebar's
+  // state-description tooltip.
+  const branchPrTooltip = branchPr
+    ? `Open ${sourceControlPresentation.terminology.singular} #${branchPr.number} (${branchPr.state}) in browser`
+    : "";
+  const openPrLink = useCallback((event: MouseEvent<HTMLElement>, prUrl: string) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const api = readLocalApi();
+    if (!api) {
+      toastManager.add({
+        type: "error",
+        title: "Link opening is unavailable.",
+      });
+      return;
+    }
+
+    void api.shell.openExternal(prUrl).catch((error) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Unable to open pull request link",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    });
+  }, []);
+
   function renderPickerItem(itemValue: string, index: number) {
     if (checkoutPullRequestItemValue && itemValue === checkoutPullRequestItemValue) {
       return (
@@ -610,15 +653,38 @@ export function BranchToolbarBranchSelector({
       open={isBranchMenuOpen}
       value={resolvedActiveBranch}
     >
-      <ComboboxTrigger
-        render={<Button variant="ghost" size="xs" />}
-        className={cn("min-w-0 text-muted-foreground/70 hover:text-foreground/80", className)}
-        disabled={isInitialBranchesLoadPending || isBranchActionPending}
-      >
-        <GitBranchIcon className="size-3 shrink-0 opacity-70" />
-        <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
-        <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
-      </ComboboxTrigger>
+      <div className={cn("flex min-w-0 items-center gap-1", className)}>
+        {branchPr && branchPrStatus ? (
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  aria-label={branchPrTooltip}
+                  onClick={(event) => openPrLink(event, branchPrStatus.url)}
+                  className={cn(
+                    "inline-flex shrink-0 items-center gap-0.5 rounded px-1 py-0.5 text-[11px] font-medium tabular-nums transition-colors hover:bg-muted/60",
+                    branchPrStatus.colorClass,
+                  )}
+                />
+              }
+            >
+              <ChangeRequestStatusIcon className="size-3" />
+              <span>#{branchPr.number}</span>
+            </TooltipTrigger>
+            <TooltipPopup side="top">{branchPrTooltip}</TooltipPopup>
+          </Tooltip>
+        ) : null}
+        <ComboboxTrigger
+          render={<Button variant="ghost" size="xs" />}
+          className="min-w-0 text-muted-foreground/70 hover:text-foreground/80"
+          disabled={isInitialBranchesLoadPending || isBranchActionPending}
+        >
+          <GitBranchIcon className="size-3 shrink-0 opacity-70" />
+          <span className="min-w-0 max-w-[240px] truncate">{triggerLabel}</span>
+          <ChevronDownIcon className="size-3 shrink-0 opacity-50" />
+        </ComboboxTrigger>
+      </div>
       <ComboboxPopup align="end" side="top" className="flex w-80 flex-col">
         <div className="shrink-0 px-3 pt-2.5">
           <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -63,6 +63,7 @@ import {
 import { usePrimaryEnvironmentId } from "../environments/primary";
 import { isElectron } from "../env";
 import { APP_STAGE_LABEL, APP_VERSION } from "../branding";
+import { useOpenPrLink } from "../lib/openPullRequestLink";
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { isMacPlatform, newCommandId } from "../lib/utils";
 import {
@@ -1011,29 +1012,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       );
     },
   });
-  const openPrLink = useCallback((event: React.MouseEvent<HTMLElement>, prUrl: string) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    const api = readLocalApi();
-    if (!api) {
-      toastManager.add({
-        type: "error",
-        title: "Link opening is unavailable.",
-      });
-      return;
-    }
-
-    void api.shell.openExternal(prUrl).catch((error) => {
-      toastManager.add(
-        stackedThreadToast({
-          type: "error",
-          title: "Unable to open pull request link",
-          description: error instanceof Error ? error.message : "An error occurred.",
-        }),
-      );
-    });
-  }, []);
+  const openPrLink = useOpenPrLink();
   const sidebarThreads = useStore(
     useShallow(
       useMemo(

--- a/apps/web/src/components/ThreadStatusIndicators.tsx
+++ b/apps/web/src/components/ThreadStatusIndicators.tsx
@@ -1,6 +1,13 @@
 import { scopeProjectRef, scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime";
 import type { VcsStatusResult } from "@t3tools/contracts";
-import { CloudIcon, GitPullRequestIcon, TerminalIcon } from "lucide-react";
+import {
+  CheckIcon,
+  CloudIcon,
+  GitPullRequestIcon,
+  LoaderCircleIcon,
+  TerminalIcon,
+  XIcon,
+} from "lucide-react";
 import { useMemo } from "react";
 import { usePrimaryEnvironmentId } from "../environments/primary";
 import {
@@ -67,6 +74,63 @@ export function prStatusIndicator(
 
 export function ChangeRequestStatusIcon({ className }: { className?: string }) {
   return <GitPullRequestIcon className={className} />;
+}
+
+export type ThreadChecks = NonNullable<ThreadPr>["checks"];
+
+export interface ChecksStatusIndicator {
+  state: "passing" | "failing" | "pending";
+  colorClass: string;
+  tooltip: string;
+}
+
+/**
+ * Maps a change request's rolled-up CI summary to a small chip's color and
+ * tooltip. Returns null when there are no checks (or no PR) so the caller
+ * renders nothing.
+ */
+export function checksStatusIndicator(
+  checks: ThreadChecks | null | undefined,
+): ChecksStatusIndicator | null {
+  if (!checks) return null;
+  if (checks.state === "failing") {
+    const count = checks.failingCount;
+    const summary =
+      count > 0 ? `${count} failing check${count === 1 ? "" : "s"}` : "Some checks failed";
+    return {
+      state: "failing",
+      colorClass: "text-red-600 dark:text-red-400/90",
+      tooltip: `CI: ${summary} (click to view)`,
+    };
+  }
+  if (checks.state === "pending") {
+    return {
+      state: "pending",
+      colorClass: "text-amber-600 dark:text-amber-400/90",
+      tooltip: "CI: checks running (click to view)",
+    };
+  }
+  return {
+    state: "passing",
+    colorClass: "text-emerald-600 dark:text-emerald-300/90",
+    tooltip: "CI: all checks passed (click to view)",
+  };
+}
+
+export function ChecksStatusIcon({
+  state,
+  className,
+}: {
+  state: ChecksStatusIndicator["state"];
+  className?: string;
+}) {
+  if (state === "failing") {
+    return <XIcon className={className} />;
+  }
+  if (state === "pending") {
+    return <LoaderCircleIcon className={`${className ?? ""} animate-spin`} />;
+  }
+  return <CheckIcon className={className} />;
 }
 
 export function resolveThreadPr(

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -1,0 +1,37 @@
+import { type MouseEvent, useCallback } from "react";
+
+import { stackedThreadToast, toastManager } from "../components/ui/toast";
+import { readLocalApi } from "../localApi";
+
+/**
+ * Returns a click handler that opens a pull request URL in the system browser.
+ *
+ * Stops event propagation/default so activating the link does not also trigger
+ * an enclosing row or trigger (e.g. opening the branch dropdown), and surfaces a
+ * toast when the local API is unavailable or the open fails.
+ */
+export function useOpenPrLink() {
+  return useCallback((event: MouseEvent<HTMLElement>, prUrl: string) => {
+    event.preventDefault();
+    event.stopPropagation();
+
+    const api = readLocalApi();
+    if (!api) {
+      toastManager.add({
+        type: "error",
+        title: "Link opening is unavailable.",
+      });
+      return;
+    }
+
+    void api.shell.openExternal(prUrl).catch((error) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Unable to open pull request link",
+          description: error instanceof Error ? error.message : "An error occurred.",
+        }),
+      );
+    });
+  }, []);
+}

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -1,6 +1,10 @@
 import * as Schema from "effect/Schema";
 import { NonNegativeInt, PositiveInt, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
-import { SourceControlProviderError, SourceControlProviderInfo } from "./sourceControl.ts";
+import {
+  ChangeRequestChecks,
+  SourceControlProviderError,
+  SourceControlProviderInfo,
+} from "./sourceControl.ts";
 import { VcsDriverKind } from "./vcs.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
@@ -193,6 +197,7 @@ const VcsStatusChangeRequest = Schema.Struct({
   baseRef: TrimmedNonEmptyStringSchema,
   headRef: TrimmedNonEmptyStringSchema,
   state: VcsStatusChangeRequestState,
+  checks: Schema.optional(Schema.NullOr(ChangeRequestChecks)),
 });
 
 const VcsStatusLocalShape = {

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -1,5 +1,5 @@
 import * as Schema from "effect/Schema";
-import { PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { NonNegativeInt, PositiveInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { VcsDriverKind } from "./vcs.ts";
 
 export const SourceControlProviderKind = Schema.Literals([
@@ -21,6 +21,19 @@ export type SourceControlProviderInfo = typeof SourceControlProviderInfo.Type;
 export const ChangeRequestState = Schema.Literals(["open", "closed", "merged"]);
 export type ChangeRequestState = typeof ChangeRequestState.Type;
 
+export const ChangeRequestChecksState = Schema.Literals(["passing", "failing", "pending"]);
+export type ChangeRequestChecksState = typeof ChangeRequestChecksState.Type;
+
+/**
+ * Rolled-up CI status for a change request, derived from the provider's check
+ * runs / status contexts. `failingCount` is only meaningful when failing.
+ */
+export const ChangeRequestChecks = Schema.Struct({
+  state: ChangeRequestChecksState,
+  failingCount: NonNegativeInt,
+});
+export type ChangeRequestChecks = typeof ChangeRequestChecks.Type;
+
 export const ChangeRequest = Schema.Struct({
   provider: SourceControlProviderKind,
   number: PositiveInt,
@@ -33,6 +46,7 @@ export const ChangeRequest = Schema.Struct({
   isCrossRepository: Schema.optional(Schema.Boolean),
   headRepositoryNameWithOwner: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   headRepositoryOwnerLogin: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  checks: Schema.optional(Schema.NullOr(ChangeRequestChecks)),
 });
 export type ChangeRequest = typeof ChangeRequest.Type;
 


### PR DESCRIPTION
## What

Adds a CI (checks) status indicator to the composer branch bar so you can see at a glance whether the current branch's PR is green, red, or still running.

- A small chip sits next to the PR pill: green check (all passed), red x (N failing), or amber spinner (running). It renders nothing when the PR has no CI or there is no PR.
- The PR pill itself is now colored by check status for an open PR (red / amber / green), falling back to the PR-state color for merged (violet) and closed (gray).
- Hovering the chip shows a tooltip ("CI: 1 failing check (click to view)", "CI: checks running...", "CI: all checks passed..."). Clicking opens the PR's `/checks` page in the browser.

## How

`statusCheckRollup` is added to the existing `gh pr view/list --json` calls (no extra round-trip). An overall summary is derived (failing if any conclusion is FAILURE/ERROR/CANCELLED/TIMED_OUT; pending if any check is queued/in-progress/unconcluded; else passing) with a failure count for the tooltip. It is threaded through the source control provider, contracts (`ChangeRequestChecks` on `ChangeRequest` and the VCS status PR), and `GitManager` into the UI. It reuses the existing VCS status refresh cadence, so there is no new polling. An empty/absent rollup yields `null` and never an error chip. Fork PRs work since the rollup is on the PR regardless of head repo.

## Screenshots

Failing PR (#3087) -> red pill + red x, tooltip:

![failing](https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets-ci-status/ci-status-failing.png)

Passing PR (#3082) -> green pill + green check, tooltip:

![passing](https://raw.githubusercontent.com/TheIcarusWings/t3code/pr-assets-ci-status/ci-status-passing.png)

Verified live by pointing the composer at branches with real open PRs and confirming the chip reflects passing/failing and opens the checks page. The amber "running" state is produced by the same code path (any in-progress/queued check); it was not captured live because no open PR had a check still running at the time.

## Notes

- Stacked on #3065 (the clickable PR pill). The first two commits here belong to that PR; review/merge this after #3065.
- Tests: added derivation tests (failing/pending/empty) and updated the `--json` field-list assertions. Typecheck, server tests, lint, and format all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only enrichment of existing gh JSON and UI indicators; no auth, persistence, or git workflow behavior changes.
> 
> **Overview**
> Adds **rolled-up CI status** for the active branch’s PR in the composer branch bar, without extra GitHub API calls.
> 
> **Backend:** Existing `gh pr view` / `gh pr list --json` requests now include `statusCheckRollup`. `gitHubPullRequests` classifies each rollup entry (CheckRun vs StatusContext) into passing, failing, or pending and exposes a `ChangeRequestChecks` summary (`state` + `failingCount`). That field is threaded through contracts (`ChangeRequest`, VCS status PR), `GitHubSourceControlProvider`, and `GitManager` status output. Empty rollups omit `checks` entirely.
> 
> **UI:** The branch toolbar shows a clickable PR pill plus a CI chip (green check / red X / amber spinner) when checks exist. Open PR pills tint by CI health; merged/closed keep state colors. Clicks open the PR or `{prUrl}/checks` via a shared `useOpenPrLink` hook (also used from the sidebar).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e32e181f3fdac854e0b1958e8aa32fcd7f5c0bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show CI status next to the PR pill in the branch toolbar
> - Adds a `ChangeRequestChecks` contract type (state + failing count) and propagates it from GitHub's `statusCheckRollup` through the provider, `GitManager`, and VCS status schemas.
> - Derives the rollup by classifying each check entry as passing, failing, or pending via `deriveChecksSummary` in [gitHubPullRequests.ts](https://github.com/pingdotgg/t3code/pull/3088/files#diff-19c412897b99cf24f2ab95ecba3ef18038a513a5a24faea301b9571fee961af1).
> - Renders a new CI checks chip next to the PR pill in [BranchToolbarBranchSelector.tsx](https://github.com/pingdotgg/t3code/pull/3088/files#diff-95e72064c321265e2363abda12fd803f217db7d06a32a076ea7337d942367734); the chip shows a pass/fail/pending icon, a tooltip, and links to the PR's checks page.
> - Extracts a shared `useOpenPrLink` hook in [openPullRequestLink.ts](https://github.com/pingdotgg/t3code/pull/3088/files#diff-953140e01f1329a36fe8f5606c9027215b588e76537644ab9819a9a618d000ae) for consistent PR URL opening with error toasts, replacing the previous inline callback in the sidebar.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e32e18.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->