### PR TITLE
[codex] Structure mobile relay token-store failures

### DIFF
--- a/apps/mobile/src/features/cloud/managedRelayTokenStore.test.ts
+++ b/apps/mobile/src/features/cloud/managedRelayTokenStore.test.ts
@@ -1,5 +1,7 @@
 import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Logger from "effect/Logger";
+import * as SecureStore from "expo-secure-store";
 import { vi } from "vite-plus/test";
 
 const secureStore = vi.hoisted(() => new Map<string, string>());
@@ -16,7 +18,10 @@ vi.mock("expo-secure-store", () => ({
   }),
 }));
 
-import { managedRelayAccessTokenStore } from "./managedRelayTokenStore";
+import {
+  ManagedRelayTokenStoreError,
+  managedRelayAccessTokenStore,
+} from "./managedRelayTokenStore";
 
 it.effect("round-trips and clears persisted managed relay access tokens", () =>
   Effect.gen(function* () {
@@ -49,3 +54,32 @@ it.effect("falls back to an empty cache when persisted data is invalid", () =>
     expect(yield* managedRelayAccessTokenStore.load).toEqual([]);
   }),
 );
+
+it.effect("logs structured storage failures before falling back to an empty cache", () => {
+  const messages: Array<unknown> = [];
+  const logger = Logger.make(({ message }) => {
+    messages.push(message);
+  });
+  const cause = new Error("secure store unavailable");
+  vi.mocked(SecureStore.getItemAsync).mockRejectedValueOnce(cause);
+
+  return Effect.gen(function* () {
+    expect(yield* managedRelayAccessTokenStore.load).toEqual([]);
+
+    const message = messages.find(
+      (candidate) =>
+        Array.isArray(candidate) && candidate[0] === "Managed relay token store operation failed.",
+    );
+    expect(message).toBeDefined();
+    const context = (message as ReadonlyArray<unknown>)[1] as {
+      readonly cause: ManagedRelayTokenStoreError;
+    };
+    expect(context.cause).toBeInstanceOf(ManagedRelayTokenStoreError);
+    expect(context.cause).toMatchObject({
+      operation: "read",
+      storageKey: "t3code.cloud.relay-access-tokens",
+      cause,
+    });
+    expect(context.cause.message).not.toContain(cause.message);
+  }).pipe(Effect.provide(Logger.layer([logger], { mergeWithExisting: false })));
+});

--- a/apps/mobile/src/features/cloud/managedRelayTokenStore.ts
+++ b/apps/mobile/src/features/cloud/managedRelayTokenStore.ts
@@ -1,5 +1,4 @@
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as SecureStore from "expo-secure-store";
@@ -31,36 +30,50 @@ const decodeManagedRelayAccessTokenCache = Schema.decodeUnknownEffect(
 );
 const encodeManagedRelayAccessTokenCache = Schema.encodeEffect(ManagedRelayAccessTokenCacheSchema);
 
-export class ManagedRelayTokenStoreError extends Data.TaggedError("ManagedRelayTokenStoreError")<{
-  readonly message: string;
-  readonly cause: unknown;
-}> {}
+export class ManagedRelayTokenStoreError extends Schema.TaggedErrorClass<ManagedRelayTokenStoreError>()(
+  "ManagedRelayTokenStoreError",
+  {
+    operation: Schema.Literals(["read", "decode", "encode", "write", "clear"]),
+    storageKey: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Managed relay token store operation "${this.operation}" failed for key "${this.storageKey}".`;
+  }
+}
 
-const storeError =
-  (message: string) =>
-  (cause: unknown): ManagedRelayTokenStoreError =>
-    new ManagedRelayTokenStoreError({ message, cause });
-
-function logStoreFailure(operation: string) {
-  return (error: ManagedRelayTokenStoreError) =>
-    Effect.logWarning(`Managed relay token store ${operation} failed.`).pipe(
-      Effect.annotateLogs({
-        errorTag: error._tag,
-        message: error.message,
-      }),
-    );
+function logStoreFailure(error: ManagedRelayTokenStoreError) {
+  return Effect.logWarning("Managed relay token store operation failed.", {
+    errorTag: error._tag,
+    operation: error.operation,
+    storageKey: error.storageKey,
+    cause: error,
+  });
 }
 
 const loadManagedRelayAccessTokens = Effect.tryPromise({
   try: () => SecureStore.getItemAsync(MANAGED_RELAY_TOKEN_CACHE_KEY),
-  catch: storeError("Could not read persisted relay access tokens."),
+  catch: (cause) =>
+    new ManagedRelayTokenStoreError({
+      operation: "read",
+      storageKey: MANAGED_RELAY_TOKEN_CACHE_KEY,
+      cause,
+    }),
 }).pipe(
   Effect.flatMap((encoded) =>
     encoded === null
       ? Effect.succeed<ReadonlyArray<ManagedRelay.ManagedRelayAccessTokenCacheEntry>>([])
       : decodeManagedRelayAccessTokenCache(encoded).pipe(
           Effect.map((cache) => cache.entries),
-          Effect.mapError(storeError("Persisted relay access tokens are invalid.")),
+          Effect.mapError(
+            (cause) =>
+              new ManagedRelayTokenStoreError({
+                operation: "decode",
+                storageKey: MANAGED_RELAY_TOKEN_CACHE_KEY,
+                cause,
+              }),
+          ),
         ),
   ),
 );
@@ -72,34 +85,48 @@ const saveManagedRelayAccessTokens = (
     version: MANAGED_RELAY_TOKEN_CACHE_VERSION,
     entries,
   }).pipe(
-    Effect.mapError(storeError("Could not encode relay access tokens.")),
+    Effect.mapError(
+      (cause) =>
+        new ManagedRelayTokenStoreError({
+          operation: "encode",
+          storageKey: MANAGED_RELAY_TOKEN_CACHE_KEY,
+          cause,
+        }),
+    ),
     Effect.flatMap((encoded) =>
       Effect.tryPromise({
         try: () => SecureStore.setItemAsync(MANAGED_RELAY_TOKEN_CACHE_KEY, encoded),
-        catch: storeError("Could not persist relay access tokens."),
+        catch: (cause) =>
+          new ManagedRelayTokenStoreError({
+            operation: "write",
+            storageKey: MANAGED_RELAY_TOKEN_CACHE_KEY,
+            cause,
+          }),
       }),
     ),
   );
 
 const clearManagedRelayAccessTokens = Effect.tryPromise({
   try: () => SecureStore.deleteItemAsync(MANAGED_RELAY_TOKEN_CACHE_KEY),
-  catch: storeError("Could not clear persisted relay access tokens."),
+  catch: (cause) =>
+    new ManagedRelayTokenStoreError({
+      operation: "clear",
+      storageKey: MANAGED_RELAY_TOKEN_CACHE_KEY,
+      cause,
+    }),
 });
 
 export const managedRelayAccessTokenStore: ManagedRelay.ManagedRelayAccessTokenStore = {
   load: loadManagedRelayAccessTokens.pipe(
-    Effect.tapError(logStoreFailure("load")),
+    Effect.tapError(logStoreFailure),
     Effect.orElseSucceed(() => []),
     Effect.withSpan("mobile.managedRelayTokenStore.load"),
   ),
   save: Effect.fn("mobile.managedRelayTokenStore.save")((entries) =>
-    saveManagedRelayAccessTokens(entries).pipe(
-      Effect.tapError(logStoreFailure("save")),
-      Effect.ignore,
-    ),
+    saveManagedRelayAccessTokens(entries).pipe(Effect.tapError(logStoreFailure), Effect.ignore),
   ),
   clear: clearManagedRelayAccessTokens.pipe(
-    Effect.tapError(logStoreFailure("clear")),
+    Effect.tapError(logStoreFailure),
     Effect.ignore,
     Effect.withSpan("mobile.managedRelayTokenStore.clear"),
   ),


### PR DESCRIPTION
## Summary

- replace message-bearing managed relay token-store failures with a structured Schema error containing the operation and secure-storage key
- construct each read/decode/encode/write/clear failure directly with its exact underlying cause
- log the structured error and full cause chain before the public best-effort store falls back or ignores persistence failures
- remove the valueless curried error-constructor wrapper

## Tests

- `vp test run apps/mobile/src/features/cloud/managedRelayTokenStore.test.ts` (3 tests)
- `vp run lint:mobile`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

## Open PR overlap

- No open pull request touches either changed file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and error-shape refactor only; persisted token load/save/clear fallback behavior is unchanged.
> 
> **Overview**
> **`ManagedRelayTokenStoreError`** is now a **Schema tagged error** with `operation` (`read` | `decode` | `encode` | `write` | `clear`), `storageKey`, and `cause`, instead of free-form `message` strings from a curried `storeError` helper.
> 
> Each secure-store path constructs the error inline with the real underlying cause. **`logStoreFailure`** logs a fixed warning plus structured fields (`operation`, `storageKey`, full error as `cause`) before the store’s existing **best-effort** behavior (empty cache on load, ignore on save/clear).
> 
> A new test asserts that a rejected **`getItemAsync`** still returns `[]` but emits the structured log and keeps the public error message generic (no raw secure-store message in `.message`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccd677a4c51070ecb844c6420457c31ce0c7afe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure `ManagedRelayTokenStoreError` with operation, storageKey, and cause fields
> - Replaces the `Data.TaggedError`-based `ManagedRelayTokenStoreError` with a `Schema.TaggedErrorClass` that carries structured `operation` ('read', 'decode', 'encode', 'write', 'clear'), `storageKey`, and `cause` fields, plus a deterministic message getter.
> - Updates `logStoreFailure` to accept only the error instance and emit a structured warning log with `errorTag`, `operation`, `storageKey`, and `cause` in context; the log message text changes to `'Managed relay token store operation failed.'`
> - All error construction sites in load, save, and clear pipelines now populate the structured fields instead of using the previous `storeError(message)` helper.
> - Adds a test verifying the empty-array fallback and structured warning log on storage read failure.
> - Behavioral Change: public behaviors of load/save/clear are unchanged, but the error type and log format differ from the previous implementation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccd677a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->