### PR TITLE
[codex] Structure release metadata failures

### DIFF
--- a/scripts/resolve-nightly-release.test.ts
+++ b/scripts/resolve-nightly-release.test.ts
@@ -1,4 +1,5 @@
 import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
 
 import {
   resolveNightlyBaseVersion,
@@ -12,11 +13,23 @@ it("strips prerelease and build metadata when deriving the nightly base version"
   assert.equal(resolveNightlyBaseVersion("1.2.3-beta.4+build.9"), "1.2.3");
 });
 
-it("bumps the patch version before deriving nightly prerelease versions", () => {
-  assert.equal(resolveNightlyTargetVersion("0.0.17"), "0.0.18");
-  assert.equal(resolveNightlyTargetVersion("9.9.9-smoke.0"), "9.9.10");
-  assert.equal(resolveNightlyTargetVersion("1.2.3-beta.4+build.9"), "1.2.4");
-});
+it.effect("bumps the patch version before deriving nightly prerelease versions", () =>
+  Effect.gen(function* () {
+    assert.equal(yield* resolveNightlyTargetVersion("0.0.17"), "0.0.18");
+    assert.equal(yield* resolveNightlyTargetVersion("9.9.9-smoke.0"), "9.9.10");
+    assert.equal(yield* resolveNightlyTargetVersion("1.2.3-beta.4+build.9"), "1.2.4");
+  }),
+);
+
+it.effect("reports the invalid desktop package version", () =>
+  Effect.gen(function* () {
+    const error = yield* resolveNightlyTargetVersion("nightly").pipe(Effect.flip);
+
+    assert.equal(error._tag, "InvalidDesktopPackageVersionError");
+    assert.equal(error.version, "nightly");
+    assert.equal(error.message, "Invalid desktop package version 'nightly'.");
+  }),
+);
 
 it("derives nightly metadata including the short commit sha in the release name", () => {
   assert.deepStrictEqual(

--- a/scripts/resolve-nightly-release.ts
+++ b/scripts/resolve-nightly-release.ts
@@ -29,6 +29,17 @@ const DesktopPackageJsonSchema = Schema.Struct({
   version: Schema.NonEmptyString,
 });
 
+export class InvalidDesktopPackageVersionError extends Schema.TaggedErrorClass<InvalidDesktopPackageVersionError>()(
+  "InvalidDesktopPackageVersionError",
+  {
+    version: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Invalid desktop package version '${this.version}'.`;
+  }
+}
+
 const RepoRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("..", import.meta.url))),
 );
@@ -42,11 +53,11 @@ export const resolveNightlyTargetVersion = (version: string) => {
   const stableCore = resolveNightlyBaseVersion(version);
   const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(stableCore);
   if (!match) {
-    throw new Error(`Invalid desktop package version '${version}'.`);
+    return Effect.fail(new InvalidDesktopPackageVersionError({ version }));
   }
 
   const [, major, minor, patch] = match;
-  return `${major}.${minor}.${Number(patch) + 1}`;
+  return Effect.succeed(`${major}.${minor}.${Number(patch) + 1}`);
 };
 
 export const resolveNightlyReleaseMetadata = (
@@ -76,7 +87,7 @@ const readDesktopBaseVersion = Effect.fn("readDesktopBaseVersion")(function* (
   const packageJson = yield* fs
     .readFileString(packageJsonPath)
     .pipe(Effect.flatMap(decodeDesktopPackageJson));
-  return resolveNightlyTargetVersion(packageJson.version);
+  return yield* resolveNightlyTargetVersion(packageJson.version);
 });
 
 const writeOutput = Effect.fn("writeOutput")(function* (

--- a/scripts/resolve-previous-release-tag.test.ts
+++ b/scripts/resolve-previous-release-tag.test.ts
@@ -1,0 +1,39 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+
+import { resolvePreviousReleaseTag } from "./resolve-previous-release-tag.ts";
+
+it.effect("selects the latest earlier stable tag and ignores nightlies", () =>
+  Effect.gen(function* () {
+    const previous = yield* resolvePreviousReleaseTag("stable", "v1.2.0", [
+      "v1.1.0",
+      "v1.1.1-nightly.20260619.1",
+      "v1.1.2",
+      "v1.2.0",
+    ]);
+
+    assert.equal(previous, "v1.1.2");
+  }),
+);
+
+it.effect("accepts legacy nightly tags when selecting the previous nightly", () =>
+  Effect.gen(function* () {
+    const previous = yield* resolvePreviousReleaseTag("nightly", "v1.2.0-nightly.20260620.2", [
+      "nightly-v1.2.0-nightly.20260620.1",
+      "v1.1.0-nightly.20260619.9",
+    ]);
+
+    assert.equal(previous, "nightly-v1.2.0-nightly.20260620.1");
+  }),
+);
+
+it.effect("reports the invalid tag with its release channel", () =>
+  Effect.gen(function* () {
+    const error = yield* resolvePreviousReleaseTag("nightly", "v1.2.0", []).pipe(Effect.flip);
+
+    assert.equal(error._tag, "InvalidReleaseTagError");
+    assert.equal(error.channel, "nightly");
+    assert.equal(error.currentTag, "v1.2.0");
+    assert.equal(error.message, "Invalid nightly release tag 'v1.2.0'.");
+  }),
+);

--- a/scripts/resolve-previous-release-tag.ts
+++ b/scripts/resolve-previous-release-tag.ts
@@ -15,6 +15,18 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 const ReleaseChannel = Schema.Literals(["stable", "nightly"]);
 type ReleaseChannel = typeof ReleaseChannel.Type;
 
+export class InvalidReleaseTagError extends Schema.TaggedErrorClass<InvalidReleaseTagError>()(
+  "InvalidReleaseTagError",
+  {
+    channel: ReleaseChannel,
+    currentTag: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Invalid ${this.channel} release tag '${this.currentTag}'.`;
+  }
+}
+
 interface StableVersion {
   readonly major: number;
   readonly minor: number;
@@ -121,41 +133,44 @@ const parseNightlyTag = (tag: string): NightlyVersion | undefined => {
   };
 };
 
-const resolvePreviousReleaseTag = (
+export const resolvePreviousReleaseTag = (
   channel: ReleaseChannel,
   currentTag: string,
   tags: ReadonlyArray<string>,
-): string | undefined => {
-  if (channel === "stable") {
-    const current = parseStableTag(currentTag);
+) =>
+  Effect.gen(function* () {
+    if (channel === "stable") {
+      const current = parseStableTag(currentTag);
+      if (!current) {
+        return yield* new InvalidReleaseTagError({ channel, currentTag });
+      }
+
+      const candidates = tags
+        .map((tag) => ({ tag, parsed: parseStableTag(tag) }))
+        .filter(
+          (entry): entry is { tag: string; parsed: StableVersion } => entry.parsed !== undefined,
+        )
+        .filter((entry) => compareStableVersions(entry.parsed, current) < 0)
+        .toSorted((left, right) => compareStableVersions(right.parsed, left.parsed));
+
+      return candidates[0]?.tag;
+    }
+
+    const current = parseNightlyTag(currentTag);
     if (!current) {
-      throw new Error(`Invalid stable release tag '${currentTag}'.`);
+      return yield* new InvalidReleaseTagError({ channel, currentTag });
     }
 
     const candidates = tags
-      .map((tag) => ({ tag, parsed: parseStableTag(tag) }))
+      .map((tag) => ({ tag, parsed: parseNightlyTag(tag) }))
       .filter(
-        (entry): entry is { tag: string; parsed: StableVersion } => entry.parsed !== undefined,
+        (entry): entry is { tag: string; parsed: NightlyVersion } => entry.parsed !== undefined,
       )
-      .filter((entry) => compareStableVersions(entry.parsed, current) < 0)
-      .toSorted((left, right) => compareStableVersions(right.parsed, left.parsed));
+      .filter((entry) => compareNightlyVersions(entry.parsed, current) < 0)
+      .toSorted((left, right) => compareNightlyVersions(right.parsed, left.parsed));
 
     return candidates[0]?.tag;
-  }
-
-  const current = parseNightlyTag(currentTag);
-  if (!current) {
-    throw new Error(`Invalid nightly release tag '${currentTag}'.`);
-  }
-
-  const candidates = tags
-    .map((tag) => ({ tag, parsed: parseNightlyTag(tag) }))
-    .filter((entry): entry is { tag: string; parsed: NightlyVersion } => entry.parsed !== undefined)
-    .filter((entry) => compareNightlyVersions(entry.parsed, current) < 0)
-    .toSorted((left, right) => compareNightlyVersions(right.parsed, left.parsed));
-
-  return candidates[0]?.tag;
-};
+  });
 
 const listGitTags = Effect.fn("listGitTags")(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
@@ -205,7 +220,7 @@ const command = Command.make(
   },
   ({ channel, currentTag, githubOutput }) =>
     listGitTags().pipe(
-      Effect.map((tags) => resolvePreviousReleaseTag(channel, currentTag, tags)),
+      Effect.flatMap((tags) => resolvePreviousReleaseTag(channel, currentTag, tags)),
       Effect.flatMap((previousTag) => writeOutput(previousTag, githubOutput)),
     ),
 ).pipe(Command.withDescription("Resolve the previous release tag for a stable or nightly series."));


### PR DESCRIPTION
## Summary

- replace generic throws for invalid nightly package versions and release tags with schema-backed errors
- retain the invalid version/tag and release channel as structured diagnostic context
- keep semantic validation failures cause-free and messages derived only from their structured fields
- add focused coverage for valid selection and structured invalid-input failures

## Validation

- `vp test run scripts/resolve-nightly-release.test.ts scripts/resolve-previous-release-tag.test.ts` (7 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release scripting only; behavior on valid inputs is unchanged aside from Effect composition, with clearer typed failures on bad versions or tags.
> 
> **Overview**
> Release helper scripts now return **Effect** failures instead of throwing when desktop package versions or release tags fail semantic validation.
> 
> `resolveNightlyTargetVersion` fails with **`InvalidDesktopPackageVersionError`** (includes the bad version string). **`resolvePreviousReleaseTag`** is exported and fails with **`InvalidReleaseTagError`** carrying **channel** and **currentTag**; invalid stable/nightly tags no longer throw generic `Error`s. Call sites (`readDesktopBaseVersion`, the previous-tag CLI) are wired with `yield*` / `Effect.flatMap`.
> 
> Tests move to **`it.effect`** for the Effect-based APIs and add **`resolve-previous-release-tag.test.ts`** for stable vs nightly predecessor selection (including legacy nightly tag shapes) and structured invalid-input assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 935105f6b471bb41100235dcbf9546d1c9fc48f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure release metadata failures with typed Effect errors
> - Adds `InvalidDesktopPackageVersionError` and `InvalidReleaseTagError` as `Schema.TaggedErrorClass` types, replacing synchronous throws with typed Effect failures.
> - Converts `resolveNightlyTargetVersion` and `resolvePreviousReleaseTag` to return `Effect` values that fail with these structured errors instead of throwing.
> - Updates the `resolve-previous-release-tag` command handler to use `Effect.flatMap` to chain the now-effectful resolver.
> - Adds effect-based tests covering both success and error paths for both functions.
> - Behavioral Change: callers of `resolveNightlyTargetVersion` and `resolvePreviousReleaseTag` must now handle `Effect` failure channels rather than catching thrown exceptions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 935105f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->