### PR TITLE
[codex] structure desktop IPC registration errors

### DIFF
--- a/apps/desktop/src/ipc/DesktopIpc.test.ts
+++ b/apps/desktop/src/ipc/DesktopIpc.test.ts
@@ -1,0 +1,79 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import { vi } from "vite-plus/test";
+
+import * as DesktopIpc from "./DesktopIpc.ts";
+
+const invokeMethod: DesktopIpc.DesktopIpcMethod<never, never> = {
+  channel: "desktop.test.invoke",
+  handler: () => Effect.void,
+};
+
+const syncMethod: DesktopIpc.DesktopSyncIpcMethod<never, never> = {
+  channel: "desktop.test.sync",
+  handler: () => Effect.void,
+};
+
+function makeIpcMain(
+  overrides: Partial<DesktopIpc.DesktopIpcMain> = {},
+): DesktopIpc.DesktopIpcMain {
+  return {
+    removeHandler: vi.fn(),
+    handle: vi.fn(),
+    removeAllListeners: vi.fn(),
+    on: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("DesktopIpc", () => {
+  it.effect("preserves invoke registration context and cause", () =>
+    Effect.gen(function* () {
+      const cause = new Error("invoke registration failed");
+      const ipcMain = makeIpcMain({
+        handle: () => {
+          throw cause;
+        },
+      });
+      const ipc = DesktopIpc.make(ipcMain);
+
+      const error = yield* Effect.flip(Effect.scoped(ipc.handle(invokeMethod)));
+
+      assert.instanceOf(error, DesktopIpc.DesktopIpcRegistrationError);
+      assert.isTrue(DesktopIpc.isDesktopIpcError(error));
+      assert.strictEqual(error.handlerKind, "invoke");
+      assert.strictEqual(error.channel, invokeMethod.channel);
+      assert.strictEqual(error.cause, cause);
+      assert.include(error.message, "invoke");
+      assert.include(error.message, invokeMethod.channel);
+      assert.notInclude(error.message, cause.message);
+    }),
+  );
+
+  it.effect("preserves sync unregistration context and cause in the finalizer defect", () =>
+    Effect.gen(function* () {
+      const cause = new Error("sync unregistration failed");
+      let removeCount = 0;
+      const ipcMain = makeIpcMain({
+        removeAllListeners: () => {
+          removeCount += 1;
+          if (removeCount === 2) throw cause;
+        },
+      });
+      const ipc = DesktopIpc.make(ipcMain);
+
+      const exit = yield* Effect.exit(Effect.scoped(ipc.handleSync(syncMethod)));
+
+      assert.isTrue(exit._tag === "Failure");
+      if (exit._tag === "Success") return;
+      const error = Cause.squash(exit.cause);
+      assert.instanceOf(error, DesktopIpc.DesktopIpcUnregistrationError);
+      assert.isTrue(DesktopIpc.isDesktopIpcError(error));
+      assert.strictEqual(error.handlerKind, "sync");
+      assert.strictEqual(error.channel, syncMethod.channel);
+      assert.strictEqual(error.cause, cause);
+      assert.notInclude(error.message, cause.message);
+    }),
+  );
+});

--- a/apps/desktop/src/ipc/DesktopIpc.ts
+++ b/apps/desktop/src/ipc/DesktopIpc.ts
@@ -24,6 +24,39 @@ export interface DesktopIpcMain {
   on(channel: string, listener: DesktopIpcSyncListener): void;
 }
 
+export class DesktopIpcRegistrationError extends Schema.TaggedErrorClass<DesktopIpcRegistrationError>()(
+  "DesktopIpcRegistrationError",
+  {
+    handlerKind: Schema.Literals(["invoke", "sync"]),
+    channel: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to register the ${this.handlerKind} IPC handler for ${this.channel}.`;
+  }
+}
+
+export class DesktopIpcUnregistrationError extends Schema.TaggedErrorClass<DesktopIpcUnregistrationError>()(
+  "DesktopIpcUnregistrationError",
+  {
+    handlerKind: Schema.Literals(["invoke", "sync"]),
+    channel: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to unregister the ${this.handlerKind} IPC handler for ${this.channel}.`;
+  }
+}
+
+export const DesktopIpcError = Schema.Union([
+  DesktopIpcRegistrationError,
+  DesktopIpcUnregistrationError,
+]);
+export type DesktopIpcError = typeof DesktopIpcError.Type;
+export const isDesktopIpcError = Schema.is(DesktopIpcError);
+
 export interface DesktopIpcMethod<E, R> {
   readonly channel: string;
   readonly handler: (raw: unknown) => Effect.Effect<unknown, E, R>;
@@ -39,10 +72,10 @@ export class DesktopIpc extends Context.Service<
   {
     readonly handle: <E, R>(
       input: DesktopIpcMethod<E, R>,
-    ) => Effect.Effect<void, never, R | Scope.Scope>;
+    ) => Effect.Effect<void, DesktopIpcRegistrationError, R | Scope.Scope>;
     readonly handleSync: <E, R>(
       input: DesktopSyncIpcMethod<E, R>,
-    ) => Effect.Effect<void, never, R | Scope.Scope>;
+    ) => Effect.Effect<void, DesktopIpcRegistrationError, R | Scope.Scope>;
   }
 >()("@t3tools/desktop/ipc/DesktopIpc") {}
 
@@ -57,18 +90,27 @@ export const make = (ipcMain: DesktopIpcMain): DesktopIpc["Service"] =>
       const runPromise = Effect.runPromiseWith(context);
 
       yield* Effect.acquireRelease(
-        Effect.sync(() => {
-          ipcMain.removeHandler(channel);
-          ipcMain.handle(channel, (_event, raw) =>
-            runPromise(
-              Effect.gen(function* () {
-                yield* Effect.annotateCurrentSpan({ channel });
-                return yield* handler(raw);
-              }).pipe(Effect.annotateLogs({ channel }), Effect.withSpan("desktop.ipc.invoke")),
-            ),
-          );
+        Effect.try({
+          try: () => {
+            ipcMain.removeHandler(channel);
+            ipcMain.handle(channel, (_event, raw) =>
+              runPromise(
+                Effect.gen(function* () {
+                  yield* Effect.annotateCurrentSpan({ channel });
+                  return yield* handler(raw);
+                }).pipe(Effect.annotateLogs({ channel }), Effect.withSpan("desktop.ipc.invoke")),
+              ),
+            );
+          },
+          catch: (cause) =>
+            new DesktopIpcRegistrationError({ handlerKind: "invoke", channel, cause }),
         }),
-        () => Effect.sync(() => ipcMain.removeHandler(channel)),
+        () =>
+          Effect.try({
+            try: () => ipcMain.removeHandler(channel),
+            catch: (cause) =>
+              new DesktopIpcUnregistrationError({ handlerKind: "invoke", channel, cause }),
+          }).pipe(Effect.orDie),
       );
     }),
 
@@ -81,18 +123,30 @@ export const make = (ipcMain: DesktopIpcMain): DesktopIpc["Service"] =>
       const runSync = Effect.runSyncWith(context);
 
       yield* Effect.acquireRelease(
-        Effect.sync(() => {
-          ipcMain.removeAllListeners(channel);
-          ipcMain.on(channel, (event) => {
-            event.returnValue = runSync(
-              Effect.gen(function* () {
-                yield* Effect.annotateCurrentSpan({ channel });
-                return yield* handler();
-              }).pipe(Effect.annotateLogs({ channel }), Effect.withSpan("desktop.ipc.invokeSync")),
-            );
-          });
+        Effect.try({
+          try: () => {
+            ipcMain.removeAllListeners(channel);
+            ipcMain.on(channel, (event) => {
+              event.returnValue = runSync(
+                Effect.gen(function* () {
+                  yield* Effect.annotateCurrentSpan({ channel });
+                  return yield* handler();
+                }).pipe(
+                  Effect.annotateLogs({ channel }),
+                  Effect.withSpan("desktop.ipc.invokeSync"),
+                ),
+              );
+            });
+          },
+          catch: (cause) =>
+            new DesktopIpcRegistrationError({ handlerKind: "sync", channel, cause }),
         }),
-        () => Effect.sync(() => ipcMain.removeAllListeners(channel)),
+        () =>
+          Effect.try({
+            try: () => ipcMain.removeAllListeners(channel),
+            catch: (cause) =>
+              new DesktopIpcUnregistrationError({ handlerKind: "sync", channel, cause }),
+          }).pipe(Effect.orDie),
       );
     }),
   });


### PR DESCRIPTION
## Summary
- return schema-backed registration failures with IPC handler kind, channel, and original cause
- preserve the same context as a structured defect when scoped handler cleanup fails
- add focused coverage for typed acquisition failure and finalizer failure semantics

## Verification
- `vp test apps/desktop/src/ipc/DesktopIpc.test.ts`
- `vp check` (0 errors; 20 existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop IPC wiring and error typing with new tests; no auth, data, or API surface changes beyond clearer Effect error channels.
> 
> **Overview**
> Desktop IPC **invoke** and **sync** handler registration now surfaces failures as typed **`DesktopIpcRegistrationError`** values (handler kind, channel, original cause) instead of opaque sync throws. Scoped cleanup wraps **`removeHandler`** / **`removeAllListeners`** in **`Effect.try`** and maps failures to **`DesktopIpcUnregistrationError`**, which become defects via **`Effect.orDie`** when the scope finalizer runs.
> 
> Adds a **`DesktopIpcError`** union plus **`isDesktopIpcError`**, and new tests that assert registration failures and sync unregistration failures preserve channel, kind, and cause without leaking the raw cause message into the public error string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9970537e691c3bc0966b7e393dfc5bba2421098c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure IPC handler registration and unregistration errors in `DesktopIpc`
> - Introduces `DesktopIpcRegistrationError` and `DesktopIpcUnregistrationError` tagged error classes, each carrying `handlerKind` ('invoke' | 'sync'), `channel`, and `cause` fields.
> - `DesktopIpc.handle` and `DesktopIpc.handleSync` now wrap `ipcMain` registration calls in `Effect.try`, surfacing failures as `DesktopIpcRegistrationError` instead of being infallible.
> - Unregistration failures during scope finalization are mapped to `DesktopIpcUnregistrationError` and converted to defects via `Effect.orDie`.
> - Behavioral Change: `DesktopIpc.handle` and `DesktopIpc.handleSync` error type changes from `never` to `DesktopIpcRegistrationError`, which may require call sites to handle the new failure channel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9970537.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->