### PR TITLE
[codex] Structure client VCS action errors

### DIFF
--- a/apps/web/src/state/sourceControlActions.ts
+++ b/apps/web/src/state/sourceControlActions.ts
@@ -126,12 +126,6 @@ function resolveScope(scope: SourceControlActionScope) {
   };
 }
 
-function unavailableResult(message: string) {
-  return AsyncResult.failure<never, VcsActionUnavailableError>(
-    Cause.fail(new VcsActionUnavailableError({ message })),
-  );
-}
-
 export function useSourceControlActionRunning(
   scope: SourceControlActionScope,
   kinds: ReadonlyArray<SourceControlActionKind>,
@@ -149,7 +143,15 @@ export function useVcsInitAction(scope: SourceControlActionScope) {
   const action = useCallback(async () => {
     const target = resolveScope(scope);
     if (target === null) {
-      return unavailableResult("Git init is unavailable.");
+      return AsyncResult.failure<never, VcsActionUnavailableError>(
+        Cause.fail(
+          new VcsActionUnavailableError({
+            operation: "init",
+            environmentId: scope.environmentId,
+            cwd: scope.cwd,
+          }),
+        ),
+      );
     }
     return init({
       environmentId: target.environmentId,
@@ -172,7 +174,15 @@ export function useVcsPullAction(scope: SourceControlActionScope) {
   const action = useCallback(async () => {
     const target = resolveScope(scope);
     if (target === null) {
-      return unavailableResult("Git pull is unavailable.");
+      return AsyncResult.failure<never, VcsActionUnavailableError>(
+        Cause.fail(
+          new VcsActionUnavailableError({
+            operation: "pull",
+            environmentId: scope.environmentId,
+            cwd: scope.cwd,
+          }),
+        ),
+      );
     }
     return pull({
       environmentId: target.environmentId,
@@ -211,7 +221,15 @@ export function useGitStackedAction(scope: SourceControlActionScope) {
       onProgress?: (event: GitActionProgressEvent) => void;
     }) => {
       if (resolveScope(scope) === null) {
-        return unavailableResult("Git action is unavailable.");
+        return AsyncResult.failure<never, VcsActionUnavailableError>(
+          Cause.fail(
+            new VcsActionUnavailableError({
+              operation: "run_change_request",
+              environmentId: scope.environmentId,
+              cwd: scope.cwd,
+            }),
+          ),
+        );
       }
       return runStackedAction({
         actionId: input.actionId,
@@ -257,7 +275,15 @@ export function useSourceControlPublishRepositoryAction(scope: SourceControlActi
     }) => {
       const target = resolveScope(scope);
       if (target === null) {
-        return unavailableResult("Repository publishing is unavailable.");
+        return AsyncResult.failure<never, VcsActionUnavailableError>(
+          Cause.fail(
+            new VcsActionUnavailableError({
+              operation: "publish_repository",
+              environmentId: scope.environmentId,
+              cwd: scope.cwd,
+            }),
+          ),
+        );
       }
       return publishRepository({
         environmentId: target.environmentId,
@@ -286,7 +312,15 @@ export function usePreparePullRequestThreadAction(scope: SourceControlActionScop
     async (input: { reference: string; mode: "local" | "worktree"; threadId?: ThreadId }) => {
       const target = resolveScope(scope);
       if (target === null) {
-        return unavailableResult("Pull request thread preparation is unavailable.");
+        return AsyncResult.failure<never, VcsActionUnavailableError>(
+          Cause.fail(
+            new VcsActionUnavailableError({
+              operation: "prepare_pull_request_thread",
+              environmentId: scope.environmentId,
+              cwd: scope.cwd,
+            }),
+          ),
+        );
       }
       return preparePullRequestThread({
         environmentId: target.environmentId,

--- a/packages/client-runtime/src/state/vcsAction.test.ts
+++ b/packages/client-runtime/src/state/vcsAction.test.ts
@@ -64,8 +64,8 @@ function progress<T extends GitActionProgressEvent>(event: T): T {
 }
 
 describe("vcsActionState", () => {
-  it("preserves malformed target keys and their native cause", () => {
-    const key = "not-json";
+  it("preserves malformed target key diagnostics and the native cause without copying the key", () => {
+    const key = "not-json-with-credential=do-not-log";
     let error: unknown;
 
     try {
@@ -75,7 +75,9 @@ describe("vcsActionState", () => {
     }
 
     expect(error).toBeInstanceOf(VcsActionTargetKeyParseError);
-    expect(error).toMatchObject({ key, cause: expect.any(SyntaxError) });
+    expect(error).toMatchObject({ keyLength: key.length, cause: expect.any(SyntaxError) });
+    expect(error).not.toHaveProperty("key");
+    expect((error as Error).message).not.toContain(key);
   });
 
   it("rejects invalid target key shapes", () => {
@@ -294,10 +296,11 @@ describe("vcsActionState", () => {
     }),
   );
 
-  it.effect("retains remote failure context in a distinct error", () =>
+  it.effect("retains structural remote failure context without copying the remote payload", () =>
     Effect.gen(function* () {
       const target = { environmentId, cwd };
       const transportActionId = createVcsActionTransportId(target, actionId);
+      const remoteMessage = "The remote rejected the push with credential=do-not-log.";
       const error = yield* consumeVcsActionProgress(
         Stream.fromIterable<GitActionProgressEvent>([
           {
@@ -306,7 +309,7 @@ describe("vcsActionState", () => {
             cwd,
             kind: "action_failed",
             phase: "push",
-            message: "The remote rejected the push.",
+            message: remoteMessage,
           },
         ]),
         {
@@ -326,11 +329,11 @@ describe("vcsActionState", () => {
         environmentId,
         cwd,
         phase: "push",
-        detail: "The remote rejected the push.",
+        remoteMessageLength: remoteMessage.length,
       });
-      expect(error.message).toBe(
-        "Source control action 'commit_push' failed during push: The remote rejected the push.",
-      );
+      expect(error).not.toHaveProperty("detail");
+      expect(error.message).toBe("Source control action 'commit_push' failed during push.");
+      expect(error.message).not.toContain(remoteMessage);
     }),
   );
 

--- a/packages/client-runtime/src/state/vcsAction.test.ts
+++ b/packages/client-runtime/src/state/vcsAction.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 
@@ -21,12 +22,16 @@ import {
   EMPTY_VCS_ACTION_STATE,
   getVcsActionTargetKey,
   normalizeVcsActionProgressEvent,
+  VcsActionMissingTerminalEventError,
+  VcsActionRemoteFailureError,
+  VcsActionUnavailableError,
 } from "./vcsAction.ts";
 
 const actionId = "action-123";
 const action = "commit_push" as const;
 const cwd = "/repo";
 const environmentId = EnvironmentId.make("environment-1");
+const isVcsActionUnavailableError = Schema.is(VcsActionUnavailableError);
 const result: GitRunStackedActionResult = {
   action,
   branch: {
@@ -254,6 +259,7 @@ describe("vcsActionState", () => {
         target,
         transportActionId,
         actionId,
+        action,
         onProgress: (event) =>
           Effect.sync(() => {
             observed.push(event);
@@ -263,6 +269,84 @@ describe("vcsActionState", () => {
       expect(actual).toEqual(result);
       expect(observed.map((event) => event.actionId)).toEqual([actionId, actionId]);
       expect(observed.map((event) => event.kind)).toEqual(["phase_started", "action_finished"]);
+    }),
+  );
+
+  it.effect("retains remote failure context in a distinct error", () =>
+    Effect.gen(function* () {
+      const target = { environmentId, cwd };
+      const transportActionId = createVcsActionTransportId(target, actionId);
+      const error = yield* consumeVcsActionProgress(
+        Stream.fromIterable<GitActionProgressEvent>([
+          {
+            actionId: transportActionId,
+            action,
+            cwd,
+            kind: "action_failed",
+            phase: "push",
+            message: "The remote rejected the push.",
+          },
+        ]),
+        {
+          target,
+          transportActionId,
+          actionId,
+          action,
+          onProgress: () => Effect.void,
+        },
+      ).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(VcsActionRemoteFailureError);
+      expect(error).toMatchObject({
+        actionId,
+        transportActionId,
+        action,
+        environmentId,
+        cwd,
+        phase: "push",
+        detail: "The remote rejected the push.",
+      });
+      expect(error.message).toBe(
+        "Source control action 'commit_push' failed during push: The remote rejected the push.",
+      );
+    }),
+  );
+
+  it.effect("reports a missing terminal event as a protocol failure", () =>
+    Effect.gen(function* () {
+      const target = { environmentId, cwd };
+      const transportActionId = createVcsActionTransportId(target, actionId);
+      const error = yield* consumeVcsActionProgress(
+        Stream.fromIterable<GitActionProgressEvent>([
+          {
+            actionId: transportActionId,
+            action,
+            cwd,
+            kind: "phase_started",
+            phase: "commit",
+            label: "Committing...",
+          },
+        ]),
+        {
+          target,
+          transportActionId,
+          actionId,
+          action,
+          onProgress: () => Effect.void,
+        },
+      ).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(VcsActionMissingTerminalEventError);
+      expect(error).toMatchObject({
+        actionId,
+        transportActionId,
+        action,
+        environmentId,
+        cwd,
+      });
+      expect(error.message).toBe(
+        "Source control action 'commit_push' ended without a terminal result.",
+      );
     }),
   );
 
@@ -282,6 +366,38 @@ describe("vcsActionState", () => {
     expect(manager.runStackedAction(target)).toBe(manager.runStackedAction({ ...target }));
     expect(manager.runStackedAction(target)).not.toBe(manager.runStackedAction(otherTarget));
     expect(registry.get(manager.stateAtom(target))).toEqual(EMPTY_VCS_ACTION_STATE);
+
+    registry.dispose();
+  });
+
+  it("retains the incomplete target and operation when tracking is unavailable", async () => {
+    const runtime = Atom.runtime(Layer.empty) as unknown as Atom.AtomRuntime<
+      EnvironmentRegistry,
+      never
+    >;
+    const manager = createVcsActionManager(runtime);
+    const registry = AtomRegistry.make();
+    const result = await manager.track(
+      registry,
+      { environmentId, cwd: null },
+      { operation: "pull", label: "Pulling latest changes" },
+      async () => AsyncResult.success(undefined),
+    );
+
+    expect(AsyncResult.isFailure(result)).toBe(true);
+    if (AsyncResult.isFailure(result)) {
+      const error = Cause.squash(result.cause);
+      expect(error).toBeInstanceOf(VcsActionUnavailableError);
+      if (!isVcsActionUnavailableError(error)) {
+        throw error;
+      }
+      expect(error).toMatchObject({
+        operation: "pull",
+        environmentId,
+        cwd: null,
+      });
+      expect(error.message).toBe("Source control operation 'pull' is unavailable.");
+    }
 
     registry.dispose();
   });

--- a/packages/client-runtime/src/state/vcsAction.test.ts
+++ b/packages/client-runtime/src/state/vcsAction.test.ts
@@ -22,8 +22,10 @@ import {
   EMPTY_VCS_ACTION_STATE,
   getVcsActionTargetKey,
   normalizeVcsActionProgressEvent,
+  parseVcsActionTargetKey,
   VcsActionMissingTerminalEventError,
   VcsActionRemoteFailureError,
+  VcsActionTargetKeyParseError,
   VcsActionUnavailableError,
 } from "./vcsAction.ts";
 
@@ -62,6 +64,26 @@ function progress<T extends GitActionProgressEvent>(event: T): T {
 }
 
 describe("vcsActionState", () => {
+  it("preserves malformed target keys and their native cause", () => {
+    const key = "not-json";
+    let error: unknown;
+
+    try {
+      parseVcsActionTargetKey(key);
+    } catch (cause) {
+      error = cause;
+    }
+
+    expect(error).toBeInstanceOf(VcsActionTargetKeyParseError);
+    expect(error).toMatchObject({ key, cause: expect.any(SyntaxError) });
+  });
+
+  it("rejects invalid target key shapes", () => {
+    const key = JSON.stringify([environmentId]);
+
+    expect(() => parseVcsActionTargetKey(key)).toThrowError(VcsActionTargetKeyParseError);
+  });
+
   it("projects phase and hook progress without owning the async operation", () => {
     const initial = beginVcsActionState({
       operation: "run_change_request",

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -1,10 +1,11 @@
 import {
   EnvironmentId,
   type EnvironmentId as EnvironmentIdType,
+  GitActionProgressPhase,
   type GitActionProgressEvent,
   type GitRunStackedActionInput,
   type GitRunStackedActionResult,
-  type GitStackedAction,
+  GitStackedAction,
   WS_METHODS,
 } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
@@ -24,16 +25,18 @@ import {
 } from "./runtime.ts";
 import { vcsCommandScheduler } from "./vcsCommandScheduler.ts";
 
-export type VcsActionOperation =
-  | "refresh_status"
-  | "run_change_request"
-  | "pull"
-  | "switch_ref"
-  | "create_ref"
-  | "create_worktree"
-  | "init"
-  | "publish_repository"
-  | "prepare_pull_request_thread";
+export const VcsActionOperation = Schema.Literals([
+  "refresh_status",
+  "run_change_request",
+  "pull",
+  "switch_ref",
+  "create_ref",
+  "create_worktree",
+  "init",
+  "publish_repository",
+  "prepare_pull_request_thread",
+]);
+export type VcsActionOperation = typeof VcsActionOperation.Type;
 
 export interface VcsActionState {
   readonly isRunning: boolean;
@@ -77,16 +80,54 @@ export interface RunVcsStackedActionInput {
 export class VcsActionUnavailableError extends Schema.TaggedErrorClass<VcsActionUnavailableError>()(
   "VcsActionUnavailableError",
   {
-    message: Schema.String,
+    operation: VcsActionOperation,
+    environmentId: Schema.NullOr(EnvironmentId),
+    cwd: Schema.NullOr(Schema.String),
   },
-) {}
+) {
+  override get message(): string {
+    return `Source control operation '${this.operation.replaceAll("_", " ")}' is unavailable.`;
+  }
+}
 
-export class VcsActionExecutionError extends Schema.TaggedErrorClass<VcsActionExecutionError>()(
-  "VcsActionExecutionError",
+export class VcsActionRemoteFailureError extends Schema.TaggedErrorClass<VcsActionRemoteFailureError>()(
+  "VcsActionRemoteFailureError",
   {
-    message: Schema.String,
+    actionId: Schema.String,
+    transportActionId: Schema.String,
+    action: GitStackedAction,
+    environmentId: EnvironmentId,
+    cwd: Schema.String,
+    phase: Schema.NullOr(GitActionProgressPhase),
+    detail: Schema.String,
   },
-) {}
+) {
+  override get message(): string {
+    const phase = this.phase === null ? "execution" : this.phase;
+    return `Source control action '${this.action}' failed during ${phase}: ${this.detail}`;
+  }
+}
+
+export class VcsActionMissingTerminalEventError extends Schema.TaggedErrorClass<VcsActionMissingTerminalEventError>()(
+  "VcsActionMissingTerminalEventError",
+  {
+    actionId: Schema.String,
+    transportActionId: Schema.String,
+    action: GitStackedAction,
+    environmentId: EnvironmentId,
+    cwd: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Source control action '${this.action}' ended without a terminal result.`;
+  }
+}
+
+export const VcsActionExecutionError = Schema.Union([
+  VcsActionRemoteFailureError,
+  VcsActionMissingTerminalEventError,
+]);
+export type VcsActionExecutionError = typeof VcsActionExecutionError.Type;
 
 export const EMPTY_VCS_ACTION_STATE = Object.freeze<VcsActionState>({
   isRunning: false,
@@ -200,6 +241,7 @@ export function consumeVcsActionProgress<E, R>(
     readonly target: ResolvedVcsActionTarget;
     readonly transportActionId: string;
     readonly actionId: string;
+    readonly action: GitStackedAction;
     readonly onProgress: (event: GitActionProgressEvent) => Effect.Effect<void>;
   },
 ): Effect.Effect<GitRunStackedActionResult, E | VcsActionExecutionError, R> {
@@ -226,15 +268,25 @@ export function consumeVcsActionProgress<E, R>(
           return Effect.succeed(terminalEvent.result);
         }
         if (terminalEvent?.kind === "action_failed") {
-          return Effect.fail(
-            new VcsActionExecutionError({
-              message: terminalEvent.message,
+          return Effect.fail<VcsActionExecutionError>(
+            new VcsActionRemoteFailureError({
+              actionId: input.actionId,
+              transportActionId: input.transportActionId,
+              action: terminalEvent.action,
+              environmentId: input.target.environmentId,
+              cwd: input.target.cwd,
+              phase: terminalEvent.phase,
+              detail: terminalEvent.message,
             }),
           );
         }
-        return Effect.fail(
-          new VcsActionExecutionError({
-            message: "Source control action ended without a result.",
+        return Effect.fail<VcsActionExecutionError>(
+          new VcsActionMissingTerminalEventError({
+            actionId: input.actionId,
+            transportActionId: input.transportActionId,
+            action: input.action,
+            environmentId: input.target.environmentId,
+            cwd: input.target.cwd,
           }),
         );
       }),
@@ -339,18 +391,25 @@ export function applyVcsActionProgressEvent(
 export function createVcsActionManager<R, E>(
   runtime: Atom.AtomRuntime<EnvironmentRegistry | R, E>,
 ) {
-  const unavailableTargetKey = "vcs-action-target:unavailable";
   const runStackedActionCommands = new Map<
     string,
     AtomCommand<RunVcsStackedActionInput, GitRunStackedActionResult, unknown>
   >();
-  const getRunStackedActionCommand = (key: string) => {
-    const existing = runStackedActionCommands.get(key);
+  const getRunStackedActionCommand = (requestedTarget: VcsActionTarget) => {
+    const targetKey = getVcsActionTargetKey(requestedTarget);
+    const commandKey =
+      targetKey ??
+      JSON.stringify([
+        "vcs-action-target:unavailable",
+        requestedTarget.environmentId,
+        requestedTarget.cwd,
+      ]);
+    const existing = runStackedActionCommands.get(commandKey);
     if (existing !== undefined) {
       return existing;
     }
-    const target = key === unavailableTargetKey ? null : parseVcsActionTargetKey(key);
-    const stateAtom = target === null ? EMPTY_VCS_ACTION_ATOM : vcsActionStateAtom(key);
+    const target = targetKey === null ? null : parseVcsActionTargetKey(targetKey);
+    const stateAtom = targetKey === null ? EMPTY_VCS_ACTION_ATOM : vcsActionStateAtom(targetKey);
     const command = createRuntimeCommand<
       EnvironmentRegistry | R,
       E,
@@ -358,14 +417,16 @@ export function createVcsActionManager<R, E>(
       GitRunStackedActionResult,
       unknown
     >(runtime, {
-      label: `vcs-action:run-stacked:${key}`,
+      label: `vcs-action:run-stacked:${commandKey}`,
       scheduler: vcsCommandScheduler,
-      concurrency: { mode: "serial", key: () => key },
+      concurrency: { mode: "serial", key: () => commandKey },
       execute: (input: RunVcsStackedActionInput, registry) => {
         if (target === null) {
           return Effect.fail(
             new VcsActionUnavailableError({
-              message: "Source control action is unavailable.",
+              operation: "run_change_request",
+              environmentId: requestedTarget.environmentId,
+              cwd: requestedTarget.cwd,
             }),
           );
         }
@@ -396,6 +457,7 @@ export function createVcsActionManager<R, E>(
             target,
             transportActionId,
             actionId: input.actionId,
+            action: input.action,
             onProgress: (event) =>
               Effect.sync(() => {
                 const current = registry.get(stateAtom);
@@ -427,7 +489,7 @@ export function createVcsActionManager<R, E>(
         );
       },
     });
-    runStackedActionCommands.set(key, command);
+    runStackedActionCommands.set(commandKey, command);
     return command;
   };
 
@@ -446,10 +508,7 @@ export function createVcsActionManager<R, E>(
 
   return {
     stateAtom: getVcsActionStateAtom,
-    runStackedAction: (target: VcsActionTarget) => {
-      const key = getVcsActionTargetKey(target);
-      return getRunStackedActionCommand(key ?? unavailableTargetKey);
-    },
+    runStackedAction: (target: VcsActionTarget) => getRunStackedActionCommand(target),
     track: async <A, E>(
       registry: AtomRegistry.AtomRegistry,
       target: VcsActionTarget,
@@ -461,7 +520,9 @@ export function createVcsActionManager<R, E>(
         return AsyncResult.failure<never, VcsActionUnavailableError>(
           Cause.fail(
             new VcsActionUnavailableError({
-              message: "Source control action is unavailable.",
+              operation: input.operation,
+              environmentId: target.environmentId,
+              cwd: target.cwd,
             }),
           ),
         );

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -99,12 +99,12 @@ export class VcsActionRemoteFailureError extends Schema.TaggedErrorClass<VcsActi
     environmentId: EnvironmentId,
     cwd: Schema.String,
     phase: Schema.NullOr(GitActionProgressPhase),
-    detail: Schema.String,
+    remoteMessageLength: Schema.Number,
   },
 ) {
   override get message(): string {
     const phase = this.phase === null ? "execution" : this.phase;
-    return `Source control action '${this.action}' failed during ${phase}: ${this.detail}`;
+    return `Source control action '${this.action}' failed during ${phase}.`;
   }
 }
 
@@ -126,12 +126,12 @@ export class VcsActionMissingTerminalEventError extends Schema.TaggedErrorClass<
 export class VcsActionTargetKeyParseError extends Schema.TaggedErrorClass<VcsActionTargetKeyParseError>()(
   "VcsActionTargetKeyParseError",
   {
-    key: Schema.String,
+    keyLength: Schema.Number,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Invalid source control action target key: ${JSON.stringify(this.key)}.`;
+    return `Invalid source control action target key (${this.keyLength} characters).`;
   }
 }
 
@@ -185,7 +185,7 @@ export function parseVcsActionTargetKey(key: string): ResolvedVcsActionTarget {
     const [environmentId, cwd] = decodeVcsActionTargetKey(JSON.parse(key));
     return { environmentId, cwd };
   } catch (cause) {
-    throw new VcsActionTargetKeyParseError({ key, cause });
+    throw new VcsActionTargetKeyParseError({ keyLength: key.length, cause });
   }
 }
 
@@ -292,7 +292,7 @@ export function consumeVcsActionProgress<E, R>(
               environmentId: input.target.environmentId,
               cwd: input.target.cwd,
               phase: terminalEvent.phase,
-              detail: terminalEvent.message,
+              remoteMessageLength: terminalEvent.message.length,
             }),
           );
         }

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -123,6 +123,18 @@ export class VcsActionMissingTerminalEventError extends Schema.TaggedErrorClass<
   }
 }
 
+export class VcsActionTargetKeyParseError extends Schema.TaggedErrorClass<VcsActionTargetKeyParseError>()(
+  "VcsActionTargetKeyParseError",
+  {
+    key: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Invalid source control action target key: ${JSON.stringify(this.key)}.`;
+  }
+}
+
 export const VcsActionExecutionError = Schema.Union([
   VcsActionRemoteFailureError,
   VcsActionMissingTerminalEventError,
@@ -145,6 +157,9 @@ export const EMPTY_VCS_ACTION_STATE = Object.freeze<VcsActionState>({
 
 const nowMs = (): number => DateTime.toEpochMillis(DateTime.nowUnsafe());
 let nextLocalActionId = 0;
+const decodeVcsActionTargetKey = Schema.decodeUnknownSync(
+  Schema.Tuple([EnvironmentId, Schema.String]),
+);
 
 export const vcsActionStateAtom = Atom.family((key: string) => {
   return Atom.make(EMPTY_VCS_ACTION_STATE).pipe(
@@ -165,12 +180,13 @@ export function getVcsActionTargetKey(target: VcsActionTarget): string | null {
   return JSON.stringify([target.environmentId, target.cwd]);
 }
 
-function parseVcsActionTargetKey(key: string): ResolvedVcsActionTarget {
-  const [environmentId, cwd] = JSON.parse(key) as [string, string];
-  return {
-    environmentId: EnvironmentId.make(environmentId),
-    cwd,
-  };
+export function parseVcsActionTargetKey(key: string): ResolvedVcsActionTarget {
+  try {
+    const [environmentId, cwd] = decodeVcsActionTargetKey(JSON.parse(key));
+    return { environmentId, cwd };
+  } catch (cause) {
+    throw new VcsActionTargetKeyParseError({ key, cause });
+  }
 }
 
 export function getVcsActionStateAtom(target: VcsActionTarget) {


### PR DESCRIPTION
## Summary
- replace message-only VCS action failures with structured tagged errors and a schema union
- retain action, logical/transport IDs, environment, repository, phase, and remote detail at the failure boundary
- remove the unavailable-result constructor wrapper and construct target-aware errors directly

## Validation
- `vp test packages/client-runtime/src/state/vcsAction.test.ts` (11 tests)
- `vp check` (passes; 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error types and messages across all VCS action entry points and progress consumption; UI that matched on old string messages may need updates, but behavior for successful paths is unchanged.
> 
> **Overview**
> Replaces ad-hoc string failures for client source-control actions with **Effect Schema tagged errors** that carry operation, target, and action identity instead of copying sensitive remote text into error messages.
> 
> **`VcsActionUnavailableError`** now includes `operation`, `environmentId`, and `cwd` with a derived user-facing message; web hooks in `sourceControlActions.ts` build this inline after removing `unavailableResult`. **`consumeVcsActionProgress`** splits execution failures into **`VcsActionRemoteFailureError`** (phase + `remoteMessageLength` only) and **`VcsActionMissingTerminalEventError`** when the progress stream never terminates; **`VcsActionExecutionError`** is now a union of those two. **`parseVcsActionTargetKey`** is schema-validated and throws **`VcsActionTargetKeyParseError`** with key length and native cause, not the raw key. The stacked-action command cache keys unavailable targets per partial `environmentId`/`cwd` rather than a single shared unavailable key.
> 
> Tests assert diagnostics stay structural and do not embed credentials or full remote payloads in `.message`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa416780644f64bf59facd665dd064f3c849bcb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure VCS action errors with operation, environmentId, and cwd context
> - Replaces free-form message strings in `VcsActionUnavailableError` with structured fields (`operation`, `environmentId`, `cwd`) and a standardized message getter across all VCS action hooks in [sourceControlActions.ts](https://github.com/pingdotgg/t3code/pull/3263/files#diff-59f4f5fdda96a5e9ae75587fcbf1c17a89bc853e2363e842036f087e28b92539).
> - Introduces two new error classes in [vcsAction.ts](https://github.com/pingdotgg/t3code/pull/3263/files#diff-9d82c1bc86fd3b8f1a9707d02b8e59da5adafee765000496e43fcedb95b0e305): `VcsActionRemoteFailureError` (for `action_failed` events, omitting remote message body but recording its length) and `VcsActionMissingTerminalEventError` (for protocol cases with no terminal event).
> - Adds `VcsActionTargetKeyParseError` for invalid target key parsing, reporting only key length to avoid leaking sensitive content.
> - Removes the `unavailableResult` helper and replaces all call sites with direct `AsyncResult.failure` construction using the new structured error shape.
> - Behavioral Change: callers of `consumeVcsActionProgress` and `track()` now receive specific typed error variants instead of a generic error; remote failure messages are no longer forwarded to the client.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa41678.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->