### PR TITLE
fix: normalize dead-key grave input in composer

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -92,6 +92,19 @@ const SURROUND_SYMBOLS: [string, string][] = [
 ];
 const SURROUND_SYMBOLS_MAP = new Map<string, string>(SURROUND_SYMBOLS);
 const BACKTICK_SURROUND_CLOSE_SYMBOL = SURROUND_SYMBOLS_MAP.get("`") ?? null;
+const DEAD_KEY_GRAVE_LOOKALIKE_CHARACTERS = new Set(["\u02cb", "\u2035", "\uff40"]);
+const RECENT_DEAD_KEY_MAX_AGE_MS = 1_000;
+
+function hasCommandModifier(event: KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey;
+}
+
+function hasRecentDeadKeyDown(recentDeadKeyDown: { timestamp: number } | null): boolean {
+  return (
+    recentDeadKeyDown !== null &&
+    performance.now() - recentDeadKeyDown.timestamp <= RECENT_DEAD_KEY_MAX_AGE_MS
+  );
+}
 
 type SerializedComposerMentionNode = Spread<
   {
@@ -1134,6 +1147,7 @@ function ComposerSurroundSelectionPlugin(props: {
     expandedStart: number;
     expandedEnd: number;
   } | null>(null);
+  const recentDeadKeyDownRef = useRef<{ timestamp: number } | null>(null);
 
   useEffect(() => {
     terminalContextsRef.current = props.terminalContexts;
@@ -1205,6 +1219,14 @@ function ComposerSurroundSelectionPlugin(props: {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      recentDeadKeyDownRef.current =
+        event.key === "Dead" &&
+        !event.defaultPrevented &&
+        !event.isComposing &&
+        !hasCommandModifier(event)
+          ? { timestamp: performance.now() }
+          : null;
+
       if (pendingDeadKeySelectionRef.current) {
         if (event.key === "Dead" || event.key === " " || event.code === "Space") {
           return;
@@ -1212,7 +1234,7 @@ function ComposerSurroundSelectionPlugin(props: {
         pendingDeadKeySelectionRef.current = null;
       }
 
-      if (event.defaultPrevented || event.isComposing || event.metaKey || event.ctrlKey) {
+      if (event.defaultPrevented || event.isComposing || hasCommandModifier(event)) {
         pendingSurroundSelectionRef.current = null;
         pendingDeadKeySelectionRef.current = null;
         return;
@@ -1259,6 +1281,7 @@ function ComposerSurroundSelectionPlugin(props: {
         BACKTICK_SURROUND_CLOSE_SYMBOL !== null &&
         pendingSurroundSelectionRef.current
       ) {
+        recentDeadKeyDownRef.current = null;
         pendingDeadKeySelectionRef.current = pendingSurroundSelectionRef.current;
         return;
       }
@@ -1267,23 +1290,52 @@ function ComposerSurroundSelectionPlugin(props: {
         return;
       }
 
+      if (
+        event.inputType === "insertCompositionText" &&
+        typeof event.data === "string" &&
+        DEAD_KEY_GRAVE_LOOKALIKE_CHARACTERS.has(event.data) &&
+        hasRecentDeadKeyDown(recentDeadKeyDownRef.current)
+      ) {
+        recentDeadKeyDownRef.current = null;
+        if (!applySurroundInsertion("`")) {
+          editor.update(() => {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) {
+              selection.insertText("`");
+            }
+            pendingSurroundSelectionRef.current = null;
+          });
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        return;
+      }
+
       if (event.inputType === "insertCompositionText") {
+        if (typeof event.data === "string" && event.data.length > 0) {
+          recentDeadKeyDownRef.current = null;
+        }
         return;
       }
 
       if (typeof event.data !== "string") {
+        recentDeadKeyDownRef.current = null;
         pendingSurroundSelectionRef.current = null;
         return;
       }
       const inputData = event.inputType === "insertText" ? event.data : null;
       if (!inputData || inputData.length !== 1) {
+        recentDeadKeyDownRef.current = null;
         pendingSurroundSelectionRef.current = null;
         return;
       }
       if (!applySurroundInsertion(inputData)) {
+        recentDeadKeyDownRef.current = null;
         return;
       }
 
+      recentDeadKeyDownRef.current = null;
       event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation();

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1219,13 +1219,21 @@ function ComposerSurroundSelectionPlugin(props: {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      recentDeadKeyDownRef.current =
+      const isPlainDeadKeyDown =
         event.key === "Dead" &&
         !event.defaultPrevented &&
         !event.isComposing &&
-        !hasCommandModifier(event)
-          ? { timestamp: performance.now() }
-          : null;
+        !hasCommandModifier(event);
+      const isPlainSpaceKeyDown =
+        (event.key === " " || event.code === "Space") &&
+        !event.defaultPrevented &&
+        !event.isComposing &&
+        !hasCommandModifier(event);
+      if (isPlainDeadKeyDown) {
+        recentDeadKeyDownRef.current = { timestamp: performance.now() };
+      } else if (!isPlainSpaceKeyDown) {
+        recentDeadKeyDownRef.current = null;
+      }
 
       if (pendingDeadKeySelectionRef.current) {
         if (event.key === "Dead" || event.key === " " || event.code === "Space") {


### PR DESCRIPTION
## Summary

- Normalize dead-key grave look-alike composition input in the web composer before it reaches stored prompt text.
- Reuse the existing selected-text backtick surround behavior and insert ASCII backticks for collapsed selections.

## Root cause

Some keyboard layouts emit grave-like Unicode characters (`ˋ`, `‵`, `｀`) through `insertCompositionText` after a dead-key press. The composer accepted those literal characters, so Markdown inline-code delimiters were not recognized.

## Impact

Dead-key grave input now produces ASCII backticks only at the input boundary. Pasted text and non-dead-key Unicode content are left unchanged.

## Validation

- `vp check`
- `vp run typecheck`
- `cd apps/web && vp test run --project browser src/components/ChatView.browser.tsx -t "supports dead-key composition"`
- Temporary browser assertion for `Dead` + `U+02CB` -> ASCII backtick passed locally and was removed.


Closes #3142

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize dead-key grave input to backtick in `ComposerSurroundSelectionPlugin`
> - Dead-key grave sequences (e.g. on macOS) can produce lookalike characters (U+02CB, U+2035, U+FF40) instead of a backtick, breaking backtick-based surround insertion in the composer.
> - Tracks plain dead-key `keydown` events via `recentDeadKeyDownRef` with a 1,000 ms recency window; when a grave-lookalike character arrives via `insertCompositionText` within that window, it is treated as a backtick.
> - Applies surround insertion if a selection is pending, or inserts a literal backtick otherwise, suppressing the original lookalike character.
> - Adds `hasCommandModifier` helper to centralize meta/ctrl modifier checks across key event handlers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c94e32.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to composer keyboard/composition handling for a specific dead-key pattern; no auth, persistence, or broad input-path changes.
> 
> **Overview**
> Fixes composer markdown inline-code behavior when some layouts emit grave **lookalike** Unicode (`ˋ`, `‵`, `｀`) via `insertCompositionText` after a **Dead** key instead of ASCII `` ` ``.
> 
> **`ComposerSurroundSelectionPlugin`** now records a plain **Dead** keydown (1s window, cleared on most other keys but not plain Space) and, on matching composition input, runs the existing backtick surround path or inserts a literal backtick, then **suppresses** the lookalike character. Modifier checks use a shared **`hasCommandModifier`** helper. Pasted text and unrelated Unicode are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c94e32dd7afae55846e60e98520dfced0b4e4dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->