### PR TITLE
Parallelize VCS status refresh and status reads

### DIFF
--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1361,7 +1361,9 @@ export const makeGitManager = Effect.fn("makeGitManager")(function* () {
     },
   );
   const status: GitManagerShape["status"] = Effect.fn("status")(function* (input) {
-    const [local, remote] = yield* Effect.all([localStatus(input), remoteStatus(input)]);
+    const [local, remote] = yield* Effect.all([localStatus(input), remoteStatus(input)], {
+      concurrency: "unbounded",
+    });
     return mergeGitStatusParts(local, remote);
   });
   const invalidateLocalStatus: GitManagerShape["invalidateLocalStatus"] = Effect.fn(

--- a/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.test.ts
@@ -17,6 +17,7 @@ import type {
   VcsStatusResult,
   VcsStatusStreamEvent,
 } from "@t3tools/contracts";
+import { GitManagerError } from "@t3tools/contracts";
 
 import * as VcsStatusBroadcaster from "./VcsStatusBroadcaster.ts";
 import * as GitWorkflowService from "../git/GitWorkflowService.ts";
@@ -147,6 +148,71 @@ describe("VcsStatusBroadcaster", () => {
       assert.equal(state.localInvalidationCalls, 1);
       assert.equal(state.remoteInvalidationCalls, 1);
     }).pipe(Effect.provide(makeTestLayer(state)));
+  });
+
+  it.effect("keeps the cached snapshot unchanged when a refresh branch fails", () => {
+    const state = {
+      currentLocalStatus: baseLocalStatus,
+      currentRemoteStatus: baseRemoteStatus,
+      localStatusCalls: 0,
+      remoteStatusCalls: 0,
+      localInvalidationCalls: 0,
+      remoteInvalidationCalls: 0,
+      failRemoteStatus: false,
+    };
+    const testLayer = VcsStatusBroadcaster.layer.pipe(
+      Layer.provideMerge(NodeServices.layer),
+      Layer.provide(
+        Layer.mock(GitWorkflowService.GitWorkflowService)({
+          localStatus: () =>
+            Effect.sync(() => {
+              state.localStatusCalls += 1;
+              return state.currentLocalStatus;
+            }),
+          remoteStatus: () =>
+            Effect.suspend(() => {
+              state.remoteStatusCalls += 1;
+              return state.failRemoteStatus
+                ? Effect.fail(
+                    new GitManagerError({
+                      operation: "VcsStatusBroadcaster.test",
+                      detail: "remote status failed",
+                    }),
+                  )
+                : Effect.succeed(state.currentRemoteStatus);
+            }),
+          invalidateLocalStatus: () =>
+            Effect.sync(() => {
+              state.localInvalidationCalls += 1;
+            }),
+          invalidateRemoteStatus: () =>
+            Effect.sync(() => {
+              state.remoteInvalidationCalls += 1;
+            }),
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const broadcaster = yield* VcsStatusBroadcaster.VcsStatusBroadcaster;
+      yield* broadcaster.getStatus({ cwd: "/repo" });
+
+      state.currentLocalStatus = {
+        ...baseLocalStatus,
+        refName: "feature/partial-refresh",
+      };
+      state.currentRemoteStatus = {
+        ...baseRemoteStatus,
+        aheadCount: 3,
+      };
+      state.failRemoteStatus = true;
+
+      const refreshExit = yield* broadcaster.refreshStatus("/repo").pipe(Effect.exit);
+      const cached = yield* broadcaster.getStatus({ cwd: "/repo" });
+
+      assert.isTrue(Exit.isFailure(refreshExit));
+      assert.deepStrictEqual(cached, baseStatus);
+    }).pipe(Effect.provide(testLayer));
   });
 
   it.effect("refreshes only the cached local snapshot when requested", () => {

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -219,20 +219,26 @@ export const layer = Layer.effect(
       "VcsStatusBroadcaster.getStatus",
     )(function* (input) {
       const cwd = yield* withFileSystem(normalizeCwd(input.cwd));
-      const [local, remote] = yield* Effect.all([
-        getOrLoadLocalStatus(cwd),
-        getOrLoadRemoteStatus(cwd),
-      ]);
+      const [local, remote] = yield* Effect.all(
+        [getOrLoadLocalStatus(cwd), getOrLoadRemoteStatus(cwd)],
+        { concurrency: "unbounded" },
+      );
       return mergeGitStatusParts(local, remote);
     });
+
+    const refreshLocalStatusCore = Effect.fn("VcsStatusBroadcaster.refreshLocalStatusCore")(
+      function* (cwd: string) {
+        yield* workflow.invalidateLocalStatus(cwd);
+        const local = yield* workflow.localStatus({ cwd });
+        return yield* updateCachedLocalStatus(cwd, local, { publish: true });
+      },
+    );
 
     const refreshLocalStatus: VcsStatusBroadcasterShape["refreshLocalStatus"] = Effect.fn(
       "VcsStatusBroadcaster.refreshLocalStatus",
     )(function* (rawCwd) {
       const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
-      yield* workflow.invalidateLocalStatus(cwd);
-      const local = yield* workflow.localStatus({ cwd });
-      return yield* updateCachedLocalStatus(cwd, local, { publish: true });
+      return yield* refreshLocalStatusCore(cwd);
     });
 
     const refreshRemoteStatus = Effect.fn("VcsStatusBroadcaster.refreshRemoteStatus")(function* (
@@ -247,10 +253,10 @@ export const layer = Layer.effect(
       "VcsStatusBroadcaster.refreshStatus",
     )(function* (rawCwd) {
       const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
-      const [local, remote] = yield* Effect.all([
-        refreshLocalStatus(cwd),
-        refreshRemoteStatus(cwd),
-      ]);
+      const [local, remote] = yield* Effect.all(
+        [refreshLocalStatusCore(cwd), refreshRemoteStatus(cwd)],
+        { concurrency: "unbounded" },
+      );
       return mergeGitStatusParts(local, remote);
     });
 

--- a/apps/server/src/vcs/VcsStatusBroadcaster.ts
+++ b/apps/server/src/vcs/VcsStatusBroadcaster.ts
@@ -179,18 +179,53 @@ export const layer = Layer.effect(
       },
     );
 
+    const updateCachedStatus = Effect.fn("VcsStatusBroadcaster.updateCachedStatus")(function* (
+      cwd: string,
+      local: VcsStatusLocalResult,
+      remote: VcsStatusRemoteResult | null,
+      options?: { publish?: boolean },
+    ) {
+      const nextLocal = {
+        fingerprint: fingerprintStatusPart(local),
+        value: local,
+      } satisfies CachedValue<VcsStatusLocalResult>;
+      const nextRemote = {
+        fingerprint: fingerprintStatusPart(remote),
+        value: remote,
+      } satisfies CachedValue<VcsStatusRemoteResult | null>;
+      const shouldPublish = yield* Ref.modify(cacheRef, (cache) => {
+        const previous = cache.get(cwd) ?? { local: null, remote: null };
+        const nextCache = new Map(cache);
+        nextCache.set(cwd, {
+          local: nextLocal,
+          remote: nextRemote,
+        });
+        return [
+          previous.local?.fingerprint !== nextLocal.fingerprint ||
+            previous.remote?.fingerprint !== nextRemote.fingerprint,
+          nextCache,
+        ] as const;
+      });
+
+      if (options?.publish && shouldPublish) {
+        yield* PubSub.publish(changesPubSub, {
+          cwd,
+          event: {
+            _tag: "snapshot",
+            local,
+            remote,
+          },
+        });
+      }
+
+      return mergeGitStatusParts(local, remote);
+    });
+
     const loadLocalStatus = Effect.fn("VcsStatusBroadcaster.loadLocalStatus")(function* (
       cwd: string,
     ) {
       const local = yield* workflow.localStatus({ cwd });
       return yield* updateCachedLocalStatus(cwd, local);
-    });
-
-    const loadRemoteStatus = Effect.fn("VcsStatusBroadcaster.loadRemoteStatus")(function* (
-      cwd: string,
-    ) {
-      const remote = yield* workflow.remoteStatus({ cwd });
-      return yield* updateCachedRemoteStatus(cwd, remote);
     });
 
     const getOrLoadLocalStatus = Effect.fn("VcsStatusBroadcaster.getOrLoadLocalStatus")(function* (
@@ -203,27 +238,24 @@ export const layer = Layer.effect(
       return yield* loadLocalStatus(cwd);
     });
 
-    const getOrLoadRemoteStatus = Effect.fn("VcsStatusBroadcaster.getOrLoadRemoteStatus")(
-      function* (cwd: string) {
-        const cached = yield* getCachedStatus(cwd);
-        if (cached?.remote) {
-          return cached.remote.value;
-        }
-        return yield* loadRemoteStatus(cwd);
-      },
-    );
-
     const withFileSystem = Effect.provideService(FileSystem.FileSystem, fs);
 
     const getStatus: VcsStatusBroadcasterShape["getStatus"] = Effect.fn(
       "VcsStatusBroadcaster.getStatus",
     )(function* (input) {
       const cwd = yield* withFileSystem(normalizeCwd(input.cwd));
+      const cached = yield* getCachedStatus(cwd);
+      if (cached?.local && cached.remote) {
+        return mergeGitStatusParts(cached.local.value, cached.remote.value);
+      }
       const [local, remote] = yield* Effect.all(
-        [getOrLoadLocalStatus(cwd), getOrLoadRemoteStatus(cwd)],
+        [
+          cached?.local ? Effect.succeed(cached.local.value) : workflow.localStatus({ cwd }),
+          cached?.remote ? Effect.succeed(cached.remote.value) : workflow.remoteStatus({ cwd }),
+        ],
         { concurrency: "unbounded" },
       );
-      return mergeGitStatusParts(local, remote);
+      return yield* updateCachedStatus(cwd, local, remote);
     });
 
     const refreshLocalStatusCore = Effect.fn("VcsStatusBroadcaster.refreshLocalStatusCore")(
@@ -253,11 +285,15 @@ export const layer = Layer.effect(
       "VcsStatusBroadcaster.refreshStatus",
     )(function* (rawCwd) {
       const cwd = yield* withFileSystem(normalizeCwd(rawCwd));
+      yield* Effect.all(
+        [workflow.invalidateLocalStatus(cwd), workflow.invalidateRemoteStatus(cwd)],
+        { concurrency: "unbounded", discard: true },
+      );
       const [local, remote] = yield* Effect.all(
-        [refreshLocalStatusCore(cwd), refreshRemoteStatus(cwd)],
+        [workflow.localStatus({ cwd }), workflow.remoteStatus({ cwd })],
         { concurrency: "unbounded" },
       );
-      return mergeGitStatusParts(local, remote);
+      return yield* updateCachedStatus(cwd, local, remote, { publish: true });
     });
 
     const makeRemoteRefreshLoop = (


### PR DESCRIPTION
## Summary
- Parallelizes local and remote VCS status reads in `GitManager.status` and `VcsStatusBroadcaster.getStatus` with unbounded Effect concurrency.
- Extracts a shared `refreshLocalStatusCore` path so `refreshStatus` can refresh local and remote status concurrently without duplicating local refresh logic.
- Keeps cached local status updates and publish behavior unchanged while reducing latency in the combined refresh flow.

## Testing
- Not run: `vp check`
- Not run: `vp run typecheck`
- Not run: project lint scripts
- Not run: backend tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core git status caching and refresh semantics (including failure behavior); concurrency changes could surface timing edge cases but scope is limited to status paths.
> 
> **Overview**
> Speeds up combined VCS status work by running **local and remote** git status fetches concurrently instead of one after the other.
> 
> In **`GitManager.status`** and **`VcsStatusBroadcaster.getStatus`**, missing cache legs are loaded with `Effect.all` and **`concurrency: "unbounded"`**. **`getStatus`** also returns immediately when both halves are already cached, and writes both parts through a new **`updateCachedStatus`** helper in one cache update.
> 
> **`refreshStatus`** now invalidates local and remote caches in parallel, refetches both sides concurrently, then updates the cache and publishes a single snapshot via **`updateCachedStatus`** (rather than chaining separate local/remote refresh paths). **`refreshLocalStatus`** delegates to a shared **`refreshLocalStatusCore`** for the invalidate→fetch→cache sequence.
> 
> A test asserts that if **`refreshStatus`** fails partway through (e.g. remote fetch errors), the **previous cached snapshot is left unchanged**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef2c9eb25eebe8e06e1ba4dea1da82f3f9cb4f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parallelize VCS status refresh and status reads with unbounded concurrency
> - `VcsStatusBroadcaster.getStatus` and `GitManager.status` now fetch local and remote status concurrently using `Effect.all` with `concurrency: "unbounded"` instead of sequentially.
> - `VcsStatusBroadcaster.refreshStatus` similarly runs local and remote refresh concurrently before merging results.
> - Extracts a `refreshLocalStatusCore` helper in [VcsStatusBroadcaster.ts](https://github.com/pingdotgg/t3code/pull/3112/files#diff-1cb99aea20f9603d7de458a7b72df1f1f1dc7c4a0a3424be90cbbbca9ab6f952) to share the invalidate→fetch→cache sequence between `refreshLocalStatus` and `refreshStatus`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c59ee80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->