### PR TITLE
[codex] Structure Electron menu failures

### DIFF
--- a/apps/desktop/src/electron/ElectronMenu.test.ts
+++ b/apps/desktop/src/electron/ElectronMenu.test.ts
@@ -1,5 +1,8 @@
 import { assert, describe, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import type * as Electron from "electron";
 import { beforeEach, vi } from "vite-plus/test";
@@ -24,6 +27,10 @@ vi.mock("electron", () => ({
 
 import * as ElectronMenu from "./ElectronMenu.ts";
 
+const TestLayer = ElectronMenu.layer.pipe(
+  Layer.provide(Layer.succeed(HostProcessPlatform, "linux")),
+);
+
 describe("ElectronMenu", () => {
   beforeEach(() => {
     buildFromTemplateMock.mockReset();
@@ -42,7 +49,7 @@ describe("ElectronMenu", () => {
 
       assert.isTrue(Option.isNone(selectedItemId));
       assert.equal(buildFromTemplateMock.mock.calls.length, 0);
-    }).pipe(Effect.provide(ElectronMenu.layer)),
+    }).pipe(Effect.provide(TestLayer)),
   );
 
   it.effect("resolves with the clicked leaf item id", () =>
@@ -69,7 +76,7 @@ describe("ElectronMenu", () => {
       });
 
       assert.equal(Option.getOrNull(selectedItemId), "copy");
-    }).pipe(Effect.provide(ElectronMenu.layer)),
+    }).pipe(Effect.provide(TestLayer)),
   );
 
   it.effect("resolves with none when the menu closes without a click", () =>
@@ -93,7 +100,7 @@ describe("ElectronMenu", () => {
         enabled: true,
         click: buildFromTemplateMock.mock.calls[0]?.[0][0].click,
       });
-    }).pipe(Effect.provide(ElectronMenu.layer)),
+    }).pipe(Effect.provide(TestLayer)),
   );
 
   it.effect("defers popupTemplate side effects until the returned Effect runs", () =>
@@ -114,6 +121,89 @@ describe("ElectronMenu", () => {
 
       assert.equal(buildFromTemplateMock.mock.calls.length, 1);
       assert.equal(popupMock.mock.calls.length, 1);
-    }).pipe(Effect.provide(ElectronMenu.layer)),
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("preserves application-menu failures as structured defects", () =>
+    Effect.gen(function* () {
+      const cause = new Error("application menu build failed");
+      buildFromTemplateMock.mockImplementationOnce(() => {
+        throw cause;
+      });
+
+      const electronMenu = yield* ElectronMenu.ElectronMenu;
+      const exit = yield* Effect.exit(
+        electronMenu.setApplicationMenu([{ label: "File" }, { label: "Edit" }]),
+      );
+
+      assert.equal(exit._tag, "Failure");
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause);
+        assert.instanceOf(error, ElectronMenu.ElectronMenuOperationError);
+        assert.equal(error.operation, "set-application-menu");
+        assert.equal(error.platform, "linux");
+        assert.isNull(error.windowId);
+        assert.equal(error.itemCount, 2);
+        assert.strictEqual(error.cause, cause);
+        assert.notInclude(error.message, cause.message);
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("preserves popup-template failures with window context", () =>
+    Effect.gen(function* () {
+      const cause = new Error("popup failed");
+      buildFromTemplateMock.mockReturnValueOnce({
+        popup: () => {
+          throw cause;
+        },
+      });
+
+      const electronMenu = yield* ElectronMenu.ElectronMenu;
+      const exit = yield* Effect.exit(
+        electronMenu.popupTemplate({
+          window: { id: 41 } as Electron.BrowserWindow,
+          template: [{ label: "Copy" }],
+        }),
+      );
+
+      assert.equal(exit._tag, "Failure");
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause);
+        assert.instanceOf(error, ElectronMenu.ElectronMenuOperationError);
+        assert.equal(error.operation, "popup-template");
+        assert.equal(error.windowId, 41);
+        assert.equal(error.itemCount, 1);
+        assert.strictEqual(error.cause, cause);
+      }
+    }).pipe(Effect.provide(TestLayer)),
+  );
+
+  it.effect("preserves context-menu failures with normalized item context", () =>
+    Effect.gen(function* () {
+      const cause = new Error("context menu build failed");
+      buildFromTemplateMock.mockImplementationOnce(() => {
+        throw cause;
+      });
+
+      const electronMenu = yield* ElectronMenu.ElectronMenu;
+      const exit = yield* Effect.exit(
+        electronMenu.showContextMenu({
+          window: { id: 42 } as Electron.BrowserWindow,
+          items: [{ id: "copy", label: "Copy" }],
+          position: Option.none(),
+        }),
+      );
+
+      assert.equal(exit._tag, "Failure");
+      if (exit._tag === "Failure") {
+        const error = Cause.squash(exit.cause);
+        assert.instanceOf(error, ElectronMenu.ElectronMenuOperationError);
+        assert.equal(error.operation, "show-context-menu");
+        assert.equal(error.windowId, 42);
+        assert.equal(error.itemCount, 1);
+        assert.strictEqual(error.cause, cause);
+      }
+    }).pipe(Effect.provide(TestLayer)),
   );
 });

--- a/apps/desktop/src/electron/ElectronMenu.ts
+++ b/apps/desktop/src/electron/ElectronMenu.ts
@@ -4,6 +4,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import * as Electron from "electron";
 
@@ -21,6 +22,28 @@ export interface ElectronMenuContextInput {
 export interface ElectronMenuTemplateInput {
   readonly window: Electron.BrowserWindow;
   readonly template: readonly Electron.MenuItemConstructorOptions[];
+}
+
+const ElectronMenuOperation = Schema.Literals([
+  "set-application-menu",
+  "popup-template",
+  "show-context-menu",
+]);
+
+export class ElectronMenuOperationError extends Schema.TaggedErrorClass<ElectronMenuOperationError>()(
+  "ElectronMenuOperationError",
+  {
+    operation: ElectronMenuOperation,
+    platform: Schema.String,
+    windowId: Schema.NullOr(Schema.Number),
+    itemCount: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const window = this.windowId === null ? "" : ` for window ${this.windowId}`;
+    return `Electron menu operation ${JSON.stringify(this.operation)} failed${window} with ${this.itemCount} items on ${this.platform}.`;
+  }
 }
 
 export class ElectronMenu extends Context.Service<
@@ -142,16 +165,36 @@ export const make = Effect.gen(function* () {
 
   return ElectronMenu.of({
     setApplicationMenu: (template) =>
-      Effect.sync(() => {
-        Electron.Menu.setApplicationMenu(Electron.Menu.buildFromTemplate([...template]));
-      }),
+      Effect.try({
+        try: () => {
+          Electron.Menu.setApplicationMenu(Electron.Menu.buildFromTemplate([...template]));
+        },
+        catch: (cause) =>
+          new ElectronMenuOperationError({
+            operation: "set-application-menu",
+            platform,
+            windowId: null,
+            itemCount: template.length,
+            cause,
+          }),
+      }).pipe(Effect.orDie),
     popupTemplate: (input) =>
-      Effect.sync(() => {
-        if (input.template.length === 0) {
-          return;
-        }
-        Electron.Menu.buildFromTemplate([...input.template]).popup({ window: input.window });
-      }),
+      input.template.length === 0
+        ? Effect.void
+        : Effect.try({
+            try: () =>
+              Electron.Menu.buildFromTemplate([...input.template]).popup({
+                window: input.window,
+              }),
+            catch: (cause) =>
+              new ElectronMenuOperationError({
+                operation: "popup-template",
+                platform,
+                windowId: input.window.id,
+                itemCount: input.template.length,
+                cause,
+              }),
+          }).pipe(Effect.orDie),
     showContextMenu: (input) =>
       Effect.callback<Option.Option<string>>((resume) => {
         const normalizedItems = normalizeContextMenuItems(input.items);
@@ -169,21 +212,39 @@ export const make = Effect.gen(function* () {
           resume(Effect.succeed(selectedItemId));
         };
 
-        const menu = Electron.Menu.buildFromTemplate(buildTemplate(normalizedItems, complete));
-        const popupPosition = normalizePosition(input.position);
-        const popupOptions = Option.match(popupPosition, {
-          onNone: (): Electron.PopupOptions => ({
-            window: input.window,
-            callback: () => complete(Option.none()),
-          }),
-          onSome: (position): Electron.PopupOptions => ({
-            window: input.window,
-            x: position.x,
-            y: position.y,
-            callback: () => complete(Option.none()),
-          }),
-        });
-        menu.popup(popupOptions);
+        try {
+          const menu = Electron.Menu.buildFromTemplate(buildTemplate(normalizedItems, complete));
+          const popupPosition = normalizePosition(input.position);
+          const popupOptions = Option.match(popupPosition, {
+            onNone: (): Electron.PopupOptions => ({
+              window: input.window,
+              callback: () => complete(Option.none()),
+            }),
+            onSome: (position): Electron.PopupOptions => ({
+              window: input.window,
+              x: position.x,
+              y: position.y,
+              callback: () => complete(Option.none()),
+            }),
+          });
+          menu.popup(popupOptions);
+        } catch (cause) {
+          if (completed) {
+            return;
+          }
+          completed = true;
+          resume(
+            Effect.die(
+              new ElectronMenuOperationError({
+                operation: "show-context-menu",
+                platform,
+                windowId: input.window.id,
+                itemCount: normalizedItems.length,
+                cause,
+              }),
+            ),
+          );
+        }
       }),
   });
 });


### PR DESCRIPTION
## Summary

- wrap Electron native menu construction and popup failures in a structured Schema error carrying operation, platform, window ID, item count, and the exact cause
- preserve the existing defect semantics while keeping messages derived only from stable structured context
- add focused coverage for application-menu, template-popup, and callback-based context-menu failures

## Validation

- `vp test apps/desktop/src/electron/ElectronMenu.test.ts` (7 tests)
- `vp check`
- `vp run typecheck`

## Overlap

The ElectronMenu source file also appears in unrelated feature PR #3177 (version control command center); the test file does not. No active error-audit PR overlaps this slice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop-only error-handling around Electron menus; behavior on success is unchanged and failures remain defects as before, with richer structure for logging and audits.
> 
> **Overview**
> Electron menu native calls now fail with a structured **`ElectronMenuOperationError`** instead of raw thrown errors. **`setApplicationMenu`**, **`popupTemplate`**, and **`showContextMenu`** wrap `buildFromTemplate` / `popup` in **`Effect.try`** (or a guarded try/catch in the callback path) and map failures to defects via **`Effect.orDie`**, carrying **operation**, **platform**, **window id**, **item count**, and the original **cause**. User-facing **message** text is derived only from that metadata, not from the underlying error string.
> 
> Tests provide **`HostProcessPlatform`** as **`linux`** through a shared **`TestLayer`** and add coverage that each menu path surfaces the tagged error with the expected context when Electron mocks throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7c6766b1f4101f2af5769f071ca06c03d6d381. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure Electron menu failures as typed `ElectronMenuOperationError` defects
> - Adds `ElectronMenuOperationError`, a tagged error class with fields `operation`, `platform`, `windowId`, `itemCount`, and `cause`, providing structured context for menu failures in [ElectronMenu.ts](https://github.com/pingdotgg/t3code/pull/3317/files#diff-d9b8a78ba725e2cc1682eccd9670045b20399b4c32a90c6f152c6b6d11396148).
> - Refactors `setApplicationMenu`, `popupTemplate`, and `showContextMenu` to catch failures, wrap them in `ElectronMenuOperationError`, and re-raise as defects via `Effect.orDie` or `Effect.die`.
> - The error message is standardized and does not echo the original cause message, keeping cause accessible only via the structured `cause` field.
> - `popupTemplate` now returns a no-op effect when the input template is empty.
> - Behavioral Change: all three menu methods now die (defect) on failure rather than failing with a typed error; callers relying on `Effect.catchAll` will no longer intercept these errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b7c676.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->