### PR TITLE
[codex] Structure desktop persisted credential errors

### DIFF
--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts
@@ -393,7 +393,21 @@ describe("DesktopConnectionCatalogStore", () => {
       assert.isTrue(yield* store.set('{"schemaVersion":1,"targets":[]}'));
       yield* Ref.set(failDecrypt, true);
       const error = yield* store.get.pipe(Effect.flip);
-      assert.instanceOf(error, ElectronSafeStorage.ElectronSafeStorageDecryptError);
+      assert.instanceOf(
+        error,
+        DesktopConnectionCatalogStore.DesktopConnectionCatalogStoreProtectionError,
+      );
+      assert.equal(error.operation, "decrypt-catalog");
+      assert.equal(error.catalogPath, `${baseDir}/userdata/connection-catalog.json`);
+      assert.instanceOf(error.cause, ElectronSafeStorage.ElectronSafeStorageDecryptError);
+      const decryptError = error.cause as ElectronSafeStorage.ElectronSafeStorageDecryptError;
+      assert.instanceOf(decryptError.cause, Error);
+      assert.equal(decryptError.cause.message, "invalid encrypted catalog");
+      assert.equal(
+        error.message,
+        `Desktop connection catalog protection failed during decrypt-catalog at ${baseDir}/userdata/connection-catalog.json.`,
+      );
+      assert.notEqual(error.message, decryptError.message);
       yield* Ref.set(failDecrypt, false);
       assert.deepStrictEqual(yield* store.get, Option.some('{"schemaVersion":1,"targets":[]}'));
     }).pipe(Effect.provide(NodeServices.layer), Effect.scoped),

--- a/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
+++ b/apps/desktop/src/app/DesktopConnectionCatalogStore.ts
@@ -53,8 +53,6 @@ const DesktopConnectionCatalogStoreWriteOperation = Schema.Literals([
   "write-temporary-file",
   "replace-catalog-file",
 ]);
-type DesktopConnectionCatalogStoreWriteOperation =
-  typeof DesktopConnectionCatalogStoreWriteOperation.Type;
 
 const DesktopConnectionCatalogStoreMigrationOperation = Schema.Literals([
   "read-legacy-registry",
@@ -62,8 +60,12 @@ const DesktopConnectionCatalogStoreMigrationOperation = Schema.Literals([
   "encode-catalog",
   "persist-catalog",
 ]);
-type DesktopConnectionCatalogStoreMigrationOperation =
-  typeof DesktopConnectionCatalogStoreMigrationOperation.Type;
+
+const DesktopConnectionCatalogStoreProtectionOperation = Schema.Literals([
+  "check-encryption-availability",
+  "encrypt-catalog",
+  "decrypt-catalog",
+]);
 
 export class DesktopConnectionCatalogStoreWriteError extends Schema.TaggedErrorClass<DesktopConnectionCatalogStoreWriteError>()(
   "DesktopConnectionCatalogStoreWriteError",
@@ -77,17 +79,6 @@ export class DesktopConnectionCatalogStoreWriteError extends Schema.TaggedErrorC
     return `Desktop connection catalog write failed during ${this.operation} at ${this.path}.`;
   }
 }
-
-const writeError = (
-  operation: DesktopConnectionCatalogStoreWriteOperation,
-  path: string,
-  cause: unknown,
-): DesktopConnectionCatalogStoreWriteError =>
-  new DesktopConnectionCatalogStoreWriteError({
-    operation,
-    path,
-    cause,
-  });
 
 export class DesktopConnectionCatalogStoreDecodeError extends Schema.TaggedErrorClass<DesktopConnectionCatalogStoreDecodeError>()(
   "DesktopConnectionCatalogStoreDecodeError",
@@ -142,18 +133,18 @@ export class DesktopConnectionCatalogStoreMigrationError extends Schema.TaggedEr
   }
 }
 
-const migrationError = (
-  operation: DesktopConnectionCatalogStoreMigrationOperation,
-  catalogPath: string,
-  cause: unknown,
-  environmentId?: string,
-): DesktopConnectionCatalogStoreMigrationError =>
-  new DesktopConnectionCatalogStoreMigrationError({
-    operation,
-    catalogPath,
-    ...(environmentId === undefined ? {} : { environmentId }),
-    cause,
-  });
+export class DesktopConnectionCatalogStoreProtectionError extends Schema.TaggedErrorClass<DesktopConnectionCatalogStoreProtectionError>()(
+  "DesktopConnectionCatalogStoreProtectionError",
+  {
+    operation: DesktopConnectionCatalogStoreProtectionOperation,
+    catalogPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Desktop connection catalog protection failed during ${this.operation} at ${this.catalogPath}.`;
+  }
+}
 
 export class DesktopConnectionCatalogStore extends Context.Service<
   DesktopConnectionCatalogStore,
@@ -164,13 +155,13 @@ export class DesktopConnectionCatalogStore extends Context.Service<
       | DesktopConnectionCatalogStoreDocumentDecodeError
       | DesktopConnectionCatalogStoreDecodeError
       | DesktopConnectionCatalogStoreMigrationError
-      | ElectronSafeStorage.ElectronSafeStorageError
+      | DesktopConnectionCatalogStoreProtectionError
     >;
     readonly set: (
       catalog: string,
     ) => Effect.Effect<
       boolean,
-      DesktopConnectionCatalogStoreWriteError | ElectronSafeStorage.ElectronSafeStorageError
+      DesktopConnectionCatalogStoreWriteError | DesktopConnectionCatalogStoreProtectionError
     >;
     readonly clear: Effect.Effect<void>;
   }
@@ -236,20 +227,46 @@ const writeDocument = Effect.fn("desktop.connectionCatalogStore.writeDocument")(
   const directory = input.path.dirname(input.catalogPath);
   const tempPath = `${input.catalogPath}.${process.pid}.${input.suffix}.tmp`;
   const encoded = yield* encodeEncryptedConnectionCatalogDocumentJson(input.document).pipe(
-    Effect.mapError((cause) => writeError("encode-document", input.catalogPath, cause)),
+    Effect.mapError(
+      (cause) =>
+        new DesktopConnectionCatalogStoreWriteError({
+          operation: "encode-document",
+          path: input.catalogPath,
+          cause,
+        }),
+    ),
   );
-  yield* input.fileSystem
-    .makeDirectory(directory, { recursive: true })
-    .pipe(Effect.mapError((cause) => writeError("create-directory", directory, cause)));
+  yield* input.fileSystem.makeDirectory(directory, { recursive: true }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new DesktopConnectionCatalogStoreWriteError({
+          operation: "create-directory",
+          path: directory,
+          cause,
+        }),
+    ),
+  );
   yield* Effect.gen(function* () {
-    yield* input.fileSystem
-      .writeFileString(tempPath, `${encoded}\n`)
-      .pipe(Effect.mapError((cause) => writeError("write-temporary-file", tempPath, cause)));
-    yield* input.fileSystem
-      .rename(tempPath, input.catalogPath)
-      .pipe(
-        Effect.mapError((cause) => writeError("replace-catalog-file", input.catalogPath, cause)),
-      );
+    yield* input.fileSystem.writeFileString(tempPath, `${encoded}\n`).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DesktopConnectionCatalogStoreWriteError({
+            operation: "write-temporary-file",
+            path: tempPath,
+            cause,
+          }),
+      ),
+    );
+    yield* input.fileSystem.rename(tempPath, input.catalogPath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DesktopConnectionCatalogStoreWriteError({
+            operation: "replace-catalog-file",
+            path: input.catalogPath,
+            cause,
+          }),
+      ),
+    );
   }).pipe(
     Effect.ensuring(
       input.fileSystem.remove(tempPath, { force: true }).pipe(
@@ -330,13 +347,17 @@ const migrateSavedEnvironmentRecords = Effect.fn(
         wsBaseUrl: record.wsBaseUrl,
       }),
     );
-    const token = yield* savedEnvironments
-      .getSecret(record.environmentId)
-      .pipe(
-        Effect.mapError((cause) =>
-          migrationError("read-legacy-secret", catalogPath, cause, record.environmentId),
-        ),
-      );
+    const token = yield* savedEnvironments.getSecret(record.environmentId).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DesktopConnectionCatalogStoreMigrationError({
+            operation: "read-legacy-secret",
+            catalogPath,
+            environmentId: record.environmentId,
+            cause,
+          }),
+      ),
+    );
     if (Option.isSome(token)) {
       credentials.push({
         connectionId: id,
@@ -362,13 +383,41 @@ export const make = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
   const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
   const catalogPath = path.join(environment.stateDir, "connection-catalog.json");
+  const encryptionAvailable = safeStorage.isEncryptionAvailable.pipe(
+    Effect.mapError(
+      (cause) =>
+        new DesktopConnectionCatalogStoreProtectionError({
+          operation: "check-encryption-availability",
+          catalogPath,
+          cause,
+        }),
+    ),
+  );
 
   const writeCatalog = Effect.fn("desktop.connectionCatalogStore.writeCatalog")(function* (
     catalog: string,
   ) {
-    const encryptedCatalog = Encoding.encodeBase64(yield* safeStorage.encryptString(catalog));
+    const encryptedCatalog = Encoding.encodeBase64(
+      yield* safeStorage.encryptString(catalog).pipe(
+        Effect.mapError(
+          (cause) =>
+            new DesktopConnectionCatalogStoreProtectionError({
+              operation: "encrypt-catalog",
+              catalogPath,
+              cause,
+            }),
+        ),
+      ),
+    );
     const suffix = (yield* crypto.randomUUIDv4.pipe(
-      Effect.mapError((cause) => writeError("create-temporary-file-name", catalogPath, cause)),
+      Effect.mapError(
+        (cause) =>
+          new DesktopConnectionCatalogStoreWriteError({
+            operation: "create-temporary-file-name",
+            path: catalogPath,
+            cause,
+          }),
+      ),
     )).replace(/-/g, "");
     yield* writeDocument({
       fileSystem,
@@ -380,21 +429,42 @@ export const make = Effect.gen(function* () {
   });
 
   const migrateLegacyCatalog = Effect.gen(function* () {
-    if (!(yield* safeStorage.isEncryptionAvailable)) {
+    if (!(yield* encryptionAvailable)) {
       return Option.none<string>();
     }
     const records = yield* savedEnvironments.getRegistry.pipe(
-      Effect.mapError((cause) => migrationError("read-legacy-registry", catalogPath, cause)),
+      Effect.mapError(
+        (cause) =>
+          new DesktopConnectionCatalogStoreMigrationError({
+            operation: "read-legacy-registry",
+            catalogPath,
+            cause,
+          }),
+      ),
     );
     if (records.length === 0) {
       return Option.none<string>();
     }
     const catalog = yield* migrateSavedEnvironmentRecords(records, savedEnvironments, catalogPath);
     const encoded = yield* encodeRuntimeConnectionCatalogDocumentJson(catalog).pipe(
-      Effect.mapError((cause) => migrationError("encode-catalog", catalogPath, cause)),
+      Effect.mapError(
+        (cause) =>
+          new DesktopConnectionCatalogStoreMigrationError({
+            operation: "encode-catalog",
+            catalogPath,
+            cause,
+          }),
+      ),
     );
     yield* writeCatalog(encoded).pipe(
-      Effect.mapError((cause) => migrationError("persist-catalog", catalogPath, cause)),
+      Effect.mapError(
+        (cause) =>
+          new DesktopConnectionCatalogStoreMigrationError({
+            operation: "persist-catalog",
+            catalogPath,
+            cause,
+          }),
+      ),
     );
     return Option.some(encoded);
   });
@@ -405,16 +475,27 @@ export const make = Effect.gen(function* () {
       if (Option.isNone(document)) {
         return yield* migrateLegacyCatalog;
       }
-      if (!(yield* safeStorage.isEncryptionAvailable)) {
+      if (!(yield* encryptionAvailable)) {
         return Option.none<string>();
       }
       const decrypted = yield* decodeSecretBytes(catalogPath, document.value.encryptedCatalog).pipe(
-        Effect.flatMap(safeStorage.decryptString),
+        Effect.flatMap((encryptedCatalog) =>
+          safeStorage.decryptString(encryptedCatalog).pipe(
+            Effect.mapError(
+              (cause) =>
+                new DesktopConnectionCatalogStoreProtectionError({
+                  operation: "decrypt-catalog",
+                  catalogPath,
+                  cause,
+                }),
+            ),
+          ),
+        ),
       );
       return Option.some(decrypted);
     }).pipe(Effect.withSpan("desktop.connectionCatalogStore.get")),
     set: Effect.fn("desktop.connectionCatalogStore.set")(function* (catalog) {
-      if (!(yield* safeStorage.isEncryptionAvailable)) {
+      if (!(yield* encryptionAvailable)) {
         return false;
       }
       yield* writeCatalog(catalog);

--- a/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
+++ b/apps/desktop/src/settings/DesktopSavedEnvironments.test.ts
@@ -271,10 +271,11 @@ describe("DesktopSavedEnvironments", () => {
     ),
   );
 
-  it.effect("surfaces typed safe storage availability failures", () => {
+  it.effect("adds saved-environment context to safe storage availability failures", () => {
     const cause = new Error("safe storage unavailable");
     return withSavedEnvironments(
       Effect.gen(function* () {
+        const environment = yield* DesktopEnvironment.DesktopEnvironment;
         const savedEnvironments = yield* DesktopSavedEnvironments.DesktopSavedEnvironments;
         yield* savedEnvironments.setRegistry([savedRegistryRecord]);
 
@@ -285,8 +286,22 @@ describe("DesktopSavedEnvironments", () => {
           })
           .pipe(Effect.flip);
 
-        assert.instanceOf(error, ElectronSafeStorage.ElectronSafeStorageAvailabilityError);
-        assert.equal(error.cause, cause);
+        assert.instanceOf(
+          error,
+          DesktopSavedEnvironments.DesktopSavedEnvironmentSecretProtectionError,
+        );
+        assert.equal(error.operation, "check-encryption-availability");
+        assert.equal(error.environmentId, savedRegistryRecord.environmentId);
+        assert.equal(error.registryPath, environment.savedEnvironmentRegistryPath);
+        assert.instanceOf(error.cause, ElectronSafeStorage.ElectronSafeStorageAvailabilityError);
+        const availabilityError =
+          error.cause as ElectronSafeStorage.ElectronSafeStorageAvailabilityError;
+        assert.strictEqual(availabilityError.cause, cause);
+        assert.equal(
+          error.message,
+          `Desktop saved-environment secret protection failed during check-encryption-availability for environment ${savedRegistryRecord.environmentId} at ${environment.savedEnvironmentRegistryPath}.`,
+        );
+        assert.notEqual(error.message, availabilityError.message);
       }),
       { availabilityError: cause },
     );

--- a/apps/desktop/src/settings/DesktopSavedEnvironments.ts
+++ b/apps/desktop/src/settings/DesktopSavedEnvironments.ts
@@ -77,7 +77,12 @@ const DesktopSavedEnvironmentsWriteOperation = Schema.Literals([
   "write-temporary-file",
   "replace-registry-file",
 ]);
-type DesktopSavedEnvironmentsWriteOperation = typeof DesktopSavedEnvironmentsWriteOperation.Type;
+
+const DesktopSavedEnvironmentSecretProtectionOperation = Schema.Literals([
+  "check-encryption-availability",
+  "encrypt-secret",
+  "decrypt-secret",
+]);
 
 export class DesktopSavedEnvironmentsWriteError extends Schema.TaggedErrorClass<DesktopSavedEnvironmentsWriteError>()(
   "DesktopSavedEnvironmentsWriteError",
@@ -91,17 +96,6 @@ export class DesktopSavedEnvironmentsWriteError extends Schema.TaggedErrorClass<
     return `Desktop saved-environment write failed during ${this.operation} at ${this.path}.`;
   }
 }
-
-const writeError = (
-  operation: DesktopSavedEnvironmentsWriteOperation,
-  path: string,
-  cause: unknown,
-): DesktopSavedEnvironmentsWriteError =>
-  new DesktopSavedEnvironmentsWriteError({
-    operation,
-    path,
-    cause,
-  });
 
 export class DesktopSavedEnvironmentsReadError extends Schema.TaggedErrorClass<DesktopSavedEnvironmentsReadError>()(
   "DesktopSavedEnvironmentsReadError",
@@ -141,6 +135,20 @@ export class DesktopSavedEnvironmentSecretDecodeError extends Schema.TaggedError
   }
 }
 
+export class DesktopSavedEnvironmentSecretProtectionError extends Schema.TaggedErrorClass<DesktopSavedEnvironmentSecretProtectionError>()(
+  "DesktopSavedEnvironmentSecretProtectionError",
+  {
+    operation: DesktopSavedEnvironmentSecretProtectionOperation,
+    environmentId: Schema.String,
+    registryPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Desktop saved-environment secret protection failed during ${this.operation} for environment ${this.environmentId} at ${this.registryPath}.`;
+  }
+}
+
 export type DesktopSavedEnvironmentsReadRegistryError =
   | DesktopSavedEnvironmentsReadError
   | DesktopSavedEnvironmentsDocumentDecodeError;
@@ -152,11 +160,11 @@ export type DesktopSavedEnvironmentsMutationError =
 export type DesktopSavedEnvironmentsGetSecretError =
   | DesktopSavedEnvironmentsReadRegistryError
   | DesktopSavedEnvironmentSecretDecodeError
-  | ElectronSafeStorage.ElectronSafeStorageError;
+  | DesktopSavedEnvironmentSecretProtectionError;
 
 export type DesktopSavedEnvironmentsSetSecretError =
   | DesktopSavedEnvironmentsMutationError
-  | ElectronSafeStorage.ElectronSafeStorageError;
+  | DesktopSavedEnvironmentSecretProtectionError;
 
 export class DesktopSavedEnvironments extends Context.Service<
   DesktopSavedEnvironments,
@@ -276,19 +284,45 @@ const writeRegistryDocument = Effect.fn("desktop.savedEnvironments.writeRegistry
     const directory = input.path.dirname(input.registryPath);
     const tempPath = `${input.registryPath}.${process.pid}.${input.suffix}.tmp`;
     const encoded = yield* encodeSavedEnvironmentRegistryDocumentJson(input.document).pipe(
-      Effect.mapError((cause) => writeError("encode-registry", input.registryPath, cause)),
+      Effect.mapError(
+        (cause) =>
+          new DesktopSavedEnvironmentsWriteError({
+            operation: "encode-registry",
+            path: input.registryPath,
+            cause,
+          }),
+      ),
     );
-    yield* input.fileSystem
-      .makeDirectory(directory, { recursive: true })
-      .pipe(Effect.mapError((cause) => writeError("create-directory", directory, cause)));
-    yield* input.fileSystem
-      .writeFileString(tempPath, `${encoded}\n`)
-      .pipe(Effect.mapError((cause) => writeError("write-temporary-file", tempPath, cause)));
-    yield* input.fileSystem
-      .rename(tempPath, input.registryPath)
-      .pipe(
-        Effect.mapError((cause) => writeError("replace-registry-file", input.registryPath, cause)),
-      );
+    yield* input.fileSystem.makeDirectory(directory, { recursive: true }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DesktopSavedEnvironmentsWriteError({
+            operation: "create-directory",
+            path: directory,
+            cause,
+          }),
+      ),
+    );
+    yield* input.fileSystem.writeFileString(tempPath, `${encoded}\n`).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DesktopSavedEnvironmentsWriteError({
+            operation: "write-temporary-file",
+            path: tempPath,
+            cause,
+          }),
+      ),
+    );
+    yield* input.fileSystem.rename(tempPath, input.registryPath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DesktopSavedEnvironmentsWriteError({
+            operation: "replace-registry-file",
+            path: input.registryPath,
+            cause,
+          }),
+      ),
+    );
   },
 );
 
@@ -341,8 +375,13 @@ export const make = Effect.gen(function* () {
   const writeDocument = (document: SavedEnvironmentRegistryDocument) =>
     crypto.randomUUIDv4.pipe(
       Effect.map((uuid) => uuid.replace(/-/g, "")),
-      Effect.mapError((cause) =>
-        writeError("create-temporary-file-name", environment.savedEnvironmentRegistryPath, cause),
+      Effect.mapError(
+        (cause) =>
+          new DesktopSavedEnvironmentsWriteError({
+            operation: "create-temporary-file-name",
+            path: environment.savedEnvironmentRegistryPath,
+            cause,
+          }),
       ),
       Effect.flatMap((suffix) =>
         writeRegistryDocument({
@@ -396,7 +435,21 @@ export const make = Effect.gen(function* () {
         document.records.find((record) => record.environmentId === environmentId)
           ?.encryptedBearerToken,
       );
-      if (Option.isNone(encoded) || !(yield* safeStorage.isEncryptionAvailable)) {
+      if (Option.isNone(encoded)) {
+        return Option.none<string>();
+      }
+      const encryptionAvailable = yield* safeStorage.isEncryptionAvailable.pipe(
+        Effect.mapError(
+          (cause) =>
+            new DesktopSavedEnvironmentSecretProtectionError({
+              operation: "check-encryption-availability",
+              environmentId,
+              registryPath: environment.savedEnvironmentRegistryPath,
+              cause,
+            }),
+        ),
+      );
+      if (!encryptionAvailable) {
         return Option.none<string>();
       }
 
@@ -405,7 +458,19 @@ export const make = Effect.gen(function* () {
         environment.savedEnvironmentRegistryPath,
         encoded.value,
       );
-      return Option.some(yield* safeStorage.decryptString(secretBytes));
+      return Option.some(
+        yield* safeStorage.decryptString(secretBytes).pipe(
+          Effect.mapError(
+            (cause) =>
+              new DesktopSavedEnvironmentSecretProtectionError({
+                operation: "decrypt-secret",
+                environmentId,
+                registryPath: environment.savedEnvironmentRegistryPath,
+                cause,
+              }),
+          ),
+        ),
+      );
     }),
     setSecret: Effect.fn("desktop.savedEnvironments.setSecret")(function* (input) {
       const { environmentId, secret } = input;
@@ -415,11 +480,34 @@ export const make = Effect.gen(function* () {
         environment.savedEnvironmentRegistryPath,
       );
 
-      if (!(yield* safeStorage.isEncryptionAvailable)) {
+      const encryptionAvailable = yield* safeStorage.isEncryptionAvailable.pipe(
+        Effect.mapError(
+          (cause) =>
+            new DesktopSavedEnvironmentSecretProtectionError({
+              operation: "check-encryption-availability",
+              environmentId,
+              registryPath: environment.savedEnvironmentRegistryPath,
+              cause,
+            }),
+        ),
+      );
+      if (!encryptionAvailable) {
         return false;
       }
 
-      const encryptedBearerToken = Encoding.encodeBase64(yield* safeStorage.encryptString(secret));
+      const encryptedBearerToken = Encoding.encodeBase64(
+        yield* safeStorage.encryptString(secret).pipe(
+          Effect.mapError(
+            (cause) =>
+              new DesktopSavedEnvironmentSecretProtectionError({
+                operation: "encrypt-secret",
+                environmentId,
+                registryPath: environment.savedEnvironmentRegistryPath,
+                cause,
+              }),
+          ),
+        ),
+      );
       let found = false;
       const nextDocument: SavedEnvironmentRegistryDocument = {
         version: document.version,


### PR DESCRIPTION
Desktop connection catalogs and saved-environment credentials crossed the Electron safe-storage boundary without adding any domain context. When availability checks, encryption, or decryption failed, telemetry only received an `ElectronSafeStorage*Error`; it could not identify the affected catalog path, saved-environment ID, or operation. The original cause chain was present, but it was not enough to correlate a failure with persisted state.

This change introduces domain errors for those boundaries. Catalog failures now carry the catalog path and one of the availability/encrypt/decrypt operations. Saved-environment secret failures carry the registry path, environment ID, and secret-protection operation. Each wrapper retains the complete upstream `ElectronSafeStorage*Error` as `cause`, so the underlying defect and stack remain available while messages are derived only from stable structured fields.

The refactor also removes the valueless `writeError` and `migrationError` constructor aliases in both modules. Construction now happens at each failure site, making the operation, path, environment ID, and preserved cause visible without following an indirection.

Validation:

- `vp test apps/desktop/src/app/DesktopConnectionCatalogStore.test.ts apps/desktop/src/settings/DesktopSavedEnvironments.test.ts` (23 tests)
- `vp check` (passes; existing unrelated warnings remain)
- `vp run typecheck`

Focused tests assert the new correlation fields, stable messages, and both levels of each preserved safe-storage cause chain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error types and wrapping around Electron safe storage for persisted credentials; callers and telemetry must handle the new tagged errors, though behavior for unavailable encryption (false/none) is largely unchanged.
> 
> **Overview**
> Desktop **connection catalog** and **saved-environment** flows no longer surface raw `ElectronSafeStorage*` failures at their public API. Each encrypt/decrypt/availability failure is wrapped in a domain tagged error that carries **catalog path** or **registry path + environment ID**, plus a stable **operation** label, while keeping the full upstream safe-storage error in **`cause`**.
> 
> `DesktopConnectionCatalogStoreProtectionError` replaces direct safe-storage errors on `get`/`set`. `DesktopSavedEnvironmentSecretProtectionError` does the same for secret read/write paths, including availability checks that now **fail with context** instead of only returning `false` when the availability probe errors.
> 
> The **`writeError`** / **`migrationError`** helpers are removed in favor of constructing write/migration errors inline at each failure site. Tests are updated to assert wrapper fields, messages, and preserved cause chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9de41e15527ea139e15893b891738dc479747182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure persisted credential errors in desktop safe storage into typed error classes
> - Introduces `DesktopConnectionCatalogStoreProtectionError` and `DesktopSavedEnvironmentSecretProtectionError` as typed error classes, replacing raw `ElectronSafeStorage` errors surfaced to callers of `get`/`set` on the connection catalog store and `getSecret`/`setSecret` on saved environments.
> - Each error carries a structured `operation` field (`check-encryption-availability`, `encrypt-*`, `decrypt-*`), the relevant path/ID context, and the original error as a typed cause.
> - Error mapping is applied consistently at the call sites for `isEncryptionAvailable`, `encryptString`, and `decryptString` in both [DesktopConnectionCatalogStore.ts](https://github.com/pingdotgg/t3code/pull/3239/files#diff-f6e1023f9846b28cc3b4d47ea3a0c78dfb0d7ee814c039d0bbd824894c743854) and [DesktopSavedEnvironments.ts](https://github.com/pingdotgg/t3code/pull/3239/files#diff-8c5e156b438cdca8b80aa299e0a70831bcbc67ffc702ca46ebde33c900570cf4).
> - Behavioral Change: callers that previously caught `ElectronSafeStorageError` or `ElectronSafeStorageAvailabilityError` directly must now handle the new typed protection errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9de41e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->