### PR TITLE
Preserve PortScanner probe defects

### DIFF
--- a/apps/server/src/preview/PortScanner.test.ts
+++ b/apps/server/src/preview/PortScanner.test.ts
@@ -3,14 +3,48 @@ import * as NodeNet from "node:net";
 import { it as effectIt } from "@effect/vitest";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Net from "@t3tools/shared/Net";
-import { Effect, Layer } from "effect";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import { expect } from "vite-plus/test";
 
 import * as ProcessRunner from "../processRunner.ts";
 import * as PortScanner from "./PortScanner.ts";
 const TestProcessRunner = Layer.succeed(ProcessRunner.ProcessRunner, {
-  run: () => Effect.die("ProcessRunner should not be used by Windows TCP probe tests"),
+  run: (input) =>
+    Effect.fail(
+      new ProcessRunner.ProcessSpawnError({
+        command: input.command,
+        argumentCount: input.args.length,
+        cwd: input.cwd,
+        cause: PlatformError.systemError({
+          _tag: "NotFound",
+          module: "ChildProcess",
+          method: "spawn",
+          description: "PowerShell is not installed in the test environment",
+        }),
+      }),
+    ),
 });
+
+const makeProbeFailureLayer = (run: ProcessRunner.ProcessRunner["Service"]["run"]) =>
+  PortScanner.layer.pipe(
+    Layer.provide(
+      Layer.mergeAll(
+        Layer.succeed(ProcessRunner.ProcessRunner, { run }),
+        Layer.succeed(Net.NetService, {
+          canListenOnHost: () => Effect.succeed(true),
+          isPortAvailableOnLoopback: () => Effect.succeed(true),
+          reserveLoopbackPort: () => Effect.succeed(40_000),
+          findAvailablePort: (preferred) => Effect.succeed(preferred),
+        }),
+        Layer.succeed(HostProcessPlatform, "linux"),
+      ),
+    ),
+  );
+
 const TestPortDiscoveryLive = PortScanner.layer.pipe(
   Layer.provide(
     Layer.mergeAll(TestProcessRunner, Net.layer, Layer.succeed(HostProcessPlatform, "win32")),
@@ -87,3 +121,37 @@ effectIt.layer(TestPortDiscoveryLive)("PortDiscovery integration (TCP probe fall
     }),
   );
 });
+
+effectIt("does not swallow process probe defects", () =>
+  Effect.gen(function* () {
+    const defect = new Error("unexpected process probe defect");
+    const layer = makeProbeFailureLayer(() => Effect.die(defect));
+
+    const exit = yield* Effect.flatMap(PortScanner.PortDiscovery, (scanner) => scanner.scan()).pipe(
+      Effect.provide(layer),
+      Effect.exit,
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Cause.hasDies(exit.cause)).toBe(true);
+      expect(Cause.squash(exit.cause)).toBe(defect);
+    }
+  }),
+);
+
+effectIt("does not swallow process probe interruption", () =>
+  Effect.gen(function* () {
+    const layer = makeProbeFailureLayer(() => Effect.interrupt);
+
+    const exit = yield* Effect.flatMap(PortScanner.PortDiscovery, (scanner) => scanner.scan()).pipe(
+      Effect.provide(layer),
+      Effect.exit,
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Cause.hasInterruptsOnly(exit.cause)).toBe(true);
+    }
+  }),
+);

--- a/apps/server/src/preview/PortScanner.ts
+++ b/apps/server/src/preview/PortScanner.ts
@@ -221,6 +221,14 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
       }));
   });
 
+  const recoverProcessProbeFailure =
+    (probe: "lsof" | "windows-listeners") => (error: ProcessRunner.ProcessRunError) =>
+      Effect.logDebug("preview port process probe failed; falling back to common-port probes", {
+        cause: error,
+        probe,
+        platform: hostPlatform,
+      }).pipe(Effect.as(null));
+
   const scanOnce = Effect.fn("PortDiscovery.scan")(function* () {
     const state = yield* Ref.get(stateRef);
     const terminalByProcessId = new Map<number, TerminalProcessOwner>();
@@ -230,6 +238,7 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
       }
     }
     if (hostPlatform === "win32") {
+      const recoverWindowsProbeFailure = recoverProcessProbeFailure("windows-listeners");
       const command =
         'Get-NetTCPConnection -State Listen -ErrorAction Stop | ForEach-Object { $processName = (Get-Process -Id $_.OwningProcess -ErrorAction SilentlyContinue).ProcessName; Write-Output "$($_.LocalAddress)|$($_.LocalPort)|$($_.OwningProcess)|$processName" }';
       const listeners = yield* processRunner
@@ -242,11 +251,18 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
         })
         .pipe(
           Effect.map((result) => parseWindowsListenerOutput(result.stdout, terminalByProcessId)),
-          Effect.catchCause(() => Effect.succeed(null)),
+          Effect.catchTags({
+            ProcessSpawnError: recoverWindowsProbeFailure,
+            ProcessStdinError: recoverWindowsProbeFailure,
+            ProcessOutputLimitError: recoverWindowsProbeFailure,
+            ProcessReadError: recoverWindowsProbeFailure,
+            ProcessTimeoutError: recoverWindowsProbeFailure,
+          }),
         );
       if (listeners !== null) return listeners;
       return yield* probeCommonPorts();
     }
+    const recoverLsofProbeFailure = recoverProcessProbeFailure("lsof");
     const lsofResult = yield* processRunner
       .run({
         command: "lsof",
@@ -257,7 +273,13 @@ export const make = Effect.gen(function* PortDiscoveryMake() {
       })
       .pipe(
         Effect.map((result) => parseLsofOutput(result.stdout, terminalByProcessId)),
-        Effect.catchCause(() => Effect.succeed(null)),
+        Effect.catchTags({
+          ProcessSpawnError: recoverLsofProbeFailure,
+          ProcessStdinError: recoverLsofProbeFailure,
+          ProcessOutputLimitError: recoverLsofProbeFailure,
+          ProcessReadError: recoverLsofProbeFailure,
+          ProcessTimeoutError: recoverLsofProbeFailure,
+        }),
       );
     if (lsofResult !== null) return lsofResult;
     return yield* probeCommonPorts();


### PR DESCRIPTION
## Summary
- recover only expected typed ProcessRunner failures from platform port probes
- retain defects and interruption instead of silently falling back
- log the structured process error with probe and host-platform context before fallback

## Validation
- `vp test apps/server/src/preview/PortScanner.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized preview port-scan error handling with clearer failure semantics; no auth, data, or security surface changes.
> 
> **Overview**
> **Port discovery** no longer treats every process-probe failure the same: `lsof` / Windows listener probes used a broad `catchCause` that turned *any* failure (including defects and cancellation) into a silent fallback to common-port scanning.
> 
> They now **`catchTags`** only the expected `ProcessRunner` failures (`ProcessSpawnError`, stdin/output/read/timeout errors). Those paths log debug context (probe name, platform, error) via `recoverProcessProbeFailure` and still fall back to common-port probes. **Defects and interruptions propagate** instead of being swallowed.
> 
> Tests add `makeProbeFailureLayer` and assert `scan()` fails with dies/interrupts-only causes when the injected probe does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac9be8923d62ae8b709e55b1aba0730669ae0e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve PortScanner probe defects and interruptions instead of swallowing them
> - Replaces broad `catchCause` handlers in [`PortScanner.ts`](https://github.com/pingdotgg/t3code/pull/3282/files#diff-0f6b3292e660acf982893ba130c26e1ffa8f91ff09032cce9b07d55074e296f4) with targeted `catchTags` covering only specific process failures (`ProcessSpawnError`, `ProcessStdinError`, `ProcessOutputLimitError`, `ProcessReadError`, `ProcessTimeoutError`).
> - Defects and interruptions from the Windows powershell and lsof probes now propagate to callers instead of being silently swallowed.
> - Adds a `recoverProcessProbeFailure` helper that logs a debug message (with probe type, platform, and error) before returning `null` to trigger fallback to common-port probing.
> - Adds two new tests in [`PortScanner.test.ts`](https://github.com/pingdotgg/t3code/pull/3282/files#diff-98bc68e3fec0e5eecd2296d96c5534119745d09603b318b5c1f35045a7325af9) verifying that defects and interruptions from process probes are preserved in the failure cause.
> - Behavioral Change: any code that previously relied on `PortDiscovery.scan` succeeding despite probe defects or interruptions will now see those failures propagate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac9be89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->