### PR TITLE
[codex] Make background VCS fetch non-interactive

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -216,7 +216,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
-    it.effect("disables SSH askpass for background upstream status fetches", () =>
+    it.effect("makes background upstream status fetches non-interactive", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();
         const tempDir = yield* makeTmpDir("git-vcs-driver-ssh-env-");
@@ -225,15 +225,26 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         const pathService = yield* Path.Path;
         const sshLogPath = pathService.join(tempDir, "ssh-env.txt");
         const sshWrapperPath = pathService.join(tempDir, "ssh-wrapper.sh");
-        const previousGitSsh = process.env.GIT_SSH;
-        const previousAskpassRequire = process.env.SSH_ASKPASS_REQUIRE;
-        const previousAskpassLog = process.env.T3_TEST_SSH_ASKPASS_LOG;
+        const envKeys = [
+          "GCM_INTERACTIVE",
+          "GIT_ASKPASS",
+          "GIT_SSH",
+          "GIT_TERMINAL_PROMPT",
+          "SSH_ASKPASS",
+          "SSH_ASKPASS_REQUIRE",
+          "T3_TEST_SSH_ASKPASS_LOG",
+        ] as const;
+        const previousEnv = new Map(envKeys.map((key) => [key, process.env[key]]));
 
         yield* fileSystem.writeFileString(
           sshWrapperPath,
           [
             "#!/bin/sh",
-            'printf "%s\\n" "${SSH_ASKPASS_REQUIRE:-}" > "$T3_TEST_SSH_ASKPASS_LOG"',
+            'printf "GCM_INTERACTIVE=%s\\n" "${GCM_INTERACTIVE:-}" > "$T3_TEST_SSH_ASKPASS_LOG"',
+            'printf "GIT_ASKPASS=%s\\n" "${GIT_ASKPASS:-}" >> "$T3_TEST_SSH_ASKPASS_LOG"',
+            'printf "GIT_TERMINAL_PROMPT=%s\\n" "${GIT_TERMINAL_PROMPT:-}" >> "$T3_TEST_SSH_ASKPASS_LOG"',
+            'printf "SSH_ASKPASS=%s\\n" "${SSH_ASKPASS:-}" >> "$T3_TEST_SSH_ASKPASS_LOG"',
+            'printf "SSH_ASKPASS_REQUIRE=%s\\n" "${SSH_ASKPASS_REQUIRE:-}" >> "$T3_TEST_SSH_ASKPASS_LOG"',
             "exit 1",
             "",
           ].join("\n"),
@@ -245,29 +256,32 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
 
         yield* Effect.gen(function* () {
           process.env.GIT_SSH = sshWrapperPath;
+          process.env.GCM_INTERACTIVE = "always";
+          process.env.GIT_ASKPASS = "git-askpass";
+          process.env.GIT_TERMINAL_PROMPT = "1";
+          process.env.SSH_ASKPASS = "ssh-askpass";
           process.env.SSH_ASKPASS_REQUIRE = "force";
           process.env.T3_TEST_SSH_ASKPASS_LOG = sshLogPath;
 
           yield* (yield* GitVcsDriver.GitVcsDriver).statusDetails(cwd);
 
-          assert.equal((yield* fileSystem.readFileString(sshLogPath)).trim(), "never");
+          assert.deepEqual((yield* fileSystem.readFileString(sshLogPath)).trim().split(/\r?\n/), [
+            "GCM_INTERACTIVE=never",
+            "GIT_ASKPASS=",
+            "GIT_TERMINAL_PROMPT=0",
+            "SSH_ASKPASS=",
+            "SSH_ASKPASS_REQUIRE=never",
+          ]);
         }).pipe(
           Effect.ensuring(
             Effect.sync(() => {
-              if (previousGitSsh === undefined) {
-                delete process.env.GIT_SSH;
-              } else {
-                process.env.GIT_SSH = previousGitSsh;
-              }
-              if (previousAskpassRequire === undefined) {
-                delete process.env.SSH_ASKPASS_REQUIRE;
-              } else {
-                process.env.SSH_ASKPASS_REQUIRE = previousAskpassRequire;
-              }
-              if (previousAskpassLog === undefined) {
-                delete process.env.T3_TEST_SSH_ASKPASS_LOG;
-              } else {
-                process.env.T3_TEST_SSH_ASKPASS_LOG = previousAskpassLog;
+              for (const key of envKeys) {
+                const previous = previousEnv.get(key);
+                if (previous === undefined) {
+                  delete process.env[key];
+                } else {
+                  process.env[key] = previous;
+                }
               }
             }),
           ),

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -54,6 +54,10 @@ const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_FAILURE_COOLDOWN = Duration.seconds(5);
 const STATUS_UPSTREAM_REFRESH_CACHE_CAPACITY = 2_048;
 const STATUS_UPSTREAM_REFRESH_ENV = Object.freeze({
+  GCM_INTERACTIVE: "never",
+  GIT_ASKPASS: "",
+  GIT_TERMINAL_PROMPT: "0",
+  SSH_ASKPASS: "",
   SSH_ASKPASS_REQUIRE: "never",
 } satisfies NodeJS.ProcessEnv);
 const DEFAULT_BASE_BRANCH_CANDIDATES = ["main", "master"] as const;


### PR DESCRIPTION
## What Changed

Background upstream status fetches now run with non-interactive Git auth env vars, not just the SSH askpass guard. The status-refresh fetch already had `SSH_ASKPASS_REQUIRE=never`; this adds `GCM_INTERACTIVE=never`, `GIT_TERMINAL_PROMPT=0`, and empty `GIT_ASKPASS`/`SSH_ASKPASS` for that same passive fetch path.

## Why

This keeps passive VCS polling from opening credential UI. The earlier fetch interval work helps users slow down or disable background fetches, but Windows HTTPS remotes can still go through Git Credential Manager. If GCM doesn't have a cached credential, it can open a GitHub auth window from a background status refresh. That window can then get killed by the short fetch timeout and reopen on the next poll. For background status checks, failing quietly is better than stealing focus. Explicit user actions like pull, push, and manual fetch still use the normal environment.

Refs #1418 and #2605.

## User Workaround

Users can usually fix their local GitHub HTTPS setup by authenticating Git directly, for example with `gh auth setup-git` if they already use GitHub CLI, or by logging into Git Credential Manager outside T3 Code. That still leaves an app-side problem though: passive polling should not be the thing that starts an interactive auth flow. If credentials are missing, the background refresh should fail quietly and let an explicit Git action handle authentication.

## Tradeoff

When credentials are not already available, passive remote status may fail quietly and ahead/behind counts can stay stale until the user authenticates through an explicit Git action or disables/re-enables background fetching. That is intentional here: background polling should not steal focus or spawn short-lived auth windows.

## UI Changes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

## Validation

- `pnpm --filter t3 exec vp test run src/vcs/GitVcsDriverCore.test.ts --reporter=dot`
- `pnpm exec vp check`
- `pnpm exec vp run typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make background VCS fetch non-interactive by setting additional environment variables
> Adds `GCM_INTERACTIVE=never`, `GIT_ASKPASS=""`, `GIT_TERMINAL_PROMPT=0`, and `SSH_ASKPASS=""` to [`GitVcsDriverCore.STATUS_UPSTREAM_REFRESH_ENV`](https://github.com/pingdotgg/t3code/pull/3133/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) alongside the existing `SSH_ASKPASS_REQUIRE=never`. The test in [`GitVcsDriverCore.test.ts`](https://github.com/pingdotgg/t3code/pull/3133/files#diff-ac30488287dac9aa8d4cb819c508d77d2e47267d4aae35819e6fa24b86312c26) is updated to verify all five variables are set to non-interactive values and to restore them after execution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c405d30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to cached background status fetches only; user-initiated pull/push/fetch paths are unchanged.
> 
> **Overview**
> Background upstream status refreshes now run Git with a fuller **non-interactive** env overlay, not only `SSH_ASKPASS_REQUIRE=never`. The passive `fetchRemoteForStatus` path sets `GCM_INTERACTIVE=never`, `GIT_TERMINAL_PROMPT=0`, and clears `GIT_ASKPASS` / `SSH_ASKPASS` so polling does not open GCM or terminal credential UI (e.g. on Windows HTTPS).
> 
> Explicit user Git actions still use the normal process environment. If credentials are missing, background refresh is expected to fail quietly and ahead/behind may stay stale until the user authenticates via an explicit action.
> 
> The integration test was broadened to assert all of these vars reach the child Git/SSH process when `statusDetails` triggers upstream refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c405d3042bbcc90bd22398a16317adc15a3c7298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->