### PR TITLE
Structure server environment ID failures

### DIFF
--- a/apps/server/src/environment/ServerEnvironment.test.ts
+++ b/apps/server/src/environment/ServerEnvironment.test.ts
@@ -1,15 +1,17 @@
-// @effect-diagnostics nodeBuiltinImport:off
-import * as NodePath from "node:path";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as PlatformError from "effect/PlatformError";
+import * as Schema from "effect/Schema";
 
 import * as ServerConfig from "../config.ts";
 import * as ServerEnvironment from "./ServerEnvironment.ts";
+
+const isServerEnvironmentIdPersistenceError = Schema.is(
+  ServerEnvironment.ServerEnvironmentIdPersistenceError,
+);
 
 const makeServerEnvironmentLayer = (baseDir: string) =>
   ServerEnvironment.layer.pipe(Layer.provide(ServerConfig.layerTest(process.cwd(), baseDir)));
@@ -68,62 +70,63 @@ it.layer(NodeServices.layer)("ServerEnvironmentLive", (it) => {
     }),
   );
 
-  it.effect("fails instead of overwriting a persisted id when reading the file errors", () =>
+  it.effect("structures persisted environment id filesystem failures", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const baseDir = yield* fileSystem.makeTempDirectoryScoped({
-        prefix: "t3-server-environment-read-error-test-",
+        prefix: "t3-server-environment-error-test-",
       });
       const serverConfig = yield* makeServerConfig(baseDir);
       const environmentIdPath = serverConfig.environmentIdPath;
-      yield* fileSystem.makeDirectory(NodePath.dirname(environmentIdPath), { recursive: true });
-      yield* fileSystem.writeFileString(environmentIdPath, "persisted-environment-id\n");
-      const writeAttempts: string[] = [];
-      const failingFileSystemLayer = FileSystem.layerNoop({
-        exists: (path) => Effect.succeed(path === environmentIdPath),
-        readFileString: (path) =>
-          path === environmentIdPath
-            ? Effect.fail(
-                PlatformError.systemError({
-                  _tag: "PermissionDenied",
-                  module: "FileSystem",
-                  method: "readFileString",
-                  description: "permission denied",
-                  pathOrDescriptor: path,
-                }),
-              )
-            : Effect.fail(
-                PlatformError.systemError({
-                  _tag: "NotFound",
-                  module: "FileSystem",
-                  method: "readFileString",
-                  description: "not found",
-                  pathOrDescriptor: path,
-                }),
-              ),
-        writeFileString: (path) => {
-          writeAttempts.push(path);
-          return Effect.void;
-        },
-      });
+      const methodByOperation = {
+        check: "exists",
+        read: "readFileString",
+        write: "writeFileString",
+      } as const;
 
-      const exit = yield* Effect.gen(function* () {
-        const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
-        return yield* serverEnvironment.getDescriptor;
-      }).pipe(
-        Effect.provide(
-          ServerEnvironment.layer.pipe(
-            Layer.provide(Layer.merge(ServerConfig.layer(serverConfig), failingFileSystemLayer)),
+      for (const operation of ["check", "read", "write"] as const) {
+        const writeAttempts: string[] = [];
+        const cause = PlatformError.systemError({
+          _tag: "PermissionDenied",
+          module: "FileSystem",
+          method: methodByOperation[operation],
+          description: "permission denied",
+          pathOrDescriptor: environmentIdPath,
+        });
+        const failingFileSystemLayer = FileSystem.layerNoop({
+          exists: () =>
+            operation === "check" ? Effect.fail(cause) : Effect.succeed(operation === "read"),
+          readFileString: () => Effect.fail(cause),
+          writeFileString: (path) => {
+            writeAttempts.push(path);
+            return Effect.fail(cause);
+          },
+        });
+
+        const error = yield* Effect.gen(function* () {
+          const serverEnvironment = yield* ServerEnvironment.ServerEnvironment;
+          return yield* serverEnvironment.getDescriptor;
+        }).pipe(
+          Effect.provide(
+            ServerEnvironment.layer.pipe(
+              Layer.provide(Layer.merge(ServerConfig.layer(serverConfig), failingFileSystemLayer)),
+            ),
           ),
-        ),
-        Effect.exit,
-      );
+          Effect.flip,
+        );
 
-      expect(Exit.isFailure(exit)).toBe(true);
-      expect(writeAttempts).toEqual([]);
-      expect(yield* fileSystem.readFileString(environmentIdPath)).toBe(
-        "persisted-environment-id\n",
-      );
+        expect(isServerEnvironmentIdPersistenceError(error)).toBe(true);
+        if (!isServerEnvironmentIdPersistenceError(error)) {
+          throw error;
+        }
+        expect(error.operation).toBe(operation);
+        expect(error.environmentIdPath).toBe(environmentIdPath);
+        expect(error.cause).toBe(cause);
+        expect(error.message).toBe(
+          `Server environment ID ${operation} failed at '${environmentIdPath}'.`,
+        );
+        expect(writeAttempts).toEqual(operation === "write" ? [environmentIdPath] : []);
+      }
     }),
   );
 });

--- a/apps/server/src/environment/ServerEnvironment.ts
+++ b/apps/server/src/environment/ServerEnvironment.ts
@@ -6,11 +6,25 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
 
 import packageJson from "../../package.json" with { type: "json" };
 import * as ServerConfig from "../config.ts";
 import * as ProcessRunner from "../processRunner.ts";
 import { resolveServerEnvironmentLabel } from "./ServerEnvironmentLabel.ts";
+
+export class ServerEnvironmentIdPersistenceError extends Schema.TaggedErrorClass<ServerEnvironmentIdPersistenceError>()(
+  "ServerEnvironmentIdPersistenceError",
+  {
+    operation: Schema.Literals(["check", "read", "write"]),
+    environmentIdPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Server environment ID ${this.operation} failed at '${this.environmentIdPath}'.`;
+  }
+}
 
 export class ServerEnvironment extends Context.Service<
   ServerEnvironment,
@@ -55,22 +69,46 @@ export const make = Effect.gen(function* () {
   const hostArchitecture = yield* HostProcessArchitecture;
 
   const readPersistedEnvironmentId = Effect.gen(function* () {
-    const exists = yield* fileSystem
-      .exists(serverConfig.environmentIdPath)
-      .pipe(Effect.orElseSucceed(() => false));
+    const exists = yield* fileSystem.exists(serverConfig.environmentIdPath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ServerEnvironmentIdPersistenceError({
+            operation: "check",
+            environmentIdPath: serverConfig.environmentIdPath,
+            cause,
+          }),
+      ),
+    );
     if (!exists) {
       return null;
     }
 
-    const raw = yield* fileSystem
-      .readFileString(serverConfig.environmentIdPath)
-      .pipe(Effect.map((value) => value.trim()));
+    const raw = yield* fileSystem.readFileString(serverConfig.environmentIdPath).pipe(
+      Effect.map((value) => value.trim()),
+      Effect.mapError(
+        (cause) =>
+          new ServerEnvironmentIdPersistenceError({
+            operation: "read",
+            environmentIdPath: serverConfig.environmentIdPath,
+            cause,
+          }),
+      ),
+    );
 
     return raw.length > 0 ? raw : null;
   });
 
   const persistEnvironmentId = (value: string) =>
-    fileSystem.writeFileString(serverConfig.environmentIdPath, `${value}\n`);
+    fileSystem.writeFileString(serverConfig.environmentIdPath, `${value}\n`).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ServerEnvironmentIdPersistenceError({
+            operation: "write",
+            environmentIdPath: serverConfig.environmentIdPath,
+            cause,
+          }),
+      ),
+    );
 
   const environmentIdRaw = yield* Effect.gen(function* () {
     const persisted = yield* readPersistedEnvironmentId;


### PR DESCRIPTION
## Summary
- stop treating environment-ID existence-check failures as a missing file
- attach check/read/write phase, environment-ID path, and the original filesystem cause
- derive a stable message from the structured fields
- prove check and read failures cannot trigger replacement writes

## Validation
- `vp test apps/server/src/environment/ServerEnvironment.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes server bootstrap when the persisted environment-ID file is unreadable or permission-denied: startup fails explicitly instead of silently generating a new ID, which is safer but alters failure modes at layer acquisition.
> 
> **Overview**
> **Server environment ID** filesystem failures now surface as `ServerEnvironmentIdPersistenceError` instead of being swallowed or misread as “no persisted id.”
> 
> `exists` on the environment-ID path no longer falls back to `false` on error, so a failed **check** cannot trigger UUID generation and a **write**. **Read** and **write** map their platform errors the same way, each tagged with `operation`, `environmentIdPath`, the original `cause`, and a stable message.
> 
> Tests were broadened to assert that shape for **check**, **read**, and **write** failures and that only **write** attempts touch the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f907709b99bc4b46c135e80c9851cf79acae7cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure server environment ID persistence failures with `ServerEnvironmentIdPersistenceError`
> - Adds `ServerEnvironmentIdPersistenceError`, a tagged Schema error class in [ServerEnvironment.ts](https://github.com/pingdotgg/t3code/pull/3286/files#diff-28d9690cbe59a84cd86ea9e149972794d5eec454e166270a91c12f5b656ecfd6) carrying `operation` ('check', 'read', or 'write'), `environmentIdPath`, and the original `cause`.
> - Filesystem errors during existence checks, reads, and writes are now wrapped in this structured error instead of being suppressed or surfaced as untyped failures.
> - Behavioral Change: a failed existence check previously treated the ID as non-existent; it now propagates as a structured error, causing `getDescriptor` to fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f90770.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->