### PR TITLE
[fix/feat:ui] Mute previous tool call row

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -791,10 +791,10 @@ const WorkGroupSection = memo(function WorkGroupSection({
       {hasOverflow && (
         <button
           type="button"
-          className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[12px] leading-5 transition-colors duration-150 hover:bg-accent/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
+          className="flex w-full cursor-pointer items-center gap-1.5 rounded-md px-0.5 py-0.5 text-left text-[12px] leading-5 text-muted-foreground/65 transition-colors duration-150 hover:bg-accent/20 hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/70"
           onClick={toggleExpanded}
         >
-          <span className="flex size-5 shrink-0 items-center justify-center text-muted-foreground/65">
+          <span className="flex size-5 shrink-0 items-center justify-center">
             {isExpanded ? (
               <ChevronUpIcon className="size-3.5 shrink-0 opacity-70" />
             ) : (
@@ -802,7 +802,7 @@ const WorkGroupSection = memo(function WorkGroupSection({
             )}
           </span>
           {isExpanded ? (
-            <span className="font-medium text-foreground/82">Show fewer tool calls</span>
+            <span>Show fewer tool calls</span>
           ) : (
             <span className="font-medium text-foreground/82">
               +{hiddenCount} previous tool {hiddenCount === 1 ? "call" : "calls"}


### PR DESCRIPTION
## What changed
The collapsed previous tool call row now uses muted text.

## Why
This row is context for hidden activity, not a tool call result. Muted styling makes that distinction clearer without changing layout.

## UI changes
Before:

![Before](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/14-07-previous-tool-call-row-old-previous-tool-calls-row.png)

After:

![After](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/13-07-previous-tool-call-row-new-muted-previous-tool-calls-row.png)

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Testing
`vp check`; `vp run typecheck` passed locally before splitting these PRs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Mute tool call toggle button styling in chat messages timeline
> Adjusts the styling of the overflow toggle button in the `WorkGroupSection` component in [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/3227/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588). The button now uses muted text by default with a hover color change, the icon container no longer enforces muted color, and the 'Show fewer tool calls' label loses its medium font weight and specific foreground color class.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a94157d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only tweaks to a single button in the chat timeline; no logic or behavior changes.
> 
> **Overview**
> Updates the **expand/collapse** control in `WorkGroupSection` (`MessagesTimeline.tsx`) so the overflow row reads more like secondary context than a tool result.
> 
> The button now uses **muted text by default** (`text-muted-foreground/65`) with **stronger text on hover**, instead of inheriting default foreground. The chevron wrapper no longer applies its own muted color (icons still use `opacity-70`). When expanded, **“Show fewer tool calls”** drops `font-medium` and `text-foreground/82` so it matches the muted treatment; the collapsed **“+N previous tool call(s)”** label is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a94157d3fca4f51e07ee8c11f9ef186484123ff5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->