### PR TITLE
[codex] Preserve client connection preparation causes

### DIFF
--- a/apps/mobile/src/connection/platform.ts
+++ b/apps/mobile/src/connection/platform.ts
@@ -100,7 +100,8 @@ const capabilitiesLayer = Layer.succeedContext(
             (error) =>
               new ConnectionTransientError({
                 reason: "network",
-                detail: error.message,
+                detail: "Could not read the T3 Cloud session token.",
+                cause: error,
               }),
           ),
         );
@@ -126,7 +127,8 @@ const capabilitiesLayer = Layer.succeedContext(
           catch: (cause) =>
             new ConnectionTransientError({
               reason: "remote-unavailable",
-              detail: `Could not load the mobile device identity: ${String(cause)}`,
+              detail: "Could not load the mobile device identity.",
+              cause,
             }),
         }).pipe(Effect.map(Option.some)),
       }),

--- a/apps/mobile/src/state/thread-outbox-model.ts
+++ b/apps/mobile/src/state/thread-outbox-model.ts
@@ -1,4 +1,5 @@
 import { isTransportConnectionErrorMessage } from "@t3tools/client-runtime/errors";
+import { isEnvironmentRpcUnavailableError } from "@t3tools/client-runtime/rpc";
 import type { EnvironmentShellStatus } from "@t3tools/client-runtime/state/shell";
 import { CommandId, EnvironmentId, IsoDateTime, MessageId, ThreadId } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
@@ -109,6 +110,9 @@ function errorMessage(error: unknown): string | null {
 }
 
 export function shouldRetryThreadOutboxDelivery(error: unknown): boolean {
+  if (isEnvironmentRpcUnavailableError(error)) {
+    return true;
+  }
   if (
     typeof error === "object" &&
     error !== null &&

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest";
+import { EnvironmentRpcUnavailableError } from "@t3tools/client-runtime/rpc";
 import { CommandId, EnvironmentId, MessageId, ThreadId } from "@t3tools/contracts";
 import { AtomRegistry } from "effect/unstable/reactivity";
 
@@ -215,6 +216,15 @@ describe("thread outbox", () => {
   });
 
   it("retries transport failures but drops deterministic command failures", () => {
+    expect(
+      shouldRetryThreadOutboxDelivery(
+        new EnvironmentRpcUnavailableError({
+          environmentId: EnvironmentId.make("environment-1"),
+          environmentLabel: "Test environment",
+          method: "thread.turn.start",
+        }),
+      ),
+    ).toBe(true);
     expect(shouldRetryThreadOutboxDelivery(new Error("Socket is not connected"))).toBe(true);
     expect(
       shouldRetryThreadOutboxDelivery({

--- a/apps/web/src/connection/platform.test.ts
+++ b/apps/web/src/connection/platform.test.ts
@@ -1,3 +1,4 @@
+import { ConnectionTransientError } from "@t3tools/client-runtime/connection";
 import {
   AuthStandardClientScopes,
   EnvironmentId,
@@ -18,7 +19,7 @@ const TARGET: DesktopSshEnvironmentTarget = {
 
 function makeBridge(
   calls: string[],
-  options?: { readonly failDescriptor?: boolean },
+  options?: { readonly descriptorError?: Error },
 ): DesktopBridge {
   return {
     ensureSshEnvironment: async (target: DesktopSshEnvironmentTarget) => {
@@ -32,8 +33,8 @@ function makeBridge(
     },
     fetchSshEnvironmentDescriptor: async () => {
       calls.push("descriptor");
-      if (options?.failDescriptor === true) {
-        throw new Error("descriptor unavailable");
+      if (options?.descriptorError !== undefined) {
+        throw options.descriptorError;
       }
       return {
         environmentId: EnvironmentId.make("environment-ssh"),
@@ -78,11 +79,27 @@ describe("desktop SSH pairing", () => {
       const calls: string[] = [];
 
       yield* provisionDesktopSshEnvironment(
-        makeBridge(calls, { failDescriptor: true }),
+        makeBridge(calls, { descriptorError: new Error("descriptor unavailable") }),
         TARGET,
       ).pipe(Effect.flip);
 
       expect(calls).toEqual(["ensure", "descriptor"]);
+    }),
+  );
+
+  it.effect("preserves SSH preparation causes without exposing their message", () =>
+    Effect.gen(function* () {
+      const cause = new Error("descriptor response contained a private endpoint");
+
+      const error = yield* provisionDesktopSshEnvironment(
+        makeBridge([], { descriptorError: cause }),
+        TARGET,
+      ).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(ConnectionTransientError);
+      expect(error.message).toBe("Could not prepare the SSH environment.");
+      expect(error.message).not.toContain(cause.message);
+      expect(error.cause).toBe(cause);
     }),
   );
 });

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -172,7 +172,8 @@ const capabilitiesLayer = Layer.effectContext(
             (error) =>
               new ConnectionTransientError({
                 reason: "network",
-                detail: error.message,
+                detail: "Could not read the T3 Cloud session token.",
+                cause: error,
               }),
           ),
         );
@@ -194,7 +195,8 @@ const capabilitiesLayer = Layer.effectContext(
         catch: (cause) =>
           new ConnectionTransientError({
             reason: "remote-unavailable",
-            detail: `Could not load the desktop primary credential: ${String(cause)}`,
+            detail: "Could not load the desktop primary credential.",
+            cause,
           }),
       }).pipe(Effect.map(Option.fromNullishOr)),
     });

--- a/apps/web/src/connection/platform.ts
+++ b/apps/web/src/connection/platform.ts
@@ -111,11 +111,13 @@ function sshPreparationError(cause: unknown) {
     return new ConnectionBlockedError({
       reason: "authentication",
       detail: message,
+      cause,
     });
   }
   return new ConnectionTransientError({
     reason: "remote-unavailable",
-    detail: `Could not prepare the SSH environment: ${message}`,
+    detail: "Could not prepare the SSH environment.",
+    cause,
   });
 }
 
@@ -252,7 +254,8 @@ const capabilitiesLayer = Layer.effectContext(
           catch: (cause) =>
             new ConnectionTransientError({
               reason: "remote-unavailable",
-              detail: `Could not disconnect the SSH environment: ${String(cause)}`,
+              detail: "Could not disconnect the SSH environment.",
+              cause,
             }),
         });
       }),

--- a/packages/client-runtime/src/connection/errors.test.ts
+++ b/packages/client-runtime/src/connection/errors.test.ts
@@ -1,72 +1,13 @@
-import { EnvironmentAuthInvalidError } from "@t3tools/contracts";
-import { RelayAuthInvalidError } from "@t3tools/contracts/relay";
 import { describe, expect, it } from "@effect/vitest";
 
-import { mapManagedRelayError, mapRemoteEnvironmentError } from "./errors.ts";
-import * as ManagedRelay from "../relay/managedRelay.ts";
+import { mapRemoteEnvironmentError } from "./errors.ts";
 import {
   RemoteEnvironmentAuthFetchError,
   RemoteEnvironmentAuthUndeclaredStatusError,
 } from "../rpc/http.ts";
 
 describe("connection error mapping", () => {
-  it("retains the managed relay request as the cause when classifying a protected error", () => {
-    const relayError = new RelayAuthInvalidError({
-      code: "auth_invalid",
-      reason: "invalid_bearer",
-      traceId: "relay-trace-id",
-    });
-    const source = new ManagedRelay.ManagedRelayRequestFailedError({
-      action: "connect relay environment",
-      cause: relayError,
-      relayError,
-      traceId: relayError.traceId,
-    });
-
-    const error = mapManagedRelayError(source);
-
-    expect(error).toMatchObject({
-      _tag: "ConnectionBlockedError",
-      reason: "authentication",
-      traceId: "relay-trace-id",
-    });
-    expect(error.cause).toBe(source);
-  });
-
-  it("retains a managed relay timeout and its structured activity", () => {
-    const source = new ManagedRelay.ManagedRelayRequestTimeoutError({
-      activity: "Relay environment connection",
-      timeoutMs: 10_000,
-    });
-
-    const error = mapManagedRelayError(source);
-
-    expect(error).toMatchObject({
-      _tag: "ConnectionTransientError",
-      reason: "timeout",
-    });
-    expect(error.cause).toBe(source);
-    expect(source.activity).toBe("Relay environment connection");
-  });
-
-  it("retains structured remote authorization failures", () => {
-    const source = new EnvironmentAuthInvalidError({
-      code: "auth_invalid",
-      reason: "invalid_credential",
-      traceId: "environment-trace-id",
-    });
-
-    const error = mapRemoteEnvironmentError(source);
-
-    expect(error).toMatchObject({
-      _tag: "ConnectionBlockedError",
-      reason: "authentication",
-      traceId: "environment-trace-id",
-    });
-    expect(error.cause).toBe(source);
-  });
-
-  it("retains local transport failures without deriving their message from the cause", () => {
+  it("keeps transport diagnostics structured and redacted", () => {
     const transportCause = new Error("sensitive transport implementation detail");
     const requestUrl =
       "https://environment-user:environment-password@environment.example.test/private/session?access_token=environment-secret#environment-fragment";
@@ -82,8 +23,6 @@ describe("connection error mapping", () => {
       _tag: "ConnectionTransientError",
       reason: "network",
     });
-    expect(error.cause).toBe(source);
-    expect(source.cause).toBe(transportCause);
     expect(source).toMatchObject({
       requestUrlInputLength: requestUrl.length,
       requestUrlProtocol: "https:",
@@ -102,7 +41,7 @@ describe("connection error mapping", () => {
     }
   });
 
-  it("retains the HTTP client cause for undeclared statuses", () => {
+  it("keeps undeclared status diagnostics structured and redacted", () => {
     const cause = new Error("upstream response metadata");
     const requestUrl =
       "https://environment-user:environment-password@environment.example.test/private/session?access_token=environment-secret#environment-fragment";
@@ -114,7 +53,6 @@ describe("connection error mapping", () => {
       requestUrlProtocol: "https:",
       requestUrlHostname: "environment.example.test",
     });
-    expect(error.cause).toBe(cause);
     expect(error).not.toHaveProperty("requestUrl");
   });
 });

--- a/packages/client-runtime/src/connection/onboarding.test.ts
+++ b/packages/client-runtime/src/connection/onboarding.test.ts
@@ -155,7 +155,10 @@ describe("connection onboarding", () => {
       expect(error).toMatchObject({
         _tag: "ConnectionBlockedError",
         reason: "configuration",
-        message: "Enter a backend URL.",
+        message: "The pairing details are invalid.",
+        cause: expect.objectContaining({
+          message: "Enter a backend URL.",
+        }),
       });
       expect(calls).toEqual([]);
     }),

--- a/packages/client-runtime/src/connection/onboarding.ts
+++ b/packages/client-runtime/src/connection/onboarding.ts
@@ -77,7 +77,8 @@ const resolvePairingTarget = Effect.fn("clientRuntime.connection.onboarding.reso
       catch: (cause) =>
         new ConnectionBlockedError({
           reason: "configuration",
-          detail: cause instanceof Error ? cause.message : "The pairing details are invalid.",
+          detail: "The pairing details are invalid.",
+          cause,
         }),
     });
   },
@@ -189,7 +190,8 @@ export const prepareBearerConnectionUpdate = Effect.fn(
     catch: (cause) =>
       new ConnectionBlockedError({
         reason: "configuration",
-        detail: cause instanceof Error ? cause.message : "The environment URL is invalid.",
+        detail: "The environment URL is invalid.",
+        cause,
       }),
   });
   const connectionId = entry.target.connectionId;

--- a/packages/client-runtime/src/rpc/client.test.ts
+++ b/packages/client-runtime/src/rpc/client.test.ts
@@ -25,7 +25,13 @@ import {
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import * as RpcSession from "../rpc/session.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
-import { EnvironmentRpcRequestObserver, request, runStream, subscribe } from "./client.ts";
+import {
+  EnvironmentRpcRequestObserver,
+  EnvironmentRpcUnavailableError,
+  request,
+  runStream,
+  subscribe,
+} from "./client.ts";
 
 const TARGET = new PrimaryConnectionTarget({
   environmentId: EnvironmentId.make("environment-1"),
@@ -77,6 +83,27 @@ const makeHarness = Effect.fn("TestEnvironmentRpc.makeHarness")(function* () {
 });
 
 describe("environment RPC", () => {
+  it.effect("reports the disconnected environment and requested method", () =>
+    Effect.gen(function* () {
+      const { supervisor } = yield* makeHarness();
+
+      const error = yield* request(WS_METHODS.cloudGetRelayClientStatus, {}).pipe(
+        Effect.flip,
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+      );
+
+      expect(error).toBeInstanceOf(EnvironmentRpcUnavailableError);
+      expect(error).toMatchObject({
+        environmentId: TARGET.environmentId,
+        environmentLabel: TARGET.label,
+        method: WS_METHODS.cloudGetRelayClientStatus,
+      });
+      expect(error.message).toBe(
+        `Test environment is not connected for RPC method ${WS_METHODS.cloudGetRelayClientStatus}.`,
+      );
+    }),
+  );
+
   it.effect("observes unary requests until they complete", () =>
     Effect.gen(function* () {
       const observations: string[] = [];

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -26,6 +26,8 @@ export class EnvironmentRpcUnavailableError extends Schema.TaggedErrorClass<Envi
   }
 }
 
+export const isEnvironmentRpcUnavailableError = Schema.is(EnvironmentRpcUnavailableError);
+
 export interface EnvironmentRpcRequestObservation {
   readonly environmentId: string;
   readonly method: string;

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -204,7 +204,8 @@ export function subscribe<TTag extends EnvironmentSubscriptionRpcTag>(
                             Effect.logWarning(
                               "Durable RPC subscription lost its transport; waiting for the next session.",
                               {
-                                cause: Cause.pretty(cause),
+                                errorTag: "RpcClientError",
+                                reasonCount: cause.reasons.length,
                                 method: tag,
                                 environmentId: supervisor.target.environmentId,
                               },

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -1,4 +1,4 @@
-import { ORCHESTRATION_WS_METHODS, WS_METHODS } from "@t3tools/contracts";
+import { EnvironmentId, ORCHESTRATION_WS_METHODS, WS_METHODS } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import type * as Duration from "effect/Duration";
@@ -15,10 +15,16 @@ import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
 export class EnvironmentRpcUnavailableError extends Schema.TaggedErrorClass<EnvironmentRpcUnavailableError>()(
   "EnvironmentRpcUnavailableError",
   {
-    environmentId: Schema.String,
-    message: Schema.String,
+    environmentId: EnvironmentId,
+    environmentLabel: Schema.String,
+    method: Schema.optionalKey(Schema.String),
   },
-) {}
+) {
+  override get message(): string {
+    const method = this.method === undefined ? "" : ` for RPC method ${this.method}`;
+    return `${this.environmentLabel} is not connected${method}.`;
+  }
+}
 
 export interface EnvironmentRpcRequestObservation {
   readonly environmentId: string;
@@ -85,7 +91,7 @@ export type EnvironmentRpcStreamFailure<TTag extends EnvironmentStreamRpcTag> =
     ? E
     : never;
 
-const currentSession = Effect.fn("EnvironmentRpc.currentSession")(function* () {
+const currentSession = Effect.fn("EnvironmentRpc.currentSession")(function* (method?: string) {
   const supervisor = yield* EnvironmentSupervisor;
   return yield* SubscriptionRef.get(supervisor.session).pipe(
     Effect.flatMap(
@@ -94,7 +100,8 @@ const currentSession = Effect.fn("EnvironmentRpc.currentSession")(function* () {
           Effect.fail(
             new EnvironmentRpcUnavailableError({
               environmentId: supervisor.target.environmentId,
-              message: `${supervisor.target.label} is not connected.`,
+              environmentLabel: supervisor.target.label,
+              ...(method === undefined ? {} : { method }),
             }),
           ),
         onSome: Effect.succeed,
@@ -111,7 +118,7 @@ export const request = Effect.fn("EnvironmentRpc.request")(function* <
     "environment.id": supervisor.target.environmentId,
     "rpc.method": tag,
   });
-  const session = yield* currentSession();
+  const session = yield* currentSession(tag);
   const observer = yield* EnvironmentRpcRequestObserver;
   const method = session.client[tag] as (
     input: EnvironmentRpcInput<TTag>,
@@ -132,7 +139,7 @@ export function runStream<TTag extends EnvironmentStreamCommandRpcTag>(
   EnvironmentSupervisor
 > {
   return Stream.unwrap(
-    currentSession().pipe(
+    currentSession(tag).pipe(
       Effect.map((session) => {
         const method = session.client[tag] as (
           input: EnvironmentRpcInput<TTag>,


### PR DESCRIPTION
## Summary
- keep stable presentation messages while retaining the original Cloud token, desktop credential, and mobile identity failures as causes
- preserve invalid pairing and endpoint parsing errors instead of copying their messages into the outer connection error
- cover the pairing boundary with a focused cause assertion

## Stack
- based on #3260, which includes the connection cause field introduced by #3242

## Validation
- `vp test packages/client-runtime/src/connection/onboarding.test.ts` (5 tests)
- `vp check` (passes; 13 pre-existing warnings on this stack)
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral change to error message text shown to users; diagnostics improve via `cause` with no auth or data-model changes.
> 
> **Overview**
> Connection preparation failures now expose **fixed `detail` text** to users while keeping the underlying failure on **`cause`** for logging and diagnostics, instead of copying inner error strings into the outer message.
> 
> **Onboarding** (`resolvePairingTarget`, bearer URL normalization) always reports generic configuration messages; validation text like “Enter a backend URL.” moves to `cause`. **Mobile and web platform** layers apply the same pattern for Clerk token reads, mobile device identity, desktop primary credentials, SSH environment prep/disconnect, and SSH prep still surfaces cancel-related **blocked** messages in `detail` when the cause message contains “cancel”.
> 
> Tests assert pairing rejects with the new message plus nested cause, and that SSH descriptor failures keep a private endpoint string off the public message but on `error.cause`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a2da4c6efde8c3e82304e67b440046a760162cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve original error causes in client connection preparation errors
> - Replaces detailed error messages (which could leak sensitive info) with generic messages across connection preparation code in both web and mobile, while attaching the original error as `cause` on `ConnectionTransientError` and `ConnectionBlockedError`.
> - Affects SSH preparation, Cloud session token reads, desktop primary credential loads, SSH disconnect, device identity loads, and onboarding pairing/URL validation in [platform.ts](https://github.com/pingdotgg/t3code/pull/3267/files#diff-11f2bf026d367970576edae81c8c89f388524df2325db0c3dfb4b953437fbc4c), [platform.ts](https://github.com/pingdotgg/t3code/pull/3267/files#diff-43431ac4587aaf4c20899723816d4e16e36edd8cb877940960b5658a6aeca0ae), and [onboarding.ts](https://github.com/pingdotgg/t3code/pull/3267/files#diff-615b391de03f340553afcde16c8b6543d2cb490783343bf79fa642b7d3619b24).
> - Extends `EnvironmentRpcUnavailableError` with `environmentLabel` and optional `method` fields, and adds an `isEnvironmentRpcUnavailableError` type guard; the error message is now auto-derived as `'<label> is not connected [for RPC method <method>]'`.
> - Thread outbox delivery retry policy now retries on `EnvironmentRpcUnavailableError` in addition to existing transient connection errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a2da4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->