### PR TITLE
[codex] Refactor primary HTTP Effect service

### DIFF
--- a/apps/web/src/environments/primary/httpClient.ts
+++ b/apps/web/src/environments/primary/httpClient.ts
@@ -5,16 +5,13 @@ import * as Layer from "effect/Layer";
 
 import { resolvePrimaryEnvironmentHttpUrl } from "./target";
 
-export type PrimaryEnvironmentHttpClientShape = Effect.Success<
-  ReturnType<typeof makeEnvironmentHttpApiClient>
->;
-
 export class PrimaryEnvironmentHttpClient extends Context.Service<
   PrimaryEnvironmentHttpClient,
-  PrimaryEnvironmentHttpClientShape
+  Effect.Success<ReturnType<typeof makeEnvironmentHttpApiClient>>
 >()("@t3tools/web/environments/primary/httpClient/PrimaryEnvironmentHttpClient") {}
 
-export const primaryEnvironmentHttpClientLive = Layer.effect(
-  PrimaryEnvironmentHttpClient,
-  Effect.suspend(() => makeEnvironmentHttpApiClient(resolvePrimaryEnvironmentHttpUrl("/"))),
+const make = Effect.suspend(() =>
+  makeEnvironmentHttpApiClient(resolvePrimaryEnvironmentHttpUrl("/")),
 );
+
+export const layer = Layer.effect(PrimaryEnvironmentHttpClient, make);

--- a/apps/web/src/lib/runtime.ts
+++ b/apps/web/src/lib/runtime.ts
@@ -5,10 +5,7 @@ import * as Socket from "effect/unstable/socket/Socket";
 
 import { remoteHttpClientLayer } from "@t3tools/client-runtime/rpc";
 import { makeRelayClientTracingLayer } from "@t3tools/shared/relayTracing";
-import {
-  PrimaryEnvironmentHttpClient,
-  primaryEnvironmentHttpClientLive,
-} from "../environments/primary/httpClient";
+import * as PrimaryEnvironmentHttpClient from "../environments/primary/httpClient";
 import { primaryEnvironmentHttpLayer } from "../environments/primary/httpLayer";
 
 import { browserCryptoLayer } from "../cloud/dpop";
@@ -30,11 +27,11 @@ const relayTracingLayer = makeRelayClientTracingLayer(resolveRelayTracingConfig(
 export const remoteHttpRuntime = ManagedRuntime.make(httpClientLayer);
 
 const primaryHttpRuntime = ManagedRuntime.make(
-  primaryEnvironmentHttpClientLive.pipe(Layer.provide(primaryEnvironmentHttpLayer)),
+  PrimaryEnvironmentHttpClient.layer.pipe(Layer.provide(primaryEnvironmentHttpLayer)),
 );
 
 export type PrimaryHttpEffectRunner = <A, E>(
-  effect: Effect.Effect<A, E, PrimaryEnvironmentHttpClient>,
+  effect: Effect.Effect<A, E, PrimaryEnvironmentHttpClient.PrimaryEnvironmentHttpClient>,
 ) => Promise<A>;
 
 const livePrimaryHttpRunner: PrimaryHttpEffectRunner = (effect) =>
@@ -42,8 +39,9 @@ const livePrimaryHttpRunner: PrimaryHttpEffectRunner = (effect) =>
 
 let primaryHttpRunner = livePrimaryHttpRunner;
 
-export const runPrimaryHttp = <A, E>(effect: Effect.Effect<A, E, PrimaryEnvironmentHttpClient>) =>
-  primaryHttpRunner(effect);
+export const runPrimaryHttp = <A, E>(
+  effect: Effect.Effect<A, E, PrimaryEnvironmentHttpClient.PrimaryEnvironmentHttpClient>,
+) => primaryHttpRunner(effect);
 
 export function __setPrimaryHttpRunnerForTests(runner?: PrimaryHttpEffectRunner): void {
   primaryHttpRunner = runner ?? livePrimaryHttpRunner;


### PR DESCRIPTION
## Summary

- inline the `PrimaryEnvironmentHttpClient` service contract and remove the standalone shape type
- expose the implementation through the canonical `layer` export
- consume the local service module through a namespace import in the web runtime

## Impact

This is a structural Effect-service cleanup with no intended user-facing behavior change. The primary HTTP target continues to resolve when the layer is built, so runtime configuration is not captured at module load.

## Validation

- existing primary-environment suite: 3 files, 11 tests passed
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export and typing refactor only; deferred URL resolution via `Effect.suspend` is unchanged, so runtime HTTP behavior should stay the same.
> 
> **Overview**
> **Structural cleanup** for the primary environment HTTP Effect service with no intended behavior change.
> 
> In `httpClient.ts`, the standalone `PrimaryEnvironmentHttpClientShape` alias is removed and the service class uses an inlined `Effect.Success<ReturnType<typeof makeEnvironmentHttpApiClient>>` type. Client construction is factored into a `make` effect still wrapped in `Effect.suspend` (so primary URL resolution happens at layer build time), and the live layer is exported as **`layer`** instead of `primaryEnvironmentHttpClientLive`.
> 
> `runtime.ts` switches to a namespace import (`* as PrimaryEnvironmentHttpClient`) and wires `PrimaryEnvironmentHttpClient.layer` into `ManagedRuntime.make`, updating `PrimaryHttpEffectRunner` / `runPrimaryHttp` generics to reference `PrimaryEnvironmentHttpClient.PrimaryEnvironmentHttpClient`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3496a6944827aa36eb10fbcaed84a10c0f96c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refactor primary HTTP Effect service to use namespace import and `layer` export
> - Removes the `PrimaryEnvironmentHttpClientShape` type alias from [httpClient.ts](https://github.com/pingdotgg/t3code/pull/3205/files#diff-4edecf6a3e8323ca24d17d4f681b67ddc80c6629f405d600d57454d2ddfbf74b), inlining the type directly into the `PrimaryEnvironmentHttpClient` service class.
> - Replaces the `primaryEnvironmentHttpClientLive` export with a `layer` export constructed via `Layer.effect` and a local `make` Effect using `Effect.suspend`.
> - Updates [runtime.ts](https://github.com/pingdotgg/t3code/pull/3205/files#diff-388a18975f48efaf80d1762c7ea994ade1601be09f5d1dc61468c84248020fdf) to use a namespace import (`* as PrimaryEnvironmentHttpClient`) and references `PrimaryEnvironmentHttpClient.layer` instead of the removed `primaryEnvironmentHttpClientLive`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f3496a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->