### PR TITLE
[fix/feat:ui] Use shared button for model favorites

### DIFF
--- a/apps/web/src/components/chat/ModelListRow.tsx
+++ b/apps/web/src/components/chat/ModelListRow.tsx
@@ -8,6 +8,7 @@ import {
   PROVIDER_ICON_BY_PROVIDER,
 } from "./providerIconUtils";
 import { ComboboxItem } from "../ui/combobox";
+import { Button } from "../ui/button";
 import { Kbd } from "../ui/kbd";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import { cn } from "~/lib/utils";
@@ -92,9 +93,11 @@ export const ModelListRow = memo(function ModelListRow(props: {
         <Tooltip>
           <TooltipTrigger
             render={
-              <button
+              <Button
+                size="icon-xs"
+                variant="ghost"
                 className={cn(
-                  "relative -mr-1 flex size-4 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground/70 opacity-64 transition-[background-color,color,opacity] hover:bg-background/70 hover:text-foreground hover:opacity-100 group-hover:opacity-100 pointer-coarse:after:absolute pointer-coarse:after:size-full pointer-coarse:after:min-h-11 pointer-coarse:after:min-w-11",
+                  "-mr-1 shrink-0 text-muted-foreground/70 opacity-64 transition-[color,opacity] hover:text-foreground hover:opacity-100 group-hover:opacity-100",
                   props.isFavorite && "text-foreground opacity-100",
                 )}
                 onClick={(event) => {
@@ -105,7 +108,6 @@ export const ModelListRow = memo(function ModelListRow(props: {
                   event.stopPropagation();
                 }}
                 disabled={Boolean(props.disabledReason)}
-                type="button"
                 aria-label={props.isFavorite ? "Remove from favorites" : "Add to favorites"}
               >
                 <StarIcon
@@ -114,7 +116,7 @@ export const ModelListRow = memo(function ModelListRow(props: {
                     props.isFavorite && "fill-current text-yellow-500",
                   )}
                 />
-              </button>
+              </Button>
             }
           />
           <TooltipPopup side="top" align="center">


### PR DESCRIPTION
## What changed
The model picker favorite action now uses the shared Button component with `variant="ghost"` and icon sizing, as the previous had improper padding and was using its own button style compared to the rest of the app.

## Why
This keeps the favorite control aligned with the rest of the compact icon buttons in the picker.

## UI changes
Before:

![Before](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/10-05-model-picker-favorite-button-old-favorite-button.png)

After:

![After](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/09-05-model-picker-favorite-button-new-favorite-button.png)

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Testing
`vp check`; `vp run typecheck` passed locally before splitting these PRs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace native button with shared `Button` component for model favorites toggle
> Swaps the hand-rolled native `<button>` in [ModelListRow.tsx](https://github.com/pingdotgg/t3code/pull/3223/files#diff-62fe7a1456b0253c1b218f2999690aea3cfa7ab23a472a3dd07e6b6221eece02) for the shared `Button` component with `size="icon-xs"` and `variant="ghost"`. Hover styling changes as a result — background-related classes are removed and transitions now cover only color and opacity.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36cf742.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI-only change in the model picker with no logic or data-path impact.
> 
> **Overview**
> The model picker favorite star in `ModelListRow` now uses the shared `Button` with `size="icon-xs"` and `variant="ghost"` instead of a custom native `<button>`.
> 
> Custom padding, sizing, and hover background classes are dropped in favor of the shared icon button styles. Row-specific classes still handle muted/opacity behavior and the filled star when favorited. Click, keyboard, disabled, and aria behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36cf74264aa37cfe280760aebaf1481876af83f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->