### PR TITLE
[codex] Enrich process runner errors

### DIFF
--- a/apps/server/src/environment/ServerEnvironmentLabel.test.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.test.ts
@@ -138,7 +138,7 @@ describe("resolveServerEnvironmentLabel", () => {
         Effect.fail(
           new ProcessRunner.ProcessSpawnError({
             command: "scutil",
-            args: ["--get", "ComputerName"],
+            argumentCount: 2,
             cause: new Error("spawn scutil ENOENT"),
           }),
         ),

--- a/apps/server/src/processRunner.test.ts
+++ b/apps/server/src/processRunner.test.ts
@@ -222,6 +222,27 @@ describe("runProcess", () => {
     }),
   );
 
+  it.effect("accepts output at the byte limit followed by an empty chunk", () =>
+    Effect.gen(function* () {
+      const output = new TextEncoder().encode("exactly");
+      const spawner = makeSpawner(() =>
+        Effect.succeed(
+          makeHandle({
+            stdout: Stream.make(output, new Uint8Array()),
+          }),
+        ),
+      );
+
+      const result = yield* runWith(spawner)({
+        command: "fake",
+        args: ["exact-limit"],
+        maxOutputBytes: output.byteLength,
+      });
+
+      expect(result.stdout).toBe("exactly");
+    }),
+  );
+
   it.effect("fails fast on output limit before timeout for long-running output", () =>
     Effect.gen(function* () {
       const textChunk = "x".repeat(64);

--- a/apps/server/src/processRunner.test.ts
+++ b/apps/server/src/processRunner.test.ts
@@ -4,6 +4,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { TestClock } from "effect/testing";
@@ -55,7 +56,9 @@ function makeHandle(input: {
 }
 
 function makeSpawner(
-  f: (command: ChildProcessCommand) => Effect.Effect<ChildProcessSpawner.ChildProcessHandle>,
+  f: (
+    command: ChildProcessCommand,
+  ) => Effect.Effect<ChildProcessSpawner.ChildProcessHandle, PlatformError.PlatformError>,
 ) {
   return ChildProcessSpawner.make((command) => f(asChildProcessCommand(command)));
 }
@@ -159,6 +162,41 @@ describe("runProcess", () => {
     );
   });
 
+  it.effect("preserves resolved spawn context and cause", () =>
+    Effect.gen(function* () {
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "ChildProcessSpawner",
+        method: "spawn",
+        pathOrDescriptor: "/actual/fake",
+      });
+      const spawner = makeSpawner(() => Effect.fail(cause));
+
+      const error = yield* runWith(spawner)({
+        command: "fake",
+        args: ["--flag"],
+        cwd: "/logical",
+        spawnCwd: "/actual",
+      }).pipe(Effect.flip);
+
+      expect(error._tag).toBe("ProcessSpawnError");
+      if (error._tag !== "ProcessSpawnError") {
+        return expect.fail("Expected ProcessSpawnError");
+      }
+      expect(error).toMatchObject({
+        command: "fake",
+        args: ["--flag"],
+        cwd: "/logical",
+        spawnCwd: "/actual",
+        resolvedCommand: "fake",
+        resolvedArgs: ["--flag"],
+        shell: false,
+      });
+      expect(error.cause).toBe(cause);
+      expect(error.message).toBe("Failed to spawn process 'fake --flag' in '/actual'");
+    }),
+  );
+
   it.effect("fails when output exceeds max buffer in default mode", () =>
     Effect.gen(function* () {
       const spawner = makeSpawner(() => Effect.succeed(makeHandle({ stdout: "x".repeat(2048) })));
@@ -169,7 +207,18 @@ describe("runProcess", () => {
         maxOutputBytes: 128,
       }).pipe(Effect.flip);
 
-      expect(error).toBeInstanceOf(ProcessRunner.ProcessOutputLimitError);
+      expect(error._tag).toBe("ProcessOutputLimitError");
+      if (error._tag !== "ProcessOutputLimitError") {
+        return expect.fail("Expected ProcessOutputLimitError");
+      }
+      expect(error).toMatchObject({
+        stream: "stdout",
+        maxBytes: 128,
+        observedBytes: 2048,
+      });
+      expect(error.message).toBe(
+        "Process 'fake stdout-bytes 2048' stdout produced 2048 bytes, exceeding the 128 byte limit",
+      );
     }),
   );
 
@@ -272,6 +321,8 @@ describe("runProcess", () => {
       const errorFiber = yield* runWith(spawner)({
         command: "fake",
         args: ["sleep"],
+        cwd: "/logical",
+        spawnCwd: "/actual",
         timeout: "50 millis",
       }).pipe(Effect.flip, Effect.forkScoped);
 
@@ -279,7 +330,18 @@ describe("runProcess", () => {
       yield* TestClock.adjust(Duration.millis(50));
       const error = yield* Fiber.join(errorFiber);
 
-      expect(error).toBeInstanceOf(ProcessRunner.ProcessTimeoutError);
+      expect(error._tag).toBe("ProcessTimeoutError");
+      if (error._tag !== "ProcessTimeoutError") {
+        return expect.fail("Expected ProcessTimeoutError");
+      }
+      expect(error).toMatchObject({
+        command: "fake",
+        args: ["sleep"],
+        cwd: "/logical",
+        spawnCwd: "/actual",
+        timeoutMs: 50,
+      });
+      expect(error.message).toBe("Process 'fake sleep' in '/actual' timed out after 50ms");
     }),
   );
 

--- a/apps/server/src/processRunner.test.ts
+++ b/apps/server/src/processRunner.test.ts
@@ -174,7 +174,7 @@ describe("runProcess", () => {
 
       const error = yield* runWith(spawner)({
         command: "fake",
-        args: ["--flag"],
+        args: ["--flag", "secret-token-value"],
         cwd: "/logical",
         spawnCwd: "/actual",
       }).pipe(Effect.flip);
@@ -185,15 +185,18 @@ describe("runProcess", () => {
       }
       expect(error).toMatchObject({
         command: "fake",
-        args: ["--flag"],
+        argumentCount: 2,
         cwd: "/logical",
         spawnCwd: "/actual",
         resolvedCommand: "fake",
-        resolvedArgs: ["--flag"],
+        resolvedArgumentCount: 2,
         shell: false,
       });
       expect(error.cause).toBe(cause);
-      expect(error.message).toBe("Failed to spawn process 'fake --flag' in '/actual'");
+      expect(error.message).toBe("Failed to spawn process 'fake' in '/actual'");
+      expect(error).not.toHaveProperty("args");
+      expect(error).not.toHaveProperty("resolvedArgs");
+      expect(error.message).not.toContain("secret-token-value");
     }),
   );
 
@@ -217,7 +220,7 @@ describe("runProcess", () => {
         observedBytes: 2048,
       });
       expect(error.message).toBe(
-        "Process 'fake stdout-bytes 2048' stdout produced 2048 bytes, exceeding the 128 byte limit",
+        "Process 'fake' stdout produced 2048 bytes, exceeding the 128 byte limit",
       );
     }),
   );
@@ -357,12 +360,12 @@ describe("runProcess", () => {
       }
       expect(error).toMatchObject({
         command: "fake",
-        args: ["sleep"],
+        argumentCount: 1,
         cwd: "/logical",
         spawnCwd: "/actual",
         timeoutMs: 50,
       });
-      expect(error.message).toBe("Process 'fake sleep' in '/actual' timed out after 50ms");
+      expect(error.message).toBe("Process 'fake' in '/actual' timed out after 50ms");
     }),
   );
 

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -215,7 +215,7 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
       () => ({ chunks: [], bytes: 0 }),
       (state, chunk) => {
         const remainingBytes = input.maxOutputBytes - state.bytes;
-        if (remainingBytes <= 0 || chunk.byteLength > remainingBytes) {
+        if (chunk.byteLength > remainingBytes) {
           return Effect.fail(
             new ProcessOutputLimitError({
               command: input.command,

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -45,20 +45,20 @@ export interface ProcessRunOutput {
 
 const ProcessInvocationFields = {
   command: Schema.String,
-  args: Schema.Array(Schema.String),
+  argumentCount: Schema.Number,
   cwd: Schema.optional(Schema.String),
   spawnCwd: Schema.optional(Schema.String),
 };
 
 const formatProcessInvocation = (input: {
   readonly command: string;
-  readonly args: ReadonlyArray<string>;
   readonly cwd?: string | undefined;
   readonly spawnCwd?: string | undefined;
 }): string => {
-  const command = [input.command, ...input.args].join(" ");
   const executionCwd = input.spawnCwd ?? input.cwd;
-  return executionCwd === undefined ? `'${command}'` : `'${command}' in '${executionCwd}'`;
+  return executionCwd === undefined
+    ? `'${input.command}'`
+    : `'${input.command}' in '${executionCwd}'`;
 };
 
 export class ProcessSpawnError extends Schema.TaggedErrorClass<ProcessSpawnError>()(
@@ -66,7 +66,7 @@ export class ProcessSpawnError extends Schema.TaggedErrorClass<ProcessSpawnError
   {
     ...ProcessInvocationFields,
     resolvedCommand: Schema.optional(Schema.String),
-    resolvedArgs: Schema.optional(Schema.Array(Schema.String)),
+    resolvedArgumentCount: Schema.optional(Schema.Number),
     shell: Schema.optional(Schema.Boolean),
     cause: Schema.Defect(),
   },
@@ -185,7 +185,7 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
       (cause) =>
         new ProcessReadError({
           command: input.command,
-          args: input.args,
+          argumentCount: input.args.length,
           cwd: input.cwd,
           spawnCwd: input.spawnCwd,
           stream: input.streamName,
@@ -219,7 +219,7 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
           return Effect.fail(
             new ProcessOutputLimitError({
               command: input.command,
-              args: input.args,
+              argumentCount: input.args.length,
               cwd: input.cwd,
               spawnCwd: input.spawnCwd,
               stream: input.streamName,
@@ -273,7 +273,7 @@ function finalizeRunProcess<R>(
       return Effect.fail(
         new ProcessTimeoutError({
           command: input.command,
-          args: input.args,
+          argumentCount: input.args.length,
           cwd: input.cwd,
           spawnCwd: input.spawnCwd,
           timeoutMs: Duration.toMillis(timeout),
@@ -315,11 +315,11 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
         (cause) =>
           new ProcessSpawnError({
             command: input.command,
-            args: input.args,
+            argumentCount: input.args.length,
             cwd: input.cwd,
             spawnCwd: input.spawnCwd,
             resolvedCommand: spawnCommand.command,
-            resolvedArgs: spawnCommand.args,
+            resolvedArgumentCount: spawnCommand.args.length,
             shell: spawnCommand.shell,
             cause,
           }),
@@ -335,7 +335,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
             (cause) =>
               new ProcessStdinError({
                 command: input.command,
-                args: input.args,
+                argumentCount: input.args.length,
                 cwd: input.cwd,
                 spawnCwd: input.spawnCwd,
                 stdinBytes: Buffer.byteLength(stdin),
@@ -378,7 +378,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
       (cause) =>
         new ProcessReadError({
           command: input.command,
-          args: input.args,
+          argumentCount: input.args.length,
           cwd: input.cwd,
           spawnCwd: input.spawnCwd,
           stream: "exitCode",

--- a/apps/server/src/processRunner.ts
+++ b/apps/server/src/processRunner.ts
@@ -47,21 +47,27 @@ const ProcessInvocationFields = {
   command: Schema.String,
   args: Schema.Array(Schema.String),
   cwd: Schema.optional(Schema.String),
+  spawnCwd: Schema.optional(Schema.String),
 };
 
 const formatProcessInvocation = (input: {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
   readonly cwd?: string | undefined;
+  readonly spawnCwd?: string | undefined;
 }): string => {
   const command = [input.command, ...input.args].join(" ");
-  return input.cwd === undefined ? `'${command}'` : `'${command}' in '${input.cwd}'`;
+  const executionCwd = input.spawnCwd ?? input.cwd;
+  return executionCwd === undefined ? `'${command}'` : `'${command}' in '${executionCwd}'`;
 };
 
 export class ProcessSpawnError extends Schema.TaggedErrorClass<ProcessSpawnError>()(
   "ProcessSpawnError",
   {
     ...ProcessInvocationFields,
+    resolvedCommand: Schema.optional(Schema.String),
+    resolvedArgs: Schema.optional(Schema.Array(Schema.String)),
+    shell: Schema.optional(Schema.Boolean),
     cause: Schema.Defect(),
   },
 ) {
@@ -74,6 +80,7 @@ export class ProcessStdinError extends Schema.TaggedErrorClass<ProcessStdinError
   "ProcessStdinError",
   {
     ...ProcessInvocationFields,
+    stdinBytes: Schema.Number,
     cause: Schema.Defect(),
   },
 ) {
@@ -88,10 +95,11 @@ export class ProcessOutputLimitError extends Schema.TaggedErrorClass<ProcessOutp
     ...ProcessInvocationFields,
     stream: Schema.Literals(["stdout", "stderr"]),
     maxBytes: Schema.Number,
+    observedBytes: Schema.Number,
   },
 ) {
   override get message(): string {
-    return `Process ${formatProcessInvocation(this)} ${this.stream} exceeded ${this.maxBytes} bytes`;
+    return `Process ${formatProcessInvocation(this)} ${this.stream} produced ${this.observedBytes} bytes, exceeding the ${this.maxBytes} byte limit`;
   }
 }
 
@@ -120,12 +128,14 @@ export class ProcessTimeoutError extends Schema.TaggedErrorClass<ProcessTimeoutE
   }
 }
 
-export type ProcessRunError =
-  | ProcessSpawnError
-  | ProcessStdinError
-  | ProcessOutputLimitError
-  | ProcessReadError
-  | ProcessTimeoutError;
+export const ProcessRunError = Schema.Union([
+  ProcessSpawnError,
+  ProcessStdinError,
+  ProcessOutputLimitError,
+  ProcessReadError,
+  ProcessTimeoutError,
+]);
+export type ProcessRunError = typeof ProcessRunError.Type;
 
 export class ProcessRunner extends Context.Service<
   ProcessRunner,
@@ -163,6 +173,7 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
   readonly command: string;
   readonly args: ReadonlyArray<string>;
   readonly cwd?: string | undefined;
+  readonly spawnCwd?: string | undefined;
   readonly streamName: "stdout" | "stderr";
   readonly stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>;
   readonly maxOutputBytes: number;
@@ -176,6 +187,7 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
           command: input.command,
           args: input.args,
           cwd: input.cwd,
+          spawnCwd: input.spawnCwd,
           stream: input.streamName,
           cause,
         }),
@@ -209,8 +221,10 @@ const collectText = Effect.fn("processRunner.collectText")(function* (input: {
               command: input.command,
               args: input.args,
               cwd: input.cwd,
+              spawnCwd: input.spawnCwd,
               stream: input.streamName,
               maxBytes: input.maxOutputBytes,
+              observedBytes: state.bytes + chunk.byteLength,
             }),
           );
         }
@@ -261,6 +275,7 @@ function finalizeRunProcess<R>(
           command: input.command,
           args: input.args,
           cwd: input.cwd,
+          spawnCwd: input.spawnCwd,
           timeoutMs: Duration.toMillis(timeout),
         }),
       );
@@ -302,21 +317,28 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
             command: input.command,
             args: input.args,
             cwd: input.cwd,
+            spawnCwd: input.spawnCwd,
+            resolvedCommand: spawnCommand.command,
+            resolvedArgs: spawnCommand.args,
+            shell: spawnCommand.shell,
             cause,
           }),
       ),
     );
 
+  const stdin = input.stdin;
   const writeStdin =
-    input.stdin === undefined
+    stdin === undefined
       ? Effect.void
-      : Stream.run(Stream.encodeText(Stream.make(input.stdin)), child.stdin).pipe(
+      : Stream.run(Stream.encodeText(Stream.make(stdin)), child.stdin).pipe(
           Effect.mapError(
             (cause) =>
               new ProcessStdinError({
                 command: input.command,
                 args: input.args,
                 cwd: input.cwd,
+                spawnCwd: input.spawnCwd,
+                stdinBytes: Buffer.byteLength(stdin),
                 cause,
               }),
           ),
@@ -328,6 +350,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
         command: input.command,
         args: input.args,
         cwd: input.cwd,
+        spawnCwd: input.spawnCwd,
         streamName: "stdout",
         stream: child.stdout,
         maxOutputBytes,
@@ -338,6 +361,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
         command: input.command,
         args: input.args,
         cwd: input.cwd,
+        spawnCwd: input.spawnCwd,
         streamName: "stderr",
         stream: child.stderr,
         maxOutputBytes,
@@ -356,6 +380,7 @@ const runProcessCore = Effect.fn("processRunner.runProcessCore")(function* (
           command: input.command,
           args: input.args,
           cwd: input.cwd,
+          spawnCwd: input.spawnCwd,
           stream: "exitCode",
           cause,
         }),


### PR DESCRIPTION
## Summary
- enrich process-runner failures with requested/actual cwd, fixed executable identity, argument counts, resolved executable context, byte limits, and timeout details
- remove raw and resolved argv from direct error fields and messages while preserving exact real causes
- expose the process error family as a Schema union and retain precise output-limit behavior

## Validation
- `vp test apps/server/src/processRunner.test.ts apps/server/src/environment/ServerEnvironmentLabel.test.ts` (20 tests)
- `vp check`
- `vp run typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enrich process runner errors with argument counts, spawn context, and observed bytes
> - Replaces `args` arrays on error classes with `argumentCount` to avoid leaking sensitive values; adds `spawnCwd`, `resolvedCommand`, `resolvedArgumentCount`, and `shell` to `ProcessSpawnError`.
> - `ProcessOutputLimitError` now includes `observedBytes` and reports both observed and max byte counts in its message.
> - `ProcessStdinError` gains a `stdinBytes` field.
> - `formatProcessInvocation` no longer includes arguments in error messages and prefers `spawnCwd` over `cwd` when formatting the working directory.
> - Behavioral Change: output collection now allows a final chunk that hits the exact byte limit (plus a subsequent empty chunk) rather than failing when `remainingBytes` reaches zero.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9293c5a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->