### PR TITLE
[codex] Fix first browser annotation capture

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -189,6 +189,55 @@ describe("PreviewManager", () => {
     ),
   );
 
+  effectIt.effect("keeps element picking active during subframe navigation", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const listeners = new Map<string, (...args: unknown[]) => void>();
+        fromId.mockReturnValue({
+          id: 42,
+          isDestroyed: () => false,
+          getType: () => "webview",
+          getURL: () => "https://example.com",
+          getTitle: () => "Example",
+          isLoading: () => false,
+          isFocused: () => true,
+          getZoomFactor: () => 1,
+          setZoomFactor: vi.fn(),
+          on: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+            listeners.set(event, listener);
+          }),
+          once: vi.fn((event: string, listener: (...args: unknown[]) => void) => {
+            listeners.set(event, listener);
+          }),
+          off: vi.fn(),
+          ipc: { on: vi.fn(), off: vi.fn(), removeListener: vi.fn() },
+          send: webviewSend,
+          navigationHistory: { canGoBack: () => false, canGoForward: () => false },
+          setWindowOpenHandler: vi.fn(),
+          debugger: {
+            isAttached: () => false,
+            attach: vi.fn(),
+            sendCommand: vi.fn(async () => undefined),
+            on: vi.fn(),
+            off: vi.fn(),
+          },
+        } as never);
+
+        yield* manager.createTab("tab_1");
+        yield* manager.registerWebview("tab_1", 42);
+        const pick = yield* manager.pickElement("tab_1").pipe(Effect.forkChild);
+        yield* Effect.yieldNow;
+
+        listeners.get("did-start-navigation")?.({}, "about:blank", false, false);
+        yield* Effect.yieldNow;
+        expect(pick.pollUnsafe()).toBeUndefined();
+
+        listeners.get("did-start-navigation")?.({}, "https://example.com/next", false, true);
+        expect(yield* Fiber.join(pick)).toBeNull();
+      }),
+    ),
+  );
+
   effectIt.effect("reveals only files inside the configured browser artifact directory", () =>
     withManager((manager) =>
       Effect.gen(function* () {

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -1344,7 +1344,14 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
           );
         };
         const onDestroyed = () => settle(null);
-        const onNavigated = () => settle(null);
+        const onNavigated = (
+          _event: Electron.Event,
+          _url: string,
+          _isInPlace: boolean,
+          isMainFrame: boolean,
+        ) => {
+          if (isMainFrame) settle(null);
+        };
         const registerPickElement = Effect.fn("PreviewManager.registerPickElement")(function* () {
           yield* attempt("pickElement.register", () => {
             wc.ipc.on(ELEMENT_PICKED_CHANNEL, onMessage);


### PR DESCRIPTION
## Summary

- keep browser annotation picking active during subframe navigation
- continue canceling an active pick when the main frame actually navigates
- add regression coverage for both behaviors

## Root cause

On the first annotation metadata capture, `react-grab` creates a hidden `about:blank` iframe to calculate baseline styles. Electron emits `did-start-navigation` for that subframe, but the preview manager treated every frame navigation as a main-page navigation and canceled the active picker. The preload then remained in the `Capturing…` state. Later attempts worked because `react-grab` reused its initialized style context.

## Impact

The first browser annotation attachment now completes normally without appearing to reload the inspected page or becoming stuck. Real main-frame navigations still cancel the picker as intended.

## Validation

- `vp test run apps/desktop/src/preview/Manager.test.ts`
- `vp run --filter @t3tools/desktop typecheck`
- `vp check`
- `vp run typecheck`

`vp check` reports the repository's existing 11 unrelated React nested-component warnings and no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to pick-session cancellation in preview Manager; behavior for real main-frame navigations is unchanged and covered by a new unit test.
> 
> **Overview**
> Fixes **first browser annotation capture** getting stuck in “Capturing…” because `pickElement` treated every `did-start-navigation` as a page leave and called `settle(null)`. Subframe navigations—such as `react-grab`’s hidden `about:blank` iframe during style baseline—no longer end the session; **main-frame** navigations still cancel the picker as before.
> 
> `PreviewManager.pickElement`’s `onNavigated` handler now reads Electron’s `isMainFrame` flag and only settles when it is true.
> 
> Adds a regression test in `Manager.test.ts` that simulates subframe vs main-frame `did-start-navigation` while a pick fiber is active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b801cbb271b92059a92814fdea5d24d67605bf45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->