### PR TITLE
[codex] fix: show nightly badge from primary web server version

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -14,6 +14,7 @@ import {
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
+  resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
   resolveThreadStatusPill,
   shouldClearThreadSelectionOnMouseDown,
@@ -35,6 +36,44 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("resolveSidebarStageBadgeLabel", () => {
+  it("returns Nightly for nightly primary server versions", () => {
+    expect(
+      resolveSidebarStageBadgeLabel({
+        primaryServerVersion: "0.0.28-nightly.20260616.12",
+        fallbackStageLabel: "Alpha",
+      }),
+    ).toBe("Nightly");
+  });
+
+  it("returns the fallback label for stable primary server versions", () => {
+    expect(
+      resolveSidebarStageBadgeLabel({
+        primaryServerVersion: "0.0.27",
+        fallbackStageLabel: "Alpha",
+      }),
+    ).toBe("Alpha");
+  });
+
+  it("returns the fallback label when the primary server version is missing", () => {
+    expect(
+      resolveSidebarStageBadgeLabel({
+        primaryServerVersion: null,
+        fallbackStageLabel: "Dev",
+      }),
+    ).toBe("Dev");
+  });
+
+  it("returns the fallback label for malformed nightly prerelease versions", () => {
+    expect(
+      resolveSidebarStageBadgeLabel({
+        primaryServerVersion: "0.0.28-nightly.20260616",
+        fallbackStageLabel: "Alpha",
+      }),
+    ).toBe("Alpha");
+  });
+});
 
 function makeLatestTurn(overrides?: {
   completedAt?: string | null;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -12,6 +12,7 @@ import { isLatestTurnSettled } from "../session-logic";
 
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
+const NIGHTLY_SERVER_VERSION_PATTERN = /-nightly\.\d{8}\.\d+$/;
 // Visible sidebar rows are prewarmed into the thread-detail cache so opening a
 // nearby thread usually reuses an already-hot subscription.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
@@ -62,6 +63,16 @@ type ThreadStatusInput = Pick<
 export interface ThreadJumpHintVisibilityController {
   sync: (shouldShow: boolean) => void;
   dispose: () => void;
+}
+
+export function resolveSidebarStageBadgeLabel(input: {
+  primaryServerVersion: string | null | undefined;
+  fallbackStageLabel: string;
+}): string {
+  return input.primaryServerVersion &&
+    NIGHTLY_SERVER_VERSION_PATTERN.test(input.primaryServerVersion)
+    ? "Nightly"
+    : input.fallbackStageLabel;
 }
 
 export function createThreadJumpHintVisibilityController(input: {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -188,6 +188,7 @@ import {
   orderItemsByPreferredIds,
   shouldClearThreadSelectionOnMouseDown,
   sortProjectsForSidebar,
+  resolveSidebarStageBadgeLabel,
   useThreadJumpHintVisibility,
   ThreadStatusPill,
 } from "./Sidebar.logic";
@@ -197,7 +198,7 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useSettings, useUpdateSettings } from "~/hooks/useSettings";
-import { primaryServerKeybindingsAtom } from "../state/server";
+import { primaryServerConfigAtom, primaryServerKeybindingsAtom } from "../state/server";
 import {
   derivePhysicalProjectKey,
   deriveProjectGroupingOverrideKey,
@@ -2680,6 +2681,12 @@ const SidebarChromeHeader = memo(function SidebarChromeHeader({
 }: {
   isElectron: boolean;
 }) {
+  const primaryServerVersion =
+    useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
+  const stageBadgeLabel = resolveSidebarStageBadgeLabel({
+    primaryServerVersion,
+    fallbackStageLabel: APP_STAGE_LABEL,
+  });
   const wordmark = (
     <div className="flex items-center gap-2">
       <SidebarTrigger className="shrink-0 md:hidden" />
@@ -2696,7 +2703,7 @@ const SidebarChromeHeader = memo(function SidebarChromeHeader({
                 Code
               </span>
               <span className="rounded-full bg-muted/50 px-1.5 py-0.5 text-[8px] font-medium uppercase tracking-[0.18em] text-muted-foreground/60">
-                {APP_STAGE_LABEL}
+                {stageBadgeLabel}
               </span>
             </Link>
           }


### PR DESCRIPTION
## Summary

- Derive the web sidebar stage badge from the primary server version exposed by `useServerConfig()`.
- Show `Nightly` for primary server versions matching the nightly release pattern, while preserving the existing fallback label for stable/dev builds.
- Add focused coverage for nightly, stable, missing, and malformed server versions.

## Root cause

The sidebar rendered the static client-side `APP_STAGE_LABEL`, so a web UI served by a nightly primary server could still display the stable fallback label `Alpha`.

## Impact

The top-left web sidebar badge now reflects the primary T3 server that served the web UI. It does not follow selected or connected remote environments.

## UI Changes

### Before
<img width="327" height="89" alt="image" src="https://github.com/user-attachments/assets/baaf9299-0126-4ddd-ad38-ba231e15a54e" />

### After
<img width="512" height="117" alt="image" src="https://github.com/user-attachments/assets/ec63dcb7-57b6-492f-ac82-dba3525c81bf" />


## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp test run apps/web/src/components/Sidebar.logic.test.ts`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

`vp check` reports the repository's existing `react(no-unstable-nested-components)` warnings and no errors.

Closes #3102

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show 'Nightly' badge in sidebar when primary server version is a nightly build
> Adds `resolveSidebarStageBadgeLabel` in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/3103/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) that returns `'Nightly'` when the primary server version matches the pattern `-nightly.<8 digits>.<digits>`, otherwise falls back to `APP_STAGE_LABEL`. The `SidebarChromeHeader` component now reads `primaryServerConfigAtom` to compute this label and displays it in the wordmark badge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a76316.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated UI labeling change in the sidebar header with no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes the web sidebar wordmark badge showing a static client `APP_STAGE_LABEL` (e.g. **Alpha**) even when the UI is served by a nightly primary server.
> 
> Adds **`resolveSidebarStageBadgeLabel`** in `Sidebar.logic.ts`, which returns **Nightly** when `primaryServerVersion` matches `-nightly.<8 digits>.<digits>` at the end of the string; stable, missing, or malformed versions still use the fallback label. **`SidebarChromeHeader`** reads `primaryServerConfigAtom` → `environment.serverVersion` and renders that label instead of always using `APP_STAGE_LABEL`.
> 
> Unit tests cover nightly, stable, null, and malformed nightly strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a763160eb9d56eb37172a467a2995318b1903f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->