### PR TITLE
[codex] Fix terminal line height for QR readability

### DIFF
--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -339,7 +339,7 @@ export function TerminalViewport({
     const fitAddon = new FitAddon();
     const terminal = new Terminal({
       cursorBlink: true,
-      lineHeight: 1.2,
+      lineHeight: 1,
       fontSize: 12,
       scrollback: 5_000,
       fontFamily:


### PR DESCRIPTION
## Summary

- Set the web terminal xterm `lineHeight` from `1.2` to `1`
- Improves readability of dense terminal output such as Expo QR codes

## Why

The extra row spacing made terminal-rendered QR codes harder for phone cameras to scan. Using the default compact terminal line height keeps QR blocks aligned more tightly.

Closes #336.

## Validation

- `vp check`
- `vp run typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix terminal line height in `TerminalViewport` for QR code readability
> Reduces the `lineHeight` in the xterm.js terminal options from `1.2` to `1` in [ThreadTerminalDrawer.tsx](https://github.com/pingdotgg/t3code/pull/3096/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636). This tightens vertical spacing so that QR codes rendered in the terminal display correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d38638e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single display option tweak in the web terminal UI with no auth, data, or backend impact.
> 
> **Overview**
> The thread terminal’s xterm instance in **`TerminalViewport`** (`ThreadTerminalDrawer`) now uses **`lineHeight: 1`** instead of **`1.2`**, so rows render with tighter vertical spacing.
> 
> That change targets dense ASCII output (e.g. Expo QR codes) so block characters stay square and are easier for phone cameras to scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d38638e95bf3ec83726d12df70d94ee318839e17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->