### PR TITLE
fix(desktop): stage ffi-rs native bindings so the packaged app launches a window

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -9,7 +9,9 @@ import {
   createStageWorkspaceConfig,
   createStagePnpmConfig,
   DESKTOP_ASAR_UNPACK,
+  parseFfiRsLockfileVersion,
   resolveDesktopRuntimeDependencies,
+  resolveFfiRsNativeDependencies,
   resolveFffNativeDependencies,
   resolveBuildOptions,
   resolveDesktopBuildIconAssets,
@@ -171,8 +173,55 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
     });
   });
 
-  it("unpacks the fff shared library for filesystem and FFI access", () => {
-    assert.deepStrictEqual(DESKTOP_ASAR_UNPACK, ["node_modules/@ff-labs/fff-bin-*/**/*"]);
+  it("unpacks the fff shared library and ffi-rs native bindings for FFI access", () => {
+    assert.deepStrictEqual(DESKTOP_ASAR_UNPACK, [
+      "node_modules/@ff-labs/fff-bin-*/**/*",
+      "node_modules/@yuuang/ffi-rs-*/**/*",
+    ]);
+  });
+
+  it("promotes the target ffi-rs native binding to a direct staged dependency", () => {
+    assert.deepStrictEqual(resolveFfiRsNativeDependencies("mac", "arm64", "1.3.2"), {
+      "@yuuang/ffi-rs-darwin-arm64": "1.3.2",
+    });
+    assert.deepStrictEqual(resolveFfiRsNativeDependencies("mac", "universal", "1.3.2"), {
+      "@yuuang/ffi-rs-darwin-arm64": "1.3.2",
+      "@yuuang/ffi-rs-darwin-x64": "1.3.2",
+    });
+    assert.deepStrictEqual(resolveFfiRsNativeDependencies("win", "x64", "1.3.2"), {
+      "@yuuang/ffi-rs-win32-x64-msvc": "1.3.2",
+    });
+    assert.deepStrictEqual(resolveFfiRsNativeDependencies("win", "arm64", "1.3.2"), {
+      "@yuuang/ffi-rs-win32-arm64-msvc": "1.3.2",
+    });
+    assert.deepStrictEqual(resolveFfiRsNativeDependencies("linux", "arm64", "1.3.2"), {
+      "@yuuang/ffi-rs-linux-arm64-gnu": "1.3.2",
+      "@yuuang/ffi-rs-linux-arm64-musl": "1.3.2",
+    });
+  });
+
+  it("reads the single resolved ffi-rs version from the lockfile", () => {
+    const lockfile = [
+      "packages:",
+      "  fetch-nodeshim@0.4.10: {}",
+      "  ffi-rs@1.3.2:",
+      "    resolution: {integrity: sha512-deadbeef==}",
+      "  fill-range@7.1.1:",
+      "snapshots:",
+      "  ffi-rs@1.3.2:",
+      "    optionalDependencies:",
+      "      '@yuuang/ffi-rs-win32-x64-msvc': 1.3.2",
+      "",
+    ].join("\n");
+    assert.equal(parseFfiRsLockfileVersion(lockfile), "1.3.2");
+  });
+
+  it("fails when ffi-rs is absent or resolves to multiple versions", () => {
+    assert.throws(() => parseFfiRsLockfileVersion("packages:\n  effect@4.0.0: {}\n"), /Could not find ffi-rs/);
+    assert.throws(
+      () => parseFfiRsLockfileVersion("packages:\n  ffi-rs@1.3.2:\n  ffi-rs@1.4.0:\n"),
+      /single ffi-rs version/,
+    );
   });
 
   it("promotes target fff binaries to direct staged dependencies", () => {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -291,7 +291,13 @@ interface StagePackageJson {
 }
 
 export const STAGE_INSTALL_ARGS = ["install", "--prod"] as const;
-export const DESKTOP_ASAR_UNPACK = ["node_modules/@ff-labs/fff-bin-*/**/*"] as const;
+export const DESKTOP_ASAR_UNPACK = [
+  "node_modules/@ff-labs/fff-bin-*/**/*",
+  // ffi-rs (used by @ff-labs/fff-node) loads its prebuilt native addon from a
+  // platform-specific @yuuang/ffi-rs-* package. The `.node` must live outside
+  // the asar archive so Electron can dlopen it at runtime.
+  "node_modules/@yuuang/ffi-rs-*/**/*",
+] as const;
 
 export function resolveFffNativeDependencies(
   platform: typeof BuildPlatform.Type,
@@ -318,6 +324,88 @@ export function resolveFffNativeDependencies(
     ),
   );
 }
+
+export function resolveFfiRsNativeDependencies(
+  platform: typeof BuildPlatform.Type,
+  arch: typeof BuildArch.Type,
+  version: string,
+): Record<string, string> {
+  const architectures = arch === "universal" ? (["arm64", "x64"] as const) : [arch];
+
+  if (platform === "mac") {
+    return Object.fromEntries(
+      architectures.map((architecture) => [`@yuuang/ffi-rs-darwin-${architecture}`, version]),
+    );
+  }
+
+  if (platform === "win") {
+    return Object.fromEntries(
+      architectures.map((architecture) => [`@yuuang/ffi-rs-win32-${architecture}-msvc`, version]),
+    );
+  }
+
+  return Object.fromEntries(
+    architectures.flatMap((architecture) =>
+      ["gnu", "musl"].map((libc) => [`@yuuang/ffi-rs-linux-${architecture}-${libc}`, version]),
+    ),
+  );
+}
+
+// ffi-rs is a transitive dependency (via @ff-labs/fff-node), so its version is
+// not declared in any package.json. Its prebuilt @yuuang/ffi-rs-* bindings are
+// published in lockstep with ffi-rs, so we read the resolved version from the
+// lockfile to pin the binding we promote into the staged install.
+export function parseFfiRsLockfileVersion(lockfileContents: string): string {
+  const versions = new Set<string>();
+  const pattern = /(?:^|\n) {2}ffi-rs@([^:\s(]+):/g;
+  for (const match of lockfileContents.matchAll(pattern)) {
+    const version = match[1];
+    if (version !== undefined) {
+      versions.add(version);
+    }
+  }
+
+  const uniqueVersions = [...versions];
+  if (uniqueVersions.length > 1) {
+    throw new Error(
+      `Expected a single ffi-rs version in pnpm-lock.yaml but found: ${uniqueVersions.sort().join(", ")}.`,
+    );
+  }
+
+  const [version] = uniqueVersions;
+  if (version === undefined) {
+    throw new Error("Could not find ffi-rs in pnpm-lock.yaml.");
+  }
+
+  return version;
+}
+
+const resolveFfiRsBindingVersion = Effect.fn("resolveFfiRsBindingVersion")(function* (
+  repoRoot: string,
+) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const lockfileContents = yield* fs
+    .readFileString(path.join(repoRoot, "pnpm-lock.yaml"))
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new BuildScriptError({
+            message: "Could not read pnpm-lock.yaml to resolve ffi-rs native bindings.",
+            cause,
+          }),
+      ),
+    );
+
+  return yield* Effect.try({
+    try: () => parseFfiRsLockfileVersion(lockfileContents),
+    catch: (cause) =>
+      new BuildScriptError({
+        message: "Could not resolve the ffi-rs native binding version from pnpm-lock.yaml.",
+        cause,
+      }),
+  });
+});
 
 export function createStageWorkspaceConfig(
   platform: typeof BuildPlatform.Type,
@@ -956,14 +1044,19 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   // electron-builder is filtering out stageResourcesDir directory in the AppImage for production
   yield* fs.copy(stageResourcesDir, path.join(stageAppDir, "apps/desktop/prod-resources"));
 
+  const fffNodeVersion = serverPackageJson.dependencies["@ff-labs/fff-node"];
+  const ffiRsNativeDependencies = fffNodeVersion
+    ? resolveFfiRsNativeDependencies(
+        options.platform,
+        options.arch,
+        yield* resolveFfiRsBindingVersion(repoRoot),
+      )
+    : {};
   const stageDependencies = {
     ...resolvedServerDependencies,
     ...resolvedDesktopRuntimeDependencies,
-    ...resolveFffNativeDependencies(
-      options.platform,
-      options.arch,
-      serverPackageJson.dependencies["@ff-labs/fff-node"],
-    ),
+    ...resolveFffNativeDependencies(options.platform, options.arch, fffNodeVersion),
+    ...ffiRsNativeDependencies,
   };
   const stagePnpmConfig = createStagePnpmConfig(workspacePatchedDependencies, stageDependencies);
   const stagePackageJson: StagePackageJson = {


### PR DESCRIPTION
## Problem

The packaged desktop app launches a main process but **never opens a window**. The bundled backend server crash-loops on startup with:

```
Error: Cannot find module '@yuuang/ffi-rs-win32-x64-msvc'
Require stack:
- <install>\resources\app.asar\node_modules\ffi-rs\index.js
```

Because the desktop window is gated on backend HTTP readiness (`DesktopBackendManager` polls `/.well-known/t3/environment`, then `DesktopWindow.handleBackendReady` creates the window), a backend that never becomes ready means the window is never created — while the main process stays alive restarting the backend forever. First observed on nightly `0.0.28-nightly.20260616.571` (win32-x64).

## Root cause

`@ff-labs/fff-node` (the `fff` workspace-search integration, #3099) loads its native binary through the **`ffi-rs`** FFI runtime. `ffi-rs@1.3.2` loads its prebuilt addon from a platform-specific package — on Windows x64, `@yuuang/ffi-rs-win32-x64-msvc` (an `optionalDependency` of `ffi-rs`).

#3109 staged the `fff` **binary** packages (`@ff-labs/fff-bin-*`) and added them to `asarUnpack`, but did not stage `ffi-rs`'s own native binding. electron-builder reliably keeps direct production deps but prunes platform-gated transitive optional deps in pnpm layouts, so `@yuuang/ffi-rs-*` was dropped from the package entirely. The staging logic omitted it for **all** platforms, so mac/linux builds are affected too.

## Fix

Mirror the `@ff-labs/fff-bin-*` treatment for the FFI binding in `scripts/build-desktop-artifact.ts`:

1. `resolveFfiRsNativeDependencies(platform, arch, version)` — promote the target-triple `@yuuang/ffi-rs-*` binding to a **direct** staged dependency so electron-builder keeps it (covers mac `darwin-{arm64,x64}`, win `win32-{x64,arm64}-msvc`, linux `linux-{x64,arm64}-{gnu,musl}`, and `universal`).
2. Add `node_modules/@yuuang/ffi-rs-*/**/*` to `DESKTOP_ASAR_UNPACK` so the `.node` loads outside the asar.
3. The version is read from `pnpm-lock.yaml` (`ffi-rs` is transitive, so it has no package.json entry; bindings ship in lockstep with `ffi-rs`). The build fails loudly if `ffi-rs` can't be resolved, so this can't silently regress.

## Validation

- `scripts` typecheck clean; new unit tests for `resolveFfiRsNativeDependencies` and `parseFfiRsLockfileVersion`; full `scripts` suite green.
- Built a win/x64 artifact and confirmed `resources/app.asar.unpacked/node_modules/@yuuang/ffi-rs-win32-x64-msvc/ffi-rs.win32-x64-msvc.node` is now present (the broken nightly had no `@yuuang` dir at all).
- **Launched the packaged build:** backend starts once with no crash loop and no "Cannot find module" error, and a real window opens (renderer process + top-level window confirmed).

## Follow-up (not in this PR)

The build now enumerates two native package families by hand (`@ff-labs/fff-bin-*`, `@yuuang/ffi-rs-*`). A deeper fix would auto-discover `.node`-bearing packages in the staged tree and unpack them, so a future native transitive dep can't reintroduce this bug class. A win32-x64 smoke test that boots the backend would also have caught this.

Fixes #3125

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the desktop staging/install path that determines which native modules ship in production artifacts; mistakes could break all platform builds, but the change mirrors an existing pattern and adds explicit lockfile validation and tests.
> 
> **Overview**
> Fixes packaged desktop builds where the bundled backend crash-looped on missing `@yuuang/ffi-rs-*` native modules (used by `@ff-labs/fff-node` via `ffi-rs`), so the window never opened.
> 
> The desktop artifact script now **promotes** platform-specific `@yuuang/ffi-rs-*` packages into staged production dependencies (same approach as `@ff-labs/fff-bin-*`), **unpacks** them from the asar via `DESKTOP_ASAR_UNPACK`, and **pins** binding versions by parsing the resolved `ffi-rs` version from `pnpm-lock.yaml` (with a hard failure if it's missing or ambiguous). Unit tests cover dependency resolution, lockfile parsing, and unpack globs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ca71abe7eb328f77fd7c3e72a3c840f63863cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Stage ffi-rs native bindings so the packaged Electron app launches a window
> - Adds `@yuuang/ffi-rs-*` packages to `DESKTOP_ASAR_UNPACK` so Electron unpacks and can load the native addons at runtime.
> - Adds `resolveFfiRsNativeDependencies` to compute the platform/arch-specific `@yuuang/ffi-rs-*` packages to stage, including both gnu and musl variants on Linux.
> - Adds `parseFfiRsLockfileVersion` to extract the single resolved ffi-rs version from `pnpm-lock.yaml`, throwing if the version is absent or inconsistent.
> - The `buildDesktopArtifact` handler now reads `pnpm-lock.yaml` to determine the ffi-rs version and merges the resulting native packages into the staged install.
> - Risk: the build now fails with a `BuildScriptError` if `pnpm-lock.yaml` is unreadable or ffi-rs is missing or resolved to multiple versions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ca71ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/3129" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->