### PR TITLE
[codex] Structure bootstrap errors

### DIFF
--- a/apps/server/src/bootstrap.test.ts
+++ b/apps/server/src/bootstrap.test.ts
@@ -3,7 +3,7 @@ import * as NodeFS from "node:fs";
 import * as NodePath from "node:path";
 import * as NodeChildProcess from "node:child_process";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import { it } from "@effect/vitest";
+import { assert, it } from "@effect/vitest";
 import * as FileSystem from "effect/FileSystem";
 import * as Schema from "effect/Schema";
 import * as Duration from "effect/Duration";
@@ -13,10 +13,19 @@ import * as TestClock from "effect/testing/TestClock";
 import { vi } from "vite-plus/test";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
-import { readBootstrapEnvelope } from "./bootstrap.ts";
+import {
+  BootstrapEnvelopeDecodeError,
+  BootstrapFdStatError,
+  BootstrapInputStreamOpenError,
+  readBootstrapEnvelope,
+} from "./bootstrap.ts";
 import { assertNone, assertSome } from "@effect/vitest/utils";
 
-const openSyncInterceptor = vi.hoisted(() => ({ failPath: null as string | null }));
+const openSyncInterceptor = vi.hoisted(() => ({
+  failPath: null as string | null,
+  errorCode: "ENXIO",
+}));
+const fstatSyncInterceptor = vi.hoisted(() => ({ failFd: null as number | null }));
 
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
@@ -29,11 +38,19 @@ vi.mock("node:fs", async (importOriginal) => {
         filePath === openSyncInterceptor.failPath &&
         flags === "r"
       ) {
-        const error = new Error("no such device or address");
-        Object.assign(error, { code: "ENXIO" });
+        const error = new Error(`open failed with ${openSyncInterceptor.errorCode}`);
+        Object.assign(error, { code: openSyncInterceptor.errorCode });
         throw error;
       }
       return (actual.openSync as (...a: typeof args) => number)(...args);
+    },
+    fstatSync: (...args: Parameters<typeof actual.fstatSync>) => {
+      if (args[0] === fstatSyncInterceptor.failFd) {
+        const error = new Error("permission denied");
+        Object.assign(error, { code: "EACCES" });
+        throw error;
+      }
+      return (actual.fstatSync as (...a: typeof args) => NodeFS.Stats)(...args);
     },
   };
 });
@@ -94,6 +111,39 @@ it.layer(NodeServices.layer)("readBootstrapEnvelope", (it) => {
     }),
   );
 
+  it.effect("preserves fd path, platform, and cause when opening the input stream fails", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const filePath = yield* fs.makeTempFileScoped({ prefix: "t3-bootstrap-", suffix: ".ndjson" });
+      const fd = yield* Effect.acquireRelease(
+        Effect.sync(() => NodeFS.openSync(filePath, "r")),
+        (fd) => Effect.sync(() => NodeFS.closeSync(fd)),
+      );
+      const fdPath = `/proc/self/fd/${fd}`;
+
+      openSyncInterceptor.failPath = fdPath;
+      openSyncInterceptor.errorCode = "EIO";
+      try {
+        const error = yield* readBootstrapEnvelope(TestEnvelopeSchema, fd, {
+          timeoutMs: 100,
+        }).pipe(Effect.provideService(HostProcessPlatform, "linux"), Effect.flip);
+
+        assert.instanceOf(error, BootstrapInputStreamOpenError);
+        assert.equal(error.fd, fd);
+        assert.equal(error.platform, "linux");
+        assert.equal(error.fdPath, fdPath);
+        assert.equal((error.cause as NodeJS.ErrnoException).code, "EIO");
+        assert.equal(
+          error.message,
+          `Failed to open bootstrap input stream for file descriptor ${fd} via '${fdPath}' on 'linux'.`,
+        );
+      } finally {
+        openSyncInterceptor.failPath = null;
+        openSyncInterceptor.errorCode = "ENXIO";
+      }
+    }),
+  );
+
   it.effect("returns none when the fd is unavailable", () =>
     Effect.gen(function* () {
       const fd = NodeFS.openSync("/dev/null", "r");
@@ -101,6 +151,53 @@ it.layer(NodeServices.layer)("readBootstrapEnvelope", (it) => {
 
       const payload = yield* readBootstrapEnvelope(TestEnvelopeSchema, fd, { timeoutMs: 100 });
       assertNone(payload);
+    }),
+  );
+
+  it.effect("preserves fd and cause when stat fails for a non-availability reason", () =>
+    Effect.gen(function* () {
+      const fd = yield* Effect.acquireRelease(
+        Effect.sync(() => NodeFS.openSync("/dev/null", "r")),
+        (fd) => Effect.sync(() => NodeFS.closeSync(fd)),
+      );
+
+      fstatSyncInterceptor.failFd = fd;
+      try {
+        const error = yield* readBootstrapEnvelope(TestEnvelopeSchema, fd, {
+          timeoutMs: 100,
+        }).pipe(Effect.flip);
+
+        assert.instanceOf(error, BootstrapFdStatError);
+        assert.equal(error.fd, fd);
+        assert.equal((error.cause as NodeJS.ErrnoException).code, "EACCES");
+        assert.equal(error.message, `Failed to stat bootstrap file descriptor ${fd}.`);
+      } finally {
+        fstatSyncInterceptor.failFd = null;
+      }
+    }),
+  );
+
+  it.effect("preserves fd and schema cause when decoding the envelope fails", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const filePath = yield* fs.makeTempFileScoped({ prefix: "t3-bootstrap-", suffix: ".ndjson" });
+      yield* fs.writeFileString(filePath, '{"mode":42}\n');
+
+      const fd = yield* Effect.acquireRelease(
+        Effect.sync(() => NodeFS.openSync(filePath, "r")),
+        (fd) => Effect.sync(() => NodeFS.closeSync(fd)),
+      );
+      const error = yield* readBootstrapEnvelope(TestEnvelopeSchema, fd, {
+        timeoutMs: 100,
+      }).pipe(Effect.flip);
+
+      assert.instanceOf(error, BootstrapEnvelopeDecodeError);
+      assert.equal(error.fd, fd);
+      assert.isDefined(error.cause);
+      assert.equal(
+        error.message,
+        `Failed to decode bootstrap envelope from file descriptor ${fd}.`,
+      );
     }),
   );
 

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -4,7 +4,6 @@ import * as NodeNet from "node:net";
 import * as NodeReadline from "node:readline";
 import type * as NodeStream from "node:stream";
 
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
@@ -13,10 +12,64 @@ import * as Schema from "effect/Schema";
 import { decodeJsonResult } from "@t3tools/shared/schemaJson";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
-class BootstrapError extends Data.TaggedError("BootstrapError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class BootstrapFdStatError extends Schema.TaggedErrorClass<BootstrapFdStatError>()(
+  "BootstrapFdStatError",
+  {
+    fd: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to stat bootstrap file descriptor ${this.fd}.`;
+  }
+}
+
+export class BootstrapInputStreamOpenError extends Schema.TaggedErrorClass<BootstrapInputStreamOpenError>()(
+  "BootstrapInputStreamOpenError",
+  {
+    fd: Schema.Number,
+    platform: Schema.String,
+    fdPath: Schema.optional(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const path = this.fdPath === undefined ? "" : ` via '${this.fdPath}'`;
+    return `Failed to open bootstrap input stream for file descriptor ${this.fd}${path} on '${this.platform}'.`;
+  }
+}
+
+export class BootstrapEnvelopeReadError extends Schema.TaggedErrorClass<BootstrapEnvelopeReadError>()(
+  "BootstrapEnvelopeReadError",
+  {
+    fd: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read bootstrap envelope from file descriptor ${this.fd}.`;
+  }
+}
+
+export class BootstrapEnvelopeDecodeError extends Schema.TaggedErrorClass<BootstrapEnvelopeDecodeError>()(
+  "BootstrapEnvelopeDecodeError",
+  {
+    fd: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to decode bootstrap envelope from file descriptor ${this.fd}.`;
+  }
+}
+
+export const BootstrapError = Schema.Union([
+  BootstrapFdStatError,
+  BootstrapInputStreamOpenError,
+  BootstrapEnvelopeReadError,
+  BootstrapEnvelopeDecodeError,
+]);
+export type BootstrapError = typeof BootstrapError.Type;
 
 export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function* <A, I>(
   schema: Schema.Codec<A, I>,
@@ -32,7 +85,10 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
 
   const timeoutMs = options?.timeoutMs ?? 1000;
 
-  return yield* Effect.callback<Option.Option<A>, BootstrapError>((resume) => {
+  return yield* Effect.callback<
+    Option.Option<A>,
+    BootstrapEnvelopeReadError | BootstrapEnvelopeDecodeError
+  >((resume) => {
     const input = NodeReadline.createInterface({
       input: stream,
       crlfDelay: Infinity,
@@ -53,8 +109,8 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       }
       resume(
         Effect.fail(
-          new BootstrapError({
-            message: "Failed to read bootstrap envelope.",
+          new BootstrapEnvelopeReadError({
+            fd,
             cause: error,
           }),
         ),
@@ -68,8 +124,8 @@ export const readBootstrapEnvelope = Effect.fn("readBootstrapEnvelope")(function
       } else {
         resume(
           Effect.fail(
-            new BootstrapError({
-              message: "Failed to decode bootstrap envelope.",
+            new BootstrapEnvelopeDecodeError({
+              fd,
               cause: parsed.failure,
             }),
           ),
@@ -98,24 +154,24 @@ const isFdReady = (fd: number) =>
   Effect.try({
     try: () => NodeFS.fstatSync(fd),
     catch: (error) =>
-      new BootstrapError({
-        message: "Failed to stat bootstrap fd.",
+      new BootstrapFdStatError({
+        fd,
         cause: error,
       }),
   }).pipe(
     Effect.as(true),
-    Effect.catchIf(
-      (error) => isUnavailableBootstrapFdError(error.cause),
-      () => Effect.succeed(false),
-    ),
+    Effect.catchTags({
+      BootstrapFdStatError: (error) =>
+        isUnavailableBootstrapFdError(error.cause) ? Effect.succeed(false) : Effect.fail(error),
+    }),
   );
 
 const makeBootstrapInputStream = (fd: number) =>
   Effect.gen(function* () {
     const platform = yield* HostProcessPlatform;
-    return yield* Effect.try<NodeStream.Readable, BootstrapError>({
+    const fdPath = resolveFdPath(fd, platform);
+    return yield* Effect.try<NodeStream.Readable, BootstrapInputStreamOpenError>({
       try: () => {
-        const fdPath = resolveFdPath(fd, platform);
         if (fdPath === undefined) {
           return makeDirectBootstrapStream(fd);
         }
@@ -139,8 +195,10 @@ const makeBootstrapInputStream = (fd: number) =>
         }
       },
       catch: (error) =>
-        new BootstrapError({
-          message: "Failed to duplicate bootstrap fd.",
+        new BootstrapInputStreamOpenError({
+          fd,
+          platform,
+          ...(fdPath === undefined ? {} : { fdPath }),
           cause: error,
         }),
     });


### PR DESCRIPTION
## Summary
- replace the generic bootstrap error with distinct tagged stat, stream-open, read, and decode failures
- attach file descriptor, platform, and fd path context while preserving original OS and schema causes
- classify unavailable descriptors through catchTags without swallowing unrelated stat failures
- retain existing unavailable, fallback, and timeout behavior

## Validation
- vp test run apps/server/src/bootstrap.test.ts
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized bootstrap I/O error typing and observability; success, timeout, unavailable-fd, and duplication-fallback behavior are unchanged and covered by tests.
> 
> **Overview**
> Replaces the single generic `BootstrapError` with **four schema-tagged failures** (`BootstrapFdStatError`, `BootstrapInputStreamOpenError`, `BootstrapEnvelopeReadError`, `BootstrapEnvelopeDecodeError`) exposed as a `BootstrapError` union, each carrying **fd** (and **platform** / **fdPath** for stream-open) plus the original **cause**.
> 
> `readBootstrapEnvelope` now fails with the specific tag at stat, stream open, read, and decode boundaries; **unavailable fds** still yield `Option.none()` via `catchTags` on stat/read when errno is EBADF/ENOENT, while **non-availability stat errors** (e.g. EACCES) propagate. Stream-open messages and context are updated (fd path resolved before the try block).
> 
> Tests add **fs mocks** for configurable `openSync` failures and `fstatSync` EACCES, plus cases that assert error type, fields, messages, and preserved causes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 933388080b5010c75df792387bed05316cfb243f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure bootstrap errors into typed error classes in `readBootstrapEnvelope`
> - Replaces the generic `BootstrapError` with four specific tagged error classes: `BootstrapFdStatError`, `BootstrapInputStreamOpenError`, `BootstrapEnvelopeReadError`, and `BootstrapEnvelopeDecodeError`.
> - Each error carries the relevant `fd` and the original `cause`, with `BootstrapInputStreamOpenError` also including `platform` and optional `fdPath`.
> - `isFdReady` now re-fails with `BootstrapFdStatError` when `fstatSync` fails for reasons other than fd unavailability, instead of silently swallowing the error.
> - Adds tests covering the new error types for open failures, stat failures, and decode failures in [bootstrap.test.ts](https://github.com/pingdotgg/t3code/pull/3256/files#diff-0ce606ba1b9ab11f436ea374b47d8760acc9ca02c427343b8690bdc8c52a2175).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9333880.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->