### PR TITLE
[codex] Structure relay Live Activity errors

### DIFF
--- a/infra/relay/src/agentActivity/LiveActivities.test.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.test.ts
@@ -254,7 +254,8 @@ describe("LiveActivities", () => {
         userId: "user-1",
         deviceId: "device-1",
         cause,
-        message: "Failed to persist Live Activity registration for device device-1.",
+        message:
+          "Failed to persist Live Activity registration for user user-1 and device device-1.",
       });
       expect(targetListError).toMatchObject({
         userId: "user-1",
@@ -275,7 +276,7 @@ describe("LiveActivities", () => {
           deviceId: "device-1",
           kind,
           cause,
-          message: `Failed to persist Live Activity state during ${operation} for device device-1.`,
+          message: `Failed to persist Live Activity state during ${operation} for user user-1 and device device-1.`,
         });
       }
     }).pipe(

--- a/infra/relay/src/agentActivity/LiveActivities.test.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.test.ts
@@ -197,4 +197,91 @@ describe("LiveActivities", () => {
       ),
     );
   });
+
+  it.effect("preserves correlation context and causes for persistence failures", () => {
+    const cause = new Error("database unavailable");
+    const registration: RelayLiveActivityRegistrationRequest = {
+      deviceId: "device-1" as RelayLiveActivityRegistrationRequest["deviceId"],
+      activityPushToken:
+        "activity-push-token" as RelayLiveActivityRegistrationRequest["activityPushToken"],
+    };
+    const fakeDb = {
+      update: () => ({
+        set: () => ({ where: () => Effect.fail(cause) }),
+      }),
+      insert: () => ({
+        values: () => ({ onConflictDoUpdate: () => Effect.fail(cause) }),
+      }),
+      select: () => ({
+        from: () => ({
+          leftJoin: () => ({ where: () => Effect.fail(cause) }),
+        }),
+      }),
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const liveActivities = yield* LiveActivities.LiveActivities;
+      const registrationError = yield* Effect.flip(
+        liveActivities.register({ userId: "user-1", registration }),
+      );
+      const targetListError = yield* Effect.flip(liveActivities.listTargets({ userId: "user-1" }));
+      const deliveryErrors = yield* Effect.all(
+        [
+          liveActivities.markDelivery({
+            userId: "user-1",
+            deviceId: "device-1",
+            kind: "live_activity_update",
+            aggregate: null,
+            deliveredAt: "2026-05-25T00:00:10.000Z",
+          }),
+          liveActivities.markStartQueued({
+            userId: "user-1",
+            deviceId: "device-1",
+            queuedAt: "2026-05-25T00:00:10.000Z",
+          }),
+          liveActivities.clearStartQueued({ userId: "user-1", deviceId: "device-1" }),
+          liveActivities.invalidateDeliveryToken({
+            userId: "user-1",
+            deviceId: "device-1",
+            kind: "push_notification",
+            invalidatedAt: "2026-05-25T00:00:10.000Z",
+          }),
+        ].map(Effect.flip),
+        { concurrency: 1 },
+      );
+
+      expect(registrationError).toMatchObject({
+        userId: "user-1",
+        deviceId: "device-1",
+        cause,
+        message: "Failed to persist Live Activity registration for device device-1.",
+      });
+      expect(targetListError).toMatchObject({
+        userId: "user-1",
+        cause,
+        message: "Failed to list Live Activity delivery targets for user user-1.",
+      });
+
+      const expectedDeliveryContext = [
+        ["mark-delivery", "live_activity_update"],
+        ["mark-start-queued", null],
+        ["clear-start-queued", null],
+        ["invalidate-delivery-token", "push_notification"],
+      ] as const;
+      for (const [index, [operation, kind]] of expectedDeliveryContext.entries()) {
+        expect(deliveryErrors[index]).toMatchObject({
+          operation,
+          userId: "user-1",
+          deviceId: "device-1",
+          kind,
+          cause,
+          message: `Failed to persist Live Activity state during ${operation} for device device-1.`,
+        });
+      }
+    }).pipe(
+      Effect.provide(
+        LiveActivities.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb))),
+      ),
+    );
+  });
 });

--- a/infra/relay/src/agentActivity/LiveActivities.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.ts
@@ -3,7 +3,10 @@ import type {
   RelayDeliveryKind,
   RelayLiveActivityRegistrationRequest,
 } from "@t3tools/contracts/relay";
-import { RelayAgentActivityAggregateState as RelayAgentActivityAggregateStateSchema } from "@t3tools/contracts/relay";
+import {
+  RelayAgentActivityAggregateState as RelayAgentActivityAggregateStateSchema,
+  RelayDeliveryKind as RelayDeliveryKindSchema,
+} from "@t3tools/contracts/relay";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
@@ -17,28 +20,46 @@ import { relayLiveActivities, relayMobileDevices } from "../persistence/schema.t
 
 export class LiveActivityRegistrationPersistenceError extends Schema.TaggedErrorClass<LiveActivityRegistrationPersistenceError>()(
   "LiveActivityRegistrationPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    userId: Schema.String,
+    deviceId: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to persist Live Activity registration";
+    return `Failed to persist Live Activity registration for device ${this.deviceId}.`;
   }
 }
 
 export class LiveActivityTargetListPersistenceError extends Schema.TaggedErrorClass<LiveActivityTargetListPersistenceError>()(
   "LiveActivityTargetListPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    userId: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to list Live Activity delivery targets";
+    return `Failed to list Live Activity delivery targets for user ${this.userId}.`;
   }
 }
 
 export class LiveActivityDeliveryMarkPersistenceError extends Schema.TaggedErrorClass<LiveActivityDeliveryMarkPersistenceError>()(
   "LiveActivityDeliveryMarkPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    operation: Schema.Literals([
+      "mark-delivery",
+      "mark-start-queued",
+      "clear-start-queued",
+      "invalidate-delivery-token",
+    ]),
+    userId: Schema.String,
+    deviceId: Schema.String,
+    kind: Schema.NullOr(RelayDeliveryKindSchema),
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to persist Live Activity delivery state";
+    return `Failed to persist Live Activity state during ${this.operation} for device ${this.deviceId}.`;
   }
 }
 
@@ -110,11 +131,11 @@ export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
 
   return LiveActivities.of({
-    register: Effect.fn("relay.live_activities.register")(
-      function* (input) {
-        yield* Effect.annotateCurrentSpan({
-          "relay.mobile.device_id": input.registration.deviceId,
-        });
+    register: Effect.fn("relay.live_activities.register")(function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "relay.mobile.device_id": input.registration.deviceId,
+      });
+      yield* Effect.gen(function* () {
         const updatedAt = DateTime.formatIso(yield* DateTime.now);
         const registration = input.registration;
 
@@ -155,9 +176,17 @@ export const make = Effect.gen(function* () {
               updatedAt,
             },
           });
-      },
-      Effect.mapError((cause) => new LiveActivityRegistrationPersistenceError({ cause })),
-    ),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new LiveActivityRegistrationPersistenceError({
+              userId: input.userId,
+              deviceId: input.registration.deviceId,
+              cause,
+            }),
+        ),
+      );
+    }),
 
     listTargets: Effect.fn("relay.live_activities.list_targets")(function* (input) {
       return yield* db
@@ -207,16 +236,22 @@ export const make = Effect.gen(function* () {
             ),
           ),
           Effect.map((rows): ReadonlyArray<TargetRow> => rows),
-          Effect.mapError((cause) => new LiveActivityTargetListPersistenceError({ cause })),
+          Effect.mapError(
+            (cause) =>
+              new LiveActivityTargetListPersistenceError({
+                userId: input.userId,
+                cause,
+              }),
+          ),
         );
     }),
 
-    markDelivery: Effect.fn("relay.live_activities.mark_delivery")(
-      function* (input) {
-        yield* Effect.annotateCurrentSpan({
-          "relay.mobile.device_id": input.deviceId,
-          "relay.delivery.kind": input.kind,
-        });
+    markDelivery: Effect.fn("relay.live_activities.mark_delivery")(function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "relay.mobile.device_id": input.deviceId,
+        "relay.delivery.kind": input.kind,
+      });
+      yield* Effect.gen(function* () {
         const aggregateJson =
           input.aggregate === null
             ? null
@@ -257,9 +292,19 @@ export const make = Effect.gen(function* () {
               updatedAt: input.deliveredAt,
             },
           });
-      },
-      Effect.mapError((cause) => new LiveActivityDeliveryMarkPersistenceError({ cause })),
-    ),
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new LiveActivityDeliveryMarkPersistenceError({
+              operation: "mark-delivery",
+              userId: input.userId,
+              deviceId: input.deviceId,
+              kind: input.kind,
+              cause,
+            }),
+        ),
+      );
+    }),
 
     markStartQueued: Effect.fn("relay.live_activities.mark_start_queued")(function* (input) {
       yield* Effect.annotateCurrentSpan({
@@ -287,7 +332,18 @@ export const make = Effect.gen(function* () {
             updatedAt: input.queuedAt,
           },
         })
-        .pipe(Effect.mapError((cause) => new LiveActivityDeliveryMarkPersistenceError({ cause })));
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new LiveActivityDeliveryMarkPersistenceError({
+                operation: "mark-start-queued",
+                userId: input.userId,
+                deviceId: input.deviceId,
+                kind: null,
+                cause,
+              }),
+          ),
+        );
     }),
 
     clearStartQueued: Effect.fn("relay.live_activities.clear_start_queued")(function* (input) {
@@ -303,7 +359,18 @@ export const make = Effect.gen(function* () {
             eq(relayLiveActivities.deviceId, input.deviceId),
           ),
         )
-        .pipe(Effect.mapError((cause) => new LiveActivityDeliveryMarkPersistenceError({ cause })));
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new LiveActivityDeliveryMarkPersistenceError({
+                operation: "clear-start-queued",
+                userId: input.userId,
+                deviceId: input.deviceId,
+                kind: null,
+                cause,
+              }),
+          ),
+        );
     }),
 
     invalidateDeliveryToken: Effect.fn("relay.live_activities.invalidate_delivery_token")(
@@ -312,39 +379,58 @@ export const make = Effect.gen(function* () {
           "relay.mobile.device_id": input.deviceId,
           "relay.delivery.kind": input.kind,
         });
-        if (input.kind === "push_notification") {
-          yield* db
-            .update(relayMobileDevices)
-            .set({
-              pushToken: null,
-              updatedAt: input.invalidatedAt,
-            })
-            .where(
-              and(
-                eq(relayMobileDevices.userId, input.userId),
-                eq(relayMobileDevices.deviceId, input.deviceId),
-              ),
-            );
-          return;
-        }
+        yield* Effect.gen(function* () {
+          if (input.kind === "push_notification") {
+            yield* db
+              .update(relayMobileDevices)
+              .set({
+                pushToken: null,
+                updatedAt: input.invalidatedAt,
+              })
+              .where(
+                and(
+                  eq(relayMobileDevices.userId, input.userId),
+                  eq(relayMobileDevices.deviceId, input.deviceId),
+                ),
+              );
+            return;
+          }
 
-        if (input.kind === "live_activity_start") {
-          yield* db
-            .update(relayMobileDevices)
-            .set({
-              pushToStartToken: null,
-              updatedAt: input.invalidatedAt,
-            })
-            .where(
-              and(
-                eq(relayMobileDevices.userId, input.userId),
-                eq(relayMobileDevices.deviceId, input.deviceId),
-              ),
-            );
+          if (input.kind === "live_activity_start") {
+            yield* db
+              .update(relayMobileDevices)
+              .set({
+                pushToStartToken: null,
+                updatedAt: input.invalidatedAt,
+              })
+              .where(
+                and(
+                  eq(relayMobileDevices.userId, input.userId),
+                  eq(relayMobileDevices.deviceId, input.deviceId),
+                ),
+              );
+            yield* db
+              .update(relayLiveActivities)
+              .set({
+                remoteStartQueuedAt: null,
+                updatedAt: input.invalidatedAt,
+              })
+              .where(
+                and(
+                  eq(relayLiveActivities.userId, input.userId),
+                  eq(relayLiveActivities.deviceId, input.deviceId),
+                ),
+              );
+            return;
+          }
+
           yield* db
             .update(relayLiveActivities)
             .set({
+              activityPushToken: null,
               remoteStartQueuedAt: null,
+              remoteStartedAt: null,
+              endedAt: input.invalidatedAt,
               updatedAt: input.invalidatedAt,
             })
             .where(
@@ -353,26 +439,19 @@ export const make = Effect.gen(function* () {
                 eq(relayLiveActivities.deviceId, input.deviceId),
               ),
             );
-          return;
-        }
-
-        yield* db
-          .update(relayLiveActivities)
-          .set({
-            activityPushToken: null,
-            remoteStartQueuedAt: null,
-            remoteStartedAt: null,
-            endedAt: input.invalidatedAt,
-            updatedAt: input.invalidatedAt,
-          })
-          .where(
-            and(
-              eq(relayLiveActivities.userId, input.userId),
-              eq(relayLiveActivities.deviceId, input.deviceId),
-            ),
-          );
+        }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new LiveActivityDeliveryMarkPersistenceError({
+                operation: "invalidate-delivery-token",
+                userId: input.userId,
+                deviceId: input.deviceId,
+                kind: input.kind,
+                cause,
+              }),
+          ),
+        );
       },
-      Effect.mapError((cause) => new LiveActivityDeliveryMarkPersistenceError({ cause })),
     ),
   });
 });

--- a/infra/relay/src/agentActivity/LiveActivities.ts
+++ b/infra/relay/src/agentActivity/LiveActivities.ts
@@ -27,7 +27,7 @@ export class LiveActivityRegistrationPersistenceError extends Schema.TaggedError
   },
 ) {
   override get message(): string {
-    return `Failed to persist Live Activity registration for device ${this.deviceId}.`;
+    return `Failed to persist Live Activity registration for user ${this.userId} and device ${this.deviceId}.`;
   }
 }
 
@@ -59,7 +59,7 @@ export class LiveActivityDeliveryMarkPersistenceError extends Schema.TaggedError
   },
 ) {
   override get message(): string {
-    return `Failed to persist Live Activity state during ${this.operation} for device ${this.deviceId}.`;
+    return `Failed to persist Live Activity state during ${this.operation} for user ${this.userId} and device ${this.deviceId}.`;
   }
 }
 


### PR DESCRIPTION
## Summary
- attach user/device correlation fields to Live Activity registration and target-list persistence failures
- add a structured operation and delivery kind to the shared Live Activity state persistence error
- preserve the original database or schema cause at every persistence boundary
- construct errors directly at each boundary and derive messages from their structured context
- add focused coverage for every service operation failure mapping

## Validation
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`
- `/Users/julius/.codex/worktrees/d5fa/codething-mvp/node_modules/.bin/vp test infra/relay/src/agentActivity/LiveActivities.test.ts --no-cache` (3 tests)

## Overlap audit
- no overlap with another active error-audit/service-refactor PR
- these paths also appear in broad draft #2925 (`feat(relay): enforce resource limits`); that unrelated overlap is reported here for visibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and error-shape changes only; persistence behavior is unchanged and covered by new failure-mapping tests.
> 
> **Overview**
> Relay **Live Activity** persistence failures now carry structured correlation data instead of only a wrapped `cause`.
> 
> The three tagged errors gain fields such as **`userId`**, **`deviceId`**, **`operation`**, and optional **`kind`**, with human-readable **`message`** strings derived from that context. Each service method (`register`, `listTargets`, `markDelivery`, `markStartQueued`, `clearStartQueued`, `invalidateDeliveryToken`) maps DB failures at the boundary via **`Effect.mapError`**, including wrapping **`invalidateDeliveryToken`** in an inner **`Effect.gen`** so all branches share the same error shape.
> 
> A new test drives a failing fake **`RelayDb`** through every operation and asserts **`userId`**, **`deviceId`**, **`operation`**/**`kind`**, **`cause`**, and messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdef70fa28e38d2e8e16c3ab16a68153a33d6fc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add correlation context fields to Live Activity persistence errors in relay
> Enriches the three persistence error classes in [LiveActivities.ts](https://github.com/pingdotgg/t3code/pull/3314/files#diff-a2f53042edef13d0dd36b7c463b4d23cb789f63f39aee68d60a242b5e4375f2e) with structured context fields so failures are easier to trace.
>
> - `LiveActivityRegistrationPersistenceError` now includes `userId` and `deviceId`; `LiveActivityTargetListPersistenceError` includes `userId`; `LiveActivityDeliveryMarkPersistenceError` includes `operation`, `userId`, `deviceId`, and `kind`.
> - Each error's message getter is updated to embed the relevant identifiers and operation name.
> - All `LiveActivities` service handlers (`register`, `listTargets`, `markDelivery`, `markStartQueued`, `clearStartQueued`, `invalidateDeliveryToken`) now map DB failures to the appropriate enriched error type.
> - Tests in [LiveActivities.test.ts](https://github.com/pingdotgg/t3code/pull/3314/files#diff-16c868a3500508fcf5553aab37e44df7c1bb84f46ef0b120ab76117d304a3a12) verify that simulated DB failures produce errors with the expected correlation fields and messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cdef70f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->