### PR TITLE
[fix/feat:ui] Capitalize Work Log heading

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -229,7 +229,7 @@ describe("MessagesTimeline", () => {
     );
 
     expect(markup).toContain("Context compacted");
-    expect(markup).toContain("work log");
+    expect(markup).toContain("Work Log");
   });
 
   it("formats changed file paths from the workspace root", async () => {

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -736,7 +736,7 @@ const WorkGroupSection = memo(function WorkGroupSection({
     ? nonEmptyEntries.length === 1
       ? "1 tool call"
       : `${nonEmptyEntries.length} tool calls`
-    : "work log";
+    : "Work Log";
 
   useLayoutEffect(() => {
     const anchorBottomBeforeToggle = anchorBottomBeforeToggleRef.current;


### PR DESCRIPTION
## What changed
The mixed activity group label now renders as `Work Log` instead of `work log`.

## Why
This label is a section heading, so it should match the capitalization used by the rest of the activity UI.

## UI changes
Before:

![Before](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/18-09-work-log-capitalization-old-work-log-lowercase.png)

After:

![After](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/17-09-work-log-capitalization-new-work-log-capitalized.png)

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Testing
`vp test apps/web/src/components/chat/MessagesTimeline.test.tsx`; `vp check`; `vp run typecheck` passed locally before splitting these PRs.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Capitalize 'Work Log' heading in work group sections
> Updates the default group label in the `WorkGroupSection` component from `'work log'` to `'Work Log'`. The corresponding test in [MessagesTimeline.test.tsx](https://github.com/pingdotgg/t3code/pull/3228/files#diff-ed3eb7f66cdae04c2cff32c0f2feb550aea5dddf9fe3af32adc68f50c0832a61) is updated to match.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 651f474.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI tweak with a matching test update; no behavior or data paths change.
> 
> **Overview**
> **Capitalizes the mixed-activity work group heading** from `work log` to `Work Log` in `WorkGroupSection` (`MessagesTimeline.tsx`), so it reads like the other activity section titles. Tool-only groups still use `1 tool call` / `N tool calls` and are unchanged.
> 
> The `MessagesTimeline` test that asserts context compaction appears in that group now expects `Work Log` in the markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 651f474da0ef6503dcbdab106087365713e104b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->