### PR TITLE
[codex] Structure relay delivery attempt errors

### DIFF
--- a/infra/relay/src/agentActivity/DeliveryAttempts.test.ts
+++ b/infra/relay/src/agentActivity/DeliveryAttempts.test.ts
@@ -320,4 +320,95 @@ describe("DeliveryAttempts", () => {
       ),
     );
   });
+
+  it.effect("preserves operation context and causes for persistence failures", () => {
+    const cause = new Error("database unavailable");
+    const fakeDb = {
+      insert: () => ({
+        values: (values: Record<string, unknown>) =>
+          values.kind === "record"
+            ? Effect.fail(cause)
+            : {
+                onConflictDoNothing: () => ({
+                  returning: () => Effect.fail(cause),
+                }),
+              },
+      }),
+      update: () => ({
+        set: () => ({
+          where: () => Effect.fail(cause),
+        }),
+      }),
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const attempts = yield* DeliveryAttempts.DeliveryAttempts;
+      const recordError = yield* Effect.flip(
+        attempts.record({
+          userId: "user-1",
+          environmentId: "env-1",
+          threadId: "thread-1",
+          deviceId: "device-1",
+          kind: "record",
+          sourceJobId: "job-1",
+          token: "apns-token",
+        }),
+      );
+      const claimError = yield* Effect.flip(
+        attempts.claimSourceJob({
+          userId: "user-2",
+          environmentId: "env-2",
+          threadId: "thread-2",
+          deviceId: "device-2",
+          kind: "claim",
+          sourceJobId: "job-2",
+          token: "apns-token",
+        }),
+      );
+      const completionError = yield* Effect.flip(
+        attempts.completeSourceJob({ sourceJobId: "job-3", apnsStatus: 500 }),
+      );
+
+      expect(recordError).toMatchObject({
+        operation: "record",
+        sourceJobId: "job-1",
+        userId: "user-1",
+        environmentId: "env-1",
+        threadId: "thread-1",
+        deviceId: "device-1",
+        kind: "record",
+        cause,
+        message: "Failed to persist APNs delivery attempt during record.",
+      });
+      expect(claimError).toMatchObject({
+        operation: "claim-source-job",
+        sourceJobId: "job-2",
+        userId: "user-2",
+        environmentId: "env-2",
+        threadId: "thread-2",
+        deviceId: "device-2",
+        kind: "claim",
+        cause,
+        message: "Failed to persist APNs delivery attempt during claim-source-job.",
+      });
+      expect(completionError).toMatchObject({
+        operation: "complete-source-job",
+        sourceJobId: "job-3",
+        userId: null,
+        environmentId: null,
+        threadId: null,
+        deviceId: null,
+        kind: null,
+        cause,
+        message: "Failed to persist APNs delivery attempt during complete-source-job.",
+      });
+    }).pipe(
+      Effect.provide(
+        DeliveryAttempts.layer.pipe(
+          Layer.provide(NodeCryptoLayer.layer),
+          Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)),
+        ),
+      ),
+    );
+  });
 });

--- a/infra/relay/src/agentActivity/DeliveryAttempts.ts
+++ b/infra/relay/src/agentActivity/DeliveryAttempts.ts
@@ -12,10 +12,19 @@ import { relayDeliveryAttempts } from "../persistence/schema.ts";
 
 export class DeliveryAttemptRecordPersistenceError extends Schema.TaggedErrorClass<DeliveryAttemptRecordPersistenceError>()(
   "DeliveryAttemptRecordPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    operation: Schema.Literals(["record", "claim-source-job", "complete-source-job"]),
+    sourceJobId: Schema.NullOr(Schema.String),
+    userId: Schema.NullOr(Schema.String),
+    environmentId: Schema.NullOr(Schema.String),
+    threadId: Schema.NullOr(Schema.String),
+    deviceId: Schema.NullOr(Schema.String),
+    kind: Schema.NullOr(Schema.String),
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to persist APNs delivery attempt";
+    return `Failed to persist APNs delivery attempt during ${this.operation}.`;
   }
 }
 
@@ -99,30 +108,43 @@ export const make = Effect.gen(function* () {
   };
 
   return DeliveryAttempts.of({
-    record: Effect.fn("relay.delivery_attempts.record")(
-      function* (input) {
-        yield* Effect.annotateCurrentSpan({
-          "relay.delivery.kind": input.kind,
-          ...(input.sourceJobId ? { "relay.delivery.job_id": input.sourceJobId } : {}),
-          ...(input.deviceId ? { "relay.mobile.device_id": input.deviceId } : {}),
-          ...(input.environmentId ? { "relay.environment_id": input.environmentId } : {}),
-          ...(input.threadId ? { "relay.thread_id": input.threadId } : {}),
-        });
+    record: Effect.fn("relay.delivery_attempts.record")(function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "relay.delivery.kind": input.kind,
+        ...(input.sourceJobId ? { "relay.delivery.job_id": input.sourceJobId } : {}),
+        ...(input.deviceId ? { "relay.mobile.device_id": input.deviceId } : {}),
+        ...(input.environmentId ? { "relay.environment_id": input.environmentId } : {}),
+        ...(input.threadId ? { "relay.thread_id": input.threadId } : {}),
+      });
+      yield* Effect.gen(function* () {
         const id = yield* crypto.randomUUIDv4;
         const createdAt = DateTime.formatIso(yield* DateTime.now);
         yield* db.insert(relayDeliveryAttempts).values(insertValues(input, id, createdAt));
-      },
-      Effect.mapError((cause) => new DeliveryAttemptRecordPersistenceError({ cause })),
-    ),
-    claimSourceJob: Effect.fn("relay.delivery_attempts.claim_source_job")(
-      function* (input) {
-        yield* Effect.annotateCurrentSpan({
-          "relay.delivery.kind": input.kind,
-          "relay.delivery.job_id": input.sourceJobId,
-          ...(input.deviceId ? { "relay.mobile.device_id": input.deviceId } : {}),
-          ...(input.environmentId ? { "relay.environment_id": input.environmentId } : {}),
-          ...(input.threadId ? { "relay.thread_id": input.threadId } : {}),
-        });
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new DeliveryAttemptRecordPersistenceError({
+              operation: "record",
+              sourceJobId: input.sourceJobId ?? null,
+              userId: input.userId,
+              environmentId: input.environmentId,
+              threadId: input.threadId,
+              deviceId: input.deviceId,
+              kind: input.kind,
+              cause,
+            }),
+        ),
+      );
+    }),
+    claimSourceJob: Effect.fn("relay.delivery_attempts.claim_source_job")(function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "relay.delivery.kind": input.kind,
+        "relay.delivery.job_id": input.sourceJobId,
+        ...(input.deviceId ? { "relay.mobile.device_id": input.deviceId } : {}),
+        ...(input.environmentId ? { "relay.environment_id": input.environmentId } : {}),
+        ...(input.threadId ? { "relay.thread_id": input.threadId } : {}),
+      });
+      return yield* Effect.gen(function* () {
         const id = yield* crypto.randomUUIDv4;
         const now = yield* DateTime.now;
         const createdAt = DateTime.formatIso(now);
@@ -179,26 +201,51 @@ export const make = Effect.gen(function* () {
           )
           .returning({ id: relayDeliveryAttempts.id });
         return reclaimed.length > 0 ? "claimed" : "in_flight";
-      },
-      Effect.mapError((cause) => new DeliveryAttemptRecordPersistenceError({ cause })),
-    ),
-    completeSourceJob: Effect.fn("relay.delivery_attempts.complete_source_job")(
-      function* (input) {
-        yield* Effect.annotateCurrentSpan({ "relay.delivery.job_id": input.sourceJobId });
-        const completedAt = DateTime.formatIso(yield* DateTime.now);
-        yield* db
-          .update(relayDeliveryAttempts)
-          .set({
-            createdAt: completedAt,
-            apnsStatus: input.apnsStatus ?? null,
-            apnsReason: input.apnsReason ?? null,
-            apnsId: input.apnsId ?? null,
-            transportError: input.transportError ?? null,
-          })
-          .where(eq(relayDeliveryAttempts.sourceJobId, input.sourceJobId));
-      },
-      Effect.mapError((cause) => new DeliveryAttemptRecordPersistenceError({ cause })),
-    ),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new DeliveryAttemptRecordPersistenceError({
+              operation: "claim-source-job",
+              sourceJobId: input.sourceJobId,
+              userId: input.userId,
+              environmentId: input.environmentId,
+              threadId: input.threadId,
+              deviceId: input.deviceId,
+              kind: input.kind,
+              cause,
+            }),
+        ),
+      );
+    }),
+    completeSourceJob: Effect.fn("relay.delivery_attempts.complete_source_job")(function* (input) {
+      yield* Effect.annotateCurrentSpan({ "relay.delivery.job_id": input.sourceJobId });
+      const completedAt = DateTime.formatIso(yield* DateTime.now);
+      yield* db
+        .update(relayDeliveryAttempts)
+        .set({
+          createdAt: completedAt,
+          apnsStatus: input.apnsStatus ?? null,
+          apnsReason: input.apnsReason ?? null,
+          apnsId: input.apnsId ?? null,
+          transportError: input.transportError ?? null,
+        })
+        .where(eq(relayDeliveryAttempts.sourceJobId, input.sourceJobId))
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new DeliveryAttemptRecordPersistenceError({
+                operation: "complete-source-job",
+                sourceJobId: input.sourceJobId,
+                userId: null,
+                environmentId: null,
+                threadId: null,
+                deviceId: null,
+                kind: null,
+                cause,
+              }),
+          ),
+        );
+    }),
   });
 });
 


### PR DESCRIPTION
## Summary
- attach the persistence operation and available delivery/job correlation fields to relay delivery-attempt failures
- preserve the original database or crypto cause for complete error chains
- derive the generic persistence message from the structured operation and construct errors directly at each boundary
- add focused coverage for record, claim, and completion failure mappings

## Validation
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`
- `/Users/julius/.codex/worktrees/d5fa/codething-mvp/node_modules/.bin/vp test infra/relay/src/agentActivity/DeliveryAttempts.test.ts --no-cache` (7 tests)

## Overlap audit
- no overlap with another active error-audit/service-refactor PR
- the same paths also appear in broad draft #2925 (`feat(relay): enforce resource limits`); that unrelated overlap is reported here for visibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only error shaping on audit persistence; no change to claim/record/completion behavior or public method signatures beyond richer error payloads.
> 
> **Overview**
> **`DeliveryAttemptRecordPersistenceError`** now carries **which operation failed** (`record`, `claim-source-job`, `complete-source-job`) plus **correlation fields** (`sourceJobId`, user/env/thread/device, `kind`) while still wrapping the underlying DB/crypto **`cause`**. Messages are derived from the operation (e.g. *during claim-source-job*).
> 
> Persistence mapping is applied **per boundary** in `DeliveryAttempts` instead of a single generic `mapError`, so success paths and tracing are unchanged but failures are easier to log and debug. A new test asserts all three operations preserve context and the original cause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a83db42ea3c5c50e9dd7e391a368b3c3cfda9e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure `DeliveryAttemptRecordPersistenceError` with operation context and input identifiers
> - Adds `operation` (one of `record`, `claim-source-job`, `complete-source-job`), contextual IDs (`sourceJobId`, `userId`, `environmentId`, `threadId`, `deviceId`, `kind`), and `cause` fields to `DeliveryAttemptRecordPersistenceError` in [DeliveryAttempts.ts](https://github.com/pingdotgg/t3code/pull/3312/files#diff-48704e5623f4c6c36e0ac21d8d371ddff72a8eed40ea470d389f5c8885e4654f).
> - Each handler now uses `Effect.mapError` scoped only to the persistence block, so span annotation failures before the db call are no longer wrapped in `DeliveryAttemptRecordPersistenceError`.
> - The error message now reads `'Failed to persist APNs delivery attempt during ${operation}.'` for easier triage.
> - Adds a test in [DeliveryAttempts.test.ts](https://github.com/pingdotgg/t3code/pull/3312/files#diff-d6252b7515e0f0758df7dc530f7cc96496cb29f6e333e3f0d58ee25c44a27b80) covering all three operations with a fake `RelayDb` that forces insert/update failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a83db42.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->