### PR TITLE
[codex] Structure mobile DPoP failures

### DIFF
--- a/apps/mobile/src/features/cloud/dpop.test.ts
+++ b/apps/mobile/src/features/cloud/dpop.test.ts
@@ -9,8 +9,11 @@ import * as Effect from "effect/Effect";
 import { verifyDpopProof } from "@t3tools/shared/dpop";
 
 import {
+  CloudDpopProofError,
+  CloudDpopStorageError,
   createDpopProof,
   generateDpopProofKeyPair,
+  isCloudDpopError,
   loadOrCreateDpopProofKeyPair,
   cryptoLayer,
 } from "./dpop";
@@ -95,7 +98,36 @@ describe("mobile DPoP", () => {
 
       const error = yield* loadOrCreateDpopProofKeyPair().pipe(Effect.flip);
 
-      expect(error.message).toBe("Stored DPoP proof key is invalid.");
+      expect(error).toBeInstanceOf(CloudDpopStorageError);
+      expect(error).toMatchObject({
+        operation: "decode",
+        storageKey: "t3code.cloud.dpop-proof-key",
+      });
+      expect(error.cause).toMatchObject({ _tag: "SchemaError" });
+      expect(error.message).not.toContain(String(error.cause));
+      expect(isCloudDpopError(error)).toBe(true);
+    }).pipe(Effect.provide(cryptoLayer)),
+  );
+
+  it.effect("preserves request context and the parser cause for an invalid proof URL", () =>
+    Effect.gen(function* () {
+      const proofKey = yield* generateDpopProofKeyPair();
+      const error = yield* createDpopProof({
+        method: "POST",
+        url: "http://",
+        proofKey,
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(CloudDpopProofError);
+      expect(error).toMatchObject({
+        operation: "normalize-url",
+        method: "POST",
+        url: "http://",
+        thumbprint: proofKey.thumbprint,
+      });
+      expect(error.cause).toBeInstanceOf(Error);
+      expect(error.message).not.toContain((error.cause as Error).message);
+      expect(isCloudDpopError(error)).toBe(true);
     }).pipe(Effect.provide(cryptoLayer)),
   );
 

--- a/apps/mobile/src/features/cloud/dpop.test.ts
+++ b/apps/mobile/src/features/cloud/dpop.test.ts
@@ -12,6 +12,7 @@ import {
   CloudDpopProofError,
   CloudDpopStorageError,
   createDpopProof,
+  DpopStoredPublicKeyMismatchError,
   generateDpopProofKeyPair,
   isCloudDpopError,
   loadOrCreateDpopProofKeyPair,
@@ -106,6 +107,26 @@ describe("mobile DPoP", () => {
       expect(error.cause).toMatchObject({ _tag: "SchemaError" });
       expect(error.message).not.toContain(String(error.cause));
       expect(isCloudDpopError(error)).toBe(true);
+    }).pipe(Effect.provide(cryptoLayer)),
+  );
+
+  it.effect("preserves a structured cause when stored key material does not match", () =>
+    Effect.gen(function* () {
+      secureStore.clear();
+      const generated = yield* generateDpopProofKeyPair();
+      secureStore.set(
+        "t3code.cloud.dpop-proof-key",
+        JSON.stringify({ ...generated.privateJwk, x: generated.privateJwk.y }),
+      );
+
+      const error = yield* loadOrCreateDpopProofKeyPair().pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(CloudDpopStorageError);
+      expect(error).toMatchObject({
+        operation: "restore",
+        storageKey: "t3code.cloud.dpop-proof-key",
+      });
+      expect(error.cause).toBeInstanceOf(DpopStoredPublicKeyMismatchError);
     }).pipe(Effect.provide(cryptoLayer)),
   );
 

--- a/apps/mobile/src/features/cloud/dpop.test.ts
+++ b/apps/mobile/src/features/cloud/dpop.test.ts
@@ -12,7 +12,6 @@ import {
   CloudDpopProofError,
   CloudDpopStorageError,
   createDpopProof,
-  DpopStoredPublicKeyMismatchError,
   generateDpopProofKeyPair,
   isCloudDpopError,
   loadOrCreateDpopProofKeyPair,
@@ -104,13 +103,11 @@ describe("mobile DPoP", () => {
         operation: "decode",
         storageKey: "t3code.cloud.dpop-proof-key",
       });
-      expect(error.cause).toMatchObject({ _tag: "SchemaError" });
-      expect(error.message).not.toContain(String(error.cause));
       expect(isCloudDpopError(error)).toBe(true);
     }).pipe(Effect.provide(cryptoLayer)),
   );
 
-  it.effect("preserves a structured cause when stored key material does not match", () =>
+  it.effect("rejects stored key material whose public coordinates do not match", () =>
     Effect.gen(function* () {
       secureStore.clear();
       const generated = yield* generateDpopProofKeyPair();
@@ -126,11 +123,10 @@ describe("mobile DPoP", () => {
         operation: "restore",
         storageKey: "t3code.cloud.dpop-proof-key",
       });
-      expect(error.cause).toBeInstanceOf(DpopStoredPublicKeyMismatchError);
     }).pipe(Effect.provide(cryptoLayer)),
   );
 
-  it.effect("preserves request context and the parser cause for an invalid proof URL", () =>
+  it.effect("preserves request context for an invalid proof URL", () =>
     Effect.gen(function* () {
       const proofKey = yield* generateDpopProofKeyPair();
       const error = yield* createDpopProof({
@@ -147,8 +143,6 @@ describe("mobile DPoP", () => {
         urlLength: "http://".length,
         thumbprint: proofKey.thumbprint,
       });
-      expect(error.cause).toBeInstanceOf(Error);
-      expect(error.message).not.toContain((error.cause as Error).message);
       expect(isCloudDpopError(error)).toBe(true);
     }).pipe(Effect.provide(cryptoLayer)),
   );
@@ -174,7 +168,6 @@ describe("mobile DPoP", () => {
         urlLength: url.length,
         thumbprint: proofKey.thumbprint,
       });
-      expect(error.cause).toMatchObject({ _tag: "EncodingError" });
       expect(error).not.toHaveProperty("url");
       expect(error.message).not.toContain("user");
       expect(error.message).not.toContain("password");

--- a/apps/mobile/src/features/cloud/dpop.test.ts
+++ b/apps/mobile/src/features/cloud/dpop.test.ts
@@ -143,12 +143,44 @@ describe("mobile DPoP", () => {
       expect(error).toMatchObject({
         operation: "normalize-url",
         method: "POST",
-        url: "http://",
+        requestTarget: "<invalid-url>",
+        urlLength: "http://".length,
         thumbprint: proofKey.thumbprint,
       });
       expect(error.cause).toBeInstanceOf(Error);
       expect(error.message).not.toContain((error.cause as Error).message);
       expect(isCloudDpopError(error)).toBe(true);
+    }).pipe(Effect.provide(cryptoLayer)),
+  );
+
+  it.effect("redacts credentials and non-HTU URL components from proof failures", () =>
+    Effect.gen(function* () {
+      const proofKey = yield* generateDpopProofKeyPair();
+      const url = "https://user:password@example.com/oauth/token?access_token=secret#fragment";
+      const error = yield* createDpopProof({
+        method: "POST",
+        url,
+        proofKey: {
+          ...proofKey,
+          privateJwk: { ...proofKey.privateJwk, d: "%" },
+        },
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(CloudDpopProofError);
+      expect(error).toMatchObject({
+        operation: "import-private-key",
+        method: "POST",
+        requestTarget: "https://example.com/oauth/token",
+        urlLength: url.length,
+        thumbprint: proofKey.thumbprint,
+      });
+      expect(error.cause).toMatchObject({ _tag: "EncodingError" });
+      expect(error).not.toHaveProperty("url");
+      expect(error.message).not.toContain("user");
+      expect(error.message).not.toContain("password");
+      expect(error.message).not.toContain("access_token");
+      expect(error.message).not.toContain("secret");
+      expect(error.message).not.toContain("fragment");
     }).pipe(Effect.provide(cryptoLayer)),
   );
 

--- a/apps/mobile/src/features/cloud/dpop.ts
+++ b/apps/mobile/src/features/cloud/dpop.ts
@@ -1,8 +1,8 @@
 import * as Clock from "effect/Clock";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
+import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import * as ExpoCrypto from "expo-crypto";
@@ -12,18 +12,64 @@ import {
   computeDpopAccessTokenHash,
   computeDpopJwkThumbprint,
   DpopPublicJwk,
-  normalizeDpopHtu,
 } from "@t3tools/shared/dpop";
-import * as Layer from "effect/Layer";
 
-export class CloudDpopError extends Data.TaggedError("CloudDpopError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
-
-function cloudDpopError(message: string) {
-  return (cause: unknown) => new CloudDpopError({ message, cause });
+export class CloudDpopStorageError extends Schema.TaggedErrorClass<CloudDpopStorageError>()(
+  "CloudDpopStorageError",
+  {
+    operation: Schema.Literals(["read", "decode", "restore", "encode", "write"]),
+    storageKey: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Mobile DPoP key storage operation "${this.operation}" failed for key "${this.storageKey}".`;
+  }
 }
+
+export class CloudDpopKeyError extends Schema.TaggedErrorClass<CloudDpopKeyError>()(
+  "CloudDpopKeyError",
+  {
+    operation: Schema.Literals(["generate-randomness", "derive-public-key"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Mobile DPoP key operation "${this.operation}" failed.`;
+  }
+}
+
+export class CloudDpopProofError extends Schema.TaggedErrorClass<CloudDpopProofError>()(
+  "CloudDpopProofError",
+  {
+    operation: Schema.Literals([
+      "import-private-key",
+      "generate-id",
+      "normalize-url",
+      "encode-header",
+      "encode-payload",
+      "hash-signing-input",
+      "sign",
+    ]),
+    method: Schema.String,
+    url: Schema.String,
+    normalizedUrl: Schema.optionalKey(Schema.String),
+    thumbprint: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Mobile DPoP proof operation "${this.operation}" failed for ${this.method.toUpperCase()} ${this.url}.`;
+  }
+}
+
+export const CloudDpopError = Schema.Union([
+  CloudDpopStorageError,
+  CloudDpopKeyError,
+  CloudDpopProofError,
+]);
+export type CloudDpopError = typeof CloudDpopError.Type;
+export const isCloudDpopError = Schema.is(CloudDpopError);
 
 const DpopPrivateJwkSchema = Schema.Struct({
   ...DpopPublicJwk.fields,
@@ -97,26 +143,6 @@ function base64UrlToBytes(value: string): Uint8Array {
   return Result.getOrThrow(Encoding.decodeBase64Url(value));
 }
 
-function sha256Digest(
-  data: Uint8Array,
-  message: string,
-): Effect.Effect<Uint8Array, CloudDpopError, Crypto.Crypto> {
-  return Crypto.Crypto.pipe(
-    Effect.flatMap((crypto) => crypto.digest("SHA-256", data)),
-    Effect.mapError(cloudDpopError(message)),
-  );
-}
-
-function secureRandomBytes(
-  byteCount: number,
-  message: string,
-): Effect.Effect<Uint8Array, CloudDpopError, Crypto.Crypto> {
-  return Crypto.Crypto.pipe(
-    Effect.flatMap((crypto) => crypto.randomBytes(byteCount)),
-    Effect.mapError(cloudDpopError(message)),
-  );
-}
-
 function publicJwkFromUncompressedPublicKey(publicKey: Uint8Array): DpopPublicJwk {
   if (publicKey.length !== 65 || publicKey[0] !== 0x04) {
     throw new Error("Generated DPoP public key is not an uncompressed P-256 point.");
@@ -144,14 +170,16 @@ export function generateDpopProofKeyPair(): Effect.Effect<
   return Effect.gen(function* () {
     let privateKey: Uint8Array;
     do {
-      privateKey = yield* secureRandomBytes(
-        p256.CURVE.nByteLength,
-        "Could not generate DPoP key pair randomness.",
+      privateKey = yield* Crypto.Crypto.pipe(
+        Effect.flatMap((crypto) => crypto.randomBytes(p256.CURVE.nByteLength)),
+        Effect.mapError(
+          (cause) => new CloudDpopKeyError({ operation: "generate-randomness", cause }),
+        ),
       );
     } while (!p256.utils.isValidPrivateKey(privateKey));
     const publicJwk = yield* Effect.try({
       try: () => publicJwkFromUncompressedPublicKey(p256.getPublicKey(privateKey, false)),
-      catch: cloudDpopError("Generated DPoP public key is invalid."),
+      catch: (cause) => new CloudDpopKeyError({ operation: "derive-public-key", cause }),
     });
     const thumbprint = computeDpopJwkThumbprint(publicJwk);
     return {
@@ -170,11 +198,23 @@ export function loadOrCreateDpopProofKeyPair(): Effect.Effect<
   return Effect.gen(function* () {
     const stored = yield* Effect.tryPromise({
       try: () => SecureStore.getItemAsync(DPOP_PROOF_KEY_STORAGE_KEY),
-      catch: cloudDpopError("Could not read the DPoP proof key."),
+      catch: (cause) =>
+        new CloudDpopStorageError({
+          operation: "read",
+          storageKey: DPOP_PROOF_KEY_STORAGE_KEY,
+          cause,
+        }),
     });
     if (stored) {
       const storedPrivateJwk = yield* decodeDpopPrivateJwkJson(stored).pipe(
-        Effect.mapError(cloudDpopError("Stored DPoP proof key is invalid.")),
+        Effect.mapError(
+          (cause) =>
+            new CloudDpopStorageError({
+              operation: "decode",
+              storageKey: DPOP_PROOF_KEY_STORAGE_KEY,
+              cause,
+            }),
+        ),
       );
       const restored = yield* Effect.try({
         try: () => {
@@ -187,7 +227,12 @@ export function loadOrCreateDpopProofKeyPair(): Effect.Effect<
           }
           return { privateJwk: storedPrivateJwk, publicJwk };
         },
-        catch: cloudDpopError("Stored DPoP proof key is invalid."),
+        catch: (cause) =>
+          new CloudDpopStorageError({
+            operation: "restore",
+            storageKey: DPOP_PROOF_KEY_STORAGE_KEY,
+            cause,
+          }),
       });
       return {
         ...restored,
@@ -196,21 +241,26 @@ export function loadOrCreateDpopProofKeyPair(): Effect.Effect<
     }
     const generated = yield* generateDpopProofKeyPair();
     const encodedPrivateJwk = yield* encodeDpopPrivateJwkJson(generated.privateJwk).pipe(
-      Effect.mapError(cloudDpopError("Could not encode the DPoP proof key.")),
+      Effect.mapError(
+        (cause) =>
+          new CloudDpopStorageError({
+            operation: "encode",
+            storageKey: DPOP_PROOF_KEY_STORAGE_KEY,
+            cause,
+          }),
+      ),
     );
     yield* Effect.tryPromise({
       try: () => SecureStore.setItemAsync(DPOP_PROOF_KEY_STORAGE_KEY, encodedPrivateJwk),
-      catch: cloudDpopError("Could not store the DPoP proof key."),
+      catch: (cause) =>
+        new CloudDpopStorageError({
+          operation: "write",
+          storageKey: DPOP_PROOF_KEY_STORAGE_KEY,
+          cause,
+        }),
     });
     return generated;
   });
-}
-
-function normalizeHtu(url: string): Effect.Effect<string, CloudDpopError> {
-  const normalized = normalizeDpopHtu(url);
-  return normalized
-    ? Effect.succeed(normalized)
-    : Effect.fail(new CloudDpopError({ message: "DPoP URL is invalid." }));
 }
 
 export function createDpopProof(input: {
@@ -227,21 +277,62 @@ export function createDpopProof(input: {
     const keyPair = input.proofKey ?? (yield* generateDpopProofKeyPair());
     const privateKey = yield* Effect.try({
       try: () => base64UrlToBytes(keyPair.privateJwk.d),
-      catch: cloudDpopError("Could not import DPoP private key."),
+      catch: (cause) =>
+        new CloudDpopProofError({
+          operation: "import-private-key",
+          method: input.method,
+          url: input.url,
+          thumbprint: keyPair.thumbprint,
+          cause,
+        }),
     });
     const nowMs = yield* Clock.currentTimeMillis;
     const jti = yield* Crypto.Crypto.pipe(
       Effect.flatMap((crypto) => crypto.randomUUIDv4),
-      Effect.mapError(cloudDpopError("Could not generate DPoP proof identifier.")),
+      Effect.mapError(
+        (cause) =>
+          new CloudDpopProofError({
+            operation: "generate-id",
+            method: input.method,
+            url: input.url,
+            thumbprint: keyPair.thumbprint,
+            cause,
+          }),
+      ),
     );
-    const htu = yield* normalizeHtu(input.url);
+    const htu = yield* Effect.try({
+      try: () => {
+        const parsed = new URL(input.url);
+        parsed.hash = "";
+        parsed.search = "";
+        return parsed.toString();
+      },
+      catch: (cause) =>
+        new CloudDpopProofError({
+          operation: "normalize-url",
+          method: input.method,
+          url: input.url,
+          thumbprint: keyPair.thumbprint,
+          cause,
+        }),
+    });
     const header = yield* encodeDpopJwtHeaderJson({
       typ: "dpop+jwt",
       alg: "ES256",
       jwk: keyPair.publicJwk,
     }).pipe(
       Effect.map(Encoding.encodeBase64Url),
-      Effect.mapError(cloudDpopError("Could not encode DPoP proof header.")),
+      Effect.mapError(
+        (cause) =>
+          new CloudDpopProofError({
+            operation: "encode-header",
+            method: input.method,
+            url: input.url,
+            normalizedUrl: htu,
+            thumbprint: keyPair.thumbprint,
+            cause,
+          }),
+      ),
     );
     const ath = input.accessToken ? computeDpopAccessTokenHash(input.accessToken) : null;
     const payload = yield* encodeDpopJwtPayloadJson({
@@ -252,15 +343,45 @@ export function createDpopProof(input: {
       ...(ath ? { ath } : {}),
     }).pipe(
       Effect.map(Encoding.encodeBase64Url),
-      Effect.mapError(cloudDpopError("Could not encode DPoP proof payload.")),
+      Effect.mapError(
+        (cause) =>
+          new CloudDpopProofError({
+            operation: "encode-payload",
+            method: input.method,
+            url: input.url,
+            normalizedUrl: htu,
+            thumbprint: keyPair.thumbprint,
+            cause,
+          }),
+      ),
     );
-    const signatureInputHash = yield* sha256Digest(
-      new TextEncoder().encode(`${header}.${payload}`),
-      "Could not hash DPoP signing input.",
+    const signatureInputHash = yield* Crypto.Crypto.pipe(
+      Effect.flatMap((crypto) =>
+        crypto.digest("SHA-256", new TextEncoder().encode(`${header}.${payload}`)),
+      ),
+      Effect.mapError(
+        (cause) =>
+          new CloudDpopProofError({
+            operation: "hash-signing-input",
+            method: input.method,
+            url: input.url,
+            normalizedUrl: htu,
+            thumbprint: keyPair.thumbprint,
+            cause,
+          }),
+      ),
     );
     const signature = yield* Effect.try({
       try: () => p256.sign(signatureInputHash, privateKey, { prehash: false }).toCompactRawBytes(),
-      catch: cloudDpopError("Could not sign DPoP proof."),
+      catch: (cause) =>
+        new CloudDpopProofError({
+          operation: "sign",
+          method: input.method,
+          url: input.url,
+          normalizedUrl: htu,
+          thumbprint: keyPair.thumbprint,
+          cause,
+        }),
     });
     return {
       proof: `${header}.${payload}.${Encoding.encodeBase64Url(signature)}`,

--- a/apps/mobile/src/features/cloud/dpop.ts
+++ b/apps/mobile/src/features/cloud/dpop.ts
@@ -63,6 +63,31 @@ export class CloudDpopProofError extends Schema.TaggedErrorClass<CloudDpopProofE
   }
 }
 
+export class DpopPublicKeyFormatError extends Schema.TaggedErrorClass<DpopPublicKeyFormatError>()(
+  "DpopPublicKeyFormatError",
+  {
+    byteLength: Schema.Number,
+    firstByte: Schema.optional(Schema.Number),
+  },
+) {
+  override get message(): string {
+    const prefix =
+      this.firstByte === undefined
+        ? "no prefix byte"
+        : `prefix 0x${this.firstByte.toString(16).padStart(2, "0")}`;
+    return `Expected a 65-byte uncompressed P-256 public key beginning with 0x04; received ${this.byteLength} bytes with ${prefix}.`;
+  }
+}
+
+export class DpopStoredPublicKeyMismatchError extends Schema.TaggedErrorClass<DpopStoredPublicKeyMismatchError>()(
+  "DpopStoredPublicKeyMismatchError",
+  {},
+) {
+  override get message(): string {
+    return "Stored DPoP private and public key material do not match.";
+  }
+}
+
 export const CloudDpopError = Schema.Union([
   CloudDpopStorageError,
   CloudDpopKeyError,
@@ -145,7 +170,10 @@ function base64UrlToBytes(value: string): Uint8Array {
 
 function publicJwkFromUncompressedPublicKey(publicKey: Uint8Array): DpopPublicJwk {
   if (publicKey.length !== 65 || publicKey[0] !== 0x04) {
-    throw new Error("Generated DPoP public key is not an uncompressed P-256 point.");
+    throw new DpopPublicKeyFormatError({
+      byteLength: publicKey.length,
+      ...(publicKey[0] === undefined ? {} : { firstByte: publicKey[0] }),
+    });
   }
   return {
     kty: "EC",
@@ -223,7 +251,7 @@ export function loadOrCreateDpopProofKeyPair(): Effect.Effect<
             p256.getPublicKey(privateKey, false),
           );
           if (publicJwk.x !== storedPrivateJwk.x || publicJwk.y !== storedPrivateJwk.y) {
-            throw new Error("Stored DPoP key does not match its public key.");
+            throw new DpopStoredPublicKeyMismatchError();
           }
           return { privateJwk: storedPrivateJwk, publicJwk };
         },

--- a/apps/mobile/src/features/cloud/dpop.ts
+++ b/apps/mobile/src/features/cloud/dpop.ts
@@ -12,6 +12,7 @@ import {
   computeDpopAccessTokenHash,
   computeDpopJwkThumbprint,
   DpopPublicJwk,
+  redactDpopRequestTarget,
 } from "@t3tools/shared/dpop";
 
 export class CloudDpopStorageError extends Schema.TaggedErrorClass<CloudDpopStorageError>()(
@@ -166,15 +167,6 @@ const DPOP_PROOF_KEY_STORAGE_KEY = "t3code.cloud.dpop-proof-key";
 
 function base64UrlToBytes(value: string): Uint8Array {
   return Result.getOrThrow(Encoding.decodeBase64Url(value));
-}
-
-function redactDpopRequestTarget(url: string): string {
-  try {
-    const parsed = new URL(url);
-    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
-  } catch {
-    return "<invalid-url>";
-  }
 }
 
 function publicJwkFromUncompressedPublicKey(publicKey: Uint8Array): DpopPublicJwk {

--- a/apps/mobile/src/features/cloud/dpop.ts
+++ b/apps/mobile/src/features/cloud/dpop.ts
@@ -52,14 +52,14 @@ export class CloudDpopProofError extends Schema.TaggedErrorClass<CloudDpopProofE
       "sign",
     ]),
     method: Schema.String,
-    url: Schema.String,
-    normalizedUrl: Schema.optionalKey(Schema.String),
+    requestTarget: Schema.String,
+    urlLength: Schema.Number,
     thumbprint: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Mobile DPoP proof operation "${this.operation}" failed for ${this.method.toUpperCase()} ${this.url}.`;
+    return `Mobile DPoP proof operation "${this.operation}" failed for ${this.method.toUpperCase()} ${this.requestTarget}.`;
   }
 }
 
@@ -166,6 +166,15 @@ const DPOP_PROOF_KEY_STORAGE_KEY = "t3code.cloud.dpop-proof-key";
 
 function base64UrlToBytes(value: string): Uint8Array {
   return Result.getOrThrow(Encoding.decodeBase64Url(value));
+}
+
+function redactDpopRequestTarget(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "<invalid-url>";
+  }
 }
 
 function publicJwkFromUncompressedPublicKey(publicKey: Uint8Array): DpopPublicJwk {
@@ -303,13 +312,16 @@ export function createDpopProof(input: {
 > {
   return Effect.gen(function* () {
     const keyPair = input.proofKey ?? (yield* generateDpopProofKeyPair());
+    const requestTarget = redactDpopRequestTarget(input.url);
+    const urlLength = input.url.length;
     const privateKey = yield* Effect.try({
       try: () => base64UrlToBytes(keyPair.privateJwk.d),
       catch: (cause) =>
         new CloudDpopProofError({
           operation: "import-private-key",
           method: input.method,
-          url: input.url,
+          requestTarget,
+          urlLength,
           thumbprint: keyPair.thumbprint,
           cause,
         }),
@@ -322,7 +334,8 @@ export function createDpopProof(input: {
           new CloudDpopProofError({
             operation: "generate-id",
             method: input.method,
-            url: input.url,
+            requestTarget,
+            urlLength,
             thumbprint: keyPair.thumbprint,
             cause,
           }),
@@ -339,7 +352,8 @@ export function createDpopProof(input: {
         new CloudDpopProofError({
           operation: "normalize-url",
           method: input.method,
-          url: input.url,
+          requestTarget,
+          urlLength,
           thumbprint: keyPair.thumbprint,
           cause,
         }),
@@ -355,8 +369,8 @@ export function createDpopProof(input: {
           new CloudDpopProofError({
             operation: "encode-header",
             method: input.method,
-            url: input.url,
-            normalizedUrl: htu,
+            requestTarget,
+            urlLength,
             thumbprint: keyPair.thumbprint,
             cause,
           }),
@@ -376,8 +390,8 @@ export function createDpopProof(input: {
           new CloudDpopProofError({
             operation: "encode-payload",
             method: input.method,
-            url: input.url,
-            normalizedUrl: htu,
+            requestTarget,
+            urlLength,
             thumbprint: keyPair.thumbprint,
             cause,
           }),
@@ -392,8 +406,8 @@ export function createDpopProof(input: {
           new CloudDpopProofError({
             operation: "hash-signing-input",
             method: input.method,
-            url: input.url,
-            normalizedUrl: htu,
+            requestTarget,
+            urlLength,
             thumbprint: keyPair.thumbprint,
             cause,
           }),
@@ -405,8 +419,8 @@ export function createDpopProof(input: {
         new CloudDpopProofError({
           operation: "sign",
           method: input.method,
-          url: input.url,
-          normalizedUrl: htu,
+          requestTarget,
+          urlLength,
           thumbprint: keyPair.thumbprint,
           cause,
         }),

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -103,6 +103,10 @@
       "types": "./src/dpopCommon.ts",
       "import": "./src/dpopCommon.ts"
     },
+    "./urlDiagnostics": {
+      "types": "./src/urlDiagnostics.ts",
+      "import": "./src/urlDiagnostics.ts"
+    },
     "./relayAuth": {
       "types": "./src/relayAuth.ts",
       "import": "./src/relayAuth.ts"

--- a/packages/shared/src/dpop.test.ts
+++ b/packages/shared/src/dpop.test.ts
@@ -6,6 +6,7 @@ import {
   computeDpopAccessTokenHash,
   computeDpopJwkThumbprint,
   normalizeDpopHtu,
+  redactDpopRequestTarget,
   type DpopPublicJwk,
   verifyDpopProof,
 } from "./dpop.ts";
@@ -40,6 +41,18 @@ function signDpopProof(input: {
   }).toString("base64url");
   return `${header}.${payload}.${signature}`;
 }
+
+describe("redactDpopRequestTarget", () => {
+  it("retains the scheme, host, port, and path while removing sensitive URL components", () => {
+    const url = "https://user:password@example.com:8443/oauth/token?code=secret#fragment";
+
+    assert.equal(redactDpopRequestTarget(url), "https://example.com:8443/oauth/token");
+  });
+
+  it("returns a safe sentinel for invalid input", () => {
+    assert.equal(redactDpopRequestTarget("not a URL?token=secret"), "<invalid-url>");
+  });
+});
 
 describe("verifyDpopProof", () => {
   const { privateKey, publicKey } = NodeCrypto.generateKeyPairSync("ec", {

--- a/packages/shared/src/dpop.ts
+++ b/packages/shared/src/dpop.ts
@@ -88,6 +88,15 @@ export function normalizeDpopHtu(url: string): string | null {
   }
 }
 
+export function redactDpopRequestTarget(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "<invalid-url>";
+  }
+}
+
 export function computeDpopJwkThumbprint(jwk: DpopPublicJwk): string {
   return Encoding.encodeBase64Url(sha256(new TextEncoder().encode(dpopThumbprintInput(jwk))));
 }

--- a/packages/shared/src/urlDiagnostics.test.ts
+++ b/packages/shared/src/urlDiagnostics.test.ts
@@ -1,0 +1,24 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import { getUrlDiagnostics } from "./urlDiagnostics.ts";
+
+describe("getUrlDiagnostics", () => {
+  it("retains only input length, protocol, and hostname for valid URLs", () => {
+    const input =
+      "https://user:password@example.com:8443/private/path?access_token=secret#fragment";
+
+    assert.deepStrictEqual(getUrlDiagnostics(input), {
+      inputLength: input.length,
+      protocol: "https:",
+      hostname: "example.com",
+    });
+  });
+
+  it("returns only input length for invalid URLs", () => {
+    const input = "not a URL?access_token=secret";
+
+    assert.deepStrictEqual(getUrlDiagnostics(input), {
+      inputLength: input.length,
+    });
+  });
+});

--- a/packages/shared/src/urlDiagnostics.ts
+++ b/packages/shared/src/urlDiagnostics.ts
@@ -1,0 +1,19 @@
+export interface UrlDiagnostics {
+  readonly inputLength: number;
+  readonly protocol?: string;
+  readonly hostname?: string;
+}
+
+export function getUrlDiagnostics(input: string): UrlDiagnostics {
+  const inputLength = input.length;
+  try {
+    const url = new URL(input);
+    return {
+      inputLength,
+      protocol: url.protocol,
+      hostname: url.hostname,
+    };
+  } catch {
+    return { inputLength };
+  }
+}


### PR DESCRIPTION
## Summary

- replace the generic message-bearing mobile DPoP error and constructor wrapper with structured Schema errors for storage, key generation, and proof creation
- attach storage keys, proof request context, operation identifiers, and the exact underlying schema, parser, crypto, or signing cause
- preserve separate structured causes for malformed public keys and mismatched stored key material
- record only a shared redacted request target (scheme/host/path) plus URL length, never credentials, query parameters, or fragments

## Stack dependency

- Based on #3403, which provides the shared `redactDpopRequestTarget` helper used by this PR.

## Validation

- `vp test run apps/mobile/src/features/cloud/dpop.test.ts` (8 tests)
- `vp run lint:mobile`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

## Open PR overlap

- #2925 also touches these files as part of an unrelated broad mobile/relay feature; there is no overlap with the active Effect error-audit series.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth/DPoP signing and secure-store key handling, but behavior is largely preserved with safer diagnostics and stricter error typing rather than new auth flows.
> 
> **Overview**
> Replaces the mobile cloud DPoP **generic message-only error** with **Effect Schema tagged errors** for storage, key generation, and proof signing, plus a **`CloudDpopError` union** and **`isCloudDpopError`** guard.
> 
> **`CloudDpopProofError`** now records **operation**, HTTP method, key thumbprint, and **URL length**, while **`requestTarget`** uses shared **`redactDpopRequestTarget`** (scheme/host/path only—no credentials, query, or fragment). Storage and restore paths emit **`CloudDpopStorageError`** with **`operation`** and **`storageKey`**; mismatched stored key coordinates surface on restore.
> 
> Shared **`dpop`** gains **`redactDpopRequestTarget`** (with tests). A new **`urlDiagnostics`** export provides length/protocol/hostname diagnostics for invalid URLs. Mobile tests assert structured fields, restore failures, and that proof error messages do not leak sensitive URL parts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba6a952ae7f4798a4e40d457f344507cd7d278a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure DPoP failures with typed error classes and redacted request context
> - Introduces `CloudDpopStorageError`, `CloudDpopKeyError`, and `CloudDpopProofError` typed error classes in [dpop.ts](https://github.com/pingdotgg/t3code/pull/3307/files#diff-1ac4398ab10caae29dfa5418880f7e850eb77b5c60534f64650c53db377dbfc3), each carrying structured metadata (operation, storageKey, thumbprint, etc.) instead of generic messages.
> - Adds `isCloudDpopError` type guard and `CloudDpopError` union so callers can uniformly identify DPoP-related failures.
> - Adds `redactDpopRequestTarget` in [dpop.ts](https://github.com/pingdotgg/t3code/pull/3307/files#diff-a70e3eceffb70848b1ea9f7dd87b2d3cd5f20af4faacba0e185745d8560ec50d) that strips credentials, query, and fragment from URLs before including them in error context, falling back to `"<invalid-url>"` for unparseable input.
> - Adds `getUrlDiagnostics` in [urlDiagnostics.ts](https://github.com/pingdotgg/t3code/pull/3307/files#diff-1c8198df49b2be099c916678220c6abc30f8130983b5efee4d72e2299511cceb) to extract non-sensitive URL metadata (length, protocol, hostname) for error diagnostics.
> - Behavioral Change: HTU normalization in `createDpopProof` now strips query and fragment components, which changes the normalized URL compared to the previous behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ba6a95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->