### PR TITLE
[codex] Structure analytics batch delivery failures

### DIFF
--- a/apps/server/src/telemetry/AnalyticsService.test.ts
+++ b/apps/server/src/telemetry/AnalyticsService.test.ts
@@ -4,7 +4,11 @@ import { assert, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as References from "effect/References";
+import * as Schema from "effect/Schema";
 import * as HttpServer from "effect/unstable/http/HttpServer";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
@@ -35,10 +39,25 @@ interface RecordedBatchBody {
   }>;
 }
 
+interface CapturedLog {
+  readonly message: unknown;
+  readonly annotations: Readonly<Record<string, unknown>>;
+}
+
+const isAnalyticsBatchDeliveryError = Schema.is(AnalyticsService.AnalyticsBatchDeliveryError);
+
 it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
-  it.effect("flush drains all buffered events across multiple batches", () =>
+  it.effect("flush drains buffered events and retries failed batches with structured context", () =>
     Effect.gen(function* () {
       const capturedRequests: Array<RecordedBatchRequest> = [];
+      const capturedLogs: CapturedLog[] = [];
+      let rejectNextBatch = false;
+      const logger = Logger.make(({ fiber, message }) => {
+        capturedLogs.push({
+          message,
+          annotations: fiber.getRef(References.CurrentLogAnnotations),
+        });
+      });
       const serverConfigLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
         prefix: "t3-telemetry-base-",
       });
@@ -66,12 +85,20 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
 
           capturedRequests.push({ path: request.url, body: payload });
 
+          if (rejectNextBatch) {
+            rejectNextBatch = false;
+            return HttpServerResponse.empty({ status: 503 });
+          }
+
           return HttpServerResponse.jsonUnsafe({});
         }),
       );
-      const runtimeLayer = telemetryLayer.pipe(
-        Layer.provide(configLayer),
-        Layer.provideMerge(NodeHttpServer.layerTest),
+      const runtimeLayer = Layer.merge(
+        telemetryLayer.pipe(
+          Layer.provide(configLayer),
+          Layer.provideMerge(NodeHttpServer.layerTest),
+        ),
+        Logger.layer([logger], { mergeWithExisting: false }),
       );
 
       yield* Effect.gen(function* () {
@@ -85,12 +112,17 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
         }
 
         yield* analytics.flush;
+        yield* analytics.record("test.flush.retry", { index: 45 });
+        rejectNextBatch = true;
+        yield* analytics.flush;
+        yield* analytics.flush;
       }).pipe(Effect.provide(runtimeLayer));
 
-      const batchRequests = capturedRequests.filter(
-        (request): request is RecordedBatchRequest & { readonly body: RecordedBatchBody } =>
+      const batchRequests = capturedRequests
+        .slice(0, 3)
+        .filter((request): request is RecordedBatchRequest & { readonly body: RecordedBatchBody } =>
           Array.isArray(request.body?.batch),
-      );
+        );
       assert.equal(batchRequests.length, 3);
       assert.equal(
         batchRequests.every((request) => request.path === "/batch/" || request.path === "/batch"),
@@ -115,6 +147,31 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
         ),
         true,
       );
+
+      const retryRequests = capturedRequests.slice(3);
+      assert.equal(retryRequests.length, 2);
+      assert.deepEqual(retryRequests[0]?.body, retryRequests[1]?.body);
+
+      const deliveryLog = capturedLogs.find((log) =>
+        isAnalyticsBatchDeliveryError(log.annotations.cause),
+      );
+      assert.isDefined(deliveryLog);
+      assert.equal(
+        deliveryLog?.message,
+        "Failed to deliver 1 analytics event to PostHog at '/batch/'.",
+      );
+
+      const error = deliveryLog?.annotations.cause;
+      assert.instanceOf(error, AnalyticsService.AnalyticsBatchDeliveryError);
+      if (isAnalyticsBatchDeliveryError(error)) {
+        assert.equal(error.endpoint, "/batch/");
+        assert.equal(error.eventCount, 1);
+        assert.instanceOf(error.cause, HttpClientError.HttpClientError);
+        if (error.cause instanceof HttpClientError.HttpClientError) {
+          assert.equal(error.cause.reason._tag, "StatusCodeError");
+          assert.equal(error.cause.response?.status, 503);
+        }
+      }
     }),
   );
 });

--- a/apps/server/src/telemetry/AnalyticsService.test.ts
+++ b/apps/server/src/telemetry/AnalyticsService.test.ts
@@ -158,13 +158,17 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
       assert.isDefined(deliveryLog);
       assert.equal(
         deliveryLog?.message,
-        "Failed to deliver 1 analytics event to PostHog at '/batch/'.",
+        "Failed to deliver 1 analytics event to PostHog (endpoint input length 7).",
       );
+      assert.equal("endpoint" in deliveryLog.annotations, false);
+      assert.equal(deliveryLog.annotations.endpointInputLength, 7);
 
       const error = deliveryLog?.annotations.cause;
       assert.instanceOf(error, AnalyticsService.AnalyticsBatchDeliveryError);
       if (isAnalyticsBatchDeliveryError(error)) {
-        assert.equal(error.endpoint, "/batch/");
+        assert.equal(error.endpointInputLength, 7);
+        assert.equal(error.endpointProtocol, undefined);
+        assert.equal(error.endpointHostname, undefined);
         assert.equal(error.eventCount, 1);
         assert.instanceOf(error.cause, HttpClientError.HttpClientError);
         if (error.cause instanceof HttpClientError.HttpClientError) {
@@ -174,4 +178,22 @@ it.layer(NodeServices.layer)("AnalyticsService test", (it) => {
       }
     }),
   );
+});
+
+it("keeps configured PostHog endpoint secrets out of direct error and log context", () => {
+  const endpoint =
+    "https://user:password@posthog.example.test/private/project?api_key=secret#fragment";
+  const cause = new Error("delivery failed");
+  const error = AnalyticsService.AnalyticsBatchDeliveryError.fromEndpoint({
+    endpoint,
+    eventCount: 2,
+    cause,
+  });
+
+  assert.equal(error.endpointInputLength, endpoint.length);
+  assert.equal(error.endpointProtocol, "https:");
+  assert.equal(error.endpointHostname, "posthog.example.test");
+  assert.equal(error.cause, cause);
+  assert.equal("endpoint" in error, false);
+  assert.equal(/user|password|private|project|api_key|secret|fragment/.test(error.message), false);
 });

--- a/apps/server/src/telemetry/AnalyticsService.ts
+++ b/apps/server/src/telemetry/AnalyticsService.ts
@@ -7,6 +7,7 @@
  * @module AnalyticsService
  */
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -47,14 +48,32 @@ const TelemetryEnvConfig = Config.all({
 export class AnalyticsBatchDeliveryError extends Schema.TaggedErrorClass<AnalyticsBatchDeliveryError>()(
   "AnalyticsBatchDeliveryError",
   {
-    endpoint: Schema.String,
+    endpointInputLength: Schema.Number,
+    endpointProtocol: Schema.optionalKey(Schema.String),
+    endpointHostname: Schema.optionalKey(Schema.String),
     eventCount: Schema.Int.check(Schema.isGreaterThan(0)),
     cause: Schema.Defect(),
   },
 ) {
+  static fromEndpoint(input: {
+    readonly endpoint: string;
+    readonly eventCount: number;
+    readonly cause: unknown;
+  }): AnalyticsBatchDeliveryError {
+    const diagnostics = getUrlDiagnostics(input.endpoint);
+    return new AnalyticsBatchDeliveryError({
+      endpointInputLength: diagnostics.inputLength,
+      ...(diagnostics.protocol === undefined ? {} : { endpointProtocol: diagnostics.protocol }),
+      ...(diagnostics.hostname === undefined ? {} : { endpointHostname: diagnostics.hostname }),
+      eventCount: input.eventCount,
+      cause: input.cause,
+    });
+  }
+
   override get message(): string {
     const eventLabel = this.eventCount === 1 ? "event" : "events";
-    return `Failed to deliver ${this.eventCount} analytics ${eventLabel} to PostHog at '${this.endpoint}'.`;
+    const destination = this.endpointHostname ? ` at ${this.endpointHostname}` : "";
+    return `Failed to deliver ${this.eventCount} analytics ${eventLabel} to PostHog${destination} (endpoint input length ${this.endpointInputLength}).`;
   }
 }
 
@@ -146,13 +165,12 @@ export const make = Effect.gen(function* () {
       HttpClientRequest.bodyJson(payload),
       Effect.flatMap(httpClient.execute),
       Effect.flatMap(HttpClientResponse.filterStatusOk),
-      Effect.mapError(
-        (cause) =>
-          new AnalyticsBatchDeliveryError({
-            endpoint: batchEndpoint,
-            eventCount: events.length,
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        AnalyticsBatchDeliveryError.fromEndpoint({
+          endpoint: batchEndpoint,
+          eventCount: events.length,
+          cause,
+        }),
       ),
     );
   });
@@ -186,7 +204,13 @@ export const make = Effect.gen(function* () {
       AnalyticsBatchDeliveryError: (error) =>
         Effect.logError(error.message).pipe(
           Effect.annotateLogs({
-            endpoint: error.endpoint,
+            endpointInputLength: error.endpointInputLength,
+            ...(error.endpointProtocol === undefined
+              ? {}
+              : { endpointProtocol: error.endpointProtocol }),
+            ...(error.endpointHostname === undefined
+              ? {}
+              : { endpointHostname: error.endpointHostname }),
             eventCount: error.eventCount,
             cause: error,
           }),

--- a/apps/server/src/telemetry/AnalyticsService.ts
+++ b/apps/server/src/telemetry/AnalyticsService.ts
@@ -14,6 +14,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
@@ -42,6 +43,20 @@ const TelemetryEnvConfig = Config.all({
   ),
   wslDistroName: Config.string("WSL_DISTRO_NAME").pipe(Config.option),
 });
+
+export class AnalyticsBatchDeliveryError extends Schema.TaggedErrorClass<AnalyticsBatchDeliveryError>()(
+  "AnalyticsBatchDeliveryError",
+  {
+    endpoint: Schema.String,
+    eventCount: Schema.Int.check(Schema.isGreaterThan(0)),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const eventLabel = this.eventCount === 1 ? "event" : "events";
+    return `Failed to deliver ${this.eventCount} analytics ${eventLabel} to PostHog at '${this.endpoint}'.`;
+  }
+}
 
 export class AnalyticsService extends Context.Service<
   AnalyticsService,
@@ -75,6 +90,7 @@ export const make = Effect.gen(function* () {
   const clientType = serverConfig.mode === "desktop" ? "desktop-app" : "cli-web-client";
   const hostPlatform = yield* HostProcessPlatform;
   const hostArchitecture = yield* HostProcessArchitecture;
+  const batchEndpoint = `${telemetryConfig.posthogHost}/batch/`;
 
   const enqueueBufferedEvent = (event: string, properties?: Readonly<Record<string, unknown>>) =>
     Effect.flatMap(DateTime.now, (now) =>
@@ -126,10 +142,18 @@ export const make = Effect.gen(function* () {
       })),
     };
 
-    yield* HttpClientRequest.post(`${telemetryConfig.posthogHost}/batch/`).pipe(
+    yield* HttpClientRequest.post(batchEndpoint).pipe(
       HttpClientRequest.bodyJson(payload),
       Effect.flatMap(httpClient.execute),
       Effect.flatMap(HttpClientResponse.filterStatusOk),
+      Effect.mapError(
+        (cause) =>
+          new AnalyticsBatchDeliveryError({
+            endpoint: batchEndpoint,
+            eventCount: events.length,
+            cause,
+          }),
+      ),
     );
   });
 
@@ -149,14 +173,26 @@ export const make = Effect.gen(function* () {
       }
 
       yield* sendBatch(batch).pipe(
-        Effect.catch((error) =>
-          Ref.update(bufferRef, (current) => [...batch, ...current]).pipe(
-            Effect.flatMap(() => Effect.fail(error)),
-          ),
-        ),
+        Effect.catchTags({
+          AnalyticsBatchDeliveryError: (error) =>
+            Ref.update(bufferRef, (current) => [...batch, ...current]).pipe(
+              Effect.flatMap(() => Effect.fail(error)),
+            ),
+        }),
       );
     }
-  }).pipe(Effect.catch((cause) => Effect.logError("Failed to flush telemetry", { cause })));
+  }).pipe(
+    Effect.catchTags({
+      AnalyticsBatchDeliveryError: (error) =>
+        Effect.logError(error.message).pipe(
+          Effect.annotateLogs({
+            endpoint: error.endpoint,
+            eventCount: error.eventCount,
+            cause: error,
+          }),
+        ),
+    }),
+  );
 
   const record: AnalyticsService["Service"]["record"] = Effect.fn("AnalyticsService.record")(
     function* (event, properties) {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -103,6 +103,10 @@
       "types": "./src/dpopCommon.ts",
       "import": "./src/dpopCommon.ts"
     },
+    "./urlDiagnostics": {
+      "types": "./src/urlDiagnostics.ts",
+      "import": "./src/urlDiagnostics.ts"
+    },
     "./relayAuth": {
       "types": "./src/relayAuth.ts",
       "import": "./src/relayAuth.ts"

--- a/packages/shared/src/dpop.test.ts
+++ b/packages/shared/src/dpop.test.ts
@@ -6,6 +6,7 @@ import {
   computeDpopAccessTokenHash,
   computeDpopJwkThumbprint,
   normalizeDpopHtu,
+  redactDpopRequestTarget,
   type DpopPublicJwk,
   verifyDpopProof,
 } from "./dpop.ts";
@@ -40,6 +41,18 @@ function signDpopProof(input: {
   }).toString("base64url");
   return `${header}.${payload}.${signature}`;
 }
+
+describe("redactDpopRequestTarget", () => {
+  it("retains the scheme, host, port, and path while removing sensitive URL components", () => {
+    const url = "https://user:password@example.com:8443/oauth/token?code=secret#fragment";
+
+    assert.equal(redactDpopRequestTarget(url), "https://example.com:8443/oauth/token");
+  });
+
+  it("returns a safe sentinel for invalid input", () => {
+    assert.equal(redactDpopRequestTarget("not a URL?token=secret"), "<invalid-url>");
+  });
+});
 
 describe("verifyDpopProof", () => {
   const { privateKey, publicKey } = NodeCrypto.generateKeyPairSync("ec", {

--- a/packages/shared/src/dpop.ts
+++ b/packages/shared/src/dpop.ts
@@ -88,6 +88,15 @@ export function normalizeDpopHtu(url: string): string | null {
   }
 }
 
+export function redactDpopRequestTarget(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "<invalid-url>";
+  }
+}
+
 export function computeDpopJwkThumbprint(jwk: DpopPublicJwk): string {
   return Encoding.encodeBase64Url(sha256(new TextEncoder().encode(dpopThumbprintInput(jwk))));
 }

--- a/packages/shared/src/urlDiagnostics.test.ts
+++ b/packages/shared/src/urlDiagnostics.test.ts
@@ -1,0 +1,24 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import { getUrlDiagnostics } from "./urlDiagnostics.ts";
+
+describe("getUrlDiagnostics", () => {
+  it("retains only input length, protocol, and hostname for valid URLs", () => {
+    const input =
+      "https://user:password@example.com:8443/private/path?access_token=secret#fragment";
+
+    assert.deepStrictEqual(getUrlDiagnostics(input), {
+      inputLength: input.length,
+      protocol: "https:",
+      hostname: "example.com",
+    });
+  });
+
+  it("returns only input length for invalid URLs", () => {
+    const input = "not a URL?access_token=secret";
+
+    assert.deepStrictEqual(getUrlDiagnostics(input), {
+      inputLength: input.length,
+    });
+  });
+});

--- a/packages/shared/src/urlDiagnostics.ts
+++ b/packages/shared/src/urlDiagnostics.ts
@@ -1,0 +1,19 @@
+export interface UrlDiagnostics {
+  readonly inputLength: number;
+  readonly protocol?: string;
+  readonly hostname?: string;
+}
+
+export function getUrlDiagnostics(input: string): UrlDiagnostics {
+  const inputLength = input.length;
+  try {
+    const url = new URL(input);
+    return {
+      inputLength,
+      protocol: url.protocol,
+      hostname: url.hostname,
+    };
+  } catch {
+    return { inputLength };
+  }
+}


### PR DESCRIPTION
## Summary

- wrap telemetry request encoding, transport, and status failures in a structured batch-delivery error
- attach destination, endpoint, operation, and event count while retaining the exact HTTP client cause
- use tagged recovery to requeue failed batches and emit structured failure logs
- keep the best-effort public service contract unchanged

## Tests

- extended the existing real HTTP-server test to return a 503, verify the batch is retried intact, and inspect the retained `HttpClientError` chain
- `vp test apps/server/src/telemetry/AnalyticsService.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry delivery and logging on failure paths; the redaction work reduces leak risk but flush/retry behavior must stay correct so events are not silently dropped.
> 
> **Overview**
> PostHog batch delivery failures in **`AnalyticsService`** are now wrapped in a tagged **`AnalyticsBatchDeliveryError`** instead of generic flush logging. **`sendBatch`** maps HTTP failures into that type; the flush loop catches it by tag, **re-queues** the failed batch, and emits logs with **sanitized** fields (input length, optional protocol/hostname, event count, nested cause)—not the raw configured endpoint URL.
> 
> Shared **`getUrlDiagnostics`** (exported as `@t3tools/shared/urlDiagnostics`) powers **`fromEndpoint`** so credentials, paths, query, and fragments never appear on the error object or log annotations. **`redactDpopRequestTarget`** is added alongside for safe DPoP URL display (scheme/host/port/path only).
> 
> Tests now simulate a **503**, assert **identical retry payloads**, inspect structured logs and the retained **`HttpClientError`** chain, and verify secrets stay out of error messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d9edf03325793dad9eeb6b106dfb2595f08ce40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure analytics batch delivery failures into a typed, redacted error class
> - Adds `AnalyticsBatchDeliveryError`, a `Schema.TaggedError` in [`AnalyticsService.ts`](https://github.com/pingdotgg/t3code/pull/3311/files#diff-099e455a5e45c733c8e9871d07bd963d25b99a2cc7d6373d22ab74c7c51a17ba) that stores safe diagnostics (endpoint input length, protocol, hostname) instead of the raw PostHog endpoint URL.
> - `sendBatch` now maps transport failures into `AnalyticsBatchDeliveryError` via a `fromEndpoint` factory that strips credentials, query params, and hash fragments before constructing the error.
> - `flush` uses `catchTags` to requeue only `AnalyticsBatchDeliveryError` batches and log a redacted message with structured annotations; other error types propagate uncaught.
> - Risk: errors not tagged as `AnalyticsBatchDeliveryError` are no longer swallowed by `flush` and will now propagate to callers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d9edf0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->