### PR TITLE
fix(server): resolve provider update command spawns

### DIFF
--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, assert } from "@effect/vitest";
+import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { SpawnExecutableResolution } from "@t3tools/shared/shell";
 import {
   ProviderDriverKind,
   ProviderInstanceId,
@@ -16,7 +18,7 @@ import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { HttpClient, HttpClientResponse } from "effect/unstable/http";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { ProviderRegistry, type ProviderRegistryShape } from "./Services/ProviderRegistry.ts";
 import * as ProviderMaintenanceRunner from "./providerMaintenanceRunner.ts";
@@ -34,6 +36,7 @@ const CODEX_INSTANCE_ID = ProviderInstanceId.make("codex");
 const CURSOR_INSTANCE_ID = ProviderInstanceId.make("cursor");
 const OPENCODE_INSTANCE_ID = ProviderInstanceId.make("opencode");
 const encoder = new TextEncoder();
+const linuxHostPlatformLayer = Layer.succeed(HostProcessPlatform, "linux");
 
 function lifecycleFor(provider: ProviderDriverKind): ProviderMaintenanceCapabilities {
   if (provider === CURSOR_DRIVER) {
@@ -121,6 +124,7 @@ function mockSpawnerLayer(
   handler: (
     command: string,
     args: ReadonlyArray<string>,
+    options: ChildProcess.CommandOptions,
   ) => {
     readonly stdout?: string;
     readonly stderr?: string;
@@ -134,8 +138,11 @@ function mockSpawnerLayer(
       const childProcess = command as unknown as {
         readonly command: string;
         readonly args: ReadonlyArray<string>;
+        readonly options: ChildProcess.CommandOptions;
       };
-      return Effect.succeed(mockHandle(handler(childProcess.command, childProcess.args)));
+      return Effect.succeed(
+        mockHandle(handler(childProcess.command, childProcess.args, childProcess.options)),
+      );
     }),
   );
 }
@@ -230,6 +237,7 @@ describe("providerMaintenanceRunner", () => {
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
+          linuxHostPlatformLayer,
           latestVersionHttpClient("0.0.0"),
           mockSpawnerLayer((command, args) => {
             calls.push({ command, args });
@@ -279,6 +287,7 @@ describe("providerMaintenanceRunner", () => {
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
+          linuxHostPlatformLayer,
           latestVersionHttpClient("0.0.0"),
           mockSpawnerLayer((command, args) => {
             calls.push({ command, args });
@@ -309,6 +318,7 @@ describe("providerMaintenanceRunner", () => {
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
+            linuxHostPlatformLayer,
             latestVersionHttpClient("0.0.0"),
             mockSpawnerLayer((command, args) => {
               calls.push({ command, args });
@@ -319,6 +329,49 @@ describe("providerMaintenanceRunner", () => {
       );
     },
   );
+
+  it.effect("resolves Windows command shims before spawning update commands", () => {
+    const calls: Array<{
+      command: string;
+      args: ReadonlyArray<string>;
+      shell: ChildProcess.CommandOptions["shell"];
+    }> = [];
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry(baseProvider);
+      const runner = yield* makeTestRunner(registry);
+
+      const result = yield* runner.updateProvider(CODEX_DRIVER);
+
+      assert.deepStrictEqual(calls, [
+        {
+          command: '^"C:\\nvm4w\\nodejs\\npm.cmd^"',
+          args: ['^"install^"', '^"-g^"', '^"@openai/codex@latest^"'],
+          shell: true,
+        },
+      ]);
+      assert.strictEqual(result.providers[0]?.updateState?.status, "succeeded");
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          latestVersionHttpClient("0.0.0"),
+          mockSpawnerLayer((command, args, options) => {
+            calls.push({ command, args, shell: options.shell });
+            return { stdout: "updated" };
+          }),
+        ),
+      ),
+      Effect.provideService(HostProcessPlatform, "win32"),
+      Effect.provideService(HostProcessEnvironment, {
+        PATH: "C:\\nvm4w\\nodejs",
+        PATHEXT: ".COM;.EXE;.BAT;.CMD",
+      }),
+      Effect.provideService(SpawnExecutableResolution, (command, platform, env) =>
+        command === "npm" && platform === "win32" && env.PATH === "C:\\nvm4w\\nodejs"
+          ? "C:\\nvm4w\\nodejs\\npm.cmd"
+          : undefined,
+      ),
+    );
+  });
 
   it.effect("updates a single provider instance without touching sibling instances", () => {
     const calls: Array<{ command: string; args: ReadonlyArray<string> }> = [];
@@ -381,6 +434,7 @@ describe("providerMaintenanceRunner", () => {
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
+          linuxHostPlatformLayer,
           latestVersionHttpClient("0.124.0-alpha.3"),
           mockSpawnerLayer((command, args) => {
             calls.push({ command, args });
@@ -405,6 +459,7 @@ describe("providerMaintenanceRunner", () => {
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
+          linuxHostPlatformLayer,
           latestVersionHttpClient("0.0.0"),
           mockSpawnerLayer(() => ({ stderr: "permission denied", code: 1 })),
         ),
@@ -430,6 +485,7 @@ describe("providerMaintenanceRunner", () => {
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
+            linuxHostPlatformLayer,
             latestVersionHttpClient("9.9.9"),
             mockSpawnerLayer(() => ({ stdout: "updated" })),
           ),
@@ -468,6 +524,7 @@ describe("providerMaintenanceRunner", () => {
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
+          linuxHostPlatformLayer,
           latestVersionHttpClient("0.0.0"),
           mockSpawnerLayer(() => {
             startedLatch.resolve();
@@ -544,6 +601,7 @@ describe("providerMaintenanceRunner", () => {
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
+          linuxHostPlatformLayer,
           latestVersionHttpClient("0.0.0"),
           mockSpawnerLayer((_command, args) => {
             calls.push(args.join(" "));
@@ -587,6 +645,7 @@ describe("providerMaintenanceRunner", () => {
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
+          linuxHostPlatformLayer,
           latestVersionHttpClient("0.0.0"),
           mockSpawnerLayer((_command, args) => {
             calls.push(args.join(" "));
@@ -641,6 +700,7 @@ describe("providerMaintenanceRunner", () => {
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
+            linuxHostPlatformLayer,
             latestVersionHttpClient("0.0.0"),
             mockSpawnerLayer(() => ({ stdout: "updated" })),
           ),

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -7,6 +7,7 @@ import {
   type ServerProviderUpdatedPayload,
   type ServerProviderUpdateState,
 } from "@t3tools/contracts";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Data from "effect/Data";
@@ -75,8 +76,13 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
   }) {
     const collectCommandResult = Effect.fn("ProviderMaintenanceRunner.collectCommandResult")(
       function* () {
+        const spawnCommand = yield* resolveSpawnCommand(input.command, input.args);
         const child = yield* input.spawner
-          .spawn(ChildProcess.make(input.command, [...input.args]))
+          .spawn(
+            ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+              shell: spawnCommand.shell,
+            }),
+          )
           .pipe(
             Effect.mapError(
               (cause) =>


### PR DESCRIPTION
## Summary

Provider update commands now go through the shared `resolveSpawnCommand` path before `ChildProcess.make`, matching the provider/runtime process paths that already handle Windows `.cmd` and `.bat` shims.

## Why

On Windows, package-manager commands such as `npm` often resolve to shim files like `npm.cmd`. The provider update runner was still spawning the raw command name, so one-click Codex updates could fail with `NotFound: ChildProcess.spawn (npm install -g @openai/codex@latest)` even though the same command worked from a terminal. This keeps the command allowlist/update flow intact while reusing the centralized shim resolution and escaping added for other process spawns. Fixes #2765.

## Validation

- `pnpm --dir apps/server exec vp test run src/provider/providerMaintenanceRunner.test.ts`
- `pnpm exec vp run --filter t3 typecheck`
- `pnpm exec vp check` passes with existing warnings outside this change

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resolve Windows command shims before spawning provider update commands
> - `ProviderMaintenanceRunner.runCommand` now calls `resolveSpawnCommand` before spawning, which may transform the command/args and set `shell: true` when the resolved executable is a `.cmd` shim on Windows.
> - Tests are updated to pass a `linuxHostPlatformLayer` to existing cases and add a new case asserting that Windows shim resolution produces the correct escaped command, args, and `shell: true`.
> - The mock spawner in tests is extended to forward `CommandOptions` to the handler, enabling assertions on spawn options.
> - Behavioral Change: on Windows, provider update commands now run via a shell when the executable resolves to a `.cmd` shim, changing the process spawning behavior for those environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60b77c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->