### PR TITLE
[codex] Remove redundant Effect type annotations

### DIFF
--- a/apps/desktop/src/app/DesktopObservability.ts
+++ b/apps/desktop/src/app/DesktopObservability.ts
@@ -50,11 +50,7 @@ export function makeComponentLogger(component: string): DesktopComponentLogger {
   };
 }
 
-const readPersistedOtlpTracesUrl: Effect.Effect<
-  Option.Option<string>,
-  never,
-  FileSystem.FileSystem | DesktopEnvironment.DesktopEnvironment
-> = Effect.gen(function* () {
+const readPersistedOtlpTracesUrl = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const raw = yield* fileSystem.readFileString(environment.serverSettingsPath).pipe(Effect.option);

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -54,11 +54,7 @@ const { logWarning: logBackendConfigurationWarning } = DesktopObservability.make
   "desktop-backend-configuration",
 );
 
-const readPersistedBackendObservabilitySettings: Effect.Effect<
-  BackendObservabilitySettings,
-  never,
-  FileSystem.FileSystem | DesktopEnvironment.DesktopEnvironment
-> = Effect.gen(function* () {
+const readPersistedBackendObservabilitySettings = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const exists = yield* fileSystem

--- a/apps/desktop/src/shell/DesktopShellEnvironment.ts
+++ b/apps/desktop/src/shell/DesktopShellEnvironment.ts
@@ -212,11 +212,7 @@ const readLoginShellEnvironment = (
         timeout: LOGIN_SHELL_TIMEOUT,
       }).pipe(Effect.map((output) => extractEnvironment(output, names)));
 
-const readLaunchctlPath: Effect.Effect<
-  Option.Option<string>,
-  never,
-  ChildProcessSpawner.ChildProcessSpawner
-> = runCommandOutput({
+const readLaunchctlPath = runCommandOutput({
   command: "/bin/launchctl",
   args: ["getenv", "PATH"],
   timeout: LAUNCHCTL_TIMEOUT,

--- a/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -37,11 +37,7 @@ const dispatchMenuAction = Effect.fn("desktop.menu.dispatchMenuAction")(function
   yield* desktopWindow.dispatchMenuAction(action);
 });
 
-const checkForUpdatesFromMenu: Effect.Effect<
-  void,
-  never,
-  DesktopUpdates.DesktopUpdates | ElectronDialog.ElectronDialog
-> = Effect.gen(function* () {
+const checkForUpdatesFromMenu = Effect.gen(function* () {
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const electronDialog = yield* ElectronDialog.ElectronDialog;
   const result = yield* updates.check("menu");
@@ -65,11 +61,7 @@ const checkForUpdatesFromMenu: Effect.Effect<
   }
 }).pipe(Effect.withSpan("desktop.menu.checkForUpdates"));
 
-const handleCheckForUpdatesMenuClick: Effect.Effect<
-  void,
-  DesktopWindow.DesktopWindowError,
-  DesktopUpdates.DesktopUpdates | ElectronDialog.ElectronDialog | DesktopWindow.DesktopWindow
-> = Effect.gen(function* () {
+const handleCheckForUpdatesMenuClick = Effect.gen(function* () {
   const updates = yield* DesktopUpdates.DesktopUpdates;
   const electronDialog = yield* ElectronDialog.ElectronDialog;
   const disabledReason = yield* updates.disabledReason;

--- a/apps/mobile/src/connection/runtime.ts
+++ b/apps/mobile/src/connection/runtime.ts
@@ -5,24 +5,20 @@ import { Atom } from "effect/unstable/reactivity";
 import { runtimeContextLayer } from "../lib/runtime";
 import { connectionPlatformLayer } from "./platform";
 
-const providedConnectionPlatformLayer: Layer.Layer<
-  Layer.Success<typeof connectionPlatformLayer>,
-  Layer.Error<typeof connectionPlatformLayer>
-> = connectionPlatformLayer.pipe(Layer.provide(runtimeContextLayer));
+const providedConnectionPlatformLayer = connectionPlatformLayer.pipe(
+  Layer.provide(runtimeContextLayer),
+);
 
 type ConnectionLayerSource =
   | typeof Connection.layer
   | typeof runtimeContextLayer
-  | typeof providedConnectionPlatformLayer;
+  | typeof connectionPlatformLayer;
 
-export const connectionLayer: Layer.Layer<
-  Layer.Success<ConnectionLayerSource>,
-  Layer.Error<ConnectionLayerSource>
-> = Connection.layer.pipe(
+const connectionLayer = Connection.layer.pipe(
   Layer.provideMerge(Layer.mergeAll(runtimeContextLayer, providedConnectionPlatformLayer)),
 );
 
 export const connectionAtomRuntime: Atom.AtomRuntime<
-  Layer.Success<typeof connectionLayer>,
-  Layer.Error<typeof connectionLayer>
+  Layer.Success<ConnectionLayerSource>,
+  Layer.Error<ConnectionLayerSource>
 > = Atom.runtime(connectionLayer);

--- a/apps/mobile/src/lib/runtime.ts
+++ b/apps/mobile/src/lib/runtime.ts
@@ -22,10 +22,7 @@ type RuntimeLayerSource =
   | typeof httpClientLayer
   | typeof tracingLayer;
 
-export const runtimeLayer: Layer.Layer<
-  Layer.Success<RuntimeLayerSource>,
-  Layer.Error<RuntimeLayerSource>
-> = Layer.merge(
+const runtimeLayer = Layer.merge(
   managedRelayClientLayer(configuredRelayUrl()),
   Socket.layerWebSocketConstructorGlobal,
 ).pipe(
@@ -35,11 +32,11 @@ export const runtimeLayer: Layer.Layer<
 );
 
 export const runtime: ManagedRuntime.ManagedRuntime<
-  Layer.Success<typeof runtimeLayer>,
-  Layer.Error<typeof runtimeLayer>
+  Layer.Success<RuntimeLayerSource>,
+  Layer.Error<RuntimeLayerSource>
 > = ManagedRuntime.make(runtimeLayer);
 
 export const runtimeContextLayer: Layer.Layer<
-  Layer.Success<typeof runtimeLayer>,
-  Layer.Error<typeof runtimeLayer>
+  Layer.Success<RuntimeLayerSource>,
+  Layer.Error<RuntimeLayerSource>
 > = Layer.effectContext(runtime.contextEffect);

--- a/apps/mobile/src/state/relay.ts
+++ b/apps/mobile/src/state/relay.ts
@@ -2,5 +2,5 @@ import { createRelayEnvironmentDiscoveryAtoms } from "@t3tools/client-runtime/st
 
 import { connectionAtomRuntime } from "../connection/runtime";
 
-export const relayEnvironmentDiscovery: ReturnType<typeof createRelayEnvironmentDiscoveryAtoms> =
+export const relayEnvironmentDiscovery =
   createRelayEnvironmentDiscoveryAtoms(connectionAtomRuntime);

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -191,11 +191,7 @@ const make = Effect.acquireRelease(
     }),
 );
 
-export const layer: Layer.Layer<
-  McpSessionRegistry,
-  never,
-  Crypto.Crypto | ServerEnvironment.ServerEnvironment | HttpServer.HttpServer
-> = Layer.effect(McpSessionRegistry, make);
+export const layer = Layer.effect(McpSessionRegistry, make);
 
 export const issueActiveMcpCredential = (
   request: McpCredentialRequest,

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryHydration.ts
@@ -114,11 +114,7 @@ export const deriveProviderInstanceConfigMap = (
  * configs, so the only way the watcher could fail is a settings stream
  * tear-down, which logs and exits cleanly.
  */
-const SettingsWatcherLive: Layer.Layer<
-  never,
-  never,
-  ProviderInstanceRegistryMutator | ServerSettingsService
-> = Layer.effectDiscard(
+const SettingsWatcherLive = Layer.effectDiscard(
   Effect.gen(function* () {
     const mutator = yield* ProviderInstanceRegistryMutator;
     const serverSettings = yield* ServerSettingsService;

--- a/apps/web/src/cloud/dpop.ts
+++ b/apps/web/src/cloud/dpop.ts
@@ -107,43 +107,40 @@ export function writeStoredBrowserDpopKey(
   );
 }
 
-export const generateBrowserDpopKey: Effect.Effect<BrowserDpopKey, BrowserDpopError> = Effect.gen(
-  function* () {
-    const generated = yield* Effect.tryPromise({
-      try: () =>
-        crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
-          "sign",
-          "verify",
-        ]) as Promise<CryptoKeyPair>,
-      catch: (cause) => dpopError("Could not generate DPoP proof key.", cause),
-    });
-    const privateJwk = yield* Effect.tryPromise({
-      try: () => crypto.subtle.exportKey("jwk", generated.privateKey),
-      catch: (cause) => dpopError("Could not export DPoP private key.", cause),
-    });
-    const publicJwk = yield* Effect.tryPromise({
-      try: () => crypto.subtle.exportKey("jwk", generated.publicKey),
-      catch: (cause) => dpopError("Could not export DPoP public key.", cause),
-    }).pipe(
-      Effect.flatMap((jwk) => decodeDpopPublicJwk(jwk)),
-      Effect.mapError((cause) =>
-        cause instanceof BrowserDpopError
-          ? cause
-          : dpopError("Generated DPoP public key is invalid.", cause),
-      ),
-    );
-    const privateKey = yield* Effect.tryPromise({
-      try: () =>
-        importJWK(privateJwk as JWK, "ES256", { extractable: false }) as Promise<CryptoKey>,
-      catch: (cause) => dpopError("Could not import DPoP private key.", cause),
-    });
-    return {
-      privateKey,
-      publicJwk,
-      thumbprint: computeDpopJwkThumbprint(publicJwk),
-    };
-  },
-);
+export const generateBrowserDpopKey = Effect.gen(function* () {
+  const generated = yield* Effect.tryPromise({
+    try: () =>
+      crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+        "sign",
+        "verify",
+      ]) as Promise<CryptoKeyPair>,
+    catch: (cause) => dpopError("Could not generate DPoP proof key.", cause),
+  });
+  const privateJwk = yield* Effect.tryPromise({
+    try: () => crypto.subtle.exportKey("jwk", generated.privateKey),
+    catch: (cause) => dpopError("Could not export DPoP private key.", cause),
+  });
+  const publicJwk = yield* Effect.tryPromise({
+    try: () => crypto.subtle.exportKey("jwk", generated.publicKey),
+    catch: (cause) => dpopError("Could not export DPoP public key.", cause),
+  }).pipe(
+    Effect.flatMap((jwk) => decodeDpopPublicJwk(jwk)),
+    Effect.mapError((cause) =>
+      cause instanceof BrowserDpopError
+        ? cause
+        : dpopError("Generated DPoP public key is invalid.", cause),
+    ),
+  );
+  const privateKey = yield* Effect.tryPromise({
+    try: () => importJWK(privateJwk as JWK, "ES256", { extractable: false }) as Promise<CryptoKey>,
+    catch: (cause) => dpopError("Could not import DPoP private key.", cause),
+  });
+  return {
+    privateKey,
+    publicJwk,
+    thumbprint: computeDpopJwkThumbprint(publicJwk),
+  };
+});
 
 export function createBrowserDpopProof(input: {
   readonly method: string;

--- a/apps/web/src/connection/runtime.ts
+++ b/apps/web/src/connection/runtime.ts
@@ -5,24 +5,20 @@ import { Atom } from "effect/unstable/reactivity";
 import { runtimeContextLayer } from "../lib/runtime";
 import { connectionPlatformLayer } from "./platform";
 
-const providedConnectionPlatformLayer: Layer.Layer<
-  Layer.Success<typeof connectionPlatformLayer>,
-  Layer.Error<typeof connectionPlatformLayer>
-> = connectionPlatformLayer.pipe(Layer.provide(runtimeContextLayer));
+const providedConnectionPlatformLayer = connectionPlatformLayer.pipe(
+  Layer.provide(runtimeContextLayer),
+);
 
 type ConnectionLayerSource =
   | typeof Connection.layer
   | typeof runtimeContextLayer
-  | typeof providedConnectionPlatformLayer;
+  | typeof connectionPlatformLayer;
 
-export const connectionLayer: Layer.Layer<
-  Layer.Success<ConnectionLayerSource>,
-  Layer.Error<ConnectionLayerSource>
-> = Connection.layer.pipe(
+const connectionLayer = Connection.layer.pipe(
   Layer.provideMerge(Layer.mergeAll(runtimeContextLayer, providedConnectionPlatformLayer)),
 );
 
 export const connectionAtomRuntime: Atom.AtomRuntime<
-  Layer.Success<typeof connectionLayer>,
-  Layer.Error<typeof connectionLayer>
+  Layer.Success<ConnectionLayerSource>,
+  Layer.Error<ConnectionLayerSource>
 > = Atom.runtime(connectionLayer);

--- a/apps/web/src/lib/runtime.ts
+++ b/apps/web/src/lib/runtime.ts
@@ -54,10 +54,7 @@ export function __setPrimaryHttpRunnerForTests(runner?: PrimaryHttpEffectRunner)
   primaryHttpRunner = runner ?? livePrimaryHttpRunner;
 }
 
-export const runtimeLayer: Layer.Layer<
-  Layer.Success<RuntimeLayerSource>,
-  Layer.Error<RuntimeLayerSource>
-> = Layer.mergeAll(
+const runtimeLayer = Layer.mergeAll(
   httpClientLayer,
   browserCryptoLayer,
   Socket.layerWebSocketConstructorGlobal,
@@ -68,11 +65,11 @@ export const runtimeLayer: Layer.Layer<
 );
 
 export const runtime: ManagedRuntime.ManagedRuntime<
-  Layer.Success<typeof runtimeLayer>,
-  Layer.Error<typeof runtimeLayer>
+  Layer.Success<RuntimeLayerSource>,
+  Layer.Error<RuntimeLayerSource>
 > = ManagedRuntime.make(runtimeLayer);
 
 export const runtimeContextLayer: Layer.Layer<
-  Layer.Success<typeof runtimeLayer>,
-  Layer.Error<typeof runtimeLayer>
+  Layer.Success<RuntimeLayerSource>,
+  Layer.Error<RuntimeLayerSource>
 > = Layer.effectContext(runtime.contextEffect);

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -1,4 +1,4 @@
-import { ORCHESTRATION_WS_METHODS, type ServerConfig, WS_METHODS } from "@t3tools/contracts";
+import { ORCHESTRATION_WS_METHODS, WS_METHODS } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import type * as Duration from "effect/Duration";
@@ -9,7 +9,6 @@ import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
 import { RpcClientError } from "effect/unstable/rpc";
 
-import type { ConnectionAttemptError } from "../connection/model.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
 
@@ -237,11 +236,7 @@ export function subscribe<TTag extends EnvironmentSubscriptionRpcTag>(
   );
 }
 
-export const config: Effect.Effect<
-  ServerConfig,
-  EnvironmentRpcUnavailableError | ConnectionAttemptError,
-  EnvironmentSupervisor
-> = Effect.gen(function* () {
+export const config = Effect.gen(function* () {
   const session = yield* currentSession();
   return yield* session.initialConfig;
 }).pipe(Effect.withSpan("EnvironmentRpc.config"));

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -135,11 +135,7 @@ export const parseTailscaleStatus = (
     }),
   );
 
-export const readTailscaleStatus: Effect.Effect<
-  TailscaleStatus,
-  TailscaleCommandError | TailscaleStatusParseError,
-  ChildProcessSpawner.ChildProcessSpawner
-> = Effect.gen(function* () {
+export const readTailscaleStatus = Effect.gen(function* () {
   const args = ["status", "--json"];
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const hostPlatform = yield* HostProcessPlatform;


### PR DESCRIPTION
## Summary

- remove directly inferred Effect, Layer, ManagedRuntime, and ReturnType annotations
- keep runtime boundary annotations that TypeScript requires for portable exported types or literal-union preservation
- make intermediate runtime layers private where only the final runtime is consumed

## Validation

- 68 focused tests across desktop, server, web, client-runtime, and tailscale
- vp check (20 pre-existing warnings)
- vp run typecheck
- vp run lint:mobile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation-only refactor with no runtime behavior changes; exported public types are preserved at API boundaries via explicit layer-source unions.
> 
> **Overview**
> This PR **strips explicit `Effect`, `Layer`, `ManagedRuntime`, and `ReturnType` annotations** where TypeScript already infers the same types from `Effect.gen`, `Layer.effect`, pipes, and similar patterns. Touch points include desktop observability/backend/menu/shell helpers, server MCP and provider registry layers, web DPoP key generation, tailscale status reading, and client-runtime `EnvironmentRpc.config`.
> 
> For **web/mobile connection and app runtimes**, intermediate composed layers (`connectionLayer`, `runtimeLayer`, `providedConnectionPlatformLayer`) are left unannotated and often non-exported, while **exported boundaries** (`connectionAtomRuntime`, `runtime`, `runtimeContextLayer`) still declare portable types via `ConnectionLayerSource` / `RuntimeLayerSource` unions instead of `typeof` the final merged layer.
> 
> **`packages/client-runtime`** drops unused imports tied to removed `config` typing and relies on inference for `config`’s return effect type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087299a3d5a6a00a2b81d0c9589aa5a7fa0425ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant explicit type annotations from Effect and Layer declarations
> Removes explicit `Effect.Effect` and `Layer.Layer` type parameters from utility functions and layer definitions across desktop, mobile, web, server, and package code, relying on TypeScript inference instead.
>
> - Several internal layers (`runtimeLayer`, `connectionLayer`) are un-exported and replaced with inferred type aliases (`RuntimeLayerSource`, `ConnectionLayerSource`) used by the exported runtimes and context layers.
> - Unused type-only imports (`ServerConfig`, `ConnectionAttemptError`) are removed from [`packages/client-runtime/src/rpc/client.ts`](https://github.com/pingdotgg/t3code/pull/3229/files#diff-f60493a8e60511194714ca2543e1d58cfb8198eb71d2bf0c9655acdc93220c38).
> - Risk: `connectionLayer` and `runtimeLayer` are no longer exported from the mobile and web runtime modules; any external consumers of these symbols will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 087299a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->