### PR TITLE
[codex] Structure desktop network interface failures

### DIFF
--- a/apps/desktop/src/backend/DesktopNetworkInterfaces.test.ts
+++ b/apps/desktop/src/backend/DesktopNetworkInterfaces.test.ts
@@ -1,0 +1,65 @@
+import { assert, describe, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { beforeEach, vi } from "vite-plus/test";
+
+const { networkInterfacesMock } = vi.hoisted(() => ({
+  networkInterfacesMock: vi.fn(),
+}));
+
+vi.mock("node:os", () => ({
+  networkInterfaces: networkInterfacesMock,
+}));
+
+import * as DesktopNetworkInterfaces from "./DesktopNetworkInterfaces.ts";
+
+const TestLayer = DesktopNetworkInterfaces.layer.pipe(
+  Layer.provide(Layer.succeed(HostProcessPlatform, "linux")),
+);
+
+describe("DesktopNetworkInterfaces", () => {
+  beforeEach(() => {
+    networkInterfacesMock.mockReset();
+  });
+
+  it.effect("reads network interfaces through the service", () => {
+    const interfaces = {
+      en0: [
+        {
+          address: "192.168.1.10",
+          family: "IPv4",
+          internal: false,
+        },
+      ],
+    };
+    networkInterfacesMock.mockReturnValueOnce(interfaces);
+
+    return Effect.gen(function* () {
+      const service = yield* DesktopNetworkInterfaces.DesktopNetworkInterfaces;
+      assert.strictEqual(yield* service.read, interfaces);
+    }).pipe(Effect.provide(TestLayer));
+  });
+
+  it.effect("preserves network interface read failures as structured defects", () => {
+    const cause = new Error("network interface probe failed");
+    networkInterfacesMock.mockImplementationOnce(() => {
+      throw cause;
+    });
+
+    return Effect.gen(function* () {
+      const service = yield* DesktopNetworkInterfaces.DesktopNetworkInterfaces;
+      const exit = yield* Effect.exit(service.read);
+
+      assert.equal(exit._tag, "Failure");
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause);
+        assert.instanceOf(error, DesktopNetworkInterfaces.DesktopNetworkInterfacesReadError);
+        assert.equal(error.platform, "linux");
+        assert.strictEqual(error.cause, cause);
+        assert.equal(error.message, "Failed to read desktop network interfaces on linux.");
+      }
+    }).pipe(Effect.provide(TestLayer));
+  });
+});

--- a/apps/desktop/src/backend/DesktopNetworkInterfaces.ts
+++ b/apps/desktop/src/backend/DesktopNetworkInterfaces.ts
@@ -1,8 +1,10 @@
 import * as NodeOS from "node:os";
 
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 
 export interface DesktopNetworkInterfaceInfo {
   readonly address: string;
@@ -18,6 +20,18 @@ export type NetworkInterfaces = Readonly<
   Record<string, readonly DesktopNetworkInterfaceInfo[] | undefined>
 >;
 
+export class DesktopNetworkInterfacesReadError extends Schema.TaggedErrorClass<DesktopNetworkInterfacesReadError>()(
+  "DesktopNetworkInterfacesReadError",
+  {
+    platform: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read desktop network interfaces on ${this.platform}.`;
+  }
+}
+
 export class DesktopNetworkInterfaces extends Context.Service<
   DesktopNetworkInterfaces,
   {
@@ -25,9 +39,14 @@ export class DesktopNetworkInterfaces extends Context.Service<
   }
 >()("@t3tools/desktop/backend/DesktopNetworkInterfaces") {}
 
-export const make = (): DesktopNetworkInterfaces["Service"] =>
-  DesktopNetworkInterfaces.of({
-    read: Effect.sync(() => NodeOS.networkInterfaces()),
+export const make = Effect.gen(function* () {
+  const platform = yield* HostProcessPlatform;
+  return DesktopNetworkInterfaces.of({
+    read: Effect.try({
+      try: () => NodeOS.networkInterfaces(),
+      catch: (cause) => new DesktopNetworkInterfacesReadError({ platform, cause }),
+    }).pipe(Effect.orDie),
   });
+});
 
-export const layer = Layer.succeed(DesktopNetworkInterfaces, make());
+export const layer = Layer.effect(DesktopNetworkInterfaces, make);


### PR DESCRIPTION
## Summary

- wrap synchronous operating-system network-interface probe failures in a Schema error
- retain the host platform and exact underlying cause while preserving the service's existing defect semantics
- inject the host platform through `HostProcessPlatform` and construct the error directly
- add focused success and failure coverage

## Validation

- `vp test apps/desktop/src/backend/DesktopNetworkInterfaces.test.ts`
- `vp check`
- `vp run typecheck`

## Overlap audit

- no open pull request touches `apps/desktop/src/backend/DesktopNetworkInterfaces.ts` or its new focused test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop backend error-handling change with no auth or data-path impact; behavior on success is unchanged and failures remain defects via orDie.
> 
> **Overview**
> **`DesktopNetworkInterfaces.read`** no longer calls `node:os.networkInterfaces()` via bare `Effect.sync`. Failures are caught and wrapped in a new **`DesktopNetworkInterfacesReadError`** (platform from **`HostProcessPlatform`**, original throwable as **`cause`**), then **`Effect.orDie`** so callers still see a defect on failure.
> 
> Service construction moves from a synchronous **`make()`** + **`Layer.succeed`** to **`Effect.gen`** + **`Layer.effect`**, so the layer depends on **`HostProcessPlatform`**.
> 
> Adds **`DesktopNetworkInterfaces.test.ts`** with a mocked **`node:os`**, covering a successful read and asserting squashed failure shape/message for probe errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406090785befa8cdb51da0cd875183d678450669. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure network interface read failures as typed defects in `DesktopNetworkInterfaces`
> - Introduces `DesktopNetworkInterfacesReadError`, a `Schema.TaggedError` carrying `platform` and `cause` fields, replacing raw thrown errors from `node:os.networkInterfaces`.
> - Refactors `make` into an `Effect.gen` that reads `HostProcessPlatform` from the environment and wraps any read failure in the structured error before converting it to a defect via `Effect.orDie`.
> - Updates `layer` from `Layer.succeed` to `Layer.effect` to match the effectful `make`.
> - Adds a vitest suite in [DesktopNetworkInterfaces.test.ts](https://github.com/pingdotgg/t3code/pull/3313/files#diff-8728d8f05bca03b887ffaa3c6ea8cb0fddb70f48b963705f832882c9deb42167) covering both successful reads and structured defect shape on failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4060907.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->