### PR TITLE
Render the plan surface in the inline right panel

### DIFF
--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -2276,6 +2276,35 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("renders the plan surface in the inline right panel", async () => {
+    useRightPanelStore.getState().open(THREAD_REF, "plan");
+
+    const mounted = await mountChatView({
+      viewport: WIDE_FOOTER_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-inline-plan-panel" as MessageId,
+        targetText: "show the inline plan panel",
+      }),
+    });
+
+    try {
+      await waitForElement(
+        () =>
+          Array.from(document.querySelectorAll<HTMLElement>("p")).find(
+            (element) => element.textContent?.trim() === "No active plan yet.",
+          ) ?? null,
+        "Unable to find inline plan panel content.",
+      );
+
+      expect(
+        document.querySelector<HTMLElement>("[data-right-panel-tabbar]")?.textContent,
+      ).toContain("Plan");
+      expect(document.body.textContent).toContain("Plans will appear here when generated.");
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("loads file previews from the active thread worktree", async () => {
     const worktreePath = "/repo/worktrees/file-preview-thread";
     const snapshot = createSnapshotForTargetUser({

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -2305,6 +2305,100 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("renders the shared panel toggles in the responsive right-panel sheet", async () => {
+    useRightPanelStore.getState().open(THREAD_REF, "plan");
+    useRightPanelStore.getState().openTerminal(THREAD_REF, DEFAULT_TERMINAL_ID);
+    useRightPanelStore.getState().activateSurface(THREAD_REF, "plan");
+    const baseSnapshot = createSnapshotForTargetUser({
+      targetMessageId: "msg-user-responsive-plan-panel-controls" as MessageId,
+      targetText: "show responsive plan panel controls",
+    });
+    const snapshot: OrchestrationReadModel = {
+      ...baseSnapshot,
+      threads: baseSnapshot.threads.map((thread) =>
+        thread.id === THREAD_ID
+          ? {
+              ...thread,
+              activities: [
+                {
+                  id: EventId.make("activity-responsive-panel-plan"),
+                  tone: "info",
+                  kind: "turn.plan.updated",
+                  summary: "Plan updated",
+                  payload: {
+                    explanation: "Claude Tasks",
+                    plan: [{ step: "Keep terminal navigation available", status: "inProgress" }],
+                  },
+                  turnId: null,
+                  sequence: 1,
+                  createdAt: isoAt(1_000),
+                },
+              ],
+            }
+          : thread,
+      ),
+    };
+
+    const mounted = await mountChatView({
+      viewport: COMPACT_FOOTER_VIEWPORT,
+      snapshot,
+    });
+
+    try {
+      const sheet = await waitForElement(
+        () => document.querySelector<HTMLElement>('[data-slot="sheet-popup"]'),
+        "Unable to find responsive right-panel sheet.",
+      );
+      const controls = await waitForElement(
+        () => sheet.querySelector<HTMLElement>("[data-panel-layout-controls]"),
+        "Unable to find shared controls in the responsive right-panel sheet.",
+      );
+
+      expect(
+        Array.from(controls.querySelectorAll<HTMLButtonElement>("button")).map((button) =>
+          button.getAttribute("aria-label"),
+        ),
+      ).toEqual(["Toggle terminal drawer", "Toggle right panel"]);
+      expect(sheet.querySelector('button[aria-label="Maximize panel"]')).toBeNull();
+      expect(sheet.querySelector('button[aria-label="Close tasks sidebar"]')).toBeNull();
+
+      const terminalTab = Array.from(
+        sheet.querySelectorAll<HTMLButtonElement>("[data-right-panel-tab-list] button"),
+      ).find((button) => button.textContent?.includes("Terminal"));
+      terminalTab?.click();
+
+      await vi.waitFor(() => {
+        expect(
+          selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF)
+            .activeSurfaceId,
+        ).toBe(`terminal:${DEFAULT_TERMINAL_ID}`);
+        expect(sheet.querySelector('[data-terminal-owner="right-panel"]')).not.toBeNull();
+        expect(sheet.textContent).not.toContain("Claude Tasks");
+      });
+
+      sheet.querySelector<HTMLButtonElement>('button[aria-label="Close Plan"]')?.click();
+
+      await vi.waitFor(() => {
+        const panelState = selectThreadRightPanelState(
+          useRightPanelStore.getState().byThreadKey,
+          THREAD_REF,
+        );
+        expect(panelState.surfaces.some((surface) => surface.kind === "plan")).toBe(false);
+        expect(panelState.activeSurfaceId).toBe(`terminal:${DEFAULT_TERMINAL_ID}`);
+      });
+
+      controls.querySelector<HTMLButtonElement>('button[aria-label="Toggle right panel"]')?.click();
+
+      await vi.waitFor(() => {
+        expect(
+          selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, THREAD_REF).isOpen,
+        ).toBe(false);
+      });
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("loads file previews from the active thread worktree", async () => {
     const worktreePath = "/repo/worktrees/file-preview-thread";
     const snapshot = createSnapshotForTargetUser({

--- a/apps/web/src/components/ChatView.browser.tsx
+++ b/apps/web/src/components/ChatView.browser.tsx
@@ -2110,6 +2110,48 @@ describe("ChatView timeline estimator parity (full app)", () => {
     }
   });
 
+  it("keeps the compact chat header on one row", async () => {
+    const mounted = await mountChatView({
+      viewport: COMPACT_FOOTER_VIEWPORT,
+      snapshot: createSnapshotForTargetUser({
+        targetMessageId: "msg-user-compact-header" as MessageId,
+        targetText: "keep the compact header aligned",
+      }),
+    });
+
+    try {
+      const chatHeader = await waitForElement(
+        () => document.querySelector<HTMLElement>("[data-chat-header]"),
+        "Unable to find chat header.",
+      );
+      const threadTitle = await waitForElement(
+        () => chatHeader.querySelector<HTMLElement>("h2"),
+        "Unable to find thread title.",
+      );
+      const headerActions = await waitForElement(
+        () => document.querySelector<HTMLElement>("[data-chat-header-actions]"),
+        "Unable to find chat header actions.",
+      );
+
+      const headerRect = chatHeader.getBoundingClientRect();
+      const titleRect = threadTitle.getBoundingClientRect();
+      const actionsRect = headerActions.getBoundingClientRect();
+      const headerCenter = headerRect.top + headerRect.height / 2;
+
+      expect(headerRect.height).toBe(52);
+      expect(titleRect.top).toBeGreaterThanOrEqual(headerRect.top);
+      expect(titleRect.bottom).toBeLessThanOrEqual(headerRect.bottom);
+      expect(actionsRect.top).toBeGreaterThanOrEqual(headerRect.top);
+      expect(actionsRect.bottom).toBeLessThanOrEqual(headerRect.bottom);
+      expect(Math.abs(titleRect.top + titleRect.height / 2 - headerCenter)).toBeLessThanOrEqual(1);
+      expect(Math.abs(actionsRect.top + actionsRect.height / 2 - headerCenter)).toBeLessThanOrEqual(
+        1,
+      );
+    } finally {
+      await mounted.cleanup();
+    }
+  });
+
   it("keeps panel toggles fixed and can maximize the right panel", async () => {
     const mounted = await mountChatView({
       viewport: WIDE_FOOTER_VIEWPORT,
@@ -2353,12 +2395,34 @@ describe("ChatView timeline estimator parity (full app)", () => {
         () => sheet.querySelector<HTMLElement>("[data-panel-layout-controls]"),
         "Unable to find shared controls in the responsive right-panel sheet.",
       );
+      const tabbar = await waitForElement(
+        () => sheet.querySelector<HTMLElement>("[data-right-panel-tabbar]"),
+        "Unable to find responsive right-panel tabbar.",
+      );
+      const controlButtons = Array.from(controls.querySelectorAll<HTMLButtonElement>("button"));
+      const tabbarRect = tabbar.getBoundingClientRect();
+      const controlsRect = controls.getBoundingClientRect();
 
+      expect(controlButtons.map((button) => button.getAttribute("aria-label"))).toEqual([
+        "Toggle terminal drawer",
+        "Toggle right panel",
+      ]);
+      expect(tabbarRect.height).toBe(52);
+      expect(controlsRect.height).toBe(52);
+      expect(controlsRect.top).toBe(tabbarRect.top);
+      expect(window.innerWidth - controlsRect.right).toBe(12);
+      for (const button of controlButtons) {
+        const rect = button.getBoundingClientRect();
+        const buttonCenter = rect.top + rect.height / 2;
+        const tabbarCenter = tabbarRect.top + tabbarRect.height / 2;
+        expect(rect.width).toBe(32);
+        expect(rect.height).toBe(32);
+        expect(Math.abs(buttonCenter - tabbarCenter)).toBeLessThanOrEqual(1);
+      }
       expect(
-        Array.from(controls.querySelectorAll<HTMLButtonElement>("button")).map((button) =>
-          button.getAttribute("aria-label"),
-        ),
-      ).toEqual(["Toggle terminal drawer", "Toggle right panel"]);
+        controlButtons[1]!.getBoundingClientRect().left -
+          controlButtons[0]!.getBoundingClientRect().right,
+      ).toBe(4);
       expect(sheet.querySelector('button[aria-label="Maximize panel"]')).toBeNull();
       expect(sheet.querySelector('button[aria-label="Close tasks sidebar"]')).toBeNull();
 

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4876,6 +4876,19 @@ function ChatViewContent(props: ChatViewProps) {
             <Suspense fallback={null}>
               <DiffPanel mode="embedded" />
             </Suspense>
+          ) : activeRightPanelSurface?.kind === "plan" ? (
+            <PlanSidebar
+              activePlan={activePlan}
+              activeProposedPlan={sidebarProposedPlan}
+              label={planSidebarLabel}
+              environmentId={environmentId}
+              threadRef={activeThreadRef}
+              markdownCwd={gitCwd ?? undefined}
+              workspaceRoot={activeWorkspaceRoot}
+              timestampFormat={timestampFormat}
+              mode="embedded"
+              onClose={closePlanSidebar}
+            />
           ) : (activeRightPanelSurface?.kind === "files" ||
               activeRightPanelSurface?.kind === "file") &&
             activeProject &&

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -3034,23 +3034,25 @@ function ChatViewContent(props: ChatViewProps) {
   const toggleInteractionMode = useCallback(() => {
     handleInteractionModeChange(interactionMode === "plan" ? "default" : "plan");
   }, [handleInteractionModeChange, interactionMode]);
+  const dismissPlanSidebarForCurrentTurn = useCallback(() => {
+    planSidebarDismissedForTurnRef.current =
+      activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
+  }, [activePlan?.turnId, sidebarProposedPlan?.turnId]);
   const togglePlanSidebar = useCallback(() => {
     if (!activeThreadRef) return;
     if (planSidebarOpen) {
-      planSidebarDismissedForTurnRef.current =
-        activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
+      dismissPlanSidebarForCurrentTurn();
     } else {
       planSidebarDismissedForTurnRef.current = null;
     }
     useRightPanelStore.getState().toggle(activeThreadRef, "plan");
-  }, [activePlan?.turnId, activeThreadRef, planSidebarOpen, sidebarProposedPlan?.turnId]);
+  }, [activeThreadRef, dismissPlanSidebarForCurrentTurn, planSidebarOpen]);
   const closePlanSidebar = useCallback(() => {
     if (!activeThreadRef) return;
     setMaximizedRightPanelThreadKey(null);
     useRightPanelStore.getState().close(activeThreadRef);
-    planSidebarDismissedForTurnRef.current =
-      activePlan?.turnId ?? sidebarProposedPlan?.turnId ?? "__dismissed__";
-  }, [activePlan?.turnId, activeThreadRef, sidebarProposedPlan?.turnId]);
+    dismissPlanSidebarForCurrentTurn();
+  }, [activeThreadRef, dismissPlanSidebarForCurrentTurn]);
   const closePreviewPanel = useCallback(() => {
     if (!activeThreadRef) return;
     setMaximizedRightPanelThreadKey(null);
@@ -3059,6 +3061,11 @@ function ChatViewContent(props: ChatViewProps) {
   const activateRightPanelSurface = useCallback(
     (surface: RightPanelSurface) => {
       if (!activeThreadRef) return;
+      if (surface.kind === "plan") {
+        planSidebarDismissedForTurnRef.current = null;
+      } else if (planSidebarOpen) {
+        dismissPlanSidebarForCurrentTurn();
+      }
       useRightPanelStore.getState().activateSurface(activeThreadRef, surface.id);
       if (surface.kind === "preview" && surface.resourceId) {
         usePreviewStateStore.getState().setActiveTab(activeThreadRef, surface.resourceId);
@@ -3083,15 +3090,29 @@ function ChatViewContent(props: ChatViewProps) {
         });
       }
     },
-    [activeThreadRef, diffOpen, environmentId, navigate, onDiffPanelOpen, threadId],
+    [
+      activeThreadRef,
+      diffOpen,
+      dismissPlanSidebarForCurrentTurn,
+      environmentId,
+      navigate,
+      onDiffPanelOpen,
+      planSidebarOpen,
+      threadId,
+    ],
   );
   const toggleRightPanel = useCallback(() => {
     if (!activeThreadRef) return;
     if (rightPanelOpen) {
-      setMaximizedRightPanelThreadKey(null);
+      if (planSidebarOpen) {
+        closePlanSidebar();
+      } else {
+        closePreviewPanel();
+      }
+      return;
     }
     useRightPanelStore.getState().toggleVisibility(activeThreadRef);
-  }, [activeThreadRef, rightPanelOpen]);
+  }, [activeThreadRef, closePlanSidebar, closePreviewPanel, planSidebarOpen, rightPanelOpen]);
   const toggleRightPanelMaximized = () => {
     if (!canMaximizeRightPanel) return;
     setMaximizedRightPanelThreadKey((threadKey) =>
@@ -3101,6 +3122,9 @@ function ChatViewContent(props: ChatViewProps) {
   const closeRightPanelSurface = useCallback(
     (surface: RightPanelSurface) => {
       if (!activeThreadRef) return;
+      if (surface.kind === "plan") {
+        dismissPlanSidebarForCurrentTurn();
+      }
       if (surface.kind === "preview" && surface.resourceId) {
         usePreviewStateStore.getState().removeSession(activeThreadRef, surface.resourceId);
         const api = readEnvironmentApi(activeThreadRef.environmentId);
@@ -3137,7 +3161,14 @@ function ChatViewContent(props: ChatViewProps) {
         });
       }
     },
-    [activeThreadRef, diffOpen, environmentId, navigate, threadId],
+    [
+      activeThreadRef,
+      diffOpen,
+      dismissPlanSidebarForCurrentTurn,
+      environmentId,
+      navigate,
+      threadId,
+    ],
   );
   const persistThreadSettingsForNextTurn = useCallback(
     async (input: {
@@ -4573,6 +4604,85 @@ function ChatViewContent(props: ChatViewProps) {
       onToggleRightPanelMaximized={toggleRightPanelMaximized}
     />
   );
+  const sheetPanelLayoutControls = (
+    <PanelLayoutControls
+      placement="panel-header"
+      terminalAvailable={Boolean(activeProject)}
+      terminalOpen={Boolean(terminalUiState.terminalOpen)}
+      terminalShortcutLabel={terminalToggleShortcutLabel}
+      rightPanelAvailable={Boolean(activeProject)}
+      rightPanelOpen={rightPanelOpen}
+      rightPanelShortcutLabel={rightPanelToggleShortcutLabel}
+      rightPanelMaximized={rightPanelMaximized}
+      canMaximizeRightPanel={canMaximizeRightPanel}
+      onToggleTerminal={toggleTerminalVisibility}
+      onToggleRightPanel={toggleRightPanel}
+      onToggleRightPanelMaximized={toggleRightPanelMaximized}
+    />
+  );
+  const rightPanelContent = activeThreadRef ? (
+    activeRightPanelSurface?.kind === "preview" ? (
+      <Suspense fallback={null}>
+        <PreviewPanel
+          mode="embedded"
+          threadRef={activeThreadRef}
+          tabId={activeRightPanelSurface.resourceId}
+          configuredUrls={configuredPreviewUrls}
+          visible
+        />
+      </Suspense>
+    ) : activeRightPanelSurface?.kind === "terminal" ? (
+      <PersistentThreadTerminalPanel
+        threadRef={activeThreadRef}
+        surface={activeRightPanelSurface}
+        launchContext={activeTerminalLaunchContext ?? null}
+        focusRequestId={terminalFocusRequestId}
+        keybindings={keybindings}
+        onAddTerminalContext={addTerminalContextToDraft}
+        onSplitTerminal={splitPanelTerminal}
+        onSplitTerminalVertical={splitPanelTerminalVertical}
+        onNewTerminal={addTerminalSurface}
+        onActiveTerminalChange={activatePanelTerminal}
+        onCloseTerminal={closePanelTerminal}
+        splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
+        splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
+        newShortcutLabel={newTerminalShortcutLabel ?? undefined}
+        closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
+      />
+    ) : activeRightPanelSurface?.kind === "diff" ? (
+      <Suspense fallback={null}>
+        <DiffPanel mode="embedded" />
+      </Suspense>
+    ) : activeRightPanelSurface?.kind === "plan" ? (
+      <PlanSidebar
+        activePlan={activePlan}
+        activeProposedPlan={sidebarProposedPlan}
+        label={planSidebarLabel}
+        environmentId={environmentId}
+        threadRef={activeThreadRef}
+        markdownCwd={gitCwd ?? undefined}
+        workspaceRoot={activeWorkspaceRoot}
+        timestampFormat={timestampFormat}
+        mode="embedded"
+      />
+    ) : (activeRightPanelSurface?.kind === "files" || activeRightPanelSurface?.kind === "file") &&
+      activeProject &&
+      activeWorkspaceRoot ? (
+      <Suspense fallback={null}>
+        <FilePreviewPanel
+          key={`${activeProject.environmentId}:${activeWorkspaceRoot}`}
+          environmentId={activeProject.environmentId}
+          cwd={activeWorkspaceRoot}
+          projectName={activeProject.name}
+          relativePath={
+            activeRightPanelSurface.kind === "file" ? activeRightPanelSurface.relativePath : null
+          }
+          onOpenFile={openFileSurface}
+          onPendingChange={handleFilePendingChange}
+        />
+      </Suspense>
+    ) : null
+  ) : null;
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
@@ -4844,78 +4954,15 @@ function ChatViewContent(props: ChatViewProps) {
           diffAvailable={isServerThread && isGitRepo}
           filesAvailable={Boolean(activeProject)}
         >
-          {activeRightPanelSurface?.kind === "preview" ? (
-            <Suspense fallback={null}>
-              <PreviewPanel
-                mode="embedded"
-                threadRef={activeThreadRef}
-                tabId={activeRightPanelSurface.resourceId}
-                configuredUrls={configuredPreviewUrls}
-                visible
-              />
-            </Suspense>
-          ) : activeRightPanelSurface?.kind === "terminal" ? (
-            <PersistentThreadTerminalPanel
-              threadRef={activeThreadRef}
-              surface={activeRightPanelSurface}
-              launchContext={activeTerminalLaunchContext ?? null}
-              focusRequestId={terminalFocusRequestId}
-              keybindings={keybindings}
-              onAddTerminalContext={addTerminalContextToDraft}
-              onSplitTerminal={splitPanelTerminal}
-              onSplitTerminalVertical={splitPanelTerminalVertical}
-              onNewTerminal={addTerminalSurface}
-              onActiveTerminalChange={activatePanelTerminal}
-              onCloseTerminal={closePanelTerminal}
-              splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
-              splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
-              newShortcutLabel={newTerminalShortcutLabel ?? undefined}
-              closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
-            />
-          ) : activeRightPanelSurface?.kind === "diff" ? (
-            <Suspense fallback={null}>
-              <DiffPanel mode="embedded" />
-            </Suspense>
-          ) : activeRightPanelSurface?.kind === "plan" ? (
-            <PlanSidebar
-              activePlan={activePlan}
-              activeProposedPlan={sidebarProposedPlan}
-              label={planSidebarLabel}
-              environmentId={environmentId}
-              threadRef={activeThreadRef}
-              markdownCwd={gitCwd ?? undefined}
-              workspaceRoot={activeWorkspaceRoot}
-              timestampFormat={timestampFormat}
-              mode="embedded"
-              onClose={closePlanSidebar}
-            />
-          ) : (activeRightPanelSurface?.kind === "files" ||
-              activeRightPanelSurface?.kind === "file") &&
-            activeProject &&
-            activeWorkspaceRoot ? (
-            <Suspense fallback={null}>
-              <FilePreviewPanel
-                key={`${activeProject.environmentId}:${activeWorkspaceRoot}`}
-                environmentId={activeProject.environmentId}
-                cwd={activeWorkspaceRoot}
-                projectName={activeProject.name}
-                relativePath={
-                  activeRightPanelSurface.kind === "file"
-                    ? activeRightPanelSurface.relativePath
-                    : null
-                }
-                onOpenFile={openFileSurface}
-                onPendingChange={handleFilePendingChange}
-              />
-            </Suspense>
-          ) : null}
+          {rightPanelContent}
         </RightPanelTabs>
       ) : null}
 
       {shouldUsePlanSidebarSheet && rightPanelOpen && activeThreadRef ? (
-        <RightPanelSheet open onClose={closePreviewPanel}>
+        <RightPanelSheet open onClose={planSidebarOpen ? closePlanSidebar : closePreviewPanel}>
           <RightPanelTabs
             mode="sheet"
+            headerControls={sheetPanelLayoutControls}
             surfaces={rightPanelState.surfaces}
             activeSurfaceId={activeRightPanelSurface?.id ?? null}
             pendingSurfaceIds={pendingFileSurfaceIds}
@@ -4931,71 +4978,7 @@ function ChatViewContent(props: ChatViewProps) {
             diffAvailable={isServerThread && isGitRepo}
             filesAvailable={Boolean(activeProject)}
           >
-            {activeRightPanelSurface?.kind === "preview" ? (
-              <Suspense fallback={null}>
-                <PreviewPanel
-                  mode="embedded"
-                  threadRef={activeThreadRef}
-                  tabId={activeRightPanelSurface.resourceId}
-                  configuredUrls={configuredPreviewUrls}
-                  visible
-                />
-              </Suspense>
-            ) : activeRightPanelSurface?.kind === "terminal" ? (
-              <PersistentThreadTerminalPanel
-                threadRef={activeThreadRef}
-                surface={activeRightPanelSurface}
-                launchContext={activeTerminalLaunchContext ?? null}
-                focusRequestId={terminalFocusRequestId}
-                keybindings={keybindings}
-                onAddTerminalContext={addTerminalContextToDraft}
-                onSplitTerminal={splitPanelTerminal}
-                onSplitTerminalVertical={splitPanelTerminalVertical}
-                onNewTerminal={addTerminalSurface}
-                onActiveTerminalChange={activatePanelTerminal}
-                onCloseTerminal={closePanelTerminal}
-                splitShortcutLabel={splitTerminalShortcutLabel ?? undefined}
-                splitVerticalShortcutLabel={splitTerminalVerticalShortcutLabel ?? undefined}
-                newShortcutLabel={newTerminalShortcutLabel ?? undefined}
-                closeShortcutLabel={closeTerminalShortcutLabel ?? undefined}
-              />
-            ) : activeRightPanelSurface?.kind === "diff" ? (
-              <Suspense fallback={null}>
-                <DiffPanel mode="embedded" />
-              </Suspense>
-            ) : activeRightPanelSurface?.kind === "plan" ? (
-              <PlanSidebar
-                activePlan={activePlan}
-                activeProposedPlan={sidebarProposedPlan}
-                label={planSidebarLabel}
-                environmentId={environmentId}
-                threadRef={activeThreadRef}
-                markdownCwd={gitCwd ?? undefined}
-                workspaceRoot={activeWorkspaceRoot}
-                timestampFormat={timestampFormat}
-                mode="embedded"
-                onClose={closePlanSidebar}
-              />
-            ) : (activeRightPanelSurface?.kind === "files" ||
-                activeRightPanelSurface?.kind === "file") &&
-              activeProject &&
-              activeWorkspaceRoot ? (
-              <Suspense fallback={null}>
-                <FilePreviewPanel
-                  key={`${activeProject.environmentId}:${activeWorkspaceRoot}`}
-                  environmentId={activeProject.environmentId}
-                  cwd={activeWorkspaceRoot}
-                  projectName={activeProject.name}
-                  relativePath={
-                    activeRightPanelSurface.kind === "file"
-                      ? activeRightPanelSurface.relativePath
-                      : null
-                  }
-                  onOpenFile={openFileSurface}
-                  onPendingChange={handleFilePendingChange}
-                />
-              </Suspense>
-            ) : null}
+            {rightPanelContent}
           </RightPanelTabs>
         </RightPanelSheet>
       ) : null}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -169,7 +169,7 @@ import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import { ChatHeader } from "./chat/ChatHeader";
-import { PanelLayoutControls } from "./chat/PanelLayoutControls";
+import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
 import { resolveEffectiveEnvMode, resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
@@ -1331,9 +1331,8 @@ function ChatViewContent(props: ChatViewProps) {
   const planSidebarOpen = activeRightPanelKind === "plan";
   const previewPanelOpen = activeRightPanelKind === "preview" && isPreviewSupportedInRuntime();
   const rightPanelOpen = rightPanelState.isOpen;
-  const canMaximizeRightPanel = rightPanelOpen && !shouldUsePlanSidebarSheet;
   const rightPanelMaximized =
-    canMaximizeRightPanel && maximizedRightPanelThreadKey === routeThreadKey;
+    rightPanelOpen && !shouldUsePlanSidebarSheet && maximizedRightPanelThreadKey === routeThreadKey;
   const inlineRightPanelOwnsTitleBar = rightPanelOpen && !shouldUsePlanSidebarSheet;
 
   useEffect(() => {
@@ -3114,7 +3113,7 @@ function ChatViewContent(props: ChatViewProps) {
     useRightPanelStore.getState().toggleVisibility(activeThreadRef);
   }, [activeThreadRef, closePlanSidebar, closePreviewPanel, planSidebarOpen, rightPanelOpen]);
   const toggleRightPanelMaximized = () => {
-    if (!canMaximizeRightPanel) return;
+    if (!rightPanelOpen || shouldUsePlanSidebarSheet) return;
     setMaximizedRightPanelThreadKey((threadKey) =>
       threadKey === routeThreadKey ? null : routeThreadKey,
     );
@@ -4589,7 +4588,7 @@ function ChatViewContent(props: ChatViewProps) {
     return <NoActiveThreadState />;
   }
 
-  const panelLayoutControls = (
+  const panelToggleControls = (
     <PanelLayoutControls
       terminalAvailable={Boolean(activeProject)}
       terminalOpen={Boolean(terminalUiState.terminalOpen)}
@@ -4597,28 +4596,20 @@ function ChatViewContent(props: ChatViewProps) {
       rightPanelAvailable={Boolean(activeProject)}
       rightPanelOpen={rightPanelOpen}
       rightPanelShortcutLabel={rightPanelToggleShortcutLabel}
-      rightPanelMaximized={rightPanelMaximized}
-      canMaximizeRightPanel={canMaximizeRightPanel}
       onToggleTerminal={toggleTerminalVisibility}
       onToggleRightPanel={toggleRightPanel}
-      onToggleRightPanelMaximized={toggleRightPanelMaximized}
     />
   );
-  const sheetPanelLayoutControls = (
-    <PanelLayoutControls
-      placement="panel-header"
-      terminalAvailable={Boolean(activeProject)}
-      terminalOpen={Boolean(terminalUiState.terminalOpen)}
-      terminalShortcutLabel={terminalToggleShortcutLabel}
-      rightPanelAvailable={Boolean(activeProject)}
-      rightPanelOpen={rightPanelOpen}
-      rightPanelShortcutLabel={rightPanelToggleShortcutLabel}
-      rightPanelMaximized={rightPanelMaximized}
-      canMaximizeRightPanel={canMaximizeRightPanel}
-      onToggleTerminal={toggleTerminalVisibility}
-      onToggleRightPanel={toggleRightPanel}
-      onToggleRightPanelMaximized={toggleRightPanelMaximized}
-    />
+  const panelLayoutControls = (
+    <div className="workspace-titlebar-controls z-50 gap-1 [-webkit-app-region:no-drag]">
+      {rightPanelOpen && !shouldUsePlanSidebarSheet ? (
+        <RightPanelMaximizeControl
+          maximized={rightPanelMaximized}
+          onToggle={toggleRightPanelMaximized}
+        />
+      ) : null}
+      {panelToggleControls}
+    </div>
   );
   const rightPanelContent = activeThreadRef ? (
     activeRightPanelSurface?.kind === "preview" ? (
@@ -4689,7 +4680,7 @@ function ChatViewContent(props: ChatViewProps) {
       {isElectron && activeThreadRef ? (
         <PreviewAutomationOwner threadRef={activeThreadRef} visible={previewPanelOpen} />
       ) : null}
-      {rightPanelOpen ? panelLayoutControls : null}
+      {rightPanelOpen && !shouldUsePlanSidebarSheet ? panelLayoutControls : null}
       <div
         className={cn(
           "flex min-h-0 min-w-0 flex-col overflow-hidden",
@@ -4962,7 +4953,7 @@ function ChatViewContent(props: ChatViewProps) {
         <RightPanelSheet open onClose={planSidebarOpen ? closePlanSidebar : closePreviewPanel}>
           <RightPanelTabs
             mode="sheet"
-            headerControls={sheetPanelLayoutControls}
+            layoutControls={panelToggleControls}
             surfaces={rightPanelState.surfaces}
             activeSurfaceId={activeRightPanelSurface?.id ?? null}
             pendingSurfaceIds={pendingFileSurfaceIds}

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -11,7 +11,6 @@ import {
   ChevronRightIcon,
   EllipsisIcon,
   LoaderIcon,
-  PanelRightCloseIcon,
 } from "lucide-react";
 import { cn } from "~/lib/utils";
 import type { ActivePlanState } from "../session-logic";
@@ -61,7 +60,6 @@ interface PlanSidebarProps {
   workspaceRoot: string | undefined;
   timestampFormat: TimestampFormat;
   mode?: "sheet" | "sidebar" | "embedded";
-  onClose: () => void;
 }
 
 const PlanSidebar = memo(function PlanSidebar({
@@ -74,7 +72,6 @@ const PlanSidebar = memo(function PlanSidebar({
   workspaceRoot,
   timestampFormat,
   mode = "sidebar",
-  onClose,
 }: PlanSidebarProps) {
   const [proposedPlanExpanded, setProposedPlanExpanded] = useState(false);
   const [isSavingToWorkspace, setIsSavingToWorkspace] = useState(false);
@@ -182,15 +179,6 @@ const PlanSidebar = memo(function PlanSidebar({
               </MenuPopup>
             </Menu>
           ) : null}
-          <Button
-            size="icon-xs"
-            variant="ghost"
-            onClick={onClose}
-            aria-label={`Close ${label.toLowerCase()} sidebar`}
-            className="text-muted-foreground/50 hover:text-foreground/70"
-          >
-            <PanelRightCloseIcon className="size-3.5" />
-          </Button>
         </div>
       </div>
 

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -18,7 +18,7 @@ import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 interface RightPanelTabsProps {
   mode: PreviewPanelMode;
   maximized?: boolean;
-  headerControls?: ReactNode;
+  layoutControls?: ReactNode;
   surfaces: readonly RightPanelSurface[];
   activeSurfaceId: string | null;
   pendingSurfaceIds: ReadonlySet<string>;
@@ -270,8 +270,8 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
     >
       <div
         className={cn(
-          "gap-1 px-2",
-          props.mode === "inline" ? "workspace-topbar pr-28" : "flex h-10 shrink-0 items-center",
+          "workspace-topbar gap-1 pl-2",
+          props.mode === "inline" ? "pr-28" : "pr-3",
           ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
         )}
         data-right-panel-tabbar
@@ -384,7 +384,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
             ) : null}
           </div>
         </ScrollArea>
-        {props.headerControls}
+        {props.layoutControls}
       </div>
       <div className="flex min-h-0 flex-1 flex-col">
         {props.activeSurfaceId === null ? (

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -18,6 +18,7 @@ import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 interface RightPanelTabsProps {
   mode: PreviewPanelMode;
   maximized?: boolean;
+  headerControls?: ReactNode;
   surfaces: readonly RightPanelSurface[];
   activeSurfaceId: string | null;
   pendingSurfaceIds: ReadonlySet<string>;
@@ -269,8 +270,8 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
     >
       <div
         className={cn(
-          "px-2 pr-28",
-          props.mode === "inline" ? "workspace-topbar" : "flex h-10 shrink-0 items-center",
+          "gap-1 px-2",
+          props.mode === "inline" ? "workspace-topbar pr-28" : "flex h-10 shrink-0 items-center",
           ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
         )}
         data-right-panel-tabbar
@@ -383,6 +384,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
             ) : null}
           </div>
         </ScrollArea>
+        {props.headerControls}
       </div>
       <div className="flex min-h-0 flex-1 flex-col">
         {props.activeSurfaceId === null ? (

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -72,15 +72,15 @@ export const ChatHeader = memo(function ChatHeader({
     primaryEnvironmentId,
   });
   return (
-    <div className="@container/header-actions flex min-w-0 flex-1 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex min-w-0 flex-wrap items-center gap-2 overflow-hidden sm:flex-1 sm:flex-nowrap sm:gap-3">
+    <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
+      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
         <SidebarTrigger className="size-7 shrink-0 md:hidden" />
         <Tooltip>
           <TooltipTrigger
             render={
               <h2
                 aria-label={activeThreadTitle}
-                className="min-w-0 flex-1 basis-40 truncate text-sm font-medium text-foreground"
+                className="min-w-0 flex-1 truncate text-sm font-medium text-foreground"
               >
                 {activeThreadTitle}
               </h2>
@@ -92,7 +92,7 @@ export const ChatHeader = memo(function ChatHeader({
       <div
         data-chat-header-actions
         className={cn(
-          "flex min-w-0 flex-wrap items-center justify-start gap-2 sm:shrink-0 sm:justify-end @3xl/header-actions:gap-3",
+          "flex shrink-0 items-center justify-end gap-2 @3xl/header-actions:gap-3",
           rightPanelOpen ? "pr-0" : "pr-16",
         )}
       >

--- a/apps/web/src/components/chat/PanelLayoutControls.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.tsx
@@ -7,6 +7,7 @@ import { Toggle } from "../ui/toggle";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 interface PanelLayoutControlsProps {
+  placement?: "titlebar" | "panel-header";
   terminalAvailable: boolean;
   terminalOpen: boolean;
   terminalShortcutLabel: string | null;
@@ -21,6 +22,7 @@ interface PanelLayoutControlsProps {
 }
 
 export const PanelLayoutControls = memo(function PanelLayoutControls({
+  placement = "titlebar",
   terminalAvailable,
   terminalOpen,
   terminalShortcutLabel,
@@ -35,10 +37,13 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
 }: PanelLayoutControlsProps) {
   return (
     <div
-      className={cn("workspace-titlebar-controls z-50 gap-1 [-webkit-app-region:no-drag]")}
+      className={cn(
+        "z-50 flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]",
+        placement === "titlebar" ? "workspace-titlebar-controls" : "h-full",
+      )}
       data-panel-layout-controls
     >
-      {rightPanelOpen ? (
+      {rightPanelOpen && canMaximizeRightPanel ? (
         <Tooltip>
           <TooltipTrigger
             render={
@@ -49,7 +54,6 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
                 aria-label={rightPanelMaximized ? "Restore panel size" : "Maximize panel"}
                 variant="ghost"
                 size="sm"
-                disabled={!canMaximizeRightPanel}
               >
                 {rightPanelMaximized ? (
                   <Minimize2Icon className="size-3.5" />
@@ -60,11 +64,7 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
             }
           />
           <TooltipPopup side="bottom">
-            {canMaximizeRightPanel
-              ? rightPanelMaximized
-                ? "Restore panel size"
-                : "Maximize panel"
-              : "Panel maximization is unavailable at this width"}
+            {rightPanelMaximized ? "Restore panel size" : "Maximize panel"}
           </TooltipPopup>
         </Tooltip>
       ) : null}

--- a/apps/web/src/components/chat/PanelLayoutControls.tsx
+++ b/apps/web/src/components/chat/PanelLayoutControls.tsx
@@ -1,73 +1,35 @@
 import { Maximize2Icon, Minimize2Icon, PanelBottomIcon, PanelRightIcon } from "lucide-react";
 import { memo } from "react";
 
-import { cn } from "~/lib/utils";
-
 import { Toggle } from "../ui/toggle";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 
 interface PanelLayoutControlsProps {
-  placement?: "titlebar" | "panel-header";
   terminalAvailable: boolean;
   terminalOpen: boolean;
   terminalShortcutLabel: string | null;
   rightPanelAvailable: boolean;
   rightPanelOpen: boolean;
   rightPanelShortcutLabel: string | null;
-  rightPanelMaximized: boolean;
-  canMaximizeRightPanel: boolean;
   onToggleTerminal: () => void;
   onToggleRightPanel: () => void;
-  onToggleRightPanelMaximized: () => void;
 }
 
 export const PanelLayoutControls = memo(function PanelLayoutControls({
-  placement = "titlebar",
   terminalAvailable,
   terminalOpen,
   terminalShortcutLabel,
   rightPanelAvailable,
   rightPanelOpen,
   rightPanelShortcutLabel,
-  rightPanelMaximized,
-  canMaximizeRightPanel,
   onToggleTerminal,
   onToggleRightPanel,
-  onToggleRightPanelMaximized,
 }: PanelLayoutControlsProps) {
   return (
     <div
-      className={cn(
-        "z-50 flex shrink-0 items-center gap-1 [-webkit-app-region:no-drag]",
-        placement === "titlebar" ? "workspace-titlebar-controls" : "h-full",
-      )}
+      className="flex h-full shrink-0 items-center gap-1 [-webkit-app-region:no-drag]"
       data-panel-layout-controls
     >
-      {rightPanelOpen && canMaximizeRightPanel ? (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <Toggle
-                className="shrink-0 [-webkit-app-region:no-drag]"
-                pressed={rightPanelMaximized}
-                onPressedChange={onToggleRightPanelMaximized}
-                aria-label={rightPanelMaximized ? "Restore panel size" : "Maximize panel"}
-                variant="ghost"
-                size="sm"
-              >
-                {rightPanelMaximized ? (
-                  <Minimize2Icon className="size-3.5" />
-                ) : (
-                  <Maximize2Icon className="size-3.5" />
-                )}
-              </Toggle>
-            }
-          />
-          <TooltipPopup side="bottom">
-            {rightPanelMaximized ? "Restore panel size" : "Maximize panel"}
-          </TooltipPopup>
-        </Tooltip>
-      ) : null}
       <Tooltip>
         <TooltipTrigger
           render={
@@ -113,5 +75,38 @@ export const PanelLayoutControls = memo(function PanelLayoutControls({
         </TooltipPopup>
       </Tooltip>
     </div>
+  );
+});
+
+export const RightPanelMaximizeControl = memo(function RightPanelMaximizeControl({
+  maximized,
+  onToggle,
+}: {
+  maximized: boolean;
+  onToggle: () => void;
+}) {
+  const label = maximized ? "Restore panel size" : "Maximize panel";
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Toggle
+            className="shrink-0 [-webkit-app-region:no-drag]"
+            pressed={maximized}
+            onPressedChange={onToggle}
+            aria-label={label}
+            variant="ghost"
+            size="sm"
+          >
+            {maximized ? (
+              <Minimize2Icon className="size-3.5" />
+            ) : (
+              <Maximize2Icon className="size-3.5" />
+            )}
+          </Toggle>
+        }
+      />
+      <TooltipPopup side="bottom">{label}</TooltipPopup>
+    </Tooltip>
   );
 });


### PR DESCRIPTION
## Summary
- Render the plan sidebar inside the inline right panel when the active surface is `plan`.
- Pass the existing plan context and close handler through to `PlanSidebar` in embedded mode.
- Add a browser test covering the inline plan panel rendering and expected copy.

## Testing
- Not run in this task.
- Existing test added in `apps/web/src/components/ChatView.browser.tsx` covers the inline plan panel path.
- Project-level checks still required before merge: `vp check` and `vp run typecheck`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches right-panel open/close, plan auto-open dismissal, and responsive vs inline layout paths in `ChatView`; regressions could affect panel visibility or plan sidebar behavior across breakpoints.
> 
> **Overview**
> **Renders the plan surface in the shared inline right panel** and deduplicates panel body rendering via a single `rightPanelContent` branch used by both inline `RightPanelTabs` and the responsive sheet.
> 
> **Panel chrome is split by layout:** `PanelLayoutControls` is terminal/right-panel toggles only; **maximize/restore** moves to `RightPanelMaximizeControl` in the inline titlebar (not in sheet mode). The responsive sheet passes those toggles into `RightPanelTabs` through a new **`layoutControls`** slot aligned with the tab bar.
> 
> **Plan dismissal and toggling** are centralized in `dismissPlanSidebarForCurrentTurn`: activating plan clears dismissal; closing surfaces, switching away from plan, or toggling the right panel while plan is active records dismissal and closes appropriately. **`PlanSidebar` loses its own close button and `onClose` prop**—closing is via tabs/sheet/parent handlers.
> 
> **`ChatHeader`** layout is tightened so title and actions stay on one row at compact widths. **Browser tests** cover compact header alignment, inline plan empty state, and responsive sheet controls (tabs, terminal switch, close plan, toggle panel).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8e942ffe4d4237012866878176db24dc93ca9c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render the plan surface in the inline right panel
> - Moves the plan surface into the inline right panel and sheet, replacing the standalone plan sidebar close button with external controls in `ChatView`.
> - Extracts `rightPanelContent` in [`ChatView.tsx`](https://github.com/pingdotgg/t3code/pull/3118/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) and reuses it for both inline and sheet modes; adds a `layoutControls` prop to [`RightPanelTabs`](https://github.com/pingdotgg/t3code/pull/3118/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91) so shared panel toggles appear in the tab bar.
> - Extracts `RightPanelMaximizeControl` from [`PanelLayoutControls`](https://github.com/pingdotgg/t3code/pull/3118/files#diff-4a8fd1569788ea7247bd600d44295eca372aea32c2d56bd144a3841b07dff51f) as a standalone component so it can be placed independently of other panel toggles.
> - Toggling the right panel now closes the active plan sidebar (recording a dismissal) or closes the preview panel depending on state, rather than uniformly toggling visibility.
> - Behavioral Change: maximize is ignored when the right panel is closed or in sheet mode; activating a plan surface clears any prior dismissal, while switching away records one.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8e942f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->