### PR TITLE
[codex] Structure rotating log sink errors

### DIFF
--- a/packages/shared/src/logging.test.ts
+++ b/packages/shared/src/logging.test.ts
@@ -1,0 +1,154 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFS from "node:fs";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  RotatingFileSink,
+  RotatingFileSinkConfigurationError,
+  RotatingFileSinkError,
+} from "./logging.ts";
+
+const tempDirectories: string[] = [];
+
+const makeTempDirectory = (): string => {
+  const directory = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3code-logging-"));
+  tempDirectories.push(directory);
+  return directory;
+};
+
+const captureError = (run: () => unknown): unknown => {
+  try {
+    run();
+  } catch (cause) {
+    return cause;
+  }
+  throw new Error("Expected operation to throw");
+};
+
+afterEach(() => {
+  for (const directory of tempDirectories.splice(0)) {
+    NodeFS.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("RotatingFileSink", () => {
+  it.each([
+    { option: "maxBytes" as const, maxBytes: 0, maxFiles: 1 },
+    { option: "maxFiles" as const, maxBytes: 1, maxFiles: 0 },
+  ])("reports invalid $option configuration structurally", (input) => {
+    const thrown = captureError(
+      () =>
+        new RotatingFileSink({
+          filePath: "/unused/log.ndjson",
+          maxBytes: input.maxBytes,
+          maxFiles: input.maxFiles,
+        }),
+    );
+
+    expect(thrown).toBeInstanceOf(RotatingFileSinkConfigurationError);
+    expect(thrown).toMatchObject({
+      option: input.option,
+      received: 0,
+      minimum: 1,
+    });
+    expect((thrown as Error).message).toBe(`${input.option} must be >= 1 (received 0)`);
+  });
+
+  it("preserves directory initialization failures", () => {
+    const directory = makeTempDirectory();
+    const parentFile = NodePath.join(directory, "not-a-directory");
+    const filePath = NodePath.join(parentFile, "log.ndjson");
+    NodeFS.writeFileSync(parentFile, "occupied");
+
+    const thrown = captureError(() => new RotatingFileSink({ filePath, maxBytes: 1, maxFiles: 1 }));
+
+    expect(thrown).toBeInstanceOf(RotatingFileSinkError);
+    expect(thrown).toMatchObject({ operation: "initialize", filePath });
+    expect((thrown as RotatingFileSinkError).cause).toBeInstanceOf(Error);
+  });
+
+  it("only treats a missing log file as an empty current size", () => {
+    const directory = makeTempDirectory();
+    const filePath = NodePath.join(directory, "a".repeat(300));
+
+    const thrown = captureError(() => new RotatingFileSink({ filePath, maxBytes: 1, maxFiles: 1 }));
+
+    expect(thrown).toBeInstanceOf(RotatingFileSinkError);
+    expect(thrown).toMatchObject({ operation: "read", filePath });
+    expect((thrown as RotatingFileSinkError).cause).toMatchObject({ code: "ENAMETOOLONG" });
+  });
+
+  it("starts an absent log file at zero bytes", () => {
+    const directory = makeTempDirectory();
+    const filePath = NodePath.join(directory, "log.ndjson");
+    const sink = new RotatingFileSink({ filePath, maxBytes: 100, maxFiles: 1 });
+
+    sink.write("entry");
+
+    expect(NodeFS.readFileSync(filePath, "utf8")).toBe("entry");
+  });
+
+  it("preserves write failures", () => {
+    const directory = makeTempDirectory();
+    const filePath = NodePath.join(directory, "log.ndjson");
+    NodeFS.mkdirSync(filePath);
+    const sink = new RotatingFileSink({
+      filePath,
+      maxBytes: Number.MAX_SAFE_INTEGER,
+      maxFiles: 1,
+      throwOnError: true,
+    });
+
+    const thrown = captureError(() => sink.write("entry"));
+
+    expect(thrown).toBeInstanceOf(RotatingFileSinkError);
+    expect(thrown).toMatchObject({ operation: "write", filePath });
+    expect((thrown as RotatingFileSinkError).cause).toMatchObject({ code: "EISDIR" });
+  });
+
+  it("retains the complete write and rotation failure chain", () => {
+    const directory = makeTempDirectory();
+    const filePath = NodePath.join(directory, "log.ndjson");
+    NodeFS.writeFileSync(filePath, "a");
+    NodeFS.mkdirSync(`${filePath}.1`);
+    const sink = new RotatingFileSink({
+      filePath,
+      maxBytes: 1,
+      maxFiles: 1,
+      throwOnError: true,
+    });
+
+    const thrown = captureError(() => sink.write("b"));
+
+    expect(thrown).toBeInstanceOf(RotatingFileSinkError);
+    expect(thrown).toMatchObject({ operation: "write", filePath });
+    const rotationError = (thrown as RotatingFileSinkError).cause;
+    expect(rotationError).toBeInstanceOf(RotatingFileSinkError);
+    expect(rotationError).toMatchObject({ operation: "rotate", filePath });
+    expect((rotationError as RotatingFileSinkError).cause).toBeInstanceOf(Error);
+  });
+
+  it("preserves backup pruning failures", () => {
+    const directory = makeTempDirectory();
+    const filePath = NodePath.join(directory, "log.ndjson");
+    const overflowBackup = `${filePath}.2`;
+    NodeFS.mkdirSync(overflowBackup);
+    NodeFS.writeFileSync(NodePath.join(overflowBackup, "entry"), "occupied");
+
+    const thrown = captureError(
+      () =>
+        new RotatingFileSink({
+          filePath,
+          maxBytes: 1,
+          maxFiles: 1,
+          throwOnError: true,
+        }),
+    );
+
+    expect(thrown).toBeInstanceOf(RotatingFileSinkError);
+    expect(thrown).toMatchObject({ operation: "prune", filePath });
+    expect((thrown as RotatingFileSinkError).cause).toBeInstanceOf(Error);
+  });
+});

--- a/packages/shared/src/logging.test.ts
+++ b/packages/shared/src/logging.test.ts
@@ -108,7 +108,7 @@ describe("RotatingFileSink", () => {
     expect((thrown as RotatingFileSinkError).cause).toMatchObject({ code: "EISDIR" });
   });
 
-  it("retains the complete write and rotation failure chain", () => {
+  it("preserves rotation failures without an artificial write wrapper", () => {
     const directory = makeTempDirectory();
     const filePath = NodePath.join(directory, "log.ndjson");
     NodeFS.writeFileSync(filePath, "a");
@@ -123,11 +123,8 @@ describe("RotatingFileSink", () => {
     const thrown = captureError(() => sink.write("b"));
 
     expect(thrown).toBeInstanceOf(RotatingFileSinkError);
-    expect(thrown).toMatchObject({ operation: "write", filePath });
-    const rotationError = (thrown as RotatingFileSinkError).cause;
-    expect(rotationError).toBeInstanceOf(RotatingFileSinkError);
-    expect(rotationError).toMatchObject({ operation: "rotate", filePath });
-    expect((rotationError as RotatingFileSinkError).cause).toBeInstanceOf(Error);
+    expect(thrown).toMatchObject({ operation: "rotate", filePath });
+    expect((thrown as RotatingFileSinkError).cause).toBeInstanceOf(Error);
   });
 
   it("preserves backup pruning failures", () => {

--- a/packages/shared/src/logging.ts
+++ b/packages/shared/src/logging.ts
@@ -98,15 +98,15 @@ export class RotatingFileSink {
         this.rotate();
       }
     } catch (cause) {
+      if (isRotatingFileSinkError(cause)) {
+        throw cause;
+      }
       if (this.throwOnError) {
         throw new RotatingFileSinkError({
           operation: "write",
           filePath: this.filePath,
           cause,
         });
-      }
-      if (isRotatingFileSinkError(cause)) {
-        throw cause;
       }
       this.currentSize = this.readCurrentSize();
     }

--- a/packages/shared/src/logging.ts
+++ b/packages/shared/src/logging.ts
@@ -1,6 +1,7 @@
 // @effect-diagnostics nodeBuiltinImport:off
 import * as NodeFS from "node:fs";
 import * as NodePath from "node:path";
+import * as Schema from "effect/Schema";
 
 export interface RotatingFileSinkOptions {
   readonly filePath: string;
@@ -8,6 +9,37 @@ export interface RotatingFileSinkOptions {
   readonly maxFiles: number;
   readonly throwOnError?: boolean;
 }
+
+export class RotatingFileSinkConfigurationError extends Schema.TaggedErrorClass<RotatingFileSinkConfigurationError>()(
+  "RotatingFileSinkConfigurationError",
+  {
+    option: Schema.Literals(["maxBytes", "maxFiles"]),
+    received: Schema.Number,
+    minimum: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `${this.option} must be >= ${this.minimum} (received ${this.received})`;
+  }
+}
+
+export class RotatingFileSinkError extends Schema.TaggedErrorClass<RotatingFileSinkError>()(
+  "RotatingFileSinkError",
+  {
+    operation: Schema.Literals(["initialize", "read", "write", "rotate", "prune"]),
+    filePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to ${this.operation} rotating log file ${this.filePath}`;
+  }
+}
+
+const isRotatingFileSinkError = Schema.is(RotatingFileSinkError);
+
+const isFileNotFoundError = (cause: unknown): cause is NodeJS.ErrnoException =>
+  cause instanceof Error && "code" in cause && cause.code === "ENOENT";
 
 export class RotatingFileSink {
   private readonly filePath: string;
@@ -18,10 +50,18 @@ export class RotatingFileSink {
 
   constructor(options: RotatingFileSinkOptions) {
     if (options.maxBytes < 1) {
-      throw new Error(`maxBytes must be >= 1 (received ${options.maxBytes})`);
+      throw new RotatingFileSinkConfigurationError({
+        option: "maxBytes",
+        received: options.maxBytes,
+        minimum: 1,
+      });
     }
     if (options.maxFiles < 1) {
-      throw new Error(`maxFiles must be >= 1 (received ${options.maxFiles})`);
+      throw new RotatingFileSinkConfigurationError({
+        option: "maxFiles",
+        received: options.maxFiles,
+        minimum: 1,
+      });
     }
 
     this.filePath = options.filePath;
@@ -29,7 +69,15 @@ export class RotatingFileSink {
     this.maxFiles = options.maxFiles;
     this.throwOnError = options.throwOnError ?? false;
 
-    NodeFS.mkdirSync(NodePath.dirname(this.filePath), { recursive: true });
+    try {
+      NodeFS.mkdirSync(NodePath.dirname(this.filePath), { recursive: true });
+    } catch (cause) {
+      throw new RotatingFileSinkError({
+        operation: "initialize",
+        filePath: this.filePath,
+        cause,
+      });
+    }
     this.pruneOverflowBackups();
     this.currentSize = this.readCurrentSize();
   }
@@ -49,11 +97,18 @@ export class RotatingFileSink {
       if (this.currentSize > this.maxBytes) {
         this.rotate();
       }
-    } catch {
-      this.currentSize = this.readCurrentSize();
+    } catch (cause) {
       if (this.throwOnError) {
-        throw new Error(`Failed to write log chunk to ${this.filePath}`);
+        throw new RotatingFileSinkError({
+          operation: "write",
+          filePath: this.filePath,
+          cause,
+        });
       }
+      if (isRotatingFileSinkError(cause)) {
+        throw cause;
+      }
+      this.currentSize = this.readCurrentSize();
     }
   }
 
@@ -77,11 +132,15 @@ export class RotatingFileSink {
       }
 
       this.currentSize = 0;
-    } catch {
-      this.currentSize = this.readCurrentSize();
+    } catch (cause) {
       if (this.throwOnError) {
-        throw new Error(`Failed to rotate log file ${this.filePath}`);
+        throw new RotatingFileSinkError({
+          operation: "rotate",
+          filePath: this.filePath,
+          cause,
+        });
       }
+      this.currentSize = this.readCurrentSize();
     }
   }
 
@@ -95,9 +154,13 @@ export class RotatingFileSink {
         if (!Number.isInteger(suffix) || suffix <= this.maxFiles) continue;
         NodeFS.rmSync(NodePath.join(dir, entry), { force: true });
       }
-    } catch {
+    } catch (cause) {
       if (this.throwOnError) {
-        throw new Error(`Failed to prune log backups for ${this.filePath}`);
+        throw new RotatingFileSinkError({
+          operation: "prune",
+          filePath: this.filePath,
+          cause,
+        });
       }
     }
   }
@@ -105,8 +168,15 @@ export class RotatingFileSink {
   private readCurrentSize(): number {
     try {
       return NodeFS.statSync(this.filePath).size;
-    } catch {
-      return 0;
+    } catch (cause) {
+      if (isFileNotFoundError(cause)) {
+        return 0;
+      }
+      throw new RotatingFileSinkError({
+        operation: "read",
+        filePath: this.filePath,
+        cause,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- replace generic rotating-log failures with structured Schema errors
- retain file operation, path, and real causal chains across write and rotation failures
- distinguish missing files from other stat failures
- cover configuration and filesystem boundaries with focused real-filesystem tests

## Verification
- vp test run packages/shared/src/logging.test.ts
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized logging sink error typing and tests; behavior for callers using throwOnError becomes more explicit but remains backward-compatible for default non-throwing use (e.g. EventNdjsonLogger).
> 
> **Overview**
> **`RotatingFileSink`** now throws typed **`RotatingFileSinkConfigurationError`** and **`RotatingFileSinkError`** (Effect **`Schema.TaggedErrorClass`**) instead of plain **`Error`** strings, with fields for invalid options, **`operation`**, **`filePath`**, and **`cause`**.
> 
> Operational paths (**`initialize`**, **`read`**, **`write`**, **`rotate`**, **`prune`**) wrap filesystem failures when **`throwOnError`** is set; **`readCurrentSize`** only treats **`ENOENT`** as zero and surfaces other stat errors. **`write`** rethrows nested **`RotatingFileSinkError`** (e.g. rotate) without double-wrapping.
> 
> Adds **`logging.test.ts`** with real-temp-dir coverage for config validation, init/read/write/rotate/prune boundaries, and error shape assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7804c6d47f8d158022955762d6d9f90c30c2808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic errors with structured error classes in `RotatingFileSink`
> - Adds `RotatingFileSinkConfigurationError` (thrown for invalid `maxBytes`/`maxFiles`) and `RotatingFileSinkError` (thrown for operational failures such as directory init, write, rotate, prune, and read), replacing generic `Error` throws throughout [logging.ts](https://github.com/pingdotgg/t3code/pull/3279/files#diff-9bdc0cb4fe4a6f527a9c8b13a6e35686e266c41a7cf47fcb346f01ec81bd6245).
> - `readCurrentSize` now only returns 0 for `ENOENT`; all other filesystem errors surface as `RotatingFileSinkError read` instead of being silently swallowed.
> - Adds a full test suite in [logging.test.ts](https://github.com/pingdotgg/t3code/pull/3279/files#diff-f300397e61ecc31f1d1dc0e6ccf1666aa4d76b4478357a021cac646d4f34c4f9) covering configuration validation, init failures, read behavior, write/rotate/prune error propagation, and `throwOnError` modes.
> - Behavioral Change: code that catches `Error` from `RotatingFileSink` operations will now receive typed tagged errors; callers that relied on all read errors returning zero-size will now see thrown errors for non-ENOENT cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7804c6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->