### PR TITLE
feat(server): add Codex thread start MCP tool

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -22,6 +22,8 @@ import {
   PreviewSnapshotToolkit,
   PreviewStandardToolkit,
 } from "./toolkits/preview/tools.ts";
+import { ThreadToolkitHandlersLive } from "./toolkits/thread/handlers.ts";
+import { ThreadToolkit } from "./toolkits/thread/tools.ts";
 
 const unauthorized = HttpServerResponse.jsonUnsafe(
   {
@@ -208,13 +210,22 @@ export const PreviewToolkitRegistrationLive = Layer.mergeAll(
   PreviewSnapshotRegistrationLive,
 );
 
+export const ThreadToolkitRegistrationLive = McpServer.toolkit(ThreadToolkit).pipe(
+  Layer.provide(ThreadToolkitHandlersLive),
+);
+
 const McpTransportLive = McpServer.layerHttp({
   name: "T3 Code",
   version: packageJson.version,
   path: "/mcp",
 }).pipe(Layer.provide(McpAuthMiddlewareLive));
 
-export const layer = PreviewToolkitRegistrationLive.pipe(
+export const ToolkitRegistrationLive = Layer.mergeAll(
+  PreviewToolkitRegistrationLive,
+  ThreadToolkitRegistrationLive,
+);
+
+export const layer = ToolkitRegistrationLive.pipe(
   Layer.provideMerge(McpTransportLive),
   Layer.provide(PreviewAutomationBroker.layer),
 );

--- a/apps/server/src/mcp/McpInvocationContext.ts
+++ b/apps/server/src/mcp/McpInvocationContext.ts
@@ -7,7 +7,7 @@ import {
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 
-export type McpCapability = "preview";
+export type McpCapability = "preview" | "thread-management";
 
 export interface McpInvocationScope {
   readonly environmentId: EnvironmentId;

--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -47,6 +47,8 @@ it.effect("stores only a token hash, resolves the bearer token, and revokes by t
 
     const resolved = yield* registry.resolve(token);
     expect(resolved?.threadId).toBe(threadId);
+    expect(resolved?.capabilities.has("preview")).toBe(true);
+    expect(resolved?.capabilities.has("thread-management")).toBe(true);
 
     yield* registry.revokeThread(threadId);
     expect(yield* registry.resolve(token)).toBeUndefined();

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -114,7 +114,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
         threadId: ThreadId.make(request.threadId),
         providerSessionId,
         providerInstanceId: ProviderInstanceId.make(request.providerInstanceId),
-        capabilities: new Set(["preview"]),
+        capabilities: new Set(["preview", "thread-management"]),
         issuedAt,
         expiresAt,
       };

--- a/apps/server/src/mcp/toolkits/thread/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.test.ts
@@ -1,0 +1,227 @@
+import { expect, it } from "@effect/vitest";
+import {
+  EnvironmentId,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+  type ModelSelection,
+  type OrchestrationCommand,
+  type OrchestrationProjectShell,
+  type OrchestrationThreadShell,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Crypto from "effect/Crypto";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Stream from "effect/Stream";
+import { McpSchema, McpServer } from "effect/unstable/ai";
+
+import { GitWorkflowService } from "../../../git/GitWorkflowService.ts";
+import * as BootstrapTurnStartDispatcher from "../../../orchestration/Services/BootstrapTurnStartDispatcher.ts";
+import { OrchestrationEngineService } from "../../../orchestration/Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import { ThreadToolkitRegistrationLive } from "../../McpHttpServer.ts";
+import { ThreadStartRuntimeLive } from "./handlers.ts";
+
+const projectId = ProjectId.make("project-thread-mcp");
+const sourceThreadId = ThreadId.make("source-thread-mcp");
+const modelSelection: ModelSelection = {
+  instanceId: ProviderInstanceId.make("codex"),
+  model: "gpt-5",
+  options: [{ id: "reasoningEffort", value: "high" }],
+};
+const sourceThread: OrchestrationThreadShell = {
+  id: sourceThreadId,
+  projectId,
+  title: "Source",
+  modelSelection,
+  runtimeMode: "auto-accept-edits",
+  interactionMode: "plan",
+  branch: "feature/source",
+  worktreePath: null,
+  latestTurn: null,
+  createdAt: "2026-06-16T00:00:00.000Z",
+  updatedAt: "2026-06-16T00:00:00.000Z",
+  archivedAt: null,
+  session: null,
+  latestUserMessageAt: null,
+  hasPendingApprovals: false,
+  hasPendingUserInput: false,
+  hasActionableProposedPlan: false,
+};
+const project: OrchestrationProjectShell = {
+  id: projectId,
+  title: "Project",
+  workspaceRoot: "/repo",
+  defaultModelSelection: modelSelection,
+  scripts: [],
+  createdAt: "2026-06-16T00:00:00.000Z",
+  updatedAt: "2026-06-16T00:00:00.000Z",
+};
+const invocation: McpInvocationContext.McpInvocationScope = {
+  environmentId: EnvironmentId.make("environment-thread-mcp"),
+  threadId: sourceThreadId,
+  providerSessionId: "provider-session-thread-mcp",
+  providerInstanceId: ProviderInstanceId.make("codex"),
+  capabilities: new Set(["thread-management"]),
+  issuedAt: 1,
+  expiresAt: Number.MAX_SAFE_INTEGER,
+};
+const client = McpSchema.McpServerClient.of({
+  clientId: 1,
+  initializePayload: {
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: { name: "thread-test", version: "1.0.0" },
+  },
+  getClient: Effect.die("unused"),
+});
+
+const TestCryptoLive = Layer.sync(Crypto.Crypto, () => {
+  let nextByte = 0;
+  return Crypto.make({
+    randomBytes: (size) =>
+      Uint8Array.from({ length: size }, () => {
+        nextByte = (nextByte + 1) % 256;
+        return nextByte;
+      }),
+    digest: (_algorithm, data) => Effect.succeed(data),
+  });
+});
+
+const makeTestLayer = (commands: OrchestrationCommand[]) => {
+  const bootstrapTurnStartDispatcherLayer = Layer.mock(
+    BootstrapTurnStartDispatcher.BootstrapTurnStartDispatcher,
+  )({
+    dispatch: (command) =>
+      Effect.sync(() => {
+        commands.push(command);
+        return { sequence: 1 };
+      }),
+  });
+
+  return ThreadToolkitRegistrationLive.pipe(
+    Layer.provideMerge(ThreadStartRuntimeLive),
+    Layer.provideMerge(
+      BootstrapTurnStartDispatcher.ActiveBootstrapTurnStartDispatcherLive.pipe(
+        Layer.provide(bootstrapTurnStartDispatcherLayer),
+      ),
+    ),
+    Layer.provideMerge(TestCryptoLive),
+    Layer.provideMerge(McpServer.McpServer.layer),
+    Layer.provide(
+      Layer.mock(ProjectionSnapshotQuery)({
+        getProjectShellById: () => Effect.succeed(Option.some(project)),
+        getThreadShellById: () => Effect.succeed(Option.some(sourceThread)),
+      }),
+    ),
+    Layer.provide(
+      Layer.mock(GitWorkflowService)({
+        listRefs: () =>
+          Effect.succeed({
+            refs: [
+              {
+                name: "main",
+                current: false,
+                isDefault: true,
+                isRemote: false,
+                worktreePath: null,
+              },
+            ],
+            isRepo: true,
+            hasPrimaryRemote: true,
+            nextCursor: null,
+            totalCount: 1,
+          }),
+        status: () =>
+          Effect.succeed({
+            isRepo: true,
+            hasPrimaryRemote: true,
+            isDefaultRef: false,
+            refName: "feature/source",
+            hasWorkingTreeChanges: false,
+            workingTree: {
+              files: [],
+              insertions: 0,
+              deletions: 0,
+            },
+            hasUpstream: true,
+            aheadCount: 0,
+            behindCount: 0,
+            aheadOfDefaultCount: 0,
+            pr: null,
+          }),
+      }),
+    ),
+    Layer.provide(
+      Layer.mock(OrchestrationEngineService)({
+        readEvents: () => Stream.empty,
+        dispatch: () => Effect.succeed({ sequence: 1 }),
+        streamDomainEvents: Stream.empty,
+      }),
+    ),
+  );
+};
+
+const callStartTool = (arguments_: Record<string, unknown>, commands: OrchestrationCommand[]) =>
+  Effect.gen(function* () {
+    const server = yield* McpServer.McpServer;
+    return yield* server
+      .callTool({ name: "t3_thread_start", arguments: arguments_ })
+      .pipe(
+        Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+        Effect.provideService(McpSchema.McpServerClient, client),
+      );
+  }).pipe(Effect.provide(makeTestLayer(commands)));
+
+it.effect("starts a new worktree thread by default and inherits source settings", () =>
+  Effect.gen(function* () {
+    const commands: OrchestrationCommand[] = [];
+    const result = yield* callStartTool({ prompt: "Investigate flaky tests" }, commands);
+
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      projectId,
+      mode: "new_worktree",
+      worktreePath: null,
+    });
+    const command = commands[0];
+    expect(command?.type).toBe("thread.turn.start");
+    if (command?.type !== "thread.turn.start") return;
+    expect(command.message.text).toBe("Investigate flaky tests");
+    expect(command.modelSelection).toEqual(modelSelection);
+    expect(command.runtimeMode).toBe("auto-accept-edits");
+    expect(command.interactionMode).toBe("plan");
+    expect(command.bootstrap?.createThread?.modelSelection).toEqual(modelSelection);
+    expect(command.bootstrap?.prepareWorktree).toMatchObject({
+      projectCwd: "/repo",
+      baseBranch: "main",
+    });
+    expect(command.bootstrap?.runSetupScript).toBe(true);
+  }),
+);
+
+it.effect("starts current-checkout threads with warning metadata", () =>
+  Effect.gen(function* () {
+    const commands: OrchestrationCommand[] = [];
+    const result = yield* callStartTool(
+      { prompt: "Read current diff", mode: "current_checkout" },
+      commands,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      projectId,
+      mode: "current_checkout",
+      branch: "feature/source",
+      worktreePath: null,
+    });
+    expect(result.structuredContent).toHaveProperty("warning");
+    const command = commands[0];
+    expect(command?.type).toBe("thread.turn.start");
+    if (command?.type !== "thread.turn.start") return;
+    expect(command.bootstrap?.prepareWorktree).toBeUndefined();
+    expect(command.bootstrap?.createThread?.worktreePath).toBeNull();
+  }),
+);

--- a/apps/server/src/mcp/toolkits/thread/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.test.ts
@@ -20,6 +20,7 @@ import { GitWorkflowService } from "../../../git/GitWorkflowService.ts";
 import * as BootstrapTurnStartDispatcher from "../../../orchestration/Services/BootstrapTurnStartDispatcher.ts";
 import { OrchestrationEngineService } from "../../../orchestration/Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as ServerRuntimeStartup from "../../../serverRuntimeStartup.ts";
 import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import { ThreadToolkitRegistrationLive } from "../../McpHttpServer.ts";
 import { ThreadStartRuntimeLive } from "./handlers.ts";
@@ -90,14 +91,26 @@ const TestCryptoLive = Layer.sync(Crypto.Crypto, () => {
   });
 });
 
-const makeTestLayer = (commands: OrchestrationCommand[]) => {
+const makeTestLayer = (
+  commands: OrchestrationCommand[],
+  options: { readonly enqueueCalls?: number[] } = {},
+) => {
   const bootstrapTurnStartDispatcherLayer = Layer.mock(
     BootstrapTurnStartDispatcher.BootstrapTurnStartDispatcher,
   )({
     dispatch: (command) =>
       Effect.sync(() => {
         commands.push(command);
-        return { sequence: 1 };
+        return {
+          sequence: 1,
+          branch:
+            command.bootstrap?.prepareWorktree?.branch ??
+            command.bootstrap?.createThread?.branch ??
+            null,
+          worktreePath: command.bootstrap?.prepareWorktree
+            ? "/repo/.worktrees/generated"
+            : (command.bootstrap?.createThread?.worktreePath ?? null),
+        };
       }),
   });
 
@@ -161,10 +174,24 @@ const makeTestLayer = (commands: OrchestrationCommand[]) => {
         streamDomainEvents: Stream.empty,
       }),
     ),
+    Layer.provide(
+      Layer.mock(ServerRuntimeStartup.ServerRuntimeStartup)({
+        awaitCommandReady: Effect.void,
+        markHttpListening: Effect.void,
+        enqueueCommand: (effect) =>
+          Effect.sync(() => {
+            options.enqueueCalls?.push(1);
+          }).pipe(Effect.flatMap(() => effect)),
+      }),
+    ),
   );
 };
 
-const callStartTool = (arguments_: Record<string, unknown>, commands: OrchestrationCommand[]) =>
+const callStartTool = (
+  arguments_: Record<string, unknown>,
+  commands: OrchestrationCommand[],
+  options: { readonly enqueueCalls?: number[] } = {},
+) =>
   Effect.gen(function* () {
     const server = yield* McpServer.McpServer;
     return yield* server
@@ -173,7 +200,7 @@ const callStartTool = (arguments_: Record<string, unknown>, commands: Orchestrat
         Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
         Effect.provideService(McpSchema.McpServerClient, client),
       );
-  }).pipe(Effect.provide(makeTestLayer(commands)));
+  }).pipe(Effect.provide(makeTestLayer(commands, options)));
 
 it.effect("starts a new worktree thread by default and inherits source settings", () =>
   Effect.gen(function* () {
@@ -184,7 +211,7 @@ it.effect("starts a new worktree thread by default and inherits source settings"
     expect(result.structuredContent).toMatchObject({
       projectId,
       mode: "new_worktree",
-      worktreePath: null,
+      worktreePath: "/repo/.worktrees/generated",
     });
     const command = commands[0];
     expect(command?.type).toBe("thread.turn.start");
@@ -198,6 +225,46 @@ it.effect("starts a new worktree thread by default and inherits source settings"
       projectCwd: "/repo",
       baseBranch: "main",
     });
+    expect(command.bootstrap?.runSetupScript).toBe(true);
+  }),
+);
+
+it.effect("queues thread starts through server runtime startup", () =>
+  Effect.gen(function* () {
+    const commands: OrchestrationCommand[] = [];
+    const enqueueCalls: number[] = [];
+    const result = yield* callStartTool({ prompt: "Wait for server readiness" }, commands, {
+      enqueueCalls,
+    });
+
+    expect(result.isError).toBe(false);
+    expect(enqueueCalls).toHaveLength(1);
+    expect(commands).toHaveLength(1);
+  }),
+);
+
+it.effect("passes explicit setup script requests for existing worktrees", () =>
+  Effect.gen(function* () {
+    const commands: OrchestrationCommand[] = [];
+    const result = yield* callStartTool(
+      {
+        prompt: "Use existing checkout",
+        mode: "existing_worktree",
+        worktreePath: "/repo/existing",
+        runSetupScript: true,
+      },
+      commands,
+    );
+
+    expect(result.isError).toBe(false);
+    expect(result.structuredContent).toMatchObject({
+      mode: "existing_worktree",
+      worktreePath: "/repo/existing",
+    });
+    const command = commands[0];
+    expect(command?.type).toBe("thread.turn.start");
+    if (command?.type !== "thread.turn.start") return;
+    expect(command.bootstrap?.prepareWorktree).toBeUndefined();
     expect(command.bootstrap?.runSetupScript).toBe(true);
   }),
 );

--- a/apps/server/src/mcp/toolkits/thread/handlers.test.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.test.ts
@@ -1,6 +1,7 @@
 import { expect, it } from "@effect/vitest";
 import {
   EnvironmentId,
+  GitCommandError,
   ProjectId,
   ProviderInstanceId,
   ThreadId,
@@ -93,7 +94,11 @@ const TestCryptoLive = Layer.sync(Crypto.Crypto, () => {
 
 const makeTestLayer = (
   commands: OrchestrationCommand[],
-  options: { readonly enqueueCalls?: number[] } = {},
+  options: {
+    readonly enqueueCalls?: number[];
+    readonly gitStatus?: GitWorkflowService["Service"]["status"];
+    readonly sourceThread?: OrchestrationThreadShell;
+  } = {},
 ) => {
   const bootstrapTurnStartDispatcherLayer = Layer.mock(
     BootstrapTurnStartDispatcher.BootstrapTurnStartDispatcher,
@@ -126,7 +131,7 @@ const makeTestLayer = (
     Layer.provide(
       Layer.mock(ProjectionSnapshotQuery)({
         getProjectShellById: () => Effect.succeed(Option.some(project)),
-        getThreadShellById: () => Effect.succeed(Option.some(sourceThread)),
+        getThreadShellById: () => Effect.succeed(Option.some(options.sourceThread ?? sourceThread)),
       }),
     ),
     Layer.provide(
@@ -147,24 +152,26 @@ const makeTestLayer = (
             nextCursor: null,
             totalCount: 1,
           }),
-        status: () =>
-          Effect.succeed({
-            isRepo: true,
-            hasPrimaryRemote: true,
-            isDefaultRef: false,
-            refName: "feature/source",
-            hasWorkingTreeChanges: false,
-            workingTree: {
-              files: [],
-              insertions: 0,
-              deletions: 0,
-            },
-            hasUpstream: true,
-            aheadCount: 0,
-            behindCount: 0,
-            aheadOfDefaultCount: 0,
-            pr: null,
-          }),
+        status:
+          options.gitStatus ??
+          (() =>
+            Effect.succeed({
+              isRepo: true,
+              hasPrimaryRemote: true,
+              isDefaultRef: false,
+              refName: "feature/source",
+              hasWorkingTreeChanges: false,
+              workingTree: {
+                files: [],
+                insertions: 0,
+                deletions: 0,
+              },
+              hasUpstream: true,
+              aheadCount: 0,
+              behindCount: 0,
+              aheadOfDefaultCount: 0,
+              pr: null,
+            })),
       }),
     ),
     Layer.provide(
@@ -190,7 +197,11 @@ const makeTestLayer = (
 const callStartTool = (
   arguments_: Record<string, unknown>,
   commands: OrchestrationCommand[],
-  options: { readonly enqueueCalls?: number[] } = {},
+  options: {
+    readonly enqueueCalls?: number[];
+    readonly gitStatus?: GitWorkflowService["Service"]["status"];
+    readonly sourceThread?: OrchestrationThreadShell;
+  } = {},
 ) =>
   Effect.gen(function* () {
     const server = yield* McpServer.McpServer;
@@ -272,9 +283,11 @@ it.effect("passes explicit setup script requests for existing worktrees", () =>
 it.effect("starts current-checkout threads with warning metadata", () =>
   Effect.gen(function* () {
     const commands: OrchestrationCommand[] = [];
+    const sourceWorktreePath = "/repo/.worktrees/source";
     const result = yield* callStartTool(
-      { prompt: "Read current diff", mode: "current_checkout" },
+      { prompt: "Read current diff", mode: "current_checkout", runSetupScript: true },
       commands,
+      { sourceThread: { ...sourceThread, worktreePath: sourceWorktreePath } },
     );
 
     expect(result.isError).toBe(false);
@@ -282,13 +295,63 @@ it.effect("starts current-checkout threads with warning metadata", () =>
       projectId,
       mode: "current_checkout",
       branch: "feature/source",
-      worktreePath: null,
+      worktreePath: sourceWorktreePath,
     });
     expect(result.structuredContent).toHaveProperty("warning");
     const command = commands[0];
     expect(command?.type).toBe("thread.turn.start");
     if (command?.type !== "thread.turn.start") return;
     expect(command.bootstrap?.prepareWorktree).toBeUndefined();
-    expect(command.bootstrap?.createThread?.worktreePath).toBeNull();
+    expect(command.bootstrap?.createThread?.worktreePath).toBe(sourceWorktreePath);
+    expect(command.bootstrap?.runSetupScript).toBe(true);
+  }),
+);
+
+it.effect("fails existing worktree mode when git status cannot resolve the branch", () =>
+  Effect.gen(function* () {
+    const commands: OrchestrationCommand[] = [];
+    const result = yield* callStartTool(
+      { prompt: "Use bad checkout", mode: "existing_worktree", worktreePath: "/missing" },
+      commands,
+      {
+        gitStatus: () =>
+          Effect.fail(
+            new GitCommandError({
+              operation: "status",
+              command: "git status",
+              cwd: "/missing",
+              detail: "not a git repository",
+            }),
+          ),
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(commands).toHaveLength(0);
+  }),
+);
+
+it.effect("fails current checkout mode when fallback branch lookup fails", () =>
+  Effect.gen(function* () {
+    const commands: OrchestrationCommand[] = [];
+    const result = yield* callStartTool(
+      { prompt: "Use current checkout", mode: "current_checkout" },
+      commands,
+      {
+        sourceThread: { ...sourceThread, branch: null, worktreePath: "/missing" },
+        gitStatus: () =>
+          Effect.fail(
+            new GitCommandError({
+              operation: "status",
+              command: "git status",
+              cwd: "/missing",
+              detail: "not a git repository",
+            }),
+          ),
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(commands).toHaveLength(0);
   }),
 );

--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -1,0 +1,283 @@
+import {
+  CommandId,
+  MessageId,
+  ThreadId,
+  type ModelSelection,
+  type OrchestrationProjectShell,
+  type OrchestrationThreadShell,
+} from "@t3tools/contracts";
+import { buildTemporaryWorktreeBranchName } from "@t3tools/shared/git";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+import * as BootstrapTurnStartDispatcher from "../../../orchestration/Services/BootstrapTurnStartDispatcher.ts";
+import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
+import { GitWorkflowService } from "../../../git/GitWorkflowService.ts";
+import {
+  ThreadStartToolError,
+  type ThreadStartMode,
+  type ThreadStartToolInput,
+  type ThreadStartToolOutput,
+  ThreadToolkit,
+} from "./tools.ts";
+
+const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+const isThreadStartToolError = Schema.is(ThreadStartToolError);
+
+const fail = (message: string) => new ThreadStartToolError({ message });
+
+const truncateTitle = (value: string): string => {
+  const trimmed = value.trim().replace(/\s+/g, " ");
+  if (trimmed.length === 0) return "New thread";
+  return trimmed.length <= 80 ? trimmed : `${trimmed.slice(0, 77)}...`;
+};
+
+const resolveOption = <A>(
+  option: Option.Option<A>,
+  message: string,
+): Effect.Effect<A, ThreadStartToolError> =>
+  Option.match(option, {
+    onNone: () => Effect.fail(fail(message)),
+    onSome: Effect.succeed,
+  });
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+
+type ActiveThreadStartRuntime = (
+  input: ThreadStartToolInput,
+  invocation: McpInvocationContext.McpInvocationScope,
+) => Effect.Effect<ThreadStartToolOutput, ThreadStartToolError>;
+
+let activeThreadStartRuntime: ActiveThreadStartRuntime | null = null;
+
+const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime")(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+  const gitWorkflow = yield* GitWorkflowService;
+  const uuid = () => crypto.randomUUIDv4.pipe(Effect.orDie);
+
+  const makeIds = Effect.fn("ThreadToolkit.makeIds")(function* () {
+    return {
+      commandId: CommandId.make(yield* uuid()),
+      messageId: MessageId.make(yield* uuid()),
+      threadId: ThreadId.make(yield* uuid()),
+    };
+  });
+
+  const makeTemporaryBranchName = Effect.fn("ThreadToolkit.makeTemporaryBranchName")(function* () {
+    const bytes = yield* crypto.randomBytes(4).pipe(Effect.orDie);
+    return buildTemporaryWorktreeBranchName((byteLength) =>
+      byteLength === 4 ? bytesToHex(bytes) : "",
+    );
+  });
+
+  const resolveCurrentBranch = Effect.fn("ThreadToolkit.resolveCurrentBranch")(function* (
+    cwd: string,
+  ) {
+    return yield* gitWorkflow.status({ cwd }).pipe(
+      Effect.map((status) => status.refName),
+      Effect.orElseSucceed(() => null),
+    );
+  });
+
+  const resolveDefaultBranch = Effect.fn("ThreadToolkit.resolveDefaultBranch")(function* (
+    cwd: string,
+  ) {
+    return yield* gitWorkflow.listRefs({ cwd, limit: 200 }).pipe(
+      Effect.map(
+        (result) => result.refs.find((ref) => ref.isDefault && !ref.isRemote)?.name ?? null,
+      ),
+      Effect.orElseSucceed(() => null),
+    );
+  });
+
+  const resolveNewWorktreeBaseBranch = Effect.fn("ThreadToolkit.resolveNewWorktreeBaseBranch")(
+    function* (
+      input: ThreadStartToolInput,
+      project: OrchestrationProjectShell,
+      sourceThread: OrchestrationThreadShell,
+    ) {
+      if (input.baseBranch) return input.baseBranch;
+      if (input.baseBranchSource === "source" && sourceThread.branch) return sourceThread.branch;
+
+      const defaultBranch = yield* resolveDefaultBranch(project.workspaceRoot);
+      if (defaultBranch) return defaultBranch;
+      if (sourceThread.branch) return sourceThread.branch;
+
+      const currentBranch = yield* resolveCurrentBranch(project.workspaceRoot);
+      if (currentBranch) return currentBranch;
+
+      return yield* fail("Could not resolve a base branch for the new worktree.");
+    },
+  );
+
+  const resolveInitialBranch = Effect.fn("ThreadToolkit.resolveInitialBranch")(function* (
+    mode: ThreadStartMode,
+    input: ThreadStartToolInput,
+    project: OrchestrationProjectShell,
+    sourceThread: OrchestrationThreadShell,
+  ) {
+    if (input.branch) return input.branch;
+    if (mode === "new_worktree") return yield* makeTemporaryBranchName();
+    if (mode === "existing_worktree") {
+      if (!input.worktreePath) {
+        return yield* fail("existing_worktree mode requires worktreePath.");
+      }
+      return yield* resolveCurrentBranch(input.worktreePath);
+    }
+    return sourceThread.branch ?? (yield* resolveCurrentBranch(project.workspaceRoot));
+  });
+
+  const loadSourceContext = Effect.fn("ThreadToolkit.loadSourceContext")(function* (
+    invocation: McpInvocationContext.McpInvocationScope,
+  ) {
+    const sourceThread = yield* projectionSnapshotQuery
+      .getThreadShellById(invocation.threadId)
+      .pipe(
+        Effect.flatMap((thread) =>
+          resolveOption(thread, `Source thread ${invocation.threadId} was not found.`),
+        ),
+        Effect.mapError((error) =>
+          isThreadStartToolError(error)
+            ? error
+            : fail(error instanceof Error ? error.message : "Failed to load source thread."),
+        ),
+      );
+    const project = yield* projectionSnapshotQuery.getProjectShellById(sourceThread.projectId).pipe(
+      Effect.flatMap((project) =>
+        resolveOption(project, `Project ${sourceThread.projectId} was not found.`),
+      ),
+      Effect.mapError((error) =>
+        isThreadStartToolError(error)
+          ? error
+          : fail(error instanceof Error ? error.message : "Failed to load source project."),
+      ),
+    );
+
+    return { sourceThread, project };
+  });
+
+  return Effect.fn("ThreadToolkit.startThread")(function* (
+    input: ThreadStartToolInput,
+    invocation: McpInvocationContext.McpInvocationScope,
+  ) {
+    const { sourceThread, project } = yield* loadSourceContext(invocation);
+    const mode = input.mode ?? "new_worktree";
+    const ids = yield* makeIds();
+    const createdAt = yield* nowIso;
+    const branch = (yield* resolveInitialBranch(mode, input, project, sourceThread)) ?? null;
+    const worktreePath: string | null =
+      mode === "existing_worktree" ? (input.worktreePath ?? null) : null;
+    const title = input.title ?? truncateTitle(input.prompt);
+    const modelSelection = resolveModelSelection(input, sourceThread);
+    const runtimeMode = input.runtimeMode ?? sourceThread.runtimeMode;
+    const interactionMode = input.interactionMode ?? sourceThread.interactionMode;
+    const prepareWorktree =
+      mode === "new_worktree"
+        ? {
+            projectCwd: project.workspaceRoot,
+            baseBranch: yield* resolveNewWorktreeBaseBranch(input, project, sourceThread),
+            branch: branch ?? undefined,
+          }
+        : undefined;
+
+    if (mode === "existing_worktree" && !worktreePath) {
+      return yield* fail("existing_worktree mode requires worktreePath.");
+    }
+
+    yield* BootstrapTurnStartDispatcher.dispatchActive({
+      type: "thread.turn.start",
+      commandId: ids.commandId,
+      threadId: ids.threadId,
+      message: {
+        messageId: ids.messageId,
+        role: "user",
+        text: input.prompt,
+        attachments: [],
+      },
+      modelSelection,
+      titleSeed: title,
+      runtimeMode,
+      interactionMode,
+      bootstrap: {
+        createThread: {
+          projectId: project.id,
+          title,
+          modelSelection,
+          runtimeMode,
+          interactionMode,
+          branch,
+          worktreePath,
+          createdAt,
+        },
+        ...(prepareWorktree
+          ? {
+              prepareWorktree,
+              runSetupScript: input.runSetupScript ?? true,
+            }
+          : {}),
+      },
+      createdAt,
+    }).pipe(
+      Effect.mapError((error) =>
+        fail(error instanceof Error ? error.message : "Failed to start child thread."),
+      ),
+    );
+
+    return {
+      threadId: ids.threadId,
+      projectId: project.id,
+      mode,
+      branch,
+      worktreePath,
+      ...(mode === "current_checkout"
+        ? {
+            warning:
+              "Child thread was started on the current checkout and may conflict with concurrent writes.",
+          }
+        : {}),
+    };
+  });
+});
+
+export const ThreadStartRuntimeLive = Layer.effectDiscard(
+  Effect.acquireRelease(
+    makeActiveThreadStartRuntime().pipe(
+      Effect.tap((runtime) =>
+        Effect.sync(() => {
+          activeThreadStartRuntime = runtime;
+        }),
+      ),
+    ),
+    (runtime) =>
+      Effect.sync(() => {
+        if (activeThreadStartRuntime === runtime) activeThreadStartRuntime = null;
+      }),
+  ),
+);
+
+const resolveModelSelection = (
+  input: ThreadStartToolInput,
+  sourceThread: OrchestrationThreadShell,
+): ModelSelection => input.modelSelection ?? sourceThread.modelSelection;
+
+const startThread = Effect.fn("ThreadToolkit.startThread")(function* (input: ThreadStartToolInput) {
+  const invocation = yield* McpInvocationContext.requireMcpCapability("thread-management").pipe(
+    Effect.mapError((error) => fail(error.message)),
+  );
+  const runtime = activeThreadStartRuntime;
+  if (!runtime) return yield* fail("Thread start runtime is not available.");
+  return yield* runtime(input, invocation);
+});
+
+const handlers = {
+  t3_thread_start: startThread,
+} satisfies Parameters<typeof ThreadToolkit.toLayer>[0];
+
+export const ThreadToolkitHandlersLive = ThreadToolkit.toLayer(handlers);

--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -94,7 +94,7 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
         Effect.mapError(
           (cause) =>
             new ThreadStartToolError({
-              message: cause instanceof Error ? cause.message : failureMessage,
+              message: failureMessage,
               operation: "git.status",
               cwd,
               cause,
@@ -196,7 +196,7 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
           isThreadStartToolError(cause)
             ? cause
             : new ThreadStartToolError({
-                message: cause instanceof Error ? cause.message : "Failed to load source thread.",
+                message: "Failed to load source thread.",
                 operation: "load-source-thread",
                 threadId: invocation.threadId,
                 cause,
@@ -219,7 +219,7 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
         isThreadStartToolError(cause)
           ? cause
           : new ThreadStartToolError({
-              message: cause instanceof Error ? cause.message : "Failed to load source project.",
+              message: "Failed to load source project.",
               operation: "load-source-project",
               threadId: sourceThread.id,
               projectId: sourceThread.projectId,
@@ -306,7 +306,7 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
         Effect.mapError(
           (cause) =>
             new ThreadStartToolError({
-              message: cause instanceof Error ? cause.message : "Failed to start child thread.",
+              message: "Failed to start child thread.",
               operation: "start-child-thread",
               threadId: ids.threadId,
               projectId: project.id,
@@ -357,7 +357,7 @@ const startThread = Effect.fn("ThreadToolkit.startThread")(function* (input: Thr
     Effect.mapError(
       (cause) =>
         new ThreadStartToolError({
-          message: cause.message,
+          message: "thread-management capability is not available for this session.",
           operation: "require-mcp-capability",
           cause,
         }),

--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -31,8 +31,6 @@ import {
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 const isThreadStartToolError = Schema.is(ThreadStartToolError);
 
-const fail = (message: string) => new ThreadStartToolError({ message });
-
 const truncateTitle = (value: string): string => {
   const trimmed = value.trim().replace(/\s+/g, " ");
   if (trimmed.length === 0) return "New thread";
@@ -41,10 +39,10 @@ const truncateTitle = (value: string): string => {
 
 const resolveOption = <A>(
   option: Option.Option<A>,
-  message: string,
+  error: ThreadStartToolError,
 ): Effect.Effect<A, ThreadStartToolError> =>
   Option.match(option, {
-    onNone: () => Effect.fail(fail(message)),
+    onNone: () => Effect.fail(error),
     onSome: Effect.succeed,
   });
 
@@ -93,10 +91,22 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
     function* (cwd: string, failureMessage: string) {
       const branch = yield* gitWorkflow.status({ cwd }).pipe(
         Effect.map((status) => status.refName),
-        Effect.mapError((error) => fail(error instanceof Error ? error.message : failureMessage)),
+        Effect.mapError(
+          (cause) =>
+            new ThreadStartToolError({
+              message: cause instanceof Error ? cause.message : failureMessage,
+              operation: "git.status",
+              cwd,
+              cause,
+            }),
+        ),
       );
       if (branch) return branch;
-      return yield* fail(failureMessage);
+      return yield* new ThreadStartToolError({
+        message: failureMessage,
+        operation: "git.status",
+        cwd,
+      });
     },
   );
 
@@ -127,7 +137,12 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
       const currentBranch = yield* resolveCurrentBranch(project.workspaceRoot);
       if (currentBranch) return currentBranch;
 
-      return yield* fail("Could not resolve a base branch for the new worktree.");
+      return yield* new ThreadStartToolError({
+        message: "Could not resolve a base branch for the new worktree.",
+        operation: "resolve-new-worktree-base-branch",
+        cwd: project.workspaceRoot,
+        projectId: project.id,
+      });
     },
   );
 
@@ -141,7 +156,11 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
     if (mode === "new_worktree") return yield* makeTemporaryBranchName();
     if (mode === "existing_worktree") {
       if (!input.worktreePath) {
-        return yield* fail("existing_worktree mode requires worktreePath.");
+        return yield* new ThreadStartToolError({
+          message: "existing_worktree mode requires worktreePath.",
+          operation: "resolve-initial-branch",
+          projectId: project.id,
+        });
       }
       return yield* resolveRequiredCurrentBranch(
         input.worktreePath,
@@ -164,22 +183,48 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
       .getThreadShellById(invocation.threadId)
       .pipe(
         Effect.flatMap((thread) =>
-          resolveOption(thread, `Source thread ${invocation.threadId} was not found.`),
+          resolveOption(
+            thread,
+            new ThreadStartToolError({
+              message: `Source thread ${invocation.threadId} was not found.`,
+              operation: "load-source-thread",
+              threadId: invocation.threadId,
+            }),
+          ),
         ),
-        Effect.mapError((error) =>
-          isThreadStartToolError(error)
-            ? error
-            : fail(error instanceof Error ? error.message : "Failed to load source thread."),
+        Effect.mapError((cause) =>
+          isThreadStartToolError(cause)
+            ? cause
+            : new ThreadStartToolError({
+                message: cause instanceof Error ? cause.message : "Failed to load source thread.",
+                operation: "load-source-thread",
+                threadId: invocation.threadId,
+                cause,
+              }),
         ),
       );
     const project = yield* projectionSnapshotQuery.getProjectShellById(sourceThread.projectId).pipe(
       Effect.flatMap((project) =>
-        resolveOption(project, `Project ${sourceThread.projectId} was not found.`),
+        resolveOption(
+          project,
+          new ThreadStartToolError({
+            message: `Project ${sourceThread.projectId} was not found.`,
+            operation: "load-source-project",
+            threadId: sourceThread.id,
+            projectId: sourceThread.projectId,
+          }),
+        ),
       ),
-      Effect.mapError((error) =>
-        isThreadStartToolError(error)
-          ? error
-          : fail(error instanceof Error ? error.message : "Failed to load source project."),
+      Effect.mapError((cause) =>
+        isThreadStartToolError(cause)
+          ? cause
+          : new ThreadStartToolError({
+              message: cause instanceof Error ? cause.message : "Failed to load source project.",
+              operation: "load-source-project",
+              threadId: sourceThread.id,
+              projectId: sourceThread.projectId,
+              cause,
+            }),
       ),
     );
 
@@ -216,7 +261,12 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
     const runSetupScript = input.runSetupScript ?? (mode === "new_worktree" ? true : undefined);
 
     if (mode === "existing_worktree" && !worktreePath) {
-      return yield* fail("existing_worktree mode requires worktreePath.");
+      return yield* new ThreadStartToolError({
+        message: "existing_worktree mode requires worktreePath.",
+        operation: "start-thread",
+        threadId: ids.threadId,
+        projectId: project.id,
+      });
     }
 
     const command: Extract<OrchestrationCommand, { type: "thread.turn.start" }> = {
@@ -253,8 +303,15 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
     const result = yield* startup
       .enqueueCommand(BootstrapTurnStartDispatcher.dispatchActive(command))
       .pipe(
-        Effect.mapError((error) =>
-          fail(error instanceof Error ? error.message : "Failed to start child thread."),
+        Effect.mapError(
+          (cause) =>
+            new ThreadStartToolError({
+              message: cause instanceof Error ? cause.message : "Failed to start child thread.",
+              operation: "start-child-thread",
+              threadId: ids.threadId,
+              projectId: project.id,
+              cause,
+            }),
         ),
       );
 
@@ -297,10 +354,22 @@ const resolveModelSelection = (
 
 const startThread = Effect.fn("ThreadToolkit.startThread")(function* (input: ThreadStartToolInput) {
   const invocation = yield* McpInvocationContext.requireMcpCapability("thread-management").pipe(
-    Effect.mapError((error) => fail(error.message)),
+    Effect.mapError(
+      (cause) =>
+        new ThreadStartToolError({
+          message: cause.message,
+          operation: "require-mcp-capability",
+          cause,
+        }),
+    ),
   );
   const runtime = activeThreadStartRuntime;
-  if (!runtime) return yield* fail("Thread start runtime is not available.");
+  if (!runtime) {
+    return yield* new ThreadStartToolError({
+      message: "Thread start runtime is not available.",
+      operation: "start-thread",
+    });
+  }
   return yield* runtime(input, invocation);
 });
 

--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -3,6 +3,7 @@ import {
   MessageId,
   ThreadId,
   type ModelSelection,
+  type OrchestrationCommand,
   type OrchestrationProjectShell,
   type OrchestrationThreadShell,
 } from "@t3tools/contracts";
@@ -18,6 +19,7 @@ import * as McpInvocationContext from "../../McpInvocationContext.ts";
 import * as BootstrapTurnStartDispatcher from "../../../orchestration/Services/BootstrapTurnStartDispatcher.ts";
 import { ProjectionSnapshotQuery } from "../../../orchestration/Services/ProjectionSnapshotQuery.ts";
 import { GitWorkflowService } from "../../../git/GitWorkflowService.ts";
+import * as ServerRuntimeStartup from "../../../serverRuntimeStartup.ts";
 import {
   ThreadStartToolError,
   type ThreadStartMode,
@@ -60,6 +62,7 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
   const crypto = yield* Crypto.Crypto;
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
   const gitWorkflow = yield* GitWorkflowService;
+  const startup = yield* ServerRuntimeStartup.ServerRuntimeStartup;
   const uuid = () => crypto.randomUUIDv4.pipe(Effect.orDie);
 
   const makeIds = Effect.fn("ThreadToolkit.makeIds")(function* () {
@@ -186,12 +189,13 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
             branch: branch ?? undefined,
           }
         : undefined;
+    const runSetupScript = input.runSetupScript ?? (mode === "new_worktree" ? true : undefined);
 
     if (mode === "existing_worktree" && !worktreePath) {
       return yield* fail("existing_worktree mode requires worktreePath.");
     }
 
-    yield* BootstrapTurnStartDispatcher.dispatchActive({
+    const command: Extract<OrchestrationCommand, { type: "thread.turn.start" }> = {
       type: "thread.turn.start",
       commandId: ids.commandId,
       threadId: ids.threadId,
@@ -216,26 +220,26 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
           worktreePath,
           createdAt,
         },
-        ...(prepareWorktree
-          ? {
-              prepareWorktree,
-              runSetupScript: input.runSetupScript ?? true,
-            }
-          : {}),
+        ...(prepareWorktree ? { prepareWorktree } : {}),
+        ...(runSetupScript === undefined ? {} : { runSetupScript }),
       },
       createdAt,
-    }).pipe(
-      Effect.mapError((error) =>
-        fail(error instanceof Error ? error.message : "Failed to start child thread."),
-      ),
-    );
+    };
+
+    const result = yield* startup
+      .enqueueCommand(BootstrapTurnStartDispatcher.dispatchActive(command))
+      .pipe(
+        Effect.mapError((error) =>
+          fail(error instanceof Error ? error.message : "Failed to start child thread."),
+        ),
+      );
 
     return {
       threadId: ids.threadId,
       projectId: project.id,
       mode,
-      branch,
-      worktreePath,
+      branch: result.branch ?? branch,
+      worktreePath: result.worktreePath,
       ...(mode === "current_checkout"
         ? {
             warning:

--- a/apps/server/src/mcp/toolkits/thread/handlers.ts
+++ b/apps/server/src/mcp/toolkits/thread/handlers.ts
@@ -89,6 +89,17 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
     );
   });
 
+  const resolveRequiredCurrentBranch = Effect.fn("ThreadToolkit.resolveRequiredCurrentBranch")(
+    function* (cwd: string, failureMessage: string) {
+      const branch = yield* gitWorkflow.status({ cwd }).pipe(
+        Effect.map((status) => status.refName),
+        Effect.mapError((error) => fail(error instanceof Error ? error.message : failureMessage)),
+      );
+      if (branch) return branch;
+      return yield* fail(failureMessage);
+    },
+  );
+
   const resolveDefaultBranch = Effect.fn("ThreadToolkit.resolveDefaultBranch")(function* (
     cwd: string,
   ) {
@@ -132,9 +143,18 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
       if (!input.worktreePath) {
         return yield* fail("existing_worktree mode requires worktreePath.");
       }
-      return yield* resolveCurrentBranch(input.worktreePath);
+      return yield* resolveRequiredCurrentBranch(
+        input.worktreePath,
+        `Could not resolve current branch for existing worktree ${input.worktreePath}.`,
+      );
     }
-    return sourceThread.branch ?? (yield* resolveCurrentBranch(project.workspaceRoot));
+    return (
+      sourceThread.branch ??
+      (yield* resolveRequiredCurrentBranch(
+        sourceThread.worktreePath ?? project.workspaceRoot,
+        "Could not resolve current branch for the current checkout.",
+      ))
+    );
   });
 
   const loadSourceContext = Effect.fn("ThreadToolkit.loadSourceContext")(function* (
@@ -176,7 +196,11 @@ const makeActiveThreadStartRuntime = Effect.fn("ThreadToolkit.makeActiveRuntime"
     const createdAt = yield* nowIso;
     const branch = (yield* resolveInitialBranch(mode, input, project, sourceThread)) ?? null;
     const worktreePath: string | null =
-      mode === "existing_worktree" ? (input.worktreePath ?? null) : null;
+      mode === "existing_worktree"
+        ? (input.worktreePath ?? null)
+        : mode === "current_checkout"
+          ? (sourceThread.worktreePath ?? project.workspaceRoot)
+          : null;
     const title = input.title ?? truncateTitle(input.prompt);
     const modelSelection = resolveModelSelection(input, sourceThread);
     const runtimeMode = input.runtimeMode ?? sourceThread.runtimeMode;

--- a/apps/server/src/mcp/toolkits/thread/tools.ts
+++ b/apps/server/src/mcp/toolkits/thread/tools.ts
@@ -1,0 +1,71 @@
+import {
+  ModelSelection,
+  ProjectId,
+  ProviderInteractionMode,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
+  RuntimeMode,
+  ThreadId,
+  TrimmedNonEmptyString,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+import * as McpInvocationContext from "../../McpInvocationContext.ts";
+
+export const ThreadStartMode = Schema.Literals([
+  "new_worktree",
+  "existing_worktree",
+  "current_checkout",
+]);
+export type ThreadStartMode = typeof ThreadStartMode.Type;
+
+const ThreadStartBaseBranchSource = Schema.Literals(["default", "source"]);
+
+export const ThreadStartToolInput = Schema.Struct({
+  prompt: TrimmedNonEmptyString.check(Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_INPUT_CHARS)),
+  title: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(255))),
+  mode: Schema.optional(ThreadStartMode),
+  worktreePath: Schema.optional(TrimmedNonEmptyString),
+  branch: Schema.optional(TrimmedNonEmptyString),
+  baseBranch: Schema.optional(TrimmedNonEmptyString),
+  baseBranchSource: Schema.optional(ThreadStartBaseBranchSource),
+  runSetupScript: Schema.optional(Schema.Boolean),
+  modelSelection: Schema.optional(ModelSelection),
+  runtimeMode: Schema.optional(RuntimeMode),
+  interactionMode: Schema.optional(ProviderInteractionMode),
+});
+export type ThreadStartToolInput = typeof ThreadStartToolInput.Type;
+
+export const ThreadStartToolOutput = Schema.Struct({
+  threadId: ThreadId,
+  projectId: ProjectId,
+  mode: ThreadStartMode,
+  branch: Schema.NullOr(TrimmedNonEmptyString),
+  worktreePath: Schema.NullOr(TrimmedNonEmptyString),
+  warning: Schema.optional(Schema.String),
+});
+export type ThreadStartToolOutput = typeof ThreadStartToolOutput.Type;
+
+export class ThreadStartToolError extends Schema.TaggedErrorClass<ThreadStartToolError>()(
+  "ThreadStartToolError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+const dependencies = [McpInvocationContext.McpInvocationContext];
+
+export const ThreadStartTool = Tool.make("t3_thread_start", {
+  description:
+    "Start a new T3 Code thread with the supplied initial prompt, only when the user explicitly asks to start/spawn/create another thread or agent. Do not use for autonomous delegation or background parallel work. Defaults to creating a new Git worktree from the repository default branch. Use current_checkout only when the user explicitly asks for the same checkout. This tool launches the child turn and returns metadata without waiting for completion.",
+  parameters: ThreadStartToolInput,
+  success: ThreadStartToolOutput,
+  failure: ThreadStartToolError,
+  dependencies,
+})
+  .annotate(Tool.Title, "Start T3 Code thread")
+  .annotate(Tool.OpenWorld, true)
+  .annotate(Tool.Destructive, true)
+  .annotate(Tool.Idempotent, false);
+
+export const ThreadToolkit = Toolkit.make(ThreadStartTool);

--- a/apps/server/src/mcp/toolkits/thread/tools.ts
+++ b/apps/server/src/mcp/toolkits/thread/tools.ts
@@ -50,6 +50,11 @@ export class ThreadStartToolError extends Schema.TaggedErrorClass<ThreadStartToo
   "ThreadStartToolError",
   {
     message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+    operation: Schema.optional(Schema.String),
+    cwd: Schema.optional(Schema.String),
+    threadId: Schema.optional(ThreadId),
+    projectId: Schema.optional(ProjectId),
   },
 ) {}
 

--- a/apps/server/src/orchestration/Services/BootstrapTurnStartDispatcher.ts
+++ b/apps/server/src/orchestration/Services/BootstrapTurnStartDispatcher.ts
@@ -1,0 +1,378 @@
+import {
+  CommandId,
+  EventId,
+  OrchestrationDispatchCommandError,
+  type OrchestrationCommand,
+  type ThreadId,
+} from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+
+import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
+import * as ProjectSetupScriptRunner from "../../project/ProjectSetupScriptRunner.ts";
+import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
+import { OrchestrationEngineService } from "./OrchestrationEngine.ts";
+
+type ThreadTurnStartCommand = Extract<OrchestrationCommand, { type: "thread.turn.start" }>;
+
+const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
+
+const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+
+function unexpectedCompatibilityError(error: never): never {
+  throw new Error(`Unhandled compatibility error: ${String(error)}`);
+}
+
+function legacySetupFailureDescription(cause: unknown): string {
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "message" in cause &&
+    typeof cause.message === "string"
+  ) {
+    return cause.message;
+  }
+  return String(cause);
+}
+
+function projectSetupScriptCompatibilityDetail(
+  error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError,
+): string {
+  switch (error._tag) {
+    case "ProjectSetupScriptOperationError":
+      return legacySetupFailureDescription(error.cause);
+    case "ProjectSetupScriptProjectNotFoundError":
+      return "Project was not found for setup script execution.";
+    default:
+      return unexpectedCompatibilityError(error);
+  }
+}
+
+export interface BootstrapTurnStartDispatcherShape {
+  readonly dispatch: (
+    command: ThreadTurnStartCommand,
+  ) => Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError>;
+}
+
+export class BootstrapTurnStartDispatcher extends Context.Service<
+  BootstrapTurnStartDispatcher,
+  BootstrapTurnStartDispatcherShape
+>()("t3/orchestration/Services/BootstrapTurnStartDispatcher") {}
+
+let activeDispatcher: BootstrapTurnStartDispatcherShape | null = null;
+
+export const dispatchActive = (
+  command: ThreadTurnStartCommand,
+): Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError> => {
+  const dispatcher = activeDispatcher;
+  if (!dispatcher) {
+    return Effect.fail(
+      new OrchestrationDispatchCommandError({
+        message: "Bootstrap turn start dispatcher is not available.",
+      }),
+    );
+  }
+  return dispatcher.dispatch(command);
+};
+
+export const ActiveBootstrapTurnStartDispatcherLive = Layer.effectDiscard(
+  Effect.acquireRelease(
+    BootstrapTurnStartDispatcher.pipe(
+      Effect.tap((dispatcher) =>
+        Effect.sync(() => {
+          activeDispatcher = dispatcher;
+        }),
+      ),
+    ),
+    (dispatcher) =>
+      Effect.sync(() => {
+        if (activeDispatcher === dispatcher) activeDispatcher = null;
+      }),
+  ),
+);
+
+export const layer = Layer.effect(
+  BootstrapTurnStartDispatcher,
+  Effect.gen(function* () {
+    const crypto = yield* Crypto.Crypto;
+    const orchestrationEngine = yield* OrchestrationEngineService;
+    const gitWorkflow = yield* GitWorkflowService;
+    const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+    const vcsStatusBroadcaster = yield* VcsStatusBroadcaster;
+
+    const toDispatchCommandError = (cause: unknown, fallbackMessage: string) =>
+      isOrchestrationDispatchCommandError(cause)
+        ? cause
+        : new OrchestrationDispatchCommandError({
+            message: cause instanceof Error ? cause.message : fallbackMessage,
+            cause,
+          });
+    const randomUUID = crypto.randomUUIDv4.pipe(
+      Effect.mapError((cause) =>
+        toDispatchCommandError(cause, "Failed to generate orchestration command identifier."),
+      ),
+    );
+    const serverEventId = randomUUID.pipe(Effect.map(EventId.make));
+    const serverCommandId = (tag: string) =>
+      randomUUID.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
+
+    const appendSetupScriptActivity = (input: {
+      readonly threadId: ThreadId;
+      readonly kind: "setup-script.requested" | "setup-script.started" | "setup-script.failed";
+      readonly summary: string;
+      readonly createdAt: string;
+      readonly payload: Record<string, unknown>;
+      readonly tone: "info" | "error";
+    }) =>
+      Effect.all({
+        commandId: serverCommandId("setup-script-activity"),
+        activityId: serverEventId,
+      }).pipe(
+        Effect.flatMap(({ commandId, activityId }) =>
+          orchestrationEngine.dispatch({
+            type: "thread.activity.append",
+            commandId,
+            threadId: input.threadId,
+            activity: {
+              id: activityId,
+              tone: input.tone,
+              kind: input.kind,
+              summary: input.summary,
+              payload: input.payload,
+              turnId: null,
+              createdAt: input.createdAt,
+            },
+            createdAt: input.createdAt,
+          }),
+        ),
+      );
+
+    const toBootstrapDispatchCommandCauseError = (cause: Cause.Cause<unknown>) => {
+      const error = Cause.squash(cause);
+      return isOrchestrationDispatchCommandError(error)
+        ? error
+        : new OrchestrationDispatchCommandError({
+            message:
+              error instanceof Error ? error.message : "Failed to bootstrap thread turn start.",
+            cause,
+          });
+    };
+
+    const refreshGitStatus = (cwd: string) =>
+      vcsStatusBroadcaster
+        .refreshStatus(cwd)
+        .pipe(Effect.ignoreCause({ log: true }), Effect.forkDetach, Effect.asVoid);
+
+    const dispatch = Effect.fn("BootstrapTurnStartDispatcher.dispatch")(function* (
+      command: ThreadTurnStartCommand,
+    ) {
+      const bootstrap = command.bootstrap;
+      const { bootstrap: _bootstrap, ...finalTurnStartCommand } = command;
+      let createdThread = false;
+      let targetProjectId = bootstrap?.createThread?.projectId;
+      let targetProjectCwd = bootstrap?.prepareWorktree?.projectCwd;
+      let targetWorktreePath = bootstrap?.createThread?.worktreePath ?? null;
+
+      const cleanupCreatedThread = () =>
+        createdThread
+          ? serverCommandId("bootstrap-thread-delete").pipe(
+              Effect.flatMap((commandId) =>
+                orchestrationEngine.dispatch({
+                  type: "thread.delete",
+                  commandId,
+                  threadId: command.threadId,
+                }),
+              ),
+              Effect.ignoreCause({ log: true }),
+            )
+          : Effect.void;
+
+      const recordSetupScriptLaunchFailure = (input: {
+        readonly error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError;
+        readonly requestedAt: string;
+        readonly worktreePath: string;
+      }) => {
+        const detail = projectSetupScriptCompatibilityDetail(input.error);
+        return appendSetupScriptActivity({
+          threadId: command.threadId,
+          kind: "setup-script.failed",
+          summary: "Setup script failed to start",
+          createdAt: input.requestedAt,
+          payload: {
+            detail,
+            worktreePath: input.worktreePath,
+          },
+          tone: "error",
+        }).pipe(
+          Effect.ignoreCause({ log: false }),
+          Effect.flatMap(() =>
+            Effect.logWarning("bootstrap turn start failed to launch setup script", {
+              threadId: command.threadId,
+              worktreePath: input.worktreePath,
+              detail,
+            }),
+          ),
+        );
+      };
+
+      const recordSetupScriptStarted = (input: {
+        readonly requestedAt: string;
+        readonly worktreePath: string;
+        readonly scriptId: string;
+        readonly scriptName: string;
+        readonly terminalId: string;
+      }) =>
+        Effect.gen(function* () {
+          const startedAt = yield* nowIso;
+          const payload = {
+            scriptId: input.scriptId,
+            scriptName: input.scriptName,
+            terminalId: input.terminalId,
+            worktreePath: input.worktreePath,
+          };
+          yield* Effect.all([
+            appendSetupScriptActivity({
+              threadId: command.threadId,
+              kind: "setup-script.requested",
+              summary: "Starting setup script",
+              createdAt: input.requestedAt,
+              payload,
+              tone: "info",
+            }),
+            appendSetupScriptActivity({
+              threadId: command.threadId,
+              kind: "setup-script.started",
+              summary: "Setup script started",
+              createdAt: startedAt,
+              payload,
+              tone: "info",
+            }),
+          ]).pipe(
+            Effect.asVoid,
+            Effect.catch((error) =>
+              Effect.logWarning(
+                "bootstrap turn start launched setup script but failed to record setup activity",
+                {
+                  threadId: command.threadId,
+                  worktreePath: input.worktreePath,
+                  scriptId: input.scriptId,
+                  terminalId: input.terminalId,
+                  detail: error.message,
+                },
+              ),
+            ),
+          );
+        });
+
+      const runSetupProgram = () =>
+        Effect.gen(function* () {
+          if (!bootstrap?.runSetupScript || !targetWorktreePath) {
+            return;
+          }
+          const worktreePath = targetWorktreePath;
+          const requestedAt = yield* nowIso;
+          yield* projectSetupScriptRunner
+            .runForThread({
+              threadId: command.threadId,
+              ...(targetProjectId ? { projectId: targetProjectId } : {}),
+              ...(targetProjectCwd ? { projectCwd: targetProjectCwd } : {}),
+              worktreePath,
+            })
+            .pipe(
+              Effect.matchEffect({
+                onFailure: (error) =>
+                  recordSetupScriptLaunchFailure({
+                    error,
+                    requestedAt,
+                    worktreePath,
+                  }),
+                onSuccess: (setupResult) => {
+                  if (setupResult.status !== "started") {
+                    return Effect.void;
+                  }
+                  return recordSetupScriptStarted({
+                    requestedAt,
+                    worktreePath,
+                    scriptId: setupResult.scriptId,
+                    scriptName: setupResult.scriptName,
+                    terminalId: setupResult.terminalId,
+                  });
+                },
+              }),
+            );
+        });
+
+      const bootstrapProgram = Effect.gen(function* () {
+        if (bootstrap?.createThread) {
+          yield* orchestrationEngine.dispatch({
+            type: "thread.create",
+            commandId: yield* serverCommandId("bootstrap-thread-create"),
+            threadId: command.threadId,
+            projectId: bootstrap.createThread.projectId,
+            title: bootstrap.createThread.title,
+            modelSelection: bootstrap.createThread.modelSelection,
+            runtimeMode: bootstrap.createThread.runtimeMode,
+            interactionMode: bootstrap.createThread.interactionMode,
+            branch: bootstrap.createThread.branch,
+            worktreePath: bootstrap.createThread.worktreePath,
+            createdAt: bootstrap.createThread.createdAt,
+          });
+          createdThread = true;
+        }
+
+        if (bootstrap?.prepareWorktree) {
+          let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
+          if (bootstrap.prepareWorktree.startFromOrigin) {
+            yield* gitWorkflow.fetchRemote({
+              cwd: bootstrap.prepareWorktree.projectCwd,
+              remoteName: "origin",
+            });
+            const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
+              cwd: bootstrap.prepareWorktree.projectCwd,
+              refName: bootstrap.prepareWorktree.baseBranch,
+              fallbackRemoteName: "origin",
+            });
+            worktreeBaseRef = resolvedRemoteBase.commitSha;
+          }
+          const worktree = yield* gitWorkflow.createWorktree({
+            cwd: bootstrap.prepareWorktree.projectCwd,
+            refName: worktreeBaseRef,
+            newRefName: bootstrap.prepareWorktree.branch,
+            baseRefName: bootstrap.prepareWorktree.baseBranch,
+            path: null,
+          });
+          targetWorktreePath = worktree.worktree.path;
+          yield* orchestrationEngine.dispatch({
+            type: "thread.meta.update",
+            commandId: yield* serverCommandId("bootstrap-thread-meta-update"),
+            threadId: command.threadId,
+            branch: worktree.worktree.refName,
+            worktreePath: targetWorktreePath,
+          });
+          yield* refreshGitStatus(targetWorktreePath);
+        }
+
+        yield* runSetupProgram();
+
+        return yield* orchestrationEngine.dispatch(finalTurnStartCommand);
+      });
+
+      return yield* bootstrapProgram.pipe(
+        Effect.catchCause((cause) => {
+          const dispatchError = toBootstrapDispatchCommandCauseError(cause);
+          if (Cause.hasInterruptsOnly(cause)) {
+            return Effect.fail(dispatchError);
+          }
+          return cleanupCreatedThread().pipe(Effect.flatMap(() => Effect.fail(dispatchError)));
+        }),
+      );
+    });
+
+    return BootstrapTurnStartDispatcher.of({ dispatch });
+  }),
+);

--- a/apps/server/src/orchestration/Services/BootstrapTurnStartDispatcher.ts
+++ b/apps/server/src/orchestration/Services/BootstrapTurnStartDispatcher.ts
@@ -54,9 +54,14 @@ function projectSetupScriptCompatibilityDetail(
 }
 
 export interface BootstrapTurnStartDispatcherShape {
-  readonly dispatch: (
-    command: ThreadTurnStartCommand,
-  ) => Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError>;
+  readonly dispatch: (command: ThreadTurnStartCommand) => Effect.Effect<
+    {
+      readonly sequence: number;
+      readonly branch: string | null;
+      readonly worktreePath: string | null;
+    },
+    OrchestrationDispatchCommandError
+  >;
 }
 
 export class BootstrapTurnStartDispatcher extends Context.Service<
@@ -68,7 +73,7 @@ let activeDispatcher: BootstrapTurnStartDispatcherShape | null = null;
 
 export const dispatchActive = (
   command: ThreadTurnStartCommand,
-): Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError> => {
+): ReturnType<BootstrapTurnStartDispatcherShape["dispatch"]> => {
   const dispatcher = activeDispatcher;
   if (!dispatcher) {
     return Effect.fail(
@@ -176,6 +181,7 @@ export const layer = Layer.effect(
       let createdThread = false;
       let targetProjectId = bootstrap?.createThread?.projectId;
       let targetProjectCwd = bootstrap?.prepareWorktree?.projectCwd;
+      let targetBranch = bootstrap?.createThread?.branch ?? null;
       let targetWorktreePath = bootstrap?.createThread?.worktreePath ?? null;
 
       const cleanupCreatedThread = () =>
@@ -346,6 +352,7 @@ export const layer = Layer.effect(
             baseRefName: bootstrap.prepareWorktree.baseBranch,
             path: null,
           });
+          targetBranch = worktree.worktree.refName;
           targetWorktreePath = worktree.worktree.path;
           yield* orchestrationEngine.dispatch({
             type: "thread.meta.update",
@@ -359,7 +366,12 @@ export const layer = Layer.effect(
 
         yield* runSetupProgram();
 
-        return yield* orchestrationEngine.dispatch(finalTurnStartCommand);
+        const result = yield* orchestrationEngine.dispatch(finalTurnStartCommand);
+        return {
+          ...result,
+          branch: targetBranch,
+          worktreePath: targetWorktreePath,
+        };
       });
 
       return yield* bootstrapProgram.pipe(

--- a/apps/server/src/orchestration/Services/BootstrapTurnStartDispatcher.ts
+++ b/apps/server/src/orchestration/Services/BootstrapTurnStartDispatcher.ts
@@ -53,27 +53,25 @@ function projectSetupScriptCompatibilityDetail(
   }
 }
 
-export interface BootstrapTurnStartDispatcherShape {
-  readonly dispatch: (command: ThreadTurnStartCommand) => Effect.Effect<
-    {
-      readonly sequence: number;
-      readonly branch: string | null;
-      readonly worktreePath: string | null;
-    },
-    OrchestrationDispatchCommandError
-  >;
-}
-
 export class BootstrapTurnStartDispatcher extends Context.Service<
   BootstrapTurnStartDispatcher,
-  BootstrapTurnStartDispatcherShape
+  {
+    readonly dispatch: (command: ThreadTurnStartCommand) => Effect.Effect<
+      {
+        readonly sequence: number;
+        readonly branch: string | null;
+        readonly worktreePath: string | null;
+      },
+      OrchestrationDispatchCommandError
+    >;
+  }
 >()("t3/orchestration/Services/BootstrapTurnStartDispatcher") {}
 
-let activeDispatcher: BootstrapTurnStartDispatcherShape | null = null;
+let activeDispatcher: BootstrapTurnStartDispatcher["Service"] | null = null;
 
 export const dispatchActive = (
   command: ThreadTurnStartCommand,
-): ReturnType<BootstrapTurnStartDispatcherShape["dispatch"]> => {
+): ReturnType<BootstrapTurnStartDispatcher["Service"]["dispatch"]> => {
   const dispatcher = activeDispatcher;
   if (!dispatcher) {
     return Effect.fail(

--- a/apps/server/src/provider/CodexDeveloperInstructions.ts
+++ b/apps/server/src/provider/CodexDeveloperInstructions.ts
@@ -9,6 +9,15 @@ For browser work, first call \`preview_status\`. If no automation-capable previe
 Do not switch to global browser skills, Chrome, Node REPL browser automation, standalone Playwright, or agent-browser merely because the preview is initially closed or a first call fails. Use an alternative browser system only when the T3 preview tools are absent, the user explicitly requests another browser, or \`preview_open\` returns an explicit unsupported/unavailable error. A failed T3 preview tool call should be inspected and retried with corrected arguments when the error is actionable.
 `;
 
+const T3_CODE_THREAD_TOOL_INSTRUCTIONS = `
+
+## T3 Code child threads
+
+When the \`t3-code\` MCP server exposes \`t3_thread_start\`, use it only when the user explicitly asks you to start/spawn/create another T3 Code thread or agent. Do not use it for autonomous delegation, parallel investigation, or background work unless the user's request clearly asks for a separate thread/agent.
+
+The tool always starts the child thread's first turn immediately and returns launch metadata only; it does not wait for child completion. Defaults inherit model/options/runtime/interaction mode from the current thread. Omitted \`mode\` means \`new_worktree\`. Use \`existing_worktree\` only when the user or context names the worktree. Use \`current_checkout\` only when the user explicitly asks for the same checkout; report the returned warning/thread id/path to the user.
+`;
+
 export const CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Plan Mode (Conversational)
 
 You work in 3 phases, and you should *chat your way* to a great plan before finalizing it. A great plan is very detailed-intent- and implementation-wise-so that it can be handed to another engineer or agent to be implemented right away. It must be **decision complete**, where the implementer does not need to make any decisions.
@@ -130,6 +139,7 @@ Do not ask "should I proceed?" in the final output. The user can easily switch o
 
 Only produce at most one \`<proposed_plan>\` block per turn, and only when you are presenting a complete spec.
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
+${T3_CODE_THREAD_TOOL_INSTRUCTIONS}
 </collaboration_mode>`;
 
 export const CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS = `<collaboration_mode># Collaboration Mode: Default
@@ -144,4 +154,5 @@ The \`request_user_input\` tool is unavailable in Default mode. If you call it w
 
 In Default mode, strongly prefer making reasonable assumptions and executing the user's request rather than stopping to ask questions. If you absolutely must ask a question because the answer cannot be discovered from local context and a reasonable assumption would be risky, ask the user directly with a concise plain-text question. Never write a multiple choice question as a textual assistant message.
 ${T3_CODE_BROWSER_TOOL_INSTRUCTIONS}
+${T3_CODE_THREAD_TOOL_INSTRUCTIONS}
 </collaboration_mode>`;

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -79,6 +79,7 @@ import * as ExternalLauncher from "./process/externalLauncher.ts";
 import * as OrchestrationEngine from "./orchestration/Services/OrchestrationEngine.ts";
 import { OrchestrationListenerCallbackError } from "./orchestration/Errors.ts";
 import * as ProjectionSnapshotQuery from "./orchestration/Services/ProjectionSnapshotQuery.ts";
+import * as BootstrapTurnStartDispatcher from "./orchestration/Services/BootstrapTurnStartDispatcher.ts";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
 import { PersistenceSqlError } from "./persistence/Errors.ts";
 import * as ProviderRegistry from "./provider/Services/ProviderRegistry.ts";
@@ -519,6 +520,24 @@ const buildAppUnderTest = (options?: {
           ...options.layers.vcsStatusBroadcaster,
         })
       : VcsStatusBroadcaster.layer.pipe(Layer.provide(gitWorkflowLayer));
+    const projectSetupScriptRunnerLayer = Layer.mock(
+      ProjectSetupScriptRunner.ProjectSetupScriptRunner,
+    )({
+      runForThread: () => Effect.succeed({ status: "no-script" as const }),
+      ...options?.layers?.projectSetupScriptRunner,
+    });
+    const orchestrationEngineLayer = Layer.mock(OrchestrationEngine.OrchestrationEngineService)({
+      readEvents: () => Stream.empty,
+      dispatch: () => Effect.succeed({ sequence: 0 }),
+      streamDomainEvents: Stream.empty,
+      ...options?.layers?.orchestrationEngine,
+    });
+    const bootstrapTurnStartDispatcherLayer = BootstrapTurnStartDispatcher.layer.pipe(
+      Layer.provideMerge(gitWorkflowLayer),
+      Layer.provideMerge(vcsStatusBroadcasterLayer),
+      Layer.provideMerge(projectSetupScriptRunnerLayer),
+      Layer.provideMerge(orchestrationEngineLayer),
+    );
 
     const servedRoutesLayer = HttpRouter.serve(makeRoutesLayer, {
       disableListenLog: true,
@@ -637,11 +656,14 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provideMerge(vcsStatusBroadcasterLayer),
-      Layer.provide(
-        Layer.mock(ProjectSetupScriptRunner.ProjectSetupScriptRunner)({
-          runForThread: () => Effect.succeed({ status: "no-script" as const }),
-          ...options?.layers?.projectSetupScriptRunner,
-        }),
+      Layer.provide(projectSetupScriptRunnerLayer),
+    );
+
+    const servedRoutesWithBootstrapLayer = servedRoutesLayer.pipe(
+      Layer.provideMerge(
+        BootstrapTurnStartDispatcher.ActiveBootstrapTurnStartDispatcherLive.pipe(
+          Layer.provide(bootstrapTurnStartDispatcherLayer),
+        ),
       ),
       Layer.provide(
         Layer.mock(TerminalManager.TerminalManager)({
@@ -671,14 +693,7 @@ const buildAppUnderTest = (options?: {
           }),
         ),
       ),
-      Layer.provide(
-        Layer.mock(OrchestrationEngine.OrchestrationEngineService)({
-          readEvents: () => Stream.empty,
-          dispatch: () => Effect.succeed({ sequence: 0 }),
-          streamDomainEvents: Stream.empty,
-          ...options?.layers?.orchestrationEngine,
-        }),
-      ),
+      Layer.provide(orchestrationEngineLayer),
       Layer.provide(
         Layer.mock(ProjectionSnapshotQuery.ProjectionSnapshotQuery)({
           getCommandReadModel: () => Effect.succeed(makeDefaultOrchestrationReadModel()),
@@ -729,7 +744,7 @@ const buildAppUnderTest = (options?: {
       ),
     );
 
-    const appLayer = servedRoutesLayer.pipe(
+    const appLayer = servedRoutesWithBootstrapLayer.pipe(
       Layer.provide(
         Layer.mock(BrowserTraceCollector.BrowserTraceCollector)({
           record: () => Effect.void,

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -42,6 +42,7 @@ import * as ProcessRunner from "./processRunner.ts";
 import * as GitManager from "./git/GitManager.ts";
 import * as Keybindings from "./keybindings.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
+import { ThreadStartRuntimeLive } from "./mcp/toolkits/thread/handlers.ts";
 import { OrchestrationReactorLive } from "./orchestration/Layers/OrchestrationReactor.ts";
 import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus.ts";
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion.ts";
@@ -82,6 +83,7 @@ import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
 import { OrchestrationLayerLive } from "./orchestration/runtimeLayer.ts";
+import * as BootstrapTurnStartDispatcher from "./orchestration/Services/BootstrapTurnStartDispatcher.ts";
 import {
   clearPersistedServerRuntimeState,
   makePersistedServerRuntimeState,
@@ -283,7 +285,7 @@ const ProviderRuntimeLayerLive = ProviderSessionReaperLive.pipe(
   Layer.provideMerge(OrchestrationLayerLive),
 );
 
-const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
+const RuntimeCoreDependenciesBaseLive = ReactorLayerLive.pipe(
   // Core Services
   Layer.provideMerge(CheckpointingLayerLive),
   Layer.provideMerge(SourceControlProviderRegistryLayerLive),
@@ -306,6 +308,9 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // Provided once at the runtime level so every consumer sees the same
   // logger instances.
   Layer.provideMerge(ProviderEventLoggers.ProviderEventLoggersLive),
+);
+
+const RuntimeCoreDependenciesLive = RuntimeCoreDependenciesBaseLive.pipe(
   // `OpenCodeDriver.create()` yields `OpenCodeRuntime`; previously the old
   // `ProviderRegistryLive` pulled `OpenCodeRuntimeLive` in for itself, but
   // the rewritten registry reads snapshots off the instance registry and
@@ -340,6 +345,13 @@ const RuntimeDependenciesLive = RuntimeCoreDependenciesLive.pipe(
 
 const RuntimeServicesLive = ServerRuntimeStartup.layer.pipe(
   Layer.provideMerge(RuntimeDependenciesLive),
+);
+
+const ServerApplicationRegistrationsLive = Layer.mergeAll(
+  BootstrapTurnStartDispatcher.ActiveBootstrapTurnStartDispatcherLive.pipe(
+    Layer.provide(BootstrapTurnStartDispatcher.layer),
+  ),
+  ThreadStartRuntimeLive,
 );
 
 export const makeRoutesLayer = Layer.mergeAll(
@@ -470,6 +482,7 @@ export const makeServerLayer = Layer.unwrap(
       HttpRouter.serve(makeRoutesLayer, {
         disableLogger: !config.logWebSocketEvents,
       }),
+      ServerApplicationRegistrationsLive,
       httpListeningLayer,
       runtimeStateLayer,
       tailscaleServeLayer,

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1,5 +1,3 @@
-import * as Cause from "effect/Cause";
-import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -23,7 +21,6 @@ import {
   AuthSessionId,
   CommandId,
   type DiscoveredLocalServerList,
-  EventId,
   type OrchestrationCommand,
   type GitActionProgressEvent,
   type GitManagerServiceError,
@@ -90,9 +87,9 @@ import * as VcsStatusBroadcaster from "./vcs/VcsStatusBroadcaster.ts";
 import * as VcsProvisioningService from "./vcs/VcsProvisioningService.ts";
 import * as GitWorkflowService from "./git/GitWorkflowService.ts";
 import * as ReviewService from "./review/ReviewService.ts";
-import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
 import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
+import * as BootstrapTurnStartDispatcher from "./orchestration/Services/BootstrapTurnStartDispatcher.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
@@ -118,19 +115,6 @@ const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
 
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
-}
-
-/** Preserve the setup runner's broader pre-refactor message normalization. */
-function legacySetupFailureDescription(cause: unknown): string {
-  if (
-    typeof cause === "object" &&
-    cause !== null &&
-    "message" in cause &&
-    typeof cause.message === "string"
-  ) {
-    return cause.message;
-  }
-  return String(cause);
 }
 
 function projectEntriesFailureContext(error: WorkspaceEntries.WorkspaceEntriesError): {
@@ -232,19 +216,6 @@ function projectFileFailureContext(
       return { failure: "path_not_file", resolvedPath: error.resolvedPath };
     case "WorkspaceBinaryFileError":
       return { failure: "binary_file", resolvedPath: error.resolvedPath };
-    default:
-      return unexpectedCompatibilityError(error);
-  }
-}
-
-function projectSetupScriptCompatibilityDetail(
-  error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError,
-): string {
-  switch (error._tag) {
-    case "ProjectSetupScriptOperationError":
-      return legacySetupFailureDescription(error.cause);
-    case "ProjectSetupScriptProjectNotFoundError":
-      return "Project was not found for setup script execution.";
     default:
       return unexpectedCompatibilityError(error);
   }
@@ -389,7 +360,6 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
   WsRpcGroup.toLayer(
     Effect.gen(function* () {
       const currentSessionId = currentSession.sessionId;
-      const crypto = yield* Crypto.Crypto;
       const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
       const orchestrationEngine = yield* OrchestrationEngine.OrchestrationEngineService;
       const checkpointDiffQuery = yield* CheckpointDiffQuery.CheckpointDiffQuery;
@@ -411,7 +381,6 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
       const startup = yield* ServerRuntimeStartup.ServerRuntimeStartup;
       const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
       const workspaceFileSystem = yield* WorkspaceFileSystem.WorkspaceFileSystem;
-      const projectSetupScriptRunner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
       const repositoryIdentityResolver =
         yield* RepositoryIdentityResolver.RepositoryIdentityResolver;
       const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
@@ -499,14 +468,6 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
               message: cause instanceof Error ? cause.message : fallbackMessage,
               cause,
             });
-      const randomUUID = crypto.randomUUIDv4.pipe(
-        Effect.mapError((cause) =>
-          toDispatchCommandError(cause, "Failed to generate orchestration command identifier."),
-        ),
-      );
-      const serverEventId = randomUUID.pipe(Effect.map(EventId.make));
-      const serverCommandId = (tag: string) =>
-        randomUUID.pipe(Effect.map((uuid) => CommandId.make(`server:${tag}:${uuid}`)));
 
       const loadAuthAccessSnapshot = () =>
         Effect.all({
@@ -520,48 +481,6 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
               }),
           ),
         );
-
-      const appendSetupScriptActivity = (input: {
-        readonly threadId: ThreadId;
-        readonly kind: "setup-script.requested" | "setup-script.started" | "setup-script.failed";
-        readonly summary: string;
-        readonly createdAt: string;
-        readonly payload: Record<string, unknown>;
-        readonly tone: "info" | "error";
-      }) =>
-        Effect.all({
-          commandId: serverCommandId("setup-script-activity"),
-          activityId: serverEventId,
-        }).pipe(
-          Effect.flatMap(({ commandId, activityId }) =>
-            orchestrationEngine.dispatch({
-              type: "thread.activity.append",
-              commandId,
-              threadId: input.threadId,
-              activity: {
-                id: activityId,
-                tone: input.tone,
-                kind: input.kind,
-                summary: input.summary,
-                payload: input.payload,
-                turnId: null,
-                createdAt: input.createdAt,
-              },
-              createdAt: input.createdAt,
-            }),
-          ),
-        );
-
-      const toBootstrapDispatchCommandCauseError = (cause: Cause.Cause<unknown>) => {
-        const error = Cause.squash(cause);
-        return isOrchestrationDispatchCommandError(error)
-          ? error
-          : new OrchestrationDispatchCommandError({
-              message:
-                error instanceof Error ? error.message : "Failed to bootstrap thread turn start.",
-              cause,
-            });
-      };
 
       const enrichProjectEvent = (
         event: OrchestrationEvent,
@@ -676,208 +595,7 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
       const dispatchBootstrapTurnStart = (
         command: Extract<OrchestrationCommand, { type: "thread.turn.start" }>,
       ): Effect.Effect<{ readonly sequence: number }, OrchestrationDispatchCommandError> =>
-        Effect.gen(function* () {
-          const bootstrap = command.bootstrap;
-          const { bootstrap: _bootstrap, ...finalTurnStartCommand } = command;
-          let createdThread = false;
-          let targetProjectId = bootstrap?.createThread?.projectId;
-          let targetProjectCwd = bootstrap?.prepareWorktree?.projectCwd;
-          let targetWorktreePath = bootstrap?.createThread?.worktreePath ?? null;
-
-          const cleanupCreatedThread = () =>
-            createdThread
-              ? serverCommandId("bootstrap-thread-delete").pipe(
-                  Effect.flatMap((commandId) =>
-                    orchestrationEngine.dispatch({
-                      type: "thread.delete",
-                      commandId,
-                      threadId: command.threadId,
-                    }),
-                  ),
-                  Effect.ignoreCause({ log: true }),
-                )
-              : Effect.void;
-
-          const recordSetupScriptLaunchFailure = (input: {
-            readonly error: ProjectSetupScriptRunner.ProjectSetupScriptRunnerError;
-            readonly requestedAt: string;
-            readonly worktreePath: string;
-          }) => {
-            const detail = projectSetupScriptCompatibilityDetail(input.error);
-            return appendSetupScriptActivity({
-              threadId: command.threadId,
-              kind: "setup-script.failed",
-              summary: "Setup script failed to start",
-              createdAt: input.requestedAt,
-              payload: {
-                detail,
-                worktreePath: input.worktreePath,
-              },
-              tone: "error",
-            }).pipe(
-              Effect.ignoreCause({ log: false }),
-              Effect.flatMap(() =>
-                Effect.logWarning("bootstrap turn start failed to launch setup script", {
-                  threadId: command.threadId,
-                  worktreePath: input.worktreePath,
-                  detail,
-                }),
-              ),
-            );
-          };
-
-          const recordSetupScriptStarted = (input: {
-            readonly requestedAt: string;
-            readonly worktreePath: string;
-            readonly scriptId: string;
-            readonly scriptName: string;
-            readonly terminalId: string;
-          }) =>
-            Effect.gen(function* () {
-              const startedAt = yield* nowIso;
-              const payload = {
-                scriptId: input.scriptId,
-                scriptName: input.scriptName,
-                terminalId: input.terminalId,
-                worktreePath: input.worktreePath,
-              };
-              yield* Effect.all([
-                appendSetupScriptActivity({
-                  threadId: command.threadId,
-                  kind: "setup-script.requested",
-                  summary: "Starting setup script",
-                  createdAt: input.requestedAt,
-                  payload,
-                  tone: "info",
-                }),
-                appendSetupScriptActivity({
-                  threadId: command.threadId,
-                  kind: "setup-script.started",
-                  summary: "Setup script started",
-                  createdAt: startedAt,
-                  payload,
-                  tone: "info",
-                }),
-              ]).pipe(
-                Effect.asVoid,
-                Effect.catch((error) =>
-                  Effect.logWarning(
-                    "bootstrap turn start launched setup script but failed to record setup activity",
-                    {
-                      threadId: command.threadId,
-                      worktreePath: input.worktreePath,
-                      scriptId: input.scriptId,
-                      terminalId: input.terminalId,
-                      detail: error.message,
-                    },
-                  ),
-                ),
-              );
-            });
-
-          const runSetupProgram = () =>
-            Effect.gen(function* () {
-              if (!bootstrap?.runSetupScript || !targetWorktreePath) {
-                return;
-              }
-              const worktreePath = targetWorktreePath;
-              const requestedAt = yield* nowIso;
-              yield* projectSetupScriptRunner
-                .runForThread({
-                  threadId: command.threadId,
-                  ...(targetProjectId ? { projectId: targetProjectId } : {}),
-                  ...(targetProjectCwd ? { projectCwd: targetProjectCwd } : {}),
-                  worktreePath,
-                })
-                .pipe(
-                  Effect.matchEffect({
-                    onFailure: (error) =>
-                      recordSetupScriptLaunchFailure({
-                        error,
-                        requestedAt,
-                        worktreePath,
-                      }),
-                    onSuccess: (setupResult) => {
-                      if (setupResult.status !== "started") {
-                        return Effect.void;
-                      }
-                      return recordSetupScriptStarted({
-                        requestedAt,
-                        worktreePath,
-                        scriptId: setupResult.scriptId,
-                        scriptName: setupResult.scriptName,
-                        terminalId: setupResult.terminalId,
-                      });
-                    },
-                  }),
-                );
-            });
-
-          const bootstrapProgram = Effect.gen(function* () {
-            if (bootstrap?.createThread) {
-              yield* orchestrationEngine.dispatch({
-                type: "thread.create",
-                commandId: yield* serverCommandId("bootstrap-thread-create"),
-                threadId: command.threadId,
-                projectId: bootstrap.createThread.projectId,
-                title: bootstrap.createThread.title,
-                modelSelection: bootstrap.createThread.modelSelection,
-                runtimeMode: bootstrap.createThread.runtimeMode,
-                interactionMode: bootstrap.createThread.interactionMode,
-                branch: bootstrap.createThread.branch,
-                worktreePath: bootstrap.createThread.worktreePath,
-                createdAt: bootstrap.createThread.createdAt,
-              });
-              createdThread = true;
-            }
-
-            if (bootstrap?.prepareWorktree) {
-              let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
-              if (bootstrap.prepareWorktree.startFromOrigin) {
-                yield* gitWorkflow.fetchRemote({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  remoteName: "origin",
-                });
-                const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  fallbackRemoteName: "origin",
-                });
-                worktreeBaseRef = resolvedRemoteBase.commitSha;
-              }
-              const worktree = yield* gitWorkflow.createWorktree({
-                cwd: bootstrap.prepareWorktree.projectCwd,
-                refName: worktreeBaseRef,
-                newRefName: bootstrap.prepareWorktree.branch,
-                baseRefName: bootstrap.prepareWorktree.baseBranch,
-                path: null,
-              });
-              targetWorktreePath = worktree.worktree.path;
-              yield* orchestrationEngine.dispatch({
-                type: "thread.meta.update",
-                commandId: yield* serverCommandId("bootstrap-thread-meta-update"),
-                threadId: command.threadId,
-                branch: worktree.worktree.refName,
-                worktreePath: targetWorktreePath,
-              });
-              yield* refreshGitStatus(targetWorktreePath);
-            }
-
-            yield* runSetupProgram();
-
-            return yield* orchestrationEngine.dispatch(finalTurnStartCommand);
-          });
-
-          return yield* bootstrapProgram.pipe(
-            Effect.catchCause((cause) => {
-              const dispatchError = toBootstrapDispatchCommandCauseError(cause);
-              if (Cause.hasInterruptsOnly(cause)) {
-                return Effect.fail(dispatchError);
-              }
-              return cleanupCreatedThread().pipe(Effect.flatMap(() => Effect.fail(dispatchError)));
-            }),
-          );
-        });
+        BootstrapTurnStartDispatcher.dispatchActive(command);
 
       const dispatchNormalizedCommand = (
         normalizedCommand: OrchestrationCommand,

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -454,7 +454,7 @@ export type PreviewAutomationResponse = typeof PreviewAutomationResponse.Type;
 export class PreviewAutomationUnavailableError extends Schema.TaggedErrorClass<PreviewAutomationUnavailableError>()(
   "PreviewAutomationUnavailableError",
   {
-    capability: Schema.Literal("preview"),
+    capability: Schema.Literals(["preview", "thread-management"]),
     environmentId: EnvironmentId,
     threadId: ThreadId,
     providerSessionId: TrimmedNonEmptyString,


### PR DESCRIPTION
## Summary

Adds a provider-scoped MCP tool, `t3_thread_start`, that lets Codex start another T3 Code thread only when the user explicitly asks to start, spawn, or create another thread/agent.

This keeps the tool available for intentional multi-thread workflows without encouraging autonomous delegation or background parallel work.

## What changed

- Registers a new thread MCP toolkit with `t3_thread_start`.
- Adds a `thread-management` MCP capability and grants it to provider-scoped MCP sessions.
- Supports three start modes:
  - `new_worktree`: creates a temporary branch/worktree from the default branch by default.
  - `existing_worktree`: starts a thread in a supplied worktree path.
  - `current_checkout`: starts a thread on the current checkout and returns warning metadata.
- Inherits model/runtime/interaction settings from the source thread unless the tool call overrides them.
- Updates Codex developer instructions so this tool is used only after explicit user intent, not for autonomous delegation.

## Implementation notes

- Extracts bootstrap turn-start handling from the WebSocket route into `BootstrapTurnStartDispatcher`.
- The shared dispatcher owns thread creation, optional worktree preparation, setup-script launch, cleanup on bootstrap failure, and VCS status refresh.
- WebSocket dispatch and MCP tool dispatch now share the same bootstrap path instead of duplicating orchestration/worktree behavior.
- MCP route registration stays lightweight; runtime-only services are registered for the server lifetime so tool registration does not leak git/projection/orchestration dependencies into HTTP route construction.

## Validation

- `vp check`
- `vp run typecheck`

## Risk

Moderate. This touches thread-start orchestration and WebSocket bootstrap routing, but the behavior is centralized behind the same command shape and covered with new thread-tool tests plus existing server type coverage.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `t3_thread_start` MCP tool for starting Codex child threads
> - Adds a new `t3_thread_start` MCP tool defined in [tools.ts](https://github.com/pingdotgg/t3code/pull/3107/files#diff-628558ee16b6edb0d4267130a7c7843ab337a9f9b8c09483e9e8182e39e39a95) supporting `new_worktree`, `existing_worktree`, and `current_checkout` modes with structured input/output schemas.
> - Implements [handlers.ts](https://github.com/pingdotgg/t3code/pull/3107/files#diff-c86137ad202b428627265a1cfb74fbaed2f5df4c5edd2ecc9289bf94241146bf) that resolves branches/worktrees, gates on the new `thread-management` capability, and enqueues a `thread.turn.start` command via `ServerRuntimeStartup`.
> - Extracts WebSocket bootstrap logic from [ws.ts](https://github.com/pingdotgg/t3code/pull/3107/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) into a new `BootstrapTurnStartDispatcher` service in [BootstrapTurnStartDispatcher.ts](https://github.com/pingdotgg/t3code/pull/3107/files#diff-73e0b0637da3ce169018207cb1a25ab7abbd07b2f7a6767635df9ab3499b003e), which handles worktree creation, setup scripts, and VCS status refresh.
> - Newly issued MCP sessions now include `thread-management` alongside `preview` in their capabilities set.
> - Adds `T3_CODE_THREAD_TOOL_INSTRUCTIONS` to Codex developer instruction strings to guide LLM usage of the new tool.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c5c105.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread creation, git worktrees, and orchestration on a shared bootstrap path used by WebSocket and MCP; behavior is covered by new MCP thread tests but mistakes could affect existing thread-start flows.
> 
> **Overview**
> Adds **`t3_thread_start`** on the T3 Code MCP server so Codex can spawn child threads when the user explicitly asks. Issued provider MCP tokens now include **`thread-management`** alongside **`preview`**. The tool builds a bootstrap **`thread.turn.start`** command (default **`new_worktree`**, or **`existing_worktree`** / **`current_checkout`**), inherits settings from the invoking thread unless overridden, queues it through server startup, and returns launch metadata without waiting for the child turn.
> 
> **Bootstrap turn-start** logic is extracted from **`ws.ts`** into **`BootstrapTurnStartDispatcher`** (thread create, optional worktree prep, setup script, failure cleanup, VCS refresh). WebSocket bootstrap dispatch and the MCP handler both call **`dispatchActive`**.
> 
> Codex developer instructions now describe when **`t3_thread_start`** is allowed (explicit user intent, not autonomous delegation). Server startup registers the thread MCP toolkit and active bootstrap/thread-start runtimes via **`ServerApplicationRegistrationsLive`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094c88c9546f759de560c041b4bb3f323195511e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->