### PR TITLE
Structure relay auth parsing errors

### DIFF
--- a/packages/shared/src/relayAuth.test.ts
+++ b/packages/shared/src/relayAuth.test.ts
@@ -1,17 +1,79 @@
 import { describe, expect, it } from "vite-plus/test";
 
 import {
+  ClerkPublishableKeyDecodeError,
+  ClerkPublishableKeyFrontendApiError,
   clerkFrontendApiHostnameFromPublishableKey,
+  clerkFrontendApiUrlFromPublishableKey,
   isAllowedClerkFrontendApiHostname,
 } from "./relayAuth.ts";
 
 const clerkPublishableKey = (hostname: string): string => `pk_test_${btoa(`${hostname}$`)}`;
+
+const captureError = (run: () => unknown): unknown => {
+  try {
+    run();
+  } catch (cause) {
+    return cause;
+  }
+  throw new Error("Expected operation to throw");
+};
 
 describe("Clerk relay auth", () => {
   it("derives a custom Frontend API hostname from a Clerk publishable key", () => {
     expect(clerkFrontendApiHostnameFromPublishableKey(clerkPublishableKey("clerk.t3.codes"))).toBe(
       "clerk.t3.codes",
     );
+    expect(clerkFrontendApiUrlFromPublishableKey(clerkPublishableKey("clerk.t3.codes"))).toBe(
+      "https://clerk.t3.codes",
+    );
+  });
+
+  it("preserves Clerk publishable key decoding failures", () => {
+    const error = captureError(() => clerkFrontendApiUrlFromPublishableKey("pk_test_%"));
+
+    expect(error).toBeInstanceOf(ClerkPublishableKeyDecodeError);
+    expect(error).toMatchObject({ keyPrefix: "pk_test" });
+    expect((error as ClerkPublishableKeyDecodeError).cause).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("Failed to decode Clerk publishable key (pk_test).");
+  });
+
+  it("reports semantic frontend API failures without inventing a cause", () => {
+    const emptyError = captureError(() => clerkFrontendApiUrlFromPublishableKey("pk_test_"));
+    const pathFrontendApi = "clerk.t3.codes/path";
+    const pathError = captureError(() =>
+      clerkFrontendApiUrlFromPublishableKey(clerkPublishableKey(pathFrontendApi)),
+    );
+
+    expect(emptyError).toBeInstanceOf(ClerkPublishableKeyFrontendApiError);
+    expect(emptyError).toMatchObject({
+      keyPrefix: "pk_test",
+      frontendApi: "",
+      reason: "empty",
+    });
+    expect((emptyError as Error & { cause?: unknown }).cause).toBeUndefined();
+    expect(pathError).toBeInstanceOf(ClerkPublishableKeyFrontendApiError);
+    expect(pathError).toMatchObject({
+      keyPrefix: "pk_test",
+      frontendApi: pathFrontendApi,
+      reason: "contains-path",
+    });
+    expect((pathError as Error & { cause?: unknown }).cause).toBeUndefined();
+  });
+
+  it("preserves URL parser failures for decoded frontend APIs", () => {
+    const frontendApi = "[invalid-host";
+    const error = captureError(() =>
+      clerkFrontendApiHostnameFromPublishableKey(clerkPublishableKey(frontendApi)),
+    );
+
+    expect(error).toBeInstanceOf(ClerkPublishableKeyFrontendApiError);
+    expect(error).toMatchObject({
+      keyPrefix: "pk_test",
+      frontendApi,
+      reason: "invalid-url",
+    });
+    expect((error as ClerkPublishableKeyFrontendApiError).cause).toBeInstanceOf(Error);
   });
 
   it("allows standard Clerk hosts and an exact configured custom hostname", () => {

--- a/packages/shared/src/relayAuth.ts
+++ b/packages/shared/src/relayAuth.ts
@@ -1,14 +1,84 @@
-export function clerkFrontendApiUrlFromPublishableKey(publishableKey: string): string {
-  const encodedFrontendApi = publishableKey.split("_").slice(2).join("_");
-  const frontendApi = globalThis.atob(encodedFrontendApi).replace(/\$$/u, "");
-  if (frontendApi.length === 0 || frontendApi.includes("/")) {
-    throw new Error("Invalid Clerk publishable key.");
+import * as Schema from "effect/Schema";
+
+const ClerkPublishableKeyPrefix = Schema.Literals(["pk_test", "pk_live", "unknown"]);
+
+export class ClerkPublishableKeyDecodeError extends Schema.TaggedErrorClass<ClerkPublishableKeyDecodeError>()(
+  "ClerkPublishableKeyDecodeError",
+  {
+    keyPrefix: ClerkPublishableKeyPrefix,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to decode Clerk publishable key (${this.keyPrefix}).`;
   }
-  return `https://${frontendApi}`;
+}
+
+export class ClerkPublishableKeyFrontendApiError extends Schema.TaggedErrorClass<ClerkPublishableKeyFrontendApiError>()(
+  "ClerkPublishableKeyFrontendApiError",
+  {
+    keyPrefix: ClerkPublishableKeyPrefix,
+    frontendApi: Schema.String,
+    reason: Schema.Literals(["empty", "contains-path", "invalid-url"]),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Invalid Clerk frontend API decoded from publishable key (${this.keyPrefix}; ${this.reason}).`;
+  }
+}
+
+function parseClerkFrontendApi(publishableKey: string): {
+  readonly hostname: string;
+  readonly url: string;
+} {
+  const keyPrefix = publishableKey.startsWith("pk_test_")
+    ? "pk_test"
+    : publishableKey.startsWith("pk_live_")
+      ? "pk_live"
+      : "unknown";
+  const encodedFrontendApi = publishableKey.split("_").slice(2).join("_");
+  let frontendApi: string;
+  try {
+    frontendApi = globalThis.atob(encodedFrontendApi).replace(/\$$/u, "");
+  } catch (cause) {
+    throw new ClerkPublishableKeyDecodeError({ keyPrefix, cause });
+  }
+
+  if (frontendApi.length === 0) {
+    throw new ClerkPublishableKeyFrontendApiError({
+      keyPrefix,
+      frontendApi,
+      reason: "empty",
+    });
+  }
+  if (frontendApi.includes("/")) {
+    throw new ClerkPublishableKeyFrontendApiError({
+      keyPrefix,
+      frontendApi,
+      reason: "contains-path",
+    });
+  }
+
+  const url = `https://${frontendApi}`;
+  try {
+    return { hostname: new URL(url).hostname, url };
+  } catch (cause) {
+    throw new ClerkPublishableKeyFrontendApiError({
+      keyPrefix,
+      frontendApi,
+      reason: "invalid-url",
+      cause,
+    });
+  }
+}
+
+export function clerkFrontendApiUrlFromPublishableKey(publishableKey: string): string {
+  return parseClerkFrontendApi(publishableKey).url;
 }
 
 export function clerkFrontendApiHostnameFromPublishableKey(publishableKey: string): string {
-  return new URL(clerkFrontendApiUrlFromPublishableKey(publishableKey)).hostname;
+  return parseClerkFrontendApi(publishableKey).hostname;
 }
 
 export function isAllowedClerkFrontendApiHostname(


### PR DESCRIPTION
## Summary
- replace raw Clerk publishable-key decode and URL failures with schema-backed errors
- attach safe key-prefix, decoded frontend API, and diagnostic reason fields
- preserve real decoder/URL causes while keeping semantic validation failures cause-free
- parse the frontend API once for both URL and hostname consumers

## Validation
- `vp test packages/shared/src/relayAuth.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relay auth key parsing and changes thrown error types/messages for invalid keys; valid-key behavior is preserved but callers catching generic `Error` may need to handle the new classes.
> 
> **Overview**
> Clerk publishable-key parsing in `relayAuth.ts` no longer throws a generic `Error` on bad input. It now throws **Effect Schema tagged errors** with structured fields (`keyPrefix`, `frontendApi`, `reason`, and optional `cause`).
> 
> **`ClerkPublishableKeyDecodeError`** wraps `atob` failures and keeps the underlying decoder error as `cause`. **`ClerkPublishableKeyFrontendApiError`** covers semantic validation (`empty`, `contains-path`, `invalid-url`); empty/path cases omit `cause`, while invalid URL attaches the URL parser error.
> 
> Parsing is centralized in **`parseClerkFrontendApi`**, so `clerkFrontendApiUrlFromPublishableKey` and `clerkFrontendApiHostnameFromPublishableKey` share one decode/validate pass. Happy-path behavior for valid keys is unchanged; **`isAllowedClerkFrontendApiHostname`** is untouched.
> 
> Tests add coverage for each failure mode and for cause presence vs absence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ed12015177177c2c62c8588f009ed2fb3b199b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic errors with structured error classes for relay auth publishable key parsing
> - Adds `ClerkPublishableKeyDecodeError` (thrown when base64 decoding fails) and `ClerkPublishableKeyFrontendApiError` (thrown for semantic issues: empty, contains-path, or invalid-url) in [relayAuth.ts](https://github.com/pingdotgg/t3code/pull/3290/files#diff-410af5027d54ec0d2b400533989d5d3988ccde98d119e45a7996b1b548a957d5).
> - Introduces `parseClerkFrontendApi` as a shared internal utility that both `clerkFrontendApiUrlFromPublishableKey` and `clerkFrontendApiHostnameFromPublishableKey` now delegate to, returning both `hostname` and `url` on success.
> - Both public functions now throw typed errors with structured `reason` fields and preserved `cause` chains instead of generic `Error` objects.
> - Behavioral Change: callers catching errors from these functions must now handle the new error classes rather than generic `Error`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ed1201.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->