### PR TITLE
[codex] Normalize Desktop IPC Effect service

### DIFF
--- a/apps/desktop/src/ipc/DesktopIpc.ts
+++ b/apps/desktop/src/ipc/DesktopIpc.ts
@@ -1,5 +1,6 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 
@@ -33,20 +34,19 @@ export interface DesktopSyncIpcMethod<E, R> {
   readonly handler: () => Effect.Effect<unknown, E, R>;
 }
 
-export interface DesktopIpcShape {
-  readonly handle: <E, R>(
-    input: DesktopIpcMethod<E, R>,
-  ) => Effect.Effect<void, never, R | Scope.Scope>;
-  readonly handleSync: <E, R>(
-    input: DesktopSyncIpcMethod<E, R>,
-  ) => Effect.Effect<void, never, R | Scope.Scope>;
-}
+export class DesktopIpc extends Context.Service<
+  DesktopIpc,
+  {
+    readonly handle: <E, R>(
+      input: DesktopIpcMethod<E, R>,
+    ) => Effect.Effect<void, never, R | Scope.Scope>;
+    readonly handleSync: <E, R>(
+      input: DesktopSyncIpcMethod<E, R>,
+    ) => Effect.Effect<void, never, R | Scope.Scope>;
+  }
+>()("@t3tools/desktop/ipc/DesktopIpc") {}
 
-export class DesktopIpc extends Context.Service<DesktopIpc, DesktopIpcShape>()(
-  "@t3tools/desktop/ipc/DesktopIpc",
-) {}
-
-export const make = (ipcMain: DesktopIpcMain): DesktopIpcShape =>
+export const make = (ipcMain: DesktopIpcMain): DesktopIpc["Service"] =>
   DesktopIpc.of({
     handle: Effect.fn("desktop.ipc.registerInvoke")(function* <E, R>({
       channel,
@@ -96,6 +96,8 @@ export const make = (ipcMain: DesktopIpcMain): DesktopIpcShape =>
       );
     }),
   });
+
+export const layer = (ipcMain: DesktopIpcMain) => Layer.succeed(DesktopIpc, make(ipcMain));
 
 /**
  * Convenience helpers for creating IPC methods

--- a/apps/desktop/src/ipc/methods/clientSettings.ts
+++ b/apps/desktop/src/ipc/methods/clientSettings.ts
@@ -5,9 +5,9 @@ import * as Schema from "effect/Schema";
 
 import * as DesktopClientSettings from "../../settings/DesktopClientSettings.ts";
 import * as IpcChannels from "../channels.ts";
-import { makeIpcMethod } from "../DesktopIpc.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
 
-export const getClientSettings = makeIpcMethod({
+export const getClientSettings = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.GET_CLIENT_SETTINGS_CHANNEL,
   payload: Schema.Void,
   result: Schema.NullOr(ClientSettingsSchema),
@@ -17,7 +17,7 @@ export const getClientSettings = makeIpcMethod({
   }),
 });
 
-export const setClientSettings = makeIpcMethod({
+export const setClientSettings = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.SET_CLIENT_SETTINGS_CHANNEL,
   payload: ClientSettingsSchema,
   result: Schema.Void,

--- a/apps/desktop/src/ipc/methods/connectionCatalog.ts
+++ b/apps/desktop/src/ipc/methods/connectionCatalog.ts
@@ -4,9 +4,9 @@ import * as Schema from "effect/Schema";
 
 import * as DesktopConnectionCatalogStore from "../../app/DesktopConnectionCatalogStore.ts";
 import * as IpcChannels from "../channels.ts";
-import { makeIpcMethod } from "../DesktopIpc.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
 
-export const getConnectionCatalog = makeIpcMethod({
+export const getConnectionCatalog = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.GET_CONNECTION_CATALOG_CHANNEL,
   payload: Schema.Void,
   result: Schema.NullOr(Schema.String),
@@ -16,7 +16,7 @@ export const getConnectionCatalog = makeIpcMethod({
   }),
 });
 
-export const setConnectionCatalog = makeIpcMethod({
+export const setConnectionCatalog = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.SET_CONNECTION_CATALOG_CHANNEL,
   payload: Schema.String,
   result: Schema.Boolean,
@@ -26,7 +26,7 @@ export const setConnectionCatalog = makeIpcMethod({
   }),
 });
 
-export const clearConnectionCatalog = makeIpcMethod({
+export const clearConnectionCatalog = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.CLEAR_CONNECTION_CATALOG_CHANNEL,
   payload: Schema.Void,
   result: Schema.Void,

--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -27,7 +27,7 @@ import { pathToFileURL } from "node:url";
 import * as PreviewManager from "../../preview/Manager.ts";
 import { PREVIEW_WEBVIEW_PREFERENCES } from "../../preview/WebviewPreferences.ts";
 import * as IpcChannels from "../channels.ts";
-import { makeIpcMethod } from "../DesktopIpc.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
 
 const broadcast = (channel: string, ...args: ReadonlyArray<unknown>): void => {
   for (const window of BrowserWindow.getAllWindows()) {
@@ -52,7 +52,7 @@ export const installPreviewEventForwarding = Effect.fn(
   });
 });
 
-export const createTab = makeIpcMethod({
+export const createTab = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_CREATE_TAB_CHANNEL,
   payload: DesktopPreviewTabInputSchema,
   result: Schema.Void,
@@ -62,7 +62,7 @@ export const createTab = makeIpcMethod({
   }),
 });
 
-export const closeTab = makeIpcMethod({
+export const closeTab = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_CLOSE_TAB_CHANNEL,
   payload: DesktopPreviewTabInputSchema,
   result: Schema.Void,
@@ -72,7 +72,7 @@ export const closeTab = makeIpcMethod({
   }),
 });
 
-export const registerWebview = makeIpcMethod({
+export const registerWebview = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_REGISTER_WEBVIEW_CHANNEL,
   payload: DesktopPreviewRegisterWebviewInputSchema,
   result: Schema.Void,
@@ -82,7 +82,7 @@ export const registerWebview = makeIpcMethod({
   }),
 });
 
-export const navigate = makeIpcMethod({
+export const navigate = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_NAVIGATE_CHANNEL,
   payload: DesktopPreviewNavigateInputSchema,
   result: Schema.Void,
@@ -100,7 +100,7 @@ const tabMethod = (
     tabId: string,
   ) => Effect.Effect<void, PreviewManager.PreviewManagerError>,
 ) =>
-  makeIpcMethod({
+  DesktopIpc.makeIpcMethod({
     channel,
     payload: DesktopPreviewTabInputSchema,
     result: Schema.Void,
@@ -166,7 +166,7 @@ export const stopRecording = tabMethod(
   (manager, tabId) => manager.stopRecording(tabId),
 );
 
-export const clearCookies = makeIpcMethod({
+export const clearCookies = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_CLEAR_COOKIES_CHANNEL,
   payload: Schema.Void,
   result: Schema.Void,
@@ -176,7 +176,7 @@ export const clearCookies = makeIpcMethod({
   }),
 });
 
-export const clearCache = makeIpcMethod({
+export const clearCache = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_CLEAR_CACHE_CHANNEL,
   payload: Schema.Void,
   result: Schema.Void,
@@ -186,7 +186,7 @@ export const clearCache = makeIpcMethod({
   }),
 });
 
-export const getPreviewConfig = makeIpcMethod({
+export const getPreviewConfig = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_GET_CONFIG_CHANNEL,
   payload: DesktopPreviewConfigInputSchema,
   result: DesktopPreviewWebviewConfigSchema,
@@ -201,7 +201,7 @@ export const getPreviewConfig = makeIpcMethod({
   }),
 });
 
-export const setAnnotationTheme = makeIpcMethod({
+export const setAnnotationTheme = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_SET_ANNOTATION_THEME_CHANNEL,
   payload: DesktopPreviewAnnotationThemeInputSchema,
   result: Schema.Void,
@@ -211,7 +211,7 @@ export const setAnnotationTheme = makeIpcMethod({
   }),
 });
 
-export const pickElement = makeIpcMethod({
+export const pickElement = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_PICK_ELEMENT_CHANNEL,
   payload: DesktopPreviewTabInputSchema,
   result: Schema.NullOr(PreviewAnnotationPayloadSchema),
@@ -221,7 +221,7 @@ export const pickElement = makeIpcMethod({
   }),
 });
 
-export const captureScreenshot = makeIpcMethod({
+export const captureScreenshot = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_CAPTURE_SCREENSHOT_CHANNEL,
   payload: DesktopPreviewTabInputSchema,
   result: DesktopPreviewScreenshotArtifactSchema,
@@ -231,7 +231,7 @@ export const captureScreenshot = makeIpcMethod({
   }),
 });
 
-export const revealArtifact = makeIpcMethod({
+export const revealArtifact = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_REVEAL_ARTIFACT_CHANNEL,
   payload: DesktopPreviewArtifactInputSchema,
   result: Schema.Void,
@@ -241,7 +241,7 @@ export const revealArtifact = makeIpcMethod({
   }),
 });
 
-export const copyArtifactToClipboard = makeIpcMethod({
+export const copyArtifactToClipboard = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_COPY_ARTIFACT_CHANNEL,
   payload: DesktopPreviewArtifactInputSchema,
   result: Schema.Void,
@@ -251,7 +251,7 @@ export const copyArtifactToClipboard = makeIpcMethod({
   }),
 });
 
-export const automationStatus = makeIpcMethod({
+export const automationStatus = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_STATUS_CHANNEL,
   payload: DesktopPreviewTabInputSchema,
   result: PreviewAutomationStatus,
@@ -261,7 +261,7 @@ export const automationStatus = makeIpcMethod({
   }),
 });
 
-export const automationSnapshot = makeIpcMethod({
+export const automationSnapshot = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_SNAPSHOT_CHANNEL,
   payload: DesktopPreviewTabInputSchema,
   result: PreviewAutomationSnapshot,
@@ -271,7 +271,7 @@ export const automationSnapshot = makeIpcMethod({
   }),
 });
 
-export const automationClick = makeIpcMethod({
+export const automationClick = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_CLICK_CHANNEL,
   payload: DesktopPreviewAutomationClickInputSchema,
   result: Schema.Void,
@@ -281,7 +281,7 @@ export const automationClick = makeIpcMethod({
   }),
 });
 
-export const automationType = makeIpcMethod({
+export const automationType = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_TYPE_CHANNEL,
   payload: DesktopPreviewAutomationTypeInputSchema,
   result: Schema.Void,
@@ -291,7 +291,7 @@ export const automationType = makeIpcMethod({
   }),
 });
 
-export const automationPress = makeIpcMethod({
+export const automationPress = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_PRESS_CHANNEL,
   payload: DesktopPreviewAutomationPressInputSchema,
   result: Schema.Void,
@@ -301,7 +301,7 @@ export const automationPress = makeIpcMethod({
   }),
 });
 
-export const automationScroll = makeIpcMethod({
+export const automationScroll = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_SCROLL_CHANNEL,
   payload: DesktopPreviewAutomationScrollInputSchema,
   result: Schema.Void,
@@ -311,7 +311,7 @@ export const automationScroll = makeIpcMethod({
   }),
 });
 
-export const automationEvaluate = makeIpcMethod({
+export const automationEvaluate = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_EVALUATE_CHANNEL,
   payload: DesktopPreviewAutomationEvaluateInputSchema,
   result: Schema.Unknown,
@@ -321,7 +321,7 @@ export const automationEvaluate = makeIpcMethod({
   }),
 });
 
-export const automationWaitFor = makeIpcMethod({
+export const automationWaitFor = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_AUTOMATION_WAIT_FOR_CHANNEL,
   payload: DesktopPreviewAutomationWaitForInputSchema,
   result: Schema.Void,
@@ -331,7 +331,7 @@ export const automationWaitFor = makeIpcMethod({
   }),
 });
 
-export const saveRecording = makeIpcMethod({
+export const saveRecording = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PREVIEW_RECORDING_SAVE_CHANNEL,
   payload: DesktopPreviewRecordingSaveInputSchema,
   result: DesktopPreviewRecordingArtifactSchema,

--- a/apps/desktop/src/ipc/methods/serverExposure.ts
+++ b/apps/desktop/src/ipc/methods/serverExposure.ts
@@ -9,14 +9,14 @@ import * as Schema from "effect/Schema";
 import * as DesktopLifecycle from "../../app/DesktopLifecycle.ts";
 import * as DesktopServerExposure from "../../backend/DesktopServerExposure.ts";
 import * as IpcChannels from "../channels.ts";
-import { makeIpcMethod } from "../DesktopIpc.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
 
 const SetTailscaleServeEnabledInput = Schema.Struct({
   enabled: Schema.Boolean,
   port: Schema.optionalKey(Schema.Number),
 });
 
-export const getServerExposureState = makeIpcMethod({
+export const getServerExposureState = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.GET_SERVER_EXPOSURE_STATE_CHANNEL,
   payload: Schema.Void,
   result: DesktopServerExposureStateSchema,
@@ -26,7 +26,7 @@ export const getServerExposureState = makeIpcMethod({
   }),
 });
 
-export const setServerExposureMode = makeIpcMethod({
+export const setServerExposureMode = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.SET_SERVER_EXPOSURE_MODE_CHANNEL,
   payload: DesktopServerExposureModeSchema,
   result: DesktopServerExposureStateSchema,
@@ -41,7 +41,7 @@ export const setServerExposureMode = makeIpcMethod({
   }),
 });
 
-export const setTailscaleServeEnabled = makeIpcMethod({
+export const setTailscaleServeEnabled = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.SET_TAILSCALE_SERVE_ENABLED_CHANNEL,
   payload: SetTailscaleServeEnabledInput,
   result: DesktopServerExposureStateSchema,
@@ -58,7 +58,7 @@ export const setTailscaleServeEnabled = makeIpcMethod({
   }),
 });
 
-export const getAdvertisedEndpoints = makeIpcMethod({
+export const getAdvertisedEndpoints = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.GET_ADVERTISED_ENDPOINTS_CHANNEL,
   payload: Schema.Void,
   result: Schema.Array(AdvertisedEndpoint),

--- a/apps/desktop/src/ipc/methods/sshEnvironment.ts
+++ b/apps/desktop/src/ipc/methods/sshEnvironment.ts
@@ -33,7 +33,7 @@ import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 import * as IpcChannels from "../channels.ts";
-import { makeIpcMethod } from "../DesktopIpc.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
 import * as DesktopSshEnvironment from "../../ssh/DesktopSshEnvironment.ts";
 import * as DesktopSshPasswordPrompts from "../../ssh/DesktopSshPasswordPrompts.ts";
 
@@ -107,7 +107,7 @@ const withLoopbackSshApi =
       ),
     );
 
-export const discoverSshHosts = makeIpcMethod({
+export const discoverSshHosts = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.DISCOVER_SSH_HOSTS_CHANNEL,
   payload: Schema.Void,
   result: Schema.Array(DesktopDiscoveredSshHostSchema),
@@ -117,7 +117,7 @@ export const discoverSshHosts = makeIpcMethod({
   }),
 });
 
-export const ensureSshEnvironment = makeIpcMethod({
+export const ensureSshEnvironment = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.ENSURE_SSH_ENVIRONMENT_CHANNEL,
   payload: DesktopSshEnvironmentEnsureInputSchema,
   result: DesktopSshEnvironmentEnsureResultSchema,
@@ -139,7 +139,7 @@ export const ensureSshEnvironment = makeIpcMethod({
   }),
 });
 
-export const disconnectSshEnvironment = makeIpcMethod({
+export const disconnectSshEnvironment = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.DISCONNECT_SSH_ENVIRONMENT_CHANNEL,
   payload: DesktopSshEnvironmentTargetSchema,
   result: Schema.Void,
@@ -149,7 +149,7 @@ export const disconnectSshEnvironment = makeIpcMethod({
   }),
 });
 
-export const fetchSshEnvironmentDescriptor = makeIpcMethod({
+export const fetchSshEnvironmentDescriptor = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.FETCH_SSH_ENVIRONMENT_DESCRIPTOR_CHANNEL,
   payload: DesktopSshHttpBaseUrlInputSchema,
   result: ExecutionEnvironmentDescriptor,
@@ -160,7 +160,7 @@ export const fetchSshEnvironmentDescriptor = makeIpcMethod({
   }),
 });
 
-export const bootstrapSshBearerSession = makeIpcMethod({
+export const bootstrapSshBearerSession = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.BOOTSTRAP_SSH_BEARER_SESSION_CHANNEL,
   payload: DesktopSshBearerBootstrapInputSchema,
   result: AuthAccessTokenResult,
@@ -177,7 +177,7 @@ export const bootstrapSshBearerSession = makeIpcMethod({
   }),
 });
 
-export const fetchSshSessionState = makeIpcMethod({
+export const fetchSshSessionState = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.FETCH_SSH_SESSION_STATE_CHANNEL,
   payload: DesktopSshBearerRequestInputSchema,
   result: AuthSessionState,
@@ -194,7 +194,7 @@ export const fetchSshSessionState = makeIpcMethod({
   }),
 });
 
-export const issueSshWebSocketTicket = makeIpcMethod({
+export const issueSshWebSocketTicket = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.ISSUE_SSH_WEBSOCKET_TOKEN_CHANNEL,
   payload: DesktopSshBearerRequestInputSchema,
   result: AuthWebSocketTicketResult,
@@ -211,7 +211,7 @@ export const issueSshWebSocketTicket = makeIpcMethod({
   }),
 });
 
-export const resolveSshPasswordPrompt = makeIpcMethod({
+export const resolveSshPasswordPrompt = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.RESOLVE_SSH_PASSWORD_PROMPT_CHANNEL,
   payload: DesktopSshPasswordPromptResolutionInputSchema,
   result: Schema.Void,

--- a/apps/desktop/src/ipc/methods/updates.ts
+++ b/apps/desktop/src/ipc/methods/updates.ts
@@ -9,9 +9,9 @@ import * as Schema from "effect/Schema";
 
 import * as DesktopUpdates from "../../updates/DesktopUpdates.ts";
 import * as IpcChannels from "../channels.ts";
-import { makeIpcMethod } from "../DesktopIpc.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
 
-export const getUpdateState = makeIpcMethod({
+export const getUpdateState = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.UPDATE_GET_STATE_CHANNEL,
   payload: Schema.Void,
   result: DesktopUpdateStateSchema,
@@ -21,7 +21,7 @@ export const getUpdateState = makeIpcMethod({
   }),
 });
 
-export const setUpdateChannel = makeIpcMethod({
+export const setUpdateChannel = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.UPDATE_SET_CHANNEL_CHANNEL,
   payload: DesktopUpdateChannelSchema,
   result: DesktopUpdateStateSchema,
@@ -31,7 +31,7 @@ export const setUpdateChannel = makeIpcMethod({
   }),
 });
 
-export const downloadUpdate = makeIpcMethod({
+export const downloadUpdate = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.UPDATE_DOWNLOAD_CHANNEL,
   payload: Schema.Void,
   result: DesktopUpdateActionResultSchema,
@@ -41,7 +41,7 @@ export const downloadUpdate = makeIpcMethod({
   }),
 });
 
-export const installUpdate = makeIpcMethod({
+export const installUpdate = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.UPDATE_INSTALL_CHANNEL,
   payload: Schema.Void,
   result: DesktopUpdateActionResultSchema,
@@ -51,7 +51,7 @@ export const installUpdate = makeIpcMethod({
   }),
 });
 
-export const checkForUpdate = makeIpcMethod({
+export const checkForUpdate = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.UPDATE_CHECK_CHANNEL,
   payload: Schema.Void,
   result: DesktopUpdateCheckResultSchema,

--- a/apps/desktop/src/ipc/methods/window.ts
+++ b/apps/desktop/src/ipc/methods/window.ts
@@ -18,7 +18,7 @@ import * as ElectronShell from "../../electron/ElectronShell.ts";
 import * as ElectronTheme from "../../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import * as IpcChannels from "../channels.ts";
-import { makeIpcMethod, makeSyncIpcMethod } from "../DesktopIpc.ts";
+import * as DesktopIpc from "../DesktopIpc.ts";
 
 const ContextMenuPosition = Schema.Struct({
   x: Schema.Number,
@@ -36,7 +36,7 @@ function toWebSocketBaseUrl(httpBaseUrl: URL): string {
   return url.href;
 }
 
-export const getAppBranding = makeSyncIpcMethod({
+export const getAppBranding = DesktopIpc.makeSyncIpcMethod({
   channel: IpcChannels.GET_APP_BRANDING_CHANNEL,
   result: Schema.NullOr(DesktopAppBrandingSchema),
   handler: Effect.fn("desktop.ipc.window.getAppBranding")(function* () {
@@ -45,7 +45,7 @@ export const getAppBranding = makeSyncIpcMethod({
   }),
 });
 
-export const getLocalEnvironmentBootstrap = makeSyncIpcMethod({
+export const getLocalEnvironmentBootstrap = DesktopIpc.makeSyncIpcMethod({
   channel: IpcChannels.GET_LOCAL_ENVIRONMENT_BOOTSTRAP_CHANNEL,
   result: Schema.NullOr(DesktopEnvironmentBootstrapSchema),
   handler: Effect.fn("desktop.ipc.window.getLocalEnvironmentBootstrap")(function* () {
@@ -65,7 +65,7 @@ export const getLocalEnvironmentBootstrap = makeSyncIpcMethod({
   }),
 });
 
-export const getLocalEnvironmentBearerToken = makeIpcMethod({
+export const getLocalEnvironmentBearerToken = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.GET_LOCAL_ENVIRONMENT_BEARER_TOKEN_CHANNEL,
   payload: Schema.Void,
   result: Schema.String,
@@ -75,7 +75,7 @@ export const getLocalEnvironmentBearerToken = makeIpcMethod({
   }),
 });
 
-export const pickFolder = makeIpcMethod({
+export const pickFolder = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.PICK_FOLDER_CHANNEL,
   payload: Schema.UndefinedOr(PickFolderOptionsSchema),
   result: Schema.NullOr(Schema.String),
@@ -91,7 +91,7 @@ export const pickFolder = makeIpcMethod({
   }),
 });
 
-export const confirm = makeIpcMethod({
+export const confirm = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.CONFIRM_CHANNEL,
   payload: Schema.String,
   result: Schema.Boolean,
@@ -104,7 +104,7 @@ export const confirm = makeIpcMethod({
   }),
 });
 
-export const setTheme = makeIpcMethod({
+export const setTheme = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.SET_THEME_CHANNEL,
   payload: DesktopThemeSchema,
   result: Schema.Void,
@@ -114,7 +114,7 @@ export const setTheme = makeIpcMethod({
   }),
 });
 
-export const showContextMenu = makeIpcMethod({
+export const showContextMenu = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.CONTEXT_MENU_CHANNEL,
   payload: ContextMenuInput,
   result: Schema.NullOr(Schema.String),
@@ -135,7 +135,7 @@ export const showContextMenu = makeIpcMethod({
   }),
 });
 
-export const openExternal = makeIpcMethod({
+export const openExternal = DesktopIpc.makeIpcMethod({
   channel: IpcChannels.OPEN_EXTERNAL_CHANNEL,
   payload: Schema.String,
   result: Schema.Boolean,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -14,7 +14,6 @@ import { resolveRemoteT3CliPackageSpec } from "@t3tools/ssh/command";
 import type { RemoteT3RunnerOptions } from "@t3tools/ssh/tunnel";
 import serverPackageJson from "../../server/package.json" with { type: "json" };
 
-import type { DesktopSettings as DesktopSettingsValue } from "./settings/DesktopAppSettings.ts";
 import * as DesktopIpc from "./ipc/DesktopIpc.ts";
 import * as ElectronApp from "./electron/ElectronApp.ts";
 import * as ElectronDialog from "./electron/ElectronDialog.ts";
@@ -68,8 +67,8 @@ const desktopEnvironmentLayer = Layer.unwrap(
 );
 
 const resolveDesktopSshCliRunner = (
-  environment: DesktopEnvironment.DesktopEnvironmentShape,
-  settings: DesktopSettingsValue,
+  environment: DesktopEnvironment.DesktopEnvironment["Service"],
+  settings: DesktopAppSettings.DesktopSettings,
 ): RemoteT3RunnerOptions => {
   const devRemoteEntryPath = Option.getOrUndefined(environment.devRemoteT3ServerEntryPath);
   if (environment.isDevelopment && devRemoteEntryPath !== undefined) {
@@ -110,7 +109,7 @@ const electronLayer = Layer.mergeAll(
   ElectronTheme.layer,
   ElectronUpdater.layer,
   ElectronWindow.layer,
-  Layer.succeed(DesktopIpc.DesktopIpc, DesktopIpc.make(Electron.ipcMain)),
+  DesktopIpc.layer(Electron.ipcMain),
 );
 
 const desktopFoundationLayer = Layer.mergeAll(


### PR DESCRIPTION
## Summary

- inline the `DesktopIpc` service contract and expose its canonical `make` and parameterized `layer`
- pair the synchronous service constructor with `Layer.succeed`; no redundant effect wrapper is introduced
- replace standalone shape references with `Service["Service"]` in desktop startup wiring
- use namespace imports and module-qualified `DesktopIpc.makeIpcMethod` / `DesktopIpc.makeSyncIpcMethod` calls across all seven IPC method modules
- preserve existing IPC method documentation and registration behavior

## Impact

This is a structural refactor. IPC decoding, encoding, handler registration, cleanup, and domain behavior are unchanged. The service does not define custom errors, so there is no error-schema migration in this diff.

## Validation

- `vp test apps/desktop/src/ipc/methods/preview.test.ts apps/desktop/src/ipc/methods/sshEnvironment.test.ts` (2 files, 5 tests passed)
- `vp test apps/desktop/src/backend/DesktopBackendConfiguration.test.ts apps/desktop/src/backend/DesktopBackendManager.test.ts apps/desktop/src/backend/DesktopLocalEnvironmentAuth.test.ts apps/desktop/src/backend/DesktopServerExposure.test.ts apps/desktop/src/backend/tailscaleEndpointProvider.test.ts` (5 files, 24 tests passed)
- `vp check` (passes; reports 20 pre-existing warnings outside this diff)
- `vp run typecheck`
- no new or modified test files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural typing and import-only changes; IPC registration logic in make is unchanged and existing IPC tests reportedly pass.
> 
> **Overview**
> Aligns **`DesktopIpc`** with the same Effect **`Context.Service`** pattern used elsewhere in the desktop app, without changing how channels are registered or handled.
> 
> The separate **`DesktopIpcShape`** type is removed and its contract is inlined on the service class. **`make`** is typed to return **`DesktopIpc["Service"]`**, and a canonical **`layer(ipcMain)`** wraps **`Layer.succeed(DesktopIpc, make(ipcMain))`**. Startup wiring in **`main.ts`** uses **`DesktopIpc.layer(Electron.ipcMain)`** instead of inlining **`Layer.succeed`** and **`make`**.
> 
> IPC method modules switch from named **`makeIpcMethod` / `makeSyncIpcMethod`** imports to namespace **`import * as DesktopIpc`** and **`DesktopIpc.makeIpcMethod`** (and sync equivalent). **`main.ts`** also updates a couple of type references to **`DesktopEnvironment["Service"]`** and **`DesktopAppSettings.DesktopSettings`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f91a4bc41cc5a452bde8dcd4967ebf472f9056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize `DesktopIpc` as an Effect `Context.Service` with a `layer` helper
> - Rewrites `DesktopIpc` in [DesktopIpc.ts](https://github.com/pingdotgg/t3code/pull/3203/files#diff-1581259023a494c1e35d1891a1bbba2b2219e769d1adfd6a39c56fd80f430ed4) to extend `Context.Service` directly, inlining the shape and dropping the separate `DesktopIpcShape` interface.
> - Adds a `layer` convenience function that wraps `Layer.succeed(DesktopIpc, make(ipcMain))`, replacing the explicit call in [main.ts](https://github.com/pingdotgg/t3code/pull/3203/files#diff-31a471f6ef958ceff6e87ee910f4bc4f7bbc4986f797f159353b328a5916f7cb).
> - Switches all IPC method files from named imports of `makeIpcMethod`/`makeSyncIpcMethod` to a `* as DesktopIpc` namespace import; no logic changes in handlers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7f91a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->