### PR TITLE
[codex] Structure web cloud-link failures

### DIFF
--- a/apps/web/src/cloud/linkEnvironment.test.ts
+++ b/apps/web/src/cloud/linkEnvironment.test.ts
@@ -221,7 +221,9 @@ describe("web cloud link environment client", () => {
       expect(error).toBeInstanceOf(CloudEnvironmentLinkOperationError);
       expect(error).toMatchObject({
         action: "list relay-managed environments",
-        relayUrl: "https://relay.example.test",
+        relayUrlInputLength: "https://relay.example.test".length,
+        relayUrlProtocol: "https:",
+        relayUrlHostname: "relay.example.test",
         traceId: "trace-web-cloud-link",
         relayError: {
           _tag: "RelayAuthInvalidError",
@@ -289,7 +291,9 @@ describe("web cloud link environment client", () => {
       expect(error).toMatchObject({
         action: "read environment cloud link state",
         environmentId: TARGET.environmentId,
-        httpBaseUrl: TARGET.httpBaseUrl,
+        httpBaseUrlInputLength: TARGET.httpBaseUrl.length,
+        httpBaseUrlProtocol: "http:",
+        httpBaseUrlHostname: "127.0.0.1",
         environmentError: {
           _tag: "EnvironmentHttpUnauthorizedError",
           message: "Environment bearer token is invalid.",
@@ -305,11 +309,13 @@ describe("web cloud link environment client", () => {
 
   it.effect("preserves invalid environment HTTP URL parser causes", () =>
     Effect.gen(function* () {
+      const invalidUrl =
+        "https://user:password@[invalid-host]/private/path?access_token=secret#fragment";
       const error = yield* withServices(
         readPrimaryCloudLinkState({
           target: {
             ...TARGET,
-            httpBaseUrl: "not a URL",
+            httpBaseUrl: invalidUrl,
           },
         }),
       ).pipe(Effect.flip);
@@ -318,11 +324,39 @@ describe("web cloud link environment client", () => {
         _tag: "CloudEnvironmentLinkOperationError",
         action: "initialize the environment HTTP client",
         environmentId: TARGET.environmentId,
-        httpBaseUrl: "not a URL",
+        httpBaseUrlInputLength: invalidUrl.length,
       });
       expect(error.cause).toBeInstanceOf(TypeError);
+      expect(error).not.toHaveProperty("httpBaseUrl");
+      expect(error).not.toHaveProperty("httpBaseUrlProtocol");
+      expect(error).not.toHaveProperty("httpBaseUrlHostname");
+      expect(error.message).not.toMatch(/user|password|private|path|access_token|secret|fragment/);
     }),
   );
+
+  it("keeps environment endpoint secrets out of mapped error attributes", () => {
+    const httpBaseUrl =
+      "https://user:password@environment.example.test/private/path?access_token=secret#fragment";
+    const cause = new Error("request failed");
+    const error = CloudEnvironmentLinkOperationError.fromEnvironmentApi({
+      action: "read environment cloud link state",
+      environmentId: TARGET.environmentId,
+      httpBaseUrl,
+      cause,
+    });
+
+    expect(error).toMatchObject({
+      httpBaseUrlInputLength: httpBaseUrl.length,
+      httpBaseUrlProtocol: "https:",
+      httpBaseUrlHostname: "environment.example.test",
+      cause,
+    });
+    expect(error.cause).toBe(cause);
+    expect(error).not.toHaveProperty("httpBaseUrl");
+    const diagnostics = JSON.stringify(error);
+    expect(diagnostics).not.toMatch(/user|password|private|path|access_token|secret|fragment/);
+    expect(error.message).not.toMatch(/user|password|private|path|access_token|secret|fragment/);
+  });
 
   it.effect("uses desktop bearer auth for primary cloud link state", () =>
     Effect.gen(function* () {

--- a/apps/web/src/cloud/linkEnvironment.test.ts
+++ b/apps/web/src/cloud/linkEnvironment.test.ts
@@ -231,7 +231,7 @@ describe("web cloud link environment client", () => {
           _tag: "ManagedRelayRequestFailedError",
         },
       });
-      expect(error.message).toContain("Relay authentication failed: invalid_bearer");
+      expect(error.message).toBe("Could not list relay-managed environments.");
       expect(isCloudEnvironmentLinkError(error)).toBe(true);
     }),
   );
@@ -296,7 +296,9 @@ describe("web cloud link environment client", () => {
         },
       });
       expect(error.cause).toBeDefined();
-      expect(error.message).toContain("Environment bearer token is invalid.");
+      expect(error.message).toBe(
+        `Could not read environment cloud link state for environment "${TARGET.environmentId}".`,
+      );
       expect(isCloudEnvironmentLinkError(error)).toBe(true);
     }),
   );

--- a/apps/web/src/cloud/linkEnvironment.test.ts
+++ b/apps/web/src/cloud/linkEnvironment.test.ts
@@ -8,6 +8,7 @@ import { RelayWebClientId } from "@t3tools/contracts/relay";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
@@ -50,10 +51,19 @@ const relayClientInstallDialog = vi.hoisted(() => ({
   finish: vi.fn(),
 }));
 
+const cloudPublicConfig = vi.hoisted(() => ({
+  relayUrl: "https://relay.example.test",
+}));
+
 vi.mock("./relayClientInstallDialog", () => ({
   requestRelayClientInstallConfirmation: relayClientInstallDialog.requestConfirmation,
   reportRelayClientInstallProgress: relayClientInstallDialog.reportProgress,
   finishRelayClientInstall: relayClientInstallDialog.finish,
+}));
+
+vi.mock("./publicConfig", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./publicConfig")>()),
+  resolveCloudPublicConfig: () => ({ relayUrl: cloudPublicConfig.relayUrl }),
 }));
 
 const createProof = vi.fn(() => Effect.succeed("dpop-proof"));
@@ -143,6 +153,7 @@ function bodyText(body: BodyInit | null | undefined): string {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  cloudPublicConfig.relayUrl = "https://relay.example.test";
   vi.stubEnv("VITE_T3CODE_RELAY_URL", "https://relay.example.test");
   relayClientInstallDialog.requestConfirmation.mockResolvedValue(true);
 });
@@ -481,4 +492,64 @@ describe("web cloud link environment client", () => {
       );
     }),
   );
+
+  it.effect("keeps configured relay URL secrets out of revoke warnings", () => {
+    const relayUrl =
+      "https://relay-user:relay-password@relay.example.test/private/workspace?access_token=relay-secret#relay-fragment";
+    cloudPublicConfig.relayUrl = relayUrl;
+    const capturedLogs: Array<ReadonlyArray<unknown>> = [];
+    const logger = Logger.make(({ message }) => {
+      capturedLogs.push(Array.isArray(message) ? message : [message]);
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json({ ok: true, endpointRuntimeStatus: { status: "disabled" } }),
+      )
+      .mockResolvedValueOnce(Response.json({ malformed: true }, { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    return unlinkPrimaryEnvironmentFromCloud({
+      target: TARGET,
+      clerkToken: "clerk-token",
+    }).pipe(
+      Effect.provide(
+        Layer.merge(
+          services(),
+          Logger.layer([logger], {
+            mergeWithExisting: false,
+          }),
+        ),
+      ),
+      Effect.tap(() =>
+        Effect.sync(() => {
+          expect(capturedLogs).toHaveLength(1);
+          const logFields = capturedLogs[0]?.find(
+            (value): value is Record<string, unknown> =>
+              typeof value === "object" && value !== null,
+          );
+          expect(logFields).toMatchObject({
+            relayUrlInputLength: relayUrl.length,
+            relayUrlProtocol: "https:",
+            relayUrlHostname: "relay.example.test",
+          });
+          expect(logFields).not.toHaveProperty("relayUrl");
+          const logText = [
+            ...(capturedLogs[0]?.filter((value): value is string => typeof value === "string") ??
+              []),
+            String(logFields?.cause),
+          ].join(" ");
+          for (const secret of [
+            "relay-user",
+            "relay-password",
+            "/private/workspace",
+            "access_token=relay-secret",
+            "relay-fragment",
+          ]) {
+            expect(logText).not.toContain(secret);
+          }
+        }),
+      ),
+    );
+  });
 });

--- a/apps/web/src/cloud/linkEnvironment.test.ts
+++ b/apps/web/src/cloud/linkEnvironment.test.ts
@@ -2,6 +2,7 @@ import {
   type DesktopBridge,
   EnvironmentId,
   type RelayClientInstallProgressEvent,
+  type RelayClientStatus,
   WS_METHODS,
 } from "@t3tools/contracts";
 import { RelayWebClientId } from "@t3tools/contracts/relay";
@@ -87,7 +88,7 @@ function relayLayer() {
 }
 
 function registryLayer(options?: {
-  readonly status?: { readonly status: "available"; readonly version: string };
+  readonly status?: RelayClientStatus;
   readonly installEvents?: ReadonlyArray<RelayClientInstallProgressEvent>;
 }) {
   return Layer.effect(
@@ -95,7 +96,14 @@ function registryLayer(options?: {
     Effect.gen(function* () {
       const client = {
         [WS_METHODS.cloudGetRelayClientStatus]: () =>
-          Effect.succeed(options?.status ?? { status: "available", version: "2026.6.0" }),
+          Effect.succeed(
+            options?.status ?? {
+              status: "available",
+              executablePath: "/managed/cloudflared",
+              source: "managed",
+              version: "2026.6.0",
+            },
+          ),
         [WS_METHODS.cloudInstallRelayClient]: () =>
           Stream.fromIterable(options?.installEvents ?? []),
       } as unknown as RpcSession["client"];
@@ -450,6 +458,37 @@ describe("web cloud link environment client", () => {
     }),
   );
 
+  it.effect("validates the environment endpoint before prompting to install a relay client", () =>
+    Effect.gen(function* () {
+      const invalidUrl =
+        "https://user:password@[invalid-host]/private/path?access_token=secret#fragment";
+
+      const error = yield* withServices(
+        linkPrimaryEnvironmentToCloud({
+          target: {
+            ...TARGET,
+            httpBaseUrl: invalidUrl,
+          },
+          clerkToken: "clerk-token",
+        }),
+        {
+          status: { status: "missing", version: "2026.6.0" },
+        },
+      ).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "CloudEnvironmentLinkOperationError",
+        action: "derive the environment endpoint origin",
+        environmentId: TARGET.environmentId,
+        httpBaseUrlInputLength: invalidUrl.length,
+      });
+      expect(error.cause).toBeInstanceOf(TypeError);
+      expect(error).not.toHaveProperty("httpBaseUrl");
+      expect(error.message).not.toMatch(/user|password|private|path|access_token|secret|fragment/);
+      expect(relayClientInstallDialog.requestConfirmation).not.toHaveBeenCalled();
+    }),
+  );
+
   it.effect("installs a missing relay client before linking", () =>
     Effect.gen(function* () {
       vi.stubGlobal("fetch", vi.fn().mockResolvedValue(Response.json({ malformed: true })));
@@ -460,7 +499,12 @@ describe("web cloud link environment client", () => {
           clerkToken: "clerk-token",
         }),
         {
-          status: { status: "available", version: "2026.6.0" },
+          status: {
+            status: "available",
+            executablePath: "/managed/cloudflared",
+            source: "managed",
+            version: "2026.6.0",
+          },
           installEvents: [],
         },
       ).pipe(Effect.flip);

--- a/apps/web/src/cloud/linkEnvironment.test.ts
+++ b/apps/web/src/cloud/linkEnvironment.test.ts
@@ -26,7 +26,9 @@ import { remoteHttpClientLayer } from "@t3tools/client-runtime/rpc";
 import { __resetDesktopPrimaryAuthForTests } from "../environments/primary/desktopAuth";
 
 import {
+  CloudEnvironmentLinkOperationError,
   collectCloudLinkTargets,
+  isCloudEnvironmentLinkError,
   linkPrimaryEnvironmentToCloud,
   listManagedCloudEnvironments,
   normalizeRelayBaseUrl,
@@ -195,6 +197,45 @@ describe("web cloud link environment client", () => {
     }),
   );
 
+  it.effect("preserves structured relay failures and trace IDs", () =>
+    Effect.gen(function* () {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          Response.json(
+            {
+              _tag: "RelayAuthInvalidError",
+              code: "auth_invalid",
+              reason: "invalid_bearer",
+              traceId: "trace-web-cloud-link",
+            },
+            { status: 401 },
+          ),
+        ),
+      );
+
+      const error = yield* withServices(
+        listManagedCloudEnvironments({ clerkToken: "clerk-token" }),
+      ).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(CloudEnvironmentLinkOperationError);
+      expect(error).toMatchObject({
+        action: "list relay-managed environments",
+        relayUrl: "https://relay.example.test",
+        traceId: "trace-web-cloud-link",
+        relayError: {
+          _tag: "RelayAuthInvalidError",
+          reason: "invalid_bearer",
+        },
+        cause: {
+          _tag: "ManagedRelayRequestFailedError",
+        },
+      });
+      expect(error.message).toContain("Relay authentication failed: invalid_bearer");
+      expect(isCloudEnvironmentLinkError(error)).toBe(true);
+    }),
+  );
+
   it.effect("reads primary cloud link state from the explicit target", () =>
     Effect.gen(function* () {
       const fetchMock = vi.fn().mockResolvedValue(
@@ -222,6 +263,62 @@ describe("web cloud link environment client", () => {
       expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
         "http://127.0.0.1:3000/api/connect/link-state",
       );
+    }),
+  );
+
+  it.effect("preserves structured environment API failures and their cause chain", () =>
+    Effect.gen(function* () {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          Response.json(
+            {
+              _tag: "EnvironmentHttpUnauthorizedError",
+              message: "Environment bearer token is invalid.",
+            },
+            { status: 401 },
+          ),
+        ),
+      );
+
+      const error = yield* withServices(readPrimaryCloudLinkState({ target: TARGET })).pipe(
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(CloudEnvironmentLinkOperationError);
+      expect(error).toMatchObject({
+        action: "read environment cloud link state",
+        environmentId: TARGET.environmentId,
+        httpBaseUrl: TARGET.httpBaseUrl,
+        environmentError: {
+          _tag: "EnvironmentHttpUnauthorizedError",
+          message: "Environment bearer token is invalid.",
+        },
+      });
+      expect(error.cause).toBeDefined();
+      expect(error.message).toContain("Environment bearer token is invalid.");
+      expect(isCloudEnvironmentLinkError(error)).toBe(true);
+    }),
+  );
+
+  it.effect("preserves invalid environment HTTP URL parser causes", () =>
+    Effect.gen(function* () {
+      const error = yield* withServices(
+        readPrimaryCloudLinkState({
+          target: {
+            ...TARGET,
+            httpBaseUrl: "not a URL",
+          },
+        }),
+      ).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        _tag: "CloudEnvironmentLinkOperationError",
+        action: "initialize the environment HTTP client",
+        environmentId: TARGET.environmentId,
+        httpBaseUrl: "not a URL",
+      });
+      expect(error.cause).toBeInstanceOf(TypeError);
     }),
   );
 

--- a/apps/web/src/cloud/linkEnvironment.test.ts
+++ b/apps/web/src/cloud/linkEnvironment.test.ts
@@ -576,13 +576,13 @@ describe("web cloud link environment client", () => {
             relayUrlInputLength: relayUrl.length,
             relayUrlProtocol: "https:",
             relayUrlHostname: "relay.example.test",
+            causeTag: "ManagedRelayRequestFailedError",
           });
           expect(logFields).not.toHaveProperty("relayUrl");
-          const logText = [
-            ...(capturedLogs[0]?.filter((value): value is string => typeof value === "string") ??
-              []),
-            String(logFields?.cause),
-          ].join(" ");
+          expect(logFields).not.toHaveProperty("cause");
+          const logText = capturedLogs[0]
+            ?.filter((value): value is string => typeof value === "string")
+            .join(" ");
           for (const secret of [
             "relay-user",
             "relay-password",

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -149,10 +149,7 @@ export class CloudEnvironmentLinkOperationError extends Schema.TaggedErrorClass<
   override get message(): string {
     const environment =
       this.environmentId === undefined ? "" : ` for environment "${this.environmentId}"`;
-    const detail = this.relayError?.message ?? this.environmentError?.message;
-    return detail
-      ? `Could not ${this.action}${environment}: ${detail}`
-      : `Could not ${this.action}${environment}.`;
+    return `Could not ${this.action}${environment}.`;
   }
 }
 

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -596,7 +596,15 @@ export function unlinkPrimaryEnvironmentFromCloud(input: {
             });
             return Effect.logWarning(error.message, {
               environmentId: input.target.environmentId,
-              relayUrl: configuredRelayUrl,
+              ...(error.relayUrlInputLength === undefined
+                ? {}
+                : { relayUrlInputLength: error.relayUrlInputLength }),
+              ...(error.relayUrlProtocol === undefined
+                ? {}
+                : { relayUrlProtocol: error.relayUrlProtocol }),
+              ...(error.relayUrlHostname === undefined
+                ? {}
+                : { relayUrlHostname: error.relayUrlHostname }),
               cause: error,
             });
           }),

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -25,6 +25,7 @@ import { EnvironmentRegistry } from "@t3tools/client-runtime/connection";
 import { request, runStream } from "@t3tools/client-runtime/rpc";
 import { makeEnvironmentHttpApiClient } from "@t3tools/client-runtime/rpc";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 
 import {
   readPrimaryEnvironmentDescriptor,
@@ -61,6 +62,26 @@ const EnvironmentCloudApiError = Schema.Union([
 type EnvironmentCloudApiError = typeof EnvironmentCloudApiError.Type;
 const isEnvironmentCloudApiError = Schema.is(EnvironmentCloudApiError);
 
+function relayUrlDiagnosticFields(relayUrl: string | undefined) {
+  if (relayUrl === undefined) return {};
+  const diagnostics = getUrlDiagnostics(relayUrl);
+  return {
+    relayUrlInputLength: diagnostics.inputLength,
+    ...(diagnostics.protocol === undefined ? {} : { relayUrlProtocol: diagnostics.protocol }),
+    ...(diagnostics.hostname === undefined ? {} : { relayUrlHostname: diagnostics.hostname }),
+  };
+}
+
+function httpBaseUrlDiagnosticFields(httpBaseUrl: string | undefined) {
+  if (httpBaseUrl === undefined) return {};
+  const diagnostics = getUrlDiagnostics(httpBaseUrl);
+  return {
+    httpBaseUrlInputLength: diagnostics.inputLength,
+    ...(diagnostics.protocol === undefined ? {} : { httpBaseUrlProtocol: diagnostics.protocol }),
+    ...(diagnostics.hostname === undefined ? {} : { httpBaseUrlHostname: diagnostics.hostname }),
+  };
+}
+
 export const CloudEnvironmentLinkAction = Schema.Literals([
   "check relay client availability",
   "confirm relay client installation",
@@ -85,8 +106,12 @@ export class CloudEnvironmentLinkOperationError extends Schema.TaggedErrorClass<
   {
     action: CloudEnvironmentLinkAction,
     environmentId: Schema.optionalKey(Schema.String),
-    relayUrl: Schema.optionalKey(Schema.String),
-    httpBaseUrl: Schema.optionalKey(Schema.String),
+    relayUrlInputLength: Schema.optionalKey(Schema.Number),
+    relayUrlProtocol: Schema.optionalKey(Schema.String),
+    relayUrlHostname: Schema.optionalKey(Schema.String),
+    httpBaseUrlInputLength: Schema.optionalKey(Schema.Number),
+    httpBaseUrlProtocol: Schema.optionalKey(Schema.String),
+    httpBaseUrlHostname: Schema.optionalKey(Schema.String),
     traceId: Schema.optionalKey(Schema.String),
     relayError: Schema.optionalKey(RelayProtectedError),
     environmentError: Schema.optionalKey(EnvironmentCloudApiError),
@@ -106,8 +131,8 @@ export class CloudEnvironmentLinkOperationError extends Schema.TaggedErrorClass<
       action: input.action,
       cause: input.cause,
       ...(input.environmentId === undefined ? {} : { environmentId: input.environmentId }),
-      ...(input.relayUrl === undefined ? {} : { relayUrl: input.relayUrl }),
-      ...(input.httpBaseUrl === undefined ? {} : { httpBaseUrl: input.httpBaseUrl }),
+      ...relayUrlDiagnosticFields(input.relayUrl),
+      ...httpBaseUrlDiagnosticFields(input.httpBaseUrl),
       ...(requestFailure?.traceId === undefined ? {} : { traceId: requestFailure.traceId }),
       ...(requestFailure?.relayError === undefined
         ? {}
@@ -127,7 +152,7 @@ export class CloudEnvironmentLinkOperationError extends Schema.TaggedErrorClass<
     return new CloudEnvironmentLinkOperationError({
       action: input.action,
       environmentId: input.environmentId,
-      httpBaseUrl: input.httpBaseUrl,
+      ...httpBaseUrlDiagnosticFields(input.httpBaseUrl),
       cause: input.cause,
       ...(environmentError === undefined ? {} : { environmentError }),
     });
@@ -339,7 +364,7 @@ function endpointOrigin(input: { readonly environmentId: string; readonly httpBa
       new CloudEnvironmentLinkOperationError({
         action: "derive the environment endpoint origin",
         environmentId: input.environmentId,
-        httpBaseUrl: input.httpBaseUrl,
+        ...httpBaseUrlDiagnosticFields(input.httpBaseUrl),
         cause,
       }),
   });
@@ -355,7 +380,7 @@ function makeCloudEnvironmentHttpApiClient(input: {
       new CloudEnvironmentLinkOperationError({
         action: "initialize the environment HTTP client",
         environmentId: input.environmentId,
-        httpBaseUrl: input.httpBaseUrl,
+        ...httpBaseUrlDiagnosticFields(input.httpBaseUrl),
         cause,
       }),
   }).pipe(Effect.flatten);

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -1,4 +1,3 @@
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
@@ -19,8 +18,8 @@ import {
   type RelayClientDeviceRecord,
   type RelayClientEnvironmentRecord,
   type RelayEnvironmentLinkResponse,
-  type RelayProtectedError as RelayProtectedErrorType,
   type RelayManagedEndpointProviderKind,
+  RelayProtectedError,
 } from "@t3tools/contracts/relay";
 import { EnvironmentRegistry } from "@t3tools/client-runtime/connection";
 import { request, runStream } from "@t3tools/client-runtime/rpc";
@@ -51,17 +50,197 @@ function relayUrl(): string | null {
   return resolveCloudPublicConfig().relayUrl;
 }
 
-export class CloudEnvironmentLinkError extends Data.TaggedError("CloudEnvironmentLinkError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-  readonly traceId?: string;
-}> {}
+const EnvironmentCloudApiError = Schema.Union([
+  EnvironmentHttpBadRequestError,
+  EnvironmentHttpUnauthorizedError,
+  EnvironmentHttpForbiddenError,
+  EnvironmentHttpConflictError,
+  EnvironmentHttpInternalServerError,
+  EnvironmentCloudEndpointUnavailableError,
+]);
+type EnvironmentCloudApiError = typeof EnvironmentCloudApiError.Type;
+const isEnvironmentCloudApiError = Schema.is(EnvironmentCloudApiError);
 
-const relayClientRpcError = (message: string) => (cause: unknown) =>
-  new CloudEnvironmentLinkError({
-    message,
-    cause,
-  });
+export const CloudEnvironmentLinkAction = Schema.Literals([
+  "check relay client availability",
+  "confirm relay client installation",
+  "install the relay client",
+  "list relay-managed environments",
+  "list cloud devices",
+  "read environment cloud link state",
+  "update environment cloud preferences",
+  "unlink the environment from cloud",
+  "revoke the cloud environment link",
+  "create an environment link challenge",
+  "obtain an environment link proof",
+  "link the environment",
+  "derive the environment endpoint origin",
+  "initialize the environment HTTP client",
+  "configure environment relay access",
+]);
+export type CloudEnvironmentLinkAction = typeof CloudEnvironmentLinkAction.Type;
+
+export class CloudEnvironmentLinkOperationError extends Schema.TaggedErrorClass<CloudEnvironmentLinkOperationError>()(
+  "CloudEnvironmentLinkOperationError",
+  {
+    action: CloudEnvironmentLinkAction,
+    environmentId: Schema.optionalKey(Schema.String),
+    relayUrl: Schema.optionalKey(Schema.String),
+    httpBaseUrl: Schema.optionalKey(Schema.String),
+    traceId: Schema.optionalKey(Schema.String),
+    relayError: Schema.optionalKey(RelayProtectedError),
+    environmentError: Schema.optionalKey(EnvironmentCloudApiError),
+    cause: Schema.Defect(),
+  },
+) {
+  static fromManagedRelay(input: {
+    readonly action: CloudEnvironmentLinkAction;
+    readonly cause: ManagedRelay.ManagedRelayClientError;
+    readonly environmentId?: string;
+    readonly relayUrl?: string;
+    readonly httpBaseUrl?: string;
+  }): CloudEnvironmentLinkOperationError {
+    const requestFailure =
+      input.cause._tag === "ManagedRelayRequestFailedError" ? input.cause : undefined;
+    return new CloudEnvironmentLinkOperationError({
+      action: input.action,
+      cause: input.cause,
+      ...(input.environmentId === undefined ? {} : { environmentId: input.environmentId }),
+      ...(input.relayUrl === undefined ? {} : { relayUrl: input.relayUrl }),
+      ...(input.httpBaseUrl === undefined ? {} : { httpBaseUrl: input.httpBaseUrl }),
+      ...(requestFailure?.traceId === undefined ? {} : { traceId: requestFailure.traceId }),
+      ...(requestFailure?.relayError === undefined
+        ? {}
+        : { relayError: requestFailure.relayError }),
+    });
+  }
+
+  static fromEnvironmentApi(input: {
+    readonly action: CloudEnvironmentLinkAction;
+    readonly cause: unknown;
+    readonly environmentId: string;
+    readonly httpBaseUrl: string;
+  }): CloudEnvironmentLinkOperationError {
+    const environmentError = CloudEnvironmentLinkOperationError.findEnvironmentApiError(
+      input.cause,
+    );
+    return new CloudEnvironmentLinkOperationError({
+      action: input.action,
+      environmentId: input.environmentId,
+      httpBaseUrl: input.httpBaseUrl,
+      cause: input.cause,
+      ...(environmentError === undefined ? {} : { environmentError }),
+    });
+  }
+
+  private static findEnvironmentApiError(cause: unknown): EnvironmentCloudApiError | undefined {
+    const seen = new Set<unknown>();
+    let current = cause;
+    while (typeof current === "object" && current !== null && !seen.has(current)) {
+      if (isEnvironmentCloudApiError(current)) {
+        return current;
+      }
+      seen.add(current);
+      current = "cause" in current ? current.cause : undefined;
+    }
+    return undefined;
+  }
+
+  override get message(): string {
+    const environment =
+      this.environmentId === undefined ? "" : ` for environment "${this.environmentId}"`;
+    const detail = this.relayError?.message ?? this.environmentError?.message;
+    return detail
+      ? `Could not ${this.action}${environment}: ${detail}`
+      : `Could not ${this.action}${environment}.`;
+  }
+}
+
+export class CloudRelayUrlNotConfiguredError extends Schema.TaggedErrorClass<CloudRelayUrlNotConfiguredError>()(
+  "CloudRelayUrlNotConfiguredError",
+  { environmentId: Schema.optionalKey(Schema.String) },
+) {
+  override get message(): string {
+    return "T3CODE_RELAY_URL is not configured.";
+  }
+}
+
+export class CloudRelayClientInstallUnsupportedError extends Schema.TaggedErrorClass<CloudRelayClientInstallUnsupportedError>()(
+  "CloudRelayClientInstallUnsupportedError",
+  {
+    environmentId: Schema.String,
+    phase: Schema.Literals(["preflight", "post-install"]),
+    version: Schema.String,
+    platform: Schema.String,
+    architecture: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `T3 Code cannot install the relay client automatically on ${this.platform}-${this.architecture}.`;
+  }
+}
+
+export class CloudRelayClientInstallCancelledError extends Schema.TaggedErrorClass<CloudRelayClientInstallCancelledError>()(
+  "CloudRelayClientInstallCancelledError",
+  {
+    environmentId: Schema.String,
+    version: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "Relay client installation was cancelled.";
+  }
+}
+
+export class CloudRelayClientInstallIncompleteError extends Schema.TaggedErrorClass<CloudRelayClientInstallIncompleteError>()(
+  "CloudRelayClientInstallIncompleteError",
+  {
+    environmentId: Schema.String,
+    version: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "The relay client install completed without a final status.";
+  }
+}
+
+export class CloudRelayClientUnavailableAfterInstallError extends Schema.TaggedErrorClass<CloudRelayClientUnavailableAfterInstallError>()(
+  "CloudRelayClientUnavailableAfterInstallError",
+  {
+    environmentId: Schema.String,
+    version: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "The relay client is still unavailable after installation.";
+  }
+}
+
+export class CloudEnvironmentLinkResponseMismatchError extends Schema.TaggedErrorClass<CloudEnvironmentLinkResponseMismatchError>()(
+  "CloudEnvironmentLinkResponseMismatchError",
+  {
+    environmentId: Schema.String,
+    field: Schema.Literals(["environment id", "endpoint provider"]),
+    expected: Schema.String,
+    actual: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Relay returned link credentials with an unexpected ${this.field}.`;
+  }
+}
+
+export const CloudEnvironmentLinkError = Schema.Union([
+  CloudEnvironmentLinkOperationError,
+  CloudRelayUrlNotConfiguredError,
+  CloudRelayClientInstallUnsupportedError,
+  CloudRelayClientInstallCancelledError,
+  CloudRelayClientInstallIncompleteError,
+  CloudRelayClientUnavailableAfterInstallError,
+  CloudEnvironmentLinkResponseMismatchError,
+]);
+export type CloudEnvironmentLinkError = typeof CloudEnvironmentLinkError.Type;
+export const isCloudEnvironmentLinkError = Schema.is(CloudEnvironmentLinkError);
 
 function ensureRelayClientAvailable(
   environmentId: EnvironmentId,
@@ -70,21 +249,40 @@ function ensureRelayClientAvailable(
     const registry = yield* EnvironmentRegistry;
     const status = yield* registry
       .run(environmentId, request(WS_METHODS.cloudGetRelayClientStatus, {}))
-      .pipe(Effect.mapError(relayClientRpcError("Could not check relay client availability.")));
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new CloudEnvironmentLinkOperationError({
+              action: "check relay client availability",
+              environmentId,
+              cause,
+            }),
+        ),
+      );
     if (status.status === "available") return;
     if (status.status === "unsupported") {
-      return yield* new CloudEnvironmentLinkError({
-        message: `T3 Code cannot install the relay client automatically on ${status.platform}-${status.arch}.`,
+      return yield* new CloudRelayClientInstallUnsupportedError({
+        environmentId,
+        phase: "preflight",
+        version: status.version,
+        platform: status.platform,
+        architecture: status.arch,
       });
     }
 
     const confirmed = yield* Effect.tryPromise({
       try: () => requestRelayClientInstallConfirmation(status.version),
-      catch: relayClientRpcError("Could not confirm relay client installation."),
+      catch: (cause) =>
+        new CloudEnvironmentLinkOperationError({
+          action: "confirm relay client installation",
+          environmentId,
+          cause,
+        }),
     });
     if (!confirmed) {
-      return yield* new CloudEnvironmentLinkError({
-        message: "Relay client installation was cancelled.",
+      return yield* new CloudRelayClientInstallCancelledError({
+        environmentId,
+        version: status.version,
       });
     }
 
@@ -97,112 +295,73 @@ function ensureRelayClientAvailable(
       )
       .pipe(
         Stream.runLast,
-        Effect.mapError(relayClientRpcError("Could not install the relay client.")),
+        Effect.mapError(
+          (cause) =>
+            new CloudEnvironmentLinkOperationError({
+              action: "install the relay client",
+              environmentId,
+              cause,
+            }),
+        ),
         Effect.ensuring(Effect.sync(finishRelayClientInstall)),
       );
     if (Option.isNone(installed) || installed.value.type !== "complete") {
-      return yield* new CloudEnvironmentLinkError({
-        message: "The relay client install completed without a final status.",
+      return yield* new CloudRelayClientInstallIncompleteError({
+        environmentId,
+        version: status.version,
       });
     }
     const installedStatus = installed.value.status;
     if (installedStatus.status !== "available") {
-      return yield* new CloudEnvironmentLinkError({
-        message:
-          installedStatus.status === "unsupported"
-            ? `T3 Code cannot install the relay client automatically on ${installedStatus.platform}-${installedStatus.arch}.`
-            : "The relay client is still unavailable after installation.",
-      });
+      return yield* installedStatus.status === "unsupported"
+        ? new CloudRelayClientInstallUnsupportedError({
+            environmentId,
+            phase: "post-install",
+            version: installedStatus.version,
+            platform: installedStatus.platform,
+            architecture: installedStatus.arch,
+          })
+        : new CloudRelayClientUnavailableAfterInstallError({
+            environmentId,
+            version: installedStatus.version,
+          });
     }
   });
 }
 
-const isEnvironmentCloudApiError = Schema.is(
-  Schema.Union([
-    EnvironmentHttpBadRequestError,
-    EnvironmentHttpUnauthorizedError,
-    EnvironmentHttpForbiddenError,
-    EnvironmentHttpConflictError,
-    EnvironmentHttpInternalServerError,
-    EnvironmentCloudEndpointUnavailableError,
-  ]),
-);
-
-function relayProtectedErrorMessage(error: RelayProtectedErrorType): string {
-  switch (error._tag) {
-    case "RelayAuthInvalidError":
-      switch (error.reason) {
-        case "missing_bearer":
-        case "invalid_bearer":
-          return "Relay rejected the cloud session token.";
-        case "invalid_dpop":
-          return "Relay rejected the DPoP proof.";
-        case "not_authorized":
-          return "Relay rejected the authenticated request.";
-      }
-    case "RelayEnvironmentLinkProofExpiredError":
-      return "Relay rejected an expired environment link proof.";
-    case "RelayEnvironmentLinkProofInvalidError":
-      return `Relay rejected the environment link proof (${error.reason}).`;
-    case "RelayEnvironmentConnectNotAuthorizedError":
-      return "Relay rejected the environment connection request.";
-    case "RelayEnvironmentEndpointUnavailableError":
-      return `Relay could not reach the environment endpoint (${error.reason}).`;
-    case "RelayEnvironmentEndpointTimedOutError":
-      return "Relay timed out while contacting the environment endpoint.";
-    case "RelayEnvironmentLinkFailedError":
-      return `Relay could not link the environment (${error.reason}).`;
-    case "RelayEnvironmentLinkUnavailableError":
-      return `Relay cannot provision the managed endpoint (${error.reason}).`;
-    case "RelayAgentActivityPublishProofExpiredError":
-      return "Relay rejected an expired agent activity publish proof.";
-    case "RelayAgentActivityPublishProofInvalidError":
-      return `Relay rejected the agent activity publish proof (${error.reason}).`;
-    case "RelayInternalError":
-      return `Relay encountered an internal error (${error.reason}).`;
-  }
-}
-
-function decodedRelayClientError(message: string) {
-  return (cause: ManagedRelay.ManagedRelayClientError) => {
-    const relayError =
-      cause._tag === "ManagedRelayRequestFailedError" ? cause.relayError : undefined;
-    const traceId = cause._tag === "ManagedRelayRequestFailedError" ? cause.traceId : undefined;
-    const detail = relayError ? relayProtectedErrorMessage(relayError) : null;
-    return new CloudEnvironmentLinkError({
-      message: detail ? `${message}: ${detail}` : message,
-      cause,
-      ...(traceId ? { traceId } : {}),
-    });
-  };
-}
-
-function findEnvironmentCloudApiError(cause: unknown): { readonly message: string } | null {
-  if (isEnvironmentCloudApiError(cause)) {
-    return cause;
-  }
-  if (typeof cause !== "object" || cause === null) {
-    return null;
-  }
-  return "cause" in cause ? findEnvironmentCloudApiError(cause.cause) : null;
-}
-
-const environmentApiError = (message: string) => (cause: unknown) => {
-  const environmentError = findEnvironmentCloudApiError(cause);
-  return new CloudEnvironmentLinkError({
-    message: environmentError
-      ? `${message.replace(/[.:]$/, "")}: ${environmentError.message}`
-      : message,
-    cause,
+function endpointOrigin(input: { readonly environmentId: string; readonly httpBaseUrl: string }) {
+  return Effect.try({
+    try: () => {
+      const url = new URL(input.httpBaseUrl);
+      return {
+        localHttpHost: "127.0.0.1",
+        localHttpPort: Number(url.port || (url.protocol === "https:" ? 443 : 80)),
+      };
+    },
+    catch: (cause) =>
+      new CloudEnvironmentLinkOperationError({
+        action: "derive the environment endpoint origin",
+        environmentId: input.environmentId,
+        httpBaseUrl: input.httpBaseUrl,
+        cause,
+      }),
   });
-};
+}
 
-function endpointOrigin(httpBaseUrl: string) {
-  const url = new URL(httpBaseUrl);
-  return {
-    localHttpHost: "127.0.0.1",
-    localHttpPort: Number(url.port || (url.protocol === "https:" ? 443 : 80)),
-  };
+function makeCloudEnvironmentHttpApiClient(input: {
+  readonly environmentId: string;
+  readonly httpBaseUrl: string;
+}) {
+  return Effect.try({
+    try: () => makeEnvironmentHttpApiClient(input.httpBaseUrl),
+    catch: (cause) =>
+      new CloudEnvironmentLinkOperationError({
+        action: "initialize the environment HTTP client",
+        environmentId: input.environmentId,
+        httpBaseUrl: input.httpBaseUrl,
+        cause,
+      }),
+  }).pipe(Effect.flatten);
 }
 
 const MANAGED_ENDPOINT_PROVIDER_KIND =
@@ -214,13 +373,19 @@ function ensureLinkedEnvironmentMatches(input: {
   readonly link: RelayEnvironmentLinkResponse;
 }): Effect.Effect<void, CloudEnvironmentLinkError> {
   if (input.link.environmentId !== input.expectedEnvironmentId) {
-    return new CloudEnvironmentLinkError({
-      message: "Relay returned credentials for a different environment.",
+    return new CloudEnvironmentLinkResponseMismatchError({
+      environmentId: input.expectedEnvironmentId,
+      field: "environment id",
+      expected: input.expectedEnvironmentId,
+      actual: input.link.environmentId,
     });
   }
   if (input.link.endpoint.providerKind !== input.expectedProviderKind) {
-    return new CloudEnvironmentLinkError({
-      message: "Relay returned credentials for a different endpoint provider.",
+    return new CloudEnvironmentLinkResponseMismatchError({
+      environmentId: input.expectedEnvironmentId,
+      field: "endpoint provider",
+      expected: input.expectedProviderKind,
+      actual: input.link.endpoint.providerKind,
     });
   }
   return Effect.void;
@@ -275,9 +440,7 @@ export function listManagedCloudEnvironments(input: {
   return Effect.gen(function* () {
     const configuredRelayUrl = relayUrl();
     if (!configuredRelayUrl) {
-      return yield* new CloudEnvironmentLinkError({
-        message: "T3CODE_RELAY_URL is not configured.",
-      });
+      return yield* new CloudRelayUrlNotConfiguredError({});
     }
     const relayClient = yield* ManagedRelay.ManagedRelayClient;
     return yield* relayClient
@@ -285,12 +448,12 @@ export function listManagedCloudEnvironments(input: {
         clerkToken: input.clerkToken,
       })
       .pipe(
-        Effect.mapError(
-          (cause) =>
-            new CloudEnvironmentLinkError({
-              message: "Could not list relay-managed environments.",
-              cause,
-            }),
+        Effect.mapError((cause) =>
+          CloudEnvironmentLinkOperationError.fromManagedRelay({
+            action: "list relay-managed environments",
+            relayUrl: configuredRelayUrl,
+            cause,
+          }),
         ),
       );
   });
@@ -304,19 +467,18 @@ export function listCloudDevices(input: {
   ManagedRelay.ManagedRelayClient
 > {
   return Effect.gen(function* () {
-    if (!relayUrl()) {
-      return yield* new CloudEnvironmentLinkError({
-        message: "T3CODE_RELAY_URL is not configured.",
-      });
+    const configuredRelayUrl = relayUrl();
+    if (!configuredRelayUrl) {
+      return yield* new CloudRelayUrlNotConfiguredError({});
     }
     const relayClient = yield* ManagedRelay.ManagedRelayClient;
     return yield* relayClient.listDevices({ clerkToken: input.clerkToken }).pipe(
-      Effect.mapError(
-        (cause) =>
-          new CloudEnvironmentLinkError({
-            message: "Could not list cloud devices.",
-            cause,
-          }),
+      Effect.mapError((cause) =>
+        CloudEnvironmentLinkOperationError.fromManagedRelay({
+          action: "list cloud devices",
+          relayUrl: configuredRelayUrl,
+          cause,
+        }),
       ),
     );
   });
@@ -326,10 +488,20 @@ export function readPrimaryCloudLinkState(input: {
   readonly target: CloudLinkTarget;
 }): Effect.Effect<CloudLinkState | null, CloudEnvironmentLinkError, HttpClient.HttpClient> {
   return Effect.gen(function* () {
-    const client = yield* makeEnvironmentHttpApiClient(input.target.httpBaseUrl);
-    return yield* client.connect
-      .linkState({ headers: {} })
-      .pipe(Effect.mapError(environmentApiError("Could not read environment cloud link state.")));
+    const client = yield* makeCloudEnvironmentHttpApiClient({
+      environmentId: input.target.environmentId,
+      httpBaseUrl: input.target.httpBaseUrl,
+    });
+    return yield* client.connect.linkState({ headers: {} }).pipe(
+      Effect.mapError((cause) =>
+        CloudEnvironmentLinkOperationError.fromEnvironmentApi({
+          action: "read environment cloud link state",
+          environmentId: input.target.environmentId,
+          httpBaseUrl: input.target.httpBaseUrl,
+          cause,
+        }),
+      ),
+    );
   }).pipe(Effect.provide(primaryEnvironmentHttpLayer));
 }
 
@@ -338,14 +510,24 @@ export function updatePrimaryCloudPreferences(input: {
   readonly publishAgentActivity: boolean;
 }): Effect.Effect<CloudLinkState, CloudEnvironmentLinkError, HttpClient.HttpClient> {
   return Effect.gen(function* () {
-    const client = yield* makeEnvironmentHttpApiClient(input.target.httpBaseUrl);
+    const client = yield* makeCloudEnvironmentHttpApiClient({
+      environmentId: input.target.environmentId,
+      httpBaseUrl: input.target.httpBaseUrl,
+    });
     return yield* client.connect
       .preferences({
         headers: {},
         payload: input,
       })
       .pipe(
-        Effect.mapError(environmentApiError("Could not update environment cloud preferences.")),
+        Effect.mapError((cause) =>
+          CloudEnvironmentLinkOperationError.fromEnvironmentApi({
+            action: "update environment cloud preferences",
+            environmentId: input.target.environmentId,
+            httpBaseUrl: input.target.httpBaseUrl,
+            cause,
+          }),
+        ),
       );
   }).pipe(Effect.provide(primaryEnvironmentHttpLayer));
 }
@@ -359,10 +541,20 @@ export function unlinkPrimaryEnvironmentFromCloud(input: {
   HttpClient.HttpClient | ManagedRelay.ManagedRelayClient
 > {
   return Effect.gen(function* () {
-    const client = yield* makeEnvironmentHttpApiClient(input.target.httpBaseUrl);
-    yield* client.connect
-      .unlink({ headers: {} })
-      .pipe(Effect.mapError(environmentApiError("Could not unlink the environment from cloud.")));
+    const client = yield* makeCloudEnvironmentHttpApiClient({
+      environmentId: input.target.environmentId,
+      httpBaseUrl: input.target.httpBaseUrl,
+    });
+    yield* client.connect.unlink({ headers: {} }).pipe(
+      Effect.mapError((cause) =>
+        CloudEnvironmentLinkOperationError.fromEnvironmentApi({
+          action: "unlink the environment from cloud",
+          environmentId: input.target.environmentId,
+          httpBaseUrl: input.target.httpBaseUrl,
+          cause,
+        }),
+      ),
+    );
 
     const configuredRelayUrl = relayUrl();
     if (configuredRelayUrl && input.clerkToken) {
@@ -373,11 +565,19 @@ export function unlinkPrimaryEnvironmentFromCloud(input: {
           environmentId: EnvironmentId.make(input.target.environmentId),
         })
         .pipe(
-          Effect.catch((cause) =>
-            Effect.logWarning("Could not revoke cloud environment link after local unlink.", {
+          Effect.catch((cause) => {
+            const error = CloudEnvironmentLinkOperationError.fromManagedRelay({
+              action: "revoke the cloud environment link",
+              environmentId: input.target.environmentId,
+              relayUrl: configuredRelayUrl,
               cause,
-            }),
-          ),
+            });
+            return Effect.logWarning(error.message, {
+              environmentId: input.target.environmentId,
+              relayUrl: configuredRelayUrl,
+              cause: error,
+            });
+          }),
         );
     }
   }).pipe(Effect.provide(primaryEnvironmentHttpLayer));
@@ -394,13 +594,21 @@ export function linkPrimaryEnvironmentToCloud(input: {
   return Effect.gen(function* () {
     const configuredRelayUrl = relayUrl();
     if (!configuredRelayUrl) {
-      return yield* new CloudEnvironmentLinkError({
-        message: "T3CODE_RELAY_URL is not configured.",
+      return yield* new CloudRelayUrlNotConfiguredError({
+        environmentId: input.target.environmentId,
       });
     }
     const relayClient = yield* ManagedRelay.ManagedRelayClient;
-    const environmentClient = yield* makeEnvironmentHttpApiClient(input.target.httpBaseUrl);
     yield* ensureRelayClientAvailable(EnvironmentId.make(input.target.environmentId));
+
+    const origin = yield* endpointOrigin({
+      environmentId: input.target.environmentId,
+      httpBaseUrl: input.target.httpBaseUrl,
+    });
+    const environmentClient = yield* makeCloudEnvironmentHttpApiClient({
+      environmentId: input.target.environmentId,
+      httpBaseUrl: input.target.httpBaseUrl,
+    });
 
     const challenge = yield* relayClient
       .createEnvironmentLinkChallenge({
@@ -412,10 +620,13 @@ export function linkPrimaryEnvironmentToCloud(input: {
         },
       })
       .pipe(
-        Effect.mapError(
-          decodedRelayClientError(
-            `${configuredRelayUrl}/v1/client/environment-link-challenges failed`,
-          ),
+        Effect.mapError((cause) =>
+          CloudEnvironmentLinkOperationError.fromManagedRelay({
+            action: "create an environment link challenge",
+            environmentId: input.target.environmentId,
+            relayUrl: configuredRelayUrl,
+            cause,
+          }),
         ),
       );
     const proof = yield* environmentClient.connect
@@ -429,10 +640,19 @@ export function linkPrimaryEnvironmentToCloud(input: {
             wsBaseUrl: input.target.wsBaseUrl,
             providerKind: MANAGED_ENDPOINT_PROVIDER_KIND,
           },
-          origin: endpointOrigin(input.target.httpBaseUrl),
+          origin,
         },
       })
-      .pipe(Effect.mapError(environmentApiError("Could not obtain environment link proof.")));
+      .pipe(
+        Effect.mapError((cause) =>
+          CloudEnvironmentLinkOperationError.fromEnvironmentApi({
+            action: "obtain an environment link proof",
+            environmentId: input.target.environmentId,
+            httpBaseUrl: input.target.httpBaseUrl,
+            cause,
+          }),
+        ),
+      );
     const link = yield* relayClient
       .linkEnvironment({
         clerkToken: input.clerkToken,
@@ -444,8 +664,13 @@ export function linkPrimaryEnvironmentToCloud(input: {
         },
       })
       .pipe(
-        Effect.mapError(
-          decodedRelayClientError(`${configuredRelayUrl}/v1/client/environment-links failed`),
+        Effect.mapError((cause) =>
+          CloudEnvironmentLinkOperationError.fromManagedRelay({
+            action: "link the environment",
+            environmentId: input.target.environmentId,
+            relayUrl: configuredRelayUrl,
+            cause,
+          }),
         ),
       );
     yield* ensureLinkedEnvironmentMatches({
@@ -466,6 +691,15 @@ export function linkPrimaryEnvironmentToCloud(input: {
           endpointRuntime: link.endpointRuntime,
         },
       })
-      .pipe(Effect.mapError(environmentApiError("Could not configure environment relay access.")));
+      .pipe(
+        Effect.mapError((cause) =>
+          CloudEnvironmentLinkOperationError.fromEnvironmentApi({
+            action: "configure environment relay access",
+            environmentId: input.target.environmentId,
+            httpBaseUrl: input.target.httpBaseUrl,
+            cause,
+          }),
+        ),
+      );
   }).pipe(Effect.provide(primaryEnvironmentHttpLayer));
 }

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -628,9 +628,6 @@ export function linkPrimaryEnvironmentToCloud(input: {
         environmentId: input.target.environmentId,
       });
     }
-    const relayClient = yield* ManagedRelay.ManagedRelayClient;
-    yield* ensureRelayClientAvailable(EnvironmentId.make(input.target.environmentId));
-
     const origin = yield* endpointOrigin({
       environmentId: input.target.environmentId,
       httpBaseUrl: input.target.httpBaseUrl,
@@ -639,6 +636,8 @@ export function linkPrimaryEnvironmentToCloud(input: {
       environmentId: input.target.environmentId,
       httpBaseUrl: input.target.httpBaseUrl,
     });
+    const relayClient = yield* ManagedRelay.ManagedRelayClient;
+    yield* ensureRelayClientAvailable(EnvironmentId.make(input.target.environmentId));
 
     const challenge = yield* relayClient
       .createEnvironmentLinkChallenge({

--- a/apps/web/src/cloud/linkEnvironment.ts
+++ b/apps/web/src/cloud/linkEnvironment.ts
@@ -605,7 +605,7 @@ export function unlinkPrimaryEnvironmentFromCloud(input: {
               ...(error.relayUrlHostname === undefined
                 ? {}
                 : { relayUrlHostname: error.relayUrlHostname }),
-              cause: error,
+              causeTag: cause._tag,
             });
           }),
         );


### PR DESCRIPTION
## Summary

- replace the generic web cloud-link error bucket and constructor wrappers with structured Schema errors
- preserve nested relay and environment API causes while promoting relay trace IDs and decoded error details through value-adding static mappers
- distinguish configuration, installation, response-mismatch, endpoint parsing, and operation failures without deriving messages from raw cause text
- add focused coverage for relay trace/error promotion and nested environment API cause preservation

## Validation

- `vp test run apps/web/src/cloud/linkEnvironment.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

## Overlap

- no open PR modifies either changed file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication-adjacent cloud link and relay flows with a breaking error shape for any UI that relied on the old generic error; behavior is largely preserved with safer logging and earlier URL validation.
> 
> **Overview**
> **Replaces the single generic `CloudEnvironmentLinkError` with a Schema union of tagged errors** (`CloudEnvironmentLinkOperationError`, relay URL/config, relay client install, and response-mismatch types) and exports `isCloudEnvironmentLinkError` for narrowing.
> 
> **Operation failures** now use stable `action`-based messages plus optional `traceId`, decoded `relayError`, and `environmentError` from cause chains via `fromManagedRelay` / `fromEnvironmentApi`, instead of string messages built from relay/environment text.
> 
> **Diagnostics** attach only sanitized relay/environment URL fields (length, protocol, hostname) via `getUrlDiagnostics`; full URLs are not stored on errors. **Link flow** validates `httpBaseUrl` with Effect (`endpointOrigin`, `makeCloudEnvironmentHttpApiClient`) before relay install prompts, and **unlink** revoke warnings log the same safe fields instead of raw `cause` or full relay URLs.
> 
> Tests cover structured relay/environment failures, invalid URLs, secret exclusion in errors and revoke logs, and updated `RelayClientStatus` fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a444b2af38cf7be9b793254cc91753b5fa535c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure cloud link failures into typed, diagnostic-carrying error classes
> - Replaces the previous `Data.TaggedError`-based `CloudEnvironmentLinkError` with a hierarchy of `Schema.TaggedErrorClass` types in [`linkEnvironment.ts`](https://github.com/pingdotgg/t3code/pull/3316/files#diff-4779753c4f4f62d3a9b8e590c438d2420171ed7338960fa78f2f0b849b66dc55), each carrying sanitized URL diagnostics, `environmentId`, `traceId`, and nested relay/environment errors.
> - Adds `CloudEnvironmentLinkOperationError` with static constructors `fromManagedRelay` and `fromEnvironmentApi` that normalize errors and redact secrets from URL fields before attaching them as diagnostics.
> - Adds specific error classes for distinct failure modes: `CloudRelayUrlNotConfiguredError`, `CloudRelayClientInstallUnsupportedError`, `CloudRelayClientInstallCancelledError`, `CloudRelayClientInstallIncompleteError`, `CloudRelayClientUnavailableAfterInstallError`, and `CloudEnvironmentLinkResponseMismatchError`.
> - Introduces `isCloudEnvironmentLinkError` for reliable discriminated detection of the full error union by callers.
> - Behavioral Change: all cloud link operations now emit structured typed errors with standardized messages (`Could not <action>[ for environment "id"].`); raw relay URLs and error objects are never included in log output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a444b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->