### PR TITLE
[codex] Standardize Effect protocol adapter services

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -7,7 +7,8 @@ import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Types from "effect/Types";
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as CodexClient from "effect-codex-app-server/client";
 import * as CodexSchema from "effect-codex-app-server/schema";
 import * as CodexErrors from "effect-codex-app-server/errors";
@@ -253,7 +254,7 @@ function parseCodexSkillsListResponse(
 }
 
 const requestAllCodexModels = Effect.fn("requestAllCodexModels")(function* (
-  client: CodexClient.CodexAppServerClientShape,
+  client: CodexClient.CodexAppServerClient["Service"],
 ) {
   const models: ServerProviderModel[] = [];
   let cursor: string | null | undefined = undefined;

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -36,7 +36,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import * as SynchronizedRef from "effect/SynchronizedRef";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
@@ -50,7 +50,7 @@ import {
   ProviderAdapterValidationError,
 } from "../Errors.ts";
 import { acpPermissionOutcome, mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
-import { type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
+import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
 import {
   makeAcpAssistantItemEvent,
   makeAcpContentDeltaEvent,
@@ -126,7 +126,7 @@ interface CursorSessionContext {
   readonly threadId: ThreadId;
   session: ProviderSession;
   readonly scope: Scope.Closeable;
-  readonly acp: AcpSessionRuntimeShape;
+  readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
   notificationFiber: Fiber.Fiber<void, never> | undefined;
   readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
@@ -246,7 +246,7 @@ function resolveRequestedModeId(input: {
 }
 
 function applyRequestedSessionConfiguration<E>(input: {
-  readonly runtime: AcpSessionRuntimeShape;
+  readonly runtime: AcpSessionRuntime.AcpSessionRuntime["Service"];
   readonly runtimeMode: RuntimeMode;
   readonly interactionMode: ProviderInteractionMode | undefined;
   readonly modelSelection:

--- a/apps/server/src/provider/Layers/CursorProvider.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.ts
@@ -21,7 +21,8 @@ import * as Path from "effect/Path";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import {
   createModelCapabilities,
   getProviderOptionBooleanSelectionValue,
@@ -43,7 +44,7 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
-import { AcpSessionRuntime } from "../acp/AcpSessionRuntime.ts";
+import * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
 import { CursorListAvailableModelsResponse } from "../acp/CursorAcpExtension.ts";
 
 const decodeCursorListAvailableModelsResponse = Schema.decodeUnknownEffect(
@@ -416,12 +417,14 @@ const makeCursorAcpProbeRuntime = (
         clientCapabilities: CURSOR_PARAMETERIZED_MODEL_PICKER_CAPABILITIES,
       }).pipe(Layer.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner))),
     );
-    return yield* Effect.service(AcpSessionRuntime).pipe(Effect.provide(acpContext));
+    return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
   });
 
 const withCursorAcpProbeRuntime = <A, E, R>(
   cursorSettings: CursorSettings,
-  useRuntime: (acp: AcpSessionRuntime["Service"]) => Effect.Effect<A, E, R>,
+  useRuntime: (acp: AcpSessionRuntime.AcpSessionRuntime["Service"]) => Effect.Effect<A, E, R>,
   environment?: NodeJS.ProcessEnv,
 ) =>
   makeCursorAcpProbeRuntime(cursorSettings, environment).pipe(

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -27,7 +27,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import * as Stream from "effect/Stream";
 import * as SynchronizedRef from "effect/SynchronizedRef";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
@@ -41,7 +41,7 @@ import {
   ProviderAdapterValidationError,
 } from "../Errors.ts";
 import { mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
-import { type AcpSessionRuntimeShape } from "../acp/AcpSessionRuntime.ts";
+import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
 import {
   makeAcpAssistantItemEvent,
   makeAcpContentDeltaEvent,
@@ -101,7 +101,7 @@ interface GrokSessionContext {
   readonly acpSessionId: string;
   session: ProviderSession;
   readonly scope: Scope.Closeable;
-  readonly acp: AcpSessionRuntimeShape;
+  readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
   notificationFiber: Fiber.Fiber<void, never> | undefined;
   readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
   readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;

--- a/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
+++ b/apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts
@@ -10,7 +10,7 @@ import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 import { describe, expect } from "vite-plus/test";
 
-import { AcpSessionRuntime, type AcpSessionRequestLogEvent } from "./AcpSessionRuntime.ts";
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 import type * as EffectAcpProtocol from "effect-acp/protocol";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -20,9 +20,9 @@ const mockAgentArgs = [mockAgentPath];
 
 describe("AcpSessionRuntime", () => {
   it.effect("merges custom initialize client capabilities into the ACP handshake", () => {
-    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    const requestEvents: Array<AcpSessionRuntime.AcpSessionRequestLogEvent> = [];
     return Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       yield* runtime.start();
 
       const initializeStarted = requestEvents.find(
@@ -64,7 +64,7 @@ describe("AcpSessionRuntime", () => {
 
   it.effect("starts a session, prompts, and emits normalized events against the mock agent", () =>
     Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       const started = yield* runtime.start();
 
       expect(started.initializeResult).toMatchObject({ protocolVersion: 1 });
@@ -115,7 +115,7 @@ describe("AcpSessionRuntime", () => {
 
   it.effect("segments assistant text around ACP tool calls", () =>
     Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       yield* runtime.start();
 
       const promptResult = yield* runtime.prompt({
@@ -176,7 +176,7 @@ describe("AcpSessionRuntime", () => {
 
   it.effect("suppresses generic placeholder tool updates until completion", () =>
     Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       yield* runtime.start();
 
       const promptResult = yield* runtime.prompt({
@@ -213,9 +213,9 @@ describe("AcpSessionRuntime", () => {
   );
 
   it.effect("logs ACP requests from the shared runtime", () => {
-    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    const requestEvents: Array<AcpSessionRuntime.AcpSessionRequestLogEvent> = [];
     return Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       yield* runtime.start();
 
       yield* runtime.setModel("composer-2");
@@ -265,9 +265,9 @@ describe("AcpSessionRuntime", () => {
   });
 
   it.effect("skips no-op session config writes when the requested value is already active", () => {
-    const requestEvents: Array<AcpSessionRequestLogEvent> = [];
+    const requestEvents: Array<AcpSessionRuntime.AcpSessionRequestLogEvent> = [];
     return Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       yield* runtime.start();
 
       yield* runtime.setConfigOption("model", "default");
@@ -302,7 +302,7 @@ describe("AcpSessionRuntime", () => {
   it.effect("emits low-level ACP protocol logs for raw and decoded messages", () => {
     const protocolEvents: Array<EffectAcpProtocol.AcpProtocolLogEvent> = [];
     return Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       yield* runtime.start();
 
       yield* runtime.prompt({
@@ -350,7 +350,7 @@ describe("AcpSessionRuntime", () => {
     const tempDir = mkdtempSync(path.join(os.tmpdir(), "acp-runtime-"));
     const requestLogPath = path.join(tempDir, "requests.ndjson");
     return Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       yield* runtime.start();
 
       const error = yield* runtime.setModel("composer-2[fast=false]").pipe(Effect.flip);

--- a/apps/server/src/provider/acp/AcpNativeLogging.ts
+++ b/apps/server/src/provider/acp/AcpNativeLogging.ts
@@ -6,9 +6,9 @@ import * as Effect from "effect/Effect";
 import type * as EffectAcpProtocol from "effect-acp/protocol";
 
 import type { EventNdjsonLogger } from "../Layers/EventNdjsonLogger.ts";
-import type { AcpSessionRequestLogEvent, AcpSessionRuntimeOptions } from "./AcpSessionRuntime.ts";
+import type * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
-function formatRequestLogPayload(event: AcpSessionRequestLogEvent) {
+function formatRequestLogPayload(event: AcpSessionRuntime.AcpSessionRequestLogEvent) {
   return {
     method: event.method,
     status: event.status,
@@ -24,7 +24,7 @@ export const makeAcpNativeLoggerFactory = Effect.fn("makeAcpNativeLoggerFactory"
     readonly nativeEventLogger: EventNdjsonLogger | undefined;
     readonly provider: ProviderDriverKind;
     readonly threadId: ThreadId;
-  }): Pick<AcpSessionRuntimeOptions, "requestLogger" | "protocolLogging"> => {
+  }): Pick<AcpSessionRuntime.AcpSessionRuntimeOptions, "requestLogger" | "protocolLogging"> => {
     const writeNativeAcpLog = (logInput: {
       readonly kind: "request" | "protocol";
       readonly payload: unknown;
@@ -57,7 +57,7 @@ export const makeAcpNativeLoggerFactory = Effect.fn("makeAcpNativeLoggerFactory"
       );
 
     return {
-      requestLogger: (event: AcpSessionRequestLogEvent) =>
+      requestLogger: (event: AcpSessionRuntime.AcpSessionRequestLogEvent) =>
         writeNativeAcpLog({
           kind: "request",
           payload: formatRequestLogPayload(event),
@@ -72,7 +72,7 @@ export const makeAcpNativeLoggerFactory = Effect.fn("makeAcpNativeLoggerFactory"
                   kind: "protocol",
                   payload: event,
                 }),
-            } satisfies NonNullable<AcpSessionRuntimeOptions["protocolLogging"]>,
+            } satisfies NonNullable<AcpSessionRuntime.AcpSessionRuntimeOptions["protocolLogging"]>,
           }
         : {}),
     };

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -1,4 +1,5 @@
 import * as Cause from "effect/Cause";
+import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -6,9 +7,9 @@ import * as Layer from "effect/Layer";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Scope from "effect/Scope";
-import * as Context from "effect/Context";
 import * as Stream from "effect/Stream";
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpClient from "effect-acp/client";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
@@ -75,50 +76,153 @@ export interface AcpSessionRuntimeStartResult {
   readonly modelConfigId: string | undefined;
 }
 
-export interface AcpSessionRuntimeShape {
-  readonly handleRequestPermission: EffectAcpClient.AcpClientShape["handleRequestPermission"];
-  readonly handleElicitation: EffectAcpClient.AcpClientShape["handleElicitation"];
-  readonly handleReadTextFile: EffectAcpClient.AcpClientShape["handleReadTextFile"];
-  readonly handleWriteTextFile: EffectAcpClient.AcpClientShape["handleWriteTextFile"];
-  readonly handleCreateTerminal: EffectAcpClient.AcpClientShape["handleCreateTerminal"];
-  readonly handleTerminalOutput: EffectAcpClient.AcpClientShape["handleTerminalOutput"];
-  readonly handleTerminalWaitForExit: EffectAcpClient.AcpClientShape["handleTerminalWaitForExit"];
-  readonly handleTerminalKill: EffectAcpClient.AcpClientShape["handleTerminalKill"];
-  readonly handleTerminalRelease: EffectAcpClient.AcpClientShape["handleTerminalRelease"];
-  readonly handleSessionUpdate: EffectAcpClient.AcpClientShape["handleSessionUpdate"];
-  readonly handleElicitationComplete: EffectAcpClient.AcpClientShape["handleElicitationComplete"];
-  readonly handleUnknownExtRequest: EffectAcpClient.AcpClientShape["handleUnknownExtRequest"];
-  readonly handleUnknownExtNotification: EffectAcpClient.AcpClientShape["handleUnknownExtNotification"];
-  readonly handleExtRequest: EffectAcpClient.AcpClientShape["handleExtRequest"];
-  readonly handleExtNotification: EffectAcpClient.AcpClientShape["handleExtNotification"];
-  readonly start: () => Effect.Effect<AcpSessionRuntimeStartResult, EffectAcpErrors.AcpError>;
-  readonly getEvents: () => Stream.Stream<AcpParsedSessionEvent, never>;
-  readonly getModeState: Effect.Effect<AcpSessionModeState | undefined>;
-  readonly getConfigOptions: Effect.Effect<ReadonlyArray<EffectAcpSchema.SessionConfigOption>>;
-  readonly prompt: (
-    payload: Omit<EffectAcpSchema.PromptRequest, "sessionId">,
-  ) => Effect.Effect<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpError>;
-  readonly cancel: Effect.Effect<void, EffectAcpErrors.AcpError>;
-  readonly setMode: (
-    modeId: string,
-  ) => Effect.Effect<EffectAcpSchema.SetSessionModeResponse, EffectAcpErrors.AcpError>;
-  readonly setConfigOption: (
-    configId: string,
-    value: string | boolean,
-  ) => Effect.Effect<EffectAcpSchema.SetSessionConfigOptionResponse, EffectAcpErrors.AcpError>;
-  readonly setModel: (model: string) => Effect.Effect<void, EffectAcpErrors.AcpError>;
-  readonly setSessionModel: (
-    modelId: string,
-  ) => Effect.Effect<EffectAcpSchema.SetSessionModelResponse, EffectAcpErrors.AcpError>;
-  readonly request: (
-    method: string,
-    payload: unknown,
-  ) => Effect.Effect<unknown, EffectAcpErrors.AcpError>;
-  readonly notify: (
-    method: string,
-    payload: unknown,
-  ) => Effect.Effect<void, EffectAcpErrors.AcpError>;
-}
+export class AcpSessionRuntime extends Context.Service<
+  AcpSessionRuntime,
+  {
+    /**
+     * Registers a handler for `session/request_permission`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/request_permission
+     */
+    readonly handleRequestPermission: EffectAcpClient.AcpClient["Service"]["handleRequestPermission"];
+    /**
+     * Registers a handler for `session/elicitation`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/elicitation
+     */
+    readonly handleElicitation: EffectAcpClient.AcpClient["Service"]["handleElicitation"];
+    /**
+     * Registers a handler for `fs/read_text_file`.
+     * @see https://agentclientprotocol.com/protocol/schema#fs/read_text_file
+     */
+    readonly handleReadTextFile: EffectAcpClient.AcpClient["Service"]["handleReadTextFile"];
+    /**
+     * Registers a handler for `fs/write_text_file`.
+     * @see https://agentclientprotocol.com/protocol/schema#fs/write_text_file
+     */
+    readonly handleWriteTextFile: EffectAcpClient.AcpClient["Service"]["handleWriteTextFile"];
+    /**
+     * Registers a handler for `terminal/create`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/create
+     */
+    readonly handleCreateTerminal: EffectAcpClient.AcpClient["Service"]["handleCreateTerminal"];
+    /**
+     * Registers a handler for `terminal/output`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/output
+     */
+    readonly handleTerminalOutput: EffectAcpClient.AcpClient["Service"]["handleTerminalOutput"];
+    /**
+     * Registers a handler for `terminal/wait_for_exit`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/wait_for_exit
+     */
+    readonly handleTerminalWaitForExit: EffectAcpClient.AcpClient["Service"]["handleTerminalWaitForExit"];
+    /**
+     * Registers a handler for `terminal/kill`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/kill
+     */
+    readonly handleTerminalKill: EffectAcpClient.AcpClient["Service"]["handleTerminalKill"];
+    /**
+     * Registers a handler for `terminal/release`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/release
+     */
+    readonly handleTerminalRelease: EffectAcpClient.AcpClient["Service"]["handleTerminalRelease"];
+    /**
+     * Registers a handler for `session/update`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/update
+     */
+    readonly handleSessionUpdate: EffectAcpClient.AcpClient["Service"]["handleSessionUpdate"];
+    /**
+     * Registers a handler for `session/elicitation/complete`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/elicitation/complete
+     */
+    readonly handleElicitationComplete: EffectAcpClient.AcpClient["Service"]["handleElicitationComplete"];
+    /**
+     * Registers a fallback extension request handler.
+     * @see https://agentclientprotocol.com/protocol/extensibility
+     */
+    readonly handleUnknownExtRequest: EffectAcpClient.AcpClient["Service"]["handleUnknownExtRequest"];
+    /**
+     * Registers a fallback extension notification handler.
+     * @see https://agentclientprotocol.com/protocol/extensibility
+     */
+    readonly handleUnknownExtNotification: EffectAcpClient.AcpClient["Service"]["handleUnknownExtNotification"];
+    /**
+     * Registers a typed extension request handler.
+     * @see https://agentclientprotocol.com/protocol/extensibility
+     */
+    readonly handleExtRequest: EffectAcpClient.AcpClient["Service"]["handleExtRequest"];
+    /**
+     * Registers a typed extension notification handler.
+     * @see https://agentclientprotocol.com/protocol/extensibility
+     */
+    readonly handleExtNotification: EffectAcpClient.AcpClient["Service"]["handleExtNotification"];
+    /**
+     * Initializes the ACP connection, authenticates, and loads, resumes, or creates the session.
+     * Concurrent calls share the same in-flight startup and a failed startup may be retried.
+     */
+    readonly start: () => Effect.Effect<AcpSessionRuntimeStartResult, EffectAcpErrors.AcpError>;
+    /** Stream of parsed ACP session events emitted after startup. */
+    readonly getEvents: () => Stream.Stream<AcpParsedSessionEvent, never>;
+    /** Latest mode state observed from session setup and `session/update` notifications. */
+    readonly getModeState: Effect.Effect<AcpSessionModeState | undefined>;
+    /** Latest configuration options observed from session setup and configuration writes. */
+    readonly getConfigOptions: Effect.Effect<ReadonlyArray<EffectAcpSchema.SessionConfigOption>>;
+    /**
+     * Sends a prompt turn to the active session.
+     * @see https://agentclientprotocol.com/protocol/schema#session/prompt
+     */
+    readonly prompt: (
+      payload: Omit<EffectAcpSchema.PromptRequest, "sessionId">,
+    ) => Effect.Effect<EffectAcpSchema.PromptResponse, EffectAcpErrors.AcpError>;
+    /**
+     * Sends a real ACP `session/cancel` notification for the active session.
+     * @see https://agentclientprotocol.com/protocol/schema#session/cancel
+     */
+    readonly cancel: Effect.Effect<void, EffectAcpErrors.AcpError>;
+    /**
+     * Selects the active mode through the negotiated `mode` configuration option.
+     * This is a no-op when the requested mode is already active.
+     * @see https://agentclientprotocol.com/protocol/schema#session/set_config_option
+     */
+    readonly setMode: (
+      modeId: string,
+    ) => Effect.Effect<EffectAcpSchema.SetSessionModeResponse, EffectAcpErrors.AcpError>;
+    /**
+     * Updates a session configuration option and the runtime configuration snapshot.
+     * @see https://agentclientprotocol.com/protocol/schema#session/set_config_option
+     */
+    readonly setConfigOption: (
+      configId: string,
+      value: string | boolean,
+    ) => Effect.Effect<EffectAcpSchema.SetSessionConfigOptionResponse, EffectAcpErrors.AcpError>;
+    /**
+     * Selects the base model through the negotiated model configuration option.
+     * @see https://agentclientprotocol.com/protocol/schema#session/set_config_option
+     */
+    readonly setModel: (model: string) => Effect.Effect<void, EffectAcpErrors.AcpError>;
+    /**
+     * Selects the active model through the unstable ACP `session/set_model` capability.
+     * @see https://agentclientprotocol.com/protocol/schema#session/set_model
+     */
+    readonly setSessionModel: (
+      modelId: string,
+    ) => Effect.Effect<EffectAcpSchema.SetSessionModelResponse, EffectAcpErrors.AcpError>;
+    /**
+     * Sends a generic ACP extension request and records it through the request logger.
+     * @see https://agentclientprotocol.com/protocol/extensibility
+     */
+    readonly request: (
+      method: string,
+      payload: unknown,
+    ) => Effect.Effect<unknown, EffectAcpErrors.AcpError>;
+    /**
+     * Sends a generic ACP extension notification.
+     * @see https://agentclientprotocol.com/protocol/extensibility
+     */
+    readonly notify: (
+      method: string,
+      payload: unknown,
+    ) => Effect.Effect<void, EffectAcpErrors.AcpError>;
+  }
+>()("t3/provider/acp/AcpSessionRuntime") {}
 
 interface AcpStartedState extends AcpSessionRuntimeStartResult {}
 
@@ -140,24 +244,10 @@ interface EnsureActiveAssistantSegmentResult {
   readonly startedEvent?: Extract<AcpParsedSessionEvent, { readonly _tag: "AssistantItemStarted" }>;
 }
 
-export class AcpSessionRuntime extends Context.Service<AcpSessionRuntime, AcpSessionRuntimeShape>()(
-  "t3/provider/acp/AcpSessionRuntime",
-) {
-  static layer(
-    options: AcpSessionRuntimeOptions,
-  ): Layer.Layer<
-    AcpSessionRuntime,
-    EffectAcpErrors.AcpError,
-    ChildProcessSpawner.ChildProcessSpawner
-  > {
-    return Layer.effect(AcpSessionRuntime, makeAcpSessionRuntime(options));
-  }
-}
-
-const makeAcpSessionRuntime = (
+export const make = (
   options: AcpSessionRuntimeOptions,
 ): Effect.Effect<
-  AcpSessionRuntimeShape,
+  AcpSessionRuntime["Service"],
   EffectAcpErrors.AcpError,
   ChildProcessSpawner.ChildProcessSpawner | Scope.Scope
 > =>
@@ -573,8 +663,16 @@ const makeAcpSessionRuntime = (
       request: (method, payload) =>
         runLoggedRequest(method, payload, acp.raw.request(method, payload)),
       notify: acp.raw.notify,
-    } satisfies AcpSessionRuntimeShape;
+    } satisfies AcpSessionRuntime["Service"];
   });
+
+export const layer = (
+  options: AcpSessionRuntimeOptions,
+): Layer.Layer<
+  AcpSessionRuntime,
+  EffectAcpErrors.AcpError,
+  ChildProcessSpawner.ChildProcessSpawner
+> => Layer.effect(AcpSessionRuntime, make(options));
 
 function sessionConfigOptionsFromSetup(
   response:

--- a/apps/server/src/provider/acp/CursorAcpCliProbe.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCliProbe.test.ts
@@ -9,12 +9,12 @@ import * as Effect from "effect/Effect";
 import { describe, expect } from "vite-plus/test";
 import type * as EffectAcpSchema from "effect-acp/schema";
 
-import { AcpSessionRuntime } from "./AcpSessionRuntime.ts";
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
 describe.runIf(process.env.T3_CURSOR_ACP_PROBE === "1")("Cursor ACP CLI probe", () => {
   it.effect("initialize and authenticate against real agent acp", () =>
     Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       const started = yield* runtime.start();
       expect(started.initializeResult).toBeDefined();
     }).pipe(
@@ -42,7 +42,7 @@ describe.runIf(process.env.T3_CURSOR_ACP_PROBE === "1")("Cursor ACP CLI probe", 
 
   it.effect("session/new returns configOptions with a model selector", () =>
     Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       const started = yield* runtime.start();
       const result = started.sessionSetupResult;
       // @effect-diagnostics-next-line preferSchemaOverJson:off
@@ -97,7 +97,7 @@ describe.runIf(process.env.T3_CURSOR_ACP_PROBE === "1")("Cursor ACP CLI probe", 
 
   it.effect("session/set_config_option switches the model in-session", () =>
     Effect.gen(function* () {
-      const runtime = yield* AcpSessionRuntime;
+      const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       const started = yield* runtime.start();
       const newResult = started.sessionSetupResult;
 

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -2,7 +2,7 @@ import { type CursorSettings, type ProviderOptionSelection } from "@t3tools/cont
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Scope from "effect/Scope";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import type * as EffectAcpErrors from "effect-acp/errors";
 
 import {
@@ -10,17 +10,12 @@ import {
   resolveCursorAcpBaseModelId,
   resolveCursorAcpConfigUpdates,
 } from "../Layers/CursorProvider.ts";
-import {
-  AcpSessionRuntime,
-  type AcpSessionRuntimeOptions,
-  type AcpSessionRuntimeShape,
-  type AcpSpawnInput,
-} from "./AcpSessionRuntime.ts";
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
 type CursorAcpRuntimeCursorSettings = Pick<CursorSettings, "apiEndpoint" | "binaryPath">;
 
 export interface CursorAcpRuntimeInput extends Omit<
-  AcpSessionRuntimeOptions,
+  AcpSessionRuntime.AcpSessionRuntimeOptions,
   "authMethodId" | "clientCapabilities" | "spawn"
 > {
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
@@ -38,7 +33,7 @@ export function buildCursorAcpSpawnInput(
   cursorSettings: CursorAcpRuntimeCursorSettings | null | undefined,
   cwd: string,
   environment?: NodeJS.ProcessEnv,
-): AcpSpawnInput {
+): AcpSessionRuntime.AcpSpawnInput {
   return {
     command: cursorSettings?.binaryPath || "agent",
     args: [
@@ -52,7 +47,11 @@ export function buildCursorAcpSpawnInput(
 
 export const makeCursorAcpRuntime = (
   input: CursorAcpRuntimeInput,
-): Effect.Effect<AcpSessionRuntimeShape, EffectAcpErrors.AcpError, Scope.Scope> =>
+): Effect.Effect<
+  AcpSessionRuntime.AcpSessionRuntime["Service"],
+  EffectAcpErrors.AcpError,
+  Scope.Scope
+> =>
   Effect.gen(function* () {
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
@@ -66,11 +65,13 @@ export const makeCursorAcpRuntime = (
         ),
       ),
     );
-    return yield* Effect.service(AcpSessionRuntime).pipe(Effect.provide(acpContext));
+    return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
   });
 
 interface CursorAcpModelSelectionRuntime {
-  readonly getConfigOptions: AcpSessionRuntimeShape["getConfigOptions"];
+  readonly getConfigOptions: AcpSessionRuntime.AcpSessionRuntime["Service"]["getConfigOptions"];
   readonly setConfigOption: (
     configId: string,
     value: string | boolean,

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -2,17 +2,12 @@ import { type GrokSettings, ProviderDriverKind } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Scope from "effect/Scope";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
 import { normalizeModelSlug } from "@t3tools/shared/model";
 
-import {
-  AcpSessionRuntime,
-  type AcpSessionRuntimeOptions,
-  type AcpSessionRuntimeShape,
-  type AcpSpawnInput,
-} from "./AcpSessionRuntime.ts";
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
 const GROK_API_KEY_ENV = "XAI_API_KEY";
 const GROK_OAUTH2_REFERRER_ENV = "GROK_OAUTH2_REFERRER";
@@ -24,7 +19,7 @@ const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 type GrokAcpRuntimeGrokSettings = Pick<GrokSettings, "binaryPath">;
 
 interface GrokAcpRuntimeInput extends Omit<
-  AcpSessionRuntimeOptions,
+  AcpSessionRuntime.AcpSessionRuntimeOptions,
   "authMethodId" | "clientCapabilities" | "spawn"
 > {
   readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
@@ -36,7 +31,7 @@ export function buildGrokAcpSpawnInput(
   grokSettings: GrokAcpRuntimeGrokSettings | null | undefined,
   cwd: string,
   environment?: NodeJS.ProcessEnv,
-): AcpSpawnInput {
+): AcpSessionRuntime.AcpSpawnInput {
   return {
     command: grokSettings?.binaryPath || "grok",
     args: ["agent", "stdio"],
@@ -56,7 +51,11 @@ function resolveGrokAuthMethodId(environment: NodeJS.ProcessEnv | undefined): st
 
 export const makeGrokAcpRuntime = (
   input: GrokAcpRuntimeInput,
-): Effect.Effect<AcpSessionRuntimeShape, EffectAcpErrors.AcpError, Scope.Scope> =>
+): Effect.Effect<
+  AcpSessionRuntime.AcpSessionRuntime["Service"],
+  EffectAcpErrors.AcpError,
+  Scope.Scope
+> =>
   Effect.gen(function* () {
     const acpContext = yield* Layer.build(
       AcpSessionRuntime.layer({
@@ -69,7 +68,9 @@ export const makeGrokAcpRuntime = (
         ),
       ),
     );
-    return yield* Effect.service(AcpSessionRuntime).pipe(Effect.provide(acpContext));
+    return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
   });
 
 export function resolveGrokAcpBaseModelId(model: string | null | undefined): string {
@@ -88,7 +89,7 @@ export function currentGrokModelIdFromSessionSetup(
 }
 
 export function applyGrokAcpModelSelection<E>(input: {
-  readonly runtime: Pick<AcpSessionRuntimeShape, "setSessionModel">;
+  readonly runtime: Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "setSessionModel">;
   readonly currentModelId: string | undefined;
   readonly requestedModelId: string | undefined;
   readonly mapError: (cause: EffectAcpErrors.AcpError) => E;

--- a/packages/effect-acp/src/agent.ts
+++ b/packages/effect-acp/src/agent.ts
@@ -27,189 +27,190 @@ export interface AcpAgentOptions {
   readonly logger?: (event: AcpProtocol.AcpProtocolLogEvent) => Effect.Effect<void, never>;
 }
 
-export interface AcpAgentShape {
-  readonly raw: {
+export class AcpAgent extends Context.Service<
+  AcpAgent,
+  {
+    readonly raw: {
+      /**
+       * Stream of inbound ACP notifications observed on the connection.
+       */
+      readonly notifications: Stream.Stream<AcpProtocol.AcpIncomingNotification>;
+      /**
+       * Sends a generic ACP extension request.
+       * @see https://agentclientprotocol.com/protocol/extensibility
+       */
+      readonly request: (
+        method: string,
+        payload: unknown,
+      ) => Effect.Effect<unknown, AcpError.AcpError>;
+      /**
+       * Sends a generic ACP extension notification.
+       * @see https://agentclientprotocol.com/protocol/extensibility
+       */
+      readonly notify: (method: string, payload: unknown) => Effect.Effect<void, AcpError.AcpError>;
+    };
+    readonly client: {
+      /**
+       * Requests client permission for an operation.
+       * @see https://agentclientprotocol.com/protocol/schema#session/request_permission
+       */
+      readonly requestPermission: (
+        payload: AcpSchema.RequestPermissionRequest,
+      ) => Effect.Effect<AcpSchema.RequestPermissionResponse, AcpError.AcpError>;
+      /**
+       * Requests structured user input from the client.
+       * @see https://agentclientprotocol.com/protocol/schema#session/elicitation
+       */
+      readonly elicit: (
+        payload: AcpSchema.ElicitationRequest,
+      ) => Effect.Effect<AcpSchema.ElicitationResponse, AcpError.AcpError>;
+      /**
+       * Requests file contents from the client.
+       * @see https://agentclientprotocol.com/protocol/schema#fs/read_text_file
+       */
+      readonly readTextFile: (
+        payload: AcpSchema.ReadTextFileRequest,
+      ) => Effect.Effect<AcpSchema.ReadTextFileResponse, AcpError.AcpError>;
+      /**
+       * Writes a text file through the client.
+       * @see https://agentclientprotocol.com/protocol/schema#fs/write_text_file
+       */
+      readonly writeTextFile: (
+        payload: AcpSchema.WriteTextFileRequest,
+      ) => Effect.Effect<AcpSchema.WriteTextFileResponse, AcpError.AcpError>;
+      /**
+       * Creates a terminal on the client side.
+       * @see https://agentclientprotocol.com/protocol/schema#terminal/create
+       */
+      readonly createTerminal: (
+        payload: AcpSchema.CreateTerminalRequest,
+      ) => Effect.Effect<AcpTerminal.AcpTerminal, AcpError.AcpError>;
+      /**
+       * Sends a `session/update` notification to the client.
+       * @see https://agentclientprotocol.com/protocol/schema#session/update
+       */
+      readonly sessionUpdate: (
+        payload: AcpSchema.SessionNotification,
+      ) => Effect.Effect<void, AcpError.AcpError>;
+      /**
+       * Sends a `session/elicitation/complete` notification to the client.
+       * @see https://agentclientprotocol.com/protocol/schema#session/elicitation/complete
+       */
+      readonly elicitationComplete: (
+        payload: AcpSchema.ElicitationCompleteNotification,
+      ) => Effect.Effect<void, AcpError.AcpError>;
+      /**
+       * Sends an ACP extension request to the client.
+       * @see https://agentclientprotocol.com/protocol/extensibility
+       */
+      readonly extRequest: (
+        method: string,
+        payload: unknown,
+      ) => Effect.Effect<unknown, AcpError.AcpError>;
+      /**
+       * Sends an ACP extension notification to the client.
+       * @see https://agentclientprotocol.com/protocol/extensibility
+       */
+      readonly extNotification: (
+        method: string,
+        payload: unknown,
+      ) => Effect.Effect<void, AcpError.AcpError>;
+    };
     /**
-     * Stream of inbound ACP notifications observed on the connection.
+     * Registers a handler for `initialize`.
+     * @see https://agentclientprotocol.com/protocol/schema#initialize
      */
-    readonly notifications: Stream.Stream<AcpProtocol.AcpIncomingNotification>;
+    readonly handleInitialize: (
+      handler: (
+        request: AcpSchema.InitializeRequest,
+      ) => Effect.Effect<AcpSchema.InitializeResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Sends a generic ACP extension request.
-     * @see https://agentclientprotocol.com/protocol/extensibility
+     * Registers a handler for `authenticate`.
+     * @see https://agentclientprotocol.com/protocol/schema#authenticate
      */
-    readonly request: (
+    readonly handleAuthenticate: (
+      handler: (
+        request: AcpSchema.AuthenticateRequest,
+      ) => Effect.Effect<AcpSchema.AuthenticateResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleLogout: (
+      handler: (
+        request: AcpSchema.LogoutRequest,
+      ) => Effect.Effect<AcpSchema.LogoutResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleCreateSession: (
+      handler: (
+        request: AcpSchema.NewSessionRequest,
+      ) => Effect.Effect<AcpSchema.NewSessionResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleLoadSession: (
+      handler: (
+        request: AcpSchema.LoadSessionRequest,
+      ) => Effect.Effect<AcpSchema.LoadSessionResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleListSessions: (
+      handler: (
+        request: AcpSchema.ListSessionsRequest,
+      ) => Effect.Effect<AcpSchema.ListSessionsResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleForkSession: (
+      handler: (
+        request: AcpSchema.ForkSessionRequest,
+      ) => Effect.Effect<AcpSchema.ForkSessionResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleResumeSession: (
+      handler: (
+        request: AcpSchema.ResumeSessionRequest,
+      ) => Effect.Effect<AcpSchema.ResumeSessionResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleCloseSession: (
+      handler: (
+        request: AcpSchema.CloseSessionRequest,
+      ) => Effect.Effect<AcpSchema.CloseSessionResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleSetSessionModel: (
+      handler: (
+        request: AcpSchema.SetSessionModelRequest,
+      ) => Effect.Effect<AcpSchema.SetSessionModelResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleSetSessionConfigOption: (
+      handler: (
+        request: AcpSchema.SetSessionConfigOptionRequest,
+      ) => Effect.Effect<AcpSchema.SetSessionConfigOptionResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handlePrompt: (
+      handler: (
+        request: AcpSchema.PromptRequest,
+      ) => Effect.Effect<AcpSchema.PromptResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    /**
+     * Registers a handler for `session/cancel`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/cancel
+     */
+    readonly handleCancel: (
+      handler: (
+        notification: AcpSchema.CancelNotification,
+      ) => Effect.Effect<void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleUnknownExtRequest: (
+      handler: (method: string, params: unknown) => Effect.Effect<unknown, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleUnknownExtNotification: (
+      handler: (method: string, params: unknown) => Effect.Effect<void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleExtRequest: <A, I>(
       method: string,
-      payload: unknown,
-    ) => Effect.Effect<unknown, AcpError.AcpError>;
-    /**
-     * Sends a generic ACP extension notification.
-     * @see https://agentclientprotocol.com/protocol/extensibility
-     */
-    readonly notify: (method: string, payload: unknown) => Effect.Effect<void, AcpError.AcpError>;
-  };
-  readonly client: {
-    /**
-     * Requests client permission for an operation.
-     * @see https://agentclientprotocol.com/protocol/schema#session/request_permission
-     */
-    readonly requestPermission: (
-      payload: AcpSchema.RequestPermissionRequest,
-    ) => Effect.Effect<AcpSchema.RequestPermissionResponse, AcpError.AcpError>;
-    /**
-     * Requests structured user input from the client.
-     * @see https://agentclientprotocol.com/protocol/schema#session/elicitation
-     */
-    readonly elicit: (
-      payload: AcpSchema.ElicitationRequest,
-    ) => Effect.Effect<AcpSchema.ElicitationResponse, AcpError.AcpError>;
-    /**
-     * Requests file contents from the client.
-     * @see https://agentclientprotocol.com/protocol/schema#fs/read_text_file
-     */
-    readonly readTextFile: (
-      payload: AcpSchema.ReadTextFileRequest,
-    ) => Effect.Effect<AcpSchema.ReadTextFileResponse, AcpError.AcpError>;
-    /**
-     * Writes a text file through the client.
-     * @see https://agentclientprotocol.com/protocol/schema#fs/write_text_file
-     */
-    readonly writeTextFile: (
-      payload: AcpSchema.WriteTextFileRequest,
-    ) => Effect.Effect<AcpSchema.WriteTextFileResponse, AcpError.AcpError>;
-    /**
-     * Creates a terminal on the client side.
-     * @see https://agentclientprotocol.com/protocol/schema#terminal/create
-     */
-    readonly createTerminal: (
-      payload: AcpSchema.CreateTerminalRequest,
-    ) => Effect.Effect<AcpTerminal.AcpTerminal, AcpError.AcpError>;
-    /**
-     * Sends a `session/update` notification to the client.
-     * @see https://agentclientprotocol.com/protocol/schema#session/update
-     */
-    readonly sessionUpdate: (
-      payload: AcpSchema.SessionNotification,
-    ) => Effect.Effect<void, AcpError.AcpError>;
-    /**
-     * Sends a `session/elicitation/complete` notification to the client.
-     * @see https://agentclientprotocol.com/protocol/schema#session/elicitation/complete
-     */
-    readonly elicitationComplete: (
-      payload: AcpSchema.ElicitationCompleteNotification,
-    ) => Effect.Effect<void, AcpError.AcpError>;
-    /**
-     * Sends an ACP extension request to the client.
-     * @see https://agentclientprotocol.com/protocol/extensibility
-     */
-    readonly extRequest: (
+      payload: Schema.Codec<A, I>,
+      handler: (payload: A) => Effect.Effect<unknown, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    readonly handleExtNotification: <A, I>(
       method: string,
-      payload: unknown,
-    ) => Effect.Effect<unknown, AcpError.AcpError>;
-    /**
-     * Sends an ACP extension notification to the client.
-     * @see https://agentclientprotocol.com/protocol/extensibility
-     */
-    readonly extNotification: (
-      method: string,
-      payload: unknown,
-    ) => Effect.Effect<void, AcpError.AcpError>;
-  };
-  /**
-   * Registers a handler for `initialize`.
-   * @see https://agentclientprotocol.com/protocol/schema#initialize
-   */
-  readonly handleInitialize: (
-    handler: (
-      request: AcpSchema.InitializeRequest,
-    ) => Effect.Effect<AcpSchema.InitializeResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `authenticate`.
-   * @see https://agentclientprotocol.com/protocol/schema#authenticate
-   */
-  readonly handleAuthenticate: (
-    handler: (
-      request: AcpSchema.AuthenticateRequest,
-    ) => Effect.Effect<AcpSchema.AuthenticateResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleLogout: (
-    handler: (
-      request: AcpSchema.LogoutRequest,
-    ) => Effect.Effect<AcpSchema.LogoutResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleCreateSession: (
-    handler: (
-      request: AcpSchema.NewSessionRequest,
-    ) => Effect.Effect<AcpSchema.NewSessionResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleLoadSession: (
-    handler: (
-      request: AcpSchema.LoadSessionRequest,
-    ) => Effect.Effect<AcpSchema.LoadSessionResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleListSessions: (
-    handler: (
-      request: AcpSchema.ListSessionsRequest,
-    ) => Effect.Effect<AcpSchema.ListSessionsResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleForkSession: (
-    handler: (
-      request: AcpSchema.ForkSessionRequest,
-    ) => Effect.Effect<AcpSchema.ForkSessionResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleResumeSession: (
-    handler: (
-      request: AcpSchema.ResumeSessionRequest,
-    ) => Effect.Effect<AcpSchema.ResumeSessionResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleCloseSession: (
-    handler: (
-      request: AcpSchema.CloseSessionRequest,
-    ) => Effect.Effect<AcpSchema.CloseSessionResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleSetSessionModel: (
-    handler: (
-      request: AcpSchema.SetSessionModelRequest,
-    ) => Effect.Effect<AcpSchema.SetSessionModelResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleSetSessionConfigOption: (
-    handler: (
-      request: AcpSchema.SetSessionConfigOptionRequest,
-    ) => Effect.Effect<AcpSchema.SetSessionConfigOptionResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handlePrompt: (
-    handler: (
-      request: AcpSchema.PromptRequest,
-    ) => Effect.Effect<AcpSchema.PromptResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `session/cancel`.
-   * @see https://agentclientprotocol.com/protocol/schema#session/cancel
-   */
-  readonly handleCancel: (
-    handler: (notification: AcpSchema.CancelNotification) => Effect.Effect<void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleUnknownExtRequest: (
-    handler: (method: string, params: unknown) => Effect.Effect<unknown, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleUnknownExtNotification: (
-    handler: (method: string, params: unknown) => Effect.Effect<void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleExtRequest: <A, I>(
-    method: string,
-    payload: Schema.Codec<A, I>,
-    handler: (payload: A) => Effect.Effect<unknown, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  readonly handleExtNotification: <A, I>(
-    method: string,
-    payload: Schema.Codec<A, I>,
-    handler: (payload: A) => Effect.Effect<void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-}
-
-export class AcpAgent extends Context.Service<AcpAgent, AcpAgentShape>()(
-  "effect-acp/agent/AcpAgent",
-) {}
+      payload: Schema.Codec<A, I>,
+      handler: (payload: A) => Effect.Effect<void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+  }
+>()("effect-acp/agent/AcpAgent") {}
 
 interface AcpCoreAgentRequestHandlers {
   initialize?: (
@@ -255,7 +256,7 @@ const decodeCancelNotification = Schema.decodeUnknownEffect(AcpSchema.CancelNoti
 export const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpAgentOptions = {},
-): Effect.fn.Return<AcpAgentShape, never, Scope.Scope> {
+): Effect.fn.Return<AcpAgent["Service"], never, Scope.Scope> {
   const coreHandlers: AcpCoreAgentRequestHandlers = {};
   const cancelHandlers: Array<
     (notification: AcpSchema.CancelNotification) => Effect.Effect<void, AcpError.AcpError>

--- a/packages/effect-acp/src/client.ts
+++ b/packages/effect-acp/src/client.ts
@@ -7,7 +7,7 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as RpcClient from "effect/unstable/rpc/RpcClient";
 import * as RpcServer from "effect/unstable/rpc/RpcServer";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as AcpError from "./errors.ts";
 import * as AcpProtocol from "./protocol.ts";
@@ -34,237 +34,236 @@ type AcpClientRaw = {
   readonly notify: (method: string, payload: unknown) => Effect.Effect<void, AcpError.AcpError>;
 };
 
-export interface AcpClientShape {
-  readonly raw: AcpClientRaw;
-  readonly agent: {
+export class AcpClient extends Context.Service<
+  AcpClient,
+  {
+    readonly raw: AcpClientRaw;
+    readonly agent: {
+      /**
+       * Initializes the ACP session and negotiates capabilities.
+       * @see https://agentclientprotocol.com/protocol/schema#initialize
+       */
+      readonly initialize: (
+        payload: AcpSchema.InitializeRequest,
+      ) => Effect.Effect<AcpSchema.InitializeResponse, AcpError.AcpError>;
+      /**
+       * Performs ACP authentication when the agent requires it.
+       * @see https://agentclientprotocol.com/protocol/schema#authenticate
+       */
+      readonly authenticate: (
+        payload: AcpSchema.AuthenticateRequest,
+      ) => Effect.Effect<AcpSchema.AuthenticateResponse, AcpError.AcpError>;
+      /**
+       * Logs out the current ACP identity.
+       * @see https://agentclientprotocol.com/protocol/schema#logout
+       */
+      readonly logout: (
+        payload: AcpSchema.LogoutRequest,
+      ) => Effect.Effect<AcpSchema.LogoutResponse, AcpError.AcpError>;
+      /**
+       * Starts a new ACP session.
+       * @see https://agentclientprotocol.com/protocol/schema#session/new
+       */
+      readonly createSession: (
+        payload: AcpSchema.NewSessionRequest,
+      ) => Effect.Effect<AcpSchema.NewSessionResponse, AcpError.AcpError>;
+      /**
+       * Loads a previously saved ACP session.
+       * @see https://agentclientprotocol.com/protocol/schema#session/load
+       */
+      readonly loadSession: (
+        payload: AcpSchema.LoadSessionRequest,
+      ) => Effect.Effect<AcpSchema.LoadSessionResponse, AcpError.AcpError>;
+      /**
+       * Lists available ACP sessions.
+       * @see https://agentclientprotocol.com/protocol/schema#session/list
+       */
+      readonly listSessions: (
+        payload: AcpSchema.ListSessionsRequest,
+      ) => Effect.Effect<AcpSchema.ListSessionsResponse, AcpError.AcpError>;
+      /**
+       * Forks an ACP session.
+       * @see https://agentclientprotocol.com/protocol/schema#session/fork
+       */
+      readonly forkSession: (
+        payload: AcpSchema.ForkSessionRequest,
+      ) => Effect.Effect<AcpSchema.ForkSessionResponse, AcpError.AcpError>;
+      /**
+       * Resumes an ACP session.
+       * @see https://agentclientprotocol.com/protocol/schema#session/resume
+       */
+      readonly resumeSession: (
+        payload: AcpSchema.ResumeSessionRequest,
+      ) => Effect.Effect<AcpSchema.ResumeSessionResponse, AcpError.AcpError>;
+      /**
+       * Closes an ACP session.
+       * @see https://agentclientprotocol.com/protocol/schema#session/close
+       */
+      readonly closeSession: (
+        payload: AcpSchema.CloseSessionRequest,
+      ) => Effect.Effect<AcpSchema.CloseSessionResponse, AcpError.AcpError>;
+      /**
+       * Selects the active model for a session.
+       * @see https://agentclientprotocol.com/protocol/schema#session/set_model
+       */
+      readonly setSessionModel: (
+        payload: AcpSchema.SetSessionModelRequest,
+      ) => Effect.Effect<AcpSchema.SetSessionModelResponse, AcpError.AcpError>;
+      /**
+       * Updates a session configuration option.
+       * @see https://agentclientprotocol.com/protocol/schema#session/set_config_option
+       */
+      readonly setSessionConfigOption: (
+        payload: AcpSchema.SetSessionConfigOptionRequest,
+      ) => Effect.Effect<AcpSchema.SetSessionConfigOptionResponse, AcpError.AcpError>;
+      /**
+       * Sends a prompt turn to the agent.
+       * @see https://agentclientprotocol.com/protocol/schema#session/prompt
+       */
+      readonly prompt: (
+        payload: AcpSchema.PromptRequest,
+      ) => Effect.Effect<AcpSchema.PromptResponse, AcpError.AcpError>;
+      /**
+       * Sends a real ACP `session/cancel` notification.
+       * @see https://agentclientprotocol.com/protocol/schema#session/cancel
+       */
+      readonly cancel: (
+        payload: AcpSchema.CancelNotification,
+      ) => Effect.Effect<void, AcpError.AcpError>;
+    };
     /**
-     * Initializes the ACP session and negotiates capabilities.
-     * @see https://agentclientprotocol.com/protocol/schema#initialize
+     * Registers a handler for `session/request_permission`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/request_permission
      */
-    readonly initialize: (
-      payload: AcpSchema.InitializeRequest,
-    ) => Effect.Effect<AcpSchema.InitializeResponse, AcpError.AcpError>;
+    readonly handleRequestPermission: (
+      handler: (
+        request: AcpSchema.RequestPermissionRequest,
+      ) => Effect.Effect<AcpSchema.RequestPermissionResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Performs ACP authentication when the agent requires it.
-     * @see https://agentclientprotocol.com/protocol/schema#authenticate
+     * Registers a handler for `session/elicitation`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/elicitation
      */
-    readonly authenticate: (
-      payload: AcpSchema.AuthenticateRequest,
-    ) => Effect.Effect<AcpSchema.AuthenticateResponse, AcpError.AcpError>;
+    readonly handleElicitation: (
+      handler: (
+        request: AcpSchema.ElicitationRequest,
+      ) => Effect.Effect<AcpSchema.ElicitationResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Logs out the current ACP identity.
-     * @see https://agentclientprotocol.com/protocol/schema#logout
+     * Registers a handler for `fs/read_text_file`.
+     * @see https://agentclientprotocol.com/protocol/schema#fs/read_text_file
      */
-    readonly logout: (
-      payload: AcpSchema.LogoutRequest,
-    ) => Effect.Effect<AcpSchema.LogoutResponse, AcpError.AcpError>;
+    readonly handleReadTextFile: (
+      handler: (
+        request: AcpSchema.ReadTextFileRequest,
+      ) => Effect.Effect<AcpSchema.ReadTextFileResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Starts a new ACP session.
-     * @see https://agentclientprotocol.com/protocol/schema#session/new
+     * Registers a handler for `fs/write_text_file`.
+     * @see https://agentclientprotocol.com/protocol/schema#fs/write_text_file
      */
-    readonly createSession: (
-      payload: AcpSchema.NewSessionRequest,
-    ) => Effect.Effect<AcpSchema.NewSessionResponse, AcpError.AcpError>;
+    readonly handleWriteTextFile: (
+      handler: (
+        request: AcpSchema.WriteTextFileRequest,
+      ) => Effect.Effect<AcpSchema.WriteTextFileResponse | void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Loads a previously saved ACP session.
-     * @see https://agentclientprotocol.com/protocol/schema#session/load
+     * Registers a handler for `terminal/create`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/create
      */
-    readonly loadSession: (
-      payload: AcpSchema.LoadSessionRequest,
-    ) => Effect.Effect<AcpSchema.LoadSessionResponse, AcpError.AcpError>;
+    readonly handleCreateTerminal: (
+      handler: (
+        request: AcpSchema.CreateTerminalRequest,
+      ) => Effect.Effect<AcpSchema.CreateTerminalResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Lists available ACP sessions.
-     * @see https://agentclientprotocol.com/protocol/schema#session/list
+     * Registers a handler for `terminal/output`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/output
      */
-    readonly listSessions: (
-      payload: AcpSchema.ListSessionsRequest,
-    ) => Effect.Effect<AcpSchema.ListSessionsResponse, AcpError.AcpError>;
+    readonly handleTerminalOutput: (
+      handler: (
+        request: AcpSchema.TerminalOutputRequest,
+      ) => Effect.Effect<AcpSchema.TerminalOutputResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Forks an ACP session.
-     * @see https://agentclientprotocol.com/protocol/schema#session/fork
+     * Registers a handler for `terminal/wait_for_exit`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/wait_for_exit
      */
-    readonly forkSession: (
-      payload: AcpSchema.ForkSessionRequest,
-    ) => Effect.Effect<AcpSchema.ForkSessionResponse, AcpError.AcpError>;
+    readonly handleTerminalWaitForExit: (
+      handler: (
+        request: AcpSchema.WaitForTerminalExitRequest,
+      ) => Effect.Effect<AcpSchema.WaitForTerminalExitResponse, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Resumes an ACP session.
-     * @see https://agentclientprotocol.com/protocol/schema#session/resume
+     * Registers a handler for `terminal/kill`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/kill
      */
-    readonly resumeSession: (
-      payload: AcpSchema.ResumeSessionRequest,
-    ) => Effect.Effect<AcpSchema.ResumeSessionResponse, AcpError.AcpError>;
+    readonly handleTerminalKill: (
+      handler: (
+        request: AcpSchema.KillTerminalRequest,
+      ) => Effect.Effect<AcpSchema.KillTerminalResponse | void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Closes an ACP session.
-     * @see https://agentclientprotocol.com/protocol/schema#session/close
+     * Registers a handler for `terminal/release`.
+     * @see https://agentclientprotocol.com/protocol/schema#terminal/release
      */
-    readonly closeSession: (
-      payload: AcpSchema.CloseSessionRequest,
-    ) => Effect.Effect<AcpSchema.CloseSessionResponse, AcpError.AcpError>;
+    readonly handleTerminalRelease: (
+      handler: (
+        request: AcpSchema.ReleaseTerminalRequest,
+      ) => Effect.Effect<AcpSchema.ReleaseTerminalResponse | void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Selects the active model for a session.
-     * @see https://agentclientprotocol.com/protocol/schema#session/set_model
+     * Registers a handler for `session/update`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/update
      */
-    readonly setSessionModel: (
-      payload: AcpSchema.SetSessionModelRequest,
-    ) => Effect.Effect<AcpSchema.SetSessionModelResponse, AcpError.AcpError>;
+    readonly handleSessionUpdate: (
+      handler: (
+        notification: AcpSchema.SessionNotification,
+      ) => Effect.Effect<void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Updates a session configuration option.
-     * @see https://agentclientprotocol.com/protocol/schema#session/set_config_option
+     * Registers a handler for `session/elicitation/complete`.
+     * @see https://agentclientprotocol.com/protocol/schema#session/elicitation/complete
      */
-    readonly setSessionConfigOption: (
-      payload: AcpSchema.SetSessionConfigOptionRequest,
-    ) => Effect.Effect<AcpSchema.SetSessionConfigOptionResponse, AcpError.AcpError>;
+    readonly handleElicitationComplete: (
+      handler: (
+        notification: AcpSchema.ElicitationCompleteNotification,
+      ) => Effect.Effect<void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Sends a prompt turn to the agent.
-     * @see https://agentclientprotocol.com/protocol/schema#session/prompt
+     * Registers a fallback extension request handler.
+     * @see https://agentclientprotocol.com/protocol/extensibility
      */
-    readonly prompt: (
-      payload: AcpSchema.PromptRequest,
-    ) => Effect.Effect<AcpSchema.PromptResponse, AcpError.AcpError>;
+    readonly handleUnknownExtRequest: (
+      handler: (method: string, params: unknown) => Effect.Effect<unknown, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
     /**
-     * Sends a real ACP `session/cancel` notification.
-     * @see https://agentclientprotocol.com/protocol/schema#session/cancel
+     * Registers a fallback extension notification handler.
+     * @see https://agentclientprotocol.com/protocol/extensibility
      */
-    readonly cancel: (
-      payload: AcpSchema.CancelNotification,
-    ) => Effect.Effect<void, AcpError.AcpError>;
-  };
-  /**
-   * Registers a handler for `session/request_permission`.
-   * @see https://agentclientprotocol.com/protocol/schema#session/request_permission
-   */
-  readonly handleRequestPermission: (
-    handler: (
-      request: AcpSchema.RequestPermissionRequest,
-    ) => Effect.Effect<AcpSchema.RequestPermissionResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `session/elicitation`.
-   * @see https://agentclientprotocol.com/protocol/schema#session/elicitation
-   */
-  readonly handleElicitation: (
-    handler: (
-      request: AcpSchema.ElicitationRequest,
-    ) => Effect.Effect<AcpSchema.ElicitationResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `fs/read_text_file`.
-   * @see https://agentclientprotocol.com/protocol/schema#fs/read_text_file
-   */
-  readonly handleReadTextFile: (
-    handler: (
-      request: AcpSchema.ReadTextFileRequest,
-    ) => Effect.Effect<AcpSchema.ReadTextFileResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `fs/write_text_file`.
-   * @see https://agentclientprotocol.com/protocol/schema#fs/write_text_file
-   */
-  readonly handleWriteTextFile: (
-    handler: (
-      request: AcpSchema.WriteTextFileRequest,
-    ) => Effect.Effect<AcpSchema.WriteTextFileResponse | void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `terminal/create`.
-   * @see https://agentclientprotocol.com/protocol/schema#terminal/create
-   */
-  readonly handleCreateTerminal: (
-    handler: (
-      request: AcpSchema.CreateTerminalRequest,
-    ) => Effect.Effect<AcpSchema.CreateTerminalResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `terminal/output`.
-   * @see https://agentclientprotocol.com/protocol/schema#terminal/output
-   */
-  readonly handleTerminalOutput: (
-    handler: (
-      request: AcpSchema.TerminalOutputRequest,
-    ) => Effect.Effect<AcpSchema.TerminalOutputResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `terminal/wait_for_exit`.
-   * @see https://agentclientprotocol.com/protocol/schema#terminal/wait_for_exit
-   */
-  readonly handleTerminalWaitForExit: (
-    handler: (
-      request: AcpSchema.WaitForTerminalExitRequest,
-    ) => Effect.Effect<AcpSchema.WaitForTerminalExitResponse, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `terminal/kill`.
-   * @see https://agentclientprotocol.com/protocol/schema#terminal/kill
-   */
-  readonly handleTerminalKill: (
-    handler: (
-      request: AcpSchema.KillTerminalRequest,
-    ) => Effect.Effect<AcpSchema.KillTerminalResponse | void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `terminal/release`.
-   * @see https://agentclientprotocol.com/protocol/schema#terminal/release
-   */
-  readonly handleTerminalRelease: (
-    handler: (
-      request: AcpSchema.ReleaseTerminalRequest,
-    ) => Effect.Effect<AcpSchema.ReleaseTerminalResponse | void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `session/update`.
-   * @see https://agentclientprotocol.com/protocol/schema#session/update
-   */
-  readonly handleSessionUpdate: (
-    handler: (
-      notification: AcpSchema.SessionNotification,
-    ) => Effect.Effect<void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a handler for `session/elicitation/complete`.
-   * @see https://agentclientprotocol.com/protocol/schema#session/elicitation/complete
-   */
-  readonly handleElicitationComplete: (
-    handler: (
-      notification: AcpSchema.ElicitationCompleteNotification,
-    ) => Effect.Effect<void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a fallback extension request handler.
-   * @see https://agentclientprotocol.com/protocol/extensibility
-   */
-  readonly handleUnknownExtRequest: (
-    handler: (method: string, params: unknown) => Effect.Effect<unknown, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a fallback extension notification handler.
-   * @see https://agentclientprotocol.com/protocol/extensibility
-   */
-  readonly handleUnknownExtNotification: (
-    handler: (method: string, params: unknown) => Effect.Effect<void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a typed extension request handler.
-   * @see https://agentclientprotocol.com/protocol/extensibility
-   */
-  readonly handleExtRequest: <A, I>(
-    method: string,
-    payload: Schema.Codec<A, I>,
-    handler: (payload: A) => Effect.Effect<unknown, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-  /**
-   * Registers a typed extension notification handler.
-   * @see https://agentclientprotocol.com/protocol/extensibility
-   */
-  readonly handleExtNotification: <A, I>(
-    method: string,
-    payload: Schema.Codec<A, I>,
-    handler: (payload: A) => Effect.Effect<void, AcpError.AcpError>,
-  ) => Effect.Effect<void>;
-}
-
-export class AcpClient extends Context.Service<AcpClient, AcpClientShape>()(
-  "effect-acp/client/AcpClient",
-) {}
+    readonly handleUnknownExtNotification: (
+      handler: (method: string, params: unknown) => Effect.Effect<void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    /**
+     * Registers a typed extension request handler.
+     * @see https://agentclientprotocol.com/protocol/extensibility
+     */
+    readonly handleExtRequest: <A, I>(
+      method: string,
+      payload: Schema.Codec<A, I>,
+      handler: (payload: A) => Effect.Effect<unknown, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+    /**
+     * Registers a typed extension notification handler.
+     * @see https://agentclientprotocol.com/protocol/extensibility
+     */
+    readonly handleExtNotification: <A, I>(
+      method: string,
+      payload: Schema.Codec<A, I>,
+      handler: (payload: A) => Effect.Effect<void, AcpError.AcpError>,
+    ) => Effect.Effect<void>;
+  }
+>()("effect-acp/client/AcpClient") {}
 
 interface AcpCoreRequestHandlers {
   requestPermission?: (
@@ -310,7 +309,7 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
   stdio: Stdio.Stdio,
   options: AcpClientOptions = {},
   terminationError?: Effect.Effect<AcpError.AcpError>,
-): Effect.fn.Return<AcpClientShape, never, Scope.Scope> {
+): Effect.fn.Return<AcpClient["Service"], never, Scope.Scope> {
   const coreHandlers: AcpCoreRequestHandlers = {};
   const notificationHandlers: AcpNotificationHandlers = {
     sessionUpdate: { handlers: [], pending: [] },
@@ -558,6 +557,9 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
       }),
   });
 });
+
+export const layer = (stdio: Stdio.Stdio, options: AcpClientOptions = {}): Layer.Layer<AcpClient> =>
+  Layer.effect(AcpClient, make(stdio, options));
 
 export const layerChildProcess = (
   handle: ChildProcessSpawner.ChildProcessHandle,

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -45,7 +45,11 @@ export class AcpTransportError extends Schema.TaggedErrorClass<AcpTransportError
     detail: Schema.String,
     cause: Schema.Defect(),
   },
-) {}
+) {
+  override get message() {
+    return this.detail;
+  }
+}
 
 export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()("AcpRequestError", {
   code: AcpSchema.ErrorCode,

--- a/packages/effect-codex-app-server/src/client.ts
+++ b/packages/effect-codex-app-server/src/client.ts
@@ -5,7 +5,7 @@ import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Stdio from "effect/Stdio";
 import * as Stream from "effect/Stream";
-import { ChildProcessSpawner } from "effect/unstable/process";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as CodexRpc from "./_generated/meta.gen.ts";
 import * as CodexError from "./errors.ts";
@@ -35,45 +35,46 @@ interface CodexAppServerClientRaw {
   readonly respondError: CodexProtocol.CodexAppServerPatchedProtocol["respondError"];
 }
 
-export interface CodexAppServerClientShape {
-  readonly raw: CodexAppServerClientRaw;
-  readonly request: <M extends CodexRpc.ClientRequestMethod>(
-    method: M,
-    payload: CodexRpc.ClientRequestParamsByMethod[M],
-  ) => Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexError.CodexAppServerError>;
-  readonly notify: <M extends CodexRpc.ClientNotificationMethod>(
-    method: M,
-    payload: CodexRpc.ClientNotificationParamsByMethod[M],
-  ) => Effect.Effect<void, CodexError.CodexAppServerError>;
-  readonly handleServerRequest: <M extends CodexRpc.ServerRequestMethod>(
-    method: M,
-    handler: (
-      payload: CodexRpc.ServerRequestParamsByMethod[M],
-    ) => Effect.Effect<CodexRpc.ServerRequestResponsesByMethod[M], CodexError.CodexAppServerError>,
-  ) => Effect.Effect<void>;
-  readonly handleServerNotification: <M extends CodexRpc.ServerNotificationMethod>(
-    method: M,
-    handler: (
-      payload: CodexRpc.ServerNotificationParamsByMethod[M],
-    ) => Effect.Effect<void, CodexError.CodexAppServerError>,
-  ) => Effect.Effect<void>;
-  readonly handleUnknownServerRequest: (
-    handler: (
-      method: string,
-      params: unknown,
-    ) => Effect.Effect<unknown, CodexError.CodexAppServerError>,
-  ) => Effect.Effect<void>;
-  readonly handleUnknownServerNotification: (
-    handler: (
-      method: string,
-      params: unknown,
-    ) => Effect.Effect<void, CodexError.CodexAppServerError>,
-  ) => Effect.Effect<void>;
-}
-
 export class CodexAppServerClient extends Context.Service<
   CodexAppServerClient,
-  CodexAppServerClientShape
+  {
+    readonly raw: CodexAppServerClientRaw;
+    readonly request: <M extends CodexRpc.ClientRequestMethod>(
+      method: M,
+      payload: CodexRpc.ClientRequestParamsByMethod[M],
+    ) => Effect.Effect<CodexRpc.ClientRequestResponsesByMethod[M], CodexError.CodexAppServerError>;
+    readonly notify: <M extends CodexRpc.ClientNotificationMethod>(
+      method: M,
+      payload: CodexRpc.ClientNotificationParamsByMethod[M],
+    ) => Effect.Effect<void, CodexError.CodexAppServerError>;
+    readonly handleServerRequest: <M extends CodexRpc.ServerRequestMethod>(
+      method: M,
+      handler: (
+        payload: CodexRpc.ServerRequestParamsByMethod[M],
+      ) => Effect.Effect<
+        CodexRpc.ServerRequestResponsesByMethod[M],
+        CodexError.CodexAppServerError
+      >,
+    ) => Effect.Effect<void>;
+    readonly handleServerNotification: <M extends CodexRpc.ServerNotificationMethod>(
+      method: M,
+      handler: (
+        payload: CodexRpc.ServerNotificationParamsByMethod[M],
+      ) => Effect.Effect<void, CodexError.CodexAppServerError>,
+    ) => Effect.Effect<void>;
+    readonly handleUnknownServerRequest: (
+      handler: (
+        method: string,
+        params: unknown,
+      ) => Effect.Effect<unknown, CodexError.CodexAppServerError>,
+    ) => Effect.Effect<void>;
+    readonly handleUnknownServerNotification: (
+      handler: (
+        method: string,
+        params: unknown,
+      ) => Effect.Effect<void, CodexError.CodexAppServerError>,
+    ) => Effect.Effect<void>;
+  }
 >()("effect-codex-app-server/client/CodexAppServerClient") {}
 
 type ServerRequestHandler = (
@@ -87,7 +88,7 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
   stdio: Stdio.Stdio,
   options: CodexAppServerClientOptions = {},
   terminationError?: Effect.Effect<CodexError.CodexAppServerError>,
-): Effect.fn.Return<CodexAppServerClientShape, never, Scope.Scope> {
+): Effect.fn.Return<CodexAppServerClient["Service"], never, Scope.Scope> {
   const requestHandlers = new Map<string, ServerRequestHandler>();
   const notificationHandlers = new Map<string, Array<ServerNotificationHandler>>();
   let unknownRequestHandler:
@@ -248,6 +249,11 @@ export const make = Effect.fn("effect-codex-app-server/CodexAppServerClient.make
       }),
   });
 });
+
+export const layer = (
+  stdio: Stdio.Stdio,
+  options: CodexAppServerClientOptions = {},
+): Layer.Layer<CodexAppServerClient> => Layer.effect(CodexAppServerClient, make(stdio, options));
 
 export const layerChildProcess = (
   handle: ChildProcessSpawner.ChildProcessHandle,


### PR DESCRIPTION
## Summary

- define the ACP agent, ACP client, Codex app-server client, and server ACP runtime contracts inline on their `Context.Service` tags
- preserve the existing ACP contract JSDoc and spec links, and expose the relevant handler/runtime documentation directly on `AcpSessionRuntime`
- replace standalone service-shape references with `Service["Service"]` and use namespace imports at service boundaries
- expose module-level `layer` factories while retaining the existing parameterized child-process factories
- derive `AcpTransportError.message` from its structured `detail` field

## Why

These protocol adapters predated the repository's current Effect service module convention. The refactor now keeps each tag, service contract, constructor, and layer in one module without losing the contract documentation that callers rely on.

## Impact

The service-layout changes preserve existing adapter and session behavior. Existing child-process APIs remain available. The intentional runtime-visible change is that ACP transport errors expose their structured detail as the standard error message.

## Checks

- `vp test packages/effect-acp/src/agent.test.ts packages/effect-acp/src/client.test.ts packages/effect-acp/src/protocol.test.ts packages/effect-codex-app-server/src/client.test.ts packages/effect-codex-app-server/src/protocol.test.ts` (5 files, 21 tests passed)
- `vp test apps/server/src/provider/acp/AcpCoreRuntimeEvents.test.ts apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts apps/server/src/provider/acp/CursorAcpCliProbe.test.ts apps/server/src/provider/acp/CursorAcpSupport.test.ts apps/server/src/provider/acp/GrokAcpSupport.test.ts apps/server/src/provider/Layers/CodexProvider.test.ts apps/server/src/provider/Layers/CursorAdapter.test.ts apps/server/src/provider/Layers/CursorProvider.test.ts apps/server/src/provider/Layers/GrokAdapter.test.ts` (8 files passed, 1 conditionally skipped; 68 tests passed, 3 skipped)
- `vp check` (passes; reports 20 pre-existing warnings outside this diff)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared ACP/Codex client/runtime wiring across many provider adapters; behavior should be unchanged except transport error messaging, but the wide refactor increases regression risk in session startup and probes.
> 
> **Overview**
> This PR **refactors how protocol adapter services are declared and consumed** across the server and `effect-acp` / `effect-codex-app-server` packages, without changing the underlying ACP/Codex session behavior beyond one error-message tweak.
> 
> **Service contracts** move from standalone `*Shape` interfaces onto **`Context.Service` class definitions** for `AcpSessionRuntime`, `AcpAgent`, `AcpClient`, and `CodexAppServerClient`. Call sites now type against **`Service["Service"]`** and use **namespace imports** at module boundaries instead of named service exports. `AcpSessionRuntime` drops the separate shape type in favor of an exported **`make`** plus **`layer`**, with ACP handler/runtime JSDoc kept on the service tag.
> 
> **Imports and layers**: aggregated `effect/unstable/process` imports become explicit **`ChildProcess`** / **`ChildProcessSpawner`** paths. **`AcpClient`** and **`CodexAppServerClient`** gain module-level **`layer`** factories alongside existing child-process layer helpers.
> 
> **Runtime-visible change**: **`AcpTransportError.message`** now returns the structured **`detail`** string instead of the default formatted message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2137f1cacfef99b77a5d4471a941530d676c1586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize Effect protocol adapter services to use `Context.Service` pattern
> - Replaces standalone `*Shape` interfaces with inline `Context.Service` class definitions across `AcpSessionRuntime`, `AcpAgent`, `AcpClient`, and `CodexAppServerClient`, standardizing how Effect services are declared and typed.
> - Adds `layer` export helpers to `AcpClient` and `CodexAppServerClient` for constructing services via `Layer.effect`.
> - Switches aggregated `effect/unstable/process` imports to explicit module paths (`ChildProcess`, `ChildProcessSpawner`) throughout adapter files.
> - Fixes `AcpTransportError.message` to return the `detail` string payload instead of the default inherited formatted message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2137f1c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->