### PR TITLE
Tighten structural Effect error checks

### DIFF
--- a/.macroscope/check-run-agents/effect-service-conventions.md
+++ b/.macroscope/check-run-agents/effect-service-conventions.md
@@ -46,6 +46,9 @@ Review changed TypeScript and directly affected call sites for the conventions b
 ## Errors and predicates
 
 - Define service failures with `Schema.TaggedErrorClass` and structured attributes. Derive `message` from those attributes rather than storing an unstructured message as the only data.
+- `Schema.Defect()` is not a substitute for modeling an error. Flag error classes whose only meaningful field is `cause`, or whose `message` merely stringifies an opaque cause.
+- Capture stable, serializable domain context such as the operation or stage, resource/path or entity identifier, normalized category/status, and a useful detail. Map failures where that context is known instead of wrapping an entire multi-step pipeline in one generic error.
+- Preserve a real underlying `cause` only when it adds diagnostic value, and make it optional supplemental data alongside the structural fields. Never manufacture an `Error` or opaque defect merely to populate `cause`, and do not erase structured upstream errors into `Schema.Defect()`.
 - Split semantically distinct failures into separate error classes when a `reason`, `kind`, `phase`, or similar discriminator is used to choose the user-facing message or drive caller control flow. A discriminator used only for internal diagnostics may remain a field.
 - Use `Schema.Union` of error classes when a shared schema, predicate, or helper type is useful.
 - Export direct schema predicates such as `export const isFoo = Schema.is(Foo)`. Flag a private `Schema.is` constant wrapped by a redundant function with the same signature.


### PR DESCRIPTION
## Summary

- teach the Effect service check to flag cause-only `Schema.Defect()` errors
- require stable, serializable domain context and failure-site mapping
- preserve genuine underlying causes only as supplemental diagnostics

## Why

PR #3188 exposed a mechanical refactor pattern that replaced typed failures with opaque defects. The check now enforces structural error modeling instead of accepting an artificial `cause` field.

## Validation

- `vp check`
- `vp run typecheck`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a check-run agent; no runtime or application code is modified.
> 
> **Overview**
> Extends the **Effect service conventions** check agent (`.macroscope/check-run-agents/effect-service-conventions.md`) so reviewers flag weak error modeling, not just missing `TaggedErrorClass` usage.
> 
> New **Errors and predicates** rules require flagging `Schema.Defect()`-style errors that only carry an opaque `cause`, insist on **stable serializable domain context** (operation, resource, category, detail) mapped at the failure site, and clarify that real `cause` values are **optional diagnostics**—not manufactured defects and not a replacement for structured upstream errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c46afb5a3579a178d2748932ee5aa34c24c29396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Tighten error modeling guidance in Effect service conventions
> Adds three bullet points to the 'Errors and predicates' section of [effect-service-conventions.md](.macroscope/check-run-agents/effect-service-conventions.md) to clarify correct error modeling:
> - Clarifies that `Schema.Defect` is not a substitute for structured error classes
> - Instructs capturing stable, serializable domain context and mapping failures where context is known
> - Advises preserving an underlying cause only when diagnostically useful, and avoiding erasing structured upstream errors into `Schema.Defect`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c46afb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->