### PR TITLE
[codex] Refactor desktop app Effect services

### DIFF
--- a/apps/desktop/src/app/DesktopAppIdentity.test.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.test.ts
@@ -63,7 +63,7 @@ const makeElectronAppLayer = (calls: ElectronAppCalls) =>
       }),
     appendCommandLineSwitch: () => Effect.void,
     on: () => Effect.void,
-  } satisfies ElectronApp.ElectronAppShape);
+  } satisfies ElectronApp.ElectronApp["Service"]);
 
 const makeAssetsLayer = (png: Option.Option<string>) =>
   Layer.succeed(DesktopAssets.DesktopAssets, {
@@ -73,7 +73,7 @@ const makeAssetsLayer = (png: Option.Option<string>) =>
       png,
     }),
     resolveResourcePath: () => Effect.succeed(Option.none()),
-  } satisfies DesktopAssets.DesktopAssetsShape);
+  } satisfies DesktopAssets.DesktopAssets["Service"]);
 
 const makeEnvironmentLayer = (overrides: TestEnvironmentInput = {}) => {
   const { env, ...environmentOverrides } = overrides;

--- a/apps/desktop/src/app/DesktopAppIdentity.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.ts
@@ -18,14 +18,12 @@ const AppPackageMetadata = Schema.Struct({
 });
 const decodeAppPackageMetadata = Schema.decodeEffect(Schema.fromJsonString(AppPackageMetadata));
 
-export interface DesktopAppIdentityShape {
-  readonly resolveUserDataPath: Effect.Effect<string>;
-  readonly configure: Effect.Effect<void>;
-}
-
 export class DesktopAppIdentity extends Context.Service<
   DesktopAppIdentity,
-  DesktopAppIdentityShape
+  {
+    readonly resolveUserDataPath: Effect.Effect<string>;
+    readonly configure: Effect.Effect<void>;
+  }
 >()("@t3tools/desktop/app/DesktopAppIdentity") {}
 
 const normalizeCommitHash = (value: string): Option.Option<string> => {

--- a/apps/desktop/src/app/DesktopAssets.ts
+++ b/apps/desktop/src/app/DesktopAssets.ts
@@ -12,14 +12,13 @@ export interface DesktopIconPaths {
   readonly png: Option.Option<string>;
 }
 
-export interface DesktopAssetsShape {
-  readonly iconPaths: Effect.Effect<DesktopIconPaths>;
-  readonly resolveResourcePath: (fileName: string) => Effect.Effect<Option.Option<string>>;
-}
-
-export class DesktopAssets extends Context.Service<DesktopAssets, DesktopAssetsShape>()(
-  "@t3tools/desktop/app/DesktopAssets",
-) {}
+export class DesktopAssets extends Context.Service<
+  DesktopAssets,
+  {
+    readonly iconPaths: Effect.Effect<DesktopIconPaths>;
+    readonly resolveResourcePath: (fileName: string) => Effect.Effect<Option.Option<string>>;
+  }
+>()("@t3tools/desktop/app/DesktopAssets") {}
 
 const resolveResourcePath = Effect.fn("desktop.assets.resolveResourcePath")(function* (
   fileName: string,

--- a/apps/desktop/src/app/DesktopBackendOutputLog.ts
+++ b/apps/desktop/src/app/DesktopBackendOutputLog.ts
@@ -1,0 +1,280 @@
+import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as References from "effect/References";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import * as Semaphore from "effect/Semaphore";
+
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+
+export const DESKTOP_LOG_FILE_MAX_BYTES = 10 * 1024 * 1024;
+export const DESKTOP_LOG_FILE_MAX_FILES = 10;
+
+const DESKTOP_BACKEND_CHILD_LOG_FIBER_ID = "#backend-child";
+
+interface RotatingLogFileWriter {
+  readonly writeBytes: (chunk: Uint8Array) => Effect.Effect<void>;
+  readonly writeText: (chunk: string) => Effect.Effect<void>;
+}
+
+export class DesktopBackendOutputLog extends Context.Service<
+  DesktopBackendOutputLog,
+  {
+    readonly writeSessionBoundary: (input: {
+      readonly phase: "START" | "END";
+      readonly details: string;
+    }) => Effect.Effect<void>;
+    readonly writeOutputChunk: (
+      streamName: "stdout" | "stderr",
+      chunk: Uint8Array,
+    ) => Effect.Effect<void>;
+  }
+>()("@t3tools/desktop/app/DesktopBackendOutputLog") {}
+
+class DesktopLogFileWriterConfigurationError extends Schema.TaggedErrorClass<DesktopLogFileWriterConfigurationError>()(
+  "DesktopLogFileWriterConfigurationError",
+  {
+    option: Schema.Literals(["maxBytes", "maxFiles"]),
+    value: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `${this.option} must be >= 1 (received ${this.value})`;
+  }
+}
+
+type DesktopLogFileWriterError =
+  | DesktopLogFileWriterConfigurationError
+  | PlatformError.PlatformError;
+
+const DesktopBackendChildLogRecord = Schema.Struct({
+  message: Schema.String,
+  level: Schema.Literals(["INFO", "ERROR"]),
+  timestamp: Schema.String,
+  annotations: Schema.Record(Schema.String, Schema.Unknown),
+  spans: Schema.Record(Schema.String, Schema.Unknown),
+  fiberId: Schema.String,
+});
+
+const encodeDesktopBackendChildLogRecord = Schema.encodeEffect(
+  Schema.fromJsonString(DesktopBackendChildLogRecord),
+);
+
+const DesktopBackendOutputLogNoop: DesktopBackendOutputLog["Service"] = {
+  writeSessionBoundary: () => Effect.void,
+  writeOutputChunk: () => Effect.void,
+};
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+const currentDesktopRunId = Effect.gen(function* () {
+  const annotations = yield* References.CurrentLogAnnotations;
+  const runId = annotations.runId;
+  return typeof runId === "string" && runId.length > 0 ? runId : "unknown";
+});
+
+const sanitizeLogValue = (value: string): string => value.replace(/\s+/g, " ").trim();
+
+const refreshFileSize = (
+  fileSystem: FileSystem.FileSystem,
+  filePath: string,
+): Effect.Effect<number, never> =>
+  fileSystem.stat(filePath).pipe(
+    Effect.map((stat) => Number(stat.size)),
+    Effect.orElseSucceed(() => 0),
+  );
+
+const makeRotatingLogFileWriter = Effect.fn("makeRotatingLogFileWriter")(function* (input: {
+  readonly filePath: string;
+  readonly maxBytes?: number;
+  readonly maxFiles?: number;
+}): Effect.fn.Return<
+  RotatingLogFileWriter,
+  DesktopLogFileWriterError,
+  FileSystem.FileSystem | Path.Path
+> {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const maxBytes = input.maxBytes ?? DESKTOP_LOG_FILE_MAX_BYTES;
+  const maxFiles = input.maxFiles ?? DESKTOP_LOG_FILE_MAX_FILES;
+  const directory = path.dirname(input.filePath);
+  const baseName = path.basename(input.filePath);
+
+  if (maxBytes < 1) {
+    return yield* new DesktopLogFileWriterConfigurationError({
+      option: "maxBytes",
+      value: maxBytes,
+    });
+  }
+  if (maxFiles < 1) {
+    return yield* new DesktopLogFileWriterConfigurationError({
+      option: "maxFiles",
+      value: maxFiles,
+    });
+  }
+
+  yield* fileSystem.makeDirectory(directory, { recursive: true });
+
+  const withSuffix = (index: number) => `${input.filePath}.${index}`;
+  const currentSize = yield* Ref.make(yield* refreshFileSize(fileSystem, input.filePath));
+  const mutex = yield* Semaphore.make(1);
+
+  const pruneOverflowBackups = Effect.gen(function* () {
+    const entries = yield* fileSystem.readDirectory(directory).pipe(Effect.orElseSucceed(() => []));
+    for (const entry of entries) {
+      if (!entry.startsWith(`${baseName}.`)) continue;
+      const suffix = Number(entry.slice(baseName.length + 1));
+      if (!Number.isInteger(suffix) || suffix <= maxFiles) continue;
+      yield* fileSystem.remove(path.join(directory, entry), { force: true }).pipe(Effect.ignore);
+    }
+  });
+
+  const rotate = Effect.gen(function* () {
+    yield* fileSystem.remove(withSuffix(maxFiles), { force: true }).pipe(Effect.ignore);
+    for (let index = maxFiles - 1; index >= 1; index -= 1) {
+      const source = withSuffix(index);
+      const sourceExists = yield* fileSystem.exists(source).pipe(Effect.orElseSucceed(() => false));
+      if (sourceExists) {
+        yield* fileSystem.rename(source, withSuffix(index + 1));
+      }
+    }
+    const currentExists = yield* fileSystem
+      .exists(input.filePath)
+      .pipe(Effect.orElseSucceed(() => false));
+    if (currentExists) {
+      yield* fileSystem.rename(input.filePath, withSuffix(1));
+    }
+    yield* Ref.set(currentSize, 0);
+  }).pipe(
+    Effect.catch(() =>
+      refreshFileSize(fileSystem, input.filePath).pipe(
+        Effect.flatMap((size) => Ref.set(currentSize, size)),
+      ),
+    ),
+  );
+
+  const writeBytes = (chunk: Uint8Array): Effect.Effect<void> => {
+    if (chunk.byteLength === 0) return Effect.void;
+
+    return mutex.withPermits(1)(
+      Effect.gen(function* () {
+        const beforeSize = yield* Ref.get(currentSize);
+        if (beforeSize > 0 && beforeSize + chunk.byteLength > maxBytes) {
+          yield* rotate;
+        }
+
+        yield* fileSystem.writeFile(input.filePath, chunk, { flag: "a" });
+        const afterSize = (yield* Ref.get(currentSize)) + chunk.byteLength;
+        yield* Ref.set(currentSize, afterSize);
+
+        if (afterSize > maxBytes) {
+          yield* rotate;
+        }
+      }).pipe(
+        Effect.catch(() =>
+          refreshFileSize(fileSystem, input.filePath).pipe(
+            Effect.flatMap((size) => Ref.set(currentSize, size)),
+          ),
+        ),
+      ),
+    );
+  };
+
+  yield* pruneOverflowBackups;
+
+  return {
+    writeBytes,
+    writeText: (chunk) => writeBytes(textEncoder.encode(chunk)),
+  } satisfies RotatingLogFileWriter;
+});
+
+const writeDevelopmentConsoleOutput = (
+  streamName: "stdout" | "stderr",
+  chunk: Uint8Array,
+): Effect.Effect<void> =>
+  Effect.sync(() => {
+    const output = streamName === "stderr" ? process.stderr : process.stdout;
+    output.write(chunk);
+  }).pipe(Effect.ignore);
+
+const writeBackendChildLogRecord = Effect.fn("desktop.observability.writeBackendChildLogRecord")(
+  function* (
+    logFile: RotatingLogFileWriter,
+    input: {
+      readonly message: string;
+      readonly level: "INFO" | "ERROR";
+      readonly annotations: Record<string, unknown>;
+    },
+  ): Effect.fn.Return<void> {
+    return yield* Effect.gen(function* () {
+      const timestamp = DateTime.formatIso(yield* DateTime.now);
+      const encoded = yield* encodeDesktopBackendChildLogRecord({
+        message: input.message,
+        level: input.level,
+        timestamp,
+        annotations: input.annotations,
+        spans: {},
+        fiberId: DESKTOP_BACKEND_CHILD_LOG_FIBER_ID,
+      });
+      yield* logFile.writeText(`${encoded}\n`);
+    }).pipe(Effect.ignore({ log: true }));
+  },
+);
+
+const make = Effect.gen(function* () {
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const writer = yield* makeRotatingLogFileWriter({
+    filePath: environment.path.join(environment.logDir, "server-child.log"),
+  }).pipe(Effect.option);
+
+  const service = Option.match(writer, {
+    onNone: () => DesktopBackendOutputLogNoop,
+    onSome: (logFile) =>
+      ({
+        writeSessionBoundary: Effect.fn("desktop.observability.backendOutput.writeSessionBoundary")(
+          function* ({ phase, details }) {
+            const runId = yield* currentDesktopRunId;
+            yield* writeBackendChildLogRecord(logFile, {
+              message: `backend child process session ${phase.toLowerCase()}`,
+              level: "INFO",
+              annotations: {
+                component: "desktop-backend-child",
+                runId,
+                phase,
+                details: sanitizeLogValue(details),
+              },
+            });
+          },
+        ),
+        writeOutputChunk: Effect.fn("desktop.observability.backendOutput.writeOutputChunk")(
+          function* (streamName, chunk) {
+            if (environment.isDevelopment) {
+              yield* writeDevelopmentConsoleOutput(streamName, chunk);
+            }
+            const runId = yield* currentDesktopRunId;
+            yield* writeBackendChildLogRecord(logFile, {
+              message: "backend child process output",
+              level: streamName === "stderr" ? "ERROR" : "INFO",
+              annotations: {
+                component: "desktop-backend-child",
+                runId,
+                stream: streamName,
+                text: textDecoder.decode(chunk),
+              },
+            });
+          },
+        ),
+      }) satisfies DesktopBackendOutputLog["Service"],
+  });
+
+  return DesktopBackendOutputLog.of(service);
+});
+
+export const layer = Layer.effect(DesktopBackendOutputLog, make);

--- a/apps/desktop/src/app/DesktopClerk.test.ts
+++ b/apps/desktop/src/app/DesktopClerk.test.ts
@@ -21,10 +21,6 @@ vi.mock("@clerk/electron/storage", () => ({
   storage: storageMock,
 }));
 
-import {
-  createDesktopClerkBridge,
-  resolveDesktopClerkFrontendApiHostname,
-} from "./DesktopClerk.ts";
 import * as DesktopClerk from "./DesktopClerk.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 
@@ -32,9 +28,12 @@ describe("DesktopClerk", () => {
   it("derives the Clerk Frontend API hostname used by the desktop CSP", () => {
     const publishableKey = `pk_test_${btoa("clerk.t3.codes$")}`;
 
-    assert.equal(resolveDesktopClerkFrontendApiHostname(publishableKey), "clerk.t3.codes");
-    assert.equal(resolveDesktopClerkFrontendApiHostname(""), undefined);
-    assert.equal(resolveDesktopClerkFrontendApiHostname("invalid"), undefined);
+    assert.equal(
+      DesktopClerk.resolveDesktopClerkFrontendApiHostname(publishableKey),
+      "clerk.t3.codes",
+    );
+    assert.equal(DesktopClerk.resolveDesktopClerkFrontendApiHostname(""), undefined);
+    assert.equal(DesktopClerk.resolveDesktopClerkFrontendApiHostname("invalid"), undefined);
   });
 
   it.effect("acquires and releases the SDK bridge with the layer", () => {
@@ -44,7 +43,7 @@ describe("DesktopClerk", () => {
     const environment = DesktopEnvironment.DesktopEnvironment.of({
       stateDir: "/tmp/t3-state",
       isDevelopment: true,
-    } as unknown as DesktopEnvironment.DesktopEnvironmentShape);
+    } as unknown as DesktopEnvironment.DesktopEnvironment["Service"]);
 
     return Effect.gen(function* () {
       yield* Effect.scoped(
@@ -78,7 +77,7 @@ describe("DesktopClerk", () => {
     storageMock.mockReturnValue(storageAdapter);
     createClerkBridgeMock.mockReturnValue(bridge);
 
-    assert.equal(createDesktopClerkBridge("/tmp/t3-state", isDevelopment), bridge);
+    assert.equal(DesktopClerk.createDesktopClerkBridge("/tmp/t3-state", isDevelopment), bridge);
     assert.deepEqual(storageMock.mock.calls, [[{ path: "/tmp/t3-state" }]]);
     assert.deepEqual(createClerkBridgeMock.mock.calls, [
       [

--- a/apps/desktop/src/app/DesktopClerk.ts
+++ b/apps/desktop/src/app/DesktopClerk.ts
@@ -14,17 +14,16 @@ import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 
 declare const __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: string | undefined;
 
-export interface DesktopClerkShape {
-  readonly configure: Effect.Effect<
-    void,
-    never,
-    ElectronApp.ElectronApp | ElectronWindow.ElectronWindow | Scope.Scope
-  >;
-}
-
-export class DesktopClerk extends Context.Service<DesktopClerk, DesktopClerkShape>()(
-  "@t3tools/desktop/app/DesktopClerk",
-) {}
+export class DesktopClerk extends Context.Service<
+  DesktopClerk,
+  {
+    readonly configure: Effect.Effect<
+      void,
+      never,
+      ElectronApp.ElectronApp | ElectronWindow.ElectronWindow | Scope.Scope
+    >;
+  }
+>()("@t3tools/desktop/app/DesktopClerk") {}
 
 export function resolveDesktopClerkFrontendApiHostname(
   publishableKey: string | undefined,

--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -11,10 +11,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 
-import {
-  type DesktopSettings,
-  resolveDefaultDesktopSettings,
-} from "../settings/DesktopAppSettings.ts";
+import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopConfig from "./DesktopConfig.ts";
 import { isNightlyDesktopVersion } from "../updates/updateChannels.ts";
 
@@ -30,55 +27,53 @@ export interface MakeDesktopEnvironmentInput {
   readonly runningUnderArm64Translation: boolean;
 }
 
-export interface DesktopEnvironmentShape {
-  readonly path: Path.Path;
-  readonly dirname: string;
-  readonly platform: NodeJS.Platform;
-  readonly processArch: string;
-  readonly isPackaged: boolean;
-  readonly isDevelopment: boolean;
-  readonly appVersion: string;
-  readonly appPath: string;
-  readonly resourcesPath: string;
-  readonly homeDirectory: string;
-  readonly appDataDirectory: string;
-  readonly baseDir: string;
-  readonly stateDir: string;
-  readonly desktopSettingsPath: string;
-  readonly clientSettingsPath: string;
-  readonly savedEnvironmentRegistryPath: string;
-  readonly serverSettingsPath: string;
-  readonly logDir: string;
-  readonly browserArtifactsDir: string;
-  readonly rootDir: string;
-  readonly appRoot: string;
-  readonly backendEntryPath: string;
-  readonly backendCwd: string;
-  readonly preloadPath: string;
-  readonly appUpdateYmlPath: string;
-  readonly devServerUrl: Option.Option<URL>;
-  readonly devRemoteT3ServerEntryPath: Option.Option<string>;
-  readonly configuredBackendPort: Option.Option<number>;
-  readonly commitHashOverride: Option.Option<string>;
-  readonly otlpTracesUrl: Option.Option<string>;
-  readonly otlpExportIntervalMs: number;
-  readonly branding: DesktopAppBranding;
-  readonly displayName: string;
-  readonly appUserModelId: string;
-  readonly linuxDesktopEntryName: string;
-  readonly linuxWmClass: string;
-  readonly userDataDirName: string;
-  readonly legacyUserDataDirName: string;
-  readonly defaultDesktopSettings: DesktopSettings;
-  readonly runtimeInfo: DesktopRuntimeInfo;
-  readonly resolvePickFolderDefaultPath: (rawOptions: unknown) => Option.Option<string>;
-  readonly resolveResourcePathCandidates: (fileName: string) => readonly string[];
-  readonly developmentDockIconPath: string;
-}
-
 export class DesktopEnvironment extends Context.Service<
   DesktopEnvironment,
-  DesktopEnvironmentShape
+  {
+    readonly path: Path.Path;
+    readonly dirname: string;
+    readonly platform: NodeJS.Platform;
+    readonly processArch: string;
+    readonly isPackaged: boolean;
+    readonly isDevelopment: boolean;
+    readonly appVersion: string;
+    readonly appPath: string;
+    readonly resourcesPath: string;
+    readonly homeDirectory: string;
+    readonly appDataDirectory: string;
+    readonly baseDir: string;
+    readonly stateDir: string;
+    readonly desktopSettingsPath: string;
+    readonly clientSettingsPath: string;
+    readonly savedEnvironmentRegistryPath: string;
+    readonly serverSettingsPath: string;
+    readonly logDir: string;
+    readonly browserArtifactsDir: string;
+    readonly rootDir: string;
+    readonly appRoot: string;
+    readonly backendEntryPath: string;
+    readonly backendCwd: string;
+    readonly preloadPath: string;
+    readonly appUpdateYmlPath: string;
+    readonly devServerUrl: Option.Option<URL>;
+    readonly devRemoteT3ServerEntryPath: Option.Option<string>;
+    readonly configuredBackendPort: Option.Option<number>;
+    readonly commitHashOverride: Option.Option<string>;
+    readonly otlpTracesUrl: Option.Option<string>;
+    readonly otlpExportIntervalMs: number;
+    readonly branding: DesktopAppBranding;
+    readonly displayName: string;
+    readonly appUserModelId: string;
+    readonly linuxDesktopEntryName: string;
+    readonly linuxWmClass: string;
+    readonly userDataDirName: string;
+    readonly legacyUserDataDirName: string;
+    readonly defaultDesktopSettings: DesktopAppSettings.DesktopSettings;
+    readonly runtimeInfo: DesktopRuntimeInfo;
+    readonly resolvePickFolderDefaultPath: (rawOptions: unknown) => Option.Option<string>;
+    readonly resolveResourcePathCandidates: (fileName: string) => readonly string[];
+    readonly developmentDockIconPath: string;
+  }
 >()("@t3tools/desktop/app/DesktopEnvironment") {}
 
 const APP_BASE_NAME = "T3 Code";
@@ -136,9 +131,9 @@ function resolveDesktopRuntimeInfo(input: {
   };
 }
 
-const makeDesktopEnvironment = Effect.fn("desktop.environment.make")(function* (
+const make = Effect.fn("desktop.environment.make")(function* (
   input: MakeDesktopEnvironmentInput,
-): Effect.fn.Return<DesktopEnvironmentShape, Config.ConfigError, Path.Path> {
+): Effect.fn.Return<DesktopEnvironment["Service"], Config.ConfigError, Path.Path> {
   const path = yield* Path.Path;
   const config = yield* DesktopConfig.DesktopConfig;
   const homeDirectory = input.homeDirectory;
@@ -208,7 +203,7 @@ const makeDesktopEnvironment = Effect.fn("desktop.environment.make")(function* (
     linuxWmClass: isDevelopment ? "t3code-dev" : "t3code",
     userDataDirName,
     legacyUserDataDirName,
-    defaultDesktopSettings: resolveDefaultDesktopSettings(input.appVersion),
+    defaultDesktopSettings: DesktopAppSettings.resolveDefaultDesktopSettings(input.appVersion),
     runtimeInfo: resolveDesktopRuntimeInfo({
       platform: input.platform,
       processArch: input.processArch,
@@ -250,4 +245,4 @@ const makeDesktopEnvironment = Effect.fn("desktop.environment.make")(function* (
 });
 
 export const layer = (input: MakeDesktopEnvironmentInput) =>
-  Layer.effect(DesktopEnvironment, makeDesktopEnvironment(input));
+  Layer.effect(DesktopEnvironment, make(input));

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -1,7 +1,6 @@
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
-import * as Deferred from "effect/Deferred";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 import * as Scope from "effect/Scope";
@@ -10,63 +9,34 @@ import type * as Electron from "electron";
 
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
+import * as DesktopShutdownModule from "./DesktopShutdown.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
-export interface DesktopShutdownShape {
-  readonly request: Effect.Effect<void>;
-  readonly awaitRequest: Effect.Effect<void>;
-  readonly markComplete: Effect.Effect<void>;
-  readonly awaitComplete: Effect.Effect<void>;
-  readonly isComplete: Effect.Effect<boolean>;
-}
-
-export class DesktopShutdown extends Context.Service<DesktopShutdown, DesktopShutdownShape>()(
-  "@t3tools/desktop/app/DesktopLifecycle/DesktopShutdown",
-) {}
-
-const makeShutdown = Effect.gen(function* () {
-  const requested = yield* Deferred.make<void>();
-  const completed = yield* Deferred.make<void>();
-  const completedRef = yield* Ref.make(false);
-
-  return DesktopShutdown.of({
-    request: Deferred.succeed(requested, undefined).pipe(Effect.asVoid),
-    awaitRequest: Deferred.await(requested),
-    markComplete: Ref.set(completedRef, true).pipe(
-      Effect.andThen(Deferred.succeed(completed, undefined)),
-      Effect.asVoid,
-    ),
-    awaitComplete: Deferred.await(completed),
-    isComplete: Ref.get(completedRef),
-  });
-});
-
-export const layerShutdown = Layer.effect(DesktopShutdown, makeShutdown);
+export { DesktopShutdown, layer as layerShutdown } from "./DesktopShutdown.ts";
 
 export type DesktopLifecycleRuntimeServices =
   | DesktopEnvironment.DesktopEnvironment
-  | DesktopShutdown
+  | DesktopShutdownModule.DesktopShutdown
   | DesktopState.DesktopState
   | DesktopWindow.DesktopWindow
   | ElectronApp.ElectronApp
   | ElectronTheme.ElectronTheme;
 
-export interface DesktopLifecycleShape {
-  readonly relaunch: (
-    reason: string,
-  ) => Effect.Effect<void, never, DesktopLifecycleRuntimeServices>;
-  readonly register: Effect.Effect<void, never, Scope.Scope | DesktopLifecycleRuntimeServices>;
-}
-
 /**
  * @effect-expect-leaking DesktopEnvironment | DesktopShutdown | DesktopState | DesktopWindow | ElectronApp | ElectronTheme
  */
-export class DesktopLifecycle extends Context.Service<DesktopLifecycle, DesktopLifecycleShape>()(
-  "@t3tools/desktop/app/DesktopLifecycle",
-) {}
+export class DesktopLifecycle extends Context.Service<
+  DesktopLifecycle,
+  {
+    readonly relaunch: (
+      reason: string,
+    ) => Effect.Effect<void, never, DesktopLifecycleRuntimeServices>;
+    readonly register: Effect.Effect<void, never, Scope.Scope | DesktopLifecycleRuntimeServices>;
+  }
+>()("@t3tools/desktop/app/DesktopLifecycle") {}
 
 const { logInfo: logLifecycleInfo, logError: logLifecycleError } =
   DesktopObservability.makeComponentLogger("desktop-lifecycle");
@@ -93,8 +63,8 @@ function addScopedListener<Args extends ReadonlyArray<unknown>>(
 }
 
 const requestDesktopShutdownAndWait = Effect.fn("desktop.lifecycle.requestShutdownAndWait")(
-  function* (): Effect.fn.Return<void, never, DesktopShutdown> {
-    const shutdown = yield* DesktopShutdown;
+  function* (): Effect.fn.Return<void, never, DesktopShutdownModule.DesktopShutdown> {
+    const shutdown = yield* DesktopShutdownModule.DesktopShutdown;
     yield* shutdown.request;
     yield* shutdown.awaitComplete;
   },
@@ -154,83 +124,82 @@ function quitFromSignal(
   );
 }
 
-export const layer = Layer.succeed(
-  DesktopLifecycle,
-  DesktopLifecycle.of({
-    relaunch: Effect.fn("desktop.lifecycle.relaunch")(function* (reason) {
-      const electronApp = yield* ElectronApp.ElectronApp;
-      const environment = yield* DesktopEnvironment.DesktopEnvironment;
-      const state = yield* DesktopState.DesktopState;
-      yield* logLifecycleInfo("desktop relaunch requested", { reason });
-      yield* Effect.gen(function* () {
-        yield* Effect.yieldNow;
-        yield* Ref.set(state.quitting, true);
-        yield* requestDesktopShutdownAndWait();
-        if (environment.isDevelopment) {
-          yield* electronApp.exit(75);
-          return;
-        }
-        yield* electronApp.relaunch({
-          execPath: process.execPath,
-          args: process.argv.slice(1),
-        });
-        yield* electronApp.exit(0);
-      }).pipe(
-        Effect.catchCause((cause) =>
-          logLifecycleError("desktop relaunch failed", {
-            cause: Cause.pretty(cause),
-          }),
-        ),
-        Effect.forkDetach,
-        Effect.asVoid,
-      );
-    }),
-    register: Effect.gen(function* () {
-      const desktopWindow = yield* DesktopWindow.DesktopWindow;
-      const electronApp = yield* ElectronApp.ElectronApp;
-      const electronTheme = yield* ElectronTheme.ElectronTheme;
-      const environment = yield* DesktopEnvironment.DesktopEnvironment;
-      const context = yield* Effect.context<DesktopLifecycleRuntimeServices>();
-      const runEffect = Effect.runPromiseWith(context);
-      let quitAllowed = false;
-      yield* electronTheme.onUpdated(() => {
-        void runEffect(
-          desktopWindow.syncAppearance.pipe(Effect.withSpan("desktop.lifecycle.themeUpdated")),
-        );
-      });
-      yield* electronApp.on("before-quit", (event: Electron.Event) => {
-        handleBeforeQuit(
-          event,
-          runEffect,
-          () => quitAllowed,
-          () => {
-            quitAllowed = true;
-          },
-        );
-      });
-      yield* electronApp.on("activate", () => {
-        void runEffect(desktopWindow.activate.pipe(Effect.withSpan("desktop.lifecycle.activate")));
-      });
-      yield* electronApp.on("window-all-closed", () => {
-        void runEffect(
-          Effect.gen(function* () {
-            const app = yield* ElectronApp.ElectronApp;
-            const state = yield* DesktopState.DesktopState;
-            if (environment.platform !== "darwin" && !(yield* Ref.get(state.quitting))) {
-              yield* app.quit;
-            }
-          }).pipe(Effect.withSpan("desktop.lifecycle.windowAllClosed")),
-        );
-      });
-
-      if (environment.platform !== "win32") {
-        yield* addScopedListener(process, "SIGINT", () => {
-          quitFromSignal("SIGINT", runEffect);
-        });
-        yield* addScopedListener(process, "SIGTERM", () => {
-          quitFromSignal("SIGTERM", runEffect);
-        });
+const make = DesktopLifecycle.of({
+  relaunch: Effect.fn("desktop.lifecycle.relaunch")(function* (reason) {
+    const electronApp = yield* ElectronApp.ElectronApp;
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    const state = yield* DesktopState.DesktopState;
+    yield* logLifecycleInfo("desktop relaunch requested", { reason });
+    yield* Effect.gen(function* () {
+      yield* Effect.yieldNow;
+      yield* Ref.set(state.quitting, true);
+      yield* requestDesktopShutdownAndWait();
+      if (environment.isDevelopment) {
+        yield* electronApp.exit(75);
+        return;
       }
-    }).pipe(Effect.withSpan("desktop.lifecycle.register")),
+      yield* electronApp.relaunch({
+        execPath: process.execPath,
+        args: process.argv.slice(1),
+      });
+      yield* electronApp.exit(0);
+    }).pipe(
+      Effect.catchCause((cause) =>
+        logLifecycleError("desktop relaunch failed", {
+          cause: Cause.pretty(cause),
+        }),
+      ),
+      Effect.forkDetach,
+      Effect.asVoid,
+    );
   }),
-);
+  register: Effect.gen(function* () {
+    const desktopWindow = yield* DesktopWindow.DesktopWindow;
+    const electronApp = yield* ElectronApp.ElectronApp;
+    const electronTheme = yield* ElectronTheme.ElectronTheme;
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    const context = yield* Effect.context<DesktopLifecycleRuntimeServices>();
+    const runEffect = Effect.runPromiseWith(context);
+    let quitAllowed = false;
+    yield* electronTheme.onUpdated(() => {
+      void runEffect(
+        desktopWindow.syncAppearance.pipe(Effect.withSpan("desktop.lifecycle.themeUpdated")),
+      );
+    });
+    yield* electronApp.on("before-quit", (event: Electron.Event) => {
+      handleBeforeQuit(
+        event,
+        runEffect,
+        () => quitAllowed,
+        () => {
+          quitAllowed = true;
+        },
+      );
+    });
+    yield* electronApp.on("activate", () => {
+      void runEffect(desktopWindow.activate.pipe(Effect.withSpan("desktop.lifecycle.activate")));
+    });
+    yield* electronApp.on("window-all-closed", () => {
+      void runEffect(
+        Effect.gen(function* () {
+          const app = yield* ElectronApp.ElectronApp;
+          const state = yield* DesktopState.DesktopState;
+          if (environment.platform !== "darwin" && !(yield* Ref.get(state.quitting))) {
+            yield* app.quit;
+          }
+        }).pipe(Effect.withSpan("desktop.lifecycle.windowAllClosed")),
+      );
+    });
+
+    if (environment.platform !== "win32") {
+      yield* addScopedListener(process, "SIGINT", () => {
+        quitFromSignal("SIGINT", runEffect);
+      });
+      yield* addScopedListener(process, "SIGTERM", () => {
+        quitFromSignal("SIGTERM", runEffect);
+      });
+    }
+  }).pipe(Effect.withSpan("desktop.lifecycle.register")),
+});
+
+export const layer = Layer.succeed(DesktopLifecycle, make);

--- a/apps/desktop/src/app/DesktopObservability.ts
+++ b/apps/desktop/src/app/DesktopObservability.ts
@@ -1,52 +1,20 @@
 import { makeLocalFileTracer, makeTraceSink } from "@t3tools/shared/observability";
 import { parsePersistedServerObservabilitySettings } from "@t3tools/shared/serverSettings";
-import * as Context from "effect/Context";
-import * as Data from "effect/Data";
-import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
-import * as Path from "effect/Path";
-import * as PlatformError from "effect/PlatformError";
 import * as References from "effect/References";
-import * as Ref from "effect/Ref";
-import * as Schema from "effect/Schema";
-import * as Semaphore from "effect/Semaphore";
 import * as Tracer from "effect/Tracer";
 import { OtlpSerialization, OtlpTracer } from "effect/unstable/observability";
 
+import * as DesktopBackendOutputLogModule from "./DesktopBackendOutputLog.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 
-const DESKTOP_LOG_FILE_MAX_BYTES = 10 * 1024 * 1024;
-const DESKTOP_LOG_FILE_MAX_FILES = 10;
-const DESKTOP_BACKEND_CHILD_LOG_FIBER_ID = "#backend-child";
 const DESKTOP_TRACE_BATCH_WINDOW_MS = 200;
 
-export interface RotatingLogFileWriter {
-  readonly writeBytes: (chunk: Uint8Array) => Effect.Effect<void>;
-  readonly writeText: (chunk: string) => Effect.Effect<void>;
-}
-
-export interface DesktopBackendOutputLogShape {
-  readonly writeSessionBoundary: (input: {
-    readonly phase: "START" | "END";
-    readonly details: string;
-  }) => Effect.Effect<void>;
-  readonly writeOutputChunk: (
-    streamName: "stdout" | "stderr",
-    chunk: Uint8Array,
-  ) => Effect.Effect<void>;
-}
-
-export class DesktopBackendOutputLog extends Context.Service<
-  DesktopBackendOutputLog,
-  DesktopBackendOutputLogShape
->()("@t3tools/desktop/app/DesktopObservability/DesktopBackendOutputLog") {}
-
-const textEncoder = new TextEncoder();
-const textDecoder = new TextDecoder();
+export { DesktopBackendOutputLog } from "./DesktopBackendOutputLog.ts";
 
 export type DesktopLogAnnotations = Record<string, unknown>;
 
@@ -82,160 +50,6 @@ export function makeComponentLogger(component: string): DesktopComponentLogger {
   };
 }
 
-class DesktopLogFileWriterConfigurationError extends Data.TaggedError(
-  "DesktopLogFileWriterConfigurationError",
-)<{
-  readonly option: "maxBytes" | "maxFiles";
-  readonly value: number;
-}> {
-  override get message() {
-    return `${this.option} must be >= 1 (received ${this.value})`;
-  }
-}
-
-type DesktopLogFileWriterError =
-  | DesktopLogFileWriterConfigurationError
-  | PlatformError.PlatformError;
-
-const sanitizeLogValue = (value: string): string => value.replace(/\s+/g, " ").trim();
-
-const DesktopBackendChildLogRecord = Schema.Struct({
-  message: Schema.String,
-  level: Schema.Literals(["INFO", "ERROR"]),
-  timestamp: Schema.String,
-  annotations: Schema.Record(Schema.String, Schema.Unknown),
-  spans: Schema.Record(Schema.String, Schema.Unknown),
-  fiberId: Schema.String,
-});
-
-const encodeDesktopBackendChildLogRecord = Schema.encodeEffect(
-  Schema.fromJsonString(DesktopBackendChildLogRecord),
-);
-
-const DesktopBackendOutputLogNoop: DesktopBackendOutputLogShape = {
-  writeSessionBoundary: () => Effect.void,
-  writeOutputChunk: () => Effect.void,
-};
-
-const currentDesktopRunId = Effect.gen(function* () {
-  const annotations = yield* References.CurrentLogAnnotations;
-  const runId = annotations.runId;
-  return typeof runId === "string" && runId.length > 0 ? runId : "unknown";
-});
-
-const refreshFileSize = (
-  fileSystem: FileSystem.FileSystem,
-  filePath: string,
-): Effect.Effect<number, never> =>
-  fileSystem.stat(filePath).pipe(
-    Effect.map((stat) => Number(stat.size)),
-    Effect.orElseSucceed(() => 0),
-  );
-
-const makeRotatingLogFileWriter = Effect.fn("makeRotatingLogFileWriter")(function* (input: {
-  readonly filePath: string;
-  readonly maxBytes?: number;
-  readonly maxFiles?: number;
-}): Effect.fn.Return<
-  RotatingLogFileWriter,
-  DesktopLogFileWriterError,
-  FileSystem.FileSystem | Path.Path
-> {
-  const fileSystem = yield* FileSystem.FileSystem;
-  const path = yield* Path.Path;
-  const maxBytes = input.maxBytes ?? DESKTOP_LOG_FILE_MAX_BYTES;
-  const maxFiles = input.maxFiles ?? DESKTOP_LOG_FILE_MAX_FILES;
-  const directory = path.dirname(input.filePath);
-  const baseName = path.basename(input.filePath);
-
-  if (maxBytes < 1) {
-    return yield* new DesktopLogFileWriterConfigurationError({
-      option: "maxBytes",
-      value: maxBytes,
-    });
-  }
-  if (maxFiles < 1) {
-    return yield* new DesktopLogFileWriterConfigurationError({
-      option: "maxFiles",
-      value: maxFiles,
-    });
-  }
-
-  yield* fileSystem.makeDirectory(directory, { recursive: true });
-
-  const withSuffix = (index: number) => `${input.filePath}.${index}`;
-  const currentSize = yield* Ref.make(yield* refreshFileSize(fileSystem, input.filePath));
-  const mutex = yield* Semaphore.make(1);
-
-  const pruneOverflowBackups = Effect.gen(function* () {
-    const entries = yield* fileSystem.readDirectory(directory).pipe(Effect.orElseSucceed(() => []));
-    for (const entry of entries) {
-      if (!entry.startsWith(`${baseName}.`)) continue;
-      const suffix = Number(entry.slice(baseName.length + 1));
-      if (!Number.isInteger(suffix) || suffix <= maxFiles) continue;
-      yield* fileSystem.remove(path.join(directory, entry), { force: true }).pipe(Effect.ignore);
-    }
-  });
-
-  const rotate = Effect.gen(function* () {
-    yield* fileSystem.remove(withSuffix(maxFiles), { force: true }).pipe(Effect.ignore);
-    for (let index = maxFiles - 1; index >= 1; index -= 1) {
-      const source = withSuffix(index);
-      const sourceExists = yield* fileSystem.exists(source).pipe(Effect.orElseSucceed(() => false));
-      if (sourceExists) {
-        yield* fileSystem.rename(source, withSuffix(index + 1));
-      }
-    }
-    const currentExists = yield* fileSystem
-      .exists(input.filePath)
-      .pipe(Effect.orElseSucceed(() => false));
-    if (currentExists) {
-      yield* fileSystem.rename(input.filePath, withSuffix(1));
-    }
-    yield* Ref.set(currentSize, 0);
-  }).pipe(
-    Effect.catch(() =>
-      refreshFileSize(fileSystem, input.filePath).pipe(
-        Effect.flatMap((size) => Ref.set(currentSize, size)),
-      ),
-    ),
-  );
-
-  const writeBytes = (chunk: Uint8Array): Effect.Effect<void> => {
-    if (chunk.byteLength === 0) return Effect.void;
-
-    return mutex.withPermits(1)(
-      Effect.gen(function* () {
-        const beforeSize = yield* Ref.get(currentSize);
-        if (beforeSize > 0 && beforeSize + chunk.byteLength > maxBytes) {
-          yield* rotate;
-        }
-
-        yield* fileSystem.writeFile(input.filePath, chunk, { flag: "a" });
-        const afterSize = (yield* Ref.get(currentSize)) + chunk.byteLength;
-        yield* Ref.set(currentSize, afterSize);
-
-        if (afterSize > maxBytes) {
-          yield* rotate;
-        }
-      }).pipe(
-        Effect.catch(() =>
-          refreshFileSize(fileSystem, input.filePath).pipe(
-            Effect.flatMap((size) => Ref.set(currentSize, size)),
-          ),
-        ),
-      ),
-    );
-  };
-
-  yield* pruneOverflowBackups;
-
-  return {
-    writeBytes,
-    writeText: (chunk) => writeBytes(textEncoder.encode(chunk)),
-  } satisfies RotatingLogFileWriter;
-});
-
 const readPersistedOtlpTracesUrl: Effect.Effect<
   Option.Option<string>,
   never,
@@ -260,90 +74,6 @@ const resolveOtlpTracesUrl = Effect.gen(function* () {
   return yield* readPersistedOtlpTracesUrl;
 });
 
-const writeDevelopmentConsoleOutput = (
-  streamName: "stdout" | "stderr",
-  chunk: Uint8Array,
-): Effect.Effect<void> =>
-  Effect.sync(() => {
-    const output = streamName === "stderr" ? process.stderr : process.stdout;
-    output.write(chunk);
-  }).pipe(Effect.ignore);
-
-const writeBackendChildLogRecord = Effect.fn("desktop.observability.writeBackendChildLogRecord")(
-  function* (
-    logFile: RotatingLogFileWriter,
-    input: {
-      readonly message: string;
-      readonly level: "INFO" | "ERROR";
-      readonly annotations: Record<string, unknown>;
-    },
-  ): Effect.fn.Return<void> {
-    return yield* Effect.gen(function* () {
-      const timestamp = DateTime.formatIso(yield* DateTime.now);
-      const encoded = yield* encodeDesktopBackendChildLogRecord({
-        message: input.message,
-        level: input.level,
-        timestamp,
-        annotations: input.annotations,
-        spans: {},
-        fiberId: DESKTOP_BACKEND_CHILD_LOG_FIBER_ID,
-      });
-      yield* logFile.writeText(`${encoded}\n`);
-    }).pipe(Effect.ignore({ log: true }));
-  },
-);
-
-const backendOutputLogLayer = Layer.effect(
-  DesktopBackendOutputLog,
-  Effect.gen(function* () {
-    const environment = yield* DesktopEnvironment.DesktopEnvironment;
-
-    const writer = yield* makeRotatingLogFileWriter({
-      filePath: environment.path.join(environment.logDir, "server-child.log"),
-    }).pipe(Effect.option);
-
-    return Option.match(writer, {
-      onNone: () => DesktopBackendOutputLogNoop,
-      onSome: (logFile) =>
-        ({
-          writeSessionBoundary: Effect.fn(
-            "desktop.observability.backendOutput.writeSessionBoundary",
-          )(function* ({ phase, details }) {
-            const runId = yield* currentDesktopRunId;
-            yield* writeBackendChildLogRecord(logFile, {
-              message: `backend child process session ${phase.toLowerCase()}`,
-              level: "INFO",
-              annotations: {
-                component: "desktop-backend-child",
-                runId,
-                phase,
-                details: sanitizeLogValue(details),
-              },
-            });
-          }),
-          writeOutputChunk: Effect.fn("desktop.observability.backendOutput.writeOutputChunk")(
-            function* (streamName, chunk) {
-              if (environment.isDevelopment) {
-                yield* writeDevelopmentConsoleOutput(streamName, chunk);
-              }
-              const runId = yield* currentDesktopRunId;
-              yield* writeBackendChildLogRecord(logFile, {
-                message: "backend child process output",
-                level: streamName === "stderr" ? "ERROR" : "INFO",
-                annotations: {
-                  component: "desktop-backend-child",
-                  runId,
-                  stream: streamName,
-                  text: textDecoder.decode(chunk),
-                },
-              });
-            },
-          ),
-        }) satisfies DesktopBackendOutputLogShape,
-    });
-  }),
-);
-
 const desktopLoggerLayer = Layer.mergeAll(
   Logger.layer([Logger.consolePretty(), Logger.tracerLogger], { mergeWithExisting: false }),
   Layer.succeed(References.MinimumLogLevel, "Info"),
@@ -356,8 +86,8 @@ const tracerLayer = Layer.unwrap(
     const tracePath = environment.path.join(environment.logDir, "desktop.trace.ndjson");
     const sink = yield* makeTraceSink({
       filePath: tracePath,
-      maxBytes: DESKTOP_LOG_FILE_MAX_BYTES,
-      maxFiles: DESKTOP_LOG_FILE_MAX_FILES,
+      maxBytes: DesktopBackendOutputLogModule.DESKTOP_LOG_FILE_MAX_BYTES,
+      maxFiles: DesktopBackendOutputLogModule.DESKTOP_LOG_FILE_MAX_FILES,
       batchWindowMs: DESKTOP_TRACE_BATCH_WINDOW_MS,
     });
     const delegate = Option.isNone(otlpTracesUrl)
@@ -375,8 +105,8 @@ const tracerLayer = Layer.unwrap(
         });
     const tracer = yield* makeLocalFileTracer({
       filePath: tracePath,
-      maxBytes: DESKTOP_LOG_FILE_MAX_BYTES,
-      maxFiles: DESKTOP_LOG_FILE_MAX_FILES,
+      maxBytes: DesktopBackendOutputLogModule.DESKTOP_LOG_FILE_MAX_BYTES,
+      maxFiles: DesktopBackendOutputLogModule.DESKTOP_LOG_FILE_MAX_FILES,
       batchWindowMs: DESKTOP_TRACE_BATCH_WINDOW_MS,
       sink,
       ...(delegate ? { delegate } : {}),
@@ -387,7 +117,7 @@ const tracerLayer = Layer.unwrap(
 ).pipe(Layer.provideMerge(OtlpSerialization.layerJson));
 
 export const layer = Layer.mergeAll(
-  backendOutputLogLayer,
+  DesktopBackendOutputLogModule.layer,
   desktopLoggerLayer,
   tracerLayer,
   Layer.succeed(Tracer.MinimumTraceLevel, "Info"),

--- a/apps/desktop/src/app/DesktopShutdown.ts
+++ b/apps/desktop/src/app/DesktopShutdown.ts
@@ -1,0 +1,35 @@
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Ref from "effect/Ref";
+
+export class DesktopShutdown extends Context.Service<
+  DesktopShutdown,
+  {
+    readonly request: Effect.Effect<void>;
+    readonly awaitRequest: Effect.Effect<void>;
+    readonly markComplete: Effect.Effect<void>;
+    readonly awaitComplete: Effect.Effect<void>;
+    readonly isComplete: Effect.Effect<boolean>;
+  }
+>()("@t3tools/desktop/app/DesktopShutdown") {}
+
+const make = Effect.gen(function* () {
+  const requested = yield* Deferred.make<void>();
+  const completed = yield* Deferred.make<void>();
+  const completedRef = yield* Ref.make(false);
+
+  return DesktopShutdown.of({
+    request: Deferred.succeed(requested, undefined).pipe(Effect.asVoid),
+    awaitRequest: Deferred.await(requested),
+    markComplete: Ref.set(completedRef, true).pipe(
+      Effect.andThen(Deferred.succeed(completed, undefined)),
+      Effect.asVoid,
+    ),
+    awaitComplete: Deferred.await(completed),
+    isComplete: Ref.get(completedRef),
+  });
+});
+
+export const layer = Layer.effect(DesktopShutdown, make);

--- a/apps/desktop/src/app/DesktopState.ts
+++ b/apps/desktop/src/app/DesktopState.ts
@@ -3,19 +3,17 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
 
-export interface DesktopStateShape {
-  readonly backendReady: Ref.Ref<boolean>;
-  readonly quitting: Ref.Ref<boolean>;
-}
-
-export class DesktopState extends Context.Service<DesktopState, DesktopStateShape>()(
-  "@t3tools/desktop/app/DesktopState",
-) {}
-
-export const layer = Layer.effect(
+export class DesktopState extends Context.Service<
   DesktopState,
-  Effect.all({
-    backendReady: Ref.make(false),
-    quitting: Ref.make(false),
-  }),
-);
+  {
+    readonly backendReady: Ref.Ref<boolean>;
+    readonly quitting: Ref.Ref<boolean>;
+  }
+>()("@t3tools/desktop/app/DesktopState") {}
+
+const make = Effect.all({
+  backendReady: Ref.make(false),
+  quitting: Ref.make(false),
+});
+
+export const layer = Layer.effect(DesktopState, make);

--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -104,9 +104,9 @@ function decodeBootstrap(raw: string) {
 function makeManagerLayer(input: {
   readonly spawnerLayer: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>;
   readonly httpClientLayer?: Layer.Layer<HttpClient.HttpClient>;
-  readonly backendOutputLog?: Partial<DesktopObservability.DesktopBackendOutputLogShape>;
-  readonly desktopState?: DesktopState.DesktopStateShape;
-  readonly desktopWindow?: Partial<DesktopWindow.DesktopWindowShape>;
+  readonly backendOutputLog?: Partial<DesktopObservability.DesktopBackendOutputLog["Service"]>;
+  readonly desktopState?: DesktopState.DesktopState["Service"];
+  readonly desktopWindow?: Partial<DesktopWindow.DesktopWindow["Service"]>;
   readonly config?: DesktopBackendManager.DesktopBackendStartConfig;
 }) {
   return DesktopBackendManager.layer.pipe(
@@ -127,7 +127,7 @@ function makeManagerLayer(input: {
           writeSessionBoundary: () => Effect.void,
           writeOutputChunk: () => Effect.void,
           ...input.backendOutputLog,
-        } satisfies DesktopObservability.DesktopBackendOutputLogShape),
+        } satisfies DesktopObservability.DesktopBackendOutputLog["Service"]),
         Layer.succeed(DesktopWindow.DesktopWindow, {
           createMain: Effect.die("unexpected createMain"),
           ensureMain: Effect.die("unexpected ensureMain"),
@@ -138,7 +138,7 @@ function makeManagerLayer(input: {
           dispatchMenuAction: () => Effect.void,
           syncAppearance: Effect.void,
           ...input.desktopWindow,
-        } satisfies DesktopWindow.DesktopWindowShape),
+        } satisfies DesktopWindow.DesktopWindow["Service"]),
       ),
     ),
   );

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -14,7 +14,6 @@ import { resolveRemoteT3CliPackageSpec } from "@t3tools/ssh/command";
 import type { RemoteT3RunnerOptions } from "@t3tools/ssh/tunnel";
 import serverPackageJson from "../../server/package.json" with { type: "json" };
 
-import type { DesktopSettings as DesktopSettingsValue } from "./settings/DesktopAppSettings.ts";
 import * as DesktopIpc from "./ipc/DesktopIpc.ts";
 import * as ElectronApp from "./electron/ElectronApp.ts";
 import * as ElectronDialog from "./electron/ElectronDialog.ts";
@@ -68,8 +67,8 @@ const desktopEnvironmentLayer = Layer.unwrap(
 );
 
 const resolveDesktopSshCliRunner = (
-  environment: DesktopEnvironment.DesktopEnvironmentShape,
-  settings: DesktopSettingsValue,
+  environment: DesktopEnvironment.DesktopEnvironment["Service"],
+  settings: DesktopAppSettings.DesktopSettings,
 ): RemoteT3RunnerOptions => {
   const devRemoteEntryPath = Option.getOrUndefined(environment.devRemoteT3ServerEntryPath);
   if (environment.isDevelopment && devRemoteEntryPath !== undefined) {

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -59,7 +59,7 @@ const environmentLayer = Layer.succeed(
   DesktopEnvironment.DesktopEnvironment,
   DesktopEnvironment.DesktopEnvironment.of({
     browserArtifactsDir: "/tmp/t3/dev/browser-artifacts",
-  } as DesktopEnvironment.DesktopEnvironmentShape),
+  } as DesktopEnvironment.DesktopEnvironment["Service"]),
 );
 
 const fileSystemLayer = FileSystem.layerNoop({
@@ -82,7 +82,7 @@ const layer = PreviewManager.layer.pipe(
 
 const withManager = <A>(
   use: (
-    manager: PreviewManager.PreviewManagerShape,
+    manager: PreviewManager.PreviewManager["Service"],
   ) => Effect.Effect<A, PreviewManager.PreviewManagerError, Scope.Scope>,
 ) =>
   Effect.gen(function* () {

--- a/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.test.ts
@@ -64,7 +64,7 @@ function runShellEnvironment(input: {
     DesktopEnvironment.DesktopEnvironment,
     DesktopEnvironment.DesktopEnvironment.of({
       platform: input.platform,
-    } as DesktopEnvironment.DesktopEnvironmentShape),
+    } as DesktopEnvironment.DesktopEnvironment["Service"]),
   );
   const spawnerLayer = Layer.succeed(
     ChildProcessSpawner.ChildProcessSpawner,

--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -127,7 +127,7 @@ function parseAppUpdateYml(raw: string): Effect.Effect<Option.Option<AppUpdateYm
 function createBaseUpdateState(
   channel: DesktopUpdateChannel,
   enabled: boolean,
-  environment: DesktopEnvironment.DesktopEnvironmentShape,
+  environment: DesktopEnvironment.DesktopEnvironment["Service"],
 ): DesktopUpdateState {
   return {
     ...createInitialDesktopUpdateState(environment.appVersion, environment.runtimeInfo, channel),

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -91,7 +91,7 @@ const desktopAssetsLayer = Layer.succeed(DesktopAssets.DesktopAssets, {
     png: Option.none<string>(),
   }),
   resolveResourcePath: () => Effect.succeed(Option.none<string>()),
-} satisfies DesktopAssets.DesktopAssetsShape);
+} satisfies DesktopAssets.DesktopAssets["Service"]);
 
 const desktopServerExposureLayer = Layer.succeed(DesktopServerExposure.DesktopServerExposure, {
   getState: Effect.die("unexpected getState"),
@@ -106,19 +106,19 @@ const desktopServerExposureLayer = Layer.succeed(DesktopServerExposure.DesktopSe
   setMode: () => Effect.die("unexpected setMode"),
   setTailscaleServeEnabled: () => Effect.die("unexpected setTailscaleServeEnabled"),
   getAdvertisedEndpoints: Effect.die("unexpected getAdvertisedEndpoints"),
-} satisfies DesktopServerExposure.DesktopServerExposureShape);
+} satisfies DesktopServerExposure.DesktopServerExposure["Service"]);
 
 const electronMenuLayer = Layer.succeed(ElectronMenu.ElectronMenu, {
   setApplicationMenu: () => Effect.void,
   popupTemplate: () => Effect.void,
   showContextMenu: () => Effect.succeed(Option.none()),
-} satisfies ElectronMenu.ElectronMenuShape);
+} satisfies ElectronMenu.ElectronMenu["Service"]);
 
 const electronThemeLayer = Layer.succeed(ElectronTheme.ElectronTheme, {
   shouldUseDarkColors: Effect.succeed(false),
   setSource: () => Effect.void,
   onUpdated: () => Effect.void,
-} satisfies ElectronTheme.ElectronThemeShape);
+} satisfies ElectronTheme.ElectronTheme["Service"]);
 
 const desktopEnvironmentLayer = DesktopEnvironment.layer(environmentInput).pipe(
   Layer.provide(
@@ -156,7 +156,7 @@ function makeTestLayer(input: {
     sendAll: () => Effect.void,
     destroyAll: Effect.void,
     syncAllAppearance: (sync) => sync(input.window),
-  } satisfies ElectronWindow.ElectronWindowShape);
+  } satisfies ElectronWindow.ElectronWindow["Service"]);
 
   return DesktopWindow.layer.pipe(
     Layer.provide(
@@ -173,7 +173,7 @@ function makeTestLayer(input: {
               return true;
             }),
           copyText: () => Effect.void,
-        } satisfies ElectronShell.ElectronShellShape),
+        } satisfies ElectronShell.ElectronShell["Service"]),
         electronThemeLayer,
         electronWindowLayer,
         Layer.mock(PreviewManager.PreviewManager)({


### PR DESCRIPTION
## Summary

- define desktop app Effect service interfaces inline on their `Context.Service` tags
- replace standalone service-shape references with `Service["Service"]`
- standardize concrete services around colocated `make` values and exported `layer` values
- use `Layer.succeed` for the static `DesktopLifecycle` service and keep `Layer.effect` only where construction genuinely acquires dependencies or resources
- convert `DesktopLogFileWriterConfigurationError` to `Schema.TaggedErrorClass` with structured attributes and a derived message
- split `DesktopShutdown` and `DesktopBackendOutputLog` into single-service modules while preserving the existing `DesktopLifecycle` and `DesktopObservability` compatibility exports

## Why

This aligns desktop app core services with the repository's target Effect module layout. Each service now exposes an honest layer constructor for how its implementation is built, without wrapping static service values in synthetic Effects.

## Impact

This is a structural refactor. Runtime behavior and existing desktop service composition remain unchanged; consumers now derive service shapes from the tags instead of separately exported interfaces.

## Validation

- `vp test run apps/desktop/src/app/DesktopAppIdentity.test.ts apps/desktop/src/app/DesktopClerk.test.ts apps/desktop/src/app/DesktopEnvironment.test.ts apps/desktop/src/app/DesktopObservability.test.ts apps/desktop/src/backend/DesktopBackendManager.test.ts apps/desktop/src/preview/Manager.test.ts apps/desktop/src/shell/DesktopShellEnvironment.test.ts apps/desktop/src/updates/DesktopUpdates.test.ts apps/desktop/src/window/DesktopWindow.test.ts` (39 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor across desktop app services with extracted modules but no described runtime behavior changes; risk is mainly merge/regression in layer wiring rather than auth or data handling.
> 
> **Overview**
> Refactors desktop **Effect `Context.Service` tags** so capabilities are declared inline on each tag instead of separate `*Shape` interfaces. Call sites and tests now type mocks and dependencies with **`ServiceName["Service"]`** rather than the removed shape types.
> 
> **`DesktopShutdown`** and **`DesktopBackendOutputLog`** move out of `DesktopLifecycle` / `DesktopObservability` into dedicated modules (same deferred shutdown API; backend child stdout/stderr still goes to a rotating `server-child.log` with dev console mirroring). `DesktopObservability` keeps a **re-export** of `DesktopBackendOutputLog` and wires the extracted layer; log rotation limits are shared via exported constants.
> 
> **Layer construction** is normalized: colocated `make` values, **`Layer.succeed`** for static services like `DesktopLifecycle`, and **`Layer.effect`** only where setup needs effects. `DesktopLogFileWriterConfigurationError` becomes a **`Schema.TaggedErrorClass`** with a derived message.
> 
> Imports shift to namespace style in a few places (e.g. `DesktopAppSettings`, `DesktopClerk` in tests). Intended as **behavior-neutral** composition/layout only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cf3cb297c5b3438c3ff62e279368691c1da9c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor desktop app Effect services to inline service shapes and extract dedicated modules
> - Removes separate `Shape` interfaces across multiple desktop services (e.g. `DesktopEnvironment`, `DesktopLifecycle`, `DesktopState`, `DesktopAssets`, `DesktopClerk`) and inlines the service shape directly into `Context.Service` generic parameters.
> - Extracts `DesktopShutdown` into its own module ([DesktopShutdown.ts](https://github.com/pingdotgg/t3code/pull/3185/files#diff-f0634ef0c8d85c83d5c12dee7103271c8f72b3af7057f1349b84c299a83c0c96)) providing shutdown coordination via `Deferred` and `Ref`, re-exported from [DesktopLifecycle.ts](https://github.com/pingdotgg/t3code/pull/3185/files#diff-e4f770e94426c2d924f6a844fa3f0e9cce3653cecebc9b95902929cad3966b6d).
> - Extracts backend child process log handling into [DesktopBackendOutputLog.ts](https://github.com/pingdotgg/t3code/pull/3185/files#diff-f3f7d07f27ad7c6206a5b5fea0c70a9cf322295512235a9b27aaa924116ac6ff) with a rotating log file writer, structured JSON encoding per record, and a noop fallback layer; [DesktopObservability.ts](https://github.com/pingdotgg/t3code/pull/3185/files#diff-9f00548d1326d2bf56bbecc063ff03019c1f1ab8a9ba99f6f613b8983c5fd99c) now imports and re-exports from this module.
> - Updates test files and type annotations across the desktop app to use `Context.Service["Service"]` types instead of the removed `Shape` interfaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cf3cb2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->