### PR TITLE
Reconcile stopped provider session projections

### DIFF
--- a/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.test.ts
@@ -18,6 +18,10 @@ import * as Stream from "effect/Stream";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import {
+  OrchestrationEngineService,
+  type OrchestrationEngineShape,
+} from "../../orchestration/Services/OrchestrationEngine.ts";
 import { SqlitePersistenceMemory } from "../../persistence/Layers/Sqlite.ts";
 import { ProviderSessionRuntimeRepositoryLive } from "../../persistence/Layers/ProviderSessionRuntime.ts";
 import { ProviderSessionRuntimeRepository } from "../../persistence/Services/ProviderSessionRuntime.ts";
@@ -118,7 +122,7 @@ function makeReadModel(
 
 describe("ProviderSessionReaper", () => {
   let runtime: ManagedRuntime.ManagedRuntime<
-    ProviderSessionReaper | ProviderSessionRuntimeRepository,
+    ProviderSessionReaper | ProviderSessionRuntimeRepository | OrchestrationEngineService,
     unknown
   > | null = null;
   let scope: Scope.Closeable | null = null;
@@ -141,6 +145,9 @@ describe("ProviderSessionReaper", () => {
     }) => ReturnType<ProviderServiceShape["stopSession"]>;
   }) {
     const stoppedThreadIds = new Set<ThreadId>();
+    const dispatch = vi.fn<OrchestrationEngineShape["dispatch"]>(() =>
+      Effect.succeed({ sequence: 1 }),
+    );
     const stopSession = vi.fn<ProviderServiceShape["stopSession"]>(
       (request) =>
         (input.stopSessionImplementation
@@ -190,6 +197,13 @@ describe("ProviderSessionReaper", () => {
       Layer.provideMerge(runtimeRepositoryLayer),
       Layer.provideMerge(Layer.succeed(ProviderService, providerService)),
       Layer.provideMerge(
+        Layer.succeed(OrchestrationEngineService, {
+          dispatch,
+          readEvents: () => Stream.empty,
+          streamDomainEvents: Stream.empty,
+        }),
+      ),
+      Layer.provideMerge(
         Layer.succeed(ProjectionSnapshotQuery, {
           getCommandReadModel: () => Effect.die("unused"),
           getSnapshot: () => Effect.die("unused"),
@@ -216,7 +230,7 @@ describe("ProviderSessionReaper", () => {
     );
 
     runtime = ManagedRuntime.make(layer);
-    return { stopSession, stoppedThreadIds };
+    return { dispatch, stopSession, stoppedThreadIds };
   }
 
   it("reaps stale persisted sessions without active turns", async () => {
@@ -404,8 +418,69 @@ describe("ProviderSessionReaper", () => {
     await Effect.runPromise(drainFibers);
 
     expect(harness.stopSession).not.toHaveBeenCalled();
+    expect(harness.dispatch).not.toHaveBeenCalled();
     const remaining = await runtime!.runPromise(repository.getByThreadId({ threadId }));
     expect(Option.isSome(remaining)).toBe(true);
+  });
+
+  it("reconciles stopped persisted sessions that still project as running", async () => {
+    const threadId = ThreadId.make("thread-reaper-stopped-projection-running");
+    const turnId = TurnId.make("turn-reaper-stopped-projection-running");
+    const now = "2026-01-01T00:00:00.000Z";
+    const harness = await createHarness({
+      readModel: makeReadModel([
+        {
+          id: threadId,
+          session: {
+            threadId,
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: turnId,
+            lastError: null,
+            updatedAt: now,
+          },
+        },
+      ]),
+    });
+    const repository = await runtime!.runPromise(Effect.service(ProviderSessionRuntimeRepository));
+
+    await runtime!.runPromise(
+      repository.upsert({
+        threadId,
+        providerName: "codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        adapterKey: "codex",
+        runtimeMode: "full-access",
+        status: "stopped",
+        lastSeenAt: "2026-04-14T00:00:00.000Z",
+        resumeCursor: {
+          opaque: "resume-stopped-projection-running",
+        },
+        runtimePayload: null,
+      }),
+    );
+
+    const reaper = await runtime!.runPromise(Effect.service(ProviderSessionReaper));
+    scope = await Effect.runPromise(Scope.make("sequential"));
+    await Effect.runPromise(reaper.start().pipe(Scope.provide(scope)));
+
+    await waitFor(() => harness.dispatch.mock.calls.length === 1);
+
+    expect(harness.stopSession).not.toHaveBeenCalled();
+    expect(harness.dispatch.mock.calls[0]?.[0]).toMatchObject({
+      type: "thread.session.set",
+      threadId,
+      session: {
+        threadId,
+        status: "stopped",
+        providerName: "codex",
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        runtimeMode: "full-access",
+        activeTurnId: null,
+        lastError: null,
+      },
+    });
   });
 
   it("continues reaping other sessions when one stop attempt fails", async () => {

--- a/apps/server/src/provider/Layers/ProviderSessionReaper.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionReaper.ts
@@ -1,10 +1,13 @@
 import * as Clock from "effect/Clock";
+import { CommandId } from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schedule from "effect/Schedule";
 
+import { OrchestrationEngineService } from "../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { ProviderSessionDirectory } from "../Services/ProviderSessionDirectory.ts";
 import {
@@ -25,7 +28,9 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
   Effect.gen(function* () {
     const providerService = yield* ProviderService;
     const directory = yield* ProviderSessionDirectory;
+    const orchestrationEngine = yield* OrchestrationEngineService;
     const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+    const crypto = yield* Crypto.Crypto;
 
     const inactivityThresholdMs = Math.max(
       1,
@@ -36,10 +41,43 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
     const sweep = Effect.gen(function* () {
       const bindings = yield* directory.listBindings();
       const now = yield* Clock.currentTimeMillis;
+      const nowIso = new Date(now).toISOString();
       let reapedCount = 0;
 
       for (const binding of bindings) {
+        const thread = yield* projectionSnapshotQuery
+          .getThreadShellById(binding.threadId)
+          .pipe(Effect.map(Option.getOrUndefined));
+
         if (binding.status === "stopped") {
+          if (thread?.session?.status === "running" || thread?.session?.status === "starting") {
+            const commandUuid = yield* crypto.randomUUIDv4;
+            yield* orchestrationEngine.dispatch({
+              type: "thread.session.set",
+              commandId: CommandId.make(
+                `provider-session-reaper:stopped-reconcile:${binding.threadId}:${commandUuid}`,
+              ),
+              threadId: binding.threadId,
+              session: {
+                threadId: binding.threadId,
+                status: "stopped",
+                providerName: binding.provider,
+                ...(binding.providerInstanceId !== undefined
+                  ? { providerInstanceId: binding.providerInstanceId }
+                  : {}),
+                runtimeMode: thread.session.runtimeMode,
+                activeTurnId: null,
+                lastError: thread.session.lastError,
+                updatedAt: nowIso,
+              },
+              createdAt: nowIso,
+            });
+            yield* Effect.logInfo("provider.session.reaper.reconciled-stopped-projection", {
+              threadId: binding.threadId,
+              provider: binding.provider,
+              projectionStatus: thread.session.status,
+            });
+          }
           continue;
         }
 
@@ -58,9 +96,6 @@ const makeProviderSessionReaper = (options?: ProviderSessionReaperLiveOptions) =
           continue;
         }
 
-        const thread = yield* projectionSnapshotQuery
-          .getThreadShellById(binding.threadId)
-          .pipe(Effect.map(Option.getOrUndefined));
         if (thread?.session?.activeTurnId != null) {
           yield* Effect.logDebug("provider.session.reaper.skipped-active-turn", {
             threadId: binding.threadId,


### PR DESCRIPTION
## Summary
- reconcile projected thread sessions that remain running/starting after their provider runtime has already been marked stopped
- dispatch a normal thread.session.set command from the reaper so stale UI state can be corrected through the orchestration path
- add regression coverage for stopped runtime bindings with stale running projections

## Test
- mise exec -- pnpm exec vp test run src/provider/Layers/ProviderSessionReaper.test.ts
- mise exec -- pnpm exec vp fmt --check apps/server/src/provider/Layers/ProviderSessionReaper.ts apps/server/src/provider/Layers/ProviderSessionReaper.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes session state through orchestration from a background sweeper; scope is limited to stopped bindings with projection drift and follows an existing command type.
> 
> **Overview**
> Fixes **stale UI/session state** when the provider runtime is already **stopped** in persistence but the thread projection still shows **running** or **starting**.
> 
> During each reaper sweep, bindings with `status === "stopped"` are no longer skipped blindly. The reaper loads the thread shell and, on mismatch, dispatches a **`thread.session.set`** command via **`OrchestrationEngineService`** (clears `activeTurnId`, sets `stopped`, preserves provider/runtime fields) instead of calling **`stopSession`**. Aligned bindings are unchanged; inactivity reaping still uses **`stopSession`** as before.
> 
> Tests mock the orchestration engine, assert no dispatch when projection is already stopped, and add a regression case for stopped runtime + running projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba2676b9b7f264d812226970497df235299e6c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reconcile stopped provider sessions that still project as running
> - When `makeProviderSessionReaper` detects a provider runtime binding with status `stopped` but the read model projects the session as `running` or `starting`, it now dispatches a `thread.session.set` command via `OrchestrationEngineService` to bring the projection in sync.
> - The dispatched command includes a `provider-session-reaper:stopped-reconcile` prefixed `CommandId`, synchronized fields from the projection, and current timestamps with a null `activeTurnId`.
> - A new test in [ProviderSessionReaper.test.ts](https://github.com/pingdotgg/t3code/pull/3106/files#diff-9c064659a893430d8c3796d891064feb010d88e0f11222f98b078f4f71c8d6e1) covers this reconciliation path and verifies no dispatch occurs for stale persisted sessions without active turns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ba2676.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->