### PR TITLE
[codex] Structure desktop Clerk bridge failures

### DIFF
--- a/apps/desktop/src/app/DesktopClerk.test.ts
+++ b/apps/desktop/src/app/DesktopClerk.test.ts
@@ -1,7 +1,8 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { vi } from "vite-plus/test";
+import { beforeEach, vi } from "vite-plus/test";
 
 const { createClerkBridgeMock, storageAdapter, storageMock } = vi.hoisted(() => ({
   createClerkBridgeMock: vi.fn(),
@@ -24,7 +25,23 @@ vi.mock("@clerk/electron/storage", () => ({
 import * as DesktopClerk from "./DesktopClerk.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 
+const makeDesktopClerkLayer = (isDevelopment = true) => {
+  const environment = DesktopEnvironment.DesktopEnvironment.of({
+    stateDir: "/tmp/t3-state",
+    isDevelopment,
+  } as unknown as DesktopEnvironment.DesktopEnvironment["Service"]);
+
+  return DesktopClerk.layer.pipe(
+    Layer.provide(Layer.succeed(DesktopEnvironment.DesktopEnvironment, environment)),
+  );
+};
+
 describe("DesktopClerk", () => {
+  beforeEach(() => {
+    createClerkBridgeMock.mockReset();
+    storageMock.mockReset();
+  });
+
   it("derives the Clerk Frontend API hostname used by the desktop CSP", () => {
     const publishableKey = `pk_test_${btoa("clerk.t3.codes$")}`;
 
@@ -40,19 +57,9 @@ describe("DesktopClerk", () => {
     const cleanup = vi.fn();
     storageMock.mockReturnValue(storageAdapter);
     createClerkBridgeMock.mockReturnValue({ cleanup });
-    const environment = DesktopEnvironment.DesktopEnvironment.of({
-      stateDir: "/tmp/t3-state",
-      isDevelopment: true,
-    } as unknown as DesktopEnvironment.DesktopEnvironment["Service"]);
 
     return Effect.gen(function* () {
-      yield* Effect.scoped(
-        Layer.build(
-          DesktopClerk.layer.pipe(
-            Layer.provide(Layer.succeed(DesktopEnvironment.DesktopEnvironment, environment)),
-          ),
-        ),
-      );
+      yield* Effect.scoped(Layer.build(makeDesktopClerkLayer()));
 
       assert.deepEqual(createClerkBridgeMock.mock.calls, [
         [
@@ -66,6 +73,54 @@ describe("DesktopClerk", () => {
       assert.equal(cleanup.mock.calls.length, 1);
       storageMock.mockClear();
       createClerkBridgeMock.mockClear();
+    });
+  });
+
+  it.effect("preserves bridge initialization failures", () => {
+    const cause = new Error("bridge initialization failed");
+    storageMock.mockReturnValue(storageAdapter);
+    createClerkBridgeMock.mockImplementationOnce(() => {
+      throw cause;
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* Effect.scoped(Layer.build(makeDesktopClerkLayer())).pipe(Effect.flip);
+
+      assert.instanceOf(error, DesktopClerk.DesktopClerkBridgeInitializationError);
+      assert.equal(error.stateDir, "/tmp/t3-state");
+      assert.equal(error.isDevelopment, true);
+      assert.strictEqual(error.cause, cause);
+      assert.equal(
+        error.message,
+        'Failed to initialize the desktop Clerk bridge for state directory "/tmp/t3-state" (development: true).',
+      );
+    });
+  });
+
+  it.effect("preserves bridge cleanup failures", () => {
+    const cause = new Error("bridge cleanup failed");
+    storageMock.mockReturnValue(storageAdapter);
+    createClerkBridgeMock.mockReturnValue({
+      cleanup: () => {
+        throw cause;
+      },
+    });
+
+    return Effect.gen(function* () {
+      const exit = yield* Effect.exit(Effect.scoped(Layer.build(makeDesktopClerkLayer(false))));
+
+      assert.equal(exit._tag, "Failure");
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause);
+        assert.instanceOf(error, DesktopClerk.DesktopClerkBridgeCleanupError);
+        assert.equal(error.stateDir, "/tmp/t3-state");
+        assert.equal(error.isDevelopment, false);
+        assert.strictEqual(error.cause, cause);
+        assert.equal(
+          error.message,
+          'Failed to clean up the desktop Clerk bridge for state directory "/tmp/t3-state" (development: false).',
+        );
+      }
     });
   });
 

--- a/apps/desktop/src/app/DesktopClerk.ts
+++ b/apps/desktop/src/app/DesktopClerk.ts
@@ -4,6 +4,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 
 import { clerkFrontendApiHostnameFromPublishableKey } from "@t3tools/shared/relayAuth";
@@ -13,6 +14,32 @@ import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 
 declare const __T3CODE_BUILD_CLERK_PUBLISHABLE_KEY__: string | undefined;
+
+export class DesktopClerkBridgeInitializationError extends Schema.TaggedErrorClass<DesktopClerkBridgeInitializationError>()(
+  "DesktopClerkBridgeInitializationError",
+  {
+    stateDir: Schema.String,
+    isDevelopment: Schema.Boolean,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to initialize the desktop Clerk bridge for state directory "${this.stateDir}" (development: ${this.isDevelopment}).`;
+  }
+}
+
+export class DesktopClerkBridgeCleanupError extends Schema.TaggedErrorClass<DesktopClerkBridgeCleanupError>()(
+  "DesktopClerkBridgeCleanupError",
+  {
+    stateDir: Schema.String,
+    isDevelopment: Schema.Boolean,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to clean up the desktop Clerk bridge for state directory "${this.stateDir}" (development: ${this.isDevelopment}).`;
+  }
+}
 
 export class DesktopClerk extends Context.Service<
   DesktopClerk,
@@ -55,11 +82,28 @@ export function createDesktopClerkBridge(stateDir: string, isDevelopment: boolea
   });
 }
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   yield* Effect.acquireRelease(
-    Effect.sync(() => createDesktopClerkBridge(environment.stateDir, environment.isDevelopment)),
-    (bridge) => Effect.sync(() => bridge.cleanup()),
+    Effect.try({
+      try: () => createDesktopClerkBridge(environment.stateDir, environment.isDevelopment),
+      catch: (cause) =>
+        new DesktopClerkBridgeInitializationError({
+          stateDir: environment.stateDir,
+          isDevelopment: environment.isDevelopment,
+          cause,
+        }),
+    }),
+    (bridge) =>
+      Effect.try({
+        try: () => bridge.cleanup(),
+        catch: (cause) =>
+          new DesktopClerkBridgeCleanupError({
+            stateDir: environment.stateDir,
+            isDevelopment: environment.isDevelopment,
+            cause,
+          }),
+      }).pipe(Effect.orDie),
   );
 
   return DesktopClerk.of({


### PR DESCRIPTION
## Summary
- add Schema-backed errors for Clerk bridge initialization and cleanup with state-directory and environment context
- preserve the exact SDK cause; initialization stays typed while cleanup becomes a structured finalizer defect
- construct errors directly at the boundary and export the existing service `make` value
- cover both failure paths with focused layer lifecycle tests

## Verification
- `vp test apps/desktop/src/app/DesktopClerk.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

## Open PR overlap audit
The exact source and test files are also touched by unrelated local-auth startup PR #3252. This PR is a focused error-boundary change and does not overlap the active Effect/error audit series.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop Clerk startup/teardown on the auth path; behavior on success is unchanged, but init failures are now typed and cleanup failures become defects via orDie.
> 
> **Overview**
> Wraps desktop Clerk bridge **acquire/release** in `Effect.try` and maps SDK throws to two new Schema tagged errors—`DesktopClerkBridgeInitializationError` and `DesktopClerkBridgeCleanupError`—each carrying `stateDir`, `isDevelopment`, and the original `cause`.
> 
> Initialization failures surface as typed layer errors; cleanup failures are still structured then passed through **`Effect.orDie`** on the release finalizer. **`make`** is exported for tests.
> 
> Tests add a shared layer helper, per-test mock resets, and layer lifecycle cases that assert message text and cause preservation for both failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96a7ff0191e39692368ebe09e0222320e4cf46b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured error types for desktop Clerk bridge initialization and cleanup failures
> - Adds `DesktopClerkBridgeInitializationError` and `DesktopClerkBridgeCleanupError` tagged error classes in [`DesktopClerk.ts`](https://github.com/pingdotgg/t3code/pull/3308/files#diff-6ee8f6640c664637b8e75826b581300f21ae329abd23d301a562639f3aff75e2), each carrying `stateDir`, `isDevelopment`, and `cause` fields.
> - Reworks the `DesktopClerk.make` layer factory to wrap bridge creation in `Effect.try`, surfacing init failures as typed errors, and wraps `bridge.cleanup` similarly, converting cleanup failures to defects via `Effect.orDie`.
> - Adds tests in [`DesktopClerk.test.ts`](https://github.com/pingdotgg/t3code/pull/3308/files#diff-dcc646bc55aac7f57fb5df517855f1d9e08783fc21a179d12ea4d173b7cbb1ce) covering both failure paths, with a `beforeEach` mock reset to prevent cross-test interference.
> - Behavioral Change: bridge initialization failures now produce a typed `DesktopClerkBridgeInitializationError` instead of an unstructured exception; cleanup failures now terminate the process as a defect rather than being silently swallowed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96a7ff0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->