### PR TITLE
[codex] Structure server runtime-state failures

### DIFF
--- a/apps/server/src/serverRuntimeState.test.ts
+++ b/apps/server/src/serverRuntimeState.test.ts
@@ -1,0 +1,167 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as References from "effect/References";
+import * as Schema from "effect/Schema";
+
+import * as ServerRuntimeState from "./serverRuntimeState.ts";
+
+const isServerRuntimeStateError = Schema.is(ServerRuntimeState.ServerRuntimeStateError);
+
+interface CapturedLog {
+  readonly message: unknown;
+  readonly annotations: Readonly<Record<string, unknown>>;
+}
+
+describe("serverRuntimeState", () => {
+  it.effect("persists and reads the runtime state", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-test-",
+      });
+      const statePath = path.join(root, "runtime", "server.json");
+      const state: ServerRuntimeState.PersistedServerRuntimeState = {
+        version: 1,
+        pid: 123,
+        host: "127.0.0.1",
+        port: 4_971,
+        origin: "http://127.0.0.1:4971",
+        startedAt: "2026-06-20T00:00:00.000Z",
+      };
+
+      yield* ServerRuntimeState.persistServerRuntimeState({ path: statePath, state });
+      const restored = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+
+      assert.deepEqual(Option.getOrThrow(restored), state);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("treats a missing runtime state file as absent", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-test-",
+      });
+
+      const restored = yield* ServerRuntimeState.readPersistedServerRuntimeState(
+        path.join(root, "missing.json"),
+      );
+
+      assert.isTrue(Option.isNone(restored));
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("preserves malformed state decode failures", () => {
+    const logs: CapturedLog[] = [];
+    const logger = Logger.make(({ fiber, message }) => {
+      logs.push({
+        message,
+        annotations: fiber.getRef(References.CurrentLogAnnotations),
+      });
+    });
+
+    return Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-test-",
+      });
+      const statePath = path.join(root, "server.json");
+      yield* fileSystem.writeFileString(statePath, "{not json");
+
+      const restored = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+
+      assert.isTrue(Option.isNone(restored));
+      assert.equal(logs[0]?.message, `Failed to decode server runtime state at ${statePath}.`);
+      const error = logs[0]?.annotations.cause;
+      assert.isTrue(isServerRuntimeStateError(error));
+      if (isServerRuntimeStateError(error)) {
+        assert.equal(error.operation, "decode");
+        assert.equal(error.statePath, statePath);
+        assert.equal(error.message, `Failed to decode server runtime state at ${statePath}.`);
+        assert.deepInclude(error.cause, { _tag: "SchemaError" });
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.merge(NodeServices.layer, Logger.layer([logger], { mergeWithExisting: false })),
+      ),
+    );
+  });
+
+  it.effect("preserves runtime state read failures", () => {
+    const logs: CapturedLog[] = [];
+    const logger = Logger.make(({ fiber, message }) => {
+      logs.push({
+        message,
+        annotations: fiber.getRef(References.CurrentLogAnnotations),
+      });
+    });
+
+    return Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-test-",
+      });
+      const statePath = path.join(root, "server.json");
+      yield* fileSystem.makeDirectory(statePath);
+
+      const restored = yield* ServerRuntimeState.readPersistedServerRuntimeState(statePath);
+
+      assert.isTrue(Option.isNone(restored));
+      assert.equal(logs[0]?.message, `Failed to read server runtime state at ${statePath}.`);
+      const error = logs[0]?.annotations.cause;
+      assert.isTrue(isServerRuntimeStateError(error));
+      if (isServerRuntimeStateError(error)) {
+        assert.equal(error.operation, "read");
+        assert.equal(error.statePath, statePath);
+        assert.equal(error.message, `Failed to read server runtime state at ${statePath}.`);
+        assert.deepInclude(error.cause, { _tag: "PlatformError" });
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.merge(NodeServices.layer, Logger.layer([logger], { mergeWithExisting: false })),
+      ),
+    );
+  });
+
+  it.effect("preserves runtime state persistence failures", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-server-runtime-state-test-",
+      });
+      const blockedDirectory = path.join(root, "not-a-directory");
+      const statePath = path.join(blockedDirectory, "server.json");
+      yield* fileSystem.writeFileString(blockedDirectory, "blocked");
+
+      const error = yield* ServerRuntimeState.persistServerRuntimeState({
+        path: statePath,
+        state: {
+          version: 1,
+          pid: 123,
+          port: 4_971,
+          origin: "http://127.0.0.1:4971",
+          startedAt: "2026-06-20T00:00:00.000Z",
+        },
+      }).pipe(Effect.flip);
+
+      assert.isTrue(isServerRuntimeStateError(error));
+      if (isServerRuntimeStateError(error)) {
+        assert.equal(error.operation, "persist");
+        assert.equal(error.statePath, statePath);
+        assert.equal(error.message, `Failed to persist server runtime state at ${statePath}.`);
+        assert.deepInclude(error.cause, { _tag: "PlatformError" });
+      }
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/apps/server/src/serverRuntimeState.ts
+++ b/apps/server/src/serverRuntimeState.ts
@@ -18,6 +18,19 @@ export const PersistedServerRuntimeState = Schema.Struct({
 });
 export type PersistedServerRuntimeState = typeof PersistedServerRuntimeState.Type;
 
+export class ServerRuntimeStateError extends Schema.TaggedErrorClass<ServerRuntimeStateError>()(
+  "ServerRuntimeStateError",
+  {
+    operation: Schema.Literals(["persist", "read", "decode", "clear"]),
+    statePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to ${this.operation} server runtime state at ${this.statePath}.`;
+  }
+}
+
 const decodePersistedServerRuntimeState = Schema.decodeUnknownEffect(
   Schema.fromJsonString(PersistedServerRuntimeState),
 );
@@ -51,27 +64,90 @@ export const persistServerRuntimeState = (input: {
   writeFileStringAtomically({
     filePath: input.path,
     contents: `${JSON.stringify(input.state)}\n`,
-  });
+  }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ServerRuntimeStateError({
+          operation: "persist",
+          statePath: input.path,
+          cause,
+        }),
+    ),
+  );
 
 export const clearPersistedServerRuntimeState = (path: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    yield* fs.remove(path, { force: true }).pipe(Effect.ignore({ log: true }));
+    yield* fs.remove(path, { force: true }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ServerRuntimeStateError({
+            operation: "clear",
+            statePath: path,
+            cause,
+          }),
+      ),
+      Effect.catchTags({
+        ServerRuntimeStateError: (error) =>
+          Effect.logWarning(error.message).pipe(
+            Effect.annotateLogs({
+              operation: error.operation,
+              statePath: error.statePath,
+              cause: error,
+            }),
+          ),
+      }),
+    );
   });
 
 export const readPersistedServerRuntimeState = (path: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
-    const exists = yield* fs.exists(path).pipe(Effect.orElseSucceed(() => false));
-    if (!exists) {
+    const raw = yield* fs.readFileString(path).pipe(
+      Effect.matchEffect({
+        onFailure: (cause) =>
+          cause.reason._tag === "NotFound"
+            ? Effect.succeed(Option.none<string>())
+            : Effect.fail(
+                new ServerRuntimeStateError({
+                  operation: "read",
+                  statePath: path,
+                  cause,
+                }),
+              ),
+        onSuccess: (contents) => Effect.succeed(Option.some(contents)),
+      }),
+    );
+    if (Option.isNone(raw)) {
       return Option.none<PersistedServerRuntimeState>();
     }
 
-    const raw = yield* fs.readFileString(path).pipe(Effect.orElseSucceed(() => ""));
-    const trimmed = raw.trim();
+    const trimmed = raw.value.trim();
     if (trimmed.length === 0) {
       return Option.none<PersistedServerRuntimeState>();
     }
 
-    return yield* decodePersistedServerRuntimeState(trimmed).pipe(Effect.option);
-  });
+    return yield* decodePersistedServerRuntimeState(trimmed).pipe(
+      Effect.map(Option.some),
+      Effect.mapError(
+        (cause) =>
+          new ServerRuntimeStateError({
+            operation: "decode",
+            statePath: path,
+            cause,
+          }),
+      ),
+    );
+  }).pipe(
+    Effect.catchTags({
+      ServerRuntimeStateError: (error) =>
+        Effect.logWarning(error.message).pipe(
+          Effect.annotateLogs({
+            operation: error.operation,
+            statePath: error.statePath,
+            cause: error,
+          }),
+          Effect.as(Option.none<PersistedServerRuntimeState>()),
+        ),
+    }),
+  );


### PR DESCRIPTION
Summary:
- add a structured server runtime-state error with operation, state path, and exact cause
- preserve missing/corrupt/unreadable-state fallback behavior while logging actionable error context
- surface structured atomic persistence failures and retain best-effort cleanup semantics

Tests:
- vp test apps/server/src/serverRuntimeState.test.ts
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized server runtime-state persistence with backward-compatible read/clear fallbacks; no auth or data-model changes.
> 
> **Overview**
> Introduces **`ServerRuntimeStateError`** (operation, `statePath`, underlying cause) for persist/read/decode/clear around the persisted server runtime JSON file.
> 
> **`persistServerRuntimeState`** now surfaces structured failures instead of leaking raw platform errors. **`readPersistedServerRuntimeState`** distinguishes missing files (`Option.none`) from read/decode problems: the latter are logged with operation/path/cause annotations and still return **`Option.none`**, preserving prior “treat bad state as absent” behavior. **`clearPersistedServerRuntimeState`** maps remove failures to the same error type but logs warnings and continues best-effort cleanup.
> 
> Adds **`serverRuntimeState.test.ts`** covering round-trip persist/read, missing file, malformed JSON, read I/O failure, and persist failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b183c833a77a57e7bc25c60bbb03314d1c478df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure server runtime state failures with `ServerRuntimeStateError`
> - Introduces `ServerRuntimeStateError`, a tagged error class with `operation` ('persist', 'read', 'decode', 'clear'), `statePath`, and `cause` fields, replacing unstructured error handling in [serverRuntimeState.ts](https://github.com/pingdotgg/t3code/pull/3319/files#diff-b7e137a54141b0eed3e4f1279655a7ebb0e17e88a6ea34e1b4e65b942939dde8).
> - `readPersistedServerRuntimeState` now maps read and decode failures to `ServerRuntimeStateError`, logs a structured warning with annotations, and returns `Option.none`; missing files are still treated as absent.
> - `persistServerRuntimeState` translates write errors into `ServerRuntimeStateError` instead of propagating raw failures.
> - `clearPersistedServerRuntimeState` logs a structured warning on removal failure instead of silently ignoring it.
> - Adds a test suite in [serverRuntimeState.test.ts](https://github.com/pingdotgg/t3code/pull/3319/files#diff-b279c11f2390b8161d9fc3bf5212b03f58022e0e93bf9b2a710002d5b0291ce7) covering round-trip persistence, missing files, malformed JSON, and I/O failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b183c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->