### PR TITLE
[codex] Structure relay activity-row persistence errors

### DIFF
--- a/infra/relay/src/agentActivity/AgentActivityRows.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.test.ts
@@ -1,0 +1,84 @@
+import type { RelayAgentActivityState } from "@t3tools/contracts/relay";
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import * as RelayDb from "../db.ts";
+import * as AgentActivityRows from "./AgentActivityRows.ts";
+
+const state: RelayAgentActivityState = {
+  environmentId: "env-1" as RelayAgentActivityState["environmentId"],
+  threadId: "thread-1" as RelayAgentActivityState["threadId"],
+  projectTitle: "Project",
+  threadTitle: "Thread",
+  modelTitle: "gpt-5.4",
+  phase: "running",
+  headline: "Running",
+  updatedAt: "2026-06-20T00:00:00.000Z",
+  deepLink: "/threads/env-1/thread-1",
+};
+
+describe("AgentActivityRows", () => {
+  it.effect("preserves activity context on persistence failures", () => {
+    const cause = new Error("database unavailable");
+    const failingDb = {
+      insert: () => ({
+        values: () => ({
+          onConflictDoUpdate: () => Effect.fail(cause),
+        }),
+      }),
+      delete: () => ({
+        where: () => Effect.fail(cause),
+      }),
+      select: () => ({
+        from: () => ({
+          innerJoin: () => ({
+            where: () => ({
+              orderBy: () => Effect.fail(cause),
+            }),
+          }),
+        }),
+      }),
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const rows = yield* AgentActivityRows.AgentActivityRows;
+
+      const upsertError = yield* rows
+        .upsert({ environmentPublicKey: "public-key", state })
+        .pipe(Effect.flip);
+      expect(upsertError).toMatchObject({
+        environmentId: "env-1",
+        threadId: "thread-1",
+        cause,
+      });
+      expect(upsertError.message).toBe(
+        "Failed to persist agent activity state for environment env-1, thread thread-1.",
+      );
+
+      const deleteError = yield* rows
+        .remove({
+          environmentId: "env-1",
+          environmentPublicKey: "public-key",
+          threadId: "thread-1",
+        })
+        .pipe(Effect.flip);
+      expect(deleteError).toMatchObject({
+        environmentId: "env-1",
+        threadId: "thread-1",
+        cause,
+      });
+      expect(deleteError.message).toBe(
+        "Failed to delete agent activity state for environment env-1, thread thread-1.",
+      );
+
+      const listError = yield* rows.listForUser({ userId: "user-2" }).pipe(Effect.flip);
+      expect(listError).toMatchObject({ userId: "user-2", cause });
+      expect(listError.message).toBe("Failed to list agent activity state for user user-2.");
+    }).pipe(
+      Effect.provide(
+        AgentActivityRows.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, failingDb))),
+      ),
+    );
+  });
+});

--- a/infra/relay/src/agentActivity/AgentActivityRows.ts
+++ b/infra/relay/src/agentActivity/AgentActivityRows.ts
@@ -14,28 +14,39 @@ import { relayAgentActivityRows, relayEnvironmentLinks } from "../persistence/sc
 
 export class AgentActivityRowUpsertPersistenceError extends Schema.TaggedErrorClass<AgentActivityRowUpsertPersistenceError>()(
   "AgentActivityRowUpsertPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    environmentId: Schema.String,
+    threadId: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to persist agent activity state";
+    return `Failed to persist agent activity state for environment ${this.environmentId}, thread ${this.threadId}.`;
   }
 }
 
 export class AgentActivityRowDeletePersistenceError extends Schema.TaggedErrorClass<AgentActivityRowDeletePersistenceError>()(
   "AgentActivityRowDeletePersistenceError",
-  { cause: Schema.Defect() },
+  {
+    environmentId: Schema.String,
+    threadId: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to delete agent activity state";
+    return `Failed to delete agent activity state for environment ${this.environmentId}, thread ${this.threadId}.`;
   }
 }
 
 export class AgentActivityRowListPersistenceError extends Schema.TaggedErrorClass<AgentActivityRowListPersistenceError>()(
   "AgentActivityRowListPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    userId: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to list agent activity state";
+    return `Failed to list agent activity state for user ${this.userId}.`;
   }
 }
 
@@ -75,41 +86,56 @@ export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
 
   return AgentActivityRows.of({
-    upsert: Effect.fn("relay.agent_activity_rows.upsert")(
-      function* (input) {
-        yield* Effect.annotateCurrentSpan({
-          "relay.environment_id": input.state.environmentId,
-          "relay.thread_id": input.state.threadId,
-        });
-        const now = yield* DateTime.now;
-        const stateJson = yield* encodeRelayAgentActivityStateJson(input.state).pipe(
-          Effect.flatMap(decodeJsonString),
-          Effect.map(Function.cast<unknown, RelayAgentActivityState>),
-        );
-        yield* db
-          .insert(relayAgentActivityRows)
-          .values({
-            environmentId: input.state.environmentId,
-            environmentPublicKey: input.environmentPublicKey,
-            threadId: input.state.threadId,
+    upsert: Effect.fn("relay.agent_activity_rows.upsert")(function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "relay.environment_id": input.state.environmentId,
+        "relay.thread_id": input.state.threadId,
+      });
+      const now = yield* DateTime.now;
+      const stateJson = yield* encodeRelayAgentActivityStateJson(input.state).pipe(
+        Effect.flatMap(decodeJsonString),
+        Effect.map(Function.cast<unknown, RelayAgentActivityState>),
+        Effect.mapError(
+          (cause) =>
+            new AgentActivityRowUpsertPersistenceError({
+              environmentId: input.state.environmentId,
+              threadId: input.state.threadId,
+              cause,
+            }),
+        ),
+      );
+      yield* db
+        .insert(relayAgentActivityRows)
+        .values({
+          environmentId: input.state.environmentId,
+          environmentPublicKey: input.environmentPublicKey,
+          threadId: input.state.threadId,
+          stateJson,
+          updatedAt: input.state.updatedAt,
+          createdAt: DateTime.formatIso(now),
+        })
+        .onConflictDoUpdate({
+          target: [
+            relayAgentActivityRows.environmentId,
+            relayAgentActivityRows.environmentPublicKey,
+            relayAgentActivityRows.threadId,
+          ],
+          set: {
             stateJson,
             updatedAt: input.state.updatedAt,
-            createdAt: DateTime.formatIso(now),
-          })
-          .onConflictDoUpdate({
-            target: [
-              relayAgentActivityRows.environmentId,
-              relayAgentActivityRows.environmentPublicKey,
-              relayAgentActivityRows.threadId,
-            ],
-            set: {
-              stateJson,
-              updatedAt: input.state.updatedAt,
-            },
-          });
-      },
-      Effect.mapError((cause) => new AgentActivityRowUpsertPersistenceError({ cause })),
-    ),
+          },
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new AgentActivityRowUpsertPersistenceError({
+                environmentId: input.state.environmentId,
+                threadId: input.state.threadId,
+                cause,
+              }),
+          ),
+        );
+    }),
 
     remove: Effect.fn("relay.agent_activity_rows.remove")(function* (input) {
       yield* Effect.annotateCurrentSpan({
@@ -125,7 +151,16 @@ export const make = Effect.gen(function* () {
             eq(relayAgentActivityRows.threadId, input.threadId),
           ),
         )
-        .pipe(Effect.mapError((cause) => new AgentActivityRowDeletePersistenceError({ cause })));
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new AgentActivityRowDeletePersistenceError({
+                environmentId: input.environmentId,
+                threadId: input.threadId,
+                cause,
+              }),
+          ),
+        );
     }),
 
     listForUser: Effect.fn("relay.agent_activity_rows.list_for_user")(function* (input) {
@@ -159,7 +194,13 @@ export const make = Effect.gen(function* () {
           Effect.map((rows) =>
             rows.flatMap((row) => Option.toArray(decodeRelayAgentActivityStateJson(row))),
           ),
-          Effect.mapError((cause) => new AgentActivityRowListPersistenceError({ cause })),
+          Effect.mapError(
+            (cause) =>
+              new AgentActivityRowListPersistenceError({
+                userId: input.userId,
+                cause,
+              }),
+          ),
         );
     }),
   });

--- a/infra/relay/src/agentActivity/MobileRegistrations.test.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.test.ts
@@ -249,6 +249,7 @@ describe("MobileRegistrations", () => {
                     replayForLiveActivityRegistration: () =>
                       Effect.fail(
                         new AgentActivityRows.AgentActivityRowListPersistenceError({
+                          userId: "dev:julius",
                           cause: "replay failed",
                         }),
                       ),


### PR DESCRIPTION
## Summary
- attach environment and thread identifiers to activity-row upsert/delete failures
- attach the user identifier to activity-row list failures
- preserve the original persistence or encoding cause and derive messages from structured fields
- cover each activity-row failure boundary with focused service-layer tests

## Consolidation
- removed the overlapping `Devices` changes; the more precise stage-aware device diagnostics remain isolated in #3344

## Validation
- `vp test src/agentActivity/AgentActivityRows.test.ts src/agentActivity/MobileRegistrations.test.ts` from `infra/relay` (6 tests)
- `vp check`
- `vp run typecheck`
- `vpr typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to error shapes and mapping; success paths and persistence logic are unchanged.
> 
> **Overview**
> Relay **agent activity row** persistence failures now carry structured identifiers and clearer messages instead of generic errors with only a `cause`.
> 
> **Upsert** and **delete** errors include `environmentId` and `threadId`; **list** errors include `userId`. Messages are derived from those fields (e.g. persist/delete name the environment and thread; list names the user). The original defect is still attached as `cause`, including when state JSON encoding fails on upsert.
> 
> A new **AgentActivityRows** service test asserts upsert, remove, and `listForUser` all surface the right context when the DB layer fails. **MobileRegistrations** tests were updated so mocked `AgentActivityRowListPersistenceError` includes `userId`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57e0304996b95afe65095a6e0b38637eeac8eec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure relay agent activity row persistence errors with contextual fields
> Adds `environmentId`, `threadId`, and `userId` fields to the `AgentActivityRowUpsertPersistenceError`, `AgentActivityRowDeletePersistenceError`, and `AgentActivityRowListPersistenceError` classes in [AgentActivityRows.ts](https://github.com/pingdotgg/t3code/pull/3305/files#diff-0c3320c24b3ea3e4c1c221776bf499f81cadd0fa30f1622749621cde23860018). Each error class now overrides `message` to include the relevant IDs, making persistence failures easier to diagnose. Error handling in `upsert`, `remove`, and `listForUser` is updated to populate these fields consistently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57e0304.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->