### PR TITLE
[codex] Simplify desktop client settings errors

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -5,6 +5,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 
 import * as DesktopConfig from "../app/DesktopConfig.ts";
@@ -117,11 +118,13 @@ describe("DesktopClientSettings", () => {
         assert.instanceOf(error, DesktopClientSettings.DesktopClientSettingsWriteError);
         assert.equal(error.operation, "replace-settings-file");
         assert.equal(error.path, environment.clientSettingsPath);
-        assert.exists(error.cause);
+        assert.instanceOf(error.cause, PlatformError.PlatformError);
+        assert.isString(error.cause.stack);
         assert.equal(
           error.message,
           `Desktop client settings write failed during replace-settings-file at ${environment.clientSettingsPath}.`,
         );
+        assert.notInclude(error.message, error.cause.message);
       }),
     ),
   );

--- a/apps/desktop/src/settings/DesktopClientSettings.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.ts
@@ -25,7 +25,9 @@ const decodeClientSettingsJsonValue = Schema.decodeEffect(ClientSettingsJson);
 const decodeClientSettingsJson = (raw: string): Effect.Effect<ClientSettings, Schema.SchemaError> =>
   decodeLegacyClientSettingsDocumentJson(raw).pipe(
     Effect.map((document) => document.settings),
-    Effect.catch(() => decodeClientSettingsJsonValue(raw)),
+    Effect.catchTags({
+      SchemaError: () => decodeClientSettingsJsonValue(raw),
+    }),
   );
 const encodeClientSettingsJson = Schema.encodeEffect(ClientSettingsJson);
 
@@ -36,7 +38,6 @@ const DesktopClientSettingsWriteOperation = Schema.Literals([
   "write-temporary-file",
   "replace-settings-file",
 ]);
-type DesktopClientSettingsWriteOperation = typeof DesktopClientSettingsWriteOperation.Type;
 
 export class DesktopClientSettingsWriteError extends Schema.TaggedErrorClass<DesktopClientSettingsWriteError>()(
   "DesktopClientSettingsWriteError",
@@ -50,13 +51,6 @@ export class DesktopClientSettingsWriteError extends Schema.TaggedErrorClass<Des
     return `Desktop client settings write failed during ${this.operation} at ${this.path}.`;
   }
 }
-
-const writeError = (
-  operation: DesktopClientSettingsWriteOperation,
-  path: string,
-  cause: unknown,
-): DesktopClientSettingsWriteError =>
-  new DesktopClientSettingsWriteError({ operation, path, cause });
 
 export class DesktopClientSettings extends Context.Service<
   DesktopClientSettings,
@@ -96,19 +90,45 @@ const writeClientSettings = Effect.fnUntraced(function* (input: {
   const directory = input.path.dirname(input.settingsPath);
   const tempPath = `${input.settingsPath}.${process.pid}.${input.suffix}.tmp`;
   const encoded = yield* encodeClientSettingsJson(input.settings).pipe(
-    Effect.mapError((cause) => writeError("encode-document", input.settingsPath, cause)),
+    Effect.mapError(
+      (cause) =>
+        new DesktopClientSettingsWriteError({
+          operation: "encode-document",
+          path: input.settingsPath,
+          cause,
+        }),
+    ),
   );
-  yield* input.fileSystem
-    .makeDirectory(directory, { recursive: true })
-    .pipe(Effect.mapError((cause) => writeError("create-directory", directory, cause)));
-  yield* input.fileSystem
-    .writeFileString(tempPath, `${encoded}\n`)
-    .pipe(Effect.mapError((cause) => writeError("write-temporary-file", tempPath, cause)));
-  yield* input.fileSystem
-    .rename(tempPath, input.settingsPath)
-    .pipe(
-      Effect.mapError((cause) => writeError("replace-settings-file", input.settingsPath, cause)),
-    );
+  yield* input.fileSystem.makeDirectory(directory, { recursive: true }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new DesktopClientSettingsWriteError({
+          operation: "create-directory",
+          path: directory,
+          cause,
+        }),
+    ),
+  );
+  yield* input.fileSystem.writeFileString(tempPath, `${encoded}\n`).pipe(
+    Effect.mapError(
+      (cause) =>
+        new DesktopClientSettingsWriteError({
+          operation: "write-temporary-file",
+          path: tempPath,
+          cause,
+        }),
+    ),
+  );
+  yield* input.fileSystem.rename(tempPath, input.settingsPath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new DesktopClientSettingsWriteError({
+          operation: "replace-settings-file",
+          path: input.settingsPath,
+          cause,
+        }),
+    ),
+  );
 });
 
 export const make = Effect.gen(function* () {
@@ -124,8 +144,13 @@ export const make = Effect.gen(function* () {
     set: (settings) =>
       crypto.randomUUIDv4.pipe(
         Effect.map((uuid) => uuid.replace(/-/g, "")),
-        Effect.mapError((cause) =>
-          writeError("create-temporary-file-name", environment.clientSettingsPath, cause),
+        Effect.mapError(
+          (cause) =>
+            new DesktopClientSettingsWriteError({
+              operation: "create-temporary-file-name",
+              path: environment.clientSettingsPath,
+              cause,
+            }),
         ),
         Effect.flatMap((suffix) =>
           writeClientSettings({


### PR DESCRIPTION
## Summary
- remove the valueless desktop client settings error constructor wrapper and instantiate structured write errors at each failure boundary
- narrow the legacy settings decode fallback to the exact SchemaError tag with catchTags
- retain operation, path, and original platform cause while keeping messages derived only from structural attributes
- strengthen focused coverage for the platform-error type, stack, and stable message

## Validation
- vp test apps/desktop/src/settings/DesktopClientSettings.test.ts
- vp check (0 errors; 20 pre-existing unrelated warnings)
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop settings I/O and parsing behavior; no auth or shared API surface changes.
> 
> **Overview**
> Desktop client settings **write failures** now build `DesktopClientSettingsWriteError` inline at each step (encode, mkdir, temp write, rename, UUID) instead of a shared `writeError` helper, while keeping messages derived only from `operation` and `path`.
> 
> **Decode path:** `decodeClientSettingsJson` uses `catchTags` so the legacy-document → direct-settings fallback runs only on `SchemaError`, not on every failure.
> 
> **Tests** expect write errors to carry a `PlatformError` cause (with stack) and a stable top-level message that does not embed the cause text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9220a47ad1e2cdc92d9f27700a2ae9b88cce28e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop client settings errors to preserve original cause and restrict fallback decoding
> - `decodeClientSettingsJson` now only falls back to lenient decoding on `SchemaError`; other errors propagate instead of incorrectly triggering the fallback.
> - `DesktopClientSettingsWriteError` construction in `writeClientSettings` and `make` now passes through the original cause (e.g., `PlatformError` with stack) instead of a generic unknown.
> - Removes the `writeError` helper and `DesktopClientSettingsWriteOperation` type alias in favor of inline construction at each error site.
> - Tests updated to assert that the cause is a `PlatformError` with a stack, and that composed error messages exclude the cause message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9220a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->