### PR TITLE
[codex] Structure preview automation errors

### DIFF
--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -64,6 +64,11 @@ it.effect("atomically registers a connected owner and correlates its response", 
 it.effect("preserves bounded request and remote selector diagnostics", () => {
   const locator = "role=button[name='request-secret']";
   const remoteMessage = "Unexpected token near remote-secret.";
+  const remoteError = {
+    _tag: "PreviewAutomationInvalidSelectorError",
+    message: remoteMessage,
+    detail: { selector: "role=button[name='remote-secret']" },
+  } as const;
 
   return Effect.scoped(
     Effect.gen(function* () {
@@ -73,11 +78,7 @@ it.effect("preserves bounded request and remote selector diagnostics", () => {
         broker.respond({
           requestId: request.requestId,
           ok: false,
-          error: {
-            _tag: "PreviewAutomationInvalidSelectorError",
-            message: remoteMessage,
-            detail: { selector: "role=button[name='remote-secret']" },
-          },
+          error: remoteError,
         }),
       ).pipe(Effect.forkScoped);
       yield* Effect.yieldNow;
@@ -112,6 +113,7 @@ it.effect("preserves bounded request and remote selector diagnostics", () => {
         `Preview automation click received an invalid locator (${locator.length} characters).`,
       );
       expect(error.message).not.toContain("secret");
+      expect(error.cause).toBe(remoteError);
       expect("selector" in error).toBe(false);
       expect("remoteMessage" in error).toBe(false);
       expect("remoteDetail" in error).toBe(false);

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -1,8 +1,10 @@
 import { expect, it } from "@effect/vitest";
 import {
   EnvironmentId,
+  PreviewAutomationClientDisconnectedError,
+  PreviewAutomationInvalidSelectorError,
+  PreviewAutomationMalformedResponseError,
   PreviewAutomationNoFocusedOwnerError,
-  PreviewAutomationUnavailableError,
   ProviderInstanceId,
   ThreadId,
   type PreviewAutomationOwner,
@@ -59,6 +61,85 @@ it.effect("atomically registers a connected owner and correlates its response", 
   ),
 );
 
+it.effect("preserves request context and remote selector diagnostics", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* PreviewAutomationBroker.make;
+      const requests = yield* broker.connect(makeOwner({ tabId: "tab-1" }));
+      yield* Stream.runForEach(requests, (request) =>
+        broker.respond({
+          requestId: request.requestId,
+          ok: false,
+          error: {
+            _tag: "PreviewAutomationInvalidSelectorError",
+            message: "Unexpected token near the locator.",
+            detail: { selector: "role=button[" },
+          },
+        }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      const error = yield* broker
+        .invoke<void>({
+          scope,
+          operation: "click",
+          input: { locator: "role=button[" },
+          timeoutMs: 1_234,
+        })
+        .pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(PreviewAutomationInvalidSelectorError);
+      expect(error).toMatchObject({
+        operation: "click",
+        environmentId: scope.environmentId,
+        threadId: scope.threadId,
+        providerSessionId: scope.providerSessionId,
+        providerInstanceId: scope.providerInstanceId,
+        clientId: "client-1",
+        requestId: "preview-0",
+        tabId: "tab-1",
+        timeoutMs: 1_234,
+        selector: "role=button[",
+        remoteTag: "PreviewAutomationInvalidSelectorError",
+        remoteMessage: "Unexpected token near the locator.",
+        remoteDetail: { selector: "role=button[" },
+      });
+      expect(error.message).toBe(
+        "Invalid preview automation selector for click: role=button[ Unexpected token near the locator.",
+      );
+    }),
+  ),
+);
+
+it.effect("distinguishes malformed remote failures", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const broker = yield* PreviewAutomationBroker.make;
+      const requests = yield* broker.connect(makeOwner());
+      yield* Stream.runForEach(requests, (request) =>
+        broker.respond({ requestId: request.requestId, ok: false }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+
+      const error = yield* broker
+        .invoke<void>({ scope, operation: "status", input: {}, timeoutMs: 2_000 })
+        .pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(PreviewAutomationMalformedResponseError);
+      expect(error).toMatchObject({
+        operation: "status",
+        environmentId: scope.environmentId,
+        threadId: scope.threadId,
+        providerSessionId: scope.providerSessionId,
+        providerInstanceId: scope.providerInstanceId,
+        clientId: "client-1",
+        requestId: "preview-0",
+        timeoutMs: 2_000,
+      });
+    }),
+  ),
+);
+
 it.effect("rejects calls when no focused owner exists", () =>
   Effect.gen(function* () {
     const broker = yield* PreviewAutomationBroker.make;
@@ -66,6 +147,13 @@ it.effect("rejects calls when no focused owner exists", () =>
       .invoke<void>({ scope, operation: "status", input: {} })
       .pipe(Effect.flip);
     expect(error).toBeInstanceOf(PreviewAutomationNoFocusedOwnerError);
+    expect(error).toMatchObject({
+      operation: "status",
+      environmentId: scope.environmentId,
+      threadId: scope.threadId,
+      providerSessionId: scope.providerSessionId,
+      providerInstanceId: scope.providerInstanceId,
+    });
   }),
 );
 
@@ -162,7 +250,17 @@ it.effect("fails requests assigned to a browser stream when that stream reconnec
       const _replacementRequests = yield* broker.connect(makeOwner());
 
       const error = yield* Fiber.join(pending);
-      expect(error).toBeInstanceOf(PreviewAutomationUnavailableError);
+      expect(error).toBeInstanceOf(PreviewAutomationClientDisconnectedError);
+      expect(error).toMatchObject({
+        operation: "status",
+        environmentId: scope.environmentId,
+        threadId: scope.threadId,
+        providerSessionId: scope.providerSessionId,
+        providerInstanceId: scope.providerInstanceId,
+        clientId: "client-1",
+        requestId: "preview-0",
+        timeoutMs: 15_000,
+      });
     }),
   ),
 );

--- a/apps/server/src/mcp/PreviewAutomationBroker.test.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.test.ts
@@ -61,8 +61,11 @@ it.effect("atomically registers a connected owner and correlates its response", 
   ),
 );
 
-it.effect("preserves request context and remote selector diagnostics", () =>
-  Effect.scoped(
+it.effect("preserves bounded request and remote selector diagnostics", () => {
+  const locator = "role=button[name='request-secret']";
+  const remoteMessage = "Unexpected token near remote-secret.";
+
+  return Effect.scoped(
     Effect.gen(function* () {
       const broker = yield* PreviewAutomationBroker.make;
       const requests = yield* broker.connect(makeOwner({ tabId: "tab-1" }));
@@ -72,8 +75,8 @@ it.effect("preserves request context and remote selector diagnostics", () =>
           ok: false,
           error: {
             _tag: "PreviewAutomationInvalidSelectorError",
-            message: "Unexpected token near the locator.",
-            detail: { selector: "role=button[" },
+            message: remoteMessage,
+            detail: { selector: "role=button[name='remote-secret']" },
           },
         }),
       ).pipe(Effect.forkScoped);
@@ -83,7 +86,7 @@ it.effect("preserves request context and remote selector diagnostics", () =>
         .invoke<void>({
           scope,
           operation: "click",
-          input: { locator: "role=button[" },
+          input: { locator },
           timeoutMs: 1_234,
         })
         .pipe(Effect.flip);
@@ -99,17 +102,22 @@ it.effect("preserves request context and remote selector diagnostics", () =>
         requestId: "preview-0",
         tabId: "tab-1",
         timeoutMs: 1_234,
-        selector: "role=button[",
+        selectorKind: "locator",
+        selectorLength: locator.length,
         remoteTag: "PreviewAutomationInvalidSelectorError",
-        remoteMessage: "Unexpected token near the locator.",
-        remoteDetail: { selector: "role=button[" },
+        remoteMessageLength: remoteMessage.length,
+        remoteDetailKind: "object",
       });
       expect(error.message).toBe(
-        "Invalid preview automation selector for click: role=button[ Unexpected token near the locator.",
+        `Preview automation click received an invalid locator (${locator.length} characters).`,
       );
+      expect(error.message).not.toContain("secret");
+      expect("selector" in error).toBe(false);
+      expect("remoteMessage" in error).toBe(false);
+      expect("remoteDetail" in error).toBe(false);
     }),
-  ),
-);
+  );
+});
 
 it.effect("distinguishes malformed remote failures", () =>
   Effect.scoped(

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -128,6 +128,7 @@ const classifyResponseError = (
     remoteTag: error._tag,
     remoteMessageLength: error.message.length,
     ...(error.detail === undefined ? {} : { remoteDetailKind: remoteDetailKind(error.detail) }),
+    cause: error,
   };
   switch (error._tag) {
     case "PreviewAutomationNoFocusedOwnerError":

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -1,12 +1,16 @@
 import {
+  PreviewAutomationClientDisconnectedError,
   PreviewAutomationControlInterruptedError,
   PreviewAutomationExecutionError,
+  PreviewAutomationHostNotConnectedError,
   PreviewAutomationInvalidSelectorError,
+  PreviewAutomationMalformedResponseError,
   PreviewAutomationNoFocusedOwnerError,
+  PreviewAutomationRemoteUnavailableError,
+  PreviewAutomationRequestQueueClosedError,
   PreviewAutomationResultTooLargeError,
   PreviewAutomationTabNotFoundError,
   PreviewAutomationTimeoutError,
-  PreviewAutomationUnavailableError,
   PreviewAutomationUnsupportedClientError,
   type PreviewAutomationError,
   type PreviewAutomationOperation,
@@ -62,6 +66,20 @@ interface ClientConnection {
 interface PendingRequest {
   readonly queue: ClientConnection["queue"];
   readonly deferred: Deferred.Deferred<unknown, PreviewAutomationError>;
+  readonly context: PreviewAutomationRequestErrorContext;
+}
+
+interface PreviewAutomationRequestErrorContext {
+  readonly operation: PreviewAutomationOperation;
+  readonly environmentId: McpInvocationContext.McpInvocationScope["environmentId"];
+  readonly threadId: McpInvocationContext.McpInvocationScope["threadId"];
+  readonly providerSessionId: string;
+  readonly providerInstanceId: McpInvocationContext.McpInvocationScope["providerInstanceId"];
+  readonly clientId: string;
+  readonly requestId: string;
+  readonly tabId?: PreviewTabId;
+  readonly timeoutMs: number;
+  readonly selector?: string;
 }
 
 interface BrokerState {
@@ -71,48 +89,91 @@ interface BrokerState {
   readonly requestSequence: number;
 }
 
-const makeResponseError = (
+const selectorFromInput = (input: unknown): string | undefined => {
+  if (typeof input !== "object" || input === null) return undefined;
+  if ("locator" in input && typeof input.locator === "string") return input.locator;
+  if ("selector" in input && typeof input.selector === "string") return input.selector;
+  return undefined;
+};
+
+const classifyResponseError = (
+  context: PreviewAutomationRequestErrorContext,
   error: NonNullable<PreviewAutomationResponse["error"]>,
 ): PreviewAutomationError => {
+  const { selector, ...requestContext } = context;
+  const remoteDiagnostics = {
+    remoteTag: error._tag,
+    remoteMessage: error.message,
+    ...(error.detail === undefined ? {} : { remoteDetail: error.detail }),
+  };
   switch (error._tag) {
     case "PreviewAutomationNoFocusedOwnerError":
-      return new PreviewAutomationNoFocusedOwnerError({ message: error.message });
+      return new PreviewAutomationNoFocusedOwnerError({
+        ...requestContext,
+        ...remoteDiagnostics,
+      });
     case "PreviewAutomationUnsupportedClientError":
-      return new PreviewAutomationUnsupportedClientError({ message: error.message });
+      return new PreviewAutomationUnsupportedClientError({
+        ...requestContext,
+        ...remoteDiagnostics,
+      });
     case "PreviewAutomationTabNotFoundError":
-      return new PreviewAutomationTabNotFoundError({ message: error.message });
+      return new PreviewAutomationTabNotFoundError({
+        ...requestContext,
+        ...remoteDiagnostics,
+      });
     case "PreviewAutomationTimeoutError":
-      return new PreviewAutomationTimeoutError({ message: error.message });
+      return new PreviewAutomationTimeoutError({
+        ...requestContext,
+        ...remoteDiagnostics,
+      });
     case "PreviewAutomationControlInterruptedError":
-      return new PreviewAutomationControlInterruptedError({ message: error.message });
+      return new PreviewAutomationControlInterruptedError({
+        ...requestContext,
+        ...remoteDiagnostics,
+      });
     case "PreviewAutomationInvalidSelectorError": {
       const detail =
         typeof error.detail === "object" && error.detail !== null ? error.detail : undefined;
+      const responseSelector =
+        detail &&
+        "selector" in detail &&
+        typeof detail.selector === "string" &&
+        detail.selector.length > 0
+          ? detail.selector
+          : selector;
       return new PreviewAutomationInvalidSelectorError({
-        message: error.message,
-        selector:
-          detail && "selector" in detail && typeof detail.selector === "string"
-            ? detail.selector
-            : "",
+        ...requestContext,
+        ...remoteDiagnostics,
+        ...(responseSelector === undefined ? {} : { selector: responseSelector }),
       });
     }
     case "PreviewAutomationResultTooLargeError": {
       const detail =
         typeof error.detail === "object" && error.detail !== null ? error.detail : undefined;
+      const maximumBytes =
+        detail &&
+        "maximumBytes" in detail &&
+        typeof detail.maximumBytes === "number" &&
+        Number.isInteger(detail.maximumBytes) &&
+        detail.maximumBytes > 0
+          ? detail.maximumBytes
+          : undefined;
       return new PreviewAutomationResultTooLargeError({
-        message: error.message,
-        maximumBytes:
-          detail && "maximumBytes" in detail && typeof detail.maximumBytes === "number"
-            ? detail.maximumBytes
-            : 64_000,
+        ...requestContext,
+        ...remoteDiagnostics,
+        ...(maximumBytes === undefined ? {} : { maximumBytes }),
       });
     }
     case "PreviewAutomationUnavailableError":
-      return new PreviewAutomationUnavailableError({ message: error.message });
+      return new PreviewAutomationRemoteUnavailableError({
+        ...requestContext,
+        ...remoteDiagnostics,
+      });
     default:
       return new PreviewAutomationExecutionError({
-        message: error.message,
-        detail: error.detail,
+        ...requestContext,
+        ...remoteDiagnostics,
       });
   }
 };
@@ -148,13 +209,8 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
     });
     yield* Effect.forEach(
       toFail,
-      ({ deferred }) =>
-        Deferred.fail(
-          deferred,
-          new PreviewAutomationUnavailableError({
-            message: "The preview automation client disconnected.",
-          }),
-        ),
+      ({ deferred, context }) =>
+        Deferred.fail(deferred, new PreviewAutomationClientDisconnectedError(context)),
       { discard: true },
     );
     yield* Queue.shutdown(queue);
@@ -228,10 +284,8 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
       yield* Deferred.fail(
         pending.deferred,
         response.error
-          ? makeResponseError(response.error)
-          : new PreviewAutomationExecutionError({
-              message: "Preview automation failed without an error payload.",
-            }),
+          ? classifyResponseError(pending.context, response.error)
+          : new PreviewAutomationMalformedResponseError(pending.context),
       );
     }
   });
@@ -250,28 +304,60 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
       .sort((left, right) => right.focusedAt.localeCompare(left.focusedAt));
     const owner = candidates.find((candidate) => current.clients.has(candidate.clientId));
     if (!owner) {
-      if (candidates.length > 0) {
-        return yield* new PreviewAutomationUnavailableError({
-          message: "The browser host is not connected.",
+      const disconnectedOwner = candidates[0];
+      if (disconnectedOwner) {
+        return yield* new PreviewAutomationHostNotConnectedError({
+          operation: input.operation,
+          environmentId: input.scope.environmentId,
+          threadId: input.scope.threadId,
+          providerSessionId: input.scope.providerSessionId,
+          providerInstanceId: input.scope.providerInstanceId,
+          clientId: disconnectedOwner.clientId,
         });
       }
       return yield* new PreviewAutomationNoFocusedOwnerError({
-        message: "No desktop browser host is available for this thread.",
+        operation: input.operation,
+        environmentId: input.scope.environmentId,
+        threadId: input.scope.threadId,
+        providerSessionId: input.scope.providerSessionId,
+        providerInstanceId: input.scope.providerInstanceId,
       });
     }
     const connection = current.clients.get(owner.clientId);
     if (!connection) {
-      return yield* new PreviewAutomationUnavailableError({
-        message: "The browser host is not connected.",
+      return yield* new PreviewAutomationHostNotConnectedError({
+        operation: input.operation,
+        environmentId: input.scope.environmentId,
+        threadId: input.scope.threadId,
+        providerSessionId: input.scope.providerSessionId,
+        providerInstanceId: input.scope.providerInstanceId,
+        clientId: owner.clientId,
       });
     }
     const timeoutMs = input.timeoutMs ?? 15_000;
     const deferred = yield* Deferred.make<unknown, PreviewAutomationError>();
-    const requestId = yield* SynchronizedRef.modify(state, (next) => {
+    const [requestId, requestContext] = yield* SynchronizedRef.modify(state, (next) => {
       const requestId = `preview-${next.requestSequence}`;
+      const tabId = input.tabId ?? owner.tabId ?? undefined;
+      const selector = selectorFromInput(input.input);
+      const context: PreviewAutomationRequestErrorContext = {
+        operation: input.operation,
+        environmentId: input.scope.environmentId,
+        threadId: input.scope.threadId,
+        providerSessionId: input.scope.providerSessionId,
+        providerInstanceId: input.scope.providerInstanceId,
+        clientId: owner.clientId,
+        requestId,
+        ...(tabId === undefined ? {} : { tabId }),
+        timeoutMs,
+        ...(selector === undefined ? {} : { selector }),
+      };
       const pending = new Map(next.pending);
-      pending.set(requestId, { queue: connection.queue, deferred });
-      return [requestId, { ...next, pending, requestSequence: next.requestSequence + 1 }] as const;
+      pending.set(requestId, { queue: connection.queue, deferred, context });
+      return [
+        [requestId, context] as const,
+        { ...next, pending, requestSequence: next.requestSequence + 1 },
+      ] as const;
     });
     const removePending = SynchronizedRef.update(state, (next) => {
       if (!next.pending.has(requestId)) return next;
@@ -283,24 +369,17 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
       const offered = yield* Queue.offer(connection.queue, {
         requestId,
         threadId: input.scope.threadId,
-        tabId: input.tabId ?? owner.tabId ?? undefined,
+        tabId: requestContext.tabId,
         operation: input.operation,
         input: input.input,
         timeoutMs,
       });
       if (!offered) {
-        return yield* new PreviewAutomationUnavailableError({
-          message: "The preview automation client is no longer accepting requests.",
-        });
+        return yield* new PreviewAutomationRequestQueueClosedError(requestContext);
       }
       const result = yield* Deferred.await(deferred).pipe(Effect.timeoutOption(timeoutMs));
       return yield* Option.match(result, {
-        onNone: () =>
-          Effect.fail(
-            new PreviewAutomationTimeoutError({
-              message: `Preview automation timed out after ${timeoutMs}ms.`,
-            }),
-          ),
+        onNone: () => Effect.fail(new PreviewAutomationTimeoutError(requestContext)),
         onSome: (value) => Effect.succeed(value as A),
       });
     });

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -375,6 +375,10 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         timeoutMs,
       });
       if (!offered) {
+        const completion = yield* Deferred.poll(deferred);
+        if (Option.isSome(completion)) {
+          return (yield* completion.value) as A;
+        }
         return yield* new PreviewAutomationRequestQueueClosedError(requestContext);
       }
       const result = yield* Deferred.await(deferred).pipe(Effect.timeoutOption(timeoutMs));

--- a/apps/server/src/mcp/PreviewAutomationBroker.ts
+++ b/apps/server/src/mcp/PreviewAutomationBroker.ts
@@ -79,7 +79,8 @@ interface PreviewAutomationRequestErrorContext {
   readonly requestId: string;
   readonly tabId?: PreviewTabId;
   readonly timeoutMs: number;
-  readonly selector?: string;
+  readonly selectorKind?: "locator" | "selector";
+  readonly selectorLength?: number;
 }
 
 interface BrokerState {
@@ -89,63 +90,75 @@ interface BrokerState {
   readonly requestSequence: number;
 }
 
-const selectorFromInput = (input: unknown): string | undefined => {
-  if (typeof input !== "object" || input === null) return undefined;
-  if ("locator" in input && typeof input.locator === "string") return input.locator;
-  if ("selector" in input && typeof input.selector === "string") return input.selector;
-  return undefined;
+const selectorDiagnosticsFromInput = (
+  input: unknown,
+): Pick<PreviewAutomationRequestErrorContext, "selectorKind" | "selectorLength"> => {
+  if (typeof input !== "object" || input === null) return {};
+  if ("locator" in input && typeof input.locator === "string") {
+    return { selectorKind: "locator", selectorLength: input.locator.length };
+  }
+  if ("selector" in input && typeof input.selector === "string") {
+    return { selectorKind: "selector", selectorLength: input.selector.length };
+  }
+  return {};
 };
+
+type RemoteDetailKind = "null" | "array" | "object" | "string" | "number" | "boolean";
+
+function remoteDetailKind(detail: unknown): RemoteDetailKind {
+  if (detail === null) return "null";
+  if (Array.isArray(detail)) return "array";
+  switch (typeof detail) {
+    case "string":
+      return "string";
+    case "number":
+      return "number";
+    case "boolean":
+      return "boolean";
+    default:
+      return "object";
+  }
+}
 
 const classifyResponseError = (
   context: PreviewAutomationRequestErrorContext,
   error: NonNullable<PreviewAutomationResponse["error"]>,
 ): PreviewAutomationError => {
-  const { selector, ...requestContext } = context;
   const remoteDiagnostics = {
     remoteTag: error._tag,
-    remoteMessage: error.message,
-    ...(error.detail === undefined ? {} : { remoteDetail: error.detail }),
+    remoteMessageLength: error.message.length,
+    ...(error.detail === undefined ? {} : { remoteDetailKind: remoteDetailKind(error.detail) }),
   };
   switch (error._tag) {
     case "PreviewAutomationNoFocusedOwnerError":
       return new PreviewAutomationNoFocusedOwnerError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
       });
     case "PreviewAutomationUnsupportedClientError":
       return new PreviewAutomationUnsupportedClientError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
       });
     case "PreviewAutomationTabNotFoundError":
       return new PreviewAutomationTabNotFoundError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
       });
     case "PreviewAutomationTimeoutError":
       return new PreviewAutomationTimeoutError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
       });
     case "PreviewAutomationControlInterruptedError":
       return new PreviewAutomationControlInterruptedError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
       });
     case "PreviewAutomationInvalidSelectorError": {
-      const detail =
-        typeof error.detail === "object" && error.detail !== null ? error.detail : undefined;
-      const responseSelector =
-        detail &&
-        "selector" in detail &&
-        typeof detail.selector === "string" &&
-        detail.selector.length > 0
-          ? detail.selector
-          : selector;
       return new PreviewAutomationInvalidSelectorError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
-        ...(responseSelector === undefined ? {} : { selector: responseSelector }),
       });
     }
     case "PreviewAutomationResultTooLargeError": {
@@ -160,19 +173,19 @@ const classifyResponseError = (
           ? detail.maximumBytes
           : undefined;
       return new PreviewAutomationResultTooLargeError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
         ...(maximumBytes === undefined ? {} : { maximumBytes }),
       });
     }
     case "PreviewAutomationUnavailableError":
       return new PreviewAutomationRemoteUnavailableError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
       });
     default:
       return new PreviewAutomationExecutionError({
-        ...requestContext,
+        ...context,
         ...remoteDiagnostics,
       });
   }
@@ -339,7 +352,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
     const [requestId, requestContext] = yield* SynchronizedRef.modify(state, (next) => {
       const requestId = `preview-${next.requestSequence}`;
       const tabId = input.tabId ?? owner.tabId ?? undefined;
-      const selector = selectorFromInput(input.input);
+      const selectorDiagnostics = selectorDiagnosticsFromInput(input.input);
       const context: PreviewAutomationRequestErrorContext = {
         operation: input.operation,
         environmentId: input.scope.environmentId,
@@ -350,7 +363,7 @@ export const make = Effect.gen(function* PreviewAutomationBrokerMake() {
         requestId,
         ...(tabId === undefined ? {} : { tabId }),
         timeoutMs,
-        ...(selector === undefined ? {} : { selector }),
+        ...selectorDiagnostics,
       };
       const pending = new Map(next.pending);
       pending.set(requestId, { queue: connection.queue, deferred, context });

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -478,6 +478,7 @@ const PreviewAutomationRemoteDiagnosticFields = {
   remoteDetailKind: Schema.optional(
     Schema.Literals(["null", "array", "object", "string", "number", "boolean"]),
   ),
+  cause: Schema.Defect(),
 };
 
 const PreviewAutomationOptionalRemoteDiagnosticFields = {
@@ -486,6 +487,7 @@ const PreviewAutomationOptionalRemoteDiagnosticFields = {
   remoteDetailKind: Schema.optional(
     Schema.Literals(["null", "array", "object", "string", "number", "boolean"]),
   ),
+  cause: Schema.optional(Schema.Defect()),
 };
 
 export class PreviewAutomationNoFocusedOwnerError extends Schema.TaggedErrorClass<PreviewAutomationNoFocusedOwnerError>()(

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -2,6 +2,7 @@ import { Schema } from "effect";
 
 import { EnvironmentId, ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
 import { PreviewTabId } from "./preview.ts";
+import { ProviderInstanceId } from "./providerInstance.ts";
 
 const BoundedUrl = Schema.String.check(Schema.isTrimmed())
   .check(
@@ -455,45 +456,195 @@ export class PreviewAutomationUnavailableError extends Schema.TaggedErrorClass<P
   { message: Schema.String },
 ) {}
 
+const PreviewAutomationScopeErrorFields = {
+  operation: PreviewAutomationOperation,
+  environmentId: EnvironmentId,
+  threadId: ThreadId,
+  providerSessionId: TrimmedNonEmptyString,
+  providerInstanceId: ProviderInstanceId,
+};
+
+const PreviewAutomationRequestErrorFields = {
+  ...PreviewAutomationScopeErrorFields,
+  clientId: TrimmedNonEmptyString,
+  requestId: TrimmedNonEmptyString,
+  tabId: Schema.optional(PreviewTabId),
+  timeoutMs: Schema.Int.check(Schema.isGreaterThan(0)),
+};
+
+const PreviewAutomationRemoteDiagnosticFields = {
+  remoteTag: TrimmedNonEmptyString,
+  remoteMessage: Schema.String,
+  remoteDetail: Schema.optional(Schema.Unknown),
+};
+
 export class PreviewAutomationNoFocusedOwnerError extends Schema.TaggedErrorClass<PreviewAutomationNoFocusedOwnerError>()(
   "PreviewAutomationNoFocusedOwnerError",
-  { message: Schema.String },
-) {}
+  {
+    ...PreviewAutomationScopeErrorFields,
+    clientId: Schema.optional(TrimmedNonEmptyString),
+    requestId: Schema.optional(TrimmedNonEmptyString),
+    tabId: Schema.optional(PreviewTabId),
+    timeoutMs: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
+    remoteTag: Schema.optional(TrimmedNonEmptyString),
+    remoteMessage: Schema.optional(Schema.String),
+    remoteDetail: Schema.optional(Schema.Unknown),
+  },
+) {
+  override get message(): string {
+    const summary = `No focused preview automation owner is available for ${this.operation} in thread ${this.threadId}.`;
+    return this.remoteMessage ? `${summary} ${this.remoteMessage}` : summary;
+  }
+}
 
 export class PreviewAutomationUnsupportedClientError extends Schema.TaggedErrorClass<PreviewAutomationUnsupportedClientError>()(
   "PreviewAutomationUnsupportedClientError",
-  { message: Schema.String },
-) {}
+  {
+    ...PreviewAutomationRequestErrorFields,
+    ...PreviewAutomationRemoteDiagnosticFields,
+  },
+) {
+  override get message(): string {
+    return `Preview automation client ${this.clientId} does not support ${this.operation}. ${this.remoteMessage}`;
+  }
+}
 
 export class PreviewAutomationTabNotFoundError extends Schema.TaggedErrorClass<PreviewAutomationTabNotFoundError>()(
   "PreviewAutomationTabNotFoundError",
-  { message: Schema.String },
-) {}
+  {
+    ...PreviewAutomationRequestErrorFields,
+    ...PreviewAutomationRemoteDiagnosticFields,
+  },
+) {
+  override get message(): string {
+    const summary = this.tabId
+      ? `Preview tab ${this.tabId} was not found for ${this.operation}.`
+      : `No active preview tab was found for ${this.operation}.`;
+    return `${summary} ${this.remoteMessage}`;
+  }
+}
 
 export class PreviewAutomationTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationTimeoutError>()(
   "PreviewAutomationTimeoutError",
-  { message: Schema.String },
-) {}
+  {
+    ...PreviewAutomationRequestErrorFields,
+    remoteMessage: Schema.optional(Schema.String),
+    remoteDetail: Schema.optional(Schema.Unknown),
+  },
+) {
+  override get message(): string {
+    const summary = `Preview automation ${this.operation} timed out after ${this.timeoutMs}ms.`;
+    return this.remoteMessage ? `${summary} ${this.remoteMessage}` : summary;
+  }
+}
 
 export class PreviewAutomationControlInterruptedError extends Schema.TaggedErrorClass<PreviewAutomationControlInterruptedError>()(
   "PreviewAutomationControlInterruptedError",
-  { message: Schema.String },
-) {}
+  {
+    ...PreviewAutomationRequestErrorFields,
+    ...PreviewAutomationRemoteDiagnosticFields,
+  },
+) {
+  override get message(): string {
+    return `Preview automation ${this.operation} was interrupted on client ${this.clientId}. ${this.remoteMessage}`;
+  }
+}
 
 export class PreviewAutomationExecutionError extends Schema.TaggedErrorClass<PreviewAutomationExecutionError>()(
   "PreviewAutomationExecutionError",
-  { message: Schema.String, detail: Schema.optional(Schema.Unknown) },
-) {}
+  {
+    ...PreviewAutomationRequestErrorFields,
+    ...PreviewAutomationRemoteDiagnosticFields,
+  },
+) {
+  override get message(): string {
+    return `Preview automation ${this.operation} failed on client ${this.clientId}. ${this.remoteMessage}`;
+  }
+}
 
 export class PreviewAutomationInvalidSelectorError extends Schema.TaggedErrorClass<PreviewAutomationInvalidSelectorError>()(
   "PreviewAutomationInvalidSelectorError",
-  { message: Schema.String, selector: Schema.String },
-) {}
+  {
+    ...PreviewAutomationRequestErrorFields,
+    ...PreviewAutomationRemoteDiagnosticFields,
+    selector: Schema.optional(Schema.String),
+  },
+) {
+  override get message(): string {
+    const summary = this.selector
+      ? `Invalid preview automation selector for ${this.operation}: ${this.selector}`
+      : `Preview automation ${this.operation} received an invalid selector.`;
+    return `${summary} ${this.remoteMessage}`;
+  }
+}
 
 export class PreviewAutomationResultTooLargeError extends Schema.TaggedErrorClass<PreviewAutomationResultTooLargeError>()(
   "PreviewAutomationResultTooLargeError",
-  { message: Schema.String, maximumBytes: Schema.Int },
-) {}
+  {
+    ...PreviewAutomationRequestErrorFields,
+    ...PreviewAutomationRemoteDiagnosticFields,
+    maximumBytes: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
+  },
+) {
+  override get message(): string {
+    const summary =
+      this.maximumBytes === undefined
+        ? `Preview automation ${this.operation} produced a result that is too large.`
+        : `Preview automation ${this.operation} produced a result larger than ${this.maximumBytes} bytes.`;
+    return `${summary} ${this.remoteMessage}`;
+  }
+}
+
+export class PreviewAutomationHostNotConnectedError extends Schema.TaggedErrorClass<PreviewAutomationHostNotConnectedError>()(
+  "PreviewAutomationHostNotConnectedError",
+  {
+    ...PreviewAutomationScopeErrorFields,
+    clientId: TrimmedNonEmptyString,
+  },
+) {
+  override get message(): string {
+    return `Preview automation host ${this.clientId} is not connected for ${this.operation}.`;
+  }
+}
+
+export class PreviewAutomationClientDisconnectedError extends Schema.TaggedErrorClass<PreviewAutomationClientDisconnectedError>()(
+  "PreviewAutomationClientDisconnectedError",
+  PreviewAutomationRequestErrorFields,
+) {
+  override get message(): string {
+    return `Preview automation client ${this.clientId} disconnected during ${this.operation}.`;
+  }
+}
+
+export class PreviewAutomationRequestQueueClosedError extends Schema.TaggedErrorClass<PreviewAutomationRequestQueueClosedError>()(
+  "PreviewAutomationRequestQueueClosedError",
+  PreviewAutomationRequestErrorFields,
+) {
+  override get message(): string {
+    return `Preview automation client ${this.clientId} stopped accepting ${this.operation} requests.`;
+  }
+}
+
+export class PreviewAutomationRemoteUnavailableError extends Schema.TaggedErrorClass<PreviewAutomationRemoteUnavailableError>()(
+  "PreviewAutomationRemoteUnavailableError",
+  {
+    ...PreviewAutomationRequestErrorFields,
+    ...PreviewAutomationRemoteDiagnosticFields,
+  },
+) {
+  override get message(): string {
+    return `Preview automation ${this.operation} is unavailable on client ${this.clientId}. ${this.remoteMessage}`;
+  }
+}
+
+export class PreviewAutomationMalformedResponseError extends Schema.TaggedErrorClass<PreviewAutomationMalformedResponseError>()(
+  "PreviewAutomationMalformedResponseError",
+  PreviewAutomationRequestErrorFields,
+) {
+  override get message(): string {
+    return `Preview automation client ${this.clientId} returned a malformed response for ${this.operation}.`;
+  }
+}
 
 export const PreviewAutomationError = Schema.Union([
   PreviewAutomationUnavailableError,
@@ -505,6 +656,11 @@ export const PreviewAutomationError = Schema.Union([
   PreviewAutomationExecutionError,
   PreviewAutomationInvalidSelectorError,
   PreviewAutomationResultTooLargeError,
+  PreviewAutomationHostNotConnectedError,
+  PreviewAutomationClientDisconnectedError,
+  PreviewAutomationRequestQueueClosedError,
+  PreviewAutomationRemoteUnavailableError,
+  PreviewAutomationMalformedResponseError,
 ]);
 export type PreviewAutomationError = typeof PreviewAutomationError.Type;
 

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -474,8 +474,18 @@ const PreviewAutomationRequestErrorFields = {
 
 const PreviewAutomationRemoteDiagnosticFields = {
   remoteTag: TrimmedNonEmptyString,
-  remoteMessage: Schema.String,
-  remoteDetail: Schema.optional(Schema.Unknown),
+  remoteMessageLength: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  remoteDetailKind: Schema.optional(
+    Schema.Literals(["null", "array", "object", "string", "number", "boolean"]),
+  ),
+};
+
+const PreviewAutomationOptionalRemoteDiagnosticFields = {
+  remoteTag: Schema.optional(TrimmedNonEmptyString),
+  remoteMessageLength: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
+  remoteDetailKind: Schema.optional(
+    Schema.Literals(["null", "array", "object", "string", "number", "boolean"]),
+  ),
 };
 
 export class PreviewAutomationNoFocusedOwnerError extends Schema.TaggedErrorClass<PreviewAutomationNoFocusedOwnerError>()(
@@ -486,14 +496,12 @@ export class PreviewAutomationNoFocusedOwnerError extends Schema.TaggedErrorClas
     requestId: Schema.optional(TrimmedNonEmptyString),
     tabId: Schema.optional(PreviewTabId),
     timeoutMs: Schema.optional(Schema.Int.check(Schema.isGreaterThan(0))),
-    remoteTag: Schema.optional(TrimmedNonEmptyString),
-    remoteMessage: Schema.optional(Schema.String),
-    remoteDetail: Schema.optional(Schema.Unknown),
+    ...PreviewAutomationOptionalRemoteDiagnosticFields,
   },
 ) {
   override get message(): string {
     const summary = `No focused preview automation owner is available for ${this.operation} in thread ${this.threadId}.`;
-    return this.remoteMessage ? `${summary} ${this.remoteMessage}` : summary;
+    return summary;
   }
 }
 
@@ -505,7 +513,7 @@ export class PreviewAutomationUnsupportedClientError extends Schema.TaggedErrorC
   },
 ) {
   override get message(): string {
-    return `Preview automation client ${this.clientId} does not support ${this.operation}. ${this.remoteMessage}`;
+    return `Preview automation client ${this.clientId} does not support ${this.operation}.`;
   }
 }
 
@@ -520,7 +528,7 @@ export class PreviewAutomationTabNotFoundError extends Schema.TaggedErrorClass<P
     const summary = this.tabId
       ? `Preview tab ${this.tabId} was not found for ${this.operation}.`
       : `No active preview tab was found for ${this.operation}.`;
-    return `${summary} ${this.remoteMessage}`;
+    return summary;
   }
 }
 
@@ -528,13 +536,12 @@ export class PreviewAutomationTimeoutError extends Schema.TaggedErrorClass<Previ
   "PreviewAutomationTimeoutError",
   {
     ...PreviewAutomationRequestErrorFields,
-    remoteMessage: Schema.optional(Schema.String),
-    remoteDetail: Schema.optional(Schema.Unknown),
+    ...PreviewAutomationOptionalRemoteDiagnosticFields,
   },
 ) {
   override get message(): string {
     const summary = `Preview automation ${this.operation} timed out after ${this.timeoutMs}ms.`;
-    return this.remoteMessage ? `${summary} ${this.remoteMessage}` : summary;
+    return summary;
   }
 }
 
@@ -546,7 +553,7 @@ export class PreviewAutomationControlInterruptedError extends Schema.TaggedError
   },
 ) {
   override get message(): string {
-    return `Preview automation ${this.operation} was interrupted on client ${this.clientId}. ${this.remoteMessage}`;
+    return `Preview automation ${this.operation} was interrupted on client ${this.clientId}.`;
   }
 }
 
@@ -558,7 +565,7 @@ export class PreviewAutomationExecutionError extends Schema.TaggedErrorClass<Pre
   },
 ) {
   override get message(): string {
-    return `Preview automation ${this.operation} failed on client ${this.clientId}. ${this.remoteMessage}`;
+    return `Preview automation ${this.operation} failed on client ${this.clientId}.`;
   }
 }
 
@@ -567,14 +574,15 @@ export class PreviewAutomationInvalidSelectorError extends Schema.TaggedErrorCla
   {
     ...PreviewAutomationRequestErrorFields,
     ...PreviewAutomationRemoteDiagnosticFields,
-    selector: Schema.optional(Schema.String),
+    selectorKind: Schema.optional(Schema.Literals(["locator", "selector"])),
+    selectorLength: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0))),
   },
 ) {
   override get message(): string {
-    const summary = this.selector
-      ? `Invalid preview automation selector for ${this.operation}: ${this.selector}`
-      : `Preview automation ${this.operation} received an invalid selector.`;
-    return `${summary} ${this.remoteMessage}`;
+    if (this.selectorKind !== undefined && this.selectorLength !== undefined) {
+      return `Preview automation ${this.operation} received an invalid ${this.selectorKind} (${this.selectorLength} characters).`;
+    }
+    return `Preview automation ${this.operation} received an invalid selector.`;
   }
 }
 
@@ -591,7 +599,7 @@ export class PreviewAutomationResultTooLargeError extends Schema.TaggedErrorClas
       this.maximumBytes === undefined
         ? `Preview automation ${this.operation} produced a result that is too large.`
         : `Preview automation ${this.operation} produced a result larger than ${this.maximumBytes} bytes.`;
-    return `${summary} ${this.remoteMessage}`;
+    return summary;
   }
 }
 
@@ -633,7 +641,7 @@ export class PreviewAutomationRemoteUnavailableError extends Schema.TaggedErrorC
   },
 ) {
   override get message(): string {
-    return `Preview automation ${this.operation} is unavailable on client ${this.clientId}. ${this.remoteMessage}`;
+    return `Preview automation ${this.operation} is unavailable on client ${this.clientId}.`;
   }
 }
 


### PR DESCRIPTION
## Summary\n- attach MCP scope, provider, client, request, tab, timeout, and bounded selector context to preview automation failures\n- distinguish host, disconnect, queue, remote-unavailable, and malformed-response failures instead of collapsing them into message bags\n- retain remote tags plus message lengths/detail kinds without copying arbitrary remote messages, details, or selectors into direct fields/messages; preserve the exact remote failure payload only as the cause chain

## Verification
- `vp test apps/server/src/mcp/PreviewAutomationBroker.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broker and contract error shapes change in ways that break `PreviewAutomationUnavailableError` matching; behavior is still localized to preview automation/MCP paths with added tests.
> 
> **Overview**
> **Preview automation failures** are now typed, request-scoped errors instead of free-form `message` bags.
> 
> Contract error classes gain **MCP scope** (`operation`, `environmentId`, `threadId`, `providerSessionId`, `providerInstanceId`) and, when a request was in flight, **client/request context** (`clientId`, `requestId`, `tabId`, `timeoutMs`). Remote failures add **bounded diagnostics** (`remoteTag`, `remoteMessageLength`, optional `remoteDetailKind`) and keep the wire payload on **`cause`**, without copying arbitrary remote messages or selector strings into surfaced fields. **`PreviewAutomationInvalidSelectorError`** drops the raw selector in favor of `selectorKind` / `selectorLength`.
> 
> **`PreviewAutomationBroker`** stores that context on each pending request, uses **`classifyResponseError`** to map remote tags (including legacy `PreviewAutomationUnavailableError`) to the right type, and splits former “unavailable” cases into **`PreviewAutomationHostNotConnectedError`**, **`PreviewAutomationClientDisconnectedError`**, **`PreviewAutomationRequestQueueClosedError`**, **`PreviewAutomationRemoteUnavailableError`**, and **`PreviewAutomationMalformedResponseError`**. Tests assert the new shapes and that secrets do not leak into `message`.
> 
> **Breaking for callers:** code that only matched **`PreviewAutomationUnavailableError`** from the broker must handle the new tags; the old class remains for other uses (e.g. MCP capability checks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9112391079bcc818c182df84242f7d924db69e76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure preview automation errors with typed context and diagnostics
> - Replaces generic error construction in `PreviewAutomationBroker` with structured per-request context (`PreviewAutomationRequestErrorContext`) carrying operation, environment, thread, provider, client, request, timeout, and selector diagnostics.
> - Adds five new error types: `PreviewAutomationHostNotConnectedError`, `PreviewAutomationClientDisconnectedError`, `PreviewAutomationRequestQueueClosedError`, `PreviewAutomationRemoteUnavailableError`, and `PreviewAutomationMalformedResponseError`.
> - Existing errors (`NoFocusedOwnerError`, `TimeoutError`, `ExecutionError`, `InvalidSelectorError`, etc.) are extended with structured request/scope fields and dynamic message getters; raw selector values are replaced with bounded `selectorKind`/`selectorLength` diagnostics.
> - `classifyResponseError` replaces `makeResponseError`, mapping remote failures to concrete typed errors with remote tag, message length, and detail kind metadata.
> - Behavioral Change: `PreviewAutomationUnavailableError` from remote is now mapped to `PreviewAutomationRemoteUnavailableError`; client disconnection during a pending request now throws `PreviewAutomationClientDisconnectedError` instead of `PreviewAutomationUnavailableError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9112391.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->