### PR TITLE
fix: normalize dead-key grave input in composer

### DIFF
--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -92,6 +92,19 @@ const SURROUND_SYMBOLS: [string, string][] = [
 ];
 const SURROUND_SYMBOLS_MAP = new Map<string, string>(SURROUND_SYMBOLS);
 const BACKTICK_SURROUND_CLOSE_SYMBOL = SURROUND_SYMBOLS_MAP.get("`") ?? null;
+const DEAD_KEY_GRAVE_LOOKALIKE_CHARACTERS = new Set(["\u02cb", "\u2035", "\uff40"]);
+const RECENT_DEAD_KEY_MAX_AGE_MS = 1_000;
+
+function hasCommandModifier(event: KeyboardEvent): boolean {
+  return event.metaKey || event.ctrlKey;
+}
+
+function hasRecentDeadKeyDown(recentDeadKeyDown: { timestamp: number } | null): boolean {
+  return (
+    recentDeadKeyDown !== null &&
+    performance.now() - recentDeadKeyDown.timestamp <= RECENT_DEAD_KEY_MAX_AGE_MS
+  );
+}
 
 type SerializedComposerMentionNode = Spread<
   {
@@ -1134,6 +1147,7 @@ function ComposerSurroundSelectionPlugin(props: {
     expandedStart: number;
     expandedEnd: number;
   } | null>(null);
+  const recentDeadKeyDownRef = useRef<{ timestamp: number } | null>(null);
 
   useEffect(() => {
     terminalContextsRef.current = props.terminalContexts;
@@ -1205,6 +1219,14 @@ function ComposerSurroundSelectionPlugin(props: {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      recentDeadKeyDownRef.current =
+        event.key === "Dead" &&
+        !event.defaultPrevented &&
+        !event.isComposing &&
+        !hasCommandModifier(event)
+          ? { timestamp: performance.now() }
+          : null;
+
       if (pendingDeadKeySelectionRef.current) {
         if (event.key === "Dead" || event.key === " " || event.code === "Space") {
           return;
@@ -1212,7 +1234,7 @@ function ComposerSurroundSelectionPlugin(props: {
         pendingDeadKeySelectionRef.current = null;
       }
 
-      if (event.defaultPrevented || event.isComposing || event.metaKey || event.ctrlKey) {
+      if (event.defaultPrevented || event.isComposing || hasCommandModifier(event)) {
         pendingSurroundSelectionRef.current = null;
         pendingDeadKeySelectionRef.current = null;
         return;
@@ -1259,6 +1281,7 @@ function ComposerSurroundSelectionPlugin(props: {
         BACKTICK_SURROUND_CLOSE_SYMBOL !== null &&
         pendingSurroundSelectionRef.current
       ) {
+        recentDeadKeyDownRef.current = null;
         pendingDeadKeySelectionRef.current = pendingSurroundSelectionRef.current;
         return;
       }
@@ -1267,23 +1290,52 @@ function ComposerSurroundSelectionPlugin(props: {
         return;
       }
 
+      if (
+        event.inputType === "insertCompositionText" &&
+        typeof event.data === "string" &&
+        DEAD_KEY_GRAVE_LOOKALIKE_CHARACTERS.has(event.data) &&
+        hasRecentDeadKeyDown(recentDeadKeyDownRef.current)
+      ) {
+        recentDeadKeyDownRef.current = null;
+        if (!applySurroundInsertion("`")) {
+          editor.update(() => {
+            const selection = $getSelection();
+            if ($isRangeSelection(selection)) {
+              selection.insertText("`");
+            }
+            pendingSurroundSelectionRef.current = null;
+          });
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        event.stopImmediatePropagation();
+        return;
+      }
+
       if (event.inputType === "insertCompositionText") {
+        if (typeof event.data === "string" && event.data.length > 0) {
+          recentDeadKeyDownRef.current = null;
+        }
         return;
       }
 
       if (typeof event.data !== "string") {
+        recentDeadKeyDownRef.current = null;
         pendingSurroundSelectionRef.current = null;
         return;
       }
       const inputData = event.inputType === "insertText" ? event.data : null;
       if (!inputData || inputData.length !== 1) {
+        recentDeadKeyDownRef.current = null;
         pendingSurroundSelectionRef.current = null;
         return;
       }
       if (!applySurroundInsertion(inputData)) {
+        recentDeadKeyDownRef.current = null;
         return;
       }
 
+      recentDeadKeyDownRef.current = null;
       event.preventDefault();
       event.stopPropagation();
       event.stopImmediatePropagation();

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1224,15 +1224,8 @@ function ComposerSurroundSelectionPlugin(props: {
         !event.defaultPrevented &&
         !event.isComposing &&
         !hasCommandModifier(event);
-      const isPlainSpaceKeyDown =
-        (event.key === " " || event.code === "Space") &&
-        !event.defaultPrevented &&
-        !event.isComposing &&
-        !hasCommandModifier(event);
       if (isPlainDeadKeyDown) {
         recentDeadKeyDownRef.current = { timestamp: performance.now() };
-      } else if (!isPlainSpaceKeyDown) {
-        recentDeadKeyDownRef.current = null;
       }
 
       if (pendingDeadKeySelectionRef.current) {

--- a/apps/web/src/components/ComposerPromptEditor.tsx
+++ b/apps/web/src/components/ComposerPromptEditor.tsx
@@ -1219,13 +1219,21 @@ function ComposerSurroundSelectionPlugin(props: {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      recentDeadKeyDownRef.current =
+      const isPlainDeadKeyDown =
         event.key === "Dead" &&
         !event.defaultPrevented &&
         !event.isComposing &&
-        !hasCommandModifier(event)
-          ? { timestamp: performance.now() }
-          : null;
+        !hasCommandModifier(event);
+      const isPlainSpaceKeyDown =
+        (event.key === " " || event.code === "Space") &&
+        !event.defaultPrevented &&
+        !event.isComposing &&
+        !hasCommandModifier(event);
+      if (isPlainDeadKeyDown) {
+        recentDeadKeyDownRef.current = { timestamp: performance.now() };
+      } else if (!isPlainSpaceKeyDown) {
+        recentDeadKeyDownRef.current = null;
+      }
 
       if (pendingDeadKeySelectionRef.current) {
         if (event.key === "Dead" || event.key === " " || event.code === "Space") {


### PR DESCRIPTION
## Summary

- Normalize dead-key grave look-alike composition input in the web composer before it reaches stored prompt text.
- Reuse the existing selected-text backtick surround behavior and insert ASCII backticks for collapsed selections.
- Replaces #3158 with a fresh branch based on current main.

## Root cause

Some keyboard layouts emit grave-like Unicode characters (`ˋ`, `‵`, `｀`) through `insertCompositionText` after a dead-key press. The composer accepted those literal characters, so Markdown inline-code delimiters were not recognized.

## Impact

Dead-key grave input now produces ASCII backticks only at the input boundary. Pasted text and non-dead-key Unicode content are left unchanged.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

`vp check` reports the repository's existing unrelated warnings and no errors.

Closes #3142

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Lexical input-handling in the composer editor; no auth, data, or API changes.
> 
> **Overview**
> Dead-key grave input on some keyboard layouts was inserting Unicode lookalikes (`ˋ`, `‵`, `｀`) instead of ASCII backticks, so inline-code surround and Markdown delimiters broke.
> 
> **`ComposerSurroundSelectionPlugin`** now records plain `Dead` keydowns in a 1s window. When `insertCompositionText` delivers one of those lookalikes shortly after, it is handled as a backtick: existing **surround-selected-text** behavior runs when applicable, otherwise a single `` ` `` is inserted, and the lookalike is suppressed via `preventDefault` / propagation stops.
> 
> Modifier handling is centralized in **`hasCommandModifier`** (meta/ctrl). The dead-key tracking ref is cleared on other composition paths and normal surround handling so unrelated input is unchanged; paste and non-dead-key Unicode are not rewritten.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e83d9ea166b4761fb56d46de88715b4d088f62d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize dead-key grave input to backtick in composer surround-selection plugin
> On macOS, pressing a dead-key grave (`` ` ``) followed by a space produces a Unicode grave-lookalike character instead of a literal backtick, breaking the surround-selection feature in [ComposerPromptEditor](https://github.com/pingdotgg/t3code/pull/3236/files#diff-12fcb05b3e147eba955638d8df57440b8cf7f796941af0989c9bfa57b5b4f4a4).
>
> - Tracks the timestamp of a plain `Dead` keydown in `recentDeadKeyDownRef` to create a 1-second detection window.
> - In `onBeforeInput`, intercepts `insertCompositionText` events where the data is a grave-accent lookalike character and a recent dead-key was recorded, then substitutes a literal `` ` `` and applies surround insertion if a selection is pending.
> - Suppresses the default browser input of the lookalike character via `preventDefault` and `stopImmediatePropagation`.
> - Adds `hasCommandModifier` and `hasRecentDeadKeyDown` helpers to unify modifier checks and dead-key age tests.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e83d9e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->