### PR TITLE
Cosmetic fix: Sync web title with nightly server branding

### DIFF
--- a/apps/web/src/branding.logic.ts
+++ b/apps/web/src/branding.logic.ts
@@ -1,0 +1,34 @@
+const NIGHTLY_SERVER_VERSION_PATTERN = /-nightly\.\d{8}\.\d+$/;
+
+export function formatAppDisplayName(input: {
+  readonly baseName: string;
+  readonly stageLabel: string;
+}): string {
+  return `${input.baseName} (${input.stageLabel})`;
+}
+
+export function resolveServerBackedAppStageLabel(input: {
+  readonly primaryServerVersion: string | null | undefined;
+  readonly fallbackStageLabel: string;
+}): string {
+  return input.primaryServerVersion &&
+    NIGHTLY_SERVER_VERSION_PATTERN.test(input.primaryServerVersion)
+    ? "Nightly"
+    : input.fallbackStageLabel;
+}
+
+export function resolveServerBackedAppDisplayName(input: {
+  readonly baseName: string;
+  readonly fallbackDisplayName: string;
+  readonly fallbackStageLabel: string;
+  readonly primaryServerVersion: string | null | undefined;
+}): string {
+  const stageLabel = resolveServerBackedAppStageLabel({
+    primaryServerVersion: input.primaryServerVersion,
+    fallbackStageLabel: input.fallbackStageLabel,
+  });
+
+  return stageLabel === input.fallbackStageLabel
+    ? input.fallbackDisplayName
+    : formatAppDisplayName({ baseName: input.baseName, stageLabel });
+}

--- a/apps/web/src/branding.test.ts
+++ b/apps/web/src/branding.test.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  resolveServerBackedAppDisplayName,
+  resolveServerBackedAppStageLabel,
+} from "./branding.logic";
 
 const originalWindow = globalThis.window;
 
@@ -53,5 +57,49 @@ describe("branding", () => {
 
     expect(branding.HOSTED_APP_CHANNEL).toBeNull();
     expect(branding.HOSTED_APP_CHANNEL_LABEL).toBeNull();
+  });
+});
+
+describe("branding logic", () => {
+  it("returns Nightly for nightly primary server versions", () => {
+    expect(
+      resolveServerBackedAppStageLabel({
+        primaryServerVersion: "0.0.28-nightly.20260616.12",
+        fallbackStageLabel: "Alpha",
+      }),
+    ).toBe("Nightly");
+  });
+
+  it("updates the display name for nightly primary server versions", () => {
+    expect(
+      resolveServerBackedAppDisplayName({
+        baseName: "T3 Code",
+        fallbackDisplayName: "T3 Code (Alpha)",
+        fallbackStageLabel: "Alpha",
+        primaryServerVersion: "0.0.28-nightly.20260616.12",
+      }),
+    ).toBe("T3 Code (Nightly)");
+  });
+
+  it("keeps the fallback display name for stable primary server versions", () => {
+    expect(
+      resolveServerBackedAppDisplayName({
+        baseName: "T3 Code",
+        fallbackDisplayName: "T3 Code (Alpha)",
+        fallbackStageLabel: "Alpha",
+        primaryServerVersion: "0.0.27",
+      }),
+    ).toBe("T3 Code (Alpha)");
+  });
+
+  it("keeps the fallback display name for malformed nightly primary server versions", () => {
+    expect(
+      resolveServerBackedAppDisplayName({
+        baseName: "T3 Code",
+        fallbackDisplayName: "T3 Code (Alpha)",
+        fallbackStageLabel: "Alpha",
+        primaryServerVersion: "0.0.28-nightly.20260616",
+      }),
+    ).toBe("T3 Code (Alpha)");
   });
 });

--- a/apps/web/src/branding.ts
+++ b/apps/web/src/branding.ts
@@ -1,4 +1,5 @@
 import type { DesktopAppBranding } from "@t3tools/contracts";
+import { formatAppDisplayName } from "./branding.logic";
 
 function readInjectedDesktopAppBranding(): DesktopAppBranding | null {
   if (typeof window === "undefined") {
@@ -21,5 +22,6 @@ export const APP_STAGE_LABEL =
   HOSTED_APP_CHANNEL_LABEL ??
   (import.meta.env.DEV ? "Dev" : "Alpha");
 export const APP_DISPLAY_NAME =
-  injectedDesktopAppBranding?.displayName ?? `${APP_BASE_NAME} (${APP_STAGE_LABEL})`;
+  injectedDesktopAppBranding?.displayName ??
+  formatAppDisplayName({ baseName: APP_BASE_NAME, stageLabel: APP_STAGE_LABEL });
 export const APP_VERSION = import.meta.env.APP_VERSION || "0.0.0";

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -9,10 +9,10 @@ import {
 import type { SidebarThreadSummary, Thread } from "../types";
 import { cn } from "../lib/utils";
 import { isLatestTurnSettled } from "../session-logic";
+import { resolveServerBackedAppStageLabel } from "../branding.logic";
 
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
-const NIGHTLY_SERVER_VERSION_PATTERN = /-nightly\.\d{8}\.\d+$/;
 // Visible sidebar rows are prewarmed into the thread-detail cache so opening a
 // nearby thread usually reuses an already-hot subscription.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
@@ -69,10 +69,7 @@ export function resolveSidebarStageBadgeLabel(input: {
   primaryServerVersion: string | null | undefined;
   fallbackStageLabel: string;
 }): string {
-  return input.primaryServerVersion &&
-    NIGHTLY_SERVER_VERSION_PATTERN.test(input.primaryServerVersion)
-    ? "Nightly"
-    : input.fallbackStageLabel;
+  return resolveServerBackedAppStageLabel(input);
 }
 
 export function createThreadJumpHintVisibilityController(input: {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -15,7 +15,6 @@ import { isElectron } from "./env";
 import { ManagedRelayAuthProvider } from "./cloud/managedAuth";
 import { hasCloudPublicConfig } from "./cloud/publicConfig";
 import { getRouter } from "./router";
-import { APP_DISPLAY_NAME } from "./branding";
 import { syncDocumentWindowControlsOverlayClass } from "./lib/windowControlsOverlay";
 import { AppRoot } from "./AppRoot";
 
@@ -27,8 +26,6 @@ const router = getRouter(history);
 if (isElectron) {
   syncDocumentWindowControlsOverlayClass();
 }
-
-document.title = APP_DISPLAY_NAME;
 
 const clerkPublishableKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined;
 

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -10,7 +10,8 @@ import {
 } from "@tanstack/react-router";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
-import { APP_DISPLAY_NAME } from "../branding";
+import { APP_BASE_NAME, APP_DISPLAY_NAME, APP_STAGE_LABEL } from "../branding";
+import { resolveServerBackedAppDisplayName } from "../branding.logic";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
 import { RelayClientInstallDialog } from "../components/cloud/RelayClientInstallDialog";
@@ -96,11 +97,21 @@ function RootRouteView() {
   }, [pathname]);
 
   if (pathname === "/pair") {
-    return <Outlet />;
+    return (
+      <>
+        <DocumentTitleSync />
+        <Outlet />
+      </>
+    );
   }
 
   if (authGateState.status !== "authenticated" && authGateState.status !== "hosted-static") {
-    return <Outlet />;
+    return (
+      <>
+        <DocumentTitleSync />
+        <Outlet />
+      </>
+    );
   }
 
   const appShell = (
@@ -114,6 +125,7 @@ function RootRouteView() {
   return (
     <ToastProvider>
       <AnchoredToastProvider>
+        <DocumentTitleSync />
         {primaryEnvironmentAuthenticated ? <AuthenticatedTracingBootstrap /> : null}
         <RelayClientInstallDialog />
         <SshPasswordPromptDialog />
@@ -125,6 +137,23 @@ function RootRouteView() {
       </AnchoredToastProvider>
     </ToastProvider>
   );
+}
+
+function DocumentTitleSync() {
+  const primaryServerVersion =
+    useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
+  const title = resolveServerBackedAppDisplayName({
+    baseName: APP_BASE_NAME,
+    fallbackDisplayName: APP_DISPLAY_NAME,
+    fallbackStageLabel: APP_STAGE_LABEL,
+    primaryServerVersion,
+  });
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+
+  return null;
 }
 
 function HostedStaticEnvironmentBootstrap() {


### PR DESCRIPTION
## Summary

- sync the loaded web document title with the primary server stage label
- share nightly-version detection between the sidebar badge and title branding path
- preserve existing stable, dev, hosted-channel, and desktop-injected branding fallbacks

## Why

PR #3103 fixed the sidebar badge, but the browser tab title still used the static app display name initialized before primary server config arrives.

## Impact

Nightly web sessions show `T3 Code (Nightly)` in the browser tab after the primary server config is available. Stable and malformed versions keep the existing fallback title.

## Validation

- `vp test run apps/web/src/components/Sidebar.logic.test.ts apps/web/src/branding.test.ts`
- `vp check`
- `vp run typecheck`

`vp check` reports the repository's existing unrelated warnings and no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic branding only; no auth, data, or routing behavior changes beyond when the tab title updates.
> 
> **Overview**
> **Browser tab title** now updates when primary server config loads, using the same nightly-version rules as the sidebar stage badge.
> 
> Shared helpers in `branding.logic.ts` (`resolveServerBackedAppStageLabel`, `resolveServerBackedAppDisplayName`) centralize the `-nightly.YYYYMMDD.N` check. The sidebar badge delegates to that module instead of duplicating the regex. Static `document.title` assignment in `main.tsx` is removed; `DocumentTitleSync` in the root route sets `document.title` from `primaryServerConfigAtom`, falling back to existing desktop, hosted-channel, and dev/alpha branding when the server is stable or the version string is malformed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da10df6462e79d197888cfdaac5365660efdb50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sync web document title with nightly server branding reactively
> - Adds `DocumentTitleSync` in [`__root.tsx`](https://github.com/pingdotgg/t3code/pull/3219/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) to update `document.title` reactively on all route paths, replacing the one-time set in [`main.tsx`](https://github.com/pingdotgg/t3code/pull/3219/files#diff-44decff659436a16ccdaaae62e456cd52d9f206c8628c8ca4447aa268c85e16b).
> - Adds `resolveServerBackedAppDisplayName` and `resolveServerBackedAppStageLabel` in [`branding.logic.ts`](https://github.com/pingdotgg/t3code/pull/3219/files#diff-a77577502cdf9da372ba72b213b865343ec8fd9f2f232b5339202241917f3551) to detect nightly server versions via a version pattern and produce a matching display name (e.g. `App (Nightly)`).
> - Consolidates the nightly version pattern into `branding.logic.ts`, removing the duplicate from [`Sidebar.logic.ts`](https://github.com/pingdotgg/t3code/pull/3219/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8da10df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->