### PR TITLE
[codex] Structure mobile native static-check failures

### DIFF
--- a/scripts/mobile-native-static-check.test.ts
+++ b/scripts/mobile-native-static-check.test.ts
@@ -1,0 +1,18 @@
+import { assert, it } from "@effect/vitest";
+
+import { NativeStaticCheckCommandError } from "./mobile-native-static-check.ts";
+
+it("describes failed native static-analysis commands structurally", () => {
+  const error = new NativeStaticCheckCommandError({
+    command: "swiftlint",
+    args: ["lint", "--strict"],
+    cwd: "/repo/apps/mobile",
+    exitCode: 2,
+  });
+
+  assert.equal(error.command, "swiftlint");
+  assert.deepStrictEqual(error.args, ["lint", "--strict"]);
+  assert.equal(error.cwd, "/repo/apps/mobile");
+  assert.equal(error.exitCode, 2);
+  assert.equal(error.message, "Native static check command 'swiftlint' exited with code 2.");
+});

--- a/scripts/mobile-native-static-check.ts
+++ b/scripts/mobile-native-static-check.ts
@@ -4,12 +4,12 @@ import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { isCommandAvailable, resolveSpawnCommand } from "@t3tools/shared/shell";
 import * as Console from "effect/Console";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Logger from "effect/Logger";
 import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
+import * as Schema from "effect/Schema";
 import { Command } from "effect/unstable/cli";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
@@ -18,9 +18,19 @@ interface NativeStaticTool {
   readonly installHint: string;
 }
 
-class NativeStaticCheckError extends Data.TaggedError("NativeStaticCheckError")<{
-  readonly message: string;
-}> {}
+export class NativeStaticCheckCommandError extends Schema.TaggedErrorClass<NativeStaticCheckCommandError>()(
+  "NativeStaticCheckCommandError",
+  {
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    cwd: Schema.String,
+    exitCode: Schema.Int,
+  },
+) {
+  override get message(): string {
+    return `Native static check command '${this.command}' exited with code ${this.exitCode}.`;
+  }
+}
 
 const tools = [
   {
@@ -85,8 +95,11 @@ const runCommand = Effect.fn("runCommand")(function* (
   const exitCode = Number(yield* child.exitCode);
 
   if (exitCode !== 0) {
-    return yield* new NativeStaticCheckError({
-      message: `Command exited with non-zero exit code (${exitCode})`,
+    return yield* new NativeStaticCheckCommandError({
+      command,
+      args,
+      cwd,
+      exitCode,
     });
   }
 });


### PR DESCRIPTION
## Summary

- replace the message-only native static-check failure with a schema-backed command error
- retain the requested command, arguments, working directory, and exit code as structured context
- keep non-zero exits cause-free because they are process results rather than thrown failures
- add focused coverage for the error shape and derived message

## Validation

- `vp test run scripts/mobile-native-static-check.test.ts` (1 test)
- `vp run lint:mobile`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to a dev CLI script’s error modeling and tests; no runtime product or security surface.
> 
> **Overview**
> Replaces the generic **message-only** native static-check failure with a **schema-backed** `NativeStaticCheckCommandError` that carries **command**, **args**, **cwd**, and **exitCode** when `swiftlint` / `ktlint` / `detekt` exit non-zero.
> 
> The error’s human-readable text is derived from those fields (e.g. which command failed and the exit code). A small Vitest file asserts the structured shape and message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1595e4aa4170aa9143bdfe8639f5ddfcb02a105. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure mobile native static-check failures into `NativeStaticCheckCommandError`
> Replaces `NativeStaticCheckError` (a `Data.TaggedError`) with `NativeStaticCheckCommandError` built using `Schema.TaggedErrorClass` in [mobile-native-static-check.ts](https://github.com/pingdotgg/t3code/pull/3302/files#diff-bf82146cd22581df064bfdf7f7976e8ae0ba18a655c5ceedcd0003f978f3d0fc). The new error exposes structured fields (`command`, `args`, `cwd`, `exitCode`) and a message getter that formats them. Adds a test in [mobile-native-static-check.test.ts](https://github.com/pingdotgg/t3code/pull/3302/files#diff-8f40ae6139a4821725818aca6ca89d2cb42142f10059af103b107d71b8888e02) asserting both the structured fields and the computed message. Behavioral Change: callers now receive a different error type and a different message format when a spawned command exits non-zero.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c1595e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->