### PR TITLE
[codex] Close right panel when its last tab closes

### DIFF
--- a/apps/web/src/rightPanelStore.test.ts
+++ b/apps/web/src/rightPanelStore.test.ts
@@ -338,12 +338,12 @@ describe("rightPanelStore", () => {
     });
   });
 
-  it("closing the final terminal pane removes its surface but keeps the panel open", () => {
+  it("closing the final terminal pane removes its surface and closes the panel", () => {
     useRightPanelStore.getState().openTerminal(refA, "term-1");
     useRightPanelStore.getState().closeTerminal(refA, "terminal:term-1", "term-1");
 
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
-      isOpen: true,
+      isOpen: false,
       activeSurfaceId: null,
       surfaces: [],
     });
@@ -359,12 +359,12 @@ describe("rightPanelStore", () => {
     );
   });
 
-  it("closing the final surface leaves the panel open and empty", () => {
+  it("closing the final surface closes the panel", () => {
     useRightPanelStore.getState().openTerminal(refA, "term-1");
     useRightPanelStore.getState().closeSurface(refA, "terminal:term-1");
 
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
-      isOpen: true,
+      isOpen: false,
       activeSurfaceId: null,
       surfaces: [],
     });
@@ -406,14 +406,14 @@ describe("rightPanelStore", () => {
     });
   });
 
-  it("closing all surfaces leaves the panel open and empty", () => {
+  it("closing all surfaces closes the panel", () => {
     useRightPanelStore.getState().openBrowser(refA, "tab-a");
     useRightPanelStore.getState().openFile(refA, "src/index.ts");
 
     useRightPanelStore.getState().closeAllSurfaces(refA);
 
     expect(selectThreadRightPanelState(useRightPanelStore.getState().byThreadKey, refA)).toEqual({
-      isOpen: true,
+      isOpen: false,
       activeSurfaceId: null,
       surfaces: [],
     });

--- a/apps/web/src/rightPanelStore.ts
+++ b/apps/web/src/rightPanelStore.ts
@@ -340,6 +340,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
               const fallback = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
               return {
                 ...current,
+                isOpen: surfaces.length > 0 && current.isOpen,
                 surfaces,
                 activeSurfaceId:
                   current.activeSurfaceId === surfaceId
@@ -378,9 +379,16 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
             const index = current.surfaces.findIndex((surface) => surface.id === surfaceId);
             if (index < 0) return current;
             const surfaces = current.surfaces.filter((surface) => surface.id !== surfaceId);
-            if (current.activeSurfaceId !== surfaceId) return { ...current, surfaces };
+            if (current.activeSurfaceId !== surfaceId) {
+              return { ...current, isOpen: surfaces.length > 0 && current.isOpen, surfaces };
+            }
             const fallback = surfaces[Math.min(index, surfaces.length - 1)] ?? null;
-            return { ...current, surfaces, activeSurfaceId: fallback?.id ?? null };
+            return {
+              ...current,
+              isOpen: surfaces.length > 0 && current.isOpen,
+              surfaces,
+              activeSurfaceId: fallback?.id ?? null,
+            };
           }),
         })),
       closeOtherSurfaces: (ref, surfaceId) =>
@@ -417,7 +425,7 @@ export const useRightPanelStore = create<RightPanelStoreState>()(
           byThreadKey: updateThread(state.byThreadKey, scopedThreadKey(ref), (current) =>
             current.surfaces.length === 0
               ? current
-              : { ...current, isOpen: true, surfaces: [], activeSurfaceId: null },
+              : { ...current, isOpen: false, surfaces: [], activeSurfaceId: null },
           ),
         })),
       reconcileBrowserSurfaces: (ref, tabIds) =>


### PR DESCRIPTION
## Summary

- close the right panel when its final surface is removed
- apply the same behavior when closing the final terminal pane or using Close All
- preserve neighboring-tab activation while other surfaces remain

## Root cause

Surface-removal actions cleared `activeSurfaceId` but left `isOpen` set to `true`, which rendered an empty right panel after the last tab closed.

## User impact

Closing the last tab now dismisses the right panel instead of leaving an empty panel visible.

## Validation

- `vp test apps/web/src/rightPanelStore.test.ts` (26 tests)
- `vp check`
- `vp run typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Close the right panel when its last tab or surface is removed
> Previously, the right panel stayed open even after all surfaces or terminal panes were closed. Three handlers in [rightPanelStore.ts](https://github.com/pingdotgg/t3code/pull/3221/files#diff-c23667fc6a40049fa00d6fba14ae4a097ed3561fcdfb9ec172bc8216cd9f82eb) are updated to set `isOpen` to `false` when no surfaces remain: `closeTerminal`, `closeSurface`, and `closeAllSurfaces`. Behavioral Change: the right panel now auto-closes when emptied, whereas before it remained open with no content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7295f63.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI state in the right-panel Zustand store with updated unit tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes a bug where **closing the last right-panel tab** left an **empty panel** visible because `isOpen` stayed `true` after surfaces were cleared.
> 
> `closeTerminal` (when the final pane removes the surface), `closeSurface`, and `closeAllSurfaces` in `rightPanelStore.ts` now set **`isOpen` to `false`** when no surfaces remain (`surfaces.length === 0`). Closing a non-active surface also applies the same rule so the panel does not stay open after the last tab is gone. **Neighboring-tab activation** when other surfaces remain is unchanged.
> 
> Tests in `rightPanelStore.test.ts` expect `isOpen: false` for the last terminal pane, last surface, and close-all flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7295f6394a45b974db69e59be7c6ea363e4569ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->