### PR TITLE
[codex] Structure server environment-label probe failures

### DIFF
--- a/apps/server/src/environment/ServerEnvironmentLabel.test.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.test.ts
@@ -171,13 +171,17 @@ describe("resolveServerEnvironmentLabel", () => {
 
       expect(result).toBe("macbook-pro");
       expect(logs[0]?.message).toEqual([
-        "Failed to run environment-label command 'scutil --get ComputerName'.",
+        "Failed to run environment-label probe 'macos-computer-name' with scutil.",
       ]);
       const error = logs[0]?.annotations.cause;
       expect(isServerEnvironmentLabelCommandError(error)).toBe(true);
       if (isServerEnvironmentLabelCommandError(error)) {
-        expect(error.command).toBe("scutil");
-        expect(error.args).toEqual(["--get", "ComputerName"]);
+        expect(error.probe).toBe("macos-computer-name");
+        expect(error.executable).toBe("scutil");
+        expect(error.argumentCount).toBe(2);
+        expect(error).not.toHaveProperty("args");
+        expect(error.message).not.toContain("--get");
+        expect(error.message).not.toContain("ComputerName");
         expect(error.cause).toBe(processError);
         expect(processError.cause).toBe(spawnCause);
       }

--- a/apps/server/src/environment/ServerEnvironmentLabel.test.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.test.ts
@@ -2,12 +2,28 @@ import { afterEach, describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as PlatformError from "effect/PlatformError";
+import * as References from "effect/References";
+import * as Schema from "effect/Schema";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import { HostProcessHostname, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { vi } from "vite-plus/test";
 
 import * as ProcessRunner from "../processRunner.ts";
-import { resolveServerEnvironmentLabel } from "./ServerEnvironmentLabel.ts";
+import * as ServerEnvironmentLabel from "./ServerEnvironmentLabel.ts";
+
+const isServerEnvironmentLabelFileError = Schema.is(
+  ServerEnvironmentLabel.ServerEnvironmentLabelFileError,
+);
+const isServerEnvironmentLabelCommandError = Schema.is(
+  ServerEnvironmentLabel.ServerEnvironmentLabelCommandError,
+);
+
+interface CapturedLog {
+  readonly message: unknown;
+  readonly annotations: Readonly<Record<string, unknown>>;
+}
 
 const runMock = vi.fn<ProcessRunner.ProcessRunner["Service"]["run"]>();
 
@@ -47,7 +63,7 @@ afterEach(() => {
 describe("resolveServerEnvironmentLabel", () => {
   it.effect("uses hostname fallback regardless of launch mode", () =>
     Effect.gen(function* () {
-      const result = yield* resolveServerEnvironmentLabel({
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
         cwdBaseName: "t3code",
       }).pipe(Effect.provide(withHostPlatform(TestLayer, "win32", "macbook-pro")));
 
@@ -68,7 +84,7 @@ describe("resolveServerEnvironmentLabel", () => {
         }),
       );
 
-      const result = yield* resolveServerEnvironmentLabel({
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
         cwdBaseName: "t3code",
       }).pipe(Effect.provide(withHostPlatform(TestLayer, "darwin", "macbook-pro")));
 
@@ -85,7 +101,7 @@ describe("resolveServerEnvironmentLabel", () => {
 
   it.effect("prefers Linux PRETTY_HOSTNAME from machine-info", () =>
     Effect.gen(function* () {
-      const result = yield* resolveServerEnvironmentLabel({
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
         cwdBaseName: "t3code",
       }).pipe(Effect.provide(withHostPlatform(LinuxMachineInfoLayer, "linux", "buildbox")));
 
@@ -107,7 +123,7 @@ describe("resolveServerEnvironmentLabel", () => {
         }),
       );
 
-      const result = yield* resolveServerEnvironmentLabel({
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
         cwdBaseName: "t3code",
       }).pipe(Effect.provide(withHostPlatform(TestLayer, "linux", "runner-01")));
 
@@ -124,7 +140,7 @@ describe("resolveServerEnvironmentLabel", () => {
 
   it.effect("falls back to the hostname when friendly labels are unavailable", () =>
     Effect.gen(function* () {
-      const result = yield* resolveServerEnvironmentLabel({
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
         cwdBaseName: "t3code",
       }).pipe(Effect.provide(withHostPlatform(TestLayer, "win32", "JULIUS-LAPTOP")));
 
@@ -132,25 +148,107 @@ describe("resolveServerEnvironmentLabel", () => {
     }),
   );
 
-  it.effect("falls back to the hostname when the friendly-label command is missing", () =>
-    Effect.gen(function* () {
-      runMock.mockReturnValueOnce(
-        Effect.fail(
-          new ProcessRunner.ProcessSpawnError({
-            command: "scutil",
-            argumentCount: 2,
-            cause: new Error("spawn scutil ENOENT"),
-          }),
-        ),
-      );
+  it.effect("falls back to the hostname when the friendly-label command is missing", () => {
+    const logs: CapturedLog[] = [];
+    const logger = Logger.make(({ fiber, message }) => {
+      logs.push({
+        message,
+        annotations: fiber.getRef(References.CurrentLogAnnotations),
+      });
+    });
+    const spawnCause = new Error("spawn scutil ENOENT");
+    const processError = new ProcessRunner.ProcessSpawnError({
+      command: "scutil",
+      argumentCount: 2,
+      cause: spawnCause,
+    });
+    runMock.mockReturnValueOnce(Effect.fail(processError));
 
-      const result = yield* resolveServerEnvironmentLabel({
+    return Effect.gen(function* () {
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
         cwdBaseName: "t3code",
-      }).pipe(Effect.provide(withHostPlatform(TestLayer, "darwin", "macbook-pro")));
+      });
 
       expect(result).toBe("macbook-pro");
-    }),
-  );
+      expect(logs[0]?.message).toEqual([
+        "Failed to run environment-label command 'scutil --get ComputerName'.",
+      ]);
+      const error = logs[0]?.annotations.cause;
+      expect(isServerEnvironmentLabelCommandError(error)).toBe(true);
+      if (isServerEnvironmentLabelCommandError(error)) {
+        expect(error.command).toBe("scutil");
+        expect(error.args).toEqual(["--get", "ComputerName"]);
+        expect(error.cause).toBe(processError);
+        expect(processError.cause).toBe(spawnCause);
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          withHostPlatform(TestLayer, "darwin", "macbook-pro"),
+          Logger.layer([logger], { mergeWithExisting: false }),
+          Layer.succeed(References.MinimumLogLevel, "Debug"),
+        ),
+      ),
+    );
+  });
+
+  it.effect("continues to hostnamectl after a machine-info inspect failure", () => {
+    const logs: CapturedLog[] = [];
+    const logger = Logger.make(({ fiber, message }) => {
+      logs.push({
+        message,
+        annotations: fiber.getRef(References.CurrentLogAnnotations),
+      });
+    });
+    const fileCause = new Error("permission denied");
+    const platformError = PlatformError.systemError({
+      _tag: "PermissionDenied",
+      module: "FileSystem",
+      method: "exists",
+      pathOrDescriptor: "/etc/machine-info",
+      cause: fileCause,
+    });
+    const fileSystemLayer = FileSystem.layerNoop({
+      exists: () => Effect.fail(platformError),
+    });
+    runMock.mockReturnValueOnce(
+      Effect.succeed({
+        stdout: "CI Runner\n",
+        stderr: "",
+        code: ChildProcessSpawner.ExitCode(0),
+        timedOut: false,
+        stdoutTruncated: false,
+        stderrTruncated: false,
+      }),
+    );
+
+    return Effect.gen(function* () {
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
+        cwdBaseName: "t3code",
+      });
+
+      expect(result).toBe("CI Runner");
+      expect(logs[0]?.message).toEqual([
+        "Failed to inspect environment-label file at /etc/machine-info.",
+      ]);
+      const error = logs[0]?.annotations.cause;
+      expect(isServerEnvironmentLabelFileError(error)).toBe(true);
+      if (isServerEnvironmentLabelFileError(error)) {
+        expect(error.operation).toBe("inspect");
+        expect(error.path).toBe("/etc/machine-info");
+        expect(error.cause).toBe(platformError);
+        expect(platformError.cause).toBe(fileCause);
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          withHostPlatform(Layer.merge(ProcessRunnerTest, fileSystemLayer), "linux", "buildbox"),
+          Logger.layer([logger], { mergeWithExisting: false }),
+          Layer.succeed(References.MinimumLogLevel, "Debug"),
+        ),
+      ),
+    );
+  });
 
   it.effect("falls back to the cwd basename when the hostname is blank", () =>
     Effect.gen(function* () {
@@ -165,7 +263,7 @@ describe("resolveServerEnvironmentLabel", () => {
         }),
       );
 
-      const result = yield* resolveServerEnvironmentLabel({
+      const result = yield* ServerEnvironmentLabel.resolveServerEnvironmentLabel({
         cwdBaseName: "t3code",
       }).pipe(Effect.provide(withHostPlatform(TestLayer, "linux", "   ")));
 

--- a/apps/server/src/environment/ServerEnvironmentLabel.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.ts
@@ -2,11 +2,38 @@ import { HostProcessHostname, HostProcessPlatform } from "@t3tools/shared/hostPr
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import * as ProcessRunner from "../processRunner.ts";
 
 interface ResolveServerEnvironmentLabelInput {
   readonly cwdBaseName: string;
+}
+
+export class ServerEnvironmentLabelFileError extends Schema.TaggedErrorClass<ServerEnvironmentLabelFileError>()(
+  "ServerEnvironmentLabelFileError",
+  {
+    operation: Schema.Literals(["inspect", "read"]),
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to ${this.operation} environment-label file at ${this.path}.`;
+  }
+}
+
+export class ServerEnvironmentLabelCommandError extends Schema.TaggedErrorClass<ServerEnvironmentLabelCommandError>()(
+  "ServerEnvironmentLabelCommandError",
+  {
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to run environment-label command '${[this.command, ...this.args].join(" ")}'.`;
+  }
 }
 
 function normalizeLabel(value: string | null | undefined): string | null {
@@ -34,16 +61,42 @@ function parseMachineInfoValue(raw: string, key: string): string | null {
 
 const readLinuxMachineInfo = Effect.fn("readLinuxMachineInfo")(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
-  const exists = yield* fileSystem
-    .exists("/etc/machine-info")
-    .pipe(Effect.orElseSucceed(() => false));
-  if (!exists) {
-    return null;
-  }
-
-  return yield* fileSystem
-    .readFileString("/etc/machine-info")
-    .pipe(Effect.orElseSucceed(() => null));
+  const machineInfoPath = "/etc/machine-info";
+  return yield* fileSystem.exists(machineInfoPath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ServerEnvironmentLabelFileError({
+          operation: "inspect",
+          path: machineInfoPath,
+          cause,
+        }),
+    ),
+    Effect.flatMap((exists) =>
+      exists
+        ? fileSystem.readFileString(machineInfoPath).pipe(
+            Effect.mapError(
+              (cause) =>
+                new ServerEnvironmentLabelFileError({
+                  operation: "read",
+                  path: machineInfoPath,
+                  cause,
+                }),
+            ),
+          )
+        : Effect.succeed(null),
+    ),
+    Effect.catchTags({
+      ServerEnvironmentLabelFileError: (error) =>
+        Effect.logDebug(error.message).pipe(
+          Effect.annotateLogs({
+            operation: error.operation,
+            path: error.path,
+            cause: error,
+          }),
+          Effect.as(null),
+        ),
+    }),
+  );
 });
 
 const runFriendlyLabelCommand = Effect.fn("runFriendlyLabelCommand")(function* (
@@ -57,7 +110,28 @@ const runFriendlyLabelCommand = Effect.fn("runFriendlyLabelCommand")(function* (
       args,
       timeoutBehavior: "timedOutResult",
     })
-    .pipe(Effect.option);
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new ServerEnvironmentLabelCommandError({
+            command,
+            args,
+            cause,
+          }),
+      ),
+      Effect.map(Option.some),
+      Effect.catchTags({
+        ServerEnvironmentLabelCommandError: (error) =>
+          Effect.logDebug(error.message).pipe(
+            Effect.annotateLogs({
+              command: error.command,
+              args: error.args,
+              cause: error,
+            }),
+            Effect.as(Option.none()),
+          ),
+      }),
+    );
 
   if (Option.isNone(result) || result.value.code !== 0) {
     return null;

--- a/apps/server/src/environment/ServerEnvironmentLabel.ts
+++ b/apps/server/src/environment/ServerEnvironmentLabel.ts
@@ -10,6 +10,12 @@ interface ResolveServerEnvironmentLabelInput {
   readonly cwdBaseName: string;
 }
 
+const ServerEnvironmentLabelCommandProbe = Schema.Literals([
+  "macos-computer-name",
+  "linux-pretty-hostname",
+]);
+type ServerEnvironmentLabelCommandProbe = typeof ServerEnvironmentLabelCommandProbe.Type;
+
 export class ServerEnvironmentLabelFileError extends Schema.TaggedErrorClass<ServerEnvironmentLabelFileError>()(
   "ServerEnvironmentLabelFileError",
   {
@@ -26,13 +32,14 @@ export class ServerEnvironmentLabelFileError extends Schema.TaggedErrorClass<Ser
 export class ServerEnvironmentLabelCommandError extends Schema.TaggedErrorClass<ServerEnvironmentLabelCommandError>()(
   "ServerEnvironmentLabelCommandError",
   {
-    command: Schema.String,
-    args: Schema.Array(Schema.String),
+    probe: ServerEnvironmentLabelCommandProbe,
+    executable: Schema.String,
+    argumentCount: Schema.Number,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to run environment-label command '${[this.command, ...this.args].join(" ")}'.`;
+    return `Failed to run environment-label probe '${this.probe}' with ${this.executable}.`;
   }
 }
 
@@ -99,23 +106,25 @@ const readLinuxMachineInfo = Effect.fn("readLinuxMachineInfo")(function* () {
   );
 });
 
-const runFriendlyLabelCommand = Effect.fn("runFriendlyLabelCommand")(function* (
-  command: string,
-  args: readonly string[],
-) {
+const runFriendlyLabelCommand = Effect.fn("runFriendlyLabelCommand")(function* (input: {
+  readonly probe: ServerEnvironmentLabelCommandProbe;
+  readonly command: string;
+  readonly args: readonly string[];
+}) {
   const processRunner = yield* ProcessRunner.ProcessRunner;
   const result = yield* processRunner
     .run({
-      command,
-      args,
+      command: input.command,
+      args: input.args,
       timeoutBehavior: "timedOutResult",
     })
     .pipe(
       Effect.mapError(
         (cause) =>
           new ServerEnvironmentLabelCommandError({
-            command,
-            args,
+            probe: input.probe,
+            executable: input.command,
+            argumentCount: input.args.length,
             cause,
           }),
       ),
@@ -124,8 +133,9 @@ const runFriendlyLabelCommand = Effect.fn("runFriendlyLabelCommand")(function* (
         ServerEnvironmentLabelCommandError: (error) =>
           Effect.logDebug(error.message).pipe(
             Effect.annotateLogs({
-              command: error.command,
-              args: error.args,
+              probe: error.probe,
+              executable: error.executable,
+              argumentCount: error.argumentCount,
               cause: error,
             }),
             Effect.as(Option.none()),
@@ -143,7 +153,11 @@ const runFriendlyLabelCommand = Effect.fn("runFriendlyLabelCommand")(function* (
 const resolveFriendlyHostLabel = Effect.fn("resolveFriendlyHostLabel")(function* () {
   const platform = yield* HostProcessPlatform;
   if (platform === "darwin") {
-    return yield* runFriendlyLabelCommand("scutil", ["--get", "ComputerName"]);
+    return yield* runFriendlyLabelCommand({
+      probe: "macos-computer-name",
+      command: "scutil",
+      args: ["--get", "ComputerName"],
+    });
   }
 
   if (platform === "linux") {
@@ -155,7 +169,11 @@ const resolveFriendlyHostLabel = Effect.fn("resolveFriendlyHostLabel")(function*
       }
     }
 
-    return yield* runFriendlyLabelCommand("hostnamectl", ["--pretty"]);
+    return yield* runFriendlyLabelCommand({
+      probe: "linux-pretty-hostname",
+      command: "hostnamectl",
+      args: ["--pretty"],
+    });
   }
 
   return null;


### PR DESCRIPTION
## Summary
- represent machine-info probe failures with operation, path, and the exact underlying cause
- represent friendly-label command failures with command, arguments, and the exact process failure
- retain best-effort hostname fallback behavior while emitting structured debug diagnostics
- verify filesystem and process error chains with external-service test layers

## Validation
- `vp test apps/server/src/environment/ServerEnvironmentLabel.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in server startup label resolution; public return values and fallback order are unchanged.
> 
> **Overview**
> Replaces silent handling of `/etc/machine-info` and friendly-label command (`scutil`, `hostnamectl`) failures with **typed tagged errors** and **debug logs** annotated with path, probe, executable, and cause chains, while **hostname / cwd fallback behavior stays the same**.
> 
> Adds `ServerEnvironmentLabelFileError` and `ServerEnvironmentLabelCommandError`; command failures record **argument count only** (not argv) so sensitive values do not appear in logs. Tests now assert debug messages and full error chains when probes fail, including Linux continuing to `hostnamectl` after a machine-info inspect error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ee5facb28d97904139467802fc823cad3849e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure environment-label probe failures as typed errors with debug logging
> - Adds `ServerEnvironmentLabelFileError` and `ServerEnvironmentLabelCommandError` tagged error classes in [`ServerEnvironmentLabel.ts`](https://github.com/pingdotgg/t3code/pull/3321/files#diff-b1aacbc192ffaacdfdd1ba5d7cbd3815df9976714c71601e826526144c769e59) to wrap failures from file inspection/read and command execution respectively.
> - Errors are now logged at debug level with structured annotations (probe, executable, path, cause) before being suppressed, replacing the previous silent `orElseSucceed` suppression.
> - Updates [`ServerEnvironmentLabel.test.ts`](https://github.com/pingdotgg/t3code/pull/3321/files#diff-5b145dcc1e0a2db3d0caf494316c97ed5fbc5d2cce6beb2bb81174710b06f17f) with tests asserting the new structured error types and captured log annotations on probe failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2ee5fac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->