### PR TITLE
fix(server): use bound host for MCP endpoint

### DIFF
--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -8,16 +8,18 @@ import { ServerEnvironment } from "../environment/Services/ServerEnvironment.ts"
 import * as McpSessionRegistry from "./McpSessionRegistry.ts";
 
 const environmentId = EnvironmentId.make("environment-1");
-const fakeHttpServer = HttpServer.HttpServer.of({
-  address: { _tag: "TcpAddress", hostname: "127.0.0.1", port: 43123 },
-  serve: (() => Effect.void) as HttpServer.HttpServer["Service"]["serve"],
-});
+const makeFakeHttpServer = (hostname: string, port = 43123) =>
+  HttpServer.HttpServer.of({
+    address: { _tag: "TcpAddress", hostname, port },
+    serve: (() => Effect.void) as HttpServer.HttpServer["Service"]["serve"],
+  });
+const fakeHttpServer = makeFakeHttpServer("127.0.0.1");
 const fakeEnvironment = ServerEnvironment.of({
   getEnvironmentId: Effect.succeed(environmentId),
   getDescriptor: Effect.die("unused"),
 });
 
-const makeRegistry = (now: () => number) =>
+const makeRegistry = (now: () => number, httpServer = fakeHttpServer) =>
   McpSessionRegistry.__testing
     .make({
       now,
@@ -25,7 +27,7 @@ const makeRegistry = (now: () => number) =>
       maximumLifetimeMs: 1_000,
     })
     .pipe(
-      Effect.provideService(HttpServer.HttpServer, fakeHttpServer),
+      Effect.provideService(HttpServer.HttpServer, httpServer),
       Effect.provideService(ServerEnvironment, fakeEnvironment),
       Effect.provide(NodeServices.layer),
     );
@@ -50,6 +52,26 @@ it.effect("stores only a token hash, resolves the bearer token, and revokes by t
     expect(yield* registry.resolve(token)).toBeUndefined();
 
     timestamp += 2_000;
+  }),
+);
+
+it.effect("builds MCP endpoints from the bound server host", () =>
+  Effect.gen(function* () {
+    const cases = [
+      ["100.64.0.40", "http://100.64.0.40:43123/mcp"],
+      ["0.0.0.0", "http://127.0.0.1:43123/mcp"],
+      ["localhost", "http://localhost:43123/mcp"],
+      ["127.0.0.1", "http://127.0.0.1:43123/mcp"],
+    ] as const;
+
+    for (const [hostname, expectedEndpoint] of cases) {
+      const registry = yield* makeRegistry(() => 1_000, makeFakeHttpServer(hostname));
+      const issued = yield* registry.issue({
+        threadId: ThreadId.make(`thread-${hostname}`),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+      });
+      expect(issued.config.endpoint).toBe(expectedEndpoint);
+    }
   }),
 );
 

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -60,6 +60,17 @@ const bytesToHex = (bytes: Uint8Array): string =>
 
 const tokenFromBytes = (bytes: Uint8Array): string => Buffer.from(bytes).toString("base64url");
 
+const getHttpMcpEndpointHost = (hostname: string): string => {
+  const normalized = hostname.toLowerCase();
+  const endpointHostname =
+    normalized === "0.0.0.0" || normalized === "::" || normalized === "[::]"
+      ? "127.0.0.1"
+      : hostname;
+  return endpointHostname.includes(":") && !endpointHostname.startsWith("[")
+    ? `[${endpointHostname}]`
+    : endpointHostname;
+};
+
 const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
   options: McpSessionRegistryOptions = {},
 ) {
@@ -73,7 +84,7 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
   const maximumLifetimeMs = options.maximumLifetimeMs ?? DEFAULT_MAXIMUM_LIFETIME_MS;
   const endpoint =
     httpServer.address._tag === "TcpAddress"
-      ? `http://127.0.0.1:${httpServer.address.port}/mcp`
+      ? `http://${getHttpMcpEndpointHost(httpServer.address.hostname)}:${httpServer.address.port}/mcp`
       : "http://127.0.0.1/mcp";
 
   const hashToken = (token: string) =>


### PR DESCRIPTION
## Summary

- Generate the T3 Code MCP session endpoint from the bound HTTP server hostname instead of always using `127.0.0.1`.
- Preserve loopback behavior for localhost and `127.0.0.1` binds.
- Keep wildcard binds reachable from the local machine by normalizing `0.0.0.0`, `::`, and `[::]` to `127.0.0.1`.
- Add regression coverage for non-loopback, wildcard, localhost, and explicit loopback bind addresses.

## Root Cause

`McpSessionRegistry` issued provider credentials with a precomputed MCP endpoint. For every TCP listener, that endpoint was hardcoded to `http://127.0.0.1:<port>/mcp`, regardless of the actual host passed to the HTTP server bind.

That is correct for a loopback bind, but incorrect when the server is intentionally bound to a reachable non-loopback interface, such as a private network address. In that configuration, provider processes receive an MCP URL pointing at local loopback even though the server is listening elsewhere, so the MCP connection is refused and tools such as `t3_thread_start` are unavailable.

## Implementation Notes

The fix stays at the credential registry boundary because the Codex, Claude, Cursor, Grok, and OpenCode adapters already consume the endpoint from `McpProviderSession`. Updating endpoint generation there fixes all provider config generation paths without duplicating host logic in each adapter.

For concrete TCP binds, the endpoint now uses `HttpServer.address.hostname` directly. Wildcard binds are the exception: they are not useful as outbound client targets, so they continue to advertise local loopback. IPv6 literal hosts are bracketed before URL construction so generated endpoint strings remain valid.

## Behavior

- Binding to `100.64.0.40:<port>` issues `http://100.64.0.40:<port>/mcp`.
- Binding to `0.0.0.0:<port>` issues `http://127.0.0.1:<port>/mcp`.
- Binding to `localhost:<port>` issues `http://localhost:<port>/mcp`.
- Binding to `127.0.0.1:<port>` issues `http://127.0.0.1:<port>/mcp`.

## Validation

- `vp test apps/server/src/mcp/McpSessionRegistry.test.ts`
- `vp check`
- `bun run --cwd apps/server typecheck`

Full workspace `vp run typecheck` currently reports unrelated mobile type resolution/type errors outside this change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix MCP endpoint URL to use the bound server host instead of always 127.0.0.1
> - Adds `getHttpMcpEndpointHost` in [McpSessionRegistry.ts](https://github.com/pingdotgg/t3code/pull/3114/files#diff-09bf7c7f63f6baf81647c385143f7e45fbb74dc80c2b3c556c6383244e48b190) to normalize the server's bound hostname: maps `0.0.0.0`, `::`, and `[::]` to `127.0.0.1`, lowercases the result, and brackets bare IPv6 literals.
> - `McpSessionRegistry.make` now uses this utility when constructing the endpoint URL for TCP servers, replacing the hardcoded `127.0.0.1`.
> - Behavioral Change: servers bound to a specific hostname (e.g. `100.64.0.40`) will now produce endpoint URLs reflecting that host rather than `127.0.0.1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93c23cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->