### PR TITLE
fix: Adapt destructive menu icon to dark mode

### DIFF
--- a/apps/desktop/src/electron/ElectronMenu.test.ts
+++ b/apps/desktop/src/electron/ElectronMenu.test.ts
@@ -1,5 +1,7 @@
 import { assert, describe, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import type * as Electron from "electron";
 import { beforeEach, vi } from "vite-plus/test";
@@ -23,6 +25,9 @@ vi.mock("electron", () => ({
 }));
 
 import * as ElectronMenu from "./ElectronMenu.ts";
+
+const electronMenuLayerForPlatform = (platform: NodeJS.Platform) =>
+  ElectronMenu.layer.pipe(Layer.provide(Layer.succeed(HostProcessPlatform, platform)));
 
 describe("ElectronMenu", () => {
   beforeEach(() => {
@@ -94,6 +99,52 @@ describe("ElectronMenu", () => {
         click: buildFromTemplateMock.mock.calls[0]?.[0][0].click,
       });
     }).pipe(Effect.provide(ElectronMenu.layer)),
+  );
+
+  it.effect("marks the macOS destructive menu icon as a template image", () =>
+    Effect.gen(function* () {
+      const setTemplateImageMock = vi.fn<(option: boolean) => void>();
+      const resizedIcon = {
+        isEmpty: vi.fn<() => boolean>(() => false),
+        setTemplateImage: setTemplateImageMock,
+      } as unknown as Electron.NativeImage;
+      const resizeMock = vi.fn<
+        (options: Parameters<Electron.NativeImage["resize"]>[0]) => Electron.NativeImage
+      >(() => resizedIcon);
+      const sourceIcon = {
+        resize: resizeMock,
+      } as unknown as Electron.NativeImage;
+      createFromNamedImageMock.mockReturnValue(sourceIcon);
+      buildFromTemplateMock.mockImplementation(() => ({
+        popup: (options: Electron.PopupOptions) => {
+          options.callback?.();
+        },
+      }));
+
+      const electronMenu = yield* ElectronMenu.ElectronMenu;
+      yield* electronMenu.showContextMenu({
+        window: {} as Electron.BrowserWindow,
+        items: [
+          { id: "copy", label: "Copy" },
+          { id: "delete", label: "Delete", destructive: true },
+        ],
+        position: Option.none(),
+      });
+
+      const template = buildFromTemplateMock.mock.calls[0]?.[0] as
+        | Electron.MenuItemConstructorOptions[]
+        | undefined;
+      assert.isDefined(template);
+      assert.deepEqual(resizeMock.mock.calls[0]?.[0], { width: 12, height: 12 });
+      assert.equal(template?.[1]?.type, "separator");
+      assert.equal(template?.[2]?.label, "Delete");
+      assert.strictEqual(template?.[2]?.icon, resizedIcon);
+      assert.deepEqual(setTemplateImageMock.mock.calls, [[true]]);
+      assert.isTrue(
+        (setTemplateImageMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY) <
+          (buildFromTemplateMock.mock.invocationCallOrder[0] ?? 0),
+      );
+    }).pipe(Effect.provide(electronMenuLayerForPlatform("darwin"))),
   );
 
   it.effect("defers popupTemplate side effects until the returned Effect runs", () =>

--- a/apps/desktop/src/electron/ElectronMenu.test.ts
+++ b/apps/desktop/src/electron/ElectronMenu.test.ts
@@ -1,7 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
-import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import type * as Electron from "electron";
 import { beforeEach, vi } from "vite-plus/test";
@@ -25,9 +23,6 @@ vi.mock("electron", () => ({
 }));
 
 import * as ElectronMenu from "./ElectronMenu.ts";
-
-const electronMenuLayerForPlatform = (platform: NodeJS.Platform) =>
-  ElectronMenu.layer.pipe(Layer.provide(Layer.succeed(HostProcessPlatform, platform)));
 
 describe("ElectronMenu", () => {
   beforeEach(() => {
@@ -99,52 +94,6 @@ describe("ElectronMenu", () => {
         click: buildFromTemplateMock.mock.calls[0]?.[0][0].click,
       });
     }).pipe(Effect.provide(ElectronMenu.layer)),
-  );
-
-  it.effect("marks the macOS destructive menu icon as a template image", () =>
-    Effect.gen(function* () {
-      const setTemplateImageMock = vi.fn<(option: boolean) => void>();
-      const resizedIcon = {
-        isEmpty: vi.fn<() => boolean>(() => false),
-        setTemplateImage: setTemplateImageMock,
-      } as unknown as Electron.NativeImage;
-      const resizeMock = vi.fn<
-        (options: Parameters<Electron.NativeImage["resize"]>[0]) => Electron.NativeImage
-      >(() => resizedIcon);
-      const sourceIcon = {
-        resize: resizeMock,
-      } as unknown as Electron.NativeImage;
-      createFromNamedImageMock.mockReturnValue(sourceIcon);
-      buildFromTemplateMock.mockImplementation(() => ({
-        popup: (options: Electron.PopupOptions) => {
-          options.callback?.();
-        },
-      }));
-
-      const electronMenu = yield* ElectronMenu.ElectronMenu;
-      yield* electronMenu.showContextMenu({
-        window: {} as Electron.BrowserWindow,
-        items: [
-          { id: "copy", label: "Copy" },
-          { id: "delete", label: "Delete", destructive: true },
-        ],
-        position: Option.none(),
-      });
-
-      const template = buildFromTemplateMock.mock.calls[0]?.[0] as
-        | Electron.MenuItemConstructorOptions[]
-        | undefined;
-      assert.isDefined(template);
-      assert.deepEqual(resizeMock.mock.calls[0]?.[0], { width: 12, height: 12 });
-      assert.equal(template?.[1]?.type, "separator");
-      assert.equal(template?.[2]?.label, "Delete");
-      assert.strictEqual(template?.[2]?.icon, resizedIcon);
-      assert.deepEqual(setTemplateImageMock.mock.calls, [[true]]);
-      assert.isTrue(
-        (setTemplateImageMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY) <
-          (buildFromTemplateMock.mock.invocationCallOrder[0] ?? 0),
-      );
-    }).pipe(Effect.provide(electronMenuLayerForPlatform("darwin"))),
   );
 
   it.effect("defers popupTemplate side effects until the returned Effect runs", () =>

--- a/apps/desktop/src/electron/ElectronMenu.ts
+++ b/apps/desktop/src/electron/ElectronMenu.ts
@@ -99,6 +99,7 @@ export const layer = Layer.effect(
           width: 12,
           height: 12,
         });
+        icon.setTemplateImage(true);
         destructiveMenuIconCache = icon.isEmpty() ? Option.none() : Option.some(icon);
       } catch {
         destructiveMenuIconCache = Option.none();


### PR DESCRIPTION
## Summary

- Mark the macOS native destructive context-menu trash icon as a template image so it adapts to light and dark menu chrome.
- Add ElectronMenu regression coverage for the macOS destructive icon path, separator insertion, resized icon assignment, and template-image call ordering.

## Root cause

The desktop Electron menu created a native macOS `trash` image for destructive menu items, but did not mark it as a template image. In dark mode, the native image could render with poor contrast instead of adapting to the menu appearance.

## Impact

The sidebar thread Delete menu item keeps its native trash icon while rendering with proper contrast in dark native menus. Non-macOS behavior and the web fallback context menu are unchanged.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp run --filter @t3tools/desktop ensure:electron`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run --filter @t3tools/desktop test -- src/electron/ElectronMenu.test.ts`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

`vp check` reports the repository's existing unrelated `react(no-unstable-nested-components)` warnings and no errors.

Closes #2984

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix destructive menu icon to display correctly in dark mode on macOS
> Marks the trash icon NativeImage as a template image in `ElectronMenu.getDestructiveMenuIcon` by calling `setTemplateImage(true)` after resizing. Template images on macOS are automatically adapted by the system for both light and dark appearances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc28ea2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line macOS-only menu icon styling change with no auth, data, or cross-platform behavior impact.
> 
> **Overview**
> Fixes low-contrast trash icons on destructive native context-menu items (e.g. thread **Delete**) when macOS uses dark menu chrome.
> 
> After resizing the native `trash` image in `getDestructiveMenuIcon`, the change calls **`setTemplateImage(true)`** so Electron/macOS can tint the icon for light and dark menus. Behavior is unchanged on non-macOS platforms and for the web fallback menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc28ea2563763f6b27276f278526ec20244791ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->