### PR TITLE
[codex] align relay agent activity Effect services

### DIFF
--- a/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
@@ -41,8 +41,8 @@ function target(deviceId: string): LiveActivities.TargetRow {
 }
 
 function makeLiveActivities(
-  overrides: Partial<LiveActivities.LiveActivitiesShape> = {},
-): LiveActivities.LiveActivitiesShape {
+  overrides: Partial<LiveActivities.LiveActivities["Service"]> = {},
+): LiveActivities.LiveActivities["Service"] {
   return {
     register: () => Effect.void,
     listTargets: () => Effect.succeed([]),
@@ -55,8 +55,8 @@ function makeLiveActivities(
 }
 
 function makeAgentActivityRows(
-  overrides: Partial<AgentActivityRows.AgentActivityRowsShape> = {},
-): AgentActivityRows.AgentActivityRowsShape {
+  overrides: Partial<AgentActivityRows.AgentActivityRows["Service"]> = {},
+): AgentActivityRows.AgentActivityRows["Service"] {
   return {
     upsert: () => Effect.void,
     remove: () => Effect.void,
@@ -88,8 +88,8 @@ function makeEnvironmentLinks(
 }
 
 function makeApnsDeliveries(
-  overrides: Partial<ApnsDeliveries.ApnsDeliveriesShape> = {},
-): ApnsDeliveries.ApnsDeliveriesShape {
+  overrides: Partial<ApnsDeliveries.ApnsDeliveries["Service"]> = {},
+): ApnsDeliveries.ApnsDeliveries["Service"] {
   return {
     sendForTarget: () => Effect.succeed(null),
     sendPushNotificationForTarget: () => Effect.succeed(null),
@@ -133,7 +133,8 @@ describe("AgentActivityPublisher", () => {
       remote_start_queued_at: null,
       remote_started_at: "1970-01-01T00:00:01.000Z",
     };
-    const sent: Array<Parameters<ApnsDeliveries.ApnsDeliveriesShape["sendForTarget"]>[0]> = [];
+    const sent: Array<Parameters<ApnsDeliveries.ApnsDeliveries["Service"]["sendForTarget"]>[0]> =
+      [];
     const deliveryResult: RelayDeliveryResult = {
       deviceId: "device-1",
       kind: "live_activity_update",
@@ -211,7 +212,8 @@ describe("AgentActivityPublisher", () => {
       readonly environmentId: string;
       readonly environmentPublicKey: string;
     }> = [];
-    const upserts: Array<Parameters<AgentActivityRows.AgentActivityRowsShape["upsert"]>[0]> = [];
+    const upserts: Array<Parameters<AgentActivityRows.AgentActivityRows["Service"]["upsert"]>[0]> =
+      [];
 
     return Effect.gen(function* () {
       const result = yield* Effect.gen(function* () {
@@ -302,9 +304,10 @@ describe("AgentActivityPublisher", () => {
       updatedAt: "1970-01-01T00:00:10.000Z",
     };
     const sentAggregates: Array<
-      Parameters<ApnsDeliveries.ApnsDeliveriesShape["sendForTarget"]>[0]
+      Parameters<ApnsDeliveries.ApnsDeliveries["Service"]["sendForTarget"]>[0]
     > = [];
-    const removals: Array<Parameters<AgentActivityRows.AgentActivityRowsShape["remove"]>[0]> = [];
+    const removals: Array<Parameters<AgentActivityRows.AgentActivityRows["Service"]["remove"]>[0]> =
+      [];
 
     return Effect.gen(function* () {
       const result = yield* Effect.gen(function* () {
@@ -405,10 +408,10 @@ describe("AgentActivityPublisher", () => {
       headline: "Needs input",
     };
     const liveAggregates: Array<
-      Parameters<ApnsDeliveries.ApnsDeliveriesShape["sendForTarget"]>[0]
+      Parameters<ApnsDeliveries.ApnsDeliveries["Service"]["sendForTarget"]>[0]
     > = [];
     const pushAggregates: Array<
-      Parameters<ApnsDeliveries.ApnsDeliveriesShape["sendPushNotificationForTarget"]>[0]
+      Parameters<ApnsDeliveries.ApnsDeliveries["Service"]["sendPushNotificationForTarget"]>[0]
     > = [];
 
     return Effect.gen(function* () {
@@ -517,10 +520,10 @@ describe("AgentActivityPublisher", () => {
         headline: "Needs approval",
       };
       const liveAggregates: Array<
-        Parameters<ApnsDeliveries.ApnsDeliveriesShape["sendForTarget"]>[0]
+        Parameters<ApnsDeliveries.ApnsDeliveries["Service"]["sendForTarget"]>[0]
       > = [];
       const pushAggregates: Array<
-        Parameters<ApnsDeliveries.ApnsDeliveriesShape["sendPushNotificationForTarget"]>[0]
+        Parameters<ApnsDeliveries.ApnsDeliveries["Service"]["sendPushNotificationForTarget"]>[0]
       > = [];
 
       return Effect.gen(function* () {

--- a/infra/relay/src/agentActivity/AgentActivityPublisher.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.ts
@@ -23,22 +23,20 @@ export type AgentActivityPublishError =
   | LiveActivities.LiveActivityTargetListPersistenceError
   | ApnsDeliveries.ApnsDeliveryError;
 
-export interface AgentActivityPublisherShape {
-  readonly publish: (input: {
-    readonly environmentId: string;
-    readonly environmentPublicKey: string;
-    readonly threadId: string;
-    readonly state: RelayAgentActivityState | null;
-  }) => Effect.Effect<RelayPublishResponse, AgentActivityPublishError>;
-  readonly replayForLiveActivityRegistration: (input: {
-    readonly userId: string;
-    readonly deviceId: string;
-  }) => Effect.Effect<RelayDeliveryResult | null, AgentActivityPublishError>;
-}
-
 export class AgentActivityPublisher extends Context.Service<
   AgentActivityPublisher,
-  AgentActivityPublisherShape
+  {
+    readonly publish: (input: {
+      readonly environmentId: string;
+      readonly environmentPublicKey: string;
+      readonly threadId: string;
+      readonly state: RelayAgentActivityState | null;
+    }) => Effect.Effect<RelayPublishResponse, AgentActivityPublishError>;
+    readonly replayForLiveActivityRegistration: (input: {
+      readonly userId: string;
+      readonly deviceId: string;
+    }) => Effect.Effect<RelayDeliveryResult | null, AgentActivityPublishError>;
+  }
 >()("t3code-relay/agentActivity/AgentActivityPublisher") {}
 
 const make = Effect.gen(function* () {

--- a/infra/relay/src/agentActivity/AgentActivityRows.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.ts
@@ -3,7 +3,7 @@ import { RelayAgentActivityState as RelayAgentActivityStateSchema } from "@t3too
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import { cast } from "effect/Function";
+import * as Function from "effect/Function";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
@@ -39,24 +39,26 @@ export class AgentActivityRowListPersistenceError extends Schema.TaggedErrorClas
   }
 }
 
-export interface AgentActivityRowsShape {
-  readonly upsert: (input: {
-    readonly environmentPublicKey: string;
-    readonly state: RelayAgentActivityState;
-  }) => Effect.Effect<void, AgentActivityRowUpsertPersistenceError>;
-  readonly remove: (input: {
-    readonly environmentId: string;
-    readonly environmentPublicKey: string;
-    readonly threadId: string;
-  }) => Effect.Effect<void, AgentActivityRowDeletePersistenceError>;
-  readonly listForUser: (input: {
-    readonly userId: string;
-  }) => Effect.Effect<ReadonlyArray<RelayAgentActivityState>, AgentActivityRowListPersistenceError>;
-}
-
-export class AgentActivityRows extends Context.Service<AgentActivityRows, AgentActivityRowsShape>()(
-  "t3code-relay/agentActivity/AgentActivityRows",
-) {}
+export class AgentActivityRows extends Context.Service<
+  AgentActivityRows,
+  {
+    readonly upsert: (input: {
+      readonly environmentPublicKey: string;
+      readonly state: RelayAgentActivityState;
+    }) => Effect.Effect<void, AgentActivityRowUpsertPersistenceError>;
+    readonly remove: (input: {
+      readonly environmentId: string;
+      readonly environmentPublicKey: string;
+      readonly threadId: string;
+    }) => Effect.Effect<void, AgentActivityRowDeletePersistenceError>;
+    readonly listForUser: (input: {
+      readonly userId: string;
+    }) => Effect.Effect<
+      ReadonlyArray<RelayAgentActivityState>,
+      AgentActivityRowListPersistenceError
+    >;
+  }
+>()("t3code-relay/agentActivity/AgentActivityRows") {}
 
 const decodeJsonString = Schema.decodeEffect(Schema.UnknownFromJsonString);
 const encodeJsonValue = Schema.encodeEffect(Schema.UnknownFromJsonString);
@@ -82,7 +84,7 @@ const make = Effect.gen(function* () {
         const now = yield* DateTime.now;
         const stateJson = yield* encodeRelayAgentActivityStateJson(input.state).pipe(
           Effect.flatMap(decodeJsonString),
-          Effect.map(cast<unknown, RelayAgentActivityState>),
+          Effect.map(Function.cast<unknown, RelayAgentActivityState>),
         );
         yield* db
           .insert(relayAgentActivityRows)

--- a/infra/relay/src/agentActivity/ApnsClient.ts
+++ b/infra/relay/src/agentActivity/ApnsClient.ts
@@ -8,8 +8,10 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
-import { Headers, HttpClient, HttpClientRequest } from "effect/unstable/http";
-import * as RelayConfiguration from "../Config.ts";
+import * as Headers from "effect/unstable/http/Headers";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type * as RelayConfiguration from "../Config.ts";
 import type { ApnsNotificationPayload } from "./apnsDeliveryJobs.ts";
 
 const LIVE_ACTIVITY_NAME = "AgentActivity";
@@ -231,29 +233,28 @@ function apnsReasonFromBody(body: string): string | undefined {
   });
 }
 
-export interface ApnsClientShape {
-  readonly makeLiveActivityRequest: typeof makeLiveActivityRequest;
-  readonly makePushNotificationRequest: typeof makePushNotificationRequest;
-  readonly sendLiveActivityRequest: (input: {
-    readonly credentials: RelayConfiguration.ApnsCredentials;
-    readonly request: ApnsLiveActivityRequest;
-    readonly issuedAtUnixSeconds: number;
-  }) => Effect.Effect<ApnsDeliveryResult, ApnsError>;
-  readonly sendPushNotificationRequest: (input: {
-    readonly credentials: RelayConfiguration.ApnsCredentials;
-    readonly request: ApnsPushNotificationRequest;
-    readonly issuedAtUnixSeconds: number;
-  }) => Effect.Effect<ApnsDeliveryResult, ApnsError>;
-}
-
-export class ApnsClient extends Context.Service<ApnsClient, ApnsClientShape>()(
-  "t3code-relay/agentActivity/ApnsClient",
-) {}
+export class ApnsClient extends Context.Service<
+  ApnsClient,
+  {
+    readonly makeLiveActivityRequest: typeof makeLiveActivityRequest;
+    readonly makePushNotificationRequest: typeof makePushNotificationRequest;
+    readonly sendLiveActivityRequest: (input: {
+      readonly credentials: RelayConfiguration.ApnsCredentials;
+      readonly request: ApnsLiveActivityRequest;
+      readonly issuedAtUnixSeconds: number;
+    }) => Effect.Effect<ApnsDeliveryResult, ApnsError>;
+    readonly sendPushNotificationRequest: (input: {
+      readonly credentials: RelayConfiguration.ApnsCredentials;
+      readonly request: ApnsPushNotificationRequest;
+      readonly issuedAtUnixSeconds: number;
+    }) => Effect.Effect<ApnsDeliveryResult, ApnsError>;
+  }
+>()("t3code-relay/agentActivity/ApnsClient") {}
 
 const make = Effect.gen(function* () {
   const httpClient = yield* HttpClient.HttpClient;
 
-  const sendLiveActivityRequest: ApnsClientShape["sendLiveActivityRequest"] = Effect.fn(
+  const sendLiveActivityRequest: ApnsClient["Service"]["sendLiveActivityRequest"] = Effect.fn(
     "relay.apns.send_live_activity_request",
   )(function* (input) {
     yield* Effect.annotateCurrentSpan({ "relay.apns.event": input.request.event });
@@ -288,40 +289,41 @@ const make = Effect.gen(function* () {
     };
   });
 
-  const sendPushNotificationRequest: ApnsClientShape["sendPushNotificationRequest"] = Effect.fn(
-    "relay.apns.send_push_notification_request",
-  )(function* (input) {
-    yield* Effect.annotateCurrentSpan({ "relay.apns.event": "push_notification" });
-    const jwt = yield* makeApnsJwt({
-      ...input.credentials,
-      issuedAtUnixSeconds: input.issuedAtUnixSeconds,
+  const sendPushNotificationRequest: ApnsClient["Service"]["sendPushNotificationRequest"] =
+    Effect.fn("relay.apns.send_push_notification_request")(function* (input) {
+      yield* Effect.annotateCurrentSpan({ "relay.apns.event": "push_notification" });
+      const jwt = yield* makeApnsJwt({
+        ...input.credentials,
+        issuedAtUnixSeconds: input.issuedAtUnixSeconds,
+      });
+      const host =
+        input.credentials.environment === "production"
+          ? "https://api.push.apple.com"
+          : "https://api.sandbox.push.apple.com";
+      const response = yield* HttpClientRequest.post(
+        `${host}/3/device/${input.request.token}`,
+      ).pipe(
+        HttpClientRequest.setHeaders({
+          authorization: `bearer ${jwt}`,
+          "apns-priority": input.request.priority,
+          "apns-push-type": "alert",
+          "apns-topic": input.credentials.bundleId,
+        }),
+        HttpClientRequest.bodyJson(input.request.payload),
+        Effect.flatMap(httpClient.execute),
+        Effect.mapError((cause) => new ApnsHttpRequestError({ cause })),
+      );
+      const responseText = yield* response.text.pipe(
+        Effect.mapError((cause) => new ApnsHttpRequestError({ cause })),
+      );
+      const reason = apnsReasonFromBody(responseText);
+      return {
+        ok: response.status >= 200 && response.status < 300,
+        status: response.status,
+        ...(reason === undefined ? {} : { reason }),
+        apnsId: Option.getOrNull(Headers.get(response.headers, "apns-id")),
+      };
     });
-    const host =
-      input.credentials.environment === "production"
-        ? "https://api.push.apple.com"
-        : "https://api.sandbox.push.apple.com";
-    const response = yield* HttpClientRequest.post(`${host}/3/device/${input.request.token}`).pipe(
-      HttpClientRequest.setHeaders({
-        authorization: `bearer ${jwt}`,
-        "apns-priority": input.request.priority,
-        "apns-push-type": "alert",
-        "apns-topic": input.credentials.bundleId,
-      }),
-      HttpClientRequest.bodyJson(input.request.payload),
-      Effect.flatMap(httpClient.execute),
-      Effect.mapError((cause) => new ApnsHttpRequestError({ cause })),
-    );
-    const responseText = yield* response.text.pipe(
-      Effect.mapError((cause) => new ApnsHttpRequestError({ cause })),
-    );
-    const reason = apnsReasonFromBody(responseText);
-    return {
-      ok: response.status >= 200 && response.status < 300,
-      status: response.status,
-      ...(reason === undefined ? {} : { reason }),
-      apnsId: Option.getOrNull(Headers.get(response.headers, "apns-id")),
-    };
-  });
 
   return ApnsClient.of({
     makeLiveActivityRequest,

--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -141,16 +141,16 @@ function makeLayer(input: {
   readonly sourceJobClaims?: ReadonlyMap<string, DeliveryAttempts.DeliverySourceJobClaimResult>;
   readonly queuedJobs?: Array<SignedApnsDeliveryJob>;
   readonly queuedStarts?: Array<
-    Parameters<LiveActivities.LiveActivitiesShape["markStartQueued"]>[0]
+    Parameters<LiveActivities.LiveActivities["Service"]["markStartQueued"]>[0]
   >;
   readonly clearedStarts?: Array<
-    Parameters<LiveActivities.LiveActivitiesShape["clearStartQueued"]>[0]
+    Parameters<LiveActivities.LiveActivities["Service"]["clearStartQueued"]>[0]
   >;
   readonly markedDeliveries?: Array<
-    Parameters<LiveActivities.LiveActivitiesShape["markDelivery"]>[0]
+    Parameters<LiveActivities.LiveActivities["Service"]["markDelivery"]>[0]
   >;
   readonly invalidatedTokens?: Array<
-    Parameters<LiveActivities.LiveActivitiesShape["invalidateDeliveryToken"]>[0]
+    Parameters<LiveActivities.LiveActivities["Service"]["invalidateDeliveryToken"]>[0]
   >;
   readonly currentTargets?: ReadonlyArray<LiveActivities.TargetRow>;
   readonly config?: RelayConfiguration.RelayConfiguration["Service"];
@@ -227,10 +227,10 @@ describe("ApnsDeliveries", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
     const queuedJobs: Array<SignedApnsDeliveryJob> = [];
     const queuedStarts: Array<
-      Parameters<LiveActivities.LiveActivitiesShape["markStartQueued"]>[0]
+      Parameters<LiveActivities.LiveActivities["Service"]["markStartQueued"]>[0]
     > = [];
     const markedDeliveries: Array<
-      Parameters<LiveActivities.LiveActivitiesShape["markDelivery"]>[0]
+      Parameters<LiveActivities.LiveActivities["Service"]["markDelivery"]>[0]
     > = [];
 
     return Effect.gen(function* () {
@@ -933,7 +933,7 @@ describe("ApnsDeliveries", () => {
   it.effect("invalidates dead device push tokens after permanent APNs alert failures", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
     const invalidatedTokens: Array<
-      Parameters<LiveActivities.LiveActivitiesShape["invalidateDeliveryToken"]>[0]
+      Parameters<LiveActivities.LiveActivities["Service"]["invalidateDeliveryToken"]>[0]
     > = [];
     const payload = makeApnsDeliveryJobPayload({
       kind: "push_notification",
@@ -1000,7 +1000,7 @@ describe("ApnsDeliveries", () => {
   it.effect("clears queued start state when a start job fails in APNs", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
     const clearedStarts: Array<
-      Parameters<LiveActivities.LiveActivitiesShape["clearStartQueued"]>[0]
+      Parameters<LiveActivities.LiveActivities["Service"]["clearStartQueued"]>[0]
     > = [];
     const payload = makeApnsDeliveryJobPayload({
       kind: "live_activity_start",
@@ -1035,7 +1035,7 @@ describe("ApnsDeliveries", () => {
   it.effect("invalidates dead push-to-start tokens after permanent APNs start failures", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
     const invalidatedTokens: Array<
-      Parameters<LiveActivities.LiveActivitiesShape["invalidateDeliveryToken"]>[0]
+      Parameters<LiveActivities.LiveActivities["Service"]["invalidateDeliveryToken"]>[0]
     > = [];
     const payload = makeApnsDeliveryJobPayload({
       kind: "live_activity_start",
@@ -1082,7 +1082,7 @@ describe("ApnsDeliveries", () => {
   it.effect("invalidates dead Live Activity tokens after APNs unregisters them", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
     const invalidatedTokens: Array<
-      Parameters<LiveActivities.LiveActivitiesShape["invalidateDeliveryToken"]>[0]
+      Parameters<LiveActivities.LiveActivities["Service"]["invalidateDeliveryToken"]>[0]
     > = [];
     const payload = makeApnsDeliveryJobPayload({
       kind: "live_activity_update",

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -356,7 +356,7 @@ export type SendLiveActivityDeliveryInput =
     });
 
 function makeLiveActivityDeliveryRequest(
-  apns: Apns.ApnsClientShape,
+  apns: Apns.ApnsClient["Service"],
   input: SendLiveActivityDeliveryInput,
   now: DateTime.DateTime,
 ) {
@@ -391,33 +391,32 @@ function makeLiveActivityDeliveryRequest(
   }
 }
 
-export interface ApnsDeliveriesShape {
-  readonly sendForTarget: (input: {
-    readonly target: LiveActivities.TargetRow;
-    readonly aggregate: RelayAgentActivityAggregateState | null;
-    readonly nowMs: number;
-  }) => Effect.Effect<RelayDeliveryResult | null, ApnsDeliveryError>;
-  readonly sendPushNotificationForTarget: (input: {
-    readonly target: LiveActivities.TargetRow;
-    readonly aggregate: RelayAgentActivityAggregateState | null;
-  }) => Effect.Effect<RelayDeliveryResult | null, ApnsDeliveryError>;
-  readonly sendLiveActivity: (
-    input: SendLiveActivityDeliveryInput,
-  ) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryError>;
-  readonly processSignedJob: (
-    body: unknown,
-  ) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryError>;
-  readonly sendPushNotification: (input: {
-    readonly target: LiveActivityDeliveryTarget;
-    readonly token: string;
-    readonly sourceJobId?: string | null;
-    readonly notification: ApnsNotificationPayload;
-  }) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryError>;
-}
-
-export class ApnsDeliveries extends Context.Service<ApnsDeliveries, ApnsDeliveriesShape>()(
-  "t3code-relay/agentActivity/ApnsDeliveries",
-) {}
+export class ApnsDeliveries extends Context.Service<
+  ApnsDeliveries,
+  {
+    readonly sendForTarget: (input: {
+      readonly target: LiveActivities.TargetRow;
+      readonly aggregate: RelayAgentActivityAggregateState | null;
+      readonly nowMs: number;
+    }) => Effect.Effect<RelayDeliveryResult | null, ApnsDeliveryError>;
+    readonly sendPushNotificationForTarget: (input: {
+      readonly target: LiveActivities.TargetRow;
+      readonly aggregate: RelayAgentActivityAggregateState | null;
+    }) => Effect.Effect<RelayDeliveryResult | null, ApnsDeliveryError>;
+    readonly sendLiveActivity: (
+      input: SendLiveActivityDeliveryInput,
+    ) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryError>;
+    readonly processSignedJob: (
+      body: unknown,
+    ) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryError>;
+    readonly sendPushNotification: (input: {
+      readonly target: LiveActivityDeliveryTarget;
+      readonly token: string;
+      readonly sourceJobId?: string | null;
+      readonly notification: ApnsNotificationPayload;
+    }) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryError>;
+  }
+>()("t3code-relay/agentActivity/ApnsDeliveries") {}
 
 const make = Effect.gen(function* () {
   const attempts = yield* DeliveryAttempts.DeliveryAttempts;
@@ -442,7 +441,7 @@ const make = Effect.gen(function* () {
     );
   });
 
-  const sendLiveActivity: ApnsDeliveriesShape["sendLiveActivity"] = Effect.fn(
+  const sendLiveActivity: ApnsDeliveries["Service"]["sendLiveActivity"] = Effect.fn(
     "relay.apns_deliveries.send_live_activity",
   )(function* (input) {
     yield* Effect.annotateCurrentSpan({
@@ -550,7 +549,7 @@ const make = Effect.gen(function* () {
     };
   });
 
-  const sendPushNotification: ApnsDeliveriesShape["sendPushNotification"] = Effect.fn(
+  const sendPushNotification: ApnsDeliveries["Service"]["sendPushNotification"] = Effect.fn(
     "relay.apns_deliveries.send_push_notification",
   )(function* (input) {
     yield* Effect.annotateCurrentSpan({
@@ -654,14 +653,14 @@ const make = Effect.gen(function* () {
     };
   });
 
-  const processSignedJob: ApnsDeliveriesShape["processSignedJob"] = Effect.fn(
+  const processSignedJob: ApnsDeliveries["Service"]["processSignedJob"] = Effect.fn(
     "relay.apns_deliveries.process_signed_job",
   )(function* (body) {
     const signedJob = yield* decodeSignedApnsDeliveryJob(body).pipe(
       Effect.mapError(
         () =>
           new ApnsDeliveryJobInvalid({
-            message: "Invalid APNs delivery queue job.",
+            reason: "invalid-queue-payload",
           }),
       ),
     );
@@ -686,7 +685,7 @@ const make = Effect.gen(function* () {
           if (payload.aggregate === null) {
             return Effect.fail(
               new ApnsDeliveryJobInvalid({
-                message: "Live Activity start/update jobs require an aggregate.",
+                reason: "missing-live-activity-aggregate",
               }),
             );
           }
@@ -715,7 +714,7 @@ const make = Effect.gen(function* () {
           if (payload.notification === null) {
             return Effect.fail(
               new ApnsDeliveryJobInvalid({
-                message: "Push notification jobs require a notification payload.",
+                reason: "missing-push-notification",
               }),
             );
           }

--- a/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
@@ -33,34 +33,31 @@ export class ApnsDeliveryQueueSendError extends Schema.TaggedErrorClass<ApnsDeli
 
 export type ApnsDeliveryQueueError = ApnsDeliveryQueueSendError;
 
-export interface ApnsDeliveryQueueSenderShape {
-  readonly send: (body: SignedApnsDeliveryJob) => Effect.Effect<void, ApnsDeliveryQueueSendError>;
-}
-
 export class ApnsDeliveryQueueSender extends Context.Service<
   ApnsDeliveryQueueSender,
-  ApnsDeliveryQueueSenderShape
+  {
+    readonly send: (body: SignedApnsDeliveryJob) => Effect.Effect<void, ApnsDeliveryQueueSendError>;
+  }
 >()("t3code-relay/agentActivity/ApnsDeliveryQueue/ApnsDeliveryQueueSender") {}
 
-export interface ApnsDeliveryQueueShape {
-  readonly enqueueLiveActivity: (input: {
-    readonly kind: ApnsDeliveryJobPayload["kind"];
-    readonly userId: string;
-    readonly deviceId: string;
-    readonly token: string;
-    readonly aggregate: ApnsDeliveryJobPayload["aggregate"];
-  }) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryQueueError>;
-  readonly enqueuePushNotification: (input: {
-    readonly userId: string;
-    readonly deviceId: string;
-    readonly token: string;
-    readonly notification: NonNullable<ApnsDeliveryJobPayload["notification"]>;
-  }) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryQueueError>;
-}
-
-export class ApnsDeliveryQueue extends Context.Service<ApnsDeliveryQueue, ApnsDeliveryQueueShape>()(
-  "t3code-relay/agentActivity/ApnsDeliveryQueue",
-) {}
+export class ApnsDeliveryQueue extends Context.Service<
+  ApnsDeliveryQueue,
+  {
+    readonly enqueueLiveActivity: (input: {
+      readonly kind: ApnsDeliveryJobPayload["kind"];
+      readonly userId: string;
+      readonly deviceId: string;
+      readonly token: string;
+      readonly aggregate: ApnsDeliveryJobPayload["aggregate"];
+    }) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryQueueError>;
+    readonly enqueuePushNotification: (input: {
+      readonly userId: string;
+      readonly deviceId: string;
+      readonly token: string;
+      readonly notification: NonNullable<ApnsDeliveryJobPayload["notification"]>;
+    }) => Effect.Effect<RelayDeliveryResult, ApnsDeliveryQueueError>;
+  }
+>()("t3code-relay/agentActivity/ApnsDeliveryQueue") {}
 
 const make = Effect.gen(function* () {
   const sender = yield* ApnsDeliveryQueueSender;

--- a/infra/relay/src/agentActivity/DeliveryAttempts.ts
+++ b/infra/relay/src/agentActivity/DeliveryAttempts.ts
@@ -43,21 +43,20 @@ export interface DeliveryAttemptCompletionInput {
 
 export type DeliverySourceJobClaimResult = "claimed" | "completed" | "in_flight";
 
-export interface DeliveryAttemptsShape {
-  readonly record: (
-    input: DeliveryAttemptInput,
-  ) => Effect.Effect<void, DeliveryAttemptRecordPersistenceError>;
-  readonly claimSourceJob: (
-    input: DeliveryAttemptInput & { readonly sourceJobId: string },
-  ) => Effect.Effect<DeliverySourceJobClaimResult, DeliveryAttemptRecordPersistenceError>;
-  readonly completeSourceJob: (
-    input: DeliveryAttemptCompletionInput,
-  ) => Effect.Effect<void, DeliveryAttemptRecordPersistenceError>;
-}
-
-export class DeliveryAttempts extends Context.Service<DeliveryAttempts, DeliveryAttemptsShape>()(
-  "t3code-relay/agentActivity/DeliveryAttempts",
-) {}
+export class DeliveryAttempts extends Context.Service<
+  DeliveryAttempts,
+  {
+    readonly record: (
+      input: DeliveryAttemptInput,
+    ) => Effect.Effect<void, DeliveryAttemptRecordPersistenceError>;
+    readonly claimSourceJob: (
+      input: DeliveryAttemptInput & { readonly sourceJobId: string },
+    ) => Effect.Effect<DeliverySourceJobClaimResult, DeliveryAttemptRecordPersistenceError>;
+    readonly completeSourceJob: (
+      input: DeliveryAttemptCompletionInput,
+    ) => Effect.Effect<void, DeliveryAttemptRecordPersistenceError>;
+  }
+>()("t3code-relay/agentActivity/DeliveryAttempts") {}
 
 const SOURCE_JOB_CLAIM_LEASE_MINUTES = 10;
 

--- a/infra/relay/src/agentActivity/Devices.ts
+++ b/infra/relay/src/agentActivity/Devices.ts
@@ -40,23 +40,22 @@ export class DeviceListPersistenceError extends Schema.TaggedErrorClass<DeviceLi
   }
 }
 
-export interface DevicesShape {
-  readonly register: (input: {
-    readonly userId: string;
-    readonly registration: RelayDeviceRegistrationRequest;
-  }) => Effect.Effect<void, DeviceRegistrationPersistenceError>;
-  readonly unregister: (input: {
-    readonly userId: string;
-    readonly deviceId: string;
-  }) => Effect.Effect<void, DeviceUnregistrationPersistenceError>;
-  readonly listForUser: (input: {
-    readonly userId: string;
-  }) => Effect.Effect<ReadonlyArray<RelayClientDeviceRecord>, DeviceListPersistenceError>;
-}
-
-export class Devices extends Context.Service<Devices, DevicesShape>()(
-  "t3code-relay/agentActivity/Devices",
-) {}
+export class Devices extends Context.Service<
+  Devices,
+  {
+    readonly register: (input: {
+      readonly userId: string;
+      readonly registration: RelayDeviceRegistrationRequest;
+    }) => Effect.Effect<void, DeviceRegistrationPersistenceError>;
+    readonly unregister: (input: {
+      readonly userId: string;
+      readonly deviceId: string;
+    }) => Effect.Effect<void, DeviceUnregistrationPersistenceError>;
+    readonly listForUser: (input: {
+      readonly userId: string;
+    }) => Effect.Effect<ReadonlyArray<RelayClientDeviceRecord>, DeviceListPersistenceError>;
+  }
+>()("t3code-relay/agentActivity/Devices") {}
 
 const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;

--- a/infra/relay/src/agentActivity/LiveActivities.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.ts
@@ -7,7 +7,7 @@ import { RelayAgentActivityAggregateState as RelayAgentActivityAggregateStateSch
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
-import { cast } from "effect/Function";
+import * as Function from "effect/Function";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import { and, eq, sql } from "drizzle-orm";
@@ -64,41 +64,40 @@ export interface LiveActivityRow {
 
 export type TargetRow = DeviceRow & LiveActivityRow;
 
-export interface LiveActivitiesShape {
-  readonly register: (input: {
-    readonly userId: string;
-    readonly registration: RelayLiveActivityRegistrationRequest;
-  }) => Effect.Effect<void, LiveActivityRegistrationPersistenceError>;
-  readonly listTargets: (input: {
-    readonly userId: string;
-  }) => Effect.Effect<ReadonlyArray<TargetRow>, LiveActivityTargetListPersistenceError>;
-  readonly markDelivery: (input: {
-    readonly userId: string;
-    readonly deviceId: string;
-    readonly kind: RelayDeliveryKind;
-    readonly aggregate: RelayAgentActivityAggregateState | null;
-    readonly deliveredAt: string;
-  }) => Effect.Effect<void, LiveActivityDeliveryMarkPersistenceError>;
-  readonly markStartQueued: (input: {
-    readonly userId: string;
-    readonly deviceId: string;
-    readonly queuedAt: string;
-  }) => Effect.Effect<void, LiveActivityDeliveryMarkPersistenceError>;
-  readonly clearStartQueued: (input: {
-    readonly userId: string;
-    readonly deviceId: string;
-  }) => Effect.Effect<void, LiveActivityDeliveryMarkPersistenceError>;
-  readonly invalidateDeliveryToken: (input: {
-    readonly userId: string;
-    readonly deviceId: string;
-    readonly kind: RelayDeliveryKind;
-    readonly invalidatedAt: string;
-  }) => Effect.Effect<void, LiveActivityDeliveryMarkPersistenceError>;
-}
-
-export class LiveActivities extends Context.Service<LiveActivities, LiveActivitiesShape>()(
-  "t3code-relay/agentActivity/LiveActivities",
-) {}
+export class LiveActivities extends Context.Service<
+  LiveActivities,
+  {
+    readonly register: (input: {
+      readonly userId: string;
+      readonly registration: RelayLiveActivityRegistrationRequest;
+    }) => Effect.Effect<void, LiveActivityRegistrationPersistenceError>;
+    readonly listTargets: (input: {
+      readonly userId: string;
+    }) => Effect.Effect<ReadonlyArray<TargetRow>, LiveActivityTargetListPersistenceError>;
+    readonly markDelivery: (input: {
+      readonly userId: string;
+      readonly deviceId: string;
+      readonly kind: RelayDeliveryKind;
+      readonly aggregate: RelayAgentActivityAggregateState | null;
+      readonly deliveredAt: string;
+    }) => Effect.Effect<void, LiveActivityDeliveryMarkPersistenceError>;
+    readonly markStartQueued: (input: {
+      readonly userId: string;
+      readonly deviceId: string;
+      readonly queuedAt: string;
+    }) => Effect.Effect<void, LiveActivityDeliveryMarkPersistenceError>;
+    readonly clearStartQueued: (input: {
+      readonly userId: string;
+      readonly deviceId: string;
+    }) => Effect.Effect<void, LiveActivityDeliveryMarkPersistenceError>;
+    readonly invalidateDeliveryToken: (input: {
+      readonly userId: string;
+      readonly deviceId: string;
+      readonly kind: RelayDeliveryKind;
+      readonly invalidatedAt: string;
+    }) => Effect.Effect<void, LiveActivityDeliveryMarkPersistenceError>;
+  }
+>()("t3code-relay/agentActivity/LiveActivities") {}
 
 const decodeJsonString = Schema.decodeEffect(Schema.UnknownFromJsonString);
 const encodeJsonValue = Schema.encodeEffect(Schema.UnknownFromJsonString);
@@ -223,7 +222,7 @@ const make = Effect.gen(function* () {
             ? null
             : yield* encodeRelayAgentActivityAggregateStateJson(input.aggregate).pipe(
                 Effect.flatMap(decodeJsonString),
-                Effect.map(cast<unknown, RelayAgentActivityAggregateState>),
+                Effect.map(Function.cast<unknown, RelayAgentActivityAggregateState>),
               );
 
         yield* db

--- a/infra/relay/src/agentActivity/MobileRegistrations.test.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.test.ts
@@ -38,7 +38,9 @@ const device: RelayDeviceRegistrationRequest = {
   },
 };
 
-function makeDevices(overrides: Partial<Devices.DevicesShape> = {}): Devices.DevicesShape {
+function makeDevices(
+  overrides: Partial<Devices.Devices["Service"]> = {},
+): Devices.Devices["Service"] {
   return {
     register: () => Effect.void,
     unregister: () => Effect.void,
@@ -48,8 +50,8 @@ function makeDevices(overrides: Partial<Devices.DevicesShape> = {}): Devices.Dev
 }
 
 function makeLiveActivities(
-  overrides: Partial<LiveActivities.LiveActivitiesShape> = {},
-): LiveActivities.LiveActivitiesShape {
+  overrides: Partial<LiveActivities.LiveActivities["Service"]> = {},
+): LiveActivities.LiveActivities["Service"] {
   return {
     register: () => Effect.void,
     listTargets: () => Effect.succeed([]),
@@ -62,8 +64,8 @@ function makeLiveActivities(
 }
 
 function makeAgentActivityRows(
-  overrides: Partial<AgentActivityRows.AgentActivityRowsShape> = {},
-): AgentActivityRows.AgentActivityRowsShape {
+  overrides: Partial<AgentActivityRows.AgentActivityRows["Service"]> = {},
+): AgentActivityRows.AgentActivityRows["Service"] {
   return {
     upsert: () => Effect.void,
     remove: () => Effect.void,
@@ -108,8 +110,8 @@ function makeEnvironmentLinks(
 }
 
 function makeDeliveryAttempts(
-  overrides: Partial<DeliveryAttempts.DeliveryAttemptsShape> = {},
-): DeliveryAttempts.DeliveryAttemptsShape {
+  overrides: Partial<DeliveryAttempts.DeliveryAttempts["Service"]> = {},
+): DeliveryAttempts.DeliveryAttempts["Service"] {
   return {
     record: () => Effect.void,
     claimSourceJob: () => Effect.succeed("claimed"),
@@ -138,8 +140,8 @@ const config = RelayConfiguration.RelayConfiguration.of({
 });
 
 function makeRegistrationReplayLayer(input: {
-  readonly devices: Devices.DevicesShape;
-  readonly liveActivities: LiveActivities.LiveActivitiesShape;
+  readonly devices: Devices.Devices["Service"];
+  readonly liveActivities: LiveActivities.LiveActivities["Service"];
   readonly queuedJobs: Array<SignedApnsDeliveryJob>;
 }) {
   return MobileRegistrations.layer.pipe(
@@ -167,8 +169,8 @@ function makeRegistrationReplayLayer(input: {
 }
 
 function makeAgentActivityPublisher(
-  overrides: Partial<AgentActivityPublisher.AgentActivityPublisherShape> = {},
-): AgentActivityPublisher.AgentActivityPublisherShape {
+  overrides: Partial<AgentActivityPublisher.AgentActivityPublisher["Service"]> = {},
+): AgentActivityPublisher.AgentActivityPublisher["Service"] {
   return {
     publish: () => Effect.succeed({ ok: true, deliveries: [] }),
     replayForLiveActivityRegistration: () => Effect.succeed(null),
@@ -178,10 +180,10 @@ function makeAgentActivityPublisher(
 
 describe("MobileRegistrations", () => {
   it.effect("registers devices through the device persistence service", () => {
-    let registered: Parameters<Devices.DevicesShape["register"]>[0] | null = null;
+    let registered: Parameters<Devices.Devices["Service"]["register"]>[0] | null = null;
     let replayed:
       | Parameters<
-          AgentActivityPublisher.AgentActivityPublisherShape["replayForLiveActivityRegistration"]
+          AgentActivityPublisher.AgentActivityPublisher["Service"]["replayForLiveActivityRegistration"]
         >[0]
       | null = null;
 
@@ -263,7 +265,7 @@ describe("MobileRegistrations", () => {
   });
 
   it.effect("unregisters the current user's device", () => {
-    let unregistered: Parameters<Devices.DevicesShape["unregister"]>[0] | null = null;
+    let unregistered: Parameters<Devices.Devices["Service"]["unregister"]>[0] | null = null;
 
     return Effect.gen(function* () {
       const result = yield* Effect.gen(function* () {
@@ -310,10 +312,11 @@ describe("MobileRegistrations", () => {
       deviceId: "device-1" as const,
       activityPushToken: "activity-token" as const,
     };
-    let registered: Parameters<LiveActivities.LiveActivitiesShape["register"]>[0] | null = null;
+    let registered: Parameters<LiveActivities.LiveActivities["Service"]["register"]>[0] | null =
+      null;
     let replayed:
       | Parameters<
-          AgentActivityPublisher.AgentActivityPublisherShape["replayForLiveActivityRegistration"]
+          AgentActivityPublisher.AgentActivityPublisher["Service"]["replayForLiveActivityRegistration"]
         >[0]
       | null = null;
 
@@ -372,9 +375,9 @@ describe("MobileRegistrations", () => {
     () => {
       const queuedJobs: Array<SignedApnsDeliveryJob> = [];
       const queuedStarts: Array<
-        Parameters<LiveActivities.LiveActivitiesShape["markStartQueued"]>[0]
+        Parameters<LiveActivities.LiveActivities["Service"]["markStartQueued"]>[0]
       > = [];
-      const registeredDevices: Array<Parameters<Devices.DevicesShape["register"]>[0]> = [];
+      const registeredDevices: Array<Parameters<Devices.Devices["Service"]["register"]>[0]> = [];
       const devices = makeDevices({
         register: (input) =>
           Effect.sync(() => {

--- a/infra/relay/src/agentActivity/MobileRegistrations.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.ts
@@ -15,24 +15,22 @@ export type MobileRegistrationError =
   | Devices.DeviceUnregistrationPersistenceError
   | LiveActivities.LiveActivityRegistrationPersistenceError;
 
-export interface MobileRegistrationsShape {
-  readonly registerDevice: (input: {
-    readonly userId: string;
-    readonly payload: RelayDeviceRegistrationRequest;
-  }) => Effect.Effect<{ readonly ok: true }, MobileRegistrationError>;
-  readonly registerLiveActivity: (input: {
-    readonly userId: string;
-    readonly payload: RelayLiveActivityRegistrationRequest;
-  }) => Effect.Effect<{ readonly ok: true }, MobileRegistrationError>;
-  readonly unregisterDevice: (input: {
-    readonly userId: string;
-    readonly deviceId: string;
-  }) => Effect.Effect<{ readonly ok: true }, MobileRegistrationError>;
-}
-
 export class MobileRegistrations extends Context.Service<
   MobileRegistrations,
-  MobileRegistrationsShape
+  {
+    readonly registerDevice: (input: {
+      readonly userId: string;
+      readonly payload: RelayDeviceRegistrationRequest;
+    }) => Effect.Effect<{ readonly ok: true }, MobileRegistrationError>;
+    readonly registerLiveActivity: (input: {
+      readonly userId: string;
+      readonly payload: RelayLiveActivityRegistrationRequest;
+    }) => Effect.Effect<{ readonly ok: true }, MobileRegistrationError>;
+    readonly unregisterDevice: (input: {
+      readonly userId: string;
+      readonly deviceId: string;
+    }) => Effect.Effect<{ readonly ok: true }, MobileRegistrationError>;
+  }
 >()("t3code-relay/agentActivity/MobileRegistrations") {}
 
 const make = Effect.gen(function* () {

--- a/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
+++ b/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
@@ -52,9 +52,45 @@ export type SignedApnsDeliveryJob = typeof SignedApnsDeliveryJob.Type;
 export class ApnsDeliveryJobInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobInvalid>()(
   "ApnsDeliveryJobInvalid",
   {
-    message: Schema.String,
+    reason: Schema.Literals([
+      "invalid-queue-payload",
+      "missing-live-activity-aggregate",
+      "unexpected-live-activity-notification",
+      "missing-push-notification",
+      "unexpected-push-notification-aggregate",
+      "invalid-created-at",
+      "invalid-expires-at",
+      "invalid-time-window",
+      "time-window-too-long",
+      "invalid-signature",
+    ]),
   },
-) {}
+) {
+  override get message(): string {
+    switch (this.reason) {
+      case "invalid-queue-payload":
+        return "Invalid APNs delivery queue job.";
+      case "missing-live-activity-aggregate":
+        return "Live Activity start/update jobs require an aggregate.";
+      case "unexpected-live-activity-notification":
+        return "Live Activity jobs must not carry push notification payloads.";
+      case "missing-push-notification":
+        return "Push notification jobs require a notification payload.";
+      case "unexpected-push-notification-aggregate":
+        return "Push notification jobs must not carry aggregate state.";
+      case "invalid-created-at":
+        return "Invalid APNs delivery job creation time.";
+      case "invalid-expires-at":
+        return "Invalid APNs delivery job expiry.";
+      case "invalid-time-window":
+        return "Invalid APNs delivery job time window.";
+      case "time-window-too-long":
+        return "APNs delivery job time window is too long.";
+      case "invalid-signature":
+        return "Invalid APNs delivery job signature.";
+    }
+  }
+}
 
 export class ApnsDeliveryJobExpired extends Schema.TaggedErrorClass<ApnsDeliveryJobExpired>()(
   "ApnsDeliveryJobExpired",
@@ -106,31 +142,31 @@ function validatePayloadShape(payload: ApnsDeliveryJobPayload): ApnsDeliveryJobI
     case "live_activity_update":
       if (payload.aggregate === null) {
         return new ApnsDeliveryJobInvalid({
-          message: "Live Activity start/update jobs require an aggregate.",
+          reason: "missing-live-activity-aggregate",
         });
       }
       if (payload.notification !== null) {
         return new ApnsDeliveryJobInvalid({
-          message: "Live Activity jobs must not carry push notification payloads.",
+          reason: "unexpected-live-activity-notification",
         });
       }
       return null;
     case "live_activity_end":
       if (payload.notification !== null) {
         return new ApnsDeliveryJobInvalid({
-          message: "Live Activity jobs must not carry push notification payloads.",
+          reason: "unexpected-live-activity-notification",
         });
       }
       return null;
     case "push_notification":
       if (payload.notification === null) {
         return new ApnsDeliveryJobInvalid({
-          message: "Push notification jobs require a notification payload.",
+          reason: "missing-push-notification",
         });
       }
       if (payload.aggregate !== null) {
         return new ApnsDeliveryJobInvalid({
-          message: "Push notification jobs must not carry aggregate state.",
+          reason: "unexpected-push-notification-aggregate",
         });
       }
       return null;
@@ -177,19 +213,19 @@ export function verifySignedApnsDeliveryJob(input: {
   }
   const createdAt = DateTime.make(input.job.payload.createdAt);
   if (Option.isNone(createdAt)) {
-    return new ApnsDeliveryJobInvalid({ message: "Invalid APNs delivery job creation time." });
+    return new ApnsDeliveryJobInvalid({ reason: "invalid-created-at" });
   }
   const expiresAt = DateTime.make(input.job.payload.expiresAt);
   if (Option.isNone(expiresAt)) {
-    return new ApnsDeliveryJobInvalid({ message: "Invalid APNs delivery job expiry." });
+    return new ApnsDeliveryJobInvalid({ reason: "invalid-expires-at" });
   }
   const createdAtMs = createdAt.value.epochMilliseconds;
   const expiresAtMs = expiresAt.value.epochMilliseconds;
   if (expiresAtMs <= createdAtMs) {
-    return new ApnsDeliveryJobInvalid({ message: "Invalid APNs delivery job time window." });
+    return new ApnsDeliveryJobInvalid({ reason: "invalid-time-window" });
   }
   if (expiresAtMs - createdAtMs > MAX_JOB_AGE_MS) {
-    return new ApnsDeliveryJobInvalid({ message: "APNs delivery job time window is too long." });
+    return new ApnsDeliveryJobInvalid({ reason: "time-window-too-long" });
   }
   if (expiresAtMs <= input.nowMs) {
     return new ApnsDeliveryJobExpired({ expiresAt: input.job.payload.expiresAt });
@@ -199,7 +235,7 @@ export function verifySignedApnsDeliveryJob(input: {
     payload: input.job.payload,
   });
   if (!timingSafeEqualBase64Url(input.job.signature, expected)) {
-    return new ApnsDeliveryJobInvalid({ message: "Invalid APNs delivery job signature." });
+    return new ApnsDeliveryJobInvalid({ reason: "invalid-signature" });
   }
   return input.job.payload;
 }


### PR DESCRIPTION
## Summary

- Inlines the relay agent-activity service contracts on their `Context.Service` tags and replaces standalone shape references with `Service["Service"]`.
- Uses namespace imports and module-qualified access for local service modules throughout the changed files.
- Preserves the existing effectful `make` values and canonical `layer` exports without synthetic `Effect.succeed` wrappers.
- Keeps the APNs queue adapter implementation-specific as `layerCloudflareQueues`.
- Replaces free-form APNs invalid-job message data with a structured finite `reason`; the human-readable message is derived from that reason.

## Behavior

Delivery, persistence, queueing, and APNs request behavior are unchanged. The invalid-job error payload is more structured while retaining the existing messages through its getter.

## Validation

- `vp test src/agentActivity` from `infra/relay` — 8 files / 50 tests passed
- `vp check` — passed; 20 pre-existing unrelated warnings
- `vp run typecheck` — passed
- `git diff --check origin/main...HEAD` — passed
- Stale shape and named service-consumer audits — no violations
- Refactor-only test audit — no test declarations or assertions added
- Orchestration/MCP diff audit — no changes
- Review-thread audit — no unresolved threads

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly structural typing and imports; the only behavioral API shift is `ApnsDeliveryJobInvalid` exposing `reason` instead of a stored `message` field—callers that relied on serialized error data should use `reason`.
> 
> **Overview**
> Refactors relay **agent-activity** modules to match the repo’s Effect `Context.Service` pattern: standalone `*Shape` interfaces are removed and service contracts are **inlined** on each service class. Call sites and tests now type mocks and implementations via `SomeService["Service"]` instead of `SomeServiceShape`.
> 
> **`ApnsClient`** switches to submodule imports for `effect/unstable/http` (`Headers`, `HttpClient`, `HttpClientRequest`) and uses `type`-only config import; implementation typing references `ApnsClient["Service"]`.
> 
> **`ApnsDeliveryJobInvalid`** no longer stores a free-text `message` field. It carries a finite **`reason`** code (e.g. `invalid-queue-payload`, `invalid-signature`, `missing-live-activity-aggregate`); human-readable text is unchanged via a **`message` getter** mapped from `reason`. Validation and `processSignedJob` paths construct errors with reason codes.
> 
> Minor import/style updates: `Function.cast` via `effect/Function` namespace in persistence modules. **No intended change** to publish/deliver/register runtime behavior beyond the error payload shape for invalid queue jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878c7d704af0d24a764811c71a90cb908b61adfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor relay agent activity services to inline `Context.Service` types and add `reason` codes to `ApnsDeliveryJobInvalid`
> - Removes separate `*Shape` interfaces from all agent activity services (`ApnsClient`, `ApnsDeliveries`, `LiveActivities`, `AgentActivityRows`, `Devices`, etc.) and inlines the service shape directly into the `Context.Service` generic, aligning with the Effect service pattern used elsewhere in the relay.
> - Redefines `ApnsDeliveryJobInvalid` in [apnsDeliveryJobs.ts](https://github.com/pingdotgg/t3code/pull/3179/files#diff-5f124fac34224b75c7c5b17f3fcb5d9e2c9b2d881e478aab85953346e58e5fbc) to carry a `reason` field with specific literal codes (e.g. `'missing-live-activity-aggregate'`, `'invalid-signature'`) instead of a raw `message` field; `message` is now derived via a getter.
> - Updates `validatePayloadShape` and `verifySignedApnsDeliveryJob` to construct `ApnsDeliveryJobInvalid` with the new `reason` codes.
> - Behavioral Change: `ApnsDeliveryJobInvalid` error objects now expose a structured `reason` code for programmatic inspection; callers reading `.message` from the schema field will need to use the getter instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 878c7d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->