### PR TITLE
Preserve trace file read causes

### DIFF
--- a/apps/server/src/diagnostics/TraceDiagnostics.test.ts
+++ b/apps/server/src/diagnostics/TraceDiagnostics.test.ts
@@ -41,6 +41,22 @@ function record(input: {
 }
 
 describe("TraceDiagnostics", () => {
+  it("retains exact trace file read causes with a normalized cause tag", () => {
+    const cause = PlatformError.systemError({
+      _tag: "PermissionDenied",
+      module: "FileSystem",
+      method: "readFileString",
+    });
+    const error = new TraceDiagnostics.TraceFileReadError({
+      traceFilePath: "/tmp/server.trace.ndjson",
+      causeTag: cause.reason._tag,
+      cause,
+    });
+
+    assert.strictEqual(error.cause, cause);
+    assert.strictEqual(error.causeTag, "PermissionDenied");
+  });
+
   it.effect("aggregates failures, slow spans, log levels, and parse errors", () =>
     Effect.sync(() => {
       const diagnostics = TraceDiagnostics.aggregateTraceDiagnostics({
@@ -243,8 +259,11 @@ describe("TraceDiagnostics", () => {
         (annotations) => annotations.traceFilePath === `${traceFilePath}.1`,
       );
       assert.exists(failureLog);
-      assert.instanceOf(failureLog.cause, TraceDiagnostics.TraceFileReadError);
-      assert.strictEqual(failureLog.cause.cause, readFailure);
+      assert.deepStrictEqual(failureLog, {
+        traceFilePath: `${traceFilePath}.1`,
+        errorTag: "TraceFileReadError",
+        causeTag: "PermissionDenied",
+      });
     }),
   );
 

--- a/apps/server/src/diagnostics/TraceDiagnostics.test.ts
+++ b/apps/server/src/diagnostics/TraceDiagnostics.test.ts
@@ -41,22 +41,6 @@ function record(input: {
 }
 
 describe("TraceDiagnostics", () => {
-  it("retains exact trace file read causes with a normalized cause tag", () => {
-    const cause = PlatformError.systemError({
-      _tag: "PermissionDenied",
-      module: "FileSystem",
-      method: "readFileString",
-    });
-    const error = new TraceDiagnostics.TraceFileReadError({
-      traceFilePath: "/tmp/server.trace.ndjson",
-      causeTag: cause.reason._tag,
-      cause,
-    });
-
-    assert.strictEqual(error.cause, cause);
-    assert.strictEqual(error.causeTag, "PermissionDenied");
-  });
-
   it.effect("aggregates failures, slow spans, log levels, and parse errors", () =>
     Effect.sync(() => {
       const diagnostics = TraceDiagnostics.aggregateTraceDiagnostics({

--- a/apps/server/src/diagnostics/TraceDiagnostics.test.ts
+++ b/apps/server/src/diagnostics/TraceDiagnostics.test.ts
@@ -3,8 +3,10 @@ import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
+import * as References from "effect/References";
 
 import * as TraceDiagnostics from "./TraceDiagnostics.ts";
 
@@ -187,18 +189,17 @@ describe("TraceDiagnostics", () => {
   it.effect("keeps loaded trace data when one rotated trace file fails to read", () =>
     Effect.gen(function* () {
       const traceFilePath = "/tmp/server.trace.ndjson";
+      const readFailure = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "readFileString",
+        description: "permission denied",
+        pathOrDescriptor: `${traceFilePath}.1`,
+      });
       const fileSystemLayer = FileSystem.layerNoop({
         readFileString: (path) =>
           path === `${traceFilePath}.1`
-            ? Effect.fail(
-                PlatformError.systemError({
-                  _tag: "PermissionDenied",
-                  module: "FileSystem",
-                  method: "readFileString",
-                  description: "permission denied",
-                  pathOrDescriptor: path,
-                }),
-              )
+            ? Effect.fail(readFailure)
             : Effect.succeed(
                 record({
                   name: "server.getConfig",
@@ -209,20 +210,41 @@ describe("TraceDiagnostics", () => {
                 }),
               ),
       });
+      const logAnnotations: Array<Record<string, unknown>> = [];
+      const logger = Logger.make<unknown, void>((options) => {
+        logAnnotations.push({ ...options.fiber.getRef(References.CurrentLogAnnotations) });
+      });
 
       const diagnostics = yield* TraceDiagnostics.readTraceDiagnostics({
         traceFilePath,
         maxFiles: 1,
         readAt: DateTime.makeUnsafe("2026-05-05T10:00:00.000Z"),
-      }).pipe(Effect.provide(TraceDiagnostics.layer.pipe(Layer.provide(fileSystemLayer))));
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            TraceDiagnostics.layer.pipe(Layer.provide(fileSystemLayer)),
+            Logger.layer([logger], { mergeWithExisting: false }),
+          ),
+        ),
+      );
 
       assert.equal(diagnostics.recordCount, 1);
       assert.equal(
         Option.getOrElse(diagnostics.partialFailure, () => false),
         true,
       );
-      assert.equal(Option.getOrUndefined(diagnostics.error)?.kind, "trace-file-read-failed");
+      assert.deepStrictEqual(Option.getOrUndefined(diagnostics.error), {
+        kind: "trace-file-read-failed",
+        message: `Failed to read local trace file '${traceFilePath}.1'.`,
+      });
       assert.deepStrictEqual(diagnostics.scannedFilePaths, [`${traceFilePath}.1`, traceFilePath]);
+
+      const failureLog = logAnnotations.find(
+        (annotations) => annotations.traceFilePath === `${traceFilePath}.1`,
+      );
+      assert.exists(failureLog);
+      assert.instanceOf(failureLog.cause, TraceDiagnostics.TraceFileReadError);
+      assert.strictEqual(failureLog.cause.cause, readFailure);
     }),
   );
 

--- a/apps/server/src/diagnostics/TraceDiagnostics.ts
+++ b/apps/server/src/diagnostics/TraceDiagnostics.ts
@@ -45,6 +45,7 @@ export class TraceFileReadError extends Schema.TaggedErrorClass<TraceFileReadErr
   "TraceFileReadError",
   {
     traceFilePath: Schema.String,
+    causeTag: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
@@ -399,7 +400,13 @@ function readTraceFile(
       PlatformError: (cause) =>
         isNotFoundError(cause)
           ? Effect.succeed<TraceFileReadResult>({ _tag: "Missing", path })
-          : Effect.fail(new TraceFileReadError({ traceFilePath: path, cause })),
+          : Effect.fail(
+              new TraceFileReadError({
+                traceFilePath: path,
+                causeTag: cause.reason._tag,
+                cause,
+              }),
+            ),
     }),
   );
 }
@@ -419,7 +426,8 @@ export const make = Effect.gen(function* () {
               Effect.logWarning("Failed to read local trace file.").pipe(
                 Effect.annotateLogs({
                   traceFilePath: cause.traceFilePath,
-                  cause,
+                  errorTag: cause._tag,
+                  causeTag: cause.causeTag,
                 }),
               ),
             ),

--- a/apps/server/src/diagnostics/TraceDiagnostics.ts
+++ b/apps/server/src/diagnostics/TraceDiagnostics.ts
@@ -14,6 +14,8 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 
 interface TraceRecordLike {
   readonly name?: unknown;
@@ -37,6 +39,18 @@ export interface TraceDiagnosticsOptions {
   readonly maxFiles: number;
   readonly slowSpanThresholdMs?: number;
   readonly readAt?: DateTime.Utc;
+}
+
+export class TraceFileReadError extends Schema.TaggedErrorClass<TraceFileReadError>()(
+  "TraceFileReadError",
+  {
+    traceFilePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read local trace file '${this.traceFilePath}'.`;
+  }
 }
 
 export class TraceDiagnostics extends Context.Service<
@@ -151,10 +165,6 @@ function makeEmptyDiagnostics(input: {
 
 function isNotFoundError(error: PlatformError.PlatformError): boolean {
   return error.reason._tag === "NotFound";
-}
-
-function platformErrorMessage(error: PlatformError.PlatformError): string {
-  return error.message || String(error);
 }
 
 function insertBoundedSlowestSpan(
@@ -377,22 +387,20 @@ export function aggregateTraceDiagnostics(
 
 type TraceFileReadResult =
   | { readonly _tag: "Loaded"; readonly path: string; readonly text: string }
-  | { readonly _tag: "Missing"; readonly path: string }
-  | { readonly _tag: "Failed"; readonly path: string; readonly message: string };
+  | { readonly _tag: "Missing"; readonly path: string };
 
 function readTraceFile(
   fileSystem: FileSystem.FileSystem,
   path: string,
-): Effect.Effect<TraceFileReadResult> {
+): Effect.Effect<TraceFileReadResult, TraceFileReadError> {
   return fileSystem.readFileString(path).pipe(
-    Effect.map((text) => ({ _tag: "Loaded" as const, path, text })),
-    Effect.catch((error: PlatformError.PlatformError) =>
-      Effect.succeed(
-        isNotFoundError(error)
-          ? { _tag: "Missing" as const, path }
-          : { _tag: "Failed" as const, path, message: platformErrorMessage(error) },
-      ),
-    ),
+    Effect.map((text): TraceFileReadResult => ({ _tag: "Loaded", path, text })),
+    Effect.catchTags({
+      PlatformError: (cause) =>
+        isNotFoundError(cause)
+          ? Effect.succeed<TraceFileReadResult>({ _tag: "Missing", path })
+          : Effect.fail(new TraceFileReadError({ traceFilePath: path, cause })),
+    }),
   );
 }
 
@@ -405,19 +413,33 @@ export const make = Effect.gen(function* () {
       const slowSpanThresholdMs = options.slowSpanThresholdMs ?? DEFAULT_SLOW_SPAN_THRESHOLD_MS;
       const paths = toRotatedTracePaths(options.traceFilePath, options.maxFiles);
       const results = yield* Effect.all(
-        paths.map((path) => readTraceFile(fileSystem, path)),
+        paths.map((path) =>
+          readTraceFile(fileSystem, path).pipe(
+            Effect.tapError((cause) =>
+              Effect.logWarning("Failed to read local trace file.").pipe(
+                Effect.annotateLogs({
+                  traceFilePath: cause.traceFilePath,
+                  cause,
+                }),
+              ),
+            ),
+            Effect.result,
+          ),
+        ),
         {
           concurrency: 1,
         },
       );
       const files = results.flatMap((result) =>
-        result._tag === "Loaded" ? [{ path: result.path, text: result.text }] : [],
+        Result.isSuccess(result) && result.success._tag === "Loaded"
+          ? [{ path: result.success.path, text: result.success.text }]
+          : [],
       );
-      const readFailure = results.find((result) => result._tag === "Failed");
+      const readFailure = results.find(Result.isFailure);
       const readFailureError = readFailure
         ? ({
             kind: "trace-file-read-failed",
-            message: readFailure.message.trim() || `Failed to read ${readFailure.path}.`,
+            message: readFailure.failure.message,
           } satisfies TraceDiagnosticsErrorSummary)
         : undefined;
 


### PR DESCRIPTION
## Summary
- represent non-NotFound trace reads as structured `TraceFileReadError` values with the failed path and exact platform cause
- use `catchTags` at the platform-error boundary, then recover with `Effect.result` only at the best-effort diagnostics aggregation boundary
- log the structured failure before recovery and keep the public message path-derived instead of cause-derived

## Validation
- `vp test apps/server/src/diagnostics/TraceDiagnostics.test.ts` (5 passed)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to local trace diagnostics reads; behavior for callers is unchanged at the public API except clearer errors and logs, with partial aggregation preserved.
> 
> **Overview**
> Trace diagnostics now treat non–not-found filesystem errors as **`TraceFileReadError`** effect failures (path, `causeTag`, and the original `PlatformError` cause) instead of a `'Failed'` success variant from `readTraceFile`.
> 
> At the aggregation boundary, each rotated file read is recovered with **`Effect.result`** so partial loads still work: failures emit a **warning log** annotated with `traceFilePath`, `errorTag`, and `causeTag`, while the public `diagnostics.error` keeps a **path-derived** message from `TraceFileReadError.message`. Tests assert that shape and the logged annotations when one rotated file fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626ccfee780347cc908726a718e9ef6f2fe530d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve trace file read causes as structured errors in `TraceDiagnostics`
> - Introduces `TraceFileReadError`, a tagged error class with `traceFilePath`, `causeTag`, and `cause` fields, replacing the previous `Failed` result payload for non-`NotFound` read errors.
> - `readTraceFile` now fails with `TraceFileReadError` (instead of returning a `Failed` result) when a trace file exists but cannot be read, while `NotFound` still yields a `Missing` result.
> - `TraceDiagnostics.read` logs a structured warning with `traceFilePath`, `errorTag`, and `causeTag` annotations on failure, and sets `diagnostics.error` to a standardized message with `kind: 'trace-file-read-failed'`.
> - Behavioral Change: callers relying on the `Failed` result shape will no longer receive it; failures now propagate as Effect failures and are surfaced in the error summary.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 626ccfe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->