### PR TITLE
[codex] Preserve desktop user-data probe failures

### DIFF
--- a/apps/desktop/src/app/DesktopAppIdentity.test.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.test.ts
@@ -4,6 +4,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
 
 import type * as Electron from "electron";
 
@@ -105,6 +106,7 @@ const withIdentity = <A, E, R>(
     readonly calls?: ElectronAppCalls;
     readonly environment?: TestEnvironmentInput;
     readonly legacyPathExists?: boolean;
+    readonly legacyPathProbeError?: PlatformError.PlatformError;
     readonly packageJson?: string;
     readonly pngIconPath?: Option.Option<string>;
   } = {},
@@ -121,7 +123,11 @@ const withIdentity = <A, E, R>(
         Layer.provideMerge(
           FileSystem.layerNoop({
             exists: (path) =>
-              Effect.succeed(input.legacyPathExists === true && path.includes("T3 Code (Alpha)")),
+              input.legacyPathProbeError
+                ? Effect.fail(input.legacyPathProbeError)
+                : Effect.succeed(
+                    input.legacyPathExists === true && path.includes("T3 Code (Alpha)"),
+                  ),
             readFileString: () =>
               Effect.succeed(input.packageJson ?? '{"t3codeCommitHash":"abcdef1234567890"}'),
           }),
@@ -146,6 +152,33 @@ describe("DesktopAppIdentity", () => {
       { legacyPathExists: true },
     ),
   );
+
+  it.effect("preserves failures while inspecting the legacy userData path", () => {
+    const legacyPath = "/Users/alice/Library/Application Support/T3 Code (Alpha)";
+    const cause = PlatformError.systemError({
+      _tag: "PermissionDenied",
+      module: "FileSystem",
+      method: "exists",
+      description: "permission denied",
+      pathOrDescriptor: legacyPath,
+    });
+
+    return withIdentity(
+      Effect.gen(function* () {
+        const identity = yield* DesktopAppIdentity.DesktopAppIdentity;
+        const error = yield* identity.resolveUserDataPath.pipe(Effect.flip);
+
+        assert.instanceOf(error, DesktopAppIdentity.DesktopUserDataPathResolutionError);
+        assert.equal(error.legacyPath, legacyPath);
+        assert.strictEqual(error.cause, cause);
+        assert.equal(
+          error.message,
+          `Failed to inspect legacy desktop user-data path at "${legacyPath}".`,
+        );
+      }),
+      { legacyPathProbeError: cause },
+    );
+  });
 
   it.effect("configures app identity from the environment commit override", () => {
     const calls: ElectronAppCalls = {

--- a/apps/desktop/src/app/DesktopAppIdentity.ts
+++ b/apps/desktop/src/app/DesktopAppIdentity.ts
@@ -18,10 +18,22 @@ const AppPackageMetadata = Schema.Struct({
 });
 const decodeAppPackageMetadata = Schema.decodeEffect(Schema.fromJsonString(AppPackageMetadata));
 
+export class DesktopUserDataPathResolutionError extends Schema.TaggedErrorClass<DesktopUserDataPathResolutionError>()(
+  "DesktopUserDataPathResolutionError",
+  {
+    legacyPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to inspect legacy desktop user-data path at "${this.legacyPath}".`;
+  }
+}
+
 export class DesktopAppIdentity extends Context.Service<
   DesktopAppIdentity,
   {
-    readonly resolveUserDataPath: Effect.Effect<string>;
+    readonly resolveUserDataPath: Effect.Effect<string, DesktopUserDataPathResolutionError>;
     readonly configure: Effect.Effect<void>;
   }
 >()("@t3tools/desktop/app/DesktopAppIdentity") {}
@@ -33,7 +45,7 @@ const normalizeCommitHash = (value: string): Option.Option<string> => {
     : Option.none();
 };
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const assets = yield* DesktopAssets.DesktopAssets;
   const electronApp = yield* ElectronApp.ElectronApp;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
@@ -83,9 +95,15 @@ const make = Effect.gen(function* () {
       environment.appDataDirectory,
       environment.legacyUserDataDirName,
     );
-    const legacyPathExists = yield* fileSystem
-      .exists(legacyPath)
-      .pipe(Effect.orElseSucceed(() => false));
+    const legacyPathExists = yield* fileSystem.exists(legacyPath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DesktopUserDataPathResolutionError({
+            legacyPath,
+            cause,
+          }),
+      ),
+    );
     return legacyPathExists
       ? legacyPath
       : environment.path.join(environment.appDataDirectory, environment.userDataDirName);


### PR DESCRIPTION
## Summary
- stop treating every legacy user-data path probe failure as path absence
- add a Schema-backed error carrying the inspected path and exact filesystem cause
- keep genuine path absence as the existing `false` result and cover permission failure with one focused test
- export the existing service `make` value to match module conventions

## Verification
- `vp test apps/desktop/src/app/DesktopAppIdentity.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

## Open PR overlap audit
Audited every open PR with `gh pr list --limit 1000` and paginated per-PR files, checking both `filename` and `previous_filename`. The test file is also touched by unrelated feature/fix PRs #2901, #2916, #2925, and #2679; the source file has no open-PR overlap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes early startup path selection in `DesktopApp`; mis-handled errors could block launch, but the new behavior avoids silently using the wrong user-data directory on probe failures.
> 
> **Overview**
> **Legacy user-data path resolution** no longer swallows filesystem errors from `exists` on the alpha directory. Probe failures now surface as `DesktopUserDataPathResolutionError` (path + underlying cause) instead of being treated like “path missing” and falling through to the new user-data dir.
> 
> `resolveUserDataPath` is typed to fail with that error; `make` is exported for module conventions. Tests simulate permission-denied probes and assert the error shape and message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da565b0a0b5817ea78ab686b594a79aeebf77071. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve `FileSystem.exists` probe failures in `DesktopAppIdentity.resolveUserDataPath`
> - Introduces `DesktopUserDataPathResolutionError` to surface failures when probing the legacy desktop user-data path via `FileSystem.exists`.
> - Previously, any error from `FileSystem.exists` was swallowed and treated as "path does not exist", silently returning the non-legacy path. Now the error is mapped and propagated.
> - `resolveUserDataPath` in the `DesktopAppIdentity` service interface now has a typed failure channel of `DesktopUserDataPathResolutionError` instead of being infallible.
> - Behavioral Change: callers of `resolveUserDataPath` must now handle the new failure case; code that previously always received a success value may now receive an error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da565b0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->