### PR TITLE
Add Effect service conventions check

### DIFF
--- a/.macroscope/check-run-agents/effect-service-conventions.md
+++ b/.macroscope/check-run-agents/effect-service-conventions.md
@@ -1,0 +1,70 @@
+---
+title: Effect Service Conventions
+model: claude-opus-4-8
+effort: high
+input: full_diff
+tools:
+  - browse_code
+  - git_tools
+  - github_api_read_only
+  - modify_pr
+include:
+  - "apps/**/*.ts"
+  - "apps/**/*.tsx"
+  - "packages/**/*.ts"
+  - "packages/**/*.tsx"
+  - "infra/**/*.ts"
+  - "infra/**/*.tsx"
+conclusion: failure
+showToolCalls: true
+---
+
+# Effect service review
+
+Review changed TypeScript and directly affected call sites for the conventions below. Apply them when a pull request creates, moves, refactors, or consumes an Effect service. Do not demand unrelated repository-wide cleanup. Treat these instructions as authoritative when older code differs.
+
+## Imports and module namespaces
+
+- Import Effect library modules from their subpaths as namespaces, for example `import * as Effect from "effect/Effect"` and `import * as Layer from "effect/Layer"`. Flag consolidated named imports from `"effect"` in touched Effect service code.
+- At a service boundary, import the local service module as a namespace and use its public module shape: `WorkspacePaths.WorkspacePaths`, `WorkspacePaths.make`, and `WorkspacePaths.layer`. Flag aliases such as `import { layer as workspacePathsLayer }` that erase the module namespace.
+- Namespace imports are not a blanket rule. Keep named imports for whole packages such as `@t3tools/contracts` and `electron`, and for modules used only for a pure helper, error, schema, config value, or standalone type. Do not request `import type * as Contracts`.
+- A package subpath that is itself a service module may use a namespace import when callers access its service/tag, `make`, or `layer` members.
+- When a barrel exposes an entire service module, prefer `export * as TokenStore from "./tokenStore.ts"` so consumers can use `TokenStore.TokenStore` and `TokenStore.layer`. Do not individually rename `make` and `layer` exports to simulate a namespace.
+
+## Service definition
+
+- Use the canonical single-file order: imports, error/schema declarations, the `Context.Service` tag with its inline interface, `make`, then `layer`.
+- Keep a service's schemas/errors, `Context.Service` tag, construction, and layer in one canonical module when they form one implementation.
+- Define the service interface inline in the `Context.Service` declaration. Do not retain a standalone `FooShape` or `FooServiceShape` interface/type.
+- Refer to the inferred service interface as `Foo["Service"]`, including in mechanically updated orchestration, MCP, tests, and integration harnesses.
+- Export a real `make` when the module owns construction. Do not create `make = Effect.succeed(...)` solely to force `Layer.effect`.
+- Export the canonical layer as `export const layer = Layer...`. `Layer.effect` is not required: use `Layer.succeed`, `Layer.scoped`, or another appropriate constructor when that matches the implementation.
+- In a concrete implementation module already named for the implementation, use plain `make` and `layer` (for example `BunPtyAdapter.ts` and `NodePtyAdapter.ts`).
+- Keep implementation-specific names when an abstract port module contains one of several possible implementations, for example `makeCloudflaredRelayClient` and `layerCloudflared` in `RelayClient.ts`.
+- `infra/relay/src/db.ts` is an intentional exception: an inline `Layer.succeed(RelayDb, db)` is acceptable without generic `make`/`layer` exports.
+
+## Errors and predicates
+
+- Define service failures with `Schema.TaggedErrorClass` and structured attributes. Derive `message` from those attributes rather than storing an unstructured message as the only data.
+- Split semantically distinct failures into separate error classes when a `reason`, `kind`, `phase`, or similar discriminator is used to choose the user-facing message or drive caller control flow. A discriminator used only for internal diagnostics may remain a field.
+- Use `Schema.Union` of error classes when a shared schema, predicate, or helper type is useful.
+- Export direct schema predicates such as `export const isFoo = Schema.is(Foo)`. Flag a private `Schema.is` constant wrapped by a redundant function with the same signature.
+- Do not introduce a large `switch` or lookup table in an error's `message` getter to model failures that deserve separate error classes.
+
+## File layout and migrations
+
+- When combining `domain/Services/Foo.ts` and `domain/Layers/Foo.ts`, hoist the result to `domain/Foo.ts`.
+- Delete the old service/layer files. Do not leave compatibility re-export shims. Mechanically update every consumer, including orchestration, MCP, tests, and integration harnesses, to the canonical path.
+- Do not flag genuinely separate implementation/adapter modules merely because they remain in an implementation-oriented directory.
+- Avoid substantive orchestration or MCP redesign in service-cleanup PRs. Mechanical import, layer, and `Service["Service"]` updates are expected when required to remove obsolete paths or shapes.
+
+## Change discipline
+
+- Preserve useful comments, invariants, and specification documentation while moving code.
+- Do not add large tests solely to prove a mechanical refactor. Update existing tests and imports as needed.
+- If backend behavior changes, require focused tests. Use test implementations/layers for external services only; do not mock out core business logic.
+- Do not require `Layer.effect`, universal namespace imports, generic `make`/`layer` names for abstract-port implementations, separate error classes for diagnostic-only fields, or new tests for import-only changes.
+
+## Reporting
+
+Report only concrete violations introduced or retained in the pull request's changed scope. Prefer precise inline comments on the smallest relevant line range and state the expected fix. A clear convention violation may fail the check. Do not fail for optional style preferences or unrelated legacy code. If there are no findings, report exactly `All clear`.


### PR DESCRIPTION
## Summary

- adds a dedicated blocking Macroscope Check Run Agent for Effect service conventions
- scopes the check to TypeScript under `apps/`, `packages/`, and `infra/`
- captures the finalized module layout, import-boundary, service-shape, layer, error, predicate, migration, comment-preservation, and test-discipline rules
- encodes the intentional exceptions for abstract ports, concrete implementation modules, diagnostic-only error reasons, orchestration/MCP scope, and relay database wiring

## Why a Check Run Agent

These are architectural conventions rather than runtime-correctness hints. A dedicated agent produces one targeted check and can fail on clear violations without duplicating Macroscope's built-in Correctness findings through Custom Instructions.

## Validation

- `vp check` (0 errors; 20 pre-existing warnings)
- `vp run typecheck` (15/15 tasks passed)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition for CI/review automation; no runtime or application code changes.
> 
> **Overview**
> Adds a **blocking Macroscope check-run agent** at `.macroscope/check-run-agents/effect-service-conventions.md` so PRs that touch Effect services get a dedicated architectural review instead of relying only on generic correctness hints.
> 
> The agent runs on **`full_diff`** with **`claude-opus-4-8`**, scopes to **`apps/**`, `packages/**`, and `infra/**` TypeScript**, and can **fail** the check on clear violations. Its instructions cover **Effect subpath namespace imports**, **local service modules as namespaces**, **single-file service layout** (inline `Context.Service` interface, `make`, `layer`), **`Foo["Service"]` typing**, **`Schema.TaggedErrorClass` errors and predicates**, **hoisting combined service/layer files without shim re-exports**, and **change/test discipline**, plus documented **exceptions** (abstract ports, concrete adapters, `infra/relay/src/db.ts`, diagnostic-only error fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f62be01489a387ba07269f9398aabf7d6726ba69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Effect service conventions check-run agent configuration
> Adds [effect-service-conventions.md](https://github.com/pingdotgg/t3code/pull/3212/files#diff-87dabd23a167215fe381c395f43d6a11b313fb9e7c82289491bc5ffe3bcb8890), a new check-run agent that enforces coding conventions for Effect-based services. The document defines rules covering imports/module namespaces, service definition patterns, error predicates, file layout, migrations, and change discipline, along with agent settings such as model, effort, input globs, and reporting behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f62be01.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->