### PR TITLE
[codex] Structure mobile file-processing failures

### DIFF
--- a/apps/mobile/src/features/files/sourceHighlightingState.test.ts
+++ b/apps/mobile/src/features/files/sourceHighlightingState.test.ts
@@ -1,9 +1,11 @@
+import * as Cause from "effect/Cause";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   createSourceHighlightAtomFamily,
+  SourceHighlightError,
   type SourceHighlightTokens,
 } from "./sourceHighlightingState";
 
@@ -100,22 +102,29 @@ describe("sourceHighlightingState", () => {
     registry.dispose();
   });
 
-  it("exposes highlighter errors as a failed async result", async () => {
-    const highlight = vi.fn(async () => {
-      throw new Error("highlight failed");
-    });
+  it("preserves highlighter failures with the source path and theme", async () => {
+    const cause = new Error("highlight failed");
+    const highlight = vi.fn(() => Promise.reject(cause));
     const sourceHighlightAtom = createSourceHighlightAtomFamily({ highlight });
     const registry = AtomRegistry.make();
+    const path = "src/example.ts";
+    const theme = "light" as const;
     const atom = sourceHighlightAtom({
-      path: "src/example.ts",
+      path,
       contents: "const value = 1;",
-      theme: "light",
+      theme,
     });
     const unmount = registry.mount(atom);
 
     await vi.waitFor(() => {
       expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
     });
+    const result = registry.get(atom);
+    if (AsyncResult.isFailure(result)) {
+      const error = Cause.squash(result.cause);
+      expect(error).toEqual(new SourceHighlightError({ path, theme, cause }));
+      expect((error as SourceHighlightError).cause).toBe(cause);
+    }
 
     unmount();
     registry.dispose();

--- a/apps/mobile/src/features/files/sourceHighlightingState.ts
+++ b/apps/mobile/src/features/files/sourceHighlightingState.ts
@@ -1,5 +1,6 @@
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { Atom } from "effect/unstable/reactivity";
 
 import {
@@ -22,9 +23,18 @@ type SourceHighlighter = (input: SourceHighlightInput) => Promise<SourceHighligh
 
 class SourceHighlightCacheKey extends Data.Class<SourceHighlightInput> {}
 
-class SourceHighlightError extends Data.TaggedError("SourceHighlightError")<{
-  readonly cause: unknown;
-}> {}
+export class SourceHighlightError extends Schema.TaggedErrorClass<SourceHighlightError>()(
+  "SourceHighlightError",
+  {
+    path: Schema.String,
+    theme: Schema.Literals(["light", "dark"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Could not highlight ${this.path} with the ${this.theme} theme.`;
+  }
+}
 
 export function createSourceHighlightAtomFamily(options?: {
   readonly highlight?: SourceHighlighter;
@@ -36,7 +46,8 @@ export function createSourceHighlightAtomFamily(options?: {
     Atom.make(
       Effect.tryPromise({
         try: () => highlight(request),
-        catch: (cause) => new SourceHighlightError({ cause }),
+        catch: (cause) =>
+          new SourceHighlightError({ path: request.path, theme: request.theme, cause }),
       }),
     ).pipe(
       Atom.setIdleTTL(idleTtlMs),

--- a/apps/mobile/src/features/files/workspace-file-image-cache.test.ts
+++ b/apps/mobile/src/features/files/workspace-file-image-cache.test.ts
@@ -1,8 +1,13 @@
+import * as Cause from "effect/Cause";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { createWorkspaceFileImageAtomFamily } from "./workspace-file-image-cache";
+import {
+  createWorkspaceFileImageAtomFamily,
+  WorkspaceImagePrefetchFailedError,
+  WorkspaceImagePrefetchUnavailableError,
+} from "./workspace-file-image-cache";
 
 describe("workspaceFileImageAtom", () => {
   it("reuses a prefetched image across route remounts", async () => {
@@ -48,15 +53,44 @@ describe("workspaceFileImageAtom", () => {
     registry.dispose();
   });
 
-  it("exposes prefetch failures", async () => {
+  it("reports an unavailable image when prefetch completes without caching it", async () => {
+    const uri = "https://example.test/missing.png";
     const imageAtom = createWorkspaceFileImageAtomFamily({ prefetch: async () => false });
     const registry = AtomRegistry.make();
-    const atom = imageAtom("https://example.test/missing.png");
+    const atom = imageAtom(uri);
     const unmount = registry.mount(atom);
 
     await vi.waitFor(() => {
       expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
     });
+    const result = registry.get(atom);
+    if (AsyncResult.isFailure(result)) {
+      expect(Cause.squash(result.cause)).toEqual(
+        new WorkspaceImagePrefetchUnavailableError({ uri }),
+      );
+    }
+
+    unmount();
+    registry.dispose();
+  });
+
+  it("preserves rejected prefetch causes with the image URI", async () => {
+    const uri = "https://example.test/rejected.png";
+    const cause = new Error("native image loader failed");
+    const imageAtom = createWorkspaceFileImageAtomFamily({ prefetch: () => Promise.reject(cause) });
+    const registry = AtomRegistry.make();
+    const atom = imageAtom(uri);
+    const unmount = registry.mount(atom);
+
+    await vi.waitFor(() => {
+      expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
+    });
+    const result = registry.get(atom);
+    if (AsyncResult.isFailure(result)) {
+      const error = Cause.squash(result.cause);
+      expect(error).toEqual(new WorkspaceImagePrefetchFailedError({ uri, cause }));
+      expect((error as WorkspaceImagePrefetchFailedError).cause).toBe(cause);
+    }
 
     unmount();
     registry.dispose();

--- a/apps/mobile/src/features/files/workspace-file-image-cache.test.ts
+++ b/apps/mobile/src/features/files/workspace-file-image-cache.test.ts
@@ -1,4 +1,5 @@
 import * as Cause from "effect/Cause";
+import * as Hash from "effect/Hash";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { describe, expect, it, vi } from "vite-plus/test";
@@ -54,10 +55,12 @@ describe("workspaceFileImageAtom", () => {
   });
 
   it("reports an unavailable image when prefetch completes without caching it", async () => {
-    const uri = "https://example.test/missing.png";
+    const uri = "https://example.test/api/assets/signed-secret-token/missing.png?signature=private";
     const imageAtom = createWorkspaceFileImageAtomFamily({ prefetch: async () => false });
     const registry = AtomRegistry.make();
     const atom = imageAtom(uri);
+    expect(atom.label?.[0]).not.toContain("signed-secret-token");
+    expect(atom.label?.[0]).not.toContain("signature=private");
     const unmount = registry.mount(atom);
 
     await vi.waitFor(() => {
@@ -65,17 +68,26 @@ describe("workspaceFileImageAtom", () => {
     });
     const result = registry.get(atom);
     if (AsyncResult.isFailure(result)) {
-      expect(Cause.squash(result.cause)).toEqual(
-        new WorkspaceImagePrefetchUnavailableError({ uri }),
+      const error = Cause.squash(result.cause);
+      expect(error).toEqual(
+        new WorkspaceImagePrefetchUnavailableError({
+          uriHash: Hash.hash(uri),
+          uriLength: uri.length,
+          uriProtocol: "https:",
+        }),
       );
+      expect(error).not.toHaveProperty("uri");
+      expect(String(error)).not.toContain("signed-secret-token");
+      expect(String(error)).not.toContain("signature=private");
     }
 
     unmount();
     registry.dispose();
   });
 
-  it("preserves rejected prefetch causes with the image URI", async () => {
-    const uri = "https://example.test/rejected.png";
+  it("preserves rejected prefetch causes without retaining the signed image URI", async () => {
+    const uri =
+      "https://example.test/api/assets/signed-secret-token/rejected.png?signature=private";
     const cause = new Error("native image loader failed");
     const imageAtom = createWorkspaceFileImageAtomFamily({ prefetch: () => Promise.reject(cause) });
     const registry = AtomRegistry.make();
@@ -88,8 +100,18 @@ describe("workspaceFileImageAtom", () => {
     const result = registry.get(atom);
     if (AsyncResult.isFailure(result)) {
       const error = Cause.squash(result.cause);
-      expect(error).toEqual(new WorkspaceImagePrefetchFailedError({ uri, cause }));
+      expect(error).toEqual(
+        new WorkspaceImagePrefetchFailedError({
+          uriHash: Hash.hash(uri),
+          uriLength: uri.length,
+          uriProtocol: "https:",
+          cause,
+        }),
+      );
       expect((error as WorkspaceImagePrefetchFailedError).cause).toBe(cause);
+      expect(error).not.toHaveProperty("uri");
+      expect(String(error)).not.toContain("signed-secret-token");
+      expect(String(error)).not.toContain("signature=private");
     }
 
     unmount();

--- a/apps/mobile/src/features/files/workspace-file-image-cache.ts
+++ b/apps/mobile/src/features/files/workspace-file-image-cache.ts
@@ -1,3 +1,4 @@
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Hash from "effect/Hash";
@@ -49,16 +50,11 @@ async function prefetchWithNativeImage(uri: string): Promise<boolean> {
 }
 
 function describeWorkspaceImageUri(uri: string) {
-  let uriProtocol: string | null = null;
-  try {
-    uriProtocol = new URL(uri).protocol || null;
-  } catch {
-    // Relative and malformed URIs still retain safe length/hash diagnostics.
-  }
+  const diagnostics = getUrlDiagnostics(uri);
   return {
     uriHash: Hash.hash(uri),
-    uriLength: uri.length,
-    uriProtocol,
+    uriLength: diagnostics.inputLength,
+    uriProtocol: diagnostics.protocol ?? null,
   };
 }
 

--- a/apps/mobile/src/features/files/workspace-file-image-cache.ts
+++ b/apps/mobile/src/features/files/workspace-file-image-cache.ts
@@ -1,5 +1,6 @@
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Hash from "effect/Hash";
 import * as Schema from "effect/Schema";
 import { Atom } from "effect/unstable/reactivity";
 
@@ -12,23 +13,27 @@ class WorkspaceImageCacheKey extends Data.Class<{ readonly uri: string }> {}
 export class WorkspaceImagePrefetchUnavailableError extends Schema.TaggedErrorClass<WorkspaceImagePrefetchUnavailableError>()(
   "WorkspaceImagePrefetchUnavailableError",
   {
-    uri: Schema.String,
+    uriHash: Schema.Number,
+    uriLength: Schema.Number,
+    uriProtocol: Schema.NullOr(Schema.String),
   },
 ) {
   override get message(): string {
-    return `Image prefetch did not cache ${this.uri}.`;
+    return `Image prefetch did not cache the requested ${this.uriProtocol ?? "unknown-protocol"} resource (URI length ${this.uriLength}).`;
   }
 }
 
 export class WorkspaceImagePrefetchFailedError extends Schema.TaggedErrorClass<WorkspaceImagePrefetchFailedError>()(
   "WorkspaceImagePrefetchFailedError",
   {
-    uri: Schema.String,
+    uriHash: Schema.Number,
+    uriLength: Schema.Number,
+    uriProtocol: Schema.NullOr(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Image prefetch failed for ${this.uri}.`;
+    return `Image prefetch failed for the requested ${this.uriProtocol ?? "unknown-protocol"} resource (URI length ${this.uriLength}).`;
   }
 }
 
@@ -43,26 +48,44 @@ async function prefetchWithNativeImage(uri: string): Promise<boolean> {
   return Image.prefetch(uri);
 }
 
+function describeWorkspaceImageUri(uri: string) {
+  let uriProtocol: string | null = null;
+  try {
+    uriProtocol = new URL(uri).protocol || null;
+  } catch {
+    // Relative and malformed URIs still retain safe length/hash diagnostics.
+  }
+  return {
+    uriHash: Hash.hash(uri),
+    uriLength: uri.length,
+    uriProtocol,
+  };
+}
+
 export function createWorkspaceFileImageAtomFamily(options?: {
   readonly idleTtlMs?: number;
   readonly prefetch?: ImagePrefetch;
 }) {
   const idleTtlMs = options?.idleTtlMs ?? WORKSPACE_IMAGE_IDLE_TTL_MS;
   const prefetch = options?.prefetch ?? prefetchWithNativeImage;
-  const family = Atom.family((key: WorkspaceImageCacheKey) =>
-    Atom.make(
+  const family = Atom.family((key: WorkspaceImageCacheKey) => {
+    const uriContext = describeWorkspaceImageUri(key.uri);
+    return Atom.make(
       Effect.gen(function* () {
         const cached = yield* Effect.tryPromise({
           try: () => prefetch(key.uri),
-          catch: (cause) => new WorkspaceImagePrefetchFailedError({ uri: key.uri, cause }),
+          catch: (cause) => new WorkspaceImagePrefetchFailedError({ ...uriContext, cause }),
         });
         if (!cached) {
-          return yield* new WorkspaceImagePrefetchUnavailableError({ uri: key.uri });
+          return yield* new WorkspaceImagePrefetchUnavailableError(uriContext);
         }
         return key.uri;
       }),
-    ).pipe(Atom.setIdleTTL(idleTtlMs), Atom.withLabel(`mobile:workspace-image:${key.uri}`)),
-  );
+    ).pipe(
+      Atom.setIdleTTL(idleTtlMs),
+      Atom.withLabel(`mobile:workspace-image:${uriContext.uriHash.toString(36)}`),
+    );
+  });
 
   return (uri: string) => family(new WorkspaceImageCacheKey({ uri }));
 }

--- a/apps/mobile/src/features/files/workspace-file-image-cache.ts
+++ b/apps/mobile/src/features/files/workspace-file-image-cache.ts
@@ -1,5 +1,6 @@
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { Atom } from "effect/unstable/reactivity";
 
 const WORKSPACE_IMAGE_IDLE_TTL_MS = 30 * 60_000;
@@ -8,10 +9,34 @@ type ImagePrefetch = (uri: string) => Promise<boolean>;
 
 class WorkspaceImageCacheKey extends Data.Class<{ readonly uri: string }> {}
 
-export class WorkspaceImagePrefetchError extends Data.TaggedError("WorkspaceImagePrefetchError")<{
-  readonly cause?: unknown;
-  readonly uri: string;
-}> {}
+export class WorkspaceImagePrefetchUnavailableError extends Schema.TaggedErrorClass<WorkspaceImagePrefetchUnavailableError>()(
+  "WorkspaceImagePrefetchUnavailableError",
+  {
+    uri: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Image prefetch did not cache ${this.uri}.`;
+  }
+}
+
+export class WorkspaceImagePrefetchFailedError extends Schema.TaggedErrorClass<WorkspaceImagePrefetchFailedError>()(
+  "WorkspaceImagePrefetchFailedError",
+  {
+    uri: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Image prefetch failed for ${this.uri}.`;
+  }
+}
+
+export const WorkspaceImagePrefetchError = Schema.Union([
+  WorkspaceImagePrefetchUnavailableError,
+  WorkspaceImagePrefetchFailedError,
+]);
+export type WorkspaceImagePrefetchError = typeof WorkspaceImagePrefetchError.Type;
 
 async function prefetchWithNativeImage(uri: string): Promise<boolean> {
   const { Image } = await import("react-native");
@@ -26,18 +51,15 @@ export function createWorkspaceFileImageAtomFamily(options?: {
   const prefetch = options?.prefetch ?? prefetchWithNativeImage;
   const family = Atom.family((key: WorkspaceImageCacheKey) =>
     Atom.make(
-      Effect.tryPromise({
-        try: async () => {
-          const cached = await prefetch(key.uri);
-          if (!cached) {
-            throw new WorkspaceImagePrefetchError({ uri: key.uri });
-          }
-          return key.uri;
-        },
-        catch: (cause) =>
-          cause instanceof WorkspaceImagePrefetchError
-            ? cause
-            : new WorkspaceImagePrefetchError({ uri: key.uri, cause }),
+      Effect.gen(function* () {
+        const cached = yield* Effect.tryPromise({
+          try: () => prefetch(key.uri),
+          catch: (cause) => new WorkspaceImagePrefetchFailedError({ uri: key.uri, cause }),
+        });
+        if (!cached) {
+          return yield* new WorkspaceImagePrefetchUnavailableError({ uri: key.uri });
+        }
+        return key.uri;
       }),
     ).pipe(Atom.setIdleTTL(idleTtlMs), Atom.withLabel(`mobile:workspace-image:${key.uri}`)),
   );


### PR DESCRIPTION
## Summary

- distinguish native image-prefetch rejection from a completed prefetch that did not cache the image
- preserve exact prefetch and source-highlighting causes with structured context
- keep signed asset URIs only in the internal cache key and return value; errors and atom labels retain only a stable hash, protocol, and input length
- derive URL fields through the shared diagnostics policy without retaining raw paths or tokens

## Stack dependency

- Based on #3403 for `@t3tools/shared/urlDiagnostics`.

## Validation

- `vp test run apps/mobile/src/features/files/workspace-file-image-cache.test.ts apps/mobile/src/features/files/sourceHighlightingState.test.ts` (8 tests)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error shapes and removes raw URIs from failure paths (good for security), but any caller matching the old prefetch error type must be updated; behavior on success is unchanged.
> 
> **Overview**
> Replaces loose tagged errors in mobile **source highlighting** and **workspace image prefetch** with Effect `Schema.TaggedErrorClass` types that carry structured context while avoiding leaking signed asset URLs in errors, messages, or atom labels.
> 
> **Source highlighting** now surfaces `SourceHighlightError` with `path`, `theme`, and the original `cause` (exported for callers/tests).
> 
> **Image prefetch** splits the old single `WorkspaceImagePrefetchError` into **`WorkspaceImagePrefetchUnavailableError`** (prefetch returned `false`) and **`WorkspaceImagePrefetchFailedError`** (rejected prefetch with `cause`). Both use `uriHash`, `uriLength`, and `uriProtocol` from new shared **`getUrlDiagnostics`**; workspace image atom labels use a base-36 hash instead of the full URI. Successful atoms still return the real URI internally.
> 
> **Shared** adds `@t3tools/shared/urlDiagnostics` and **`redactDpopRequestTarget`** (scheme/host/port/path only; invalid → `"<invalid-url>"`) with tests—supporting safer diagnostics outside mobile file cache.
> 
> **Breaking:** code matching the previous `WorkspaceImagePrefetchError` type must handle the two new variants (union exported as `WorkspaceImagePrefetchError`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0369ec2043c7c79b7d8ad4f22f2283734778394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure mobile file-processing failures with URI-safe, typed error classes
> - Replaces `Data.TaggedError` with `Schema.TaggedErrorClass` for `SourceHighlightError`, adding `path` and `theme` fields to failed highlight operations in [sourceHighlightingState.ts](https://github.com/pingdotgg/t3code/pull/3287/files#diff-86880d07d44c5e55c4aab5e140eb14cf6c39c147d88ff72ce00163e0cf661b8e).
> - Introduces two new error classes in [workspace-file-image-cache.ts](https://github.com/pingdotgg/t3code/pull/3287/files#diff-075ae584ebec6aaf452dd742ca033b0994b47a284c5c44d36a4255827e0df5b4): `WorkspaceImagePrefetchUnavailableError` (prefetch returned false) and `WorkspaceImagePrefetchFailedError` (prefetch rejected), both carrying URI diagnostics (`uriHash`, `uriLength`, `uriProtocol`) without the raw URI.
> - Atom labels in the image cache now use a base36 URI hash instead of the full URI, preventing sensitive data from leaking into labels or error messages.
> - Behavioral Change: error shapes and messages for highlight and image prefetch failures change; consumers inspecting these errors directly will need to update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e0369ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->