### PR TITLE
[codex] Add PATCH.md fork upgrade workflow

### DIFF
--- a/PATCH.md
+++ b/PATCH.md
@@ -1,0 +1,52 @@
+# PATCH.md - Overwrite-prone local changes only
+
+**Purpose.** This manifest tracks local changes to T3 Code-owned files that are
+likely to collide with upstream when this repository is used as a private fork.
+It is not for dependency patches under `patches/`, generated files, local
+environment files, or one-off workspace notes.
+
+No code snippets here. Record intent, scope, and enough reconstruction guidance
+for a capable agent or developer to re-apply the change on top of newer upstream
+code.
+
+Last updated: 2026-06-18.
+
+## How this file is used
+
+`pnpm patch:upgrade` rebases the current branch onto its configured upstream.
+Clean local patch commits replay automatically. When a local patch commit
+conflicts, the command keeps the upstream version by default, saves the old
+patched file under `~/.t3code/patch-upgrade-backups/<id>/`, and writes a
+`manifest.json` with each conflict.
+
+After that, use `skills/patch-resolve/SKILL.md` to re-apply the intended local
+changes with explicit approval. The resolver should compare three reference
+points: the new upstream file, the backed-up patched file, and the matching
+entry in this manifest.
+
+## Safe-change protocol
+
+1. Commit each local patch as its own logical commit.
+2. Add or refresh the matching entry in this file in the same logical unit.
+3. Describe intent, not implementation text: what changed, why, and how to
+   recreate it.
+4. When upstream absorbs or obsoletes a patch, mark the entry `Status: retired`
+   instead of deleting it.
+
+Entries should use this format:
+
+```md
+## N. MODIFIED <area> - `path/to/file.ts`
+
+**Change:** what behavior changed.
+**Edit made:** concise implementation shape.
+**Why:** why the patch exists.
+**How to recreate:** how to rebuild it on top of new upstream code.
+**Status:** optional status, for example `retired (upstreamed)`.
+```
+
+---
+
+## Active Patches
+
+Add local fork patches here as they are created.

--- a/docs/operations/patch-md.md
+++ b/docs/operations/patch-md.md
@@ -1,0 +1,83 @@
+# PATCH.md fork maintenance
+
+T3 Code supports an agent-readable `PATCH.md` workflow for private forks. The
+goal is to make local changes durable across upstream updates without storing
+fragile code hunks as the source of truth.
+
+## Files
+
+- `PATCH.md` records overwrite-prone local patch intent.
+- `scripts/patch-upgrade.ts` rebases local patch commits onto upstream safely.
+- `skills/managed-t3code/SKILL.md` keeps future T3 Code edits patch-aware.
+- `skills/upgrade-t3code/SKILL.md` runs the update workflow.
+- `skills/patch-resolve/SKILL.md` re-applies conflicting patch intent after an
+  upstream-wins upgrade.
+
+## Normal patch workflow
+
+1. Work on a patch branch, not directly on `main`.
+2. Keep local fork changes in committed logical patches.
+3. Add or refresh the matching `PATCH.md` entry in the same logical unit.
+4. Run the normal verification checks before handing off:
+
+```sh
+vp check
+vp run typecheck
+```
+
+If native mobile code changed, also run:
+
+```sh
+vp run lint:mobile
+```
+
+## Upgrade workflow
+
+Run the upgrade through the skill:
+
+```text
+Use skills/upgrade-t3code/SKILL.md
+```
+
+The skill runs:
+
+```sh
+pnpm patch:upgrade
+```
+
+The script requires a clean working tree, fetches the configured upstream,
+creates a rollback branch, and rebases local patch commits. If a local patch
+conflicts with upstream, upstream wins by default and the previous patched file
+is backed up under:
+
+```text
+~/.t3code/patch-upgrade-backups/<id>/
+```
+
+The backup directory includes `manifest.json`, which points the resolver skill
+at the conflicted files and original patch commits.
+
+## Resolving conflicts
+
+Use:
+
+```text
+Use skills/patch-resolve/SKILL.md
+```
+
+The resolver compares:
+
+- the new upstream file,
+- the backed-up patched file,
+- the matching `PATCH.md` entry,
+- the original patch commit diff when useful.
+
+It should re-apply intent, not paste old code over upstream. If upstream already
+implemented the intent, mark the `PATCH.md` entry retired instead of deleting it.
+
+## Launching from the app
+
+The safest product path is to launch an external agent session instead of making
+T3 Code update itself while hosting the agent. A future UI button can open a
+Codex or Claude Code deep link with a prompt that tells the external agent to
+use `skills/upgrade-t3code/SKILL.md` in the target repo path.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "dist:desktop:win:x64": "node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64",
     "release:smoke": "node scripts/release-smoke.ts",
     "clean": "rm -rf node_modules apps/*/node_modules packages/*/node_modules apps/*/dist apps/*/dist-electron packages/*/dist .vite-plus apps/*/.vite-plus packages/*/.vite-plus",
-    "sync:repos": "node scripts/sync-reference-repos.ts"
+    "sync:repos": "node scripts/sync-reference-repos.ts",
+    "patch:upgrade": "node scripts/patch-upgrade.ts"
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "7.28.6",

--- a/scripts/patch-upgrade.test.ts
+++ b/scripts/patch-upgrade.test.ts
@@ -1,0 +1,112 @@
+// @effect-diagnostics nodeBuiltinImport:off - Tests create throwaway Git repositories directly.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assert, describe, it } from "@effect/vitest";
+
+import { runPatchUpgrade } from "./patch-upgrade.ts";
+
+function normalizeNewlines(input: string): string {
+  return input.replace(/\r\n/g, "\n");
+}
+
+function git(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf-8",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "Test",
+      GIT_AUTHOR_EMAIL: "test@example.com",
+      GIT_COMMITTER_NAME: "Test",
+      GIT_COMMITTER_EMAIL: "test@example.com",
+    },
+  }).trim();
+}
+
+async function makeRepoPair(prefix: string) {
+  const baseDir = await mkdtemp(join(tmpdir(), prefix));
+  const upstream = join(baseDir, "upstream");
+  const fork = join(baseDir, "fork");
+
+  await mkdir(upstream);
+  git(upstream, "init", "-b", "main");
+  await writeFile(join(upstream, "app.txt"), "one\n");
+  git(upstream, "add", "app.txt");
+  git(upstream, "commit", "-m", "upstream: initial");
+
+  execFileSync("git", ["clone", upstream, fork], { encoding: "utf-8" });
+  git(fork, "branch", "--set-upstream-to=origin/main", "main");
+
+  return { baseDir, upstream, fork };
+}
+
+describe("patch-upgrade", () => {
+  it("reports current when there are no upstream commits", async () => {
+    const { fork } = await makeRepoPair("t3code-patch-current-");
+
+    const result = runPatchUpgrade(fork, { id: "current-test" });
+
+    assert.equal(result.status, "current");
+    assert.equal(result.pulled, 0);
+  });
+
+  it("refuses to run with uncommitted work", async () => {
+    const { upstream, fork } = await makeRepoPair("t3code-patch-dirty-");
+    await writeFile(join(upstream, "app.txt"), "two\n");
+    git(upstream, "commit", "-am", "upstream: update");
+    await writeFile(join(fork, "local.txt"), "dirty\n");
+
+    const result = runPatchUpgrade(fork, { id: "dirty-test" });
+
+    assert.equal(result.status, "dirty");
+    assert.match(result.error ?? "", /uncommitted changes/);
+  });
+
+  it("rebases clean local commits and creates a rollback branch", async () => {
+    const { upstream, fork } = await makeRepoPair("t3code-patch-clean-");
+    await writeFile(join(fork, "local.txt"), "local\n");
+    git(fork, "add", "local.txt");
+    git(fork, "commit", "-m", "patch: add local file");
+
+    await writeFile(join(upstream, "app.txt"), "two\n");
+    git(upstream, "commit", "-am", "upstream: update");
+
+    const result = runPatchUpgrade(fork, { id: "clean-test" });
+
+    assert.equal(result.status, "upgraded");
+    assert.equal(result.pulled, 1);
+    assert.equal(result.replayed, 1);
+    assert.equal(
+      git(fork, "rev-parse", "--verify", "backup/pre-patch-upgrade-clean-test").length > 0,
+      true,
+    );
+    assert.equal(normalizeNewlines(await readFile(join(fork, "local.txt"), "utf-8")), "local\n");
+  });
+
+  it("keeps upstream on conflict, backs up patched bytes, and writes a manifest", async () => {
+    const { upstream, fork, baseDir } = await makeRepoPair("t3code-patch-conflict-");
+    await writeFile(join(fork, "app.txt"), "local patch\n");
+    git(fork, "commit", "-am", "patch: local app text");
+
+    await writeFile(join(upstream, "app.txt"), "upstream text\n");
+    git(upstream, "commit", "-am", "upstream: app text");
+
+    const backupBase = join(baseDir, "backups");
+    const result = runPatchUpgrade(fork, { id: "conflict-test", backupBase });
+
+    assert.equal(result.status, "upgraded_with_conflicts");
+    assert.equal(
+      normalizeNewlines(await readFile(join(fork, "app.txt"), "utf-8")),
+      "upstream text\n",
+    );
+    assert.equal(
+      normalizeNewlines(readFileSync(join(backupBase, "conflict-test", "app.txt"), "utf-8")),
+      "local patch\n",
+    );
+    assert.equal(existsSync(join(backupBase, "conflict-test", "manifest.json")), true);
+    assert.equal(result.conflicts?.[0]?.file, "app.txt");
+  });
+});

--- a/scripts/patch-upgrade.ts
+++ b/scripts/patch-upgrade.ts
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+// @effect-diagnostics nodeBuiltinImport:off - Standalone Git maintenance boundary.
+// @effect-diagnostics globalDate:off - Backup ids and manifests use wall-clock timestamps.
+// @effect-diagnostics globalConsole:off - CLI prints a human-readable briefing.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+
+export interface PatchUpgradeConflict {
+  readonly file: string;
+  readonly commit: string;
+  readonly subject: string;
+  readonly backupPath: string | null;
+}
+
+export interface PatchUpgradeManifest {
+  readonly id: string;
+  readonly repoRoot: string;
+  readonly backupRef: string;
+  readonly upstream: string;
+  readonly createdAt: string;
+  readonly conflicts: ReadonlyArray<PatchUpgradeConflict>;
+}
+
+export type PatchUpgradeStatus =
+  | "current"
+  | "upgraded"
+  | "upgraded_with_conflicts"
+  | "dirty"
+  | "no_upstream"
+  | "failed";
+
+export interface PatchUpgradeResult {
+  readonly status: PatchUpgradeStatus;
+  readonly upstream?: string;
+  readonly pulled?: number;
+  readonly replayed?: number;
+  readonly conflicts?: ReadonlyArray<PatchUpgradeConflict>;
+  readonly backupRef?: string;
+  readonly backupDir?: string;
+  readonly error?: string;
+}
+
+export interface PatchUpgradeOptions {
+  readonly id?: string;
+  readonly backupBase?: string;
+}
+
+function git(repoRoot: string, ...args: ReadonlyArray<string>): string {
+  return execFileSync("git", ["-C", repoRoot, ...args], {
+    encoding: "utf-8",
+    timeout: 120_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, GIT_EDITOR: "true" },
+  }).trim();
+}
+
+function gitBlob(repoRoot: string, revPath: string): Buffer {
+  return execFileSync("git", ["-C", repoRoot, "show", revPath], {
+    timeout: 120_000,
+    maxBuffer: 64 * 1024 * 1024,
+    env: { ...process.env, GIT_EDITOR: "true" },
+  });
+}
+
+function rebaseInProgress(repoRoot: string): boolean {
+  return (
+    existsSync(join(repoRoot, ".git", "rebase-merge")) ||
+    existsSync(join(repoRoot, ".git", "rebase-apply"))
+  );
+}
+
+function timestampId(): string {
+  const now = new Date();
+  const pad = (value: number) => String(value).padStart(2, "0");
+  return `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(
+    now.getHours(),
+  )}${pad(now.getMinutes())}${pad(now.getSeconds())}`;
+}
+
+function defaultBackupBase(): string {
+  const home = process.env.HOME || process.env.USERPROFILE;
+  return home
+    ? join(home, ".t3code", "patch-upgrade-backups")
+    : resolve(".t3code", "patch-upgrade-backups");
+}
+
+function splitRemote(upstream: string): string {
+  return upstream.split("/")[0] ?? upstream;
+}
+
+/**
+ * Rebase local fork patches onto the configured upstream.
+ *
+ * Clean local patch commits replay automatically. If a patch commit conflicts,
+ * upstream wins, the previous patched file is saved in the backup directory,
+ * and the rebase is completed so the repo is not left mid-conflict. Re-applying
+ * local intent is a separate user-approved step handled by
+ * `skills/patch-resolve`.
+ */
+export function runPatchUpgrade(
+  repoRoot: string,
+  options: PatchUpgradeOptions = {},
+): PatchUpgradeResult {
+  let upstream: string;
+  try {
+    upstream = git(repoRoot, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}");
+  } catch {
+    return {
+      status: "no_upstream",
+      error:
+        "Current branch has no upstream tracking branch. Set one with: git branch --set-upstream-to=<remote>/<branch>",
+    };
+  }
+
+  const remote = splitRemote(upstream);
+  try {
+    git(repoRoot, "fetch", remote);
+  } catch (error) {
+    return {
+      status: "failed",
+      upstream,
+      error: `git fetch ${remote} failed: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+
+  const pulled = Number(git(repoRoot, "rev-list", "--count", `HEAD..${upstream}`));
+  if (pulled === 0) {
+    return { status: "current", upstream, pulled: 0 };
+  }
+
+  if (git(repoRoot, "status", "--porcelain") !== "") {
+    return {
+      status: "dirty",
+      upstream,
+      error:
+        "Working tree has uncommitted changes. Commit or stash them, then re-run the patch upgrade.",
+    };
+  }
+
+  const id = options.id ?? timestampId();
+  const backupRef = `backup/pre-patch-upgrade-${id}`;
+  git(repoRoot, "branch", backupRef);
+  const backupDir = join(options.backupBase ?? defaultBackupBase(), id);
+  const conflicts: Array<PatchUpgradeConflict> = [];
+
+  try {
+    try {
+      git(repoRoot, "rebase", upstream);
+    } catch {
+      let guard = 0;
+      while (rebaseInProgress(repoRoot)) {
+        if (++guard > 200) {
+          throw new Error("rebase conflict loop exceeded 200 iterations");
+        }
+
+        const files = git(repoRoot, "diff", "--name-only", "--diff-filter=U")
+          .split("\n")
+          .filter(Boolean);
+        if (files.length === 0) {
+          throw new Error("rebase stopped without content conflicts; resolve manually");
+        }
+
+        const commit = git(repoRoot, "rev-parse", "REBASE_HEAD");
+        const subject = git(repoRoot, "log", "-1", "--format=%s", commit);
+
+        for (const file of files) {
+          let backupPath: string | null = null;
+          try {
+            const patched = gitBlob(repoRoot, `${backupRef}:${file}`);
+            backupPath = join(backupDir, file);
+            mkdirSync(dirname(backupPath), { recursive: true });
+            writeFileSync(backupPath, patched);
+          } catch {
+            backupPath = null;
+          }
+
+          try {
+            git(repoRoot, "checkout", "--ours", "--", file);
+            git(repoRoot, "add", "--", file);
+          } catch {
+            git(repoRoot, "rm", "--quiet", "--ignore-unmatch", "--", file);
+          }
+
+          conflicts.push({ file, commit, subject, backupPath });
+        }
+
+        let hasStagedChanges = false;
+        try {
+          git(repoRoot, "diff", "--cached", "--quiet");
+        } catch {
+          hasStagedChanges = true;
+        }
+
+        try {
+          git(repoRoot, "rebase", hasStagedChanges ? "--continue" : "--skip");
+        } catch {
+          if (!rebaseInProgress(repoRoot)) {
+            throw new Error("rebase --continue failed in an unexpected way");
+          }
+        }
+      }
+    }
+  } catch (error) {
+    try {
+      git(repoRoot, "rebase", "--abort");
+    } catch {
+      // Not in a rebase; keep rollback best-effort.
+    }
+    try {
+      git(repoRoot, "reset", "--hard", backupRef);
+    } catch {
+      // Best-effort rollback already reported below.
+    }
+    return {
+      status: "failed",
+      upstream,
+      backupRef,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const replayed = Number(git(repoRoot, "rev-list", "--count", `${upstream}..HEAD`));
+  if (conflicts.length > 0) {
+    mkdirSync(backupDir, { recursive: true });
+    const manifest: PatchUpgradeManifest = {
+      id,
+      repoRoot,
+      backupRef,
+      upstream,
+      createdAt: new Date().toISOString(),
+      conflicts,
+    };
+    writeFileSync(join(backupDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+    return {
+      status: "upgraded_with_conflicts",
+      upstream,
+      pulled,
+      replayed,
+      conflicts,
+      backupRef,
+      backupDir,
+    };
+  }
+
+  return { status: "upgraded", upstream, pulled, replayed, backupRef };
+}
+
+export function printPatchUpgradeBriefing(result: PatchUpgradeResult): void {
+  switch (result.status) {
+    case "current":
+      console.log("Already on the latest upstream commit.");
+      break;
+    case "no_upstream":
+    case "dirty":
+      console.error(result.error);
+      break;
+    case "failed":
+      console.error(`Patch upgrade failed: ${result.error}`);
+      if (result.backupRef) {
+        console.error(`Repo restored to pre-upgrade state (${result.backupRef}).`);
+      }
+      break;
+    case "upgraded":
+      console.log(
+        `Pulled ${result.pulled} upstream commit(s); ${result.replayed} local patch commit(s) replayed cleanly.`,
+      );
+      console.log(`Rollback point: ${result.backupRef}`);
+      break;
+    case "upgraded_with_conflicts":
+      console.log(
+        `Pulled ${result.pulled} upstream commit(s); ${result.replayed} local patch commit(s) replayed cleanly.`,
+      );
+      console.log("");
+      console.log(`Conflicts resolved upstream-wins for ${result.conflicts?.length ?? 0} file(s):`);
+      for (const conflict of result.conflicts ?? []) {
+        console.log(`  ${conflict.file} (patch: "${conflict.subject}")`);
+      }
+      console.log("");
+      console.log(`Patched versions backed up at: ${result.backupDir}`);
+      console.log(`Rollback point: ${result.backupRef}`);
+      console.log(
+        "To re-apply local intent, ask your agent to run skills/patch-resolve/SKILL.md. It will ask for approval first.",
+      );
+      break;
+  }
+}
+
+if (import.meta.main) {
+  const repoRoot = resolve(process.argv[2] ?? process.cwd());
+  const result = runPatchUpgrade(repoRoot);
+  printPatchUpgradeBriefing(result);
+  if (result.status === "dirty" || result.status === "no_upstream" || result.status === "failed") {
+    process.exitCode = 1;
+  }
+}

--- a/skills/managed-t3code/SKILL.md
+++ b/skills/managed-t3code/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: managed-t3code
+description: |
+  Use whenever editing T3 Code, especially a private fork. Keeps local
+  overwrite-prone changes on patch branches, maintains PATCH.md, and routes
+  update work through the upgrade-t3code skill.
+triggers:
+  - "edit t3code"
+  - "work on t3code"
+  - "change t3 code"
+  - "modify t3 code"
+  - "t3code patch"
+  - "private t3code fork"
+tools:
+  - exec
+  - read
+  - write
+mutating: true
+---
+
+# Managed T3 Code
+
+Use this skill before making changes in this repository.
+
+## First checks
+
+1. Confirm the repo root with `git rev-parse --show-toplevel`.
+2. Check the branch with `git branch --show-current`.
+3. Check the working tree with `git status --short`.
+4. Read `PATCH.md` before editing if the work may be a private fork patch.
+
+## Branch rules
+
+- Do not make private fork patches directly on `main`.
+- If the user asks for local/private behavior and no patch branch exists, create
+  a focused branch such as `patch/<short-name>` or ask before using an existing
+  branch.
+- Keep each local patch as a committed logical unit. The upgrade flow can only
+  replay committed patches.
+
+## PATCH.md rules
+
+Update `PATCH.md` whenever a change:
+
+- modifies T3 Code-owned files,
+- is private/local rather than intended for immediate upstream contribution, and
+- is likely to be overwritten or conflicted by upstream updates.
+
+Do not add entries for:
+
+- dependency patch files under `patches/`,
+- generated files,
+- local `.env` or machine config,
+- vendored `.repos/` reference material unless explicitly patching that vendor
+  copy as a tracked fork decision.
+
+Each entry should describe intent, not code. Use:
+
+```md
+## N. MODIFIED <area> - `path/to/file.ts`
+
+**Change:** what behavior changed.
+**Edit made:** concise implementation shape.
+**Why:** why the patch exists.
+**How to recreate:** how to rebuild it on top of new upstream code.
+**Status:** optional, for example `retired (upstreamed)`.
+```
+
+## During implementation
+
+- Prefer existing T3 Code architecture and Effect patterns.
+- Keep patch commits small enough that `pnpm patch:upgrade` can replay them
+  independently.
+- If a patch spans multiple areas, split it into separate commits and separate
+  `PATCH.md` entries.
+- When upstream already satisfies a patch intent, mark the entry
+  `Status: retired (upstreamed)` instead of deleting it.
+
+## Before finishing
+
+1. Re-read the diff and decide whether `PATCH.md` needs an entry.
+2. Run the repo-required checks:
+
+```sh
+vp check
+vp run typecheck
+```
+
+3. If native mobile code changed, also run:
+
+```sh
+vp run lint:mobile
+```
+
+4. Report whether `PATCH.md` was updated or why it was not needed.

--- a/skills/patch-resolve/SKILL.md
+++ b/skills/patch-resolve/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: patch-resolve
+description: |
+  Re-apply local T3 Code fork patches after `pnpm patch:upgrade` resolved
+  conflicts by keeping upstream. Reads the backup manifest, asks for approval,
+  then reconstructs each patch's intent from PATCH.md on top of the new code.
+triggers:
+  - "resolve patch upgrade conflicts"
+  - "re-apply my t3code patches"
+  - "reapply my t3code patches"
+  - "patch upgrade had conflicts"
+  - "restore my PATCH.md changes"
+tools:
+  - exec
+  - read
+mutating: true
+---
+
+# Patch Resolve - re-apply patches after an upstream-wins upgrade
+
+`pnpm patch:upgrade` rebases local patch commits onto upstream. When a file
+conflicts, upstream wins and the previous patched file is backed up. This skill
+re-applies local intent afterward. It never runs unattended.
+
+## Hard rules
+
+1. Ask before changing anything. Show the conflicted files, patch commit
+   subjects, and matching `PATCH.md` entries first.
+2. Re-apply intent, not text. Use the backed-up file as evidence, not as a blob
+   to paste over new upstream code.
+3. Never guess. If the upstream code changed too much or `PATCH.md` is missing a
+   clear entry, stop for that file and ask.
+4. Verify before declaring done. At minimum run `vp check` and
+   `vp run typecheck`; if native mobile code changed, also run
+   `vp run lint:mobile`.
+
+## Workflow
+
+### 1. Locate the upgrade record
+
+- Find the newest backup directory:
+  `ls -t ~/.t3code/patch-upgrade-backups | head -1`
+- Or use the `<id>` named by the user.
+- Read `~/.t3code/patch-upgrade-backups/<id>/manifest.json`.
+
+The manifest contains `repoRoot`, `backupRef`, `upstream`, and `conflicts[]`.
+Each conflict includes `file`, `commit`, `subject`, and `backupPath`.
+
+### 2. Ask for approval
+
+Read `PATCH.md` at `repoRoot`. For each conflicted file, present:
+
+- file path
+- patch commit subject
+- matching `PATCH.md` entry title
+- backup path
+
+Ask: "Re-apply these patches now?" Honor partial approval.
+
+### 3. Re-apply one file at a time
+
+For each approved file, gather:
+
+- new upstream code: `<repoRoot>/<file>`
+- old patched code: `backupPath`
+- intent: matching `PATCH.md` entry
+- optional context: `git -C <repoRoot> show <commit>`
+
+Rewrite the new upstream file so the patch intent still holds. If upstream
+already implemented the intent, skip the file and mark the `PATCH.md` entry
+`Status: retired (upstreamed)`.
+
+### 4. Verify
+
+Run:
+
+```sh
+vp check
+vp run typecheck
+```
+
+If native mobile code changed, also run:
+
+```sh
+vp run lint:mobile
+```
+
+If verification fails, revert the re-application for that file and report the
+failure with the three reference points.
+
+### 5. Commit and report
+
+Commit one logical patch at a time:
+
+```sh
+git add <files>
+git commit -m "patch: re-apply <subject> after upgrade <id>"
+```
+
+Refresh `PATCH.md` entries in a separate commit when needed.
+
+Final report must include:
+
+- files re-applied and how the new implementation differs from the old patch
+- files skipped as upstreamed
+- files blocked or ambiguous
+- verification results
+- rollback point and backup directory

--- a/skills/upgrade-t3code/SKILL.md
+++ b/skills/upgrade-t3code/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: upgrade-t3code
+description: |
+  Upgrade a private T3 Code fork to the latest upstream while preserving local
+  patch intent through PATCH.md. Runs the safe rebase script, then routes any
+  conflicts to patch-resolve.
+triggers:
+  - "upgrade t3code"
+  - "update t3code"
+  - "upgrade my t3code fork"
+  - "update my t3code fork"
+  - "run patch upgrade"
+  - "bring t3code up to latest"
+tools:
+  - exec
+  - read
+mutating: true
+---
+
+# Upgrade T3 Code
+
+This skill updates a private/local T3 Code fork without silently discarding
+local patch intent.
+
+## Safety model
+
+- `pnpm patch:upgrade` handles Git mechanics.
+- `PATCH.md` explains local patch intent.
+- `skills/patch-resolve` re-applies conflicting intent after explicit approval.
+- The app itself should not be expected to survive its own update. If this is
+  launched from inside T3 Code, open an external Codex or Claude Code session
+  and run this skill there.
+
+## Workflow
+
+### 1. Preflight
+
+Run:
+
+```sh
+git rev-parse --show-toplevel
+git branch --show-current
+git status --short
+git remote -v
+git rev-parse --abbrev-ref --symbolic-full-name @{upstream}
+```
+
+Stop if the working tree is dirty unless the user explicitly approves committing
+or stashing unrelated work. Do not update directly on `main` for private fork
+patches; use a patch branch.
+
+### 2. Read patch intent
+
+Read `PATCH.md`. If it is missing, stop and ask whether this fork has local
+patches that need a manifest before upgrading.
+
+### 3. Run the safe upgrade
+
+Run:
+
+```sh
+pnpm patch:upgrade
+```
+
+The command will:
+
+- fetch the configured upstream,
+- create `backup/pre-patch-upgrade-<id>`,
+- rebase local patch commits,
+- keep upstream on conflicting files,
+- save old patched file bytes to `~/.t3code/patch-upgrade-backups/<id>/`,
+- write `manifest.json` when conflicts occur.
+
+### 4. Resolve conflicts through the resolver skill
+
+If the output says `upgraded_with_conflicts`, invoke
+`skills/patch-resolve/SKILL.md`.
+
+Do not paste old files over upstream. Re-apply intent using:
+
+- current upstream file,
+- backed-up patched file,
+- matching `PATCH.md` entry,
+- original patch commit diff if useful.
+
+### 5. Verify
+
+Run:
+
+```sh
+vp check
+vp run typecheck
+```
+
+If native mobile code changed, also run:
+
+```sh
+vp run lint:mobile
+```
+
+### 6. Final report
+
+Report:
+
+- upstream branch and commits pulled,
+- local patch commits replayed cleanly,
+- conflicts and how each was handled,
+- backup directory,
+- rollback branch,
+- verification results,
+- any `PATCH.md` entries refreshed or retired.
+
+## External-agent launch prompt
+
+When T3 Code wants to start this from the UI, launch an external agent with a
+prompt shaped like:
+
+```text
+Use the upgrade-t3code skill in this repo:
+<absolute repo path>
+
+Update this private T3 Code fork to the latest configured upstream. Run
+`pnpm patch:upgrade`, use `skills/patch-resolve/SKILL.md` if conflicts are
+reported, preserve PATCH.md intent, and run the required verification checks.
+Report the rollback branch and backup directory.
+```


### PR DESCRIPTION
## Summary

Adds a PATCH.md-based fork maintenance workflow for T3 Code:

- root `PATCH.md` manifest for overwrite-prone local fork changes
- `pnpm patch:upgrade` safe rebase command with rollback branches and conflict backups
- `managed-t3code`, `upgrade-t3code`, and `patch-resolve` skills
- operations docs for normal patch work, upgrades, conflict resolution, and external-agent launch
- focused tests for current, dirty tree, clean replay, and upstream-wins conflict backup cases

## Validation

- `pnpm exec vp test run scripts/patch-upgrade.test.ts`
- `pnpm exec vp run --filter @t3tools/scripts typecheck`
- `pnpm exec vp run typecheck`
- `pnpm exec vp check`

Notes: `vp check` exits successfully and reports existing unrelated `react(no-unstable-nested-components)` warnings in web/mobile files. Local shell used Node v22.22.3, while the repo requests Node ^24.13.1; checks still passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `patch:upgrade` script and workflow documentation for maintaining a private fork
> - Adds [`scripts/patch-upgrade.ts`](https://github.com/pingdotgg/t3code/pull/3146/files#diff-8907585004ae86bc71d7ad41410dc4af1e19ea4b93354b79fa2a7d283957f8b3) implementing `runPatchUpgrade`, which fetches upstream, rebases local patches onto it, and handles conflicts by keeping upstream content, backing up pre-upgrade file bytes, and writing a manifest to a configurable backup directory.
> - On conflicts, a rollback branch (`backup/pre-patch-upgrade-<id>`) is created before rebasing so the previous state is recoverable.
> - Adds an npm script `patch:upgrade` in [`package.json`](https://github.com/pingdotgg/t3code/pull/3146/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) to invoke the script via `pnpm patch:upgrade`.
> - Adds [`PATCH.md`](https://github.com/pingdotgg/t3code/pull/3146/files#diff-ca29946b721a221da35a828c77353092f269281aab16ec1ed874697a463c22c1), [`docs/operations/patch-md.md`](https://github.com/pingdotgg/t3code/pull/3146/files#diff-db303a8738bace7020d8ac02c507f2c8bc733c5b7030883ec48bac007b84566e), and three skill manifests under [`skills/`](https://github.com/pingdotgg/t3code/pull/3146/files#diff-f1e8d760c12cd1f80217308b44c3daa31e801ecb0576c6f18c148e4451fcdabc) documenting the patch tracking format, upgrade workflow, and conflict resolution process.
> - Test coverage in [`scripts/patch-upgrade.test.ts`](https://github.com/pingdotgg/t3code/pull/3146/files#diff-eaf39a99937090f4b8ce65676bc02e663b7be00d16d52686d40a983ac8907b67) covers clean upgrades, dirty-tree rejection, rebase with rollback, and conflict backup/manifest writing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08e4517.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->