### PR TITLE
[codex] Use namespace imports for desktop core services

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -17,6 +17,7 @@ import * as DesktopBackendManager from "../backend/DesktopBackendManager.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./DesktopLifecycle.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
+import * as DesktopShutdown from "./DesktopShutdown.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 import * as DesktopShellEnvironment from "../shell/DesktopShellEnvironment.ts";
@@ -100,12 +101,12 @@ const handleFatalStartupError = Effect.fn("desktop.startup.handleFatalStartupErr
 ): Effect.fn.Return<
   void,
   never,
-  | DesktopLifecycle.DesktopShutdown
+  | DesktopShutdown.DesktopShutdown
   | DesktopState.DesktopState
   | ElectronApp.ElectronApp
   | ElectronDialog.ElectronDialog
 > {
-  const shutdown = yield* DesktopLifecycle.DesktopShutdown;
+  const shutdown = yield* DesktopShutdown.DesktopShutdown;
   const state = yield* DesktopState.DesktopState;
   const electronApp = yield* ElectronApp.ElectronApp;
   const electronDialog = yield* ElectronDialog.ElectronDialog;
@@ -237,7 +238,7 @@ const scopedProgram = Effect.scoped(
     yield* Effect.annotateLogsScoped({ scope: "desktop", runId });
     yield* Effect.annotateCurrentSpan({ scope: "desktop", runId });
 
-    const shutdown = yield* DesktopLifecycle.DesktopShutdown;
+    const shutdown = yield* DesktopShutdown.DesktopShutdown;
     const backendManager = yield* DesktopBackendManager.DesktopBackendManager;
 
     yield* Effect.addFinalizer(() =>

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -9,17 +9,15 @@ import type * as Electron from "electron";
 
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 import * as DesktopObservability from "./DesktopObservability.ts";
-import * as DesktopShutdownModule from "./DesktopShutdown.ts";
+import * as DesktopShutdown from "./DesktopShutdown.ts";
 import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
 
-export { DesktopShutdown, layer as layerShutdown } from "./DesktopShutdown.ts";
-
 export type DesktopLifecycleRuntimeServices =
   | DesktopEnvironment.DesktopEnvironment
-  | DesktopShutdownModule.DesktopShutdown
+  | DesktopShutdown.DesktopShutdown
   | DesktopState.DesktopState
   | DesktopWindow.DesktopWindow
   | ElectronApp.ElectronApp
@@ -63,8 +61,8 @@ function addScopedListener<Args extends ReadonlyArray<unknown>>(
 }
 
 const requestDesktopShutdownAndWait = Effect.fn("desktop.lifecycle.requestShutdownAndWait")(
-  function* (): Effect.fn.Return<void, never, DesktopShutdownModule.DesktopShutdown> {
-    const shutdown = yield* DesktopShutdownModule.DesktopShutdown;
+  function* (): Effect.fn.Return<void, never, DesktopShutdown.DesktopShutdown> {
+    const shutdown = yield* DesktopShutdown.DesktopShutdown;
     yield* shutdown.request;
     yield* shutdown.awaitComplete;
   },

--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -9,19 +9,15 @@ import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
-import {
-  DesktopEnvironment,
-  layer as makeDesktopEnvironmentLayer,
-} from "../app/DesktopEnvironment.ts";
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopConfig from "../app/DesktopConfig.ts";
 import * as DesktopServerExposure from "./DesktopServerExposure.ts";
-import type { DesktopNetworkInterfaces } from "./DesktopServerExposure.ts";
 import * as DesktopAppSettings from "../settings/DesktopAppSettings.ts";
 
 const encoder = new TextEncoder();
 
-const emptyNetworkInterfaces: DesktopNetworkInterfaces = {};
-const lanNetworkInterfaces: DesktopNetworkInterfaces = {
+const emptyNetworkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces = {};
+const lanNetworkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces = {
   en0: [
     {
       address: "192.168.1.20",
@@ -31,7 +27,7 @@ const lanNetworkInterfaces: DesktopNetworkInterfaces = {
   ],
 };
 
-const tailnetNetworkInterfaces: DesktopNetworkInterfaces = {
+const tailnetNetworkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces = {
   tailscale0: [
     {
       address: "100.90.1.2",
@@ -72,7 +68,7 @@ function dieOnSpawnLayer() {
 }
 
 function makeEnvironmentLayer(baseDir: string, env: Record<string, string | undefined> = {}) {
-  return makeDesktopEnvironmentLayer({
+  return DesktopEnvironment.layer({
     dirname: "/repo/apps/desktop/src",
     homeDirectory: baseDir,
     platform: "darwin",
@@ -91,7 +87,7 @@ function makeEnvironmentLayer(baseDir: string, env: Record<string, string | unde
 
 function makeLayer(input: {
   readonly baseDir: string;
-  readonly networkInterfaces?: DesktopNetworkInterfaces;
+  readonly networkInterfaces?: DesktopServerExposure.DesktopNetworkInterfaces;
   readonly env?: Record<string, string | undefined>;
   readonly spawnerLayer?: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>;
 }) {
@@ -113,12 +109,12 @@ function makeLayer(input: {
 }
 
 const withHarness = <A, E, R>(
-  networkInterfaces: DesktopNetworkInterfaces,
+  networkInterfaces: DesktopServerExposure.DesktopNetworkInterfaces,
   effect: Effect.Effect<
     A,
     E,
     | R
-    | DesktopEnvironment
+    | DesktopEnvironment.DesktopEnvironment
     | FileSystem.FileSystem
     | DesktopServerExposure.DesktopServerExposure
     | DesktopAppSettings.DesktopAppSettings

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -35,6 +35,7 @@ import * as DesktopBackendManager from "./backend/DesktopBackendManager.ts";
 import * as DesktopLocalEnvironmentAuth from "./backend/DesktopLocalEnvironmentAuth.ts";
 import * as DesktopEnvironment from "./app/DesktopEnvironment.ts";
 import * as DesktopLifecycle from "./app/DesktopLifecycle.ts";
+import * as DesktopShutdown from "./app/DesktopShutdown.ts";
 import * as DesktopObservability from "./app/DesktopObservability.ts";
 import * as DesktopServerExposure from "./backend/DesktopServerExposure.ts";
 import * as DesktopClientSettings from "./settings/DesktopClientSettings.ts";
@@ -114,7 +115,7 @@ const electronLayer = Layer.mergeAll(
 
 const desktopFoundationLayer = Layer.mergeAll(
   DesktopState.layer,
-  DesktopLifecycle.layerShutdown,
+  DesktopShutdown.layer,
   DesktopAppSettings.layer,
   DesktopClientSettings.layer,
   DesktopConnectionCatalogStore.layer.pipe(Layer.provideMerge(DesktopSavedEnvironments.layer)),


### PR DESCRIPTION
## Summary

- remove the aliased DesktopShutdown layer re-export left by #3185
- consume DesktopShutdown, DesktopEnvironment, and DesktopServerExposure through namespace imports
- keep service and layer access module-qualified

## Validation

- `vp test apps/desktop/src/backend/DesktopServerExposure.test.ts` (8 tests)
- `vp check`
- `vp run typecheck`

No tests were added; this is the narrow follow-up for the already-merged desktop-core refactor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and layer-wiring cleanup only; shutdown and server-exposure behavior is unchanged.
> 
> **Overview**
> Follow-up to the desktop-core refactor: **`DesktopShutdown` is no longer re-exported from `DesktopLifecycle`**. Call sites import **`DesktopShutdown`** directly and wire **`DesktopShutdown.layer`** in `main` instead of **`DesktopLifecycle.layerShutdown`**.
> 
> **`DesktopApp`** and **`DesktopLifecycle`** now reference the shutdown service as **`DesktopShutdown.DesktopShutdown`** via a namespace import (replacing the aliased `DesktopShutdownModule` pattern). **`DesktopServerExposure.test`** switches to namespace imports for **`DesktopEnvironment`** and **`DesktopServerExposure`** (including **`DesktopNetworkInterfaces`** and effect requirements), with no intended runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2933dae93cf347ae6bdd566527c3c7452cb9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use namespace imports for desktop core services
> Refactors imports in the desktop app to use namespace imports (`* as Module`) instead of named imports with aliases for `DesktopShutdown` and `DesktopEnvironment`. Removes re-exports of `DesktopShutdown` from [DesktopLifecycle.ts](https://github.com/pingdotgg/t3code/pull/3207/files#diff-e4f770e94426c2d924f6a844fa3f0e9cce3653cecebc9b95902929cad3966b6d), replacing them with direct imports at each call site.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7a2933d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->