### PR TITLE
[codex] Structure desktop browser session errors

### DIFF
--- a/apps/desktop/src/preview/BrowserSession.test.ts
+++ b/apps/desktop/src/preview/BrowserSession.test.ts
@@ -1,7 +1,9 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import { beforeEach, vi } from "vite-plus/test";
 
 const { fromPartition, sessions } = vi.hoisted(() => ({
@@ -59,6 +61,64 @@ describe("BrowserSession", () => {
     }).pipe(Effect.provide(layer)),
   );
 
+  it.effect("preserves partition scope and the platform failure chain", () => {
+    const nativeCause = new Error("native digest failed");
+    const platformCause = PlatformError.systemError({
+      _tag: "Unknown",
+      module: "Crypto",
+      method: "digest",
+      cause: nativeCause,
+    });
+    const failingCryptoLayer = Layer.succeed(
+      Crypto.Crypto,
+      Crypto.make({
+        randomBytes: (size) => new Uint8Array(size),
+        digest: () => Effect.fail(platformCause),
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const browserSessions = yield* BrowserSession.BrowserSession;
+      const error = yield* browserSessions.getPartition("environment-a").pipe(Effect.flip);
+
+      assert.instanceOf(error, BrowserSession.BrowserSessionPartitionDerivationError);
+      assert.isTrue(BrowserSession.isBrowserSessionGetSessionError(error));
+      assert.isTrue(BrowserSession.isBrowserSessionError(error));
+      assert.equal(error.scope, "environment-a");
+      assert.strictEqual(error.cause, platformCause);
+      assert.strictEqual(error.cause.reason.cause, nativeCause);
+      assert.equal(
+        error.message,
+        "Failed to derive a desktop preview browser partition for scope environment-a.",
+      );
+      assert.notInclude(error.message, nativeCause.message);
+    }).pipe(Effect.provide(BrowserSession.layer.pipe(Layer.provide(failingCryptoLayer))));
+  });
+
+  it.effect("preserves session scope, partition, and the Electron failure", () =>
+    Effect.gen(function* () {
+      const cause = new Error("Electron session failed");
+      fromPartition.mockImplementationOnce(() => {
+        throw cause;
+      });
+      const browserSessions = yield* BrowserSession.BrowserSession;
+      const partition = yield* browserSessions.getPartition("environment-b");
+      const error = yield* browserSessions.getSession("environment-b").pipe(Effect.flip);
+
+      assert.instanceOf(error, BrowserSession.BrowserSessionCreationError);
+      assert.isTrue(BrowserSession.isBrowserSessionGetSessionError(error));
+      assert.isTrue(BrowserSession.isBrowserSessionError(error));
+      assert.equal(error.scope, "environment-b");
+      assert.equal(error.partition, partition);
+      assert.strictEqual(error.cause, cause);
+      assert.equal(
+        error.message,
+        `Failed to create a desktop preview browser session for scope environment-b (partition ${partition}).`,
+      );
+      assert.notInclude(error.message, cause.message);
+    }).pipe(Effect.provide(layer)),
+  );
+
   it.effect("clears storage and cache for every created session", () =>
     Effect.gen(function* () {
       const browserSessions = yield* BrowserSession.BrowserSession;
@@ -76,6 +136,54 @@ describe("BrowserSession", () => {
             storages: ["cookies", "localstorage", "indexdb", "websql", "serviceworkers"],
           },
         ]);
+        assert.strictEqual(browserSession.clearCache.mock.calls.length, 1);
+      }
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("correlates clear failures while still attempting every session", () =>
+    Effect.gen(function* () {
+      const browserSessions = yield* BrowserSession.BrowserSession;
+      yield* browserSessions.getSession("scope-a");
+      yield* browserSessions.getSession("scope-b");
+      const firstPartition = yield* browserSessions.getPartition("scope-a");
+      const secondPartition = yield* browserSessions.getPartition("scope-b");
+      const firstSession = sessions.get(firstPartition);
+      const secondSession = sessions.get(secondPartition);
+      assert.isDefined(firstSession);
+      assert.isDefined(secondSession);
+
+      const storageCause = new Error("storage clear failed");
+      secondSession.clearStorageData.mockImplementationOnce(() => Promise.reject(storageCause));
+      const storageError = yield* browserSessions.clearCookies().pipe(Effect.flip);
+
+      assert.instanceOf(storageError, BrowserSession.BrowserSessionStorageClearError);
+      assert.isTrue(BrowserSession.isBrowserSessionError(storageError));
+      assert.equal(storageError.partition, secondPartition);
+      assert.strictEqual(storageError.cause, storageCause);
+      assert.equal(
+        storageError.message,
+        `Failed to clear desktop preview browser storage for partition ${secondPartition}.`,
+      );
+      assert.notInclude(storageError.message, storageCause.message);
+      for (const browserSession of sessions.values()) {
+        assert.strictEqual(browserSession.clearStorageData.mock.calls.length, 1);
+      }
+
+      const cacheCause = new Error("cache clear failed");
+      firstSession.clearCache.mockImplementationOnce(() => Promise.reject(cacheCause));
+      const cacheError = yield* browserSessions.clearCache().pipe(Effect.flip);
+
+      assert.instanceOf(cacheError, BrowserSession.BrowserSessionCacheClearError);
+      assert.isTrue(BrowserSession.isBrowserSessionError(cacheError));
+      assert.equal(cacheError.partition, firstPartition);
+      assert.strictEqual(cacheError.cause, cacheCause);
+      assert.equal(
+        cacheError.message,
+        `Failed to clear the desktop preview browser cache for partition ${firstPartition}.`,
+      );
+      assert.notInclude(cacheError.message, cacheCause.message);
+      for (const browserSession of sessions.values()) {
         assert.strictEqual(browserSession.clearCache.mock.calls.length, 1);
       }
     }).pipe(Effect.provide(layer)),

--- a/apps/desktop/src/preview/BrowserSession.ts
+++ b/apps/desktop/src/preview/BrowserSession.ts
@@ -5,31 +5,87 @@ import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as SynchronizedRef from "effect/SynchronizedRef";
 
 const PREVIEW_PARTITION_PREFIX = "persist:t3code-preview-";
 
-export class BrowserSessionError extends Schema.TaggedErrorClass<BrowserSessionError>()(
-  "BrowserSessionError",
+export class BrowserSessionPartitionDerivationError extends Schema.TaggedErrorClass<BrowserSessionPartitionDerivationError>()(
+  "BrowserSessionPartitionDerivationError",
   {
-    operation: Schema.Literals(["getPartition", "getSession", "clearCookies", "clearCache"]),
+    scope: Schema.String,
+    cause: Schema.instanceOf(PlatformError.PlatformError),
+  },
+) {
+  override get message(): string {
+    return `Failed to derive a desktop preview browser partition for scope ${this.scope}.`;
+  }
+}
+
+export class BrowserSessionCreationError extends Schema.TaggedErrorClass<BrowserSessionCreationError>()(
+  "BrowserSessionCreationError",
+  {
+    scope: Schema.String,
+    partition: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Desktop preview browser session operation failed: ${this.operation}`;
+    return `Failed to create a desktop preview browser session for scope ${this.scope} (partition ${this.partition}).`;
   }
 }
+
+export class BrowserSessionStorageClearError extends Schema.TaggedErrorClass<BrowserSessionStorageClearError>()(
+  "BrowserSessionStorageClearError",
+  {
+    partition: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to clear desktop preview browser storage for partition ${this.partition}.`;
+  }
+}
+
+export class BrowserSessionCacheClearError extends Schema.TaggedErrorClass<BrowserSessionCacheClearError>()(
+  "BrowserSessionCacheClearError",
+  {
+    partition: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to clear the desktop preview browser cache for partition ${this.partition}.`;
+  }
+}
+
+export const BrowserSessionGetSessionError = Schema.Union([
+  BrowserSessionPartitionDerivationError,
+  BrowserSessionCreationError,
+]);
+export type BrowserSessionGetSessionError = typeof BrowserSessionGetSessionError.Type;
+export const isBrowserSessionGetSessionError = Schema.is(BrowserSessionGetSessionError);
+
+export const BrowserSessionError = Schema.Union([
+  BrowserSessionPartitionDerivationError,
+  BrowserSessionCreationError,
+  BrowserSessionStorageClearError,
+  BrowserSessionCacheClearError,
+]);
+export type BrowserSessionError = typeof BrowserSessionError.Type;
+export const isBrowserSessionError = Schema.is(BrowserSessionError);
 
 export class BrowserSession extends Context.Service<
   BrowserSession,
   {
-    readonly getPartition: (scope?: string) => Effect.Effect<string, BrowserSessionError>;
+    readonly getPartition: (
+      scope?: string,
+    ) => Effect.Effect<string, BrowserSessionPartitionDerivationError>;
     readonly isPartition: (partition: string) => boolean;
-    readonly getSession: (scope?: string) => Effect.Effect<Session, BrowserSessionError>;
-    readonly clearCookies: () => Effect.Effect<void, BrowserSessionError>;
-    readonly clearCache: () => Effect.Effect<void, BrowserSessionError>;
+    readonly getSession: (scope?: string) => Effect.Effect<Session, BrowserSessionGetSessionError>;
+    readonly clearCookies: () => Effect.Effect<void, BrowserSessionStorageClearError>;
+    readonly clearCache: () => Effect.Effect<void, BrowserSessionCacheClearError>;
   }
 >()("@t3tools/desktop/preview/BrowserSession") {}
 
@@ -38,11 +94,15 @@ export const make = Effect.gen(function* BrowserSessionMake() {
   const sessionsRef = yield* SynchronizedRef.make<ReadonlyMap<string, Session>>(new Map());
 
   const getPartition = Effect.fn("BrowserSession.getPartition")(function* (scope = "shared") {
-    const digest = yield* crypto
-      .digest("SHA-256", new TextEncoder().encode(scope))
-      .pipe(
-        Effect.mapError((cause) => new BrowserSessionError({ operation: "getPartition", cause })),
-      );
+    const digest = yield* crypto.digest("SHA-256", new TextEncoder().encode(scope)).pipe(
+      Effect.mapError(
+        (cause) =>
+          new BrowserSessionPartitionDerivationError({
+            scope,
+            cause,
+          }),
+      ),
+    );
     return `${PREVIEW_PARTITION_PREFIX}${Encoding.encodeHex(digest).slice(0, 20)}`;
   });
 
@@ -67,7 +127,12 @@ export const make = Effect.gen(function* BrowserSessionMake() {
           next.set(partition, browserSession);
           return [browserSession, next] as const;
         },
-        catch: (cause) => new BrowserSessionError({ operation: "getSession", cause }),
+        catch: (cause) =>
+          new BrowserSessionCreationError({
+            scope,
+            partition,
+            cause,
+          }),
       });
     });
   });
@@ -79,13 +144,17 @@ export const make = Effect.gen(function* BrowserSessionMake() {
     clearCookies: Effect.fn("BrowserSession.clearCookies")(function* () {
       const sessions = yield* SynchronizedRef.get(sessionsRef);
       yield* Effect.all(
-        [...sessions.values()].map((browserSession) =>
+        [...sessions.entries()].map(([partition, browserSession]) =>
           Effect.tryPromise({
             try: () =>
               browserSession.clearStorageData({
                 storages: ["cookies", "localstorage", "indexdb", "websql", "serviceworkers"],
               }),
-            catch: (cause) => new BrowserSessionError({ operation: "clearCookies", cause }),
+            catch: (cause) =>
+              new BrowserSessionStorageClearError({
+                partition,
+                cause,
+              }),
           }),
         ),
         { concurrency: "unbounded", discard: true },
@@ -94,10 +163,14 @@ export const make = Effect.gen(function* BrowserSessionMake() {
     clearCache: Effect.fn("BrowserSession.clearCache")(function* () {
       const sessions = yield* SynchronizedRef.get(sessionsRef);
       yield* Effect.all(
-        [...sessions.values()].map((browserSession) =>
+        [...sessions.entries()].map(([partition, browserSession]) =>
           Effect.tryPromise({
             try: () => browserSession.clearCache(),
-            catch: (cause) => new BrowserSessionError({ operation: "clearCache", cause }),
+            catch: (cause) =>
+              new BrowserSessionCacheClearError({
+                partition,
+                cause,
+              }),
           }),
         ),
         { concurrency: "unbounded", discard: true },


### PR DESCRIPTION
## Summary
- replace the generic browser-session operation error with method-specific Schema errors
- retain scope and partition identifiers so failures can be correlated to the affected preview session
- preserve the concrete PlatformError chain for partition derivation and original Electron/session causes elsewhere
- keep unbounded clear behavior while identifying the failing partition
- expose Schema unions and direct predicates for the service and get-session error sets

## Validation
- vp test apps/desktop/src/preview/BrowserSession.test.ts
- vp check (0 errors; 20 existing unrelated warnings)
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of preview session error modeling and tests; behavior for success paths and bulk clear concurrency is unchanged aside from richer error shapes.
> 
> **Overview**
> Replaces the single **`BrowserSessionError`** (operation string + defect) with **four tagged Schema errors** for partition derivation, session creation, storage clear, and cache clear. Each failure now carries **scope** and/or **partition** for correlation, keeps the **original `PlatformError` or Electron cause** on the error object, and uses **stable user-facing messages** that omit raw underlying error text.
> 
> The **`BrowserSession`** service API is narrowed so **`getPartition`**, **`getSession`**, **`clearCookies`**, and **`clearCache`** each declare their specific error types, with **`BrowserSessionGetSessionError`** and **`BrowserSessionError`** unions plus **`isBrowserSession*`** predicates. Clear paths still run **unbounded `Effect.all`** over all sessions but map failures to errors that identify the **failing partition**.
> 
> Tests add coverage for crypto digest failures, Electron **`fromPartition`** throws, and partial clear failures while still attempting every session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db0241bf2e120ce67ceaf571bcdd3b5a066f1d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure `BrowserSession` errors into typed, contextual error classes
> - Replaces a generic error type in [`BrowserSession.ts`](https://github.com/pingdotgg/t3code/pull/3273/files#diff-17a3bda9cc115ba14d32576e0f787fbd4488b05312afb31216156b1616efee0f) with four specific tagged error classes: `BrowserSessionPartitionDerivationError`, `BrowserSessionCreationError`, `BrowserSessionStorageClearError`, and `BrowserSessionCacheClearError`.
> - Each error carries contextual fields (scope, partition, or cause) and a sanitized message; errors preserve the original underlying cause chain.
> - Exports `BrowserSessionGetSessionError` and `BrowserSessionError` as discriminated union schemas with `is*` type guards for callers.
> - `clearCookies` and `clearCache` now iterate all sessions with unbounded concurrency, correlating failures to specific partitions while still attempting every session.
> - New tests in [`BrowserSession.test.ts`](https://github.com/pingdotgg/t3code/pull/3273/files#diff-bfb816daf00b721b7015b3d41241ae829ecb9997ff6ddf8a6fde1d746df58182) validate the full error shape, cause chain, and type guards for each failure path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db0241b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->