### PR TITLE
[codex] Structure update manifest failures

### DIFF
--- a/scripts/lib/update-manifest.ts
+++ b/scripts/lib/update-manifest.ts
@@ -1,6 +1,8 @@
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
+
 export interface UpdateManifestFile {
   readonly url: string;
   readonly sha512: string;
@@ -9,6 +11,9 @@ export interface UpdateManifestFile {
 
 export const UpdateManifestScalar = Schema.Union([Schema.String, Schema.Number, Schema.Boolean]);
 export type UpdateManifestScalar = typeof UpdateManifestScalar.Type;
+
+export const UpdateManifestScalarType = Schema.Literals(["string", "number", "boolean"]);
+export type UpdateManifestScalarType = typeof UpdateManifestScalarType.Type;
 
 export const UpdateManifestParseReason = Schema.Literals([
   "incomplete file entry",
@@ -59,12 +64,14 @@ export class UpdateManifestExtraConflictError extends Schema.TaggedErrorClass<Up
   {
     platformLabel: Schema.String,
     key: Schema.String,
-    primaryValue: UpdateManifestScalar,
-    secondaryValue: UpdateManifestScalar,
+    primaryValueType: UpdateManifestScalarType,
+    primaryValueLength: Schema.optionalKey(Schema.Number),
+    secondaryValueType: UpdateManifestScalarType,
+    secondaryValueLength: Schema.optionalKey(Schema.Number),
   },
 ) {
   override get message(): string {
-    return `Cannot merge ${this.platformLabel} update manifests: conflicting '${this.key}' values ('${this.primaryValue}' vs '${this.secondaryValue}').`;
+    return `Cannot merge ${this.platformLabel} update manifests: conflicting '${this.key}' ${this.primaryValueType} and ${this.secondaryValueType} values.`;
   }
 }
 
@@ -72,17 +79,25 @@ export class UpdateManifestFileConflictError extends Schema.TaggedErrorClass<Upd
   "UpdateManifestFileConflictError",
   {
     platformLabel: Schema.String,
-    url: Schema.String,
+    urlInputLength: Schema.Number,
+    urlProtocol: Schema.optionalKey(Schema.String),
+    urlHostname: Schema.optionalKey(Schema.String),
     existingManifest: Schema.Literals(["primary", "secondary"]),
-    existingSha512: Schema.String,
+    existingSha512Length: Schema.Number,
     existingSize: Schema.Number,
     conflictingManifest: Schema.Literals(["primary", "secondary"]),
-    conflictingSha512: Schema.String,
+    conflictingSha512Length: Schema.Number,
     conflictingSize: Schema.Number,
+    sha512Conflict: Schema.Boolean,
+    sizeConflict: Schema.Boolean,
   },
 ) {
   override get message(): string {
-    return `Cannot merge ${this.platformLabel} update manifests: conflicting file entry for ${this.url}.`;
+    const origin =
+      this.urlProtocol === undefined || this.urlHostname === undefined
+        ? ""
+        : ` at ${this.urlProtocol}//${this.urlHostname}`;
+    return `Cannot merge ${this.platformLabel} update manifests: conflicting file entry${origin} (URL input length: ${this.urlInputLength}).`;
   }
 }
 
@@ -327,6 +342,12 @@ export function parseUpdateManifest(
   };
 }
 
+function getScalarType(value: UpdateManifestScalar): UpdateManifestScalarType {
+  if (typeof value === "string") return "string";
+  if (typeof value === "number") return "number";
+  return "boolean";
+}
+
 function mergeExtras(
   primary: Readonly<Record<string, UpdateManifestScalar>>,
   secondary: Readonly<Record<string, UpdateManifestScalar>>,
@@ -340,8 +361,10 @@ function mergeExtras(
       throw new UpdateManifestExtraConflictError({
         platformLabel,
         key,
-        primaryValue: existing,
-        secondaryValue: value,
+        primaryValueType: getScalarType(existing),
+        ...(typeof existing === "string" ? { primaryValueLength: existing.length } : {}),
+        secondaryValueType: getScalarType(value),
+        ...(typeof value === "string" ? { secondaryValueLength: value.length } : {}),
       });
     }
     merged[key] = value;
@@ -374,15 +397,24 @@ export function mergeUpdateManifests(
     for (const file of files) {
       const existing = filesByUrl.get(file.url);
       if (existing && (existing.file.sha512 !== file.sha512 || existing.file.size !== file.size)) {
+        const urlDiagnostics = getUrlDiagnostics(file.url);
         throw new UpdateManifestFileConflictError({
           platformLabel,
-          url: file.url,
+          urlInputLength: urlDiagnostics.inputLength,
+          ...(urlDiagnostics.protocol === undefined
+            ? {}
+            : { urlProtocol: urlDiagnostics.protocol }),
+          ...(urlDiagnostics.hostname === undefined
+            ? {}
+            : { urlHostname: urlDiagnostics.hostname }),
           existingManifest: existing.manifest,
-          existingSha512: existing.file.sha512,
+          existingSha512Length: existing.file.sha512.length,
           existingSize: existing.file.size,
           conflictingManifest: manifest,
-          conflictingSha512: file.sha512,
+          conflictingSha512Length: file.sha512.length,
           conflictingSize: file.size,
+          sha512Conflict: existing.file.sha512 !== file.sha512,
+          sizeConflict: existing.file.size !== file.size,
         });
       }
       filesByUrl.set(file.url, { manifest, file });

--- a/scripts/lib/update-manifest.ts
+++ b/scripts/lib/update-manifest.ts
@@ -1,10 +1,120 @@
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
 export interface UpdateManifestFile {
   readonly url: string;
   readonly sha512: string;
   readonly size: number;
 }
 
-export type UpdateManifestScalar = string | number | boolean;
+export const UpdateManifestScalar = Schema.Union([Schema.String, Schema.Number, Schema.Boolean]);
+export type UpdateManifestScalar = typeof UpdateManifestScalar.Type;
+
+export const UpdateManifestParseReason = Schema.Literals([
+  "incomplete file entry",
+  "sha512 without a file entry",
+  "size without a file entry",
+  "unsupported line",
+  "version must be a string",
+  "releaseDate must be a string",
+  "missing version",
+  "missing releaseDate",
+  "missing files",
+]);
+export type UpdateManifestParseReason = typeof UpdateManifestParseReason.Type;
+
+export class UpdateManifestParseError extends Schema.TaggedErrorClass<UpdateManifestParseError>()(
+  "UpdateManifestParseError",
+  {
+    platformLabel: Schema.String,
+    sourcePath: Schema.String,
+    lineNumber: Schema.optionalKey(Schema.Number),
+    reason: UpdateManifestParseReason,
+    offendingLine: Schema.optionalKey(Schema.String),
+  },
+) {
+  override get message(): string {
+    const location =
+      this.lineNumber === undefined ? this.sourcePath : `${this.sourcePath}:${this.lineNumber}`;
+    return `Invalid ${this.platformLabel} update manifest at ${location}: ${this.reason}.`;
+  }
+}
+
+export class UpdateManifestVersionConflictError extends Schema.TaggedErrorClass<UpdateManifestVersionConflictError>()(
+  "UpdateManifestVersionConflictError",
+  {
+    platformLabel: Schema.String,
+    primaryVersion: Schema.String,
+    secondaryVersion: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Cannot merge ${this.platformLabel} update manifests with different versions (${this.primaryVersion} vs ${this.secondaryVersion}).`;
+  }
+}
+
+export class UpdateManifestExtraConflictError extends Schema.TaggedErrorClass<UpdateManifestExtraConflictError>()(
+  "UpdateManifestExtraConflictError",
+  {
+    platformLabel: Schema.String,
+    key: Schema.String,
+    primaryValue: UpdateManifestScalar,
+    secondaryValue: UpdateManifestScalar,
+  },
+) {
+  override get message(): string {
+    return `Cannot merge ${this.platformLabel} update manifests: conflicting '${this.key}' values ('${this.primaryValue}' vs '${this.secondaryValue}').`;
+  }
+}
+
+export class UpdateManifestFileConflictError extends Schema.TaggedErrorClass<UpdateManifestFileConflictError>()(
+  "UpdateManifestFileConflictError",
+  {
+    platformLabel: Schema.String,
+    url: Schema.String,
+    primarySha512: Schema.String,
+    primarySize: Schema.Number,
+    secondarySha512: Schema.String,
+    secondarySize: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Cannot merge ${this.platformLabel} update manifests: conflicting file entry for ${this.url}.`;
+  }
+}
+
+export class UpdateManifestSerializationError extends Schema.TaggedErrorClass<UpdateManifestSerializationError>()(
+  "UpdateManifestSerializationError",
+  {
+    platformLabel: Schema.String,
+    key: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Cannot serialize ${this.platformLabel} update manifest: missing value for '${this.key}'.`;
+  }
+}
+
+export const UpdateManifestError = Schema.Union([
+  UpdateManifestParseError,
+  UpdateManifestVersionConflictError,
+  UpdateManifestExtraConflictError,
+  UpdateManifestFileConflictError,
+  UpdateManifestSerializationError,
+]);
+export type UpdateManifestError = typeof UpdateManifestError.Type;
+export const isUpdateManifestError = Schema.is(UpdateManifestError);
+
+export const attemptUpdateManifest = <A>(
+  evaluate: () => A,
+): Effect.Effect<A, UpdateManifestError> =>
+  Effect.suspend(() => {
+    try {
+      return Effect.succeed(evaluate());
+    } catch (error) {
+      return isUpdateManifestError(error) ? Effect.fail(error) : Effect.die(error);
+    }
+  });
 
 export interface UpdateManifest {
   readonly version: string;
@@ -40,9 +150,12 @@ function parseFileRecord(
     typeof currentFile.sha512 !== "string" ||
     typeof currentFile.size !== "number"
   ) {
-    throw new Error(
-      `Invalid ${platformLabel} update manifest at ${sourcePath}:${lineNumber}: incomplete file entry.`,
-    );
+    throw new UpdateManifestParseError({
+      platformLabel,
+      sourcePath,
+      lineNumber,
+      reason: "incomplete file entry",
+    });
   }
   return {
     url: currentFile.url,
@@ -94,9 +207,12 @@ export function parseUpdateManifest(
     const fileShaMatch = line.match(/^    sha512:\s*(.+)$/);
     if (fileShaMatch?.[1]) {
       if (currentFile === null) {
-        throw new Error(
-          `Invalid ${platformLabel} update manifest at ${sourcePath}:${lineNumber}: sha512 without a file entry.`,
-        );
+        throw new UpdateManifestParseError({
+          platformLabel,
+          sourcePath,
+          lineNumber,
+          reason: "sha512 without a file entry",
+        });
       }
       currentFile.sha512 = stripSingleQuotes(fileShaMatch[1].trim());
       continue;
@@ -105,9 +221,12 @@ export function parseUpdateManifest(
     const fileSizeMatch = line.match(/^    size:\s*(\d+)$/);
     if (fileSizeMatch?.[1]) {
       if (currentFile === null) {
-        throw new Error(
-          `Invalid ${platformLabel} update manifest at ${sourcePath}:${lineNumber}: size without a file entry.`,
-        );
+        throw new UpdateManifestParseError({
+          platformLabel,
+          sourcePath,
+          lineNumber,
+          reason: "size without a file entry",
+        });
       }
       currentFile.size = Number(fileSizeMatch[1]);
       continue;
@@ -127,9 +246,13 @@ export function parseUpdateManifest(
 
     const topLevelMatch = line.match(/^([A-Za-z][A-Za-z0-9]*):\s*(.+)$/);
     if (!topLevelMatch?.[1] || topLevelMatch[2] === undefined) {
-      throw new Error(
-        `Invalid ${platformLabel} update manifest at ${sourcePath}:${lineNumber}: unsupported line '${line}'.`,
-      );
+      throw new UpdateManifestParseError({
+        platformLabel,
+        sourcePath,
+        lineNumber,
+        reason: "unsupported line",
+        offendingLine: line,
+      });
     }
 
     const [, key, rawValue] = topLevelMatch;
@@ -137,9 +260,12 @@ export function parseUpdateManifest(
 
     if (key === "version") {
       if (typeof value !== "string") {
-        throw new Error(
-          `Invalid ${platformLabel} update manifest at ${sourcePath}:${lineNumber}: version must be a string.`,
-        );
+        throw new UpdateManifestParseError({
+          platformLabel,
+          sourcePath,
+          lineNumber,
+          reason: "version must be a string",
+        });
       }
       version = value;
       continue;
@@ -147,9 +273,12 @@ export function parseUpdateManifest(
 
     if (key === "releaseDate") {
       if (typeof value !== "string") {
-        throw new Error(
-          `Invalid ${platformLabel} update manifest at ${sourcePath}:${lineNumber}: releaseDate must be a string.`,
-        );
+        throw new UpdateManifestParseError({
+          platformLabel,
+          sourcePath,
+          lineNumber,
+          reason: "releaseDate must be a string",
+        });
       }
       releaseDate = value;
       continue;
@@ -166,15 +295,25 @@ export function parseUpdateManifest(
   if (finalized) files.push(finalized);
 
   if (!version) {
-    throw new Error(`Invalid ${platformLabel} update manifest at ${sourcePath}: missing version.`);
+    throw new UpdateManifestParseError({
+      platformLabel,
+      sourcePath,
+      reason: "missing version",
+    });
   }
   if (!releaseDate) {
-    throw new Error(
-      `Invalid ${platformLabel} update manifest at ${sourcePath}: missing releaseDate.`,
-    );
+    throw new UpdateManifestParseError({
+      platformLabel,
+      sourcePath,
+      reason: "missing releaseDate",
+    });
   }
   if (files.length === 0) {
-    throw new Error(`Invalid ${platformLabel} update manifest at ${sourcePath}: missing files.`);
+    throw new UpdateManifestParseError({
+      platformLabel,
+      sourcePath,
+      reason: "missing files",
+    });
   }
 
   return {
@@ -195,9 +334,12 @@ function mergeExtras(
   for (const [key, value] of Object.entries(secondary)) {
     const existing = merged[key];
     if (existing !== undefined && existing !== value) {
-      throw new Error(
-        `Cannot merge ${platformLabel} update manifests: conflicting '${key}' values ('${existing}' vs '${value}').`,
-      );
+      throw new UpdateManifestExtraConflictError({
+        platformLabel,
+        key,
+        primaryValue: existing,
+        secondaryValue: value,
+      });
     }
     merged[key] = value;
   }
@@ -211,18 +353,25 @@ export function mergeUpdateManifests(
   platformLabel: string,
 ): UpdateManifest {
   if (primary.version !== secondary.version) {
-    throw new Error(
-      `Cannot merge ${platformLabel} update manifests with different versions (${primary.version} vs ${secondary.version}).`,
-    );
+    throw new UpdateManifestVersionConflictError({
+      platformLabel,
+      primaryVersion: primary.version,
+      secondaryVersion: secondary.version,
+    });
   }
 
   const filesByUrl = new Map<string, UpdateManifestFile>();
   for (const file of [...primary.files, ...secondary.files]) {
     const existing = filesByUrl.get(file.url);
     if (existing && (existing.sha512 !== file.sha512 || existing.size !== file.size)) {
-      throw new Error(
-        `Cannot merge ${platformLabel} update manifests: conflicting file entry for ${file.url}.`,
-      );
+      throw new UpdateManifestFileConflictError({
+        platformLabel,
+        url: file.url,
+        primarySha512: existing.sha512,
+        primarySize: existing.size,
+        secondarySha512: file.sha512,
+        secondarySize: file.size,
+      });
     }
     filesByUrl.set(file.url, file);
   }
@@ -264,9 +413,10 @@ export function serializeUpdateManifest(
   for (const key of Object.keys(manifest.extras).toSorted()) {
     const value = manifest.extras[key];
     if (value === undefined) {
-      throw new Error(
-        `Cannot serialize ${options.platformLabel} update manifest: missing value for '${key}'.`,
-      );
+      throw new UpdateManifestSerializationError({
+        platformLabel: options.platformLabel,
+        key,
+      });
     }
     lines.push(`${key}: ${serializeScalarValue(value)}`);
   }

--- a/scripts/lib/update-manifest.ts
+++ b/scripts/lib/update-manifest.ts
@@ -30,13 +30,13 @@ export class UpdateManifestParseError extends Schema.TaggedErrorClass<UpdateMani
     sourcePath: Schema.String,
     lineNumber: Schema.optionalKey(Schema.Number),
     reason: UpdateManifestParseReason,
-    offendingLine: Schema.optionalKey(Schema.String),
+    lineLength: Schema.optionalKey(Schema.Number),
   },
 ) {
   override get message(): string {
     const location =
       this.lineNumber === undefined ? this.sourcePath : `${this.sourcePath}:${this.lineNumber}`;
-    const input = this.offendingLine === undefined ? "" : ` Input: ${this.offendingLine}`;
+    const input = this.lineLength === undefined ? "" : ` Input length: ${this.lineLength}.`;
     return `Invalid ${this.platformLabel} update manifest at ${location}: ${this.reason}.${input}`;
   }
 }
@@ -254,7 +254,7 @@ export function parseUpdateManifest(
         sourcePath,
         lineNumber,
         reason: "unsupported line",
-        offendingLine: line,
+        lineLength: line.length,
       });
     }
 

--- a/scripts/lib/update-manifest.ts
+++ b/scripts/lib/update-manifest.ts
@@ -36,7 +36,8 @@ export class UpdateManifestParseError extends Schema.TaggedErrorClass<UpdateMani
   override get message(): string {
     const location =
       this.lineNumber === undefined ? this.sourcePath : `${this.sourcePath}:${this.lineNumber}`;
-    return `Invalid ${this.platformLabel} update manifest at ${location}: ${this.reason}.`;
+    const input = this.offendingLine === undefined ? "" : ` Input: ${this.offendingLine}`;
+    return `Invalid ${this.platformLabel} update manifest at ${location}: ${this.reason}.${input}`;
   }
 }
 
@@ -72,10 +73,12 @@ export class UpdateManifestFileConflictError extends Schema.TaggedErrorClass<Upd
   {
     platformLabel: Schema.String,
     url: Schema.String,
-    primarySha512: Schema.String,
-    primarySize: Schema.Number,
-    secondarySha512: Schema.String,
-    secondarySize: Schema.Number,
+    existingManifest: Schema.Literals(["primary", "secondary"]),
+    existingSha512: Schema.String,
+    existingSize: Schema.Number,
+    conflictingManifest: Schema.Literals(["primary", "secondary"]),
+    conflictingSha512: Schema.String,
+    conflictingSize: Schema.Number,
   },
 ) {
   override get message(): string {
@@ -360,27 +363,37 @@ export function mergeUpdateManifests(
     });
   }
 
-  const filesByUrl = new Map<string, UpdateManifestFile>();
-  for (const file of [...primary.files, ...secondary.files]) {
-    const existing = filesByUrl.get(file.url);
-    if (existing && (existing.sha512 !== file.sha512 || existing.size !== file.size)) {
-      throw new UpdateManifestFileConflictError({
-        platformLabel,
-        url: file.url,
-        primarySha512: existing.sha512,
-        primarySize: existing.size,
-        secondarySha512: file.sha512,
-        secondarySize: file.size,
-      });
+  const filesByUrl = new Map<
+    string,
+    { readonly manifest: "primary" | "secondary"; readonly file: UpdateManifestFile }
+  >();
+  for (const [manifest, files] of [
+    ["primary", primary.files],
+    ["secondary", secondary.files],
+  ] as const) {
+    for (const file of files) {
+      const existing = filesByUrl.get(file.url);
+      if (existing && (existing.file.sha512 !== file.sha512 || existing.file.size !== file.size)) {
+        throw new UpdateManifestFileConflictError({
+          platformLabel,
+          url: file.url,
+          existingManifest: existing.manifest,
+          existingSha512: existing.file.sha512,
+          existingSize: existing.file.size,
+          conflictingManifest: manifest,
+          conflictingSha512: file.sha512,
+          conflictingSize: file.size,
+        });
+      }
+      filesByUrl.set(file.url, { manifest, file });
     }
-    filesByUrl.set(file.url, file);
   }
 
   return {
     version: primary.version,
     releaseDate:
       primary.releaseDate >= secondary.releaseDate ? primary.releaseDate : secondary.releaseDate,
-    files: [...filesByUrl.values()],
+    files: [...filesByUrl.values()].map(({ file }) => file),
     extras: mergeExtras(primary.extras, secondary.extras, platformLabel),
   };
 }

--- a/scripts/merge-update-manifests.test.ts
+++ b/scripts/merge-update-manifests.test.ts
@@ -195,6 +195,10 @@ releaseDate: '2026-03-07T10:36:07.540Z'
   });
 
   it("identifies both sources when duplicate primary file entries conflict", () => {
+    const privateUrl =
+      "https://user:password@example.test/releases/private/app.exe?token=secret-token#fragment";
+    const firstSha512 = "first-private-sha";
+    const secondSha512 = "second-private-sha";
     const manifest = {
       version: "1.0.0",
       releaseDate: "2026-06-20T00:00:00.000Z",
@@ -206,8 +210,8 @@ releaseDate: '2026-03-07T10:36:07.540Z'
         {
           ...manifest,
           files: [
-            { url: "app.exe", sha512: "first", size: 1 },
-            { url: "app.exe", sha512: "second", size: 2 },
+            { url: privateUrl, sha512: firstSha512, size: 1 },
+            { url: privateUrl, sha512: secondSha512, size: 2 },
           ],
         },
         { ...manifest, files: [] },
@@ -217,9 +221,60 @@ releaseDate: '2026-03-07T10:36:07.540Z'
     assert.equal(error._tag, "UpdateManifestFileConflictError");
     if (error._tag === "UpdateManifestFileConflictError") {
       assert.equal(error.existingManifest, "primary");
-      assert.equal(error.existingSha512, "first");
       assert.equal(error.conflictingManifest, "primary");
-      assert.equal(error.conflictingSha512, "second");
+      assert.equal(error.urlInputLength, privateUrl.length);
+      assert.equal(error.urlProtocol, "https:");
+      assert.equal(error.urlHostname, "example.test");
+      assert.equal(error.existingSha512Length, firstSha512.length);
+      assert.equal(error.existingSize, 1);
+      assert.equal(error.conflictingSha512Length, secondSha512.length);
+      assert.equal(error.conflictingSize, 2);
+      assert.isTrue(error.sha512Conflict);
+      assert.isTrue(error.sizeConflict);
+      assert.notProperty(error, "url");
+      assert.notProperty(error, "existingSha512");
+      assert.notProperty(error, "conflictingSha512");
+
+      const diagnostics = [error.message, ...Object.values(error).map(String)].join("\n");
+      assert.notInclude(diagnostics, "user");
+      assert.notInclude(diagnostics, "password");
+      assert.notInclude(diagnostics, "/releases/private/app.exe");
+      assert.notInclude(diagnostics, "secret-token");
+      assert.notInclude(diagnostics, firstSha512);
+      assert.notInclude(diagnostics, secondSha512);
+    }
+  });
+
+  it("reports extra conflicts without retaining arbitrary scalar values", () => {
+    const primaryValue = "primary-private-value";
+    const secondaryValue = "secondary-private-value";
+    const manifest = {
+      version: "1.0.0",
+      releaseDate: "2026-06-20T00:00:00.000Z",
+      files: [{ url: "app.exe", sha512: "sha", size: 1 }],
+    };
+
+    const error = captureUpdateManifestError(() =>
+      mergePlatformUpdateManifests(
+        "win",
+        { ...manifest, extras: { releaseNotes: primaryValue } },
+        { ...manifest, extras: { releaseNotes: secondaryValue } },
+      ),
+    );
+
+    assert.equal(error._tag, "UpdateManifestExtraConflictError");
+    if (error._tag === "UpdateManifestExtraConflictError") {
+      assert.equal(error.key, "releaseNotes");
+      assert.equal(error.primaryValueType, "string");
+      assert.equal(error.primaryValueLength, primaryValue.length);
+      assert.equal(error.secondaryValueType, "string");
+      assert.equal(error.secondaryValueLength, secondaryValue.length);
+      assert.notProperty(error, "primaryValue");
+      assert.notProperty(error, "secondaryValue");
+
+      const diagnostics = [error.message, ...Object.values(error).map(String)].join("\n");
+      assert.notInclude(diagnostics, primaryValue);
+      assert.notInclude(diagnostics, secondaryValue);
     }
   });
 

--- a/scripts/merge-update-manifests.test.ts
+++ b/scripts/merge-update-manifests.test.ts
@@ -6,13 +6,26 @@ import * as Path from "effect/Path";
 import { Command, CliError } from "effect/unstable/cli";
 
 import {
+  mergeUpdateManifestFiles,
   mergePlatformUpdateManifests,
   mergeUpdateManifestsCommand,
   parsePlatformUpdateManifest,
   serializePlatformUpdateManifest,
 } from "./merge-update-manifests.ts";
+import { isUpdateManifestError, type UpdateManifestError } from "./lib/update-manifest.ts";
 
 const runCli = Command.runWith(mergeUpdateManifestsCommand, { version: "0.0.0" });
+
+function captureUpdateManifestError(run: () => unknown): UpdateManifestError {
+  let caught: unknown;
+  try {
+    run();
+  } catch (error) {
+    caught = error;
+  }
+  assert.ok(isUpdateManifestError(caught));
+  return caught;
+}
 
 describe("merge-update-manifests", () => {
   it("merges arm64 and x64 macOS update manifests into one multi-arch manifest", () => {
@@ -148,10 +161,29 @@ releaseDate: '2026-03-07T10:36:07.540Z'
       "latest-win-x64.yml",
     );
 
-    assert.throws(
-      () => mergePlatformUpdateManifests("win", primary, secondary),
-      /different versions/,
+    const error = captureUpdateManifestError(() =>
+      mergePlatformUpdateManifests("win", primary, secondary),
     );
+    assert.equal(error._tag, "UpdateManifestVersionConflictError");
+    if (error._tag === "UpdateManifestVersionConflictError") {
+      assert.equal(error.platformLabel, "Windows");
+      assert.equal(error.primaryVersion, "0.0.4");
+      assert.equal(error.secondaryVersion, "0.0.5");
+    }
+  });
+
+  it("reports manifest parse location and the unsupported input", () => {
+    const error = captureUpdateManifestError(() =>
+      parsePlatformUpdateManifest("mac", "not yaml", "latest-mac.yml"),
+    );
+    assert.equal(error._tag, "UpdateManifestParseError");
+    if (error._tag === "UpdateManifestParseError") {
+      assert.equal(error.platformLabel, "macOS");
+      assert.equal(error.sourcePath, "latest-mac.yml");
+      assert.equal(error.lineNumber, 1);
+      assert.equal(error.reason, "unsupported line");
+      assert.equal(error.offendingLine, "not yaml");
+    }
   });
 
   it("preserves quoted scalars as strings", () => {
@@ -283,6 +315,35 @@ releaseDate: '2026-03-07T10:36:07.540Z'
       const merged = yield* fs.readFileString(outputPath);
       assert.ok(merged.includes("T3-Code-0.0.4-arm64.exe"));
       assert.ok(merged.includes("T3-Code-0.0.4-x64.exe"));
+    }),
+  );
+
+  it.effect("surfaces manifest validation as a typed failure", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "merge-update-manifests-invalid-",
+      });
+      const primaryPath = path.join(baseDir, "latest-mac.yml");
+      const secondaryPath = path.join(baseDir, "latest-mac-x64.yml");
+
+      yield* fs.writeFileString(primaryPath, "not yaml");
+      yield* fs.writeFileString(secondaryPath, arm64MacManifest);
+
+      const error = yield* mergeUpdateManifestFiles(
+        "mac",
+        primaryPath,
+        secondaryPath,
+        undefined,
+      ).pipe(Effect.flip);
+
+      assert.ok(isUpdateManifestError(error));
+      assert.equal(error._tag, "UpdateManifestParseError");
+      if (error._tag === "UpdateManifestParseError") {
+        assert.equal(error.sourcePath, primaryPath);
+        assert.equal(error.reason, "unsupported line");
+      }
     }),
   );
 

--- a/scripts/merge-update-manifests.test.ts
+++ b/scripts/merge-update-manifests.test.ts
@@ -183,6 +183,39 @@ releaseDate: '2026-03-07T10:36:07.540Z'
       assert.equal(error.lineNumber, 1);
       assert.equal(error.reason, "unsupported line");
       assert.equal(error.offendingLine, "not yaml");
+      assert.equal(
+        error.message,
+        "Invalid macOS update manifest at latest-mac.yml:1: unsupported line. Input: not yaml",
+      );
+    }
+  });
+
+  it("identifies both sources when duplicate primary file entries conflict", () => {
+    const manifest = {
+      version: "1.0.0",
+      releaseDate: "2026-06-20T00:00:00.000Z",
+      extras: {},
+    };
+    const error = captureUpdateManifestError(() =>
+      mergePlatformUpdateManifests(
+        "win",
+        {
+          ...manifest,
+          files: [
+            { url: "app.exe", sha512: "first", size: 1 },
+            { url: "app.exe", sha512: "second", size: 2 },
+          ],
+        },
+        { ...manifest, files: [] },
+      ),
+    );
+
+    assert.equal(error._tag, "UpdateManifestFileConflictError");
+    if (error._tag === "UpdateManifestFileConflictError") {
+      assert.equal(error.existingManifest, "primary");
+      assert.equal(error.existingSha512, "first");
+      assert.equal(error.conflictingManifest, "primary");
+      assert.equal(error.conflictingSha512, "second");
     }
   });
 

--- a/scripts/merge-update-manifests.test.ts
+++ b/scripts/merge-update-manifests.test.ts
@@ -172,9 +172,10 @@ releaseDate: '2026-03-07T10:36:07.540Z'
     }
   });
 
-  it("reports manifest parse location and the unsupported input", () => {
+  it("reports manifest parse location without retaining the unsupported input", () => {
+    const unsupportedLine = "authorization Bearer secret-token without-separator";
     const error = captureUpdateManifestError(() =>
-      parsePlatformUpdateManifest("mac", "not yaml", "latest-mac.yml"),
+      parsePlatformUpdateManifest("mac", unsupportedLine, "latest-mac.yml"),
     );
     assert.equal(error._tag, "UpdateManifestParseError");
     if (error._tag === "UpdateManifestParseError") {
@@ -182,11 +183,14 @@ releaseDate: '2026-03-07T10:36:07.540Z'
       assert.equal(error.sourcePath, "latest-mac.yml");
       assert.equal(error.lineNumber, 1);
       assert.equal(error.reason, "unsupported line");
-      assert.equal(error.offendingLine, "not yaml");
+      assert.equal(error.lineLength, unsupportedLine.length);
+      assert.notProperty(error, "offendingLine");
       assert.equal(
         error.message,
-        "Invalid macOS update manifest at latest-mac.yml:1: unsupported line. Input: not yaml",
+        `Invalid macOS update manifest at latest-mac.yml:1: unsupported line. Input length: ${unsupportedLine.length}.`,
       );
+      assert.notInclude(error.message, "Bearer");
+      assert.notInclude(error.message, "secret-token");
     }
   });
 

--- a/scripts/merge-update-manifests.ts
+++ b/scripts/merge-update-manifests.ts
@@ -10,6 +10,7 @@ import * as Schema from "effect/Schema";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 
 import {
+  attemptUpdateManifest,
   mergeUpdateManifests,
   parseUpdateManifest,
   serializeUpdateManifest,
@@ -61,19 +62,22 @@ export const mergeUpdateManifestFiles = Effect.fn("mergeUpdateManifestFiles")(fu
   const secondaryPath = path.resolve(secondaryPathArg);
   const outputPath = path.resolve(outputPathArg ?? primaryPathArg);
 
-  const primaryManifest = parsePlatformUpdateManifest(
-    platform,
-    yield* fs.readFileString(primaryPath),
-    primaryPath,
+  const primaryRaw = yield* fs.readFileString(primaryPath);
+  const primaryManifest = yield* attemptUpdateManifest(() =>
+    parsePlatformUpdateManifest(platform, primaryRaw, primaryPath),
   );
-  const secondaryManifest = parsePlatformUpdateManifest(
-    platform,
-    yield* fs.readFileString(secondaryPath),
-    secondaryPath,
+  const secondaryRaw = yield* fs.readFileString(secondaryPath);
+  const secondaryManifest = yield* attemptUpdateManifest(() =>
+    parsePlatformUpdateManifest(platform, secondaryRaw, secondaryPath),
   );
-  const merged = mergePlatformUpdateManifests(platform, primaryManifest, secondaryManifest);
+  const merged = yield* attemptUpdateManifest(() =>
+    mergePlatformUpdateManifests(platform, primaryManifest, secondaryManifest),
+  );
 
-  yield* fs.writeFileString(outputPath, serializePlatformUpdateManifest(platform, merged));
+  const serialized = yield* attemptUpdateManifest(() =>
+    serializePlatformUpdateManifest(platform, merged),
+  );
+  yield* fs.writeFileString(outputPath, serialized);
 });
 
 export const mergeUpdateManifestsCommand = Command.make(


### PR DESCRIPTION
## Summary

- replace generic update-manifest parse, merge, and serialization exceptions with structured Schema errors
- retain platform, source location, offending input, and conflicting version/field/file metadata
- expose known validation failures through the Effect error channel while leaving unexpected exceptions as defects
- keep semantic validation failures cause-free

## Validation

- `vp test run scripts/merge-update-manifests.test.ts` (10 tests)
- `vp check`
- `vp run typecheck`


<!-- sensitive-context-follow-up -->
## Sensitive-context follow-up\n- unsupported manifest lines are represented by line number and line length rather than raw contents\n- parse messages no longer echo potentially sensitive line text

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how merge-update-manifest failures are represented (typed Effect errors vs generic throws), which callers must handle; scope is release scripting, not runtime auth, with lower blast radius but a behavioral contract shift.
> 
> **Overview**
> Replaces generic `Error` throws in update manifest **parse, merge, and serialize** with **Effect Schema tagged errors** (`UpdateManifestParseError`, version/extra/file conflict errors, serialization errors). Adds `attemptUpdateManifest` so the merge CLI surfaces known failures on the **Effect error channel** while unexpected exceptions still die as defects.
> 
> Failure payloads and messages are tightened so logs do not echo sensitive input: unsupported lines report **line number and length** (not the line text), file URL conflicts use **`getUrlDiagnostics`** (length, protocol, hostname only), and extra-field conflicts record **types and string lengths** instead of raw values. File merge conflicts also record **which manifest** (`primary` / `secondary`) and **hash/size metadata** without embedding full URLs or `sha512` strings.
> 
> Adds shared **`getUrlDiagnostics`** (exported from `@t3tools/shared/urlDiagnostics`) and **`redactDpopRequestTarget`** in `dpop.ts` for the same redaction pattern; tests assert neither helper leaks credentials, paths, or query tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bd4e6d8879fc7ec9e48eed9b9acb4755f54798c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic errors with typed structured errors in update manifest parsing and merging
> - Introduces typed error classes (`UpdateManifestParseError`, `UpdateManifestVersionConflictError`, `UpdateManifestExtraConflictError`, `UpdateManifestFileConflictError`, `UpdateManifestSerializationError`) using `effect/Schema` in [update-manifest.ts](https://github.com/pingdotgg/t3code/pull/3293/files#diff-d53353d95dd4393b6aa78d349d1d5d9647a6b5daf7a81acb9104a1a2a6f8bd86), replacing all generic `Error` throws.
> - Conflict errors expose only non-sensitive diagnostics (types, lengths, URL protocol/hostname) rather than raw values, using a new `getUrlDiagnostics` utility in [urlDiagnostics.ts](https://github.com/pingdotgg/t3code/pull/3293/files#diff-1c8198df49b2be099c916678220c6abc30f8130983b5efee4d72e2299511cceb) and `redactDpopRequestTarget` in [dpop.ts](https://github.com/pingdotgg/t3code/pull/3293/files#diff-a70e3eceffb70848b1ea9f7dd87b2d3cd5f20af4faacba0e185745d8560ec50d).
> - Adds `attemptUpdateManifest` helper to wrap manifest operations as Effect failures instead of defects; [merge-update-manifests.ts](https://github.com/pingdotgg/t3code/pull/3293/files#diff-697f3f51010528f886327ae0545dfee8733a39813758ce1fbe566be4956f0174) is updated to use it, surfacing errors on the Effect error channel.
> - Behavioral Change: callers of `mergeUpdateManifestFiles` now receive typed Effect failures instead of thrown exceptions for all parse, merge, and serialization errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bd4e6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->