### PR TITLE
Unify mobile typography tokens across the app

### DIFF
--- a/apps/mobile/.swiftlint.yml
+++ b/apps/mobile/.swiftlint.yml
@@ -1,5 +1,6 @@
 included:
   - ios/T3Code
+  - modules/t3-composer-editor/ios
   - modules/t3-terminal/ios
   - modules/t3-review-diff/ios
 

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -192,11 +192,31 @@
   }
 }
 
-/* ─── Font family ───────────────────────────────────────────────────── */
+/* ─── Typography ────────────────────────────────────────────────────── */
 @theme {
   --font-sans: "DMSans_400Regular";
   --font-medium: "DMSans_500Medium";
   --font-bold: "DMSans_700Bold";
+
+  /* Keep this scale aligned with src/lib/typography.ts for native style props. */
+  --text-3xs: 10px;
+  --text-3xs--line-height: 13px;
+  --text-2xs: 11px;
+  --text-2xs--line-height: 15px;
+  --text-xs: 12px;
+  --text-xs--line-height: 16px;
+  --text-sm: 13px;
+  --text-sm--line-height: 18px;
+  --text-base: 15px;
+  --text-base--line-height: 22px;
+  --text-lg: 17px;
+  --text-lg--line-height: 22px;
+  --text-xl: 20px;
+  --text-xl--line-height: 26px;
+  --text-2xl: 24px;
+  --text-2xl--line-height: 30px;
+  --text-3xl: 28px;
+  --text-3xl--line-height: 34px;
 }
 
 /* ─── Custom utilities ──────────────────────────────────────────────── */

--- a/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
+++ b/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
@@ -275,8 +275,8 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
     fileTint: "#737373"
   )
   private var fontFamily = "DMSans_400Regular"
-  private var fontSize: CGFloat = 15
-  private var lineHeight: CGFloat = 22
+  private var fontSize: CGFloat = 14
+  private var lineHeight: CGFloat = 20
   private var contentInsetVertical: CGFloat = 0
   private var shouldAutoFocus = false
   private var didAutoFocus = false
@@ -460,7 +460,17 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
     guard !isApplyingControlledValue else {
       return
     }
+    restoreBaseTypingAttributes()
     emitSelection()
+  }
+
+  public func textView(
+    _ textView: UITextView,
+    shouldChangeTextIn range: NSRange,
+    replacementText text: String
+  ) -> Bool {
+    restoreBaseTypingAttributes()
+    return true
   }
 
   public func textViewDidBeginEditing(_ textView: UITextView) {
@@ -484,6 +494,7 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
     let targetSelection = requestedSelection ?? previousSelection
     requestedSelection = nil
     textView.selectedRange = displayRange(for: targetSelection)
+    restoreBaseTypingAttributes()
     isApplyingControlledValue = false
     updatePlaceholderVisibility()
     emitContentSizeIfNeeded()
@@ -556,7 +567,12 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
       size: image.size,
       baselineOffset: baselineOffset
     )
-    return NSAttributedString(attachment: attachment)
+    let attributedAttachment = NSMutableAttributedString(attachment: attachment)
+    attributedAttachment.addAttributes(
+      baseAttributes(),
+      range: NSRange(location: 0, length: attributedAttachment.length)
+    )
+    return attributedAttachment
   }
 
   private func renderChip(
@@ -660,9 +676,16 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
     let font = UIFont(name: fontFamily, size: fontSize)
       ?? UIFont.systemFont(ofSize: fontSize)
     textView.font = font
-    textView.typingAttributes = baseAttributes()
+    restoreBaseTypingAttributes()
     placeholderLabel.font = font
     setNeedsLayout()
+  }
+
+  private func restoreBaseTypingAttributes() {
+    guard textView.markedTextRange == nil else {
+      return
+    }
+    textView.typingAttributes = baseAttributes()
   }
 
   private func applyTheme() {

--- a/apps/mobile/src/app/+not-found.tsx
+++ b/apps/mobile/src/app/+not-found.tsx
@@ -21,7 +21,7 @@ export default function NotFoundRoute() {
       }}
       style={[{ flex: 1 }, screenBgStyle]}
     >
-      <Text className="text-[28px] font-t3-bold text-foreground" selectable>
+      <Text className="text-3xl font-t3-bold text-foreground" selectable>
         Route not found
       </Text>
       <Link href="/" asChild>
@@ -35,7 +35,7 @@ export default function NotFoundRoute() {
             primaryBgStyle,
           ]}
         >
-          <Text className="text-[16px] font-t3-bold text-primary-foreground">Return home</Text>
+          <Text className="text-base font-t3-bold text-primary-foreground">Return home</Text>
         </Pressable>
       </Link>
     </ScrollView>

--- a/apps/mobile/src/app/connections/index.tsx
+++ b/apps/mobile/src/app/connections/index.tsx
@@ -85,7 +85,7 @@ export default function ConnectionsRouteScreen() {
                 type="monochrome"
               />
             </View>
-            <Text className="text-center text-[14px] leading-[20px] text-foreground-muted">
+            <Text className="text-center text-sm leading-[20px] text-foreground-muted">
               No environments connected yet.{"\n"}Tap{" "}
               <Text className="font-t3-bold text-foreground">+</Text> to add one.
             </Text>

--- a/apps/mobile/src/app/connections/new.tsx
+++ b/apps/mobile/src/app/connections/new.tsx
@@ -171,7 +171,7 @@ export default function ConnectionsNewRouteScreen() {
                 className="items-center gap-3 rounded-[24px] bg-card px-5 py-8"
                 style={{ borderCurve: "continuous" }}
               >
-                <Text className="text-center text-[14px] leading-[20px] text-foreground-muted">
+                <Text className="text-center text-sm leading-[20px] text-foreground-muted">
                   Camera permission is required to scan a QR code.
                 </Text>
                 <ConnectionSheetButton
@@ -189,7 +189,7 @@ export default function ConnectionsNewRouteScreen() {
             <View collapsable={false} className="gap-4 rounded-[24px] bg-card p-4">
               <View collapsable={false} className="gap-1.5">
                 <Text
-                  className="text-[11px] font-t3-bold uppercase text-foreground-muted"
+                  className="text-2xs font-t3-bold uppercase text-foreground-muted"
                   style={{ letterSpacing: 0.8 }}
                 >
                   Host
@@ -202,13 +202,13 @@ export default function ConnectionsNewRouteScreen() {
                   placeholderTextColor={placeholderColor}
                   value={hostInput}
                   onChangeText={handleHostChange}
-                  className="rounded-[14px] border border-input-border bg-input px-4 py-3.5 text-[15px] text-foreground"
+                  className="rounded-[14px] border border-input-border bg-input px-4 py-3.5 text-base text-foreground"
                 />
               </View>
 
               <View collapsable={false} className="gap-1.5">
                 <Text
-                  className="text-[11px] font-t3-bold uppercase text-foreground-muted"
+                  className="text-2xs font-t3-bold uppercase text-foreground-muted"
                   style={{ letterSpacing: 0.8 }}
                 >
                   Pairing code
@@ -220,7 +220,7 @@ export default function ConnectionsNewRouteScreen() {
                   placeholderTextColor={placeholderColor}
                   value={codeInput}
                   onChangeText={handleCodeChange}
-                  className="rounded-[14px] border border-input-border bg-input px-4 py-3.5 text-[15px] text-foreground"
+                  className="rounded-[14px] border border-input-border bg-input px-4 py-3.5 text-base text-foreground"
                 />
               </View>
 

--- a/apps/mobile/src/app/new/index.tsx
+++ b/apps/mobile/src/app/new/index.tsx
@@ -129,10 +129,10 @@ export default function NewTaskRoute() {
         {items.length === 0 ? (
           <View collapsable={false} className="items-center gap-3 rounded-[24px] bg-card px-6 py-8">
             {projectEmptyState.loading ? <ActivityIndicator color={accentColor} /> : null}
-            <Text className="text-center text-[17px] font-t3-bold text-foreground">
+            <Text className="text-center text-lg font-t3-bold text-foreground">
               {projectEmptyState.title}
             </Text>
-            <Text className="text-center text-[14px] leading-[20px] text-foreground-muted">
+            <Text className="text-center text-sm leading-[20px] text-foreground-muted">
               {projectEmptyState.detail}
             </Text>
             {!catalogState.hasReadyEnvironment ? (
@@ -140,7 +140,7 @@ export default function NewTaskRoute() {
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
                 onPress={() => router.push("/connections/new")}
               >
-                <Text className="text-[13px] font-t3-bold text-primary-foreground">
+                <Text className="text-sm font-t3-bold text-primary-foreground">
                   Add environment
                 </Text>
               </Pressable>
@@ -149,7 +149,7 @@ export default function NewTaskRoute() {
                 className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
                 onPress={() => router.push("/new/add-project")}
               >
-                <Text className="text-[13px] font-t3-bold text-primary-foreground">
+                <Text className="text-sm font-t3-bold text-primary-foreground">
                   Add new project
                 </Text>
               </Pressable>
@@ -197,9 +197,7 @@ export default function NewTaskRoute() {
                         />
                       </View>
                       <View className="flex-1">
-                        <Text className="text-[16px] leading-[21px] font-t3-bold">
-                          {item.title}
-                        </Text>
+                        <Text className="text-base leading-[21px] font-t3-bold">{item.title}</Text>
                       </View>
                       <SymbolView
                         name="chevron.right"

--- a/apps/mobile/src/app/settings/environments.tsx
+++ b/apps/mobile/src/app/settings/environments.tsx
@@ -111,7 +111,7 @@ export default function SettingsEnvironmentsRouteScreen() {
                 type="monochrome"
               />
             </View>
-            <Text className="text-center text-[14px] leading-[20px] text-foreground-muted">
+            <Text className="text-center text-sm leading-[20px] text-foreground-muted">
               No environments connected yet.{"\n"}Tap{" "}
               <Text className="font-t3-bold text-foreground">+</Text> to add one.
             </Text>
@@ -160,7 +160,7 @@ function ConfiguredCloudEnvironmentRows(props: {
   return (
     <View collapsable={false} className="mt-5 gap-3">
       <View className="flex-row items-center justify-between px-1">
-        <Text className="text-[13px] font-t3-bold uppercase text-foreground-muted">T3 Cloud</Text>
+        <Text className="text-sm font-t3-bold uppercase text-foreground-muted">T3 Cloud</Text>
         <Pressable
           accessibilityRole="button"
           disabled={controller.relayDiscovery.isRefreshing}
@@ -204,16 +204,16 @@ function ConfiguredCloudEnvironmentRows(props: {
       ) : controller.relayDiscovery.isRefreshing ? (
         <View collapsable={false} className="items-center gap-3 rounded-[24px] bg-card p-6">
           <ActivityIndicator color={iconColor} />
-          <Text className="text-center text-[14px] leading-[20px] text-foreground-muted">
+          <Text className="text-center text-sm leading-[20px] text-foreground-muted">
             Loading linked cloud environments.
           </Text>
         </View>
       ) : controller.relayDiscovery.error ? (
         <View collapsable={false} className="gap-3 rounded-[24px] bg-card p-5">
-          <Text className="text-[15px] font-t3-bold text-foreground">
+          <Text className="text-base font-t3-bold text-foreground">
             Could not load T3 Cloud environments
           </Text>
-          <Text className="text-[13px] leading-[18px] text-foreground-muted">
+          <Text className="text-sm leading-[18px] text-foreground-muted">
             {controller.relayDiscovery.error}
           </Text>
           {controller.relayDiscovery.errorTraceId ? (
@@ -222,7 +222,7 @@ function ConfiguredCloudEnvironmentRows(props: {
         </View>
       ) : (
         <View collapsable={false} className="rounded-[24px] bg-card p-5">
-          <Text className="text-[14px] leading-[20px] text-foreground-muted">
+          <Text className="text-sm leading-[20px] text-foreground-muted">
             No additional linked cloud environments.
           </Text>
         </View>
@@ -361,7 +361,7 @@ function CloudEnvironmentRowShell(props: {
         <View className="min-w-0 flex-row items-center gap-2">
           <ConnectionStatusDot state={props.connectionState} pulse={shouldPulse} size={7} />
           <Text
-            className="min-w-0 flex-shrink text-[16px] font-t3-bold leading-[21px] text-foreground"
+            className="min-w-0 flex-shrink text-base font-t3-bold leading-[21px] text-foreground"
             numberOfLines={1}
           >
             {props.label}
@@ -370,7 +370,7 @@ function CloudEnvironmentRowShell(props: {
         {props.connectionError ? (
           <Text
             aria-hidden
-            className={cn("absolute left-0 right-0 text-[12px] leading-[16px]", statusClassName)}
+            className={cn("absolute left-0 right-0 text-xs leading-[16px]", statusClassName)}
             onTextLayout={onMeasuredErrorTextLayout}
             style={{ opacity: 0, zIndex: -1 }}
           >
@@ -384,7 +384,7 @@ function CloudEnvironmentRowShell(props: {
           className="min-w-0 flex-row items-start gap-1"
         >
           <Text
-            className={cn("min-w-0 flex-1 text-[12px] leading-[16px]", statusClassName)}
+            className={cn("min-w-0 flex-1 text-xs leading-[16px]", statusClassName)}
             numberOfLines={isErrorExpanded ? undefined : 1}
           >
             {statusText}
@@ -394,7 +394,7 @@ function CloudEnvironmentRowShell(props: {
                 <Text
                   accessibilityHint="Copies the trace ID"
                   accessibilityRole="button"
-                  className={cn("text-[12px] leading-[16px] underline", statusClassName)}
+                  className={cn("text-xs leading-[16px] underline", statusClassName)}
                   onLongPress={(event) => {
                     event.stopPropagation();
                     copyTextWithHaptic(errorTraceId);
@@ -446,7 +446,7 @@ function CopyTraceIdButton(props: { readonly traceId: string }) {
       className="self-start flex-row items-center gap-1.5 rounded-full bg-subtle px-3 py-2 active:opacity-70"
     >
       <SymbolView name="doc.on.doc" size={12} tintColor={iconColor} type="monochrome" />
-      <Text className="text-[12px] font-t3-bold text-foreground">Copy trace ID</Text>
+      <Text className="text-xs font-t3-bold text-foreground">Copy trace ID</Text>
     </Pressable>
   );
 }

--- a/apps/mobile/src/app/settings/index.tsx
+++ b/apps/mobile/src/app/settings/index.tsx
@@ -346,7 +346,7 @@ function ConfiguredSettingsRouteScreen() {
               onPress={openAccount}
             />
           </SettingsSection>
-          <Text className="px-2 text-[13px] leading-[18px] text-foreground-muted">
+          <Text className="px-2 text-sm leading-[18px] text-foreground-muted">
             T3 Code works locally without signing in. Cloud features are optional.
           </Text>
         </View>
@@ -389,7 +389,7 @@ type SymbolName = ComponentProps<typeof SymbolView>["name"];
 function SettingsSection(props: { readonly title: string; readonly children: ReactNode }) {
   return (
     <View className="gap-2">
-      <Text className="px-2 text-[13px] font-t3-medium text-foreground-muted">{props.title}</Text>
+      <Text className="px-2 text-sm font-t3-medium text-foreground-muted">{props.title}</Text>
       <View
         className="overflow-hidden rounded-[28px] bg-card"
         style={{ borderCurve: "continuous" }}
@@ -413,8 +413,8 @@ function AppSettingsSection() {
           type="monochrome"
           weight="regular"
         />
-        <Text className="flex-1 text-[17px] text-foreground">Version</Text>
-        <Text className="text-[17px] text-foreground-muted">Alpha</Text>
+        <Text className="flex-1 text-lg text-foreground">Version</Text>
+        <Text className="text-lg text-foreground-muted">Alpha</Text>
       </View>
     </SettingsSection>
   );
@@ -444,13 +444,13 @@ function SettingsRow(props: {
       style={{ opacity: props.disabled ? 0.45 : 1 }}
     >
       <SymbolView name={props.icon} size={22} tintColor={icon} type="monochrome" weight="regular" />
-      <Text className="shrink-0 text-[17px] text-foreground" numberOfLines={1}>
+      <Text className="shrink-0 text-lg text-foreground" numberOfLines={1}>
         {props.label}
       </Text>
       <View className="min-w-0 flex-1 items-end">
         {props.value ? (
           <Text
-            className="max-w-[180px] text-right text-[16px] text-foreground-muted"
+            className="max-w-[180px] text-right text-base text-foreground-muted"
             ellipsizeMode="middle"
             numberOfLines={1}
           >
@@ -502,7 +502,7 @@ function SettingsSwitchRow(props: {
       style={{ opacity: props.disabled ? 0.45 : 1 }}
     >
       <SymbolView name={props.icon} size={22} tintColor={icon} type="monochrome" weight="regular" />
-      <Text className="flex-1 text-[17px] text-foreground">{props.label}</Text>
+      <Text className="flex-1 text-lg text-foreground">{props.label}</Text>
       <Switch
         disabled={props.disabled}
         ios_backgroundColor={track}

--- a/apps/mobile/src/components/AppText.tsx
+++ b/apps/mobile/src/components/AppText.tsx
@@ -40,7 +40,7 @@ export function AppTextInput({
     <RNTextInput
       ref={ref}
       className={cn(
-        "min-h-[54px] rounded-2xl border border-input-border bg-input px-3.5 py-3 font-sans text-[15px] text-foreground",
+        "min-h-[54px] rounded-2xl border border-input-border bg-input px-3.5 py-3 font-sans text-base text-foreground",
         className,
       )}
       placeholderTextColor={placeholderTextColor ?? placeholderColor}

--- a/apps/mobile/src/components/BrandMark.tsx
+++ b/apps/mobile/src/components/BrandMark.tsx
@@ -22,15 +22,12 @@ export function BrandMark(props: { readonly compact?: boolean; readonly stageLab
       />
       <View className="gap-1">
         <View className="flex-row items-center gap-2">
-          <Text
-            className="text-[17px] font-t3-bold text-foreground"
-            style={{ letterSpacing: -0.4 }}
-          >
+          <Text className="text-lg font-t3-bold text-foreground" style={{ letterSpacing: -0.4 }}>
             T3 Code
           </Text>
           <View className="rounded-full bg-subtle px-2 py-1">
             <Text
-              className="text-[10px] font-t3-bold uppercase text-foreground-muted"
+              className="text-3xs font-t3-bold uppercase text-foreground-muted"
               style={{ letterSpacing: 1.1 }}
             >
               {stageLabel}
@@ -38,7 +35,7 @@ export function BrandMark(props: { readonly compact?: boolean; readonly stageLab
           </View>
         </View>
         {!compact ? (
-          <Text className="text-[12px] font-medium text-foreground-muted">
+          <Text className="text-xs font-medium text-foreground-muted">
             Mobile control surface for your live coding environments
           </Text>
         ) : null}

--- a/apps/mobile/src/components/ComposerToolbarTrigger.tsx
+++ b/apps/mobile/src/components/ComposerToolbarTrigger.tsx
@@ -223,7 +223,7 @@ export function ComposerToolbarButton(props: {
       {props.label ? (
         <Text
           className={cn(
-            "shrink text-center text-[13px] font-t3-bold",
+            "shrink text-center text-sm font-t3-bold",
             variant === "primary"
               ? props.disabled
                 ? "text-foreground-muted"

--- a/apps/mobile/src/components/ControlPill.tsx
+++ b/apps/mobile/src/components/ControlPill.tsx
@@ -48,7 +48,7 @@ export function ControlPill(props: {
         : "bg-subtle",
   );
   const labelClassName = cn(
-    "text-center text-[12px] font-t3-bold",
+    "text-center text-xs font-t3-bold",
     variant === "primary"
       ? props.disabled
         ? "text-foreground-muted"

--- a/apps/mobile/src/components/EmptyState.tsx
+++ b/apps/mobile/src/components/EmptyState.tsx
@@ -19,9 +19,7 @@ export function EmptyState(props: {
           className="mt-4 self-start rounded-full bg-primary px-4 py-2.5 active:opacity-70"
           onPress={props.onAction}
         >
-          <Text className="text-[13px] font-t3-bold text-primary-foreground">
-            {props.actionLabel}
-          </Text>
+          <Text className="text-sm font-t3-bold text-primary-foreground">{props.actionLabel}</Text>
         </Pressable>
       ) : null}
     </View>

--- a/apps/mobile/src/components/ErrorBanner.tsx
+++ b/apps/mobile/src/components/ErrorBanner.tsx
@@ -4,7 +4,7 @@ import { AppText as Text } from "./AppText";
 export function ErrorBanner(props: { readonly message: string }) {
   return (
     <View className="rounded-2xl border border-rose-300/70 bg-rose-100/80 px-3.5 py-3 dark:border-rose-400/28 dark:bg-rose-500/12">
-      <Text className="font-t3-medium text-[13px] leading-[18px] text-rose-700 dark:text-rose-300">
+      <Text className="font-t3-medium text-sm leading-[18px] text-rose-700 dark:text-rose-300">
         {props.message}
       </Text>
     </View>

--- a/apps/mobile/src/components/StatusPill.tsx
+++ b/apps/mobile/src/components/StatusPill.tsx
@@ -26,7 +26,7 @@ export function StatusPill(
       <Text
         className={cn(
           "font-t3-bold",
-          size === "compact" ? "text-[11px]" : "text-xs",
+          size === "compact" ? "text-2xs" : "text-xs",
           props.textClassName,
         )}
       >

--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -147,14 +147,14 @@ function ProjectGroupLabel(props: {
         workspaceRoot={props.project.workspaceRoot}
       />
       <Text
-        className="flex-1 text-[12px] font-t3-medium uppercase text-foreground-muted"
+        className="flex-1 text-xs font-t3-medium uppercase text-foreground-muted"
         numberOfLines={1}
         style={{ letterSpacing: 0.5 }}
       >
         {props.project.title}
       </Text>
       {props.environmentLabel ? (
-        <Text className="max-w-[42%] text-[11px] text-foreground-tertiary" numberOfLines={1}>
+        <Text className="max-w-[42%] text-2xs text-foreground-tertiary" numberOfLines={1}>
           {props.environmentLabel}
         </Text>
       ) : null}
@@ -265,13 +265,13 @@ function ArchivedThreadRow(props: {
         <View className="min-w-0 flex-1 gap-1">
           <View className="flex-row items-center gap-2">
             <Text
-              className="min-w-0 flex-1 text-[15px] font-t3-bold leading-[20px] text-foreground"
+              className="min-w-0 flex-1 text-base font-t3-bold leading-[20px] text-foreground"
               numberOfLines={1}
             >
               {props.thread.title}
             </Text>
             <Text
-              className="text-[12px] text-foreground-tertiary"
+              className="text-xs text-foreground-tertiary"
               style={{ fontVariant: ["tabular-nums"] }}
             >
               {timestamp}
@@ -286,7 +286,7 @@ function ArchivedThreadRow(props: {
                 type="monochrome"
               />
               <Text
-                className="min-w-0 flex-1 text-[11px] text-foreground-tertiary"
+                className="min-w-0 flex-1 text-2xs text-foreground-tertiary"
                 numberOfLines={1}
                 style={{ fontFamily: "monospace" }}
               >
@@ -314,10 +314,12 @@ function ArchivedThreadRow(props: {
 function ArchiveError(props: { readonly message: string; readonly onRetry: () => void }) {
   return (
     <View className="rounded-[20px] border border-danger-border bg-danger p-4">
-      <Text className="font-t3-bold text-danger-foreground">Could not load every archive</Text>
-      <Text className="mt-1 text-[13px] leading-[18px] text-foreground-muted">{props.message}</Text>
+      <Text className="text-sm font-t3-bold text-danger-foreground">
+        Could not load every archive
+      </Text>
+      <Text className="mt-1 text-sm leading-[18px] text-foreground-muted">{props.message}</Text>
       <Pressable className="mt-3 self-start active:opacity-60" onPress={props.onRetry}>
-        <Text className="text-[13px] font-t3-bold text-danger-foreground">Try again</Text>
+        <Text className="text-sm font-t3-bold text-danger-foreground">Try again</Text>
       </Pressable>
     </View>
   );
@@ -386,7 +388,7 @@ export function ArchivedThreadsScreen(props: {
         {isInitialLoad ? (
           <View className="items-center py-16">
             <ActivityIndicator color={refreshTint} />
-            <Text className="mt-3 text-[13px] text-foreground-muted">Loading archive…</Text>
+            <Text className="mt-3 text-sm text-foreground-muted">Loading archive…</Text>
           </View>
         ) : props.groups.length === 0 ? (
           <EmptyState

--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -314,7 +314,7 @@ function ArchivedThreadRow(props: {
 function ArchiveError(props: { readonly message: string; readonly onRetry: () => void }) {
   return (
     <View className="rounded-[20px] border border-danger-border bg-danger p-4">
-      <Text className="text-sm font-t3-bold text-danger-foreground">
+      <Text className="text-base font-t3-bold text-danger-foreground">
         Could not load every archive
       </Text>
       <Text className="mt-1 text-sm leading-[18px] text-foreground-muted">{props.message}</Text>

--- a/apps/mobile/src/features/cloud/CloudWaitlistEnrollment.tsx
+++ b/apps/mobile/src/features/cloud/CloudWaitlistEnrollment.tsx
@@ -2,6 +2,7 @@ import { useWaitlist } from "@clerk/expo";
 import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import { useState } from "react";
 
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThemeColor } from "../../lib/useThemeColor";
 
 export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }) {
@@ -141,12 +142,11 @@ function useCloudWaitlistColors() {
 const styles = StyleSheet.create({
   body: {
     fontFamily: "DMSans_400Regular",
-    fontSize: 15,
-    lineHeight: 21,
+    ...MOBILE_TYPOGRAPHY.body,
   },
   buttonText: {
     fontFamily: "DMSans_700Bold",
-    fontSize: 16,
+    fontSize: MOBILE_TYPOGRAPHY.body.fontSize,
   },
   content: {
     gap: 18,
@@ -156,8 +156,7 @@ const styles = StyleSheet.create({
   },
   error: {
     fontFamily: "DMSans_400Regular",
-    fontSize: 13,
-    lineHeight: 18,
+    ...MOBILE_TYPOGRAPHY.footnote,
   },
   field: {
     gap: 8,
@@ -167,15 +166,14 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     borderWidth: 1,
     fontFamily: "DMSans_400Regular",
-    fontSize: 17,
+    fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
     minHeight: 54,
     paddingHorizontal: 16,
     paddingVertical: 14,
   },
   label: {
     fontFamily: "DMSans_700Bold",
-    fontSize: 13,
-    lineHeight: 18,
+    ...MOBILE_TYPOGRAPHY.footnote,
   },
   primaryButton: {
     alignItems: "center",
@@ -196,13 +194,11 @@ const styles = StyleSheet.create({
   },
   signInText: {
     fontFamily: "DMSans_700Bold",
-    fontSize: 15,
-    lineHeight: 21,
+    ...MOBILE_TYPOGRAPHY.body,
   },
   title: {
     fontFamily: "DMSans_700Bold",
-    fontSize: 20,
-    lineHeight: 26,
+    ...MOBILE_TYPOGRAPHY.title,
     textAlign: "center",
   },
 });

--- a/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
+++ b/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
@@ -76,19 +76,16 @@ export function ConnectionEnvironmentRow(props: {
         />
 
         <View className="flex-1 gap-0.5">
-          <Text
-            className="text-[16px] font-t3-bold leading-[21px] text-foreground"
-            numberOfLines={1}
-          >
+          <Text className="text-base font-t3-bold leading-[21px] text-foreground" numberOfLines={1}>
             {props.environment.environmentLabel}
           </Text>
-          <Text className="text-[12px] leading-[16px] text-foreground-muted" numberOfLines={1}>
+          <Text className="text-xs leading-[16px] text-foreground-muted" numberOfLines={1}>
             {props.environment.displayUrl}
           </Text>
           {statusLabel ? (
             <Text
               className={cn(
-                "text-[12px] leading-[16px]",
+                "text-xs leading-[16px]",
                 hasConnectionFailure ? "text-rose-500 dark:text-rose-400" : "text-foreground-muted",
               )}
               numberOfLines={props.expanded ? undefined : 1}
@@ -137,14 +134,14 @@ export function ConnectionEnvironmentRow(props: {
           className="gap-3 px-4 pb-4"
         >
           {props.environment.isRelayManaged ? (
-            <Text className="text-[13px] leading-[18px] text-foreground-muted">
+            <Text className="text-sm leading-[18px] text-foreground-muted">
               Managed by T3 Cloud. Tunnel details update automatically.
             </Text>
           ) : (
             <>
               <View className="gap-1.5">
                 <Text
-                  className="text-[11px] font-t3-bold uppercase text-foreground-muted"
+                  className="text-2xs font-t3-bold uppercase text-foreground-muted"
                   style={{ letterSpacing: 0.8 }}
                 >
                   Label
@@ -156,13 +153,13 @@ export function ConnectionEnvironmentRow(props: {
                   placeholderTextColor={placeholderColor}
                   value={label}
                   onChangeText={setLabel}
-                  className="rounded-[14px] border border-input-border bg-input px-4 py-3 text-[15px] text-foreground"
+                  className="rounded-[14px] border border-input-border bg-input px-4 py-3 text-base text-foreground"
                 />
               </View>
 
               <View className="gap-1.5">
                 <Text
-                  className="text-[11px] font-t3-bold uppercase text-foreground-muted"
+                  className="text-2xs font-t3-bold uppercase text-foreground-muted"
                   style={{ letterSpacing: 0.8 }}
                 >
                   URL
@@ -175,7 +172,7 @@ export function ConnectionEnvironmentRow(props: {
                   placeholderTextColor={placeholderColor}
                   value={url}
                   onChangeText={setUrl}
-                  className="rounded-[14px] border border-input-border bg-input px-4 py-3 text-[15px] text-foreground"
+                  className="rounded-[14px] border border-input-border bg-input px-4 py-3 text-base text-foreground"
                 />
               </View>
             </>
@@ -189,7 +186,7 @@ export function ConnectionEnvironmentRow(props: {
               >
                 <SymbolView name="checkmark" size={13} tintColor={primaryFg} type="monochrome" />
                 <Text
-                  className="text-[12px] font-t3-bold uppercase text-primary-foreground"
+                  className="text-xs font-t3-bold uppercase text-primary-foreground"
                   style={{ letterSpacing: 0.8 }}
                 >
                   Save

--- a/apps/mobile/src/features/connection/ConnectionSheetButton.tsx
+++ b/apps/mobile/src/features/connection/ConnectionSheetButton.tsx
@@ -104,7 +104,7 @@ export function ConnectionSheetButton(props: {
         type="monochrome"
       />
       <Text
-        className="text-[12px] font-t3-bold uppercase"
+        className="text-xs font-t3-bold uppercase"
         style={{ color: colors.textColor, letterSpacing: 0.8 }}
       >
         {props.label}

--- a/apps/mobile/src/features/connection/EnvironmentConnectionNotice.tsx
+++ b/apps/mobile/src/features/connection/EnvironmentConnectionNotice.tsx
@@ -73,10 +73,10 @@ export function EnvironmentConnectionNotice(props: {
           />
         )}
 
-        <Text className="text-center text-[17px] font-t3-bold leading-[22px] text-foreground">
+        <Text className="text-center text-lg font-t3-bold leading-[22px] text-foreground">
           {noticeTitle(props.connection.phase, props.environmentLabel)}
         </Text>
-        <Text className="text-center text-[14px] leading-[20px] text-foreground-muted">
+        <Text className="text-center text-sm leading-[20px] text-foreground-muted">
           {noticeDetail(props.connection.phase, props.resourceName, props.connection.error)}
           {props.connection.traceId ? (
             <>
@@ -99,7 +99,7 @@ export function EnvironmentConnectionNotice(props: {
             className="mt-1 rounded-full bg-subtle px-4 py-2.5 active:opacity-70"
             onPress={props.onRetry}
           >
-            <Text className="text-[13px] font-t3-bold text-foreground">Retry now</Text>
+            <Text className="text-sm font-t3-bold text-foreground">Retry now</Text>
           </Pressable>
         ) : null}
       </View>

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -7,6 +7,7 @@ import {
 } from "react-native-nitro-markdown";
 import { Linking, ScrollView, Text as NativeText, View } from "react-native";
 
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThemeColor } from "../../lib/useThemeColor";
 import {
   hasNativeSelectableMarkdownText,
@@ -72,8 +73,7 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
         text: {
           color: body,
           fontFamily: "DMSans_400Regular",
-          fontSize: 15,
-          lineHeight: 22,
+          ...MOBILE_TYPOGRAPHY.body,
         },
         heading: {
           color: strong,
@@ -123,8 +123,7 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
         skillTextColor: codeText,
         quoteMarkerColor: blockquoteBorder,
         dividerColor: horizontalRule,
-        fontSize: 15,
-        lineHeight: 22,
+        ...MOBILE_TYPOGRAPHY.body,
         fontFamily: "DMSans_400Regular",
         headingFontFamily: "DMSans_700Bold",
         boldFontFamily: "DMSans_700Bold",

--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -64,7 +64,7 @@ const FileTreeRow = memo(function FileTreeRow(props: {
       <PierreEntryIcon path={node.path} kind={node.kind} size={17} />
       <Text
         className={cn(
-          "min-w-0 flex-1 text-[14px] leading-[19px]",
+          "min-w-0 flex-1 text-sm leading-[19px]",
           selected ? "font-t3-bold text-foreground" : "font-t3-medium text-foreground-secondary",
         )}
         numberOfLines={1}
@@ -72,7 +72,7 @@ const FileTreeRow = memo(function FileTreeRow(props: {
         {node.name}
       </Text>
       {node.kind === "directory" ? (
-        <Text className="text-[11px] font-t3-medium text-foreground-tertiary">
+        <Text className="text-2xs font-t3-medium text-foreground-tertiary">
           {node.children.length}
         </Text>
       ) : null}
@@ -142,10 +142,8 @@ export function FileTreeBrowser(props: {
     <View className="flex-1 bg-sheet">
       {props.error && props.entries.length === 0 ? (
         <View className="px-4 py-5">
-          <Text className="text-[13px] font-t3-bold text-foreground">Files unavailable</Text>
-          <Text className="mt-1 text-[12px] leading-[18px] text-foreground-muted">
-            {props.error}
-          </Text>
+          <Text className="text-sm font-t3-bold text-foreground">Files unavailable</Text>
+          <Text className="mt-1 text-xs leading-[18px] text-foreground-muted">{props.error}</Text>
         </View>
       ) : (
         <FlatList
@@ -174,8 +172,8 @@ export function FileTreeBrowser(props: {
                 <ActivityIndicator size="small" />
               ) : (
                 <>
-                  <Text className="text-[13px] font-t3-bold text-foreground">No files found</Text>
-                  <Text className="mt-1 text-[12px] leading-[18px] text-foreground-muted">
+                  <Text className="text-sm font-t3-bold text-foreground">No files found</Text>
+                  <Text className="mt-1 text-xs leading-[18px] text-foreground-muted">
                     {props.searchQuery.trim().length > 0
                       ? "Try a different search."
                       : "The workspace file index is empty."}

--- a/apps/mobile/src/features/files/SourceFileSurface.tsx
+++ b/apps/mobile/src/features/files/SourceFileSurface.tsx
@@ -18,6 +18,7 @@ import {
 } from "../review/reviewDiffRendering";
 import type { ReviewHighlightedToken } from "../review/shikiReviewHighlighter";
 import { cn } from "../../lib/cn";
+import { MOBILE_CODE_SURFACE } from "../../lib/typography";
 import {
   buildNativeSourceRows,
   buildNativeSourceTokens,
@@ -28,8 +29,8 @@ import {
 } from "./nativeSourceFileAdapter";
 import { sourceHighlightAtom } from "./sourceHighlightingState";
 
-const SOURCE_LINE_HEIGHT = 24;
-const SOURCE_LINE_NUMBER_WIDTH = 58;
+const SOURCE_LINE_HEIGHT = MOBILE_CODE_SURFACE.rowHeight;
+const SOURCE_LINE_NUMBER_WIDTH = MOBILE_CODE_SURFACE.gutterWidth;
 const NATIVE_SOURCE_STYLE_JSON = JSON.stringify(NATIVE_SOURCE_STYLE);
 
 interface SourceFileSurfaceProps {
@@ -56,10 +57,12 @@ const HighlightedSourceLine = memo(function HighlightedSourceLine(props: {
       style={{ minHeight: SOURCE_LINE_HEIGHT }}
     >
       <NativeText
-        className="select-none pr-3 text-right text-[11px] leading-[24px] text-foreground-tertiary"
+        className="select-none pr-3 text-right text-foreground-tertiary"
         style={{
           width: SOURCE_LINE_NUMBER_WIDTH,
           fontFamily: REVIEW_MONO_FONT_FAMILY,
+          fontSize: MOBILE_CODE_SURFACE.lineNumberFontSize,
+          lineHeight: MOBILE_CODE_SURFACE.rowHeight,
         }}
       >
         {props.index + 1}
@@ -67,8 +70,13 @@ const HighlightedSourceLine = memo(function HighlightedSourceLine(props: {
       <NativeText
         selectable
         numberOfLines={1}
-        className="text-[13px] font-medium leading-[24px] text-foreground"
-        style={{ fontFamily: REVIEW_MONO_FONT_FAMILY, minWidth: 320 }}
+        className="font-normal text-foreground"
+        style={{
+          fontFamily: REVIEW_MONO_FONT_FAMILY,
+          fontSize: MOBILE_CODE_SURFACE.fontSize,
+          lineHeight: MOBILE_CODE_SURFACE.rowHeight,
+          minWidth: 320,
+        }}
       >
         {props.tokens && props.tokens.length > 0
           ? (() => {
@@ -80,7 +88,7 @@ const HighlightedSourceLine = memo(function HighlightedSourceLine(props: {
                 const fontWeight =
                   token.fontStyle !== null && (token.fontStyle & 2) === 2
                     ? ("700" as const)
-                    : ("500" as const);
+                    : ("400" as const);
                 const fontStyle =
                   token.fontStyle !== null && (token.fontStyle & 1) === 1
                     ? ("italic" as const)
@@ -142,9 +150,7 @@ function SourceHighlightStatusView(props: { readonly status: SourceHighlightStat
   if (props.status === "error") {
     return (
       <View className="border-b border-border bg-card px-4 py-2">
-        <Text className="text-[11px] font-t3-medium uppercase text-foreground-muted">
-          Plain text
-        </Text>
+        <Text className="text-2xs font-t3-medium uppercase text-foreground-muted">Plain text</Text>
       </View>
     );
   }

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -24,6 +24,7 @@ import { EmptyState } from "../../components/EmptyState";
 import { LoadingScreen } from "../../components/LoadingScreen";
 import { cn } from "../../lib/cn";
 import { buildThreadFilesNavigation } from "../../lib/routes";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
@@ -100,7 +101,7 @@ function ModeButton(props: {
       <SymbolView name={props.icon} size={13} tintColor={iconColor} type="monochrome" />
       <Text
         className={cn(
-          "text-[12px] font-t3-bold",
+          "text-xs font-t3-bold",
           props.active ? "text-primary-foreground" : "text-foreground-muted",
         )}
       >
@@ -187,7 +188,7 @@ function FileBreadcrumbs(props: { readonly projectName: string; readonly relativ
               ) : null}
               <Text
                 className={cn(
-                  "max-w-[180px] px-1 text-[12px]",
+                  "max-w-[180px] px-1 text-xs",
                   crumb.kind === "file"
                     ? "font-t3-bold text-foreground"
                     : "font-t3-medium text-foreground-muted",
@@ -308,7 +309,7 @@ function FileContent(props: {
     return (
       <View className="flex-1 items-center justify-center gap-3 bg-card px-6">
         <ActivityIndicator />
-        <Text className="text-center text-[13px] text-foreground-muted">Loading file...</Text>
+        <Text className="text-center text-sm text-foreground-muted">Loading file...</Text>
       </View>
     );
   }
@@ -317,10 +318,10 @@ function FileContent(props: {
     <View className="flex-1 bg-card">
       {props.truncated ? (
         <View className="border-b border-amber-200 bg-amber-50 px-4 py-2 dark:border-amber-900/60 dark:bg-amber-950/40">
-          <Text className="text-[11px] font-t3-bold uppercase text-amber-700 dark:text-amber-300">
+          <Text className="text-2xs font-t3-bold uppercase text-amber-700 dark:text-amber-300">
             Partial file
           </Text>
-          <Text className="text-[12px] leading-[17px] text-amber-800 dark:text-amber-200">
+          <Text className="text-xs leading-[17px] text-amber-800 dark:text-amber-200">
             Preview limited to the first 1 MB of a truncated file.
           </Text>
         </View>
@@ -389,7 +390,7 @@ function FilesHeaderTitle(props: { readonly projectName: string }) {
         style={{
           color: foregroundColor,
           fontFamily: "DMSans_700Bold",
-          fontSize: 18,
+          fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
           fontWeight: "900",
           letterSpacing: -0.4,
         }}
@@ -401,7 +402,7 @@ function FilesHeaderTitle(props: { readonly projectName: string }) {
         style={{
           color: secondaryForegroundColor,
           fontFamily: "DMSans_500Medium",
-          fontSize: 12,
+          fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
           fontWeight: "500",
           letterSpacing: 0.2,
         }}

--- a/apps/mobile/src/features/files/WorkspaceFileImagePreview.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFileImagePreview.tsx
@@ -81,7 +81,7 @@ function CachedWorkspaceFileImagePreview(props: {
     return (
       <View className="flex-1 items-center justify-center gap-3 bg-card px-6">
         <ActivityIndicator />
-        <Text className="text-center text-[13px] text-foreground-muted">Loading image...</Text>
+        <Text className="text-center text-sm text-foreground-muted">Loading image...</Text>
       </View>
     );
   }
@@ -102,7 +102,7 @@ export function WorkspaceFileImagePreview(props: {
     return (
       <View className="flex-1 items-center justify-center gap-3 bg-card px-6">
         <ActivityIndicator />
-        <Text className="text-center text-[13px] text-foreground-muted">
+        <Text className="text-center text-sm text-foreground-muted">
           Preparing image preview...
         </Text>
       </View>

--- a/apps/mobile/src/features/files/WorkspaceFileWebPreview.tsx
+++ b/apps/mobile/src/features/files/WorkspaceFileWebPreview.tsx
@@ -13,7 +13,7 @@ export function WorkspaceFileWebPreview(props: { readonly uri: string | null }) 
     return (
       <View className="flex-1 items-center justify-center gap-3 bg-card px-6">
         <ActivityIndicator />
-        <Text className="text-center text-[13px] text-foreground-muted">Preparing preview...</Text>
+        <Text className="text-center text-sm text-foreground-muted">Preparing preview...</Text>
       </View>
     );
   }
@@ -23,10 +23,8 @@ export function WorkspaceFileWebPreview(props: { readonly uri: string | null }) 
       {loadProgress > 0 && loadProgress < 1 ? <LoadingStrip progress={loadProgress} /> : null}
       {loadError ? (
         <View className="border-b border-border bg-card px-4 py-2">
-          <Text className="text-[12px] font-t3-bold text-foreground">Preview failed</Text>
-          <Text className="mt-0.5 text-[12px] leading-[17px] text-foreground-muted">
-            {loadError}
-          </Text>
+          <Text className="text-xs font-t3-bold text-foreground">Preview failed</Text>
+          <Text className="mt-0.5 text-xs leading-[17px] text-foreground-muted">{loadError}</Text>
         </View>
       ) : null}
       <WebView

--- a/apps/mobile/src/features/files/nativeSourceFileAdapter.test.ts
+++ b/apps/mobile/src/features/files/nativeSourceFileAdapter.test.ts
@@ -3,10 +3,30 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   buildNativeSourceRows,
   buildNativeSourceTokens,
+  NATIVE_SOURCE_ROW_HEIGHT,
+  NATIVE_SOURCE_STYLE,
   nativeSourceRowId,
 } from "./nativeSourceFileAdapter";
+import {
+  NATIVE_REVIEW_DIFF_ROW_HEIGHT,
+  NATIVE_REVIEW_DIFF_STYLE,
+} from "../review/nativeReviewDiffAdapter";
 
 describe("nativeSourceFileAdapter", () => {
+  it("uses the same compact code typography as the diff viewer", () => {
+    expect(NATIVE_SOURCE_ROW_HEIGHT).toBe(NATIVE_REVIEW_DIFF_ROW_HEIGHT);
+    expect(NATIVE_SOURCE_STYLE).toMatchObject({
+      rowHeight: NATIVE_REVIEW_DIFF_STYLE.rowHeight,
+      gutterWidth: NATIVE_REVIEW_DIFF_STYLE.gutterWidth,
+      codePadding: NATIVE_REVIEW_DIFF_STYLE.codePadding,
+      textVerticalInset: NATIVE_REVIEW_DIFF_STYLE.textVerticalInset,
+      codeFontSize: NATIVE_REVIEW_DIFF_STYLE.codeFontSize,
+      codeFontWeight: NATIVE_REVIEW_DIFF_STYLE.codeFontWeight,
+      lineNumberFontSize: NATIVE_REVIEW_DIFF_STYLE.lineNumberFontSize,
+      lineNumberFontWeight: NATIVE_REVIEW_DIFF_STYLE.lineNumberFontWeight,
+    });
+  });
+
   it("maps plain source lines onto context rows with stable line numbers", () => {
     expect(buildNativeSourceRows(["const value = 1;", "\treturn value;"])).toEqual([
       {

--- a/apps/mobile/src/features/files/nativeSourceFileAdapter.ts
+++ b/apps/mobile/src/features/files/nativeSourceFileAdapter.ts
@@ -3,22 +3,24 @@ import type {
   NativeReviewDiffStyle,
   NativeReviewDiffToken,
 } from "../diffs/nativeReviewDiffSurface";
+import { MOBILE_CODE_SURFACE, MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import type { SourceHighlightTokens } from "./sourceHighlightingState";
 
-export const NATIVE_SOURCE_ROW_HEIGHT = 24;
+export const NATIVE_SOURCE_ROW_HEIGHT = MOBILE_CODE_SURFACE.rowHeight;
 export const NATIVE_SOURCE_CONTENT_WIDTH = 32_000;
 
 export const NATIVE_SOURCE_STYLE: NativeReviewDiffStyle = {
   rowHeight: NATIVE_SOURCE_ROW_HEIGHT,
   contentWidth: NATIVE_SOURCE_CONTENT_WIDTH,
   changeBarWidth: 0,
-  gutterWidth: 58,
-  codePadding: 8,
-  codeFontSize: 13,
-  codeFontWeight: "medium",
-  lineNumberFontSize: 11,
-  lineNumberFontWeight: "medium",
-  emptyStateFontSize: 12,
+  gutterWidth: MOBILE_CODE_SURFACE.gutterWidth,
+  codePadding: MOBILE_CODE_SURFACE.codePadding,
+  textVerticalInset: MOBILE_CODE_SURFACE.textVerticalInset,
+  codeFontSize: MOBILE_CODE_SURFACE.fontSize,
+  codeFontWeight: "regular",
+  lineNumberFontSize: MOBILE_CODE_SURFACE.lineNumberFontSize,
+  lineNumberFontWeight: "regular",
+  emptyStateFontSize: MOBILE_TYPOGRAPHY.label.fontSize,
   emptyStateFontWeight: "medium",
 };
 

--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -12,6 +12,7 @@ import { Stack } from "expo-router";
 import { Text as RNText, View } from "react-native";
 
 import { useThemeColor } from "../../lib/useThemeColor";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import type { HomeProjectSortOrder } from "./homeThreadList";
 
 export interface HomeHeaderEnvironment {
@@ -118,7 +119,7 @@ export function HomeHeader(props: {
             <RNText
               style={{
                 fontFamily: "DMSans_700Bold",
-                fontSize: 17,
+                fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
                 color: iconColor,
                 letterSpacing: -0.4,
               }}
@@ -136,7 +137,7 @@ export function HomeHeader(props: {
               <RNText
                 style={{
                   fontFamily: "DMSans_700Bold",
-                  fontSize: 10,
+                  fontSize: MOBILE_TYPOGRAPHY.micro.fontSize,
                   color: mutedColor,
                   letterSpacing: 1.1,
                   textTransform: "uppercase",

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -186,7 +186,7 @@ function ProjectGroupLabel(props: {
         workspaceRoot={props.project.workspaceRoot}
       />
       <Text
-        className="flex-1 text-[12px] font-t3-medium uppercase text-foreground-muted"
+        className="flex-1 text-xs font-t3-medium uppercase text-foreground-muted"
         style={{ letterSpacing: 0.5 }}
         numberOfLines={1}
       >
@@ -196,7 +196,7 @@ function ProjectGroupLabel(props: {
       {hiddenCount > 0 ? (
         <Pressable onPress={props.onToggleExpand} hitSlop={8}>
           <Text
-            className="text-[12px] font-t3-medium text-foreground-muted"
+            className="text-xs font-t3-medium text-foreground-muted"
             style={{ letterSpacing: 0.4 }}
           >
             {props.isExpanded ? "Show less" : `${hiddenCount} more`}
@@ -335,7 +335,7 @@ function ThreadRow(props: {
           <View style={{ flex: 1, gap: 3 }}>
             <View className="flex-row items-center justify-between gap-2">
               <Text
-                className="flex-1 text-[15px] font-t3-bold leading-[20px] text-foreground"
+                className="flex-1 text-base font-t3-bold leading-[20px] text-foreground"
                 numberOfLines={1}
               >
                 {props.thread.title}
@@ -345,12 +345,12 @@ function ThreadRow(props: {
                   className={tone.pillClassName}
                   style={{ borderRadius: 99, paddingHorizontal: 6, paddingVertical: 2 }}
                 >
-                  <Text className={`text-[10px] font-t3-bold ${tone.textClassName}`}>
+                  <Text className={`text-3xs font-t3-bold ${tone.textClassName}`}>
                     {tone.label}
                   </Text>
                 </View>
                 <Text
-                  className="text-[12px] text-foreground-tertiary"
+                  className="text-xs text-foreground-tertiary"
                   style={{ fontVariant: ["tabular-nums"] }}
                 >
                   {timestamp}
@@ -367,7 +367,7 @@ function ThreadRow(props: {
                   type="monochrome"
                 />
                 <Text
-                  className="text-[11px] text-foreground-tertiary"
+                  className="text-2xs text-foreground-tertiary"
                   numberOfLines={1}
                   style={{ fontFamily: "monospace" }}
                 >
@@ -429,7 +429,7 @@ function StaleCatalogStatusPill(props: {
           weight="semibold"
         />
       )}
-      <Text className="max-w-[260px] text-[13px] font-t3-bold text-foreground" numberOfLines={1}>
+      <Text className="max-w-[260px] text-sm font-t3-bold text-foreground" numberOfLines={1}>
         {label}
       </Text>
     </Pressable>

--- a/apps/mobile/src/features/home/thread-swipe-actions.tsx
+++ b/apps/mobile/src/features/home/thread-swipe-actions.tsx
@@ -167,7 +167,7 @@ function SwipeActionButton(props: {
           </Animated.View>
         </View>
         <Animated.View style={[{ paddingTop: 2 }, labelStyle]}>
-          <Text className="text-[10px] font-t3-medium text-foreground-muted">{props.label}</Text>
+          <Text className="text-3xs font-t3-medium text-foreground-muted">{props.label}</Text>
         </Animated.View>
       </Pressable>
     </Animated.View>

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -100,7 +100,7 @@ function sourceFromParam(value: string | string[] | undefined): AddProjectRemote
 function SectionTitle(props: { readonly children: string }) {
   return (
     <Text
-      className="px-1 text-[11px] font-t3-bold uppercase text-foreground-muted"
+      className="px-1 text-2xs font-t3-bold uppercase text-foreground-muted"
       style={{ letterSpacing: 0.7 }}
     >
       {props.children}
@@ -168,9 +168,9 @@ function ListRow(props: {
           {props.icon}
         </View>
         <View className="flex-1 gap-0.5">
-          <Text className="text-[16px] leading-[21px] font-t3-bold">{props.title}</Text>
+          <Text className="text-base leading-[21px] font-t3-bold">{props.title}</Text>
           {props.subtitle ? (
-            <Text className="text-[13px] leading-[17px] text-foreground-muted" numberOfLines={2}>
+            <Text className="text-sm leading-[17px] text-foreground-muted" numberOfLines={2}>
               {props.subtitle}
             </Text>
           ) : null}
@@ -202,7 +202,7 @@ function PrimaryActionButton(props: {
       {props.loading ? (
         <ActivityIndicator color={String(primaryForeground)} />
       ) : (
-        <Text className="text-[14px] font-t3-bold text-primary-foreground">{props.label}</Text>
+        <Text className="text-base font-t3-bold text-primary-foreground">{props.label}</Text>
       )}
     </Pressable>
   );
@@ -215,7 +215,7 @@ function ProjectPathInput(props: {
 }) {
   return (
     <TextInput
-      className="h-12 min-h-12 rounded-[24px] px-4 py-0 text-[15px] leading-[20px]"
+      className="h-12 min-h-12 rounded-[24px] px-4 py-0 text-base leading-[20px]"
       value={props.value}
       onChangeText={props.onChangeText}
       autoCapitalize="none"
@@ -273,15 +273,15 @@ function EmptyEnvironmentState() {
 
   return (
     <View className="items-center gap-3 rounded-2xl bg-card px-5 py-8">
-      <Text className="text-center text-[17px] font-t3-bold">No environments connected</Text>
-      <Text className="text-center text-[14px] leading-[20px] text-foreground-muted">
+      <Text className="text-center text-lg font-t3-bold">No environments connected</Text>
+      <Text className="text-center text-sm leading-[20px] text-foreground-muted">
         Add an environment before adding a project.
       </Text>
       <Pressable
         onPress={() => router.replace("/connections/new")}
         className="mt-1 rounded-full bg-primary px-4 py-2.5 active:opacity-70"
       >
-        <Text className="text-[13px] font-t3-bold text-primary-foreground">Add environment</Text>
+        <Text className="text-sm font-t3-bold text-primary-foreground">Add environment</Text>
       </Pressable>
     </View>
   );
@@ -565,7 +565,7 @@ export function AddProjectRepositoryScreen() {
     <AddProjectShell>
       {error ? <ErrorBanner message={error} /> : null}
       <TextInput
-        className="h-12 min-h-12 rounded-[24px] px-4 py-0 text-[15px] leading-[20px]"
+        className="h-12 min-h-12 rounded-[24px] px-4 py-0 text-base leading-[20px]"
         value={repositoryInput}
         onChangeText={setRepositoryInput}
         autoCapitalize="none"
@@ -806,8 +806,8 @@ export function AddProjectDestinationScreen() {
       {error ? <ErrorBanner message={error} /> : null}
       {repositoryTitle ? (
         <View className="rounded-[24px] bg-card px-4 py-3">
-          <Text className="text-[14px] font-t3-bold">{repositoryTitle}</Text>
-          <Text className="mt-0.5 text-[12px] text-foreground-muted" numberOfLines={2}>
+          <Text className="text-base font-t3-bold">{repositoryTitle}</Text>
+          <Text className="mt-0.5 text-xs text-foreground-muted" numberOfLines={2}>
             {remoteUrl}
           </Text>
         </View>

--- a/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
@@ -159,26 +159,26 @@ export function ReviewCommentComposerSheet() {
               <SymbolView name="xmark" size={18} tintColor={iconTint} type="monochrome" />
             </Pressable>
 
-            <Text className="text-[18px] font-t3-bold text-foreground">Add Comment</Text>
+            <Text className="text-lg font-t3-bold text-foreground">Add Comment</Text>
 
             <View className="h-12 w-12" />
           </View>
 
           {!target ? (
             <View className="rounded-[22px] border border-border bg-card px-4 py-5">
-              <Text className="text-[15px] font-t3-bold text-foreground">No selection</Text>
-              <Text className="mt-1 text-[13px] leading-[19px] text-foreground-muted">
+              <Text className="text-base font-t3-bold text-foreground">No selection</Text>
+              <Text className="mt-1 text-sm leading-[19px] text-foreground-muted">
                 Select a diff line or range first.
               </Text>
             </View>
           ) : (
             <View className="min-h-0 flex-1 gap-4">
               <View className="gap-1 px-1">
-                <Text className="text-[11px] font-t3-bold uppercase text-foreground-muted">
+                <Text className="text-2xs font-t3-bold uppercase text-foreground-muted">
                   {selectionLabel}
                 </Text>
                 <Text
-                  className="font-mono text-[12px] leading-[17px] text-foreground-muted"
+                  className="font-mono text-xs leading-[17px] text-foreground-muted"
                   ellipsizeMode="middle"
                   numberOfLines={2}
                 >
@@ -215,7 +215,7 @@ export function ReviewCommentComposerSheet() {
                           >
                             <ReviewChangeBar change={line.change} />
                             <Text
-                              className="w-9 py-1 pr-1 text-right text-[11px] font-t3-medium text-foreground-muted"
+                              className="w-9 py-1 pr-1 text-right text-2xs font-t3-medium text-foreground-muted"
                               style={{ fontFamily: REVIEW_MONO_FONT_FAMILY }}
                             >
                               {lineNumber ?? ""}
@@ -236,7 +236,7 @@ export function ReviewCommentComposerSheet() {
               </View>
 
               <View className="min-h-0 flex-1 gap-2">
-                <Text className="text-[13px] font-t3-bold text-foreground">Comment</Text>
+                <Text className="text-sm font-t3-bold text-foreground">Comment</Text>
                 <View className="min-h-[132px] flex-1 overflow-hidden rounded-[20px] border border-border bg-card">
                   <View className="min-h-0 flex-1 px-4 pt-3.5">
                     <TextInputWrapper onPaste={handleNativePaste} style={{ flex: 1, minHeight: 0 }}>
@@ -248,7 +248,7 @@ export function ReviewCommentComposerSheet() {
                         textAlignVertical="top"
                         value={commentText}
                         onChangeText={setCommentText}
-                        className="h-full flex-1 border-0 bg-transparent px-0 py-0 font-sans text-[15px]"
+                        className="h-full flex-1 border-0 bg-transparent px-0 py-0 font-sans text-base"
                         style={{ flex: 1, minHeight: 0 }}
                       />
                     </TextInputWrapper>

--- a/apps/mobile/src/features/review/ReviewSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewSheet.tsx
@@ -20,6 +20,7 @@ import { environmentCatalog } from "../../connection/catalog";
 import { useEnvironmentPresentation } from "../../state/presentation";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useThemeColor } from "../../lib/useThemeColor";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThreadDraftForThread } from "../../state/use-thread-composer-state";
 import { EnvironmentConnectionNotice } from "../connection/EnvironmentConnectionNotice";
 import { useReviewCacheForThread } from "./reviewState";
@@ -41,10 +42,10 @@ const REVIEW_HEADER_SPACING = 0;
 const ReviewNotice = memo(function ReviewNotice(props: { readonly notice: string }) {
   return (
     <View className="border-b border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900/60 dark:bg-amber-950/40">
-      <Text className="text-[12px] font-t3-bold uppercase text-amber-700 dark:text-amber-300">
+      <Text className="text-xs font-t3-bold uppercase text-amber-700 dark:text-amber-300">
         Partial diff
       </Text>
-      <Text className="text-[12px] leading-[18px] text-amber-800 dark:text-amber-200">
+      <Text className="text-xs leading-[18px] text-amber-800 dark:text-amber-200">
         {props.notice}
       </Text>
     </View>
@@ -69,7 +70,7 @@ function ReviewSelectionActionBar(props: {
         tintColor="#ffffff"
         type="monochrome"
       />
-      <Text className="text-[15px] font-t3-bold text-white">{props.title}</Text>
+      <Text className="text-base font-t3-bold text-white">{props.title}</Text>
     </>
   );
 
@@ -218,8 +219,8 @@ export function ReviewSheet() {
     if (error) {
       children.push(
         <View key="review-error" className="border-b border-border bg-card px-4 py-3">
-          <Text className="text-[13px] font-t3-bold text-foreground">Review unavailable</Text>
-          <Text className="text-[12px] leading-[18px] text-foreground-muted">{error}</Text>
+          <Text className="text-sm font-t3-bold text-foreground">Review unavailable</Text>
+          <Text className="text-xs leading-[18px] text-foreground-muted">{error}</Text>
         </View>,
       );
     }
@@ -251,7 +252,7 @@ export function ReviewSheet() {
                 numberOfLines={1}
                 style={{
                   fontFamily: "DMSans_700Bold",
-                  fontSize: 18,
+                  fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
                   fontWeight: "900",
                   color: headerForeground,
                   letterSpacing: -0.4,
@@ -273,7 +274,7 @@ export function ReviewSheet() {
                     <NativeText
                       style={{
                         fontFamily: "DMSans_700Bold",
-                        fontSize: 12,
+                        fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
                         fontWeight: "700",
                         color: "#16a34a",
                       }}
@@ -283,7 +284,7 @@ export function ReviewSheet() {
                     <NativeText
                       style={{
                         fontFamily: "DMSans_700Bold",
-                        fontSize: 12,
+                        fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
                         fontWeight: "700",
                         color: "#e11d48",
                       }}
@@ -294,7 +295,7 @@ export function ReviewSheet() {
                       <NativeText
                         style={{
                           fontFamily: "DMSans_700Bold",
-                          fontSize: 12,
+                          fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
                           fontWeight: "700",
                           color: "#b45309",
                         }}
@@ -309,7 +310,7 @@ export function ReviewSheet() {
                       numberOfLines={1}
                       style={{
                         fontFamily: "DMSans_700Bold",
-                        fontSize: 12,
+                        fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
                         fontWeight: "700",
                         color: headerMuted,
                       }}
@@ -320,7 +321,7 @@ export function ReviewSheet() {
                       <NativeText
                         style={{
                           fontFamily: "DMSans_700Bold",
-                          fontSize: 12,
+                          fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
                           fontWeight: "700",
                           color: "#b45309",
                         }}
@@ -430,30 +431,30 @@ export function ReviewSheet() {
             {listHeader}
             {!selectedSection ? (
               <View className="border-b border-border bg-card px-4 py-5">
-                <Text className="text-[14px] font-t3-bold text-foreground">No review diffs</Text>
-                <Text className="text-[12px] leading-[18px] text-foreground-muted">
+                <Text className="text-sm font-t3-bold text-foreground">No review diffs</Text>
+                <Text className="text-xs leading-[18px] text-foreground-muted">
                   This thread has no ready turn diffs and the worktree diff is empty.
                 </Text>
               </View>
             ) : selectedSection.isLoading && selectedSection.diff === null ? (
               <View className="items-center gap-3 border-b border-border bg-card px-4 py-6">
                 <ActivityIndicator size="small" />
-                <Text className="text-[12px] text-foreground-muted">Loading diff…</Text>
+                <Text className="text-xs text-foreground-muted">Loading diff…</Text>
               </View>
             ) : parsedDiff.kind === "empty" ? (
               <View className="border-b border-border bg-card px-4 py-5">
-                <Text className="text-[14px] font-t3-bold text-foreground">No changes</Text>
-                <Text className="text-[12px] leading-[18px] text-foreground-muted">
+                <Text className="text-sm font-t3-bold text-foreground">No changes</Text>
+                <Text className="text-xs leading-[18px] text-foreground-muted">
                   {selectedSection.subtitle ?? "This diff is empty."}
                 </Text>
               </View>
             ) : parsedDiff.kind === "raw" ? (
               <View className="gap-3 border-b border-border bg-card px-4 py-4">
-                <Text className="text-[12px] leading-[18px] text-foreground-muted">
+                <Text className="text-xs leading-[18px] text-foreground-muted">
                   {parsedDiff.reason}
                 </Text>
                 <ScrollView horizontal showsHorizontalScrollIndicator={false} bounces={false}>
-                  <Text selectable className="font-mono text-[12px] leading-[19px] text-foreground">
+                  <Text selectable className="font-mono text-xs leading-[19px] text-foreground">
                     {parsedDiff.text}
                   </Text>
                 </ScrollView>

--- a/apps/mobile/src/features/review/nativeReviewDiffAdapter.ts
+++ b/apps/mobile/src/features/review/nativeReviewDiffAdapter.ts
@@ -5,6 +5,7 @@ import type {
 } from "../diffs/nativeReviewDiffTypes";
 import * as Arr from "effect/Array";
 import { pipe } from "effect/Function";
+import { MOBILE_CODE_SURFACE } from "../../lib/typography";
 import { getPierreTerminalTheme, type TerminalAppearanceScheme } from "../terminal/terminalTheme";
 import { computeWordAltDiffRanges } from "./reviewWordDiffs";
 import {
@@ -18,16 +19,16 @@ import type { ReviewInlineComment } from "./reviewCommentSelection";
 const NATIVE_REVIEW_MAX_WORD_DIFF_RANGE_COUNT = 4;
 const NATIVE_REVIEW_MAX_WORD_DIFF_COVERAGE = 0.45;
 
-export const NATIVE_REVIEW_DIFF_ROW_HEIGHT = 20;
+export const NATIVE_REVIEW_DIFF_ROW_HEIGHT = MOBILE_CODE_SURFACE.rowHeight;
 export const NATIVE_REVIEW_DIFF_CONTENT_WIDTH = 2_800;
 
 export const NATIVE_REVIEW_DIFF_STYLE = {
   rowHeight: NATIVE_REVIEW_DIFF_ROW_HEIGHT,
   contentWidth: NATIVE_REVIEW_DIFF_CONTENT_WIDTH,
   changeBarWidth: 4,
-  gutterWidth: 46,
-  codePadding: 7,
-  textVerticalInset: 2,
+  gutterWidth: MOBILE_CODE_SURFACE.gutterWidth,
+  codePadding: MOBILE_CODE_SURFACE.codePadding,
+  textVerticalInset: MOBILE_CODE_SURFACE.textVerticalInset,
   fileHeaderHeight: 56,
   fileHeaderHorizontalMargin: 8,
   fileHeaderVerticalMargin: 6,
@@ -36,9 +37,9 @@ export const NATIVE_REVIEW_DIFF_STYLE = {
   fileHeaderPathRightPadding: 118,
   fileHeaderCountColumnWidth: 38,
   fileHeaderCountGap: 5,
-  codeFontSize: 11,
+  codeFontSize: MOBILE_CODE_SURFACE.fontSize,
   codeFontWeight: "regular",
-  lineNumberFontSize: 10,
+  lineNumberFontSize: MOBILE_CODE_SURFACE.lineNumberFontSize,
   lineNumberFontWeight: "regular",
   hunkFontSize: 11,
   hunkFontWeight: "medium",

--- a/apps/mobile/src/features/review/reviewDiffRendering.tsx
+++ b/apps/mobile/src/features/review/reviewDiffRendering.tsx
@@ -1,6 +1,7 @@
 import { Platform, Text as NativeText, View } from "react-native";
 
 import { cn } from "../../lib/cn";
+import { MOBILE_CODE_SURFACE } from "../../lib/typography";
 
 import type { ReviewRenderableLineRow } from "./reviewModel";
 import type { ReviewHighlightedToken } from "./shikiReviewHighlighter";
@@ -11,7 +12,7 @@ export const REVIEW_MONO_FONT_FAMILY = Platform.select({
   default: "monospace",
 });
 
-export const REVIEW_DIFF_LINE_HEIGHT = 26;
+export const REVIEW_DIFF_LINE_HEIGHT = MOBILE_CODE_SURFACE.rowHeight;
 const REVIEW_DELETE_STRIPE_COUNT = REVIEW_DIFF_LINE_HEIGHT / 2;
 
 export function renderVisibleWhitespace(value: string): string {
@@ -71,8 +72,12 @@ export function DiffTokenText(props: {
       <NativeText
         numberOfLines={1}
         selectable
-        className={cn("text-[13px] leading-[17px] font-medium text-foreground", props.className)}
-        style={{ fontFamily: REVIEW_MONO_FONT_FAMILY }}
+        className={cn("font-normal text-foreground", props.className)}
+        style={{
+          fontFamily: REVIEW_MONO_FONT_FAMILY,
+          fontSize: MOBILE_CODE_SURFACE.fontSize,
+          lineHeight: MOBILE_CODE_SURFACE.rowHeight,
+        }}
       >
         {renderVisibleWhitespace(props.fallback || " ")}
       </NativeText>
@@ -83,8 +88,12 @@ export function DiffTokenText(props: {
     <NativeText
       numberOfLines={1}
       selectable
-      className={cn("text-[13px] leading-[17px] font-medium text-foreground", props.className)}
-      style={{ fontFamily: REVIEW_MONO_FONT_FAMILY }}
+      className={cn("font-normal text-foreground", props.className)}
+      style={{
+        fontFamily: REVIEW_MONO_FONT_FAMILY,
+        fontSize: MOBILE_CODE_SURFACE.fontSize,
+        lineHeight: MOBILE_CODE_SURFACE.rowHeight,
+      }}
     >
       {(() => {
         let offset = 0;

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 
 import { AppText as Text } from "../../components/AppText";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { resolveNativeTerminalSurfaceView } from "./nativeTerminalModule";
 import {
   buildGhosttyThemeConfig,
@@ -53,7 +54,7 @@ function estimateGridSize(input: {
 }
 
 const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: TerminalSurfaceProps) {
-  const fontSize = props.fontSize ?? 12;
+  const fontSize = props.fontSize ?? MOBILE_TYPOGRAPHY.label.fontSize;
   const inputRef = useRef<TextInput>(null);
   const appearanceScheme = useColorScheme() === "light" ? "light" : "dark";
   const theme = props.theme ?? getPierreTerminalTheme(appearanceScheme);
@@ -93,7 +94,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
         <Text
           style={{
             color: theme.mutedForeground,
-            fontSize: 11,
+            fontSize: MOBILE_TYPOGRAPHY.caption.fontSize,
             paddingBottom: 8,
           }}
         >
@@ -140,7 +141,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
             color: theme.foreground,
             flex: 1,
             fontFamily: "Menlo",
-            fontSize: 13,
+            fontSize: MOBILE_TYPOGRAPHY.footnote.fontSize,
             padding: 0,
           }}
           onSubmitEditing={(event) => {
@@ -165,7 +166,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
             style={{
               color: theme.foreground,
               fontFamily: "DMSans_700Bold",
-              fontSize: 11,
+              fontSize: MOBILE_TYPOGRAPHY.caption.fontSize,
             }}
           >
             Ctrl-C
@@ -177,7 +178,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
 });
 
 export const TerminalSurface = memo(function TerminalSurface(props: TerminalSurfaceProps) {
-  const fontSize = props.fontSize ?? 12;
+  const fontSize = props.fontSize ?? MOBILE_TYPOGRAPHY.label.fontSize;
   const keyboardInputRef = useRef<TextInput>(null);
   const appearanceScheme = useColorScheme() === "light" ? "light" : "dark";
   const theme = props.theme ?? getPierreTerminalTheme(appearanceScheme);

--- a/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalPanel.tsx
@@ -127,16 +127,16 @@ export const ThreadTerminalPanel = memo(function ThreadTerminalPanel(
     <View className="absolute inset-x-3 bottom-28 top-28 overflow-hidden rounded-[8px] border border-white/10 bg-neutral-950 shadow-2xl">
       <View className="flex-row items-center justify-between border-b border-white/10 px-3 py-2">
         <View className="min-w-0 flex-1">
-          <Text className="font-t3-bold text-[13px] text-neutral-100" numberOfLines={1}>
+          <Text className="font-t3-bold text-sm text-neutral-100" numberOfLines={1}>
             Terminal
           </Text>
-          <Text className="text-[11px] text-neutral-500" numberOfLines={1}>
+          <Text className="text-2xs text-neutral-500" numberOfLines={1}>
             {nativeTerminalAvailable ? "Native Ghostty surface" : "Text fallback active"}
           </Text>
         </View>
         <View className="flex-row items-center gap-2">
           {terminal.error ? (
-            <Text className="max-w-44 text-right text-[11px] text-red-300" numberOfLines={1}>
+            <Text className="max-w-44 text-right text-2xs text-red-300" numberOfLines={1}>
               {terminal.error}
             </Text>
           ) : null}

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -25,6 +25,7 @@ import { terminalEnvironment } from "../../state/terminal";
 import { useAtomCommand } from "../../state/use-atom-command";
 import { useWorkspaceState } from "../../state/workspace";
 import { buildThreadTerminalNavigation } from "../../lib/routes";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import {
   useAttachedTerminalSession,
   useKnownTerminalSessions,
@@ -920,7 +921,7 @@ export function ThreadTerminalRouteScreen() {
                 style={{
                   color: terminalTheme.foreground,
                   fontFamily: "DMSans_700Bold",
-                  fontSize: 13,
+                  fontSize: MOBILE_TYPOGRAPHY.footnote.fontSize,
                   lineHeight: 16,
                 }}
               >
@@ -932,7 +933,7 @@ export function ThreadTerminalRouteScreen() {
                 style={{
                   color: terminalTheme.mutedForeground,
                   fontFamily: "Menlo",
-                  fontSize: 11,
+                  fontSize: MOBILE_TYPOGRAPHY.caption.fontSize,
                   lineHeight: 14,
                 }}
               >

--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -7,6 +7,7 @@ import { Pressable, ScrollView, useColorScheme, View, type ViewStyle } from "rea
 
 import { AppText as Text } from "../../components/AppText";
 import { PierreEntryIcon } from "../../components/PierreEntryIcon";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 
 export type ComposerCommandItem =
   | {
@@ -156,14 +157,22 @@ const CommandRow = memo(function CommandRow(props: {
         <SymbolView name={iconName} size={14} tintColor={iconColor} type="monochrome" />
       ) : null}
       <Text
-        className="text-[14px] font-t3-medium text-foreground"
+        className="text-base font-t3-medium text-foreground"
         numberOfLines={1}
         style={{ flexShrink: 0 }}
       >
         {props.item.label}
       </Text>
       {props.item.description ? (
-        <Text numberOfLines={1} style={{ flex: 1, minWidth: 0, fontSize: 12, color: "#a1a1aa" }}>
+        <Text
+          numberOfLines={1}
+          style={{
+            flex: 1,
+            minWidth: 0,
+            fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
+            color: "#a1a1aa",
+          }}
+        >
           {props.item.description}
         </Text>
       ) : null}
@@ -182,7 +191,7 @@ export const ComposerCommandPopover = memo(function ComposerCommandPopover(
       {label ? (
         <View style={{ paddingHorizontal: 14, paddingTop: 10, paddingBottom: 4 }}>
           <Text
-            className="text-[10px] font-t3-bold text-foreground-muted"
+            className="text-3xs font-t3-bold text-foreground-muted"
             style={{ letterSpacing: 0.8, textTransform: "uppercase" }}
           >
             {label}
@@ -206,7 +215,7 @@ export const ComposerCommandPopover = memo(function ComposerCommandPopover(
         </ScrollView>
       ) : (
         <View style={{ paddingHorizontal: 14, paddingVertical: 10 }}>
-          <Text className="text-[12px] text-foreground-tertiary">
+          <Text className="text-xs text-foreground-tertiary">
             {emptyText(props.triggerKind, props.isLoading)}
           </Text>
         </View>

--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -73,12 +73,12 @@ function OverlayContent(props: { readonly progress: GitActionProgress }) {
 
       <View className="flex-1 gap-0.5">
         {progress.label ? (
-          <Text className="text-[13px] font-t3-bold text-foreground" numberOfLines={1}>
+          <Text className="text-sm font-t3-bold text-foreground" numberOfLines={1}>
             {progress.label}
           </Text>
         ) : null}
         {progress.description ? (
-          <Text className="text-[11px] text-foreground-muted" numberOfLines={1}>
+          <Text className="text-2xs text-foreground-muted" numberOfLines={1}>
             {progress.description}
           </Text>
         ) : null}

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -431,10 +431,7 @@ export function NewTaskDraftScreen(props: {
             onPasteImages={(uris) => void handleNativePasteImages(uris)}
             placeholder={`Describe a coding task in ${selectedProject.title}`}
             style={{ flex: 1, minHeight: 0 }}
-            textStyle={{
-              fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
-              lineHeight: MOBILE_TYPOGRAPHY.title.lineHeight,
-            }}
+            textStyle={MOBILE_TYPOGRAPHY.composer}
           />
         </View>
 

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -30,6 +30,7 @@ import {
   resolveProviderOptionDescriptors,
 } from "../../lib/providerOptions";
 import { buildThreadRoutePath } from "../../lib/routes";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useProjects } from "../../state/entities";
 import { branchBadgeLabel, useNewTaskFlow } from "./new-task-flow-provider";
 import { useCreateProjectThread } from "./use-project-actions";
@@ -430,7 +431,10 @@ export function NewTaskDraftScreen(props: {
             onPasteImages={(uris) => void handleNativePasteImages(uris)}
             placeholder={`Describe a coding task in ${selectedProject.title}`}
             style={{ flex: 1, minHeight: 0 }}
-            textStyle={{ fontSize: 18, lineHeight: 28 }}
+            textStyle={{
+              fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
+              lineHeight: MOBILE_TYPOGRAPHY.title.lineHeight,
+            }}
           />
         </View>
 

--- a/apps/mobile/src/features/threads/PendingApprovalCard.tsx
+++ b/apps/mobile/src/features/threads/PendingApprovalCard.tsx
@@ -16,7 +16,7 @@ export interface PendingApprovalCardProps {
 export function PendingApprovalCard(props: PendingApprovalCardProps) {
   return (
     <View className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100/80 p-4 dark:border-white/6 dark:bg-neutral-900/80">
-      <Text className="font-t3-bold text-[11px] uppercase tracking-[1.1px] text-sky-700 dark:text-sky-300">
+      <Text className="font-t3-bold text-2xs uppercase tracking-[1.1px] text-sky-700 dark:text-sky-300">
         Approval needed
       </Text>
       <Text className="font-t3-bold text-lg text-neutral-950 dark:text-neutral-50">

--- a/apps/mobile/src/features/threads/PendingUserInputCard.tsx
+++ b/apps/mobile/src/features/threads/PendingUserInputCard.tsx
@@ -26,7 +26,7 @@ export interface PendingUserInputCardProps {
 export function PendingUserInputCard(props: PendingUserInputCardProps) {
   return (
     <View className="gap-2.5 rounded-[20px] border border-neutral-200 bg-neutral-100/80 p-4 dark:border-white/6 dark:bg-neutral-900/80">
-      <Text className="font-t3-bold text-[11px] uppercase tracking-[1.1px] text-sky-700 dark:text-sky-300">
+      <Text className="font-t3-bold text-2xs uppercase tracking-[1.1px] text-sky-700 dark:text-sky-300">
         User input needed
       </Text>
       <Text className="font-t3-bold text-lg text-neutral-950 dark:text-neutral-50">
@@ -39,7 +39,7 @@ export function PendingUserInputCard(props: PendingUserInputCardProps) {
             <Text className="font-t3-bold text-xs uppercase tracking-[1px] text-neutral-500 dark:text-neutral-500">
               {question.header}
             </Text>
-            <Text className="font-sans text-[15px] leading-[21px] text-neutral-950 dark:text-neutral-50">
+            <Text className="font-sans text-base leading-[21px] text-neutral-950 dark:text-neutral-50">
               {question.question}
             </Text>
             <View className="flex-row flex-wrap gap-2.5">
@@ -65,7 +65,7 @@ export function PendingUserInputCard(props: PendingUserInputCardProps) {
                   >
                     <Text
                       className={cn(
-                        "font-t3-bold text-[13px]",
+                        "font-t3-bold text-sm",
                         selected
                           ? "text-sky-700 dark:text-sky-300"
                           : "text-neutral-600 dark:text-neutral-300",
@@ -83,7 +83,7 @@ export function PendingUserInputCard(props: PendingUserInputCardProps) {
                 props.onChangeCustomAnswer(props.pendingUserInput.requestId, question.id, value)
               }
               placeholder="Or type a custom answer"
-              className="min-h-[54px] rounded-2xl border border-neutral-200 bg-white px-3.5 py-3 font-sans text-[15px] text-neutral-950 dark:border-white/8 dark:bg-neutral-950/70 dark:text-neutral-50"
+              className="min-h-[54px] rounded-2xl border border-neutral-200 bg-white px-3.5 py-3 font-sans text-base text-neutral-950 dark:border-white/8 dark:bg-neutral-950/70 dark:text-neutral-50"
             />
           </View>
         );

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -718,8 +718,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                     }
               }
               textStyle={{
-                fontSize: MOBILE_TYPOGRAPHY.body.fontSize,
-                lineHeight: isExpanded ? 22 : 20,
+                ...MOBILE_TYPOGRAPHY.composer,
                 color: foregroundColor,
                 fontFamily: "DMSans_400Regular",
               }}

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -43,6 +43,7 @@ import { ControlPill, ControlPillMenu } from "../../components/ControlPill";
 import { ProviderIcon } from "../../components/ProviderIcon";
 import type { DraftComposerImageAttachment } from "../../lib/composerImages";
 import { buildModelOptions, groupByProvider } from "../../lib/modelOptions";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import type { RemoteClientConnectionState } from "../../lib/connection";
 import {
   insertRankedSearchResult,
@@ -189,7 +190,7 @@ const ComposerConnectionStatusPill = memo(function ComposerConnectionStatusPill(
           <View className="h-2 w-2 rounded-full bg-red-500" />
         )}
         <Text
-          className="max-w-[260px] text-[13px] font-t3-bold leading-[17px] text-foreground"
+          className="max-w-[260px] text-sm font-t3-bold leading-[17px] text-foreground"
           numberOfLines={1}
         >
           {props.status.label}
@@ -717,7 +718,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                     }
               }
               textStyle={{
-                fontSize: 15,
+                fontSize: MOBILE_TYPOGRAPHY.body.fontSize,
                 lineHeight: isExpanded ? 22 : 20,
                 color: foregroundColor,
                 fontFamily: "DMSans_400Regular",
@@ -751,7 +752,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
                     justifyContent: "center",
                   }}
                 >
-                  <Text className="text-foreground-muted text-[11px] font-t3-bold">
+                  <Text className="text-foreground-muted text-2xs font-t3-bold">
                     +{props.draftAttachments.length - 3}
                   </Text>
                 </View>
@@ -831,8 +832,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
           <Text
             className="text-foreground-muted"
             style={{
-              fontSize: 12,
-              lineHeight: 18,
+              ...MOBILE_TYPOGRAPHY.label,
               paddingTop: 8,
             }}
           >

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -56,6 +56,7 @@ import { buildReviewParsedDiff } from "../review/reviewModel";
 import { cn } from "../../lib/cn";
 import type { LayoutVariant } from "../../lib/layout";
 import { buildThreadFilesNavigation } from "../../lib/routes";
+import { MOBILE_CODE_SURFACE, MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { markdownFileIconSource } from "@t3tools/mobile-markdown-text/file-icons";
 import { resolveMarkdownLinkPresentation } from "@t3tools/mobile-markdown-text/links";
 import {
@@ -444,8 +445,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
                     marginRight: 5,
                     color: inlineTextColor,
                     fontFamily: "DMSans_400Regular",
-                    fontSize: 15,
-                    lineHeight: 22,
+                    ...MOBILE_TYPOGRAPHY.body,
                     textAlign: ordered ? "right" : "center",
                   }}
                 >
@@ -466,7 +466,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
             style={{
               color: inlineCodeTextColor,
               fontFamily: "ui-monospace",
-              fontSize: 12,
+              fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
               lineHeight: 22,
             }}
           >
@@ -503,7 +503,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
                 style={{
                   color: markdownBodyColor,
                   fontFamily: "ui-monospace",
-                  fontSize: 12,
+                  fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
                   opacity: 0.7,
                   textTransform: "uppercase",
                 }}
@@ -523,7 +523,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
               style={{
                 color: blockTextColor,
                 fontFamily: "ui-monospace",
-                fontSize: 12,
+                fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
                 lineHeight: 18,
               }}
             >
@@ -603,8 +603,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
           skillTextColor: "#f0abfc",
           quoteMarkerColor: markdownUserBodyColor,
           dividerColor: markdownUserBodyColor,
-          fontSize: 15,
-          lineHeight: 22,
+          ...MOBILE_TYPOGRAPHY.body,
           fontFamily: "DMSans_400Regular",
           headingFontFamily: "DMSans_700Bold",
           boldFontFamily: "DMSans_700Bold",
@@ -633,8 +632,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
           skillTextColor: inlineSkillForeground,
           quoteMarkerColor: markdownBlockquoteBorder,
           dividerColor: markdownHrColor,
-          fontSize: 15,
-          lineHeight: 22,
+          ...MOBILE_TYPOGRAPHY.body,
           fontFamily: "DMSans_400Regular",
           headingFontFamily: "DMSans_700Bold",
           boldFontFamily: "DMSans_700Bold",
@@ -821,7 +819,7 @@ function renderFeedEntry(
           className="max-w-[85%] gap-2 rounded-[22px] rounded-br-[6px] px-3.5 py-2.5 opacity-60"
           style={{ backgroundColor: userBubbleColor }}
         >
-          <Text className="font-sans text-[15px] leading-[22px] text-white">
+          <Text className="font-sans text-base leading-[22px] text-white">
             {entry.queuedMessage.text}
           </Text>
           {entry.queuedMessage.attachments.length > 0 ? (
@@ -995,7 +993,7 @@ const ReviewCommentCard = memo(function ReviewCommentCard(props: {
         </View>
         <View className="min-w-0 flex-1">
           <Text
-            className="font-mono text-[12px] leading-[16px]"
+            className="font-mono text-xs leading-[16px]"
             numberOfLines={1}
             style={{ color: props.colors.text }}
           >
@@ -1040,8 +1038,8 @@ const ReviewCommentCard = memo(function ReviewCommentCard(props: {
             style={{
               color: props.colors.text,
               fontFamily: "ui-monospace",
-              fontSize: 12,
-              lineHeight: 18,
+              fontSize: MOBILE_CODE_SURFACE.fontSize,
+              lineHeight: MOBILE_CODE_SURFACE.rowHeight,
             }}
           >
             {props.comment.diff.trim()}
@@ -1052,7 +1050,7 @@ const ReviewCommentCard = memo(function ReviewCommentCard(props: {
         <View className="border-t px-3 py-3" style={{ borderColor: props.colors.border }}>
           <Text
             selectable
-            className="text-[15px] leading-[21px]"
+            className="text-base leading-[21px]"
             style={{ color: props.colors.text }}
           >
             {props.comment.text}

--- a/apps/mobile/src/features/threads/ThreadNavigationDrawer.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationDrawer.tsx
@@ -152,7 +152,7 @@ export function ThreadNavigationDrawer(props: {
             ]}
           >
             <View className="flex-row items-center justify-between px-4 pb-5">
-              <Text className="text-[26px] font-t3-bold">Threads</Text>
+              <Text className="text-2xl font-t3-bold">Threads</Text>
               <Pressable
                 onPress={() => {
                   props.onClose();
@@ -224,7 +224,7 @@ function ThreadNavigationDrawerContent(props: {
       {groupedThreads.map((group) => (
         <View key={group.key} className="gap-3">
           <Text
-            className="px-1 text-[15px] font-t3-bold text-foreground-muted"
+            className="px-1 text-base font-t3-bold text-foreground-muted"
             style={{ letterSpacing: -0.2 }}
           >
             {group.title}
@@ -233,9 +233,7 @@ function ThreadNavigationDrawerContent(props: {
           <View className="overflow-hidden rounded-[22px] bg-card">
             {group.threads.length === 0 ? (
               <View className="px-4 py-4">
-                <Text className="text-[14px] font-medium text-foreground-tertiary">
-                  No threads yet
-                </Text>
+                <Text className="text-sm font-medium text-foreground-tertiary">No threads yet</Text>
               </View>
             ) : (
               group.threads.map((thread, index) => {
@@ -260,11 +258,11 @@ function ThreadNavigationDrawerContent(props: {
                   >
                     <View className="flex-row items-start justify-between gap-3">
                       <View className="flex-1 gap-1">
-                        <Text className="text-[16px] font-t3-bold" numberOfLines={1}>
+                        <Text className="text-base font-t3-bold" numberOfLines={1}>
                           {thread.title}
                         </Text>
                         <Text
-                          className="text-[13px] font-medium text-foreground-muted"
+                          className="text-sm font-medium text-foreground-muted"
                           numberOfLines={1}
                         >
                           {relativeTime(thread.updatedAt ?? thread.createdAt)}

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -20,6 +20,7 @@ import { EmptyState } from "../../components/EmptyState";
 import { LoadingScreen } from "../../components/LoadingScreen";
 import { buildThreadRoutePath, buildThreadTerminalNavigation } from "../../lib/routes";
 import { scopedThreadKey } from "../../lib/scopedEntities";
+import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { connectionTone } from "../connection/connectionTone";
 
 import {
@@ -390,7 +391,7 @@ export function ThreadRouteScreen() {
                 numberOfLines={1}
                 style={{
                   fontFamily: "DMSans_700Bold",
-                  fontSize: 18,
+                  fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
                   fontWeight: "900",
                   color: foregroundColor,
                   letterSpacing: -0.4,
@@ -402,7 +403,7 @@ export function ThreadRouteScreen() {
                 numberOfLines={1}
                 style={{
                   fontFamily: "DMSans_700Bold",
-                  fontSize: 12,
+                  fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
                   fontWeight: "700",
                   color: secondaryFg,
                   letterSpacing: 0.3,

--- a/apps/mobile/src/features/threads/git/GitBranchesSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitBranchesSheet.tsx
@@ -69,7 +69,7 @@ export function GitBranchesSheet() {
     >
       <View className="gap-2 rounded-[18px] border border-border bg-card px-4 py-4">
         <Text
-          className="text-foreground-secondary text-[11px] font-t3-bold uppercase"
+          className="text-foreground-secondary text-2xs font-t3-bold uppercase"
           style={{ letterSpacing: 1 }}
         >
           New branch
@@ -78,7 +78,7 @@ export function GitBranchesSheet() {
           value={newBranchName}
           onChangeText={setNewBranchName}
           placeholder="feature/mobile-polish"
-          className="rounded-[18px] px-3.5 py-3 font-sans text-[15px]"
+          className="rounded-[18px] px-3.5 py-3 font-sans text-base"
           style={{
             borderWidth: 1,
             borderColor: inputBorderColor,
@@ -104,7 +104,7 @@ export function GitBranchesSheet() {
 
       <View className="gap-2 rounded-[18px] border border-border bg-card px-4 py-4">
         <Text
-          className="text-foreground-secondary text-[11px] font-t3-bold uppercase"
+          className="text-foreground-secondary text-2xs font-t3-bold uppercase"
           style={{ letterSpacing: 1 }}
         >
           New worktree
@@ -113,7 +113,7 @@ export function GitBranchesSheet() {
           value={worktreeBaseBranch}
           onChangeText={setWorktreeBaseBranch}
           placeholder="main"
-          className="rounded-[18px] px-3.5 py-3 font-sans text-[15px]"
+          className="rounded-[18px] px-3.5 py-3 font-sans text-base"
           style={{
             borderWidth: 1,
             borderColor: inputBorderColor,
@@ -125,7 +125,7 @@ export function GitBranchesSheet() {
           value={worktreeBranchName}
           onChangeText={setWorktreeBranchName}
           placeholder="feature/mobile-thread"
-          className="rounded-[18px] px-3.5 py-3 font-sans text-[15px]"
+          className="rounded-[18px] px-3.5 py-3 font-sans text-base"
           style={{
             borderWidth: 1,
             borderColor: inputBorderColor,
@@ -154,18 +154,16 @@ export function GitBranchesSheet() {
 
       <View className="gap-2">
         <Text
-          className="text-foreground-secondary text-[11px] font-t3-bold uppercase"
+          className="text-foreground-secondary text-2xs font-t3-bold uppercase"
           style={{ letterSpacing: 1 }}
         >
           Existing branches
         </Text>
         {branchesLoading ? (
-          <Text className="text-foreground-secondary text-[13px] font-medium">
-            Loading branches...
-          </Text>
+          <Text className="text-foreground-secondary text-sm font-medium">Loading branches...</Text>
         ) : null}
         {!branchesLoading && availableBranches.length === 0 ? (
-          <Text className="text-foreground-secondary text-[13px] font-medium">
+          <Text className="text-foreground-secondary text-sm font-medium">
             No local branches found.
           </Text>
         ) : null}
@@ -195,8 +193,8 @@ export function GitBranchesSheet() {
               }}
             >
               <View className="absolute inset-0 rounded-[18px] bg-card" />
-              <Text className="text-foreground text-[15px] font-t3-bold">{branch.name}</Text>
-              <Text className="text-foreground-secondary text-[12px] font-medium">{subtitle}</Text>
+              <Text className="text-foreground text-base font-t3-bold">{branch.name}</Text>
+              <Text className="text-foreground-secondary text-xs font-medium">{subtitle}</Text>
             </Pressable>
           );
         })}

--- a/apps/mobile/src/features/threads/git/GitCommitSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitCommitSheet.tsx
@@ -79,14 +79,14 @@ export function GitCommitSheet() {
     >
       <View className="gap-3 rounded-[22px] border border-border bg-card px-4 py-4">
         <View className="flex-row items-center justify-between gap-3">
-          <Text className="text-foreground-muted text-[13px] font-medium">Branch</Text>
-          <Text className="text-foreground text-[15px] font-t3-bold">
+          <Text className="text-foreground-muted text-sm font-medium">Branch</Text>
+          <Text className="text-foreground text-base font-t3-bold">
             {gitStatus.data?.refName ?? "(detached HEAD)"}
           </Text>
         </View>
         {isDefaultRef ? (
           <Text
-            className="text-[12px] leading-[18px]"
+            className="text-xs leading-[18px]"
             style={{ color: isDarkMode ? "#fbbf24" : "#b45309" }}
           >
             Warning: this is the default branch.
@@ -97,8 +97,8 @@ export function GitCommitSheet() {
       <View className="gap-3 rounded-[22px] border border-border bg-card px-4 py-4">
         <View className="flex-row items-center justify-between gap-3">
           <View className="gap-1">
-            <Text className="text-foreground text-[16px] font-t3-bold">Files</Text>
-            <Text className="text-foreground-muted text-[12px] leading-[18px]">
+            <Text className="text-foreground text-base font-t3-bold">Files</Text>
+            <Text className="text-foreground-muted text-xs leading-[18px]">
               {selectedFiles.length} selected · +{selectedInsertions} / -{selectedDeletions}
             </Text>
           </View>
@@ -108,14 +108,14 @@ export function GitCommitSheet() {
                 className="bg-subtle rounded-full px-3 py-2"
                 onPress={() => setExcludedFiles(new Set())}
               >
-                <Text className="text-foreground text-[11px] font-t3-bold uppercase">Reset</Text>
+                <Text className="text-foreground text-2xs font-t3-bold uppercase">Reset</Text>
               </Pressable>
             ) : null}
             <Pressable
               className="bg-subtle rounded-full px-3 py-2"
               onPress={() => setIsEditingFiles((current) => !current)}
             >
-              <Text className="text-foreground text-[11px] font-t3-bold uppercase">
+              <Text className="text-foreground text-2xs font-t3-bold uppercase">
                 {isEditingFiles ? "Done" : "Edit"}
               </Text>
             </Pressable>
@@ -123,26 +123,26 @@ export function GitCommitSheet() {
         </View>
 
         {allFiles.length === 0 ? (
-          <Text className="text-foreground-secondary text-[13px] leading-[19px]">
+          <Text className="text-foreground-secondary text-sm leading-[19px]">
             No changed files are available to commit.
           </Text>
         ) : !isEditingFiles ? (
           <View className="gap-2">
             {selectedFilePreview.map((file) => (
               <View key={file.path} className="flex-row items-center justify-between gap-3">
-                <Text className="text-foreground flex-1 text-[13px] font-medium" numberOfLines={1}>
+                <Text className="text-foreground flex-1 text-sm font-medium" numberOfLines={1}>
                   {file.path}
                 </Text>
-                <Text className="text-[12px] font-t3-bold" style={{ color: "#10b981" }}>
+                <Text className="text-xs font-t3-bold" style={{ color: "#10b981" }}>
                   +{file.insertions}
                 </Text>
-                <Text className="text-[12px] font-t3-bold" style={{ color: "#f43f5e" }}>
+                <Text className="text-xs font-t3-bold" style={{ color: "#f43f5e" }}>
                   -{file.deletions}
                 </Text>
               </View>
             ))}
             {selectedFiles.length > selectedFilePreview.length ? (
-              <Text className="text-foreground-muted text-[12px] leading-[17px]">
+              <Text className="text-foreground-muted text-xs leading-[17px]">
                 +{selectedFiles.length - selectedFilePreview.length} more files
               </Text>
             ) : null}
@@ -177,21 +177,21 @@ export function GitCommitSheet() {
                     <View className="flex-1 gap-1">
                       <Text
                         selectable
-                        className={`text-[13px] font-t3-bold ${included ? "text-foreground" : "text-foreground-muted"}`}
+                        className={`text-sm font-t3-bold ${included ? "text-foreground" : "text-foreground-muted"}`}
                       >
                         {file.path}
                       </Text>
                       {!included ? (
-                        <Text className="text-foreground-muted text-[11px] leading-[16px]">
+                        <Text className="text-foreground-muted text-2xs leading-[16px]">
                           Excluded from this commit
                         </Text>
                       ) : null}
                     </View>
                     <View className="items-end gap-1">
-                      <Text className="text-[12px] font-t3-bold" style={{ color: "#10b981" }}>
+                      <Text className="text-xs font-t3-bold" style={{ color: "#10b981" }}>
                         +{file.insertions}
                       </Text>
-                      <Text className="text-[12px] font-t3-bold" style={{ color: "#f43f5e" }}>
+                      <Text className="text-xs font-t3-bold" style={{ color: "#f43f5e" }}>
                         -{file.deletions}
                       </Text>
                     </View>
@@ -204,14 +204,14 @@ export function GitCommitSheet() {
       </View>
 
       <View className="gap-2">
-        <Text className="text-foreground text-[13px] font-t3-bold">Commit message</Text>
+        <Text className="text-foreground text-sm font-t3-bold">Commit message</Text>
         <TextInput
           multiline
           value={dialogCommitMessage}
           onChangeText={setDialogCommitMessage}
           placeholder="Leave empty to auto-generate"
           textAlignVertical="top"
-          className="min-h-[128px] rounded-[20px] px-4 py-3.5 font-sans text-[15px]"
+          className="min-h-[128px] rounded-[20px] px-4 py-3.5 font-sans text-base"
           style={{
             minHeight: 128,
             borderWidth: 1,

--- a/apps/mobile/src/features/threads/git/GitConfirmSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitConfirmSheet.tsx
@@ -90,15 +90,15 @@ export function GitConfirmSheet() {
 
       <View className="items-center gap-1 px-5 pb-3 pt-4">
         <Text
-          className="text-[12px] font-t3-bold uppercase text-foreground-muted"
+          className="text-xs font-t3-bold uppercase text-foreground-muted"
           style={{ letterSpacing: 1 }}
         >
           Confirm
         </Text>
-        <Text className="text-center text-[28px] font-t3-bold">
+        <Text className="text-center text-3xl font-t3-bold">
           {copy?.title ?? "Run action on default branch?"}
         </Text>
-        <Text className="text-center text-foreground-secondary text-[13px] font-medium leading-[19px]">
+        <Text className="text-center text-foreground-secondary text-sm font-medium leading-[19px]">
           {copy?.description ?? "Choose how to continue."}
         </Text>
       </View>

--- a/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
@@ -175,13 +175,13 @@ export function GitOverviewSheet() {
           />
         </Pressable>
         <Text
-          className="text-[12px] font-t3-bold uppercase text-foreground-muted"
+          className="text-xs font-t3-bold uppercase text-foreground-muted"
           style={{ letterSpacing: 1 }}
         >
           Branch
         </Text>
-        <Text className="text-[28px] font-t3-bold">{currentBranchLabel}</Text>
-        <Text className="text-foreground-secondary text-[13px] font-medium leading-[19px]">
+        <Text className="text-3xl font-t3-bold">{currentBranchLabel}</Text>
+        <Text className="text-foreground-secondary text-sm font-medium leading-[19px]">
           {statusSummary(gitStatus.data)}
         </Text>
       </View>

--- a/apps/mobile/src/features/threads/git/gitSheetComponents.tsx
+++ b/apps/mobile/src/features/threads/git/gitSheetComponents.tsx
@@ -56,7 +56,7 @@ export function SheetActionButton(props: {
     >
       <SymbolView name={props.icon} size={16} tintColor={colors.textColor} type="monochrome" />
       <Text
-        className="text-[12px] font-t3-bold uppercase"
+        className="text-xs font-t3-bold uppercase"
         style={{ color: colors.textColor, letterSpacing: 0.9 }}
       >
         {props.label}
@@ -69,12 +69,12 @@ export function MetaCard(props: { readonly label: string; readonly value: string
   return (
     <View className="rounded-[18px] border border-border bg-card px-4 py-3">
       <Text
-        className="text-foreground-muted text-[11px] font-t3-bold uppercase"
+        className="text-foreground-muted text-2xs font-t3-bold uppercase"
         style={{ letterSpacing: 0.9 }}
       >
         {props.label}
       </Text>
-      <Text selectable className="text-foreground text-[13px] font-medium" numberOfLines={1}>
+      <Text selectable className="text-foreground text-sm font-medium" numberOfLines={1}>
         {props.value}
       </Text>
     </View>
@@ -102,9 +102,9 @@ export function SheetListRow(props: {
         <SymbolView name={props.icon} size={16} tintColor={iconColor} type="monochrome" />
       </View>
       <View className="flex-1 gap-0.5">
-        <Text className="text-foreground text-[16px] font-t3-bold">{props.title}</Text>
+        <Text className="text-foreground text-base font-t3-bold">{props.title}</Text>
         {props.subtitle ? (
-          <Text className="text-foreground-muted text-[12px] leading-[17px]">{props.subtitle}</Text>
+          <Text className="text-foreground-muted text-xs leading-[17px]">{props.subtitle}</Text>
         ) : null}
       </View>
       <SymbolView name="chevron.right" size={13} tintColor={iconSubtleColor} type="monochrome" />

--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -98,7 +98,7 @@ export function ThreadWorkLog(props: {
   return (
     <View className="-mx-1 mb-3 px-1 py-0.5">
       {!onlyToolRows ? (
-        <Text className="px-0.5 pb-0.5 font-t3-medium text-[11px] text-foreground-muted opacity-60">
+        <Text className="px-0.5 pb-0.5 font-t3-medium text-2xs text-foreground-muted opacity-60">
           work log
         </Text>
       ) : null}
@@ -164,7 +164,7 @@ export function ThreadWorkLog(props: {
 
                   <View className="shrink-0 flex-row items-center gap-px">
                     {props.copiedRowId === row.id ? (
-                      <Text className="pr-1 font-t3-medium text-[10px] text-emerald-600 dark:text-emerald-400">
+                      <Text className="pr-1 font-t3-medium text-3xs text-emerald-600 dark:text-emerald-400">
                         Copied
                       </Text>
                     ) : null}
@@ -209,7 +209,7 @@ export function ThreadWorkLog(props: {
                   >
                     <Text
                       selectable
-                      className="text-[11px] leading-[17px] text-foreground-muted"
+                      className="text-2xs leading-[17px] text-foreground-muted"
                       style={{ fontFamily: "ui-monospace" }}
                     >
                       {row.fullDetail}

--- a/apps/mobile/src/lib/typography.test.ts
+++ b/apps/mobile/src/lib/typography.test.ts
@@ -5,8 +5,12 @@ import { MOBILE_CODE_SURFACE, MOBILE_TYPOGRAPHY } from "./typography";
 describe("mobile typography", () => {
   it("uses the intentional compact mobile font scale", () => {
     expect(Object.values(MOBILE_TYPOGRAPHY).map(({ fontSize }) => fontSize)).toEqual([
-      10, 11, 12, 13, 15, 17, 20, 24, 28,
+      10, 11, 12, 13, 14, 15, 17, 20, 24, 28,
     ]);
+  });
+
+  it("uses a compact shared style for editable composer text", () => {
+    expect(MOBILE_TYPOGRAPHY.composer).toEqual({ fontSize: 14, lineHeight: 20 });
   });
 
   it("uses caption-sized code with a compact readable row height", () => {

--- a/apps/mobile/src/lib/typography.test.ts
+++ b/apps/mobile/src/lib/typography.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { MOBILE_CODE_SURFACE, MOBILE_TYPOGRAPHY } from "./typography";
+
+describe("mobile typography", () => {
+  it("uses the intentional compact mobile font scale", () => {
+    expect(Object.values(MOBILE_TYPOGRAPHY).map(({ fontSize }) => fontSize)).toEqual([
+      10, 11, 12, 13, 15, 17, 20, 24, 28,
+    ]);
+  });
+
+  it("uses caption-sized code with a compact readable row height", () => {
+    expect(MOBILE_CODE_SURFACE).toMatchObject({
+      fontSize: MOBILE_TYPOGRAPHY.caption.fontSize,
+      lineNumberFontSize: MOBILE_TYPOGRAPHY.micro.fontSize,
+      rowHeight: 20,
+    });
+  });
+});

--- a/apps/mobile/src/lib/typography.ts
+++ b/apps/mobile/src/lib/typography.ts
@@ -3,6 +3,7 @@ export const MOBILE_TYPOGRAPHY = {
   caption: { fontSize: 11, lineHeight: 15 },
   label: { fontSize: 12, lineHeight: 16 },
   footnote: { fontSize: 13, lineHeight: 18 },
+  composer: { fontSize: 14, lineHeight: 20 },
   body: { fontSize: 15, lineHeight: 22 },
   headline: { fontSize: 17, lineHeight: 22 },
   title: { fontSize: 20, lineHeight: 26 },

--- a/apps/mobile/src/lib/typography.ts
+++ b/apps/mobile/src/lib/typography.ts
@@ -1,0 +1,21 @@
+export const MOBILE_TYPOGRAPHY = {
+  micro: { fontSize: 10, lineHeight: 13 },
+  caption: { fontSize: 11, lineHeight: 15 },
+  label: { fontSize: 12, lineHeight: 16 },
+  footnote: { fontSize: 13, lineHeight: 18 },
+  body: { fontSize: 15, lineHeight: 22 },
+  headline: { fontSize: 17, lineHeight: 22 },
+  title: { fontSize: 20, lineHeight: 26 },
+  largeTitle: { fontSize: 24, lineHeight: 30 },
+  display: { fontSize: 28, lineHeight: 34 },
+} as const;
+
+/** Shared geometry for dense, horizontally scrolling code surfaces. */
+export const MOBILE_CODE_SURFACE = {
+  rowHeight: 20,
+  gutterWidth: 46,
+  codePadding: 7,
+  textVerticalInset: 2,
+  fontSize: MOBILE_TYPOGRAPHY.caption.fontSize,
+  lineNumberFontSize: MOBILE_TYPOGRAPHY.micro.fontSize,
+} as const;

--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -6,6 +6,7 @@ import { Image, StyleSheet } from "react-native";
 
 import { markdownFileIconSource } from "@t3tools/mobile-markdown-text/file-icons";
 import { resolveMarkdownFileIcon } from "@t3tools/mobile-markdown-text/links";
+import { MOBILE_TYPOGRAPHY } from "../lib/typography";
 import { useThemeColor } from "../lib/useThemeColor";
 import type { ComposerEditorProps, ComposerEditorSelection } from "./T3ComposerEditor.types";
 
@@ -150,9 +151,15 @@ export function ComposerEditor({
           ? resolvedTextStyle.fontFamily
           : "DMSans_400Regular"
       }
-      fontSize={typeof resolvedTextStyle.fontSize === "number" ? resolvedTextStyle.fontSize : 15}
+      fontSize={
+        typeof resolvedTextStyle.fontSize === "number"
+          ? resolvedTextStyle.fontSize
+          : MOBILE_TYPOGRAPHY.composer.fontSize
+      }
       lineHeight={
-        typeof resolvedTextStyle.lineHeight === "number" ? resolvedTextStyle.lineHeight : 22
+        typeof resolvedTextStyle.lineHeight === "number"
+          ? resolvedTextStyle.lineHeight
+          : MOBILE_TYPOGRAPHY.composer.lineHeight
       }
       contentInsetVertical={contentInsetVertical}
       editable={props.editable ?? true}

--- a/apps/mobile/src/native/T3ComposerEditor.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.tsx
@@ -48,7 +48,7 @@ export function ComposerEditor({
             minHeight: 0,
             color: foregroundColor,
             fontFamily: "DMSans_400Regular",
-            ...MOBILE_TYPOGRAPHY.body,
+            ...MOBILE_TYPOGRAPHY.composer,
             paddingVertical: contentInsetVertical,
           },
           textStyle,

--- a/apps/mobile/src/native/T3ComposerEditor.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.tsx
@@ -2,6 +2,7 @@ import { TextInputWrapper } from "expo-paste-input";
 import { useImperativeHandle, useRef } from "react";
 import { TextInput, type TextInput as RNTextInput } from "react-native";
 
+import { MOBILE_TYPOGRAPHY } from "../lib/typography";
 import { useThemeColor } from "../lib/useThemeColor";
 import { useNativePaste } from "../lib/useNativePaste";
 import type { ComposerEditorProps } from "./T3ComposerEditor.types";
@@ -47,8 +48,7 @@ export function ComposerEditor({
             minHeight: 0,
             color: foregroundColor,
             fontFamily: "DMSans_400Regular",
-            fontSize: 15,
-            lineHeight: 22,
+            ...MOBILE_TYPOGRAPHY.body,
             paddingVertical: contentInsetVertical,
           },
           textStyle,


### PR DESCRIPTION
## Summary
- Introduce shared mobile typography tokens in `apps/mobile/src/lib/typography.ts` and align web `global.css` text scales to match.
- Replace scattered hard-coded font sizes across mobile screens and components with the shared typography scale.
- Update code and content surfaces to use shared code-surface measurements for line height, gutter width, and font sizing.
- Add tests covering the new typography token helpers and the native source file adapter behavior.

## Testing
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`
- `vp test` or `vp run test`
- Not run: I did not execute the repository commands in this branch while drafting this PR description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad visual typography changes across most screens; code/diff readability may shift due to smaller rows and font-weight changes on syntax tokens.
> 
> **Overview**
> Introduces **`MOBILE_TYPOGRAPHY`** and **`MOBILE_CODE_SURFACE`** in `typography.ts`, with matching **`text-3xs`–`text-3xl`** tokens in `global.css`, and replaces ad-hoc `text-[Npx]` classes across the mobile app with semantic scale classes.
> 
> **Composer & native editor:** Default composer text moves to **14/20**; iOS `T3ComposerEditorView` matches that and **re-applies base typing attributes** on selection/text changes so inline chips/attachments keep consistent styling.
> 
> **Code surfaces:** Source viewer, diff adapter, and feed markdown/code blocks share **`MOBILE_CODE_SURFACE`** (row height 20, compact gutter/fonts); syntax token weight shifts from medium to **regular** where applicable.
> 
> **Tooling:** SwiftLint now includes the composer editor module; tests lock the typography scale and source/diff adapter parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 124e471ff04f78e320d37e7c1356a7e6c9dccb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify mobile typography across the app using a shared token scale
> - Introduces [typography.ts](https://github.com/pingdotgg/t3code/pull/3162/files#diff-0566755a3e133690dcd7b810ba63aee8374074ff8cf960d81d0b62739e417267) exporting `MOBILE_TYPOGRAPHY` (font size/line height pairs) and `MOBILE_CODE_SURFACE` (code viewer geometry), and adds matching CSS custom properties in [global.css](https://github.com/pingdotgg/t3code/pull/3162/files#diff-7866ed7dabc2533089bba8b32fc861187ccbafd1ab2ef9bb833bc842a07bdf96) for Tailwind utility classes (`text-3xs` through `text-3xl`).
> - Replaces hardcoded pixel-based Tailwind classes (e.g. `text-[13px]`) and inline `fontSize`/`lineHeight` style values with the new tokens across all mobile screens, components, and feature areas.
> - Aligns code surface rendering (diff viewer, source viewer, terminal) to `MOBILE_CODE_SURFACE` metrics for consistent row height, gutter width, and font sizes.
> - Updates the iOS `T3ComposerEditorView` default font size from 15→14 and line height from 22→20, and adds `restoreBaseTypingAttributes()` calls to prevent attribute drift on selection change and controlled updates.
> - Risk: Visual font sizes change throughout the app wherever tokenized values differ from previous hardcoded pixel values; the composer editor size reduction (15/22 → 14/20) affects all platforms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 124e471.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->