### PR TITLE
[codex] Structure relay JWT failures

### DIFF
--- a/infra/relay/src/auth/RelayTokens.ts
+++ b/infra/relay/src/auth/RelayTokens.ts
@@ -11,9 +11,9 @@ import {
 import { encodeOAuthScope, parseAllowedOAuthScope } from "@t3tools/shared/oauthScope";
 import {
   normalizeRelayIssuer,
+  RelayJwtError,
   signRelayJwt,
   verifyRelayJwt,
-  type RelayJwtError,
 } from "@t3tools/shared/relayJwt";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -71,17 +71,6 @@ const allowedScopesByClientId: Record<
   ]),
   [RelayWebClientId]: new Set([RelayEnvironmentConnectScope, RelayEnvironmentStatusScope]),
 };
-
-function relayJwtVerificationFailureReason(error: RelayJwtError): string {
-  const cause = error.cause;
-  if (typeof cause === "object" && cause !== null && "code" in cause) {
-    const code = (cause as { readonly code?: unknown }).code;
-    if (typeof code === "string" && code.length > 0) {
-      return code;
-    }
-  }
-  return cause instanceof Error && cause.name ? cause.name : "unknown";
-}
 
 function resolveDpopAccessTokenScopes(input: {
   readonly clientId: RelayPublicClientId;
@@ -211,7 +200,7 @@ const make = Effect.gen(function* () {
       Effect.tapError((error) =>
         Effect.annotateCurrentSpan(
           "relay.tokens.verification_failure",
-          relayJwtVerificationFailureReason(error),
+          RelayJwtError.diagnosticCode(error),
         ),
       ),
       Effect.flatMap(decodeDpopAccessTokenClaims),

--- a/packages/shared/src/relayJwt.test.ts
+++ b/packages/shared/src/relayJwt.test.ts
@@ -1,0 +1,58 @@
+import * as NodeCrypto from "node:crypto";
+
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { RelayJwtError, signRelayJwt, verifyRelayJwt } from "./relayJwt.ts";
+
+describe("relayJwt", () => {
+  it.effect("preserves signing context and the JOSE cause", () =>
+    Effect.gen(function* () {
+      const error = yield* signRelayJwt({
+        privateKey: "not-a-private-key",
+        typ: "test-sign+jwt",
+        payload: { sub: "subject" },
+      }).pipe(Effect.flip);
+
+      expect(error.operation).toBe("sign");
+      expect(error.typ).toBe("test-sign+jwt");
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(error.message).toBe('Failed to sign relay JWT of type "test-sign+jwt".');
+    }),
+  );
+
+  it.effect("preserves verification request context and the JOSE cause", () =>
+    Effect.gen(function* () {
+      const keyPair = NodeCrypto.generateKeyPairSync("ed25519", {
+        publicKeyEncoding: { format: "pem", type: "spki" },
+        privateKeyEncoding: { format: "pem", type: "pkcs8" },
+      });
+      const error = yield* verifyRelayJwt({
+        publicKey: keyPair.publicKey,
+        token: "not-a-jwt",
+        typ: "test-verify+jwt",
+        issuer: "https://issuer.example.test",
+        audience: "test-audience",
+        nowEpochSeconds: 100,
+      }).pipe(Effect.flip);
+
+      expect(error.operation).toBe("verify");
+      expect(error.typ).toBe("test-verify+jwt");
+      expect(error.issuer).toBe("https://issuer.example.test");
+      expect(error.audience).toBe("test-audience");
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(error.message).toBe('Failed to verify relay JWT of type "test-verify+jwt".');
+    }),
+  );
+
+  it("extracts stable diagnostic codes without copying cause text into the error message", () => {
+    const error = new RelayJwtError({
+      operation: "verify",
+      typ: "test+jwt",
+      cause: { code: "ERR_JWT_EXPIRED", message: "sensitive library detail" },
+    });
+
+    expect(RelayJwtError.diagnosticCode(error)).toBe("ERR_JWT_EXPIRED");
+    expect(error.message).not.toContain("sensitive library detail");
+  });
+});

--- a/packages/shared/src/relayJwt.ts
+++ b/packages/shared/src/relayJwt.ts
@@ -1,7 +1,8 @@
 import { decodeJwt, importPKCS8, importSPKI, jwtVerify, SignJWT, type JWTPayload } from "jose";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as Predicate from "effect/Predicate";
+import * as Schema from "effect/Schema";
 
 export const RELAY_LINK_PROOF_TYP = "t3-env-link+jwt";
 export const RELAY_MINT_REQUEST_TYP = "t3-cloud-mint+jwt";
@@ -10,9 +11,30 @@ export const RELAY_MINT_RESPONSE_TYP = "t3-env-mint+jwt";
 export const RELAY_HEALTH_RESPONSE_TYP = "t3-env-health+jwt";
 export const RELAY_ACTIVITY_PUBLISH_TYP = "t3-env-activity+jwt";
 
-export class RelayJwtError extends Data.TaggedError("RelayJwtError")<{
-  readonly cause: unknown;
-}> {}
+export class RelayJwtError extends Schema.TaggedErrorClass<RelayJwtError>()("RelayJwtError", {
+  operation: Schema.Literals(["sign", "verify"]),
+  typ: Schema.String,
+  issuer: Schema.optional(Schema.String),
+  audience: Schema.optional(Schema.String),
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    return `Failed to ${this.operation} relay JWT of type "${this.typ}".`;
+  }
+
+  static diagnosticCode(error: RelayJwtError): string {
+    if (
+      Predicate.isObject(error.cause) &&
+      Predicate.hasProperty(error.cause, "code") &&
+      Predicate.isString(error.cause.code) &&
+      error.cause.code.length > 0
+    ) {
+      return error.cause.code;
+    }
+
+    return error.cause instanceof Error && error.cause.name ? error.cause.name : "unknown";
+  }
+}
 
 export function normalizeRelayIssuer(value: string): string {
   return value.trim().replace(/\/+$/gu, "");
@@ -38,7 +60,7 @@ export function signRelayJwt(input: {
         .setProtectedHeader({ alg: "EdDSA", typ: input.typ })
         .sign(key);
     },
-    catch: (cause) => new RelayJwtError({ cause }),
+    catch: (cause) => new RelayJwtError({ operation: "sign", typ: input.typ, cause }),
   });
 }
 
@@ -65,6 +87,13 @@ export function verifyRelayJwt(input: {
       });
       return verified.payload;
     },
-    catch: (cause) => new RelayJwtError({ cause }),
+    catch: (cause) =>
+      new RelayJwtError({
+        operation: "verify",
+        typ: input.typ,
+        issuer: input.issuer,
+        audience: input.audience,
+        cause,
+      }),
   });
 }


### PR DESCRIPTION
## Summary
- attach sign/verify operation, JWT type, issuer, and audience context to relay JWT failures
- preserve the original JOSE cause while keeping messages stable and free of cause text
- move diagnostic-code extraction onto `RelayJwtError` and remove the adjacent mapper

## Validation
- `vp test run packages/shared/src/relayJwt.test.ts`
- `vp test run infra/relay/src/auth/RelayTokens.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and error-shape changes only; JWT sign/verify success paths and relay auth decisions are unchanged aside from richer failure metadata.
> 
> **Overview**
> **`RelayJwtError`** is expanded from a bare tagged cause to a schema-backed error that records **sign vs verify**, JWT **`typ`**, and optional **issuer/audience**, while keeping a fixed user-facing **`message`** that does not embed JOSE library text. The original failure is still stored on **`cause`**.
> 
> **`signRelayJwt`** and **`verifyRelayJwt`** now populate that context when mapping promise failures. **`RelayJwtError.diagnosticCode`** centralizes stable span/log codes (JOSE `code`, else error name, else `"unknown"`).
> 
> In relay token verification, the local **`relayJwtVerificationFailureReason`** helper is removed in favor of **`RelayJwtError.diagnosticCode`** for the `relay.tokens.verification_failure` span annotation. New unit tests cover context preservation, diagnostic codes, and message stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfe281212d8d4859f16cefef34ba6b579163e953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured context fields and `diagnosticCode` to `RelayJwtError`
> - Replaces the `Data.TaggedError`-based `RelayJwtError` with a `Schema.TaggedErrorClass` that carries structured fields: `operation` (`'sign'|'verify'`), `typ`, optional `issuer` and `audience`, and `cause` as a Defect.
> - Adds a `message` getter formatting `'Failed to {operation} relay JWT of type "{typ}".'` and a static `RelayJwtError.diagnosticCode(error)` that returns a stable code from `cause.code`, `cause.name`, or `'unknown'`.
> - Updates `signRelayJwt` and `verifyRelayJwt` in [relayJwt.ts](https://github.com/pingdotgg/t3code/pull/3270/files#diff-27a4fc93cbc699f37bb9eee030c2f714daf2ce5e2b63209ec8b6d66ad502e967) to populate these fields on failure.
> - Replaces the local `relayJwtVerificationFailureReason` helper in [RelayTokens.ts](https://github.com/pingdotgg/t3code/pull/3270/files#diff-06dab6cd1628df4090d6ada3b629a67d62988fedb2e4d4a37dae6ff8c3801fac) with `RelayJwtError.diagnosticCode(error)` for the `relay.tokens.verification_failure` span annotation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfe2812.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->