### PR TITLE
[codex] Structure preview URL failures

### DIFF
--- a/apps/server/src/preview/Manager.test.ts
+++ b/apps/server/src/preview/Manager.test.ts
@@ -1,5 +1,6 @@
 import { it } from "@effect/vitest";
 import { type PreviewEvent, ThreadId } from "@t3tools/contracts";
+import { PreviewUrlNormalizationError } from "@t3tools/shared/preview";
 import { Effect, PubSub } from "effect";
 import { expect } from "vite-plus/test";
 
@@ -83,6 +84,23 @@ it.layer(PreviewManager.layer)("PreviewManager", (it) => {
       const manager = yield* PreviewManager.PreviewManager;
       const error = yield* Effect.flip(manager.open({ threadId, url: "   " }));
       expect(error._tag).toBe("PreviewInvalidUrlError");
+      expect(error).toMatchObject({ rawUrl: "   ", reason: "empty" });
+      expect(error.cause).toBeInstanceOf(PreviewUrlNormalizationError);
+      expect((error.cause as PreviewUrlNormalizationError).reason).toBe("empty");
+    }),
+  );
+
+  it.effect("preserves URL parser failures as the invalid URL cause chain", () =>
+    Effect.gen(function* () {
+      const threadId = freshThreadId();
+      const manager = yield* PreviewManager.PreviewManager;
+      const error = yield* Effect.flip(manager.open({ threadId, url: "http://" }));
+
+      expect(error).toMatchObject({ rawUrl: "http://", reason: "parse" });
+      expect(error.cause).toBeInstanceOf(PreviewUrlNormalizationError);
+      const normalizationError = error.cause as PreviewUrlNormalizationError;
+      expect(normalizationError.cause).toBeInstanceOf(Error);
+      expect(error.message).not.toContain((normalizationError.cause as Error).message);
     }),
   );
 

--- a/apps/server/src/preview/Manager.test.ts
+++ b/apps/server/src/preview/Manager.test.ts
@@ -84,7 +84,8 @@ it.layer(PreviewManager.layer)("PreviewManager", (it) => {
       const manager = yield* PreviewManager.PreviewManager;
       const error = yield* Effect.flip(manager.open({ threadId, url: "   " }));
       expect(error._tag).toBe("PreviewInvalidUrlError");
-      expect(error).toMatchObject({ rawUrl: "   ", reason: "empty" });
+      expect(error).toMatchObject({ inputLength: 3, reason: "empty" });
+      expect(error).not.toHaveProperty("rawUrl");
       expect(error.cause).toBeInstanceOf(PreviewUrlNormalizationError);
       expect((error.cause as PreviewUrlNormalizationError).reason).toBe("empty");
     }),
@@ -94,13 +95,20 @@ it.layer(PreviewManager.layer)("PreviewManager", (it) => {
     Effect.gen(function* () {
       const threadId = freshThreadId();
       const manager = yield* PreviewManager.PreviewManager;
-      const error = yield* Effect.flip(manager.open({ threadId, url: "http://" }));
+      const rawUrl = "https://user:password@example.com:bad/path?access_token=secret#fragment";
+      const error = yield* Effect.flip(manager.open({ threadId, url: rawUrl }));
 
-      expect(error).toMatchObject({ rawUrl: "http://", reason: "parse" });
+      expect(error).toMatchObject({
+        inputLength: rawUrl.length,
+        reason: "parse",
+        protocol: "https:",
+      });
+      expect(error).not.toHaveProperty("rawUrl");
       expect(error.cause).toBeInstanceOf(PreviewUrlNormalizationError);
       const normalizationError = error.cause as PreviewUrlNormalizationError;
       expect(normalizationError.cause).toBeInstanceOf(Error);
       expect(error.message).not.toContain((normalizationError.cause as Error).message);
+      expect(error.message).not.toMatch(/user|password|access_token|secret|fragment/);
     }),
   );
 

--- a/apps/server/src/preview/Manager.ts
+++ b/apps/server/src/preview/Manager.ts
@@ -24,9 +24,9 @@ import {
   type PreviewSessionSnapshot,
 } from "@t3tools/contracts";
 import {
+  isPreviewUrlNormalizationError,
   newPreviewTabId,
   normalizePreviewUrl,
-  PreviewUrlNormalizationError,
 } from "@t3tools/shared/preview";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -82,16 +82,18 @@ const sessionsForThread = (
 const normalizeUrl = (rawUrl: string): Effect.Effect<string, PreviewInvalidUrlError> =>
   Effect.try({
     try: () => normalizePreviewUrl(rawUrl),
-    catch: (cause) =>
-      new PreviewInvalidUrlError({
-        rawUrl,
-        detail:
-          cause instanceof PreviewUrlNormalizationError
-            ? cause.detail
-            : cause instanceof Error
-              ? cause.message
-              : String(cause),
-      }),
+    catch: (cause) => {
+      if (isPreviewUrlNormalizationError(cause)) {
+        return new PreviewInvalidUrlError({
+          rawUrl: cause.rawUrl,
+          reason: cause.reason,
+          protocol: cause.protocol,
+          cause,
+        });
+      }
+
+      return new PreviewInvalidUrlError({ rawUrl, reason: "unexpected", cause });
+    },
   });
 
 const currentIsoTimestamp = DateTime.now.pipe(Effect.map(DateTime.formatIso));

--- a/apps/server/src/preview/Manager.ts
+++ b/apps/server/src/preview/Manager.ts
@@ -85,14 +85,18 @@ const normalizeUrl = (rawUrl: string): Effect.Effect<string, PreviewInvalidUrlEr
     catch: (cause) => {
       if (isPreviewUrlNormalizationError(cause)) {
         return new PreviewInvalidUrlError({
-          rawUrl: cause.rawUrl,
+          inputLength: cause.inputLength,
           reason: cause.reason,
           protocol: cause.protocol,
           cause,
         });
       }
 
-      return new PreviewInvalidUrlError({ rawUrl, reason: "unexpected", cause });
+      return new PreviewInvalidUrlError({
+        inputLength: rawUrl.length,
+        reason: "unexpected",
+        cause,
+      });
     },
   });
 

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -175,7 +175,7 @@ export class PreviewInvalidUrlError extends Schema.TaggedErrorClass<PreviewInval
     inputLength: Schema.Number,
     reason: Schema.Literals(["empty", "parse", "unsupported-protocol", "unexpected"]),
     protocol: Schema.optional(Schema.String),
-    cause: Schema.optional(Schema.Defect()),
+    cause: Schema.Defect(),
   },
 ) {
   override get message() {

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -173,13 +173,14 @@ export class PreviewInvalidUrlError extends Schema.TaggedErrorClass<PreviewInval
   "PreviewInvalidUrlError",
   {
     rawUrl: Schema.String,
-    detail: Schema.optional(Schema.String),
+    reason: Schema.Literals(["empty", "parse", "unsupported-protocol", "unexpected"]),
+    protocol: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message() {
-    return this.detail
-      ? `Invalid preview URL: ${this.rawUrl} (${this.detail})`
-      : `Invalid preview URL: ${this.rawUrl}`;
+    const protocol = this.protocol === undefined ? "" : `: ${this.protocol}`;
+    return `Invalid preview URL "${this.rawUrl}" (${this.reason}${protocol}).`;
   }
 }
 

--- a/packages/contracts/src/preview.ts
+++ b/packages/contracts/src/preview.ts
@@ -172,7 +172,7 @@ export class PreviewSessionLookupError extends Schema.TaggedErrorClass<PreviewSe
 export class PreviewInvalidUrlError extends Schema.TaggedErrorClass<PreviewInvalidUrlError>()(
   "PreviewInvalidUrlError",
   {
-    rawUrl: Schema.String,
+    inputLength: Schema.Number,
     reason: Schema.Literals(["empty", "parse", "unsupported-protocol", "unexpected"]),
     protocol: Schema.optional(Schema.String),
     cause: Schema.optional(Schema.Defect()),
@@ -180,7 +180,7 @@ export class PreviewInvalidUrlError extends Schema.TaggedErrorClass<PreviewInval
 ) {
   override get message() {
     const protocol = this.protocol === undefined ? "" : `: ${this.protocol}`;
-    return `Invalid preview URL "${this.rawUrl}" (${this.reason}${protocol}).`;
+    return `Invalid preview URL (${this.reason}${protocol}; input length ${this.inputLength}).`;
   }
 }
 

--- a/packages/shared/src/preview.test.ts
+++ b/packages/shared/src/preview.test.ts
@@ -66,7 +66,8 @@ describe("normalizePreviewUrl", () => {
       expect.unreachable("expected URL normalization to fail");
     } catch (error) {
       expect(error).toBeInstanceOf(PreviewUrlNormalizationError);
-      expect(error).toMatchObject({ rawUrl: "   ", reason: "empty" });
+      expect(error).toMatchObject({ inputLength: 3, reason: "empty" });
+      expect(error).not.toHaveProperty("rawUrl");
       expect("cause" in (error as object)).toBe(false);
     }
   });
@@ -78,23 +79,32 @@ describe("normalizePreviewUrl", () => {
     } catch (error) {
       expect(error).toBeInstanceOf(PreviewUrlNormalizationError);
       expect(error).toMatchObject({
-        rawUrl: "ftp://example.com",
+        inputLength: "ftp://example.com".length,
         reason: "unsupported-protocol",
         protocol: "ftp:",
       });
     }
   });
 
-  it("rejects unparseable junk", () => {
+  it("rejects unparseable input without retaining credentials or tokens", () => {
+    const rawUrl = "https://user:password@example.com:bad/path?access_token=secret#fragment";
     try {
-      normalizePreviewUrl("http://");
+      normalizePreviewUrl(rawUrl);
       expect.unreachable("expected URL normalization to fail");
     } catch (error) {
       expect(error).toBeInstanceOf(PreviewUrlNormalizationError);
-      expect(error).toMatchObject({ rawUrl: "http://", reason: "parse" });
+      expect(error).toMatchObject({
+        inputLength: rawUrl.length,
+        reason: "parse",
+        protocol: "https:",
+      });
+      expect(error).not.toHaveProperty("rawUrl");
       expect((error as PreviewUrlNormalizationError).cause).toBeInstanceOf(Error);
       expect((error as PreviewUrlNormalizationError).message).not.toContain(
         ((error as PreviewUrlNormalizationError).cause as Error).message,
+      );
+      expect((error as PreviewUrlNormalizationError).message).not.toMatch(
+        /user|password|access_token|secret|fragment/,
       );
     }
   });

--- a/packages/shared/src/preview.test.ts
+++ b/packages/shared/src/preview.test.ts
@@ -61,15 +61,41 @@ describe("normalizePreviewUrl", () => {
   });
 
   it("rejects empty input", () => {
-    expect(() => normalizePreviewUrl("   ")).toThrow(PreviewUrlNormalizationError);
+    try {
+      normalizePreviewUrl("   ");
+      expect.unreachable("expected URL normalization to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PreviewUrlNormalizationError);
+      expect(error).toMatchObject({ rawUrl: "   ", reason: "empty" });
+      expect("cause" in (error as object)).toBe(false);
+    }
   });
 
   it("rejects unsupported protocols", () => {
-    expect(() => normalizePreviewUrl("ftp://example.com")).toThrow(PreviewUrlNormalizationError);
-    expect(() => normalizePreviewUrl("file:///etc/passwd")).toThrow(PreviewUrlNormalizationError);
+    try {
+      normalizePreviewUrl("ftp://example.com");
+      expect.unreachable("expected URL normalization to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PreviewUrlNormalizationError);
+      expect(error).toMatchObject({
+        rawUrl: "ftp://example.com",
+        reason: "unsupported-protocol",
+        protocol: "ftp:",
+      });
+    }
   });
 
   it("rejects unparseable junk", () => {
-    expect(() => normalizePreviewUrl("http://")).toThrow(PreviewUrlNormalizationError);
+    try {
+      normalizePreviewUrl("http://");
+      expect.unreachable("expected URL normalization to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PreviewUrlNormalizationError);
+      expect(error).toMatchObject({ rawUrl: "http://", reason: "parse" });
+      expect((error as PreviewUrlNormalizationError).cause).toBeInstanceOf(Error);
+      expect((error as PreviewUrlNormalizationError).message).not.toContain(
+        ((error as PreviewUrlNormalizationError).cause as Error).message,
+      );
+    }
   });
 });

--- a/packages/shared/src/preview.ts
+++ b/packages/shared/src/preview.ts
@@ -50,7 +50,7 @@ export function isPreviewableUrl(rawUrl: string): boolean {
 export class PreviewUrlNormalizationError extends Schema.TaggedErrorClass<PreviewUrlNormalizationError>()(
   "PreviewUrlNormalizationError",
   {
-    rawUrl: Schema.String,
+    inputLength: Schema.Number,
     reason: Schema.Literals(["empty", "parse", "unsupported-protocol"]),
     protocol: Schema.optional(Schema.String),
     cause: Schema.optional(Schema.Defect()),
@@ -58,11 +58,15 @@ export class PreviewUrlNormalizationError extends Schema.TaggedErrorClass<Previe
 ) {
   override get message(): string {
     const protocol = this.protocol === undefined ? "" : `: ${this.protocol}`;
-    return `Invalid preview URL "${this.rawUrl}" (${this.reason}${protocol}).`;
+    return `Invalid preview URL (${this.reason}${protocol}; input length ${this.inputLength}).`;
   }
 }
 
 export const isPreviewUrlNormalizationError = Schema.is(PreviewUrlNormalizationError);
+
+function previewUrlProtocol(rawUrl: string): string | undefined {
+  return /^([A-Za-z][A-Za-z\d+.-]*):/.exec(rawUrl)?.[1]?.toLowerCase().concat(":");
+}
 
 /**
  * Normalise a free-form URL string into a fully-qualified `http(s)://` URL.
@@ -77,7 +81,7 @@ export const isPreviewUrlNormalizationError = Schema.is(PreviewUrlNormalizationE
 export function normalizePreviewUrl(rawUrl: string): string {
   const trimmed = rawUrl.trim();
   if (trimmed.length === 0) {
-    throw new PreviewUrlNormalizationError({ rawUrl, reason: "empty" });
+    throw new PreviewUrlNormalizationError({ inputLength: rawUrl.length, reason: "empty" });
   }
   const useHttp = LOOPBACK_PREFIX_PATTERN.test(trimmed);
   const candidate = trimmed.includes("://")
@@ -87,11 +91,16 @@ export function normalizePreviewUrl(rawUrl: string): string {
   try {
     parsed = new URL(candidate);
   } catch (cause) {
-    throw new PreviewUrlNormalizationError({ rawUrl, reason: "parse", cause });
+    throw new PreviewUrlNormalizationError({
+      inputLength: rawUrl.length,
+      reason: "parse",
+      protocol: previewUrlProtocol(candidate),
+      cause,
+    });
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new PreviewUrlNormalizationError({
-      rawUrl,
+      inputLength: rawUrl.length,
       reason: "unsupported-protocol",
       protocol: parsed.protocol,
     });

--- a/packages/shared/src/preview.ts
+++ b/packages/shared/src/preview.ts
@@ -4,6 +4,8 @@
  * on what counts as "loopback" and how to normalise a free-form URL string.
  */
 
+import * as Schema from "effect/Schema";
+
 const TAB_ID_PREFIX = "tab_";
 let nextPreviewTabSequence = 0;
 
@@ -45,16 +47,22 @@ export function isPreviewableUrl(rawUrl: string): boolean {
   }
 }
 
-export class PreviewUrlNormalizationError extends Error {
-  readonly rawUrl: string;
-  readonly detail: string;
-  constructor(rawUrl: string, detail: string) {
-    super(`Invalid preview URL: ${rawUrl} (${detail})`);
-    this.name = "PreviewUrlNormalizationError";
-    this.rawUrl = rawUrl;
-    this.detail = detail;
+export class PreviewUrlNormalizationError extends Schema.TaggedErrorClass<PreviewUrlNormalizationError>()(
+  "PreviewUrlNormalizationError",
+  {
+    rawUrl: Schema.String,
+    reason: Schema.Literals(["empty", "parse", "unsupported-protocol"]),
+    protocol: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    const protocol = this.protocol === undefined ? "" : `: ${this.protocol}`;
+    return `Invalid preview URL "${this.rawUrl}" (${this.reason}${protocol}).`;
   }
 }
+
+export const isPreviewUrlNormalizationError = Schema.is(PreviewUrlNormalizationError);
 
 /**
  * Normalise a free-form URL string into a fully-qualified `http(s)://` URL.
@@ -69,7 +77,7 @@ export class PreviewUrlNormalizationError extends Error {
 export function normalizePreviewUrl(rawUrl: string): string {
   const trimmed = rawUrl.trim();
   if (trimmed.length === 0) {
-    throw new PreviewUrlNormalizationError(rawUrl, "empty");
+    throw new PreviewUrlNormalizationError({ rawUrl, reason: "empty" });
   }
   const useHttp = LOOPBACK_PREFIX_PATTERN.test(trimmed);
   const candidate = trimmed.includes("://")
@@ -79,13 +87,14 @@ export function normalizePreviewUrl(rawUrl: string): string {
   try {
     parsed = new URL(candidate);
   } catch (cause) {
-    throw new PreviewUrlNormalizationError(
-      rawUrl,
-      cause instanceof Error ? cause.message : "unparseable",
-    );
+    throw new PreviewUrlNormalizationError({ rawUrl, reason: "parse", cause });
   }
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new PreviewUrlNormalizationError(rawUrl, `unsupported protocol ${parsed.protocol}`);
+    throw new PreviewUrlNormalizationError({
+      rawUrl,
+      reason: "unsupported-protocol",
+      protocol: parsed.protocol,
+    });
   }
   return parsed.href;
 }


### PR DESCRIPTION
## Summary
- replace free-form URL normalization detail strings with structured reason/protocol fields
- preserve the native URL parser failure as the nested cause without copying its message
- propagate normalization context and the complete cause chain through the preview manager error

## Validation
- `vp test run packages/shared/src/preview.test.ts`
- `vp test run apps/server/src/preview/Manager.test.ts`
- `vp check`
- `vp run typecheck`


<!-- sensitive-context-follow-up -->
## Sensitive-context follow-up\n- invalid URL errors now retain only input length, typed reason, and safe protocol\n- raw URLs, credentials, query parameters, and fragments are absent from attributes and messages\n- parser failures still preserve the exact nested cause

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public error contract (`rawUrl`/`detail` removed) and how preview open/navigate failures are surfaced; behavior is safer for secrets but callers must migrate to new fields.
> 
> **Overview**
> **Preview URL failures are now structured and sanitized** so error messages and serialized fields no longer echo the user’s input (credentials, tokens, fragments, or full URLs).
> 
> `PreviewUrlNormalizationError` becomes an Effect `Schema.TaggedErrorClass` with `inputLength`, typed `reason`, optional `protocol`, and optional nested `cause` (for parse failures only). `PreviewInvalidUrlError` in contracts drops `rawUrl`/`detail` in favor of the same shape plus an `unexpected` reason when normalization fails outside that path. User-facing messages use only reason, protocol, and input length.
> 
> The server preview manager maps normalization failures via `isPreviewUrlNormalizationError` and chains the full cause into `PreviewInvalidUrlError`. Tests assert empty/parse/unsupported cases and that messages do not contain sensitive substrings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c33f26a28cd99cf20e34a7e4a4c1d1a6cb05e0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure preview URL errors with typed reason, input length, and cause chain
> - Replaces the string-based `PreviewUrlNormalizationError` with a `Schema.TaggedErrorClass` carrying structured fields: `inputLength`, `reason` (`'empty'|'parse'|'unsupported-protocol'`), optional `protocol`, and optional `cause`.
> - Updates `PreviewInvalidUrlError` in [preview.ts](https://github.com/pingdotgg/t3code/pull/3275/files#diff-77fe1c85162b7ba16ab070d87c12024e0eb68eeebd0b5272e481eec4ecf0bb39) to expose the same structured fields plus an `'unexpected'` reason; removes `rawUrl` and `detail`.
> - Updates `normalizeUrl` in [Manager.ts](https://github.com/pingdotgg/t3code/pull/3275/files#diff-377ad24fc9187608a35f448399c3553c7eabe0fa9eef50a6510b96a3ab6e5a5b) to map normalization errors to structured `PreviewInvalidUrlError` instances, preserving the cause chain.
> - Behavioral Change: error messages no longer include the raw input URL, and `rawUrl` is no longer available on either error class; callers reading those fields will break.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c33f26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->