### PR TITLE
[codex] Structure desktop server exposure errors

### DIFF
--- a/apps/desktop/src/backend/DesktopServerExposure.test.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.test.ts
@@ -91,6 +91,7 @@ function makeLayer(input: {
   readonly networkInterfaces?: DesktopNetworkInterfaces.NetworkInterfaces;
   readonly env?: Record<string, string | undefined>;
   readonly spawnerLayer?: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>;
+  readonly desktopSettingsLayer?: Layer.Layer<DesktopAppSettings.DesktopAppSettings>;
 }) {
   const env = { T3CODE_HOME: input.baseDir, ...input.env };
   const environmentLayer = makeEnvironmentLayer(input.baseDir, env);
@@ -99,7 +100,7 @@ function makeLayer(input: {
   });
 
   return DesktopServerExposure.layer.pipe(
-    Layer.provideMerge(DesktopAppSettings.layer),
+    Layer.provideMerge(input.desktopSettingsLayer ?? DesktopAppSettings.layer),
     Layer.provideMerge(NodeFileSystem.layer),
     Layer.provideMerge(NodeHttpClient.layerUndici),
     Layer.provideMerge(input.spawnerLayer ?? mockSpawnerLayer()),
@@ -122,6 +123,7 @@ const withHarness = <A, E, R>(
   >,
   env: Record<string, string | undefined> = {},
   spawnerLayer?: Layer.Layer<ChildProcessSpawner.ChildProcessSpawner>,
+  desktopSettingsLayer?: Layer.Layer<DesktopAppSettings.DesktopAppSettings>,
 ) =>
   Effect.gen(function* () {
     const fileSystem = yield* FileSystem.FileSystem;
@@ -135,6 +137,7 @@ const withHarness = <A, E, R>(
           networkInterfaces,
           env,
           ...(spawnerLayer ? { spawnerLayer } : {}),
+          ...(desktopSettingsLayer ? { desktopSettingsLayer } : {}),
         }),
       ),
     );
@@ -236,6 +239,67 @@ describe("DesktopServerExposure", () => {
       }),
     ),
   );
+
+  it.effect("preserves persistence request context and the settings failure chain", () => {
+    const diskFailure = new Error("disk exploded");
+    const settingsFailure = new DesktopAppSettings.DesktopSettingsWriteError({
+      operation: "replace-settings-file",
+      path: "/tmp/desktop-settings.json",
+      cause: diskFailure,
+    });
+    const settingsLayer = Layer.succeed(DesktopAppSettings.DesktopAppSettings, {
+      get: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
+      load: Effect.succeed(DesktopAppSettings.DEFAULT_DESKTOP_SETTINGS),
+      setServerExposureMode: () => Effect.fail(settingsFailure),
+      setTailscaleServe: () => Effect.fail(settingsFailure),
+      setUpdateChannel: () => Effect.die("unexpected update channel change"),
+    } satisfies DesktopAppSettings.DesktopAppSettings["Service"]);
+
+    return withHarness(
+      lanNetworkInterfaces,
+      Effect.gen(function* () {
+        const serverExposure = yield* DesktopServerExposure.DesktopServerExposure;
+        yield* serverExposure.configureFromSettings({ port: 4173 });
+
+        const modeError = yield* serverExposure.setMode("network-accessible").pipe(Effect.flip);
+        assert.instanceOf(
+          modeError,
+          DesktopServerExposure.DesktopServerExposureModePersistenceError,
+        );
+        assert.isTrue(DesktopServerExposure.isDesktopServerExposureSetModeError(modeError));
+        assert.isTrue(DesktopServerExposure.isDesktopServerExposureError(modeError));
+        assert.equal(modeError.mode, "network-accessible");
+        assert.strictEqual(modeError.cause, settingsFailure);
+        assert.strictEqual(modeError.cause.cause, diskFailure);
+        assert.equal(
+          modeError.message,
+          "Failed to persist desktop server exposure mode network-accessible.",
+        );
+        assert.notInclude(modeError.message, diskFailure.message);
+
+        const tailscaleError = yield* serverExposure
+          .setTailscaleServeEnabled({ enabled: true, port: 8443 })
+          .pipe(Effect.flip);
+        assert.instanceOf(
+          tailscaleError,
+          DesktopServerExposure.DesktopTailscaleServePersistenceError,
+        );
+        assert.isTrue(DesktopServerExposure.isDesktopServerExposureError(tailscaleError));
+        assert.equal(tailscaleError.enabled, true);
+        assert.equal(tailscaleError.port, 8443);
+        assert.strictEqual(tailscaleError.cause, settingsFailure);
+        assert.strictEqual(tailscaleError.cause.cause, diskFailure);
+        assert.equal(
+          tailscaleError.message,
+          "Failed to persist desktop Tailscale Serve settings (enabled: true, port: 8443).",
+        );
+        assert.notInclude(tailscaleError.message, diskFailure.message);
+      }),
+      {},
+      undefined,
+      settingsLayer,
+    );
+  });
 
   it.effect("resolves advertised endpoints from the scoped runtime state", () =>
     withHarness(

--- a/apps/desktop/src/backend/DesktopServerExposure.ts
+++ b/apps/desktop/src/backend/DesktopServerExposure.ts
@@ -2,11 +2,12 @@ import {
   createAdvertisedEndpoint,
   type CreateAdvertisedEndpointInput,
 } from "@t3tools/shared/advertisedEndpoint";
-import type {
-  AdvertisedEndpoint,
-  AdvertisedEndpointProvider,
-  DesktopServerExposureMode,
-  DesktopServerExposureState,
+import {
+  DesktopServerExposureModeSchema,
+  type AdvertisedEndpoint,
+  type AdvertisedEndpointProvider,
+  type DesktopServerExposureMode,
+  type DesktopServerExposureState,
 } from "@t3tools/contracts";
 import { readTailscaleStatus } from "@t3tools/tailscale";
 import * as Context from "effect/Context";
@@ -213,23 +214,45 @@ export class DesktopServerExposureNoNetworkAddressError extends Schema.TaggedErr
   }
 }
 
-export class DesktopServerExposurePersistenceError extends Schema.TaggedErrorClass<DesktopServerExposurePersistenceError>()(
-  "DesktopServerExposurePersistenceError",
+export class DesktopServerExposureModePersistenceError extends Schema.TaggedErrorClass<DesktopServerExposureModePersistenceError>()(
+  "DesktopServerExposureModePersistenceError",
   {
-    operation: Schema.Literals(["server-exposure-mode", "tailscale-serve"]),
+    mode: DesktopServerExposureModeSchema,
     cause: Schema.instanceOf(DesktopAppSettings.DesktopSettingsWriteError),
   },
 ) {
   override get message(): string {
-    return `Failed to persist desktop ${this.operation} settings.`;
+    return `Failed to persist desktop server exposure mode ${this.mode}.`;
   }
 }
 
-export type DesktopServerExposureSetModeError =
-  | DesktopServerExposureNoNetworkAddressError
-  | DesktopServerExposurePersistenceError;
+export class DesktopTailscaleServePersistenceError extends Schema.TaggedErrorClass<DesktopTailscaleServePersistenceError>()(
+  "DesktopTailscaleServePersistenceError",
+  {
+    enabled: Schema.Boolean,
+    port: Schema.NullOr(Schema.Number),
+    cause: Schema.instanceOf(DesktopAppSettings.DesktopSettingsWriteError),
+  },
+) {
+  override get message(): string {
+    return `Failed to persist desktop Tailscale Serve settings (enabled: ${this.enabled}, port: ${this.port ?? "unchanged"}).`;
+  }
+}
 
-export type DesktopServerExposureError = DesktopServerExposureSetModeError;
+export const DesktopServerExposureSetModeError = Schema.Union([
+  DesktopServerExposureNoNetworkAddressError,
+  DesktopServerExposureModePersistenceError,
+]);
+export type DesktopServerExposureSetModeError = typeof DesktopServerExposureSetModeError.Type;
+export const isDesktopServerExposureSetModeError = Schema.is(DesktopServerExposureSetModeError);
+
+export const DesktopServerExposureError = Schema.Union([
+  DesktopServerExposureNoNetworkAddressError,
+  DesktopServerExposureModePersistenceError,
+  DesktopTailscaleServePersistenceError,
+]);
+export type DesktopServerExposureError = typeof DesktopServerExposureError.Type;
+export const isDesktopServerExposureError = Schema.is(DesktopServerExposureError);
 
 export interface DesktopServerExposureBackendConfig {
   readonly port: number;
@@ -258,7 +281,7 @@ export class DesktopServerExposure extends Context.Service<
     readonly setTailscaleServeEnabled: (input: {
       readonly enabled: boolean;
       readonly port?: number;
-    }) => Effect.Effect<DesktopServerExposureChange, DesktopServerExposurePersistenceError>;
+    }) => Effect.Effect<DesktopServerExposureChange, DesktopTailscaleServePersistenceError>;
     readonly getAdvertisedEndpoints: Effect.Effect<readonly AdvertisedEndpoint[]>;
   }
 >()("@t3tools/desktop/backend/DesktopServerExposure") {}
@@ -449,8 +472,8 @@ export const make = Effect.gen(function* () {
     const change = yield* desktopSettings.setServerExposureMode(mode).pipe(
       Effect.mapError(
         (cause) =>
-          new DesktopServerExposurePersistenceError({
-            operation: "server-exposure-mode",
+          new DesktopServerExposureModePersistenceError({
+            mode,
             cause,
           }),
       ),
@@ -477,8 +500,9 @@ export const make = Effect.gen(function* () {
         .pipe(
           Effect.mapError(
             (cause) =>
-              new DesktopServerExposurePersistenceError({
-                operation: "tailscale-serve",
+              new DesktopTailscaleServePersistenceError({
+                enabled: input.enabled,
+                port: input.port ?? null,
                 cause,
               }),
           ),


### PR DESCRIPTION
## Summary
- split exposure-mode and Tailscale Serve persistence failures into distinct Schema errors with request context
- preserve the concrete DesktopSettingsWriteError cause and its nested failure chain
- expose Schema unions and direct predicates for set-mode and service errors
- verify stable messages, structured attributes, predicates, and exact cause identity

## Validation
- vp test apps/desktop/src/backend/DesktopServerExposure.test.ts
- vp check (0 errors; 20 existing unrelated warnings)
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 932202f620f43b87735577fd1da62aebc2d4ddb9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure desktop server exposure errors with specific typed error classes
> - Replaces the generic `DesktopServerExposurePersistenceError` with two specific `TaggedError` classes: `DesktopServerExposureModePersistenceError` (captures attempted mode) and `DesktopTailscaleServePersistenceError` (captures `enabled` and `port` fields).
> - Adds `DesktopServerExposureSetModeError` and `DesktopServerExposureError` union schemas with corresponding type-guard predicates for runtime error discrimination.
> - Updates `setMode` and `setTailscaleServeEnabled` in [DesktopServerExposure.ts](https://github.com/pingdotgg/t3code/pull/3269/files#diff-87d5808073ddb6ad6696185597726c0867bb1276e88997a57829cf9839e8abcb) to construct the new error types with richer context on persistence failure.
> - Adds tests in [DesktopServerExposure.test.ts](https://github.com/pingdotgg/t3code/pull/3269/files#diff-b697fab61000dcfcd9dc8f96c474398f400aa85d838e0c98e249235ec04f287d) covering error fields, cause chains, predicates, and user-facing messages.
> - Behavioral Change: `setTailscaleServeEnabled` now surfaces `DesktopTailscaleServePersistenceError` instead of the previous generic error type; error messages now include mode/enabled/port values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 932202f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->