### PR TITLE
[codex] Align desktop preview Effect services

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -96,7 +96,7 @@ const tabMethod = (
   channel: string,
   name: string,
   invoke: (
-    manager: PreviewManager.PreviewManagerShape,
+    manager: PreviewManager.PreviewManager["Service"],
     tabId: string,
   ) => Effect.Effect<void, PreviewManager.PreviewManagerError>,
 ) =>

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -45,7 +45,7 @@ import * as DesktopSshEnvironment from "./ssh/DesktopSshEnvironment.ts";
 import * as DesktopSshPasswordPrompts from "./ssh/DesktopSshPasswordPrompts.ts";
 import * as DesktopState from "./app/DesktopState.ts";
 import * as DesktopUpdates from "./updates/DesktopUpdates.ts";
-import * as PreviewBrowserSession from "./preview/BrowserSession.ts";
+import * as BrowserSession from "./preview/BrowserSession.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as DesktopWindow from "./window/DesktopWindow.ts";
 
@@ -132,7 +132,7 @@ const desktopServerExposureLayer = DesktopServerExposure.layer.pipe(
 );
 
 const desktopPreviewLayer = PreviewManager.layer.pipe(
-  Layer.provideMerge(PreviewBrowserSession.layer),
+  Layer.provideMerge(BrowserSession.layer),
   Layer.provideMerge(desktopFoundationLayer),
 );
 

--- a/apps/desktop/src/preview/BrowserSession.ts
+++ b/apps/desktop/src/preview/BrowserSession.ts
@@ -2,36 +2,38 @@ import type { Session } from "electron";
 import { session } from "electron";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 const PREVIEW_PARTITION_PREFIX = "persist:t3code-preview-";
 
-export class BrowserSessionError extends Data.TaggedError("BrowserSessionError")<{
-  readonly operation: string;
-  readonly cause: unknown;
-}> {
-  override get message() {
+export class BrowserSessionError extends Schema.TaggedErrorClass<BrowserSessionError>()(
+  "BrowserSessionError",
+  {
+    operation: Schema.Literals(["getPartition", "getSession", "clearCookies", "clearCache"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
     return `Desktop preview browser session operation failed: ${this.operation}`;
   }
 }
 
-export interface BrowserSessionShape {
-  readonly getPartition: (scope?: string) => Effect.Effect<string, BrowserSessionError>;
-  readonly isPartition: (partition: string) => boolean;
-  readonly getSession: (scope?: string) => Effect.Effect<Session, BrowserSessionError>;
-  readonly clearCookies: () => Effect.Effect<void, BrowserSessionError>;
-  readonly clearCache: () => Effect.Effect<void, BrowserSessionError>;
-}
+export class BrowserSession extends Context.Service<
+  BrowserSession,
+  {
+    readonly getPartition: (scope?: string) => Effect.Effect<string, BrowserSessionError>;
+    readonly isPartition: (partition: string) => boolean;
+    readonly getSession: (scope?: string) => Effect.Effect<Session, BrowserSessionError>;
+    readonly clearCookies: () => Effect.Effect<void, BrowserSessionError>;
+    readonly clearCache: () => Effect.Effect<void, BrowserSessionError>;
+  }
+>()("@t3tools/desktop/preview/BrowserSession") {}
 
-export class BrowserSession extends Context.Service<BrowserSession, BrowserSessionShape>()(
-  "@t3tools/desktop/preview/BrowserSession",
-) {}
-
-const make = Effect.gen(function* BrowserSessionMake() {
+export const make = Effect.gen(function* BrowserSessionMake() {
   const crypto = yield* Crypto.Crypto;
   const sessionsRef = yield* SynchronizedRef.make<ReadonlyMap<string, Session>>(new Map());
 

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -37,7 +37,6 @@ import {
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -432,15 +431,17 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   ) {
     const tabs = yield* SynchronizedRef.get(tabsRef);
     const tab = tabs.get(tabId);
-    if (!tab) return yield* fail("requireWebContents", new PreviewTabNotFoundError(tabId));
+    if (!tab) {
+      return yield* fail("requireWebContents", new PreviewTabNotFoundError({ tabId }));
+    }
     if (tab.webContentsId == null) {
-      return yield* fail("requireWebContents", new PreviewWebviewNotInitializedError(tabId));
+      return yield* fail("requireWebContents", new PreviewWebviewNotInitializedError({ tabId }));
     }
     const wc = webContents.fromId(tab.webContentsId);
     if (!wc) {
       return yield* fail(
         "requireWebContents",
-        new PreviewWebContentsNotFoundError(tabId, tab.webContentsId),
+        new PreviewWebContentsNotFoundError({ tabId, webContentsId: tab.webContentsId }),
       );
     }
     return wc;
@@ -845,7 +846,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
         });
       } else {
         const error = Option.getOrNull(Cause.findErrorOption(exit.cause));
-        const underlying = error instanceof PreviewManagerError ? error.cause : error;
+        const underlying = isPreviewManagerError(error) ? error.cause : error;
         const interrupted =
           underlying instanceof Error &&
           underlying.name === "PreviewAutomationControlInterruptedError";
@@ -1161,7 +1162,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   ) {
     const tab = (yield* SynchronizedRef.get(tabsRef)).get(tabId);
     if (!tab) {
-      return yield* fail("registerWebview", new PreviewTabNotFoundError(tabId));
+      return yield* fail("registerWebview", new PreviewTabNotFoundError({ tabId }));
     }
     const wc = webContents.fromId(webContentsId);
     const mainWindow = yield* Ref.get(mainWindowRef);
@@ -1172,7 +1173,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     ) {
       return yield* fail(
         "registerWebview",
-        new PreviewWebContentsNotFoundError(tabId, webContentsId),
+        new PreviewWebContentsNotFoundError({ tabId, webContentsId }),
       );
     }
     const attached = yield* Ref.get(attachedRef);
@@ -1224,7 +1225,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
       ] as const;
     });
     if (Option.isNone(registration)) {
-      return yield* fail("registerWebview", new PreviewTabNotFoundError(tabId));
+      return yield* fail("registerWebview", new PreviewTabNotFoundError({ tabId }));
     }
     const { state: registered, pendingUrl } = registration.value;
     yield* emit(tabId, registered);
@@ -2200,129 +2201,131 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   };
 });
 
-export class PreviewTabNotFoundError extends Error {
-  readonly tabId: string;
-  constructor(tabId: string) {
-    super(`Preview tab not found: ${tabId}`);
-    this.name = "PreviewTabNotFoundError";
-    this.tabId = tabId;
+export class PreviewTabNotFoundError extends Schema.TaggedErrorClass<PreviewTabNotFoundError>()(
+  "PreviewTabNotFoundError",
+  { tabId: Schema.String },
+) {
+  override get message(): string {
+    return `Preview tab not found: ${this.tabId}`;
   }
 }
 
-export class PreviewWebContentsNotFoundError extends Error {
-  readonly tabId: string;
-  readonly webContentsId: number;
-  constructor(tabId: string, webContentsId: number) {
-    super(`WebContents ${webContentsId} not found for preview tab ${tabId}`);
-    this.name = "PreviewWebContentsNotFoundError";
-    this.tabId = tabId;
-    this.webContentsId = webContentsId;
+export class PreviewWebContentsNotFoundError extends Schema.TaggedErrorClass<PreviewWebContentsNotFoundError>()(
+  "PreviewWebContentsNotFoundError",
+  { tabId: Schema.String, webContentsId: Schema.Number },
+) {
+  override get message(): string {
+    return `WebContents ${this.webContentsId} not found for preview tab ${this.tabId}`;
   }
 }
 
-export class PreviewWebviewNotInitializedError extends Error {
-  readonly tabId: string;
-  constructor(tabId: string) {
-    super(`Preview tab "${tabId}" has no webview registered`);
-    this.name = "PreviewWebviewNotInitializedError";
-    this.tabId = tabId;
+export class PreviewWebviewNotInitializedError extends Schema.TaggedErrorClass<PreviewWebviewNotInitializedError>()(
+  "PreviewWebviewNotInitializedError",
+  { tabId: Schema.String },
+) {
+  override get message(): string {
+    return `Preview tab "${this.tabId}" has no webview registered`;
   }
 }
 
-export class PreviewManagerError extends Data.TaggedError("PreviewManagerError")<{
-  readonly operation: string;
-  readonly cause: unknown;
-}> {
-  override get message() {
+export class PreviewManagerError extends Schema.TaggedErrorClass<PreviewManagerError>()(
+  "PreviewManagerError",
+  {
+    operation: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
     return `Desktop preview operation failed: ${this.operation}`;
   }
 }
 
-export interface PreviewManagerShape {
-  readonly setMainWindow: (window: BrowserWindow) => Effect.Effect<void, PreviewManagerError>;
-  readonly getBrowserSession: (scope?: string) => Effect.Effect<Session, PreviewManagerError>;
-  readonly isBrowserPartition: (partition: string) => boolean;
-  readonly createTab: (tabId: string) => Effect.Effect<PreviewTabState, PreviewManagerError>;
-  readonly closeTab: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly registerWebview: (
-    tabId: string,
-    webContentsId: number,
-  ) => Effect.Effect<void, PreviewManagerError>;
-  readonly navigate: (tabId: string, url: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly goBack: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly goForward: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly refresh: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly zoomIn: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly zoomOut: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly resetZoom: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly hardReload: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly openDevTools: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly clearCookies: () => Effect.Effect<void, PreviewManagerError>;
-  readonly clearCache: () => Effect.Effect<void, PreviewManagerError>;
-  readonly getBrowserPartition: (scope?: string) => Effect.Effect<string, PreviewManagerError>;
-  readonly setAnnotationTheme: (
-    theme: DesktopPreviewAnnotationTheme,
-  ) => Effect.Effect<void, PreviewManagerError>;
-  readonly pickElement: (
-    tabId: string,
-  ) => Effect.Effect<PreviewAnnotationPayload | null, PreviewManagerError>;
-  readonly cancelPickElement: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly captureScreenshot: (
-    tabId: string,
-  ) => Effect.Effect<DesktopPreviewScreenshotArtifact, PreviewManagerError>;
-  readonly revealArtifact: (path: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly copyArtifactToClipboard: (path: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly startRecording: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly stopRecording: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
-  readonly saveRecording: (
-    tabId: string,
-    mimeType: string,
-    data: Uint8Array,
-  ) => Effect.Effect<DesktopPreviewRecordingArtifact, PreviewManagerError>;
-  readonly automationStatus: (
-    tabId: string,
-  ) => Effect.Effect<PreviewAutomationStatus, PreviewManagerError>;
-  readonly automationSnapshot: (
-    tabId: string,
-  ) => Effect.Effect<PreviewAutomationSnapshot, PreviewManagerError>;
-  readonly automationClick: (
-    tabId: string,
-    input: PreviewAutomationClickInput,
-  ) => Effect.Effect<void, PreviewManagerError>;
-  readonly automationType: (
-    tabId: string,
-    input: PreviewAutomationTypeInput,
-  ) => Effect.Effect<void, PreviewManagerError>;
-  readonly automationPress: (
-    tabId: string,
-    input: PreviewAutomationPressInput,
-  ) => Effect.Effect<void, PreviewManagerError>;
-  readonly automationScroll: (
-    tabId: string,
-    input: PreviewAutomationScrollInput,
-  ) => Effect.Effect<void, PreviewManagerError>;
-  readonly automationEvaluate: (
-    tabId: string,
-    input: PreviewAutomationEvaluateInput,
-  ) => Effect.Effect<unknown, PreviewManagerError>;
-  readonly automationWaitFor: (
-    tabId: string,
-    input: PreviewAutomationWaitForInput,
-  ) => Effect.Effect<void, PreviewManagerError>;
-  readonly subscribeStateChanges: (listener: Listener) => Effect.Effect<void, never, Scope.Scope>;
-  readonly subscribePointerEvents: (
-    listener: PointerEventListener,
-  ) => Effect.Effect<void, never, Scope.Scope>;
-  readonly subscribeRecordingFrames: (
-    listener: RecordingFrameListener,
-  ) => Effect.Effect<void, never, Scope.Scope>;
-}
+const isPreviewManagerError = Schema.is(PreviewManagerError);
 
-export class PreviewManager extends Context.Service<PreviewManager, PreviewManagerShape>()(
-  "@t3tools/desktop/preview/Manager/PreviewManager",
-) {}
+export class PreviewManager extends Context.Service<
+  PreviewManager,
+  {
+    readonly setMainWindow: (window: BrowserWindow) => Effect.Effect<void, PreviewManagerError>;
+    readonly getBrowserSession: (scope?: string) => Effect.Effect<Session, PreviewManagerError>;
+    readonly isBrowserPartition: (partition: string) => boolean;
+    readonly createTab: (tabId: string) => Effect.Effect<PreviewTabState, PreviewManagerError>;
+    readonly closeTab: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly registerWebview: (
+      tabId: string,
+      webContentsId: number,
+    ) => Effect.Effect<void, PreviewManagerError>;
+    readonly navigate: (tabId: string, url: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly goBack: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly goForward: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly refresh: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly zoomIn: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly zoomOut: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly resetZoom: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly hardReload: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly openDevTools: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly clearCookies: () => Effect.Effect<void, PreviewManagerError>;
+    readonly clearCache: () => Effect.Effect<void, PreviewManagerError>;
+    readonly getBrowserPartition: (scope?: string) => Effect.Effect<string, PreviewManagerError>;
+    readonly setAnnotationTheme: (
+      theme: DesktopPreviewAnnotationTheme,
+    ) => Effect.Effect<void, PreviewManagerError>;
+    readonly pickElement: (
+      tabId: string,
+    ) => Effect.Effect<PreviewAnnotationPayload | null, PreviewManagerError>;
+    readonly cancelPickElement: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly captureScreenshot: (
+      tabId: string,
+    ) => Effect.Effect<DesktopPreviewScreenshotArtifact, PreviewManagerError>;
+    readonly revealArtifact: (path: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly copyArtifactToClipboard: (path: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly startRecording: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly stopRecording: (tabId: string) => Effect.Effect<void, PreviewManagerError>;
+    readonly saveRecording: (
+      tabId: string,
+      mimeType: string,
+      data: Uint8Array,
+    ) => Effect.Effect<DesktopPreviewRecordingArtifact, PreviewManagerError>;
+    readonly automationStatus: (
+      tabId: string,
+    ) => Effect.Effect<PreviewAutomationStatus, PreviewManagerError>;
+    readonly automationSnapshot: (
+      tabId: string,
+    ) => Effect.Effect<PreviewAutomationSnapshot, PreviewManagerError>;
+    readonly automationClick: (
+      tabId: string,
+      input: PreviewAutomationClickInput,
+    ) => Effect.Effect<void, PreviewManagerError>;
+    readonly automationType: (
+      tabId: string,
+      input: PreviewAutomationTypeInput,
+    ) => Effect.Effect<void, PreviewManagerError>;
+    readonly automationPress: (
+      tabId: string,
+      input: PreviewAutomationPressInput,
+    ) => Effect.Effect<void, PreviewManagerError>;
+    readonly automationScroll: (
+      tabId: string,
+      input: PreviewAutomationScrollInput,
+    ) => Effect.Effect<void, PreviewManagerError>;
+    readonly automationEvaluate: (
+      tabId: string,
+      input: PreviewAutomationEvaluateInput,
+    ) => Effect.Effect<unknown, PreviewManagerError>;
+    readonly automationWaitFor: (
+      tabId: string,
+      input: PreviewAutomationWaitForInput,
+    ) => Effect.Effect<void, PreviewManagerError>;
+    readonly subscribeStateChanges: (listener: Listener) => Effect.Effect<void, never, Scope.Scope>;
+    readonly subscribePointerEvents: (
+      listener: PointerEventListener,
+    ) => Effect.Effect<void, never, Scope.Scope>;
+    readonly subscribeRecordingFrames: (
+      listener: RecordingFrameListener,
+    ) => Effect.Effect<void, never, Scope.Scope>;
+  }
+>()("@t3tools/desktop/preview/Manager/PreviewManager") {}
 
-const make = Effect.gen(function* PreviewManagerMake() {
+export const make = Effect.gen(function* PreviewManagerMake() {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const browserSession = yield* BrowserSession.BrowserSession;
   const operations = yield* makeNativeOperations(environment.browserArtifactsDir);


### PR DESCRIPTION
## Summary
- inline BrowserSession and PreviewManager service contracts and use Service["Service"] at consumers
- migrate preview errors to Schema.TaggedErrorClass with structured attributes and derived messages
- export the existing effectful `make` values and canonical `layer` exports, and replace schema-class `instanceof` checks with `Schema.is`
- preserve existing coverage without adding refactor-only tests

## Verification
- `vp test apps/desktop/src/preview/BrowserSession.test.ts apps/desktop/src/preview/Manager.test.ts apps/desktop/src/ipc/methods/preview.test.ts` — 3 files and 12 tests passed
- `vp check`
- `vp run typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align desktop preview Effect services to use `Schema.TaggedErrorClass`
> - Replaces `Data.TaggedError` with `Schema.TaggedErrorClass` for all error types in [`BrowserSession.ts`](https://github.com/pingdotgg/t3code/pull/3199/files#diff-17a3bda9cc115ba14d32576e0f787fbd4488b05312afb31216156b1616efee0f) and [`Manager.ts`](https://github.com/pingdotgg/t3code/pull/3199/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53), adding typed schemas and `message` getters to each error class.
> - Removes the separate `BrowserSessionShape` and `PreviewManagerShape` interfaces, inlining service shapes directly into `Context.Service` generic parameters.
> - Exports the `make` factory effects from both services and adds `isPreviewManagerError = Schema.is(PreviewManagerError)` as a utility predicate.
> - Behavioral Change: `PreviewManagerError` instance detection in action completion handling now uses `Schema.is()` instead of `instanceof`, which affects whether an action resolves to `interrupted` vs `failed`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3181c39.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches preview error typing and automation failure unwrapping (instanceof → Schema.is), which can change reported action errors; behavior is otherwise structural with regression tests noted in the PR.
> 
> **Overview**
> Aligns desktop **BrowserSession** and **PreviewManager** with the repo’s Effect service pattern: service contracts live on `Context.Service` (consumers use `PreviewManager["Service"]`), and **`make`** is exported for tests/layers.
> 
> Preview errors move from plain `Error` / `Data.TaggedError` to **`Schema.TaggedErrorClass`** with object constructors (e.g. `new PreviewTabNotFoundError({ tabId })`) and typed **`operation`** / **`cause`** fields where applicable. Automation action completion now unwraps failures via **`Schema.is(PreviewManagerError)`** instead of **`instanceof`**, which can change which error surfaces in the action timeline when failures are wrapped.
> 
> **`main.ts`** renames the browser session import to **`BrowserSession`** for consistency with the module export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3181c39be61410ddb574b03afc4fcc664f577cf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

