### PR TITLE
Prefer catchTags for tagged failures

### DIFF
--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -238,13 +238,12 @@ export const relayEnvironmentAuthLayer = Layer.effect(
         { credential },
       ) {
         const token = readHttpAuthorizationCredential(credential);
-        const principal = yield* credentials
-          .authenticate(token)
-          .pipe(
-            Effect.catchTag("EnvironmentCredentialAuthenticatePersistenceError", () =>
+        const principal = yield* credentials.authenticate(token).pipe(
+          Effect.catchTags({
+            EnvironmentCredentialAuthenticatePersistenceError: () =>
               relayInternalErrorResponse("persistence_failed"),
-            ),
-          );
+          }),
+        );
         if (principal._tag === "None") {
           return yield* relayAuthInvalidError("not_authorized");
         }

--- a/packages/client-runtime/src/connection/registry.ts
+++ b/packages/client-runtime/src/connection/registry.ts
@@ -345,7 +345,9 @@ export const make = Effect.gen(function* () {
       persistedTargets,
       (target) =>
         acquireSupervisor(target.environmentId).pipe(
-          Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+          Effect.catchTags({
+            EnvironmentNotRegisteredError: () => Effect.void,
+          }),
         ),
       {
         concurrency: "unbounded",
@@ -516,7 +518,9 @@ export const make = Effect.gen(function* () {
         relayEnvironmentIds,
         (environmentId) =>
           remove(environmentId).pipe(
-            Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+            Effect.catchTags({
+              EnvironmentNotRegisteredError: () => Effect.void,
+            }),
           ),
         {
           concurrency: "unbounded",
@@ -529,7 +533,9 @@ export const make = Effect.gen(function* () {
   const retryNow = (environmentId: EnvironmentId) =>
     acquireSupervisor(environmentId).pipe(
       Effect.flatMap((supervisor) => supervisor.retryNow),
-      Effect.catchTag("EnvironmentNotRegisteredError", () => Effect.void),
+      Effect.catchTags({
+        EnvironmentNotRegisteredError: () => Effect.void,
+      }),
       Effect.withSpan("EnvironmentRegistry.retryNow"),
     );
   const state = Effect.fn("EnvironmentRegistry.state")(function* (environmentId: EnvironmentId) {

--- a/packages/effect-acp/src/_internal/shared.ts
+++ b/packages/effect-acp/src/_internal/shared.ts
@@ -14,14 +14,15 @@ export const callRpc = <A>(
   effect: Effect.Effect<A, RpcClientError.RpcClientError | AcpSchema.Error>,
 ): Effect.Effect<A, AcpError.AcpError> =>
   effect.pipe(
-    Effect.catchTag("RpcClientError", (error) =>
-      Effect.fail(
-        new AcpError.AcpTransportError({
-          detail: error.message,
-          cause: error,
-        }),
-      ),
-    ),
+    Effect.catchTags({
+      RpcClientError: (error) =>
+        Effect.fail(
+          new AcpError.AcpTransportError({
+            detail: error.message,
+            cause: error,
+          }),
+        ),
+    }),
     Effect.catchIf(isError, (error) =>
       Effect.fail(AcpError.AcpRequestError.fromProtocolError(error)),
     ),

--- a/packages/shared/src/relayClient.ts
+++ b/packages/shared/src/relayClient.ts
@@ -381,15 +381,16 @@ export const makeCloudflaredRelayClient = Effect.fn("cloudflared.make")(function
       );
     yield* report("waiting_for_lock");
     yield* acquireInstallLock(lockPath).pipe(
-      Effect.catchTag("PlatformError", (cause) =>
-        Effect.fail(
-          new RelayClientInstallError({
-            reason: "write_failed",
-            message: "Could not acquire the relay client installation lock.",
-            cause,
-          }),
-        ),
-      ),
+      Effect.catchTags({
+        PlatformError: (cause) =>
+          Effect.fail(
+            new RelayClientInstallError({
+              reason: "write_failed",
+              message: "Could not acquire the relay client installation lock.",
+              cause,
+            }),
+          ),
+      }),
     );
     return yield* Effect.gen(function* () {
       const afterLock = yield* resolve;

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -604,7 +604,9 @@ export const isCommandAvailable = Effect.fn("shell.isCommandAvailable")(function
 ) {
   return yield* resolveCommandPath(command, options).pipe(
     Effect.as(true),
-    Effect.catchTag("CommandResolutionError", () => Effect.succeed(false)),
+    Effect.catchTags({
+      CommandResolutionError: () => Effect.succeed(false),
+    }),
   );
 });
 


### PR DESCRIPTION
## Summary
- replace every remaining production `Effect.catchTag` call in package and relay code with `Effect.catchTags`
- keep recovery exhaustive and colocated for tagged error channels
- retain ACP protocol `catchIf` because the generated JSON-RPC error payload is structurally untagged

## Validation
- `vp test packages/shared/src/shell.test.ts packages/shared/src/relayClient.test.ts packages/client-runtime/src/connection/registry.test.ts packages/effect-acp/src/client.test.ts packages/effect-acp/src/agent.test.ts infra/relay/src/http/Api.test.ts --no-cache` (64 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving API/style refactor with no new logic paths; tagged handlers map one-to-one to the previous catchTag calls.
> 
> **Overview**
> Replaces remaining production **`Effect.catchTag`** usage in relay and package code with **`Effect.catchTags`** and an object map of tag handlers, so tagged-error recovery stays colocated and easier to extend.
> 
> Touches **relay environment bearer auth** (`EnvironmentCredentialAuthenticatePersistenceError`), **client-runtime environment registry** startup/removal/retry paths (`EnvironmentNotRegisteredError`), **ACP RPC** transport errors (`RpcClientError`), **relay client install** lock acquisition (`PlatformError`), and **shell** command availability (`CommandResolutionError`). **ACP** still uses **`Effect.catchIf`** for structurally untagged JSON-RPC protocol errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 341535100a38e1356ae22747d0e6e8f201744c28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `Effect.catchTag` with `Effect.catchTags` across multiple modules
> Replaces all single-tag `Effect.catchTag(...)` calls with the multi-tag form `Effect.catchTags({ ... })` for consistency. No error handling logic or behavior is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3415351.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->