### PR TITLE
[codex] Preserve workspace root stat failures

### DIFF
--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -2,6 +2,7 @@ import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
 import * as NodeSocket from "@effect/platform-node/NodeSocket";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as NodeCrypto from "node:crypto";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import {
   AuthAccessTokenType,
@@ -4538,6 +4539,39 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       assert.equal(browseError.failure, "read_directory_failed");
       assert.equal(browseError.parentPath, missingBrowseParent);
       assert.isDefined(browseError.cause);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("reports workspace root stat failures without relabeling them as missing", () =>
+    Effect.gen(function* () {
+      if ((yield* HostProcessPlatform) === "win32") return;
+
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const blockedRoot = yield* fs.makeTempDirectoryScoped({
+        prefix: "t3-ws-workspace-stat-error-",
+      });
+      const workspaceRoot = path.join(blockedRoot, "workspace");
+      yield* fs.makeDirectory(workspaceRoot);
+      yield* fs.chmod(blockedRoot, 0o000);
+
+      const result = yield* Effect.gen(function* () {
+        yield* buildAppUnderTest();
+        const wsUrl = yield* getWsServerUrl("/ws");
+        return yield* Effect.scoped(
+          withWsRpcClient(wsUrl, (client) =>
+            client[WS_METHODS.projectsListEntries]({ cwd: workspaceRoot }).pipe(Effect.result),
+          ),
+        );
+      }).pipe(Effect.ensuring(fs.chmod(blockedRoot, 0o700).pipe(Effect.ignore)));
+
+      if (result._tag !== "Failure" || result.failure._tag !== "ProjectListEntriesError") {
+        assert.fail("Expected a ProjectListEntriesError");
+      }
+      const error = result.failure;
+      assert.equal(error.failure, "workspace_root_stat_failed");
+      assert.equal(error.normalizedCwd, workspaceRoot);
+      assert.equal(error.detail, "validate-existing");
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -73,6 +73,7 @@ export type WorkspaceEntriesBrowseError = typeof WorkspaceEntriesBrowseError.Typ
 export const WorkspaceEntriesError = Schema.Union([
   WorkspacePaths.WorkspaceRootNotExistsError,
   WorkspacePaths.WorkspaceRootCreateFailedError,
+  WorkspacePaths.WorkspaceRootStatFailedError,
   WorkspacePaths.WorkspaceRootNotDirectoryError,
   WorkspaceSearchIndex.WorkspaceSearchIndexCreateFailed,
   WorkspaceSearchIndex.WorkspaceSearchIndexScanTimedOut,

--- a/apps/server/src/workspace/WorkspacePaths.test.ts
+++ b/apps/server/src/workspace/WorkspacePaths.test.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 
 import * as WorkspacePaths from "./WorkspacePaths.ts";
 
@@ -89,6 +90,79 @@ it.layer(TestLayer)("WorkspacePathsLive", (it) => {
         const error = yield* workspacePaths.normalizeWorkspaceRoot(filePath).pipe(Effect.flip);
 
         expect(error.message).toContain("Workspace root is not a directory:");
+      }),
+    );
+
+    it.effect("preserves non-NotFound stat failures while validating the root", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const workspacePaths = yield* WorkspacePaths.make.pipe(
+          Effect.provideService(FileSystem.FileSystem, {
+            ...fileSystem,
+            stat: (path) =>
+              Effect.fail(
+                PlatformError.systemError({
+                  _tag: "PermissionDenied",
+                  module: "FileSystem",
+                  method: "stat",
+                  pathOrDescriptor: String(path),
+                  description: "Test PermissionDenied stat failure.",
+                }),
+              ),
+          }),
+        );
+        const path = yield* Path.Path;
+        const workspaceRoot = " ./permission-denied ";
+        const normalizedWorkspaceRoot = path.resolve(workspaceRoot.trim());
+
+        const error = yield* workspacePaths.normalizeWorkspaceRoot(workspaceRoot).pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(WorkspacePaths.WorkspaceRootStatFailedError);
+        expect(error).toMatchObject({
+          workspaceRoot,
+          normalizedWorkspaceRoot,
+          phase: "validate-existing",
+        });
+      }),
+    );
+
+    it.effect("preserves stat failures while verifying a newly created root", () =>
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        let statCalls = 0;
+        const workspacePaths = yield* WorkspacePaths.make.pipe(
+          Effect.provideService(FileSystem.FileSystem, {
+            ...fileSystem,
+            stat: (path) => {
+              statCalls += 1;
+              const reason = statCalls === 1 ? "NotFound" : "PermissionDenied";
+              return Effect.fail(
+                PlatformError.systemError({
+                  _tag: reason,
+                  module: "FileSystem",
+                  method: "stat",
+                  pathOrDescriptor: String(path),
+                  description: `Test ${reason} stat failure.`,
+                }),
+              );
+            },
+            makeDirectory: () => Effect.void,
+          }),
+        );
+        const path = yield* Path.Path;
+        const workspaceRoot = " ./created-then-unreadable ";
+        const normalizedWorkspaceRoot = path.resolve(workspaceRoot.trim());
+
+        const error = yield* workspacePaths
+          .normalizeWorkspaceRoot(workspaceRoot, { createIfMissing: true })
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(WorkspacePaths.WorkspaceRootStatFailedError);
+        expect(error).toMatchObject({
+          workspaceRoot,
+          normalizedWorkspaceRoot,
+          phase: "verify-created",
+        });
       }),
     );
   });

--- a/apps/server/src/workspace/WorkspacePaths.ts
+++ b/apps/server/src/workspace/WorkspacePaths.ts
@@ -40,6 +40,20 @@ export class WorkspaceRootCreateFailedError extends Schema.TaggedErrorClass<Work
   }
 }
 
+export class WorkspaceRootStatFailedError extends Schema.TaggedErrorClass<WorkspaceRootStatFailedError>()(
+  "WorkspaceRootStatFailedError",
+  {
+    workspaceRoot: Schema.String,
+    normalizedWorkspaceRoot: Schema.String,
+    phase: Schema.Literals(["validate-existing", "verify-created"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to stat workspace root '${this.normalizedWorkspaceRoot}' during '${this.phase}'.`;
+  }
+}
+
 export class WorkspaceRootNotDirectoryError extends Schema.TaggedErrorClass<WorkspaceRootNotDirectoryError>()(
   "WorkspaceRootNotDirectoryError",
   {
@@ -67,6 +81,7 @@ export class WorkspacePathOutsideRootError extends Schema.TaggedErrorClass<Works
 export const WorkspacePathsError = Schema.Union([
   WorkspaceRootNotExistsError,
   WorkspaceRootCreateFailedError,
+  WorkspaceRootStatFailedError,
   WorkspaceRootNotDirectoryError,
   WorkspacePathOutsideRootError,
 ]);
@@ -82,7 +97,10 @@ export class WorkspacePaths extends Context.Service<
       options?: { readonly createIfMissing?: boolean },
     ) => Effect.Effect<
       string,
-      WorkspaceRootNotExistsError | WorkspaceRootCreateFailedError | WorkspaceRootNotDirectoryError
+      | WorkspaceRootNotExistsError
+      | WorkspaceRootCreateFailedError
+      | WorkspaceRootStatFailedError
+      | WorkspaceRootNotDirectoryError
     >;
     /**
      * Resolve a relative path within a validated workspace root.
@@ -117,13 +135,38 @@ export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
 
+  const statWorkspaceRoot = Effect.fn("WorkspacePaths.statWorkspaceRoot")(function* (
+    workspaceRoot: string,
+    normalizedWorkspaceRoot: string,
+    phase: WorkspaceRootStatFailedError["phase"],
+  ) {
+    return yield* fileSystem.stat(normalizedWorkspaceRoot).pipe(
+      Effect.matchEffect({
+        onFailure: (cause) =>
+          cause.reason._tag === "NotFound"
+            ? Effect.succeed(null)
+            : Effect.fail(
+                new WorkspaceRootStatFailedError({
+                  workspaceRoot,
+                  normalizedWorkspaceRoot,
+                  phase,
+                  cause,
+                }),
+              ),
+        onSuccess: Effect.succeed,
+      }),
+    );
+  });
+
   const normalizeWorkspaceRoot: WorkspacePaths["Service"]["normalizeWorkspaceRoot"] = Effect.fn(
     "WorkspacePaths.normalizeWorkspaceRoot",
   )(function* (workspaceRoot, options) {
     const normalizedWorkspaceRoot = path.resolve(expandHomePath(workspaceRoot.trim(), path));
-    let workspaceStat = yield* fileSystem
-      .stat(normalizedWorkspaceRoot)
-      .pipe(Effect.orElseSucceed(() => null));
+    let workspaceStat = yield* statWorkspaceRoot(
+      workspaceRoot,
+      normalizedWorkspaceRoot,
+      "validate-existing",
+    );
     if (!workspaceStat && options?.createIfMissing) {
       yield* fileSystem.makeDirectory(normalizedWorkspaceRoot, { recursive: true }).pipe(
         Effect.mapError(
@@ -135,9 +178,11 @@ export const make = Effect.gen(function* () {
             }),
         ),
       );
-      workspaceStat = yield* fileSystem
-        .stat(normalizedWorkspaceRoot)
-        .pipe(Effect.orElseSucceed(() => null));
+      workspaceStat = yield* statWorkspaceRoot(
+        workspaceRoot,
+        normalizedWorkspaceRoot,
+        "verify-created",
+      );
     }
     if (!workspaceStat) {
       return yield* new WorkspaceRootNotExistsError({

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -149,6 +149,12 @@ function projectEntriesFailureContext(error: WorkspaceEntries.WorkspaceEntriesEr
         failure: "workspace_root_create_failed",
         normalizedCwd: error.normalizedWorkspaceRoot,
       };
+    case "WorkspaceRootStatFailedError":
+      return {
+        failure: "workspace_root_stat_failed",
+        normalizedCwd: error.normalizedWorkspaceRoot,
+        detail: error.phase,
+      };
     case "WorkspaceRootNotDirectoryError":
       return {
         failure: "workspace_root_not_directory",

--- a/packages/contracts/src/project.ts
+++ b/packages/contracts/src/project.ts
@@ -40,6 +40,7 @@ export type ProjectListEntriesResult = typeof ProjectListEntriesResult.Type;
 export const ProjectEntriesFailure = Schema.Literals([
   "workspace_root_not_found",
   "workspace_root_create_failed",
+  "workspace_root_stat_failed",
   "workspace_root_not_directory",
   "search_index_create_failed",
   "search_index_scan_timed_out",


### PR DESCRIPTION
## Summary
- distinguish missing workspace roots from non-NotFound stat failures
- preserve the original platform cause with root, normalized path, and validation phase
- propagate the structured failure through workspace entries and the websocket compatibility boundary
- cover validation, post-create verification, and RPC display behavior

## Validation
- `vp test apps/server/src/workspace/WorkspacePaths.test.ts apps/server/src/workspace/WorkspaceEntries.test.ts apps/server/src/server.test.ts`
- `vp check`
- `vp run typecheck`

## Overlap
- `apps/server/src/workspace/WorkspaceEntries.ts` also changes in #2798; this PR only adds the new error union member there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling change in workspace path validation with clearer client-facing failures; no auth or data mutation paths.
> 
> **Overview**
> **Workspace root validation** no longer treats every `stat` failure as “path missing.” Only `NotFound` still maps to `WorkspaceRootNotExistsError`; permission and other platform errors become a new **`WorkspaceRootStatFailedError`** with `phase` (`validate-existing` or `verify-created`) and the original cause.
> 
> That error is wired through **`WorkspaceEntries`**, the websocket **`ProjectListEntries`** failure mapping (`workspace_root_stat_failed` + `detail`), and **`packages/contracts`**. Integration coverage asserts the RPC reports `workspace_root_stat_failed` when the root directory is unreadable (non-Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c946155e44f39b519ddaa11db42d6ffdbb4c14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate workspace root stat failures as distinct `workspace_root_stat_failed` errors
> - Previously, all stat failures on the workspace root in `normalizeWorkspaceRoot` were swallowed via `orElseSucceed(null)`, treating permission errors and other non-NotFound failures as "missing directory".
> - Introduces `WorkspaceRootStatFailedError` in [`WorkspacePaths.ts`](https://github.com/pingdotgg/t3code/pull/3278/files#diff-00b5de5a0decfbe7e12877947e9ad06b85f63905b560473035087e54361b7888) with a `phase` field (`validate-existing` or `verify-created`) and the original cause, so callers can distinguish stat failures from missing directories.
> - Surfaces this error through the WebSocket project listing response as `workspace_root_stat_failed` with the `phase` as detail in [`ws.ts`](https://github.com/pingdotgg/t3code/pull/3278/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125).
> - Extends the `ProjectEntriesFailure` contract schema and `WorkspaceEntriesError` union to include the new error variant.
> - Behavioral Change: non-NotFound stat errors on the workspace root now propagate as failures instead of being silently treated as not found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0c9461.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->