### PR TITLE
Prefer catchTags for command resolution

### DIFF
--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -604,7 +604,9 @@ export const isCommandAvailable = Effect.fn("shell.isCommandAvailable")(function
 ) {
   return yield* resolveCommandPath(command, options).pipe(
     Effect.as(true),
-    Effect.catchTag("CommandResolutionError", () => Effect.succeed(false)),
+    Effect.catchTags({
+      CommandResolutionError: () => Effect.succeed(false),
+    }),
   );
 });
 


### PR DESCRIPTION
## Summary
- replace the command-resolution `Effect.catchTag` recovery with `Effect.catchTags`
- keep the missing-command fallback behavior unchanged

## Validation
- `vp test packages/shared/src/shell.test.ts --no-cache` (29 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line API swap with unchanged fallback behavior; shared shell tests cover command availability.
> 
> **Overview**
> Updates **`isCommandAvailable`** in `shell.ts` so command-path resolution failures are handled with **`Effect.catchTags`** instead of **`Effect.catchTag`**.
> 
> Missing commands still map **`CommandResolutionError`** to **`false`**; only the Effect error-handling API shape changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dbd5a4ec7bb172a42f127f50bcb90ea49a4ca1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace `Effect.catchTag` with `Effect.catchTags` in `shell.isCommandAvailable`
> Swaps the single-tag `Effect.catchTag("CommandResolutionError", ...)` call for the multi-tag variant `Effect.catchTags({ CommandResolutionError: ... })` in [shell.ts](https://github.com/pingdotgg/t3code/pull/3299/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce). No logic changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dbd5a4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->