### PR TITLE
[codex] Structure catalog dependency resolution failures

### DIFF
--- a/scripts/lib/resolve-catalog.test.ts
+++ b/scripts/lib/resolve-catalog.test.ts
@@ -1,0 +1,20 @@
+import { assert, it } from "@effect/vitest";
+
+import { CatalogDependencyResolutionError, resolveCatalogDependencies } from "./resolve-catalog.ts";
+
+it("reports unresolved catalog dependencies with lookup context", () => {
+  try {
+    resolveCatalogDependencies({ effect: "catalog:runtime" }, {}, "apps/server");
+    assert.fail("Expected catalog resolution to fail.");
+  } catch (error) {
+    assert.instanceOf(error, CatalogDependencyResolutionError);
+    assert.equal(error.workspacePackage, "apps/server");
+    assert.equal(error.dependencyName, "effect");
+    assert.equal(error.catalogSpec, "catalog:runtime");
+    assert.equal(error.catalogKey, "runtime");
+    assert.equal(
+      error.message,
+      "Unable to resolve 'catalog:runtime' for apps/server dependency 'effect'. Expected key 'runtime' in root workspace catalog.",
+    );
+  }
+});

--- a/scripts/lib/resolve-catalog.ts
+++ b/scripts/lib/resolve-catalog.ts
@@ -1,3 +1,19 @@
+import * as Schema from "effect/Schema";
+
+export class CatalogDependencyResolutionError extends Schema.TaggedErrorClass<CatalogDependencyResolutionError>()(
+  "CatalogDependencyResolutionError",
+  {
+    workspacePackage: Schema.String,
+    dependencyName: Schema.String,
+    catalogSpec: Schema.String,
+    catalogKey: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Unable to resolve '${this.catalogSpec}' for ${this.workspacePackage} dependency '${this.dependencyName}'. Expected key '${this.catalogKey}' in root workspace catalog.`;
+  }
+}
+
 /**
  * Resolve `catalog:` dependency specs using the workspace catalog.
  *
@@ -7,7 +23,7 @@
 export function resolveCatalogDependencies(
   dependencies: Record<string, string>,
   catalog: Record<string, string>,
-  label: string,
+  workspacePackage: string,
 ): Record<string, string> {
   return Object.fromEntries(
     Object.entries(dependencies).map(([name, spec]) => {
@@ -20,9 +36,12 @@ export function resolveCatalogDependencies(
       const resolved = catalog[lookupKey];
 
       if (typeof resolved !== "string" || resolved.length === 0) {
-        throw new Error(
-          `Unable to resolve '${spec}' for ${label} dependency '${name}'. Expected key '${lookupKey}' in root workspace catalog.`,
-        );
+        throw new CatalogDependencyResolutionError({
+          workspacePackage,
+          dependencyName: name,
+          catalogSpec: spec,
+          catalogKey: lookupKey,
+        });
       }
 
       return [name, resolved];


### PR DESCRIPTION
## Summary

- replace the generic missing-catalog throw with a schema-backed `CatalogDependencyResolutionError`
- retain the workspace package, dependency name, catalog spec, and resolved lookup key as structured context
- preserve existing wrapping behavior so build-script errors keep the catalog error as their cause
- add focused coverage for the structured failure

## Validation

- `vp test run scripts/lib/resolve-catalog.test.ts scripts/build-desktop-artifact.test.ts` (20 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to build-script error typing and messaging; behavior on failure stays the same aside from error class and structured fields.
> 
> **Overview**
> Catalog resolution failures in `resolveCatalogDependencies` now throw **`CatalogDependencyResolutionError`** (Effect `Schema.TaggedErrorClass`) instead of a plain `Error`, with fields for workspace package, dependency name, catalog spec, and catalog lookup key. The third argument is renamed from `label` to **`workspacePackage`**; the human-readable **`message`** matches the previous string.
> 
> Adds **`resolve-catalog.test.ts`** to assert the error type, structured fields, and message when a `catalog:` spec cannot be resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a661d2e0534cb2e478155d833866cc237b4952d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic `Error` with structured `CatalogDependencyResolutionError` in catalog resolution
> Introduces `CatalogDependencyResolutionError`, a tagged error class (via `effect/Schema`) with structured fields: `workspacePackage`, `dependencyName`, `catalogSpec`, and `catalogKey`. When `resolveCatalogDependencies` fails to find a catalog key, it now throws this typed error instead of a plain `Error`, making failures easier to catch and inspect programmatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a661d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->