### PR TITLE
[codex] Preserve client connection error causes

### DIFF
--- a/apps/desktop/src/ipc/methods/sshEnvironment.ts
+++ b/apps/desktop/src/ipc/methods/sshEnvironment.ts
@@ -2,7 +2,7 @@ import {
   bootstrapRemoteBearerSession,
   fetchRemoteSessionState,
   issueRemoteWebSocketTicket,
-  RemoteEnvironmentAuthUndeclaredStatusError,
+  isRemoteEnvironmentAuthUndeclaredStatusError,
   type RemoteEnvironmentAuthError,
 } from "@t3tools/client-runtime/authorization";
 import { fetchRemoteEnvironmentDescriptor } from "@t3tools/client-runtime/environment";
@@ -52,10 +52,7 @@ const isEnvironmentRequestInvalidError = Schema.is(EnvironmentRequestInvalidErro
 const isEnvironmentScopeRequiredError = Schema.is(EnvironmentScopeRequiredError);
 
 function readSshHttpStatus(cause: DesktopSshEnvironmentRequestCause): number | null {
-  if (
-    cause instanceof RemoteEnvironmentAuthUndeclaredStatusError ||
-    cause instanceof SshHttpBridgeError
-  ) {
+  if (isRemoteEnvironmentAuthUndeclaredStatusError(cause) || cause instanceof SshHttpBridgeError) {
     return cause.status ?? null;
   }
   if (isEnvironmentRequestInvalidError(cause)) {

--- a/apps/mobile/src/features/cloud/managedRelayLayer.ts
+++ b/apps/mobile/src/features/cloud/managedRelayLayer.ts
@@ -28,26 +28,24 @@ const relayDpopSignerLayer = Layer.effect(
       ),
       createProof: Effect.fn("mobile.managedRelayDpopSigner.createProof")(function* (input) {
         const proofKey = yield* loadProofKey.pipe(
-          Effect.mapError(
-            (error) =>
-              new ManagedRelay.ManagedRelayDpopKeyLoadError({
-                keyStore: "expo-secure-store",
-                method: input.method,
-                url: input.url,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            ManagedRelay.ManagedRelayDpopKeyLoadError.fromTarget({
+              keyStore: "expo-secure-store",
+              method: input.method,
+              url: input.url,
+              cause: error,
+            }),
           ),
         );
         return yield* createDpopProof({ ...input, proofKey }).pipe(
           Effect.provideService(Crypto.Crypto, crypto),
           Effect.map((proof) => proof.proof),
-          Effect.mapError(
-            (error) =>
-              new ManagedRelay.ManagedRelayDpopProofCreationError({
-                method: input.method,
-                url: input.url,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            ManagedRelay.ManagedRelayDpopProofCreationError.fromTarget({
+              method: input.method,
+              url: input.url,
+              cause: error,
+            }),
           ),
         );
       }),

--- a/apps/mobile/src/features/cloud/managedRelayLayer.ts
+++ b/apps/mobile/src/features/cloud/managedRelayLayer.ts
@@ -30,8 +30,8 @@ const relayDpopSignerLayer = Layer.effect(
         const proofKey = yield* loadProofKey.pipe(
           Effect.mapError(
             (error) =>
-              new ManagedRelay.ManagedRelayDpopProofCreationError({
-                stage: "load-key",
+              new ManagedRelay.ManagedRelayDpopKeyLoadError({
+                keyStore: "expo-secure-store",
                 method: input.method,
                 url: input.url,
                 cause: error,
@@ -44,7 +44,6 @@ const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
-                stage: "create-proof",
                 method: input.method,
                 url: input.url,
                 cause: error,

--- a/apps/mobile/src/features/cloud/managedRelayLayer.ts
+++ b/apps/mobile/src/features/cloud/managedRelayLayer.ts
@@ -31,6 +31,7 @@ const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
+                stage: "load-key",
                 method: input.method,
                 url: input.url,
                 cause: error,
@@ -43,6 +44,7 @@ const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
+                stage: "create-proof",
                 method: input.method,
                 url: input.url,
                 cause: error,

--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -1,17 +1,16 @@
 import { KeybindingCommand, KeybindingRule, KeybindingsConfig } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
-import { assertFailure } from "@effect/vitest/utils";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Path from "effect/Path";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import * as ServerConfig from "./config.ts";
 import * as Keybindings from "./keybindings.ts";
-import { KeybindingsConfigError } from "@t3tools/contracts";
 
 const KeybindingsConfigJson = Schema.fromJsonString(KeybindingsConfig);
 const encodeKeybindingsConfigJson = Schema.encodeEffect(KeybindingsConfigJson);
@@ -33,12 +32,6 @@ const makeKeybindingsLayer = () => {
     ),
   );
 };
-
-const toDetailResult = <A, R>(effect: Effect.Effect<A, KeybindingsConfigError, R>) =>
-  effect.pipe(
-    Effect.mapError((error) => error.detail),
-    Effect.result,
-  );
 
 const writeKeybindingsConfig = (configPath: string, rules: readonly KeybindingRule[]) =>
   Effect.gen(function* () {
@@ -223,15 +216,21 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.deepEqual(configState.issues, [
         {
           kind: "keybindings.malformed-config",
-          message: configState.issues[0]?.message ?? "",
+          message: "Expected the keybindings configuration to be a JSON array.",
         },
       ]);
       assert.equal(yield* fs.readFileString(keybindingsConfigPath), "{ not-json");
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
-  it.effect("ignores invalid entries in runtime and reports them as issues", () =>
-    Effect.gen(function* () {
+  it.effect("ignores invalid entries in runtime and reports them as issues", () => {
+    const logs: ReadonlyArray<unknown>[] = [];
+    const logger = Logger.make(({ message }) => {
+      logs.push(Array.isArray(message) ? message : [message]);
+    });
+    const secret = "private-shortcut-payload";
+
+    return Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
       yield* fs.writeFileString(
@@ -240,7 +239,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
         JSON.stringify([
           { key: "mod+j", command: "terminal.toggle" },
           { key: "mod+shift+d+o", command: "terminal.new" },
-          { key: "mod+x", command: "invalid.command" },
+          { key: "mod+x", command: secret },
         ]),
       );
 
@@ -250,23 +249,55 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       });
 
       assert.isTrue(configState.keybindings.some((entry) => entry.command === "terminal.toggle"));
-      assert.isFalse(
-        configState.keybindings.some((entry) => String(entry.command) === "invalid.command"),
-      );
+      assert.isFalse(configState.keybindings.some((entry) => String(entry.command) === secret));
       assert.deepEqual(configState.issues, [
         {
           kind: "keybindings.invalid-entry",
           index: 1,
-          message: configState.issues[0]?.message ?? "",
+          message: "The keybinding entry contains an invalid shortcut or when expression.",
         },
         {
           kind: "keybindings.invalid-entry",
           index: 2,
-          message: configState.issues[1]?.message ?? "",
+          message: "Expected a keybinding entry with key, command, and optional when fields.",
         },
       ]);
-    }).pipe(Effect.provide(makeKeybindingsLayer())),
-  );
+      const invalidEntryLog = logs.find((log) => {
+        const attributes = log[1];
+        return (
+          String(log[0]).includes("ignoring invalid keybinding entry") &&
+          typeof attributes === "object" &&
+          attributes !== null &&
+          Reflect.get(attributes, "entryIndex") === 2
+        );
+      });
+      if (!invalidEntryLog) {
+        return assert.fail("Expected invalid keybinding warning");
+      }
+      const attributes = invalidEntryLog[1];
+      if (typeof attributes !== "object" || attributes === null) {
+        return assert.fail("Expected structured invalid keybinding attributes");
+      }
+      assert.equal(Reflect.get(attributes, "validationStage"), "entry-schema");
+      assert.equal(Reflect.get(attributes, "validationInputKind"), "object");
+      assert.equal(Reflect.get(attributes, "validationInputSize"), 2);
+      assert.equal(Reflect.get(attributes, "validationHasKeyField"), true);
+      assert.equal(Reflect.get(attributes, "validationHasCommandField"), true);
+      assert.equal(Reflect.get(attributes, "validationHasWhenField"), false);
+      assert.equal(Reflect.get(attributes, "causeReasonCount"), 1);
+      assert.isFalse("entry" in attributes);
+      assert.isFalse("cause" in attributes);
+      assert.isFalse(String(invalidEntryLog[0]).includes(secret));
+      assert.isFalse(Object.values(attributes).some((value) => String(value).includes(secret)));
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          makeKeybindingsLayer(),
+          Logger.layer([logger], { mergeWithExisting: false }),
+        ),
+      ),
+    );
+  });
 
   it.effect(
     "upserts missing default keybindings on startup without overriding existing command rules",
@@ -301,9 +332,9 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
   );
 
   it.effect("skips conflicting default keybindings on startup and logs a detailed warning", () => {
-    const messages: string[] = [];
+    const logs: ReadonlyArray<unknown>[] = [];
     const logger = Logger.make(({ message }) => {
-      messages.push(String(message));
+      logs.push(Array.isArray(message) ? message : [message]);
     });
 
     return Effect.gen(function* () {
@@ -321,11 +352,21 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.isFalse(persisted.some((entry) => entry.command === "terminal.toggle"));
       assert.isTrue(persisted.some((entry) => entry.command === "script.custom-action.run"));
 
-      assert.isTrue(
-        messages.some((message) =>
-          message.includes("skipping default keybinding due to shortcut conflict"),
-        ),
+      const warning = logs.find((log) =>
+        String(log[0]).includes("skipping default keybinding due to shortcut conflict"),
       );
+      if (!warning) {
+        return assert.fail("Expected shortcut conflict warning");
+      }
+      const attributes = warning[1];
+      if (typeof attributes !== "object" || attributes === null) {
+        return assert.fail("Expected structured shortcut conflict attributes");
+      }
+      assert.equal(Reflect.get(attributes, "defaultCommand"), "terminal.toggle");
+      assert.equal(Reflect.get(attributes, "conflictingCommand"), "script.custom-action.run");
+      assert.equal(Reflect.get(attributes, "hasWhenContext"), false);
+      assert.isFalse("key" in attributes);
+      assert.isFalse("when" in attributes);
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
@@ -443,15 +484,24 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
           key: "mod+shift+r",
           command: "script.run-tests.run",
         });
-      }).pipe(toDetailResult);
-      assertFailure(result, "expected JSON array");
+      }).pipe(Effect.result);
+      if (Result.isSuccess(result)) {
+        return assert.fail("Expected malformed config update to fail");
+      }
+      assert.equal(result.failure._tag, "KeybindingsConfigError");
+      assert.equal(result.failure.operation, "decode");
+      assert.isTrue(Schema.isSchemaError(result.failure.cause));
+      assert.equal(
+        result.failure.message,
+        `Keybindings config operation 'decode' failed at ${keybindingsConfigPath}.`,
+      );
 
       const persistedRaw = yield* fs.readFileString(keybindingsConfigPath);
       assert.equal(persistedRaw, "{ not-json");
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
-  it.effect("reports non-array config parse errors without duplicate prefix", () =>
+  it.effect("returns stable structured decode errors across retries", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
       const { keybindingsConfigPath } = yield* ServerConfig.ServerConfig;
@@ -466,8 +516,12 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
           key: "mod+shift+r",
           command: "script.run-tests.run",
         });
-      }).pipe(toDetailResult);
-      assertFailure(firstResult, "expected JSON array");
+      }).pipe(Effect.result);
+      if (Result.isSuccess(firstResult)) {
+        return assert.fail("Expected first malformed config update to fail");
+      }
+      assert.equal(firstResult.failure.operation, "decode");
+      assert.isTrue(Schema.isSchemaError(firstResult.failure.cause));
 
       const secondResult = yield* Effect.gen(function* () {
         const keybindings = yield* Keybindings.Keybindings;
@@ -475,8 +529,13 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
           key: "mod+shift+r",
           command: "script.run-tests.run",
         });
-      }).pipe(toDetailResult);
-      assertFailure(secondResult, "expected JSON array");
+      }).pipe(Effect.result);
+      if (Result.isSuccess(secondResult)) {
+        return assert.fail("Expected second malformed config update to fail");
+      }
+      assert.equal(secondResult.failure.operation, "decode");
+      assert.isTrue(Schema.isSchemaError(secondResult.failure.cause));
+      assert.equal(secondResult.failure.message, firstResult.failure.message);
     }).pipe(Effect.provide(makeKeybindingsLayer())),
   );
 
@@ -496,8 +555,11 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
           key: "mod+shift+r",
           command: "script.run-tests.run",
         });
-      }).pipe(toDetailResult);
-      assertFailure(result, "failed to write keybindings config");
+      }).pipe(Effect.result);
+      if (Result.isSuccess(result)) {
+        return assert.fail("Expected update in a read-only directory to fail");
+      }
+      assert.equal(result.failure.operation, "write");
 
       yield* fs.chmod(dirname(keybindingsConfigPath), 0o700);
 

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -44,6 +44,7 @@ import * as Semaphore from "effect/Semaphore";
 import * as ServerConfig from "./config.ts";
 import { writeFileStringAtomically } from "./atomicWrite.ts";
 import { fromJsonStringPretty, fromLenientJson } from "@t3tools/shared/schemaJson";
+import { causeErrorTag } from "@t3tools/shared/observability";
 import {
   DEFAULT_KEYBINDINGS,
   DEFAULT_RESOLVED_KEYBINDINGS,
@@ -186,23 +187,53 @@ export interface KeybindingsChangeEvent {
   readonly issues: readonly ServerConfigIssue[];
 }
 
-function trimIssueMessage(message: string): string {
-  const trimmed = message.trim();
-  return trimmed.length > 0 ? trimmed : "Invalid keybindings configuration.";
-}
+const MALFORMED_KEYBINDINGS_CONFIG_MESSAGE =
+  "Expected the keybindings configuration to be a JSON array.";
+const INVALID_KEYBINDING_ENTRY_MESSAGE =
+  "Expected a keybinding entry with key, command, and optional when fields.";
+const INVALID_KEYBINDING_RULE_MESSAGE =
+  "The keybinding entry contains an invalid shortcut or when expression.";
 
-function malformedConfigIssue(detail: string): ServerConfigIssue {
+function keybindingsCauseLogAttributes(cause: Cause.Cause<unknown>) {
   return {
-    kind: "keybindings.malformed-config",
-    message: trimIssueMessage(detail),
+    errorTag: causeErrorTag(cause),
+    causeReasonCount: cause.reasons.length,
+    causeFailureCount: cause.reasons.filter(Cause.isFailReason).length,
+    causeDefectCount: cause.reasons.filter(Cause.isDieReason).length,
+    causeInterruptionCount: cause.reasons.filter(Cause.isInterruptReason).length,
   };
 }
 
-function invalidEntryIssue(index: number, detail: string): ServerConfigIssue {
+function keybindingsValidationInputLogAttributes(value: unknown) {
+  if (typeof value === "string") {
+    return { validationInputKind: "string", validationInputSize: value.length };
+  }
+  if (Array.isArray(value)) {
+    return { validationInputKind: "array", validationInputSize: value.length };
+  }
+  if (typeof value === "object" && value !== null) {
+    return {
+      validationInputKind: "object",
+      validationInputSize: Object.keys(value).length,
+      validationHasKeyField: Object.hasOwn(value, "key"),
+      validationHasCommandField: Object.hasOwn(value, "command"),
+      validationHasWhenField: Object.hasOwn(value, "when"),
+    };
+  }
+  return { validationInputKind: value === null ? "null" : typeof value };
+}
+
+function keybindingsValidationLogAttributes(input: {
+  readonly stage: "document" | "entry-schema" | "resolved-rule";
+  readonly value: unknown;
+  readonly cause: Cause.Cause<unknown>;
+  readonly index?: number;
+}) {
   return {
-    kind: "keybindings.invalid-entry",
-    index,
-    message: trimIssueMessage(detail),
+    validationStage: input.stage,
+    ...(input.index === undefined ? {} : { entryIndex: input.index }),
+    ...keybindingsValidationInputLogAttributes(input.value),
+    ...keybindingsCauseLogAttributes(input.cause),
   };
 }
 
@@ -306,7 +337,7 @@ const make = Effect.gen(function* () {
       (cause) =>
         new KeybindingsConfigError({
           configPath: keybindingsConfigPath,
-          detail: "failed to access keybindings config",
+          operation: "access",
           cause,
         }),
     ),
@@ -317,7 +348,7 @@ const make = Effect.gen(function* () {
       (cause) =>
         new KeybindingsConfigError({
           configPath: keybindingsConfigPath,
-          detail: "failed to read keybindings config",
+          operation: "read",
           cause,
         }),
     ),
@@ -337,20 +368,24 @@ const make = Effect.gen(function* () {
         (cause) =>
           new KeybindingsConfigError({
             configPath: keybindingsConfigPath,
-            detail: "expected JSON array",
+            operation: "decode",
             cause,
           }),
       ),
     );
 
-    return yield* Effect.forEach(rawConfig, (entry) =>
+    return yield* Effect.forEach(rawConfig, (entry, index) =>
       Effect.gen(function* () {
         const decodedRule = decodeKeybindingRuleExit(entry);
         if (decodedRule._tag === "Failure") {
           yield* Effect.logWarning("ignoring invalid keybinding entry", {
             path: keybindingsConfigPath,
-            entry,
-            error: Cause.pretty(decodedRule.cause),
+            ...keybindingsValidationLogAttributes({
+              stage: "entry-schema",
+              value: entry,
+              cause: decodedRule.cause,
+              index,
+            }),
           });
           return null;
         }
@@ -358,8 +393,12 @@ const make = Effect.gen(function* () {
         if (resolved._tag === "Failure") {
           yield* Effect.logWarning("ignoring invalid keybinding entry", {
             path: keybindingsConfigPath,
-            entry,
-            error: Cause.pretty(resolved.cause),
+            ...keybindingsValidationLogAttributes({
+              stage: "resolved-rule",
+              value: entry,
+              cause: resolved.cause,
+              index,
+            }),
           });
           return null;
         }
@@ -382,10 +421,22 @@ const make = Effect.gen(function* () {
     const rawConfig = yield* readRawConfig;
     const decodedEntries = decodeRawKeybindingsEntriesExit(rawConfig);
     if (decodedEntries._tag === "Failure") {
-      const detail = `expected JSON array (${Cause.pretty(decodedEntries.cause)})`;
+      yield* Effect.logWarning("ignoring malformed keybindings config", {
+        path: keybindingsConfigPath,
+        ...keybindingsValidationLogAttributes({
+          stage: "document",
+          value: rawConfig,
+          cause: decodedEntries.cause,
+        }),
+      });
       return {
         keybindings: [],
-        issues: [malformedConfigIssue(detail)],
+        issues: [
+          {
+            kind: "keybindings.malformed-config",
+            message: MALFORMED_KEYBINDINGS_CONFIG_MESSAGE,
+          },
+        ],
       };
     }
 
@@ -394,26 +445,38 @@ const make = Effect.gen(function* () {
     for (const [index, entry] of decodedEntries.value.entries()) {
       const decodedRule = decodeKeybindingRuleExit(entry);
       if (decodedRule._tag === "Failure") {
-        const detail = Cause.pretty(decodedRule.cause);
-        issues.push(invalidEntryIssue(index, detail));
+        issues.push({
+          kind: "keybindings.invalid-entry",
+          index,
+          message: INVALID_KEYBINDING_ENTRY_MESSAGE,
+        });
         yield* Effect.logWarning("ignoring invalid keybinding entry", {
           path: keybindingsConfigPath,
-          index,
-          entry,
-          error: detail,
+          ...keybindingsValidationLogAttributes({
+            stage: "entry-schema",
+            value: entry,
+            cause: decodedRule.cause,
+            index,
+          }),
         });
         continue;
       }
 
       const resolvedRule = decodeResolvedKeybindingFromConfigExit(decodedRule.value);
       if (resolvedRule._tag === "Failure") {
-        const detail = Cause.pretty(resolvedRule.cause);
-        issues.push(invalidEntryIssue(index, detail));
+        issues.push({
+          kind: "keybindings.invalid-entry",
+          index,
+          message: INVALID_KEYBINDING_RULE_MESSAGE,
+        });
         yield* Effect.logWarning("ignoring invalid keybinding entry", {
           path: keybindingsConfigPath,
-          index,
-          entry,
-          error: detail,
+          ...keybindingsValidationLogAttributes({
+            stage: "resolved-rule",
+            value: entry,
+            cause: resolvedRule.cause,
+            index,
+          }),
         });
         continue;
       }
@@ -425,6 +488,14 @@ const make = Effect.gen(function* () {
 
   const writeConfigAtomically = (rules: readonly KeybindingRule[]) => {
     return encodeKeybindingsConfigPrettyJson(rules).pipe(
+      Effect.mapError(
+        (cause) =>
+          new KeybindingsConfigError({
+            configPath: keybindingsConfigPath,
+            operation: "encode",
+            cause,
+          }),
+      ),
       Effect.map((encoded) => `${encoded}\n`),
       Effect.flatMap((encoded) =>
         writeFileStringAtomically({
@@ -433,15 +504,15 @@ const make = Effect.gen(function* () {
         }).pipe(
           Effect.provideService(FileSystem.FileSystem, fs),
           Effect.provideService(Path.Path, path),
+          Effect.mapError(
+            (cause) =>
+              new KeybindingsConfigError({
+                configPath: keybindingsConfigPath,
+                operation: "write",
+                cause,
+              }),
+          ),
         ),
-      ),
-      Effect.mapError(
-        (cause) =>
-          new KeybindingsConfigError({
-            configPath: keybindingsConfigPath,
-            detail: "failed to write keybindings config",
-            cause,
-          }),
       ),
     );
   };
@@ -487,7 +558,13 @@ const make = Effect.gen(function* () {
           "skipping startup keybindings default sync because config has issues",
           {
             path: keybindingsConfigPath,
-            issues: runtimeConfig.issues,
+            issueCount: runtimeConfig.issues.length,
+            malformedConfigIssueCount: runtimeConfig.issues.filter(
+              (issue) => issue.kind === "keybindings.malformed-config",
+            ).length,
+            invalidEntryIssueCount: runtimeConfig.issues.filter(
+              (issue) => issue.kind === "keybindings.invalid-entry",
+            ).length,
           },
         );
         yield* Cache.invalidate(resolvedConfigCache, resolvedConfigCacheKey);
@@ -499,8 +576,7 @@ const make = Effect.gen(function* () {
       const shortcutConflictWarnings: Array<{
         defaultCommand: KeybindingRule["command"];
         conflictingCommand: KeybindingRule["command"];
-        key: string;
-        when: string | null;
+        hasWhenContext: boolean;
       }> = [];
       for (const defaultRule of DEFAULT_KEYBINDINGS) {
         if (existingCommands.has(defaultRule.command)) {
@@ -513,8 +589,7 @@ const make = Effect.gen(function* () {
           shortcutConflictWarnings.push({
             defaultCommand: defaultRule.command,
             conflictingCommand: conflictingEntry.command,
-            key: defaultRule.key,
-            when: defaultRule.when ?? null,
+            hasWhenContext: defaultRule.when !== undefined,
           });
           continue;
         }
@@ -525,8 +600,7 @@ const make = Effect.gen(function* () {
           path: keybindingsConfigPath,
           defaultCommand: conflict.defaultCommand,
           conflictingCommand: conflict.conflictingCommand,
-          key: conflict.key,
-          when: conflict.when,
+          hasWhenContext: conflict.hasWhenContext,
           reason: "shortcut context already used by existing rule",
         });
       }
@@ -574,13 +648,22 @@ const make = Effect.gen(function* () {
         (cause) =>
           new KeybindingsConfigError({
             configPath: keybindingsConfigPath,
-            detail: "failed to prepare keybindings config directory",
+            operation: "prepare-directory",
             cause,
           }),
       ),
     );
 
-    const revalidateAndEmitSafely = revalidateAndEmit.pipe(Effect.ignoreCause({ log: true }));
+    const revalidateAndEmitSafely = revalidateAndEmit.pipe(
+      Effect.catchCause((cause) =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.void
+          : Effect.logWarning("keybindings config revalidation failed", {
+              path: keybindingsConfigPath,
+              ...keybindingsCauseLogAttributes(cause),
+            }),
+      ),
+    );
 
     // Debounce watch events so the file is fully written before we read it.
     // Editors emit multiple events per save (truncate, write, rename) and
@@ -597,7 +680,14 @@ const make = Effect.gen(function* () {
     );
 
     yield* Stream.runForEach(debouncedKeybindingsEvents, () => revalidateAndEmitSafely).pipe(
-      Effect.ignoreCause({ log: true }),
+      Effect.catchCause((cause) =>
+        Cause.hasInterruptsOnly(cause)
+          ? Effect.void
+          : Effect.logWarning("keybindings config watcher failed", {
+              path: keybindingsConfigPath,
+              ...keybindingsCauseLogAttributes(cause),
+            }),
+      ),
       Effect.forkIn(watcherScope),
       Effect.asVoid,
     );

--- a/apps/server/src/serverRuntimeStartup.ts
+++ b/apps/server/src/serverRuntimeStartup.ts
@@ -309,13 +309,14 @@ export const make = Effect.gen(function* () {
     yield* runStartupPhase(
       "keybindings.start",
       keybindings.start.pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("failed to start keybindings runtime", {
-            path: error.configPath,
-            detail: error.detail,
-            cause: error.cause,
-          }),
-        ),
+        Effect.catchTags({
+          KeybindingsConfigError: (error) =>
+            Effect.logWarning("failed to start keybindings runtime", {
+              path: error.configPath,
+              operation: error.operation,
+              errorTag: error._tag,
+            }),
+        }),
         Effect.forkScoped,
       ),
     );

--- a/apps/web/src/cloud/managedRelayLayer.ts
+++ b/apps/web/src/cloud/managedRelayLayer.ts
@@ -53,6 +53,7 @@ export const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
+                stage: "load-key",
                 method: input.method,
                 url: input.url,
                 cause: error,
@@ -65,6 +66,7 @@ export const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
+                stage: "create-proof",
                 method: input.method,
                 url: input.url,
                 cause: error,

--- a/apps/web/src/cloud/managedRelayLayer.ts
+++ b/apps/web/src/cloud/managedRelayLayer.ts
@@ -52,8 +52,8 @@ export const relayDpopSignerLayer = Layer.effect(
         const proofKey = yield* loadOrCreateBrowserDpopKey.pipe(
           Effect.mapError(
             (error) =>
-              new ManagedRelay.ManagedRelayDpopProofCreationError({
-                stage: "load-key",
+              new ManagedRelay.ManagedRelayDpopKeyLoadError({
+                keyStore: "indexed-db",
                 method: input.method,
                 url: input.url,
                 cause: error,
@@ -66,7 +66,6 @@ export const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
-                stage: "create-proof",
                 method: input.method,
                 url: input.url,
                 cause: error,

--- a/apps/web/src/cloud/managedRelayLayer.ts
+++ b/apps/web/src/cloud/managedRelayLayer.ts
@@ -50,26 +50,24 @@ export const relayDpopSignerLayer = Layer.effect(
       ),
       createProof: Effect.fn("web.managedRelayDpopSigner.createProof")(function* (input) {
         const proofKey = yield* loadOrCreateBrowserDpopKey.pipe(
-          Effect.mapError(
-            (error) =>
-              new ManagedRelay.ManagedRelayDpopKeyLoadError({
-                keyStore: "indexed-db",
-                method: input.method,
-                url: input.url,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            ManagedRelay.ManagedRelayDpopKeyLoadError.fromTarget({
+              keyStore: "indexed-db",
+              method: input.method,
+              url: input.url,
+              cause: error,
+            }),
           ),
         );
         return yield* createBrowserDpopProof({ ...input, proofKey }).pipe(
           Effect.provideService(Crypto.Crypto, crypto),
           Effect.map((proof) => proof.proof),
-          Effect.mapError(
-            (error) =>
-              new ManagedRelay.ManagedRelayDpopProofCreationError({
-                method: input.method,
-                url: input.url,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            ManagedRelay.ManagedRelayDpopProofCreationError.fromTarget({
+              method: input.method,
+              url: input.url,
+              cause: error,
+            }),
           ),
         );
       }),

--- a/packages/client-runtime/src/authorization/remote.test.ts
+++ b/packages/client-runtime/src/authorization/remote.test.ts
@@ -391,7 +391,9 @@ describe("remote environment authorization", () => {
 
       expect(error).toBeInstanceOf(RemoteEnvironmentAuthTimeoutError);
       expect(error.message).toBe(
-        "Remote environment endpoint http://remote.example.com/.well-known/t3/environment timed out after 25ms.",
+        `Remote environment endpoint at host remote.example.com (${
+          "http://remote.example.com/.well-known/t3/environment".length
+        } URL characters) timed out after 25ms.`,
       );
     }).pipe(Effect.provide(TestClock.layer())),
   );
@@ -446,7 +448,9 @@ describe("remote environment authorization", () => {
 
       expect(error).toBeInstanceOf(RemoteEnvironmentAuthInvalidJsonError);
       expect(error.message).toBe(
-        "Remote environment endpoint returned an invalid response from https://remote.example.com/oauth/token.",
+        `Remote environment endpoint at host remote.example.com (${
+          "https://remote.example.com/oauth/token".length
+        } URL characters) returned an invalid response.`,
       );
     }),
   );

--- a/packages/client-runtime/src/authorization/remote.ts
+++ b/packages/client-runtime/src/authorization/remote.ts
@@ -15,6 +15,7 @@ import {
 } from "../rpc/http.ts";
 
 export {
+  isRemoteEnvironmentAuthUndeclaredStatusError,
   RemoteEnvironmentAuthFetchError,
   RemoteEnvironmentAuthInvalidJsonError,
   RemoteEnvironmentAuthTimeoutError,

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -148,10 +148,11 @@ export const make = Effect.gen(function* () {
         })
         .pipe(
           Effect.mapError(
-            () =>
+            (cause) =>
               new ConnectionBlockedError({
                 reason: "configuration",
                 detail: "Could not create the websocket authorization proof.",
+                cause,
               }),
           ),
         );
@@ -175,10 +176,11 @@ export const make = Effect.gen(function* () {
     }) {
       const thumbprint = yield* signer.thumbprint.pipe(
         Effect.mapError(
-          () =>
+          (cause) =>
             new ConnectionBlockedError({
               reason: "configuration",
               detail: "Could not load the environment authorization key.",
+              cause,
             }),
         ),
         Effect.withSpan("environment.authorization.dpopKey.resolve"),
@@ -248,10 +250,11 @@ export const make = Effect.gen(function* () {
         })
         .pipe(
           Effect.mapError(
-            () =>
+            (cause) =>
               new ConnectionBlockedError({
                 reason: "configuration",
                 detail: "Could not create the environment authorization proof.",
+                cause,
               }),
           ),
         );

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -6,7 +6,7 @@ import {
   resolveRemoteDpopWebSocketConnectionUrl,
   resolveRemoteWebSocketConnectionUrl,
 } from "./remote.ts";
-import { environmentMismatchError, mapRemoteEnvironmentError } from "../connection/errors.ts";
+import { mapRemoteEnvironmentError } from "../connection/errors.ts";
 import { ConnectionBlockedError, type ConnectionAttemptError } from "../connection/model.ts";
 import { fetchRemoteEnvironmentDescriptor } from "../environment/descriptor.ts";
 import { environmentEndpointUrl } from "../environment/endpoint.ts";
@@ -112,9 +112,11 @@ export const make = Effect.gen(function* () {
         Effect.provideService(HttpClient.HttpClient, httpClient),
       );
       if (descriptor.environmentId !== input.expectedEnvironmentId) {
-        return yield* environmentMismatchError({
-          expected: input.expectedEnvironmentId,
-          actual: descriptor.environmentId,
+        return yield* new ConnectionBlockedError({
+          reason: "configuration",
+          detail: `Connected environment ${descriptor.environmentId} does not match ${input.expectedEnvironmentId}.`,
+          expectedEnvironmentId: input.expectedEnvironmentId,
+          actualEnvironmentId: descriptor.environmentId,
         });
       }
       const socketUrl = yield* resolveRemoteWebSocketConnectionUrl({
@@ -238,9 +240,11 @@ export const make = Effect.gen(function* () {
         Effect.withSpan("environment.authorization.descriptor"),
       );
       if (descriptor.environmentId !== input.expectedEnvironmentId) {
-        return yield* environmentMismatchError({
-          expected: input.expectedEnvironmentId,
-          actual: descriptor.environmentId,
+        return yield* new ConnectionBlockedError({
+          reason: "configuration",
+          detail: `Connected environment ${descriptor.environmentId} does not match ${input.expectedEnvironmentId}.`,
+          expectedEnvironmentId: input.expectedEnvironmentId,
+          actualEnvironmentId: descriptor.environmentId,
         });
       }
       const bootstrapProof = yield* signer

--- a/packages/client-runtime/src/connection/errors.test.ts
+++ b/packages/client-runtime/src/connection/errors.test.ts
@@ -1,0 +1,86 @@
+import { EnvironmentAuthInvalidError } from "@t3tools/contracts";
+import { RelayAuthInvalidError } from "@t3tools/contracts/relay";
+import { describe, expect, it } from "@effect/vitest";
+
+import { mapManagedRelayError, mapRemoteEnvironmentError } from "./errors.ts";
+import * as ManagedRelay from "../relay/managedRelay.ts";
+import { RemoteEnvironmentAuthFetchError } from "../rpc/http.ts";
+
+describe("connection error mapping", () => {
+  it("retains the managed relay request as the cause when classifying a protected error", () => {
+    const relayError = new RelayAuthInvalidError({
+      code: "auth_invalid",
+      reason: "invalid_bearer",
+      traceId: "relay-trace-id",
+    });
+    const source = new ManagedRelay.ManagedRelayRequestFailedError({
+      action: "connect relay environment",
+      cause: relayError,
+      relayError,
+      traceId: relayError.traceId,
+    });
+
+    const error = mapManagedRelayError(source);
+
+    expect(error).toMatchObject({
+      _tag: "ConnectionBlockedError",
+      reason: "authentication",
+      traceId: "relay-trace-id",
+    });
+    expect(error.cause).toBe(source);
+  });
+
+  it("retains a managed relay timeout and its structured activity", () => {
+    const source = new ManagedRelay.ManagedRelayRequestTimeoutError({
+      activity: "Relay environment connection",
+      timeoutMs: 10_000,
+    });
+
+    const error = mapManagedRelayError(source);
+
+    expect(error).toMatchObject({
+      _tag: "ConnectionTransientError",
+      reason: "timeout",
+    });
+    expect(error.cause).toBe(source);
+    expect(source.activity).toBe("Relay environment connection");
+  });
+
+  it("retains structured remote authorization failures", () => {
+    const source = new EnvironmentAuthInvalidError({
+      code: "auth_invalid",
+      reason: "invalid_credential",
+      traceId: "environment-trace-id",
+    });
+
+    const error = mapRemoteEnvironmentError(source);
+
+    expect(error).toMatchObject({
+      _tag: "ConnectionBlockedError",
+      reason: "authentication",
+      traceId: "environment-trace-id",
+    });
+    expect(error.cause).toBe(source);
+  });
+
+  it("retains local transport failures without deriving their message from the cause", () => {
+    const transportCause = new Error("sensitive transport implementation detail");
+    const source = new RemoteEnvironmentAuthFetchError({
+      requestUrl: "https://environment.example.test/api/auth/session",
+      cause: transportCause,
+    });
+
+    const error = mapRemoteEnvironmentError(source);
+
+    expect(source.message).toBe(
+      "Failed to fetch remote environment endpoint https://environment.example.test/api/auth/session.",
+    );
+    expect(source.message).not.toContain(transportCause.message);
+    expect(error).toMatchObject({
+      _tag: "ConnectionTransientError",
+      reason: "network",
+    });
+    expect(error.cause).toBe(source);
+    expect(source.cause).toBe(transportCause);
+  });
+});

--- a/packages/client-runtime/src/connection/errors.test.ts
+++ b/packages/client-runtime/src/connection/errors.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it } from "@effect/vitest";
 
 import { mapManagedRelayError, mapRemoteEnvironmentError } from "./errors.ts";
 import * as ManagedRelay from "../relay/managedRelay.ts";
-import { RemoteEnvironmentAuthFetchError } from "../rpc/http.ts";
+import {
+  RemoteEnvironmentAuthFetchError,
+  RemoteEnvironmentAuthUndeclaredStatusError,
+} from "../rpc/http.ts";
 
 describe("connection error mapping", () => {
   it("retains the managed relay request as the cause when classifying a protected error", () => {
@@ -65,15 +68,14 @@ describe("connection error mapping", () => {
 
   it("retains local transport failures without deriving their message from the cause", () => {
     const transportCause = new Error("sensitive transport implementation detail");
-    const source = new RemoteEnvironmentAuthFetchError({
-      requestUrl: "https://environment.example.test/api/auth/session",
-      cause: transportCause,
-    });
+    const requestUrl =
+      "https://environment-user:environment-password@environment.example.test/private/session?access_token=environment-secret#environment-fragment";
+    const source = RemoteEnvironmentAuthFetchError.fromRequestUrl(requestUrl, transportCause);
 
     const error = mapRemoteEnvironmentError(source);
 
     expect(source.message).toBe(
-      "Failed to fetch remote environment endpoint https://environment.example.test/api/auth/session.",
+      `Failed to fetch remote environment endpoint at host environment.example.test (${requestUrl.length} URL characters).`,
     );
     expect(source.message).not.toContain(transportCause.message);
     expect(error).toMatchObject({
@@ -82,5 +84,37 @@ describe("connection error mapping", () => {
     });
     expect(error.cause).toBe(source);
     expect(source.cause).toBe(transportCause);
+    expect(source).toMatchObject({
+      requestUrlInputLength: requestUrl.length,
+      requestUrlProtocol: "https:",
+      requestUrlHostname: "environment.example.test",
+    });
+    const diagnostics = JSON.stringify(source);
+    for (const secret of [
+      "environment-user",
+      "environment-password",
+      "/private/session",
+      "environment-secret",
+      "environment-fragment",
+    ]) {
+      expect(diagnostics).not.toContain(secret);
+      expect(source.message).not.toContain(secret);
+    }
+  });
+
+  it("retains the HTTP client cause for undeclared statuses", () => {
+    const cause = new Error("upstream response metadata");
+    const requestUrl =
+      "https://environment-user:environment-password@environment.example.test/private/session?access_token=environment-secret#environment-fragment";
+    const error = RemoteEnvironmentAuthUndeclaredStatusError.fromRequestUrl(requestUrl, 502, cause);
+
+    expect(error).toMatchObject({
+      status: 502,
+      requestUrlInputLength: requestUrl.length,
+      requestUrlProtocol: "https:",
+      requestUrlHostname: "environment.example.test",
+    });
+    expect(error.cause).toBe(cause);
+    expect(error).not.toHaveProperty("requestUrl");
   });
 });

--- a/packages/client-runtime/src/connection/errors.ts
+++ b/packages/client-runtime/src/connection/errors.ts
@@ -1,6 +1,9 @@
 import type { EnvironmentId } from "@t3tools/contracts";
 import type { RelayProtectedError } from "@t3tools/contracts/relay";
-import type { ManagedRelayClientError } from "../relay/managedRelay.ts";
+import type {
+  ManagedRelayClientError,
+  ManagedRelayRequestFailedError,
+} from "../relay/managedRelay.ts";
 import type { RemoteEnvironmentAuthError } from "../authorization/remote.ts";
 import {
   ConnectionBlockedError,
@@ -32,7 +35,10 @@ export function environmentMismatchError(input: {
   });
 }
 
-function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError {
+function connectionErrorFromRelayProtectedError(
+  error: RelayProtectedError,
+  cause: ManagedRelayRequestFailedError,
+): ConnectionAttemptError {
   switch (error._tag) {
     case "RelayAuthInvalidError":
     case "RelayEnvironmentLinkProofExpiredError":
@@ -42,6 +48,7 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
         reason: "authentication",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
     case "RelayEnvironmentConnectNotAuthorizedError":
     case "RelayEnvironmentLinkProofInvalidError":
@@ -49,12 +56,14 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
         reason: "permission",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
     case "RelayEnvironmentEndpointTimedOutError":
       return new ConnectionTransientError({
         reason: "timeout",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
     case "RelayEnvironmentEndpointUnavailableError":
     case "RelayEnvironmentLinkUnavailableError":
@@ -62,6 +71,7 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
         reason: "endpoint-unavailable",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
     case "RelayEnvironmentLinkFailedError":
     case "RelayInternalError":
@@ -69,6 +79,7 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
         reason: "relay-unavailable",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
   }
 }
@@ -77,27 +88,31 @@ export function mapManagedRelayError(error: ManagedRelayClientError): Connection
   switch (error._tag) {
     case "ManagedRelayRequestFailedError":
       if (error.relayError) {
-        return relayProtectedError(error.relayError);
+        return connectionErrorFromRelayProtectedError(error.relayError, error);
       }
       return new ConnectionTransientError({
         reason: "relay-unavailable",
         detail: error.message,
         ...(error.traceId ? { traceId: error.traceId } : {}),
+        cause: error,
       });
     case "ManagedRelayRequestTimeoutError":
       return new ConnectionTransientError({
         reason: "timeout",
         detail: error.message,
+        cause: error,
       });
     case "ManagedRelayUrlInvalidError":
       return new ConnectionBlockedError({
         reason: "configuration",
         detail: error.message,
+        cause: error,
       });
     case "ManagedRelayAccessTokenScopesUnexpectedError":
       return new ConnectionBlockedError({
         reason: "permission",
         detail: error.message,
+        cause: error,
       });
     case "ManagedRelayDpopKeyLoadError":
     case "ManagedRelayTokenProofCreationError":
@@ -105,6 +120,7 @@ export function mapManagedRelayError(error: ManagedRelayClientError): Connection
       return new ConnectionBlockedError({
         reason: "authentication",
         detail: error.message,
+        cause: error,
       });
   }
 }
@@ -118,6 +134,7 @@ export function mapRemoteEnvironmentError(
         reason: "authentication",
         detail: "The environment credential is invalid.",
         traceId: error.traceId,
+        cause: error,
       });
     case "EnvironmentScopeRequiredError":
     case "EnvironmentOperationForbiddenError":
@@ -125,34 +142,40 @@ export function mapRemoteEnvironmentError(
         reason: "permission",
         detail: "The environment credential does not grant the required access.",
         traceId: error.traceId,
+        cause: error,
       });
     case "EnvironmentRequestInvalidError":
       return new ConnectionBlockedError({
         reason: "configuration",
         detail: "The environment rejected the authentication request.",
         traceId: error.traceId,
+        cause: error,
       });
     case "RemoteEnvironmentAuthTimeoutError":
       return new ConnectionTransientError({
         reason: "timeout",
         detail: error.message,
+        cause: error,
       });
     case "RemoteEnvironmentAuthFetchError":
       return new ConnectionTransientError({
         reason: "network",
         detail: error.message,
+        cause: error,
       });
     case "EnvironmentInternalError":
       return new ConnectionTransientError({
         reason: "remote-unavailable",
         detail: "The environment could not authorize the connection.",
         traceId: error.traceId,
+        cause: error,
       });
     case "RemoteEnvironmentAuthInvalidJsonError":
     case "RemoteEnvironmentAuthUndeclaredStatusError":
       return new ConnectionTransientError({
         reason: "remote-unavailable",
         detail: error.message,
+        cause: error,
       });
   }
 }

--- a/packages/client-runtime/src/connection/errors.ts
+++ b/packages/client-runtime/src/connection/errors.ts
@@ -1,4 +1,3 @@
-import type { EnvironmentId } from "@t3tools/contracts";
 import type { RelayProtectedError } from "@t3tools/contracts/relay";
 import type {
   ManagedRelayClientError,
@@ -10,30 +9,6 @@ import {
   type ConnectionAttemptError,
   ConnectionTransientError,
 } from "./model.ts";
-
-export function profileMissingError(connectionId: string): ConnectionBlockedError {
-  return new ConnectionBlockedError({
-    reason: "configuration",
-    detail: `Connection profile ${connectionId} is unavailable.`,
-  });
-}
-
-export function credentialMissingError(connectionId: string): ConnectionBlockedError {
-  return new ConnectionBlockedError({
-    reason: "authentication",
-    detail: `Connection credential ${connectionId} is unavailable.`,
-  });
-}
-
-export function environmentMismatchError(input: {
-  readonly expected: EnvironmentId;
-  readonly actual: EnvironmentId;
-}): ConnectionBlockedError {
-  return new ConnectionBlockedError({
-    reason: "configuration",
-    detail: `Connected environment ${input.actual} does not match ${input.expected}.`,
-  });
-}
 
 function connectionErrorFromRelayProtectedError(
   error: RelayProtectedError,

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -81,6 +81,7 @@ export class ConnectionTransientError extends Schema.TaggedErrorClass<Connection
     reason: ConnectionTransientReason,
     detail: Schema.String,
     traceId: Schema.optionalKey(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
@@ -94,6 +95,7 @@ export class ConnectionBlockedError extends Schema.TaggedErrorClass<ConnectionBl
     reason: ConnectionBlockedReason,
     detail: Schema.String,
     traceId: Schema.optionalKey(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -94,6 +94,9 @@ export class ConnectionBlockedError extends Schema.TaggedErrorClass<ConnectionBl
   {
     reason: ConnectionBlockedReason,
     detail: Schema.String,
+    connectionId: Schema.optionalKey(Schema.String),
+    expectedEnvironmentId: Schema.optionalKey(EnvironmentId),
+    actualEnvironmentId: Schema.optionalKey(EnvironmentId),
     traceId: Schema.optionalKey(Schema.String),
     cause: Schema.optional(Schema.Defect()),
   },

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -345,7 +345,9 @@ export const make = Effect.gen(function* () {
       persistedTargets,
       (target) =>
         acquireSupervisor(target.environmentId).pipe(
-          Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+          Effect.catchTags({
+            EnvironmentNotRegisteredError: () => Effect.void,
+          }),
         ),
       {
         concurrency: "unbounded",
@@ -516,7 +518,9 @@ export const make = Effect.gen(function* () {
         relayEnvironmentIds,
         (environmentId) =>
           remove(environmentId).pipe(
-            Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+            Effect.catchTags({
+              EnvironmentNotRegisteredError: () => Effect.void,
+            }),
           ),
         {
           concurrency: "unbounded",
@@ -529,7 +533,9 @@ export const make = Effect.gen(function* () {
   const retryNow = (environmentId: EnvironmentId) =>
     acquireSupervisor(environmentId).pipe(
       Effect.flatMap((supervisor) => supervisor.retryNow),
-      Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+      Effect.catchTags({
+        EnvironmentNotRegisteredError: () => Effect.void,
+      }),
       Effect.withSpan("EnvironmentRegistry.retryNow"),
     );
   const state = Effect.fn("EnvironmentRegistry.state")(function* (environmentId: EnvironmentId) {

--- a/packages/client-runtime/src/connection/resolver.test.ts
+++ b/packages/client-runtime/src/connection/resolver.test.ts
@@ -23,6 +23,7 @@ import {
 import * as ConnectionCredentialStore from "./credentialStore.ts";
 import {
   BearerConnectionTarget,
+  ConnectionBlockedError,
   ConnectionTransientError,
   PrimaryConnectionTarget,
   RelayConnectionTarget,
@@ -434,6 +435,62 @@ describe("ConnectionResolver", () => {
         (yield* broker.prepare(catalogEntry(target, Option.some(profile)))).socketUrl,
       ).toContain("wsTicket=bearer");
       expect(yield* Ref.get(preparedTargets)).toEqual([SSH_TARGET]);
+    }),
+  );
+
+  it.effect("retains the connection id when a bearer credential is unavailable", () =>
+    Effect.gen(function* () {
+      const target = new BearerConnectionTarget({
+        environmentId: ENVIRONMENT_ID,
+        label: "Saved",
+        connectionId: "saved-1",
+      });
+      const profile = new BearerConnectionProfile({
+        connectionId: "saved-1",
+        environmentId: ENVIRONMENT_ID,
+        label: "Saved",
+        httpBaseUrl: ENDPOINT.httpBaseUrl,
+        wsBaseUrl: ENDPOINT.wsBaseUrl,
+      });
+      const brokerLayer = yield* makeDependencies();
+      const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
+
+      const error = yield* Effect.flip(broker.prepare(catalogEntry(target, Option.some(profile))));
+
+      expect(error).toBeInstanceOf(ConnectionBlockedError);
+      expect(error).toMatchObject({
+        reason: "authentication",
+        connectionId: "saved-1",
+      });
+    }),
+  );
+
+  it.effect("retains both environment ids when a connection profile does not match", () =>
+    Effect.gen(function* () {
+      const actualEnvironmentId = EnvironmentId.make("environment-2");
+      const target = new BearerConnectionTarget({
+        environmentId: ENVIRONMENT_ID,
+        label: "Saved",
+        connectionId: "saved-1",
+      });
+      const profile = new BearerConnectionProfile({
+        connectionId: "saved-1",
+        environmentId: actualEnvironmentId,
+        label: "Saved",
+        httpBaseUrl: ENDPOINT.httpBaseUrl,
+        wsBaseUrl: ENDPOINT.wsBaseUrl,
+      });
+      const brokerLayer = yield* makeDependencies();
+      const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
+
+      const error = yield* Effect.flip(broker.prepare(catalogEntry(target, Option.some(profile))));
+
+      expect(error).toBeInstanceOf(ConnectionBlockedError);
+      expect(error).toMatchObject({
+        reason: "configuration",
+        expectedEnvironmentId: ENVIRONMENT_ID,
+        actualEnvironmentId,
+      });
     }),
   );
 

--- a/packages/client-runtime/src/connection/resolver.ts
+++ b/packages/client-runtime/src/connection/resolver.ts
@@ -16,12 +16,7 @@ import {
   SshConnectionProfile,
 } from "./catalog.ts";
 import * as ConnectionCredentialStore from "./credentialStore.ts";
-import {
-  credentialMissingError,
-  environmentMismatchError,
-  mapManagedRelayError,
-  profileMissingError,
-} from "./errors.ts";
+import { mapManagedRelayError } from "./errors.ts";
 import type {
   BearerConnectionTarget,
   ConnectionTarget,
@@ -95,7 +90,14 @@ const makeBearerBroker = Effect.fn("clientRuntime.connection.broker.makeBearer")
   ) {
     const target = entry.target;
     const profile = yield* Option.match(entry.profile, {
-      onNone: () => Effect.fail(profileMissingError(target.connectionId)),
+      onNone: () =>
+        Effect.fail(
+          new ConnectionBlockedError({
+            reason: "configuration",
+            detail: `Connection profile ${target.connectionId} is unavailable.`,
+            connectionId: target.connectionId,
+          }),
+        ),
       onSome: Effect.succeed,
     });
     if (!isBearerProfile(profile)) {
@@ -105,21 +107,34 @@ const makeBearerBroker = Effect.fn("clientRuntime.connection.broker.makeBearer")
       });
     }
     if (profile.environmentId !== target.environmentId) {
-      return yield* environmentMismatchError({
-        expected: target.environmentId,
-        actual: profile.environmentId,
+      return yield* new ConnectionBlockedError({
+        reason: "configuration",
+        detail: `Connected environment ${profile.environmentId} does not match ${target.environmentId}.`,
+        expectedEnvironmentId: target.environmentId,
+        actualEnvironmentId: profile.environmentId,
       });
     }
     const credential = yield* credentials.get(target.connectionId).pipe(
       Effect.flatMap(
         Option.match({
-          onNone: () => Effect.fail(credentialMissingError(target.connectionId)),
+          onNone: () =>
+            Effect.fail(
+              new ConnectionBlockedError({
+                reason: "authentication",
+                detail: `Connection credential ${target.connectionId} is unavailable.`,
+                connectionId: target.connectionId,
+              }),
+            ),
           onSome: Effect.succeed,
         }),
       ),
     );
     if (!isBearerCredential(credential)) {
-      return yield* credentialMissingError(target.connectionId);
+      return yield* new ConnectionBlockedError({
+        reason: "authentication",
+        detail: `Connection credential ${target.connectionId} is unavailable.`,
+        connectionId: target.connectionId,
+      });
     }
     const authorized = yield* remote.authorizeBearer({
       expectedEnvironmentId: target.environmentId,
@@ -164,9 +179,11 @@ const makeRelayBroker = Effect.fn("clientRuntime.connection.broker.makeRelay")(f
             })
             .pipe(Effect.mapError(mapManagedRelayError));
           if (connected.environmentId !== target.environmentId) {
-            return yield* environmentMismatchError({
-              expected: target.environmentId,
-              actual: connected.environmentId,
+            return yield* new ConnectionBlockedError({
+              reason: "configuration",
+              detail: `Connected environment ${connected.environmentId} does not match ${target.environmentId}.`,
+              expectedEnvironmentId: target.environmentId,
+              actualEnvironmentId: connected.environmentId,
             });
           }
           return connected;
@@ -196,7 +213,14 @@ const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(funct
   ) {
     const target = entry.target;
     const profile = yield* Option.match(entry.profile, {
-      onNone: () => Effect.fail(profileMissingError(target.connectionId)),
+      onNone: () =>
+        Effect.fail(
+          new ConnectionBlockedError({
+            reason: "configuration",
+            detail: `Connection profile ${target.connectionId} is unavailable.`,
+            connectionId: target.connectionId,
+          }),
+        ),
       onSome: Effect.succeed,
     });
     if (!isSshProfile(profile)) {
@@ -206,9 +230,11 @@ const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(funct
       });
     }
     if (profile.environmentId !== target.environmentId) {
-      return yield* environmentMismatchError({
-        expected: target.environmentId,
-        actual: profile.environmentId,
+      return yield* new ConnectionBlockedError({
+        reason: "configuration",
+        detail: `Connected environment ${profile.environmentId} does not match ${target.environmentId}.`,
+        expectedEnvironmentId: target.environmentId,
+        actualEnvironmentId: profile.environmentId,
       });
     }
     const prepared = yield* ssh.prepare({

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -8,6 +8,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
@@ -55,7 +56,9 @@ function status(
   };
 }
 
-const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
+const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
+  testEnvironments: ReadonlyArray<RelayClientEnvironmentRecord> = environments,
+) {
   const networkStatus = yield* SubscriptionRef.make<NetworkStatus>("online");
   const listCalls = yield* Ref.make(0);
   const listFailure = yield* Ref.make<ManagedRelay.ManagedRelayClientError | null>(null);
@@ -74,7 +77,7 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
       Deferred.Deferred<RelayEnvironmentStatusResponse, ManagedRelay.ManagedRelayClientError>
     >(),
   );
-  for (const environment of environments) {
+  for (const environment of testEnvironments) {
     const request = yield* Deferred.make<
       RelayEnvironmentStatusResponse,
       ManagedRelay.ManagedRelayClientError
@@ -98,7 +101,7 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
         if (failure) {
           return yield* failure;
         }
-        return environments;
+        return testEnvironments;
       }),
     getEnvironmentStatus: ({ environmentId }) =>
       Ref.get(statusRequests).pipe(
@@ -170,6 +173,52 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
 });
 
 describe("RelayEnvironmentDiscovery", () => {
+  it.effect("keeps managed endpoint secrets out of offline warnings", () => {
+    const httpBaseUrl =
+      "https://endpoint-user:endpoint-password@offline.example.test/private/workspace?access_token=endpoint-secret#endpoint-fragment";
+    const environment = {
+      ...environments[0]!,
+      endpoint: {
+        ...environments[0]!.endpoint,
+        httpBaseUrl,
+      },
+    } satisfies RelayClientEnvironmentRecord;
+    const capturedLogs: Array<ReadonlyArray<unknown>> = [];
+    const logger = Logger.make(({ message }) => {
+      capturedLogs.push(Array.isArray(message) ? message : [message]);
+    });
+
+    return Effect.gen(function* () {
+      const harness = yield* makeHarness([environment]);
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        const refreshFiber = yield* Effect.forkChild(discovery.refresh);
+        const requests = yield* Ref.get(harness.statusRequests);
+        yield* Deferred.succeed(
+          requests.get(environment.environmentId)!,
+          status(environment, "offline"),
+        );
+        yield* Fiber.join(refreshFiber);
+
+        expect(capturedLogs).toHaveLength(1);
+        const logFields = capturedLogs[0]?.find(
+          (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+        );
+        expect(logFields).toMatchObject({
+          environmentId: environment.environmentId,
+          endpointInputLength: httpBaseUrl.length,
+          endpointProtocol: "https:",
+          endpointHostname: "offline.example.test",
+        });
+        expect(logFields).not.toHaveProperty("endpoint");
+      }).pipe(
+        Effect.provide(
+          Layer.merge(harness.layer, Logger.layer([logger], { mergeWithExisting: false })),
+        ),
+      );
+    });
+  });
+
   it.effect("publishes each environment status as soon as that lookup completes", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness();

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -63,6 +63,8 @@ function validateStatus(
       new ConnectionBlockedError({
         reason: "configuration",
         detail: "Relay returned status for a different environment.",
+        expectedEnvironmentId: environment.environmentId,
+        actualEnvironmentId: status.environmentId,
       }),
     );
   }
@@ -86,6 +88,8 @@ function validateStatus(
       new ConnectionBlockedError({
         reason: "configuration",
         detail: "Relay returned a descriptor for a different environment.",
+        expectedEnvironmentId: environment.environmentId,
+        actualEnvironmentId: status.descriptor.environmentId,
       }),
     );
   }

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -3,6 +3,7 @@ import type {
   RelayEnvironmentStatusResponse,
 } from "@t3tools/contracts/relay";
 import { decodeRelayJwt } from "@t3tools/shared/relayJwt";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import {
   RelayEnvironmentConnectScope,
   RelayEnvironmentStatusScope,
@@ -178,9 +179,16 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
           return [true, new Map(current).set(environment.environmentId, fingerprint)];
         });
         if (shouldReport) {
+          const endpointDiagnostics = getUrlDiagnostics(result.success.endpoint.httpBaseUrl);
           yield* Effect.logWarning("Relay environment health check reported offline", {
             environmentId: result.success.environmentId,
-            endpoint: result.success.endpoint.httpBaseUrl,
+            endpointInputLength: endpointDiagnostics.inputLength,
+            ...(endpointDiagnostics.protocol === undefined
+              ? {}
+              : { endpointProtocol: endpointDiagnostics.protocol }),
+            ...(endpointDiagnostics.hostname === undefined
+              ? {}
+              : { endpointHostname: endpointDiagnostics.hostname }),
             message: result.success.error,
             traceId: result.success.traceId,
           });

--- a/packages/client-runtime/src/relay/managedRelay.test.ts
+++ b/packages/client-runtime/src/relay/managedRelay.test.ts
@@ -39,6 +39,65 @@ function clerkToken(subject: string, nonce: string): string {
 }
 
 describe("ManagedRelayClient", () => {
+  it("redacts relay URLs and DPoP targets while preserving causes", () => {
+    const relayUrl =
+      "http://relay-user:relay-password@relay.example.test/private/workspace?access_token=relay-secret#relay-fragment";
+    const dpopTarget =
+      "https://dpop-user:dpop-password@relay.example.test/v1/client/dpop-token?access_token=dpop-secret#dpop-fragment";
+    const cause = new Error("proof failed");
+    const invalidUrlError = ManagedRelay.ManagedRelayUrlInvalidError.fromInput(relayUrl);
+    const proofErrors = [
+      ManagedRelay.ManagedRelayDpopKeyLoadError.fromTarget({
+        keyStore: "indexed-db",
+        method: "POST",
+        url: dpopTarget,
+        cause,
+      }),
+      ManagedRelay.ManagedRelayDpopProofCreationError.fromTarget({
+        method: "POST",
+        url: dpopTarget,
+        cause,
+      }),
+      ManagedRelay.ManagedRelayTokenProofCreationError.fromTarget({
+        method: "POST",
+        url: dpopTarget,
+        cause,
+      }),
+      ManagedRelay.ManagedRelayRequestProofCreationError.fromTarget({
+        method: "POST",
+        url: dpopTarget,
+        cause,
+      }),
+    ];
+
+    expect(invalidUrlError).toMatchObject({
+      relayUrlInputLength: relayUrl.length,
+      relayUrlProtocol: "http:",
+      relayUrlHostname: "relay.example.test",
+    });
+    const invalidUrlDiagnostics = JSON.stringify(invalidUrlError);
+    for (const secret of [
+      "relay-user",
+      "relay-password",
+      "/private/workspace",
+      "relay-secret",
+      "relay-fragment",
+    ]) {
+      expect(invalidUrlDiagnostics).not.toContain(secret);
+      expect(invalidUrlError.message).not.toContain(secret);
+    }
+
+    for (const error of proofErrors) {
+      expect(error.requestTarget).toBe("https://relay.example.test/v1/client/dpop-token");
+      expect(error.cause).toBe(cause);
+      const diagnostics = JSON.stringify(error);
+      for (const secret of ["dpop-user", "dpop-password", "dpop-secret", "dpop-fragment"]) {
+        expect(diagnostics).not.toContain(secret);
+        expect(error.message).not.toContain(secret);
+      }
+    }
+  });
+
   it.effect("owns tracing at service and implementation boundaries", () => {
     const spanNames: Array<string> = [];
     const tracer = Tracer.make({
@@ -124,7 +183,9 @@ describe("ManagedRelayClient", () => {
 
       expect(error).toMatchObject({
         _tag: "ManagedRelayUrlInvalidError",
-        relayUrl: "http://relay.example.test",
+        relayUrlInputLength: "http://relay.example.test".length,
+        relayUrlProtocol: "http:",
+        relayUrlHostname: "relay.example.test",
         message: "Relay URL must be a secure absolute HTTPS origin.",
       });
       expect(requestCount).toBe(0);
@@ -161,7 +222,7 @@ describe("ManagedRelayClient", () => {
           thumbprint: Effect.succeed("client-thumbprint"),
           createProof: (input) =>
             Effect.fail(
-              new ManagedRelay.ManagedRelayDpopKeyLoadError({
+              ManagedRelay.ManagedRelayDpopKeyLoadError.fromTarget({
                 keyStore: "indexed-db",
                 method: input.method,
                 url: input.url,

--- a/packages/client-runtime/src/relay/managedRelay.test.ts
+++ b/packages/client-runtime/src/relay/managedRelay.test.ts
@@ -15,15 +15,15 @@ function managedRelayTestLayer(
   fetchFn: typeof globalThis.fetch,
   relayUrl = "https://relay.example.test",
   accessTokenStore?: ManagedRelay.ManagedRelayAccessTokenStore,
+  signer: ManagedRelay.ManagedRelayDpopSigner["Service"] = {
+    thumbprint: Effect.succeed("client-thumbprint"),
+    createProof: (input) => Effect.succeed(`proof:${input.url}`),
+  },
 ) {
   const httpClientLayer = remoteHttpClientLayer(fetchFn);
   const signerLayer = Layer.succeed(
     ManagedRelay.ManagedRelayDpopSigner,
-    ManagedRelay.ManagedRelayDpopSigner.of({
-      thumbprint: Effect.succeed("client-thumbprint"),
-      createProof: (input: ManagedRelay.ManagedRelayDpopProofInput) =>
-        Effect.succeed(`proof:${input.url}`),
-    }),
+    ManagedRelay.ManagedRelayDpopSigner.of(signer),
   );
   return ManagedRelay.layer({
     relayUrl,
@@ -129,6 +129,48 @@ describe("ManagedRelayClient", () => {
       });
       expect(requestCount).toBe(0);
     }).pipe(Effect.provide(managedRelayTestLayer(fetchFn, "http://relay.example.test")));
+  });
+
+  it.effect("preserves key-load failures when creating a token proof", () => {
+    const keyStoreCause = new Error("IndexedDB unavailable");
+    const fetchFn = (() => Promise.resolve(Response.json({}))) satisfies typeof globalThis.fetch;
+
+    return Effect.gen(function* () {
+      const relayClient = yield* ManagedRelay.ManagedRelayClient;
+      const error = yield* relayClient
+        .getEnvironmentStatus({
+          clerkToken: clerkToken("user-1", "session-1"),
+          scopes: [RelayEnvironmentStatusScope],
+          environmentId: EnvironmentId.make("env-1"),
+        })
+        .pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "ManagedRelayTokenProofCreationError",
+        cause: {
+          _tag: "ManagedRelayDpopKeyLoadError",
+          keyStore: "indexed-db",
+          method: "POST",
+          message: "Could not load relay DPoP proof key.",
+          cause: keyStoreCause,
+        },
+      });
+    }).pipe(
+      Effect.provide(
+        managedRelayTestLayer(fetchFn, undefined, undefined, {
+          thumbprint: Effect.succeed("client-thumbprint"),
+          createProof: (input) =>
+            Effect.fail(
+              new ManagedRelay.ManagedRelayDpopKeyLoadError({
+                keyStore: "indexed-db",
+                method: input.method,
+                url: input.url,
+                cause: keyStoreCause,
+              }),
+            ),
+        }),
+      ),
+    );
   });
 
   it.effect("reuses usable DPoP tokens and refreshes cleared or expiring cache entries", () => {

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -133,6 +133,13 @@ export class ManagedRelayUrlInvalidError extends Schema.TaggedErrorClass<Managed
   }
 }
 
+type RelayHttpRequestError =
+  | RelayProtectedErrorType
+  | HttpClientError.HttpClientError
+  | Schema.SchemaError;
+
+const isRelayProtectedError = Schema.is(RelayProtectedError);
+
 export class ManagedRelayRequestFailedError extends Schema.TaggedErrorClass<ManagedRelayRequestFailedError>()(
   "ManagedRelayRequestFailedError",
   {
@@ -144,6 +151,15 @@ export class ManagedRelayRequestFailedError extends Schema.TaggedErrorClass<Mana
 ) {
   override get message(): string {
     return `Could not ${this.action}.`;
+  }
+
+  static fromHttpRequest(action: ManagedRelayRequestAction) {
+    return (cause: RelayHttpRequestError) =>
+      new ManagedRelayRequestFailedError({
+        action,
+        cause,
+        ...(isRelayProtectedError(cause) ? { relayError: cause, traceId: cause.traceId } : {}),
+      });
   }
 }
 
@@ -195,11 +211,6 @@ export const ManagedRelayClientError = Schema.Union([
   ManagedRelayRequestProofCreationError,
 ]);
 export type ManagedRelayClientError = typeof ManagedRelayClientError.Type;
-
-type RelayHttpRequestError =
-  | RelayProtectedErrorType
-  | HttpClientError.HttpClientError
-  | Schema.SchemaError;
 
 export class ManagedRelayDpopSigner extends Context.Service<
   ManagedRelayDpopSigner,
@@ -290,28 +301,8 @@ export class ManagedRelayClient extends Context.Service<
   }
 >()("@t3tools/client-runtime/relay/managedRelay/ManagedRelayClient") {}
 
-const isRelayProtectedError = Schema.is(RelayProtectedError);
-
-function relayRequestError(action: ManagedRelayRequestAction) {
-  return (cause: RelayHttpRequestError): ManagedRelayClientError =>
-    new ManagedRelayRequestFailedError({
-      action,
-      cause,
-      ...(isRelayProtectedError(cause) ? { relayError: cause, traceId: cause.traceId } : {}),
-    });
-}
-
-function proofCreationErrorFields(error: ManagedRelayDpopProofCreationError) {
-  return {
-    method: error.method,
-    url: error.url,
-    cause: error,
-  };
-}
-
-function isRejectedDpopAccessToken(error: ManagedRelayClientError): boolean {
+function isRejectedDpopAccessToken(error: ManagedRelayRequestFailedError): boolean {
   return (
-    error._tag === "ManagedRelayRequestFailedError" &&
     error.relayError?._tag === "RelayAuthInvalidError" &&
     error.relayError.reason === "invalid_bearer"
   );
@@ -461,13 +452,16 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         "relay.client_id": options.clientId,
         "relay.scopes": input.scopes.join(" "),
       });
-      const proof = yield* signer
-        .createProof(dpopProofTargets.exchangeAccessToken())
-        .pipe(
-          Effect.mapError(
-            (error) => new ManagedRelayTokenProofCreationError(proofCreationErrorFields(error)),
-          ),
-        );
+      const proof = yield* signer.createProof(dpopProofTargets.exchangeAccessToken()).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ManagedRelayTokenProofCreationError({
+              method: cause.method,
+              url: cause.url,
+              cause,
+            }),
+        ),
+      );
       const response = yield* client.token
         .exchangeDpopAccessToken({
           headers: { dpop: proof },
@@ -482,7 +476,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
           },
         })
         .pipe(
-          Effect.mapError(relayRequestError("exchange relay DPoP access token")),
+          Effect.mapError(
+            ManagedRelayRequestFailedError.fromHttpRequest("exchange relay DPoP access token"),
+          ),
           timeoutRelayRequest("Relay DPoP access token exchange"),
         );
       if (!oauthScopeSetEquals(response.scope, input.scopes)) {
@@ -589,7 +585,12 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       })
       .pipe(
         Effect.mapError(
-          (error) => new ManagedRelayRequestProofCreationError(proofCreationErrorFields(error)),
+          (cause) =>
+            new ManagedRelayRequestProofCreationError({
+              method: cause.method,
+              url: cause.url,
+              cause,
+            }),
         ),
       );
     return { accessToken: token.accessToken, proof, thumbprint };
@@ -623,27 +624,29 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       authorize(input).pipe(
         Effect.flatMap((authorization) =>
           request(authorization).pipe(
-            Effect.catch((error) => {
-              if (!isRejectedDpopAccessToken(error)) {
-                return Effect.fail(error);
-              }
-              return invalidateAccessToken(authorization.accessToken).pipe(
-                Effect.tap((invalidated) =>
-                  Effect.annotateCurrentSpan({
-                    "relay.token_cache.invalidated": invalidated,
-                    "relay.token_cache.invalidation_reason": "invalid_bearer",
-                    "relay.token_cache.retry_after_invalidation": refreshRejectedToken,
-                  }),
-                ),
-                Effect.tap((invalidated) =>
-                  invalidated && refreshRejectedToken
-                    ? Effect.logWarning(
-                        "Relay rejected a cached DPoP access token; refreshing it once.",
-                      )
-                    : Effect.void,
-                ),
-                Effect.andThen(refreshRejectedToken ? attempt(false) : Effect.fail(error)),
-              );
+            Effect.catchTags({
+              ManagedRelayRequestFailedError: (error) => {
+                if (!isRejectedDpopAccessToken(error)) {
+                  return Effect.fail(error);
+                }
+                return invalidateAccessToken(authorization.accessToken).pipe(
+                  Effect.tap((invalidated) =>
+                    Effect.annotateCurrentSpan({
+                      "relay.token_cache.invalidated": invalidated,
+                      "relay.token_cache.invalidation_reason": "invalid_bearer",
+                      "relay.token_cache.retry_after_invalidation": refreshRejectedToken,
+                    }),
+                  ),
+                  Effect.tap((invalidated) =>
+                    invalidated && refreshRejectedToken
+                      ? Effect.logWarning(
+                          "Relay rejected a cached DPoP access token; refreshing it once.",
+                        )
+                      : Effect.void,
+                  ),
+                  Effect.andThen(refreshRejectedToken ? attempt(false) : Effect.fail(error)),
+                );
+              },
             }),
           ),
         ),
@@ -676,7 +679,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
           .listEnvironments({ headers: bearerHeaders(input.clerkToken) })
           .pipe(
             Effect.map((response) => response.environments),
-            Effect.mapError(relayRequestError("list relay-managed environments")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest("list relay-managed environments"),
+            ),
             timeoutRelayRequest("Relay environment listing"),
           );
       },
@@ -691,7 +696,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
           })
           .pipe(
             Effect.map((response) => response.devices),
-            Effect.mapError(relayRequestError("list relay client devices")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest("list relay client devices"),
+            ),
             timeoutRelayRequest("Relay client device listing"),
           );
       },
@@ -706,7 +713,11 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
             payload: input.payload,
           })
           .pipe(
-            Effect.mapError(relayRequestError("create relay environment link challenge")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest(
+                "create relay environment link challenge",
+              ),
+            ),
             timeoutRelayRequest("Relay environment link challenge"),
           );
       },
@@ -721,7 +732,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
             payload: input.payload,
           })
           .pipe(
-            Effect.mapError(relayRequestError("link relay environment")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest("link relay environment"),
+            ),
             timeoutRelayRequest("Relay environment linking"),
           );
       },
@@ -736,7 +749,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
             params: { environmentId: input.environmentId },
           })
           .pipe(
-            Effect.mapError(relayRequestError("unlink relay environment")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest("unlink relay environment"),
+            ),
             timeoutRelayRequest("Relay environment unlinking"),
           );
       },
@@ -761,7 +776,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 params: { environmentId: input.environmentId },
               })
               .pipe(
-                Effect.mapError(relayRequestError("get relay environment status")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("get relay environment status"),
+                ),
                 timeoutRelayRequest("Relay environment status request"),
               ),
         );
@@ -792,7 +809,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 payload,
               })
               .pipe(
-                Effect.mapError(relayRequestError("connect relay environment")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("connect relay environment"),
+                ),
                 timeoutRelayRequest("Relay environment connection"),
               );
           },
@@ -815,7 +834,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 payload: input.payload,
               })
               .pipe(
-                Effect.mapError(relayRequestError("register relay mobile device")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("register relay mobile device"),
+                ),
                 timeoutRelayRequest("Relay mobile device registration"),
               ),
         );
@@ -837,7 +858,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 params: { deviceId: input.deviceId },
               })
               .pipe(
-                Effect.mapError(relayRequestError("unregister relay mobile device")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("unregister relay mobile device"),
+                ),
                 timeoutRelayRequest("Relay mobile device unregistration"),
               ),
         );
@@ -859,7 +882,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 payload: input.payload,
               })
               .pipe(
-                Effect.mapError(relayRequestError("register relay live activity")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("register relay live activity"),
+                ),
                 timeoutRelayRequest("Relay Live Activity registration"),
               ),
         );

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -64,6 +64,7 @@ export class ManagedRelayDpopKeyLoadError extends Schema.TaggedErrorClass<Manage
 export class ManagedRelayDpopProofCreationError extends Schema.TaggedErrorClass<ManagedRelayDpopProofCreationError>()(
   "ManagedRelayDpopProofCreationError",
   {
+    stage: Schema.Literals(["load-key", "create-proof"]),
     method: Schema.String,
     url: Schema.String,
     cause: Schema.Defect(),

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -53,6 +53,8 @@ export class ManagedRelayDpopKeyLoadError extends Schema.TaggedErrorClass<Manage
   "ManagedRelayDpopKeyLoadError",
   {
     keyStore: Schema.Literals(["expo-secure-store", "indexed-db"]),
+    method: Schema.optional(Schema.String),
+    url: Schema.optional(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
@@ -64,7 +66,6 @@ export class ManagedRelayDpopKeyLoadError extends Schema.TaggedErrorClass<Manage
 export class ManagedRelayDpopProofCreationError extends Schema.TaggedErrorClass<ManagedRelayDpopProofCreationError>()(
   "ManagedRelayDpopProofCreationError",
   {
-    stage: Schema.Literals(["load-key", "create-proof"]),
     method: Schema.String,
     url: Schema.String,
     cause: Schema.Defect(),
@@ -219,7 +220,7 @@ export class ManagedRelayDpopSigner extends Context.Service<
     readonly thumbprint: Effect.Effect<string, ManagedRelayDpopKeyLoadError>;
     readonly createProof: (
       input: ManagedRelayDpopProofInput,
-    ) => Effect.Effect<string, ManagedRelayDpopProofCreationError>;
+    ) => Effect.Effect<string, ManagedRelayDpopSignerError>;
   }
 >()("@t3tools/client-runtime/relay/managedRelay/ManagedRelayDpopSigner") {}
 
@@ -453,12 +454,13 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         "relay.client_id": options.clientId,
         "relay.scopes": input.scopes.join(" "),
       });
-      const proof = yield* signer.createProof(dpopProofTargets.exchangeAccessToken()).pipe(
+      const proofTarget = dpopProofTargets.exchangeAccessToken();
+      const proof = yield* signer.createProof(proofTarget).pipe(
         Effect.mapError(
           (cause) =>
             new ManagedRelayTokenProofCreationError({
-              method: cause.method,
-              url: cause.url,
+              method: proofTarget.method,
+              url: proofTarget.url,
               cause,
             }),
         ),
@@ -588,8 +590,8 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         Effect.mapError(
           (cause) =>
             new ManagedRelayRequestProofCreationError({
-              method: cause.method,
-              url: cause.url,
+              method: input.target.method,
+              url: input.target.url,
               cause,
             }),
         ),

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -28,9 +28,11 @@ import {
   RelayUnregisterDeviceEndpoint,
 } from "@t3tools/contracts/relay";
 import { encodeOAuthScope, oauthScopeSetEquals } from "@t3tools/shared/oauthScope";
+import { redactDpopRequestTarget } from "@t3tools/shared/dpop";
 import { decodeRelayJwt } from "@t3tools/shared/relayJwt";
 import { withRelayClientTracing } from "@t3tools/shared/relayTracing";
 import { normalizeSecureRelayUrl } from "@t3tools/shared/relayUrl";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
@@ -54,10 +56,24 @@ export class ManagedRelayDpopKeyLoadError extends Schema.TaggedErrorClass<Manage
   {
     keyStore: Schema.Literals(["expo-secure-store", "indexed-db"]),
     method: Schema.optional(Schema.String),
-    url: Schema.optional(Schema.String),
+    requestTarget: Schema.optional(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
+  static fromTarget(input: {
+    readonly keyStore: "expo-secure-store" | "indexed-db";
+    readonly method: string;
+    readonly url: string;
+    readonly cause: unknown;
+  }): ManagedRelayDpopKeyLoadError {
+    return new ManagedRelayDpopKeyLoadError({
+      keyStore: input.keyStore,
+      method: input.method,
+      requestTarget: redactDpopRequestTarget(input.url),
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
     return "Could not load relay DPoP proof key.";
   }
@@ -67,12 +83,24 @@ export class ManagedRelayDpopProofCreationError extends Schema.TaggedErrorClass<
   "ManagedRelayDpopProofCreationError",
   {
     method: Schema.String,
-    url: Schema.String,
+    requestTarget: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
+  static fromTarget(input: {
+    readonly method: string;
+    readonly url: string;
+    readonly cause: unknown;
+  }): ManagedRelayDpopProofCreationError {
+    return new ManagedRelayDpopProofCreationError({
+      method: input.method,
+      requestTarget: redactDpopRequestTarget(input.url),
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
-    return `Could not create the relay DPoP proof for ${this.method} ${this.url}.`;
+    return `Could not create the relay DPoP proof for ${this.method} ${this.requestTarget}.`;
   }
 }
 
@@ -127,9 +155,20 @@ export class ManagedRelayRequestTimeoutError extends Schema.TaggedErrorClass<Man
 export class ManagedRelayUrlInvalidError extends Schema.TaggedErrorClass<ManagedRelayUrlInvalidError>()(
   "ManagedRelayUrlInvalidError",
   {
-    relayUrl: Schema.String,
+    relayUrlInputLength: Schema.Number,
+    relayUrlProtocol: Schema.optionalKey(Schema.String),
+    relayUrlHostname: Schema.optionalKey(Schema.String),
   },
 ) {
+  static fromInput(relayUrl: string): ManagedRelayUrlInvalidError {
+    const diagnostics = getUrlDiagnostics(relayUrl);
+    return new ManagedRelayUrlInvalidError({
+      relayUrlInputLength: diagnostics.inputLength,
+      ...(diagnostics.protocol === undefined ? {} : { relayUrlProtocol: diagnostics.protocol }),
+      ...(diagnostics.hostname === undefined ? {} : { relayUrlHostname: diagnostics.hostname }),
+    });
+  }
+
   override get message(): string {
     return "Relay URL must be a secure absolute HTTPS origin.";
   }
@@ -181,10 +220,22 @@ export class ManagedRelayTokenProofCreationError extends Schema.TaggedErrorClass
   "ManagedRelayTokenProofCreationError",
   {
     method: Schema.String,
-    url: Schema.String,
+    requestTarget: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
+  static fromTarget(input: {
+    readonly method: string;
+    readonly url: string;
+    readonly cause: unknown;
+  }): ManagedRelayTokenProofCreationError {
+    return new ManagedRelayTokenProofCreationError({
+      method: input.method,
+      requestTarget: redactDpopRequestTarget(input.url),
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
     return "Could not create relay token DPoP proof.";
   }
@@ -194,10 +245,22 @@ export class ManagedRelayRequestProofCreationError extends Schema.TaggedErrorCla
   "ManagedRelayRequestProofCreationError",
   {
     method: Schema.String,
-    url: Schema.String,
+    requestTarget: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
+  static fromTarget(input: {
+    readonly method: string;
+    readonly url: string;
+    readonly cause: unknown;
+  }): ManagedRelayRequestProofCreationError {
+    return new ManagedRelayRequestProofCreationError({
+      method: input.method,
+      requestTarget: redactDpopRequestTarget(input.url),
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
     return "Could not create relay request DPoP proof.";
   }
@@ -376,7 +439,7 @@ function dpopHeaders(authorization: ManagedRelayAuthorization) {
 function disabledManagedRelayClient(relayUrl: string): ManagedRelayClient["Service"] {
   const unavailable = (spanName: string) =>
     Effect.fn(spanName)(function* () {
-      return yield* new ManagedRelayUrlInvalidError({ relayUrl });
+      return yield* ManagedRelayUrlInvalidError.fromInput(relayUrl);
     });
   return ManagedRelayClient.of({
     relayUrl,
@@ -456,13 +519,12 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       });
       const proofTarget = dpopProofTargets.exchangeAccessToken();
       const proof = yield* signer.createProof(proofTarget).pipe(
-        Effect.mapError(
-          (cause) =>
-            new ManagedRelayTokenProofCreationError({
-              method: proofTarget.method,
-              url: proofTarget.url,
-              cause,
-            }),
+        Effect.mapError((cause) =>
+          ManagedRelayTokenProofCreationError.fromTarget({
+            method: proofTarget.method,
+            url: proofTarget.url,
+            cause,
+          }),
         ),
       );
       const response = yield* client.token
@@ -573,7 +635,7 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       "relay.client_id": options.clientId,
       "relay.scopes": input.scopes.join(" "),
       "http.request.method": input.target.method,
-      "url.full": input.target.url,
+      "url.full": redactDpopRequestTarget(input.target.url),
     });
     const thumbprint = yield* signer.thumbprint;
     const token = yield* obtainAccessToken({
@@ -587,13 +649,12 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         accessToken: token.accessToken,
       })
       .pipe(
-        Effect.mapError(
-          (cause) =>
-            new ManagedRelayRequestProofCreationError({
-              method: input.target.method,
-              url: input.target.url,
-              cause,
-            }),
+        Effect.mapError((cause) =>
+          ManagedRelayRequestProofCreationError.fromTarget({
+            method: input.target.method,
+            url: input.target.url,
+            cause,
+          }),
         ),
       );
     return { accessToken: token.accessToken, proof, thumbprint };

--- a/packages/client-runtime/src/relay/managedRelayState.test.ts
+++ b/packages/client-runtime/src/relay/managedRelayState.test.ts
@@ -5,6 +5,7 @@ import type {
   RelayEnvironmentStatusResponse,
 } from "@t3tools/contracts/relay";
 import { describe, expect, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
@@ -17,6 +18,11 @@ import {
   createManagedRelayQueryManager,
   createManagedRelaySession,
   managedRelayAccountChanges,
+  ManagedRelaySessionUnavailableError,
+  ManagedRelayStatusEndpointMismatchError,
+  ManagedRelayStatusEnvironmentMismatchError,
+  ManagedRelayTokenReadError,
+  ManagedRelayTokenUnavailableError,
   type ManagedRelayQueryEvent,
   managedRelaySessionAtom,
   readManagedRelaySnapshotState,
@@ -109,6 +115,65 @@ function clerkToken(expiresAtSeconds: number): string {
 describe("createManagedRelayQueryManager", () => {
   afterEach(resetRegistry);
 
+  it("redacts endpoint mismatch secrets while retaining correlation fields", () => {
+    const expectedHttpBaseUrl =
+      "https://expected-user:expected-password@expected.example.test/private/catalog?token=expected-secret#expected-fragment";
+    const expectedWsBaseUrl =
+      "wss://expected-user:expected-password@expected.example.test/private/socket?token=expected-secret#expected-fragment";
+    const actualHttpBaseUrl =
+      "https://actual-user:actual-password@actual.example.test/private/catalog?token=actual-secret#actual-fragment";
+    const actualWsBaseUrl =
+      "wss://actual-user:actual-password@actual.example.test/private/socket?token=actual-secret#actual-fragment";
+
+    const error = ManagedRelayStatusEndpointMismatchError.fromEndpoints({
+      environmentId: environment.environmentId,
+      expectedEndpoint: {
+        providerKind: "cloudflare_tunnel",
+        httpBaseUrl: expectedHttpBaseUrl,
+        wsBaseUrl: expectedWsBaseUrl,
+      },
+      actualEndpoint: {
+        providerKind: "cloudflare_tunnel",
+        httpBaseUrl: actualHttpBaseUrl,
+        wsBaseUrl: actualWsBaseUrl,
+      },
+    });
+
+    expect(error).toMatchObject({
+      expectedProviderKind: "cloudflare_tunnel",
+      expectedHttpBaseUrlInputLength: expectedHttpBaseUrl.length,
+      expectedHttpBaseUrlProtocol: "https:",
+      expectedHttpBaseUrlHostname: "expected.example.test",
+      expectedWsBaseUrlInputLength: expectedWsBaseUrl.length,
+      expectedWsBaseUrlProtocol: "wss:",
+      expectedWsBaseUrlHostname: "expected.example.test",
+      actualProviderKind: "cloudflare_tunnel",
+      actualHttpBaseUrlInputLength: actualHttpBaseUrl.length,
+      actualHttpBaseUrlProtocol: "https:",
+      actualHttpBaseUrlHostname: "actual.example.test",
+      actualWsBaseUrlInputLength: actualWsBaseUrl.length,
+      actualWsBaseUrlProtocol: "wss:",
+      actualWsBaseUrlHostname: "actual.example.test",
+    });
+    expect(error).not.toHaveProperty("expectedEndpoint");
+    expect(error).not.toHaveProperty("actualEndpoint");
+    const exposedText = `${Object.values(error).join(" ")} ${error.message}`;
+    for (const secret of [
+      "expected-user",
+      "expected-password",
+      "/private/catalog",
+      "/private/socket",
+      "expected-secret",
+      "expected-fragment",
+      "actual-user",
+      "actual-password",
+      "actual-secret",
+      "actual-fragment",
+    ]) {
+      expect(exposedText).not.toContain(secret);
+    }
+  });
+
   it.effect("waits for the current cloud session before reading its token", () =>
     Effect.gen(function* () {
       const tokenFiber = yield* waitForManagedRelayClerkToken(registry).pipe(Effect.forkChild);
@@ -145,6 +210,62 @@ describe("createManagedRelayQueryManager", () => {
       expect(yield* Fiber.join(readsFiber)).toEqual([token, token]);
       expect(yield* session.readClerkToken()).toBe(token);
       expect(readClerkToken).toHaveBeenCalledTimes(1);
+    }),
+  );
+
+  it.effect("preserves token provider failure context", () =>
+    Effect.gen(function* () {
+      const cause = new Error("Clerk session failed");
+      const session = createManagedRelaySession({
+        accountId: "account-1",
+        readClerkToken: () => Promise.reject(cause),
+      });
+
+      const error = yield* Effect.flip(session.readClerkToken());
+
+      expect(error).toBeInstanceOf(ManagedRelayTokenReadError);
+      expect(error).toMatchObject({
+        _tag: "ManagedRelayTokenReadError",
+        accountId: "account-1",
+        cause,
+      });
+    }),
+  );
+
+  it.effect("distinguishes unavailable tokens from unavailable sessions", () =>
+    Effect.gen(function* () {
+      setManagedRelaySession(registry, {
+        accountId: "account-1",
+        readClerkToken: () => Promise.resolve(null),
+      });
+
+      const tokenError = yield* Effect.flip(waitForManagedRelayClerkToken(registry));
+      expect(tokenError).toBeInstanceOf(ManagedRelayTokenUnavailableError);
+      expect(tokenError).toMatchObject({
+        _tag: "ManagedRelayTokenUnavailableError",
+        accountId: "account-1",
+      });
+
+      setManagedRelaySession(registry, null);
+      const manager = createManager();
+      const atom = manager.environmentsAtom("account-1");
+      registry.get(atom);
+
+      yield* Effect.promise(() =>
+        vi.waitFor(() => {
+          const result = registry.get(atom);
+          expect(result._tag).toBe("Failure");
+          if (result._tag !== "Failure") {
+            return;
+          }
+          const error = Cause.squash(result.cause);
+          expect(error).toBeInstanceOf(ManagedRelaySessionUnavailableError);
+          expect(error).toMatchObject({
+            _tag: "ManagedRelaySessionUnavailableError",
+            requestedAccountId: "account-1",
+          });
+        }),
+      );
     }),
   );
 
@@ -197,30 +318,38 @@ describe("createManagedRelayQueryManager", () => {
     }),
   );
 
-  it("emits credential changes only when the managed relay account changes", async () => {
-    setManagedRelaySession(registry, {
-      accountId: "account-1",
-      readClerkToken: () => Promise.resolve("first-token"),
-    });
-    const changes = Effect.runPromise(
-      managedRelayAccountChanges(registry).pipe(Stream.take(2), Stream.runCollect),
-    );
-    await vi.waitFor(() => {
-      expect(registry.getNodes().get(managedRelaySessionAtom)?.listeners.size).toBeGreaterThan(0);
-    });
+  it.effect("emits credential changes only when the managed relay account changes", () =>
+    Effect.gen(function* () {
+      setManagedRelaySession(registry, {
+        accountId: "account-1",
+        readClerkToken: () => Promise.resolve("first-token"),
+      });
+      const changes = yield* managedRelayAccountChanges(registry).pipe(
+        Stream.take(2),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+      yield* Effect.promise(() =>
+        vi.waitFor(() => {
+          expect(registry.getNodes().get(managedRelaySessionAtom)?.listeners.size).toBeGreaterThan(
+            0,
+          );
+        }),
+      );
 
-    setManagedRelaySession(registry, {
-      accountId: "account-1",
-      readClerkToken: () => Promise.resolve("refreshed-token"),
-    });
-    setManagedRelaySession(registry, {
-      accountId: "account-2",
-      readClerkToken: () => Promise.resolve("second-token"),
-    });
-    setManagedRelaySession(registry, null);
+      setManagedRelaySession(registry, {
+        accountId: "account-1",
+        readClerkToken: () => Promise.resolve("refreshed-token"),
+      });
+      setManagedRelaySession(registry, {
+        accountId: "account-2",
+        readClerkToken: () => Promise.resolve("second-token"),
+      });
+      setManagedRelaySession(registry, null);
 
-    expect(Array.from(await changes)).toEqual(["account-2", null]);
-  });
+      expect(Array.from(yield* Fiber.join(changes))).toEqual(["account-2", null]);
+    }),
+  );
 
   it("shares one Clerk token read across concurrent relay list and status queries", async () => {
     const secondEnvironment = {
@@ -349,8 +478,20 @@ describe("createManagedRelayQueryManager", () => {
 
     registry.get(atom);
     await vi.waitFor(() => {
-      expect(readManagedRelaySnapshotState(registry.get(atom)).error).toBe(
-        "Relay returned status for a different environment.",
+      const result = registry.get(atom);
+      expect(result._tag).toBe("Failure");
+      if (result._tag !== "Failure") {
+        return;
+      }
+      const error = Cause.squash(result.cause);
+      expect(error).toBeInstanceOf(ManagedRelayStatusEnvironmentMismatchError);
+      expect(error).toMatchObject({
+        _tag: "ManagedRelayStatusEnvironmentMismatchError",
+        expectedEnvironmentId: environment.environmentId,
+        actualEnvironmentId: mismatchedStatus.environmentId,
+      });
+      expect(readManagedRelaySnapshotState(result).error).toBe(
+        "Relay returned status for environment environment-2 instead of environment-1.",
       );
     });
   });

--- a/packages/client-runtime/src/relay/managedRelayState.ts
+++ b/packages/client-runtime/src/relay/managedRelayState.ts
@@ -2,16 +2,19 @@ import type {
   RelayClientEnvironmentRecord,
   RelayEnvironmentStatusResponse,
 } from "@t3tools/contracts/relay";
+import { EnvironmentId } from "@t3tools/contracts";
 import {
   RelayEnvironmentConnectScope,
   RelayEnvironmentStatusScope,
+  RelayManagedEndpointProviderKind,
 } from "@t3tools/contracts/relay";
 import { decodeRelayJwt } from "@t3tools/shared/relayJwt";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Cause from "effect/Cause";
 import * as Clock from "effect/Clock";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
@@ -55,14 +58,138 @@ export interface ManagedRelayQueryEvent {
   readonly traceId?: string | null;
 }
 
-export class ManagedRelaySessionError extends Data.TaggedError("ManagedRelaySessionError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class ManagedRelayTokenReadError extends Schema.TaggedErrorClass<ManagedRelayTokenReadError>()(
+  "ManagedRelayTokenReadError",
+  {
+    accountId: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Could not obtain the T3 Cloud session token for account ${this.accountId}.`;
+  }
+}
 
-export class ManagedRelaySnapshotError extends Data.TaggedError("ManagedRelaySnapshotError")<{
-  readonly message: string;
-}> {}
+export class ManagedRelayTokenUnavailableError extends Schema.TaggedErrorClass<ManagedRelayTokenUnavailableError>()(
+  "ManagedRelayTokenUnavailableError",
+  { accountId: Schema.String },
+) {
+  override get message(): string {
+    return `The T3 Cloud session token is unavailable for account ${this.accountId}.`;
+  }
+}
+
+export class ManagedRelaySessionUnavailableError extends Schema.TaggedErrorClass<ManagedRelaySessionUnavailableError>()(
+  "ManagedRelaySessionUnavailableError",
+  { requestedAccountId: Schema.String },
+) {
+  override get message(): string {
+    return `Sign in to T3 Cloud as account ${this.requestedAccountId} before loading relay data.`;
+  }
+}
+
+export const ManagedRelaySessionError = Schema.Union([
+  ManagedRelayTokenReadError,
+  ManagedRelayTokenUnavailableError,
+  ManagedRelaySessionUnavailableError,
+]);
+export type ManagedRelaySessionError = typeof ManagedRelaySessionError.Type;
+
+export class ManagedRelayStatusEnvironmentMismatchError extends Schema.TaggedErrorClass<ManagedRelayStatusEnvironmentMismatchError>()(
+  "ManagedRelayStatusEnvironmentMismatchError",
+  {
+    expectedEnvironmentId: EnvironmentId,
+    actualEnvironmentId: EnvironmentId,
+  },
+) {
+  override get message(): string {
+    return `Relay returned status for environment ${this.actualEnvironmentId} instead of ${this.expectedEnvironmentId}.`;
+  }
+}
+
+export class ManagedRelayStatusEndpointMismatchError extends Schema.TaggedErrorClass<ManagedRelayStatusEndpointMismatchError>()(
+  "ManagedRelayStatusEndpointMismatchError",
+  {
+    environmentId: EnvironmentId,
+    expectedProviderKind: RelayManagedEndpointProviderKind,
+    expectedHttpBaseUrlInputLength: Schema.Number,
+    expectedHttpBaseUrlProtocol: Schema.optionalKey(Schema.String),
+    expectedHttpBaseUrlHostname: Schema.optionalKey(Schema.String),
+    expectedWsBaseUrlInputLength: Schema.Number,
+    expectedWsBaseUrlProtocol: Schema.optionalKey(Schema.String),
+    expectedWsBaseUrlHostname: Schema.optionalKey(Schema.String),
+    actualProviderKind: RelayManagedEndpointProviderKind,
+    actualHttpBaseUrlInputLength: Schema.Number,
+    actualHttpBaseUrlProtocol: Schema.optionalKey(Schema.String),
+    actualHttpBaseUrlHostname: Schema.optionalKey(Schema.String),
+    actualWsBaseUrlInputLength: Schema.Number,
+    actualWsBaseUrlProtocol: Schema.optionalKey(Schema.String),
+    actualWsBaseUrlHostname: Schema.optionalKey(Schema.String),
+  },
+) {
+  static fromEndpoints(input: {
+    readonly environmentId: EnvironmentId;
+    readonly expectedEndpoint: RelayClientEnvironmentRecord["endpoint"];
+    readonly actualEndpoint: RelayClientEnvironmentRecord["endpoint"];
+  }): ManagedRelayStatusEndpointMismatchError {
+    const expectedHttp = getUrlDiagnostics(input.expectedEndpoint.httpBaseUrl);
+    const expectedWs = getUrlDiagnostics(input.expectedEndpoint.wsBaseUrl);
+    const actualHttp = getUrlDiagnostics(input.actualEndpoint.httpBaseUrl);
+    const actualWs = getUrlDiagnostics(input.actualEndpoint.wsBaseUrl);
+    return new ManagedRelayStatusEndpointMismatchError({
+      environmentId: input.environmentId,
+      expectedProviderKind: input.expectedEndpoint.providerKind,
+      expectedHttpBaseUrlInputLength: expectedHttp.inputLength,
+      ...(expectedHttp.protocol === undefined
+        ? {}
+        : { expectedHttpBaseUrlProtocol: expectedHttp.protocol }),
+      ...(expectedHttp.hostname === undefined
+        ? {}
+        : { expectedHttpBaseUrlHostname: expectedHttp.hostname }),
+      expectedWsBaseUrlInputLength: expectedWs.inputLength,
+      ...(expectedWs.protocol === undefined
+        ? {}
+        : { expectedWsBaseUrlProtocol: expectedWs.protocol }),
+      ...(expectedWs.hostname === undefined
+        ? {}
+        : { expectedWsBaseUrlHostname: expectedWs.hostname }),
+      actualProviderKind: input.actualEndpoint.providerKind,
+      actualHttpBaseUrlInputLength: actualHttp.inputLength,
+      ...(actualHttp.protocol === undefined
+        ? {}
+        : { actualHttpBaseUrlProtocol: actualHttp.protocol }),
+      ...(actualHttp.hostname === undefined
+        ? {}
+        : { actualHttpBaseUrlHostname: actualHttp.hostname }),
+      actualWsBaseUrlInputLength: actualWs.inputLength,
+      ...(actualWs.protocol === undefined ? {} : { actualWsBaseUrlProtocol: actualWs.protocol }),
+      ...(actualWs.hostname === undefined ? {} : { actualWsBaseUrlHostname: actualWs.hostname }),
+    });
+  }
+
+  override get message(): string {
+    return `Relay returned a different endpoint for environment ${this.environmentId}.`;
+  }
+}
+
+export class ManagedRelayStatusDescriptorEnvironmentMismatchError extends Schema.TaggedErrorClass<ManagedRelayStatusDescriptorEnvironmentMismatchError>()(
+  "ManagedRelayStatusDescriptorEnvironmentMismatchError",
+  {
+    expectedEnvironmentId: EnvironmentId,
+    actualEnvironmentId: EnvironmentId,
+  },
+) {
+  override get message(): string {
+    return `Relay returned a descriptor for environment ${this.actualEnvironmentId} instead of ${this.expectedEnvironmentId}.`;
+  }
+}
+
+export const ManagedRelaySnapshotError = Schema.Union([
+  ManagedRelayStatusEnvironmentMismatchError,
+  ManagedRelayStatusEndpointMismatchError,
+  ManagedRelayStatusDescriptorEnvironmentMismatchError,
+]);
+export type ManagedRelaySnapshotError = typeof ManagedRelaySnapshotError.Type;
 
 export const managedRelaySessionAtom = Atom.make<ManagedRelaySession | null>(null).pipe(
   Atom.keepAlive,
@@ -122,8 +249,8 @@ export function createManagedRelaySession(input: ManagedRelaySessionInput): Mana
       return yield* Effect.tryPromise({
         try: () => readCachedClerkToken(nowMillis),
         catch: (cause) =>
-          new ManagedRelaySessionError({
-            message: "Could not obtain the T3 Cloud session token.",
+          new ManagedRelayTokenReadError({
+            accountId: input.accountId,
             cause,
           }),
       });
@@ -180,8 +307,8 @@ function readSessionClerkToken(
       token
         ? Effect.succeed(token)
         : Effect.fail(
-            new ManagedRelaySessionError({
-              message: "The T3 Cloud session token is unavailable.",
+            new ManagedRelayTokenUnavailableError({
+              accountId: session.accountId,
             }),
           ),
     ),
@@ -225,8 +352,8 @@ function requireClerkToken(
   const session = get(managedRelaySessionAtom);
   if (!session || session.accountId !== accountId) {
     return Effect.fail(
-      new ManagedRelaySessionError({
-        message: "Sign in to T3 Cloud before loading relay data.",
+      new ManagedRelaySessionUnavailableError({
+        requestedAccountId: accountId,
       }),
     );
   }
@@ -267,22 +394,26 @@ function validateEnvironmentStatus(
 ): Effect.Effect<RelayEnvironmentStatusResponse, ManagedRelaySnapshotError> {
   if (status.environmentId !== environment.environmentId) {
     return Effect.fail(
-      new ManagedRelaySnapshotError({
-        message: "Relay returned status for a different environment.",
+      new ManagedRelayStatusEnvironmentMismatchError({
+        expectedEnvironmentId: environment.environmentId,
+        actualEnvironmentId: status.environmentId,
       }),
     );
   }
   if (!endpointMatches(status.endpoint, environment.endpoint)) {
     return Effect.fail(
-      new ManagedRelaySnapshotError({
-        message: "Relay returned status for a different endpoint.",
+      ManagedRelayStatusEndpointMismatchError.fromEndpoints({
+        environmentId: environment.environmentId,
+        expectedEndpoint: environment.endpoint,
+        actualEndpoint: status.endpoint,
       }),
     );
   }
   if (status.descriptor && status.descriptor.environmentId !== environment.environmentId) {
     return Effect.fail(
-      new ManagedRelaySnapshotError({
-        message: "Relay returned status descriptor for a different environment.",
+      new ManagedRelayStatusDescriptorEnvironmentMismatchError({
+        expectedEnvironmentId: environment.environmentId,
+        actualEnvironmentId: status.descriptor.environmentId,
       }),
     );
   }

--- a/packages/client-runtime/src/rpc/http.ts
+++ b/packages/client-runtime/src/rpc/http.ts
@@ -14,24 +14,36 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
-import { FetchHttpClient, HttpClient, HttpClientError } from "effect/unstable/http";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 
 const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
 
-export class RemoteEnvironmentAuthFetchError extends Data.TaggedError(
+export class RemoteEnvironmentAuthFetchError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthFetchError>()(
   "RemoteEnvironmentAuthFetchError",
-)<{
-  readonly message: string;
-  readonly cause: unknown;
-}> {}
+  {
+    requestUrl: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to fetch remote environment endpoint ${this.requestUrl}.`;
+  }
+}
 
-export class RemoteEnvironmentAuthInvalidJsonError extends Data.TaggedError(
+export class RemoteEnvironmentAuthInvalidJsonError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthInvalidJsonError>()(
   "RemoteEnvironmentAuthInvalidJsonError",
-)<{
-  readonly message: string;
-  readonly cause: unknown;
-}> {}
+  {
+    requestUrl: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Remote environment endpoint returned an invalid response from ${this.requestUrl}.`;
+  }
+}
 
 export class RemoteEnvironmentAuthUndeclaredStatusError extends Data.TaggedError(
   "RemoteEnvironmentAuthUndeclaredStatusError",
@@ -49,21 +61,19 @@ export class RemoteEnvironmentAuthUndeclaredStatusError extends Data.TaggedError
   }
 }
 
-export class RemoteEnvironmentAuthTimeoutError extends Data.TaggedError(
+export class RemoteEnvironmentAuthTimeoutError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthTimeoutError>()(
   "RemoteEnvironmentAuthTimeoutError",
-)<{
-  readonly message: string;
-  readonly requestUrl: string;
-  readonly timeoutMs: number;
-}> {
-  constructor(requestUrl: string, timeoutMs: number) {
-    super({
-      message: `Remote environment endpoint ${requestUrl} timed out after ${timeoutMs}ms.`,
-      requestUrl,
-      timeoutMs,
-    });
+  {
+    requestUrl: Schema.String,
+    timeoutMs: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Remote environment endpoint ${this.requestUrl} timed out after ${this.timeoutMs}ms.`;
   }
 }
+
+const isRemoteEnvironmentAuthTimeoutError = Schema.is(RemoteEnvironmentAuthTimeoutError);
 
 export type RemoteEnvironmentRequestError =
   | EnvironmentRequestInvalidError
@@ -101,7 +111,7 @@ const failRemoteRequest = (
   requestUrl: string,
   cause: unknown,
 ): Effect.Effect<never, RemoteEnvironmentRequestError> => {
-  if (cause instanceof RemoteEnvironmentAuthTimeoutError) {
+  if (isRemoteEnvironmentAuthTimeoutError(cause)) {
     return Effect.fail(cause);
   }
   if (isEnvironmentHttpCommonError(cause)) {
@@ -110,7 +120,7 @@ const failRemoteRequest = (
   if (Schema.isSchemaError(cause)) {
     return Effect.fail(
       new RemoteEnvironmentAuthInvalidJsonError({
-        message: `Remote environment endpoint returned an invalid response from ${requestUrl}.`,
+        requestUrl,
         cause,
       }),
     );
@@ -124,14 +134,14 @@ const failRemoteRequest = (
     }
     return Effect.fail(
       new RemoteEnvironmentAuthInvalidJsonError({
-        message: `Remote environment endpoint returned an invalid response from ${requestUrl}.`,
+        requestUrl,
         cause,
       }),
     );
   }
   return Effect.fail(
     new RemoteEnvironmentAuthFetchError({
-      message: `Failed to fetch remote environment endpoint ${requestUrl} (${String(cause)}).`,
+      requestUrl,
       cause,
     }),
   );
@@ -146,7 +156,7 @@ export const executeEnvironmentHttpRequest = <A, E, R>(
     Effect.timeoutOption(Duration.millis(timeoutMs)),
     Effect.flatMap(
       Option.match({
-        onNone: () => Effect.fail(new RemoteEnvironmentAuthTimeoutError(requestUrl, timeoutMs)),
+        onNone: () => Effect.fail(new RemoteEnvironmentAuthTimeoutError({ requestUrl, timeoutMs })),
         onSome: Effect.succeed,
       }),
     ),

--- a/packages/client-runtime/src/rpc/http.ts
+++ b/packages/client-runtime/src/rpc/http.ts
@@ -8,7 +8,7 @@ import {
   type EnvironmentScopeRequiredError,
 } from "@t3tools/contracts";
 import { httpHeaderRedactionLayer } from "@t3tools/shared/httpObservability";
-import * as Data from "effect/Data";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -21,55 +21,113 @@ import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 
 const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
 
+const requestUrlDiagnosticSchema = {
+  requestUrlInputLength: Schema.Number,
+  requestUrlProtocol: Schema.optionalKey(Schema.String),
+  requestUrlHostname: Schema.optionalKey(Schema.String),
+} as const;
+
+function requestUrlDiagnosticFields(requestUrl: string) {
+  const diagnostics = getUrlDiagnostics(requestUrl);
+  return {
+    requestUrlInputLength: diagnostics.inputLength,
+    ...(diagnostics.protocol === undefined ? {} : { requestUrlProtocol: diagnostics.protocol }),
+    ...(diagnostics.hostname === undefined ? {} : { requestUrlHostname: diagnostics.hostname }),
+  };
+}
+
+function requestUrlDescription(input: {
+  readonly requestUrlInputLength: number;
+  readonly requestUrlHostname?: string;
+}): string {
+  return input.requestUrlHostname === undefined
+    ? `an invalid URL (${input.requestUrlInputLength} characters)`
+    : `host ${input.requestUrlHostname} (${input.requestUrlInputLength} URL characters)`;
+}
+
 export class RemoteEnvironmentAuthFetchError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthFetchError>()(
   "RemoteEnvironmentAuthFetchError",
   {
-    requestUrl: Schema.String,
+    ...requestUrlDiagnosticSchema,
     cause: Schema.Defect(),
   },
 ) {
+  static fromRequestUrl(requestUrl: string, cause: unknown): RemoteEnvironmentAuthFetchError {
+    return new RemoteEnvironmentAuthFetchError({
+      ...requestUrlDiagnosticFields(requestUrl),
+      cause,
+    });
+  }
+
   override get message(): string {
-    return `Failed to fetch remote environment endpoint ${this.requestUrl}.`;
+    return `Failed to fetch remote environment endpoint at ${requestUrlDescription(this)}.`;
   }
 }
 
 export class RemoteEnvironmentAuthInvalidJsonError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthInvalidJsonError>()(
   "RemoteEnvironmentAuthInvalidJsonError",
   {
-    requestUrl: Schema.String,
+    ...requestUrlDiagnosticSchema,
     cause: Schema.Defect(),
   },
 ) {
+  static fromRequestUrl(requestUrl: string, cause: unknown): RemoteEnvironmentAuthInvalidJsonError {
+    return new RemoteEnvironmentAuthInvalidJsonError({
+      ...requestUrlDiagnosticFields(requestUrl),
+      cause,
+    });
+  }
+
   override get message(): string {
-    return `Remote environment endpoint returned an invalid response from ${this.requestUrl}.`;
+    return `Remote environment endpoint at ${requestUrlDescription(this)} returned an invalid response.`;
   }
 }
 
-export class RemoteEnvironmentAuthUndeclaredStatusError extends Data.TaggedError(
+export class RemoteEnvironmentAuthUndeclaredStatusError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthUndeclaredStatusError>()(
   "RemoteEnvironmentAuthUndeclaredStatusError",
-)<{
-  readonly message: string;
-  readonly status: number;
-  readonly requestUrl: string;
-}> {
-  constructor(requestUrl: string, status: number) {
-    super({
-      message: `Remote environment endpoint ${requestUrl} returned undeclared status ${status}.`,
-      requestUrl,
+  {
+    ...requestUrlDiagnosticSchema,
+    status: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  static fromRequestUrl(
+    requestUrl: string,
+    status: number,
+    cause: unknown,
+  ): RemoteEnvironmentAuthUndeclaredStatusError {
+    return new RemoteEnvironmentAuthUndeclaredStatusError({
+      ...requestUrlDiagnosticFields(requestUrl),
       status,
+      cause,
     });
   }
+
+  override get message(): string {
+    return `Remote environment endpoint at ${requestUrlDescription(this)} returned undeclared status ${this.status}.`;
+  }
 }
+
+export const isRemoteEnvironmentAuthUndeclaredStatusError = Schema.is(
+  RemoteEnvironmentAuthUndeclaredStatusError,
+);
 
 export class RemoteEnvironmentAuthTimeoutError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthTimeoutError>()(
   "RemoteEnvironmentAuthTimeoutError",
   {
-    requestUrl: Schema.String,
+    ...requestUrlDiagnosticSchema,
     timeoutMs: Schema.Number,
   },
 ) {
+  static fromRequestUrl(requestUrl: string, timeoutMs: number): RemoteEnvironmentAuthTimeoutError {
+    return new RemoteEnvironmentAuthTimeoutError({
+      ...requestUrlDiagnosticFields(requestUrl),
+      timeoutMs,
+    });
+  }
+
   override get message(): string {
-    return `Remote environment endpoint ${this.requestUrl} timed out after ${this.timeoutMs}ms.`;
+    return `Remote environment endpoint at ${requestUrlDescription(this)} timed out after ${this.timeoutMs}ms.`;
   }
 }
 
@@ -118,33 +176,22 @@ const failRemoteRequest = (
     return Effect.fail(cause);
   }
   if (Schema.isSchemaError(cause)) {
-    return Effect.fail(
-      new RemoteEnvironmentAuthInvalidJsonError({
-        requestUrl,
-        cause,
-      }),
-    );
+    return Effect.fail(RemoteEnvironmentAuthInvalidJsonError.fromRequestUrl(requestUrl, cause));
   }
   if (HttpClientError.isHttpClientError(cause) && cause.response !== undefined) {
     const response = cause.response;
     if (response.status < 200 || response.status >= 300) {
       return Effect.fail(
-        new RemoteEnvironmentAuthUndeclaredStatusError(requestUrl, response.status),
+        RemoteEnvironmentAuthUndeclaredStatusError.fromRequestUrl(
+          requestUrl,
+          response.status,
+          cause,
+        ),
       );
     }
-    return Effect.fail(
-      new RemoteEnvironmentAuthInvalidJsonError({
-        requestUrl,
-        cause,
-      }),
-    );
+    return Effect.fail(RemoteEnvironmentAuthInvalidJsonError.fromRequestUrl(requestUrl, cause));
   }
-  return Effect.fail(
-    new RemoteEnvironmentAuthFetchError({
-      requestUrl,
-      cause,
-    }),
-  );
+  return Effect.fail(RemoteEnvironmentAuthFetchError.fromRequestUrl(requestUrl, cause));
 };
 
 export const executeEnvironmentHttpRequest = <A, E, R>(
@@ -156,7 +203,8 @@ export const executeEnvironmentHttpRequest = <A, E, R>(
     Effect.timeoutOption(Duration.millis(timeoutMs)),
     Effect.flatMap(
       Option.match({
-        onNone: () => Effect.fail(new RemoteEnvironmentAuthTimeoutError({ requestUrl, timeoutMs })),
+        onNone: () =>
+          Effect.fail(RemoteEnvironmentAuthTimeoutError.fromRequestUrl(requestUrl, timeoutMs)),
         onSome: Effect.succeed,
       }),
     ),

--- a/packages/client-runtime/src/rpc/session.ts
+++ b/packages/client-runtime/src/rpc/session.ts
@@ -51,7 +51,7 @@ function mapInitialConfigError(error: InitialConfigError): ConnectionAttemptErro
         detail: error.message,
         cause: error,
       });
-    case "KeybindingsConfigParseError":
+    case "KeybindingsConfigError":
     case "ServerSettingsError":
       return new ConnectionTransientErrorClass({
         reason: "remote-unavailable",

--- a/packages/client-runtime/src/rpc/session.ts
+++ b/packages/client-runtime/src/rpc/session.ts
@@ -49,17 +49,20 @@ function mapInitialConfigError(error: InitialConfigError): ConnectionAttemptErro
       return new ConnectionBlockedError({
         reason: "permission",
         detail: error.message,
+        cause: error,
       });
     case "KeybindingsConfigParseError":
     case "ServerSettingsError":
       return new ConnectionTransientErrorClass({
         reason: "remote-unavailable",
         detail: error.message,
+        cause: error,
       });
     case "RpcClientError":
       return new ConnectionTransientErrorClass({
         reason: "transport",
         detail: error.message,
+        cause: error,
       });
   }
 }

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -157,14 +157,21 @@ export const ResolvedKeybindingsConfig = Schema.Array(ResolvedKeybindingRule).ch
 export type ResolvedKeybindingsConfig = typeof ResolvedKeybindingsConfig.Type;
 
 export class KeybindingsConfigError extends Schema.TaggedErrorClass<KeybindingsConfigError>()(
-  "KeybindingsConfigParseError",
+  "KeybindingsConfigError",
   {
     configPath: Schema.String,
-    detail: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
+    operation: Schema.Literals([
+      "access",
+      "read",
+      "decode",
+      "encode",
+      "write",
+      "prepare-directory",
+    ]),
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Unable to parse keybindings config at ${this.configPath}: ${this.detail}`;
+    return `Keybindings config operation '${this.operation}' failed at ${this.configPath}.`;
   }
 }


### PR DESCRIPTION
## Summary

- model remote fetch, invalid-response, and timeout failures with structured request context and messages that do not stringify their causes
- retain the immediate relay, remote authorization, DPoP, and RPC failure as `cause` when translating into connection classifications
- move relay HTTP failure mapping onto `ManagedRelayRequestFailedError`, use tag-directed retry handling, and inline a no-value proof-error field wrapper
- add focused coverage for classification metadata and complete cause chains

The undeclared-status conversion is intentionally left for the SSH follow-up because its current `instanceof` consumer is being changed by #3206.

## Validation

- `vp check`
- `vp run typecheck`
- `vp test packages/client-runtime/src/connection/errors.test.ts packages/client-runtime/src/authorization/remote.test.ts packages/client-runtime/src/authorization/layer.test.ts packages/client-runtime/src/rpc/session.test.ts packages/client-runtime/src/relay/managedRelay.test.ts packages/client-runtime/src/connection/onboarding.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication, connection resolution, and relay/remote HTTP error paths across desktop, mobile, web, and server; behavior changes for error shape and logging are broad but covered by focused tests.
> 
> **Overview**
> This PR tightens **client connection and relay error handling** so failures keep a inspectable **`cause` chain** while **logs and user-facing messages stop embedding full URLs, credentials, or raw config entries**.
> 
> **Connection layer:** `ConnectionBlockedError` and `ConnectionTransientError` gain optional **`cause`** plus structured fields (`connectionId`, `expectedEnvironmentId`, `actualEnvironmentId`). Relay and remote-environment mappers attach the original error instead of dropping it. Environment mismatch and missing profile/credential paths build `ConnectionBlockedError` inline with those fields.
> 
> **Remote HTTP / auth:** `RemoteEnvironmentAuthFetchError`, timeout, invalid JSON, and undeclared-status errors become **`Schema.TaggedErrorClass`** types with **hostname / protocol / URL length** diagnostics; messages no longer stringify transport details or embed request URLs. Desktop SSH uses **`isRemoteEnvironmentAuthUndeclaredStatusError`** instead of `instanceof`.
> 
> **Managed relay:** Invalid relay URLs and DPoP failures use **`getUrlDiagnostics`** / **`redactDpopRequestTarget`**; proof errors distinguish key-load vs creation via **`fromTarget`**. HTTP failures map through **`ManagedRelayRequestFailedError.fromHttpRequest`**; DPoP token retry uses **`catchTags`**. Offline health-check logs emit endpoint diagnostics, not raw `httpBaseUrl`.
> 
> **Server keybindings:** **`KeybindingsConfigError`** is renamed and modeled with **`operation`** + **`cause`** (replacing free-form `detail`). Runtime issues use **stable messages**; warnings log **validation metadata** (stage, field presence, cause counts) without full entries or secrets. Startup and watcher failures log structured cause attributes.
> 
> **Tests** cover redaction, cause retention, and stable decode errors across the touched paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b8b72c68f23230c72ca8281b9ae3ef2571cf141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve error causes and redact sensitive URLs in client connection errors
> - Extends `ConnectionBlockedError` and `ConnectionTransientError` with optional `cause`, `connectionId`, `expectedEnvironmentId`, and `actualEnvironmentId` fields so callers can inspect the original error chain.
> - Replaces generic session/snapshot error classes in `managedRelayState.ts` with structured union types (`ManagedRelayTokenReadError`, `ManagedRelayTokenUnavailableError`, `ManagedRelaySessionUnavailableError`, and snapshot-specific variants) that preserve account IDs and original causes.
> - Replaces raw URL fields in `ManagedRelayUrlInvalidError`, `ManagedRelayDpopProofCreationError`, and related classes with redacted diagnostics (input length, protocol, hostname) via `getUrlDiagnostics`; DPoP errors use new `fromTarget` static factories.
> - Rewrites `RemoteEnvironmentAuthFetchError`, `RemoteEnvironmentAuthTimeoutError`, `RemoteEnvironmentAuthInvalidJsonError`, and `RemoteEnvironmentAuthUndeclaredStatusError` in `rpc/http.ts` as `Schema.TaggedErrorClass` with URL diagnostics and `fromRequestUrl` factories; messages no longer include raw URLs or cause strings.
> - Updates `keybindings.ts` to emit structured `KeybindingsConfigError` (renamed from `KeybindingsConfigParseError`) with an `operation` field and sanitized log attributes that omit raw entries and secret values.
> - Behavioral Change: error message strings across relay, remote auth, and keybindings change to reference redacted URL metadata (host, character count) rather than full URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b8b72c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->