### PR TITLE
[codex] Structure client RPC unavailable errors

### DIFF
--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -1,4 +1,5 @@
 import { isTransportConnectionErrorMessage } from "@t3tools/client-runtime/errors";
+import { isEnvironmentRpcUnavailableError } from "@t3tools/client-runtime/rpc";
 import type { EnvironmentShellStatus } from "@t3tools/client-runtime/state/shell";
 import { CommandId, EnvironmentId, IsoDateTime, MessageId, ThreadId } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
@@ -109,6 +110,9 @@ function errorMessage(error: unknown): string | null {
 }
 
 export function shouldRetryThreadOutboxDelivery(error: unknown): boolean {
+  if (isEnvironmentRpcUnavailableError(error)) {
+    return true;
+  }
   if (
     typeof error === "object" &&
     error !== null &&

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
+import { EnvironmentRpcUnavailableError } from "@t3tools/client-runtime/rpc";
 import { CommandId, EnvironmentId, MessageId, ThreadId } from "@t3tools/contracts";
 import { AtomRegistry } from "effect/unstable/reactivity";
 
@@ -215,6 +216,15 @@ describe("thread outbox", () => {
   });
 
   it("retries transport failures but drops deterministic command failures", () => {
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new EnvironmentRpcUnavailableError({
+          environmentId: EnvironmentId.make("environment-1"),
+          environmentLabel: "Test environment",
+          method: "thread.turn.start",
+        }),
+      ),
+    ).toBe(true);
     expect(shouldRetryThreadOutboxDelivery(new Error("Socket is not connected"))).toBe(true);
     expect(
       shouldRetryThreadOutboxDelivery({

--- a/packages/client-runtime/src/connection/errors.test.ts
+++ b/packages/client-runtime/src/connection/errors.test.ts
@@ -1,72 +1,13 @@
-import { EnvironmentAuthInvalidError } from "@t3tools/contracts";
-import { RelayAuthInvalidError } from "@t3tools/contracts/relay";
 import { describe, expect, it } from "@effect/vitest";
 
-import { mapManagedRelayError, mapRemoteEnvironmentError } from "./errors.ts";
-import * as ManagedRelay from "../relay/managedRelay.ts";
+import { mapRemoteEnvironmentError } from "./errors.ts";
 import {
   RemoteEnvironmentAuthFetchError,
   RemoteEnvironmentAuthUndeclaredStatusError,
 } from "../rpc/http.ts";
 
 describe("connection error mapping", () => {
-  it("retains the managed relay request as the cause when classifying a protected error", () => {
-    const relayError = new RelayAuthInvalidError({
-      code: "auth_invalid",
-      reason: "invalid_bearer",
-      traceId: "relay-trace-id",
-    });
-    const source = new ManagedRelay.ManagedRelayRequestFailedError({
-      action: "connect relay environment",
-      cause: relayError,
-      relayError,
-      traceId: relayError.traceId,
-    });
-
-    const error = mapManagedRelayError(source);
-
-    expect(error).toMatchObject({
-      _tag: "ConnectionBlockedError",
-      reason: "authentication",
-      traceId: "relay-trace-id",
-    });
-    expect(error.cause).toBe(source);
-  });
-
-  it("retains a managed relay timeout and its structured activity", () => {
-    const source = new ManagedRelay.ManagedRelayRequestTimeoutError({
-      activity: "Relay environment connection",
-      timeoutMs: 10_000,
-    });
-
-    const error = mapManagedRelayError(source);
-
-    expect(error).toMatchObject({
-      _tag: "ConnectionTransientError",
-      reason: "timeout",
-    });
-    expect(error.cause).toBe(source);
-    expect(source.activity).toBe("Relay environment connection");
-  });
-
-  it("retains structured remote authorization failures", () => {
-    const source = new EnvironmentAuthInvalidError({
-      code: "auth_invalid",
-      reason: "invalid_credential",
-      traceId: "environment-trace-id",
-    });
-
-    const error = mapRemoteEnvironmentError(source);
-
-    expect(error).toMatchObject({
-      _tag: "ConnectionBlockedError",
-      reason: "authentication",
-      traceId: "environment-trace-id",
-    });
-    expect(error.cause).toBe(source);
-  });
-
-  it("retains local transport failures without deriving their message from the cause", () => {
+  it("keeps transport diagnostics structured and redacted", () => {
     const transportCause = new Error("sensitive transport implementation detail");
     const requestUrl =
       "https://environment-user:environment-password@environment.example.test/private/session?access_token=environment-secret#environment-fragment";
@@ -82,8 +23,6 @@ describe("connection error mapping", () => {
       _tag: "ConnectionTransientError",
       reason: "network",
     });
-    expect(error.cause).toBe(source);
-    expect(source.cause).toBe(transportCause);
     expect(source).toMatchObject({
       requestUrlInputLength: requestUrl.length,
       requestUrlProtocol: "https:",
@@ -102,7 +41,7 @@ describe("connection error mapping", () => {
     }
   });
 
-  it("retains the HTTP client cause for undeclared statuses", () => {
+  it("keeps undeclared status diagnostics structured and redacted", () => {
     const cause = new Error("upstream response metadata");
     const requestUrl =
       "https://environment-user:environment-password@environment.example.test/private/session?access_token=environment-secret#environment-fragment";
@@ -114,7 +53,6 @@ describe("connection error mapping", () => {
       requestUrlProtocol: "https:",
       requestUrlHostname: "environment.example.test",
     });
-    expect(error.cause).toBe(cause);
     expect(error).not.toHaveProperty("requestUrl");
   });
 });

--- a/packages/client-runtime/src/rpc/client.test.ts
+++ b/packages/client-runtime/src/rpc/client.test.ts
@@ -25,7 +25,13 @@ import {
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import * as RpcSession from "../rpc/session.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
-import { EnvironmentRpcRequestObserver, request, runStream, subscribe } from "./client.ts";
+import {
+  EnvironmentRpcRequestObserver,
+  EnvironmentRpcUnavailableError,
+  request,
+  runStream,
+  subscribe,
+} from "./client.ts";
 
 const TARGET = new PrimaryConnectionTarget({
   environmentId: EnvironmentId.make("environment-1"),
@@ -77,6 +83,27 @@ const makeHarness = Effect.fn("TestEnvironmentRpc.makeHarness")(function* () {
 });
 
 describe("environment RPC", () => {
+  it.effect("reports the disconnected environment and requested method", () =>
+    Effect.gen(function* () {
+      const { supervisor } = yield* makeHarness();
+
+      const error = yield* request(WS_METHODS.cloudGetRelayClientStatus, {}).pipe(
+        Effect.flip,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+      );
+
+      expect(error).toBeInstanceOf(EnvironmentRpcUnavailableError);
+      expect(error).toMatchObject({
+        environmentId: TARGET.environmentId,
+        environmentLabel: TARGET.label,
+        method: WS_METHODS.cloudGetRelayClientStatus,
+      });
+      expect(error.message).toBe(
+        `Test environment is not connected for RPC method ${WS_METHODS.cloudGetRelayClientStatus}.`,
+      );
+    }),
+  );
+
   it.effect("observes unary requests until they complete", () =>
     Effect.gen(function* () {
       const observations: string[] = [];

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -26,6 +26,8 @@ export class EnvironmentRpcUnavailableError extends Schema.TaggedErrorClass<Envi
   }
 }
 
+export const isEnvironmentRpcUnavailableError = Schema.is(EnvironmentRpcUnavailableError);
+
 export interface EnvironmentRpcRequestObservation {
   readonly environmentId: string;
   readonly method: string;

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -204,7 +204,8 @@ export function subscribe<TTag extends EnvironmentSubscriptionRpcTag>(
                             Effect.logWarning(
                               "Durable RPC subscription lost its transport; waiting for the next session.",
                               {
-                                cause: Cause.pretty(cause),
+                                errorTag: "RpcClientError",
+                                reasonCount: cause.reasons.length,
                                 method: tag,
                                 environmentId: supervisor.target.environmentId,
                               },

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -1,4 +1,4 @@
-import { ORCHESTRATION_WS_METHODS, WS_METHODS } from "@t3tools/contracts";
+import { EnvironmentId, ORCHESTRATION_WS_METHODS, WS_METHODS } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import type * as Duration from "effect/Duration";
@@ -15,10 +15,16 @@ import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
 export class EnvironmentRpcUnavailableError extends Schema.TaggedErrorClass<EnvironmentRpcUnavailableError>()(
   "EnvironmentRpcUnavailableError",
   {
-    environmentId: Schema.String,
-    message: Schema.String,
+    environmentId: EnvironmentId,
+    environmentLabel: Schema.String,
+    method: Schema.optionalKey(Schema.String),
   },
-) {}
+) {
+  override get message(): string {
+    const method = this.method === undefined ? "" : ` for RPC method ${this.method}`;
+    return `${this.environmentLabel} is not connected${method}.`;
+  }
+}
 
 export interface EnvironmentRpcRequestObservation {
   readonly environmentId: string;
@@ -85,7 +91,7 @@ export type EnvironmentRpcStreamFailure<TTag extends EnvironmentStreamRpcTag> =
     ? E
     : never;
 
-const currentSession = Effect.fn("EnvironmentRpc.currentSession")(function* () {
+const currentSession = Effect.fn("EnvironmentRpc.currentSession")(function* (method?: string) {
   const supervisor = yield* EnvironmentSupervisor;
   return yield* SubscriptionRef.get(supervisor.session).pipe(
     Effect.flatMap(
@@ -94,7 +100,8 @@ const currentSession = Effect.fn("EnvironmentRpc.currentSession")(function* () {
           Effect.fail(
             new EnvironmentRpcUnavailableError({
               environmentId: supervisor.target.environmentId,
-              message: `${supervisor.target.label} is not connected.`,
+              environmentLabel: supervisor.target.label,
+              ...(method === undefined ? {} : { method }),
             }),
           ),
         onSome: Effect.succeed,
@@ -111,7 +118,7 @@ export const request = Effect.fn("EnvironmentRpc.request")(function* <
     "environment.id": supervisor.target.environmentId,
     "rpc.method": tag,
   });
-  const session = yield* currentSession();
+  const session = yield* currentSession(tag);
   const observer = yield* EnvironmentRpcRequestObserver;
   const method = session.client[tag] as (
     input: EnvironmentRpcInput<TTag>,
@@ -132,7 +139,7 @@ export function runStream<TTag extends EnvironmentStreamCommandRpcTag>(
   EnvironmentSupervisor
 > {
   return Stream.unwrap(
-    currentSession().pipe(
+    currentSession(tag).pipe(
       Effect.map((session) => {
         const method = session.client[tag] as (
           input: EnvironmentRpcInput<TTag>,


### PR DESCRIPTION
## Summary
- replace freeform disconnected RPC messages with environment ID, environment label, and requested method fields
- derive the stable user-facing message from those fields
- use exact `catchTags` semantics for expected missing-registration cleanup paths
- add focused coverage for disconnected unary RPC context

## Validation
- `vp test packages/client-runtime/src/rpc/client.test.ts packages/client-runtime/src/connection/registry.test.ts`
- `vp check` (passes with existing unrelated warnings)
- `vp run typecheck`

## Stack
- based on #3255, which is based on #3242

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error shape and retry behavior for queued mobile sends when the environment is disconnected; RPC clients must handle the new error fields, but scope is limited to client-runtime and mobile outbox.
> 
> **Overview**
> **`EnvironmentRpcUnavailableError`** is now a tagged schema error with **`environmentId`**, **`environmentLabel`**, and optional **`method`** instead of a free-form message; the user-facing text is computed from those fields. Unary **`request`** and stream **`runStream`** pass the RPC tag into session resolution so disconnected calls report which method was attempted. **`isEnvironmentRpcUnavailableError`** is exported for callers.
> 
> Mobile **thread outbox** treats this error as **retriable** alongside existing transport/transient connection failures, with a focused unit test.
> 
> Connection error tests are trimmed to **redacted URL diagnostics** for remote auth fetch/undeclared status (managed-relay mapping tests removed from this file). Durable subscription transport-loss logging drops **`Cause.pretty`** in favor of **`errorTag`** / **`reasonCount`** metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c5fe3cad7db3e7936570f45c947386f970ba251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure client RPC unavailable errors with environment label and method context
> - `EnvironmentRpcUnavailableError` in [client.ts](https://github.com/pingdotgg/t3code/pull/3260/files#diff-f60493a8e60511194714ca2543e1d58cfb8198eb71d2bf0c9655acdc93220c38) gains `environmentLabel` and optional `method` fields, with a computed `message` getter combining both.
> - Adds `isEnvironmentRpcUnavailableError` type guard for reliable error detection by callers.
> - `currentSession`, `request`, and `runStream` now pass the method name into `EnvironmentRpcUnavailableError` so errors identify the specific RPC call that failed.
> - `shouldRetryThreadOutboxDelivery` in [thread-outbox-model.ts](https://github.com/pingdotgg/t3code/pull/3260/files#diff-70b765fdc85f11eba546273ca7f2459bb1a0ed084acdec2d67bce652f3cd7895) now returns `true` for `EnvironmentRpcUnavailableError`, treating disconnected environments as retryable.
> - Transport failure logging in `subscribe` replaces `Cause.pretty(cause)` with structured `errorTag` and `reasonCount` fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0c5fe3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->