### PR TITLE
[codex] Complete relay agent activity Effect cleanup

### DIFF
--- a/infra/relay/src/agentActivity/AgentActivityPublisher.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.ts
@@ -39,7 +39,7 @@ export class AgentActivityPublisher extends Context.Service<
   }
 >()("t3code-relay/agentActivity/AgentActivityPublisher") {}
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const rows = yield* AgentActivityRows.AgentActivityRows;
   const links = yield* EnvironmentLinks.EnvironmentLinks;
   const liveActivities = yield* LiveActivities.LiveActivities;

--- a/infra/relay/src/agentActivity/AgentActivityRows.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.ts
@@ -71,7 +71,7 @@ const decodeRelayAgentActivityStateJson = Schema.decodeUnknownOption(
   Schema.fromJsonString(RelayAgentActivityStateSchema),
 );
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
 
   return AgentActivityRows.of({

--- a/infra/relay/src/agentActivity/ApnsClient.ts
+++ b/infra/relay/src/agentActivity/ApnsClient.ts
@@ -40,15 +40,21 @@ export interface ApnsDeliveryResult {
   readonly apnsId: string | null;
 }
 
-export class ApnsSigningError extends Schema.TaggedErrorClass<ApnsSigningError>()(
-  "ApnsSigningError",
-  {
-    phase: Schema.Literals(["encoding", "signing"]),
-    cause: Schema.Defect(),
-  },
+export class ApnsJwtEncodingError extends Schema.TaggedErrorClass<ApnsJwtEncodingError>()(
+  "ApnsJwtEncodingError",
+  { cause: Schema.Defect() },
 ) {
   override get message(): string {
-    return `Failed during APNs JWT ${this.phase}`;
+    return "Failed to encode APNs JWT.";
+  }
+}
+
+export class ApnsJwtSigningError extends Schema.TaggedErrorClass<ApnsJwtSigningError>()(
+  "ApnsJwtSigningError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to sign APNs JWT.";
   }
 }
 
@@ -59,7 +65,7 @@ export class ApnsHttpRequestError extends Schema.TaggedErrorClass<ApnsHttpReques
   },
 ) {
   override get message(): string {
-    return "APNs HTTP request failed";
+    return "APNs HTTP request failed.";
   }
 }
 
@@ -70,11 +76,17 @@ export class ApnsInvalidResponseError extends Schema.TaggedErrorClass<ApnsInvali
   },
 ) {
   override get message(): string {
-    return "APNs returned an invalid response";
+    return "APNs returned an invalid response.";
   }
 }
 
-export type ApnsError = ApnsSigningError | ApnsHttpRequestError | ApnsInvalidResponseError;
+export const ApnsError = Schema.Union([
+  ApnsJwtEncodingError,
+  ApnsJwtSigningError,
+  ApnsHttpRequestError,
+  ApnsInvalidResponseError,
+]);
+export type ApnsError = typeof ApnsError.Type;
 
 const decodeApnsErrorResponseJson = Schema.decodeUnknownOption(
   Schema.fromJsonString(
@@ -107,12 +119,12 @@ const makeApnsJwt = Effect.fn("relay.apns.make_jwt")(function* (input: {
   readonly issuedAtUnixSeconds: number;
 }) {
   const headerJson = yield* encodeApnsJwtHeaderJson({ alg: "ES256", kid: input.keyId }).pipe(
-    Effect.mapError((cause) => new ApnsSigningError({ cause, phase: "encoding" })),
+    Effect.mapError((cause) => new ApnsJwtEncodingError({ cause })),
   );
   const payloadJson = yield* encodeApnsJwtPayloadJson({
     iss: input.teamId,
     iat: input.issuedAtUnixSeconds,
-  }).pipe(Effect.mapError((cause) => new ApnsSigningError({ cause, phase: "encoding" })));
+  }).pipe(Effect.mapError((cause) => new ApnsJwtEncodingError({ cause })));
 
   const privateKey = Redacted.value(input.privateKey);
   const header = Encoding.encodeBase64Url(headerJson);
@@ -129,7 +141,7 @@ const makeApnsJwt = Effect.fn("relay.apns.make_jwt")(function* (input: {
         });
       return `${signingInput}.${Encoding.encodeBase64Url(signature)}`;
     },
-    catch: (cause) => new ApnsSigningError({ cause, phase: "signing" }),
+    catch: (cause) => new ApnsJwtSigningError({ cause }),
   });
 });
 
@@ -251,7 +263,7 @@ export class ApnsClient extends Context.Service<
   }
 >()("t3code-relay/agentActivity/ApnsClient") {}
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const httpClient = yield* HttpClient.HttpClient;
 
   const sendLiveActivityRequest: ApnsClient["Service"]["sendLiveActivityRequest"] = Effect.fn(

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -21,9 +21,12 @@ import {
 } from "./agentActivityPayloads.ts";
 import * as Apns from "./ApnsClient.ts";
 import {
-  ApnsDeliveryJobInvalid,
+  ApnsDeliveryJobLiveActivityAggregateMissing,
+  ApnsDeliveryJobPushNotificationMissing,
+  ApnsDeliveryJobQueuePayloadInvalid,
   type ApnsNotificationPayload,
   SignedApnsDeliveryJob,
+  isApnsDeliveryJobVerificationError,
   verifySignedApnsDeliveryJob,
   type ApnsDeliveryJobVerificationError,
 } from "./apnsDeliveryJobs.ts";
@@ -91,17 +94,6 @@ const decodeRelayAgentAwarenessPreferencesJson = Schema.decodeUnknownOption(
   Schema.fromJsonString(RelayAgentAwarenessPreferencesSchema),
 );
 const decodeSignedApnsDeliveryJob = Schema.decodeUnknownEffect(SignedApnsDeliveryJob);
-
-function apnsErrorMessage(error: Apns.ApnsError): string {
-  switch (error._tag) {
-    case "ApnsSigningError":
-      return "Failed to sign APNs request.";
-    case "ApnsHttpRequestError":
-      return "Failed to send APNs request.";
-    case "ApnsInvalidResponseError":
-      return "APNs returned an invalid response.";
-  }
-}
 
 function parseAggregate(value: string | null): RelayAgentActivityAggregateState | null {
   if (!value) {
@@ -273,15 +265,6 @@ function isPermanentApnsTokenFailure(result: Apns.ApnsDeliveryResult): boolean {
   );
 }
 
-function isDeliveryJobVerificationError(value: unknown): value is ApnsDeliveryJobVerificationError {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "_tag" in value &&
-    (value._tag === "ApnsDeliveryJobInvalid" || value._tag === "ApnsDeliveryJobExpired")
-  );
-}
-
 function duplicateJobResult(input: {
   readonly deviceId: string;
   readonly kind: RelayDeliveryKind;
@@ -418,7 +401,7 @@ export class ApnsDeliveries extends Context.Service<
   }
 >()("t3code-relay/agentActivity/ApnsDeliveries") {}
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const attempts = yield* DeliveryAttempts.DeliveryAttempts;
   const liveActivities = yield* LiveActivities.LiveActivities;
   const deliveryQueue = yield* ApnsDeliveryQueue.ApnsDeliveryQueue;
@@ -497,7 +480,7 @@ const make = Effect.gen(function* () {
           Effect.succeed({
             ok: false,
             status: 0,
-            reason: apnsErrorMessage(error),
+            reason: error.message,
             apnsId: null,
           }),
         ),
@@ -614,7 +597,7 @@ const make = Effect.gen(function* () {
           Effect.succeed({
             ok: false,
             status: 0,
-            reason: apnsErrorMessage(error),
+            reason: error.message,
             apnsId: null,
           }),
         ),
@@ -657,12 +640,7 @@ const make = Effect.gen(function* () {
     "relay.apns_deliveries.process_signed_job",
   )(function* (body) {
     const signedJob = yield* decodeSignedApnsDeliveryJob(body).pipe(
-      Effect.mapError(
-        () =>
-          new ApnsDeliveryJobInvalid({
-            reason: "invalid-queue-payload",
-          }),
-      ),
+      Effect.mapError(() => new ApnsDeliveryJobQueuePayloadInvalid()),
     );
     const now = yield* DateTime.now;
     const payload = verifySignedApnsDeliveryJob({
@@ -670,7 +648,7 @@ const make = Effect.gen(function* () {
       job: signedJob,
       nowMs: now.epochMilliseconds,
     });
-    if (isDeliveryJobVerificationError(payload)) {
+    if (isApnsDeliveryJobVerificationError(payload)) {
       return yield* payload;
     }
     yield* Effect.annotateCurrentSpan({
@@ -683,11 +661,7 @@ const make = Effect.gen(function* () {
         case "live_activity_start":
         case "live_activity_update":
           if (payload.aggregate === null) {
-            return Effect.fail(
-              new ApnsDeliveryJobInvalid({
-                reason: "missing-live-activity-aggregate",
-              }),
-            );
+            return Effect.fail(new ApnsDeliveryJobLiveActivityAggregateMissing());
           }
           return sendLiveActivity({
             target: {
@@ -712,11 +686,7 @@ const make = Effect.gen(function* () {
           });
         case "push_notification":
           if (payload.notification === null) {
-            return Effect.fail(
-              new ApnsDeliveryJobInvalid({
-                reason: "missing-push-notification",
-              }),
-            );
+            return Effect.fail(new ApnsDeliveryJobPushNotificationMissing());
           }
           return sendPushNotification({
             target: {

--- a/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
@@ -59,7 +59,7 @@ export class ApnsDeliveryQueue extends Context.Service<
   }
 >()("t3code-relay/agentActivity/ApnsDeliveryQueue") {}
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const sender = yield* ApnsDeliveryQueueSender;
   const crypto = yield* Crypto.Crypto;
   const config = yield* RelayConfiguration.RelayConfiguration;

--- a/infra/relay/src/agentActivity/DeliveryAttempts.ts
+++ b/infra/relay/src/agentActivity/DeliveryAttempts.ts
@@ -82,7 +82,7 @@ function insertValues(
   };
 }
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
   const crypto = yield* Crypto.Crypto;
 

--- a/infra/relay/src/agentActivity/Devices.ts
+++ b/infra/relay/src/agentActivity/Devices.ts
@@ -57,7 +57,7 @@ export class Devices extends Context.Service<
   }
 >()("t3code-relay/agentActivity/Devices") {}
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
 
   return Devices.of({

--- a/infra/relay/src/agentActivity/LiveActivities.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.ts
@@ -106,7 +106,7 @@ const encodeRelayAgentActivityAggregateStateJson = Schema.encodeEffect(
   Schema.fromJsonString(RelayAgentActivityAggregateStateSchema),
 );
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
 
   return LiveActivities.of({

--- a/infra/relay/src/agentActivity/MobileRegistrations.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.ts
@@ -33,7 +33,7 @@ export class MobileRegistrations extends Context.Service<
   }
 >()("t3code-relay/agentActivity/MobileRegistrations") {}
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const devices = yield* Devices.Devices;
   const liveActivities = yield* LiveActivities.LiveActivities;
   const publisher = yield* AgentActivityPublisher.AgentActivityPublisher;

--- a/infra/relay/src/agentActivity/apnsDeliveryJobs.test.ts
+++ b/infra/relay/src/agentActivity/apnsDeliveryJobs.test.ts
@@ -69,7 +69,7 @@ describe("apnsDeliveryJobs", () => {
     });
 
     expect(result).toMatchObject({
-      _tag: "ApnsDeliveryJobInvalid",
+      _tag: "ApnsDeliveryJobSignatureInvalid",
     });
   });
 
@@ -93,7 +93,7 @@ describe("apnsDeliveryJobs", () => {
     });
 
     expect(result).toMatchObject({
-      _tag: "ApnsDeliveryJobInvalid",
+      _tag: "ApnsDeliveryJobLiveActivityAggregateMissing",
       message: "Live Activity start/update jobs require an aggregate.",
     });
   });
@@ -119,7 +119,7 @@ describe("apnsDeliveryJobs", () => {
     });
 
     expect(result).toMatchObject({
-      _tag: "ApnsDeliveryJobInvalid",
+      _tag: "ApnsDeliveryJobPushNotificationAggregateUnexpected",
       message: "Push notification jobs must not carry aggregate state.",
     });
   });
@@ -194,7 +194,7 @@ describe("apnsDeliveryJobs", () => {
         nowMs: 0,
       }),
     ).toMatchObject({
-      _tag: "ApnsDeliveryJobInvalid",
+      _tag: "ApnsDeliveryJobCreatedAtInvalid",
       message: "Invalid APNs delivery job creation time.",
     });
     expect(
@@ -204,7 +204,7 @@ describe("apnsDeliveryJobs", () => {
         nowMs: 0,
       }),
     ).toMatchObject({
-      _tag: "ApnsDeliveryJobInvalid",
+      _tag: "ApnsDeliveryJobTimeWindowInvalid",
       message: "Invalid APNs delivery job time window.",
     });
     expect(
@@ -214,7 +214,7 @@ describe("apnsDeliveryJobs", () => {
         nowMs: 0,
       }),
     ).toMatchObject({
-      _tag: "ApnsDeliveryJobInvalid",
+      _tag: "ApnsDeliveryJobTimeWindowTooLong",
       message: "APNs delivery job time window is too long.",
     });
   });

--- a/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
+++ b/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
@@ -49,48 +49,109 @@ export const SignedApnsDeliveryJob = Schema.Struct({
 });
 export type SignedApnsDeliveryJob = typeof SignedApnsDeliveryJob.Type;
 
-export class ApnsDeliveryJobInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobInvalid>()(
-  "ApnsDeliveryJobInvalid",
-  {
-    reason: Schema.Literals([
-      "invalid-queue-payload",
-      "missing-live-activity-aggregate",
-      "unexpected-live-activity-notification",
-      "missing-push-notification",
-      "unexpected-push-notification-aggregate",
-      "invalid-created-at",
-      "invalid-expires-at",
-      "invalid-time-window",
-      "time-window-too-long",
-      "invalid-signature",
-    ]),
-  },
+export class ApnsDeliveryJobQueuePayloadInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobQueuePayloadInvalid>()(
+  "ApnsDeliveryJobQueuePayloadInvalid",
+  {},
 ) {
   override get message(): string {
-    switch (this.reason) {
-      case "invalid-queue-payload":
-        return "Invalid APNs delivery queue job.";
-      case "missing-live-activity-aggregate":
-        return "Live Activity start/update jobs require an aggregate.";
-      case "unexpected-live-activity-notification":
-        return "Live Activity jobs must not carry push notification payloads.";
-      case "missing-push-notification":
-        return "Push notification jobs require a notification payload.";
-      case "unexpected-push-notification-aggregate":
-        return "Push notification jobs must not carry aggregate state.";
-      case "invalid-created-at":
-        return "Invalid APNs delivery job creation time.";
-      case "invalid-expires-at":
-        return "Invalid APNs delivery job expiry.";
-      case "invalid-time-window":
-        return "Invalid APNs delivery job time window.";
-      case "time-window-too-long":
-        return "APNs delivery job time window is too long.";
-      case "invalid-signature":
-        return "Invalid APNs delivery job signature.";
-    }
+    return "Invalid APNs delivery queue job.";
   }
 }
+
+export class ApnsDeliveryJobLiveActivityAggregateMissing extends Schema.TaggedErrorClass<ApnsDeliveryJobLiveActivityAggregateMissing>()(
+  "ApnsDeliveryJobLiveActivityAggregateMissing",
+  {},
+) {
+  override get message(): string {
+    return "Live Activity start/update jobs require an aggregate.";
+  }
+}
+
+export class ApnsDeliveryJobLiveActivityNotificationUnexpected extends Schema.TaggedErrorClass<ApnsDeliveryJobLiveActivityNotificationUnexpected>()(
+  "ApnsDeliveryJobLiveActivityNotificationUnexpected",
+  {},
+) {
+  override get message(): string {
+    return "Live Activity jobs must not carry push notification payloads.";
+  }
+}
+
+export class ApnsDeliveryJobPushNotificationMissing extends Schema.TaggedErrorClass<ApnsDeliveryJobPushNotificationMissing>()(
+  "ApnsDeliveryJobPushNotificationMissing",
+  {},
+) {
+  override get message(): string {
+    return "Push notification jobs require a notification payload.";
+  }
+}
+
+export class ApnsDeliveryJobPushNotificationAggregateUnexpected extends Schema.TaggedErrorClass<ApnsDeliveryJobPushNotificationAggregateUnexpected>()(
+  "ApnsDeliveryJobPushNotificationAggregateUnexpected",
+  {},
+) {
+  override get message(): string {
+    return "Push notification jobs must not carry aggregate state.";
+  }
+}
+
+export class ApnsDeliveryJobCreatedAtInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobCreatedAtInvalid>()(
+  "ApnsDeliveryJobCreatedAtInvalid",
+  {},
+) {
+  override get message(): string {
+    return "Invalid APNs delivery job creation time.";
+  }
+}
+
+export class ApnsDeliveryJobExpiresAtInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobExpiresAtInvalid>()(
+  "ApnsDeliveryJobExpiresAtInvalid",
+  {},
+) {
+  override get message(): string {
+    return "Invalid APNs delivery job expiry.";
+  }
+}
+
+export class ApnsDeliveryJobTimeWindowInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobTimeWindowInvalid>()(
+  "ApnsDeliveryJobTimeWindowInvalid",
+  {},
+) {
+  override get message(): string {
+    return "Invalid APNs delivery job time window.";
+  }
+}
+
+export class ApnsDeliveryJobTimeWindowTooLong extends Schema.TaggedErrorClass<ApnsDeliveryJobTimeWindowTooLong>()(
+  "ApnsDeliveryJobTimeWindowTooLong",
+  {},
+) {
+  override get message(): string {
+    return "APNs delivery job time window is too long.";
+  }
+}
+
+export class ApnsDeliveryJobSignatureInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobSignatureInvalid>()(
+  "ApnsDeliveryJobSignatureInvalid",
+  {},
+) {
+  override get message(): string {
+    return "Invalid APNs delivery job signature.";
+  }
+}
+
+export const ApnsDeliveryJobInvalid = Schema.Union([
+  ApnsDeliveryJobQueuePayloadInvalid,
+  ApnsDeliveryJobLiveActivityAggregateMissing,
+  ApnsDeliveryJobLiveActivityNotificationUnexpected,
+  ApnsDeliveryJobPushNotificationMissing,
+  ApnsDeliveryJobPushNotificationAggregateUnexpected,
+  ApnsDeliveryJobCreatedAtInvalid,
+  ApnsDeliveryJobExpiresAtInvalid,
+  ApnsDeliveryJobTimeWindowInvalid,
+  ApnsDeliveryJobTimeWindowTooLong,
+  ApnsDeliveryJobSignatureInvalid,
+]);
+export type ApnsDeliveryJobInvalid = typeof ApnsDeliveryJobInvalid.Type;
 
 export class ApnsDeliveryJobExpired extends Schema.TaggedErrorClass<ApnsDeliveryJobExpired>()(
   "ApnsDeliveryJobExpired",
@@ -103,7 +164,13 @@ export class ApnsDeliveryJobExpired extends Schema.TaggedErrorClass<ApnsDelivery
   }
 }
 
-export type ApnsDeliveryJobVerificationError = ApnsDeliveryJobInvalid | ApnsDeliveryJobExpired;
+export const ApnsDeliveryJobVerificationError = Schema.Union([
+  ApnsDeliveryJobInvalid,
+  ApnsDeliveryJobExpired,
+]);
+export type ApnsDeliveryJobVerificationError = typeof ApnsDeliveryJobVerificationError.Type;
+
+export const isApnsDeliveryJobVerificationError = Schema.is(ApnsDeliveryJobVerificationError);
 
 export function makeApnsDeliveryJobPayload(input: {
   readonly kind: RelayDeliveryKind;
@@ -141,33 +208,23 @@ function validatePayloadShape(payload: ApnsDeliveryJobPayload): ApnsDeliveryJobI
     case "live_activity_start":
     case "live_activity_update":
       if (payload.aggregate === null) {
-        return new ApnsDeliveryJobInvalid({
-          reason: "missing-live-activity-aggregate",
-        });
+        return new ApnsDeliveryJobLiveActivityAggregateMissing();
       }
       if (payload.notification !== null) {
-        return new ApnsDeliveryJobInvalid({
-          reason: "unexpected-live-activity-notification",
-        });
+        return new ApnsDeliveryJobLiveActivityNotificationUnexpected();
       }
       return null;
     case "live_activity_end":
       if (payload.notification !== null) {
-        return new ApnsDeliveryJobInvalid({
-          reason: "unexpected-live-activity-notification",
-        });
+        return new ApnsDeliveryJobLiveActivityNotificationUnexpected();
       }
       return null;
     case "push_notification":
       if (payload.notification === null) {
-        return new ApnsDeliveryJobInvalid({
-          reason: "missing-push-notification",
-        });
+        return new ApnsDeliveryJobPushNotificationMissing();
       }
       if (payload.aggregate !== null) {
-        return new ApnsDeliveryJobInvalid({
-          reason: "unexpected-push-notification-aggregate",
-        });
+        return new ApnsDeliveryJobPushNotificationAggregateUnexpected();
       }
       return null;
   }
@@ -213,19 +270,19 @@ export function verifySignedApnsDeliveryJob(input: {
   }
   const createdAt = DateTime.make(input.job.payload.createdAt);
   if (Option.isNone(createdAt)) {
-    return new ApnsDeliveryJobInvalid({ reason: "invalid-created-at" });
+    return new ApnsDeliveryJobCreatedAtInvalid();
   }
   const expiresAt = DateTime.make(input.job.payload.expiresAt);
   if (Option.isNone(expiresAt)) {
-    return new ApnsDeliveryJobInvalid({ reason: "invalid-expires-at" });
+    return new ApnsDeliveryJobExpiresAtInvalid();
   }
   const createdAtMs = createdAt.value.epochMilliseconds;
   const expiresAtMs = expiresAt.value.epochMilliseconds;
   if (expiresAtMs <= createdAtMs) {
-    return new ApnsDeliveryJobInvalid({ reason: "invalid-time-window" });
+    return new ApnsDeliveryJobTimeWindowInvalid();
   }
   if (expiresAtMs - createdAtMs > MAX_JOB_AGE_MS) {
-    return new ApnsDeliveryJobInvalid({ reason: "time-window-too-long" });
+    return new ApnsDeliveryJobTimeWindowTooLong();
   }
   if (expiresAtMs <= input.nowMs) {
     return new ApnsDeliveryJobExpired({ expiresAt: input.job.payload.expiresAt });
@@ -235,7 +292,7 @@ export function verifySignedApnsDeliveryJob(input: {
     payload: input.job.payload,
   });
   if (!timingSafeEqualBase64Url(input.job.signature, expected)) {
-    return new ApnsDeliveryJobInvalid({ reason: "invalid-signature" });
+    return new ApnsDeliveryJobSignatureInvalid();
   }
   return input.job.payload;
 }

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -777,18 +777,17 @@ export const serverApi = HttpApiBuilder.group(
               reason: "persistence_failed",
               traceId,
             }),
-          ApnsDeliveryJobInvalid: (_error, traceId) =>
-            new RelayInternalError({
-              code: "internal_error",
-              reason: "internal_error",
-              traceId,
-            }),
-          ApnsDeliveryJobExpired: (_error, traceId) =>
-            new RelayInternalError({
-              code: "internal_error",
-              reason: "internal_error",
-              traceId,
-            }),
+          ApnsDeliveryJobQueuePayloadInvalid: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobLiveActivityAggregateMissing: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobLiveActivityNotificationUnexpected: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobPushNotificationMissing: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobPushNotificationAggregateUnexpected: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobCreatedAtInvalid: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobExpiresAtInvalid: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobTimeWindowInvalid: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobTimeWindowTooLong: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobSignatureInvalid: mapApnsDeliveryJobInternalError,
+          ApnsDeliveryJobExpired: mapApnsDeliveryJobInternalError,
           ApnsDeliveryJobClaimInFlight: (_error, traceId) =>
             new RelayInternalError({
               code: "internal_error",
@@ -891,6 +890,14 @@ function mapRelayCommonApiErrors(authReason: RelayAuthInvalidReason) {
   return <A, E, R>(
     effect: Effect.Effect<A, E, R>,
   ): Effect.Effect<A, MapRelayCommonApiError<E>, R> => effect.pipe(Effect.catch(mapError));
+}
+
+function mapApnsDeliveryJobInternalError(_error: unknown, traceId: string) {
+  return new RelayInternalError({
+    code: "internal_error",
+    reason: "internal_error",
+    traceId,
+  });
 }
 
 type TaggedErrorTag<E> = Extract<E, { readonly _tag: string }>["_tag"];


### PR DESCRIPTION
## Summary

- export the real make value from each relay agent-activity service module
- split APNs signing and delivery verification failures into concrete schema errors
- expose schema unions and inferred predicates for grouped error handling

## Validation

- vp test infra/relay/src/agentActivity infra/relay/src/http/Api.test.ts (56 tests)
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signed APNs delivery-job verification and publish-path error mapping in mobile push infrastructure; behavior should be equivalent but error tags and API mapping changed across many call sites.
> 
> **Overview**
> This PR **refactors relay agent-activity Effect services** so each module’s layer factory is an **`export const make`**, and it **replaces coarse tagged errors with concrete Schema error types** for APNs signing and signed delivery-job verification.
> 
> **APNs client errors** split `ApnsSigningError` (encoding vs signing via `phase`) into **`ApnsJwtEncodingError`** and **`ApnsJwtSigningError`**, with **`ApnsError`** as a `Schema.Union`. **`ApnsDeliveries`** drops the manual `apnsErrorMessage` switch and uses **`error.message`** when transport failures are caught into delivery results.
> 
> **Signed queue jobs** replace a single **`ApnsDeliveryJobInvalid`** with `reason` literals by **one tagged class per failure** (payload shape, timestamps, signature, etc.), plus **`ApnsDeliveryJobInvalid`** / **`ApnsDeliveryJobVerificationError`** unions and **`isApnsDeliveryJobVerificationError`** from `Schema.is`. Tests and **`processSignedJob`** / **`verifySignedApnsDeliveryJob`** use the new `_tag` values.
> 
> **HTTP API** maps each new delivery-job verification tag through shared **`mapApnsDeliveryJobInternalError`** on the publish-agent-activity route instead of only the old invalid/expired pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 323d31cdb972a5df1855b8b761f2eac1dd145d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refine APNs delivery job error types in relay agent activity module
> - Replaces the single generic `ApnsDeliveryJobInvalid` error with a set of specific tagged error classes (e.g. `ApnsDeliveryJobSignatureInvalid`, `ApnsDeliveryJobLiveActivityAggregateMissing`, `ApnsDeliveryJobTimeWindowTooLong`) defined via `Schema.Union` in [apnsDeliveryJobs.ts](https://github.com/pingdotgg/t3code/pull/3210/files#diff-5f124fac34224b75c7c5b17f3fcb5d9e2c9b2d881e478aab85953346e58e5fbc).
> - Splits the previous `ApnsSigningError` in [ApnsClient.ts](https://github.com/pingdotgg/t3code/pull/3210/files#diff-82639ee23f151886bc577cd1def586205d54b4910ed581af8c0f7ff714e260ed) into two distinct errors: `ApnsJwtEncodingError` and `ApnsJwtSigningError`.
> - Updates [ApnsDeliveries.ts](https://github.com/pingdotgg/t3code/pull/3210/files#diff-b5f76b7b901b1e00d834ecfbecbc61c1b181e71f588fb216a5c94d753dca03e6) to use the new specific error classes and derive failure reasons directly from `error.message` rather than a local mapping function.
> - Exports `make` factory functions from all `agentActivity` modules to support direct named imports.
> - Updates [Api.ts](https://github.com/pingdotgg/t3code/pull/3210/files#diff-3d5eba18078d78073bb4006f100be6945ab735705ffea2653230814ae0597055) to map all specific `ApnsDeliveryJob*` error tags uniformly via a new `mapApnsDeliveryJobInternalError` helper; the resulting `RelayInternalError` shape is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 323d31c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->