### PR TITLE
Share thread state idle TTL across client atoms

### DIFF
--- a/packages/client-runtime/src/state/threadDetail.ts
+++ b/packages/client-runtime/src/state/threadDetail.ts
@@ -15,12 +15,12 @@ import type { EnvironmentThread, EnvironmentThreadShell } from "./models.ts";
 import { scopeThread } from "./models.ts";
 import { EMPTY_ENVIRONMENT_THREAD_STATE, type EnvironmentThreadState } from "./threads.ts";
 import { parseThreadKey, threadKey } from "./entities.ts";
+import { THREAD_STATE_IDLE_TTL_MS } from "./threadRetention.ts";
 
 const EMPTY_MESSAGES: ReadonlyArray<OrchestrationMessage> = Object.freeze([]);
 const EMPTY_ACTIVITIES: ReadonlyArray<OrchestrationThreadActivity> = Object.freeze([]);
 const EMPTY_PROPOSED_PLANS: ReadonlyArray<OrchestrationProposedPlan> = Object.freeze([]);
 const EMPTY_CHECKPOINTS: ReadonlyArray<OrchestrationCheckpointSummary> = Object.freeze([]);
-const THREAD_DETAIL_IDLE_TTL_MS = 5 * 60_000;
 
 /**
  * Combine detail-only collections with the shell's authoritative thread metadata.
@@ -75,7 +75,7 @@ export function createEnvironmentThreadDetailAtoms<E>(
         () => EMPTY_ENVIRONMENT_THREAD_STATE,
       ),
     ).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-state-value:${key}`),
     );
   });
@@ -93,21 +93,21 @@ export function createEnvironmentThreadDetailAtoms<E>(
       previousValue = source === null ? null : scopeThread(ref.environmentId, source);
       return previousValue;
     }).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-detail:${key}`),
     );
   });
 
   const threadStatusAtomFamily = Atom.family((key: string) =>
     Atom.make((get) => get(threadStateValueAtomFamily(key)).status).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-status:${key}`),
     ),
   );
 
   const threadErrorAtomFamily = Atom.family((key: string) =>
     Atom.make((get) => Option.getOrNull(get(threadStateValueAtomFamily(key)).error)).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-error:${key}`),
     ),
   );
@@ -117,7 +117,7 @@ export function createEnvironmentThreadDetailAtoms<E>(
       (get): ReadonlyArray<OrchestrationMessage> =>
         get(threadDetailAtomFamily(key))?.messages ?? EMPTY_MESSAGES,
     ).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-messages:${key}`),
     ),
   );
@@ -127,7 +127,7 @@ export function createEnvironmentThreadDetailAtoms<E>(
       (get): ReadonlyArray<OrchestrationThreadActivity> =>
         get(threadDetailAtomFamily(key))?.activities ?? EMPTY_ACTIVITIES,
     ).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-activities:${key}`),
     ),
   );
@@ -137,7 +137,7 @@ export function createEnvironmentThreadDetailAtoms<E>(
       (get): ReadonlyArray<OrchestrationProposedPlan> =>
         get(threadDetailAtomFamily(key))?.proposedPlans ?? EMPTY_PROPOSED_PLANS,
     ).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-proposed-plans:${key}`),
     ),
   );
@@ -147,7 +147,7 @@ export function createEnvironmentThreadDetailAtoms<E>(
       (get): ReadonlyArray<OrchestrationCheckpointSummary> =>
         get(threadDetailAtomFamily(key))?.checkpoints ?? EMPTY_CHECKPOINTS,
     ).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-checkpoints:${key}`),
     ),
   );
@@ -156,7 +156,7 @@ export function createEnvironmentThreadDetailAtoms<E>(
     Atom.make(
       (get): OrchestrationSession | null => get(threadDetailAtomFamily(key))?.session ?? null,
     ).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-session:${key}`),
     ),
   );
@@ -165,7 +165,7 @@ export function createEnvironmentThreadDetailAtoms<E>(
     Atom.make(
       (get): OrchestrationLatestTurn | null => get(threadDetailAtomFamily(key))?.latestTurn ?? null,
     ).pipe(
-      Atom.setIdleTTL(THREAD_DETAIL_IDLE_TTL_MS),
+      Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
       Atom.withLabel(`environment-thread-latest-turn:${key}`),
     ),
   );

--- a/packages/client-runtime/src/state/threadRetention.ts
+++ b/packages/client-runtime/src/state/threadRetention.ts
@@ -1,0 +1,3 @@
+// Mobile thread routes unmount during back navigation. Retain the stream-backed
+// state across short subscriber gaps without keeping every opened thread alive.
+export const THREAD_STATE_IDLE_TTL_MS = 5 * 60_000;

--- a/packages/client-runtime/src/state/threads-atoms.test.ts
+++ b/packages/client-runtime/src/state/threads-atoms.test.ts
@@ -1,0 +1,26 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as Layer from "effect/Layer";
+import { Atom } from "effect/unstable/reactivity";
+
+import type { EnvironmentRegistry } from "../connection/registry.ts";
+import type { EnvironmentCacheStore } from "../platform/persistence.ts";
+import { THREAD_STATE_IDLE_TTL_MS } from "./threadRetention.ts";
+import { createEnvironmentThreadStateAtoms } from "./threads.ts";
+
+describe("createEnvironmentThreadStateAtoms", () => {
+  it("retains thread state across short subscriber gaps", () => {
+    const runtime = Atom.runtime(Layer.empty) as unknown as Atom.AtomRuntime<
+      EnvironmentRegistry | EnvironmentCacheStore,
+      never
+    >;
+    const threads = createEnvironmentThreadStateAtoms(runtime);
+    const environmentId = EnvironmentId.make("environment-1");
+    const threadId = ThreadId.make("thread-1");
+    const atom = threads.stateAtom(environmentId, threadId);
+
+    expect(atom.idleTTL).toBe(THREAD_STATE_IDLE_TTL_MS);
+    expect(threads.stateAtom(environmentId, threadId)).toBe(atom);
+    expect(threads.stateAtom(environmentId, ThreadId.make("thread-2"))).not.toBe(atom);
+  });
+});

--- a/packages/client-runtime/src/state/threads.ts
+++ b/packages/client-runtime/src/state/threads.ts
@@ -21,6 +21,7 @@ import { EnvironmentSupervisor } from "../connection/supervisor.ts";
 import { EnvironmentCacheStore } from "../platform/persistence.ts";
 import { subscribe } from "../rpc/client.ts";
 import { applyThreadDetailEvent } from "./threadReducer.ts";
+import { THREAD_STATE_IDLE_TTL_MS } from "./threadRetention.ts";
 import { followStreamInEnvironment } from "./runtime.ts";
 
 export type EnvironmentThreadStatus = "empty" | "cached" | "synchronizing" | "live" | "deleted";
@@ -249,9 +250,14 @@ export function createEnvironmentThreadStateAtoms<R, E>(
 ) {
   const family = Atom.family((key: string) => {
     const { environmentId, threadId } = parseThreadAtomKey(key);
-    return runtime.atom(threadStateChanges(environmentId, threadId), {
-      initialValue: EMPTY_ENVIRONMENT_THREAD_STATE,
-    });
+    return runtime
+      .atom(threadStateChanges(environmentId, threadId), {
+        initialValue: EMPTY_ENVIRONMENT_THREAD_STATE,
+      })
+      .pipe(
+        Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS),
+        Atom.withLabel(`environment-thread-state:${key}`),
+      );
   });
 
   return {


### PR DESCRIPTION
## Summary
- Extracted the thread idle retention window into a shared `THREAD_STATE_IDLE_TTL_MS` constant.
- Applied the shared TTL to thread state atoms and all thread detail-derived atoms for consistent retention behavior.
- Added a regression test covering thread state atom idle TTL and family caching behavior.

## Testing
- `vp check`
- `vp run typecheck`
- `vp run lint`
- `vp test packages/client-runtime/src/state/threads-atoms.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side atom caching/retention only; behavior change is bounded TTL alignment and slightly longer retention for primary thread state atoms.
> 
> **Overview**
> Introduces **`THREAD_STATE_IDLE_TTL_MS`** (5 minutes) in `threadRetention.ts` so stream-backed thread state and all thread-detail-derived atoms use the same idle retention window—aimed at keeping thread data alive across brief subscriber gaps (e.g. mobile back navigation) without retaining every opened thread indefinitely.
> 
> **`createEnvironmentThreadStateAtoms`** now pipes **`Atom.setIdleTTL`** and a debug label onto each per-thread state atom; detail atoms in `threadDetail.ts` switch from a local constant to the shared one. A small test asserts the TTL value and **`Atom.family`** identity per environment/thread pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5fe4563abf02c37fedea53a64a7c0e4b2112254. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Share idle TTL constant across thread state client atoms
> - Extracts a shared `THREAD_STATE_IDLE_TTL_MS` constant (5 minutes) into a new [threadRetention.ts](https://github.com/pingdotgg/t3code/pull/3163/files#diff-bb865fdf1b8c850c42ef9e8964f7466d4a4bd932bf9a54ba73db58662e8b1d1d) module, replacing the local copy in [threadDetail.ts](https://github.com/pingdotgg/t3code/pull/3163/files#diff-81802f19dec9af93c9d0340dd9731bea2093279e1fbd4feda5e0eaf67b4564c7).
> - Updates `createEnvironmentThreadStateAtoms` in [threads.ts](https://github.com/pingdotgg/t3code/pull/3163/files#diff-3389d9e86e5f65222bc1be800d0aa21f5356629eaf916680112dcbd606822815) to apply `Atom.setIdleTTL(THREAD_STATE_IDLE_TTL_MS)` and a descriptive label to each atom in the family — previously these atoms had no idle TTL or label.
> - Adds tests in [threads-atoms.test.ts](https://github.com/pingdotgg/t3code/pull/3163/files#diff-8989fd45265b2dffbb3c8416490e37c45ae35eb5152cf782f838f594dca2fc9b) verifying the idle TTL value and atom family memoization behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c5fe456.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->