### PR TITLE
[codex] Allow removing stale remote backends while reconnecting

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1413,6 +1413,7 @@ function SavedBackendListRow({
   const connectionState = environment.connection.phase;
   const isConnected = connectionState === "connected";
   const isConnecting = connectionState === "connecting" || connectionState === "reconnecting";
+  const canDisconnect = isConnected || isConnecting;
   const stateDotClassName =
     connectionState === "connected"
       ? "bg-success"
@@ -1480,16 +1481,16 @@ function SavedBackendListRow({
           <Button
             size="xs"
             variant="outline"
-            disabled={isConnecting || removingEnvironmentId === environmentId}
-            onClick={() => void (isConnected ? onRemove(environmentId) : onConnect(environmentId))}
+            disabled={removingEnvironmentId === environmentId}
+            onClick={() =>
+              void (canDisconnect ? onRemove(environmentId) : onConnect(environmentId))
+            }
           >
-            {isConnected
+            {canDisconnect
               ? removingEnvironmentId === environmentId
                 ? "Disconnecting…"
                 : "Disconnect"
-              : isConnecting
-                ? "Connecting…"
-                : "Connect"}
+              : "Connect"}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- allow saved backend rows to disconnect while they are connecting or reconnecting
- keep the existing connect action for available, offline, and error states
- reuse the existing environment removal path instead of adding backend behavior
- no tests were added; existing runtime coverage validates the removal path

## Root cause

The saved backend row disabled its only action while the connection phase was `connecting` or `reconnecting`, so a stale backend could keep retrying without exposing the existing remove action.

## Impact

Users can remove stale remote or SSH backends even while the client is retrying the connection. Connected and disconnected backend behavior is otherwise unchanged.

## Validation

- `vp test run packages/client-runtime/src/connection/supervisor.test.ts -t "explicit disconnect"`
- `vp test run packages/client-runtime/src/connection/registry.test.ts -t "remove"`
- `vp test run packages/client-runtime/src/platform/storageDocument.test.ts`
- `vp check`
- `vp run typecheck`

`vp check` reports the repository's existing 20 unrelated warnings and no errors.

Closes #3214

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow disconnecting backends that are in a connecting or reconnecting state
> Updates `SavedBackendListRow` in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/3247/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) so the Disconnect button is active during connecting and reconnecting phases. Previously, the button was disabled and showed "Connecting…" during these phases; now it shows "Disconnect" and calls `onRemove` instead of `onConnect`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f22b3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component UX change in Connections settings; disconnect still uses the established environment removal path with no auth or connection-layer edits in this diff.
> 
> **Overview**
> **Saved backend rows** in Connections settings no longer lock the action button while the client is in `connecting` or `reconnecting`. The row treats those phases like a live session via `canDisconnect`, so the button stays enabled and shows **Disconnect** (or **Disconnecting…** while removal runs) instead of a disabled **Connecting…** state.
> 
> **Connect** is unchanged for disconnected, offline, and error phases; disconnect still goes through the existing `onRemove` / environment removal path—no new backend behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f22b3c31ccda3abeb2c833e561a8e2dcf1d1f7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->