### PR TITLE
fix: show completed status for first-seen threads

### DIFF
--- a/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
+++ b/apps/web/src/hooks/useMarkFirstSeenCompletedThreadsUnread.ts
@@ -1,0 +1,57 @@
+import { useAtomValue } from "@effect/atom-react";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
+import type { EnvironmentId } from "@t3tools/contracts";
+import * as Option from "effect/Option";
+import { Atom } from "effect/unstable/reactivity";
+import { useEffect, useRef } from "react";
+
+import { environmentCatalog } from "../connection/catalog";
+import { useThreadShells } from "../state/entities";
+import { environmentShell } from "../state/shell";
+import { useUiStateStore } from "../uiStateStore";
+
+const environmentSnapshotIdsAtom = Atom.make((get): ReadonlyArray<EnvironmentId> => {
+  const environmentIds: EnvironmentId[] = [];
+  for (const environmentId of get(environmentCatalog.catalogValueAtom).entries.keys()) {
+    if (Option.isSome(get(environmentShell.stateValueAtom(environmentId)).snapshot)) {
+      environmentIds.push(environmentId);
+    }
+  }
+  return environmentIds;
+}).pipe(Atom.withLabel("completed-thread-unread:snapshot-environments"));
+
+export function useMarkFirstSeenCompletedThreadsUnread(): void {
+  const threads = useThreadShells();
+  const environmentSnapshotIds = useAtomValue(environmentSnapshotIdsAtom);
+  const seenThreadKeysByEnvironmentRef = useRef<Map<EnvironmentId, Set<string>>>(new Map());
+
+  useEffect(() => {
+    const snapshotEnvironmentIds = new Set(environmentSnapshotIds);
+    const nextThreadKeysByEnvironment = new Map<EnvironmentId, Set<string>>();
+    for (const environmentId of snapshotEnvironmentIds) {
+      nextThreadKeysByEnvironment.set(environmentId, new Set());
+    }
+
+    for (const thread of threads) {
+      if (!snapshotEnvironmentIds.has(thread.environmentId)) {
+        continue;
+      }
+
+      const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+      const threadKey = scopedThreadKey(threadRef);
+      const nextThreadKeys = nextThreadKeysByEnvironment.get(thread.environmentId);
+      nextThreadKeys?.add(threadKey);
+
+      const previousThreadKeys = seenThreadKeysByEnvironmentRef.current.get(thread.environmentId);
+      if (
+        previousThreadKeys !== undefined &&
+        !previousThreadKeys.has(threadKey) &&
+        thread.latestTurn?.state === "completed"
+      ) {
+        useUiStateStore.getState().markThreadUnread(threadKey, thread.latestTurn.completedAt);
+      }
+    }
+
+    seenThreadKeysByEnvironmentRef.current = nextThreadKeysByEnvironment;
+  }, [environmentSnapshotIds, threads]);
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -26,6 +26,7 @@ import {
   toastManager,
 } from "../components/ui/toast";
 import { resolveAndPersistPreferredEditor } from "../editorPreferences";
+import { useMarkFirstSeenCompletedThreadsUnread } from "../hooks/useMarkFirstSeenCompletedThreadsUnread";
 import { useClientSettings } from "../hooks/useSettings";
 import {
   deriveLogicalProjectKeyFromSettings,
@@ -264,6 +265,8 @@ function AuthenticatedTracingBootstrap() {
 }
 
 function EventRouter() {
+  useMarkFirstSeenCompletedThreadsUnread();
+
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);


### PR DESCRIPTION
## Summary

- Mark first-seen completed shell threads unread after `thread-upserted` seeds sidebar visit state.
- Reuses the existing `markThreadUnread` helper so the sidebar can surface the unread `Completed` status.
- No tests were added; existing focused UI-state/sidebar tests cover the helper behavior used by this fix.

## Root cause

Newly observed shell threads seed `threadLastVisitedAtById` from `thread.updatedAt ?? thread.createdAt`. When a completed thread first arrives through `thread-upserted`, that seeded timestamp can equal or be later than `latestTurn.completedAt`, so the sidebar strict comparison treats the completed turn as already seen.

## Impact

Background threads that finish before the web client observes them now show the unread `Completed` status instead of silently appearing idle/read. Initial snapshot bootstrap behavior is unchanged because this only runs for first-seen live `thread-upserted` events.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp test apps/web/src/uiStateStore.test.ts apps/web/src/components/Sidebar.logic.test.ts`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

`vp check` reports the repository's existing unrelated warnings and no errors.

Closes #3131


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mark first-seen completed threads as unread in snapshot-enabled environments
> - Adds `useMarkFirstSeenCompletedThreadsUnread` in [useMarkFirstSeenCompletedThreadsUnread.ts](https://github.com/pingdotgg/t3code/pull/3139/files#diff-9d86c723ae0d6d52ba69039ad812c60fc7d45ea0e349a9cb20557af24fd4534b) that tracks which threads have been seen per environment and calls `markThreadUnread` when a completed thread is observed for the first time.
> - Adds `environmentSnapshotIdsAtom` to reactively compute which environments currently have a snapshot present, scoping the unread-marking logic to those environments only.
> - Activates the hook in [__root.tsx](https://github.com/pingdotgg/t3code/pull/3139/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) via the `EventRouter` component so it runs globally.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c87567a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI-state fix using an existing `markThreadUnread` helper; no auth, data, or API changes.
> 
> **Overview**
> Fixes background threads that finish before the client sees them showing as idle/read instead of unread **Completed** in the sidebar.
> 
> Adds **`useMarkFirstSeenCompletedThreadsUnread`**, which tracks per-environment thread keys and, only for environments with an active shell snapshot, calls **`markThreadUnread`** when a thread appears for the first time with **`latestTurn.state === "completed"`**. That works around visit state seeded from **`thread-upserted`** timestamps that can be at or after **`completedAt`**, so the sidebar’s strict comparison no longer treats the turn as already seen.
> 
> The hook is mounted from **`EventRouter`** in **`__root.tsx`** so it runs globally for authenticated sessions. Initial snapshot bootstrap is unchanged; the logic targets first-seen live upserts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c87567aa1f16fcb43652d224c38d37a167312875. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->