### PR TITLE
[codex] Structure preview config failures

### DIFF
--- a/apps/web/src/browser/previewWebviewConfigState.test.ts
+++ b/apps/web/src/browser/previewWebviewConfigState.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "@effect/vitest";
+import { EnvironmentId } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import {
+  loadPreviewWebviewConfig,
+  PreviewWebviewBridgeUnavailableError,
+  PreviewWebviewConfigLoadError,
+} from "./previewWebviewConfigState";
+
+const environmentId = EnvironmentId.make("environment-1");
+
+describe("loadPreviewWebviewConfig", () => {
+  it.effect("reports a structurally distinct missing-bridge failure", () =>
+    Effect.gen(function* () {
+      const error = yield* loadPreviewWebviewConfig(environmentId, null).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(PreviewWebviewBridgeUnavailableError);
+      expect(error.environmentId).toBe(environmentId);
+      expect(error.message).toContain(environmentId);
+      expect("cause" in error).toBe(false);
+    }),
+  );
+
+  it.effect("preserves the bridge rejection as the load failure cause", () =>
+    Effect.gen(function* () {
+      const cause = new Error("ipc unavailable");
+      const error = yield* loadPreviewWebviewConfig(environmentId, {
+        getPreviewConfig: () => Promise.reject(cause),
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(PreviewWebviewConfigLoadError);
+      expect(error.environmentId).toBe(environmentId);
+      expect(error.cause).toBe(cause);
+      expect(error.message).not.toContain(cause.message);
+    }),
+  );
+
+  it.effect("forwards the environment id to the bridge", () =>
+    Effect.gen(function* () {
+      let requestedEnvironmentId: EnvironmentId | null = null;
+      const config = {
+        partition: "persist:test-preview",
+        webPreferences: "sandbox=yes",
+        preloadUrl: null,
+      };
+      const result = yield* loadPreviewWebviewConfig(environmentId, {
+        getPreviewConfig: (input) => {
+          requestedEnvironmentId = input;
+          return Promise.resolve(config);
+        },
+      });
+
+      expect(requestedEnvironmentId).toBe(environmentId);
+      expect(result).toEqual(config);
+    }),
+  );
+});

--- a/apps/web/src/browser/previewWebviewConfigState.ts
+++ b/apps/web/src/browser/previewWebviewConfigState.ts
@@ -1,8 +1,12 @@
 import { useAtomValue } from "@effect/atom-react";
-import type { DesktopPreviewWebviewConfig, EnvironmentId } from "@t3tools/contracts";
-import * as Data from "effect/Data";
+import type {
+  DesktopPreviewBridge,
+  DesktopPreviewWebviewConfig,
+  EnvironmentId,
+} from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import { previewBridge } from "~/components/preview/previewBridge";
@@ -10,27 +14,51 @@ import { previewBridge } from "~/components/preview/previewBridge";
 const PREVIEW_CONFIG_STALE_TIME_MS = 5 * 60_000;
 const PREVIEW_CONFIG_IDLE_TTL_MS = 10 * 60_000;
 
-class PreviewWebviewConfigError extends Data.TaggedError("PreviewWebviewConfigError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class PreviewWebviewBridgeUnavailableError extends Schema.TaggedErrorClass<PreviewWebviewBridgeUnavailableError>()(
+  "PreviewWebviewBridgeUnavailableError",
+  { environmentId: Schema.String },
+) {
+  override get message(): string {
+    return `Desktop preview configuration is unavailable for environment "${this.environmentId}".`;
+  }
+}
+
+export class PreviewWebviewConfigLoadError extends Schema.TaggedErrorClass<PreviewWebviewConfigLoadError>()(
+  "PreviewWebviewConfigLoadError",
+  {
+    environmentId: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to load desktop preview configuration for environment "${this.environmentId}".`;
+  }
+}
+
+export const PreviewWebviewConfigError = Schema.Union([
+  PreviewWebviewBridgeUnavailableError,
+  PreviewWebviewConfigLoadError,
+]);
+export type PreviewWebviewConfigError = typeof PreviewWebviewConfigError.Type;
+
+type PreviewConfigBridge = Pick<DesktopPreviewBridge, "getPreviewConfig">;
+
+export const loadPreviewWebviewConfig = (
+  environmentId: EnvironmentId,
+  bridge: PreviewConfigBridge | null = previewBridge,
+): Effect.Effect<DesktopPreviewWebviewConfig, PreviewWebviewConfigError> => {
+  if (bridge === null) {
+    return Effect.fail(new PreviewWebviewBridgeUnavailableError({ environmentId }));
+  }
+
+  return Effect.tryPromise({
+    try: () => bridge.getPreviewConfig(environmentId),
+    catch: (cause) => new PreviewWebviewConfigLoadError({ environmentId, cause }),
+  });
+};
 
 const previewWebviewConfigAtom = Atom.family((environmentId: EnvironmentId) =>
-  Atom.make(
-    Effect.tryPromise({
-      try: () => {
-        if (!previewBridge) {
-          throw new Error("Desktop preview bridge is unavailable.");
-        }
-        return previewBridge.getPreviewConfig(environmentId);
-      },
-      catch: (cause) =>
-        new PreviewWebviewConfigError({
-          message: "Could not load desktop preview configuration.",
-          cause,
-        }),
-    }),
-  ).pipe(
+  Atom.make(loadPreviewWebviewConfig(environmentId)).pipe(
     Atom.swr({
       staleTime: PREVIEW_CONFIG_STALE_TIME_MS,
       revalidateOnMount: true,


### PR DESCRIPTION
## Summary
- distinguish an unavailable desktop preview bridge from a rejected config load
- attach the requested environment id and preserve the real IPC rejection cause
- remove the synthetic `Error` previously used to represent a missing bridge

## Validation
- `vp test run apps/web/src/browser/previewWebviewConfigState.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized preview-config error modeling and atom wiring; callers must discriminate two error tags instead of one.
> 
> **Overview**
> Desktop preview webview config loading now fails with **two typed errors** instead of one generic tag: `PreviewWebviewBridgeUnavailableError` when the bridge is missing, and `PreviewWebviewConfigLoadError` when `getPreviewConfig` rejects. Both include the **environment id**; load failures keep the IPC rejection on **`cause`** without folding it into the user-facing message.
> 
> The atom path delegates to a new exported **`loadPreviewWebviewConfig`** (optional injectable bridge), replacing inline `tryPromise` logic and the synthetic `Error` used for a null bridge. A **`PreviewWebviewConfigError`** schema union covers the combined failure type.
> 
> Adds **Effect/Vitest** coverage for missing bridge, rejected load, and successful config forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b9cec016fb434852f5ca76953974adc6b04283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure preview config failures into typed error classes
> - Replaces the single generic `PreviewWebviewConfigError` with two distinct typed errors: `PreviewWebviewBridgeUnavailableError` (when bridge is null) and `PreviewWebviewConfigLoadError` (when the bridge rejects), both carrying `environmentId`.
> - Extracts the inline Effect logic from `previewWebviewConfigAtom` into a new `loadPreviewWebviewConfig` function in [previewWebviewConfigState.ts](https://github.com/pingdotgg/t3code/pull/3271/files#diff-f926d059f47e3206cd9c0430037a9f79928940400c7c80e9a9b28d594741eb2e).
> - Bridge rejection causes are now preserved as a separate `cause` field rather than merged into the error message.
> - Adds effect-based tests covering the three main code paths in [previewWebviewConfigState.test.ts](https://github.com/pingdotgg/t3code/pull/3271/files#diff-77c261ff92812635d9a42bf2ac9150a43a33d20136f5b5ebfff118a1445a62d8).
> - Behavioral Change: callers that previously matched on a single `PreviewWebviewConfigError` tag must now discriminate between the two new error types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8b9cec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->