### PR TITLE
[codex] Structure Electron app boundary failures

### DIFF
--- a/apps/desktop/src/electron/ElectronApp.test.ts
+++ b/apps/desktop/src/electron/ElectronApp.test.ts
@@ -100,6 +100,44 @@ describe("ElectronApp", () => {
     }).pipe(Effect.provide(ElectronApp.layer)),
   );
 
+  it.effect("reports which app metadata property failed", () =>
+    Effect.gen(function* () {
+      const cause = new Error("version unavailable");
+      getVersionMock.mockImplementationOnce(() => {
+        throw cause;
+      });
+
+      const electronApp = yield* ElectronApp.ElectronApp;
+      const error = yield* electronApp.metadata.pipe(Effect.flip);
+
+      assert.instanceOf(error, ElectronApp.ElectronAppMetadataReadError);
+      assert.strictEqual(error.property, "app-version");
+      assert.strictEqual(error.cause, cause);
+      assert.strictEqual(
+        error.message,
+        'Failed to read Electron app metadata property "app-version".',
+      );
+    }).pipe(Effect.provide(ElectronApp.layer)),
+  );
+
+  it.effect("preserves Electron readiness failures", () =>
+    Effect.gen(function* () {
+      const cause = new Error("ready failed");
+      whenReadyMock.mockRejectedValueOnce(cause);
+
+      const electronApp = yield* ElectronApp.ElectronApp;
+      const error = yield* electronApp.whenReady.pipe(Effect.flip);
+
+      assert.instanceOf(error, ElectronApp.ElectronAppWhenReadyError);
+      assert.strictEqual(error.isPackaged, true);
+      assert.strictEqual(error.cause, cause);
+      assert.strictEqual(
+        error.message,
+        "Failed to wait for the Electron app to become ready (packaged: true).",
+      );
+    }).pipe(Effect.provide(ElectronApp.layer)),
+  );
+
   it.effect("scopes app event listeners", () =>
     Effect.gen(function* () {
       const listener = vi.fn();

--- a/apps/desktop/src/electron/ElectronApp.ts
+++ b/apps/desktop/src/electron/ElectronApp.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 
 import * as Electron from "electron";
@@ -13,12 +14,36 @@ export interface ElectronAppMetadata {
   readonly runningUnderArm64Translation: boolean;
 }
 
+export class ElectronAppMetadataReadError extends Schema.TaggedErrorClass<ElectronAppMetadataReadError>()(
+  "ElectronAppMetadataReadError",
+  {
+    property: Schema.Literals(["app-version", "app-path"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read Electron app metadata property "${this.property}".`;
+  }
+}
+
+export class ElectronAppWhenReadyError extends Schema.TaggedErrorClass<ElectronAppWhenReadyError>()(
+  "ElectronAppWhenReadyError",
+  {
+    isPackaged: Schema.Boolean,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to wait for the Electron app to become ready (packaged: ${this.isPackaged}).`;
+  }
+}
+
 export class ElectronApp extends Context.Service<
   ElectronApp,
   {
-    readonly metadata: Effect.Effect<ElectronAppMetadata>;
+    readonly metadata: Effect.Effect<ElectronAppMetadata, ElectronAppMetadataReadError>;
     readonly name: Effect.Effect<string>;
-    readonly whenReady: Effect.Effect<void>;
+    readonly whenReady: Effect.Effect<void, ElectronAppWhenReadyError>;
     readonly quit: Effect.Effect<void>;
     readonly exit: (code: number) => Effect.Effect<void>;
     readonly relaunch: (options: Electron.RelaunchOptions) => Effect.Effect<void>;
@@ -63,15 +88,40 @@ const addScopedAppListener = <Args extends ReadonlyArray<unknown>>(
   ).pipe(Effect.asVoid);
 
 export const make = ElectronApp.of({
-  metadata: Effect.sync(() => ({
-    appVersion: Electron.app.getVersion(),
-    appPath: Electron.app.getAppPath(),
-    isPackaged: Electron.app.isPackaged,
-    resourcesPath: process.resourcesPath,
-    runningUnderArm64Translation: Electron.app.runningUnderARM64Translation === true,
-  })),
+  metadata: Effect.gen(function* () {
+    const appVersion = yield* Effect.try({
+      try: () => Electron.app.getVersion(),
+      catch: (cause) =>
+        new ElectronAppMetadataReadError({
+          property: "app-version",
+          cause,
+        }),
+    });
+    const appPath = yield* Effect.try({
+      try: () => Electron.app.getAppPath(),
+      catch: (cause) =>
+        new ElectronAppMetadataReadError({
+          property: "app-path",
+          cause,
+        }),
+    });
+
+    return {
+      appVersion,
+      appPath,
+      isPackaged: Electron.app.isPackaged,
+      resourcesPath: process.resourcesPath,
+      runningUnderArm64Translation: Electron.app.runningUnderARM64Translation === true,
+    };
+  }),
   name: Effect.sync(() => Electron.app.name),
-  whenReady: Effect.promise(() => Electron.app.whenReady()).pipe(Effect.asVoid),
+  whenReady: Effect.gen(function* () {
+    const isPackaged = Electron.app.isPackaged;
+    yield* Effect.tryPromise({
+      try: () => Electron.app.whenReady(),
+      catch: (cause) => new ElectronAppWhenReadyError({ isPackaged, cause }),
+    });
+  }),
   quit: Effect.sync(() => {
     Electron.app.quit();
   }),


### PR DESCRIPTION
## Summary
- add Schema-backed errors for Electron app metadata reads and readiness failures
- preserve the exact underlying cause while attaching the failed metadata property or packaged state
- keep construction direct at each boundary and cover both failure paths with focused tests

## Verification
- `vp test apps/desktop/src/electron/ElectronApp.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

## Open PR overlap audit
Audited every open PR with `gh pr list --limit 1000` and paginated per-PR files, checking both `filename` and `previous_filename`. These files are also touched by unrelated feature/fix PRs #2901, #2916, #2925, and #2679; none belongs to the Effect/error audit series.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized to the Electron app adapter and tests; startup already handles `whenReady` failures via `catchCause`, and success paths are unchanged.
> 
> **Overview**
> The `ElectronApp` service now surfaces **typed, Schema-backed errors** at two Electron boundaries instead of letting sync/promise failures escape as untyped defects.
> 
> **`metadata`** wraps `getVersion` and `getAppPath` in `Effect.try` and fails with `ElectronAppMetadataReadError`, which records which property (`app-version` or `app-path`) failed and keeps the original **cause**. **`whenReady`** uses `Effect.tryPromise` and maps rejections to `ElectronAppWhenReadyError` with **packaged state** and the underlying cause. The service API’s error channels are updated accordingly.
> 
> New unit tests assert error type, fields, messages, and cause preservation for a version read failure and a readiness rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41799e3e22eb9bc9fe98cafaa5bedd7166969027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured error types for `ElectronApp` metadata and readiness failures
> - Introduces `ElectronAppMetadataReadError` and `ElectronAppWhenReadyError` tagged error classes in [`ElectronApp.ts`](https://github.com/pingdotgg/t3code/pull/3301/files#diff-b1967bf80c9bfada48edbd76cf62f126b181a23dad547e1c4c25d999e2230f1e), each preserving the original cause and relevant context (`property` or `isPackaged`).
> - The `metadata` effect now individually wraps reads of `appVersion` and `appPath` via `Effect.try`, failing with a typed error instead of defecting on throw.
> - The `whenReady` effect wraps `Electron.app.whenReady()` via `Effect.tryPromise`, mapping rejections to `ElectronAppWhenReadyError` with the packaging state attached.
> - Tests in [`ElectronApp.test.ts`](https://github.com/pingdotgg/t3code/pull/3301/files#diff-6fda859c0bfb8079cad6433fbec3a0b1c884fefbca3e2ffd72636df9fa7c62c7) verify error type, cause propagation, and message content for both failure paths.
> - Behavioral Change: metadata and readiness failures now surface as typed errors in the Effect channel rather than untyped defects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41799e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->