### PR TITLE
[codex] refactor server cloud Effect services

### DIFF
--- a/apps/server/src/cloud/CliTokenManager.ts
+++ b/apps/server/src/cloud/CliTokenManager.ts
@@ -6,7 +6,6 @@ import * as Clock from "effect/Clock";
 import * as Console from "effect/Console";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -15,10 +14,12 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import { cloudCliOAuthConfig, type CloudCliOAuthConfig } from "./publicConfig.ts";
@@ -45,35 +46,74 @@ const OAuthTokenResponse = Schema.Struct({
   token_type: Schema.String,
 });
 
-export class CloudCliTokenManagerError extends Data.TaggedError("CloudCliTokenManagerError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
-
-export interface CloudCliTokenManagerShape {
-  readonly get: Effect.Effect<PersistedToken, CloudCliTokenManagerError>;
-  readonly getExisting: Effect.Effect<Option.Option<PersistedToken>, CloudCliTokenManagerError>;
-  readonly hasCredential: Effect.Effect<boolean, CloudCliTokenManagerError>;
-  readonly clear: Effect.Effect<void, CloudCliTokenManagerError>;
+export class CloudCliCredentialRemovalError extends Schema.TaggedErrorClass<CloudCliCredentialRemovalError>()(
+  "CloudCliCredentialRemovalError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Could not remove the stored T3 Connect CLI credential.";
+  }
 }
+
+export class CloudCliCredentialRefreshError extends Schema.TaggedErrorClass<CloudCliCredentialRefreshError>()(
+  "CloudCliCredentialRefreshError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Could not refresh the T3 Connect CLI credential.";
+  }
+}
+
+export class CloudCliCredentialReadError extends Schema.TaggedErrorClass<CloudCliCredentialReadError>()(
+  "CloudCliCredentialReadError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Could not read the stored T3 Connect CLI credential.";
+  }
+}
+
+export class CloudCliAuthorizationError extends Schema.TaggedErrorClass<CloudCliAuthorizationError>()(
+  "CloudCliAuthorizationError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Could not authorize the T3 Connect CLI.";
+  }
+}
+
+export class CloudCliAuthorizationTimeoutError extends Schema.TaggedErrorClass<CloudCliAuthorizationTimeoutError>()(
+  "CloudCliAuthorizationTimeoutError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Timed out waiting for T3 Connect authorization.";
+  }
+}
+
+export const CloudCliTokenManagerError = Schema.Union([
+  CloudCliCredentialRemovalError,
+  CloudCliCredentialRefreshError,
+  CloudCliCredentialReadError,
+  CloudCliAuthorizationError,
+  CloudCliAuthorizationTimeoutError,
+]);
+export type CloudCliTokenManagerError = typeof CloudCliTokenManagerError.Type;
 
 export class CloudCliTokenManager extends Context.Service<
   CloudCliTokenManager,
-  CloudCliTokenManagerShape
+  {
+    readonly get: Effect.Effect<PersistedToken, CloudCliTokenManagerError>;
+    readonly getExisting: Effect.Effect<Option.Option<PersistedToken>, CloudCliTokenManagerError>;
+    readonly hasCredential: Effect.Effect<boolean, CloudCliTokenManagerError>;
+    readonly clear: Effect.Effect<void, CloudCliTokenManagerError>;
+  }
 >()("t3/cloud/CliTokenManager/CloudCliTokenManager") {}
 
 const wrapError =
-  (message: string) =>
-  <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, CloudCliTokenManagerError, R> =>
-    effect.pipe(
-      Effect.mapError(
-        (cause) =>
-          new CloudCliTokenManagerError({
-            message,
-            cause,
-          }),
-      ),
-    );
+  <WrappedError extends CloudCliTokenManagerError>(makeError: (cause: unknown) => WrappedError) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, WrappedError, R> =>
+    effect.pipe(Effect.mapError(makeError));
 
 function stringToBytes(value: string): Uint8Array {
   return new TextEncoder().encode(value);
@@ -83,7 +123,7 @@ function bytesToString(value: Uint8Array): string {
   return new TextDecoder().decode(value);
 }
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const httpClient = (yield* HttpClient.HttpClient).pipe(HttpClient.filterStatusOk);
   const secrets = yield* ServerSecretStore.ServerSecretStore;
@@ -96,7 +136,7 @@ const make = Effect.gen(function* () {
 
   const clear = secrets
     .remove(CLOUD_CLI_OAUTH_TOKEN_SECRET)
-    .pipe(wrapError("Could not remove the stored T3 Connect CLI credential."));
+    .pipe(wrapError((cause) => new CloudCliCredentialRemovalError({ cause })));
 
   const read = Effect.fn("cloud.cli_token.read")(function* () {
     const encoded = yield* secrets.get(CLOUD_CLI_OAUTH_TOKEN_SECRET);
@@ -185,10 +225,10 @@ const make = Effect.gen(function* () {
     yield* Console.log(`Open this URL to authorize T3 Connect:\n${authorizationUrl.toString()}\n`);
     const code = yield* Deferred.await(callback).pipe(
       Effect.timeout(CLOUD_CLI_OAUTH_CALLBACK_TIMEOUT),
-      Effect.catchTag("TimeoutError", () =>
+      Effect.catchTag("TimeoutError", (cause) =>
         Effect.fail(
-          new CloudCliTokenManagerError({
-            message: "Timed out waiting for T3 Connect authorization.",
+          new CloudCliAuthorizationTimeoutError({
+            cause,
           }),
         ),
       ),
@@ -213,12 +253,12 @@ const make = Effect.gen(function* () {
   });
 
   const getExisting = semaphore.withPermits(1)(
-    getExistingNoLock().pipe(wrapError("Could not refresh the T3 Connect CLI credential.")),
+    getExistingNoLock().pipe(wrapError((cause) => new CloudCliCredentialRefreshError({ cause }))),
   );
   const hasCredential = semaphore.withPermits(1)(
     read().pipe(
       Effect.map(Option.isSome),
-      wrapError("Could not read the stored T3 Connect CLI credential."),
+      wrapError((cause) => new CloudCliCredentialReadError({ cause })),
     ),
   );
   const get = semaphore.withPermits(1)(
@@ -227,7 +267,7 @@ const make = Effect.gen(function* () {
       return Option.isSome(token)
         ? token.value
         : yield* Effect.scoped(login()).pipe(Effect.flatMap(persist));
-    }).pipe(wrapError("Could not authorize the T3 Connect CLI.")),
+    }).pipe(wrapError((cause) => new CloudCliAuthorizationError({ cause }))),
   );
 
   return CloudCliTokenManager.of({ get, getExisting, hasCredential, clear });

--- a/apps/server/src/cloud/ManagedEndpointRuntime.test.ts
+++ b/apps/server/src/cloud/ManagedEndpointRuntime.test.ts
@@ -4,16 +4,15 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import * as RelayClient from "@t3tools/shared/relayClient";
 
-import {
-  classifyRelayClientOutput,
-  makeCloudManagedEndpointRuntime,
-} from "./ManagedEndpointRuntime.ts";
+import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
+import * as ManagedEndpointRuntime from "./ManagedEndpointRuntime.ts";
 
 const relayClientAvailableLayer = Layer.succeed(
   RelayClient.RelayClient,
@@ -29,11 +28,32 @@ const relayClientAvailableLayer = Layer.succeed(
   }),
 );
 
-const runtimeDependencies = (spawner: ReturnType<typeof ChildProcessSpawner.make>) =>
+const runtimeDependencies = (
+  spawner: ReturnType<typeof ChildProcessSpawner.make>,
+  relayClientLayer = relayClientAvailableLayer,
+) =>
   Layer.mergeAll(
     Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
-    relayClientAvailableLayer,
+    relayClientLayer,
+    Layer.mock(ServerSecretStore.ServerSecretStore)({
+      get: () => Effect.succeed(Option.none()),
+    }),
   );
+
+const buildCloudManagedEndpointRuntime = (
+  spawner: ReturnType<typeof ChildProcessSpawner.make>,
+  relayClientLayer = relayClientAvailableLayer,
+) =>
+  Effect.gen(function* () {
+    const context = yield* Layer.build(
+      ManagedEndpointRuntime.layer.pipe(
+        Layer.provide(runtimeDependencies(spawner, relayClientLayer)),
+      ),
+    );
+    return yield* Effect.service(ManagedEndpointRuntime.CloudManagedEndpointRuntime).pipe(
+      Effect.provide(context),
+    );
+  });
 
 function makeHandle(input: {
   readonly pid: number;
@@ -62,16 +82,20 @@ function makeHandle(input: {
 describe("CloudManagedEndpointRuntime", () => {
   it("classifies Cloudflare connection and warning output", () => {
     expect(
-      classifyRelayClientOutput(
+      ManagedEndpointRuntime.classifyRelayClientOutput(
         "2026-06-17T02:00:00Z INF Registered tunnel connection connIndex=0",
       ),
     ).toBe("connected");
     expect(
-      classifyRelayClientOutput("2026-06-17T02:00:00Z ERR Failed to serve tunnel connection"),
+      ManagedEndpointRuntime.classifyRelayClientOutput(
+        "2026-06-17T02:00:00Z ERR Failed to serve tunnel connection",
+      ),
     ).toBe("warning");
-    expect(classifyRelayClientOutput("2026-06-17T02:00:00Z INF Starting metrics server")).toBe(
-      "debug",
-    );
+    expect(
+      ManagedEndpointRuntime.classifyRelayClientOutput(
+        "2026-06-17T02:00:00Z INF Starting metrics server",
+      ),
+    ).toBe("debug");
   });
 
   it.effect("starts, deduplicates, rotates, and stops the Cloudflare connector", () =>
@@ -97,9 +121,7 @@ describe("CloudManagedEndpointRuntime", () => {
           return handle;
         }),
       );
-      const runtime = yield* makeCloudManagedEndpointRuntime.pipe(
-        Effect.provide(runtimeDependencies(spawner)),
-      );
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
 
       yield* runtime.applyConfig({
         providerKind: "cloudflare_tunnel",
@@ -154,9 +176,7 @@ describe("CloudManagedEndpointRuntime", () => {
           return handle;
         }),
       );
-      const runtime = yield* makeCloudManagedEndpointRuntime.pipe(
-        Effect.provide(runtimeDependencies(spawner)),
-      );
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
 
       const started = yield* runtime.applyConfig({
         providerKind: "cloudflare_tunnel",
@@ -193,9 +213,7 @@ describe("CloudManagedEndpointRuntime", () => {
           return handle;
         }),
       );
-      const runtime = yield* makeCloudManagedEndpointRuntime.pipe(
-        Effect.provide(runtimeDependencies(spawner)),
-      );
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
       const config = {
         providerKind: "cloudflare_tunnel" as const,
         connectorToken: "token",
@@ -240,9 +258,7 @@ describe("CloudManagedEndpointRuntime", () => {
           return handle;
         }),
       );
-      const runtime = yield* makeCloudManagedEndpointRuntime.pipe(
-        Effect.provide(runtimeDependencies(spawner)),
-      );
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
 
       const started = yield* runtime.applyConfig({
         providerKind: "cloudflare_tunnel",
@@ -282,9 +298,7 @@ describe("CloudManagedEndpointRuntime", () => {
           return handle;
         }),
       );
-      const runtime = yield* makeCloudManagedEndpointRuntime.pipe(
-        Effect.provide(runtimeDependencies(spawner)),
-      );
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
 
       const first = yield* runtime
         .applyConfig({
@@ -322,9 +336,7 @@ describe("CloudManagedEndpointRuntime", () => {
           }),
         ),
       );
-      const runtime = yield* makeCloudManagedEndpointRuntime.pipe(
-        Effect.provide(runtimeDependencies(spawner)),
-      );
+      const runtime = yield* buildCloudManagedEndpointRuntime(spawner);
 
       const status = yield* runtime.applyConfig({
         providerKind: "cloudflare_tunnel",
@@ -344,22 +356,18 @@ describe("CloudManagedEndpointRuntime", () => {
     Effect.gen(function* () {
       const spawn = vi.fn();
       const spawner = ChildProcessSpawner.make(spawn);
-      const runtime = yield* makeCloudManagedEndpointRuntime.pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
-            Layer.succeed(
-              RelayClient.RelayClient,
-              RelayClient.RelayClient.of({
-                resolve: Effect.succeed({
-                  status: "missing",
-                  version: RelayClient.CLOUDFLARED_VERSION,
-                }),
-                install: Effect.die("unused"),
-                installWithProgress: () => Effect.die("unused"),
-              }),
-            ),
-          ),
+      const runtime = yield* buildCloudManagedEndpointRuntime(
+        spawner,
+        Layer.succeed(
+          RelayClient.RelayClient,
+          RelayClient.RelayClient.of({
+            resolve: Effect.succeed({
+              status: "missing",
+              version: RelayClient.CLOUDFLARED_VERSION,
+            }),
+            install: Effect.die("unused"),
+            installWithProgress: () => Effect.die("unused"),
+          }),
         ),
       );
 

--- a/apps/server/src/cloud/ManagedEndpointRuntime.ts
+++ b/apps/server/src/cloud/ManagedEndpointRuntime.ts
@@ -10,7 +10,8 @@ import * as Result from "effect/Result";
 import * as Semaphore from "effect/Semaphore";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import { CLOUD_ENDPOINT_RUNTIME_CONFIG, decodeRuntimeConfig } from "./config.ts";
@@ -27,17 +28,6 @@ const readRuntimeConfig = Effect.gen(function* () {
   }
   return Option.getOrNull(decodeRuntimeConfig(bytesToString(bytes.value)));
 });
-
-export interface CloudManagedEndpointRuntimeShape {
-  readonly applyConfig: (
-    config: RelayManagedEndpointRuntimeConfig | null,
-  ) => Effect.Effect<CloudManagedEndpointRuntimeStatus>;
-}
-
-export class CloudManagedEndpointRuntime extends Context.Service<
-  CloudManagedEndpointRuntime,
-  CloudManagedEndpointRuntimeShape
->()("t3/cloud/ManagedEndpointRuntime/CloudManagedEndpointRuntime") {}
 
 export type CloudManagedEndpointRuntimeStatus =
   | {
@@ -61,6 +51,15 @@ export type CloudManagedEndpointRuntimeStatus =
       readonly status: "unsupported";
       readonly providerKind: RelayManagedEndpointRuntimeConfig["providerKind"];
     };
+
+export class CloudManagedEndpointRuntime extends Context.Service<
+  CloudManagedEndpointRuntime,
+  {
+    readonly applyConfig: (
+      config: RelayManagedEndpointRuntimeConfig | null,
+    ) => Effect.Effect<CloudManagedEndpointRuntimeStatus>;
+  }
+>()("t3/cloud/ManagedEndpointRuntime/CloudManagedEndpointRuntime") {}
 
 interface ActiveConnector {
   readonly child: ChildProcessSpawner.ChildProcessHandle;
@@ -97,13 +96,13 @@ const stopConnector = (connector: ActiveConnector | null) =>
       )
     : Effect.void;
 
-export const makeCloudManagedEndpointRuntime = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const relayClient = yield* RelayClient.RelayClient;
   const activeRef = yield* Ref.make<ActiveConnector | null>(null);
   const desiredConfigRef = yield* Ref.make<RelayManagedEndpointRuntimeConfig | null>(null);
   const reconcileSemaphore = yield* Semaphore.make(1);
-  let reconcileConfig: CloudManagedEndpointRuntimeShape["applyConfig"];
+  let reconcileConfig: CloudManagedEndpointRuntime["Service"]["applyConfig"];
 
   const stopActive = Effect.gen(function* () {
     const active = yield* Ref.getAndSet(activeRef, null);
@@ -301,24 +300,20 @@ export const makeCloudManagedEndpointRuntime = Effect.gen(function* () {
       ),
   );
 
-  return CloudManagedEndpointRuntime.of({
+  const runtime = CloudManagedEndpointRuntime.of({
     applyConfig,
   });
+
+  const initialConfig = yield* readRuntimeConfig.pipe(
+    Effect.catch((cause) =>
+      Effect.logWarning("Failed to read managed endpoint runtime config", { cause }).pipe(
+        Effect.as(null),
+      ),
+    ),
+  );
+  yield* runtime.applyConfig(initialConfig);
+  yield* Effect.addFinalizer(() => runtime.applyConfig(null));
+  return runtime;
 });
 
-export const layer = Layer.effect(
-  CloudManagedEndpointRuntime,
-  Effect.gen(function* () {
-    const runtime = yield* makeCloudManagedEndpointRuntime;
-    const initialConfig = yield* readRuntimeConfig.pipe(
-      Effect.catch((cause) =>
-        Effect.logWarning("Failed to read managed endpoint runtime config", { cause }).pipe(
-          Effect.as(null),
-        ),
-      ),
-    );
-    yield* runtime.applyConfig(initialConfig);
-    yield* Effect.addFinalizer(() => runtime.applyConfig(null));
-    return runtime;
-  }),
-);
+export const layer = Layer.effect(CloudManagedEndpointRuntime, make);

--- a/apps/server/src/cloud/http.test.ts
+++ b/apps/server/src/cloud/http.test.ts
@@ -9,13 +9,10 @@ import { HttpClient, HttpServerRequest } from "effect/unstable/http";
 import { RelayClientTracer } from "@t3tools/shared/relayTracing";
 import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
-import { ServerEnvironment } from "../environment/Services/ServerEnvironment.ts";
+import * as ServerEnvironment from "../environment/Services/ServerEnvironment.ts";
 import * as CliTokenManager from "./CliTokenManager.ts";
 import { consumeCloudReplayGuards, reconcileDesiredCloudLink } from "./http.ts";
-import {
-  CloudManagedEndpointRuntime,
-  type CloudManagedEndpointRuntimeShape,
-} from "./ManagedEndpointRuntime.ts";
+import * as ManagedEndpointRuntime from "./ManagedEndpointRuntime.ts";
 import { traceAuthenticatedRelayRequest, traceRelayRequest } from "./traceRelayRequest.ts";
 
 const storeFailure = (tag: "AlreadyExists" | "PermissionDenied") =>
@@ -32,8 +29,8 @@ const storeFailure = (tag: "AlreadyExists" | "PermissionDenied") =>
 const unusedSecretStoreOperation = () => Effect.die("unused secret-store operation");
 
 function makeSecretStore(
-  create: ServerSecretStore.ServerSecretStoreShape["create"],
-): ServerSecretStore.ServerSecretStoreShape {
+  create: ServerSecretStore.ServerSecretStore["Service"]["create"],
+): ServerSecretStore.ServerSecretStore["Service"] {
   return {
     get: unusedSecretStoreOperation,
     set: unusedSecretStoreOperation,
@@ -151,21 +148,21 @@ describe("reconcileDesiredCloudLink", () => {
         makeSecretStore(unusedSecretStoreOperation),
       ),
       Effect.provideService(
-        ServerEnvironment,
-        ServerEnvironment.of({
+        ServerEnvironment.ServerEnvironment,
+        ServerEnvironment.ServerEnvironment.of({
           getEnvironmentId: unusedSecretStoreOperation(),
           getDescriptor: unusedSecretStoreOperation(),
         }),
       ),
       Effect.provideService(
-        CloudManagedEndpointRuntime,
-        CloudManagedEndpointRuntime.of({
+        ManagedEndpointRuntime.CloudManagedEndpointRuntime,
+        ManagedEndpointRuntime.CloudManagedEndpointRuntime.of({
           applyConfig: unusedSecretStoreOperation,
-        } satisfies CloudManagedEndpointRuntimeShape),
+        } satisfies ManagedEndpointRuntime.CloudManagedEndpointRuntime["Service"]),
       ),
       Effect.provideService(
         EnvironmentAuth.EnvironmentAuth,
-        EnvironmentAuth.EnvironmentAuth.of({} as EnvironmentAuth.EnvironmentAuthShape),
+        EnvironmentAuth.EnvironmentAuth.of({} as EnvironmentAuth.EnvironmentAuth["Service"]),
       ),
       Effect.provideService(
         CliTokenManager.CloudCliTokenManager,

--- a/apps/server/src/cloud/http.ts
+++ b/apps/server/src/cloud/http.ts
@@ -55,14 +55,8 @@ import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 import * as EnvironmentAuth from "../auth/EnvironmentAuth.ts";
 import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import { requireEnvironmentScope } from "../auth/http.ts";
-import {
-  ServerEnvironment,
-  type ServerEnvironmentShape,
-} from "../environment/Services/ServerEnvironment.ts";
-import {
-  CloudManagedEndpointRuntime,
-  type CloudManagedEndpointRuntimeShape,
-} from "./ManagedEndpointRuntime.ts";
+import * as ServerEnvironment from "../environment/Services/ServerEnvironment.ts";
+import * as ManagedEndpointRuntime from "./ManagedEndpointRuntime.ts";
 import {
   CLOUD_ENDPOINT_RUNTIME_CONFIG,
   CLOUD_LINKED_USER_ID,
@@ -103,6 +97,9 @@ const failEnvironmentCloudInternalError =
       Effect.flatMap(() => Effect.fail(new EnvironmentHttpInternalServerError({ message }))),
     );
 
+const failCloudCliTokenManagerError = (error: CliTokenManager.CloudCliTokenManagerError) =>
+  failEnvironmentCloudInternalError(error.message)(error.cause);
+
 const requireRelayUrl = relayUrlConfig.pipe(
   Effect.mapError(
     () =>
@@ -121,7 +118,7 @@ function stringToBytes(value: string): Uint8Array {
 }
 
 export function consumeCloudReplayGuards(input: {
-  readonly secrets: ServerSecretStore.ServerSecretStoreShape;
+  readonly secrets: ServerSecretStore.ServerSecretStore["Service"];
   readonly names: ReadonlyArray<string>;
   readonly value: Uint8Array;
 }) {
@@ -208,7 +205,7 @@ function validateRelayConfigPayload(
 }
 
 function validateLinkedCloudUser(input: {
-  readonly secrets: ServerSecretStore.ServerSecretStoreShape;
+  readonly secrets: ServerSecretStore.ServerSecretStore["Service"];
   readonly cloudUserId: string;
 }): Effect.Effect<void, EnvironmentAuth.ServerAuthInternalError | EnvironmentHttpConflictError> {
   return input.secrets.get(CLOUD_LINKED_USER_ID).pipe(
@@ -237,7 +234,7 @@ function validateLinkedCloudUser(input: {
 }
 
 function readInstalledCloudUserId(
-  secrets: ServerSecretStore.ServerSecretStoreShape,
+  secrets: ServerSecretStore.ServerSecretStore["Service"],
 ): Effect.Effect<string, EnvironmentAuth.ServerAuthInternalError> {
   return secrets.get(CLOUD_LINKED_USER_ID).pipe(
     Effect.mapError(
@@ -335,19 +332,19 @@ const decodeCloudHealthProof = Schema.decodeUnknownEffect(RelayCloudEnvironmentH
 const decodeCloudMintProof = Schema.decodeUnknownEffect(RelayCloudMintCredentialProofPayload);
 
 interface CloudHttpDependencies {
-  readonly secrets: ServerSecretStore.ServerSecretStoreShape;
-  readonly environment: ServerEnvironmentShape;
-  readonly endpointRuntime: CloudManagedEndpointRuntimeShape;
-  readonly environmentAuth: EnvironmentAuth.EnvironmentAuthShape;
-  readonly cliTokenManager: CliTokenManager.CloudCliTokenManagerShape;
+  readonly secrets: ServerSecretStore.ServerSecretStore["Service"];
+  readonly environment: ServerEnvironment.ServerEnvironment["Service"];
+  readonly endpointRuntime: ManagedEndpointRuntime.CloudManagedEndpointRuntime["Service"];
+  readonly environmentAuth: EnvironmentAuth.EnvironmentAuth["Service"];
+  readonly cliTokenManager: CliTokenManager.CloudCliTokenManager["Service"];
   readonly httpClient: HttpClient.HttpClient;
 }
 
 const cloudHttpDependencies = Effect.gen(function* () {
   return {
     secrets: yield* ServerSecretStore.ServerSecretStore,
-    environment: yield* ServerEnvironment,
-    endpointRuntime: yield* CloudManagedEndpointRuntime,
+    environment: yield* ServerEnvironment.ServerEnvironment,
+    endpointRuntime: yield* ManagedEndpointRuntime.CloudManagedEndpointRuntime,
     environmentAuth: yield* EnvironmentAuth.EnvironmentAuth,
     cliTokenManager: yield* CliTokenManager.CloudCliTokenManager,
     httpClient: yield* HttpClient.HttpClient,
@@ -595,8 +592,11 @@ const reconcileDesiredCloudLinkWith = Effect.fn("environment.cloud.reconcileDesi
     });
   },
   Effect.catchTags({
-    CloudCliTokenManagerError: (error) =>
-      failEnvironmentCloudInternalError(error.message)(error.cause),
+    CloudCliCredentialRemovalError: failCloudCliTokenManagerError,
+    CloudCliCredentialRefreshError: failCloudCliTokenManagerError,
+    CloudCliCredentialReadError: failCloudCliTokenManagerError,
+    CloudCliAuthorizationError: failCloudCliTokenManagerError,
+    CloudCliAuthorizationTimeoutError: failCloudCliTokenManagerError,
     SecretStoreError: failEnvironmentCloudInternalError(
       "Could not persist desired T3 Connect link state.",
     ),


### PR DESCRIPTION
## Summary

- inline the cloud CLI token manager and managed endpoint runtime contracts on their `Context.Service` tags
- export each concrete service's canonical `make` and `layer` values and reference contracts through `Service["Service"]`
- replace the CLI token manager's operation-switched error with five concrete `Schema.TaggedErrorClass` failures and an exported `Schema.Union`
- namespace-import service-bearing modules while retaining named imports for contracts and pure helper/config APIs
- preserve the current server/config migrations; the diff remains limited to five cloud files with no orchestration, MCP, or harness changes

## Design notes

Credential removal, credential refresh, credential read, authorization, and authorization timeout are materially different failures, so each now has its own tag and required structured cause. The HTTP boundary handles all concrete tags through the shared inferred error union.

Both service constructors are effectful and dependency-backed, and the managed endpoint runtime owns lifecycle finalization. Their layers therefore use `Layer.effect`. Existing managed-endpoint tests construct the service through its production layer so startup and finalization remain covered; no refactor-only test cases were added.

## Validation

- `vp test run apps/server/src/cloud/ManagedEndpointRuntime.test.ts apps/server/src/cloud/http.test.ts apps/server/src/server.test.ts` (3 files, 110 tests)
- `vp check` (zero errors; 20 pre-existing warnings)
- `vp run typecheck`
- `git diff --check origin/main...HEAD`
- audit: two inline service contracts, two exported canonical `make`/`layer` pairs, zero standalone target service-shape references, exact parity across 13 changed-file test declarations, comments preserved, and no excluded paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor in non-orchestration cloud paths; CLI errors gain distinct `_tag` values but HTTP still maps them to the same internal error messages.
> 
> **Overview**
> This PR **restructures** the server **cloud** module’s Effect services without changing OAuth, tunnel, or HTTP behavior.
> 
> **CLI token manager** replaces one `Data.TaggedError` with **operation-specific** `Schema.TaggedErrorClass` types (read, refresh, authorize, timeout, removal) united as `CloudCliTokenManagerError`, and maps failures through typed constructors instead of generic message strings. The service contract moves **inline** on `Context.Service`, and **`make`** is exported as the canonical factory.
> 
> **Managed endpoint runtime** drops standalone `*Shape` interfaces, renames **`makeCloudManagedEndpointRuntime`** to **`make`** (startup config + teardown finalizer live in that effect), and exposes **`layer`** as `Layer.effect(Service, make)`. Process/HTTP imports use **explicit submodule paths**.
> 
> **Cloud HTTP** and tests switch to **namespace imports** and `Service["Service"]` for dependency typing; **`reconcileDesiredCloudLink`** catches each CLI error tag separately while still surfacing the same user-facing messages via `error.message`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7c67c1e33a5bb8dbcb3269c47b14c2a6fa6cb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor cloud Effect services to use specific error classes and namespace imports
> - Replaces the single generic `CloudCliTokenManagerError` with five specific error classes (`CloudCliCredentialRemovalError`, `CloudCliCredentialRefreshError`, `CloudCliCredentialReadError`, `CloudCliAuthorizationError`, `CloudCliAuthorizationTimeoutError`), each preserving the original cause.
> - Updates `ManagedEndpointRuntime` to consolidate the factory into `export const make`, inline the service shape, and simplify layer construction.
> - Updates `http.ts` to catch and map each specific token manager error variant via a new `failCloudCliTokenManagerError` helper, rather than a single generic catch.
> - Replaces direct named imports with namespace imports across all affected cloud modules and tests for consistency with Effect conventions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b7c67c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->