### PR TITLE
[codex] Structure Electron updater errors

### DIFF
--- a/apps/desktop/src/electron/ElectronUpdater.test.ts
+++ b/apps/desktop/src/electron/ElectronUpdater.test.ts
@@ -1,5 +1,4 @@
 import { assert, describe, it } from "@effect/vitest";
-import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import { beforeEach, vi } from "vite-plus/test";
 
@@ -65,16 +64,65 @@ describe("ElectronUpdater", () => {
       const cause = new Error("network unavailable");
       autoUpdaterMock.checkForUpdates.mockImplementationOnce(() => Promise.reject(cause));
       const updater = yield* ElectronUpdater.ElectronUpdater;
+      autoUpdaterMock.channel = "beta";
 
-      const exit = yield* Effect.exit(updater.checkForUpdates);
+      const error = yield* updater.checkForUpdates.pipe(Effect.flip);
 
-      assert.equal(exit._tag, "Failure");
-      if (exit._tag === "Failure") {
-        const error = Cause.squash(exit.cause);
-        assert.instanceOf(error, ElectronUpdater.ElectronUpdaterCheckForUpdatesError);
-        assert.equal(error.cause, cause);
-        assert.equal(error.message, "Electron updater failed to check for updates.");
-      }
+      assert.instanceOf(error, ElectronUpdater.ElectronUpdaterCheckForUpdatesError);
+      assert.isTrue(ElectronUpdater.isElectronUpdaterError(error));
+      assert.equal(error.channel, "beta");
+      assert.strictEqual(error.cause, cause);
+      assert.equal(error.message, "Electron updater failed to check for updates on channel beta.");
+      assert.notInclude(error.message, cause.message);
+    }).pipe(Effect.provide(ElectronUpdater.layer)),
+  );
+
+  it.effect("preserves the execution-time channel on download failures", () =>
+    Effect.gen(function* () {
+      const cause = new Error("download unavailable");
+      autoUpdaterMock.downloadUpdate.mockImplementationOnce(() => Promise.reject(cause));
+      const updater = yield* ElectronUpdater.ElectronUpdater;
+      autoUpdaterMock.channel = "nightly";
+
+      const error = yield* updater.downloadUpdate.pipe(Effect.flip);
+
+      assert.instanceOf(error, ElectronUpdater.ElectronUpdaterDownloadUpdateError);
+      assert.isTrue(ElectronUpdater.isElectronUpdaterError(error));
+      assert.equal(error.channel, "nightly");
+      assert.strictEqual(error.cause, cause);
+      assert.equal(
+        error.message,
+        "Electron updater failed to download the update on channel nightly.",
+      );
+      assert.notInclude(error.message, cause.message);
+    }).pipe(Effect.provide(ElectronUpdater.layer)),
+  );
+
+  it.effect("preserves quit-and-install flags and the execution-time channel", () =>
+    Effect.gen(function* () {
+      const cause = new Error("quit and install failed");
+      autoUpdaterMock.quitAndInstall.mockImplementationOnce(() => {
+        throw cause;
+      });
+      const updater = yield* ElectronUpdater.ElectronUpdater;
+      autoUpdaterMock.channel = "alpha";
+
+      const error = yield* updater
+        .quitAndInstall({ isSilent: true, isForceRunAfter: false })
+        .pipe(Effect.flip);
+
+      assert.instanceOf(error, ElectronUpdater.ElectronUpdaterQuitAndInstallError);
+      assert.isTrue(ElectronUpdater.isElectronUpdaterError(error));
+      assert.equal(error.channel, "alpha");
+      assert.equal(error.isSilent, true);
+      assert.equal(error.isForceRunAfter, false);
+      assert.strictEqual(error.cause, cause);
+      assert.equal(
+        error.message,
+        "Electron updater failed to quit and install the update on channel alpha (silent: true, force run after: false).",
+      );
+      assert.notInclude(error.message, cause.message);
+      assert.deepEqual(autoUpdaterMock.quitAndInstall.mock.calls, [[true, false]]);
     }).pipe(Effect.provide(ElectronUpdater.layer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronUpdater.ts
+++ b/apps/desktop/src/electron/ElectronUpdater.ts
@@ -10,40 +10,41 @@ type AutoUpdater = typeof autoUpdater;
 
 export type ElectronUpdaterFeedUrl = Parameters<AutoUpdater["setFeedURL"]>[0];
 
-const electronUpdaterErrorFields = {
-  cause: Schema.Defect(),
-};
-
 export class ElectronUpdaterCheckForUpdatesError extends Schema.TaggedErrorClass<ElectronUpdaterCheckForUpdatesError>()(
   "ElectronUpdaterCheckForUpdatesError",
   {
-    ...electronUpdaterErrorFields,
+    channel: Schema.NullOr(Schema.String),
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return "Electron updater failed to check for updates.";
+    return `Electron updater failed to check for updates on channel ${this.channel ?? "default"}.`;
   }
 }
 
 export class ElectronUpdaterDownloadUpdateError extends Schema.TaggedErrorClass<ElectronUpdaterDownloadUpdateError>()(
   "ElectronUpdaterDownloadUpdateError",
   {
-    ...electronUpdaterErrorFields,
+    channel: Schema.NullOr(Schema.String),
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return "Electron updater failed to download the update.";
+    return `Electron updater failed to download the update on channel ${this.channel ?? "default"}.`;
   }
 }
 
 export class ElectronUpdaterQuitAndInstallError extends Schema.TaggedErrorClass<ElectronUpdaterQuitAndInstallError>()(
   "ElectronUpdaterQuitAndInstallError",
   {
-    ...electronUpdaterErrorFields,
+    channel: Schema.NullOr(Schema.String),
+    isSilent: Schema.Boolean,
+    isForceRunAfter: Schema.Boolean,
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return "Electron updater failed to quit and install the update.";
+    return `Electron updater failed to quit and install the update on channel ${this.channel ?? "default"} (silent: ${this.isSilent}, force run after: ${this.isForceRunAfter}).`;
   }
 }
 
@@ -116,18 +117,33 @@ export const make = ElectronUpdater.of({
       autoUpdater.disableDifferentialDownload = value;
       return Effect.void;
     }),
-  checkForUpdates: Effect.tryPromise({
-    try: () => autoUpdater.checkForUpdates(),
-    catch: (cause) => new ElectronUpdaterCheckForUpdatesError({ cause }),
-  }).pipe(Effect.asVoid),
-  downloadUpdate: Effect.tryPromise({
-    try: () => autoUpdater.downloadUpdate(),
-    catch: (cause) => new ElectronUpdaterDownloadUpdateError({ cause }),
-  }).pipe(Effect.asVoid),
+  checkForUpdates: Effect.suspend(() => {
+    const channel = autoUpdater.channel;
+    return Effect.tryPromise({
+      try: () => autoUpdater.checkForUpdates(),
+      catch: (cause) => new ElectronUpdaterCheckForUpdatesError({ channel, cause }),
+    }).pipe(Effect.asVoid);
+  }),
+  downloadUpdate: Effect.suspend(() => {
+    const channel = autoUpdater.channel;
+    return Effect.tryPromise({
+      try: () => autoUpdater.downloadUpdate(),
+      catch: (cause) => new ElectronUpdaterDownloadUpdateError({ channel, cause }),
+    }).pipe(Effect.asVoid);
+  }),
   quitAndInstall: ({ isSilent, isForceRunAfter }) =>
-    Effect.try({
-      try: () => autoUpdater.quitAndInstall(isSilent, isForceRunAfter),
-      catch: (cause) => new ElectronUpdaterQuitAndInstallError({ cause }),
+    Effect.suspend(() => {
+      const channel = autoUpdater.channel;
+      return Effect.try({
+        try: () => autoUpdater.quitAndInstall(isSilent, isForceRunAfter),
+        catch: (cause) =>
+          new ElectronUpdaterQuitAndInstallError({
+            channel,
+            isSilent,
+            isForceRunAfter,
+            cause,
+          }),
+      });
     }),
   on: (eventName, listener) => {
     const eventTarget = autoUpdater as unknown as {


### PR DESCRIPTION
## Summary
- record the active update channel on check, download, and quit/install failures
- capture the quit/install silent and force-run flags as structured fields
- read the channel when each effect executes and preserve the exact updater cause
- keep messages derived from request context rather than cause text
- cover all three failure paths and the existing Schema union predicate

## Validation
- vp test apps/desktop/src/electron/ElectronUpdater.test.ts
- vp check (0 errors; 20 existing unrelated warnings)
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to error shape and logging-friendly messages around the desktop auto-updater wrapper; update behavior is unchanged aside from richer failure metadata.
> 
> **Overview**
> **Electron updater failures** now carry **structured context** instead of generic messages: the active **`channel`** is stored on check, download, and quit/install errors, and **`isSilent`** / **`isForceRunAfter`** are fields on quit/install failures. User-facing **`message`** strings are built from that context (e.g. channel name, flags) and **do not embed** the underlying cause text; the original failure is still on **`cause`**.
> 
> **`checkForUpdates`**, **`downloadUpdate`**, and **`quitAndInstall`** use **`Effect.suspend`** so **`autoUpdater.channel`** is read when each effect runs, matching the channel at failure time. Tests cover all three paths, **`isElectronUpdaterError`**, and the new message shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04636500daf2c42d9b6fe4769bd751fa047b8b22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add channel and flag context to ElectronUpdater error classes
> - Each error class (`ElectronUpdaterCheckForUpdatesError`, `ElectronUpdaterDownloadUpdateError`, `ElectronUpdaterQuitAndInstallError`) now carries a `channel` field captured at execution time via `Effect.suspend`.
> - `ElectronUpdaterQuitAndInstallError` additionally stores `isSilent` and `isForceRunAfter` flags on the error.
> - Error `message` getters are updated to include channel (defaulting to `'default'` when null) and, for quit-and-install, the flag values.
> - Tests in [ElectronUpdater.test.ts](https://github.com/pingdotgg/t3code/pull/3280/files#diff-0b5978a77d3ea30c8190ac497fe40ddd03c3eb96a485fd3250d9f19982f5863a) are extended to assert channel and flag presence on each failure path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0463650.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->