### PR TITLE
[codex] structure Electron theme source errors

### DIFF
--- a/apps/desktop/src/electron/ElectronTheme.test.ts
+++ b/apps/desktop/src/electron/ElectronTheme.test.ts
@@ -8,6 +8,7 @@ const { onMock, removeListenerMock, themeState } = vi.hoisted(() => ({
   themeState: {
     shouldUseDarkColors: true,
     themeSource: "system",
+    setSourceError: null as unknown,
   },
 }));
 
@@ -17,6 +18,9 @@ vi.mock("electron", () => ({
       return themeState.shouldUseDarkColors;
     },
     set themeSource(value: string) {
+      if (themeState.setSourceError !== null) {
+        throw themeState.setSourceError;
+      }
       themeState.themeSource = value;
     },
     on: onMock,
@@ -32,6 +36,7 @@ describe("ElectronTheme", () => {
     removeListenerMock.mockClear();
     themeState.shouldUseDarkColors = true;
     themeState.themeSource = "system";
+    themeState.setSourceError = null;
   });
 
   it.effect("scopes native theme update listeners", () =>
@@ -47,6 +52,23 @@ describe("ElectronTheme", () => {
 
       assert.deepEqual(onMock.mock.calls, [["updated", listener]]);
       assert.deepEqual(removeListenerMock.mock.calls, [["updated", listener]]);
+    }).pipe(Effect.provide(ElectronTheme.layer)),
+  );
+
+  it.effect("preserves the requested source and cause when setting the theme fails", () =>
+    Effect.gen(function* () {
+      const cause = new Error("theme source failed");
+      themeState.setSourceError = cause;
+      const electronTheme = yield* ElectronTheme.ElectronTheme;
+
+      const error = yield* Effect.flip(electronTheme.setSource("dark"));
+
+      assert.instanceOf(error, ElectronTheme.ElectronThemeSetSourceError);
+      assert.isTrue(ElectronTheme.isElectronThemeSetSourceError(error));
+      assert.strictEqual(error.source, "dark");
+      assert.strictEqual(error.cause, cause);
+      assert.include(error.message, "dark");
+      assert.notInclude(error.message, cause.message);
     }).pipe(Effect.provide(ElectronTheme.layer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronTheme.ts
+++ b/apps/desktop/src/electron/ElectronTheme.ts
@@ -1,16 +1,31 @@
-import type { DesktopTheme } from "@t3tools/contracts";
+import { DesktopThemeSchema, type DesktopTheme } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 
 import * as Electron from "electron";
+
+export class ElectronThemeSetSourceError extends Schema.TaggedErrorClass<ElectronThemeSetSourceError>()(
+  "ElectronThemeSetSourceError",
+  {
+    source: DesktopThemeSchema,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to set the Electron theme source to ${this.source}.`;
+  }
+}
+
+export const isElectronThemeSetSourceError = Schema.is(ElectronThemeSetSourceError);
 
 export class ElectronTheme extends Context.Service<
   ElectronTheme,
   {
     readonly shouldUseDarkColors: Effect.Effect<boolean>;
-    readonly setSource: (theme: DesktopTheme) => Effect.Effect<void>;
+    readonly setSource: (theme: DesktopTheme) => Effect.Effect<void, ElectronThemeSetSourceError>;
     readonly onUpdated: (listener: () => void) => Effect.Effect<void, never, Scope.Scope>;
   }
 >()("@t3tools/desktop/electron/ElectronTheme") {}
@@ -18,9 +33,11 @@ export class ElectronTheme extends Context.Service<
 export const make = ElectronTheme.of({
   shouldUseDarkColors: Effect.sync(() => Electron.nativeTheme.shouldUseDarkColors),
   setSource: (theme) =>
-    Effect.suspend(() => {
-      Electron.nativeTheme.themeSource = theme;
-      return Effect.void;
+    Effect.try({
+      try: () => {
+        Electron.nativeTheme.themeSource = theme;
+      },
+      catch: (cause) => new ElectronThemeSetSourceError({ source: theme, cause }),
     }),
   onUpdated: (listener) =>
     Effect.acquireRelease(


### PR DESCRIPTION
## Summary
- expose Electron theme-source assignment failures as a schema-backed error
- retain the requested theme source and exact Electron cause
- add focused coverage without expanding into currently overlapping theme read/subscription consumers

## Verification
- `vp test apps/desktop/src/electron/ElectronTheme.test.ts`
- `vp check` (0 errors; 20 existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized Electron theme wrapper change; `setTheme` IPC may now surface failures that previously could throw uncaught, but scope is non-critical UI theming.
> 
> **Overview**
> **`ElectronTheme.setSource`** no longer assumes native `themeSource` assignment always succeeds. It now runs the Electron setter inside **`Effect.try`** and fails with a schema-backed **`ElectronThemeSetSourceError`** that carries the requested **`DesktopTheme`** (`source`) and the underlying defect (`cause`), plus a stable user-facing message that names the source but not the raw cause.
> 
> The service type and a **`Schema.is`** guard are exported so callers (e.g. IPC **`setTheme`**) can narrow failures. Tests extend the Electron mock to throw on set and assert error shape, source, cause, and message content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1ea12332459aa9243b11e8b9279bfdd13919a26. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure Electron theme source errors into a typed `ElectronThemeSetSourceError`
> - Adds `ElectronThemeSetSourceError`, a `Schema.TaggedErrorClass` carrying the requested `source` and original `cause`, replacing raw thrown errors from `nativeTheme.themeSource` assignment.
> - Updates `ElectronTheme.setSource` return type from `Effect<void>` to `Effect<void, ElectronThemeSetSourceError>`, making failures explicit to callers.
> - Adds `isElectronThemeSetSourceError` type guard for consumers to narrow the error type.
> - Behavioral Change: errors previously propagated as unhandled throws now surface as typed failing effects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1ea123.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->