### PR TITLE
[codex] add structured Electron dialog errors

### DIFF
--- a/apps/desktop/src/electron/ElectronDialog.test.ts
+++ b/apps/desktop/src/electron/ElectronDialog.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import type { BrowserWindow } from "electron";
@@ -88,6 +89,106 @@ describe("ElectronDialog", () => {
           message: "Delete worktree?",
         },
       ]);
+    }).pipe(Effect.provide(ElectronDialog.layer)),
+  );
+
+  it.effect("preserves folder picker request context and cause", () =>
+    Effect.gen(function* () {
+      const cause = new Error("folder picker failed");
+      const owner = { id: 7 } as BrowserWindow;
+      showOpenDialogMock.mockRejectedValue(cause);
+      const dialog = yield* ElectronDialog.ElectronDialog;
+
+      const error = yield* Effect.flip(
+        dialog.pickFolder({
+          owner: Option.some(owner),
+          defaultPath: Option.some("/workspace"),
+        }),
+      );
+
+      assert.instanceOf(error, ElectronDialog.ElectronDialogPickFolderError);
+      assert.isTrue(ElectronDialog.isElectronDialogError(error));
+      assert.strictEqual(error.ownerWindowId, 7);
+      assert.strictEqual(error.defaultPath, "/workspace");
+      assert.strictEqual(error.cause, cause);
+      assert.include(error.message, "window 7");
+      assert.include(error.message, "/workspace");
+      assert.notInclude(error.message, cause.message);
+    }).pipe(Effect.provide(ElectronDialog.layer)),
+  );
+
+  it.effect("preserves confirmation request context and cause", () =>
+    Effect.gen(function* () {
+      const cause = new Error("confirmation failed");
+      const owner = { id: 9 } as BrowserWindow;
+      showMessageBoxMock.mockRejectedValue(cause);
+      const dialog = yield* ElectronDialog.ElectronDialog;
+
+      const error = yield* Effect.flip(
+        dialog.confirm({
+          owner: Option.some(owner),
+          message: "  Confirm removal?  ",
+        }),
+      );
+
+      assert.instanceOf(error, ElectronDialog.ElectronDialogConfirmError);
+      assert.strictEqual(error.ownerWindowId, 9);
+      assert.strictEqual(error.promptMessage, "Confirm removal?");
+      assert.strictEqual(error.cause, cause);
+      assert.include(error.message, "window 9");
+      assert.include(error.message, "Confirm removal?");
+      assert.notInclude(error.message, cause.message);
+    }).pipe(Effect.provide(ElectronDialog.layer)),
+  );
+
+  it.effect("preserves message box request context and cause", () =>
+    Effect.gen(function* () {
+      const cause = new Error("message box failed");
+      showMessageBoxMock.mockRejectedValue(cause);
+      const dialog = yield* ElectronDialog.ElectronDialog;
+
+      const error = yield* Effect.flip(
+        dialog.showMessageBox({
+          type: "warning",
+          title: "Unsaved changes",
+          message: "Discard changes?",
+          detail: "This cannot be undone.",
+          buttons: ["Cancel", "Discard"],
+        }),
+      );
+
+      assert.instanceOf(error, ElectronDialog.ElectronDialogShowMessageBoxError);
+      assert.strictEqual(error.type, "warning");
+      assert.strictEqual(error.title, "Unsaved changes");
+      assert.strictEqual(error.dialogMessage, "Discard changes?");
+      assert.strictEqual(error.dialogDetail, "This cannot be undone.");
+      assert.deepEqual(error.buttons, ["Cancel", "Discard"]);
+      assert.strictEqual(error.cause, cause);
+      assert.include(error.message, "warning");
+      assert.include(error.message, "Unsaved changes");
+      assert.notInclude(error.message, cause.message);
+    }).pipe(Effect.provide(ElectronDialog.layer)),
+  );
+
+  it.effect("preserves error box request context and cause in the defect", () =>
+    Effect.gen(function* () {
+      const cause = new Error("error box failed");
+      showErrorBoxMock.mockImplementation(() => {
+        throw cause;
+      });
+      const dialog = yield* ElectronDialog.ElectronDialog;
+
+      const exit = yield* Effect.exit(dialog.showErrorBox("Startup failed", "Could not start."));
+
+      assert.isTrue(exit._tag === "Failure");
+      if (exit._tag === "Success") return;
+      const error = Cause.squash(exit.cause);
+      assert.instanceOf(error, ElectronDialog.ElectronDialogShowErrorBoxError);
+      assert.strictEqual(error.title, "Startup failed");
+      assert.strictEqual(error.content, "Could not start.");
+      assert.strictEqual(error.cause, cause);
+      assert.include(error.message, "Startup failed");
+      assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronDialog.layer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronDialog.test.ts
+++ b/apps/desktop/src/electron/ElectronDialog.test.ts
@@ -133,10 +133,11 @@ describe("ElectronDialog", () => {
 
       assert.instanceOf(error, ElectronDialog.ElectronDialogConfirmError);
       assert.strictEqual(error.ownerWindowId, 9);
-      assert.strictEqual(error.promptMessage, "Confirm removal?");
+      assert.strictEqual(error.promptLength, "Confirm removal?".length);
+      assert.notProperty(error, "promptMessage");
       assert.strictEqual(error.cause, cause);
       assert.include(error.message, "window 9");
-      assert.include(error.message, "Confirm removal?");
+      assert.notInclude(error.message, "Confirm removal?");
       assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronDialog.layer)),
   );
@@ -159,13 +160,21 @@ describe("ElectronDialog", () => {
 
       assert.instanceOf(error, ElectronDialog.ElectronDialogShowMessageBoxError);
       assert.strictEqual(error.type, "warning");
-      assert.strictEqual(error.title, "Unsaved changes");
-      assert.strictEqual(error.dialogMessage, "Discard changes?");
-      assert.strictEqual(error.dialogDetail, "This cannot be undone.");
-      assert.deepEqual(error.buttons, ["Cancel", "Discard"]);
+      assert.strictEqual(error.titleLength, "Unsaved changes".length);
+      assert.strictEqual(error.messageLength, "Discard changes?".length);
+      assert.strictEqual(error.detailLength, "This cannot be undone.".length);
+      assert.strictEqual(error.buttonCount, 2);
+      assert.notProperty(error, "title");
+      assert.notProperty(error, "dialogMessage");
+      assert.notProperty(error, "dialogDetail");
+      assert.notProperty(error, "buttons");
       assert.strictEqual(error.cause, cause);
       assert.include(error.message, "warning");
-      assert.include(error.message, "Unsaved changes");
+      assert.notInclude(error.message, "Unsaved changes");
+      assert.notInclude(error.message, "Discard changes?");
+      assert.notInclude(error.message, "This cannot be undone.");
+      assert.notInclude(error.message, "Cancel");
+      assert.notInclude(error.message, "Discard");
       assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronDialog.layer)),
   );
@@ -184,10 +193,13 @@ describe("ElectronDialog", () => {
       if (exit._tag === "Success") return;
       const error = Cause.squash(exit.cause);
       assert.instanceOf(error, ElectronDialog.ElectronDialogShowErrorBoxError);
-      assert.strictEqual(error.title, "Startup failed");
-      assert.strictEqual(error.content, "Could not start.");
+      assert.strictEqual(error.titleLength, "Startup failed".length);
+      assert.strictEqual(error.contentLength, "Could not start.".length);
+      assert.notProperty(error, "title");
+      assert.notProperty(error, "content");
       assert.strictEqual(error.cause, cause);
-      assert.include(error.message, "Startup failed");
+      assert.notInclude(error.message, "Startup failed");
+      assert.notInclude(error.message, "Could not start.");
       assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronDialog.layer)),
   );

--- a/apps/desktop/src/electron/ElectronDialog.ts
+++ b/apps/desktop/src/electron/ElectronDialog.ts
@@ -2,10 +2,80 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import * as Electron from "electron";
 
 const CONFIRM_BUTTON_INDEX = 1;
+
+export class ElectronDialogPickFolderError extends Schema.TaggedErrorClass<ElectronDialogPickFolderError>()(
+  "ElectronDialogPickFolderError",
+  {
+    ownerWindowId: Schema.NullOr(Schema.Number),
+    defaultPath: Schema.NullOr(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const owner = this.ownerWindowId === null ? "the application" : `window ${this.ownerWindowId}`;
+    const defaultPath = this.defaultPath === null ? "no default path" : this.defaultPath;
+    return `Failed to open the Electron folder picker for ${owner} with ${defaultPath}.`;
+  }
+}
+
+export class ElectronDialogConfirmError extends Schema.TaggedErrorClass<ElectronDialogConfirmError>()(
+  "ElectronDialogConfirmError",
+  {
+    ownerWindowId: Schema.NullOr(Schema.Number),
+    promptMessage: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const owner = this.ownerWindowId === null ? "the application" : `window ${this.ownerWindowId}`;
+    return `Failed to open an Electron confirmation dialog for ${owner}: ${this.promptMessage}`;
+  }
+}
+
+export class ElectronDialogShowMessageBoxError extends Schema.TaggedErrorClass<ElectronDialogShowMessageBoxError>()(
+  "ElectronDialogShowMessageBoxError",
+  {
+    type: Schema.NullOr(Schema.Literals(["none", "info", "error", "question", "warning"])),
+    title: Schema.NullOr(Schema.String),
+    dialogMessage: Schema.String,
+    dialogDetail: Schema.NullOr(Schema.String),
+    buttons: Schema.Array(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const type = this.type === null ? "untyped" : this.type;
+    const title = this.title === null ? "untitled" : this.title;
+    return `Failed to show the Electron ${type} message box titled ${title}.`;
+  }
+}
+
+export class ElectronDialogShowErrorBoxError extends Schema.TaggedErrorClass<ElectronDialogShowErrorBoxError>()(
+  "ElectronDialogShowErrorBoxError",
+  {
+    title: Schema.String,
+    content: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to show the Electron error box titled ${this.title}.`;
+  }
+}
+
+export const ElectronDialogError = Schema.Union([
+  ElectronDialogPickFolderError,
+  ElectronDialogConfirmError,
+  ElectronDialogShowMessageBoxError,
+  ElectronDialogShowErrorBoxError,
+]);
+export type ElectronDialogError = typeof ElectronDialogError.Type;
+export const isElectronDialogError = Schema.is(ElectronDialogError);
 
 export interface ElectronDialogPickFolderInput {
   readonly owner: Option.Option<Electron.BrowserWindow>;
@@ -22,17 +92,24 @@ export class ElectronDialog extends Context.Service<
   {
     readonly pickFolder: (
       input: ElectronDialogPickFolderInput,
-    ) => Effect.Effect<Option.Option<string>>;
-    readonly confirm: (input: ElectronDialogConfirmInput) => Effect.Effect<boolean>;
+    ) => Effect.Effect<Option.Option<string>, ElectronDialogPickFolderError>;
+    readonly confirm: (
+      input: ElectronDialogConfirmInput,
+    ) => Effect.Effect<boolean, ElectronDialogConfirmError>;
     readonly showMessageBox: (
       options: Electron.MessageBoxOptions,
-    ) => Effect.Effect<Electron.MessageBoxReturnValue>;
+    ) => Effect.Effect<Electron.MessageBoxReturnValue, ElectronDialogShowMessageBoxError>;
     readonly showErrorBox: (title: string, content: string) => Effect.Effect<void>;
   }
 >()("@t3tools/desktop/electron/ElectronDialog") {}
 
 export const make = ElectronDialog.of({
   pickFolder: Effect.fn("desktop.electron.dialog.pickFolder")(function* (input) {
+    const ownerWindowId = Option.match(input.owner, {
+      onNone: () => null,
+      onSome: (owner) => owner.id,
+    });
+    const defaultPath = Option.getOrNull(input.defaultPath);
     const openDialogOptions: Electron.OpenDialogOptions = Option.match(input.defaultPath, {
       onNone: () => ({
         properties: ["openDirectory", "createDirectory"],
@@ -42,10 +119,18 @@ export const make = ElectronDialog.of({
         defaultPath,
       }),
     });
-    const result = yield* Option.match(input.owner, {
-      onNone: () => Effect.promise(() => Electron.dialog.showOpenDialog(openDialogOptions)),
-      onSome: (owner) =>
-        Effect.promise(() => Electron.dialog.showOpenDialog(owner, openDialogOptions)),
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        Option.match(input.owner, {
+          onNone: () => Electron.dialog.showOpenDialog(openDialogOptions),
+          onSome: (owner) => Electron.dialog.showOpenDialog(owner, openDialogOptions),
+        }),
+      catch: (cause) =>
+        new ElectronDialogPickFolderError({
+          ownerWindowId,
+          defaultPath,
+          cause,
+        }),
     });
 
     if (result.canceled) {
@@ -67,17 +152,43 @@ export const make = ElectronDialog.of({
       noLink: true,
       message: normalizedMessage,
     };
-    const result = yield* Option.match(input.owner, {
-      onNone: () => Effect.promise(() => Electron.dialog.showMessageBox(options)),
-      onSome: (owner) => Effect.promise(() => Electron.dialog.showMessageBox(owner, options)),
+    const ownerWindowId = Option.match(input.owner, {
+      onNone: () => null,
+      onSome: (owner) => owner.id,
+    });
+    const result = yield* Effect.tryPromise({
+      try: () =>
+        Option.match(input.owner, {
+          onNone: () => Electron.dialog.showMessageBox(options),
+          onSome: (owner) => Electron.dialog.showMessageBox(owner, options),
+        }),
+      catch: (cause) =>
+        new ElectronDialogConfirmError({
+          ownerWindowId,
+          promptMessage: normalizedMessage,
+          cause,
+        }),
     });
     return result.response === CONFIRM_BUTTON_INDEX;
   }),
-  showMessageBox: (options) => Effect.promise(() => Electron.dialog.showMessageBox(options)),
-  showErrorBox: (title, content) =>
-    Effect.sync(() => {
-      Electron.dialog.showErrorBox(title, content);
+  showMessageBox: (options) =>
+    Effect.tryPromise({
+      try: () => Electron.dialog.showMessageBox(options),
+      catch: (cause) =>
+        new ElectronDialogShowMessageBoxError({
+          type: options.type ?? null,
+          title: options.title ?? null,
+          dialogMessage: options.message,
+          dialogDetail: options.detail ?? null,
+          buttons: options.buttons ?? [],
+          cause,
+        }),
     }),
+  showErrorBox: (title, content) =>
+    Effect.try({
+      try: () => Electron.dialog.showErrorBox(title, content),
+      catch: (cause) => new ElectronDialogShowErrorBoxError({ title, content, cause }),
+    }).pipe(Effect.orDie),
 });
 
 export const layer = Layer.succeed(ElectronDialog, make);

--- a/apps/desktop/src/electron/ElectronDialog.ts
+++ b/apps/desktop/src/electron/ElectronDialog.ts
@@ -27,13 +27,13 @@ export class ElectronDialogConfirmError extends Schema.TaggedErrorClass<Electron
   "ElectronDialogConfirmError",
   {
     ownerWindowId: Schema.NullOr(Schema.Number),
-    promptMessage: Schema.String,
+    promptLength: Schema.Number,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
     const owner = this.ownerWindowId === null ? "the application" : `window ${this.ownerWindowId}`;
-    return `Failed to open an Electron confirmation dialog for ${owner}: ${this.promptMessage}`;
+    return `Failed to open an Electron confirmation dialog for ${owner} with a ${this.promptLength}-character prompt.`;
   }
 }
 
@@ -41,30 +41,29 @@ export class ElectronDialogShowMessageBoxError extends Schema.TaggedErrorClass<E
   "ElectronDialogShowMessageBoxError",
   {
     type: Schema.NullOr(Schema.Literals(["none", "info", "error", "question", "warning"])),
-    title: Schema.NullOr(Schema.String),
-    dialogMessage: Schema.String,
-    dialogDetail: Schema.NullOr(Schema.String),
-    buttons: Schema.Array(Schema.String),
+    titleLength: Schema.NullOr(Schema.Number),
+    messageLength: Schema.Number,
+    detailLength: Schema.NullOr(Schema.Number),
+    buttonCount: Schema.Number,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
     const type = this.type === null ? "untyped" : this.type;
-    const title = this.title === null ? "untitled" : this.title;
-    return `Failed to show the Electron ${type} message box titled ${title}.`;
+    return `Failed to show the Electron ${type} message box with ${this.buttonCount} buttons.`;
   }
 }
 
 export class ElectronDialogShowErrorBoxError extends Schema.TaggedErrorClass<ElectronDialogShowErrorBoxError>()(
   "ElectronDialogShowErrorBoxError",
   {
-    title: Schema.String,
-    content: Schema.String,
+    titleLength: Schema.Number,
+    contentLength: Schema.Number,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to show the Electron error box titled ${this.title}.`;
+    return `Failed to show the Electron error box with a ${this.titleLength}-character title and ${this.contentLength}-character content.`;
   }
 }
 
@@ -165,7 +164,7 @@ export const make = ElectronDialog.of({
       catch: (cause) =>
         new ElectronDialogConfirmError({
           ownerWindowId,
-          promptMessage: normalizedMessage,
+          promptLength: normalizedMessage.length,
           cause,
         }),
     });
@@ -177,17 +176,22 @@ export const make = ElectronDialog.of({
       catch: (cause) =>
         new ElectronDialogShowMessageBoxError({
           type: options.type ?? null,
-          title: options.title ?? null,
-          dialogMessage: options.message,
-          dialogDetail: options.detail ?? null,
-          buttons: options.buttons ?? [],
+          titleLength: options.title?.length ?? null,
+          messageLength: options.message.length,
+          detailLength: options.detail?.length ?? null,
+          buttonCount: options.buttons?.length ?? 0,
           cause,
         }),
     }),
   showErrorBox: (title, content) =>
     Effect.try({
       try: () => Electron.dialog.showErrorBox(title, content),
-      catch: (cause) => new ElectronDialogShowErrorBoxError({ title, content, cause }),
+      catch: (cause) =>
+        new ElectronDialogShowErrorBoxError({
+          titleLength: title.length,
+          contentLength: content.length,
+          cause,
+        }),
     }).pipe(Effect.orDie),
 });
 


### PR DESCRIPTION
## Summary
- model Electron dialog failures as schema-backed errors with operation-specific context
- preserve original causes for folder picker, confirmation, message-box, and fatal error-box failures
- add focused coverage for structured attributes, messages, predicates, and cause chains

## Verification
- `vp test apps/desktop/src/electron/ElectronDialog.test.ts`
- `vp check` (0 errors; 20 existing warnings)
- `vp run typecheck`


<!-- sensitive-context-follow-up -->
## Sensitive-context follow-up\n- confirmation, message-box, and error-box payload text is represented only by lengths and counts\n- owner window, dialog type, and intentional folder default paths remain available for correlation\n- all original Electron causes remain intact

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes failure channels for dialog APIs (typed failures vs generic rejections; error box as defects), which callers must handle correctly though happy-path behavior is unchanged.
> 
> **Overview**
> **Electron dialog failures are now typed, schema-backed errors** instead of raw promise rejections.
> 
> `pickFolder`, `confirm`, and `showMessageBox` use `Effect.tryPromise` and fail with operation-specific tagged errors that keep the original **cause** plus safe metadata (window id, path, prompt/message lengths, button counts)—not full user-facing strings in `message`. An `ElectronDialogError` union and `isElectronDialogError` are exported for callers.
> 
> `showErrorBox` wraps sync throws in `ElectronDialogShowErrorBoxError` and **`Effect.orDie`**, so those failures surface as defects rather than recoverable typed errors.
> 
> New tests assert error shape, predicate usage, and that messages omit prompt/title/content and cause text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 513653f3b1a4886c8c368ce5b5e24c1e40a0c39d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured error types to `ElectronDialog` methods for failures and defects
> - Introduces four `Schema.TaggedErrorClass` types (`ElectronDialogPickFolderError`, `ElectronDialogConfirmError`, `ElectronDialogShowMessageBoxError`, `ElectronDialogShowErrorBoxError`) in [ElectronDialog.ts](https://github.com/pingdotgg/t3code/pull/3284/files#diff-53f5b0844b1021de7b71f933ac4e23c378283921213c129f76333738ac661b72), each carrying summarized request context (e.g. lengths, IDs) and the original cause.
> - Replaces `Effect.promise`/`Effect.sync` calls with `Effect.tryPromise`/`Effect.try` so rejections and throws are caught and wrapped in the appropriate typed error.
> - `showErrorBox` failures are converted to defects via `Effect.orDie`, matching Electron's fire-and-forget semantics.
> - Adds an `ElectronDialogError` union type and `isElectronDialogError` predicate for runtime type-checking.
> - Error messages include only summarized metadata (lengths, counts, IDs) and never expose raw prompt text, titles, or the original cause message.
> - Behavioral Change: `pickFolder`, `confirm`, and `showMessageBox` now fail with typed errors instead of untyped rejections; `showErrorBox` now dies with a typed defect instead of completing silently on throw.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 513653f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->