### PR TITLE
[codex] refactor desktop backend Effect services

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -34,7 +34,7 @@ const serverExposureLayer = Layer.succeed(DesktopServerExposure.DesktopServerExp
   setMode: () => Effect.die("unexpected setMode"),
   setTailscaleServeEnabled: () => Effect.die("unexpected setTailscaleServeEnabled"),
   getAdvertisedEndpoints: Effect.succeed([]),
-} satisfies DesktopServerExposure.DesktopServerExposureShape);
+} satisfies DesktopServerExposure.DesktopServerExposure["Service"]);
 
 function makeEnvironmentLayer(
   baseDir: string,

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -14,16 +14,14 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopServerExposure from "./DesktopServerExposure.ts";
 
-export interface DesktopBackendConfigurationShape {
-  readonly resolve: Effect.Effect<
-    DesktopBackendManager.DesktopBackendStartConfig,
-    PlatformError.PlatformError
-  >;
-}
-
 export class DesktopBackendConfiguration extends Context.Service<
   DesktopBackendConfiguration,
-  DesktopBackendConfigurationShape
+  {
+    readonly resolve: Effect.Effect<
+      DesktopBackendManager.DesktopBackendStartConfig,
+      PlatformError.PlatformError
+    >;
+  }
 >()("@t3tools/desktop/backend/DesktopBackendConfiguration") {}
 
 interface BackendObservabilitySettings {
@@ -130,40 +128,39 @@ const resolveBackendStartConfig = Effect.fn("desktop.backendConfiguration.resolv
   },
 );
 
-export const layer = Layer.effect(
-  DesktopBackendConfiguration,
-  Effect.gen(function* () {
-    const environment = yield* DesktopEnvironment.DesktopEnvironment;
-    const fileSystem = yield* FileSystem.FileSystem;
-    const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
-    const crypto = yield* Crypto.Crypto;
-    const tokenRef = yield* Ref.make(Option.none<string>());
-    const getOrCreateBootstrapToken = Effect.gen(function* () {
-      const existing = yield* Ref.get(tokenRef);
-      if (Option.isSome(existing)) {
-        return existing.value;
-      }
+export const make = Effect.gen(function* () {
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+  const crypto = yield* Crypto.Crypto;
+  const tokenRef = yield* Ref.make(Option.none<string>());
+  const getOrCreateBootstrapToken = Effect.gen(function* () {
+    const existing = yield* Ref.get(tokenRef);
+    if (Option.isSome(existing)) {
+      return existing.value;
+    }
 
-      const token = Encoding.encodeHex(yield* crypto.randomBytes(24));
-      yield* Ref.set(tokenRef, Option.some(token));
-      return token;
-    });
+    const token = Encoding.encodeHex(yield* crypto.randomBytes(24));
+    yield* Ref.set(tokenRef, Option.some(token));
+    return token;
+  });
 
-    return DesktopBackendConfiguration.of({
-      resolve: Effect.gen(function* () {
-        const bootstrapToken = yield* getOrCreateBootstrapToken;
-        const observabilitySettings = yield* readPersistedBackendObservabilitySettings.pipe(
-          Effect.provideService(FileSystem.FileSystem, fileSystem),
-          Effect.provideService(DesktopEnvironment.DesktopEnvironment, environment),
-        );
-        return yield* resolveBackendStartConfig({
-          bootstrapToken,
-          observabilitySettings,
-        }).pipe(
-          Effect.provideService(DesktopEnvironment.DesktopEnvironment, environment),
-          Effect.provideService(DesktopServerExposure.DesktopServerExposure, serverExposure),
-        );
-      }).pipe(Effect.withSpan("desktop.backendConfiguration.resolve")),
-    });
-  }),
-);
+  return DesktopBackendConfiguration.of({
+    resolve: Effect.gen(function* () {
+      const bootstrapToken = yield* getOrCreateBootstrapToken;
+      const observabilitySettings = yield* readPersistedBackendObservabilitySettings.pipe(
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(DesktopEnvironment.DesktopEnvironment, environment),
+      );
+      return yield* resolveBackendStartConfig({
+        bootstrapToken,
+        observabilitySettings,
+      }).pipe(
+        Effect.provideService(DesktopEnvironment.DesktopEnvironment, environment),
+        Effect.provideService(DesktopServerExposure.DesktopServerExposure, serverExposure),
+      );
+    }).pipe(Effect.withSpan("desktop.backendConfiguration.resolve")),
+  });
+});
+
+export const layer = Layer.effect(DesktopBackendConfiguration, make);

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -1,6 +1,5 @@
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -16,8 +15,9 @@ import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
 import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
-import { HttpClient } from "effect/unstable/http";
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import {
   DesktopBackendBootstrap,
@@ -59,29 +59,38 @@ interface BackendProcessExit {
   readonly result: Result.Result<ChildProcessSpawner.ExitCode, PlatformError.PlatformError>;
 }
 
-export class BackendTimeoutError extends Data.TaggedError("BackendTimeoutError")<{
-  readonly url: URL;
-}> {
-  override get message() {
+export class BackendTimeoutError extends Schema.TaggedErrorClass<BackendTimeoutError>()(
+  "BackendTimeoutError",
+  {
+    url: Schema.URL,
+  },
+) {
+  override get message(): string {
     return `Timed out waiting for backend readiness at ${this.url.href}.`;
   }
 }
 
-class BackendProcessBootstrapEncodeError extends Data.TaggedError(
+class BackendProcessBootstrapEncodeError extends Schema.TaggedErrorClass<BackendProcessBootstrapEncodeError>()(
   "BackendProcessBootstrapEncodeError",
-)<{
-  readonly cause: Schema.SchemaError;
-}> {
-  override get message() {
-    return `Failed to encode desktop backend bootstrap payload: ${this.cause.message}`;
+  {
+    detail: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to encode desktop backend bootstrap payload: ${this.detail}`;
   }
 }
 
-class BackendProcessSpawnError extends Data.TaggedError("BackendProcessSpawnError")<{
-  readonly cause: PlatformError.PlatformError;
-}> {
-  override get message() {
-    return `Failed to spawn desktop backend process: ${this.cause.message}`;
+class BackendProcessSpawnError extends Schema.TaggedErrorClass<BackendProcessSpawnError>()(
+  "BackendProcessSpawnError",
+  {
+    detail: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to spawn desktop backend process: ${this.detail}`;
   }
 }
 
@@ -106,16 +115,14 @@ export interface DesktopBackendSnapshot {
   readonly restartScheduled: boolean;
 }
 
-export interface DesktopBackendManagerShape {
-  readonly start: Effect.Effect<void>;
-  readonly stop: (options?: { readonly timeout?: Duration.Duration }) => Effect.Effect<void>;
-  readonly currentConfig: Effect.Effect<Option.Option<DesktopBackendStartConfig>>;
-  readonly snapshot: Effect.Effect<DesktopBackendSnapshot>;
-}
-
 export class DesktopBackendManager extends Context.Service<
   DesktopBackendManager,
-  DesktopBackendManagerShape
+  {
+    readonly start: Effect.Effect<void>;
+    readonly stop: (options?: { readonly timeout?: Duration.Duration }) => Effect.Effect<void>;
+    readonly currentConfig: Effect.Effect<Option.Option<DesktopBackendStartConfig>>;
+    readonly snapshot: Effect.Effect<DesktopBackendSnapshot>;
+  }
 >()("@t3tools/desktop/backend/DesktopBackendManager") {}
 
 const { logWarning: logBackendManagerWarning, logError: logBackendManagerError } =
@@ -230,7 +237,13 @@ const runBackendProcess = Effect.fn("runBackendProcess")(function* (
 ): Effect.fn.Return<BackendProcessExit, BackendProcessError, BackendProcessRunRequirements> {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const bootstrapJson = yield* encodeBootstrapJson(options.bootstrap).pipe(
-    Effect.mapError((cause) => new BackendProcessBootstrapEncodeError({ cause })),
+    Effect.mapError(
+      (cause) =>
+        new BackendProcessBootstrapEncodeError({
+          detail: cause.message,
+          cause,
+        }),
+    ),
   );
   const onOutput = options.onOutput ?? (() => Effect.void);
   const command = ChildProcess.make(
@@ -256,9 +269,15 @@ const runBackendProcess = Effect.fn("runBackendProcess")(function* (
     },
   );
 
-  const handle = yield* spawner
-    .spawn(command)
-    .pipe(Effect.mapError((cause) => new BackendProcessSpawnError({ cause })));
+  const handle = yield* spawner.spawn(command).pipe(
+    Effect.mapError(
+      (cause) =>
+        new BackendProcessSpawnError({
+          detail: cause.message,
+          cause,
+        }),
+    ),
+  );
 
   yield* options.onStarted?.(handle.pid) ?? Effect.void;
   if (options.captureOutput) {
@@ -277,7 +296,7 @@ const runBackendProcess = Effect.fn("runBackendProcess")(function* (
   return describeProcessExit(yield* Effect.result(handle.exitCode));
 });
 
-const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(function* () {
+export const make = Effect.gen(function* () {
   const parentScope = yield* Scope.Scope;
   const fileSystem = yield* FileSystem.FileSystem;
   const configuration = yield* DesktopBackendConfiguration.DesktopBackendConfiguration;
@@ -603,4 +622,4 @@ const makeDesktopBackendManager = Effect.fn("makeDesktopBackendManager")(functio
   });
 });
 
-export const layer = Layer.effect(DesktopBackendManager, makeDesktopBackendManager());
+export const layer = Layer.effect(DesktopBackendManager, make);

--- a/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.test.ts
+++ b/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.test.ts
@@ -3,7 +3,8 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
-import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 
 import * as DesktopBackendManager from "./DesktopBackendManager.ts";
 import * as DesktopLocalEnvironmentAuth from "./DesktopLocalEnvironmentAuth.ts";

--- a/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.ts
+++ b/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.ts
@@ -1,77 +1,88 @@
 import { bootstrapRemoteBearerSession } from "@t3tools/client-runtime/authorization";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Semaphore from "effect/Semaphore";
-import { HttpClient } from "effect/unstable/http";
+import * as HttpClient from "effect/unstable/http/HttpClient";
 
 import * as DesktopBackendManager from "./DesktopBackendManager.ts";
 
-export interface DesktopLocalEnvironmentAuthShape {
-  readonly getBearerToken: Effect.Effect<string, DesktopLocalEnvironmentAuthError>;
+export class DesktopLocalEnvironmentAuthBackendNotConfiguredError extends Schema.TaggedErrorClass<DesktopLocalEnvironmentAuthBackendNotConfiguredError>()(
+  "DesktopLocalEnvironmentAuthBackendNotConfiguredError",
+  {},
+) {
+  override get message(): string {
+    return "Local backend is not configured.";
+  }
 }
 
-export class DesktopLocalEnvironmentAuthError extends Data.TaggedError(
-  "DesktopLocalEnvironmentAuthError",
-)<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class DesktopLocalEnvironmentAuthSessionBootstrapError extends Schema.TaggedErrorClass<DesktopLocalEnvironmentAuthSessionBootstrapError>()(
+  "DesktopLocalEnvironmentAuthSessionBootstrapError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to create the local desktop bearer session.";
+  }
+}
+
+export const DesktopLocalEnvironmentAuthError = Schema.Union([
+  DesktopLocalEnvironmentAuthBackendNotConfiguredError,
+  DesktopLocalEnvironmentAuthSessionBootstrapError,
+]);
+export type DesktopLocalEnvironmentAuthError = typeof DesktopLocalEnvironmentAuthError.Type;
 
 export class DesktopLocalEnvironmentAuth extends Context.Service<
   DesktopLocalEnvironmentAuth,
-  DesktopLocalEnvironmentAuthShape
+  {
+    readonly getBearerToken: Effect.Effect<string, DesktopLocalEnvironmentAuthError>;
+  }
 >()("@t3tools/desktop/backend/DesktopLocalEnvironmentAuth") {}
 
-export const layer = Layer.effect(
-  DesktopLocalEnvironmentAuth,
-  Effect.gen(function* () {
-    const backendManager = yield* DesktopBackendManager.DesktopBackendManager;
-    const httpClient = yield* HttpClient.HttpClient;
-    const tokenRef = yield* Ref.make(Option.none<string>());
-    const mutex = yield* Semaphore.make(1);
+export const make = Effect.gen(function* () {
+  const backendManager = yield* DesktopBackendManager.DesktopBackendManager;
+  const httpClient = yield* HttpClient.HttpClient;
+  const tokenRef = yield* Ref.make(Option.none<string>());
+  const mutex = yield* Semaphore.make(1);
 
-    const getBearerToken = mutex
-      .withPermits(1)(
-        Effect.gen(function* () {
-          const cached = yield* Ref.get(tokenRef);
-          if (Option.isSome(cached)) {
-            return cached.value;
-          }
+  const getBearerToken = mutex
+    .withPermits(1)(
+      Effect.gen(function* () {
+        const cached = yield* Ref.get(tokenRef);
+        if (Option.isSome(cached)) {
+          return cached.value;
+        }
 
-          const configOption = yield* backendManager.currentConfig;
-          if (Option.isNone(configOption)) {
-            return yield* new DesktopLocalEnvironmentAuthError({
-              message: "Local backend is not configured.",
-            });
-          }
-          const config = configOption.value;
-          const session = yield* bootstrapRemoteBearerSession({
-            httpBaseUrl: config.httpBaseUrl.href,
-            credential: config.bootstrap.desktopBootstrapToken,
-            clientMetadata: {
-              label: "T3 Code Desktop",
-              deviceType: "desktop",
-            },
-          }).pipe(
-            Effect.provideService(HttpClient.HttpClient, httpClient),
-            Effect.mapError(
-              (cause) =>
-                new DesktopLocalEnvironmentAuthError({
-                  message: "Failed to create the local desktop bearer session.",
-                  cause,
-                }),
-            ),
-          );
-          yield* Ref.set(tokenRef, Option.some(session.access_token));
-          return session.access_token;
-        }),
-      )
-      .pipe(Effect.withSpan("desktop.localEnvironmentAuth.getBearerToken"));
+        const configOption = yield* backendManager.currentConfig;
+        if (Option.isNone(configOption)) {
+          return yield* new DesktopLocalEnvironmentAuthBackendNotConfiguredError();
+        }
+        const config = configOption.value;
+        const session = yield* bootstrapRemoteBearerSession({
+          httpBaseUrl: config.httpBaseUrl.href,
+          credential: config.bootstrap.desktopBootstrapToken,
+          clientMetadata: {
+            label: "T3 Code Desktop",
+            deviceType: "desktop",
+          },
+        }).pipe(
+          Effect.provideService(HttpClient.HttpClient, httpClient),
+          Effect.mapError(
+            (cause) =>
+              new DesktopLocalEnvironmentAuthSessionBootstrapError({
+                cause,
+              }),
+          ),
+        );
+        yield* Ref.set(tokenRef, Option.some(session.access_token));
+        return session.access_token;
+      }),
+    )
+    .pipe(Effect.withSpan("desktop.localEnvironmentAuth.getBearerToken"));
 
-    return DesktopLocalEnvironmentAuth.of({ getBearerToken });
-  }),
-);
+  return DesktopLocalEnvironmentAuth.of({ getBearerToken });
+});
+
+export const layer = Layer.effect(DesktopLocalEnvironmentAuth, make);

--- a/apps/desktop/src/backend/DesktopNetworkInterfaces.ts
+++ b/apps/desktop/src/backend/DesktopNetworkInterfaces.ts
@@ -1,0 +1,33 @@
+import { networkInterfaces } from "node:os";
+
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+export interface DesktopNetworkInterfaceInfo {
+  readonly address: string;
+  readonly family: string | number;
+  readonly internal: boolean;
+  readonly netmask?: string;
+  readonly mac?: string;
+  readonly cidr?: string | null;
+  readonly scopeid?: number;
+}
+
+export type NetworkInterfaces = Readonly<
+  Record<string, readonly DesktopNetworkInterfaceInfo[] | undefined>
+>;
+
+export class DesktopNetworkInterfaces extends Context.Service<
+  DesktopNetworkInterfaces,
+  {
+    readonly read: Effect.Effect<NetworkInterfaces>;
+  }
+>()("@t3tools/desktop/backend/DesktopNetworkInterfaces") {}
+
+export const make = (): DesktopNetworkInterfaces["Service"] =>
+  DesktopNetworkInterfaces.of({
+    read: Effect.sync(() => networkInterfaces()),
+  });
+
+export const layer = Layer.succeed(DesktopNetworkInterfaces, make());

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -7,17 +7,18 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopConfig from "../app/DesktopConfig.ts";
+import * as DesktopNetworkInterfaces from "./DesktopNetworkInterfaces.ts";
 import * as DesktopServerExposure from "./DesktopServerExposure.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 
 const encoder = new TextEncoder();
 
-const emptyNetworkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces = {};
-const lanNetworkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces = {
+const emptyNetworkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces = {};
+const lanNetworkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces = {
   en0: [
     {
       address: "192.168.1.20",
@@ -27,7 +28,7 @@ const lanNetworkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces = {
   ],
 };
 
-const tailnetNetworkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces = {
+const tailnetNetworkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces = {
   tailscale0: [
     {
       address: "100.90.1.2",
@@ -87,13 +88,13 @@ function makeEnvironmentLayer(baseDir: string, env: Record<string, string | unde
 
 function makeLayer(input: {
   readonly baseDir: string;
-  readonly networkInterfaces?: DesktopServerExposure.DesktopNetworkInterfaces;
+  readonly networkInterfaces?: DesktopNetworkInterfaces.NetworkInterfaces;
   readonly env?: Record<string, string | undefined>;
   readonly spawnerLayer?: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>;
 }) {
   const env = { T3CODE_HOME: input.baseDir, ...input.env };
   const environmentLayer = makeEnvironmentLayer(input.baseDir, env);
-  const networkLayer = Layer.succeed(DesktopServerExposure.DesktopNetworkInterfacesService, {
+  const networkLayer = Layer.succeed(DesktopNetworkInterfaces.DesktopNetworkInterfaces, {
     read: Effect.succeed(input.networkInterfaces ?? emptyNetworkInterfaces),
   });
 
@@ -109,7 +110,7 @@ function makeLayer(input: {
 }
 
 const withHarness = <A, E, R>(
-  networkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces,
+  networkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces,
   effect: Effect.Effect<
     A,
     E,

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -1,5 +1,3 @@
-import * as NodeOS from "node:os";
-
 import {
   createAdvertisedEndpoint,
   type CreateAdvertisedEndpointInput,
@@ -10,40 +8,26 @@ import type {
   DesktopServerExposureMode,
   DesktopServerExposureState,
 } from "@t3tools/contracts";
+import { readTailscaleStatus } from "@t3tools/tailscale";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
-import { HttpClient } from "effect/unstable/http";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as Schema from "effect/Schema";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
-import { DEFAULT_DESKTOP_SETTINGS, type DesktopSettings } from "../settings/DesktopAppSettings.ts";
+import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopConfig from "../app/DesktopConfig.ts";
+import * as DesktopNetworkInterfaces from "./DesktopNetworkInterfaces.ts";
 import { resolveTailscaleAdvertisedEndpoints } from "./tailscaleEndpointProvider.ts";
-import { readTailscaleStatus } from "@t3tools/tailscale";
-import * as DesktopAppSettingsService from "../settings/DesktopAppSettings.ts";
 
 const TAILSCALE_STATUS_CACHE_TTL = Duration.seconds(60);
 
 export const DESKTOP_LOOPBACK_HOST = "127.0.0.1";
 const DESKTOP_LAN_BIND_HOST = "0.0.0.0";
-
-export interface DesktopNetworkInterfaceInfo {
-  readonly address: string;
-  readonly family: string | number;
-  readonly internal: boolean;
-  readonly netmask?: string;
-  readonly mac?: string;
-  readonly cidr?: string | null;
-  readonly scopeid?: number;
-}
-
-export type DesktopNetworkInterfaces = Readonly<
-  Record<string, readonly DesktopNetworkInterfaceInfo[] | undefined>
->;
 
 interface ResolvedDesktopServerExposure {
   readonly mode: DesktopServerExposureMode;
@@ -91,7 +75,7 @@ const isHttpsEndpointUrl = (value: string): boolean => {
 };
 
 const resolveLanAdvertisedHost = (
-  networkInterfaces: DesktopNetworkInterfaces,
+  networkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces,
   explicitHost: string | undefined,
 ): string | null => {
   const normalizedExplicitHost = normalizeOptionalHost(explicitHost);
@@ -116,7 +100,7 @@ const resolveLanAdvertisedHost = (
 const resolveDesktopServerExposure = (input: {
   readonly mode: DesktopServerExposureMode;
   readonly port: number;
-  readonly networkInterfaces: DesktopNetworkInterfaces;
+  readonly networkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces;
   readonly advertisedHostOverride?: string;
 }): ResolvedDesktopServerExposure => {
   const localHttpUrl = `http://${DESKTOP_LOOPBACK_HOST}:${input.port}`;
@@ -218,25 +202,25 @@ const resolveDesktopCoreAdvertisedEndpoints = (
   return endpoints;
 };
 
-type DesktopServerExposurePersistenceOperation = "server-exposure-mode" | "tailscale-serve";
-
-export class DesktopServerExposureNoNetworkAddressError extends Data.TaggedError(
+export class DesktopServerExposureNoNetworkAddressError extends Schema.TaggedErrorClass<DesktopServerExposureNoNetworkAddressError>()(
   "DesktopServerExposureNoNetworkAddressError",
-)<{
-  readonly port: number;
-}> {
-  override get message() {
+  {
+    port: Schema.Number,
+  },
+) {
+  override get message(): string {
     return `No reachable network address is available for desktop network access on port ${this.port}.`;
   }
 }
 
-export class DesktopServerExposurePersistenceError extends Data.TaggedError(
+export class DesktopServerExposurePersistenceError extends Schema.TaggedErrorClass<DesktopServerExposurePersistenceError>()(
   "DesktopServerExposurePersistenceError",
-)<{
-  readonly operation: DesktopServerExposurePersistenceOperation;
-  readonly cause: DesktopAppSettingsService.DesktopSettingsWriteError;
-}> {
-  override get message() {
+  {
+    operation: Schema.Literals(["server-exposure-mode", "tailscale-serve"]),
+    cause: Schema.instanceOf(DesktopAppSettings.DesktopSettingsWriteError),
+  },
+) {
+  override get message(): string {
     return `Failed to persist desktop ${this.operation} settings.`;
   }
 }
@@ -260,35 +244,24 @@ export interface DesktopServerExposureChange {
   readonly requiresRelaunch: boolean;
 }
 
-export interface DesktopServerExposureShape {
-  readonly getState: Effect.Effect<DesktopServerExposureState>;
-  readonly backendConfig: Effect.Effect<DesktopServerExposureBackendConfig>;
-  readonly configureFromSettings: (input: {
-    readonly port: number;
-  }) => Effect.Effect<DesktopServerExposureState>;
-  readonly setMode: (
-    mode: DesktopServerExposureMode,
-  ) => Effect.Effect<DesktopServerExposureChange, DesktopServerExposureSetModeError>;
-  readonly setTailscaleServeEnabled: (input: {
-    readonly enabled: boolean;
-    readonly port?: number;
-  }) => Effect.Effect<DesktopServerExposureChange, DesktopServerExposurePersistenceError>;
-  readonly getAdvertisedEndpoints: Effect.Effect<readonly AdvertisedEndpoint[]>;
-}
-
 export class DesktopServerExposure extends Context.Service<
   DesktopServerExposure,
-  DesktopServerExposureShape
+  {
+    readonly getState: Effect.Effect<DesktopServerExposureState>;
+    readonly backendConfig: Effect.Effect<DesktopServerExposureBackendConfig>;
+    readonly configureFromSettings: (input: {
+      readonly port: number;
+    }) => Effect.Effect<DesktopServerExposureState>;
+    readonly setMode: (
+      mode: DesktopServerExposureMode,
+    ) => Effect.Effect<DesktopServerExposureChange, DesktopServerExposureSetModeError>;
+    readonly setTailscaleServeEnabled: (input: {
+      readonly enabled: boolean;
+      readonly port?: number;
+    }) => Effect.Effect<DesktopServerExposureChange, DesktopServerExposurePersistenceError>;
+    readonly getAdvertisedEndpoints: Effect.Effect<readonly AdvertisedEndpoint[]>;
+  }
 >()("@t3tools/desktop/backend/DesktopServerExposure") {}
-
-export interface DesktopNetworkInterfacesServiceShape {
-  readonly read: Effect.Effect<DesktopNetworkInterfaces>;
-}
-
-export class DesktopNetworkInterfacesService extends Context.Service<
-  DesktopNetworkInterfacesService,
-  DesktopNetworkInterfacesServiceShape
->()("@t3tools/desktop/backend/DesktopServerExposure/DesktopNetworkInterfacesService") {}
 
 interface RuntimeState {
   readonly requestedMode: DesktopServerExposureMode;
@@ -311,10 +284,10 @@ interface ResolvedRuntimeState {
 
 const initialRuntimeState = (): RuntimeState =>
   runtimeStateFromResolvedExposure({
-    requestedMode: DEFAULT_DESKTOP_SETTINGS.serverExposureMode,
-    settings: DEFAULT_DESKTOP_SETTINGS,
+    requestedMode: DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS.serverExposureMode,
+    settings: DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS,
     exposure: resolveDesktopServerExposure({
-      mode: DEFAULT_DESKTOP_SETTINGS.serverExposureMode,
+      mode: DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS.serverExposureMode,
       port: 0,
       networkInterfaces: {},
     }),
@@ -348,7 +321,7 @@ const toResolvedExposure = (state: RuntimeState): ResolvedDesktopServerExposure 
 
 function runtimeStateFromResolvedExposure(input: {
   readonly requestedMode: DesktopServerExposureMode;
-  readonly settings: DesktopSettings;
+  readonly settings: DesktopAppSettings.DesktopSettings;
   readonly exposure: ResolvedDesktopServerExposure;
   readonly port: number;
 }): RuntimeState {
@@ -369,9 +342,9 @@ function runtimeStateFromResolvedExposure(input: {
 
 function resolveRuntimeState(input: {
   readonly requestedMode: DesktopServerExposureMode;
-  readonly settings: DesktopSettings;
+  readonly settings: DesktopAppSettings.DesktopSettings;
   readonly port: number;
-  readonly networkInterfaces: DesktopNetworkInterfaces;
+  readonly networkInterfaces: DesktopNetworkInterfaces.NetworkInterfaces;
   readonly advertisedHostOverride: Option.Option<string>;
 }): ResolvedRuntimeState {
   const advertisedHostOverride = Option.getOrUndefined(input.advertisedHostOverride);
@@ -408,12 +381,12 @@ const requiresBackendRelaunch = (previous: RuntimeState, next: RuntimeState): bo
   previous.bindHost !== next.bindHost ||
   previous.localHttpUrl !== next.localHttpUrl;
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const config = yield* DesktopConfig.DesktopConfig;
-  const networkInterfaces = yield* DesktopNetworkInterfacesService;
+  const networkInterfaces = yield* DesktopNetworkInterfaces.DesktopNetworkInterfaces;
   const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
-  const desktopSettings = yield* DesktopAppSettingsService.DesktopAppSettings;
+  const desktopSettings = yield* DesktopAppSettings.DesktopAppSettings;
   const stateRef = yield* Ref.make(initialRuntimeState());
 
   // Cache the `tailscale status` spawn for the TTL. On macOS, the Mac App
@@ -564,10 +537,3 @@ const make = Effect.gen(function* () {
 });
 
 export const layer = Layer.effect(DesktopServerExposure, make);
-
-export const networkInterfacesLayer = Layer.succeed(
-  DesktopNetworkInterfacesService,
-  DesktopNetworkInterfacesService.of({
-    read: Effect.sync(() => NodeOS.networkInterfaces()),
-  }),
-);

--- a/apps/desktop/src/backend/tailscaleEndpointProvider.ts
+++ b/apps/desktop/src/backend/tailscaleEndpointProvider.ts
@@ -9,10 +9,10 @@ import {
 } from "@t3tools/tailscale";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
-import { HttpClient } from "effect/unstable/http";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
-import type { DesktopNetworkInterfaces } from "./DesktopServerExposure.ts";
+import type { NetworkInterfaces } from "./DesktopNetworkInterfaces.ts";
 
 export { isTailscaleIpv4Address, parseTailscaleMagicDnsName } from "@t3tools/tailscale";
 
@@ -25,7 +25,7 @@ const TAILSCALE_ENDPOINT_PROVIDER: AdvertisedEndpointProvider = {
 
 function resolveTailscaleIpAdvertisedEndpoints(input: {
   readonly port: number;
-  readonly networkInterfaces: DesktopNetworkInterfaces;
+  readonly networkInterfaces: NetworkInterfaces;
 }): readonly AdvertisedEndpoint[] {
   const seen = new Set<string>();
   const endpoints: AdvertisedEndpoint[] = [];
@@ -103,7 +103,7 @@ export const resolveTailscaleAdvertisedEndpoints = Effect.fn("resolveTailscaleAd
     readonly port: number;
     readonly serveEnabled?: boolean;
     readonly servePort?: number;
-    readonly networkInterfaces: DesktopNetworkInterfaces;
+    readonly networkInterfaces: NetworkInterfaces;
     readonly statusJson?: string | null;
     readonly readMagicDnsName?: Effect.Effect<
       string | null,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -33,6 +33,7 @@ import * as DesktopAssets from "./app/DesktopAssets.ts";
 import * as DesktopBackendConfiguration from "./backend/DesktopBackendConfiguration.ts";
 import * as DesktopBackendManager from "./backend/DesktopBackendManager.ts";
 import * as DesktopLocalEnvironmentAuth from "./backend/DesktopLocalEnvironmentAuth.ts";
+import * as DesktopNetworkInterfaces from "./backend/DesktopNetworkInterfaces.ts";
 import * as DesktopEnvironment from "./app/DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./app/DesktopLifecycle.ts";
 import * as DesktopShutdown from "./app/DesktopShutdown.ts";
@@ -128,7 +129,7 @@ const desktopSshLayer = desktopSshEnvironmentLayer.pipe(
 );
 
 const desktopServerExposureLayer = DesktopServerExposure.layer.pipe(
-  Layer.provideMerge(DesktopServerExposure.networkInterfacesLayer),
+  Layer.provideMerge(DesktopNetworkInterfaces.layer),
   Layer.provideMerge(desktopFoundationLayer),
 );
 


### PR DESCRIPTION
## Summary

- inline desktop backend service contracts on their `Context.Service` tags and reference them through `Service["Service"]`
- export canonical `make` and `layer` values for each service, using `Layer.succeed` for the static network adapter
- replace free-form tagged errors with structured `Schema.TaggedErrorClass` errors whose messages derive from their attributes
- represent local-auth backend configuration and session bootstrap failures as distinct tagged errors, with an exported `Schema.Union` for shared decoding/predicates
- extract the network-interface adapter into its own canonical service module while retaining compatibility exports from `DesktopServerExposure`
- standardize local service and helper consumption on namespace imports

## Why

This aligns the desktop backend/network domain with the repository's target Effect module layout without adding behavioral coverage solely for the refactor. Orchestration, MCP, and harness modules are intentionally excluded.

## Validation

- focused desktop backend/window tests: 27 passed
- `vp check` (zero errors; 20 pre-existing warnings)
- `vp run typecheck`
- `git diff --check`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor desktop backend Effect services to use schema-based errors and extracted service factories
> - Replaces `Data.TaggedError` with `Schema.TaggedErrorClass` across backend services (`DesktopBackendManager`, `DesktopServerExposure`, `DesktopLocalEnvironmentAuth`), giving error types structured, schema-validated fields.
> - Extracts anonymous `Layer.effect` implementations into named `make` factory Effects across all refactored services, and removes separate `*Shape` interfaces by inlining service shapes into `Context.Service` generics.
> - Adds a new [`DesktopNetworkInterfaces`](https://github.com/pingdotgg/t3code/pull/3192/files#diff-7a853546c1249bac45306a6a573ec0821ed866dea7be3e5780cdbaa5017e3a04) service that wraps `node:os.networkInterfaces()`, replacing the internal network interfaces service previously embedded in `DesktopServerExposure`.
> - Switches unstable `http` and `process` imports to namespaced module imports throughout the desktop backend.
> - Behavioral Change: consumers of `DesktopServerExposure` must now provide a `DesktopNetworkInterfaces` layer explicitly; error payloads from affected services carry different field structures (`detail`/`cause` instead of raw cause types).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58e245e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Error types and fields changed (auth split, schema errors with `detail`/`cause`), which can break code that pattern-matches old tags or shapes; core backend spawn, exposure, and bearer bootstrap paths are touched but logic is largely moved, not rewritten.
> 
> **Overview**
> Refactors the desktop **backend/network** Effect modules to match the repo’s service layout: service APIs live on `Context.Service` tags (via `Service["Service"]` in tests), and each module exposes a shared **`make`** plus **`layer`** instead of anonymous `Layer.effect` bodies.
> 
> **Errors** move from `Data.TaggedError` to **`Schema.TaggedErrorClass`** (backend spawn/encode/timeout, server exposure persistence/no-address). Spawn/encode failures now carry a **`detail`** string plus **`cause`** as `Schema.Defect()`. **Local environment auth** replaces one generic error with **`DesktopLocalEnvironmentAuthBackendNotConfiguredError`** and **`DesktopLocalEnvironmentAuthSessionBootstrapError`**, exported as a **`Schema.Union`** for the shared error type.
> 
> **Network interfaces** are extracted to **`DesktopNetworkInterfaces`** (`read` via `node:os`); `DesktopServerExposure` drops the nested service and **`networkInterfacesLayer`**, and **`main.ts`** composes **`DesktopNetworkInterfaces.layer`** instead. Imports for unstable HTTP/child-process modules switch to **namespace** paths (`effect/unstable/http/HttpClient`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e245e38c21495717f9089974fbc6eab07ee687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->