### PR TITLE
[codex] Structure telemetry identity errors

### DIFF
--- a/apps/server/src/telemetry/Identify.test.ts
+++ b/apps/server/src/telemetry/Identify.test.ts
@@ -1,0 +1,151 @@
+import * as NodeCrypto from "node:crypto";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as References from "effect/References";
+import * as Schema from "effect/Schema";
+
+import * as ServerConfig from "../config.ts";
+import * as Identify from "./Identify.ts";
+
+interface CapturedLog {
+  readonly message: unknown;
+  readonly annotations: Readonly<Record<string, unknown>>;
+}
+
+const sha256 = (value: string) =>
+  NodeCrypto.createHash("sha256").update(value, "utf8").digest("hex");
+
+const isTelemetryIdentityDecodeError = Schema.is(Identify.TelemetryIdentityDecodeError);
+const isTelemetryIdentityReadError = Schema.is(Identify.TelemetryIdentityReadError);
+
+const makeCaptureLogger = (logs: CapturedLog[]) =>
+  Logger.make(({ fiber, message }) => {
+    logs.push({
+      message,
+      annotations: fiber.getRef(References.CurrentLogAnnotations),
+    });
+  });
+
+const findIdentityLog = (
+  logs: ReadonlyArray<CapturedLog>,
+  source: Identify.TelemetryIdentitySource,
+  operation: string,
+) =>
+  logs.find((log) => log.annotations.source === source && log.annotations.operation === operation);
+
+it.layer(NodeServices.layer)("telemetry identity", (it) => {
+  it.effect("uses the persisted anonymous id when provider identities are absent", () =>
+    Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const anonymousId = "persisted-anonymous-id";
+
+      yield* fileSystem.writeFileString(config.anonymousIdPath, anonymousId);
+
+      const identifier = yield* Identify.getTelemetryIdentifierForHome(
+        path.join(config.baseDir, "home"),
+      );
+
+      assert.equal(identifier, sha256(anonymousId));
+    }).pipe(
+      Effect.provide(
+        ServerConfig.layerTest(process.cwd(), {
+          prefix: "t3-telemetry-identify-anonymous-",
+        }),
+      ),
+    ),
+  );
+
+  it.effect("logs structured decode context and falls back from malformed Codex auth", () => {
+    const logs: CapturedLog[] = [];
+    const logger = makeCaptureLogger(logs);
+
+    return Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const homeDirectory = path.join(config.baseDir, "home");
+      const codexAuthPath = path.join(homeDirectory, ".codex", "auth.json");
+      const anonymousId = "decode-fallback-anonymous-id";
+
+      yield* fileSystem.makeDirectory(path.dirname(codexAuthPath), { recursive: true });
+      yield* fileSystem.writeFileString(codexAuthPath, '{"tokens":{}}');
+      yield* fileSystem.writeFileString(config.anonymousIdPath, anonymousId);
+
+      const identifier = yield* Identify.getTelemetryIdentifierForHome(homeDirectory);
+
+      assert.equal(identifier, sha256(anonymousId));
+      const decodeLog = findIdentityLog(logs, "codex", "decode");
+      assert.isDefined(decodeLog);
+      assert.equal(
+        decodeLog?.message,
+        `Failed to decode codex telemetry identity at '${codexAuthPath}'.`,
+      );
+
+      const error = decodeLog?.annotations.cause;
+      assert.instanceOf(error, Identify.TelemetryIdentityDecodeError);
+      if (isTelemetryIdentityDecodeError(error)) {
+        assert.equal(error.filePath, codexAuthPath);
+        assert.equal(error.source, "codex");
+        assert.instanceOf(error.cause, Schema.SchemaError);
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          ServerConfig.layerTest(process.cwd(), {
+            prefix: "t3-telemetry-identify-decode-",
+          }),
+          Logger.layer([logger], { mergeWithExisting: false }),
+        ),
+      ),
+    );
+  });
+
+  it.effect("does not overwrite the anonymous id path after a non-NotFound read failure", () => {
+    const logs: CapturedLog[] = [];
+    const logger = makeCaptureLogger(logs);
+
+    return Effect.gen(function* () {
+      const config = yield* ServerConfig.ServerConfig;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const homeDirectory = path.join(config.baseDir, "home");
+
+      yield* fileSystem.makeDirectory(config.anonymousIdPath);
+
+      const identifier = yield* Identify.getTelemetryIdentifierForHome(homeDirectory);
+
+      assert.isNull(identifier);
+      assert.deepEqual(yield* fileSystem.readDirectory(config.anonymousIdPath), []);
+
+      const readLog = findIdentityLog(logs, "anonymous", "read");
+      assert.isDefined(readLog);
+      const error = readLog?.annotations.cause;
+      assert.instanceOf(error, Identify.TelemetryIdentityReadError);
+      if (isTelemetryIdentityReadError(error)) {
+        assert.equal(error.filePath, config.anonymousIdPath);
+        assert.instanceOf(error.cause, PlatformError.PlatformError);
+        if (error.cause instanceof PlatformError.PlatformError) {
+          assert.notEqual(error.cause.reason._tag, "NotFound");
+        }
+      }
+      assert.isUndefined(findIdentityLog(logs, "anonymous", "write"));
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          ServerConfig.layerTest(process.cwd(), {
+            prefix: "t3-telemetry-identify-read-",
+          }),
+          Logger.layer([logger], { mergeWithExisting: false }),
+        ),
+      ),
+    );
+  });
+});

--- a/apps/server/src/telemetry/Identify.test.ts
+++ b/apps/server/src/telemetry/Identify.test.ts
@@ -6,9 +6,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Path from "effect/Path";
-import * as PlatformError from "effect/PlatformError";
 import * as References from "effect/References";
-import * as Schema from "effect/Schema";
 
 import * as ServerConfig from "../config.ts";
 import * as Identify from "./Identify.ts";
@@ -20,9 +18,6 @@ interface CapturedLog {
 
 const sha256 = (value: string) =>
   NodeCrypto.createHash("sha256").update(value, "utf8").digest("hex");
-
-const isTelemetryIdentityDecodeError = Schema.is(Identify.TelemetryIdentityDecodeError);
-const isTelemetryIdentityReadError = Schema.is(Identify.TelemetryIdentityReadError);
 
 const makeCaptureLogger = (logs: CapturedLog[]) =>
   Logger.make(({ fiber, message }) => {
@@ -37,6 +32,26 @@ const findIdentityLog = (
   source: Identify.TelemetryIdentitySource,
   errorTag: string,
 ) => logs.find((log) => log.annotations.source === source && log.annotations.errorTag === errorTag);
+
+it("preserves exact telemetry identity causes without deriving messages from them", () => {
+  const decodeCause = new Error("private nested decode details");
+  const decodeError = new Identify.TelemetryIdentityDecodeError({
+    source: "codex",
+    filePath: "/tmp/auth.json",
+    cause: decodeCause,
+  });
+  const readCause = new Error("private nested read details");
+  const readError = new Identify.TelemetryIdentityReadError({
+    source: "anonymous",
+    filePath: "/tmp/anonymous-id",
+    cause: readCause,
+  });
+
+  assert.strictEqual(decodeError.cause, decodeCause);
+  assert.strictEqual(readError.cause, readCause);
+  assert.notInclude(decodeError.message, decodeCause.message);
+  assert.notInclude(readError.message, readCause.message);
+});
 
 it.layer(NodeServices.layer)("telemetry identity", (it) => {
   it.effect("uses the persisted anonymous id when provider identities are absent", () =>
@@ -73,9 +88,13 @@ it.layer(NodeServices.layer)("telemetry identity", (it) => {
       const homeDirectory = path.join(config.baseDir, "home");
       const codexAuthPath = path.join(homeDirectory, ".codex", "auth.json");
       const anonymousId = "decode-fallback-anonymous-id";
+      const privateAccessToken = "private-codex-access-token";
 
       yield* fileSystem.makeDirectory(path.dirname(codexAuthPath), { recursive: true });
-      yield* fileSystem.writeFileString(codexAuthPath, '{"tokens":{}}');
+      yield* fileSystem.writeFileString(
+        codexAuthPath,
+        `{"tokens":{"access_token":"${privateAccessToken}"}}`,
+      );
       yield* fileSystem.writeFileString(config.anonymousIdPath, anonymousId);
 
       const identifier = yield* Identify.getTelemetryIdentifierForHome(homeDirectory);
@@ -88,13 +107,16 @@ it.layer(NodeServices.layer)("telemetry identity", (it) => {
         `Failed to decode codex telemetry identity at '${codexAuthPath}'.`,
       );
 
-      const error = decodeLog?.annotations.cause;
-      assert.instanceOf(error, Identify.TelemetryIdentityDecodeError);
-      if (isTelemetryIdentityDecodeError(error)) {
-        assert.equal(error.filePath, codexAuthPath);
-        assert.equal(error.source, "codex");
-        assert.instanceOf(error.cause, Schema.SchemaError);
-      }
+      assert.equal(decodeLog?.annotations.filePath, codexAuthPath);
+      assert.equal(decodeLog?.annotations.causeKind, "schema");
+      assert.notProperty(decodeLog?.annotations ?? {}, "cause");
+      const errorStack = decodeLog?.annotations.errorStack;
+      assert.isString(errorStack);
+      assert.include(errorStack, "Failed to decode codex telemetry identity");
+      const annotations = Object.values(decodeLog?.annotations ?? {})
+        .map(String)
+        .join("\n");
+      assert.notInclude(annotations, privateAccessToken);
     }).pipe(
       Effect.provide(
         Layer.merge(
@@ -126,15 +148,13 @@ it.layer(NodeServices.layer)("telemetry identity", (it) => {
 
       const readLog = findIdentityLog(logs, "anonymous", "TelemetryIdentityReadError");
       assert.isDefined(readLog);
-      const error = readLog?.annotations.cause;
-      assert.instanceOf(error, Identify.TelemetryIdentityReadError);
-      if (isTelemetryIdentityReadError(error)) {
-        assert.equal(error.filePath, config.anonymousIdPath);
-        assert.instanceOf(error.cause, PlatformError.PlatformError);
-        if (error.cause instanceof PlatformError.PlatformError) {
-          assert.notEqual(error.cause.reason._tag, "NotFound");
-        }
-      }
+      assert.equal(readLog?.annotations.filePath, config.anonymousIdPath);
+      assert.equal(readLog?.annotations.causeKind, "platform");
+      assert.notEqual(readLog?.annotations.platformReason, "NotFound");
+      assert.notProperty(readLog?.annotations ?? {}, "cause");
+      const errorStack = readLog?.annotations.errorStack;
+      assert.isString(errorStack);
+      assert.include(errorStack, "Failed to read anonymous telemetry identity");
       assert.isUndefined(
         findIdentityLog(logs, "anonymous", "TelemetryAnonymousIdPersistenceError"),
       );

--- a/apps/server/src/telemetry/Identify.test.ts
+++ b/apps/server/src/telemetry/Identify.test.ts
@@ -35,9 +35,8 @@ const makeCaptureLogger = (logs: CapturedLog[]) =>
 const findIdentityLog = (
   logs: ReadonlyArray<CapturedLog>,
   source: Identify.TelemetryIdentitySource,
-  operation: string,
-) =>
-  logs.find((log) => log.annotations.source === source && log.annotations.operation === operation);
+  errorTag: string,
+) => logs.find((log) => log.annotations.source === source && log.annotations.errorTag === errorTag);
 
 it.layer(NodeServices.layer)("telemetry identity", (it) => {
   it.effect("uses the persisted anonymous id when provider identities are absent", () =>
@@ -82,7 +81,7 @@ it.layer(NodeServices.layer)("telemetry identity", (it) => {
       const identifier = yield* Identify.getTelemetryIdentifierForHome(homeDirectory);
 
       assert.equal(identifier, sha256(anonymousId));
-      const decodeLog = findIdentityLog(logs, "codex", "decode");
+      const decodeLog = findIdentityLog(logs, "codex", "TelemetryIdentityDecodeError");
       assert.isDefined(decodeLog);
       assert.equal(
         decodeLog?.message,
@@ -125,7 +124,7 @@ it.layer(NodeServices.layer)("telemetry identity", (it) => {
       assert.isNull(identifier);
       assert.deepEqual(yield* fileSystem.readDirectory(config.anonymousIdPath), []);
 
-      const readLog = findIdentityLog(logs, "anonymous", "read");
+      const readLog = findIdentityLog(logs, "anonymous", "TelemetryIdentityReadError");
       assert.isDefined(readLog);
       const error = readLog?.annotations.cause;
       assert.instanceOf(error, Identify.TelemetryIdentityReadError);
@@ -136,7 +135,9 @@ it.layer(NodeServices.layer)("telemetry identity", (it) => {
           assert.notEqual(error.cause.reason._tag, "NotFound");
         }
       }
-      assert.isUndefined(findIdentityLog(logs, "anonymous", "write"));
+      assert.isUndefined(
+        findIdentityLog(logs, "anonymous", "TelemetryAnonymousIdPersistenceError"),
+      );
     }).pipe(
       Effect.provide(
         Layer.merge(

--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -3,7 +3,9 @@ import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 
 import * as ServerConfig from "../config.ts";
@@ -18,66 +20,222 @@ const ClaudeJsonSchema = Schema.Struct({
   userID: Schema.String,
 });
 
-class IdentifyUserError extends Schema.TaggedErrorClass<IdentifyUserError>()("IdentifyUserError", {
-  operation: Schema.Literal("hash_identifier"),
-  algorithm: Schema.Literal("SHA-256"),
-  cause: Schema.Defect(),
-}) {
+export const TelemetryIdentitySource = Schema.Literals(["codex", "claude", "anonymous"]);
+export type TelemetryIdentitySource = typeof TelemetryIdentitySource.Type;
+
+export class TelemetryIdentityReadError extends Schema.TaggedErrorClass<TelemetryIdentityReadError>()(
+  "TelemetryIdentityReadError",
+  {
+    operation: Schema.Literal("read"),
+    source: TelemetryIdentitySource,
+    filePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
   override get message(): string {
-    return `Failed to hash telemetry identifier with ${this.algorithm}.`;
+    return `Failed to read ${this.source} telemetry identity at '${this.filePath}'.`;
   }
 }
 
-const hash = (value: string) =>
+export class TelemetryIdentityDecodeError extends Schema.TaggedErrorClass<TelemetryIdentityDecodeError>()(
+  "TelemetryIdentityDecodeError",
+  {
+    operation: Schema.Literal("decode"),
+    source: Schema.Literals(["codex", "claude"]),
+    filePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to decode ${this.source} telemetry identity at '${this.filePath}'.`;
+  }
+}
+
+export class TelemetryAnonymousIdGenerationError extends Schema.TaggedErrorClass<TelemetryAnonymousIdGenerationError>()(
+  "TelemetryAnonymousIdGenerationError",
+  {
+    operation: Schema.Literal("generate"),
+    source: Schema.Literal("anonymous"),
+    filePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to generate anonymous telemetry identity for '${this.filePath}'.`;
+  }
+}
+
+export class TelemetryAnonymousIdPersistenceError extends Schema.TaggedErrorClass<TelemetryAnonymousIdPersistenceError>()(
+  "TelemetryAnonymousIdPersistenceError",
+  {
+    operation: Schema.Literal("write"),
+    source: Schema.Literal("anonymous"),
+    filePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to persist anonymous telemetry identity at '${this.filePath}'.`;
+  }
+}
+
+export class TelemetryIdentityHashError extends Schema.TaggedErrorClass<TelemetryIdentityHashError>()(
+  "TelemetryIdentityHashError",
+  {
+    operation: Schema.Literal("hash"),
+    source: TelemetryIdentitySource,
+    algorithm: Schema.Literal("SHA-256"),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to hash ${this.source} telemetry identity with ${this.algorithm}.`;
+  }
+}
+
+type TelemetryIdentityError =
+  | TelemetryIdentityReadError
+  | TelemetryIdentityDecodeError
+  | TelemetryAnonymousIdGenerationError
+  | TelemetryAnonymousIdPersistenceError
+  | TelemetryIdentityHashError;
+
+const decodeCodexAuthJson = Schema.decodeEffect(Schema.fromJsonString(CodexAuthJsonSchema));
+const decodeClaudeJson = Schema.decodeEffect(Schema.fromJsonString(ClaudeJsonSchema));
+
+function isNotFoundError(error: PlatformError.PlatformError): boolean {
+  return error.reason._tag === "NotFound";
+}
+
+const logTelemetryIdentityError = (error: TelemetryIdentityError) =>
+  Effect.logWarning(error.message).pipe(
+    Effect.annotateLogs({
+      operation: error.operation,
+      source: error.source,
+      ...("filePath" in error ? { filePath: error.filePath } : {}),
+      cause: error,
+    }),
+  );
+
+const readIdentityFile = (
+  fileSystem: FileSystem.FileSystem,
+  source: TelemetryIdentitySource,
+  filePath: string,
+) =>
+  fileSystem.readFileString(filePath).pipe(
+    Effect.map(Option.some),
+    Effect.catchTags({
+      PlatformError: (cause) =>
+        isNotFoundError(cause)
+          ? Effect.succeed(Option.none<string>())
+          : Effect.fail(
+              new TelemetryIdentityReadError({
+                operation: "read",
+                source,
+                filePath,
+                cause,
+              }),
+            ),
+    }),
+  );
+
+const hash = (source: TelemetryIdentitySource, value: string) =>
   Crypto.Crypto.pipe(
     Effect.flatMap((crypto) => crypto.digest("SHA-256", new TextEncoder().encode(value))),
     Effect.map(Encoding.encodeHex),
     Effect.mapError(
       (cause) =>
-        new IdentifyUserError({
-          operation: "hash_identifier",
+        new TelemetryIdentityHashError({
+          operation: "hash",
+          source,
           algorithm: "SHA-256",
           cause,
         }),
     ),
   );
 
-const getCodexAccountId = Effect.gen(function* () {
+const getCodexAccountId = Effect.fn("TelemetryIdentity.getCodexAccountId")(function* (
+  homeDirectory: string,
+) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
 
-  const authJsonPath = path.join(NodeOS.homedir(), ".codex", "auth.json");
-  const authJson = yield* Effect.flatMap(
-    fileSystem.readFileString(authJsonPath),
-    Schema.decodeEffect(Schema.fromJsonString(CodexAuthJsonSchema)),
+  const authJsonPath = path.join(homeDirectory, ".codex", "auth.json");
+  const encoded = yield* readIdentityFile(fileSystem, "codex", authJsonPath);
+  if (Option.isNone(encoded)) {
+    return Option.none<string>();
+  }
+  const authJson = yield* decodeCodexAuthJson(encoded.value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new TelemetryIdentityDecodeError({
+          operation: "decode",
+          source: "codex",
+          filePath: authJsonPath,
+          cause,
+        }),
+    ),
   );
 
-  return authJson.tokens.account_id;
+  return Option.some(authJson.tokens.account_id);
 });
 
-const getClaudeUserId = Effect.gen(function* () {
+const getClaudeUserId = Effect.fn("TelemetryIdentity.getClaudeUserId")(function* (
+  homeDirectory: string,
+) {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
 
-  const claudeJsonPath = path.join(NodeOS.homedir(), ".claude.json");
-  const claudeJson = yield* Effect.flatMap(
-    fileSystem.readFileString(claudeJsonPath),
-    Schema.decodeEffect(Schema.fromJsonString(ClaudeJsonSchema)),
+  const claudeJsonPath = path.join(homeDirectory, ".claude.json");
+  const encoded = yield* readIdentityFile(fileSystem, "claude", claudeJsonPath);
+  if (Option.isNone(encoded)) {
+    return Option.none<string>();
+  }
+  const claudeJson = yield* decodeClaudeJson(encoded.value).pipe(
+    Effect.mapError(
+      (cause) =>
+        new TelemetryIdentityDecodeError({
+          operation: "decode",
+          source: "claude",
+          filePath: claudeJsonPath,
+          cause,
+        }),
+    ),
   );
 
-  return claudeJson.userID;
+  return Option.some(claudeJson.userID);
 });
 
 const upsertAnonymousId = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const { anonymousIdPath } = yield* ServerConfig.ServerConfig;
 
-  const anonymousId = yield* fileSystem.readFileString(anonymousIdPath).pipe(
-    Effect.catch(() =>
-      Crypto.Crypto.pipe(
-        Effect.flatMap((crypto) => crypto.randomUUIDv4),
-        Effect.tap((randomId) => fileSystem.writeFileString(anonymousIdPath, randomId)),
-      ),
+  const existing = yield* readIdentityFile(fileSystem, "anonymous", anonymousIdPath);
+  if (Option.isSome(existing)) {
+    return existing.value;
+  }
+
+  const anonymousId = yield* Crypto.Crypto.pipe(
+    Effect.flatMap((crypto) => crypto.randomUUIDv4),
+    Effect.mapError(
+      (cause) =>
+        new TelemetryAnonymousIdGenerationError({
+          operation: "generate",
+          source: "anonymous",
+          filePath: anonymousIdPath,
+          cause,
+        }),
+    ),
+  );
+  yield* fileSystem.writeFileString(anonymousIdPath, anonymousId).pipe(
+    Effect.mapError(
+      (cause) =>
+        new TelemetryAnonymousIdPersistenceError({
+          operation: "write",
+          source: "anonymous",
+          filePath: anonymousIdPath,
+          cause,
+        }),
     ),
   );
 
@@ -90,24 +248,53 @@ const upsertAnonymousId = Effect.gen(function* () {
  * 2. ~/.claude.json userID
  * 3. ~/.t3/telemetry/anonymous-id
  */
-export const getTelemetryIdentifier = Effect.gen(function* () {
-  const codexAccountId = yield* Effect.result(getCodexAccountId);
-  if (codexAccountId._tag === "Success") {
-    return yield* hash(codexAccountId.success);
-  }
+export const getTelemetryIdentifierForHome = Effect.fn("getTelemetryIdentifierForHome")(
+  function* (homeDirectory: string) {
+    const codexAccountId = yield* getCodexAccountId(homeDirectory).pipe(
+      Effect.catchTags({
+        TelemetryIdentityReadError: (error) =>
+          logTelemetryIdentityError(error).pipe(Effect.as(Option.none<string>())),
+        TelemetryIdentityDecodeError: (error) =>
+          logTelemetryIdentityError(error).pipe(Effect.as(Option.none<string>())),
+      }),
+    );
+    if (Option.isSome(codexAccountId)) {
+      return yield* hash("codex", codexAccountId.value);
+    }
 
-  const claudeUserId = yield* Effect.result(getClaudeUserId);
-  if (claudeUserId._tag === "Success") {
-    return yield* hash(claudeUserId.success);
-  }
+    const claudeUserId = yield* getClaudeUserId(homeDirectory).pipe(
+      Effect.catchTags({
+        TelemetryIdentityReadError: (error) =>
+          logTelemetryIdentityError(error).pipe(Effect.as(Option.none<string>())),
+        TelemetryIdentityDecodeError: (error) =>
+          logTelemetryIdentityError(error).pipe(Effect.as(Option.none<string>())),
+      }),
+    );
+    if (Option.isSome(claudeUserId)) {
+      return yield* hash("claude", claudeUserId.value);
+    }
 
-  const anonymousId = yield* Effect.result(upsertAnonymousId);
-  if (anonymousId._tag === "Success") {
-    return yield* hash(anonymousId.success);
-  }
+    const anonymousId = yield* upsertAnonymousId.pipe(
+      Effect.map(Option.some),
+      Effect.catchTags({
+        TelemetryIdentityReadError: (error) =>
+          logTelemetryIdentityError(error).pipe(Effect.as(Option.none<string>())),
+        TelemetryAnonymousIdGenerationError: (error) =>
+          logTelemetryIdentityError(error).pipe(Effect.as(Option.none<string>())),
+        TelemetryAnonymousIdPersistenceError: (error) =>
+          logTelemetryIdentityError(error).pipe(Effect.as(Option.none<string>())),
+      }),
+    );
+    if (Option.isSome(anonymousId)) {
+      return yield* hash("anonymous", anonymousId.value);
+    }
 
-  return null;
-}).pipe(
-  Effect.tapError((error) => Effect.logWarning("Failed to get identifier", { cause: error })),
+    return null;
+  },
+  Effect.tapError(logTelemetryIdentityError),
   Effect.orElseSucceed(() => null),
+);
+
+export const getTelemetryIdentifier = Effect.suspend(() =>
+  getTelemetryIdentifierForHome(NodeOS.homedir()),
 );

--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -102,13 +102,27 @@ function isNotFoundError(error: PlatformError.PlatformError): boolean {
   return error.reason._tag === "NotFound";
 }
 
+const getTelemetryIdentityCauseAnnotations = (cause: unknown) => {
+  if (cause instanceof PlatformError.PlatformError) {
+    return {
+      causeKind: "platform",
+      platformReason: cause.reason._tag,
+    };
+  }
+  if (cause instanceof Schema.SchemaError) {
+    return { causeKind: "schema" };
+  }
+  return { causeKind: "other" };
+};
+
 const logTelemetryIdentityError = (error: TelemetryIdentityError) =>
   Effect.logWarning(error.message).pipe(
     Effect.annotateLogs({
       errorTag: error._tag,
       source: error.source,
       ...("filePath" in error ? { filePath: error.filePath } : {}),
-      cause: error,
+      ...getTelemetryIdentityCauseAnnotations(error.cause),
+      ...(error.stack === undefined ? {} : { errorStack: error.stack }),
     }),
   );
 

--- a/apps/server/src/telemetry/Identify.ts
+++ b/apps/server/src/telemetry/Identify.ts
@@ -26,7 +26,6 @@ export type TelemetryIdentitySource = typeof TelemetryIdentitySource.Type;
 export class TelemetryIdentityReadError extends Schema.TaggedErrorClass<TelemetryIdentityReadError>()(
   "TelemetryIdentityReadError",
   {
-    operation: Schema.Literal("read"),
     source: TelemetryIdentitySource,
     filePath: Schema.String,
     cause: Schema.Defect(),
@@ -40,7 +39,6 @@ export class TelemetryIdentityReadError extends Schema.TaggedErrorClass<Telemetr
 export class TelemetryIdentityDecodeError extends Schema.TaggedErrorClass<TelemetryIdentityDecodeError>()(
   "TelemetryIdentityDecodeError",
   {
-    operation: Schema.Literal("decode"),
     source: Schema.Literals(["codex", "claude"]),
     filePath: Schema.String,
     cause: Schema.Defect(),
@@ -54,7 +52,6 @@ export class TelemetryIdentityDecodeError extends Schema.TaggedErrorClass<Teleme
 export class TelemetryAnonymousIdGenerationError extends Schema.TaggedErrorClass<TelemetryAnonymousIdGenerationError>()(
   "TelemetryAnonymousIdGenerationError",
   {
-    operation: Schema.Literal("generate"),
     source: Schema.Literal("anonymous"),
     filePath: Schema.String,
     cause: Schema.Defect(),
@@ -68,7 +65,6 @@ export class TelemetryAnonymousIdGenerationError extends Schema.TaggedErrorClass
 export class TelemetryAnonymousIdPersistenceError extends Schema.TaggedErrorClass<TelemetryAnonymousIdPersistenceError>()(
   "TelemetryAnonymousIdPersistenceError",
   {
-    operation: Schema.Literal("write"),
     source: Schema.Literal("anonymous"),
     filePath: Schema.String,
     cause: Schema.Defect(),
@@ -82,7 +78,6 @@ export class TelemetryAnonymousIdPersistenceError extends Schema.TaggedErrorClas
 export class TelemetryIdentityHashError extends Schema.TaggedErrorClass<TelemetryIdentityHashError>()(
   "TelemetryIdentityHashError",
   {
-    operation: Schema.Literal("hash"),
     source: TelemetryIdentitySource,
     algorithm: Schema.Literal("SHA-256"),
     cause: Schema.Defect(),
@@ -110,7 +105,7 @@ function isNotFoundError(error: PlatformError.PlatformError): boolean {
 const logTelemetryIdentityError = (error: TelemetryIdentityError) =>
   Effect.logWarning(error.message).pipe(
     Effect.annotateLogs({
-      operation: error.operation,
+      errorTag: error._tag,
       source: error.source,
       ...("filePath" in error ? { filePath: error.filePath } : {}),
       cause: error,
@@ -130,7 +125,6 @@ const readIdentityFile = (
           ? Effect.succeed(Option.none<string>())
           : Effect.fail(
               new TelemetryIdentityReadError({
-                operation: "read",
                 source,
                 filePath,
                 cause,
@@ -146,7 +140,6 @@ const hash = (source: TelemetryIdentitySource, value: string) =>
     Effect.mapError(
       (cause) =>
         new TelemetryIdentityHashError({
-          operation: "hash",
           source,
           algorithm: "SHA-256",
           cause,
@@ -169,7 +162,6 @@ const getCodexAccountId = Effect.fn("TelemetryIdentity.getCodexAccountId")(funct
     Effect.mapError(
       (cause) =>
         new TelemetryIdentityDecodeError({
-          operation: "decode",
           source: "codex",
           filePath: authJsonPath,
           cause,
@@ -195,7 +187,6 @@ const getClaudeUserId = Effect.fn("TelemetryIdentity.getClaudeUserId")(function*
     Effect.mapError(
       (cause) =>
         new TelemetryIdentityDecodeError({
-          operation: "decode",
           source: "claude",
           filePath: claudeJsonPath,
           cause,
@@ -220,7 +211,6 @@ const upsertAnonymousId = Effect.gen(function* () {
     Effect.mapError(
       (cause) =>
         new TelemetryAnonymousIdGenerationError({
-          operation: "generate",
           source: "anonymous",
           filePath: anonymousIdPath,
           cause,
@@ -231,7 +221,6 @@ const upsertAnonymousId = Effect.gen(function* () {
     Effect.mapError(
       (cause) =>
         new TelemetryAnonymousIdPersistenceError({
-          operation: "write",
           source: "anonymous",
           filePath: anonymousIdPath,
           cause,


### PR DESCRIPTION
## Summary

- split telemetry identity failures into structured read, decode, generate, persist, and hash errors with source/path/operation context
- preserve the original cause chain while keeping messages independent from cause text
- recover provider sources with `catchTags`, treating only `NotFound` as absence and refusing to overwrite the anonymous-id path after other read failures
- log the structured wrapper before falling back to the next identity source

## Tests

- `vp test apps/server/src/telemetry/Identify.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how telemetry user IDs are derived and persisted when auth files are missing or corrupt; mis-handling could affect analytics identity stability but scope is limited to telemetry identification.
> 
> **Overview**
> Replaces the single hash error with **typed telemetry identity errors** (read, decode, generate, persist, hash) that keep the original `cause` but use fixed messages that do not echo nested cause text.
> 
> **`getTelemetryIdentifierForHome`** resolves codex → claude → anonymous: only **NotFound** counts as “missing”; other read failures are logged with structured annotations (`errorTag`, `source`, `filePath`, `causeKind`, no raw `cause` or secrets) and the flow falls through to the next source. **`upsertAnonymousId`** reuses an existing file when readable and **does not write** a new anonymous id after a non-NotFound read failure (can return **`null`** instead of minting an id). **`getTelemetryIdentifier`** delegates to the new home-directory API.
> 
> Adds **`Identify.test.ts`** for anonymous reuse, malformed Codex JSON fallback/logging, and directory-at-anonymous-path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7c377b9fe0a56c0f7d37af2d19b0d244d45eaf5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure telemetry identity errors with typed error classes and source-aware logging
> - Replaces generic error handling in [Identify.ts](https://github.com/pingdotgg/t3code/pull/3306/files#diff-a50c9348071512e0bea296dca3a49a3f8fe4e903cf32378d3d94c5341161b174) with typed error classes (`TelemetryIdentityReadError`, `TelemetryIdentityDecodeError`, `TelemetryAnonymousIdGenerationError`, `TelemetryAnonymousIdPersistenceError`, `TelemetryIdentityHashError`) that carry source, filePath, and cause fields.
> - Adds `logTelemetryIdentityError` to emit structured warnings with consistent annotations (errorTag, source, causeKind, platformReason, errorStack).
> - NotFound file reads now return `Option.none` for silent fallback; other read failures propagate as typed errors, preventing anonymous id from being silently overwritten on non-NotFound errors.
> - Introduces `getTelemetryIdentifierForHome` to resolve identity across Codex → Claude → anonymous sources deterministically, returning `null` when all sources fail.
> - Risk: `upsertAnonymousId` now propagates non-NotFound read failures instead of silently overwriting, which is a behavioral change for degraded filesystem states.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7c377b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->