### PR TITLE
Structure advertised endpoint errors

### DIFF
--- a/packages/shared/src/advertisedEndpoint.test.ts
+++ b/packages/shared/src/advertisedEndpoint.test.ts
@@ -22,23 +22,34 @@ describe("advertised endpoints", () => {
     );
   });
 
-  it("preserves URL parser failures with their input", () => {
+  it("preserves URL parser failures without retaining their raw input", () => {
     const input = "not a URL";
     const error = captureError(() => normalizeHttpBaseUrl(input));
 
     expect(error).toBeInstanceOf(AdvertisedEndpointUrlParseError);
-    expect(error).toMatchObject({ input });
+    expect(error).toMatchObject({ inputLength: input.length });
+    expect(error).not.toHaveProperty("input");
     expect((error as AdvertisedEndpointUrlParseError).cause).toBeInstanceOf(Error);
-    expect((error as Error).message).toBe(`Invalid advertised endpoint URL: ${input}`);
+    expect((error as Error).message).toBe("Invalid advertised endpoint URL.");
   });
 
   it("reports unsupported protocols without inventing a cause", () => {
-    const input = "ftp://relay.example.com/path";
+    const input =
+      "ftp://endpoint-user:endpoint-password@relay.example.com/private/path?token=secret#fragment";
     const error = captureError(() => normalizeHttpBaseUrl(input));
 
     expect(error).toBeInstanceOf(AdvertisedEndpointProtocolError);
-    expect(error).toMatchObject({ input, protocol: "ftp:" });
+    expect(error).toMatchObject({
+      inputLength: input.length,
+      inputProtocol: "ftp:",
+      inputHostname: "relay.example.com",
+      protocol: "ftp:",
+    });
+    expect(error).not.toHaveProperty("input");
     expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
     expect((error as Error).message).toBe("Endpoint must use HTTP or HTTPS. Received ftp:");
+    expect((error as Error).message).not.toContain("endpoint-password");
+    expect((error as Error).message).not.toContain("/private/path");
+    expect((error as Error).message).not.toContain("token=secret");
   });
 });

--- a/packages/shared/src/advertisedEndpoint.test.ts
+++ b/packages/shared/src/advertisedEndpoint.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  AdvertisedEndpointProtocolError,
+  AdvertisedEndpointUrlParseError,
+  normalizeHttpBaseUrl,
+} from "./advertisedEndpoint.ts";
+
+const captureError = (run: () => unknown): unknown => {
+  try {
+    run();
+  } catch (cause) {
+    return cause;
+  }
+  throw new Error("Expected operation to throw");
+};
+
+describe("advertised endpoints", () => {
+  it("normalizes websocket endpoints to an HTTP base URL", () => {
+    expect(normalizeHttpBaseUrl("wss://relay.example.com/path?query=value#fragment")).toBe(
+      "https://relay.example.com/",
+    );
+  });
+
+  it("preserves URL parser failures with their input", () => {
+    const input = "not a URL";
+    const error = captureError(() => normalizeHttpBaseUrl(input));
+
+    expect(error).toBeInstanceOf(AdvertisedEndpointUrlParseError);
+    expect(error).toMatchObject({ input });
+    expect((error as AdvertisedEndpointUrlParseError).cause).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(`Invalid advertised endpoint URL: ${input}`);
+  });
+
+  it("reports unsupported protocols without inventing a cause", () => {
+    const input = "ftp://relay.example.com/path";
+    const error = captureError(() => normalizeHttpBaseUrl(input));
+
+    expect(error).toBeInstanceOf(AdvertisedEndpointProtocolError);
+    expect(error).toMatchObject({ input, protocol: "ftp:" });
+    expect((error as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect((error as Error).message).toBe("Endpoint must use HTTP or HTTPS. Received ftp:");
+  });
+});

--- a/packages/shared/src/advertisedEndpoint.ts
+++ b/packages/shared/src/advertisedEndpoint.ts
@@ -8,22 +8,39 @@ import type {
 } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
 
+import { getUrlDiagnostics } from "./urlDiagnostics.ts";
+
+const AdvertisedEndpointInputDiagnosticFields = {
+  inputLength: Schema.Number,
+  inputProtocol: Schema.optional(Schema.String),
+  inputHostname: Schema.optional(Schema.String),
+};
+
+function advertisedEndpointInputDiagnostics(input: string) {
+  const diagnostics = getUrlDiagnostics(input);
+  return {
+    inputLength: diagnostics.inputLength,
+    ...(diagnostics.protocol === undefined ? {} : { inputProtocol: diagnostics.protocol }),
+    ...(diagnostics.hostname === undefined ? {} : { inputHostname: diagnostics.hostname }),
+  };
+}
+
 export class AdvertisedEndpointUrlParseError extends Schema.TaggedErrorClass<AdvertisedEndpointUrlParseError>()(
   "AdvertisedEndpointUrlParseError",
   {
-    input: Schema.String,
+    ...AdvertisedEndpointInputDiagnosticFields,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Invalid advertised endpoint URL: ${this.input}`;
+    return "Invalid advertised endpoint URL.";
   }
 }
 
 export class AdvertisedEndpointProtocolError extends Schema.TaggedErrorClass<AdvertisedEndpointProtocolError>()(
   "AdvertisedEndpointProtocolError",
   {
-    input: Schema.String,
+    ...AdvertisedEndpointInputDiagnosticFields,
     protocol: Schema.String,
   },
 ) {
@@ -51,7 +68,10 @@ export function normalizeHttpBaseUrl(rawValue: string): string {
   try {
     url = new URL(rawValue);
   } catch (cause) {
-    throw new AdvertisedEndpointUrlParseError({ input: rawValue, cause });
+    throw new AdvertisedEndpointUrlParseError({
+      ...advertisedEndpointInputDiagnostics(rawValue),
+      cause,
+    });
   }
   if (url.protocol === "ws:") {
     url.protocol = "http:";
@@ -60,7 +80,10 @@ export function normalizeHttpBaseUrl(rawValue: string): string {
   }
 
   if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new AdvertisedEndpointProtocolError({ input: rawValue, protocol: url.protocol });
+    throw new AdvertisedEndpointProtocolError({
+      ...advertisedEndpointInputDiagnostics(rawValue),
+      protocol: url.protocol,
+    });
   }
 
   url.pathname = "/";

--- a/packages/shared/src/advertisedEndpoint.ts
+++ b/packages/shared/src/advertisedEndpoint.ts
@@ -6,6 +6,31 @@ import type {
   AdvertisedEndpointSource,
   AdvertisedEndpointStatus,
 } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+export class AdvertisedEndpointUrlParseError extends Schema.TaggedErrorClass<AdvertisedEndpointUrlParseError>()(
+  "AdvertisedEndpointUrlParseError",
+  {
+    input: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Invalid advertised endpoint URL: ${this.input}`;
+  }
+}
+
+export class AdvertisedEndpointProtocolError extends Schema.TaggedErrorClass<AdvertisedEndpointProtocolError>()(
+  "AdvertisedEndpointProtocolError",
+  {
+    input: Schema.String,
+    protocol: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Endpoint must use HTTP or HTTPS. Received ${this.protocol}`;
+  }
+}
 
 export interface CreateAdvertisedEndpointInput {
   readonly id: string;
@@ -22,7 +47,12 @@ export interface CreateAdvertisedEndpointInput {
 }
 
 export function normalizeHttpBaseUrl(rawValue: string): string {
-  const url = new URL(rawValue);
+  let url: URL;
+  try {
+    url = new URL(rawValue);
+  } catch (cause) {
+    throw new AdvertisedEndpointUrlParseError({ input: rawValue, cause });
+  }
   if (url.protocol === "ws:") {
     url.protocol = "http:";
   } else if (url.protocol === "wss:") {
@@ -30,7 +60,7 @@ export function normalizeHttpBaseUrl(rawValue: string): string {
   }
 
   if (url.protocol !== "http:" && url.protocol !== "https:") {
-    throw new Error(`Endpoint must use HTTP or HTTPS. Received ${url.protocol}`);
+    throw new AdvertisedEndpointProtocolError({ input: rawValue, protocol: url.protocol });
   }
 
   url.pathname = "/";


### PR DESCRIPTION
## Summary
- replace generic advertised-endpoint URL failures with schema-backed parse and protocol errors
- preserve the original URL constructor failure as `cause` while keeping unsupported protocols cause-free
- attach the original input and normalized protocol for diagnostics

## Validation
- `vp test packages/shared/src/advertisedEndpoint.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-shape change in shared URL normalization; callers that only read `.message` (e.g. onboarding) should behave similarly, with richer typed errors for new code.
> 
> **Overview**
> **`normalizeHttpBaseUrl`** in `advertisedEndpoint.ts` now throws **Effect Schema tagged errors** instead of plain `Error` for invalid URLs and unsupported schemes.
> 
> **`AdvertisedEndpointUrlParseError`** wraps `URL` constructor failures with **`cause`**, plus **`inputLength`** and optional **`inputProtocol` / `inputHostname`** from `getUrlDiagnostics`—**not** the raw URL string. **`AdvertisedEndpointProtocolError`** carries the same diagnostics and the rejected **`protocol`**, with **no `cause`**, and user-facing messages avoid credentials, paths, or query strings.
> 
> Success-path behavior (ws/wss → http/https, strip path/query/hash) is unchanged. New unit tests in `advertisedEndpoint.test.ts` cover normalization and both error shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c4cb0a27ae3403d7d903bc7efed76a758ff9205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure advertised endpoint errors with typed error classes and redacted URL diagnostics
> - Replaces the generic `Error` thrown by `normalizeHttpBaseUrl` with two typed error classes: `AdvertisedEndpointUrlParseError` (parse failure) and `AdvertisedEndpointProtocolError` (unsupported protocol), both carrying redacted diagnostic fields (`inputLength`, `inputProtocol`, `inputHostname`).
> - Adds `getUrlDiagnostics` in a new [`urlDiagnostics.ts`](https://github.com/pingdotgg/t3code/pull/3289/files#diff-1c8198df49b2be099c916678220c6abc30f8130983b5efee4d72e2299511cceb) module to extract safe, redacted metadata from a URL string without exposing raw input.
> - Adds `redactDpopRequestTarget` in [`dpop.ts`](https://github.com/pingdotgg/t3code/pull/3289/files#diff-a70e3eceffb70848b1ea9f7dd87b2d3cd5f20af4faacba0e185745d8560ec50d) that strips userinfo, query, and fragment from a URL, returning `'<invalid-url>'` on parse failure.
> - Behavioral Change: callers catching errors from `normalizeHttpBaseUrl` will now receive typed errors instead of a plain `Error`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3c4cb0a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->