### PR TITLE
[codex] Structure APNs delivery job errors

### DIFF
--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -611,6 +611,22 @@ describe("ApnsDeliveries", () => {
     }).pipe(Effect.provide(makeLayer({ attempts, queuedJobs })));
   });
 
+  it.effect("preserves the schema cause for invalid queue payloads", () => {
+    const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
+
+    return Effect.gen(function* () {
+      const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
+      const error = yield* Effect.flip(deliveries.processSignedJob({ invalid: true }));
+
+      expect(error).toMatchObject({
+        _tag: "ApnsDeliveryJobQueuePayloadInvalid",
+        receivedType: "object",
+        message: "Invalid APNs delivery queue job with object payload.",
+      });
+      expect(error.cause).toMatchObject({ _tag: "SchemaError" });
+    }).pipe(Effect.provide(makeLayer({ attempts })));
+  });
+
   it.effect("processes signed jobs through APNs and records attempts", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
     const payload = makeApnsDeliveryJobPayload({

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -640,7 +640,13 @@ export const make = Effect.gen(function* () {
     "relay.apns_deliveries.process_signed_job",
   )(function* (body) {
     const signedJob = yield* decodeSignedApnsDeliveryJob(body).pipe(
-      Effect.mapError(() => new ApnsDeliveryJobQueuePayloadInvalid()),
+      Effect.mapError(
+        (cause) =>
+          new ApnsDeliveryJobQueuePayloadInvalid({
+            receivedType: Array.isArray(body) ? "array" : body === null ? "null" : typeof body,
+            cause,
+          }),
+      ),
     );
     const now = yield* DateTime.now;
     const payload = verifySignedApnsDeliveryJob({
@@ -661,7 +667,14 @@ export const make = Effect.gen(function* () {
         case "live_activity_start":
         case "live_activity_update":
           if (payload.aggregate === null) {
-            return Effect.fail(new ApnsDeliveryJobLiveActivityAggregateMissing());
+            return Effect.fail(
+              new ApnsDeliveryJobLiveActivityAggregateMissing({
+                jobId: payload.jobId,
+                kind: payload.kind,
+                userId: payload.target.userId,
+                deviceId: payload.target.deviceId,
+              }),
+            );
           }
           return sendLiveActivity({
             target: {
@@ -686,7 +699,13 @@ export const make = Effect.gen(function* () {
           });
         case "push_notification":
           if (payload.notification === null) {
-            return Effect.fail(new ApnsDeliveryJobPushNotificationMissing());
+            return Effect.fail(
+              new ApnsDeliveryJobPushNotificationMissing({
+                jobId: payload.jobId,
+                userId: payload.target.userId,
+                deviceId: payload.target.deviceId,
+              }),
+            );
           }
           return sendPushNotification({
             target: {

--- a/infra/relay/src/agentActivity/apnsDeliveryJobs.test.ts
+++ b/infra/relay/src/agentActivity/apnsDeliveryJobs.test.ts
@@ -70,6 +70,11 @@ describe("apnsDeliveryJobs", () => {
 
     expect(result).toMatchObject({
       _tag: "ApnsDeliveryJobSignatureInvalid",
+      jobId: "job-1",
+      kind: "live_activity_end",
+      userId: "user-1",
+      deviceId: "device-1",
+      message: "Invalid signature for APNs delivery job job-1.",
     });
   });
 
@@ -94,7 +99,11 @@ describe("apnsDeliveryJobs", () => {
 
     expect(result).toMatchObject({
       _tag: "ApnsDeliveryJobLiveActivityAggregateMissing",
-      message: "Live Activity start/update jobs require an aggregate.",
+      jobId: "job-start-invalid",
+      kind: "live_activity_start",
+      userId: "user-1",
+      deviceId: "device-1",
+      message: "APNs live activity start job job-start-invalid requires an aggregate.",
     });
   });
 
@@ -120,7 +129,10 @@ describe("apnsDeliveryJobs", () => {
 
     expect(result).toMatchObject({
       _tag: "ApnsDeliveryJobPushNotificationAggregateUnexpected",
-      message: "Push notification jobs must not carry aggregate state.",
+      jobId: "job-push-invalid",
+      userId: "user-1",
+      deviceId: "device-1",
+      message: "APNs push notification job job-push-invalid must not carry aggregate state.",
     });
   });
 
@@ -195,7 +207,12 @@ describe("apnsDeliveryJobs", () => {
       }),
     ).toMatchObject({
       _tag: "ApnsDeliveryJobCreatedAtInvalid",
-      message: "Invalid APNs delivery job creation time.",
+      jobId: "job-window",
+      kind: "live_activity_end",
+      userId: "user-1",
+      deviceId: "device-1",
+      createdAt: "not-a-date",
+      message: "APNs delivery job job-window has invalid creation time not-a-date.",
     });
     expect(
       verifySignedApnsDeliveryJob({
@@ -205,7 +222,14 @@ describe("apnsDeliveryJobs", () => {
       }),
     ).toMatchObject({
       _tag: "ApnsDeliveryJobTimeWindowInvalid",
-      message: "Invalid APNs delivery job time window.",
+      jobId: "job-window",
+      kind: "live_activity_end",
+      userId: "user-1",
+      deviceId: "device-1",
+      createdAt: "2026-05-25T00:00:00.000Z",
+      expiresAt: "2026-05-24T23:59:59.000Z",
+      message:
+        "APNs delivery job job-window has invalid time window 2026-05-25T00:00:00.000Z to 2026-05-24T23:59:59.000Z.",
     });
     expect(
       verifySignedApnsDeliveryJob({
@@ -215,7 +239,14 @@ describe("apnsDeliveryJobs", () => {
       }),
     ).toMatchObject({
       _tag: "ApnsDeliveryJobTimeWindowTooLong",
-      message: "APNs delivery job time window is too long.",
+      jobId: "job-window",
+      kind: "live_activity_end",
+      userId: "user-1",
+      deviceId: "device-1",
+      createdAt: "2026-05-25T00:00:00.000Z",
+      expiresAt: "2026-05-25T00:10:01.000Z",
+      message:
+        "APNs delivery job job-window time window 2026-05-25T00:00:00.000Z to 2026-05-25T00:10:01.000Z is too long.",
     });
   });
 });

--- a/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
+++ b/infra/relay/src/agentActivity/apnsDeliveryJobs.ts
@@ -10,12 +10,27 @@ import * as Schema from "effect/Schema";
 const MAX_JOB_AGE_MS = 10 * 60 * 1_000;
 export const APNS_DELIVERY_JOB_SIGNING_ALGORITHM = "hmac-sha256";
 
-const ApnsDeliveryKind = Schema.Literals([
+const ApnsDeliveryKindSchema = Schema.Literals([
   "live_activity_start",
   "live_activity_update",
   "live_activity_end",
   "push_notification",
 ]);
+const LiveActivityStartOrUpdateKindSchema = Schema.Literals([
+  "live_activity_start",
+  "live_activity_update",
+]);
+const LiveActivityKindSchema = Schema.Literals([
+  "live_activity_start",
+  "live_activity_update",
+  "live_activity_end",
+]);
+
+const ApnsDeliveryJobContext = {
+  jobId: Schema.String,
+  userId: Schema.String,
+  deviceId: Schema.String,
+};
 
 export const ApnsNotificationPayload = Schema.Struct({
   title: Schema.String,
@@ -29,7 +44,7 @@ export type ApnsNotificationPayload = typeof ApnsNotificationPayload.Type;
 export const ApnsDeliveryJobPayload = Schema.Struct({
   version: Schema.Literal(1),
   jobId: Schema.String,
-  kind: ApnsDeliveryKind,
+  kind: ApnsDeliveryKindSchema,
   target: Schema.Struct({
     userId: Schema.String,
     deviceId: Schema.String,
@@ -51,91 +66,121 @@ export type SignedApnsDeliveryJob = typeof SignedApnsDeliveryJob.Type;
 
 export class ApnsDeliveryJobQueuePayloadInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobQueuePayloadInvalid>()(
   "ApnsDeliveryJobQueuePayloadInvalid",
-  {},
+  {
+    receivedType: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Invalid APNs delivery queue job.";
+    return `Invalid APNs delivery queue job with ${this.receivedType} payload.`;
   }
 }
 
 export class ApnsDeliveryJobLiveActivityAggregateMissing extends Schema.TaggedErrorClass<ApnsDeliveryJobLiveActivityAggregateMissing>()(
   "ApnsDeliveryJobLiveActivityAggregateMissing",
-  {},
+  {
+    ...ApnsDeliveryJobContext,
+    kind: LiveActivityStartOrUpdateKindSchema,
+  },
 ) {
   override get message(): string {
-    return "Live Activity start/update jobs require an aggregate.";
+    return `APNs ${this.kind.replaceAll("_", " ")} job ${this.jobId} requires an aggregate.`;
   }
 }
 
 export class ApnsDeliveryJobLiveActivityNotificationUnexpected extends Schema.TaggedErrorClass<ApnsDeliveryJobLiveActivityNotificationUnexpected>()(
   "ApnsDeliveryJobLiveActivityNotificationUnexpected",
-  {},
+  {
+    ...ApnsDeliveryJobContext,
+    kind: LiveActivityKindSchema,
+  },
 ) {
   override get message(): string {
-    return "Live Activity jobs must not carry push notification payloads.";
+    return `APNs ${this.kind.replaceAll("_", " ")} job ${this.jobId} must not carry a push notification payload.`;
   }
 }
 
 export class ApnsDeliveryJobPushNotificationMissing extends Schema.TaggedErrorClass<ApnsDeliveryJobPushNotificationMissing>()(
   "ApnsDeliveryJobPushNotificationMissing",
-  {},
+  ApnsDeliveryJobContext,
 ) {
   override get message(): string {
-    return "Push notification jobs require a notification payload.";
+    return `APNs push notification job ${this.jobId} requires a notification payload.`;
   }
 }
 
 export class ApnsDeliveryJobPushNotificationAggregateUnexpected extends Schema.TaggedErrorClass<ApnsDeliveryJobPushNotificationAggregateUnexpected>()(
   "ApnsDeliveryJobPushNotificationAggregateUnexpected",
-  {},
+  ApnsDeliveryJobContext,
 ) {
   override get message(): string {
-    return "Push notification jobs must not carry aggregate state.";
+    return `APNs push notification job ${this.jobId} must not carry aggregate state.`;
   }
 }
 
 export class ApnsDeliveryJobCreatedAtInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobCreatedAtInvalid>()(
   "ApnsDeliveryJobCreatedAtInvalid",
-  {},
+  {
+    ...ApnsDeliveryJobContext,
+    kind: ApnsDeliveryKindSchema,
+    createdAt: Schema.String,
+  },
 ) {
   override get message(): string {
-    return "Invalid APNs delivery job creation time.";
+    return `APNs delivery job ${this.jobId} has invalid creation time ${this.createdAt}.`;
   }
 }
 
 export class ApnsDeliveryJobExpiresAtInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobExpiresAtInvalid>()(
   "ApnsDeliveryJobExpiresAtInvalid",
-  {},
+  {
+    ...ApnsDeliveryJobContext,
+    kind: ApnsDeliveryKindSchema,
+    expiresAt: Schema.String,
+  },
 ) {
   override get message(): string {
-    return "Invalid APNs delivery job expiry.";
+    return `APNs delivery job ${this.jobId} has invalid expiry ${this.expiresAt}.`;
   }
 }
 
 export class ApnsDeliveryJobTimeWindowInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobTimeWindowInvalid>()(
   "ApnsDeliveryJobTimeWindowInvalid",
-  {},
+  {
+    ...ApnsDeliveryJobContext,
+    kind: ApnsDeliveryKindSchema,
+    createdAt: Schema.String,
+    expiresAt: Schema.String,
+  },
 ) {
   override get message(): string {
-    return "Invalid APNs delivery job time window.";
+    return `APNs delivery job ${this.jobId} has invalid time window ${this.createdAt} to ${this.expiresAt}.`;
   }
 }
 
 export class ApnsDeliveryJobTimeWindowTooLong extends Schema.TaggedErrorClass<ApnsDeliveryJobTimeWindowTooLong>()(
   "ApnsDeliveryJobTimeWindowTooLong",
-  {},
+  {
+    ...ApnsDeliveryJobContext,
+    kind: ApnsDeliveryKindSchema,
+    createdAt: Schema.String,
+    expiresAt: Schema.String,
+  },
 ) {
   override get message(): string {
-    return "APNs delivery job time window is too long.";
+    return `APNs delivery job ${this.jobId} time window ${this.createdAt} to ${this.expiresAt} is too long.`;
   }
 }
 
 export class ApnsDeliveryJobSignatureInvalid extends Schema.TaggedErrorClass<ApnsDeliveryJobSignatureInvalid>()(
   "ApnsDeliveryJobSignatureInvalid",
-  {},
+  {
+    ...ApnsDeliveryJobContext,
+    kind: ApnsDeliveryKindSchema,
+  },
 ) {
   override get message(): string {
-    return "Invalid APNs delivery job signature.";
+    return `Invalid signature for APNs delivery job ${this.jobId}.`;
   }
 }
 
@@ -156,11 +201,13 @@ export type ApnsDeliveryJobInvalid = typeof ApnsDeliveryJobInvalid.Type;
 export class ApnsDeliveryJobExpired extends Schema.TaggedErrorClass<ApnsDeliveryJobExpired>()(
   "ApnsDeliveryJobExpired",
   {
+    ...ApnsDeliveryJobContext,
+    kind: ApnsDeliveryKindSchema,
     expiresAt: Schema.String,
   },
 ) {
   override get message(): string {
-    return `APNs delivery job expired at ${this.expiresAt}`;
+    return `APNs delivery job ${this.jobId} expired at ${this.expiresAt}.`;
   }
 }
 
@@ -208,23 +255,46 @@ function validatePayloadShape(payload: ApnsDeliveryJobPayload): ApnsDeliveryJobI
     case "live_activity_start":
     case "live_activity_update":
       if (payload.aggregate === null) {
-        return new ApnsDeliveryJobLiveActivityAggregateMissing();
+        return new ApnsDeliveryJobLiveActivityAggregateMissing({
+          jobId: payload.jobId,
+          kind: payload.kind,
+          userId: payload.target.userId,
+          deviceId: payload.target.deviceId,
+        });
       }
       if (payload.notification !== null) {
-        return new ApnsDeliveryJobLiveActivityNotificationUnexpected();
+        return new ApnsDeliveryJobLiveActivityNotificationUnexpected({
+          jobId: payload.jobId,
+          kind: payload.kind,
+          userId: payload.target.userId,
+          deviceId: payload.target.deviceId,
+        });
       }
       return null;
     case "live_activity_end":
       if (payload.notification !== null) {
-        return new ApnsDeliveryJobLiveActivityNotificationUnexpected();
+        return new ApnsDeliveryJobLiveActivityNotificationUnexpected({
+          jobId: payload.jobId,
+          kind: payload.kind,
+          userId: payload.target.userId,
+          deviceId: payload.target.deviceId,
+        });
       }
       return null;
     case "push_notification":
       if (payload.notification === null) {
-        return new ApnsDeliveryJobPushNotificationMissing();
+        return new ApnsDeliveryJobPushNotificationMissing({
+          jobId: payload.jobId,
+          userId: payload.target.userId,
+          deviceId: payload.target.deviceId,
+        });
       }
       if (payload.aggregate !== null) {
-        return new ApnsDeliveryJobPushNotificationAggregateUnexpected();
+        return new ApnsDeliveryJobPushNotificationAggregateUnexpected({
+          jobId: payload.jobId,
+          userId: payload.target.userId,
+          deviceId: payload.target.deviceId,
+        });
       }
       return null;
   }
@@ -264,35 +334,73 @@ export function verifySignedApnsDeliveryJob(input: {
   readonly job: SignedApnsDeliveryJob;
   readonly nowMs: number;
 }): ApnsDeliveryJobPayload | ApnsDeliveryJobVerificationError {
-  const invalidPayload = validatePayloadShape(input.job.payload);
+  const payload = input.job.payload;
+  const invalidPayload = validatePayloadShape(payload);
   if (invalidPayload !== null) {
     return invalidPayload;
   }
-  const createdAt = DateTime.make(input.job.payload.createdAt);
+  const createdAt = DateTime.make(payload.createdAt);
   if (Option.isNone(createdAt)) {
-    return new ApnsDeliveryJobCreatedAtInvalid();
+    return new ApnsDeliveryJobCreatedAtInvalid({
+      jobId: payload.jobId,
+      kind: payload.kind,
+      userId: payload.target.userId,
+      deviceId: payload.target.deviceId,
+      createdAt: payload.createdAt,
+    });
   }
-  const expiresAt = DateTime.make(input.job.payload.expiresAt);
+  const expiresAt = DateTime.make(payload.expiresAt);
   if (Option.isNone(expiresAt)) {
-    return new ApnsDeliveryJobExpiresAtInvalid();
+    return new ApnsDeliveryJobExpiresAtInvalid({
+      jobId: payload.jobId,
+      kind: payload.kind,
+      userId: payload.target.userId,
+      deviceId: payload.target.deviceId,
+      expiresAt: payload.expiresAt,
+    });
   }
   const createdAtMs = createdAt.value.epochMilliseconds;
   const expiresAtMs = expiresAt.value.epochMilliseconds;
   if (expiresAtMs <= createdAtMs) {
-    return new ApnsDeliveryJobTimeWindowInvalid();
+    return new ApnsDeliveryJobTimeWindowInvalid({
+      jobId: payload.jobId,
+      kind: payload.kind,
+      userId: payload.target.userId,
+      deviceId: payload.target.deviceId,
+      createdAt: payload.createdAt,
+      expiresAt: payload.expiresAt,
+    });
   }
   if (expiresAtMs - createdAtMs > MAX_JOB_AGE_MS) {
-    return new ApnsDeliveryJobTimeWindowTooLong();
+    return new ApnsDeliveryJobTimeWindowTooLong({
+      jobId: payload.jobId,
+      kind: payload.kind,
+      userId: payload.target.userId,
+      deviceId: payload.target.deviceId,
+      createdAt: payload.createdAt,
+      expiresAt: payload.expiresAt,
+    });
   }
   if (expiresAtMs <= input.nowMs) {
-    return new ApnsDeliveryJobExpired({ expiresAt: input.job.payload.expiresAt });
+    return new ApnsDeliveryJobExpired({
+      jobId: payload.jobId,
+      kind: payload.kind,
+      userId: payload.target.userId,
+      deviceId: payload.target.deviceId,
+      expiresAt: payload.expiresAt,
+    });
   }
   const expected = signatureForPayload({
     secret: input.secret,
-    payload: input.job.payload,
+    payload,
   });
   if (!timingSafeEqualBase64Url(input.job.signature, expected)) {
-    return new ApnsDeliveryJobSignatureInvalid();
+    return new ApnsDeliveryJobSignatureInvalid({
+      jobId: payload.jobId,
+      kind: payload.kind,
+      userId: payload.target.userId,
+      deviceId: payload.target.deviceId,
+    });
   }
-  return input.job.payload;
+  return payload;
 }


### PR DESCRIPTION
## Summary
- attach job, delivery kind, user, device, and timestamp context to APNs queue validation failures
- preserve the schema decode failure as the invalid-payload error cause
- derive diagnostic messages from stable structured fields without constructor wrappers

## Tests
- `vp test infra/relay/src/agentActivity/apnsDeliveryJobs.test.ts infra/relay/src/agentActivity/ApnsDeliveries.test.ts --no-cache`
- `vp check`
- `vp run typecheck`
- `vpr typecheck`

## Overlap audit
- No active error-audit/service-refactor PR overlaps these files.
- Draft feature PRs #3135 and #2925 also touch some or all of these files; their scope is unrelated and was reviewed as acceptable overlap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation rules and delivery paths are unchanged; only error shape and messaging for logging and debugging are enriched.
> 
> **Overview**
> APNs queue and signed-job validation failures now carry **structured context** (`jobId`, `kind`, `userId`, `deviceId`, and relevant timestamps) instead of tag-only errors, with **human-readable messages** built from those fields.
> 
> Invalid queue bodies from `processSignedJob` record the **payload JavaScript type** and keep the **schema decode failure** as `cause` on `ApnsDeliveryJobQueuePayloadInvalid`. Verification and post-verify shape checks in `ApnsDeliveries` pass the same context when failing live-activity or push-notification jobs.
> 
> Tests assert the new fields, messages, and schema-cause behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f7ca5f7926e3b63a08a921ed4aed76a577ba08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add contextual fields to APNs delivery job error types
> - Extends all APNs delivery job error classes in [`apnsDeliveryJobs.ts`](https://github.com/pingdotgg/t3code/pull/3322/files#diff-5f124fac34224b75c7c5b17f3fcb5d9e2c9b2d881e478aab85953346e58e5fbc) to include `jobId`, `kind`, `userId`, and `deviceId` for richer error context.
> - `ApnsDeliveryJobQueuePayloadInvalid` now carries `receivedType` and the original schema defect as `cause`.
> - Time-related errors (`CreatedAtInvalid`, `ExpiresAtInvalid`, `TimeWindowInvalid`, `TimeWindowTooLong`) now include the offending timestamp values.
> - Error messages are updated throughout to reference `jobId` and other contextual values for easier debugging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 95f7ca5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->