### PR TITLE
[codex] Structure Electron protocol teardown failures

### DIFF
--- a/apps/desktop/src/electron/ElectronProtocol.test.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import { beforeEach, vi } from "vite-plus/test";
 
@@ -95,6 +96,60 @@ describe("ElectronProtocol", () => {
 
       assert.equal(response.status, 404);
       assert.equal(netFetchMock.mock.calls.length, 0);
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
+
+  it.effect("preserves protocol registration failures", () =>
+    Effect.gen(function* () {
+      const cause = new Error("protocol registration failed");
+      handleMock.mockImplementationOnce(() => {
+        throw cause;
+      });
+
+      const protocol = yield* ElectronProtocol.ElectronProtocol;
+      const error = yield* Effect.scoped(
+        protocol.registerDesktopProtocol({
+          scheme: "t3code-dev",
+          targetOrigin: new URL("http://127.0.0.1:3773/"),
+          backendOrigin: new URL("http://127.0.0.1:3774/"),
+          clerkFrontendApiHostname: undefined,
+        }),
+      ).pipe(Effect.flip);
+
+      assert.instanceOf(error, ElectronProtocol.ElectronProtocolRegistrationError);
+      assert.equal(error.scheme, "t3code-dev");
+      assert.strictEqual(error.cause, cause);
+      assert.equal(error.message, 'Failed to register Electron protocol scheme "t3code-dev".');
+    }).pipe(Effect.provide(ElectronProtocol.layer)),
+  );
+
+  it.effect("preserves protocol unregistration failures", () =>
+    Effect.gen(function* () {
+      const cause = new Error("protocol unregistration failed");
+      unhandleMock.mockImplementationOnce(() => {
+        throw cause;
+      });
+
+      const protocol = yield* ElectronProtocol.ElectronProtocol;
+      const exit = yield* Effect.exit(
+        Effect.scoped(
+          protocol.registerDesktopProtocol({
+            scheme: "t3code",
+            targetOrigin: new URL("http://127.0.0.1:3773/"),
+            backendOrigin: new URL("http://127.0.0.1:3773/"),
+            clerkFrontendApiHostname: undefined,
+          }),
+        ),
+      );
+
+      assert.equal(exit._tag, "Failure");
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause);
+        assert.instanceOf(error, ElectronProtocol.ElectronProtocolUnregistrationError);
+        assert.equal(error.scheme, "t3code");
+        assert.strictEqual(error.cause, cause);
+        assert.equal(error.message, 'Failed to unregister Electron protocol scheme "t3code".');
+      }
     }).pipe(Effect.provide(ElectronProtocol.layer)),
   );
 

--- a/apps/desktop/src/electron/ElectronProtocol.ts
+++ b/apps/desktop/src/electron/ElectronProtocol.ts
@@ -31,7 +31,19 @@ export class ElectronProtocolRegistrationError extends Schema.TaggedErrorClass<E
   },
 ) {
   override get message(): string {
-    return `Failed to register ${this.scheme}: protocol.`;
+    return `Failed to register Electron protocol scheme "${this.scheme}".`;
+  }
+}
+
+export class ElectronProtocolUnregistrationError extends Schema.TaggedErrorClass<ElectronProtocolUnregistrationError>()(
+  "ElectronProtocolUnregistrationError",
+  {
+    scheme: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to unregister Electron protocol scheme "${this.scheme}".`;
   }
 }
 
@@ -133,9 +145,14 @@ export const make = Effect.gen(function* () {
           catch: (cause) => new ElectronProtocolRegistrationError({ scheme: input.scheme, cause }),
         }).pipe(Effect.andThen(Ref.set(registered, true))),
         () =>
-          Effect.sync(() => {
-            Electron.protocol.unhandle(input.scheme);
-          }).pipe(Effect.andThen(Ref.set(registered, false))),
+          Effect.try({
+            try: () => Electron.protocol.unhandle(input.scheme),
+            catch: (cause) =>
+              new ElectronProtocolUnregistrationError({
+                scheme: input.scheme,
+                cause,
+              }),
+          }).pipe(Effect.andThen(Ref.set(registered, false)), Effect.orDie),
       );
     },
   );


### PR DESCRIPTION
## Summary

- preserve the protocol scheme and exact underlying cause for scoped Electron protocol unregistration failures
- keep registration failures typed while surfacing teardown failures as structured finalizer defects
- construct errors directly and make registration/unregistration messages derive from structured fields
- cover both registration and scoped unregistration cause preservation

## Validation

- `vp test apps/desktop/src/electron/ElectronProtocol.test.ts`
- `vp check`
- `vp run typecheck`

## Overlap audit

- `apps/desktop/src/electron/ElectronProtocol.ts` also appears in unrelated local-auth startup PR #3252; no active error-audit PR touches this module.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure Electron protocol teardown failures into typed errors
> - Adds `ElectronProtocolUnregistrationError` to capture failures from `Electron.protocol.unhandle`, preserving the scheme and original cause.
> - Updates the `acquireRelease` teardown in `registerDesktopProtocol` to use `Effect.try` instead of `Effect.sync`, wrapping thrown exceptions in the new error type and terminating via `orDie`.
> - Updates `ElectronProtocolRegistrationError` message format to `Failed to register Electron protocol scheme "<scheme>"`.
> - Adds tests verifying error class, scheme, cause, and message for both registration and unregistration failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dda508c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->