### PR TITLE
[fix/feat:ui] Split service tier controls

### DIFF
--- a/apps/web/src/components/chat/TraitsPicker.tsx
+++ b/apps/web/src/components/chat/TraitsPicker.tsx
@@ -1,6 +1,5 @@
 import {
   type ProviderDriverKind,
-  type ProviderInstanceId,
   type ProviderOptionDescriptor,
   type ProviderOptionSelection,
   type ScopedThreadRef,
@@ -16,7 +15,14 @@ import {
 } from "@t3tools/shared/model";
 import { memo, useCallback, useState } from "react";
 import type { VariantProps } from "class-variance-authority";
-import { ChevronDownIcon } from "lucide-react";
+import {
+  BookOpenIcon,
+  BrainIcon,
+  ChevronDownIcon,
+  RabbitIcon,
+  TurtleIcon,
+  ZapIcon,
+} from "lucide-react";
 import { Button, buttonVariants } from "../ui/button";
 import {
   Menu,
@@ -30,6 +36,8 @@ import {
 import { useComposerDraftStore, DraftId } from "../../composerDraftStore";
 import { getProviderModelCapabilities } from "../../providerModels";
 import { cn } from "~/lib/utils";
+import { Separator } from "../ui/separator";
+import { Fragment } from "react";
 
 type ProviderOptions = ReadonlyArray<ProviderOptionSelection>;
 
@@ -45,6 +53,50 @@ type TraitsPersistence =
     };
 
 const ULTRATHINK_PROMPT_PREFIX = "Ultrathink:\n";
+
+function getBooleanDescriptorLabel(
+  descriptor: Extract<ProviderOptionDescriptor, { type: "boolean" }>,
+): string {
+  return descriptor.id === "fastMode" ? "Speed" : descriptor.label;
+}
+
+function getBooleanDescriptorOptionLabel(
+  descriptor: Extract<ProviderOptionDescriptor, { type: "boolean" }>,
+  value: "on" | "off",
+): string {
+  if (descriptor.id === "fastMode") {
+    return value === "on" ? "Fast" : "Normal";
+  }
+  return value === "on" ? "On" : "Off";
+}
+
+function getSpeedOptionDescription(input: {
+  provider: ProviderDriverKind;
+  model: string | null | undefined;
+  value: "on" | "off";
+}): string {
+  if (input.value === "off") {
+    return "Uses standard speed and normal usage.";
+  }
+  if (input.provider === "claudeAgent") {
+    return "Works up to 2.5x faster, but uses 6x more usage than normal.";
+  }
+  if (input.model === "gpt-5.5") {
+    return "Works up to 1.5x faster, but uses 2.5x more usage than normal.";
+  }
+  return "Works up to 1.5x faster, but uses 2x more usage than normal.";
+}
+
+function BooleanDescriptorOptionIcon(props: {
+  descriptor: Extract<ProviderOptionDescriptor, { type: "boolean" }>;
+  value: "on" | "off";
+}) {
+  if (props.descriptor.id !== "fastMode") {
+    return null;
+  }
+  const Icon = props.value === "on" ? RabbitIcon : TurtleIcon;
+  return <Icon aria-hidden="true" className="size-3.5 shrink-0 text-muted-foreground" />;
+}
 
 function replaceDescriptorCurrentValue(
   descriptors: ReadonlyArray<ProviderOptionDescriptor>,
@@ -191,32 +243,40 @@ export function shouldRenderTraitsControls(input: {
   prompt: string;
   modelOptions: ProviderOptions | null | undefined;
   allowPromptInjectedEffort?: boolean;
+  hiddenDescriptorIds?: ReadonlyArray<string>;
 }): boolean {
-  return getTraitsSectionVisibility(input).hasAnyControls;
+  const visibility = getTraitsSectionVisibility(input);
+  if (!visibility.hasAnyControls) return false;
+  const hidden = new Set(input.hiddenDescriptorIds ?? []);
+  if (hidden.size === 0) return true;
+  return visibility.descriptors.some((descriptor) => !hidden.has(descriptor.id));
 }
 
 export interface TraitsMenuContentProps {
   provider: ProviderDriverKind;
-  instanceId?: ProviderInstanceId;
   models: ReadonlyArray<ServerProviderModel>;
   model: string | null | undefined;
   prompt: string;
   onPromptChange: (prompt: string) => void;
   modelOptions?: ProviderOptions | null | undefined;
   allowPromptInjectedEffort?: boolean;
+  hiddenDescriptorIds?: ReadonlyArray<string>;
+  showTriggerSeparators?: boolean;
   triggerVariant?: VariantProps<typeof buttonVariants>["variant"];
   triggerClassName?: string;
+  onRequestClose?: () => void;
 }
 
 export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
   provider,
-  instanceId,
   models,
   model,
   prompt,
   onPromptChange,
   modelOptions,
   allowPromptInjectedEffort = true,
+  hiddenDescriptorIds,
+  onRequestClose,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
   const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
@@ -231,12 +291,11 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
         return;
       }
       setProviderModelOptions(threadTarget, provider, nextOptions, {
-        ...(instanceId ? { instanceId } : {}),
         model,
         persistSticky: true,
       });
     },
-    [instanceId, model, persistence, provider, setProviderModelOptions],
+    [model, persistence, provider, setProviderModelOptions],
   );
   const {
     descriptors,
@@ -254,6 +313,16 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
     modelOptions,
     allowPromptInjectedEffort,
   });
+  const hiddenDescriptorIdSet = new Set(hiddenDescriptorIds ?? []);
+  const visibleDescriptors = descriptors.filter(
+    (descriptor) => !hiddenDescriptorIdSet.has(descriptor.id),
+  );
+  const visibleSelectDescriptors = selectDescriptors.filter(
+    (descriptor) => !hiddenDescriptorIdSet.has(descriptor.id),
+  );
+  const visibleBooleanDescriptors = booleanDescriptors.filter(
+    (descriptor) => !hiddenDescriptorIdSet.has(descriptor.id),
+  );
   const updateDescriptors = (nextDescriptors: ReadonlyArray<ProviderOptionDescriptor>) => {
     updateModelOptions(buildProviderOptionSelectionsFromDescriptors(nextDescriptors));
   };
@@ -277,15 +346,16 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
       onPromptChange(stripped);
     }
     updateDescriptors(replaceDescriptorCurrentValue(descriptors, descriptor.id, value));
+    onRequestClose?.();
   };
 
-  if (!hasAnyControls) {
+  if (!hasAnyControls || visibleDescriptors.length === 0) {
     return null;
   }
 
   return (
     <>
-      {selectDescriptors.map((descriptor, index) => (
+      {visibleSelectDescriptors.map((descriptor, index) => (
         <div key={descriptor.id}>
           {index > 0 ? <MenuDivider /> : null}
           <MenuGroup>
@@ -298,46 +368,77 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
                 option.
               </div>
             ) : null}
-            <MenuRadioGroup
-              value={
+            {(() => {
+              const selectedValue =
                 ultrathinkPromptControlled && descriptor.id === primarySelectDescriptor?.id
                   ? "ultrathink"
-                  : (getDescriptorStringValue(descriptor) ?? "")
-              }
-              onValueChange={(value) => handleSelectChange(descriptor, value)}
-            >
-              {descriptor.options.map((option) => (
-                <MenuRadioItem
-                  key={option.id}
-                  value={option.id}
-                  disabled={ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id}
+                  : (getDescriptorStringValue(descriptor) ?? "");
+              return (
+                <MenuRadioGroup
+                  value={selectedValue}
+                  onValueChange={(value) => handleSelectChange(descriptor, value)}
                 >
-                  {option.label}
-                  {option.isDefault ? " (default)" : ""}
-                </MenuRadioItem>
-              ))}
-            </MenuRadioGroup>
+                  {descriptor.options.map((option) => (
+                    <MenuRadioItem
+                      key={option.id}
+                      value={option.id}
+                      disabled={
+                        ultrathinkInBodyText && descriptor.id === primarySelectDescriptor?.id
+                      }
+                    >
+                      {option.label}
+                      {option.isDefault ? " (default)" : ""}
+                    </MenuRadioItem>
+                  ))}
+                </MenuRadioGroup>
+              );
+            })()}
           </MenuGroup>
         </div>
       ))}
-      {booleanDescriptors.map((descriptor, index) => (
+      {visibleBooleanDescriptors.map((descriptor, index) => (
         <div key={descriptor.id}>
-          {index > 0 || selectDescriptors.length > 0 ? <MenuDivider /> : null}
+          {index > 0 || visibleSelectDescriptors.length > 0 ? <MenuDivider /> : null}
           <MenuGroup>
             <div className="px-2 py-1.5 font-medium text-muted-foreground text-xs">
-              {descriptor.label}
+              {getBooleanDescriptorLabel(descriptor)}
             </div>
-            <MenuRadioGroup
-              value={descriptor.currentValue === true ? "on" : "off"}
-              onValueChange={(value) => {
-                updateDescriptors(
-                  replaceDescriptorCurrentValue(descriptors, descriptor.id, value === "on"),
-                );
-              }}
-            >
-              <MenuRadioItem value="on">On</MenuRadioItem>
-              <MenuRadioItem value="off">Off</MenuRadioItem>
-            </MenuRadioGroup>
+            {(() => {
+              const selectedValue = descriptor.currentValue === true ? "on" : "off";
+              return (
+                <MenuRadioGroup
+                  value={selectedValue}
+                  onValueChange={(value) => {
+                    updateDescriptors(
+                      replaceDescriptorCurrentValue(descriptors, descriptor.id, value === "on"),
+                    );
+                    onRequestClose?.();
+                  }}
+                >
+                  {(["on", "off"] as const).map((value) => (
+                    <MenuRadioItem
+                      key={value}
+                      value={value}
+                      className={descriptor.id === "fastMode" ? "min-w-72 items-start py-2" : ""}
+                    >
+                      <span className="grid min-w-0 gap-0.5">
+                        <span className="inline-flex min-w-0 items-center gap-1.5">
+                          <BooleanDescriptorOptionIcon descriptor={descriptor} value={value} />
+                          <span className="min-w-0 truncate">
+                            {getBooleanDescriptorOptionLabel(descriptor, value)}
+                          </span>
+                        </span>
+                        {descriptor.id === "fastMode" ? (
+                          <span className="text-muted-foreground text-xs leading-4">
+                            {getSpeedOptionDescription({ provider, model, value })}
+                          </span>
+                        ) : null}
+                      </span>
+                    </MenuRadioItem>
+                  ))}
+                </MenuRadioGroup>
+              );
+            })()}
           </MenuGroup>
         </div>
       ))}
@@ -347,18 +448,18 @@ export const TraitsMenuContent = memo(function TraitsMenuContentImpl({
 
 export const TraitsPicker = memo(function TraitsPicker({
   provider,
-  instanceId,
   models,
   model,
   prompt,
   onPromptChange,
   modelOptions,
   allowPromptInjectedEffort = true,
+  hiddenDescriptorIds,
+  showTriggerSeparators = true,
   triggerVariant,
   triggerClassName,
   ...persistence
 }: TraitsMenuContentProps & TraitsPersistence) {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { descriptors, primarySelectDescriptor, ultrathinkPromptControlled } =
     getTraitsSectionVisibility({
       provider,
@@ -368,6 +469,32 @@ export const TraitsPicker = memo(function TraitsPicker({
       modelOptions,
       allowPromptInjectedEffort,
     });
+  const hiddenDescriptorIdSet = new Set(hiddenDescriptorIds ?? []);
+  const visibleDescriptors = descriptors.filter(
+    (descriptor) => !hiddenDescriptorIdSet.has(descriptor.id),
+  );
+  const isCodexStyle = provider === "codex";
+  const [openDescriptorId, setOpenDescriptorId] = useState<string | null>(null);
+
+  const setProviderModelOptions = useComposerDraftStore((store) => store.setProviderModelOptions);
+  const updateModelOptions = useCallback(
+    (nextOptions: ProviderOptions | undefined) => {
+      if ("onModelOptionsChange" in persistence) {
+        persistence.onModelOptionsChange(nextOptions);
+        return;
+      }
+      const threadTarget = persistence.threadRef ?? persistence.draftId;
+      if (!threadTarget) {
+        return;
+      }
+      setProviderModelOptions(threadTarget, provider, nextOptions, {
+        model,
+        persistSticky: true,
+      });
+    },
+    [model, persistence, provider, setProviderModelOptions],
+  );
+
   if (
     !shouldRenderTraitsControls({
       provider,
@@ -376,77 +503,161 @@ export const TraitsPicker = memo(function TraitsPicker({
       prompt,
       modelOptions,
       allowPromptInjectedEffort,
-    })
+    }) ||
+    visibleDescriptors.length === 0
   ) {
     return null;
   }
 
-  const triggerLabels: Array<string> = [];
-  for (const descriptor of descriptors) {
-    const label =
-      ultrathinkPromptControlled && descriptor.id === primarySelectDescriptor?.id
-        ? "Ultrathink"
-        : descriptor.type === "boolean"
-          ? descriptor.id === "fastMode"
-            ? descriptor.currentValue === true
-              ? "Fast"
-              : "Normal"
-            : `${descriptor.label} ${descriptor.currentValue === true ? "On" : "Off"}`
-          : getProviderOptionCurrentLabel(descriptor);
-    if (typeof label === "string" && label.length > 0) {
-      triggerLabels.push(label);
-    }
-  }
-  const triggerLabel = triggerLabels.join(" · ");
-
-  const isCodexStyle = provider === "codex";
-
   return (
-    <Menu
-      open={isMenuOpen}
-      onOpenChange={(open) => {
-        setIsMenuOpen(open);
-      }}
-    >
-      <MenuTrigger
-        render={
-          <Button
-            size="sm"
-            variant={triggerVariant ?? "ghost"}
-            className={cn(
-              isCodexStyle
-                ? "min-w-0 max-w-40 shrink justify-start overflow-hidden whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:max-w-48 sm:px-3 [&_svg]:mx-0"
-                : "shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3",
-              triggerClassName,
+    <>
+      {visibleDescriptors.map((descriptor, descriptorIndex) => {
+        const resolvedSelectLabel = getProviderOptionCurrentLabel(descriptor);
+        const descriptorIdLower = descriptor.id.toLowerCase();
+        const descriptorLabelLower = descriptor.label.toLowerCase();
+        const isThinkingLike =
+          descriptorIdLower.includes("reason") ||
+          descriptorLabelLower.includes("reason") ||
+          descriptorIdLower === "variant" ||
+          descriptorLabelLower === "variant" ||
+          descriptorIdLower.includes("thinking") ||
+          descriptorLabelLower.includes("thinking");
+        const triggerLabel =
+          ultrathinkPromptControlled && descriptor.id === primarySelectDescriptor?.id
+            ? "Ultrathink"
+            : descriptor.type === "boolean"
+              ? descriptor.id === "fastMode"
+                ? descriptor.currentValue === true
+                  ? "Fast"
+                  : "Normal"
+                : isThinkingLike
+                  ? descriptor.currentValue === true
+                    ? "On"
+                    : "Off"
+                  : `${descriptor.label} ${descriptor.currentValue === true ? "On" : "Off"}`
+              : resolvedSelectLabel && resolvedSelectLabel.length > 0
+                ? resolvedSelectLabel
+                : descriptor.label;
+        const isContextWindow =
+          descriptorIdLower === "contextwindow" ||
+          descriptorIdLower === "context_window" ||
+          descriptorIdLower.includes("contextwindow") ||
+          descriptorLabelLower.includes("context window");
+        const isServiceTier =
+          descriptorIdLower === "servicetier" ||
+          descriptorIdLower === "service_tier" ||
+          (descriptorIdLower.includes("service") && descriptorIdLower.includes("tier")) ||
+          descriptorLabelLower.includes("service tier");
+        const TriggerIcon =
+          descriptor.id === "fastMode" || isServiceTier
+            ? ZapIcon
+            : isThinkingLike
+              ? BrainIcon
+              : isContextWindow
+                ? BookOpenIcon
+                : null;
+        const popupHiddenDescriptorIds = [
+          ...(hiddenDescriptorIds ?? []),
+          ...visibleDescriptors
+            .filter((visibleDescriptor) => visibleDescriptor.id !== descriptor.id)
+            .map((visibleDescriptor) => visibleDescriptor.id),
+        ];
+
+        const isBooleanToggle = descriptor.type === "boolean" && isThinkingLike;
+        const toggleOn = isBooleanToggle && descriptor.currentValue === true;
+        const toggleLabel = toggleOn ? "Thinking" : "Instant";
+
+        return (
+          <Fragment key={descriptor.id}>
+            {showTriggerSeparators && descriptorIndex > 0 ? (
+              <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
+            ) : null}
+            {isBooleanToggle ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                aria-pressed={toggleOn}
+                title={
+                  toggleOn
+                    ? "Thinking enabled - click to switch to instant responses"
+                    : "Instant responses - click to enable thinking"
+                }
+                onClick={() => {
+                  updateModelOptions(
+                    buildProviderOptionSelectionsFromDescriptors(
+                      replaceDescriptorCurrentValue(descriptors, descriptor.id, !toggleOn),
+                    ),
+                  );
+                }}
+                className={cn(
+                  "shrink-0 whitespace-nowrap px-2 sm:px-3",
+                  toggleOn
+                    ? "bg-blue-500/10 text-blue-400 hover:bg-blue-500/15 hover:text-blue-300"
+                    : "text-muted-foreground/70 hover:text-foreground/80",
+                  triggerClassName,
+                )}
+              >
+                <BrainIcon
+                  aria-hidden="true"
+                  className={cn("size-3.5", toggleOn ? "text-current opacity-100" : "opacity-70")}
+                />
+                <span className="sr-only sm:not-sr-only">{toggleLabel}</span>
+              </Button>
+            ) : (
+              <Menu
+                open={openDescriptorId === descriptor.id}
+                onOpenChange={(open) => setOpenDescriptorId(open ? descriptor.id : null)}
+              >
+                <MenuTrigger
+                  render={
+                    <Button
+                      size="sm"
+                      variant={triggerVariant ?? "ghost"}
+                      className={cn(
+                        isCodexStyle
+                          ? "min-w-0 max-w-40 shrink justify-between whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:max-w-48 sm:px-3"
+                          : "shrink-0 justify-between whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3",
+                        triggerClassName,
+                      )}
+                    />
+                  }
+                >
+                  <span className="flex min-w-0 flex-1 justify-center items-center gap-1.5 overflow-hidden">
+                    {TriggerIcon ? (
+                      <TriggerIcon
+                        aria-hidden="true"
+                        className="size-3.5 shrink-0 ps-[2px] opacity-70"
+                      />
+                    ) : null}
+                    <span className="min-w-0 truncate">{triggerLabel}</span>
+                  </span>
+                  <span aria-hidden="true" className="flex items-center">
+                    <ChevronDownIcon
+                      aria-hidden="true"
+                      className="!ms-0 !-me-1 size-3 shrink-0 opacity-60"
+                    />
+                  </span>
+                </MenuTrigger>
+                <MenuPopup align="start">
+                  <TraitsMenuContent
+                    provider={provider}
+                    models={models}
+                    model={model}
+                    prompt={prompt}
+                    onPromptChange={onPromptChange}
+                    modelOptions={modelOptions}
+                    allowPromptInjectedEffort={allowPromptInjectedEffort}
+                    hiddenDescriptorIds={popupHiddenDescriptorIds}
+                    onRequestClose={() => setOpenDescriptorId(null)}
+                    {...persistence}
+                  />
+                </MenuPopup>
+              </Menu>
             )}
-          />
-        }
-      >
-        {isCodexStyle ? (
-          <span className="flex min-w-0 w-full items-center gap-2 overflow-hidden">
-            {triggerLabel}
-            <ChevronDownIcon aria-hidden="true" className="size-3 shrink-0 opacity-60" />
-          </span>
-        ) : (
-          <>
-            <span>{triggerLabel}</span>
-            <ChevronDownIcon aria-hidden="true" className="size-3 opacity-60" />
-          </>
-        )}
-      </MenuTrigger>
-      <MenuPopup align="start">
-        <TraitsMenuContent
-          provider={provider}
-          {...(instanceId ? { instanceId } : {})}
-          models={models}
-          model={model}
-          prompt={prompt}
-          onPromptChange={onPromptChange}
-          modelOptions={modelOptions}
-          allowPromptInjectedEffort={allowPromptInjectedEffort}
-          {...persistence}
-        />
-      </MenuPopup>
-    </Menu>
+          </Fragment>
+        );
+      })}
+    </>
   );
 });


### PR DESCRIPTION
## What changed
Provider traits now render as separate compact controls in the composer footer. Service Tier gets its own dropdown and uses a small lightning icon in the trigger.

## Why
The dropdown should not have two controls inside it.

## UI changes
Before:

![Before](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/04-02-split-service-tier-controls-old-combined-service-tier-control.png)

After:

![After](https://raw.githubusercontent.com/sandersonstabo/t3code/sanderson/ui-polish-screenshots/screenshots/03-02-split-service-tier-controls-new-split-service-tier-control.png)

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Testing
`vp check apps/web/src/components/chat/TraitsPicker.tsx`; `vp run --filter @t3tools/web typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split service tier controls into per-descriptor triggers in TraitsPicker
> - Replaces the single combined dropdown in `TraitsPicker` with individual per-descriptor triggers, each opening its own popup menu independently.
> - Thinking-like boolean descriptors (e.g. reasoning/thinking/variant) become a direct toggle button with a `BrainIcon`, switching between 'Thinking' and 'Instant' labels.
> - `fastMode` boolean descriptor now shows 'Speed' as its label, 'Fast'/'Normal' as options, rabbit/turtle icons, and explanatory helper text describing speed and usage tradeoffs per provider/model.
> - Adds `hiddenDescriptorIds` support to both `TraitsMenuContent` and `TraitsPicker` to suppress specific descriptors from rendering.
> - Behavioral Change: menus now close automatically after a selection via `onRequestClose`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5594406.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->