### PR TITLE
[fix/feat:ui] Fix clipped chatbar provider badge

### DIFF
--- a/apps/web/src/components/chat/ProviderModelPicker.tsx
+++ b/apps/web/src/components/chat/ProviderModelPicker.tsx
@@ -158,7 +158,7 @@ export const ProviderModelPicker = memo(function ProviderModelPicker(props: {
           />
         }
       >
-        <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+        <span className="flex min-w-0 flex-1 items-center gap-2">
           {activeEntry ? (
             <ProviderInstanceIcon
               driverKind={activeEntry.driverKind}


### PR DESCRIPTION
## What changed
The chatbar provider badge no longer clips the circular provider mark.

## Why
The icon wrapper was flattening the bottom edge, which made the badge look rectangular in the composer footer.

## UI changes
Before:

![Before](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/12-06-chatbar-provider-badge-clipping-old-clipped-provider-badge.png)

After:

![After](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/11-06-chatbar-provider-badge-clipping-new-provider-badge-unclipped.png)

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Testing
`vp check`; `vp run typecheck` passed locally before splitting these PRs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix clipped provider badge in chatbar `ProviderModelPicker`
> Removes `overflow-hidden` from the active entry `<span>` in [ProviderModelPicker.tsx](https://github.com/pingdotgg/t3code/pull/3224/files#diff-01e915fe10bb55b513fb511c18383cd09199ea82c807cdf1fa405ba3261b0a40), which was clipping the provider badge display in the chatbar trigger row.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff8054f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single class change on a chat UI wrapper with no logic, auth, or data impact.
> 
> **Overview**
> **Fixes clipped provider badge** in the chat composer’s `ProviderModelPicker` trigger by removing `overflow-hidden` from the flex wrapper around the active provider icon and model label.
> 
> The badge on `ProviderInstanceIcon` sits slightly outside its box (`right-[-0.125rem] bottom-[-0.125rem]`), so the parent overflow was cropping the circular mark. Long model names still truncate via `overflow-hidden truncate` on the inner tooltip trigger span.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8054ff22ac9f805fe9a1611e313756ff3ab2d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->