### PR TITLE
[codex] add structured Electron shell errors

### DIFF
--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -46,14 +46,42 @@ describe("ElectronShell", () => {
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 
-  it.effect("returns false when Electron rejects openExternal", () =>
+  it.effect("preserves the URL and cause when Electron rejects openExternal", () =>
     Effect.gen(function* () {
-      openExternalMock.mockRejectedValue(new Error("open failed"));
+      const cause = new Error("open failed");
+      openExternalMock.mockRejectedValue(cause);
 
       const electronShell = yield* ElectronShell.ElectronShell;
-      const result = yield* electronShell.openExternal("https://example.com/path");
+      const error = yield* Effect.flip(
+        electronShell.openExternal("https://example.com/path?view=desktop"),
+      );
 
-      assert.equal(result, false);
+      assert.instanceOf(error, ElectronShell.ElectronShellOpenExternalError);
+      assert.isTrue(ElectronShell.isElectronShellError(error));
+      assert.strictEqual(error.externalUrl, "https://example.com/path?view=desktop");
+      assert.strictEqual(error.cause, cause);
+      assert.include(error.message, error.externalUrl);
+      assert.notInclude(error.message, cause.message);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
+  it.effect("preserves non-sensitive clipboard context and cause", () =>
+    Effect.gen(function* () {
+      const cause = new Error("clipboard failed");
+      writeTextMock.mockImplementation(() => {
+        throw cause;
+      });
+
+      const electronShell = yield* ElectronShell.ElectronShell;
+      const error = yield* Effect.flip(electronShell.copyText("secret text"));
+
+      assert.instanceOf(error, ElectronShell.ElectronShellCopyTextError);
+      assert.isTrue(ElectronShell.isElectronShellError(error));
+      assert.strictEqual(error.textLength, 11);
+      assert.strictEqual(error.cause, cause);
+      assert.include(error.message, "11 characters");
+      assert.notInclude(error.message, "secret text");
+      assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -51,7 +51,7 @@ describe("ElectronShell", () => {
       const cause = new Error("open failed");
       openExternalMock.mockRejectedValue(cause);
       const externalUrl =
-        "https://user:password@example.com/signed-secret-token/path?access_token=secret#fragment";
+        "HTTPS://user:password@example.com:443/signed-secret-token/path?access_token=secret#fragment";
 
       const electronShell = yield* ElectronShell.ElectronShell;
       const error = yield* Effect.flip(electronShell.openExternal(externalUrl));

--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -50,19 +50,24 @@ describe("ElectronShell", () => {
     Effect.gen(function* () {
       const cause = new Error("open failed");
       openExternalMock.mockRejectedValue(cause);
-      const externalUrl = "https://user:password@example.com/path?access_token=secret#fragment";
+      const externalUrl =
+        "https://user:password@example.com/signed-secret-token/path?access_token=secret#fragment";
 
       const electronShell = yield* ElectronShell.ElectronShell;
       const error = yield* Effect.flip(electronShell.openExternal(externalUrl));
 
       assert.instanceOf(error, ElectronShell.ElectronShellOpenExternalError);
       assert.isTrue(ElectronShell.isElectronShellError(error));
-      assert.strictEqual(error.requestTarget, "https://example.com/path");
+      assert.strictEqual(error.urlHostname, "example.com");
       assert.strictEqual(error.urlLength, externalUrl.length);
+      assert.strictEqual(error.urlProtocol, "https:");
       assert.strictEqual(error.cause, cause);
       assert.notProperty(error, "externalUrl");
-      assert.include(error.message, error.requestTarget);
-      assert.notMatch(error.message, /user|password|access_token|secret|fragment/);
+      assert.notProperty(error, "requestTarget");
+      assert.notMatch(
+        error.message,
+        /user|password|signed-secret-token|path|access_token|secret|fragment/,
+      );
       assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronShell.layer)),
   );

--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -46,21 +46,23 @@ describe("ElectronShell", () => {
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 
-  it.effect("preserves the URL and cause when Electron rejects openExternal", () =>
+  it.effect("preserves safe URL context and cause when Electron rejects openExternal", () =>
     Effect.gen(function* () {
       const cause = new Error("open failed");
       openExternalMock.mockRejectedValue(cause);
+      const externalUrl = "https://user:password@example.com/path?access_token=secret#fragment";
 
       const electronShell = yield* ElectronShell.ElectronShell;
-      const error = yield* Effect.flip(
-        electronShell.openExternal("https://example.com/path?view=desktop"),
-      );
+      const error = yield* Effect.flip(electronShell.openExternal(externalUrl));
 
       assert.instanceOf(error, ElectronShell.ElectronShellOpenExternalError);
       assert.isTrue(ElectronShell.isElectronShellError(error));
-      assert.strictEqual(error.externalUrl, "https://example.com/path?view=desktop");
+      assert.strictEqual(error.requestTarget, "https://example.com/path");
+      assert.strictEqual(error.urlLength, externalUrl.length);
       assert.strictEqual(error.cause, cause);
-      assert.include(error.message, error.externalUrl);
+      assert.notProperty(error, "externalUrl");
+      assert.include(error.message, error.requestTarget);
+      assert.notMatch(error.message, /user|password|access_token|secret|fragment/);
       assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronShell.layer)),
   );

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -11,13 +11,14 @@ const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
 export class ElectronShellOpenExternalError extends Schema.TaggedErrorClass<ElectronShellOpenExternalError>()(
   "ElectronShellOpenExternalError",
   {
-    requestTarget: Schema.String,
+    urlHostname: Schema.String,
     urlLength: Schema.Number,
+    urlProtocol: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to open external URL ${this.requestTarget}.`;
+    return `Failed to open external URL for ${this.urlHostname} (${this.urlProtocol}, input length ${this.urlLength}).`;
   }
 }
 
@@ -53,9 +54,13 @@ export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
   }
 }
 
-function externalRequestTarget(externalUrl: string): string {
+function describeExternalUrl(externalUrl: string) {
   const url = new URL(externalUrl);
-  return `${url.protocol}//${url.host}${url.pathname}`;
+  return {
+    urlHostname: url.hostname,
+    urlLength: externalUrl.length,
+    urlProtocol: url.protocol,
+  };
 }
 
 export class ElectronShell extends Context.Service<
@@ -77,8 +82,7 @@ export const make = ElectronShell.of({
           try: () => Electron.shell.openExternal(externalUrl),
           catch: (cause) =>
             new ElectronShellOpenExternalError({
-              requestTarget: externalRequestTarget(externalUrl),
-              urlLength: externalUrl.length,
+              ...describeExternalUrl(externalUrl),
               cause,
             }),
         }).pipe(Effect.as(true)),

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -55,11 +55,11 @@ export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
   }
 }
 
-function describeExternalUrl(externalUrl: string) {
+function describeExternalUrl(externalUrl: string, inputLength: number) {
   const diagnostics = getUrlDiagnostics(externalUrl);
   return {
     urlHostname: diagnostics.hostname ?? "",
-    urlLength: diagnostics.inputLength,
+    urlLength: inputLength,
     urlProtocol: diagnostics.protocol ?? "",
   };
 }
@@ -75,19 +75,22 @@ export class ElectronShell extends Context.Service<
 >()("@t3tools/desktop/electron/ElectronShell") {}
 
 export const make = ElectronShell.of({
-  openExternal: (rawUrl) =>
-    Option.match(parseSafeExternalUrl(rawUrl), {
+  openExternal: (rawUrl) => {
+    const inputLength = typeof rawUrl === "string" ? rawUrl.length : 0;
+
+    return Option.match(parseSafeExternalUrl(rawUrl), {
       onNone: () => Effect.succeed(false),
       onSome: (externalUrl) =>
         Effect.tryPromise({
           try: () => Electron.shell.openExternal(externalUrl),
           catch: (cause) =>
             new ElectronShellOpenExternalError({
-              ...describeExternalUrl(externalUrl),
+              ...describeExternalUrl(externalUrl, inputLength),
               cause,
             }),
         }).pipe(Effect.as(true)),
-    }),
+    });
+  },
   copyText: (text) =>
     Effect.try({
       try: () => Electron.clipboard.writeText(text),

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -2,10 +2,42 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import * as Electron from "electron";
 
 const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
+
+export class ElectronShellOpenExternalError extends Schema.TaggedErrorClass<ElectronShellOpenExternalError>()(
+  "ElectronShellOpenExternalError",
+  {
+    externalUrl: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to open external URL ${this.externalUrl}.`;
+  }
+}
+
+export class ElectronShellCopyTextError extends Schema.TaggedErrorClass<ElectronShellCopyTextError>()(
+  "ElectronShellCopyTextError",
+  {
+    textLength: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to copy ${this.textLength} characters to the clipboard.`;
+  }
+}
+
+export const ElectronShellError = Schema.Union([
+  ElectronShellOpenExternalError,
+  ElectronShellCopyTextError,
+]);
+export type ElectronShellError = typeof ElectronShellError.Type;
+export const isElectronShellError = Schema.is(ElectronShellError);
 
 export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
   if (typeof rawUrl !== "string") {
@@ -23,8 +55,10 @@ export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
 export class ElectronShell extends Context.Service<
   ElectronShell,
   {
-    readonly openExternal: (rawUrl: unknown) => Effect.Effect<boolean>;
-    readonly copyText: (text: string) => Effect.Effect<void>;
+    readonly openExternal: (
+      rawUrl: unknown,
+    ) => Effect.Effect<boolean, ElectronShellOpenExternalError>;
+    readonly copyText: (text: string) => Effect.Effect<void, ElectronShellCopyTextError>;
   }
 >()("@t3tools/desktop/electron/ElectronShell") {}
 
@@ -33,16 +67,15 @@ export const make = ElectronShell.of({
     Option.match(parseSafeExternalUrl(rawUrl), {
       onNone: () => Effect.succeed(false),
       onSome: (externalUrl) =>
-        Effect.promise(() =>
-          Electron.shell.openExternal(externalUrl).then(
-            () => true,
-            () => false,
-          ),
-        ),
+        Effect.tryPromise({
+          try: () => Electron.shell.openExternal(externalUrl),
+          catch: (cause) => new ElectronShellOpenExternalError({ externalUrl, cause }),
+        }).pipe(Effect.as(true)),
     }),
   copyText: (text) =>
-    Effect.sync(() => {
-      Electron.clipboard.writeText(text);
+    Effect.try({
+      try: () => Electron.clipboard.writeText(text),
+      catch: (cause) => new ElectronShellCopyTextError({ textLength: text.length, cause }),
     }),
 });
 

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -1,3 +1,4 @@
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -55,11 +56,11 @@ export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
 }
 
 function describeExternalUrl(externalUrl: string) {
-  const url = new URL(externalUrl);
+  const diagnostics = getUrlDiagnostics(externalUrl);
   return {
-    urlHostname: url.hostname,
-    urlLength: externalUrl.length,
-    urlProtocol: url.protocol,
+    urlHostname: diagnostics.hostname ?? "",
+    urlLength: diagnostics.inputLength,
+    urlProtocol: diagnostics.protocol ?? "",
   };
 }
 

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -11,12 +11,13 @@ const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
 export class ElectronShellOpenExternalError extends Schema.TaggedErrorClass<ElectronShellOpenExternalError>()(
   "ElectronShellOpenExternalError",
   {
-    externalUrl: Schema.String,
+    requestTarget: Schema.String,
+    urlLength: Schema.Number,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to open external URL ${this.externalUrl}.`;
+    return `Failed to open external URL ${this.requestTarget}.`;
   }
 }
 
@@ -52,6 +53,11 @@ export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
   }
 }
 
+function externalRequestTarget(externalUrl: string): string {
+  const url = new URL(externalUrl);
+  return `${url.protocol}//${url.host}${url.pathname}`;
+}
+
 export class ElectronShell extends Context.Service<
   ElectronShell,
   {
@@ -69,7 +75,12 @@ export const make = ElectronShell.of({
       onSome: (externalUrl) =>
         Effect.tryPromise({
           try: () => Electron.shell.openExternal(externalUrl),
-          catch: (cause) => new ElectronShellOpenExternalError({ externalUrl, cause }),
+          catch: (cause) =>
+            new ElectronShellOpenExternalError({
+              requestTarget: externalRequestTarget(externalUrl),
+              urlLength: externalUrl.length,
+              cause,
+            }),
         }).pipe(Effect.as(true)),
     }),
   copyText: (text) =>

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -253,7 +253,7 @@ export const make = Effect.gen(function* () {
 
     window.webContents.setWindowOpenHandler(({ url }) => {
       if (Option.isSome(ElectronShell.parseSafeExternalUrl(url))) {
-        void runPromise(electronShell.openExternal(url));
+        void runPromise(electronShell.openExternal(url).pipe(Effect.ignore({ log: true })));
       }
       return { action: "deny" };
     });
@@ -269,7 +269,7 @@ export const make = Effect.gen(function* () {
 
       event.preventDefault();
       if (Option.isSome(ElectronShell.parseSafeExternalUrl(url))) {
-        void runPromise(electronShell.openExternal(url));
+        void runPromise(electronShell.openExternal(url).pipe(Effect.ignore({ log: true })));
       }
     });
 

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -226,7 +226,9 @@ export const make = Effect.gen(function* () {
           {
             label: "Copy Link",
             click: () => {
-              void runPromise(electronShell.copyText(params.linkURL));
+              void runPromise(
+                electronShell.copyText(params.linkURL).pipe(Effect.ignore({ log: true })),
+              );
             },
           },
           { type: "separator" },


### PR DESCRIPTION
## Summary

- distinguish unsafe URL validation from genuine Electron `openExternal` failures
- preserve only protocol, hostname, and input length in schema-backed URL errors while forwarding the exact Electron rejection cause
- wrap clipboard failures with the original cause and non-sensitive text-length context
- log and consume failures at fire-and-forget window event call sites while IPC callers retain typed failures

Raw URLs, userinfo, paths, query parameters, and fragments are never stored in error attributes or messages.

## Stack dependency

- Based on #3403 for `@t3tools/shared/urlDiagnostics`.

## Validation

- `vp test run apps/desktop/src/electron/ElectronShell.test.ts` (4 tests)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured typed errors to `ElectronShell.openExternal` and `ElectronShell.copyText`
> - Introduces `ElectronShellOpenExternalError` and `ElectronShellCopyTextError` as tagged error classes with sanitized diagnostics (URL hostname, protocol, length; text length) and the underlying cause, replacing untyped defects.
> - Changes the `ElectronShell` service signature so both methods now declare typed failures in their Effect return types.
> - Call sites in [DesktopWindow.ts](https://github.com/pingdotgg/t3code/pull/3288/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) wrap both calls with `Effect.ignore({ log: true })` so failures are logged but not propagated.
> - Behavioral Change: `openExternal` now fails with a typed error on Electron rejection instead of resolving to `false`; `copyText` failures surface as typed failures instead of untyped defects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 316cc7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change: callers that treated `openExternal` rejection as `false` must handle `ElectronShellOpenExternalError`; external-link and clipboard UX paths rely on logging instead of explicit user-facing errors.
> 
> **Overview**
> **`ElectronShell.openExternal` and `copyText` now surface typed Effect failures** instead of swallowing Electron/clipboard errors (`false` on rejected `openExternal`, silent defects on clipboard throws). Unsafe or invalid URLs still resolve to `false` without calling Electron.
> 
> New schema-backed errors carry **sanitized context only**: hostname, protocol, and input length for URLs (via `getUrlDiagnostics`); character count for clipboard failures; plus the original `cause`. Messages and fields never include full URLs, credentials, paths, query tokens, or clipboard text.
> 
> **`DesktopWindow`** fire-and-forget call sites (context menu copy link, window-open handler, external navigation) pipe failures through **`Effect.ignore({ log: true })`** so UI handlers keep running while errors are logged.
> 
> Tests were updated to assert the new failure shapes and redaction guarantees.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 316cc7aa7e03ca99c8dc07249cf5617191501977. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->