### PR TITLE
[codex] Refactor desktop window and update Effect services

### DIFF
--- a/apps/desktop/src/updates/DesktopUpdates.ts
+++ b/apps/desktop/src/updates/DesktopUpdates.ts
@@ -7,7 +7,6 @@ import type {
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -60,23 +59,26 @@ const decodeDownloadProgressInfo = Schema.decodeUnknownEffect(DownloadProgressIn
 
 const currentIsoTimestamp = DateTime.now.pipe(Effect.map(DateTime.formatIso));
 
-export class DesktopUpdateActionInProgressError extends Data.TaggedError(
+export class DesktopUpdateActionInProgressError extends Schema.TaggedErrorClass<DesktopUpdateActionInProgressError>()(
   "DesktopUpdateActionInProgressError",
-)<{
-  readonly action: "check" | "download" | "install";
-}> {
-  override get message() {
+  {
+    action: Schema.Literals(["check", "download", "install"]),
+  },
+) {
+  override get message(): string {
     return `Cannot change update tracks while an update ${this.action} action is in progress.`;
   }
 }
 
-export class DesktopUpdatePersistenceError extends Data.TaggedError(
+export class DesktopUpdatePersistenceError extends Schema.TaggedErrorClass<DesktopUpdatePersistenceError>()(
   "DesktopUpdatePersistenceError",
-)<{
-  readonly cause: DesktopAppSettings.DesktopSettingsWriteError;
-}> {
-  override get message() {
-    return "Failed to persist desktop update settings.";
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const detail = this.cause instanceof Error ? this.cause.message : String(this.cause);
+    return `Failed to persist desktop update settings: ${detail}`;
   }
 }
 
@@ -86,22 +88,21 @@ export type DesktopUpdateSetChannelError =
   | DesktopUpdateActionInProgressError
   | DesktopUpdatePersistenceError;
 
-export interface DesktopUpdatesShape {
-  readonly getState: Effect.Effect<DesktopUpdateState>;
-  readonly emitState: Effect.Effect<void>;
-  readonly disabledReason: Effect.Effect<Option.Option<string>>;
-  readonly configure: Effect.Effect<void, DesktopUpdateConfigureError, Scope.Scope>;
-  readonly setChannel: (
-    channel: DesktopUpdateChannel,
-  ) => Effect.Effect<DesktopUpdateState, DesktopUpdateSetChannelError>;
-  readonly check: (reason: string) => Effect.Effect<DesktopUpdateCheckResult>;
-  readonly download: Effect.Effect<DesktopUpdateActionResult>;
-  readonly install: Effect.Effect<DesktopUpdateActionResult>;
-}
-
-export class DesktopUpdates extends Context.Service<DesktopUpdates, DesktopUpdatesShape>()(
-  "@t3tools/desktop/updates/DesktopUpdates",
-) {}
+export class DesktopUpdates extends Context.Service<
+  DesktopUpdates,
+  {
+    readonly getState: Effect.Effect<DesktopUpdateState>;
+    readonly emitState: Effect.Effect<void>;
+    readonly disabledReason: Effect.Effect<Option.Option<string>>;
+    readonly configure: Effect.Effect<void, DesktopUpdateConfigureError, Scope.Scope>;
+    readonly setChannel: (
+      channel: DesktopUpdateChannel,
+    ) => Effect.Effect<DesktopUpdateState, DesktopUpdateSetChannelError>;
+    readonly check: (reason: string) => Effect.Effect<DesktopUpdateCheckResult>;
+    readonly download: Effect.Effect<DesktopUpdateActionResult>;
+    readonly install: Effect.Effect<DesktopUpdateActionResult>;
+  }
+>()("@t3tools/desktop/updates/DesktopUpdates") {}
 
 const {
   logInfo: logUpdaterInfo,
@@ -185,7 +186,7 @@ function isArm64HostRunningIntelBuild(runtimeInfo: DesktopRuntimeInfo): boolean 
   return runtimeInfo.hostArch === "arm64" && runtimeInfo.appArch === "x64";
 }
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const config = yield* DesktopConfig.DesktopConfig;
   const backendManager = yield* DesktopBackendManager.DesktopBackendManager;
   const desktopState = yield* DesktopState.DesktopState;

--- a/apps/desktop/src/window/DesktopApplicationMenu.test.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.test.ts
@@ -64,7 +64,7 @@ const desktopUpdatesLayer = Layer.succeed(DesktopUpdates.DesktopUpdates, {
   check: () => Effect.die("unexpected check"),
   download: Effect.die("unexpected download"),
   install: Effect.die("unexpected install"),
-} satisfies DesktopUpdates.DesktopUpdatesShape);
+} satisfies DesktopUpdates.DesktopUpdates["Service"]);
 
 const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
   Layer.succeed(DesktopWindow.DesktopWindow, {
@@ -76,7 +76,7 @@ const makeDesktopWindowLayer = (selectedAction: Deferred.Deferred<string>) =>
     handleBackendReady: Effect.void,
     dispatchMenuAction: (action) => Deferred.succeed(selectedAction, action).pipe(Effect.asVoid),
     syncAppearance: Effect.void,
-  } satisfies DesktopWindow.DesktopWindowShape);
+  } satisfies DesktopWindow.DesktopWindow["Service"]);
 
 const makeElectronMenuLayer = (
   applicationMenuTemplate: Deferred.Deferred<readonly Electron.MenuItemConstructorOptions[]>,

--- a/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -14,13 +14,11 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
 
-export interface DesktopApplicationMenuShape {
-  readonly configure: Effect.Effect<void>;
-}
-
 export class DesktopApplicationMenu extends Context.Service<
   DesktopApplicationMenu,
-  DesktopApplicationMenuShape
+  {
+    readonly configure: Effect.Effect<void>;
+  }
 >()("@t3tools/desktop/window/DesktopApplicationMenu") {}
 
 type DesktopApplicationMenuRuntimeServices =
@@ -94,7 +92,7 @@ const handleCheckForUpdatesMenuClick: Effect.Effect<
   yield* checkForUpdatesFromMenu;
 }).pipe(Effect.withSpan("desktop.menu.handleCheckForUpdatesClick"));
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const electronApp = yield* ElectronApp.ElectronApp;
   const electronMenu = yield* ElectronMenu.ElectronMenu;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -42,20 +42,19 @@ export type DesktopWindowError =
   | ElectronWindow.ElectronWindowCreateError
   | PreviewManager.PreviewManagerError;
 
-export interface DesktopWindowShape {
-  readonly createMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
-  readonly ensureMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
-  readonly revealOrCreateMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
-  readonly activate: Effect.Effect<void, DesktopWindowError>;
-  readonly createMainIfBackendReady: Effect.Effect<void, DesktopWindowError>;
-  readonly handleBackendReady: Effect.Effect<void, DesktopWindowError>;
-  readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
-  readonly syncAppearance: Effect.Effect<void>;
-}
-
-export class DesktopWindow extends Context.Service<DesktopWindow, DesktopWindowShape>()(
-  "@t3tools/desktop/window/DesktopWindow",
-) {}
+export class DesktopWindow extends Context.Service<
+  DesktopWindow,
+  {
+    readonly createMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
+    readonly ensureMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
+    readonly revealOrCreateMain: Effect.Effect<Electron.BrowserWindow, DesktopWindowError>;
+    readonly activate: Effect.Effect<void, DesktopWindowError>;
+    readonly createMainIfBackendReady: Effect.Effect<void, DesktopWindowError>;
+    readonly handleBackendReady: Effect.Effect<void, DesktopWindowError>;
+    readonly dispatchMenuAction: (action: string) => Effect.Effect<void, DesktopWindowError>;
+    readonly syncAppearance: Effect.Effect<void>;
+  }
+>()("@t3tools/desktop/window/DesktopWindow") {}
 
 const { logInfo: logWindowInfo, logWarning: logWindowWarning } =
   DesktopObservability.makeComponentLogger("desktop-window");
@@ -143,7 +142,7 @@ function bindFirstRevealTrigger(
   }
 }
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const assets = yield* DesktopAssets.DesktopAssets;
   const electronMenu = yield* ElectronMenu.ElectronMenu;


### PR DESCRIPTION
## Summary

- inline the desktop window, application menu, and update service contracts
- export each service's `make` factory and canonical `layer`
- use namespace imports at service boundaries and module-qualified `Service["Service"]` references
- convert desktop update errors to schema-backed tagged errors with structured attributes and derived messages

## Impact

This is a structural service cleanup. Desktop update and window behavior is preserved; persistence failures now include the structured cause detail in their derived message.

## Scope

Orchestration and MCP modules are intentionally untouched. Existing tests changed only where service references moved; this PR adds no refactor-only tests or test cases.

## Validation

- affected desktop suites: 4 files, 15 tests passed
- `vp check` (passes with 20 existing warnings in files outside this PR)
- `vp run typecheck`
- `git diff --check origin/main...HEAD`
- zero-diff audit for orchestration and MCP paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural Effect service cleanup with no orchestration changes; the only behavioral tweak is more detailed text on update settings persistence failures.
> 
> **Overview**
> Refactors **desktop updates, window, and application menu** Effect services so their contracts live inline on `Context.Service` instead of separate `*Shape` interfaces, and test stubs type-check against `Service["Service"]`.
> 
> **Update errors** move from `Data.TaggedError` to **`Schema.TaggedErrorClass`**. `DesktopUpdatePersistenceError` now carries a generic `cause` (`Schema.Defect()`) and its message includes the underlying failure detail instead of a fixed string.
> 
> Each of **`DesktopUpdates`**, **`DesktopWindow`**, and **`DesktopApplicationMenu`** now **exports its `make` factory** (previously module-private). Runtime behavior for updates and windows is unchanged aside from richer persistence error messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d1374f986e118c4dfc5504ec606a3f7488726da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor desktop window services to inline service shapes and export factory functions
> - Removes separate `Shape` interfaces (`DesktopUpdatesShape`, `DesktopWindowShape`, `DesktopApplicationMenuShape`) and inlines service definitions directly into `Context.Service` generic parameters in [`DesktopUpdates.ts`](https://github.com/pingdotgg/t3code/pull/3202/files#diff-18a0ceefd3e1e39787998729982d5555c0ccc2aebe58959eace7686e89af0e99), [`DesktopWindow.ts`](https://github.com/pingdotgg/t3code/pull/3202/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429), and [`DesktopApplicationMenu.ts`](https://github.com/pingdotgg/t3code/pull/3202/files#diff-1d27d62f2db6ae3d67221b54135a0260783acf7594fd4ad9f60035f0819a96eb).
> - Exports the `make` factory from each service module so other modules can import it directly.
> - Migrates `DesktopUpdateActionInProgressError` and `DesktopUpdatePersistenceError` from `Data.TaggedError` to `Schema.TaggedErrorClass`, with `DesktopUpdatePersistenceError` now including the underlying cause detail in its error message.
> - Updates test type assertions in [`DesktopApplicationMenu.test.ts`](https://github.com/pingdotgg/t3code/pull/3202/files#diff-8d5bec06ba45f3e665f14b20edc2ddc14c12cb26ddd4849ee16a056301814b24) to reference `["Service"]` from the `Context.Service` class instead of the removed shape interfaces.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5d1374f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
