### PR TITLE
[codex] Structure connection persistence failures

### DIFF
--- a/apps/desktop/src/ipc/methods/sshEnvironment.ts
+++ b/apps/desktop/src/ipc/methods/sshEnvironment.ts
@@ -2,7 +2,7 @@ import {
   bootstrapRemoteBearerSession,
   fetchRemoteSessionState,
   issueRemoteWebSocketTicket,
-  RemoteEnvironmentAuthUndeclaredStatusError,
+  isRemoteEnvironmentAuthUndeclaredStatusError,
   type RemoteEnvironmentAuthError,
 } from "@t3tools/client-runtime/authorization";
 import { fetchRemoteEnvironmentDescriptor } from "@t3tools/client-runtime/environment";
@@ -52,10 +52,7 @@ const isEnvironmentRequestInvalidError = Schema.is(EnvironmentRequestInvalidErro
 const isEnvironmentScopeRequiredError = Schema.is(EnvironmentScopeRequiredError);
 
 function readSshHttpStatus(cause: DesktopSshEnvironmentRequestCause): number | null {
-  if (
-    cause instanceof RemoteEnvironmentAuthUndeclaredStatusError ||
-    cause instanceof SshHttpBridgeError
-  ) {
+  if (isRemoteEnvironmentAuthUndeclaredStatusError(cause) || cause instanceof SshHttpBridgeError) {
     return cause.status ?? null;
   }
   if (isEnvironmentRequestInvalidError(cause)) {

--- a/apps/mobile/src/connection/catalog-store.ts
+++ b/apps/mobile/src/connection/catalog-store.ts
@@ -3,7 +3,10 @@ import {
   type ConnectionCatalogDocument as ConnectionCatalogDocumentType,
   EMPTY_CONNECTION_CATALOG_DOCUMENT,
 } from "@t3tools/client-runtime/platform";
-import { ConnectionTransientError } from "@t3tools/client-runtime/connection";
+import {
+  ConnectionStorageOperationError,
+  ConnectionTransientError,
+} from "@t3tools/client-runtime/connection";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
@@ -21,13 +24,14 @@ const encodeConnectionCatalogDocument = Schema.encodeEffect(ConnectionCatalogDoc
 
 const decodeCatalog = Effect.fn("mobile.connectionStorage.decodeCatalog")(function* (raw: string) {
   return yield* decodeConnectionCatalogDocument(raw).pipe(
-    Effect.mapError(
-      (cause) =>
-        new ConnectionTransientError({
-          reason: "remote-unavailable",
-          detail: "Could not decode the local connection catalog.",
+    Effect.mapError((cause) =>
+      ConnectionTransientError.fromStorageFailure(
+        new ConnectionStorageOperationError({
+          operation: "decode",
+          backend: "schema",
           cause,
         }),
+      ),
     ),
   );
 });
@@ -36,13 +40,14 @@ const encodeCatalog = Effect.fn("mobile.connectionStorage.encodeCatalog")(functi
   catalog: ConnectionCatalogDocumentType,
 ) {
   return yield* encodeConnectionCatalogDocument(catalog).pipe(
-    Effect.mapError(
-      (cause) =>
-        new ConnectionTransientError({
-          reason: "remote-unavailable",
-          detail: "Could not encode the local connection catalog.",
+    Effect.mapError((cause) =>
+      ConnectionTransientError.fromStorageFailure(
+        new ConnectionStorageOperationError({
+          operation: "encode",
+          backend: "schema",
           cause,
         }),
+      ),
     ),
   );
 });
@@ -72,13 +77,14 @@ export const makeCatalogStore = Effect.fn("mobile.connectionStorage.makeCatalogS
       legacyRaw === null || legacyRaw.trim() === ""
         ? EMPTY_CONNECTION_CATALOG_DOCUMENT
         : yield* migrateLegacyConnectionCatalog(legacyRaw).pipe(
-            Effect.mapError(
-              (cause) =>
-                new ConnectionTransientError({
-                  reason: "remote-unavailable",
-                  detail: "Could not migrate the legacy local connection catalog.",
+            Effect.mapError((cause) =>
+              ConnectionTransientError.fromStorageFailure(
+                new ConnectionStorageOperationError({
+                  operation: "migrate",
+                  backend: "legacy-migration",
                   cause,
                 }),
+              ),
             ),
             Effect.catchTags({
               ConnectionTransientError: (error) =>

--- a/apps/mobile/src/connection/catalog-store.ts
+++ b/apps/mobile/src/connection/catalog-store.ts
@@ -15,30 +15,36 @@ import { migrateLegacyConnectionCatalog } from "./migration";
 export const CONNECTION_CATALOG_KEY = "t3code.connection-catalog.v1";
 export const LEGACY_CONNECTIONS_KEY = "t3code.connections";
 
-function catalogError(operation: string, cause: unknown) {
-  return new ConnectionTransientError({
-    reason: "remote-unavailable",
-    detail: `Could not ${operation} the local connection catalog: ${String(cause)}`,
-  });
-}
+const ConnectionCatalogDocumentJson = Schema.fromJsonString(ConnectionCatalogDocument);
+const decodeConnectionCatalogDocument = Schema.decodeUnknownEffect(ConnectionCatalogDocumentJson);
+const encodeConnectionCatalogDocument = Schema.encodeEffect(ConnectionCatalogDocumentJson);
 
 const decodeCatalog = Effect.fn("mobile.connectionStorage.decodeCatalog")(function* (raw: string) {
-  const parsed = yield* Effect.try({
-    try: () => JSON.parse(raw) as unknown,
-    catch: (cause) => catalogError("decode", cause),
-  });
-  return yield* Effect.fromResult(
-    Schema.decodeUnknownResult(ConnectionCatalogDocument)(parsed),
-  ).pipe(Effect.mapError((cause) => catalogError("decode", cause)));
+  return yield* decodeConnectionCatalogDocument(raw).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ConnectionTransientError({
+          reason: "remote-unavailable",
+          detail: "Could not decode the local connection catalog.",
+          cause,
+        }),
+    ),
+  );
 });
 
 const encodeCatalog = Effect.fn("mobile.connectionStorage.encodeCatalog")(function* (
   catalog: ConnectionCatalogDocumentType,
 ) {
-  const encoded = yield* Effect.fromResult(
-    Schema.encodeUnknownResult(ConnectionCatalogDocument)(catalog),
-  ).pipe(Effect.mapError((cause) => catalogError("encode", cause)));
-  return JSON.stringify(encoded);
+  return yield* encodeConnectionCatalogDocument(catalog).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ConnectionTransientError({
+          reason: "remote-unavailable",
+          detail: "Could not encode the local connection catalog.",
+          cause,
+        }),
+    ),
+  );
 });
 
 interface CatalogStore {
@@ -66,12 +72,20 @@ export const makeCatalogStore = Effect.fn("mobile.connectionStorage.makeCatalogS
       legacyRaw === null || legacyRaw.trim() === ""
         ? EMPTY_CONNECTION_CATALOG_DOCUMENT
         : yield* migrateLegacyConnectionCatalog(legacyRaw).pipe(
-            Effect.mapError((cause) => catalogError("migrate", cause)),
-            Effect.catch((error) =>
-              Effect.logWarning("Discarding corrupt legacy mobile connections", error).pipe(
-                Effect.as(EMPTY_CONNECTION_CATALOG_DOCUMENT),
-              ),
+            Effect.mapError(
+              (cause) =>
+                new ConnectionTransientError({
+                  reason: "remote-unavailable",
+                  detail: "Could not migrate the legacy local connection catalog.",
+                  cause,
+                }),
             ),
+            Effect.catchTags({
+              ConnectionTransientError: (error) =>
+                Effect.logWarning("Discarding corrupt legacy mobile connections", error).pipe(
+                  Effect.as(EMPTY_CONNECTION_CATALOG_DOCUMENT),
+                ),
+            }),
           );
     if (legacyRaw !== null && legacyRaw.trim() !== "") {
       const encoded = yield* encodeCatalog(catalog);
@@ -90,12 +104,13 @@ export const makeCatalogStore = Effect.fn("mobile.connectionStorage.makeCatalogS
     let catalog: ConnectionCatalogDocumentType;
     if (raw !== null && raw.trim() !== "") {
       catalog = yield* decodeCatalog(raw).pipe(
-        Effect.catch((error) =>
-          Effect.logWarning("Discarding corrupt mobile connection catalog", error).pipe(
-            Effect.andThen(storage.deleteItem(CONNECTION_CATALOG_KEY)),
-            Effect.andThen(loadLegacyCatalog()),
-          ),
-        ),
+        Effect.catchTags({
+          ConnectionTransientError: (error) =>
+            Effect.logWarning("Discarding corrupt mobile connection catalog", error).pipe(
+              Effect.andThen(storage.deleteItem(CONNECTION_CATALOG_KEY)),
+              Effect.andThen(loadLegacyCatalog()),
+            ),
+        }),
       );
     } else {
       catalog = yield* loadLegacyCatalog();

--- a/apps/mobile/src/connection/migration.test.ts
+++ b/apps/mobile/src/connection/migration.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@effect/vitest";
 import { EnvironmentId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 
-import { migrateLegacyConnectionCatalog } from "./migration";
+import { LegacyConnectionMigrationError, migrateLegacyConnectionCatalog } from "./migration";
 
 describe("migrateLegacyConnectionCatalog", () => {
   it.effect("migrates bearer and relay-managed connections into the new catalog", () =>
@@ -73,6 +73,30 @@ describe("migrateLegacyConnectionCatalog", () => {
       );
 
       expect(catalog.targets).toEqual([]);
+    }),
+  );
+
+  it.effect("preserves parse failures with a stable structural error", () =>
+    Effect.gen(function* () {
+      const error = yield* migrateLegacyConnectionCatalog("{not-json").pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(LegacyConnectionMigrationError);
+      expect(error.stage).toBe("parse");
+      expect(error.cause).toBeInstanceOf(SyntaxError);
+      expect(error.message).toBe("Could not parse the legacy mobile connection catalog.");
+    }),
+  );
+
+  it.effect("distinguishes catalog decoding failures", () =>
+    Effect.gen(function* () {
+      const error = yield* migrateLegacyConnectionCatalog('{"connections":"invalid"}').pipe(
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(LegacyConnectionMigrationError);
+      expect(error.stage).toBe("decode");
+      expect(error.cause).toBeDefined();
+      expect(error.message).toBe("Could not decode the legacy mobile connection catalog.");
     }),
   );
 });

--- a/apps/mobile/src/connection/migration.ts
+++ b/apps/mobile/src/connection/migration.ts
@@ -36,9 +36,14 @@ const decodeLegacyConnectionDocument = Schema.decodeUnknownEffect(LegacyConnecti
 export class LegacyConnectionMigrationError extends Schema.TaggedErrorClass<LegacyConnectionMigrationError>()(
   "LegacyConnectionMigrationError",
   {
-    message: Schema.String,
+    stage: Schema.Literals(["parse", "decode"]),
+    cause: Schema.Defect(),
   },
-) {}
+) {
+  override get message(): string {
+    return `Could not ${this.stage} the legacy mobile connection catalog.`;
+  }
+}
 
 function isRelayManaged(connection: typeof LegacySavedRemoteConnection.Type): boolean {
   return connection.relayManaged === true || connection.authenticationMethod === "dpop";
@@ -92,18 +97,10 @@ export const migrateLegacyConnectionCatalog = Effect.fn(
 )(function* (raw: string) {
   const parsed = yield* Effect.try({
     try: () => JSON.parse(raw) as unknown,
-    catch: (cause) =>
-      new LegacyConnectionMigrationError({
-        message: `Could not parse the legacy mobile connection catalog: ${String(cause)}`,
-      }),
+    catch: (cause) => new LegacyConnectionMigrationError({ stage: "parse", cause }),
   });
   const legacy = yield* decodeLegacyConnectionDocument(parsed).pipe(
-    Effect.mapError(
-      (cause) =>
-        new LegacyConnectionMigrationError({
-          message: `Could not decode the legacy mobile connection catalog: ${String(cause)}`,
-        }),
-    ),
+    Effect.mapError((cause) => new LegacyConnectionMigrationError({ stage: "decode", cause })),
   );
 
   return (legacy.connections ?? []).reduce(migrateConnection, EMPTY_CONNECTION_CATALOG_DOCUMENT);

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -10,6 +10,7 @@ import {
 } from "@t3tools/client-runtime/platform";
 import { TokenStore } from "@t3tools/client-runtime/authorization";
 import {
+  ConnectionStorageOperationError,
   ConnectionTransientError,
   CredentialStore,
   ProfileStore,
@@ -122,31 +123,40 @@ const secureCatalogStorage: SecureCatalogStorage = {
     Effect.tryPromise({
       try: () => SecureStore.getItemAsync(key),
       catch: (cause) =>
-        new ConnectionTransientError({
-          reason: "remote-unavailable",
-          detail: "Could not load the local connection catalog from secure storage.",
-          cause,
-        }),
+        ConnectionTransientError.fromStorageFailure(
+          new ConnectionStorageOperationError({
+            operation: "load",
+            backend: "mobile-secure-storage",
+            key,
+            cause,
+          }),
+        ),
     }),
   setItem: (key, value) =>
     Effect.tryPromise({
       try: () => SecureStore.setItemAsync(key, value),
       catch: (cause) =>
-        new ConnectionTransientError({
-          reason: "remote-unavailable",
-          detail: "Could not save the local connection catalog to secure storage.",
-          cause,
-        }),
+        ConnectionTransientError.fromStorageFailure(
+          new ConnectionStorageOperationError({
+            operation: "save",
+            backend: "mobile-secure-storage",
+            key,
+            cause,
+          }),
+        ),
     }),
   deleteItem: (key) =>
     Effect.tryPromise({
       try: () => SecureStore.deleteItemAsync(key),
       catch: (cause) =>
-        new ConnectionTransientError({
-          reason: "remote-unavailable",
-          detail: "Could not remove the local connection catalog from secure storage.",
-          cause,
-        }),
+        ConnectionTransientError.fromStorageFailure(
+          new ConnectionStorageOperationError({
+            operation: "delete",
+            backend: "mobile-secure-storage",
+            key,
+            cause,
+          }),
+        ),
     }),
 };
 

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -54,29 +54,11 @@ const LegacyStoredShellSnapshot = Schema.Struct({
   snapshotReceivedAt: Schema.String,
   snapshot: OrchestrationShellSnapshot,
 });
-
-function catalogError(operation: string, cause: unknown) {
-  return new ConnectionTransientError({
-    reason: "remote-unavailable",
-    detail: `Could not ${operation} the local connection catalog: ${String(cause)}`,
-  });
-}
-
-function shellPersistenceError(
-  operation:
-    | "load-shell"
-    | "save-shell"
-    | "load-thread"
-    | "save-thread"
-    | "remove-thread"
-    | "clear-environment",
-  cause: unknown,
-) {
-  return new ConnectionPersistenceError({
-    operation,
-    message: `Could not ${operation.replaceAll("-", " ")}: ${String(cause)}`,
-  });
-}
+const decodeStoredShellSnapshot = Schema.decodeUnknownEffect(StoredShellSnapshot);
+const encodeStoredShellSnapshot = Schema.encodeEffect(StoredShellSnapshot);
+const decodeStoredThreadSnapshot = Schema.decodeUnknownEffect(StoredThreadSnapshot);
+const encodeStoredThreadSnapshot = Schema.encodeEffect(StoredThreadSnapshot);
+const decodeLegacyStoredShellSnapshot = Schema.decodeUnknownEffect(LegacyStoredShellSnapshot);
 
 function threadSnapshotFileName(threadId: ThreadId): string {
   return `${encodeURIComponent(threadId)}.json`;
@@ -100,7 +82,14 @@ const threadSnapshotDirectory = Effect.fn("mobile.connectionStorage.threadSnapsh
         }
         return directory;
       },
-      catch: (cause) => shellPersistenceError(operation, cause),
+      catch: (cause) =>
+        new ConnectionPersistenceError({
+          operation,
+          stage: "resolve",
+          resource: "thread-cache",
+          environmentId,
+          cause,
+        }),
     });
   },
 );
@@ -110,38 +99,54 @@ const threadSnapshotFile = Effect.fn("mobile.connectionStorage.threadSnapshotFil
   threadId: ThreadId,
   operation: "load-thread" | "save-thread" | "remove-thread",
 ) {
-  const { File } = yield* Effect.promise(() => import("expo-file-system"));
-  return new File(
-    yield* threadSnapshotDirectory(environmentId, operation),
-    threadSnapshotFileName(threadId),
-  );
-});
-
-function targetPersistenceError(
-  operation: "list-targets" | "register-connection" | "remove-connection",
-  error: ConnectionTransientError,
-) {
-  return new ConnectionPersistenceError({
-    operation,
-    message: error.message,
+  const directory = yield* threadSnapshotDirectory(environmentId, operation);
+  return yield* Effect.tryPromise({
+    try: async () => {
+      const { File } = await import("expo-file-system");
+      return new File(directory, threadSnapshotFileName(threadId));
+    },
+    catch: (cause) =>
+      new ConnectionPersistenceError({
+        operation,
+        stage: "resolve",
+        resource: "thread-cache",
+        environmentId,
+        threadId,
+        cause,
+      }),
   });
-}
+});
 
 const secureCatalogStorage: SecureCatalogStorage = {
   getItem: (key) =>
     Effect.tryPromise({
       try: () => SecureStore.getItemAsync(key),
-      catch: (cause) => catalogError("load", cause),
+      catch: (cause) =>
+        new ConnectionTransientError({
+          reason: "remote-unavailable",
+          detail: "Could not load the local connection catalog from secure storage.",
+          cause,
+        }),
     }),
   setItem: (key, value) =>
     Effect.tryPromise({
       try: () => SecureStore.setItemAsync(key, value),
-      catch: (cause) => catalogError("save", cause),
+      catch: (cause) =>
+        new ConnectionTransientError({
+          reason: "remote-unavailable",
+          detail: "Could not save the local connection catalog to secure storage.",
+          cause,
+        }),
     }),
   deleteItem: (key) =>
     Effect.tryPromise({
       try: () => SecureStore.deleteItemAsync(key),
-      catch: (cause) => catalogError("delete", cause),
+      catch: (cause) =>
+        new ConnectionTransientError({
+          reason: "remote-unavailable",
+          detail: "Could not remove the local connection catalog from secure storage.",
+          cause,
+        }),
     }),
 };
 
@@ -156,6 +161,8 @@ const shellSnapshotFileInDirectory = Effect.fn(
   operation: "load-shell" | "save-shell" | "clear-environment",
   directoryName: string,
 ) {
+  const resource =
+    directoryName === LEGACY_SHELL_SNAPSHOT_CACHE_DIRECTORY ? "legacy-shell-cache" : "shell-cache";
   return yield* Effect.tryPromise({
     try: async () => {
       const { Directory, File, Paths } = await import("expo-file-system");
@@ -163,7 +170,14 @@ const shellSnapshotFileInDirectory = Effect.fn(
       directory.create({ idempotent: true, intermediates: true });
       return new File(directory, shellSnapshotFileName(environmentId));
     },
-    catch: (cause) => shellPersistenceError(operation, cause),
+    catch: (cause) =>
+      new ConnectionPersistenceError({
+        operation,
+        stage: "resolve",
+        resource,
+        environmentId,
+        cause,
+      }),
   });
 });
 
@@ -184,18 +198,48 @@ export const connectionStorageLayer = Layer.effectContext(
     const targetStore = ConnectionTargetStore.of({
       list: catalog.read.pipe(
         Effect.map((document) => document.targets),
-        Effect.mapError((error) => targetPersistenceError("list-targets", error)),
+        Effect.mapError(
+          (cause) =>
+            new ConnectionPersistenceError({
+              operation: "list-targets",
+              stage: "read",
+              resource: "connection-catalog",
+              cause,
+            }),
+        ),
       ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
       register: (registration) =>
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
-          .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "register-connection",
+                  stage: "write",
+                  resource: "connection-catalog",
+                  environmentId: registration.target.environmentId,
+                  cause,
+                }),
+            ),
+          ),
       remove: (target) =>
         catalog
           .update((document) => removeConnectionFromCatalog(document, target))
-          .pipe(Effect.mapError((error) => targetPersistenceError("remove-connection", error))),
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "remove-connection",
+                  stage: "write",
+                  resource: "connection-catalog",
+                  environmentId: target.environmentId,
+                  cause,
+                }),
+            ),
+          ),
     });
     const profileStore = ProfileStore.make({
       get: (connectionId) =>
@@ -283,15 +327,41 @@ export const connectionStorageLayer = Layer.effectContext(
           if (file.exists) {
             const raw = yield* Effect.tryPromise({
               try: () => file.text(),
-              catch: (cause) => shellPersistenceError("load-shell", cause),
+              catch: (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "load-shell",
+                  stage: "read",
+                  resource: "shell-cache",
+                  environmentId,
+                  path: file.uri,
+                  cause,
+                }),
             });
             const parsed = yield* Effect.try({
               try: () => JSON.parse(raw) as unknown,
-              catch: (cause) => shellPersistenceError("load-shell", cause),
+              catch: (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "load-shell",
+                  stage: "parse",
+                  resource: "shell-cache",
+                  environmentId,
+                  path: file.uri,
+                  cause,
+                }),
             });
-            const stored = yield* Effect.fromResult(
-              Schema.decodeUnknownResult(StoredShellSnapshot)(parsed),
-            ).pipe(Effect.mapError((cause) => shellPersistenceError("load-shell", cause)));
+            const stored = yield* decodeStoredShellSnapshot(parsed).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ConnectionPersistenceError({
+                    operation: "load-shell",
+                    stage: "decode",
+                    resource: "shell-cache",
+                    environmentId,
+                    path: file.uri,
+                    cause,
+                  }),
+              ),
+            );
             return stored.environmentId === environmentId
               ? Option.some(stored.snapshot)
               : Option.none();
@@ -303,15 +373,41 @@ export const connectionStorageLayer = Layer.effectContext(
           }
           const legacyRaw = yield* Effect.tryPromise({
             try: () => legacyFile.text(),
-            catch: (cause) => shellPersistenceError("load-shell", cause),
+            catch: (cause) =>
+              new ConnectionPersistenceError({
+                operation: "load-shell",
+                stage: "read",
+                resource: "legacy-shell-cache",
+                environmentId,
+                path: legacyFile.uri,
+                cause,
+              }),
           });
           const legacyParsed = yield* Effect.try({
             try: () => JSON.parse(legacyRaw) as unknown,
-            catch: (cause) => shellPersistenceError("load-shell", cause),
+            catch: (cause) =>
+              new ConnectionPersistenceError({
+                operation: "load-shell",
+                stage: "parse",
+                resource: "legacy-shell-cache",
+                environmentId,
+                path: legacyFile.uri,
+                cause,
+              }),
           });
-          const legacyStored = yield* Effect.fromResult(
-            Schema.decodeUnknownResult(LegacyStoredShellSnapshot)(legacyParsed),
-          ).pipe(Effect.mapError((cause) => shellPersistenceError("load-shell", cause)));
+          const legacyStored = yield* decodeLegacyStoredShellSnapshot(legacyParsed).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "load-shell",
+                  stage: "decode",
+                  resource: "legacy-shell-cache",
+                  environmentId,
+                  path: legacyFile.uri,
+                  cause,
+                }),
+            ),
+          );
           return legacyStored.environmentId === environmentId
             ? Option.some(legacyStored.snapshot)
             : Option.none();
@@ -324,9 +420,19 @@ export const connectionStorageLayer = Layer.effectContext(
             environmentId,
             snapshot,
           } as const;
-          const encoded = yield* Effect.fromResult(
-            Schema.encodeUnknownResult(StoredShellSnapshot)(stored),
-          ).pipe(Effect.mapError((cause) => shellPersistenceError("save-shell", cause)));
+          const encoded = yield* encodeStoredShellSnapshot(stored).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "save-shell",
+                  stage: "encode",
+                  resource: "shell-cache",
+                  environmentId,
+                  path: file.uri,
+                  cause,
+                }),
+            ),
+          );
           yield* Effect.try({
             try: () => {
               if (!file.exists) {
@@ -334,7 +440,15 @@ export const connectionStorageLayer = Layer.effectContext(
               }
               file.write(JSON.stringify(encoded));
             },
-            catch: (cause) => shellPersistenceError("save-shell", cause),
+            catch: (cause) =>
+              new ConnectionPersistenceError({
+                operation: "save-shell",
+                stage: "write",
+                resource: "shell-cache",
+                environmentId,
+                path: file.uri,
+                cause,
+              }),
           });
         }),
       loadThread: (environmentId, threadId) =>
@@ -345,15 +459,44 @@ export const connectionStorageLayer = Layer.effectContext(
           }
           const raw = yield* Effect.tryPromise({
             try: () => file.text(),
-            catch: (cause) => shellPersistenceError("load-thread", cause),
+            catch: (cause) =>
+              new ConnectionPersistenceError({
+                operation: "load-thread",
+                stage: "read",
+                resource: "thread-cache",
+                environmentId,
+                threadId,
+                path: file.uri,
+                cause,
+              }),
           });
           const parsed = yield* Effect.try({
             try: () => JSON.parse(raw) as unknown,
-            catch: (cause) => shellPersistenceError("load-thread", cause),
+            catch: (cause) =>
+              new ConnectionPersistenceError({
+                operation: "load-thread",
+                stage: "parse",
+                resource: "thread-cache",
+                environmentId,
+                threadId,
+                path: file.uri,
+                cause,
+              }),
           });
-          const stored = yield* Effect.fromResult(
-            Schema.decodeUnknownResult(StoredThreadSnapshot)(parsed),
-          ).pipe(Effect.mapError((cause) => shellPersistenceError("load-thread", cause)));
+          const stored = yield* decodeStoredThreadSnapshot(parsed).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "load-thread",
+                  stage: "decode",
+                  resource: "thread-cache",
+                  environmentId,
+                  threadId,
+                  path: file.uri,
+                  cause,
+                }),
+            ),
+          );
           return stored.environmentId === environmentId && stored.threadId === threadId
             ? Option.some(stored.thread)
             : Option.none();
@@ -361,14 +504,25 @@ export const connectionStorageLayer = Layer.effectContext(
       saveThread: (environmentId, thread) =>
         Effect.gen(function* () {
           const file = yield* threadSnapshotFile(environmentId, thread.id, "save-thread");
-          const encoded = yield* Effect.fromResult(
-            Schema.encodeUnknownResult(StoredThreadSnapshot)({
-              schemaVersion: THREAD_SNAPSHOT_CACHE_SCHEMA_VERSION,
-              environmentId,
-              threadId: thread.id,
-              thread,
-            }),
-          ).pipe(Effect.mapError((cause) => shellPersistenceError("save-thread", cause)));
+          const encoded = yield* encodeStoredThreadSnapshot({
+            schemaVersion: THREAD_SNAPSHOT_CACHE_SCHEMA_VERSION,
+            environmentId,
+            threadId: thread.id,
+            thread,
+          }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "save-thread",
+                  stage: "encode",
+                  resource: "thread-cache",
+                  environmentId,
+                  threadId: thread.id,
+                  path: file.uri,
+                  cause,
+                }),
+            ),
+          );
           yield* Effect.try({
             try: () => {
               if (!file.exists) {
@@ -376,36 +530,67 @@ export const connectionStorageLayer = Layer.effectContext(
               }
               file.write(JSON.stringify(encoded));
             },
-            catch: (cause) => shellPersistenceError("save-thread", cause),
+            catch: (cause) =>
+              new ConnectionPersistenceError({
+                operation: "save-thread",
+                stage: "write",
+                resource: "thread-cache",
+                environmentId,
+                threadId: thread.id,
+                path: file.uri,
+                cause,
+              }),
           });
         }),
       removeThread: (environmentId, threadId) =>
         Effect.gen(function* () {
           const file = yield* threadSnapshotFile(environmentId, threadId, "remove-thread");
           if (file.exists) {
-            file.delete();
+            yield* Effect.try({
+              try: () => file.delete(),
+              catch: (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "remove-thread",
+                  stage: "remove",
+                  resource: "thread-cache",
+                  environmentId,
+                  threadId,
+                  path: file.uri,
+                  cause,
+                }),
+            });
           }
-        }).pipe(
-          Effect.mapError((cause) =>
-            cause._tag === "ConnectionPersistenceError"
-              ? cause
-              : shellPersistenceError("remove-thread", cause),
-          ),
-        ),
+        }),
       clear: (environmentId) =>
         Effect.gen(function* () {
           const file = yield* shellSnapshotFile(environmentId, "clear-environment");
           if (file.exists) {
             yield* Effect.try({
               try: () => file.delete(),
-              catch: (cause) => shellPersistenceError("clear-environment", cause),
+              catch: (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "clear-environment",
+                  stage: "remove",
+                  resource: "shell-cache",
+                  environmentId,
+                  path: file.uri,
+                  cause,
+                }),
             });
           }
           const legacyFile = yield* legacyShellSnapshotFile(environmentId, "clear-environment");
           if (legacyFile.exists) {
             yield* Effect.try({
               try: () => legacyFile.delete(),
-              catch: (cause) => shellPersistenceError("clear-environment", cause),
+              catch: (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "clear-environment",
+                  stage: "remove",
+                  resource: "legacy-shell-cache",
+                  environmentId,
+                  path: legacyFile.uri,
+                  cause,
+                }),
             });
           }
           const threadDirectory = yield* threadSnapshotDirectory(
@@ -415,7 +600,15 @@ export const connectionStorageLayer = Layer.effectContext(
           if (threadDirectory.exists) {
             yield* Effect.try({
               try: () => threadDirectory.delete(),
-              catch: (cause) => shellPersistenceError("clear-environment", cause),
+              catch: (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "clear-environment",
+                  stage: "remove",
+                  resource: "thread-cache",
+                  environmentId,
+                  path: threadDirectory.uri,
+                  cause,
+                }),
             });
           }
         }),

--- a/apps/mobile/src/features/cloud/managedRelayLayer.ts
+++ b/apps/mobile/src/features/cloud/managedRelayLayer.ts
@@ -28,26 +28,24 @@ const relayDpopSignerLayer = Layer.effect(
       ),
       createProof: Effect.fn("mobile.managedRelayDpopSigner.createProof")(function* (input) {
         const proofKey = yield* loadProofKey.pipe(
-          Effect.mapError(
-            (error) =>
-              new ManagedRelay.ManagedRelayDpopKeyLoadError({
-                keyStore: "expo-secure-store",
-                method: input.method,
-                url: input.url,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            ManagedRelay.ManagedRelayDpopKeyLoadError.fromTarget({
+              keyStore: "expo-secure-store",
+              method: input.method,
+              url: input.url,
+              cause: error,
+            }),
           ),
         );
         return yield* createDpopProof({ ...input, proofKey }).pipe(
           Effect.provideService(Crypto.Crypto, crypto),
           Effect.map((proof) => proof.proof),
-          Effect.mapError(
-            (error) =>
-              new ManagedRelay.ManagedRelayDpopProofCreationError({
-                method: input.method,
-                url: input.url,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            ManagedRelay.ManagedRelayDpopProofCreationError.fromTarget({
+              method: input.method,
+              url: input.url,
+              cause: error,
+            }),
           ),
         );
       }),

--- a/apps/mobile/src/features/cloud/managedRelayLayer.ts
+++ b/apps/mobile/src/features/cloud/managedRelayLayer.ts
@@ -30,8 +30,8 @@ const relayDpopSignerLayer = Layer.effect(
         const proofKey = yield* loadProofKey.pipe(
           Effect.mapError(
             (error) =>
-              new ManagedRelay.ManagedRelayDpopProofCreationError({
-                stage: "load-key",
+              new ManagedRelay.ManagedRelayDpopKeyLoadError({
+                keyStore: "expo-secure-store",
                 method: input.method,
                 url: input.url,
                 cause: error,
@@ -44,7 +44,6 @@ const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
-                stage: "create-proof",
                 method: input.method,
                 url: input.url,
                 cause: error,

--- a/apps/mobile/src/features/cloud/managedRelayLayer.ts
+++ b/apps/mobile/src/features/cloud/managedRelayLayer.ts
@@ -31,6 +31,7 @@ const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
+                stage: "load-key",
                 method: input.method,
                 url: input.url,
                 cause: error,
@@ -43,6 +44,7 @@ const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
+                stage: "create-proof",
                 method: input.method,
                 url: input.url,
                 cause: error,

--- a/apps/web/src/cloud/managedRelayLayer.ts
+++ b/apps/web/src/cloud/managedRelayLayer.ts
@@ -53,6 +53,7 @@ export const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
+                stage: "load-key",
                 method: input.method,
                 url: input.url,
                 cause: error,
@@ -65,6 +66,7 @@ export const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
+                stage: "create-proof",
                 method: input.method,
                 url: input.url,
                 cause: error,

--- a/apps/web/src/cloud/managedRelayLayer.ts
+++ b/apps/web/src/cloud/managedRelayLayer.ts
@@ -52,8 +52,8 @@ export const relayDpopSignerLayer = Layer.effect(
         const proofKey = yield* loadOrCreateBrowserDpopKey.pipe(
           Effect.mapError(
             (error) =>
-              new ManagedRelay.ManagedRelayDpopProofCreationError({
-                stage: "load-key",
+              new ManagedRelay.ManagedRelayDpopKeyLoadError({
+                keyStore: "indexed-db",
                 method: input.method,
                 url: input.url,
                 cause: error,
@@ -66,7 +66,6 @@ export const relayDpopSignerLayer = Layer.effect(
           Effect.mapError(
             (error) =>
               new ManagedRelay.ManagedRelayDpopProofCreationError({
-                stage: "create-proof",
                 method: input.method,
                 url: input.url,
                 cause: error,

--- a/apps/web/src/cloud/managedRelayLayer.ts
+++ b/apps/web/src/cloud/managedRelayLayer.ts
@@ -50,26 +50,24 @@ export const relayDpopSignerLayer = Layer.effect(
       ),
       createProof: Effect.fn("web.managedRelayDpopSigner.createProof")(function* (input) {
         const proofKey = yield* loadOrCreateBrowserDpopKey.pipe(
-          Effect.mapError(
-            (error) =>
-              new ManagedRelay.ManagedRelayDpopKeyLoadError({
-                keyStore: "indexed-db",
-                method: input.method,
-                url: input.url,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            ManagedRelay.ManagedRelayDpopKeyLoadError.fromTarget({
+              keyStore: "indexed-db",
+              method: input.method,
+              url: input.url,
+              cause: error,
+            }),
           ),
         );
         return yield* createBrowserDpopProof({ ...input, proofKey }).pipe(
           Effect.provideService(Crypto.Crypto, crypto),
           Effect.map((proof) => proof.proof),
-          Effect.mapError(
-            (error) =>
-              new ManagedRelay.ManagedRelayDpopProofCreationError({
-                method: input.method,
-                url: input.url,
-                cause: error,
-              }),
+          Effect.mapError((error) =>
+            ManagedRelay.ManagedRelayDpopProofCreationError.fromTarget({
+              method: input.method,
+              url: input.url,
+              cause: error,
+            }),
           ),
         );
       }),

--- a/apps/web/src/connection/storage.test.ts
+++ b/apps/web/src/connection/storage.test.ts
@@ -71,6 +71,7 @@ describe("makeCatalogBackend", () => {
 
       expect(error).toBeInstanceOf(ConnectionTransientError);
       expect(error.message).toContain("Desktop secure storage is unavailable");
+      expect(error.cause).toMatchObject({ _tag: "DesktopSecureStorageUnavailableError" });
       expect(setConnectionCatalog).toHaveBeenCalledWith("{}");
     }),
   );
@@ -88,10 +89,13 @@ describe("makeCatalogBackend", () => {
 
       const error = yield* backend.write("{}").pipe(Effect.flip);
 
-      expect(error.cause).toBe(cause);
-      expect(error.message).toBe(
-        "Could not save the local connection catalog to desktop secure storage.",
-      );
+      expect(error.cause).toMatchObject({
+        _tag: "ConnectionStorageOperationError",
+        operation: "save",
+        backend: "desktop-secure-storage",
+        cause,
+      });
+      expect(error.message).toBe("Could not save local connection data.");
       expect(error.message).not.toContain(cause.message);
     }),
   );

--- a/apps/web/src/connection/storage.test.ts
+++ b/apps/web/src/connection/storage.test.ts
@@ -74,4 +74,25 @@ describe("makeCatalogBackend", () => {
       expect(setConnectionCatalog).toHaveBeenCalledWith("{}");
     }),
   );
+
+  it.effect("preserves secure-storage write failures without exposing them in the message", () =>
+    Effect.gen(function* () {
+      const cause = new Error("credential vault path leaked");
+      vi.stubGlobal("window", {
+        desktopBridge: {
+          getConnectionCatalog: vi.fn().mockResolvedValue(null),
+          setConnectionCatalog: vi.fn().mockRejectedValue(cause),
+        },
+      });
+      const backend = makeCatalogBackend({} as IDBDatabase);
+
+      const error = yield* backend.write("{}").pipe(Effect.flip);
+
+      expect(error.cause).toBe(cause);
+      expect(error.message).toBe(
+        "Could not save the local connection catalog to desktop secure storage.",
+      );
+      expect(error.message).not.toContain(cause.message);
+    }),
+  );
 });

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -13,8 +13,11 @@ import {
 } from "@t3tools/client-runtime/platform";
 import { TokenStore } from "@t3tools/client-runtime/authorization";
 import {
+  ConnectionStorageOperationError,
   ConnectionTransientError,
   CredentialStore,
+  DesktopSecureStorageUnavailableError,
+  IndexedDbUnavailableError,
   ProfileStore,
 } from "@t3tools/client-runtime/connection";
 import {
@@ -64,12 +67,7 @@ const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(function* (
   return yield* Effect.callback<IDBDatabase, ConnectionTransientError>((resume) => {
     if (typeof indexedDB === "undefined") {
       resume(
-        Effect.fail(
-          new ConnectionTransientError({
-            reason: "remote-unavailable",
-            detail: "IndexedDB is unavailable in this browser context.",
-          }),
-        ),
+        Effect.fail(ConnectionTransientError.fromStorageFailure(new IndexedDbUnavailableError())),
       );
       return;
     }
@@ -85,14 +83,16 @@ const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(function* (
         request.result.createObjectStore(THREAD_STORE_NAME);
       }
     });
-    request.addEventListener("error", () => {
+    request.addEventListener("error", (event) => {
       resume(
         Effect.fail(
-          new ConnectionTransientError({
-            reason: "remote-unavailable",
-            detail: "Could not open the local connection catalog database.",
-            cause: request.error ?? undefined,
-          }),
+          ConnectionTransientError.fromStorageFailure(
+            new ConnectionStorageOperationError({
+              operation: "open",
+              backend: "indexed-db",
+              cause: request.error ?? event,
+            }),
+          ),
         ),
       );
     });
@@ -105,14 +105,18 @@ const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(function* (
 function readDatabaseValue(database: IDBDatabase, storeName: string, key: IDBValidKey) {
   return Effect.callback<unknown, ConnectionTransientError>((resume) => {
     const request = database.transaction(storeName, "readonly").objectStore(storeName).get(key);
-    request.addEventListener("error", () => {
+    request.addEventListener("error", (event) => {
       resume(
         Effect.fail(
-          new ConnectionTransientError({
-            reason: "remote-unavailable",
-            detail: "Could not read the local connection database.",
-            cause: request.error ?? undefined,
-          }),
+          ConnectionTransientError.fromStorageFailure(
+            new ConnectionStorageOperationError({
+              operation: "read",
+              backend: "indexed-db",
+              storeName,
+              key,
+              cause: request.error ?? event,
+            }),
+          ),
         ),
       );
     });
@@ -130,14 +134,18 @@ function writeDatabaseValue(
 ) {
   return Effect.callback<void, ConnectionTransientError>((resume) => {
     const transaction = database.transaction(storeName, "readwrite");
-    transaction.addEventListener("error", () => {
+    transaction.addEventListener("error", (event) => {
       resume(
         Effect.fail(
-          new ConnectionTransientError({
-            reason: "remote-unavailable",
-            detail: "Could not write the local connection database.",
-            cause: transaction.error ?? undefined,
-          }),
+          ConnectionTransientError.fromStorageFailure(
+            new ConnectionStorageOperationError({
+              operation: "write",
+              backend: "indexed-db",
+              storeName,
+              key,
+              cause: transaction.error ?? event,
+            }),
+          ),
         ),
       );
     });
@@ -151,14 +159,18 @@ function writeDatabaseValue(
 function removeDatabaseValue(database: IDBDatabase, storeName: string, key: IDBValidKey) {
   return Effect.callback<void, ConnectionTransientError>((resume) => {
     const transaction = database.transaction(storeName, "readwrite");
-    transaction.addEventListener("error", () => {
+    transaction.addEventListener("error", (event) => {
       resume(
         Effect.fail(
-          new ConnectionTransientError({
-            reason: "remote-unavailable",
-            detail: "Could not remove data from the local connection database.",
-            cause: transaction.error ?? undefined,
-          }),
+          ConnectionTransientError.fromStorageFailure(
+            new ConnectionStorageOperationError({
+              operation: "remove",
+              backend: "indexed-db",
+              storeName,
+              key,
+              cause: transaction.error ?? event,
+            }),
+          ),
         ),
       );
     });
@@ -172,14 +184,17 @@ function removeDatabaseValue(database: IDBDatabase, storeName: string, key: IDBV
 function removeDatabaseValuesInRange(database: IDBDatabase, storeName: string, range: IDBKeyRange) {
   return Effect.callback<void, ConnectionTransientError>((resume) => {
     const transaction = database.transaction(storeName, "readwrite");
-    transaction.addEventListener("error", () => {
+    transaction.addEventListener("error", (event) => {
       resume(
         Effect.fail(
-          new ConnectionTransientError({
-            reason: "remote-unavailable",
-            detail: "Could not remove data from the local connection database.",
-            cause: transaction.error ?? undefined,
-          }),
+          ConnectionTransientError.fromStorageFailure(
+            new ConnectionStorageOperationError({
+              operation: "remove",
+              backend: "indexed-db",
+              storeName,
+              cause: transaction.error ?? event,
+            }),
+          ),
         ),
       );
     });
@@ -187,14 +202,17 @@ function removeDatabaseValuesInRange(database: IDBDatabase, storeName: string, r
       resume(Effect.void);
     });
     const request = transaction.objectStore(storeName).openCursor(range);
-    request.addEventListener("error", () => {
+    request.addEventListener("error", (event) => {
       resume(
         Effect.fail(
-          new ConnectionTransientError({
-            reason: "remote-unavailable",
-            detail: "Could not scan the local connection database for removal.",
-            cause: request.error ?? undefined,
-          }),
+          ConnectionTransientError.fromStorageFailure(
+            new ConnectionStorageOperationError({
+              operation: "remove",
+              backend: "indexed-db",
+              storeName,
+              cause: request.error ?? event,
+            }),
+          ),
         ),
       );
     });
@@ -215,13 +233,14 @@ function threadCacheKey(environmentId: EnvironmentId, threadId: ThreadId) {
 
 const decodeCatalog = Effect.fn("web.connectionStorage.decodeCatalog")(function* (raw: string) {
   return yield* decodeConnectionCatalogDocument(raw).pipe(
-    Effect.mapError(
-      (cause) =>
-        new ConnectionTransientError({
-          reason: "remote-unavailable",
-          detail: "Could not decode the local connection catalog.",
+    Effect.mapError((cause) =>
+      ConnectionTransientError.fromStorageFailure(
+        new ConnectionStorageOperationError({
+          operation: "decode",
+          backend: "schema",
           cause,
         }),
+      ),
     ),
   );
 });
@@ -230,13 +249,14 @@ const encodeCatalog = Effect.fn("web.connectionStorage.encodeCatalog")(function*
   catalog: ConnectionCatalogDocumentType,
 ) {
   return yield* encodeConnectionCatalogDocument(catalog).pipe(
-    Effect.mapError(
-      (cause) =>
-        new ConnectionTransientError({
-          reason: "remote-unavailable",
-          detail: "Could not encode the local connection catalog.",
+    Effect.mapError((cause) =>
+      ConnectionTransientError.fromStorageFailure(
+        new ConnectionStorageOperationError({
+          operation: "encode",
+          backend: "schema",
           cause,
         }),
+      ),
     ),
   );
 });
@@ -254,30 +274,33 @@ export function makeCatalogBackend(database: IDBDatabase): CatalogBackend {
       read: Effect.tryPromise({
         try: () => bridge.getConnectionCatalog!(),
         catch: (cause) =>
-          new ConnectionTransientError({
-            reason: "remote-unavailable",
-            detail: "Could not load the local connection catalog from desktop secure storage.",
-            cause,
-          }),
+          ConnectionTransientError.fromStorageFailure(
+            new ConnectionStorageOperationError({
+              operation: "load",
+              backend: "desktop-secure-storage",
+              cause,
+            }),
+          ),
       }),
       write: (raw) =>
         Effect.tryPromise({
           try: () => bridge.setConnectionCatalog!(raw),
           catch: (cause) =>
-            new ConnectionTransientError({
-              reason: "remote-unavailable",
-              detail: "Could not save the local connection catalog to desktop secure storage.",
-              cause,
-            }),
+            ConnectionTransientError.fromStorageFailure(
+              new ConnectionStorageOperationError({
+                operation: "save",
+                backend: "desktop-secure-storage",
+                cause,
+              }),
+            ),
         }).pipe(
           Effect.flatMap((stored) =>
             stored
               ? Effect.void
               : Effect.fail(
-                  new ConnectionTransientError({
-                    reason: "remote-unavailable",
-                    detail: "Desktop secure storage is unavailable in this system context.",
-                  }),
+                  ConnectionTransientError.fromStorageFailure(
+                    new DesktopSecureStorageUnavailableError(),
+                  ),
                 ),
           ),
         ),

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -60,37 +60,16 @@ const encodeStoredShellSnapshot = Schema.encodeEffect(StoredShellSnapshotJson);
 const decodeStoredThreadSnapshot = Schema.decodeUnknownEffect(StoredThreadSnapshotJson);
 const encodeStoredThreadSnapshot = Schema.encodeEffect(StoredThreadSnapshotJson);
 
-function catalogError(operation: string, cause: unknown) {
-  return new ConnectionTransientError({
-    reason: "remote-unavailable",
-    detail: `Could not ${operation} the local connection catalog: ${String(cause)}`,
-  });
-}
-
-function persistenceError(
-  operation:
-    | "list-targets"
-    | "register-connection"
-    | "remove-connection"
-    | "load-shell"
-    | "save-shell"
-    | "load-thread"
-    | "save-thread"
-    | "remove-thread"
-    | "clear-environment",
-  cause: unknown,
-) {
-  return new ConnectionPersistenceError({
-    operation,
-    message: `Could not ${operation.replaceAll("-", " ")}: ${String(cause)}`,
-  });
-}
-
 const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(function* () {
   return yield* Effect.callback<IDBDatabase, ConnectionTransientError>((resume) => {
     if (typeof indexedDB === "undefined") {
       resume(
-        Effect.fail(catalogError("open", "IndexedDB is unavailable in this browser context.")),
+        Effect.fail(
+          new ConnectionTransientError({
+            reason: "remote-unavailable",
+            detail: "IndexedDB is unavailable in this browser context.",
+          }),
+        ),
       );
       return;
     }
@@ -107,7 +86,15 @@ const openDatabase = Effect.fn("web.connectionStorage.openDatabase")(function* (
       }
     });
     request.addEventListener("error", () => {
-      resume(Effect.fail(catalogError("open", request.error ?? "Unknown IndexedDB error")));
+      resume(
+        Effect.fail(
+          new ConnectionTransientError({
+            reason: "remote-unavailable",
+            detail: "Could not open the local connection catalog database.",
+            cause: request.error ?? undefined,
+          }),
+        ),
+      );
     });
     request.addEventListener("success", () => {
       resume(Effect.succeed(request.result));
@@ -119,7 +106,15 @@ function readDatabaseValue(database: IDBDatabase, storeName: string, key: IDBVal
   return Effect.callback<unknown, ConnectionTransientError>((resume) => {
     const request = database.transaction(storeName, "readonly").objectStore(storeName).get(key);
     request.addEventListener("error", () => {
-      resume(Effect.fail(catalogError("read", request.error ?? "Unknown IndexedDB read error")));
+      resume(
+        Effect.fail(
+          new ConnectionTransientError({
+            reason: "remote-unavailable",
+            detail: "Could not read the local connection database.",
+            cause: request.error ?? undefined,
+          }),
+        ),
+      );
     });
     request.addEventListener("success", () => {
       resume(Effect.succeed(request.result));
@@ -137,7 +132,13 @@ function writeDatabaseValue(
     const transaction = database.transaction(storeName, "readwrite");
     transaction.addEventListener("error", () => {
       resume(
-        Effect.fail(catalogError("write", transaction.error ?? "Unknown IndexedDB write error")),
+        Effect.fail(
+          new ConnectionTransientError({
+            reason: "remote-unavailable",
+            detail: "Could not write the local connection database.",
+            cause: transaction.error ?? undefined,
+          }),
+        ),
       );
     });
     transaction.addEventListener("complete", () => {
@@ -152,7 +153,13 @@ function removeDatabaseValue(database: IDBDatabase, storeName: string, key: IDBV
     const transaction = database.transaction(storeName, "readwrite");
     transaction.addEventListener("error", () => {
       resume(
-        Effect.fail(catalogError("remove", transaction.error ?? "Unknown IndexedDB remove error")),
+        Effect.fail(
+          new ConnectionTransientError({
+            reason: "remote-unavailable",
+            detail: "Could not remove data from the local connection database.",
+            cause: transaction.error ?? undefined,
+          }),
+        ),
       );
     });
     transaction.addEventListener("complete", () => {
@@ -167,7 +174,13 @@ function removeDatabaseValuesInRange(database: IDBDatabase, storeName: string, r
     const transaction = database.transaction(storeName, "readwrite");
     transaction.addEventListener("error", () => {
       resume(
-        Effect.fail(catalogError("remove", transaction.error ?? "Unknown IndexedDB cursor error")),
+        Effect.fail(
+          new ConnectionTransientError({
+            reason: "remote-unavailable",
+            detail: "Could not remove data from the local connection database.",
+            cause: transaction.error ?? undefined,
+          }),
+        ),
       );
     });
     transaction.addEventListener("complete", () => {
@@ -176,7 +189,13 @@ function removeDatabaseValuesInRange(database: IDBDatabase, storeName: string, r
     const request = transaction.objectStore(storeName).openCursor(range);
     request.addEventListener("error", () => {
       resume(
-        Effect.fail(catalogError("remove", request.error ?? "Unknown IndexedDB cursor error")),
+        Effect.fail(
+          new ConnectionTransientError({
+            reason: "remote-unavailable",
+            detail: "Could not scan the local connection database for removal.",
+            cause: request.error ?? undefined,
+          }),
+        ),
       );
     });
     request.addEventListener("success", () => {
@@ -196,7 +215,14 @@ function threadCacheKey(environmentId: EnvironmentId, threadId: ThreadId) {
 
 const decodeCatalog = Effect.fn("web.connectionStorage.decodeCatalog")(function* (raw: string) {
   return yield* decodeConnectionCatalogDocument(raw).pipe(
-    Effect.mapError((cause) => catalogError("decode", cause)),
+    Effect.mapError(
+      (cause) =>
+        new ConnectionTransientError({
+          reason: "remote-unavailable",
+          detail: "Could not decode the local connection catalog.",
+          cause,
+        }),
+    ),
   );
 });
 
@@ -204,7 +230,14 @@ const encodeCatalog = Effect.fn("web.connectionStorage.encodeCatalog")(function*
   catalog: ConnectionCatalogDocumentType,
 ) {
   return yield* encodeConnectionCatalogDocument(catalog).pipe(
-    Effect.mapError((cause) => catalogError("encode", cause)),
+    Effect.mapError(
+      (cause) =>
+        new ConnectionTransientError({
+          reason: "remote-unavailable",
+          detail: "Could not encode the local connection catalog.",
+          cause,
+        }),
+    ),
   );
 });
 
@@ -220,21 +253,31 @@ export function makeCatalogBackend(database: IDBDatabase): CatalogBackend {
     return {
       read: Effect.tryPromise({
         try: () => bridge.getConnectionCatalog!(),
-        catch: (cause) => catalogError("load", cause),
+        catch: (cause) =>
+          new ConnectionTransientError({
+            reason: "remote-unavailable",
+            detail: "Could not load the local connection catalog from desktop secure storage.",
+            cause,
+          }),
       }),
       write: (raw) =>
         Effect.tryPromise({
           try: () => bridge.setConnectionCatalog!(raw),
-          catch: (cause) => catalogError("save", cause),
+          catch: (cause) =>
+            new ConnectionTransientError({
+              reason: "remote-unavailable",
+              detail: "Could not save the local connection catalog to desktop secure storage.",
+              cause,
+            }),
         }).pipe(
           Effect.flatMap((stored) =>
             stored
               ? Effect.void
               : Effect.fail(
-                  catalogError(
-                    "save",
-                    "Desktop secure storage is unavailable in this system context.",
-                  ),
+                  new ConnectionTransientError({
+                    reason: "remote-unavailable",
+                    detail: "Desktop secure storage is unavailable in this system context.",
+                  }),
                 ),
           ),
         ),
@@ -273,31 +316,33 @@ export const makeCatalogStore = Effect.fn("web.connectionStorage.makeCatalogStor
     let catalog = EMPTY_CONNECTION_CATALOG_DOCUMENT;
     if (raw !== null && raw.trim() !== "") {
       catalog = yield* decodeCatalog(raw).pipe(
-        Effect.catch((error) =>
-          Effect.gen(function* () {
-            yield* Effect.logWarning("Discarding a corrupt web connection catalog.", {
-              error: error.message,
-            });
-            if (backend.quarantine !== undefined) {
-              yield* backend.quarantine(raw).pipe(
-                Effect.catch((cause) =>
-                  Effect.logWarning("Could not quarantine the corrupt web connection catalog.", {
-                    error: cause.message,
+        Effect.catchTags({
+          ConnectionTransientError: (error) =>
+            Effect.gen(function* () {
+              yield* Effect.logWarning("Discarding a corrupt web connection catalog.", { error });
+              if (backend.quarantine !== undefined) {
+                yield* backend.quarantine(raw).pipe(
+                  Effect.catchTags({
+                    ConnectionTransientError: (error) =>
+                      Effect.logWarning(
+                        "Could not quarantine the corrupt web connection catalog.",
+                        { error },
+                      ),
                   }),
-                ),
-              );
-            }
-            const encoded = yield* encodeCatalog(EMPTY_CONNECTION_CATALOG_DOCUMENT);
-            yield* backend.write(encoded).pipe(
-              Effect.catch((cause) =>
-                Effect.logWarning("Could not persist the recovered web connection catalog.", {
-                  error: cause.message,
+                );
+              }
+              const encoded = yield* encodeCatalog(EMPTY_CONNECTION_CATALOG_DOCUMENT);
+              yield* backend.write(encoded).pipe(
+                Effect.catchTags({
+                  ConnectionTransientError: (error) =>
+                    Effect.logWarning("Could not persist the recovered web connection catalog.", {
+                      error,
+                    }),
                 }),
-              ),
-            );
-            return EMPTY_CONNECTION_CATALOG_DOCUMENT;
-          }),
-        ),
+              );
+              return EMPTY_CONNECTION_CATALOG_DOCUMENT;
+            }),
+        }),
       );
     }
     yield* Ref.set(state, Option.some(catalog));
@@ -330,18 +375,48 @@ export const connectionStorageLayer = Layer.effectContext(
     const targetStore = ConnectionTargetStore.of({
       list: catalog.read.pipe(
         Effect.map((document) => document.targets),
-        Effect.mapError((cause) => persistenceError("list-targets", cause)),
+        Effect.mapError(
+          (cause) =>
+            new ConnectionPersistenceError({
+              operation: "list-targets",
+              stage: "read",
+              resource: "connection-catalog",
+              cause,
+            }),
+        ),
       ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
       register: (registration) =>
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
-          .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "register-connection",
+                  stage: "write",
+                  resource: "connection-catalog",
+                  environmentId: registration.target.environmentId,
+                  cause,
+                }),
+            ),
+          ),
       remove: (target) =>
         catalog
           .update((document) => removeConnectionFromCatalog(document, target))
-          .pipe(Effect.mapError((cause) => persistenceError("remove-connection", cause))),
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "remove-connection",
+                  stage: "write",
+                  resource: "connection-catalog",
+                  environmentId: target.environmentId,
+                  cause,
+                }),
+            ),
+          ),
     });
     const profileStore = ProfileStore.make({
       get: (connectionId) =>
@@ -425,12 +500,31 @@ export const connectionStorageLayer = Layer.effectContext(
     const cacheStore = EnvironmentCacheStore.of({
       loadShell: (environmentId) =>
         readDatabaseValue(database, SHELL_STORE_NAME, environmentId).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ConnectionPersistenceError({
+                operation: "load-shell",
+                stage: "read",
+                resource: "shell-cache",
+                environmentId,
+                cause,
+              }),
+          ),
           Effect.flatMap((raw) => {
             if (typeof raw !== "string") {
               return Effect.succeed(Option.none());
             }
             return decodeStoredShellSnapshot(raw).pipe(
-              Effect.mapError((cause) => persistenceError("load-shell", cause)),
+              Effect.mapError(
+                (cause) =>
+                  new ConnectionPersistenceError({
+                    operation: "load-shell",
+                    stage: "decode",
+                    resource: "shell-cache",
+                    environmentId,
+                    cause,
+                  }),
+              ),
               Effect.map((stored) =>
                 stored.environmentId === environmentId
                   ? Option.some(stored.snapshot)
@@ -438,11 +532,6 @@ export const connectionStorageLayer = Layer.effectContext(
               ),
             );
           }),
-          Effect.mapError((cause) =>
-            cause._tag === "ConnectionPersistenceError"
-              ? cause
-              : persistenceError("load-shell", cause),
-          ),
         ),
       saveShell: (environmentId, snapshot) =>
         Effect.gen(function* () {
@@ -450,27 +539,64 @@ export const connectionStorageLayer = Layer.effectContext(
             schemaVersion: SHELL_SNAPSHOT_CACHE_SCHEMA_VERSION,
             environmentId,
             snapshot,
-          }).pipe(Effect.mapError((cause) => persistenceError("save-shell", cause)));
-          yield* writeDatabaseValue(database, SHELL_STORE_NAME, environmentId, encoded);
-        }).pipe(
-          Effect.mapError((cause) =>
-            cause._tag === "ConnectionPersistenceError"
-              ? cause
-              : persistenceError("save-shell", cause),
-          ),
-        ),
+          }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "save-shell",
+                  stage: "encode",
+                  resource: "shell-cache",
+                  environmentId,
+                  cause,
+                }),
+            ),
+          );
+          yield* writeDatabaseValue(database, SHELL_STORE_NAME, environmentId, encoded).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "save-shell",
+                  stage: "write",
+                  resource: "shell-cache",
+                  environmentId,
+                  cause,
+                }),
+            ),
+          );
+        }),
       loadThread: (environmentId, threadId) =>
         readDatabaseValue(
           database,
           THREAD_STORE_NAME,
           threadCacheKey(environmentId, threadId),
         ).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ConnectionPersistenceError({
+                operation: "load-thread",
+                stage: "read",
+                resource: "thread-cache",
+                environmentId,
+                threadId,
+                cause,
+              }),
+          ),
           Effect.flatMap((raw) => {
             if (typeof raw !== "string") {
               return Effect.succeed(Option.none());
             }
             return decodeStoredThreadSnapshot(raw).pipe(
-              Effect.mapError((cause) => persistenceError("load-thread", cause)),
+              Effect.mapError(
+                (cause) =>
+                  new ConnectionPersistenceError({
+                    operation: "load-thread",
+                    stage: "decode",
+                    resource: "thread-cache",
+                    environmentId,
+                    threadId,
+                    cause,
+                  }),
+              ),
               Effect.map((stored) =>
                 stored.environmentId === environmentId && stored.threadId === threadId
                   ? Option.some(stored.thread)
@@ -478,11 +604,6 @@ export const connectionStorageLayer = Layer.effectContext(
               ),
             );
           }),
-          Effect.mapError((cause) =>
-            cause._tag === "ConnectionPersistenceError"
-              ? cause
-              : persistenceError("load-thread", cause),
-          ),
         ),
       saveThread: (environmentId, thread) =>
         Effect.gen(function* () {
@@ -491,38 +612,90 @@ export const connectionStorageLayer = Layer.effectContext(
             environmentId,
             threadId: thread.id,
             thread,
-          }).pipe(Effect.mapError((cause) => persistenceError("save-thread", cause)));
+          }).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "save-thread",
+                  stage: "encode",
+                  resource: "thread-cache",
+                  environmentId,
+                  threadId: thread.id,
+                  cause,
+                }),
+            ),
+          );
           yield* writeDatabaseValue(
             database,
             THREAD_STORE_NAME,
             threadCacheKey(environmentId, thread.id),
             encoded,
+          ).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({
+                  operation: "save-thread",
+                  stage: "write",
+                  resource: "thread-cache",
+                  environmentId,
+                  threadId: thread.id,
+                  cause,
+                }),
+            ),
           );
-        }).pipe(
-          Effect.mapError((cause) =>
-            cause._tag === "ConnectionPersistenceError"
-              ? cause
-              : persistenceError("save-thread", cause),
-          ),
-        ),
+        }),
       removeThread: (environmentId, threadId) =>
         removeDatabaseValue(
           database,
           THREAD_STORE_NAME,
           threadCacheKey(environmentId, threadId),
-        ).pipe(Effect.mapError((cause) => persistenceError("remove-thread", cause))),
+        ).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ConnectionPersistenceError({
+                operation: "remove-thread",
+                stage: "remove",
+                resource: "thread-cache",
+                environmentId,
+                threadId,
+                cause,
+              }),
+          ),
+        ),
       clear: (environmentId) =>
         Effect.all(
           [
-            removeDatabaseValue(database, SHELL_STORE_NAME, environmentId),
+            removeDatabaseValue(database, SHELL_STORE_NAME, environmentId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ConnectionPersistenceError({
+                    operation: "clear-environment",
+                    stage: "remove",
+                    resource: "shell-cache",
+                    environmentId,
+                    cause,
+                  }),
+              ),
+            ),
             removeDatabaseValuesInRange(
               database,
               THREAD_STORE_NAME,
               IDBKeyRange.bound(`${environmentId}:`, `${environmentId}:\uffff`),
+            ).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ConnectionPersistenceError({
+                    operation: "clear-environment",
+                    stage: "remove",
+                    resource: "thread-cache",
+                    environmentId,
+                    cause,
+                  }),
+              ),
             ),
           ],
           { concurrency: "unbounded", discard: true },
-        ).pipe(Effect.mapError((cause) => persistenceError("clear-environment", cause))),
+        ),
     });
 
     return Context.make(ConnectionTargetStore, targetStore).pipe(

--- a/packages/client-runtime/src/authorization/remote.test.ts
+++ b/packages/client-runtime/src/authorization/remote.test.ts
@@ -391,7 +391,9 @@ describe("remote environment authorization", () => {
 
       expect(error).toBeInstanceOf(RemoteEnvironmentAuthTimeoutError);
       expect(error.message).toBe(
-        "Remote environment endpoint http://remote.example.com/.well-known/t3/environment timed out after 25ms.",
+        `Remote environment endpoint at host remote.example.com (${
+          "http://remote.example.com/.well-known/t3/environment".length
+        } URL characters) timed out after 25ms.`,
       );
     }).pipe(Effect.provide(TestClock.layer())),
   );
@@ -446,7 +448,9 @@ describe("remote environment authorization", () => {
 
       expect(error).toBeInstanceOf(RemoteEnvironmentAuthInvalidJsonError);
       expect(error.message).toBe(
-        "Remote environment endpoint returned an invalid response from https://remote.example.com/oauth/token.",
+        `Remote environment endpoint at host remote.example.com (${
+          "https://remote.example.com/oauth/token".length
+        } URL characters) returned an invalid response.`,
       );
     }),
   );

--- a/packages/client-runtime/src/authorization/remote.ts
+++ b/packages/client-runtime/src/authorization/remote.ts
@@ -15,6 +15,7 @@ import {
 } from "../rpc/http.ts";
 
 export {
+  isRemoteEnvironmentAuthUndeclaredStatusError,
   RemoteEnvironmentAuthFetchError,
   RemoteEnvironmentAuthInvalidJsonError,
   RemoteEnvironmentAuthTimeoutError,

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -148,10 +148,11 @@ export const make = Effect.gen(function* () {
         })
         .pipe(
           Effect.mapError(
-            () =>
+            (cause) =>
               new ConnectionBlockedError({
                 reason: "configuration",
                 detail: "Could not create the websocket authorization proof.",
+                cause,
               }),
           ),
         );
@@ -175,10 +176,11 @@ export const make = Effect.gen(function* () {
     }) {
       const thumbprint = yield* signer.thumbprint.pipe(
         Effect.mapError(
-          () =>
+          (cause) =>
             new ConnectionBlockedError({
               reason: "configuration",
               detail: "Could not load the environment authorization key.",
+              cause,
             }),
         ),
         Effect.withSpan("environment.authorization.dpopKey.resolve"),
@@ -248,10 +250,11 @@ export const make = Effect.gen(function* () {
         })
         .pipe(
           Effect.mapError(
-            () =>
+            (cause) =>
               new ConnectionBlockedError({
                 reason: "configuration",
                 detail: "Could not create the environment authorization proof.",
+                cause,
               }),
           ),
         );

--- a/packages/client-runtime/src/authorization/service.ts
+++ b/packages/client-runtime/src/authorization/service.ts
@@ -6,7 +6,7 @@ import {
   resolveRemoteDpopWebSocketConnectionUrl,
   resolveRemoteWebSocketConnectionUrl,
 } from "./remote.ts";
-import { environmentMismatchError, mapRemoteEnvironmentError } from "../connection/errors.ts";
+import { mapRemoteEnvironmentError } from "../connection/errors.ts";
 import { ConnectionBlockedError, type ConnectionAttemptError } from "../connection/model.ts";
 import { fetchRemoteEnvironmentDescriptor } from "../environment/descriptor.ts";
 import { environmentEndpointUrl } from "../environment/endpoint.ts";
@@ -112,9 +112,11 @@ export const make = Effect.gen(function* () {
         Effect.provideService(HttpClient.HttpClient, httpClient),
       );
       if (descriptor.environmentId !== input.expectedEnvironmentId) {
-        return yield* environmentMismatchError({
-          expected: input.expectedEnvironmentId,
-          actual: descriptor.environmentId,
+        return yield* new ConnectionBlockedError({
+          reason: "configuration",
+          detail: `Connected environment ${descriptor.environmentId} does not match ${input.expectedEnvironmentId}.`,
+          expectedEnvironmentId: input.expectedEnvironmentId,
+          actualEnvironmentId: descriptor.environmentId,
         });
       }
       const socketUrl = yield* resolveRemoteWebSocketConnectionUrl({
@@ -238,9 +240,11 @@ export const make = Effect.gen(function* () {
         Effect.withSpan("environment.authorization.descriptor"),
       );
       if (descriptor.environmentId !== input.expectedEnvironmentId) {
-        return yield* environmentMismatchError({
-          expected: input.expectedEnvironmentId,
-          actual: descriptor.environmentId,
+        return yield* new ConnectionBlockedError({
+          reason: "configuration",
+          detail: `Connected environment ${descriptor.environmentId} does not match ${input.expectedEnvironmentId}.`,
+          expectedEnvironmentId: input.expectedEnvironmentId,
+          actualEnvironmentId: descriptor.environmentId,
         });
       }
       const bootstrapProof = yield* signer

--- a/packages/client-runtime/src/connection/errors.test.ts
+++ b/packages/client-runtime/src/connection/errors.test.ts
@@ -1,0 +1,86 @@
+import { EnvironmentAuthInvalidError } from "@t3tools/contracts";
+import { RelayAuthInvalidError } from "@t3tools/contracts/relay";
+import { describe, expect, it } from "@effect/vitest";
+
+import { mapManagedRelayError, mapRemoteEnvironmentError } from "./errors.ts";
+import * as ManagedRelay from "../relay/managedRelay.ts";
+import { RemoteEnvironmentAuthFetchError } from "../rpc/http.ts";
+
+describe("connection error mapping", () => {
+  it("retains the managed relay request as the cause when classifying a protected error", () => {
+    const relayError = new RelayAuthInvalidError({
+      code: "auth_invalid",
+      reason: "invalid_bearer",
+      traceId: "relay-trace-id",
+    });
+    const source = new ManagedRelay.ManagedRelayRequestFailedError({
+      action: "connect relay environment",
+      cause: relayError,
+      relayError,
+      traceId: relayError.traceId,
+    });
+
+    const error = mapManagedRelayError(source);
+
+    expect(error).toMatchObject({
+      _tag: "ConnectionBlockedError",
+      reason: "authentication",
+      traceId: "relay-trace-id",
+    });
+    expect(error.cause).toBe(source);
+  });
+
+  it("retains a managed relay timeout and its structured activity", () => {
+    const source = new ManagedRelay.ManagedRelayRequestTimeoutError({
+      activity: "Relay environment connection",
+      timeoutMs: 10_000,
+    });
+
+    const error = mapManagedRelayError(source);
+
+    expect(error).toMatchObject({
+      _tag: "ConnectionTransientError",
+      reason: "timeout",
+    });
+    expect(error.cause).toBe(source);
+    expect(source.activity).toBe("Relay environment connection");
+  });
+
+  it("retains structured remote authorization failures", () => {
+    const source = new EnvironmentAuthInvalidError({
+      code: "auth_invalid",
+      reason: "invalid_credential",
+      traceId: "environment-trace-id",
+    });
+
+    const error = mapRemoteEnvironmentError(source);
+
+    expect(error).toMatchObject({
+      _tag: "ConnectionBlockedError",
+      reason: "authentication",
+      traceId: "environment-trace-id",
+    });
+    expect(error.cause).toBe(source);
+  });
+
+  it("retains local transport failures without deriving their message from the cause", () => {
+    const transportCause = new Error("sensitive transport implementation detail");
+    const source = new RemoteEnvironmentAuthFetchError({
+      requestUrl: "https://environment.example.test/api/auth/session",
+      cause: transportCause,
+    });
+
+    const error = mapRemoteEnvironmentError(source);
+
+    expect(source.message).toBe(
+      "Failed to fetch remote environment endpoint https://environment.example.test/api/auth/session.",
+    );
+    expect(source.message).not.toContain(transportCause.message);
+    expect(error).toMatchObject({
+      _tag: "ConnectionTransientError",
+      reason: "network",
+    });
+    expect(error.cause).toBe(source);
+    expect(source.cause).toBe(transportCause);
+  });
+});

--- a/packages/client-runtime/src/connection/errors.test.ts
+++ b/packages/client-runtime/src/connection/errors.test.ts
@@ -4,7 +4,10 @@ import { describe, expect, it } from "@effect/vitest";
 
 import { mapManagedRelayError, mapRemoteEnvironmentError } from "./errors.ts";
 import * as ManagedRelay from "../relay/managedRelay.ts";
-import { RemoteEnvironmentAuthFetchError } from "../rpc/http.ts";
+import {
+  RemoteEnvironmentAuthFetchError,
+  RemoteEnvironmentAuthUndeclaredStatusError,
+} from "../rpc/http.ts";
 
 describe("connection error mapping", () => {
   it("retains the managed relay request as the cause when classifying a protected error", () => {
@@ -65,15 +68,14 @@ describe("connection error mapping", () => {
 
   it("retains local transport failures without deriving their message from the cause", () => {
     const transportCause = new Error("sensitive transport implementation detail");
-    const source = new RemoteEnvironmentAuthFetchError({
-      requestUrl: "https://environment.example.test/api/auth/session",
-      cause: transportCause,
-    });
+    const requestUrl =
+      "https://environment-user:environment-password@environment.example.test/private/session?access_token=environment-secret#environment-fragment";
+    const source = RemoteEnvironmentAuthFetchError.fromRequestUrl(requestUrl, transportCause);
 
     const error = mapRemoteEnvironmentError(source);
 
     expect(source.message).toBe(
-      "Failed to fetch remote environment endpoint https://environment.example.test/api/auth/session.",
+      `Failed to fetch remote environment endpoint at host environment.example.test (${requestUrl.length} URL characters).`,
     );
     expect(source.message).not.toContain(transportCause.message);
     expect(error).toMatchObject({
@@ -82,5 +84,37 @@ describe("connection error mapping", () => {
     });
     expect(error.cause).toBe(source);
     expect(source.cause).toBe(transportCause);
+    expect(source).toMatchObject({
+      requestUrlInputLength: requestUrl.length,
+      requestUrlProtocol: "https:",
+      requestUrlHostname: "environment.example.test",
+    });
+    const diagnostics = JSON.stringify(source);
+    for (const secret of [
+      "environment-user",
+      "environment-password",
+      "/private/session",
+      "environment-secret",
+      "environment-fragment",
+    ]) {
+      expect(diagnostics).not.toContain(secret);
+      expect(source.message).not.toContain(secret);
+    }
+  });
+
+  it("retains the HTTP client cause for undeclared statuses", () => {
+    const cause = new Error("upstream response metadata");
+    const requestUrl =
+      "https://environment-user:environment-password@environment.example.test/private/session?access_token=environment-secret#environment-fragment";
+    const error = RemoteEnvironmentAuthUndeclaredStatusError.fromRequestUrl(requestUrl, 502, cause);
+
+    expect(error).toMatchObject({
+      status: 502,
+      requestUrlInputLength: requestUrl.length,
+      requestUrlProtocol: "https:",
+      requestUrlHostname: "environment.example.test",
+    });
+    expect(error.cause).toBe(cause);
+    expect(error).not.toHaveProperty("requestUrl");
   });
 });

--- a/packages/client-runtime/src/connection/errors.ts
+++ b/packages/client-runtime/src/connection/errors.ts
@@ -1,6 +1,9 @@
 import type { EnvironmentId } from "@t3tools/contracts";
 import type { RelayProtectedError } from "@t3tools/contracts/relay";
-import type { ManagedRelayClientError } from "../relay/managedRelay.ts";
+import type {
+  ManagedRelayClientError,
+  ManagedRelayRequestFailedError,
+} from "../relay/managedRelay.ts";
 import type { RemoteEnvironmentAuthError } from "../authorization/remote.ts";
 import {
   ConnectionBlockedError,
@@ -32,7 +35,10 @@ export function environmentMismatchError(input: {
   });
 }
 
-function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError {
+function connectionErrorFromRelayProtectedError(
+  error: RelayProtectedError,
+  cause: ManagedRelayRequestFailedError,
+): ConnectionAttemptError {
   switch (error._tag) {
     case "RelayAuthInvalidError":
     case "RelayEnvironmentLinkProofExpiredError":
@@ -42,6 +48,7 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
         reason: "authentication",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
     case "RelayEnvironmentConnectNotAuthorizedError":
     case "RelayEnvironmentLinkProofInvalidError":
@@ -49,12 +56,14 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
         reason: "permission",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
     case "RelayEnvironmentEndpointTimedOutError":
       return new ConnectionTransientError({
         reason: "timeout",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
     case "RelayEnvironmentEndpointUnavailableError":
     case "RelayEnvironmentLinkUnavailableError":
@@ -62,6 +71,7 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
         reason: "endpoint-unavailable",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
     case "RelayEnvironmentLinkFailedError":
     case "RelayInternalError":
@@ -69,6 +79,7 @@ function relayProtectedError(error: RelayProtectedError): ConnectionAttemptError
         reason: "relay-unavailable",
         detail: error.message,
         traceId: error.traceId,
+        cause,
       });
   }
 }
@@ -77,27 +88,31 @@ export function mapManagedRelayError(error: ManagedRelayClientError): Connection
   switch (error._tag) {
     case "ManagedRelayRequestFailedError":
       if (error.relayError) {
-        return relayProtectedError(error.relayError);
+        return connectionErrorFromRelayProtectedError(error.relayError, error);
       }
       return new ConnectionTransientError({
         reason: "relay-unavailable",
         detail: error.message,
         ...(error.traceId ? { traceId: error.traceId } : {}),
+        cause: error,
       });
     case "ManagedRelayRequestTimeoutError":
       return new ConnectionTransientError({
         reason: "timeout",
         detail: error.message,
+        cause: error,
       });
     case "ManagedRelayUrlInvalidError":
       return new ConnectionBlockedError({
         reason: "configuration",
         detail: error.message,
+        cause: error,
       });
     case "ManagedRelayAccessTokenScopesUnexpectedError":
       return new ConnectionBlockedError({
         reason: "permission",
         detail: error.message,
+        cause: error,
       });
     case "ManagedRelayDpopKeyLoadError":
     case "ManagedRelayTokenProofCreationError":
@@ -105,6 +120,7 @@ export function mapManagedRelayError(error: ManagedRelayClientError): Connection
       return new ConnectionBlockedError({
         reason: "authentication",
         detail: error.message,
+        cause: error,
       });
   }
 }
@@ -118,6 +134,7 @@ export function mapRemoteEnvironmentError(
         reason: "authentication",
         detail: "The environment credential is invalid.",
         traceId: error.traceId,
+        cause: error,
       });
     case "EnvironmentScopeRequiredError":
     case "EnvironmentOperationForbiddenError":
@@ -125,34 +142,40 @@ export function mapRemoteEnvironmentError(
         reason: "permission",
         detail: "The environment credential does not grant the required access.",
         traceId: error.traceId,
+        cause: error,
       });
     case "EnvironmentRequestInvalidError":
       return new ConnectionBlockedError({
         reason: "configuration",
         detail: "The environment rejected the authentication request.",
         traceId: error.traceId,
+        cause: error,
       });
     case "RemoteEnvironmentAuthTimeoutError":
       return new ConnectionTransientError({
         reason: "timeout",
         detail: error.message,
+        cause: error,
       });
     case "RemoteEnvironmentAuthFetchError":
       return new ConnectionTransientError({
         reason: "network",
         detail: error.message,
+        cause: error,
       });
     case "EnvironmentInternalError":
       return new ConnectionTransientError({
         reason: "remote-unavailable",
         detail: "The environment could not authorize the connection.",
         traceId: error.traceId,
+        cause: error,
       });
     case "RemoteEnvironmentAuthInvalidJsonError":
     case "RemoteEnvironmentAuthUndeclaredStatusError":
       return new ConnectionTransientError({
         reason: "remote-unavailable",
         detail: error.message,
+        cause: error,
       });
   }
 }

--- a/packages/client-runtime/src/connection/errors.ts
+++ b/packages/client-runtime/src/connection/errors.ts
@@ -1,4 +1,3 @@
-import type { EnvironmentId } from "@t3tools/contracts";
 import type { RelayProtectedError } from "@t3tools/contracts/relay";
 import type {
   ManagedRelayClientError,
@@ -10,30 +9,6 @@ import {
   type ConnectionAttemptError,
   ConnectionTransientError,
 } from "./model.ts";
-
-export function profileMissingError(connectionId: string): ConnectionBlockedError {
-  return new ConnectionBlockedError({
-    reason: "configuration",
-    detail: `Connection profile ${connectionId} is unavailable.`,
-  });
-}
-
-export function credentialMissingError(connectionId: string): ConnectionBlockedError {
-  return new ConnectionBlockedError({
-    reason: "authentication",
-    detail: `Connection credential ${connectionId} is unavailable.`,
-  });
-}
-
-export function environmentMismatchError(input: {
-  readonly expected: EnvironmentId;
-  readonly actual: EnvironmentId;
-}): ConnectionBlockedError {
-  return new ConnectionBlockedError({
-    reason: "configuration",
-    detail: `Connected environment ${input.actual} does not match ${input.expected}.`,
-  });
-}
 
 function connectionErrorFromRelayProtectedError(
   error: RelayProtectedError,

--- a/packages/client-runtime/src/connection/model.test.ts
+++ b/packages/client-runtime/src/connection/model.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  ConnectionStorageOperationError,
+  ConnectionTransientError,
+  IndexedDbUnavailableError,
+} from "./model.ts";
+
+describe("ConnectionTransientError.fromStorageFailure", () => {
+  it("preserves structured operation context and the complete failure chain", () => {
+    const storageCause = new Error("quota exceeded");
+    const storageOperationCause = new ConnectionStorageOperationError({
+      operation: "write",
+      backend: "indexed-db",
+      storeName: "catalog",
+      cause: storageCause,
+    });
+
+    const error = ConnectionTransientError.fromStorageFailure(storageOperationCause);
+
+    expect(error).toMatchObject({
+      reason: "remote-unavailable",
+      cause: {
+        _tag: "ConnectionStorageOperationError",
+        operation: "write",
+        backend: "indexed-db",
+        storeName: "catalog",
+        cause: storageCause,
+      },
+    });
+    expect(error.message).toBe("Could not write local connection data.");
+  });
+
+  it("maps a cause-free availability failure without inventing a defect", () => {
+    const error = ConnectionTransientError.fromStorageFailure(new IndexedDbUnavailableError());
+
+    expect(error.cause).toMatchObject({ _tag: "IndexedDbUnavailableError" });
+    expect((error.cause as IndexedDbUnavailableError).cause).toBeUndefined();
+  });
+});

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -81,6 +81,7 @@ export class ConnectionTransientError extends Schema.TaggedErrorClass<Connection
     reason: ConnectionTransientReason,
     detail: Schema.String,
     traceId: Schema.optionalKey(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
@@ -94,6 +95,7 @@ export class ConnectionBlockedError extends Schema.TaggedErrorClass<ConnectionBl
     reason: ConnectionBlockedReason,
     detail: Schema.String,
     traceId: Schema.optionalKey(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -75,6 +75,69 @@ export const ConnectionBlockedReason = Schema.Literals([
 ]);
 export type ConnectionBlockedReason = typeof ConnectionBlockedReason.Type;
 
+export const ConnectionStorageOperation = Schema.Literals([
+  "open",
+  "read",
+  "write",
+  "remove",
+  "load",
+  "save",
+  "delete",
+  "decode",
+  "encode",
+  "migrate",
+]);
+export type ConnectionStorageOperation = typeof ConnectionStorageOperation.Type;
+
+export const ConnectionStorageBackend = Schema.Literals([
+  "indexed-db",
+  "desktop-secure-storage",
+  "mobile-secure-storage",
+  "legacy-migration",
+  "schema",
+]);
+export type ConnectionStorageBackend = typeof ConnectionStorageBackend.Type;
+
+export class ConnectionStorageOperationError extends Schema.TaggedErrorClass<ConnectionStorageOperationError>()(
+  "ConnectionStorageOperationError",
+  {
+    operation: ConnectionStorageOperation,
+    backend: ConnectionStorageBackend,
+    storeName: Schema.optionalKey(Schema.String),
+    key: Schema.optionalKey(Schema.Unknown),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Could not ${this.operation} local connection data.`;
+  }
+}
+
+export class IndexedDbUnavailableError extends Schema.TaggedErrorClass<IndexedDbUnavailableError>()(
+  "IndexedDbUnavailableError",
+  {},
+) {
+  override get message(): string {
+    return "IndexedDB is unavailable in this browser context.";
+  }
+}
+
+export class DesktopSecureStorageUnavailableError extends Schema.TaggedErrorClass<DesktopSecureStorageUnavailableError>()(
+  "DesktopSecureStorageUnavailableError",
+  {},
+) {
+  override get message(): string {
+    return "Desktop secure storage is unavailable in this system context.";
+  }
+}
+
+export const ConnectionStorageFailure = Schema.Union([
+  ConnectionStorageOperationError,
+  IndexedDbUnavailableError,
+  DesktopSecureStorageUnavailableError,
+]);
+export type ConnectionStorageFailure = typeof ConnectionStorageFailure.Type;
+
 export class ConnectionTransientError extends Schema.TaggedErrorClass<ConnectionTransientError>()(
   "ConnectionTransientError",
   {
@@ -84,6 +147,26 @@ export class ConnectionTransientError extends Schema.TaggedErrorClass<Connection
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
+  static fromStorageFailure(cause: ConnectionStorageFailure): ConnectionTransientError {
+    let detail: string;
+    switch (cause._tag) {
+      case "ConnectionStorageOperationError":
+        detail = `Could not ${cause.operation} local connection data.`;
+        break;
+      case "IndexedDbUnavailableError":
+        detail = "IndexedDB is unavailable in this browser context.";
+        break;
+      case "DesktopSecureStorageUnavailableError":
+        detail = "Desktop secure storage is unavailable in this system context.";
+        break;
+    }
+    return new ConnectionTransientError({
+      reason: "remote-unavailable",
+      detail,
+      cause,
+    });
+  }
+
   override get message(): string {
     return this.detail;
   }

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -94,6 +94,9 @@ export class ConnectionBlockedError extends Schema.TaggedErrorClass<ConnectionBl
   {
     reason: ConnectionBlockedReason,
     detail: Schema.String,
+    connectionId: Schema.optionalKey(Schema.String),
+    expectedEnvironmentId: Schema.optionalKey(EnvironmentId),
+    actualEnvironmentId: Schema.optionalKey(EnvironmentId),
     traceId: Schema.optionalKey(Schema.String),
     cause: Schema.optional(Schema.Defect()),
   },

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -694,7 +694,10 @@ describe("EnvironmentRegistry", () => {
           Effect.fail(
             new Persistence.ConnectionPersistenceError({
               operation: "remove-connection",
-              message: "Storage is unavailable.",
+              stage: "write",
+              resource: "connection-catalog",
+              environmentId: RELAY_TARGET.environmentId,
+              cause: new Error("Storage is unavailable."),
             }),
           ),
       });

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -345,7 +345,9 @@ export const make = Effect.gen(function* () {
       persistedTargets,
       (target) =>
         acquireSupervisor(target.environmentId).pipe(
-          Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+          Effect.catchTags({
+            EnvironmentNotRegisteredError: () => Effect.void,
+          }),
         ),
       {
         concurrency: "unbounded",
@@ -516,7 +518,9 @@ export const make = Effect.gen(function* () {
         relayEnvironmentIds,
         (environmentId) =>
           remove(environmentId).pipe(
-            Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+            Effect.catchTags({
+              EnvironmentNotRegisteredError: () => Effect.void,
+            }),
           ),
         {
           concurrency: "unbounded",
@@ -529,7 +533,9 @@ export const make = Effect.gen(function* () {
   const retryNow = (environmentId: EnvironmentId) =>
     acquireSupervisor(environmentId).pipe(
       Effect.flatMap((supervisor) => supervisor.retryNow),
-      Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+      Effect.catchTags({
+        EnvironmentNotRegisteredError: () => Effect.void,
+      }),
       Effect.withSpan("EnvironmentRegistry.retryNow"),
     );
   const state = Effect.fn("EnvironmentRegistry.state")(function* (environmentId: EnvironmentId) {

--- a/packages/client-runtime/src/connection/resolver.test.ts
+++ b/packages/client-runtime/src/connection/resolver.test.ts
@@ -23,6 +23,7 @@ import {
 import * as ConnectionCredentialStore from "./credentialStore.ts";
 import {
   BearerConnectionTarget,
+  ConnectionBlockedError,
   ConnectionTransientError,
   PrimaryConnectionTarget,
   RelayConnectionTarget,
@@ -434,6 +435,62 @@ describe("ConnectionResolver", () => {
         (yield* broker.prepare(catalogEntry(target, Option.some(profile)))).socketUrl,
       ).toContain("wsTicket=bearer");
       expect(yield* Ref.get(preparedTargets)).toEqual([SSH_TARGET]);
+    }),
+  );
+
+  it.effect("retains the connection id when a bearer credential is unavailable", () =>
+    Effect.gen(function* () {
+      const target = new BearerConnectionTarget({
+        environmentId: ENVIRONMENT_ID,
+        label: "Saved",
+        connectionId: "saved-1",
+      });
+      const profile = new BearerConnectionProfile({
+        connectionId: "saved-1",
+        environmentId: ENVIRONMENT_ID,
+        label: "Saved",
+        httpBaseUrl: ENDPOINT.httpBaseUrl,
+        wsBaseUrl: ENDPOINT.wsBaseUrl,
+      });
+      const brokerLayer = yield* makeDependencies();
+      const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
+
+      const error = yield* Effect.flip(broker.prepare(catalogEntry(target, Option.some(profile))));
+
+      expect(error).toBeInstanceOf(ConnectionBlockedError);
+      expect(error).toMatchObject({
+        reason: "authentication",
+        connectionId: "saved-1",
+      });
+    }),
+  );
+
+  it.effect("retains both environment ids when a connection profile does not match", () =>
+    Effect.gen(function* () {
+      const actualEnvironmentId = EnvironmentId.make("environment-2");
+      const target = new BearerConnectionTarget({
+        environmentId: ENVIRONMENT_ID,
+        label: "Saved",
+        connectionId: "saved-1",
+      });
+      const profile = new BearerConnectionProfile({
+        connectionId: "saved-1",
+        environmentId: actualEnvironmentId,
+        label: "Saved",
+        httpBaseUrl: ENDPOINT.httpBaseUrl,
+        wsBaseUrl: ENDPOINT.wsBaseUrl,
+      });
+      const brokerLayer = yield* makeDependencies();
+      const broker = yield* ConnectionResolver.ConnectionResolver.pipe(Effect.provide(brokerLayer));
+
+      const error = yield* Effect.flip(broker.prepare(catalogEntry(target, Option.some(profile))));
+
+      expect(error).toBeInstanceOf(ConnectionBlockedError);
+      expect(error).toMatchObject({
+        reason: "configuration",
+        expectedEnvironmentId: ENVIRONMENT_ID,
+        actualEnvironmentId,
+      });
     }),
   );
 

--- a/packages/client-runtime/src/connection/resolver.ts
+++ b/packages/client-runtime/src/connection/resolver.ts
@@ -16,12 +16,7 @@ import {
   SshConnectionProfile,
 } from "./catalog.ts";
 import * as ConnectionCredentialStore from "./credentialStore.ts";
-import {
-  credentialMissingError,
-  environmentMismatchError,
-  mapManagedRelayError,
-  profileMissingError,
-} from "./errors.ts";
+import { mapManagedRelayError } from "./errors.ts";
 import type {
   BearerConnectionTarget,
   ConnectionTarget,
@@ -95,7 +90,14 @@ const makeBearerBroker = Effect.fn("clientRuntime.connection.broker.makeBearer")
   ) {
     const target = entry.target;
     const profile = yield* Option.match(entry.profile, {
-      onNone: () => Effect.fail(profileMissingError(target.connectionId)),
+      onNone: () =>
+        Effect.fail(
+          new ConnectionBlockedError({
+            reason: "configuration",
+            detail: `Connection profile ${target.connectionId} is unavailable.`,
+            connectionId: target.connectionId,
+          }),
+        ),
       onSome: Effect.succeed,
     });
     if (!isBearerProfile(profile)) {
@@ -105,21 +107,34 @@ const makeBearerBroker = Effect.fn("clientRuntime.connection.broker.makeBearer")
       });
     }
     if (profile.environmentId !== target.environmentId) {
-      return yield* environmentMismatchError({
-        expected: target.environmentId,
-        actual: profile.environmentId,
+      return yield* new ConnectionBlockedError({
+        reason: "configuration",
+        detail: `Connected environment ${profile.environmentId} does not match ${target.environmentId}.`,
+        expectedEnvironmentId: target.environmentId,
+        actualEnvironmentId: profile.environmentId,
       });
     }
     const credential = yield* credentials.get(target.connectionId).pipe(
       Effect.flatMap(
         Option.match({
-          onNone: () => Effect.fail(credentialMissingError(target.connectionId)),
+          onNone: () =>
+            Effect.fail(
+              new ConnectionBlockedError({
+                reason: "authentication",
+                detail: `Connection credential ${target.connectionId} is unavailable.`,
+                connectionId: target.connectionId,
+              }),
+            ),
           onSome: Effect.succeed,
         }),
       ),
     );
     if (!isBearerCredential(credential)) {
-      return yield* credentialMissingError(target.connectionId);
+      return yield* new ConnectionBlockedError({
+        reason: "authentication",
+        detail: `Connection credential ${target.connectionId} is unavailable.`,
+        connectionId: target.connectionId,
+      });
     }
     const authorized = yield* remote.authorizeBearer({
       expectedEnvironmentId: target.environmentId,
@@ -164,9 +179,11 @@ const makeRelayBroker = Effect.fn("clientRuntime.connection.broker.makeRelay")(f
             })
             .pipe(Effect.mapError(mapManagedRelayError));
           if (connected.environmentId !== target.environmentId) {
-            return yield* environmentMismatchError({
-              expected: target.environmentId,
-              actual: connected.environmentId,
+            return yield* new ConnectionBlockedError({
+              reason: "configuration",
+              detail: `Connected environment ${connected.environmentId} does not match ${target.environmentId}.`,
+              expectedEnvironmentId: target.environmentId,
+              actualEnvironmentId: connected.environmentId,
             });
           }
           return connected;
@@ -196,7 +213,14 @@ const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(funct
   ) {
     const target = entry.target;
     const profile = yield* Option.match(entry.profile, {
-      onNone: () => Effect.fail(profileMissingError(target.connectionId)),
+      onNone: () =>
+        Effect.fail(
+          new ConnectionBlockedError({
+            reason: "configuration",
+            detail: `Connection profile ${target.connectionId} is unavailable.`,
+            connectionId: target.connectionId,
+          }),
+        ),
       onSome: Effect.succeed,
     });
     if (!isSshProfile(profile)) {
@@ -206,9 +230,11 @@ const makeSshBroker = Effect.fn("clientRuntime.connection.broker.makeSsh")(funct
       });
     }
     if (profile.environmentId !== target.environmentId) {
-      return yield* environmentMismatchError({
-        expected: target.environmentId,
-        actual: profile.environmentId,
+      return yield* new ConnectionBlockedError({
+        reason: "configuration",
+        detail: `Connected environment ${profile.environmentId} does not match ${target.environmentId}.`,
+        expectedEnvironmentId: target.environmentId,
+        actualEnvironmentId: profile.environmentId,
       });
     }
     const prepared = yield* ssh.prepare({

--- a/packages/client-runtime/src/platform/persistence.test.ts
+++ b/packages/client-runtime/src/platform/persistence.test.ts
@@ -1,0 +1,25 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+
+import { ConnectionPersistenceError } from "./persistence.ts";
+
+describe("ConnectionPersistenceError", () => {
+  it("retains storage context and cause without deriving its message from the cause", () => {
+    const cause = new Error("sensitive filesystem detail");
+    const error = new ConnectionPersistenceError({
+      operation: "load-thread",
+      stage: "decode",
+      resource: "thread-cache",
+      environmentId: EnvironmentId.make("environment-1"),
+      threadId: ThreadId.make("thread-1"),
+      path: "file:///cache/thread-1.json",
+      cause,
+    });
+
+    expect(error.cause).toBe(cause);
+    expect(error.message).toBe(
+      "Could not load thread: thread cache decode failed for environment environment-1 and thread thread-1 at file:///cache/thread-1.json.",
+    );
+    expect(error.message).not.toContain(cause.message);
+  });
+});

--- a/packages/client-runtime/src/platform/persistence.ts
+++ b/packages/client-runtime/src/platform/persistence.ts
@@ -1,8 +1,8 @@
 import {
-  type EnvironmentId,
+  EnvironmentId,
   type OrchestrationThread,
   type OrchestrationShellSnapshot,
-  type ThreadId,
+  ThreadId,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -26,9 +26,27 @@ export class ConnectionPersistenceError extends Schema.TaggedErrorClass<Connecti
       "remove-thread",
       "clear-environment",
     ]),
-    message: Schema.String,
+    stage: Schema.Literals(["resolve", "read", "parse", "decode", "encode", "write", "remove"]),
+    resource: Schema.Literals([
+      "connection-catalog",
+      "shell-cache",
+      "legacy-shell-cache",
+      "thread-cache",
+    ]),
+    environmentId: Schema.optionalKey(EnvironmentId),
+    threadId: Schema.optionalKey(ThreadId),
+    path: Schema.optionalKey(Schema.String),
+    cause: Schema.Defect(),
   },
-) {}
+) {
+  override get message(): string {
+    const environment =
+      this.environmentId === undefined ? "" : ` for environment ${this.environmentId}`;
+    const thread = this.threadId === undefined ? "" : ` and thread ${this.threadId}`;
+    const path = this.path === undefined ? "" : ` at ${this.path}`;
+    return `Could not ${this.operation.replaceAll("-", " ")}: ${this.resource.replaceAll("-", " ")} ${this.stage} failed${environment}${thread}${path}.`;
+  }
+}
 
 export class ConnectionTargetStore extends Context.Service<
   ConnectionTargetStore,

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -8,6 +8,7 @@ import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
@@ -55,7 +56,9 @@ function status(
   };
 }
 
-const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
+const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* (
+  testEnvironments: ReadonlyArray<RelayClientEnvironmentRecord> = environments,
+) {
   const networkStatus = yield* SubscriptionRef.make<NetworkStatus>("online");
   const listCalls = yield* Ref.make(0);
   const listFailure = yield* Ref.make<ManagedRelay.ManagedRelayClientError | null>(null);
@@ -74,7 +77,7 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
       Deferred.Deferred<RelayEnvironmentStatusResponse, ManagedRelay.ManagedRelayClientError>
     >(),
   );
-  for (const environment of environments) {
+  for (const environment of testEnvironments) {
     const request = yield* Deferred.make<
       RelayEnvironmentStatusResponse,
       ManagedRelay.ManagedRelayClientError
@@ -98,7 +101,7 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
         if (failure) {
           return yield* failure;
         }
-        return environments;
+        return testEnvironments;
       }),
     getEnvironmentStatus: ({ environmentId }) =>
       Ref.get(statusRequests).pipe(
@@ -170,6 +173,52 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
 });
 
 describe("RelayEnvironmentDiscovery", () => {
+  it.effect("keeps managed endpoint secrets out of offline warnings", () => {
+    const httpBaseUrl =
+      "https://endpoint-user:endpoint-password@offline.example.test/private/workspace?access_token=endpoint-secret#endpoint-fragment";
+    const environment = {
+      ...environments[0]!,
+      endpoint: {
+        ...environments[0]!.endpoint,
+        httpBaseUrl,
+      },
+    } satisfies RelayClientEnvironmentRecord;
+    const capturedLogs: Array<ReadonlyArray<unknown>> = [];
+    const logger = Logger.make(({ message }) => {
+      capturedLogs.push(Array.isArray(message) ? message : [message]);
+    });
+
+    return Effect.gen(function* () {
+      const harness = yield* makeHarness([environment]);
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        const refreshFiber = yield* Effect.forkChild(discovery.refresh);
+        const requests = yield* Ref.get(harness.statusRequests);
+        yield* Deferred.succeed(
+          requests.get(environment.environmentId)!,
+          status(environment, "offline"),
+        );
+        yield* Fiber.join(refreshFiber);
+
+        expect(capturedLogs).toHaveLength(1);
+        const logFields = capturedLogs[0]?.find(
+          (value): value is Record<string, unknown> => typeof value === "object" && value !== null,
+        );
+        expect(logFields).toMatchObject({
+          environmentId: environment.environmentId,
+          endpointInputLength: httpBaseUrl.length,
+          endpointProtocol: "https:",
+          endpointHostname: "offline.example.test",
+        });
+        expect(logFields).not.toHaveProperty("endpoint");
+      }).pipe(
+        Effect.provide(
+          Layer.merge(harness.layer, Logger.layer([logger], { mergeWithExisting: false })),
+        ),
+      );
+    });
+  });
+
   it.effect("publishes each environment status as soon as that lookup completes", () =>
     Effect.gen(function* () {
       const harness = yield* makeHarness();

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -63,6 +63,8 @@ function validateStatus(
       new ConnectionBlockedError({
         reason: "configuration",
         detail: "Relay returned status for a different environment.",
+        expectedEnvironmentId: environment.environmentId,
+        actualEnvironmentId: status.environmentId,
       }),
     );
   }
@@ -86,6 +88,8 @@ function validateStatus(
       new ConnectionBlockedError({
         reason: "configuration",
         detail: "Relay returned a descriptor for a different environment.",
+        expectedEnvironmentId: environment.environmentId,
+        actualEnvironmentId: status.descriptor.environmentId,
       }),
     );
   }

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -3,6 +3,7 @@ import type {
   RelayEnvironmentStatusResponse,
 } from "@t3tools/contracts/relay";
 import { decodeRelayJwt } from "@t3tools/shared/relayJwt";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import {
   RelayEnvironmentConnectScope,
   RelayEnvironmentStatusScope,
@@ -178,9 +179,16 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
           return [true, new Map(current).set(environment.environmentId, fingerprint)];
         });
         if (shouldReport) {
+          const endpointDiagnostics = getUrlDiagnostics(result.success.endpoint.httpBaseUrl);
           yield* Effect.logWarning("Relay environment health check reported offline", {
             environmentId: result.success.environmentId,
-            endpoint: result.success.endpoint.httpBaseUrl,
+            endpointInputLength: endpointDiagnostics.inputLength,
+            ...(endpointDiagnostics.protocol === undefined
+              ? {}
+              : { endpointProtocol: endpointDiagnostics.protocol }),
+            ...(endpointDiagnostics.hostname === undefined
+              ? {}
+              : { endpointHostname: endpointDiagnostics.hostname }),
             message: result.success.error,
             traceId: result.success.traceId,
           });

--- a/packages/client-runtime/src/relay/managedRelay.test.ts
+++ b/packages/client-runtime/src/relay/managedRelay.test.ts
@@ -39,6 +39,65 @@ function clerkToken(subject: string, nonce: string): string {
 }
 
 describe("ManagedRelayClient", () => {
+  it("redacts relay URLs and DPoP targets while preserving causes", () => {
+    const relayUrl =
+      "http://relay-user:relay-password@relay.example.test/private/workspace?access_token=relay-secret#relay-fragment";
+    const dpopTarget =
+      "https://dpop-user:dpop-password@relay.example.test/v1/client/dpop-token?access_token=dpop-secret#dpop-fragment";
+    const cause = new Error("proof failed");
+    const invalidUrlError = ManagedRelay.ManagedRelayUrlInvalidError.fromInput(relayUrl);
+    const proofErrors = [
+      ManagedRelay.ManagedRelayDpopKeyLoadError.fromTarget({
+        keyStore: "indexed-db",
+        method: "POST",
+        url: dpopTarget,
+        cause,
+      }),
+      ManagedRelay.ManagedRelayDpopProofCreationError.fromTarget({
+        method: "POST",
+        url: dpopTarget,
+        cause,
+      }),
+      ManagedRelay.ManagedRelayTokenProofCreationError.fromTarget({
+        method: "POST",
+        url: dpopTarget,
+        cause,
+      }),
+      ManagedRelay.ManagedRelayRequestProofCreationError.fromTarget({
+        method: "POST",
+        url: dpopTarget,
+        cause,
+      }),
+    ];
+
+    expect(invalidUrlError).toMatchObject({
+      relayUrlInputLength: relayUrl.length,
+      relayUrlProtocol: "http:",
+      relayUrlHostname: "relay.example.test",
+    });
+    const invalidUrlDiagnostics = JSON.stringify(invalidUrlError);
+    for (const secret of [
+      "relay-user",
+      "relay-password",
+      "/private/workspace",
+      "relay-secret",
+      "relay-fragment",
+    ]) {
+      expect(invalidUrlDiagnostics).not.toContain(secret);
+      expect(invalidUrlError.message).not.toContain(secret);
+    }
+
+    for (const error of proofErrors) {
+      expect(error.requestTarget).toBe("https://relay.example.test/v1/client/dpop-token");
+      expect(error.cause).toBe(cause);
+      const diagnostics = JSON.stringify(error);
+      for (const secret of ["dpop-user", "dpop-password", "dpop-secret", "dpop-fragment"]) {
+        expect(diagnostics).not.toContain(secret);
+        expect(error.message).not.toContain(secret);
+      }
+    }
+  });
+
   it.effect("owns tracing at service and implementation boundaries", () => {
     const spanNames: Array<string> = [];
     const tracer = Tracer.make({
@@ -124,7 +183,9 @@ describe("ManagedRelayClient", () => {
 
       expect(error).toMatchObject({
         _tag: "ManagedRelayUrlInvalidError",
-        relayUrl: "http://relay.example.test",
+        relayUrlInputLength: "http://relay.example.test".length,
+        relayUrlProtocol: "http:",
+        relayUrlHostname: "relay.example.test",
         message: "Relay URL must be a secure absolute HTTPS origin.",
       });
       expect(requestCount).toBe(0);
@@ -161,7 +222,7 @@ describe("ManagedRelayClient", () => {
           thumbprint: Effect.succeed("client-thumbprint"),
           createProof: (input) =>
             Effect.fail(
-              new ManagedRelay.ManagedRelayDpopKeyLoadError({
+              ManagedRelay.ManagedRelayDpopKeyLoadError.fromTarget({
                 keyStore: "indexed-db",
                 method: input.method,
                 url: input.url,

--- a/packages/client-runtime/src/relay/managedRelay.test.ts
+++ b/packages/client-runtime/src/relay/managedRelay.test.ts
@@ -15,15 +15,15 @@ function managedRelayTestLayer(
   fetchFn: typeof globalThis.fetch,
   relayUrl = "https://relay.example.test",
   accessTokenStore?: ManagedRelay.ManagedRelayAccessTokenStore,
+  signer: ManagedRelay.ManagedRelayDpopSigner["Service"] = {
+    thumbprint: Effect.succeed("client-thumbprint"),
+    createProof: (input) => Effect.succeed(`proof:${input.url}`),
+  },
 ) {
   const httpClientLayer = remoteHttpClientLayer(fetchFn);
   const signerLayer = Layer.succeed(
     ManagedRelay.ManagedRelayDpopSigner,
-    ManagedRelay.ManagedRelayDpopSigner.of({
-      thumbprint: Effect.succeed("client-thumbprint"),
-      createProof: (input: ManagedRelay.ManagedRelayDpopProofInput) =>
-        Effect.succeed(`proof:${input.url}`),
-    }),
+    ManagedRelay.ManagedRelayDpopSigner.of(signer),
   );
   return ManagedRelay.layer({
     relayUrl,
@@ -129,6 +129,48 @@ describe("ManagedRelayClient", () => {
       });
       expect(requestCount).toBe(0);
     }).pipe(Effect.provide(managedRelayTestLayer(fetchFn, "http://relay.example.test")));
+  });
+
+  it.effect("preserves key-load failures when creating a token proof", () => {
+    const keyStoreCause = new Error("IndexedDB unavailable");
+    const fetchFn = (() => Promise.resolve(Response.json({}))) satisfies typeof globalThis.fetch;
+
+    return Effect.gen(function* () {
+      const relayClient = yield* ManagedRelay.ManagedRelayClient;
+      const error = yield* relayClient
+        .getEnvironmentStatus({
+          clerkToken: clerkToken("user-1", "session-1"),
+          scopes: [RelayEnvironmentStatusScope],
+          environmentId: EnvironmentId.make("env-1"),
+        })
+        .pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "ManagedRelayTokenProofCreationError",
+        cause: {
+          _tag: "ManagedRelayDpopKeyLoadError",
+          keyStore: "indexed-db",
+          method: "POST",
+          message: "Could not load relay DPoP proof key.",
+          cause: keyStoreCause,
+        },
+      });
+    }).pipe(
+      Effect.provide(
+        managedRelayTestLayer(fetchFn, undefined, undefined, {
+          thumbprint: Effect.succeed("client-thumbprint"),
+          createProof: (input) =>
+            Effect.fail(
+              new ManagedRelay.ManagedRelayDpopKeyLoadError({
+                keyStore: "indexed-db",
+                method: input.method,
+                url: input.url,
+                cause: keyStoreCause,
+              }),
+            ),
+        }),
+      ),
+    );
   });
 
   it.effect("reuses usable DPoP tokens and refreshes cleared or expiring cache entries", () => {

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -133,6 +133,13 @@ export class ManagedRelayUrlInvalidError extends Schema.TaggedErrorClass<Managed
   }
 }
 
+type RelayHttpRequestError =
+  | RelayProtectedErrorType
+  | HttpClientError.HttpClientError
+  | Schema.SchemaError;
+
+const isRelayProtectedError = Schema.is(RelayProtectedError);
+
 export class ManagedRelayRequestFailedError extends Schema.TaggedErrorClass<ManagedRelayRequestFailedError>()(
   "ManagedRelayRequestFailedError",
   {
@@ -144,6 +151,15 @@ export class ManagedRelayRequestFailedError extends Schema.TaggedErrorClass<Mana
 ) {
   override get message(): string {
     return `Could not ${this.action}.`;
+  }
+
+  static fromHttpRequest(action: ManagedRelayRequestAction) {
+    return (cause: RelayHttpRequestError) =>
+      new ManagedRelayRequestFailedError({
+        action,
+        cause,
+        ...(isRelayProtectedError(cause) ? { relayError: cause, traceId: cause.traceId } : {}),
+      });
   }
 }
 
@@ -195,11 +211,6 @@ export const ManagedRelayClientError = Schema.Union([
   ManagedRelayRequestProofCreationError,
 ]);
 export type ManagedRelayClientError = typeof ManagedRelayClientError.Type;
-
-type RelayHttpRequestError =
-  | RelayProtectedErrorType
-  | HttpClientError.HttpClientError
-  | Schema.SchemaError;
 
 export class ManagedRelayDpopSigner extends Context.Service<
   ManagedRelayDpopSigner,
@@ -290,28 +301,8 @@ export class ManagedRelayClient extends Context.Service<
   }
 >()("@t3tools/client-runtime/relay/managedRelay/ManagedRelayClient") {}
 
-const isRelayProtectedError = Schema.is(RelayProtectedError);
-
-function relayRequestError(action: ManagedRelayRequestAction) {
-  return (cause: RelayHttpRequestError): ManagedRelayClientError =>
-    new ManagedRelayRequestFailedError({
-      action,
-      cause,
-      ...(isRelayProtectedError(cause) ? { relayError: cause, traceId: cause.traceId } : {}),
-    });
-}
-
-function proofCreationErrorFields(error: ManagedRelayDpopProofCreationError) {
-  return {
-    method: error.method,
-    url: error.url,
-    cause: error,
-  };
-}
-
-function isRejectedDpopAccessToken(error: ManagedRelayClientError): boolean {
+function isRejectedDpopAccessToken(error: ManagedRelayRequestFailedError): boolean {
   return (
-    error._tag === "ManagedRelayRequestFailedError" &&
     error.relayError?._tag === "RelayAuthInvalidError" &&
     error.relayError.reason === "invalid_bearer"
   );
@@ -461,13 +452,16 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         "relay.client_id": options.clientId,
         "relay.scopes": input.scopes.join(" "),
       });
-      const proof = yield* signer
-        .createProof(dpopProofTargets.exchangeAccessToken())
-        .pipe(
-          Effect.mapError(
-            (error) => new ManagedRelayTokenProofCreationError(proofCreationErrorFields(error)),
-          ),
-        );
+      const proof = yield* signer.createProof(dpopProofTargets.exchangeAccessToken()).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ManagedRelayTokenProofCreationError({
+              method: cause.method,
+              url: cause.url,
+              cause,
+            }),
+        ),
+      );
       const response = yield* client.token
         .exchangeDpopAccessToken({
           headers: { dpop: proof },
@@ -482,7 +476,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
           },
         })
         .pipe(
-          Effect.mapError(relayRequestError("exchange relay DPoP access token")),
+          Effect.mapError(
+            ManagedRelayRequestFailedError.fromHttpRequest("exchange relay DPoP access token"),
+          ),
           timeoutRelayRequest("Relay DPoP access token exchange"),
         );
       if (!oauthScopeSetEquals(response.scope, input.scopes)) {
@@ -589,7 +585,12 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       })
       .pipe(
         Effect.mapError(
-          (error) => new ManagedRelayRequestProofCreationError(proofCreationErrorFields(error)),
+          (cause) =>
+            new ManagedRelayRequestProofCreationError({
+              method: cause.method,
+              url: cause.url,
+              cause,
+            }),
         ),
       );
     return { accessToken: token.accessToken, proof, thumbprint };
@@ -623,27 +624,29 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       authorize(input).pipe(
         Effect.flatMap((authorization) =>
           request(authorization).pipe(
-            Effect.catch((error) => {
-              if (!isRejectedDpopAccessToken(error)) {
-                return Effect.fail(error);
-              }
-              return invalidateAccessToken(authorization.accessToken).pipe(
-                Effect.tap((invalidated) =>
-                  Effect.annotateCurrentSpan({
-                    "relay.token_cache.invalidated": invalidated,
-                    "relay.token_cache.invalidation_reason": "invalid_bearer",
-                    "relay.token_cache.retry_after_invalidation": refreshRejectedToken,
-                  }),
-                ),
-                Effect.tap((invalidated) =>
-                  invalidated && refreshRejectedToken
-                    ? Effect.logWarning(
-                        "Relay rejected a cached DPoP access token; refreshing it once.",
-                      )
-                    : Effect.void,
-                ),
-                Effect.andThen(refreshRejectedToken ? attempt(false) : Effect.fail(error)),
-              );
+            Effect.catchTags({
+              ManagedRelayRequestFailedError: (error) => {
+                if (!isRejectedDpopAccessToken(error)) {
+                  return Effect.fail(error);
+                }
+                return invalidateAccessToken(authorization.accessToken).pipe(
+                  Effect.tap((invalidated) =>
+                    Effect.annotateCurrentSpan({
+                      "relay.token_cache.invalidated": invalidated,
+                      "relay.token_cache.invalidation_reason": "invalid_bearer",
+                      "relay.token_cache.retry_after_invalidation": refreshRejectedToken,
+                    }),
+                  ),
+                  Effect.tap((invalidated) =>
+                    invalidated && refreshRejectedToken
+                      ? Effect.logWarning(
+                          "Relay rejected a cached DPoP access token; refreshing it once.",
+                        )
+                      : Effect.void,
+                  ),
+                  Effect.andThen(refreshRejectedToken ? attempt(false) : Effect.fail(error)),
+                );
+              },
             }),
           ),
         ),
@@ -676,7 +679,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
           .listEnvironments({ headers: bearerHeaders(input.clerkToken) })
           .pipe(
             Effect.map((response) => response.environments),
-            Effect.mapError(relayRequestError("list relay-managed environments")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest("list relay-managed environments"),
+            ),
             timeoutRelayRequest("Relay environment listing"),
           );
       },
@@ -691,7 +696,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
           })
           .pipe(
             Effect.map((response) => response.devices),
-            Effect.mapError(relayRequestError("list relay client devices")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest("list relay client devices"),
+            ),
             timeoutRelayRequest("Relay client device listing"),
           );
       },
@@ -706,7 +713,11 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
             payload: input.payload,
           })
           .pipe(
-            Effect.mapError(relayRequestError("create relay environment link challenge")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest(
+                "create relay environment link challenge",
+              ),
+            ),
             timeoutRelayRequest("Relay environment link challenge"),
           );
       },
@@ -721,7 +732,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
             payload: input.payload,
           })
           .pipe(
-            Effect.mapError(relayRequestError("link relay environment")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest("link relay environment"),
+            ),
             timeoutRelayRequest("Relay environment linking"),
           );
       },
@@ -736,7 +749,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
             params: { environmentId: input.environmentId },
           })
           .pipe(
-            Effect.mapError(relayRequestError("unlink relay environment")),
+            Effect.mapError(
+              ManagedRelayRequestFailedError.fromHttpRequest("unlink relay environment"),
+            ),
             timeoutRelayRequest("Relay environment unlinking"),
           );
       },
@@ -761,7 +776,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 params: { environmentId: input.environmentId },
               })
               .pipe(
-                Effect.mapError(relayRequestError("get relay environment status")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("get relay environment status"),
+                ),
                 timeoutRelayRequest("Relay environment status request"),
               ),
         );
@@ -792,7 +809,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 payload,
               })
               .pipe(
-                Effect.mapError(relayRequestError("connect relay environment")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("connect relay environment"),
+                ),
                 timeoutRelayRequest("Relay environment connection"),
               );
           },
@@ -815,7 +834,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 payload: input.payload,
               })
               .pipe(
-                Effect.mapError(relayRequestError("register relay mobile device")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("register relay mobile device"),
+                ),
                 timeoutRelayRequest("Relay mobile device registration"),
               ),
         );
@@ -837,7 +858,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 params: { deviceId: input.deviceId },
               })
               .pipe(
-                Effect.mapError(relayRequestError("unregister relay mobile device")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("unregister relay mobile device"),
+                ),
                 timeoutRelayRequest("Relay mobile device unregistration"),
               ),
         );
@@ -859,7 +882,9 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
                 payload: input.payload,
               })
               .pipe(
-                Effect.mapError(relayRequestError("register relay live activity")),
+                Effect.mapError(
+                  ManagedRelayRequestFailedError.fromHttpRequest("register relay live activity"),
+                ),
                 timeoutRelayRequest("Relay Live Activity registration"),
               ),
         );

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -64,6 +64,7 @@ export class ManagedRelayDpopKeyLoadError extends Schema.TaggedErrorClass<Manage
 export class ManagedRelayDpopProofCreationError extends Schema.TaggedErrorClass<ManagedRelayDpopProofCreationError>()(
   "ManagedRelayDpopProofCreationError",
   {
+    stage: Schema.Literals(["load-key", "create-proof"]),
     method: Schema.String,
     url: Schema.String,
     cause: Schema.Defect(),

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -53,6 +53,8 @@ export class ManagedRelayDpopKeyLoadError extends Schema.TaggedErrorClass<Manage
   "ManagedRelayDpopKeyLoadError",
   {
     keyStore: Schema.Literals(["expo-secure-store", "indexed-db"]),
+    method: Schema.optional(Schema.String),
+    url: Schema.optional(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
@@ -64,7 +66,6 @@ export class ManagedRelayDpopKeyLoadError extends Schema.TaggedErrorClass<Manage
 export class ManagedRelayDpopProofCreationError extends Schema.TaggedErrorClass<ManagedRelayDpopProofCreationError>()(
   "ManagedRelayDpopProofCreationError",
   {
-    stage: Schema.Literals(["load-key", "create-proof"]),
     method: Schema.String,
     url: Schema.String,
     cause: Schema.Defect(),
@@ -219,7 +220,7 @@ export class ManagedRelayDpopSigner extends Context.Service<
     readonly thumbprint: Effect.Effect<string, ManagedRelayDpopKeyLoadError>;
     readonly createProof: (
       input: ManagedRelayDpopProofInput,
-    ) => Effect.Effect<string, ManagedRelayDpopProofCreationError>;
+    ) => Effect.Effect<string, ManagedRelayDpopSignerError>;
   }
 >()("@t3tools/client-runtime/relay/managedRelay/ManagedRelayDpopSigner") {}
 
@@ -453,12 +454,13 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         "relay.client_id": options.clientId,
         "relay.scopes": input.scopes.join(" "),
       });
-      const proof = yield* signer.createProof(dpopProofTargets.exchangeAccessToken()).pipe(
+      const proofTarget = dpopProofTargets.exchangeAccessToken();
+      const proof = yield* signer.createProof(proofTarget).pipe(
         Effect.mapError(
           (cause) =>
             new ManagedRelayTokenProofCreationError({
-              method: cause.method,
-              url: cause.url,
+              method: proofTarget.method,
+              url: proofTarget.url,
               cause,
             }),
         ),
@@ -588,8 +590,8 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         Effect.mapError(
           (cause) =>
             new ManagedRelayRequestProofCreationError({
-              method: cause.method,
-              url: cause.url,
+              method: input.target.method,
+              url: input.target.url,
               cause,
             }),
         ),

--- a/packages/client-runtime/src/relay/managedRelay.ts
+++ b/packages/client-runtime/src/relay/managedRelay.ts
@@ -28,9 +28,11 @@ import {
   RelayUnregisterDeviceEndpoint,
 } from "@t3tools/contracts/relay";
 import { encodeOAuthScope, oauthScopeSetEquals } from "@t3tools/shared/oauthScope";
+import { redactDpopRequestTarget } from "@t3tools/shared/dpop";
 import { decodeRelayJwt } from "@t3tools/shared/relayJwt";
 import { withRelayClientTracing } from "@t3tools/shared/relayTracing";
 import { normalizeSecureRelayUrl } from "@t3tools/shared/relayUrl";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Clock from "effect/Clock";
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
@@ -54,10 +56,24 @@ export class ManagedRelayDpopKeyLoadError extends Schema.TaggedErrorClass<Manage
   {
     keyStore: Schema.Literals(["expo-secure-store", "indexed-db"]),
     method: Schema.optional(Schema.String),
-    url: Schema.optional(Schema.String),
+    requestTarget: Schema.optional(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
+  static fromTarget(input: {
+    readonly keyStore: "expo-secure-store" | "indexed-db";
+    readonly method: string;
+    readonly url: string;
+    readonly cause: unknown;
+  }): ManagedRelayDpopKeyLoadError {
+    return new ManagedRelayDpopKeyLoadError({
+      keyStore: input.keyStore,
+      method: input.method,
+      requestTarget: redactDpopRequestTarget(input.url),
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
     return "Could not load relay DPoP proof key.";
   }
@@ -67,12 +83,24 @@ export class ManagedRelayDpopProofCreationError extends Schema.TaggedErrorClass<
   "ManagedRelayDpopProofCreationError",
   {
     method: Schema.String,
-    url: Schema.String,
+    requestTarget: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
+  static fromTarget(input: {
+    readonly method: string;
+    readonly url: string;
+    readonly cause: unknown;
+  }): ManagedRelayDpopProofCreationError {
+    return new ManagedRelayDpopProofCreationError({
+      method: input.method,
+      requestTarget: redactDpopRequestTarget(input.url),
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
-    return `Could not create the relay DPoP proof for ${this.method} ${this.url}.`;
+    return `Could not create the relay DPoP proof for ${this.method} ${this.requestTarget}.`;
   }
 }
 
@@ -127,9 +155,20 @@ export class ManagedRelayRequestTimeoutError extends Schema.TaggedErrorClass<Man
 export class ManagedRelayUrlInvalidError extends Schema.TaggedErrorClass<ManagedRelayUrlInvalidError>()(
   "ManagedRelayUrlInvalidError",
   {
-    relayUrl: Schema.String,
+    relayUrlInputLength: Schema.Number,
+    relayUrlProtocol: Schema.optionalKey(Schema.String),
+    relayUrlHostname: Schema.optionalKey(Schema.String),
   },
 ) {
+  static fromInput(relayUrl: string): ManagedRelayUrlInvalidError {
+    const diagnostics = getUrlDiagnostics(relayUrl);
+    return new ManagedRelayUrlInvalidError({
+      relayUrlInputLength: diagnostics.inputLength,
+      ...(diagnostics.protocol === undefined ? {} : { relayUrlProtocol: diagnostics.protocol }),
+      ...(diagnostics.hostname === undefined ? {} : { relayUrlHostname: diagnostics.hostname }),
+    });
+  }
+
   override get message(): string {
     return "Relay URL must be a secure absolute HTTPS origin.";
   }
@@ -181,10 +220,22 @@ export class ManagedRelayTokenProofCreationError extends Schema.TaggedErrorClass
   "ManagedRelayTokenProofCreationError",
   {
     method: Schema.String,
-    url: Schema.String,
+    requestTarget: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
+  static fromTarget(input: {
+    readonly method: string;
+    readonly url: string;
+    readonly cause: unknown;
+  }): ManagedRelayTokenProofCreationError {
+    return new ManagedRelayTokenProofCreationError({
+      method: input.method,
+      requestTarget: redactDpopRequestTarget(input.url),
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
     return "Could not create relay token DPoP proof.";
   }
@@ -194,10 +245,22 @@ export class ManagedRelayRequestProofCreationError extends Schema.TaggedErrorCla
   "ManagedRelayRequestProofCreationError",
   {
     method: Schema.String,
-    url: Schema.String,
+    requestTarget: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
+  static fromTarget(input: {
+    readonly method: string;
+    readonly url: string;
+    readonly cause: unknown;
+  }): ManagedRelayRequestProofCreationError {
+    return new ManagedRelayRequestProofCreationError({
+      method: input.method,
+      requestTarget: redactDpopRequestTarget(input.url),
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
     return "Could not create relay request DPoP proof.";
   }
@@ -376,7 +439,7 @@ function dpopHeaders(authorization: ManagedRelayAuthorization) {
 function disabledManagedRelayClient(relayUrl: string): ManagedRelayClient["Service"] {
   const unavailable = (spanName: string) =>
     Effect.fn(spanName)(function* () {
-      return yield* new ManagedRelayUrlInvalidError({ relayUrl });
+      return yield* ManagedRelayUrlInvalidError.fromInput(relayUrl);
     });
   return ManagedRelayClient.of({
     relayUrl,
@@ -456,13 +519,12 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       });
       const proofTarget = dpopProofTargets.exchangeAccessToken();
       const proof = yield* signer.createProof(proofTarget).pipe(
-        Effect.mapError(
-          (cause) =>
-            new ManagedRelayTokenProofCreationError({
-              method: proofTarget.method,
-              url: proofTarget.url,
-              cause,
-            }),
+        Effect.mapError((cause) =>
+          ManagedRelayTokenProofCreationError.fromTarget({
+            method: proofTarget.method,
+            url: proofTarget.url,
+            cause,
+          }),
         ),
       );
       const response = yield* client.token
@@ -573,7 +635,7 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
       "relay.client_id": options.clientId,
       "relay.scopes": input.scopes.join(" "),
       "http.request.method": input.target.method,
-      "url.full": input.target.url,
+      "url.full": redactDpopRequestTarget(input.target.url),
     });
     const thumbprint = yield* signer.thumbprint;
     const token = yield* obtainAccessToken({
@@ -587,13 +649,12 @@ export const make = Effect.fn("ManagedRelayClient.make")(function* (
         accessToken: token.accessToken,
       })
       .pipe(
-        Effect.mapError(
-          (cause) =>
-            new ManagedRelayRequestProofCreationError({
-              method: input.target.method,
-              url: input.target.url,
-              cause,
-            }),
+        Effect.mapError((cause) =>
+          ManagedRelayRequestProofCreationError.fromTarget({
+            method: input.target.method,
+            url: input.target.url,
+            cause,
+          }),
         ),
       );
     return { accessToken: token.accessToken, proof, thumbprint };

--- a/packages/client-runtime/src/rpc/http.ts
+++ b/packages/client-runtime/src/rpc/http.ts
@@ -14,24 +14,36 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
-import { FetchHttpClient, HttpClient, HttpClientError } from "effect/unstable/http";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 
 const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
 
-export class RemoteEnvironmentAuthFetchError extends Data.TaggedError(
+export class RemoteEnvironmentAuthFetchError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthFetchError>()(
   "RemoteEnvironmentAuthFetchError",
-)<{
-  readonly message: string;
-  readonly cause: unknown;
-}> {}
+  {
+    requestUrl: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to fetch remote environment endpoint ${this.requestUrl}.`;
+  }
+}
 
-export class RemoteEnvironmentAuthInvalidJsonError extends Data.TaggedError(
+export class RemoteEnvironmentAuthInvalidJsonError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthInvalidJsonError>()(
   "RemoteEnvironmentAuthInvalidJsonError",
-)<{
-  readonly message: string;
-  readonly cause: unknown;
-}> {}
+  {
+    requestUrl: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Remote environment endpoint returned an invalid response from ${this.requestUrl}.`;
+  }
+}
 
 export class RemoteEnvironmentAuthUndeclaredStatusError extends Data.TaggedError(
   "RemoteEnvironmentAuthUndeclaredStatusError",
@@ -49,21 +61,19 @@ export class RemoteEnvironmentAuthUndeclaredStatusError extends Data.TaggedError
   }
 }
 
-export class RemoteEnvironmentAuthTimeoutError extends Data.TaggedError(
+export class RemoteEnvironmentAuthTimeoutError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthTimeoutError>()(
   "RemoteEnvironmentAuthTimeoutError",
-)<{
-  readonly message: string;
-  readonly requestUrl: string;
-  readonly timeoutMs: number;
-}> {
-  constructor(requestUrl: string, timeoutMs: number) {
-    super({
-      message: `Remote environment endpoint ${requestUrl} timed out after ${timeoutMs}ms.`,
-      requestUrl,
-      timeoutMs,
-    });
+  {
+    requestUrl: Schema.String,
+    timeoutMs: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Remote environment endpoint ${this.requestUrl} timed out after ${this.timeoutMs}ms.`;
   }
 }
+
+const isRemoteEnvironmentAuthTimeoutError = Schema.is(RemoteEnvironmentAuthTimeoutError);
 
 export type RemoteEnvironmentRequestError =
   | EnvironmentRequestInvalidError
@@ -101,7 +111,7 @@ const failRemoteRequest = (
   requestUrl: string,
   cause: unknown,
 ): Effect.Effect<never, RemoteEnvironmentRequestError> => {
-  if (cause instanceof RemoteEnvironmentAuthTimeoutError) {
+  if (isRemoteEnvironmentAuthTimeoutError(cause)) {
     return Effect.fail(cause);
   }
   if (isEnvironmentHttpCommonError(cause)) {
@@ -110,7 +120,7 @@ const failRemoteRequest = (
   if (Schema.isSchemaError(cause)) {
     return Effect.fail(
       new RemoteEnvironmentAuthInvalidJsonError({
-        message: `Remote environment endpoint returned an invalid response from ${requestUrl}.`,
+        requestUrl,
         cause,
       }),
     );
@@ -124,14 +134,14 @@ const failRemoteRequest = (
     }
     return Effect.fail(
       new RemoteEnvironmentAuthInvalidJsonError({
-        message: `Remote environment endpoint returned an invalid response from ${requestUrl}.`,
+        requestUrl,
         cause,
       }),
     );
   }
   return Effect.fail(
     new RemoteEnvironmentAuthFetchError({
-      message: `Failed to fetch remote environment endpoint ${requestUrl} (${String(cause)}).`,
+      requestUrl,
       cause,
     }),
   );
@@ -146,7 +156,7 @@ export const executeEnvironmentHttpRequest = <A, E, R>(
     Effect.timeoutOption(Duration.millis(timeoutMs)),
     Effect.flatMap(
       Option.match({
-        onNone: () => Effect.fail(new RemoteEnvironmentAuthTimeoutError(requestUrl, timeoutMs)),
+        onNone: () => Effect.fail(new RemoteEnvironmentAuthTimeoutError({ requestUrl, timeoutMs })),
         onSome: Effect.succeed,
       }),
     ),

--- a/packages/client-runtime/src/rpc/http.ts
+++ b/packages/client-runtime/src/rpc/http.ts
@@ -8,7 +8,7 @@ import {
   type EnvironmentScopeRequiredError,
 } from "@t3tools/contracts";
 import { httpHeaderRedactionLayer } from "@t3tools/shared/httpObservability";
-import * as Data from "effect/Data";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -21,55 +21,113 @@ import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
 
 const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
 
+const requestUrlDiagnosticSchema = {
+  requestUrlInputLength: Schema.Number,
+  requestUrlProtocol: Schema.optionalKey(Schema.String),
+  requestUrlHostname: Schema.optionalKey(Schema.String),
+} as const;
+
+function requestUrlDiagnosticFields(requestUrl: string) {
+  const diagnostics = getUrlDiagnostics(requestUrl);
+  return {
+    requestUrlInputLength: diagnostics.inputLength,
+    ...(diagnostics.protocol === undefined ? {} : { requestUrlProtocol: diagnostics.protocol }),
+    ...(diagnostics.hostname === undefined ? {} : { requestUrlHostname: diagnostics.hostname }),
+  };
+}
+
+function requestUrlDescription(input: {
+  readonly requestUrlInputLength: number;
+  readonly requestUrlHostname?: string;
+}): string {
+  return input.requestUrlHostname === undefined
+    ? `an invalid URL (${input.requestUrlInputLength} characters)`
+    : `host ${input.requestUrlHostname} (${input.requestUrlInputLength} URL characters)`;
+}
+
 export class RemoteEnvironmentAuthFetchError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthFetchError>()(
   "RemoteEnvironmentAuthFetchError",
   {
-    requestUrl: Schema.String,
+    ...requestUrlDiagnosticSchema,
     cause: Schema.Defect(),
   },
 ) {
+  static fromRequestUrl(requestUrl: string, cause: unknown): RemoteEnvironmentAuthFetchError {
+    return new RemoteEnvironmentAuthFetchError({
+      ...requestUrlDiagnosticFields(requestUrl),
+      cause,
+    });
+  }
+
   override get message(): string {
-    return `Failed to fetch remote environment endpoint ${this.requestUrl}.`;
+    return `Failed to fetch remote environment endpoint at ${requestUrlDescription(this)}.`;
   }
 }
 
 export class RemoteEnvironmentAuthInvalidJsonError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthInvalidJsonError>()(
   "RemoteEnvironmentAuthInvalidJsonError",
   {
-    requestUrl: Schema.String,
+    ...requestUrlDiagnosticSchema,
     cause: Schema.Defect(),
   },
 ) {
+  static fromRequestUrl(requestUrl: string, cause: unknown): RemoteEnvironmentAuthInvalidJsonError {
+    return new RemoteEnvironmentAuthInvalidJsonError({
+      ...requestUrlDiagnosticFields(requestUrl),
+      cause,
+    });
+  }
+
   override get message(): string {
-    return `Remote environment endpoint returned an invalid response from ${this.requestUrl}.`;
+    return `Remote environment endpoint at ${requestUrlDescription(this)} returned an invalid response.`;
   }
 }
 
-export class RemoteEnvironmentAuthUndeclaredStatusError extends Data.TaggedError(
+export class RemoteEnvironmentAuthUndeclaredStatusError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthUndeclaredStatusError>()(
   "RemoteEnvironmentAuthUndeclaredStatusError",
-)<{
-  readonly message: string;
-  readonly status: number;
-  readonly requestUrl: string;
-}> {
-  constructor(requestUrl: string, status: number) {
-    super({
-      message: `Remote environment endpoint ${requestUrl} returned undeclared status ${status}.`,
-      requestUrl,
+  {
+    ...requestUrlDiagnosticSchema,
+    status: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  static fromRequestUrl(
+    requestUrl: string,
+    status: number,
+    cause: unknown,
+  ): RemoteEnvironmentAuthUndeclaredStatusError {
+    return new RemoteEnvironmentAuthUndeclaredStatusError({
+      ...requestUrlDiagnosticFields(requestUrl),
       status,
+      cause,
     });
   }
+
+  override get message(): string {
+    return `Remote environment endpoint at ${requestUrlDescription(this)} returned undeclared status ${this.status}.`;
+  }
 }
+
+export const isRemoteEnvironmentAuthUndeclaredStatusError = Schema.is(
+  RemoteEnvironmentAuthUndeclaredStatusError,
+);
 
 export class RemoteEnvironmentAuthTimeoutError extends Schema.TaggedErrorClass<RemoteEnvironmentAuthTimeoutError>()(
   "RemoteEnvironmentAuthTimeoutError",
   {
-    requestUrl: Schema.String,
+    ...requestUrlDiagnosticSchema,
     timeoutMs: Schema.Number,
   },
 ) {
+  static fromRequestUrl(requestUrl: string, timeoutMs: number): RemoteEnvironmentAuthTimeoutError {
+    return new RemoteEnvironmentAuthTimeoutError({
+      ...requestUrlDiagnosticFields(requestUrl),
+      timeoutMs,
+    });
+  }
+
   override get message(): string {
-    return `Remote environment endpoint ${this.requestUrl} timed out after ${this.timeoutMs}ms.`;
+    return `Remote environment endpoint at ${requestUrlDescription(this)} timed out after ${this.timeoutMs}ms.`;
   }
 }
 
@@ -118,33 +176,22 @@ const failRemoteRequest = (
     return Effect.fail(cause);
   }
   if (Schema.isSchemaError(cause)) {
-    return Effect.fail(
-      new RemoteEnvironmentAuthInvalidJsonError({
-        requestUrl,
-        cause,
-      }),
-    );
+    return Effect.fail(RemoteEnvironmentAuthInvalidJsonError.fromRequestUrl(requestUrl, cause));
   }
   if (HttpClientError.isHttpClientError(cause) && cause.response !== undefined) {
     const response = cause.response;
     if (response.status < 200 || response.status >= 300) {
       return Effect.fail(
-        new RemoteEnvironmentAuthUndeclaredStatusError(requestUrl, response.status),
+        RemoteEnvironmentAuthUndeclaredStatusError.fromRequestUrl(
+          requestUrl,
+          response.status,
+          cause,
+        ),
       );
     }
-    return Effect.fail(
-      new RemoteEnvironmentAuthInvalidJsonError({
-        requestUrl,
-        cause,
-      }),
-    );
+    return Effect.fail(RemoteEnvironmentAuthInvalidJsonError.fromRequestUrl(requestUrl, cause));
   }
-  return Effect.fail(
-    new RemoteEnvironmentAuthFetchError({
-      requestUrl,
-      cause,
-    }),
-  );
+  return Effect.fail(RemoteEnvironmentAuthFetchError.fromRequestUrl(requestUrl, cause));
 };
 
 export const executeEnvironmentHttpRequest = <A, E, R>(
@@ -156,7 +203,8 @@ export const executeEnvironmentHttpRequest = <A, E, R>(
     Effect.timeoutOption(Duration.millis(timeoutMs)),
     Effect.flatMap(
       Option.match({
-        onNone: () => Effect.fail(new RemoteEnvironmentAuthTimeoutError({ requestUrl, timeoutMs })),
+        onNone: () =>
+          Effect.fail(RemoteEnvironmentAuthTimeoutError.fromRequestUrl(requestUrl, timeoutMs)),
         onSome: Effect.succeed,
       }),
     ),

--- a/packages/client-runtime/src/rpc/session.ts
+++ b/packages/client-runtime/src/rpc/session.ts
@@ -49,17 +49,20 @@ function mapInitialConfigError(error: InitialConfigError): ConnectionAttemptErro
       return new ConnectionBlockedError({
         reason: "permission",
         detail: error.message,
+        cause: error,
       });
     case "KeybindingsConfigParseError":
     case "ServerSettingsError":
       return new ConnectionTransientErrorClass({
         reason: "remote-unavailable",
         detail: error.message,
+        cause: error,
       });
     case "RpcClientError":
       return new ConnectionTransientErrorClass({
         reason: "transport",
         detail: error.message,
+        cause: error,
       });
   }
 }


### PR DESCRIPTION
## Summary
- replace web and mobile persistence constructor wrappers with explicit error mappings at each failure boundary
- attach operation, stage, resource, environment, thread, path, and the original cause to persistence failures
- preserve catalog and migration causes while keeping stable messages independent of cause text
- use tagged catch semantics for catalog recovery paths and hoist reusable Schema codecs

## Validation
- `vp test packages/client-runtime/src/platform/persistence.test.ts packages/client-runtime/src/connection/registry.test.ts apps/web/src/connection/storage.test.ts apps/mobile/src/connection/storage.test.ts apps/mobile/src/connection/migration.test.ts`
- `vp check` (passes with existing unrelated warnings)
- `vp run typecheck`
- `vp run lint:mobile`

## Stack
- based on #3242 because it uses the optional cause support added to ConnectionTransientError there

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all connection catalog and cache I/O on web and mobile; behavior change where non-transient catalog/migration errors may propagate instead of being swallowed during recovery.
> 
> **Overview**
> Connection persistence and local storage now use **typed, structured errors** instead of ad-hoc string wrappers, with **stable user-facing messages** that do not echo underlying cause text.
> 
> **Client runtime** adds `ConnectionStorageOperationError`, availability errors for IndexedDB and desktop secure storage, and `ConnectionTransientError.fromStorageFailure`. `ConnectionPersistenceError` drops free-form `message` in favor of `operation`, `stage`, `resource`, optional `environmentId` / `threadId` / `path`, and `cause`, with a derived message.
> 
> **Web and mobile** storage layers map each failure boundary (IndexedDB, secure store, file cache, schema encode/decode) to those types. Catalog encode/decode uses shared Schema JSON codecs. Corrupt-catalog recovery uses **`catchTags` for `ConnectionTransientError` only**, so other failures propagate instead of being treated as recoverable corruption.
> 
> **Mobile legacy migration** uses `LegacyConnectionMigrationError` with `stage` (`parse` / `decode`) and `cause` instead of embedding cause strings in messages. Tests assert cause chains are preserved while messages stay generic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b39a73fee4a02b7acabab31c7cfee617acc58132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure connection persistence and relay errors with typed fields and redacted URLs
> - Replaces interpolated message strings across connection storage, relay, and authorization error paths with structured error types carrying typed fields (`stage`, `resource`, `operation`, `backend`, `cause`, `environmentId`, etc.).
> - Adds new error classes in [`model.ts`](https://github.com/pingdotgg/t3code/pull/3255/files#diff-66cda97fd489ec4edb5b6ff01ef7a7084f47b6f60e511045bb4aae3f616395d6) and [`persistence.ts`](https://github.com/pingdotgg/t3code/pull/3255/files#diff-911d79898a37f3b5cedb7bc5ef366c91355ef19d144eb9d27dc539af9f33e584): `ConnectionStorageOperationError`, `IndexedDbUnavailableError`, `DesktopSecureStorageUnavailableError`, and a reworked `ConnectionPersistenceError` with a computed message that excludes the raw cause.
> - Redacts sensitive URL data from relay errors and logs: `ManagedRelayUrlInvalidError`, `ManagedRelayDpopProofCreationError`, and offline log records now expose only length, protocol, and hostname instead of full URLs or credentials.
> - `ConnectionBlockedError` and `ConnectionTransientError` are extended to carry optional `cause`, `connectionId`, `expectedEnvironmentId`, and `actualEnvironmentId` for configuration and authentication failures in bearer, relay, SSH, and DPoP paths.
> - Risk: error message text changes across storage, relay, and authorization paths may break any callers that pattern-match on message strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b39a73f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->