### PR TITLE
[codex] Structure ACP transport errors

### DIFF
--- a/packages/effect-acp/src/_internal/shared.ts
+++ b/packages/effect-acp/src/_internal/shared.ts
@@ -11,20 +11,23 @@ const isAcpRequestError = Schema.is(AcpError.AcpRequestError);
 const formatSchemaIssue = SchemaIssue.makeFormatterDefault();
 
 export const callRpc = <A>(
+  method: string,
   effect: Effect.Effect<A, RpcClientError.RpcClientError | AcpSchema.Error>,
 ): Effect.Effect<A, AcpError.AcpError> =>
   effect.pipe(
-    Effect.catchTag("RpcClientError", (error) =>
-      Effect.fail(
-        new AcpError.AcpTransportError({
-          detail: error.message,
-          cause: error,
-        }),
-      ),
-    ),
     Effect.catchIf(isError, (error) =>
       Effect.fail(AcpError.AcpRequestError.fromProtocolError(error)),
     ),
+    Effect.catchTags({
+      RpcClientError: (cause) =>
+        Effect.fail(
+          new AcpError.AcpTransportError({
+            operation: "call-rpc",
+            method,
+            cause,
+          }),
+        ),
+    }),
   );
 
 export const runHandler = Effect.fnUntraced(function* <A, B>(

--- a/packages/effect-acp/src/_internal/shared.ts
+++ b/packages/effect-acp/src/_internal/shared.ts
@@ -6,7 +6,6 @@ import { RpcClientError } from "effect/unstable/rpc";
 import * as AcpSchema from "../_generated/schema.gen.ts";
 import * as AcpError from "../errors.ts";
 const isError = Schema.is(AcpSchema.Error);
-const isAcpRequestError = Schema.is(AcpError.AcpRequestError);
 
 const formatSchemaIssue = SchemaIssue.makeFormatterDefault();
 
@@ -40,9 +39,7 @@ export const runHandler = Effect.fnUntraced(function* <A, B>(
   }
   return yield* handler(payload).pipe(
     Effect.mapError((error) =>
-      isAcpRequestError(error)
-        ? error.toProtocolError()
-        : AcpError.AcpRequestError.internalError(error.message).toProtocolError(),
+      AcpError.AcpRequestError.fromHandlerError(error, method).toProtocolError(),
     ),
   );
 });

--- a/packages/effect-acp/src/_internal/shared.ts
+++ b/packages/effect-acp/src/_internal/shared.ts
@@ -74,7 +74,9 @@ export function decodeExtNotificationRegistration<A, I>(
       Effect.mapError(
         (error) =>
           new AcpError.AcpProtocolParseError({
-            detail: `Invalid ${method} notification payload: ${formatSchemaIssue(error.issue)}`,
+            operation: "decode-notification-payload",
+            method,
+            detail: formatSchemaIssue(error.issue),
             cause: error,
           }),
       ),

--- a/packages/effect-acp/src/_internal/shared.ts
+++ b/packages/effect-acp/src/_internal/shared.ts
@@ -36,7 +36,7 @@ export const runHandler = Effect.fnUntraced(function* <A, B>(
   }
   return yield* handler(payload).pipe(
     Effect.mapError((error) =>
-      AcpError.AcpRequestError.fromHandlerError(error, method).toProtocolError(),
+      AcpError.AcpRequestError.fromCoreHandlerError(error, method).toProtocolError(),
     ),
   );
 });

--- a/packages/effect-acp/src/_internal/shared.ts
+++ b/packages/effect-acp/src/_internal/shared.ts
@@ -1,13 +1,10 @@
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
-import * as SchemaIssue from "effect/SchemaIssue";
 import { RpcClientError } from "effect/unstable/rpc";
 
 import * as AcpSchema from "../_generated/schema.gen.ts";
 import * as AcpError from "../errors.ts";
 const isError = Schema.is(AcpSchema.Error);
-
-const formatSchemaIssue = SchemaIssue.makeFormatterDefault();
 
 export const callRpc = <A>(
   method: string,
@@ -51,12 +48,7 @@ export function decodeExtRequestRegistration<A, I>(
 ) {
   return (params: unknown): Effect.Effect<unknown, AcpError.AcpError> =>
     Schema.decodeUnknownEffect(payload)(params).pipe(
-      Effect.mapError((error) =>
-        AcpError.AcpRequestError.invalidParams(
-          `Invalid ${method} payload: ${formatSchemaIssue(error.issue)}`,
-          { issue: error.issue },
-        ),
-      ),
+      Effect.mapError((error) => AcpError.AcpRequestError.invalidExtensionPayload(method, error)),
       Effect.flatMap((decoded) => handler(decoded)),
     );
 }
@@ -68,14 +60,12 @@ export function decodeExtNotificationRegistration<A, I>(
 ) {
   return (params: unknown): Effect.Effect<void, AcpError.AcpError> =>
     Schema.decodeUnknownEffect(payload)(params).pipe(
-      Effect.mapError(
-        (error) =>
-          new AcpError.AcpProtocolParseError({
-            operation: "decode-notification-payload",
-            method,
-            detail: formatSchemaIssue(error.issue),
-            cause: error,
-          }),
+      Effect.mapError((error) =>
+        AcpError.AcpProtocolParseError.fromSchemaError(
+          "decode-notification-payload",
+          method,
+          error,
+        ),
       ),
       Effect.flatMap((decoded) => handler(decoded)),
     );

--- a/packages/effect-acp/src/_internal/stdio.ts
+++ b/packages/effect-acp/src/_internal/stdio.ts
@@ -50,7 +50,7 @@ export const makeTerminationError = (
   Effect.match(handle.exitCode, {
     onFailure: (cause) =>
       new AcpError.AcpTransportError({
-        detail: "Failed to determine ACP process exit status",
+        operation: "read-process-exit-status",
         cause,
       }),
     onSuccess: (code) => new AcpError.AcpProcessExitedError({ code }),

--- a/packages/effect-acp/src/agent.ts
+++ b/packages/effect-acp/src/agent.ts
@@ -376,35 +376,48 @@ export const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
     },
     client: {
       requestPermission: (payload) =>
-        callRpc(rpc[CLIENT_METHODS.session_request_permission](payload)),
-      elicit: (payload) => callRpc(rpc[CLIENT_METHODS.session_elicitation](payload)),
-      readTextFile: (payload) => callRpc(rpc[CLIENT_METHODS.fs_read_text_file](payload)),
-      writeTextFile: (payload) => callRpc(rpc[CLIENT_METHODS.fs_write_text_file](payload)),
+        callRpc(
+          CLIENT_METHODS.session_request_permission,
+          rpc[CLIENT_METHODS.session_request_permission](payload),
+        ),
+      elicit: (payload) =>
+        callRpc(
+          CLIENT_METHODS.session_elicitation,
+          rpc[CLIENT_METHODS.session_elicitation](payload),
+        ),
+      readTextFile: (payload) =>
+        callRpc(CLIENT_METHODS.fs_read_text_file, rpc[CLIENT_METHODS.fs_read_text_file](payload)),
+      writeTextFile: (payload) =>
+        callRpc(CLIENT_METHODS.fs_write_text_file, rpc[CLIENT_METHODS.fs_write_text_file](payload)),
       createTerminal: (payload) =>
-        callRpc(rpc[CLIENT_METHODS.terminal_create](payload)).pipe(
+        callRpc(CLIENT_METHODS.terminal_create, rpc[CLIENT_METHODS.terminal_create](payload)).pipe(
           Effect.map((response) =>
             AcpTerminal.makeTerminal({
               sessionId: payload.sessionId,
               terminalId: response.terminalId,
               output: callRpc(
+                CLIENT_METHODS.terminal_output,
                 rpc[CLIENT_METHODS.terminal_output]({
                   sessionId: payload.sessionId,
                   terminalId: response.terminalId,
                 }),
               ),
               waitForExit: callRpc(
+                CLIENT_METHODS.terminal_wait_for_exit,
                 rpc[CLIENT_METHODS.terminal_wait_for_exit]({
                   sessionId: payload.sessionId,
                   terminalId: response.terminalId,
                 }),
               ),
               kill: callRpc(
+                CLIENT_METHODS.terminal_kill,
                 rpc[CLIENT_METHODS.terminal_kill]({
                   sessionId: payload.sessionId,
                   terminalId: response.terminalId,
                 }),
               ),
               release: callRpc(
+                CLIENT_METHODS.terminal_release,
                 rpc[CLIENT_METHODS.terminal_release]({
                   sessionId: payload.sessionId,
                   terminalId: response.terminalId,

--- a/packages/effect-acp/src/agent.ts
+++ b/packages/effect-acp/src/agent.ts
@@ -288,13 +288,12 @@ export const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
         notification.method === AGENT_METHODS.session_cancel
       ) {
         return decodeCancelNotification(notification.params).pipe(
-          Effect.mapError(
-            (error) =>
-              new AcpError.AcpProtocolParseError({
-                operation: "decode-notification-payload",
-                method: AGENT_METHODS.session_cancel,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            AcpError.AcpProtocolParseError.fromSchemaError(
+              "decode-notification-payload",
+              AGENT_METHODS.session_cancel,
+              error,
+            ),
           ),
           Effect.flatMap((decoded) =>
             Effect.forEach(cancelHandlers, (handler) => handler(decoded), { discard: true }),

--- a/packages/effect-acp/src/agent.ts
+++ b/packages/effect-acp/src/agent.ts
@@ -291,7 +291,8 @@ export const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
           Effect.mapError(
             (error) =>
               new AcpError.AcpProtocolParseError({
-                detail: `Invalid ${AGENT_METHODS.session_cancel} notification payload`,
+                operation: "decode-notification-payload",
+                method: AGENT_METHODS.session_cancel,
                 cause: error,
               }),
           ),

--- a/packages/effect-acp/src/agent.ts
+++ b/packages/effect-acp/src/agent.ts
@@ -391,39 +391,40 @@ export const make = Effect.fn("effect-acp/AcpAgent.make")(function* (
         callRpc(CLIENT_METHODS.fs_write_text_file, rpc[CLIENT_METHODS.fs_write_text_file](payload)),
       createTerminal: (payload) =>
         callRpc(CLIENT_METHODS.terminal_create, rpc[CLIENT_METHODS.terminal_create](payload)).pipe(
-          Effect.map((response) =>
-            AcpTerminal.makeTerminal({
-              sessionId: payload.sessionId,
-              terminalId: response.terminalId,
-              output: callRpc(
-                CLIENT_METHODS.terminal_output,
-                rpc[CLIENT_METHODS.terminal_output]({
-                  sessionId: payload.sessionId,
-                  terminalId: response.terminalId,
-                }),
-              ),
-              waitForExit: callRpc(
-                CLIENT_METHODS.terminal_wait_for_exit,
-                rpc[CLIENT_METHODS.terminal_wait_for_exit]({
-                  sessionId: payload.sessionId,
-                  terminalId: response.terminalId,
-                }),
-              ),
-              kill: callRpc(
-                CLIENT_METHODS.terminal_kill,
-                rpc[CLIENT_METHODS.terminal_kill]({
-                  sessionId: payload.sessionId,
-                  terminalId: response.terminalId,
-                }),
-              ),
-              release: callRpc(
-                CLIENT_METHODS.terminal_release,
-                rpc[CLIENT_METHODS.terminal_release]({
-                  sessionId: payload.sessionId,
-                  terminalId: response.terminalId,
-                }),
-              ),
-            }),
+          Effect.map(
+            (response) =>
+              ({
+                sessionId: payload.sessionId,
+                terminalId: response.terminalId,
+                output: callRpc(
+                  CLIENT_METHODS.terminal_output,
+                  rpc[CLIENT_METHODS.terminal_output]({
+                    sessionId: payload.sessionId,
+                    terminalId: response.terminalId,
+                  }),
+                ),
+                waitForExit: callRpc(
+                  CLIENT_METHODS.terminal_wait_for_exit,
+                  rpc[CLIENT_METHODS.terminal_wait_for_exit]({
+                    sessionId: payload.sessionId,
+                    terminalId: response.terminalId,
+                  }),
+                ),
+                kill: callRpc(
+                  CLIENT_METHODS.terminal_kill,
+                  rpc[CLIENT_METHODS.terminal_kill]({
+                    sessionId: payload.sessionId,
+                    terminalId: response.terminalId,
+                  }),
+                ),
+                release: callRpc(
+                  CLIENT_METHODS.terminal_release,
+                  rpc[CLIENT_METHODS.terminal_release]({
+                    sessionId: payload.sessionId,
+                    terminalId: response.terminalId,
+                  }),
+                ),
+              }) satisfies AcpTerminal.AcpTerminal,
           ),
         ),
       sessionUpdate: (payload) => transport.notify(CLIENT_METHODS.session_update, payload),

--- a/packages/effect-acp/src/client.test.ts
+++ b/packages/effect-acp/src/client.test.ts
@@ -147,7 +147,7 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
   );
 
   it.effect(
-    "returns formatted invalid params when a typed extension request payload is wrong",
+    "returns structured invalid params without exposing values from typed extension request payloads",
     () =>
       Effect.gen(function* () {
         const handle = yield* makeHandle({ ACP_MOCK_BAD_TYPED_REQUEST: "1" });
@@ -213,8 +213,8 @@ it.layer(NodeServices.layer)("effect-acp client", (it) => {
           assert.fail("Expected prompt to fail for invalid typed extension payload");
         }
         const rendered = Cause.pretty(result.cause);
-        assert.include(rendered, "Invalid x/typed_request payload:");
-        assert.include(rendered, "Expected string, got 123");
+        assert.include(rendered, "Invalid payload for ACP extension method 'x/typed_request'.");
+        assert.notInclude(rendered, "Expected string, got 123");
       }),
   );
 

--- a/packages/effect-acp/src/client.ts
+++ b/packages/effect-acp/src/client.ts
@@ -462,19 +462,32 @@ export const make = Effect.fn("effect-acp/AcpClient.make")(function* (
       notify: transport.notify,
     },
     agent: {
-      initialize: (payload) => callRpc(rpc[AGENT_METHODS.initialize](payload)),
-      authenticate: (payload) => callRpc(rpc[AGENT_METHODS.authenticate](payload)),
-      logout: (payload) => callRpc(rpc[AGENT_METHODS.logout](payload)),
-      createSession: (payload) => callRpc(rpc[AGENT_METHODS.session_new](payload)),
-      loadSession: (payload) => callRpc(rpc[AGENT_METHODS.session_load](payload)),
-      listSessions: (payload) => callRpc(rpc[AGENT_METHODS.session_list](payload)),
-      forkSession: (payload) => callRpc(rpc[AGENT_METHODS.session_fork](payload)),
-      resumeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_resume](payload)),
-      closeSession: (payload) => callRpc(rpc[AGENT_METHODS.session_close](payload)),
-      setSessionModel: (payload) => callRpc(rpc[AGENT_METHODS.session_set_model](payload)),
+      initialize: (payload) =>
+        callRpc(AGENT_METHODS.initialize, rpc[AGENT_METHODS.initialize](payload)),
+      authenticate: (payload) =>
+        callRpc(AGENT_METHODS.authenticate, rpc[AGENT_METHODS.authenticate](payload)),
+      logout: (payload) => callRpc(AGENT_METHODS.logout, rpc[AGENT_METHODS.logout](payload)),
+      createSession: (payload) =>
+        callRpc(AGENT_METHODS.session_new, rpc[AGENT_METHODS.session_new](payload)),
+      loadSession: (payload) =>
+        callRpc(AGENT_METHODS.session_load, rpc[AGENT_METHODS.session_load](payload)),
+      listSessions: (payload) =>
+        callRpc(AGENT_METHODS.session_list, rpc[AGENT_METHODS.session_list](payload)),
+      forkSession: (payload) =>
+        callRpc(AGENT_METHODS.session_fork, rpc[AGENT_METHODS.session_fork](payload)),
+      resumeSession: (payload) =>
+        callRpc(AGENT_METHODS.session_resume, rpc[AGENT_METHODS.session_resume](payload)),
+      closeSession: (payload) =>
+        callRpc(AGENT_METHODS.session_close, rpc[AGENT_METHODS.session_close](payload)),
+      setSessionModel: (payload) =>
+        callRpc(AGENT_METHODS.session_set_model, rpc[AGENT_METHODS.session_set_model](payload)),
       setSessionConfigOption: (payload) =>
-        callRpc(rpc[AGENT_METHODS.session_set_config_option](payload)),
-      prompt: (payload) => callRpc(rpc[AGENT_METHODS.session_prompt](payload)),
+        callRpc(
+          AGENT_METHODS.session_set_config_option,
+          rpc[AGENT_METHODS.session_set_config_option](payload),
+        ),
+      prompt: (payload) =>
+        callRpc(AGENT_METHODS.session_prompt, rpc[AGENT_METHODS.session_prompt](payload)),
       cancel: (payload) => transport.notify(AGENT_METHODS.session_cancel, payload),
     },
     handleRequestPermission: (handler) =>

--- a/packages/effect-acp/src/errors.test.ts
+++ b/packages/effect-acp/src/errors.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as RpcClientError from "effect/unstable/rpc/RpcClientError";
+
+import * as AcpSchema from "./_generated/schema.gen.ts";
+import { callRpc } from "./_internal/shared.ts";
+import * as AcpError from "./errors.ts";
+
+describe("effect-acp errors", () => {
+  it.effect("retains RPC method and cause without deriving the message from the cause", () => {
+    const rootCause = new Error("connection details that must not become the public message");
+    const failure = new RpcClientError.RpcClientError({
+      reason: new RpcClientError.RpcClientDefect({
+        message: rootCause.message,
+        cause: rootCause,
+      }),
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* callRpc("session/new", Effect.fail(failure)).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "AcpTransportError",
+        operation: "call-rpc",
+        method: "session/new",
+        cause: failure,
+      });
+      expect(error.message).toBe("ACP transport operation call-rpc failed for method session/new.");
+      expect(error.message).not.toContain(rootCause.message);
+    });
+  });
+
+  it.effect("preserves protocol request errors as request errors", () => {
+    const failure = AcpSchema.Error.make({
+      code: -32602,
+      message: "Invalid params",
+      data: { field: "sessionId" },
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* callRpc("session/load", Effect.fail(failure)).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "AcpRequestError",
+        code: -32602,
+        errorMessage: "Invalid params",
+        data: { field: "sessionId" },
+      });
+    });
+  });
+
+  it("does not expose legacy diagnostic detail as the transport message", () => {
+    const cause = new Error("connection refused at a private endpoint");
+    const error = new AcpError.AcpTransportError({
+      detail: cause.message,
+      cause,
+    });
+
+    expect(error.message).toBe("ACP transport operation failed.");
+    expect(error.cause).toBe(cause);
+  });
+});

--- a/packages/effect-acp/src/errors.test.ts
+++ b/packages/effect-acp/src/errors.test.ts
@@ -59,4 +59,21 @@ describe("effect-acp errors", () => {
     expect(error.message).toBe("ACP transport operation failed.");
     expect(error.cause).toBe(cause);
   });
+
+  it("preserves structured extension handler failures behind stable request errors", () => {
+    const cause = new AcpError.AcpTransportError({
+      operation: "read-input-stream",
+      cause: new Error("private transport diagnostics"),
+    });
+    const error = AcpError.AcpRequestError.fromHandlerError(cause, "x/test");
+
+    expect(error).toMatchObject({
+      code: -32603,
+      method: "x/test",
+      operation: "handle-extension-request",
+      cause,
+    });
+    expect(error.message).toBe("ACP extension request handler failed for method 'x/test'");
+    expect(error.message).not.toContain(cause.message);
+  });
 });

--- a/packages/effect-acp/src/errors.test.ts
+++ b/packages/effect-acp/src/errors.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import * as RpcClientError from "effect/unstable/rpc/RpcClientError";
 
 import * as AcpSchema from "./_generated/schema.gen.ts";
 import { callRpc, runHandler } from "./_internal/shared.ts";
 import * as AcpError from "./errors.ts";
+
+const decodeNestedNumberPayload = Schema.decodeUnknownEffect(
+  Schema.Struct({ profile: Schema.Struct({ token: Schema.Number }) }),
+);
+const encodeUnknownJson = Schema.encodeSync(Schema.UnknownFromJsonString);
 
 describe("effect-acp errors", () => {
   it.effect("retains RPC method and cause without deriving the message from the cause", () => {
@@ -95,4 +101,44 @@ describe("effect-acp errors", () => {
       expect(error.message).not.toContain(cause.message);
     });
   });
+
+  it.effect("keeps invalid extension payload values only in the exact schema cause", () =>
+    Effect.gen(function* () {
+      const secret = "acp-schema-payload-secret";
+      const cause = yield* decodeNestedNumberPayload({ profile: { token: secret } }).pipe(
+        Effect.flip,
+      );
+      const error = AcpError.AcpRequestError.invalidExtensionPayload("x/private", cause);
+      const { cause: directCause, ...directDiagnostics } = error;
+
+      expect(directCause).toBe(cause);
+      expect(error).toMatchObject({
+        method: "x/private",
+        operation: "decode-extension-request-payload",
+        maximumPathDepth: 2,
+      });
+      expect(error.issueCount).toBeGreaterThan(0);
+      expect(error.issueKinds).toContain("Pointer");
+      expect(error.message).toBe("Invalid payload for ACP extension method 'x/private'.");
+      expect(error.message).not.toContain(secret);
+      expect(encodeUnknownJson(directDiagnostics)).not.toContain(secret);
+      expect(encodeUnknownJson(error.toProtocolError())).not.toContain(secret);
+
+      const protocolError = AcpError.AcpProtocolParseError.fromSchemaError(
+        "decode-notification-payload",
+        "x/private",
+        cause,
+      );
+      const { cause: protocolCause, ...protocolDiagnostics } = protocolError;
+      expect(protocolCause).toBe(cause);
+      expect(protocolError).toMatchObject({
+        method: "x/private",
+        operation: "decode-notification-payload",
+        maximumPathDepth: 2,
+      });
+      expect(protocolError.message).not.toContain(secret);
+      expect(encodeUnknownJson(protocolDiagnostics)).not.toContain(secret);
+      expect("detail" in protocolError).toBe(false);
+    }),
+  );
 });

--- a/packages/effect-acp/src/errors.test.ts
+++ b/packages/effect-acp/src/errors.test.ts
@@ -71,7 +71,7 @@ describe("effect-acp errors", () => {
       operation: "read-input-stream",
       cause: new Error("private transport diagnostics"),
     });
-    const error = AcpError.AcpRequestError.fromHandlerError(cause, "x/test");
+    const error = AcpError.AcpRequestError.fromExtensionHandlerError(cause, "x/test");
 
     expect(error).toMatchObject({
       code: -32603,
@@ -96,7 +96,7 @@ describe("effect-acp errors", () => {
 
       expect(error).toMatchObject({
         code: -32603,
-        message: "ACP extension request handler failed for method 'fs/read_text_file'",
+        message: "ACP request handler failed for method 'fs/read_text_file'",
       });
       expect(error.message).not.toContain(cause.message);
     });

--- a/packages/effect-acp/src/errors.test.ts
+++ b/packages/effect-acp/src/errors.test.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import * as RpcClientError from "effect/unstable/rpc/RpcClientError";
 
 import * as AcpSchema from "./_generated/schema.gen.ts";
-import { callRpc } from "./_internal/shared.ts";
+import { callRpc, runHandler } from "./_internal/shared.ts";
 import * as AcpError from "./errors.ts";
 
 describe("effect-acp errors", () => {
@@ -75,5 +75,24 @@ describe("effect-acp errors", () => {
     });
     expect(error.message).toBe("ACP extension request handler failed for method 'x/test'");
     expect(error.message).not.toContain(cause.message);
+  });
+
+  it.effect("uses the structured mapper for core handler failures", () => {
+    const cause = new AcpError.AcpTransportError({
+      operation: "read-input-stream",
+      cause: new Error("private transport diagnostics"),
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* runHandler(() => Effect.fail(cause), {}, "fs/read_text_file").pipe(
+        Effect.flip,
+      );
+
+      expect(error).toMatchObject({
+        code: -32603,
+        message: "ACP extension request handler failed for method 'fs/read_text_file'",
+      });
+      expect(error.message).not.toContain(cause.message);
+    });
   });
 });

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -42,12 +42,28 @@ export class AcpProtocolParseError extends Schema.TaggedErrorClass<AcpProtocolPa
 export class AcpTransportError extends Schema.TaggedErrorClass<AcpTransportError>()(
   "AcpTransportError",
   {
-    detail: Schema.String,
+    operation: Schema.optional(
+      Schema.Literals(["call-rpc", "read-input-stream", "read-process-exit-status"]),
+    ),
+    method: Schema.optional(Schema.String),
+    detail: Schema.optional(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
   override get message() {
-    return this.detail;
+    const method = this.method ? ` for method ${this.method}` : "";
+    return this.operation
+      ? `ACP transport operation ${this.operation} failed${method}.`
+      : "ACP transport operation failed.";
+  }
+}
+
+export class AcpInputStreamEndedError extends Schema.TaggedErrorClass<AcpInputStreamEndedError>()(
+  "AcpInputStreamEndedError",
+  {},
+) {
+  override get message() {
+    return "ACP input stream ended.";
   }
 }
 
@@ -138,6 +154,7 @@ export const AcpError = Schema.Union([
   AcpProcessExitedError,
   AcpProtocolParseError,
   AcpTransportError,
+  AcpInputStreamEndedError,
 ]);
 
 export type AcpError = typeof AcpError.Type;

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -108,7 +108,6 @@ export class AcpProtocolParseError extends Schema.TaggedErrorClass<AcpProtocolPa
   {
     operation: AcpProtocolParseOperation,
     method: Schema.optionalKey(Schema.String),
-    detail: Schema.optionalKey(Schema.String),
     issueCount: Schema.optionalKey(Schema.Number),
     issueKinds: Schema.optionalKey(Schema.Array(AcpSchemaIssueKind)),
     maximumPathDepth: Schema.optionalKey(Schema.Number),

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -1,14 +1,74 @@
 import * as Schema from "effect/Schema";
+import type * as SchemaIssue from "effect/SchemaIssue";
 
 import * as AcpSchema from "./_generated/schema.gen.ts";
 
-export const AcpRequestOperation = Schema.Literal("handle-extension-request");
+export const AcpRequestOperation = Schema.Literals([
+  "decode-extension-request-payload",
+  "handle-extension-request",
+]);
 export type AcpRequestOperation = typeof AcpRequestOperation.Type;
+
+export const AcpSchemaIssueKind = Schema.Literals([
+  "Filter",
+  "Encoding",
+  "Pointer",
+  "Composite",
+  "AnyOf",
+  "InvalidType",
+  "InvalidValue",
+  "MissingKey",
+  "UnexpectedKey",
+  "Forbidden",
+  "OneOf",
+]);
+export type AcpSchemaIssueKind = typeof AcpSchemaIssueKind.Type;
+
+export interface AcpSchemaIssueDiagnostics {
+  readonly issueCount: number;
+  readonly issueKinds: ReadonlyArray<AcpSchemaIssueKind>;
+  readonly maximumPathDepth: number;
+}
+
+const schemaIssueDiagnostics = (root: SchemaIssue.Issue): AcpSchemaIssueDiagnostics => {
+  let issueCount = 0;
+  let maximumPathDepth = 0;
+  const issueKinds = new Set<AcpSchemaIssueKind>();
+
+  const visit = (issue: SchemaIssue.Issue, pathDepth: number): void => {
+    issueCount += 1;
+    issueKinds.add(issue._tag);
+    maximumPathDepth = Math.max(maximumPathDepth, pathDepth);
+    switch (issue._tag) {
+      case "Filter":
+      case "Encoding":
+        visit(issue.issue, pathDepth);
+        break;
+      case "Pointer":
+        visit(issue.issue, pathDepth + issue.path.length);
+        break;
+      case "Composite":
+      case "AnyOf":
+        for (const child of issue.issues) visit(child, pathDepth);
+        break;
+    }
+  };
+
+  visit(root, 0);
+  return {
+    issueCount,
+    issueKinds: [...issueKinds],
+    maximumPathDepth,
+  };
+};
 
 export interface AcpRequestDiagnostics {
   readonly method?: string;
   readonly operation?: AcpRequestOperation;
   readonly cause?: unknown;
+  readonly issueCount?: number;
+  readonly issueKinds?: ReadonlyArray<AcpSchemaIssueKind>;
+  readonly maximumPathDepth?: number;
 }
 
 export class AcpSpawnError extends Schema.TaggedErrorClass<AcpSpawnError>()("AcpSpawnError", {
@@ -49,12 +109,28 @@ export class AcpProtocolParseError extends Schema.TaggedErrorClass<AcpProtocolPa
     operation: AcpProtocolParseOperation,
     method: Schema.optionalKey(Schema.String),
     detail: Schema.optionalKey(Schema.String),
+    issueCount: Schema.optionalKey(Schema.Number),
+    issueKinds: Schema.optionalKey(Schema.Array(AcpSchemaIssueKind)),
+    maximumPathDepth: Schema.optionalKey(Schema.Number),
     cause: Schema.Defect(),
   },
 ) {
   override get message() {
     const method = this.method === undefined ? "" : ` for method '${this.method}'`;
     return `ACP protocol operation '${this.operation}' failed${method}.`;
+  }
+
+  static fromSchemaError(
+    operation: AcpProtocolParseOperation,
+    method: string,
+    cause: Schema.SchemaError,
+  ) {
+    return new AcpProtocolParseError({
+      operation,
+      method,
+      ...schemaIssueDiagnostics(cause.issue),
+      cause,
+    });
   }
 }
 
@@ -92,6 +168,9 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
   data: Schema.optional(Schema.Unknown),
   method: Schema.optionalKey(Schema.String),
   operation: Schema.optionalKey(AcpRequestOperation),
+  issueCount: Schema.optionalKey(Schema.Number),
+  issueKinds: Schema.optionalKey(Schema.Array(AcpSchemaIssueKind)),
+  maximumPathDepth: Schema.optionalKey(Schema.Number),
   cause: Schema.optionalKey(Schema.Defect()),
 }) {
   override get message() {
@@ -149,6 +228,19 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
       code: -32602,
       errorMessage: message,
       ...(data !== undefined ? { data } : {}),
+    });
+  }
+
+  static invalidExtensionPayload(method: string, cause: Schema.SchemaError) {
+    const diagnostics = schemaIssueDiagnostics(cause.issue);
+    return new AcpRequestError({
+      code: -32602,
+      errorMessage: `Invalid payload for ACP extension method '${method}'.`,
+      data: diagnostics,
+      method,
+      operation: "decode-extension-request-payload",
+      ...diagnostics,
+      cause,
     });
   }
 

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -36,15 +36,25 @@ export class AcpProcessExitedError extends Schema.TaggedErrorClass<AcpProcessExi
   }
 }
 
+export const AcpProtocolParseOperation = Schema.Literals([
+  "encode-message",
+  "decode-wire-message",
+  "decode-notification-payload",
+]);
+export type AcpProtocolParseOperation = typeof AcpProtocolParseOperation.Type;
+
 export class AcpProtocolParseError extends Schema.TaggedErrorClass<AcpProtocolParseError>()(
   "AcpProtocolParseError",
   {
-    detail: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
+    operation: AcpProtocolParseOperation,
+    method: Schema.optionalKey(Schema.String),
+    detail: Schema.optionalKey(Schema.String),
+    cause: Schema.Defect(),
   },
 ) {
   override get message() {
-    return `Failed to parse ACP protocol message: ${this.detail}`;
+    const method = this.method === undefined ? "" : ` for method '${this.method}'`;
+    return `ACP protocol operation '${this.operation}' failed${method}.`;
   }
 }
 

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -2,6 +2,15 @@ import * as Schema from "effect/Schema";
 
 import * as AcpSchema from "./_generated/schema.gen.ts";
 
+export const AcpRequestOperation = Schema.Literal("handle-extension-request");
+export type AcpRequestOperation = typeof AcpRequestOperation.Type;
+
+export interface AcpRequestDiagnostics {
+  readonly method?: string;
+  readonly operation?: AcpRequestOperation;
+  readonly cause?: unknown;
+}
+
 export class AcpSpawnError extends Schema.TaggedErrorClass<AcpSpawnError>()("AcpSpawnError", {
   command: Schema.optional(Schema.String),
   cause: Schema.Defect(),
@@ -71,6 +80,9 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
   code: AcpSchema.ErrorCode,
   errorMessage: Schema.String,
   data: Schema.optional(Schema.Unknown),
+  method: Schema.optionalKey(Schema.String),
+  operation: Schema.optionalKey(AcpRequestOperation),
+  cause: Schema.optionalKey(Schema.Defect()),
 }) {
   override get message() {
     return this.errorMessage;
@@ -82,6 +94,21 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
       errorMessage: error.message,
       ...(error.data !== undefined ? { data: error.data } : {}),
     });
+  }
+
+  static fromHandlerError(error: AcpError, method: string) {
+    if (error._tag === "AcpRequestError") {
+      return error;
+    }
+    return AcpRequestError.internalError(
+      `ACP extension request handler failed for method '${method}'`,
+      undefined,
+      {
+        method,
+        operation: "handle-extension-request",
+        cause: error,
+      },
+    );
   }
 
   static parseError(message = "Parse error", data?: unknown) {
@@ -115,11 +142,16 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
     });
   }
 
-  static internalError(message = "Internal error", data?: unknown) {
+  static internalError(
+    message = "Internal error",
+    data?: unknown,
+    diagnostics: AcpRequestDiagnostics = {},
+  ) {
     return new AcpRequestError({
       code: -32603,
       errorMessage: message,
       ...(data !== undefined ? { data } : {}),
+      ...diagnostics,
     });
   }
 

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -5,6 +5,7 @@ import * as AcpSchema from "./_generated/schema.gen.ts";
 
 export const AcpRequestOperation = Schema.Literals([
   "decode-extension-request-payload",
+  "handle-request",
   "handle-extension-request",
 ]);
 export type AcpRequestOperation = typeof AcpRequestOperation.Type;
@@ -184,7 +185,22 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
     });
   }
 
-  static fromHandlerError(error: AcpError, method: string) {
+  static fromCoreHandlerError(error: AcpError, method: string) {
+    if (error._tag === "AcpRequestError") {
+      return error;
+    }
+    return AcpRequestError.internalError(
+      `ACP request handler failed for method '${method}'`,
+      undefined,
+      {
+        method,
+        operation: "handle-request",
+        cause: error,
+      },
+    );
+  }
+
+  static fromExtensionHandlerError(error: AcpError, method: string) {
     if (error._tag === "AcpRequestError") {
       return error;
     }

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -134,6 +134,49 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
       }),
   );
 
+  it.effect("keeps invalid core notification values only in the schema cause", () =>
+    Effect.gen(function* () {
+      const secret = "acp-core-notification-secret-sentinel";
+      const { stdio, input } = yield* makeInMemoryStdio();
+      const termination = yield* Deferred.make<AcpError.AcpError>();
+      yield* AcpProtocol.makeAcpPatchedProtocol({
+        stdio,
+        serverRequestMethods: new Set(),
+        onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+      });
+
+      yield* Queue.offer(
+        input,
+        encoder.encode(
+          `${encodeUnknownJsonString({
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId: { secret },
+              update: {
+                sessionUpdate: "plan",
+                entries: [],
+              },
+            },
+          })}\n`,
+        ),
+      );
+
+      const error = yield* Deferred.await(termination);
+      assert.instanceOf(error, AcpError.AcpProtocolParseError);
+      const parseError = error as AcpError.AcpProtocolParseError;
+      const { cause, ...directDiagnostics } = parseError;
+      assert.equal(parseError.operation, "decode-notification-payload");
+      assert.equal(parseError.method, "session/update");
+      assert.isAbove(parseError.issueCount ?? 0, 0);
+      assert.include(parseError.issueKinds ?? [], "Pointer");
+      assert.isAbove(parseError.maximumPathDepth ?? 0, 0);
+      assert.isTrue(Schema.isSchemaError(cause));
+      assert.notInclude(parseError.message, secret);
+      assert.notInclude(encodeUnknownJsonString(directDiagnostics), secret);
+    }),
+  );
+
   it.effect("logs outgoing notifications when logOutgoing is enabled", () =>
     Effect.gen(function* () {
       const { stdio } = yield* makeInMemoryStdio();

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -48,6 +48,8 @@ const decodeExtRequest = Schema.decodeEffect(Schema.fromJsonString(ExtRequest));
 const decodeRequestPermissionResponse = Schema.decodeEffect(
   Schema.fromJsonString(RequestPermissionResponse),
 );
+const encodeUnknownJsonString = Schema.encodeUnknownSync(Schema.UnknownFromJsonString);
+const encoder = new TextEncoder();
 const mockPeerPath = Effect.map(Effect.service(Path.Path), (path) =>
   path.join(import.meta.dirname, "../test/fixtures/acp-mock-peer.ts"),
 );
@@ -169,6 +171,38 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
             '{"jsonrpc":"2.0","method":"session/cancel","params":{"sessionId":"session-1"},"id":"","headers":[]}\n',
         },
       ]);
+    }),
+  );
+
+  it.effect("logs decode failures without copying the cause or wire payload", () =>
+    Effect.gen(function* () {
+      const secret = "acp-wire-secret-sentinel";
+      const { stdio, input } = yield* makeInMemoryStdio();
+      const events: Array<AcpProtocol.AcpProtocolLogEvent> = [];
+      const termination = yield* Deferred.make<AcpError.AcpError>();
+      yield* AcpProtocol.makeAcpPatchedProtocol({
+        stdio,
+        serverRequestMethods: new Set(),
+        logIncoming: true,
+        logger: (event) =>
+          Effect.sync(() => {
+            events.push(event);
+          }),
+        onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+      });
+
+      yield* Queue.offer(input, encoder.encode(`{"secret":"${secret}"\n`));
+      yield* Deferred.await(termination);
+
+      const event = events.find(({ stage }) => stage === "decode_failed");
+      assert.deepEqual(event, {
+        direction: "incoming",
+        stage: "decode_failed",
+        payload: {
+          operation: "decode-wire-message",
+        },
+      });
+      assert.notInclude(encodeUnknownJsonString(event), secret);
     }),
   );
 

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -389,6 +389,25 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
     }),
   );
 
+  it.effect("classifies an input stream ending without inventing a cause", () =>
+    Effect.gen(function* () {
+      const { stdio, input } = yield* makeInMemoryStdio();
+      const termination = yield* Deferred.make<AcpError.AcpError>();
+      yield* AcpProtocol.makeAcpPatchedProtocol({
+        stdio,
+        serverRequestMethods: new Set(),
+        onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+      });
+
+      yield* Queue.end(input);
+
+      const error = yield* Deferred.await(termination);
+      assert.instanceOf(error, AcpError.AcpInputStreamEndedError);
+      assert.equal(error.message, "ACP input stream ended.");
+      assert.equal("cause" in error, false);
+    }),
+  );
+
   it.effect("does not emit a second process-exit error after a decode failure", () =>
     Effect.gen(function* () {
       const handle = yield* makeHandle({

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -461,9 +461,11 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
       assert.equal((message as { readonly _tag?: string })._tag, "ClientProtocolError");
       const defect = (message as { readonly error: { readonly reason: unknown } }).error.reason as {
         readonly _tag: string;
+        readonly message: string;
         readonly cause: unknown;
       };
       assert.equal(defect._tag, "RpcClientDefect");
+      assert.equal(defect.message, "ACP protocol terminated.");
       assert.instanceOf(defect.cause, AcpError.AcpProcessExitedError);
       assert.equal((defect.cause as AcpError.AcpProcessExitedError).code, 7);
     }),
@@ -512,9 +514,40 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
       assert.equal((message as { readonly _tag?: string })._tag, "ClientProtocolError");
       const defect = (message as { readonly error: { readonly reason: unknown } }).error.reason as {
         readonly _tag: string;
+        readonly message: string;
         readonly cause: unknown;
       };
       assert.equal(defect._tag, "RpcClientDefect");
+      assert.equal(defect.message, "ACP protocol terminated.");
+      assert.instanceOf(defect.cause, AcpError.AcpProtocolParseError);
+    }),
+  );
+
+  it.effect("keeps client send failure messages independent from the cause", () =>
+    Effect.gen(function* () {
+      const { stdio } = yield* makeInMemoryStdio();
+      const transport = yield* AcpProtocol.makeAcpPatchedProtocol({
+        stdio,
+        serverRequestMethods: new Set(),
+      });
+
+      const failure = yield* transport.clientProtocol
+        .send(0, {
+          _tag: "Request",
+          id: "request-1",
+          tag: "x/test",
+          payload: 1n,
+          headers: [],
+        })
+        .pipe(Effect.flip);
+      const defect = failure.reason as {
+        readonly _tag: string;
+        readonly message: string;
+        readonly cause: unknown;
+      };
+
+      assert.equal(defect._tag, "RpcClientDefect");
+      assert.equal(defect.message, "Failed to send ACP protocol message.");
       assert.instanceOf(defect.cause, AcpError.AcpProtocolParseError);
     }),
   );

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -182,13 +182,16 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
 
       const bigintError = yield* transport.notify("x/test", 1n).pipe(Effect.flip);
       assert.instanceOf(bigintError, AcpError.AcpProtocolParseError);
-      assert.equal(bigintError.detail, "Failed to encode ACP message");
+      assert.equal(bigintError.operation, "encode-message");
+      assert.instanceOf(bigintError.cause, TypeError);
+      assert.equal(bigintError.message, "ACP protocol operation 'encode-message' failed.");
 
       const circular: Record<string, unknown> = {};
       circular.self = circular;
       const circularError = yield* transport.notify("x/test", circular).pipe(Effect.flip);
       assert.instanceOf(circularError, AcpError.AcpProtocolParseError);
-      assert.equal(circularError.detail, "Failed to encode ACP message");
+      assert.equal(circularError.operation, "encode-message");
+      assert.instanceOf(circularError.cause, TypeError);
     }),
   );
 

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -403,8 +403,11 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
             payload: {
               operation: error.operation,
               ...(error.method === undefined ? {} : { method: error.method }),
-              detail: error.detail,
-              cause: error.cause,
+              ...(error.issueCount === undefined ? {} : { issueCount: error.issueCount }),
+              ...(error.issueKinds === undefined ? {} : { issueKinds: error.issueKinds }),
+              ...(error.maximumPathDepth === undefined
+                ? {}
+                : { maximumPathDepth: error.maximumPathDepth }),
             },
           }),
         ),

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -264,13 +264,12 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
                 params,
               }) satisfies AcpIncomingNotification,
           ),
-          Effect.mapError(
-            (cause) =>
-              new AcpError.AcpProtocolParseError({
-                operation: "decode-notification-payload",
-                method: CLIENT_METHODS.session_update,
-                cause,
-              }),
+          Effect.mapError((cause) =>
+            AcpError.AcpProtocolParseError.fromSchemaError(
+              "decode-notification-payload",
+              CLIENT_METHODS.session_update,
+              cause,
+            ),
           ),
           Effect.flatMap(dispatchNotification),
         );
@@ -285,13 +284,12 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
                 params,
               }) satisfies AcpIncomingNotification,
           ),
-          Effect.mapError(
-            (cause) =>
-              new AcpError.AcpProtocolParseError({
-                operation: "decode-notification-payload",
-                method: CLIENT_METHODS.session_elicitation_complete,
-                cause,
-              }),
+          Effect.mapError((cause) =>
+            AcpError.AcpProtocolParseError.fromSchemaError(
+              "decode-notification-payload",
+              CLIENT_METHODS.session_elicitation_complete,
+              cause,
+            ),
           ),
           Effect.flatMap(dispatchNotification),
         );

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -413,7 +413,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
         const normalized: AcpError.AcpError = isAcpError(error)
           ? error
           : new AcpError.AcpTransportError({
-              detail: error instanceof Error ? error.message : String(error),
+              operation: "read-input-stream",
               cause: error,
             });
         return handleTermination(() => Effect.succeed(normalized));
@@ -421,13 +421,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
       onSuccess: () =>
         handleTermination(
           () =>
-            options.terminationError ??
-            Effect.succeed(
-              new AcpError.AcpTransportError({
-                detail: "ACP input stream ended",
-                cause: new Error("ACP input stream ended"),
-              }),
-            ),
+            options.terminationError ?? Effect.succeed(new AcpError.AcpInputStreamEndedError({})),
         ),
     }),
     Effect.forkScoped,

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -183,7 +183,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
       _tag: "ClientProtocolError",
       error: new RpcClientError.RpcClientError({
         reason: new RpcClientError.RpcClientDefect({
-          message: error.message,
+          message: "ACP protocol terminated.",
           cause: error,
         }),
       }),
@@ -449,7 +449,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
           (error) =>
             new RpcClientError.RpcClientError({
               reason: new RpcClientError.RpcClientDefect({
-                message: error.message,
+                message: "Failed to send ACP protocol message.",
                 cause: error,
               }),
             }),

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -245,7 +245,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
         onFailure: (error) =>
           respondWithError(
             message.id,
-            AcpError.AcpRequestError.fromHandlerError(error, message.tag),
+            AcpError.AcpRequestError.fromExtensionHandlerError(error, message.tag),
           ),
         onSuccess: (value) => respondWithSuccess(message.id, value),
       }),

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -17,7 +17,6 @@ import * as AcpSchema from "./_generated/schema.gen.ts";
 import { CLIENT_METHODS } from "./_generated/meta.gen.ts";
 import * as AcpError from "./errors.ts";
 const isAcpError = Schema.is(AcpError.AcpError);
-const isAcpRequestError = Schema.is(AcpError.AcpRequestError);
 
 export interface AcpProtocolLogEvent {
   readonly direction: "incoming" | "outgoing";
@@ -243,7 +242,11 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
     }
     return options.onExtRequest(message.tag, message.payload).pipe(
       Effect.matchEffect({
-        onFailure: (error) => respondWithError(message.id, normalizeToRequestError(error)),
+        onFailure: (error) =>
+          respondWithError(
+            message.id,
+            AcpError.AcpRequestError.fromHandlerError(error, message.tag),
+          ),
         onSuccess: (value) => respondWithSuccess(message.id, value),
       }),
     );
@@ -435,7 +438,18 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
         Stream.runForEach((message) => f(message)),
         Effect.forever,
       ),
-    send: (_clientId, request) => offerOutgoing(request).pipe(Effect.mapError(toRpcClientError)),
+    send: (_clientId, request) =>
+      offerOutgoing(request).pipe(
+        Effect.mapError(
+          (error) =>
+            new RpcClientError.RpcClientError({
+              reason: new RpcClientError.RpcClientDefect({
+                message: error.message,
+                cause: error,
+              }),
+            }),
+        ),
+      ),
     supportsAck: true,
     supportsTransferables: false,
   });
@@ -514,17 +528,4 @@ function isProtocolError(
     "message" in value &&
     typeof value.message === "string"
   );
-}
-
-function normalizeToRequestError(error: AcpError.AcpError): AcpError.AcpRequestError {
-  return isAcpRequestError(error) ? error : AcpError.AcpRequestError.internalError(error.message);
-}
-
-function toRpcClientError(error: AcpError.AcpError): RpcClientError.RpcClientError {
-  return new RpcClientError.RpcClientError({
-    reason: new RpcClientError.RpcClientDefect({
-      message: error.message,
-      cause: error,
-    }),
-  });
 }

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -113,7 +113,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
       try: () => parser.encode(message),
       catch: (cause) =>
         new AcpError.AcpProtocolParseError({
-          detail: "Failed to encode ACP message",
+          operation: "encode-message",
           cause,
         }),
     });
@@ -267,7 +267,8 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
           Effect.mapError(
             (cause) =>
               new AcpError.AcpProtocolParseError({
-                detail: `Invalid ${CLIENT_METHODS.session_update} notification payload`,
+                operation: "decode-notification-payload",
+                method: CLIENT_METHODS.session_update,
                 cause,
               }),
           ),
@@ -287,7 +288,8 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
           Effect.mapError(
             (cause) =>
               new AcpError.AcpProtocolParseError({
-                detail: `Invalid ${CLIENT_METHODS.session_elicitation_complete} notification payload`,
+                operation: "decode-notification-payload",
+                method: CLIENT_METHODS.session_elicitation_complete,
                 cause,
               }),
           ),
@@ -382,7 +384,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
               >,
             catch: (cause) =>
               new AcpError.AcpProtocolParseError({
-                detail: "Failed to decode ACP wire message",
+                operation: "decode-wire-message",
                 cause,
               }),
           }),
@@ -399,6 +401,8 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
             direction: "incoming",
             stage: "decode_failed",
             payload: {
+              operation: error.operation,
+              ...(error.method === undefined ? {} : { method: error.method }),
               detail: error.detail,
               cause: error.cause,
             },

--- a/packages/effect-acp/src/terminal.ts
+++ b/packages/effect-acp/src/terminal.ts
@@ -23,23 +23,3 @@ export interface AcpTerminal {
    */
   readonly release: Effect.Effect<AcpSchema.ReleaseTerminalResponse, AcpError.AcpError>;
 }
-
-export interface MakeTerminalOptions {
-  readonly sessionId: string;
-  readonly terminalId: string;
-  readonly output: Effect.Effect<AcpSchema.TerminalOutputResponse, AcpError.AcpError>;
-  readonly waitForExit: Effect.Effect<AcpSchema.WaitForTerminalExitResponse, AcpError.AcpError>;
-  readonly kill: Effect.Effect<AcpSchema.KillTerminalResponse, AcpError.AcpError>;
-  readonly release: Effect.Effect<AcpSchema.ReleaseTerminalResponse, AcpError.AcpError>;
-}
-
-export function makeTerminal(options: MakeTerminalOptions): AcpTerminal {
-  return {
-    sessionId: options.sessionId,
-    terminalId: options.terminalId,
-    output: options.output,
-    waitForExit: options.waitForExit,
-    kill: options.kill,
-    release: options.release,
-  };
-}


### PR DESCRIPTION
## Summary
- attach transport operation and RPC method context while preserving original RPC, stream, process, and SchemaError causes
- keep messages stable instead of copying cause-derived diagnostics
- summarize schema failures with issue count, issue kinds, and maximum path depth; raw invalid payload values are never copied into direct fields or JSON-RPC data
- normalize core and extension notification SchemaErrors through one payload-safe structural mapper
- represent a clean ACP input-stream end as its own error rather than inventing a cause
- centralize reusable error transformations on the error classes

## Validation
- vp test run packages/effect-acp/src/errors.test.ts packages/effect-acp/src/protocol.test.ts packages/effect-acp/src/agent.test.ts packages/effect-acp/src/client.test.ts (25 tests)
- vp check (0 errors; 20 pre-existing warnings)
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Error shapes and user-visible messages change across the ACP client/agent stack, which may break callers that match on message text; the changes are security-motivated (avoid leaking payload/cause details) and are covered by new and updated tests.
> 
> **Overview**
> **Restructures ACP transport, protocol parse, and request errors** so public `message` strings are fixed templates with optional `operation` and `method` fields, while the original `cause` (RPC, stream, `SchemaError`, etc.) is preserved on the error object.
> 
> **Schema validation failures** no longer embed formatted issue text or raw invalid values in messages, logs, or JSON-RPC `data`. Instead they attach summarized diagnostics (`issueCount`, `issueKinds`, `maximumPathDepth`) via shared helpers on `AcpProtocolParseError` and `AcpRequestError`, with full details only on the `SchemaError` cause.
> 
> **Protocol and RPC plumbing** passes RPC method names into `callRpc`, maps handler failures through `fromCoreHandlerError` / `fromExtensionHandlerError`, logs decode failures with operation metadata only, uses stable RpcClient defect messages for termination and send failures, and treats a clean stdin end as **`AcpInputStreamEndedError`** instead of a synthetic transport error.
> 
> **API cleanup:** removes `makeTerminal`; the agent builds terminal handles as plain `AcpTerminal`-shaped objects. Adds **`errors.test.ts`** and extends protocol/client tests for the new error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3948b515fe08b49f55f1a90528a9970c5a7520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure ACP transport, request, and protocol parse errors with operation and method context
> - Replaces free-form `detail` strings on `AcpTransportError`, `AcpProtocolParseError`, and `AcpRequestError` with structured `operation` and `method` fields, standardizing all user-facing error messages.
> - Adds `schemaIssueDiagnostics` to aggregate schema issue counts, kinds, and path depth into error metadata without leaking raw payload values.
> - Introduces `AcpInputStreamEndedError` as a distinct error type for end-of-input conditions, replacing ad-hoc `AcpTransportError` construction.
> - Removes `makeTerminal` from [terminal.ts](https://github.com/pingdotgg/t3code/pull/3251/files#diff-3bc321a232a7686e9a64a381866785256b3feab50bb203abcf15f1e934ea4ae5) and the `normalizeToRequestError`/`toRpcClientError` helpers from [protocol.ts](https://github.com/pingdotgg/t3code/pull/3251/files#diff-c41432f9e7fbaf0a7a40c325bf318ea40df32aed6b771c8b6fa5c935e37006d2); callers must construct terminal objects directly.
> - Risk: all public-facing error messages change, and `callRpc` now requires an explicit method string as its first argument — call sites in [agent.ts](https://github.com/pingdotgg/t3code/pull/3251/files#diff-415a5c4cd630e10567267b633202406c195291d0fb9f60bd2c5c012150c2efbf) and [client.ts](https://github.com/pingdotgg/t3code/pull/3251/files#diff-091e8e68924b7a3d640d3992a8d4470d153a4e2744b28980bff64924f937f12a) are updated accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b3948b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->