### PR TITLE
[codex] Structure desktop network access errors

### DIFF
--- a/apps/web/src/state/desktopNetworkAccess.test.ts
+++ b/apps/web/src/state/desktopNetworkAccess.test.ts
@@ -1,9 +1,15 @@
 import type { AdvertisedEndpoint, DesktopServerExposureState } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Schema from "effect/Schema";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { createDesktopNetworkAccessStateAtom } from "./desktopNetworkAccess";
+import {
+  createDesktopNetworkAccessStateAtom,
+  DesktopNetworkAccessLoadError,
+  DesktopNetworkAccessUnavailableError,
+} from "./desktopNetworkAccess";
 
 const serverExposureState: DesktopServerExposureState = {
   advertisedHost: "192.168.1.10",
@@ -14,6 +20,7 @@ const serverExposureState: DesktopServerExposureState = {
 };
 
 const advertisedEndpoints: ReadonlyArray<AdvertisedEndpoint> = [];
+const isDesktopNetworkAccessLoadError = Schema.is(DesktopNetworkAccessLoadError);
 
 describe("desktopNetworkAccessState", () => {
   it("retains the loaded snapshot when the settings screen remounts", async () => {
@@ -45,6 +52,59 @@ describe("desktopNetworkAccessState", () => {
     expect(getAdvertisedEndpoints).toHaveBeenCalledTimes(1);
 
     remount();
+    registry.dispose();
+  });
+
+  it("reports an unavailable desktop bridge without inventing a cause", async () => {
+    const atom = createDesktopNetworkAccessStateAtom(() => undefined);
+    const registry = AtomRegistry.make();
+    registry.mount(atom);
+
+    await vi.waitFor(() => {
+      expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
+    });
+    const result = registry.get(atom);
+    if (!AsyncResult.isFailure(result)) {
+      throw new Error("Expected desktop network access to fail");
+    }
+    const error = Cause.squash(result.cause);
+
+    expect(error).toBeInstanceOf(DesktopNetworkAccessUnavailableError);
+    expect(error).toMatchObject({
+      _tag: "DesktopNetworkAccessUnavailableError",
+      message: "Desktop network access is unavailable.",
+    });
+
+    registry.dispose();
+  });
+
+  it("retains the failing bridge operation and cause", async () => {
+    const cause = new Error("native bridge rejected");
+    const atom = createDesktopNetworkAccessStateAtom(() => ({
+      getAdvertisedEndpoints: () => Promise.reject(cause),
+      getServerExposureState: () => Promise.resolve(serverExposureState),
+    }));
+    const registry = AtomRegistry.make();
+    registry.mount(atom);
+
+    await vi.waitFor(() => {
+      expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
+    });
+    const result = registry.get(atom);
+    if (!AsyncResult.isFailure(result)) {
+      throw new Error("Expected desktop network access to fail");
+    }
+    const error = Cause.squash(result.cause);
+    if (!isDesktopNetworkAccessLoadError(error)) {
+      throw error;
+    }
+
+    expect(error).toMatchObject({
+      operation: "get-advertised-endpoints",
+      message: "Desktop network access operation 'get advertised endpoints' failed.",
+    });
+    expect(error.cause).toBe(cause);
+
     registry.dispose();
   });
 });

--- a/apps/web/src/state/desktopNetworkAccess.ts
+++ b/apps/web/src/state/desktopNetworkAccess.ts
@@ -21,13 +21,32 @@ export interface DesktopNetworkAccessSnapshot {
   readonly serverExposureState: DesktopServerExposureState;
 }
 
-class DesktopNetworkAccessError extends Schema.TaggedErrorClass<DesktopNetworkAccessError>()(
-  "DesktopNetworkAccessError",
+export class DesktopNetworkAccessUnavailableError extends Schema.TaggedErrorClass<DesktopNetworkAccessUnavailableError>()(
+  "DesktopNetworkAccessUnavailableError",
+  {},
+) {
+  override get message(): string {
+    return "Desktop network access is unavailable.";
+  }
+}
+
+export class DesktopNetworkAccessLoadError extends Schema.TaggedErrorClass<DesktopNetworkAccessLoadError>()(
+  "DesktopNetworkAccessLoadError",
   {
-    message: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
+    operation: Schema.Literals(["get-advertised-endpoints", "get-server-exposure-state"]),
+    cause: Schema.Defect(),
   },
-) {}
+) {
+  override get message(): string {
+    return `Desktop network access operation '${this.operation.replaceAll("-", " ")}' failed.`;
+  }
+}
+
+export const DesktopNetworkAccessError = Schema.Union([
+  DesktopNetworkAccessUnavailableError,
+  DesktopNetworkAccessLoadError,
+]);
+export type DesktopNetworkAccessError = typeof DesktopNetworkAccessError.Type;
 
 function getDesktopNetworkAccessBridge(): DesktopNetworkAccessBridge | undefined {
   return typeof window === "undefined" ? undefined : window.desktopBridge;
@@ -39,25 +58,30 @@ export function createDesktopNetworkAccessStateAtom(
   const loadDesktopNetworkAccess = Effect.fn("loadDesktopNetworkAccess")(function* () {
     const bridge = getBridge();
     if (!bridge) {
-      return yield* new DesktopNetworkAccessError({
-        message: "Desktop network access is unavailable.",
-      });
+      return yield* new DesktopNetworkAccessUnavailableError();
     }
-    return yield* Effect.tryPromise({
-      try: async (): Promise<DesktopNetworkAccessSnapshot> => {
-        const [serverExposureState, advertisedEndpoints] = await Promise.all([
-          bridge.getServerExposureState(),
-          bridge.getAdvertisedEndpoints(),
-        ]);
-        return { advertisedEndpoints, serverExposureState };
-      },
-      catch: (cause) =>
-        new DesktopNetworkAccessError({
-          message:
-            cause instanceof Error ? cause.message : "Failed to load desktop network access.",
-          cause,
+    const { serverExposureState, advertisedEndpoints } = yield* Effect.all(
+      {
+        serverExposureState: Effect.tryPromise({
+          try: () => bridge.getServerExposureState(),
+          catch: (cause) =>
+            new DesktopNetworkAccessLoadError({
+              operation: "get-server-exposure-state",
+              cause,
+            }),
         }),
-    });
+        advertisedEndpoints: Effect.tryPromise({
+          try: () => bridge.getAdvertisedEndpoints(),
+          catch: (cause) =>
+            new DesktopNetworkAccessLoadError({
+              operation: "get-advertised-endpoints",
+              cause,
+            }),
+        }),
+      },
+      { concurrency: "unbounded" },
+    );
+    return { advertisedEndpoints, serverExposureState };
   });
 
   return Atom.make(loadDesktopNetworkAccess()).pipe(


### PR DESCRIPTION
## Summary
- distinguish a missing desktop bridge from native bridge request failures
- retain the exact bridge operation and original cause instead of using cause text as the error message
- execute the two bridge reads concurrently while mapping each failure at its own boundary

## Validation
- `vp test apps/web/src/state/desktopNetworkAccess.test.ts` (3 tests)
- `vp check` (passes; 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to desktop network access state loading and error typing; behavior for settings consumers is clearer failures with no auth or data-model changes.
> 
> **Overview**
> Replaces the single `DesktopNetworkAccessError` with **two tagged errors**: `DesktopNetworkAccessUnavailableError` when `window.desktopBridge` is missing, and `DesktopNetworkAccessLoadError` when a native bridge call fails—each load error records the **operation** (`get-advertised-endpoints` / `get-server-exposure-state`) and the **original `cause`**, with stable messages instead of copying the underlying error text.
> 
> The loader now runs **`getServerExposureState` and `getAdvertisedEndpoints` in parallel** via `Effect.all`, mapping failures at each call’s boundary. Tests cover unavailable-bridge failures (no fabricated cause) and load failures that preserve operation and cause identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b444300af02947b61b42d999fe797f3637894dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure desktop network access errors into typed classes with operation metadata
> - Introduces `DesktopNetworkAccessUnavailableError` (emitted when the desktop bridge is absent) and `DesktopNetworkAccessLoadError` (emitted when a bridge sub-operation rejects, carrying the failing operation name and original cause).
> - Replaces the prior single `tryPromise`/`Promise.all` block in `createDesktopNetworkAccessStateAtom` with `Effect.all` running both sub-operations concurrently, each wrapped in its own `Effect.tryPromise`.
> - Adds tests covering the unavailable-bridge path and per-operation failure with preserved cause, using `Schema.is` predicates to validate the structured error types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b444300.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->