### PR TITLE
Collapse work details during final answer streaming

### DIFF
--- a/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
+++ b/apps/server/src/orchestration/Layers/ProjectionPipeline.ts
@@ -840,6 +840,7 @@ const makeOrchestrationProjectionPipeline = Effect.fn("makeOrchestrationProjecti
             turnId: event.payload.turnId,
             role: event.payload.role,
             text: nextText,
+            ...(event.payload.phase !== undefined ? { phase: event.payload.phase } : {}),
             ...(nextAttachments !== undefined ? { attachments: [...nextAttachments] } : {}),
             isStreaming: event.payload.streaming,
             createdAt: previousMessage?.createdAt ?? event.payload.createdAt,

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -5,9 +5,11 @@ import {
   MessageId,
   type OrchestrationEvent,
   type OrchestrationMessage,
+  type OrchestrationMessagePhase,
   type OrchestrationProposedPlanId,
   CheckpointRef,
   isToolLifecycleItemType,
+  RuntimeItemId,
   ThreadId,
   type ThreadTokenUsageSnapshot,
   TurnId,
@@ -53,6 +55,10 @@ const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
 const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
 const BUFFERED_PROPOSED_PLAN_BY_ID_CACHE_CAPACITY = 10_000;
 const BUFFERED_PROPOSED_PLAN_BY_ID_TTL = Duration.minutes(120);
+const ASSISTANT_MESSAGE_PHASE_BY_MESSAGE_ID_CACHE_CAPACITY = 20_000;
+const ASSISTANT_MESSAGE_PHASE_BY_MESSAGE_ID_TTL = Duration.minutes(120);
+const ASSISTANT_MESSAGE_PHASE_BY_ITEM_KEY_CACHE_CAPACITY = 20_000;
+const ASSISTANT_MESSAGE_PHASE_BY_ITEM_KEY_TTL = Duration.minutes(120);
 const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
 const STRICT_PROVIDER_LIFECYCLE_GUARD = process.env.T3CODE_STRICT_PROVIDER_LIFECYCLE_GUARD !== "0";
 
@@ -202,6 +208,11 @@ function assistantSegmentMessageId(baseKey: string, segmentIndex: number): Messa
     segmentIndex === 0 ? `assistant:${baseKey}` : `assistant:${baseKey}:segment:${segmentIndex}`,
   );
 }
+
+function runtimeItemKey(threadId: ThreadId, itemId: RuntimeItemId): string {
+  return `${threadId}:${itemId}`;
+}
+
 function buildContextWindowActivityPayload(
   event: ProviderRuntimeEvent,
 ): ThreadTokenUsageSnapshot | undefined {
@@ -666,6 +677,18 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed({ text: "", createdAt: "" }),
   });
 
+  const assistantMessagePhaseByMessageId = yield* Cache.make<MessageId, OrchestrationMessagePhase>({
+    capacity: ASSISTANT_MESSAGE_PHASE_BY_MESSAGE_ID_CACHE_CAPACITY,
+    timeToLive: ASSISTANT_MESSAGE_PHASE_BY_MESSAGE_ID_TTL,
+    lookup: () => Effect.die(new Error("assistant message phase should be read through getOption")),
+  });
+
+  const assistantMessagePhaseByItemKey = yield* Cache.make<string, OrchestrationMessagePhase>({
+    capacity: ASSISTANT_MESSAGE_PHASE_BY_ITEM_KEY_CACHE_CAPACITY,
+    timeToLive: ASSISTANT_MESSAGE_PHASE_BY_ITEM_KEY_TTL,
+    lookup: () => Effect.die(new Error("assistant item phase should be read through getOption")),
+  });
+
   const resolveThreadDetail = Effect.fn("resolveThreadDetail")(function* (threadId: ThreadId) {
     return yield* projectionSnapshotQuery
       .getThreadDetailById(threadId)
@@ -855,8 +878,29 @@ const make = Effect.gen(function* () {
   const clearBufferedProposedPlan = (planId: string) =>
     Cache.invalidate(bufferedProposedPlanById, planId);
 
+  const rememberAssistantMessagePhase = (messageId: MessageId, phase: OrchestrationMessagePhase) =>
+    Cache.set(assistantMessagePhaseByMessageId, messageId, phase);
+
+  const getAssistantMessagePhase = (messageId: MessageId) =>
+    Cache.getOption(assistantMessagePhaseByMessageId, messageId).pipe(
+      Effect.map(Option.getOrUndefined),
+    );
+
+  const clearAssistantMessagePhase = (messageId: MessageId) =>
+    Cache.invalidate(assistantMessagePhaseByMessageId, messageId);
+
+  const getAssistantMessagePhaseForRuntimeEvent = (event: ProviderRuntimeEvent) =>
+    event.itemId
+      ? Cache.getOption(
+          assistantMessagePhaseByItemKey,
+          runtimeItemKey(event.threadId, event.itemId),
+        ).pipe(Effect.map(Option.getOrUndefined))
+      : Effect.succeed(undefined as OrchestrationMessagePhase | undefined);
+
   const clearAssistantMessageState = (messageId: MessageId) =>
-    clearBufferedAssistantText(messageId);
+    clearBufferedAssistantText(messageId).pipe(
+      Effect.andThen(clearAssistantMessagePhase(messageId)),
+    );
 
   const flushBufferedAssistantMessage = (input: {
     event: ProviderRuntimeEvent;
@@ -871,6 +915,7 @@ const make = Effect.gen(function* () {
       if (!hasRenderableAssistantText(bufferedText)) {
         return false;
       }
+      const phase = yield* getAssistantMessagePhase(input.messageId);
 
       yield* orchestrationEngine.dispatch({
         type: "thread.message.assistant.delta",
@@ -879,6 +924,7 @@ const make = Effect.gen(function* () {
         messageId: input.messageId,
         delta: bufferedText,
         ...(input.turnId ? { turnId: input.turnId } : {}),
+        ...(phase !== undefined ? { phase } : {}),
         createdAt: input.createdAt,
       });
       return true;
@@ -937,6 +983,7 @@ const make = Effect.gen(function* () {
             ? input.fallbackText!
             : "";
       const hasRenderableText = hasRenderableAssistantText(text);
+      const phase = yield* getAssistantMessagePhase(input.messageId);
 
       if (hasRenderableText) {
         yield* orchestrationEngine.dispatch({
@@ -946,6 +993,7 @@ const make = Effect.gen(function* () {
           messageId: input.messageId,
           delta: text,
           ...(input.turnId ? { turnId: input.turnId } : {}),
+          ...(phase !== undefined ? { phase } : {}),
           createdAt: input.createdAt,
         });
       }
@@ -1358,6 +1406,19 @@ const make = Effect.gen(function* () {
         }
       }
 
+      if (
+        event.type === "item.started" &&
+        event.payload.itemType === "assistant_message" &&
+        event.payload.messagePhase !== undefined &&
+        event.itemId !== undefined
+      ) {
+        yield* Cache.set(
+          assistantMessagePhaseByItemKey,
+          runtimeItemKey(event.threadId, event.itemId),
+          event.payload.messagePhase,
+        );
+      }
+
       const assistantDelta =
         event.type === "content.delta" && event.payload.streamKind === "assistant_text"
           ? event.payload.delta
@@ -1372,6 +1433,10 @@ const make = Effect.gen(function* () {
           event,
           ...(turnId ? { turnId } : {}),
         });
+        const assistantMessagePhase = yield* getAssistantMessagePhaseForRuntimeEvent(event);
+        if (assistantMessagePhase !== undefined) {
+          yield* rememberAssistantMessagePhase(assistantMessageId, assistantMessagePhase);
+        }
         if (turnId) {
           yield* rememberAssistantMessageId(thread.id, turnId, assistantMessageId);
         }
@@ -1390,6 +1455,7 @@ const make = Effect.gen(function* () {
               messageId: assistantMessageId,
               delta: spillChunk,
               ...(turnId ? { turnId } : {}),
+              ...(assistantMessagePhase !== undefined ? { phase: assistantMessagePhase } : {}),
               createdAt: now,
             });
           }
@@ -1401,6 +1467,7 @@ const make = Effect.gen(function* () {
             messageId: assistantMessageId,
             delta: assistantDelta,
             ...(turnId ? { turnId } : {}),
+            ...(assistantMessagePhase !== undefined ? { phase: assistantMessagePhase } : {}),
             createdAt: now,
           });
         }
@@ -1463,6 +1530,7 @@ const make = Effect.gen(function* () {
                 `assistant:${event.itemId ?? event.turnId ?? event.eventId}`,
               ),
               fallbackText: event.payload.detail,
+              messagePhase: event.payload.messagePhase,
             }
           : undefined;
       const proposedPlanCompletion =
@@ -1487,6 +1555,12 @@ const make = Effect.gen(function* () {
           activeAssistantMessageId,
           () => assistantCompletion.messageId,
         );
+        if (assistantCompletion.messagePhase !== undefined) {
+          yield* rememberAssistantMessagePhase(
+            assistantMessageId,
+            assistantCompletion.messagePhase,
+          );
+        }
         const existingAssistantMessage = findMessageById(messages, assistantMessageId);
         const shouldApplyFallbackCompletionText =
           !existingAssistantMessage || existingAssistantMessage.text.length === 0;

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -620,6 +620,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           role: "assistant",
           text: command.delta,
           turnId: command.turnId ?? null,
+          ...(command.phase !== undefined ? { phase: command.phase } : {}),
           streaming: true,
           createdAt: command.createdAt,
           updatedAt: command.createdAt,

--- a/apps/server/src/orchestration/projector.ts
+++ b/apps/server/src/orchestration/projector.ts
@@ -401,6 +401,7 @@ export function projectEvent(
             text: payload.text,
             ...(payload.attachments !== undefined ? { attachments: payload.attachments } : {}),
             turnId: payload.turnId,
+            ...(payload.phase !== undefined ? { phase: payload.phase } : {}),
             streaming: payload.streaming,
             createdAt: payload.createdAt,
             updatedAt: payload.updatedAt,
@@ -423,6 +424,7 @@ export function projectEvent(
                     streaming: message.streaming,
                     updatedAt: message.updatedAt,
                     turnId: message.turnId,
+                    ...(message.phase !== undefined ? { phase: message.phase } : {}),
                     ...(message.attachments !== undefined
                       ? { attachments: message.attachments }
                       : {}),

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -284,6 +284,13 @@ function itemDetail(item: CodexLifecycleItem): string | undefined {
   return undefined;
 }
 
+function itemMessagePhase(item: CodexLifecycleItem): "commentary" | "final_answer" | undefined {
+  if (!("phase" in item)) {
+    return undefined;
+  }
+  return item.phase === "commentary" || item.phase === "final_answer" ? item.phase : undefined;
+}
+
 function toRequestTypeFromMethod(method: string): CanonicalRequestType {
   switch (method) {
     case "item/commandExecution/requestApproval":
@@ -481,6 +488,9 @@ function mapItemLifecycle(
       ...(status ? { status } : {}),
       ...(itemTitle(itemType, item) ? { title: itemTitle(itemType, item) } : {}),
       ...(detail ? { detail } : {}),
+      ...(itemType === "assistant_message" && itemMessagePhase(item)
+        ? { messagePhase: itemMessagePhase(item) }
+        : {}),
       ...(event.payload !== undefined ? { data: event.payload } : {}),
     },
   };

--- a/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.test.ts
@@ -729,6 +729,75 @@ describe("deriveMessagesTimelineRows", () => {
     ]);
   });
 
+  it("folds active-turn work once the final answer starts streaming", () => {
+    const rows = deriveMessagesTimelineRows({
+      timelineEntries: [
+        {
+          id: "assistant-commentary-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:05Z",
+          message: {
+            id: "assistant-commentary" as never,
+            role: "assistant",
+            text: "Checking the repo.",
+            turnId: "turn-1" as never,
+            phase: "commentary",
+            createdAt: "2026-01-01T00:00:05Z",
+            completedAt: "2026-01-01T00:00:06Z",
+            streaming: false,
+          },
+        },
+        {
+          id: "work-entry-1",
+          kind: "work",
+          createdAt: "2026-01-01T00:00:08Z",
+          entry: {
+            id: "work-1",
+            createdAt: "2026-01-01T00:00:08Z",
+            turnId: "turn-1" as never,
+            label: "Ran command",
+            tone: "tool" as const,
+          },
+        },
+        {
+          id: "assistant-final-entry",
+          kind: "message",
+          createdAt: "2026-01-01T00:00:20Z",
+          message: {
+            id: "assistant-final" as never,
+            role: "assistant",
+            text: "The answer is streaming",
+            turnId: "turn-1" as never,
+            phase: "final_answer",
+            createdAt: "2026-01-01T00:00:20Z",
+            streaming: true,
+          },
+        },
+      ],
+      latestTurn: {
+        turnId: "turn-1" as never,
+        state: "running",
+        startedAt: "2026-01-01T00:00:00Z",
+        completedAt: null,
+      },
+      isWorking: true,
+      activeTurnStartedAt: "2026-01-01T00:00:00Z",
+      turnDiffSummaryByAssistantMessageId: new Map(),
+      revertTurnCountByUserMessageId: new Map(),
+    });
+
+    expect(rows.map((row) => row.id)).toEqual([
+      "turn-fold:turn-1",
+      "assistant-final-entry",
+      "working-indicator-row",
+    ]);
+    const foldRow = rows.find(
+      (row): row is Extract<(typeof rows)[number], { kind: "turn-fold" }> =>
+        row.kind === "turn-fold",
+    );
+    expect(foldRow?.expanded).toBe(false);
+  });
+
   it("only shows assistant metadata on the terminal assistant message", () => {
     const rows = deriveMessagesTimelineRows({
       timelineEntries: [

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -139,6 +139,21 @@ function deriveTerminalAssistantMessageIds(timelineEntries: ReadonlyArray<Timeli
   return new Set(lastAssistantMessageIdByResponseKey.values());
 }
 
+function deriveFinalAnswerStartedTurnIds(timelineEntries: ReadonlyArray<TimelineEntry>) {
+  const turnIds = new Set<TurnId>();
+  for (const timelineEntry of timelineEntries) {
+    if (
+      timelineEntry.kind === "message" &&
+      timelineEntry.message.role === "assistant" &&
+      timelineEntry.message.turnId &&
+      timelineEntry.message.phase === "final_answer"
+    ) {
+      turnIds.add(timelineEntry.message.turnId);
+    }
+  }
+  return turnIds;
+}
+
 interface TurnFold {
   turnId: TurnId;
   anchorEntryId: string;
@@ -170,6 +185,7 @@ function deriveUnsettledTurnId(latestTurn: TimelineLatestTurn | null): TurnId | 
 function deriveTurnFolds(input: {
   timelineEntries: ReadonlyArray<TimelineEntry>;
   terminalAssistantMessageIds: ReadonlySet<string>;
+  finalAnswerStartedTurnIds: ReadonlySet<TurnId>;
   latestTurn: TimelineLatestTurn | null;
   unsettledTurnId: TurnId | null;
 }): ReadonlyMap<string, TurnFold> {
@@ -229,10 +245,11 @@ function deriveTurnFolds(input: {
 
   const foldsByAnchorEntryId = new Map<string, TurnFold>();
   for (const [turnId, group] of groupsByTurnId) {
-    if (turnId === input.unsettledTurnId) {
+    const finalAnswerStarted = input.finalAnswerStartedTurnIds.has(turnId);
+    if (turnId === input.unsettledTurnId && !finalAnswerStarted) {
       continue;
     }
-    if (group.hasStreamingMessage) {
+    if (group.hasStreamingMessage && !finalAnswerStarted) {
       continue;
     }
     const hiddenEntryIds = new Set<string>();
@@ -303,10 +320,12 @@ export function deriveMessagesTimelineRows(input: {
     input.timelineEntries.flatMap((entry) => (entry.kind === "message" ? [entry.message] : [])),
   );
   const terminalAssistantMessageIds = deriveTerminalAssistantMessageIds(input.timelineEntries);
+  const finalAnswerStartedTurnIds = deriveFinalAnswerStartedTurnIds(input.timelineEntries);
   const unsettledTurnId = deriveUnsettledTurnId(input.latestTurn ?? null);
   const foldsByAnchorEntryId = deriveTurnFolds({
     timelineEntries: input.timelineEntries,
     terminalAssistantMessageIds,
+    finalAnswerStartedTurnIds,
     latestTurn: input.latestTurn ?? null,
     unsettledTurnId,
   });

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -179,6 +179,7 @@ function mapMessage(environmentId: EnvironmentId, message: OrchestrationMessage)
     role: message.role,
     text: message.text,
     turnId: message.turnId,
+    ...(message.phase !== undefined ? { phase: message.phase } : {}),
     createdAt: message.createdAt,
     streaming: message.streaming,
     ...(message.streaming ? {} : { completedAt: message.updatedAt }),
@@ -1393,6 +1394,7 @@ function applyEnvironmentOrchestrationEvent(
             ? { attachments: event.payload.attachments }
             : {}),
           turnId: event.payload.turnId,
+          ...(event.payload.phase !== undefined ? { phase: event.payload.phase } : {}),
           streaming: event.payload.streaming,
           createdAt: event.payload.createdAt,
           updatedAt: event.payload.updatedAt,
@@ -1411,6 +1413,7 @@ function applyEnvironmentOrchestrationEvent(
                         : entry.text,
                     streaming: message.streaming,
                     ...(message.turnId !== undefined ? { turnId: message.turnId } : {}),
+                    ...(message.phase !== undefined ? { phase: message.phase } : {}),
                     ...(message.streaming
                       ? entry.completedAt !== undefined
                         ? { completedAt: entry.completedAt }

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -50,6 +50,7 @@ export interface ChatMessage {
   text: string;
   attachments?: ChatAttachment[];
   turnId?: TurnId | null;
+  phase?: "commentary" | "final_answer";
   createdAt: string;
   completedAt?: string | undefined;
   streaming: boolean;

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -224,12 +224,16 @@ export type OrchestrationProject = typeof OrchestrationProject.Type;
 export const OrchestrationMessageRole = Schema.Literals(["user", "assistant", "system"]);
 export type OrchestrationMessageRole = typeof OrchestrationMessageRole.Type;
 
+export const OrchestrationMessagePhase = Schema.Literals(["commentary", "final_answer"]);
+export type OrchestrationMessagePhase = typeof OrchestrationMessagePhase.Type;
+
 export const OrchestrationMessage = Schema.Struct({
   id: MessageId,
   role: OrchestrationMessageRole,
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   turnId: Schema.NullOr(TurnId),
+  phase: Schema.optional(OrchestrationMessagePhase),
   streaming: Schema.Boolean,
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,
@@ -712,6 +716,7 @@ const ThreadMessageAssistantDeltaCommand = Schema.Struct({
   messageId: MessageId,
   delta: Schema.String,
   turnId: Schema.optional(TurnId),
+  phase: Schema.optional(OrchestrationMessagePhase),
   createdAt: IsoDateTime,
 });
 
@@ -896,6 +901,7 @@ export const ThreadMessageSentPayload = Schema.Struct({
   text: Schema.String,
   attachments: Schema.optional(Schema.Array(ChatAttachment)),
   turnId: Schema.NullOr(TurnId),
+  phase: Schema.optional(OrchestrationMessagePhase),
   streaming: Schema.Boolean,
   createdAt: IsoDateTime,
   updatedAt: IsoDateTime,

--- a/packages/contracts/src/providerRuntime.ts
+++ b/packages/contracts/src/providerRuntime.ts
@@ -17,6 +17,7 @@ import { ProviderInstanceId, ProviderDriverKind } from "./providerInstance.ts";
 
 const TrimmedNonEmptyStringSchema = TrimmedNonEmptyString;
 const UnknownRecordSchema = Schema.Record(Schema.String, Schema.Unknown);
+const RuntimeMessagePhase = Schema.Literals(["commentary", "final_answer"]);
 
 const RuntimeEventRawSource = Schema.Union([
   Schema.Literal("codex.app-server.notification"),
@@ -406,6 +407,7 @@ export const ItemLifecyclePayload = Schema.Struct({
   status: Schema.optional(RuntimeItemStatus),
   title: Schema.optional(TrimmedNonEmptyStringSchema),
   detail: Schema.optional(TrimmedNonEmptyStringSchema),
+  messagePhase: Schema.optional(RuntimeMessagePhase),
   data: Schema.optional(Schema.Unknown),
 });
 export type ItemLifecyclePayload = typeof ItemLifecyclePayload.Type;


### PR DESCRIPTION
## What Changed

- T3 Code now collapses the “worked for...” details as soon as the final answer starts streaming.
- Before, it waited until the answer was fully done before collapsing that section.
- This matches the behavior in the Codex desktop app more closely.

## Why

When an agent is working, the timeline shows tool calls and progress updates. Once the final answer starts, those details should move out of the way immediately so the answer is easier to read.

The old behavior was based on the final message being finished. That was too late, and if the user was actively trying to read the message, it would be jarring as everything shifted upward.

## UI Changes

This changes when the work-session section collapses during a streaming response.

Before: the work session stays open until the final answer finishes.

After: the work session collapses when the final answer starts streaming, like Codex desktop.

https://github.com/user-attachments/assets/20b62b4c-5276-4fab-a9d0-2d5f4208a07a

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches orchestration events, provider ingestion, and timeline folding logic; changes are additive (optional phase) but affect live streaming UX and message projection.
> 
> **Overview**
> Adds an optional assistant message **`phase`** (`commentary` | `final_answer`) end-to-end so the chat timeline can tell commentary from the final answer.
> 
> **Codex** maps lifecycle item `phase` into runtime `messagePhase`; **provider runtime ingestion** caches phase per runtime item and message and attaches it to assistant delta commands. **Orchestration** (decider, projector, SQL projection) and the **web store** persist and merge `phase` on streaming updates.
> 
> **UI:** `MessagesTimeline` folds the active turn’s “worked for…” section as soon as any assistant message in that turn has `phase === "final_answer"`, including while it is still streaming—instead of waiting for the turn to settle or streaming to finish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a50270e7cbea4aa5fbf2c82ea81fc970d7a217aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Collapse work details during final answer streaming by propagating message phase end-to-end
> - Introduces a `phase` field (`'commentary' | 'final_answer'`) on messages across contracts, server orchestration, and client state, sourced from provider item lifecycle events in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/3152/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d).
> - The server ingestion pipeline in [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/3152/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) tracks phase per assistant message and includes it on `thread.message.assistant.delta` commands, which flow through the decider and projector into persisted thread state.
> - On the client, [MessagesTimeline.logic.ts](https://github.com/pingdotgg/t3code/pull/3152/files#diff-6cdfacc6ebbdbc5c4b4058c0a430b87d768ac2b6accf35fb4c9dfc23500914fe) adds `deriveFinalAnswerStartedTurnIds` and updates `deriveTurnFolds` to fold commentary/tool activity turns as soon as a `final_answer`-phase message starts streaming, without waiting for the turn to settle.
> - Behavioral Change: turns with active work items now fold mid-stream once a final answer begins, changing the visible chat layout during streaming.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a50270e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->