### PR TITLE
chore: run eas only when labelled

### DIFF
--- a/.github/workflows/mobile-eas-preview.yml
+++ b/.github/workflows/mobile-eas-preview.yml
@@ -2,10 +2,12 @@ name: Mobile EAS Preview
 
 on:
   pull_request:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
   preview:
     name: EAS Preview
+    if: contains(github.event.pull_request.labels.*.name, '🚀 Mobile Continuous Deployment')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     permissions:
       contents: read


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow gating with no application, auth, or data-path changes.
> 
> **Overview**
> **EAS Preview** no longer runs on every pull request. The `mobile-eas-preview` workflow still listens to PR activity, but the preview job is skipped unless the PR carries the **`🚀 Mobile Continuous Deployment`** label.
> 
> The workflow now declares explicit `pull_request` types (`opened`, `reopened`, `synchronize`, `labeled`, `unlabeled`) so adding or removing that label re-triggers the workflow and the `if` condition is evaluated again—e.g. a label added after open can start a build without a new push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 191eb3d4822caaec813a13172e32343af09305c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run EAS preview job only when PR has the Mobile CD label
> The `preview` job in [mobile-eas-preview.yml](.github/workflows/mobile-eas-preview.yml) now requires the `🚀 Mobile Continuous Deployment` label to run. The workflow also adds `labeled` and `unlabeled` to its trigger events so the condition is evaluated when labels change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 191eb3d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->