### PR TITLE
Render path-like inline code as file chips

### DIFF
--- a/apps/web/src/components/ChatMarkdown.browser.tsx
+++ b/apps/web/src/components/ChatMarkdown.browser.tsx
@@ -384,6 +384,64 @@ describe("ChatMarkdown", () => {
     }
   });
 
+  it("renders path-shaped inline code as interactive file chips", async () => {
+    const source = [
+      "Call `appendFileSync` once per batch.",
+      "Inspect `apps/server/src/provider/Layers/EventNdjsonLogger.ts:148` and keep `1.2.3` unchanged.",
+    ].join("\n\n");
+    const screen = await render(
+      <ChatMarkdown text={source} cwd="/repo/project" threadRef={threadRef} />,
+    );
+
+    try {
+      const link = page.getByRole("link", { name: "EventNdjsonLogger.ts · L148" });
+      await expect.element(link).toHaveClass(/chat-markdown-file-link/);
+      await expect
+        .element(link)
+        .toHaveAttribute(
+          "href",
+          "/repo/project/apps/server/src/provider/Layers/EventNdjsonLogger.ts:148",
+        );
+
+      const inlineCodeValues = [
+        ...document.querySelectorAll<HTMLElement>(".chat-markdown :not(pre) > code"),
+      ].map((element) => element.textContent);
+      expect(inlineCodeValues).toEqual(["appendFileSync", "1.2.3"]);
+
+      await link.click();
+      await vi.waitFor(() => {
+        expect(
+          selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, threadRef),
+        ).toMatchObject({
+          isOpen: true,
+          activeSurfaceId: "file:apps/server/src/provider/Layers/EventNdjsonLogger.ts",
+        });
+      });
+    } finally {
+      await screen.unmount();
+    }
+  });
+
+  it("disambiguates inline-code file chips with duplicate basenames", async () => {
+    const screen = await render(
+      <ChatMarkdown
+        text="Compare `apps/web/src/first/config.ts` with `packages/shared/src/second/config.ts`."
+        cwd="/repo/project"
+      />,
+    );
+
+    try {
+      await expect
+        .element(page.getByRole("link", { name: "config.ts · src/first" }))
+        .toBeInTheDocument();
+      await expect
+        .element(page.getByRole("link", { name: "config.ts · src/second" }))
+        .toBeInTheDocument();
+    } finally {
+      await screen.unmount();
+    }
+  });
+
   it("renders sanitized details with the design-system collapsible", async () => {
     const source = [
       "<details open>",

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -54,6 +54,7 @@ import {
 import {
   normalizeMarkdownLinkDestination,
   resolveMarkdownFileLinkMeta,
+  resolveMarkdownInlineCodeFileLinkMeta,
   rewriteMarkdownFileUriHref,
 } from "../markdown-links";
 import { readLocalApi } from "../localApi";
@@ -161,6 +162,8 @@ function extractPreCodeMeta(node: unknown): string | undefined {
 type MarkdownAstNode = {
   type?: string;
   meta?: unknown;
+  value?: unknown;
+  url?: string;
   data?: {
     hProperties?: Record<string, unknown>;
   };
@@ -178,6 +181,25 @@ function remarkPreserveCodeMeta() {
             dataCodeMeta: node.meta.trim(),
           },
         };
+      }
+      node.children?.forEach(visit);
+    };
+
+    visit(tree);
+  };
+}
+
+function remarkLinkInlineCodeFilePaths(options: { readonly cwd: string | undefined }) {
+  return (tree: MarkdownAstNode) => {
+    const visit = (node: MarkdownAstNode) => {
+      if (node.type === "inlineCode" && typeof node.value === "string") {
+        const value = node.value;
+        if (resolveMarkdownInlineCodeFileLinkMeta(value, options.cwd)) {
+          node.type = "link";
+          node.url = value.trim();
+          node.children = [{ type: "text", value }];
+          delete node.value;
+        }
       }
       node.children?.forEach(visit);
     };
@@ -667,6 +689,7 @@ interface MarkdownFileLinkProps {
 }
 
 const MARKDOWN_LINK_HREF_PATTERN = /\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+const MARKDOWN_INLINE_CODE_PATTERN = /(?<!`)(`{1,2})(?!`)([\s\S]*?)(?<!`)\1(?!`)/g;
 const MARKDOWN_FILE_LINK_CLASS_NAME =
   "chat-markdown-file-link cursor-pointer transition-colors hover:bg-accent/70";
 
@@ -738,6 +761,16 @@ function extractMarkdownLinkHrefs(text: string): string[] {
     hrefs.push(href);
   }
   return hrefs;
+}
+
+function extractMarkdownInlineCodeValues(text: string): string[] {
+  const values: string[] = [];
+  for (const match of text.matchAll(MARKDOWN_INLINE_CODE_PATTERN)) {
+    const value = match[2]?.trim();
+    if (!value) continue;
+    values.push(value);
+  }
+  return values;
 }
 
 function normalizeMarkdownLinkHrefKey(href: string): string {
@@ -1190,6 +1223,14 @@ function ChatMarkdown({
         metaByHref.set(normalizedHref, meta);
       }
     }
+    for (const value of extractMarkdownInlineCodeValues(text)) {
+      const normalizedHref = normalizeMarkdownLinkHrefKey(value);
+      if (metaByHref.has(normalizedHref)) continue;
+      const meta = resolveMarkdownInlineCodeFileLinkMeta(normalizedHref, cwd);
+      if (meta) {
+        metaByHref.set(normalizedHref, meta);
+      }
+    }
     return metaByHref;
   }, [cwd, text]);
   const fileLinkParentSuffixByPath = useMemo(() => {
@@ -1220,7 +1261,10 @@ function ChatMarkdown({
       },
       a({ node, href, children, ...props }) {
         const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
-        const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
+        const fileLinkMeta = normalizedHref
+          ? (markdownFileLinkMetaByHref.get(normalizedHref) ??
+            resolveMarkdownFileLinkMeta(normalizedHref, cwd))
+          : null;
         if (!fileLinkMeta) {
           const faviconHost = resolveExternalLinkHost(href);
           const isSameDocumentLink = href?.startsWith("#") ?? false;
@@ -1327,6 +1371,7 @@ function ChatMarkdown({
     }),
     [
       diffThemeName,
+      cwd,
       fileLinkParentSuffixByPath,
       isStreaming,
       markdownFileLinkMetaByHref,
@@ -1347,8 +1392,13 @@ function ChatMarkdown({
       <ReactMarkdown
         remarkPlugins={
           lineBreaks
-            ? [remarkGfm, remarkBreaks, remarkPreserveCodeMeta]
-            : [remarkGfm, remarkPreserveCodeMeta]
+            ? [
+                remarkGfm,
+                remarkBreaks,
+                [remarkLinkInlineCodeFilePaths, { cwd }],
+                remarkPreserveCodeMeta,
+              ]
+            : [remarkGfm, [remarkLinkInlineCodeFilePaths, { cwd }], remarkPreserveCodeMeta]
         }
         rehypePlugins={[rehypeRaw, [rehypeSanitize, CHAT_MARKDOWN_SANITIZE_SCHEMA]]}
         components={markdownComponents}

--- a/apps/web/src/markdown-links.test.ts
+++ b/apps/web/src/markdown-links.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   resolveMarkdownFileLinkMeta,
   resolveMarkdownFileLinkTarget,
+  resolveMarkdownInlineCodeFileLinkMeta,
   rewriteMarkdownFileUriHref,
 } from "./markdown-links";
 
@@ -125,5 +126,37 @@ describe("resolveMarkdownFileLinkTarget", () => {
 
   it("does not treat app routes as file links", () => {
     expect(resolveMarkdownFileLinkTarget("/chat/settings")).toBeNull();
+  });
+});
+
+describe("resolveMarkdownInlineCodeFileLinkMeta", () => {
+  it("resolves path-shaped inline code with source positions", () => {
+    expect(
+      resolveMarkdownInlineCodeFileLinkMeta(
+        "apps/server/src/provider/Layers/EventNdjsonLogger.ts:148",
+        "/repo/project",
+      ),
+    ).toMatchObject({
+      basename: "EventNdjsonLogger.ts",
+      line: 148,
+      targetPath: "/repo/project/apps/server/src/provider/Layers/EventNdjsonLogger.ts:148",
+      workspaceRelativePath: "apps/server/src/provider/Layers/EventNdjsonLogger.ts",
+    });
+  });
+
+  it("resolves bare filenames only when they include a source position", () => {
+    expect(resolveMarkdownInlineCodeFileLinkMeta("script.ts:10", "/repo/project")).toMatchObject({
+      basename: "script.ts",
+      line: 10,
+      targetPath: "/repo/project/script.ts:10",
+    });
+    expect(resolveMarkdownInlineCodeFileLinkMeta("script.ts", "/repo/project")).toBeNull();
+  });
+
+  it("leaves ordinary code and ambiguous slash values alone", () => {
+    expect(resolveMarkdownInlineCodeFileLinkMeta("sink.write()", "/repo/project")).toBeNull();
+    expect(resolveMarkdownInlineCodeFileLinkMeta("1.2.3", "/repo/project")).toBeNull();
+    expect(resolveMarkdownInlineCodeFileLinkMeta("1/2", "/repo/project")).toBeNull();
+    expect(resolveMarkdownInlineCodeFileLinkMeta("client/server", "/repo/project")).toBeNull();
   });
 });

--- a/apps/web/src/markdown-links.ts
+++ b/apps/web/src/markdown-links.ts
@@ -211,3 +211,28 @@ export function resolveMarkdownFileLinkMeta(
     ...(columnNumber !== undefined ? { column: columnNumber } : {}),
   };
 }
+
+/**
+ * Inline code is used for many non-path values, so only promote references
+ * with unambiguous path syntax. Markdown links remain more permissive because
+ * the link destination itself already signals intent.
+ */
+export function resolveMarkdownInlineCodeFileLinkMeta(
+  value: string,
+  cwd?: string,
+): MarkdownFileLinkMeta | null {
+  const candidate = value.trim();
+  const hasSourcePosition =
+    POSITION_SUFFIX_PATTERN.test(candidate) || /#L\d+(?:C\d+)?$/i.test(candidate);
+  if (!/[\\/]/.test(candidate) && !hasSourcePosition) {
+    return null;
+  }
+  const meta = resolveMarkdownFileLinkMeta(candidate, cwd);
+  if (!meta) {
+    return null;
+  }
+  if (!/[A-Za-z]/.test(meta.basename) || (!meta.basename.includes(".") && !hasSourcePosition)) {
+    return null;
+  }
+  return meta;
+}


### PR DESCRIPTION
## Summary
- Promote unambiguous inline code references to interactive file chips in chat markdown.
- Add shared resolution logic for inline-code file paths, including line/column suffix handling and basename disambiguation.
- Cover the new behavior with unit tests for link resolution and browser-level rendering.

## Testing
- `vp check`
- `vp run typecheck`
- `vp run lint`
- `vp test`
- `vp run test`
- Not run: native mobile lint (no mobile code changed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to chat markdown rendering and link heuristics; false positives are mitigated by stricter inline-code rules, with unit and browser tests.
> 
> **Overview**
> **Chat markdown** now turns unambiguous `` `path/to/file.ts:line` `` inline code into the same interactive **file tag chips** used for markdown file links, instead of plain monospace spans.
> 
> A new **remark** pass rewrites qualifying ``inlineCode`` nodes into links before render, and the message text is pre-scanned so chips get **line/column labels** and **parent-path disambiguation** when basenames collide. Promotion is intentionally **stricter than link hrefs**: values need a path separator or a ``:line`` / ``#L`` suffix, and obvious non-paths (e.g. ``1.2.3``, ``client/server``, API snippets) stay as code.
> 
> Shared resolution lives in ``resolveMarkdownInlineCodeFileLinkMeta`` in ``markdown-links.ts``; behavior is covered by unit tests and browser tests (chip styling, href resolution, right-panel file preview on click).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5350fea9387b10d1499a1f2386a7b2af71015844. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render path-like inline code as interactive file chips in ChatMarkdown
> - Adds a `remarkLinkInlineCodeFilePaths` remark plugin in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/3134/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) that converts inline code nodes whose text looks like a file path into link nodes during AST processing.
> - Adds `resolveMarkdownInlineCodeFileLinkMeta` in [markdown-links.ts](https://github.com/pingdotgg/t3code/pull/3134/files#diff-010f94b966be6604cb228ce225d1f3ce41b15470b641a970ec5ed07cd2ed2040) to constrain resolution to unambiguous path-like values — requiring a slash/backslash or a source position suffix (e.g. `:148`), an alphabetic basename, and either a `.` in the basename or a source position.
> - `ChatMarkdown` scans inline code values and pre-resolves them into its `markdownFileLinkMetaByHref` map so they render with the same file-link class and click behavior as explicit markdown links.
> - Bare filenames without a path separator are only linkified when accompanied by a line/column suffix, preventing false positives on values like `1.2.3` or `sink.write()`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5350fea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->