### PR TITLE
[codex] align relay foundation Effect services

### DIFF
--- a/infra/relay/alchemy.run.ts
+++ b/infra/relay/alchemy.run.ts
@@ -7,7 +7,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Planetscale from "alchemy/Planetscale";
 
-import { PlanetscaleDatabase, RelayHyperdrive } from "./src/db.ts";
+import * as RelayDb from "./src/db.ts";
 import { RelayObservability } from "./src/observability.ts";
 import { ManagedEndpointZone, RelayApiZone } from "./src/zone.ts";
 import Api from "./src/worker.ts";
@@ -24,8 +24,8 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const db = yield* PlanetscaleDatabase;
-    const hyperdrive = yield* RelayHyperdrive;
+    const db = yield* RelayDb.PlanetscaleDatabase;
+    const hyperdrive = yield* RelayDb.RelayHyperdrive;
     const managedEndpointZone = yield* ManagedEndpointZone.pipe(Effect.orDie);
     const relayApiZone = yield* RelayApiZone.pipe(Effect.orDie);
     const observability = yield* RelayObservability;

--- a/infra/relay/src/Config.ts
+++ b/infra/relay/src/Config.ts
@@ -1,4 +1,5 @@
 import * as Context from "effect/Context";
+import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 
@@ -13,20 +14,24 @@ export interface ApnsCredentials {
   readonly environment: ApnsEnvironment;
 }
 
-export interface RelayConfigurationShape {
-  readonly relayIssuer: string;
-  readonly apns: ApnsCredentials;
-  readonly clerkSecretKey: Redacted.Redacted<string>;
-  readonly clerkPublishableKey: string;
-  readonly clerkJwtAudience: string;
-  readonly apnsDeliveryJobSigningSecret: Redacted.Redacted<string>;
-  readonly cloudMintPrivateKey: Redacted.Redacted<string>;
-  readonly cloudMintPublicKey: string;
-  readonly managedEndpointBaseDomain: string | undefined;
-  readonly managedEndpointNamespace: string | undefined;
-}
-
 export class RelayConfiguration extends Context.Service<
   RelayConfiguration,
-  RelayConfigurationShape
+  {
+    readonly relayIssuer: string;
+    readonly apns: ApnsCredentials;
+    readonly clerkSecretKey: Redacted.Redacted<string>;
+    readonly clerkPublishableKey: string;
+    readonly clerkJwtAudience: string;
+    readonly apnsDeliveryJobSigningSecret: Redacted.Redacted<string>;
+    readonly cloudMintPrivateKey: Redacted.Redacted<string>;
+    readonly cloudMintPublicKey: string;
+    readonly managedEndpointBaseDomain: string | undefined;
+    readonly managedEndpointNamespace: string | undefined;
+  }
 >()("t3code-relay/Config/RelayConfiguration") {}
+
+export const make = (configuration: RelayConfiguration["Service"]) =>
+  RelayConfiguration.of(configuration);
+
+export const layer = (configuration: RelayConfiguration["Service"]) =>
+  Layer.succeed(RelayConfiguration, make(configuration));

--- a/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
@@ -66,8 +66,8 @@ function makeAgentActivityRows(
 }
 
 function makeEnvironmentLinks(
-  overrides: Partial<EnvironmentLinks.EnvironmentLinksShape> = {},
-): EnvironmentLinks.EnvironmentLinksShape {
+  overrides: Partial<EnvironmentLinks.EnvironmentLinks["Service"]> = {},
+): EnvironmentLinks.EnvironmentLinks["Service"] {
   return {
     upsert: () => Effect.void,
     listUsersForEnvironment: () => Effect.succeed(["dev:julius"]),

--- a/infra/relay/src/agentActivity/AgentActivityRows.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.ts
@@ -9,7 +9,7 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { and, desc, eq, isNull } from "drizzle-orm";
 
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayAgentActivityRows, relayEnvironmentLinks } from "../persistence/schema.ts";
 
 export class AgentActivityRowUpsertPersistenceError extends Schema.TaggedErrorClass<AgentActivityRowUpsertPersistenceError>()(
@@ -70,7 +70,7 @@ const decodeRelayAgentActivityStateJson = Schema.decodeUnknownOption(
 );
 
 const make = Effect.gen(function* () {
-  const db = yield* RelayDb;
+  const db = yield* RelayDb.RelayDb;
 
   return AgentActivityRows.of({
     upsert: Effect.fn("relay.agent_activity_rows.upsert")(

--- a/infra/relay/src/agentActivity/ApnsClient.ts
+++ b/infra/relay/src/agentActivity/ApnsClient.ts
@@ -9,7 +9,7 @@ import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import { Headers, HttpClient, HttpClientRequest } from "effect/unstable/http";
-import type { ApnsCredentials } from "../Config.ts";
+import * as RelayConfiguration from "../Config.ts";
 import type { ApnsNotificationPayload } from "./apnsDeliveryJobs.ts";
 
 const LIVE_ACTIVITY_NAME = "AgentActivity";
@@ -99,9 +99,9 @@ const encodeApnsJwtPayloadJson = Schema.encodeEffect(
 );
 
 const makeApnsJwt = Effect.fn("relay.apns.make_jwt")(function* (input: {
-  readonly teamId: ApnsCredentials["teamId"];
-  readonly keyId: ApnsCredentials["keyId"];
-  readonly privateKey: ApnsCredentials["privateKey"];
+  readonly teamId: RelayConfiguration.ApnsCredentials["teamId"];
+  readonly keyId: RelayConfiguration.ApnsCredentials["keyId"];
+  readonly privateKey: RelayConfiguration.ApnsCredentials["privateKey"];
   readonly issuedAtUnixSeconds: number;
 }) {
   const headerJson = yield* encodeApnsJwtHeaderJson({ alg: "ES256", kid: input.keyId }).pipe(
@@ -235,12 +235,12 @@ export interface ApnsClientShape {
   readonly makeLiveActivityRequest: typeof makeLiveActivityRequest;
   readonly makePushNotificationRequest: typeof makePushNotificationRequest;
   readonly sendLiveActivityRequest: (input: {
-    readonly credentials: ApnsCredentials;
+    readonly credentials: RelayConfiguration.ApnsCredentials;
     readonly request: ApnsLiveActivityRequest;
     readonly issuedAtUnixSeconds: number;
   }) => Effect.Effect<ApnsDeliveryResult, ApnsError>;
   readonly sendPushNotificationRequest: (input: {
-    readonly credentials: ApnsCredentials;
+    readonly credentials: RelayConfiguration.ApnsCredentials;
     readonly request: ApnsPushNotificationRequest;
     readonly issuedAtUnixSeconds: number;
   }) => Effect.Effect<ApnsDeliveryResult, ApnsError>;

--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -153,7 +153,7 @@ function makeLayer(input: {
     Parameters<LiveActivities.LiveActivitiesShape["invalidateDeliveryToken"]>[0]
   >;
   readonly currentTargets?: ReadonlyArray<LiveActivities.TargetRow>;
-  readonly config?: RelayConfiguration.RelayConfigurationShape;
+  readonly config?: RelayConfiguration.RelayConfiguration["Service"];
   readonly execute?: (
     request: HttpClientRequest.HttpClientRequest,
   ) => Effect.Effect<HttpClientResponse.HttpClientResponse>;
@@ -213,7 +213,7 @@ function makeLayer(input: {
               input.invalidatedTokens?.push(invalidated);
             }),
         }),
-        Layer.succeed(RelayConfiguration.RelayConfiguration, input.config ?? config),
+        RelayConfiguration.layer(input.config ?? config),
         input.execute
           ? Layer.succeed(HttpClient.HttpClient, HttpClient.make(input.execute))
           : FetchHttpClient.layer,

--- a/infra/relay/src/agentActivity/DeliveryAttempts.test.ts
+++ b/infra/relay/src/agentActivity/DeliveryAttempts.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { RelayDb, type RelayDatabase } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayDeliveryAttempts } from "../persistence/schema.ts";
 import * as DeliveryAttempts from "./DeliveryAttempts.ts";
 
@@ -20,7 +20,7 @@ describe("DeliveryAttempts", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const attempts = yield* DeliveryAttempts.DeliveryAttempts;
@@ -52,7 +52,7 @@ describe("DeliveryAttempts", () => {
       Effect.provide(
         DeliveryAttempts.layer.pipe(
           Layer.provide(NodeCryptoLayer.layer),
-          Layer.provide(Layer.succeed(RelayDb, fakeDb)),
+          Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
         ),
       ),
     );
@@ -78,7 +78,7 @@ describe("DeliveryAttempts", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const attempts = yield* DeliveryAttempts.DeliveryAttempts;
@@ -104,7 +104,7 @@ describe("DeliveryAttempts", () => {
       Effect.provide(
         DeliveryAttempts.layer.pipe(
           Layer.provide(NodeCryptoLayer.layer),
-          Layer.provide(Layer.succeed(RelayDb, fakeDb)),
+          Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
         ),
       ),
     );
@@ -135,7 +135,7 @@ describe("DeliveryAttempts", () => {
           }),
         }),
       }),
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const attempts = yield* DeliveryAttempts.DeliveryAttempts;
@@ -154,7 +154,7 @@ describe("DeliveryAttempts", () => {
       Effect.provide(
         DeliveryAttempts.layer.pipe(
           Layer.provide(NodeCryptoLayer.layer),
-          Layer.provide(Layer.succeed(RelayDb, fakeDb)),
+          Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
         ),
       ),
     );
@@ -185,7 +185,7 @@ describe("DeliveryAttempts", () => {
           }),
         }),
       }),
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const attempts = yield* DeliveryAttempts.DeliveryAttempts;
@@ -204,7 +204,7 @@ describe("DeliveryAttempts", () => {
       Effect.provide(
         DeliveryAttempts.layer.pipe(
           Layer.provide(NodeCryptoLayer.layer),
-          Layer.provide(Layer.succeed(RelayDb, fakeDb)),
+          Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
         ),
       ),
     );
@@ -246,7 +246,7 @@ describe("DeliveryAttempts", () => {
           };
         },
       }),
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const attempts = yield* DeliveryAttempts.DeliveryAttempts;
@@ -266,7 +266,7 @@ describe("DeliveryAttempts", () => {
       Effect.provide(
         DeliveryAttempts.layer.pipe(
           Layer.provide(NodeCryptoLayer.layer),
-          Layer.provide(Layer.succeed(RelayDb, fakeDb)),
+          Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
         ),
       ),
     );
@@ -290,7 +290,7 @@ describe("DeliveryAttempts", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const attempts = yield* DeliveryAttempts.DeliveryAttempts;
@@ -315,7 +315,7 @@ describe("DeliveryAttempts", () => {
       Effect.provide(
         DeliveryAttempts.layer.pipe(
           Layer.provide(NodeCryptoLayer.layer),
-          Layer.provide(Layer.succeed(RelayDb, fakeDb)),
+          Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
         ),
       ),
     );

--- a/infra/relay/src/agentActivity/DeliveryAttempts.ts
+++ b/infra/relay/src/agentActivity/DeliveryAttempts.ts
@@ -7,7 +7,7 @@ import { and, eq, isNull } from "drizzle-orm";
 import * as Crypto from "effect/Crypto";
 import * as Schema from "effect/Schema";
 
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayDeliveryAttempts } from "../persistence/schema.ts";
 
 export class DeliveryAttemptRecordPersistenceError extends Schema.TaggedErrorClass<DeliveryAttemptRecordPersistenceError>()(
@@ -84,7 +84,7 @@ function insertValues(
 }
 
 const make = Effect.gen(function* () {
-  const db = yield* RelayDb;
+  const db = yield* RelayDb.RelayDb;
   const crypto = yield* Crypto.Crypto;
 
   const isExpiredClaim = (claimedAt: string | null, now: DateTime.DateTime) => {

--- a/infra/relay/src/agentActivity/Devices.test.ts
+++ b/infra/relay/src/agentActivity/Devices.test.ts
@@ -5,7 +5,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { RelayDb, type RelayDatabase } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayLiveActivities, relayMobileDevices } from "../persistence/schema.ts";
 import * as Devices from "./Devices.ts";
 
@@ -71,7 +71,7 @@ describe("Devices", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const devices = yield* Devices.Devices;
@@ -110,7 +110,9 @@ describe("Devices", () => {
           pushToStartToken: "push-to-start-token",
         }),
       ]);
-    }).pipe(Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))));
+    }).pipe(
+      Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
+    );
   });
 
   it.effect("unregisters APNs state only for the current user device", () => {
@@ -130,7 +132,7 @@ describe("Devices", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const devices = yield* Devices.Devices;
@@ -156,7 +158,9 @@ describe("Devices", () => {
           params: ["user-2", "device-1"],
         },
       ]);
-    }).pipe(Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))));
+    }).pipe(
+      Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
+    );
   });
 
   it.effect("lists safe notification state without exposing APNs tokens", () => {
@@ -184,7 +188,7 @@ describe("Devices", () => {
           };
         },
       }),
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const devices = yield* Devices.Devices;
@@ -215,6 +219,8 @@ describe("Devices", () => {
           updatedAt: "2026-06-01T00:00:00.000Z",
         },
       ]);
-    }).pipe(Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))));
+    }).pipe(
+      Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
+    );
   });
 });

--- a/infra/relay/src/agentActivity/Devices.ts
+++ b/infra/relay/src/agentActivity/Devices.ts
@@ -10,7 +10,7 @@ import * as Schema from "effect/Schema";
 import { and, eq } from "drizzle-orm";
 import { sql } from "drizzle-orm";
 
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayLiveActivities, relayMobileDevices } from "../persistence/schema.ts";
 
 export class DeviceRegistrationPersistenceError extends Schema.TaggedErrorClass<DeviceRegistrationPersistenceError>()(
@@ -59,7 +59,7 @@ export class Devices extends Context.Service<Devices, DevicesShape>()(
 ) {}
 
 const make = Effect.gen(function* () {
-  const db = yield* RelayDb;
+  const db = yield* RelayDb.RelayDb;
 
   return Devices.of({
     register: Effect.fn("relay.devices.register")(

--- a/infra/relay/src/agentActivity/LiveActivities.test.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.test.ts
@@ -8,7 +8,7 @@ import { PgDialect } from "drizzle-orm/pg-core";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { RelayDb, type RelayDatabase } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayLiveActivities } from "../persistence/schema.ts";
 import * as LiveActivities from "./LiveActivities.ts";
 
@@ -88,7 +88,7 @@ describe("LiveActivities", () => {
             },
           };
         },
-      } as unknown as RelayDatabase;
+      } as unknown as RelayDb.RelayDb["Service"];
 
       return Effect.gen(function* () {
         const liveActivities = yield* LiveActivities.LiveActivities;
@@ -138,7 +138,9 @@ describe("LiveActivities", () => {
           }),
         );
       }).pipe(
-        Effect.provide(LiveActivities.layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))),
+        Effect.provide(
+          LiveActivities.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb))),
+        ),
       );
     },
   );
@@ -164,7 +166,7 @@ describe("LiveActivities", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const liveActivities = yield* LiveActivities.LiveActivities;
@@ -190,7 +192,9 @@ describe("LiveActivities", () => {
         }),
       );
     }).pipe(
-      Effect.provide(LiveActivities.layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))),
+      Effect.provide(
+        LiveActivities.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb))),
+      ),
     );
   });
 });

--- a/infra/relay/src/agentActivity/LiveActivities.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.ts
@@ -12,7 +12,7 @@ import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import { and, eq, sql } from "drizzle-orm";
 
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayLiveActivities, relayMobileDevices } from "../persistence/schema.ts";
 
 export class LiveActivityRegistrationPersistenceError extends Schema.TaggedErrorClass<LiveActivityRegistrationPersistenceError>()(
@@ -108,7 +108,7 @@ const encodeRelayAgentActivityAggregateStateJson = Schema.encodeEffect(
 );
 
 const make = Effect.gen(function* () {
-  const db = yield* RelayDb;
+  const db = yield* RelayDb.RelayDb;
 
   return LiveActivities.of({
     register: Effect.fn("relay.live_activities.register")(

--- a/infra/relay/src/agentActivity/MobileRegistrations.test.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.test.ts
@@ -86,8 +86,8 @@ function makeAgentActivityRows(
 }
 
 function makeEnvironmentLinks(
-  overrides: Partial<EnvironmentLinks.EnvironmentLinksShape> = {},
-): EnvironmentLinks.EnvironmentLinksShape {
+  overrides: Partial<EnvironmentLinks.EnvironmentLinks["Service"]> = {},
+): EnvironmentLinks.EnvironmentLinks["Service"] {
   return {
     upsert: () => Effect.void,
     listUsersForEnvironment: () => Effect.succeed(["dev:julius"]),
@@ -153,7 +153,7 @@ function makeRegistrationReplayLayer(input: {
         Layer.succeed(EnvironmentLinks.EnvironmentLinks, makeEnvironmentLinks()),
         Layer.succeed(LiveActivities.LiveActivities, input.liveActivities),
         Layer.succeed(DeliveryAttempts.DeliveryAttempts, makeDeliveryAttempts()),
-        Layer.succeed(RelayConfiguration.RelayConfiguration, config),
+        RelayConfiguration.layer(config),
         Layer.succeed(ApnsDeliveryQueue.ApnsDeliveryQueueSender, {
           send: (body) =>
             Effect.sync(() => {

--- a/infra/relay/src/auth/DpopProofs.test.ts
+++ b/infra/relay/src/auth/DpopProofs.test.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 
-import { RelayDb, type RelayDatabase } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayDpopProofs } from "../persistence/schema.ts";
 import * as DpopProofs from "./DpopProofs.ts";
 
@@ -41,7 +41,7 @@ describe("DpopProofReplay", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const replay = yield* DpopProofs.DpopProofReplay;
@@ -67,7 +67,9 @@ describe("DpopProofReplay", () => {
           expiresAt: "2026-05-25T12:00:00.000Z",
         },
       ]);
-    }).pipe(Effect.provide(DpopProofs.layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))));
+    }).pipe(
+      Effect.provide(DpopProofs.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
+    );
   });
 
   it.effect("prunes expired proof rows from the maintenance path", () => {
@@ -84,12 +86,14 @@ describe("DpopProofReplay", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const replay = yield* DpopProofs.DpopProofReplay;
       yield* replay.pruneExpired;
       expect(calls).toEqual(["delete", "delete.where"]);
-    }).pipe(Effect.provide(DpopProofs.layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))));
+    }).pipe(
+      Effect.provide(DpopProofs.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
+    );
   });
 });

--- a/infra/relay/src/auth/DpopProofs.ts
+++ b/infra/relay/src/auth/DpopProofs.ts
@@ -7,7 +7,7 @@ import * as HttpApiError from "effect/unstable/httpapi/HttpApiError";
 import { lt } from "drizzle-orm";
 
 import { verifyDpopProof } from "@t3tools/shared/dpop";
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayDpopProofs } from "../persistence/schema.ts";
 
 export class DpopProofReplayPersistenceError extends Schema.TaggedErrorClass<DpopProofReplayPersistenceError>()(
@@ -21,34 +21,31 @@ export class DpopProofReplayPersistenceError extends Schema.TaggedErrorClass<Dpo
   }
 }
 
-export interface DpopProofReplayShape {
-  readonly verifyAndConsume: (input: {
-    readonly proof: string | undefined;
-    readonly method: string;
-    readonly url: string;
-    readonly expectedThumbprint?: string;
-    readonly expectedAccessToken?: string;
-    readonly now: DateTime.DateTime;
-  }) => Effect.Effect<string, HttpApiError.Unauthorized | DpopProofReplayPersistenceError>;
-
-  readonly consume: (input: {
-    readonly thumbprint: string;
-    readonly jti: string;
-    readonly iat: number;
-    readonly expiresAt: DateTime.DateTime;
-  }) => Effect.Effect<boolean, DpopProofReplayPersistenceError>;
-
-  readonly pruneExpired: Effect.Effect<void, DpopProofReplayPersistenceError>;
-}
-
-export class DpopProofReplay extends Context.Service<DpopProofReplay, DpopProofReplayShape>()(
-  "t3code-relay/auth/DpopProofs/DpopProofReplay",
-) {}
+export class DpopProofReplay extends Context.Service<
+  DpopProofReplay,
+  {
+    readonly verifyAndConsume: (input: {
+      readonly proof: string | undefined;
+      readonly method: string;
+      readonly url: string;
+      readonly expectedThumbprint?: string;
+      readonly expectedAccessToken?: string;
+      readonly now: DateTime.DateTime;
+    }) => Effect.Effect<string, HttpApiError.Unauthorized | DpopProofReplayPersistenceError>;
+    readonly consume: (input: {
+      readonly thumbprint: string;
+      readonly jti: string;
+      readonly iat: number;
+      readonly expiresAt: DateTime.DateTime;
+    }) => Effect.Effect<boolean, DpopProofReplayPersistenceError>;
+    readonly pruneExpired: Effect.Effect<void, DpopProofReplayPersistenceError>;
+  }
+>()("t3code-relay/auth/DpopProofs/DpopProofReplay") {}
 
 const make = Effect.gen(function* () {
-  const db = yield* RelayDb;
+  const db = yield* RelayDb.RelayDb;
 
-  const consume: DpopProofReplayShape["consume"] = Effect.fn("relay.dpop_proofs.consume")(
+  const consume: DpopProofReplay["Service"]["consume"] = Effect.fn("relay.dpop_proofs.consume")(
     function* (input) {
       const createdAt = DateTime.formatIso(yield* DateTime.now);
       const inserted = yield* db
@@ -67,7 +64,7 @@ const make = Effect.gen(function* () {
     Effect.mapError((cause) => new DpopProofReplayPersistenceError({ cause })),
   );
 
-  const verifyAndConsume: DpopProofReplayShape["verifyAndConsume"] = Effect.fn(
+  const verifyAndConsume: DpopProofReplay["Service"]["verifyAndConsume"] = Effect.fn(
     "relay.dpop_proofs.verify_and_consume",
   )(function* (input) {
     yield* Effect.annotateCurrentSpan({
@@ -114,7 +111,7 @@ const make = Effect.gen(function* () {
     return result.thumbprint;
   });
 
-  const pruneExpired: DpopProofReplayShape["pruneExpired"] = Effect.gen(function* () {
+  const pruneExpired: DpopProofReplay["Service"]["pruneExpired"] = Effect.gen(function* () {
     const now = DateTime.formatIso(yield* DateTime.now);
     yield* Effect.annotateCurrentSpan({ "relay.dpop_prune.before": now });
     yield* db.delete(relayDpopProofs).where(lt(relayDpopProofs.expiresAt, now));

--- a/infra/relay/src/auth/DpopProofs.verifyAndConsume.test.ts
+++ b/infra/relay/src/auth/DpopProofs.verifyAndConsume.test.ts
@@ -10,7 +10,7 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { RelayDb, type RelayDatabase } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayDpopProofs } from "../persistence/schema.ts";
 import * as DpopProofs from "./DpopProofs.ts";
 
@@ -78,8 +78,8 @@ function layer(
         }),
       };
     },
-  } as unknown as RelayDatabase;
-  return DpopProofs.layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)));
+  } as unknown as RelayDb.RelayDb["Service"];
+  return DpopProofs.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)));
 }
 
 function consumeEachProofOnce() {

--- a/infra/relay/src/auth/RelayTokens.test.ts
+++ b/infra/relay/src/auth/RelayTokens.test.ts
@@ -33,9 +33,7 @@ const config = RelayConfiguration.RelayConfiguration.of({
   managedEndpointNamespace: undefined,
 });
 
-const layer = RelayTokens.layer.pipe(
-  Layer.provide(Layer.succeed(RelayConfiguration.RelayConfiguration, config)),
-);
+const layer = RelayTokens.layer.pipe(Layer.provide(RelayConfiguration.layer(config)));
 
 describe("RelayTokens", () => {
   it.effect("issues a user-bound environment link challenge", () =>

--- a/infra/relay/src/auth/RelayTokens.ts
+++ b/infra/relay/src/auth/RelayTokens.ts
@@ -93,45 +93,44 @@ function resolveDpopAccessTokenScopes(input: {
   });
 }
 
-export interface RelayTokensShape {
-  readonly resolveDpopAccessTokenScopes: typeof resolveDpopAccessTokenScopes;
-  readonly issueLinkChallenge: (input: {
-    readonly userId: string;
-    readonly request: RelayEnvironmentLinkChallengeRequest;
-    readonly jti: string;
-    readonly issuedAtEpochSeconds: number;
-    readonly expiresAtEpochSeconds: number;
-  }) => Effect.Effect<string, RelayJwtError>;
-  readonly verifyLinkChallenge: (input: {
-    readonly token: string;
-    readonly userId: string;
-    readonly request: RelayEnvironmentLinkChallengeRequest;
-    readonly nowEpochSeconds: number;
-  }) => Effect.Effect<LinkChallengeClaims | null>;
-  readonly issueDpopAccessToken: (input: {
-    readonly userId: string;
-    readonly proofKeyThumbprint: string;
-    readonly jti: string;
-    readonly issuedAtEpochSeconds: number;
-    readonly expiresAtEpochSeconds: number;
-    readonly clientId: RelayPublicClientId;
-    readonly scopes: ReadonlyArray<RelayDpopAccessTokenScope>;
-  }) => Effect.Effect<string, RelayJwtError>;
-  readonly verifyDpopAccessToken: (input: {
-    readonly token: string;
-    readonly nowEpochSeconds: number;
-  }) => Effect.Effect<RelayDpopAccessTokenClaims | null>;
-}
-
-export class RelayTokens extends Context.Service<RelayTokens, RelayTokensShape>()(
-  "t3code-relay/auth/RelayTokens",
-) {}
+export class RelayTokens extends Context.Service<
+  RelayTokens,
+  {
+    readonly resolveDpopAccessTokenScopes: typeof resolveDpopAccessTokenScopes;
+    readonly issueLinkChallenge: (input: {
+      readonly userId: string;
+      readonly request: RelayEnvironmentLinkChallengeRequest;
+      readonly jti: string;
+      readonly issuedAtEpochSeconds: number;
+      readonly expiresAtEpochSeconds: number;
+    }) => Effect.Effect<string, RelayJwtError>;
+    readonly verifyLinkChallenge: (input: {
+      readonly token: string;
+      readonly userId: string;
+      readonly request: RelayEnvironmentLinkChallengeRequest;
+      readonly nowEpochSeconds: number;
+    }) => Effect.Effect<LinkChallengeClaims | null>;
+    readonly issueDpopAccessToken: (input: {
+      readonly userId: string;
+      readonly proofKeyThumbprint: string;
+      readonly jti: string;
+      readonly issuedAtEpochSeconds: number;
+      readonly expiresAtEpochSeconds: number;
+      readonly clientId: RelayPublicClientId;
+      readonly scopes: ReadonlyArray<RelayDpopAccessTokenScope>;
+    }) => Effect.Effect<string, RelayJwtError>;
+    readonly verifyDpopAccessToken: (input: {
+      readonly token: string;
+      readonly nowEpochSeconds: number;
+    }) => Effect.Effect<RelayDpopAccessTokenClaims | null>;
+  }
+>()("t3code-relay/auth/RelayTokens") {}
 
 const make = Effect.gen(function* () {
   const config = yield* RelayConfiguration.RelayConfiguration;
   const issuer = normalizeRelayIssuer(config.relayIssuer);
 
-  const issueLinkChallenge: RelayTokensShape["issueLinkChallenge"] = Effect.fn(
+  const issueLinkChallenge: RelayTokens["Service"]["issueLinkChallenge"] = Effect.fn(
     "relay.tokens.issue_link_challenge",
   )(function* (input) {
     return yield* signRelayJwt({
@@ -150,7 +149,7 @@ const make = Effect.gen(function* () {
     });
   });
 
-  const verifyLinkChallenge: RelayTokensShape["verifyLinkChallenge"] = Effect.fn(
+  const verifyLinkChallenge: RelayTokens["Service"]["verifyLinkChallenge"] = Effect.fn(
     "relay.tokens.verify_link_challenge",
   )((input) =>
     verifyRelayJwt({
@@ -177,7 +176,7 @@ const make = Effect.gen(function* () {
     ),
   );
 
-  const issueDpopAccessToken: RelayTokensShape["issueDpopAccessToken"] = Effect.fn(
+  const issueDpopAccessToken: RelayTokens["Service"]["issueDpopAccessToken"] = Effect.fn(
     "relay.tokens.issue_dpop_access_token",
   )(function* (input) {
     return yield* signRelayJwt({
@@ -197,7 +196,7 @@ const make = Effect.gen(function* () {
     });
   });
 
-  const verifyDpopAccessToken: RelayTokensShape["verifyDpopAccessToken"] = Effect.fn(
+  const verifyDpopAccessToken: RelayTokens["Service"]["verifyDpopAccessToken"] = Effect.fn(
     "relay.tokens.verify_dpop_access_token",
   )((input) =>
     verifyRelayJwt({

--- a/infra/relay/src/db.ts
+++ b/infra/relay/src/db.ts
@@ -10,11 +10,12 @@ import * as Effect from "effect/Effect";
 
 import { relayDatabaseMode } from "./dbConfig.ts";
 
-export interface RelayDatabase extends EffectPgDatabase {
-  readonly $client: PgClient;
-}
-
-export class RelayDb extends Context.Service<RelayDb, RelayDatabase>()("t3code-relay/db/RelayDb") {}
+export class RelayDb extends Context.Service<
+  RelayDb,
+  EffectPgDatabase & {
+    readonly $client: PgClient;
+  }
+>()("t3code-relay/db/RelayDb") {}
 
 export const PlanetscaleDatabase = Effect.gen(function* () {
   const { stage } = yield* Alchemy.Stack;

--- a/infra/relay/src/environments/EnvironmentConnector.test.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.test.ts
@@ -161,8 +161,8 @@ function connectorTestLayer(
     request: HttpClientRequest.HttpClientRequest,
   ) => Effect.Effect<HttpClientResponse.HttpClientResponse>,
   options?: {
-    readonly links?: EnvironmentLinks.EnvironmentLinksShape;
-    readonly allocations?: ManagedEndpointAllocations.ManagedEndpointAllocationsShape;
+    readonly links?: EnvironmentLinks.EnvironmentLinks["Service"];
+    readonly allocations?: ManagedEndpointAllocations.ManagedEndpointAllocations["Service"];
   },
 ) {
   return EnvironmentConnector.layer.pipe(
@@ -174,7 +174,7 @@ function connectorTestLayer(
         options?.allocations ?? makeAllocations(),
       ),
     ),
-    Layer.provide(Layer.succeed(RelayConfiguration.RelayConfiguration, settings)),
+    Layer.provide(RelayConfiguration.layer(settings)),
     Layer.provide(Layer.succeed(HttpClient.HttpClient, HttpClient.make(execute))),
   );
 }
@@ -189,7 +189,7 @@ function makeAllocations(
     dnsRecordId: "dns-record-id",
     readyAt: "2026-05-25T00:00:00.000Z",
   },
-): ManagedEndpointAllocations.ManagedEndpointAllocationsShape {
+): ManagedEndpointAllocations.ManagedEndpointAllocations["Service"] {
   return {
     get: () => Effect.succeed(allocation),
     reserve: () => Effect.die("unused"),
@@ -202,7 +202,7 @@ function makeAllocations(
 
 function makeLinks(
   overrides: Partial<EnvironmentLinks.RelayLinkedEnvironmentRecord> = {},
-): EnvironmentLinks.EnvironmentLinksShape {
+): EnvironmentLinks.EnvironmentLinks["Service"] {
   return {
     upsert: () => Effect.void,
     listUsersForEnvironment: () => Effect.succeed([]),

--- a/infra/relay/src/environments/EnvironmentConnector.ts
+++ b/infra/relay/src/environments/EnvironmentConnector.ts
@@ -35,7 +35,9 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
-import { FetchHttpClient, HttpClient, HttpClientError } from "effect/unstable/http";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 
 import * as EnvironmentLinks from "./EnvironmentLinks.ts";
 import * as ManagedEndpointAllocations from "./ManagedEndpointAllocations.ts";
@@ -139,22 +141,20 @@ export type EnvironmentConnectorError =
 export const ENVIRONMENT_MINT_REQUEST_TIMEOUT_MS = 10_000;
 const ENVIRONMENT_HEALTH_CLOCK_SKEW_MILLIS = 60 * 1_000;
 
-export interface EnvironmentConnectorShape {
-  readonly connect: (input: {
-    readonly userId: string;
-    readonly environmentId: string;
-    readonly clientProofKeyThumbprint: string;
-    readonly deviceId?: string;
-  }) => Effect.Effect<RelayEnvironmentConnectResponse, EnvironmentConnectorError>;
-  readonly status: (input: {
-    readonly userId: string;
-    readonly environmentId: string;
-  }) => Effect.Effect<RelayEnvironmentStatusResponse, EnvironmentConnectorError>;
-}
-
 export class EnvironmentConnector extends Context.Service<
   EnvironmentConnector,
-  EnvironmentConnectorShape
+  {
+    readonly connect: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+      readonly clientProofKeyThumbprint: string;
+      readonly deviceId?: string;
+    }) => Effect.Effect<RelayEnvironmentConnectResponse, EnvironmentConnectorError>;
+    readonly status: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+    }) => Effect.Effect<RelayEnvironmentStatusResponse, EnvironmentConnectorError>;
+  }
 >()("t3code-relay/environments/EnvironmentConnector") {}
 
 const decodeMintResponseProof = Schema.decodeUnknownEffect(

--- a/infra/relay/src/environments/EnvironmentCredentials.test.ts
+++ b/infra/relay/src/environments/EnvironmentCredentials.test.ts
@@ -4,7 +4,7 @@ import { PgDialect, QueryBuilder } from "drizzle-orm/pg-core";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
-import { RelayDb, type RelayDatabase } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayEnvironmentCredentials } from "../persistence/schema.ts";
 import * as EnvironmentCredentials from "./EnvironmentCredentials.ts";
 
@@ -47,7 +47,7 @@ describe("EnvironmentCredentials", () => {
             }),
           };
         },
-      } as unknown as RelayDatabase;
+      } as unknown as RelayDb.RelayDb["Service"];
 
       return Effect.gen(function* () {
         const credentials = yield* EnvironmentCredentials.EnvironmentCredentials;
@@ -87,7 +87,7 @@ describe("EnvironmentCredentials", () => {
         Effect.provide(
           EnvironmentCredentials.layer.pipe(
             Layer.provide(NodeCryptoLayer.layer),
-            Layer.provide(Layer.succeed(RelayDb, fakeDb)),
+            Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
           ),
         ),
       );
@@ -118,7 +118,7 @@ describe("EnvironmentCredentials", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
       const credentials = yield* EnvironmentCredentials.EnvironmentCredentials;
@@ -150,7 +150,7 @@ describe("EnvironmentCredentials", () => {
       Effect.provide(
         EnvironmentCredentials.layer.pipe(
           Layer.provide(NodeCryptoLayer.layer),
-          Layer.provide(Layer.succeed(RelayDb, fakeDb)),
+          Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
         ),
       ),
     );

--- a/infra/relay/src/environments/EnvironmentCredentials.ts
+++ b/infra/relay/src/environments/EnvironmentCredentials.ts
@@ -8,7 +8,7 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { and, eq, isNull, ne, notExists } from "drizzle-orm";
 
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayEnvironmentCredentials, relayEnvironmentLinks } from "../persistence/schema.ts";
 
 export class EnvironmentCredentialCreatePersistenceError extends Schema.TaggedErrorClass<EnvironmentCredentialCreatePersistenceError>()(
@@ -44,30 +44,28 @@ export interface EnvironmentCredentialPrincipal {
   readonly environmentPublicKey: string;
 }
 
-export interface EnvironmentCredentialsShape {
-  readonly create: (input: {
-    readonly environmentId: string;
-    readonly environmentPublicKey: string;
-  }) => Effect.Effect<string, EnvironmentCredentialCreatePersistenceError>;
-  readonly authenticate: (
-    token: string,
-  ) => Effect.Effect<
-    Option.Option<EnvironmentCredentialPrincipal>,
-    EnvironmentCredentialAuthenticatePersistenceError
-  >;
-  readonly revokeForEnvironmentPublicKey: (input: {
-    readonly environmentId: string;
-    readonly environmentPublicKey: string;
-  }) => Effect.Effect<boolean, EnvironmentCredentialRevokePersistenceError>;
-}
-
 export class EnvironmentCredentials extends Context.Service<
   EnvironmentCredentials,
-  EnvironmentCredentialsShape
+  {
+    readonly create: (input: {
+      readonly environmentId: string;
+      readonly environmentPublicKey: string;
+    }) => Effect.Effect<string, EnvironmentCredentialCreatePersistenceError>;
+    readonly authenticate: (
+      token: string,
+    ) => Effect.Effect<
+      Option.Option<EnvironmentCredentialPrincipal>,
+      EnvironmentCredentialAuthenticatePersistenceError
+    >;
+    readonly revokeForEnvironmentPublicKey: (input: {
+      readonly environmentId: string;
+      readonly environmentPublicKey: string;
+    }) => Effect.Effect<boolean, EnvironmentCredentialRevokePersistenceError>;
+  }
 >()("t3code-relay/environments/EnvironmentCredentials") {}
 
 const make = Effect.gen(function* () {
-  const db = yield* RelayDb;
+  const db = yield* RelayDb.RelayDb;
   const crypto = yield* Crypto.Crypto;
   const hashToken = (token: string) =>
     crypto

--- a/infra/relay/src/environments/EnvironmentLinker.test.ts
+++ b/infra/relay/src/environments/EnvironmentLinker.test.ts
@@ -105,14 +105,14 @@ const makeRequest = Effect.gen(function* () {
 });
 
 function testLayer(input?: {
-  readonly upsert?: EnvironmentLinks.EnvironmentLinksShape["upsert"];
-  readonly consume?: DpopProofs.DpopProofReplayShape["consume"];
+  readonly upsert?: EnvironmentLinks.EnvironmentLinks["Service"]["upsert"];
+  readonly consume?: DpopProofs.DpopProofReplay["Service"]["consume"];
 }) {
   return EnvironmentLinker.layer.pipe(
     Layer.provideMerge(RelayTokens.layer),
     Layer.provide(
       Layer.mergeAll(
-        Layer.succeed(RelayConfiguration.RelayConfiguration, config),
+        RelayConfiguration.layer(config),
         Layer.succeed(DpopProofs.DpopProofReplay, {
           verifyAndConsume: () => Effect.die("unexpected DPoP proof verification"),
           consume: input?.consume ?? (() => Effect.succeed(true)),

--- a/infra/relay/src/environments/EnvironmentLinker.ts
+++ b/infra/relay/src/environments/EnvironmentLinker.ts
@@ -53,26 +53,25 @@ export type EnvironmentLinkError =
   | EnvironmentCredentials.EnvironmentCredentialCreatePersistenceError
   | ManagedEndpointProvider.ManagedEndpointProviderError;
 
-export interface EnvironmentLinkerShape {
-  readonly link: (input: {
-    readonly userId: string;
-    readonly request: RelayEnvironmentLinkRequest;
-  }) => Effect.Effect<
-    {
-      readonly environmentId: RelayEnvironmentLinkProofPayload["environmentId"];
-      readonly endpoint: RelayEnvironmentLinkProofPayload["endpoint"];
-      readonly endpointRuntime:
-        | ManagedEndpointProvider.ManagedEndpointProvisioningResult["runtime"]
-        | null;
-      readonly environmentCredential: string;
-    },
-    EnvironmentLinkError
-  >;
-}
-
-export class EnvironmentLinker extends Context.Service<EnvironmentLinker, EnvironmentLinkerShape>()(
-  "t3code-relay/environments/EnvironmentLinker",
-) {}
+export class EnvironmentLinker extends Context.Service<
+  EnvironmentLinker,
+  {
+    readonly link: (input: {
+      readonly userId: string;
+      readonly request: RelayEnvironmentLinkRequest;
+    }) => Effect.Effect<
+      {
+        readonly environmentId: RelayEnvironmentLinkProofPayload["environmentId"];
+        readonly endpoint: RelayEnvironmentLinkProofPayload["endpoint"];
+        readonly endpointRuntime:
+          | ManagedEndpointProvider.ManagedEndpointProvisioningResult["runtime"]
+          | null;
+        readonly environmentCredential: string;
+      },
+      EnvironmentLinkError
+    >;
+  }
+>()("t3code-relay/environments/EnvironmentLinker") {}
 
 const decodeProof = Schema.decodeUnknownEffect(RelayEnvironmentLinkProofPayload);
 

--- a/infra/relay/src/environments/EnvironmentLinks.test.ts
+++ b/infra/relay/src/environments/EnvironmentLinks.test.ts
@@ -3,9 +3,9 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { PgDialect } from "drizzle-orm/pg-core";
 
-import { RelayDb, type RelayDatabase } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayEnvironmentLinks } from "../persistence/schema.ts";
-import { EnvironmentLinks, layer } from "./EnvironmentLinks.ts";
+import * as EnvironmentLinks from "./EnvironmentLinks.ts";
 
 describe("EnvironmentLinks", () => {
   it.effect("selects users when either notifications or Live Activities are enabled", () => {
@@ -25,10 +25,10 @@ describe("EnvironmentLinks", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
-      const links = yield* EnvironmentLinks;
+      const links = yield* EnvironmentLinks.EnvironmentLinks;
       expect(yield* links.listUsersForEnvironment({ environmentId: "env-1" })).toEqual([]);
       expect(whereConditions).toHaveLength(1);
 
@@ -39,7 +39,11 @@ describe("EnvironmentLinks", () => {
       expect(query.sql).toContain('"relay_environment_links"."live_activities_enabled" = $3');
       expect(query.sql).toContain(" or ");
       expect(query.params).toEqual(["env-1", true, true]);
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))));
+    }).pipe(
+      Effect.provide(
+        EnvironmentLinks.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb))),
+      ),
+    );
   });
 
   it.effect("revokes only the active link owned by the requesting user", () => {
@@ -65,10 +69,10 @@ describe("EnvironmentLinks", () => {
           },
         };
       },
-    } as unknown as RelayDatabase;
+    } as unknown as RelayDb.RelayDb["Service"];
 
     return Effect.gen(function* () {
-      const links = yield* EnvironmentLinks;
+      const links = yield* EnvironmentLinks.EnvironmentLinks;
       const revoked = yield* links.revokeForUser({
         userId: "user-1",
         environmentId: "env-1",
@@ -86,6 +90,10 @@ describe("EnvironmentLinks", () => {
       expect(query.sql).toContain('"relay_environment_links"."environment_id" = $2');
       expect(query.sql).toContain('"relay_environment_links"."revoked_at" is null');
       expect(query.params).toEqual(["user-1", "env-1"]);
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(Layer.succeed(RelayDb, fakeDb)))));
+    }).pipe(
+      Effect.provide(
+        EnvironmentLinks.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb))),
+      ),
+    );
   });
 });

--- a/infra/relay/src/environments/EnvironmentLinks.ts
+++ b/infra/relay/src/environments/EnvironmentLinks.ts
@@ -11,7 +11,7 @@ import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import { and, eq, isNull, or } from "drizzle-orm";
 
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { relayEnvironmentLinks } from "../persistence/schema.ts";
 
 export interface RelayLinkedEnvironmentRecord extends RelayClientEnvironmentRecord {
@@ -78,45 +78,44 @@ export class EnvironmentLinkRevokePersistenceError extends Schema.TaggedErrorCla
   }
 }
 
-export interface EnvironmentLinksShape {
-  readonly upsert: (input: {
-    readonly userId: string;
-    readonly request: RelayEnvironmentLinkRequest;
-    readonly proof: RelayEnvironmentLinkProofPayload;
-    readonly endpoint: RelayManagedEndpoint;
-  }) => Effect.Effect<void, EnvironmentLinkUpsertPersistenceError>;
-  readonly listUsersForEnvironment: (input: {
-    readonly environmentId: string;
-  }) => Effect.Effect<ReadonlyArray<string>, EnvironmentLinkUserListPersistenceError>;
-  readonly listDeliveryUsersForEnvironment: (input: {
-    readonly environmentId: string;
-    readonly environmentPublicKey: string;
-  }) => Effect.Effect<
-    ReadonlyArray<AgentAwarenessDeliveryUserRecord>,
-    EnvironmentLinkUserListPersistenceError
-  >;
-  readonly listPublicKeysForEnvironment: (input: {
-    readonly environmentId: string;
-  }) => Effect.Effect<ReadonlyArray<string>, EnvironmentPublicKeyListPersistenceError>;
-  readonly listForUser: (input: {
-    readonly userId: string;
-  }) => Effect.Effect<
-    ReadonlyArray<RelayClientEnvironmentRecord>,
-    EnvironmentLinkListPersistenceError
-  >;
-  readonly getForUser: (input: {
-    readonly userId: string;
-    readonly environmentId: string;
-  }) => Effect.Effect<RelayLinkedEnvironmentRecord | null, EnvironmentLinkLookupPersistenceError>;
-  readonly revokeForUser: (input: {
-    readonly userId: string;
-    readonly environmentId: string;
-  }) => Effect.Effect<boolean, EnvironmentLinkRevokePersistenceError>;
-}
-
-export class EnvironmentLinks extends Context.Service<EnvironmentLinks, EnvironmentLinksShape>()(
-  "t3code-relay/environments/EnvironmentLinks",
-) {}
+export class EnvironmentLinks extends Context.Service<
+  EnvironmentLinks,
+  {
+    readonly upsert: (input: {
+      readonly userId: string;
+      readonly request: RelayEnvironmentLinkRequest;
+      readonly proof: RelayEnvironmentLinkProofPayload;
+      readonly endpoint: RelayManagedEndpoint;
+    }) => Effect.Effect<void, EnvironmentLinkUpsertPersistenceError>;
+    readonly listUsersForEnvironment: (input: {
+      readonly environmentId: string;
+    }) => Effect.Effect<ReadonlyArray<string>, EnvironmentLinkUserListPersistenceError>;
+    readonly listDeliveryUsersForEnvironment: (input: {
+      readonly environmentId: string;
+      readonly environmentPublicKey: string;
+    }) => Effect.Effect<
+      ReadonlyArray<AgentAwarenessDeliveryUserRecord>,
+      EnvironmentLinkUserListPersistenceError
+    >;
+    readonly listPublicKeysForEnvironment: (input: {
+      readonly environmentId: string;
+    }) => Effect.Effect<ReadonlyArray<string>, EnvironmentPublicKeyListPersistenceError>;
+    readonly listForUser: (input: {
+      readonly userId: string;
+    }) => Effect.Effect<
+      ReadonlyArray<RelayClientEnvironmentRecord>,
+      EnvironmentLinkListPersistenceError
+    >;
+    readonly getForUser: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+    }) => Effect.Effect<RelayLinkedEnvironmentRecord | null, EnvironmentLinkLookupPersistenceError>;
+    readonly revokeForUser: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+    }) => Effect.Effect<boolean, EnvironmentLinkRevokePersistenceError>;
+  }
+>()("t3code-relay/environments/EnvironmentLinks") {}
 
 function agentAwarenessDeliveryUserCondition(environmentId: string) {
   return and(
@@ -140,7 +139,7 @@ function agentAwarenessDeliveryUserKeyCondition(input: {
 }
 
 const make = Effect.gen(function* () {
-  const db = yield* RelayDb;
+  const db = yield* RelayDb.RelayDb;
 
   return EnvironmentLinks.of({
     upsert: Effect.fn("relay.environment_links.upsert")(

--- a/infra/relay/src/environments/EnvironmentPublishSignatures.test.ts
+++ b/infra/relay/src/environments/EnvironmentPublishSignatures.test.ts
@@ -80,11 +80,11 @@ const freshRequest = Effect.gen(function* () {
   } satisfies RelayAgentActivityPublishRequest;
 });
 
-function layer(replay?: Partial<DpopProofs.DpopProofReplayShape>) {
+function layer(replay?: Partial<DpopProofs.DpopProofReplay["Service"]>) {
   return EnvironmentPublishSignatures.layer.pipe(
     Layer.provide(
       Layer.merge(
-        Layer.succeed(RelayConfiguration.RelayConfiguration, config),
+        RelayConfiguration.layer(config),
         Layer.succeed(DpopProofs.DpopProofReplay, {
           verifyAndConsume:
             replay?.verifyAndConsume ?? (() => Effect.die("unexpected DPoP proof verification")),

--- a/infra/relay/src/environments/EnvironmentPublishSignatures.ts
+++ b/infra/relay/src/environments/EnvironmentPublishSignatures.ts
@@ -59,18 +59,16 @@ export type EnvironmentPublishSignatureError =
   | EnvironmentPublishPublicKeyMissing
   | DpopProofs.DpopProofReplayPersistenceError;
 
-export interface EnvironmentPublishSignaturesShape {
-  readonly verify: (input: {
-    readonly environmentId: string;
-    readonly environmentPublicKey: string;
-    readonly threadId: string;
-    readonly request: RelayAgentActivityPublishRequest;
-  }) => Effect.Effect<void, EnvironmentPublishSignatureError>;
-}
-
 export class EnvironmentPublishSignatures extends Context.Service<
   EnvironmentPublishSignatures,
-  EnvironmentPublishSignaturesShape
+  {
+    readonly verify: (input: {
+      readonly environmentId: string;
+      readonly environmentPublicKey: string;
+      readonly threadId: string;
+      readonly request: RelayAgentActivityPublishRequest;
+    }) => Effect.Effect<void, EnvironmentPublishSignatureError>;
+  }
 >()("t3code-relay/environments/EnvironmentPublishSignatures") {}
 
 const decodeProof = Schema.decodeUnknownEffect(RelayAgentActivityPublishProofPayload);

--- a/infra/relay/src/environments/ManagedEndpointAllocations.ts
+++ b/infra/relay/src/environments/ManagedEndpointAllocations.ts
@@ -6,7 +6,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 import { isManagedEndpointHostname, managedEndpointForHostname } from "../deploymentConfig.ts";
 import { relayManagedEndpointAllocations } from "../persistence/schema.ts";
 
@@ -66,26 +66,29 @@ interface RecordManagedEndpointDnsInput extends ManagedEndpointAllocationKey {
   readonly dnsRecordId: string;
 }
 
-export interface ManagedEndpointAllocationsShape {
-  readonly get: (
-    input: ManagedEndpointAllocationKey,
-  ) => Effect.Effect<ManagedEndpointAllocation | null, ManagedEndpointAllocationPersistenceError>;
-  readonly reserve: (
-    input: ReserveManagedEndpointAllocationInput,
-  ) => Effect.Effect<ManagedEndpointAllocation, ManagedEndpointAllocationPersistenceError>;
-  readonly recordTunnel: (
-    input: RecordManagedEndpointTunnelInput,
-  ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
-  readonly recordDns: (
-    input: RecordManagedEndpointDnsInput,
-  ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
-  readonly markReady: (
-    input: ManagedEndpointAllocationKey,
-  ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
-  readonly remove: (
-    input: ManagedEndpointAllocationKey,
-  ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
-}
+export class ManagedEndpointAllocations extends Context.Service<
+  ManagedEndpointAllocations,
+  {
+    readonly get: (
+      input: ManagedEndpointAllocationKey,
+    ) => Effect.Effect<ManagedEndpointAllocation | null, ManagedEndpointAllocationPersistenceError>;
+    readonly reserve: (
+      input: ReserveManagedEndpointAllocationInput,
+    ) => Effect.Effect<ManagedEndpointAllocation, ManagedEndpointAllocationPersistenceError>;
+    readonly recordTunnel: (
+      input: RecordManagedEndpointTunnelInput,
+    ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
+    readonly recordDns: (
+      input: RecordManagedEndpointDnsInput,
+    ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
+    readonly markReady: (
+      input: ManagedEndpointAllocationKey,
+    ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
+    readonly remove: (
+      input: ManagedEndpointAllocationKey,
+    ) => Effect.Effect<void, ManagedEndpointAllocationPersistenceError>;
+  }
+>()("t3code-relay/environments/ManagedEndpointAllocations") {}
 
 const allocationSelection = {
   userId: relayManagedEndpointAllocations.userId,
@@ -109,7 +112,7 @@ const persistenceError = (cause: unknown) =>
     : new ManagedEndpointAllocationPersistenceError({ cause });
 
 const make = Effect.gen(function* () {
-  const db = yield* RelayDb;
+  const db = yield* RelayDb.RelayDb;
 
   return ManagedEndpointAllocations.of({
     get: Effect.fn("relay.managed_endpoint_allocations.get")(function* (
@@ -198,9 +201,4 @@ const make = Effect.gen(function* () {
   });
 });
 
-export class ManagedEndpointAllocations extends Context.Service<
-  ManagedEndpointAllocations,
-  ManagedEndpointAllocationsShape
->()("t3code-relay/environments/ManagedEndpointAllocations") {
-  static readonly layer = Layer.effect(this, make);
-}
+export const layer = Layer.effect(ManagedEndpointAllocations, make);

--- a/infra/relay/src/environments/ManagedEndpointProvider.test.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.test.ts
@@ -204,9 +204,9 @@ function providerLayer(
 ) {
   return ManagedEndpointProvider.layer.pipe(
     Layer.provideMerge(NodeServices.layer),
-    Layer.provide(Layer.succeed(RelayConfiguration.RelayConfiguration, config)),
-    Layer.provide(Layer.succeed(ManagedEndpointProvider.ManagedEndpointTunnelClient, tunnelClient)),
-    Layer.provide(Layer.succeed(ManagedEndpointProvider.ManagedEndpointDnsClient, dnsClient)),
+    Layer.provide(RelayConfiguration.layer(config)),
+    Layer.provide(ManagedEndpointProvider.layerTunnelClient(tunnelClient)),
+    Layer.provide(ManagedEndpointProvider.layerDnsClient(dnsClient)),
     Layer.provide(
       Layer.succeed(ManagedEndpointAllocations.ManagedEndpointAllocations, allocations),
     ),

--- a/infra/relay/src/environments/ManagedEndpointProvider.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.ts
@@ -23,7 +23,7 @@ import {
   managedEndpointHostname,
   managedEndpointTunnelName,
 } from "../deploymentConfig.ts";
-import { ManagedEndpointAllocations } from "./ManagedEndpointAllocations.ts";
+import * as ManagedEndpointAllocations from "./ManagedEndpointAllocations.ts";
 
 export class ManagedEndpointProvisioningNotConfigured extends Schema.TaggedErrorClass<ManagedEndpointProvisioningNotConfigured>()(
   "ManagedEndpointProvisioningNotConfigured",
@@ -74,21 +74,19 @@ export interface ManagedEndpointProvisioningResult {
   readonly runtime: RelayManagedEndpointRuntimeConfig;
 }
 
-export interface ManagedEndpointProviderShape {
-  readonly provision: (input: {
-    readonly userId: string;
-    readonly environmentId: string;
-    readonly origin: RelayManagedEndpointOrigin;
-  }) => Effect.Effect<ManagedEndpointProvisioningResult, ManagedEndpointProviderError>;
-  readonly deprovision: (input: {
-    readonly userId: string;
-    readonly environmentId: string;
-  }) => Effect.Effect<void, ManagedEndpointDeprovisioningFailed>;
-}
-
 export class ManagedEndpointProvider extends Context.Service<
   ManagedEndpointProvider,
-  ManagedEndpointProviderShape
+  {
+    readonly provision: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+      readonly origin: RelayManagedEndpointOrigin;
+    }) => Effect.Effect<ManagedEndpointProvisioningResult, ManagedEndpointProviderError>;
+    readonly deprovision: (input: {
+      readonly userId: string;
+      readonly environmentId: string;
+    }) => Effect.Effect<void, ManagedEndpointDeprovisioningFailed>;
+  }
 >()("t3code-relay/environments/ManagedEndpointProvider") {}
 
 interface ManagedEndpointTunnel {
@@ -105,35 +103,41 @@ export class ManagedEndpointTunnelClientError extends Schema.TaggedErrorClass<Ma
   }
 }
 
-export interface ManagedEndpointTunnelClientShape {
-  readonly list: (request: {
-    readonly name: string;
-    readonly isDeleted: false;
-  }) => Effect.Effect<
-    { readonly result: ReadonlyArray<ManagedEndpointTunnel> },
-    ManagedEndpointTunnelClientError
-  >;
-  readonly create: (request: {
-    readonly name: string;
-    readonly configSrc: "cloudflare";
-  }) => Effect.Effect<ManagedEndpointTunnel, ManagedEndpointTunnelClientError>;
-  readonly putConfiguration: (
-    tunnelId: string,
-    config: {
-      readonly ingress: Array<{
-        readonly hostname?: string;
-        readonly service: string;
-      }>;
-    },
-  ) => Effect.Effect<unknown, ManagedEndpointTunnelClientError>;
-  readonly getToken: (tunnelId: string) => Effect.Effect<string, ManagedEndpointTunnelClientError>;
-  readonly delete: (tunnelId: string) => Effect.Effect<unknown, ManagedEndpointTunnelClientError>;
-}
-
 export class ManagedEndpointTunnelClient extends Context.Service<
   ManagedEndpointTunnelClient,
-  ManagedEndpointTunnelClientShape
+  {
+    readonly list: (request: {
+      readonly name: string;
+      readonly isDeleted: false;
+    }) => Effect.Effect<
+      { readonly result: ReadonlyArray<ManagedEndpointTunnel> },
+      ManagedEndpointTunnelClientError
+    >;
+    readonly create: (request: {
+      readonly name: string;
+      readonly configSrc: "cloudflare";
+    }) => Effect.Effect<ManagedEndpointTunnel, ManagedEndpointTunnelClientError>;
+    readonly putConfiguration: (
+      tunnelId: string,
+      config: {
+        readonly ingress: Array<{
+          readonly hostname?: string;
+          readonly service: string;
+        }>;
+      },
+    ) => Effect.Effect<unknown, ManagedEndpointTunnelClientError>;
+    readonly getToken: (
+      tunnelId: string,
+    ) => Effect.Effect<string, ManagedEndpointTunnelClientError>;
+    readonly delete: (tunnelId: string) => Effect.Effect<unknown, ManagedEndpointTunnelClientError>;
+  }
 >()("t3code-relay/environments/ManagedEndpointProvider/ManagedEndpointTunnelClient") {}
+
+export const makeTunnelClient = (client: ManagedEndpointTunnelClient["Service"]) =>
+  ManagedEndpointTunnelClient.of(client);
+
+export const layerTunnelClient = (client: ManagedEndpointTunnelClient["Service"]) =>
+  Layer.succeed(ManagedEndpointTunnelClient, makeTunnelClient(client));
 
 interface ManagedEndpointCnameRecordInput {
   readonly type: "CNAME";
@@ -152,29 +156,33 @@ export class ManagedEndpointDnsClientError extends Schema.TaggedErrorClass<Manag
   }
 }
 
-export interface ManagedEndpointDnsClientShape {
-  readonly listRecords: (
-    hostname: string,
-  ) => Effect.Effect<ReadonlyArray<{ readonly id: string }>, ManagedEndpointDnsClientError>;
-  readonly createRecord: (
-    request: ManagedEndpointCnameRecordInput,
-  ) => Effect.Effect<{ readonly id: string }, ManagedEndpointDnsClientError>;
-  readonly updateRecord: (
-    dnsRecordId: string,
-    request: ManagedEndpointCnameRecordInput,
-  ) => Effect.Effect<unknown, ManagedEndpointDnsClientError>;
-  readonly deleteRecord: (
-    dnsRecordId: string,
-  ) => Effect.Effect<unknown, ManagedEndpointDnsClientError>;
-}
-
 export class ManagedEndpointDnsClient extends Context.Service<
   ManagedEndpointDnsClient,
-  ManagedEndpointDnsClientShape
+  {
+    readonly listRecords: (
+      hostname: string,
+    ) => Effect.Effect<ReadonlyArray<{ readonly id: string }>, ManagedEndpointDnsClientError>;
+    readonly createRecord: (
+      request: ManagedEndpointCnameRecordInput,
+    ) => Effect.Effect<{ readonly id: string }, ManagedEndpointDnsClientError>;
+    readonly updateRecord: (
+      dnsRecordId: string,
+      request: ManagedEndpointCnameRecordInput,
+    ) => Effect.Effect<unknown, ManagedEndpointDnsClientError>;
+    readonly deleteRecord: (
+      dnsRecordId: string,
+    ) => Effect.Effect<unknown, ManagedEndpointDnsClientError>;
+  }
 >()("t3code-relay/environments/ManagedEndpointProvider/ManagedEndpointDnsClient") {}
 
+export const makeDnsClient = (client: ManagedEndpointDnsClient["Service"]) =>
+  ManagedEndpointDnsClient.of(client);
+
+export const layerDnsClient = (client: ManagedEndpointDnsClient["Service"]) =>
+  Layer.succeed(ManagedEndpointDnsClient, makeDnsClient(client));
+
 const requireCloudflareSettings = Effect.fnUntraced(function* (
-  settings: RelayConfiguration.RelayConfigurationShape,
+  settings: RelayConfiguration.RelayConfiguration["Service"],
 ) {
   if (!settings.managedEndpointBaseDomain || !settings.managedEndpointNamespace) {
     return yield* new ManagedEndpointProvisioningNotConfigured();
@@ -234,7 +242,7 @@ const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const tunnels = yield* ManagedEndpointTunnelClient;
   const dns = yield* ManagedEndpointDnsClient;
-  const allocations = yield* ManagedEndpointAllocations;
+  const allocations = yield* ManagedEndpointAllocations.ManagedEndpointAllocations;
 
   const updateExistingDnsRecords = Effect.fnUntraced(function* (
     records: ReadonlyArray<{ readonly id: string }>,
@@ -452,8 +460,7 @@ export const layerCloudflareBindings = (
   layer.pipe(
     Layer.provide(
       Layer.mergeAll(
-        Layer.succeed(
-          ManagedEndpointTunnelClient,
+        layerTunnelClient(
           ManagedEndpointTunnelClient.of({
             list: (request) =>
               tunnelClient.list(request).pipe(
@@ -482,8 +489,7 @@ export const layerCloudflareBindings = (
               ),
           }),
         ),
-        Layer.succeed(
-          ManagedEndpointDnsClient,
+        layerDnsClient(
           ManagedEndpointDnsClient.of({
             listRecords: (hostname) =>
               dnsClient.listDnsRecords({ search: hostname }).pipe(

--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -30,7 +30,7 @@ vi.mock("@clerk/backend", () => ({
   verifyToken: vi.fn(),
 }));
 
-const relaySettings: RelayConfiguration.RelayConfigurationShape = {
+const relaySettings: RelayConfiguration.RelayConfiguration["Service"] = {
   relayIssuer: "https://relay.example.test",
   apns: {
     teamId: "apns-team",
@@ -110,7 +110,7 @@ describe("relay environment authentication", () => {
     const failure = new EnvironmentCredentials.EnvironmentCredentialAuthenticatePersistenceError({
       cause: "database unavailable",
     });
-    const credentials: EnvironmentCredentials.EnvironmentCredentialsShape = {
+    const credentials: EnvironmentCredentials.EnvironmentCredentials["Service"] = {
       create: () => Effect.die("unused create"),
       authenticate: () => Effect.fail(failure),
       revokeForEnvironmentPublicKey: () => Effect.die("unused revoke"),

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -66,7 +66,7 @@ import * as ManagedEndpointAllocations from "../environments/ManagedEndpointAllo
 import * as EnvironmentPublishSignatures from "../environments/EnvironmentPublishSignatures.ts";
 import * as MobileRegistrations from "../agentActivity/MobileRegistrations.ts";
 import { withSpanAttributes } from "../observability.ts";
-import { RelayDb } from "../db.ts";
+import * as RelayDb from "../db.ts";
 
 const relayCorsAllowedMethods = ["GET", "POST", "DELETE", "OPTIONS"] as const;
 const relayCorsAllowedHeaders = [
@@ -347,7 +347,7 @@ export const healthApi = HttpApiBuilder.group(
   RelayApi,
   "health",
   Effect.fnUntraced(function* (handlers) {
-    const db = yield* RelayDb;
+    const db = yield* RelayDb.RelayDb;
     return handlers.handle(
       "health",
       Effect.fn("relay.api.health")(
@@ -985,7 +985,10 @@ function hasExpectedClerkAudience(audience: unknown, expectedAudience: string): 
         audience.some((entry) => typeof entry === "string" && entry === expectedAudience);
 }
 
-function verifyClerkBearerToken(config: RelayConfiguration.RelayConfigurationShape, token: string) {
+function verifyClerkBearerToken(
+  config: RelayConfiguration.RelayConfiguration["Service"],
+  token: string,
+) {
   return Effect.tryPromise({
     try: () =>
       verifyToken(token, {
@@ -1001,7 +1004,7 @@ function verifyClerkBearerToken(config: RelayConfiguration.RelayConfigurationSha
 }
 
 function verifyClerkOAuthBearerToken(
-  config: RelayConfiguration.RelayConfigurationShape,
+  config: RelayConfiguration.RelayConfiguration["Service"],
   token: string,
 ) {
   return Effect.tryPromise({
@@ -1027,7 +1030,7 @@ function verifyClerkOAuthBearerToken(
 }
 
 export function verifyRelayClientBearerToken(
-  config: RelayConfiguration.RelayConfigurationShape,
+  config: RelayConfiguration.RelayConfiguration["Service"],
   token: string,
 ) {
   return verifyClerkBearerToken(config, token).pipe(

--- a/infra/relay/src/observability.test.ts
+++ b/infra/relay/src/observability.test.ts
@@ -9,7 +9,7 @@ import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import type { OtlpTracer } from "effect/unstable/observability";
 
-import { EnvironmentConnectNotAuthorized } from "./environments/EnvironmentConnector.ts";
+import * as EnvironmentConnector from "./environments/EnvironmentConnector.ts";
 import { makeRelayTraceLayer } from "./observability.ts";
 
 interface ExportedRequest {
@@ -43,7 +43,7 @@ it.effect("exports schema error fields as span attributes", () =>
     );
 
     yield* Effect.fail(
-      new EnvironmentConnectNotAuthorized({
+      new EnvironmentConnector.EnvironmentConnectNotAuthorized({
         environmentId: "environment-1",
         operation: "connect",
         reason: "managed_endpoint_allocation_not_ready",

--- a/infra/relay/src/worker.ts
+++ b/infra/relay/src/worker.ts
@@ -42,7 +42,7 @@ import * as EnvironmentCredentials from "./environments/EnvironmentCredentials.t
 import * as EnvironmentLinks from "./environments/EnvironmentLinks.ts";
 import * as ManagedEndpointAllocations from "./environments/ManagedEndpointAllocations.ts";
 import * as LiveActivities from "./agentActivity/LiveActivities.ts";
-import { RelayDb, RelayHyperdrive } from "./db.ts";
+import * as RelayDb from "./db.ts";
 import { RelayApnsDeliveryDeadLetterQueue, RelayApnsDeliveryQueue } from "./queues.ts";
 import * as RelayConfiguration from "./Config.ts";
 import * as AgentActivityPublisher from "./agentActivity/AgentActivityPublisher.ts";
@@ -138,7 +138,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
 
     const cloudMintPrivateKey = yield* cloudMintKeyPair.privateKey;
     const cloudMintPublicKey = yield* cloudMintKeyPair.publicKey;
-    const hyperdrive = yield* Cloudflare.Hyperdrive.bind(yield* RelayHyperdrive);
+    const hyperdrive = yield* Cloudflare.Hyperdrive.bind(yield* RelayDb.RelayHyperdrive);
     const db = yield* Drizzle.postgres(hyperdrive.connectionString);
 
     const managedEndpointTunnelBinding = yield* Cloudflare.TunnelReadWrite.bind();
@@ -203,16 +203,11 @@ export default class Api extends Cloudflare.Worker<Api>()(
       Layer.provideMerge(AgentActivityRows.layer),
       Layer.provideMerge(Devices.layer),
       Layer.provideMerge(EnvironmentCredentials.layer),
-      Layer.provideMerge(
-        Layer.mergeAll(
-          EnvironmentLinks.layer,
-          ManagedEndpointAllocations.ManagedEndpointAllocations.layer,
-        ),
-      ),
+      Layer.provideMerge(Layer.mergeAll(EnvironmentLinks.layer, ManagedEndpointAllocations.layer)),
       Layer.provideMerge(LiveActivities.layer),
       Layer.provideMerge(DeliveryAttempts.layer),
       Layer.provideMerge(RelayTokens.layer),
-      Layer.provideMerge(Layer.succeed(RelayDb, db)),
+      Layer.provideMerge(Layer.succeed(RelayDb.RelayDb, db)),
       Layer.provideMerge(Layer.effect(RelayConfiguration.RelayConfiguration, loadSettings)),
       Layer.provideMerge(webcryptoLayer),
     );


### PR DESCRIPTION
## Summary

- inline the Effect service contracts for relay configuration, auth, and environment modules
- replace standalone `*Shape` references with `Service["Service"]`
- normalize concrete services to colocated `make` functions and exported `layer` values
- import every relay-local `Context.Service` module as a namespace, including helper types and schema errors
- keep `RelayDb` tag-only and provide database values inline with `Layer.succeed(RelayDb.RelayDb, db)`
- use synchronous `make` functions and `Layer.succeed` factories for runtime-supplied configuration, tunnel, and DNS values

## Why

These modules used several service-definition and import variants. Standardizing the layout makes service contracts, namespace access, and construction predictable across the relay while preserving whether construction is synchronous or effectful. `RelayDb` is intentionally the exception because its implementation is always supplied by a composition or test site.

## Impact

Runtime behavior is unchanged. Production wiring, deployment composition, and tests now consistently access local service exports through their module namespaces. Genuinely effectful construction remains on `Layer.effect`; prebuilt external values use `Layer.succeed`.

## Validation

- `vp test run src` from `infra/relay` — 21 files, 119 tests
- `vp check` — passes with 0 errors; 20 pre-existing warnings remain outside this scope
- `vp run typecheck` — all 15 packages pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only across relay DI and types; auth and delivery logic are unchanged, with tests updated to match new layer helpers.
> 
> **Overview**
> This PR **mechanically aligns** relay foundation modules on a single Effect service layout without changing runtime behavior.
> 
> **Service contracts** drop standalone `*Shape` / `RelayConfigurationShape` / `RelayDatabase` types where touched; the capability is declared **inline** on `Context.Service`, and callers/tests use **`Tag["Service"]`** instead of separate shape exports. Auth and environment services (`RelayTokens`, `DpopProofReplay`, `EnvironmentLinks`, `EnvironmentConnector`, `ManagedEndpointAllocations`, etc.) follow that pattern in the diff.
> 
> **Wiring helpers** add **`RelayConfiguration.make` / `RelayConfiguration.layer`** for prebuilt config in tests and Cloudflare bindings. **`ManagedEndpointAllocations`** moves from a static `ManagedEndpointAllocations.layer` on the class to a **module-level `layer`**. **`ManagedEndpointProvider`** adds **`layerTunnelClient` / `layerDnsClient`** (and uses them in tests and `layerCloudflareBindings`).
> 
> **Imports and tags**: production and tests switch to **namespace imports** (`import * as RelayDb`, `import * as RelayConfiguration`) and resolve services as **`RelayDb.RelayDb`**, **`RelayDb.PlanetscaleDatabase`**, **`RelayDb.RelayHyperdrive`**. **`EnvironmentConnector`** splits HTTP imports to **`FetchHttpClient` / `HttpClient` / `HttpClientError`** submodules.
> 
> **Worker / Alchemy** layers use **`RelayConfiguration.layer`** only where config is supplied synchronously; **dynamic relay settings at startup** stay on **`Layer.effect(RelayConfiguration, loadSettings)`**. DB injection uses **`Layer.succeed(RelayDb.RelayDb, db)`** and **`ManagedEndpointAllocations.layer`** in the merged runtime stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b56d6c59ae983ede273ba8bac865528b6707f614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align relay Effect services to use inline service types and namespace imports
> - Removes separate `Shape` interfaces (e.g. `RelayConfigurationShape`, `EnvironmentLinksShape`) across relay services, inlining the service type directly into `Context.Service` generic parameters.
> - Switches all `RelayDb` imports to namespace-style (`import * as RelayDb`) and updates service acquisition from `yield* RelayDb` to `yield* RelayDb.RelayDb` throughout the codebase.
> - Adds `make` and `layer` factory helpers to [Config.ts](https://github.com/pingdotgg/t3code/pull/3182/files#diff-aa766307a384e831a436608a38af2d08aee3ac8580be3b0c86321275eaee29f7) and replaces `Layer.succeed(RelayConfiguration, ...)` callsites with `RelayConfiguration.layer(config)`.
> - Moves `ManagedEndpointAllocations.layer` from a static class property to a top-level exported constant in [ManagedEndpointAllocations.ts](https://github.com/pingdotgg/t3code/pull/3182/files#diff-72c745c6c0b82e84b54917f48f9ec62bf5f7dfce5692c9cfe5c043347a76fdd8), and adds `makeTunnelClient`/`layerTunnelClient` and `makeDnsClient`/`layerDnsClient` helpers to [ManagedEndpointProvider.ts](https://github.com/pingdotgg/t3code/pull/3182/files#diff-4df570d49d34096d4992fad35ad0a18c440ebb4b3a073b3dfb5c8812c77cb6d3).
> - Behavioral Change: `ManagedEndpointAllocations.layer` is now a module-level export instead of a static class property; callsites referencing `ManagedEndpointAllocations.ManagedEndpointAllocations.layer` must update to `ManagedEndpointAllocations.layer`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b56d6c5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->