### PR TITLE
[codex] Structure desktop SSH host discovery failures

### DIFF
--- a/apps/web/src/state/desktopSshHosts.test.ts
+++ b/apps/web/src/state/desktopSshHosts.test.ts
@@ -1,4 +1,5 @@
 import type { DesktopDiscoveredSshHost } from "@t3tools/contracts";
+import * as Option from "effect/Option";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { describe, expect, it, vi } from "vite-plus/test";
@@ -36,6 +37,46 @@ describe("desktopSshHostsState", () => {
     expect(discoverSshHosts).toHaveBeenCalledTimes(1);
 
     remount();
+    registry.dispose();
+  });
+
+  it("distinguishes an unavailable desktop bridge", async () => {
+    const atom = createDesktopSshHostsStateAtom(() => undefined);
+    const registry = AtomRegistry.make();
+    const unmount = registry.mount(atom);
+
+    await vi.waitFor(() => {
+      expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
+    });
+
+    const error = Option.getOrThrow(AsyncResult.error(registry.get(atom)));
+    expect(error._tag).toBe("DesktopSshDiscoveryBridgeUnavailableError");
+    expect(error.message).toBe("Desktop SSH host discovery is unavailable.");
+    expect("cause" in error).toBe(false);
+
+    unmount();
+    registry.dispose();
+  });
+
+  it("preserves the exact SSH discovery failure cause", async () => {
+    const cause = new Error("Could not parse Include directive");
+    const discoverSshHosts = vi.fn(() => Promise.reject(cause));
+    const atom = createDesktopSshHostsStateAtom(() => ({ discoverSshHosts }));
+    const registry = AtomRegistry.make();
+    const unmount = registry.mount(atom);
+
+    await vi.waitFor(() => {
+      expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
+    });
+
+    const error = Option.getOrThrow(AsyncResult.error(registry.get(atom)));
+    expect(error._tag).toBe("DesktopSshDiscoveryError");
+    expect(error.message).toBe("Failed to discover SSH hosts.");
+    expect(error.message).not.toContain(cause.message);
+    expect("cause" in error ? error.cause : undefined).toBe(cause);
+    expect(discoverSshHosts).toHaveBeenCalledTimes(1);
+
+    unmount();
     registry.dispose();
   });
 });

--- a/apps/web/src/state/desktopSshHosts.ts
+++ b/apps/web/src/state/desktopSshHosts.ts
@@ -1,17 +1,29 @@
-import type { DesktopBridge, DesktopDiscoveredSshHost } from "@t3tools/contracts";
+import type { DesktopBridge } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { Atom } from "effect/unstable/reactivity";
 
 type DesktopSshDiscoveryBridge = Pick<DesktopBridge, "discoverSshHosts">;
 
-class DesktopSshDiscoveryError extends Schema.TaggedErrorClass<DesktopSshDiscoveryError>()(
+export class DesktopSshDiscoveryBridgeUnavailableError extends Schema.TaggedErrorClass<DesktopSshDiscoveryBridgeUnavailableError>()(
+  "DesktopSshDiscoveryBridgeUnavailableError",
+  {},
+) {
+  override get message(): string {
+    return "Desktop SSH host discovery is unavailable.";
+  }
+}
+
+export class DesktopSshDiscoveryError extends Schema.TaggedErrorClass<DesktopSshDiscoveryError>()(
   "DesktopSshDiscoveryError",
   {
-    message: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
+    cause: Schema.Defect(),
   },
-) {}
+) {
+  override get message(): string {
+    return "Failed to discover SSH hosts.";
+  }
+}
 
 function getDesktopSshDiscoveryBridge(): DesktopSshDiscoveryBridge | undefined {
   return typeof window === "undefined" ? undefined : window.desktopBridge;
@@ -23,17 +35,11 @@ export function createDesktopSshHostsStateAtom(
   const discoverDesktopSshHosts = Effect.fn("discoverDesktopSshHosts")(function* () {
     const bridge = getBridge();
     if (!bridge) {
-      return yield* new DesktopSshDiscoveryError({
-        message: "Desktop SSH host discovery is unavailable.",
-      });
+      return yield* new DesktopSshDiscoveryBridgeUnavailableError();
     }
     return yield* Effect.tryPromise({
-      try: (): Promise<ReadonlyArray<DesktopDiscoveredSshHost>> => bridge.discoverSshHosts(),
-      catch: (cause) =>
-        new DesktopSshDiscoveryError({
-          message: cause instanceof Error ? cause.message : "Failed to discover SSH hosts.",
-          cause,
-        }),
+      try: () => bridge.discoverSshHosts(),
+      catch: (cause) => new DesktopSshDiscoveryError({ cause }),
     });
   });
 


### PR DESCRIPTION
## Summary

- split an unavailable desktop bridge from an SSH host discovery failure with distinct Schema error tags
- require and preserve the exact discovery cause while keeping the error message stable and cause-independent
- remove the redundant promise return annotation and cover both failure branches through the state atom

## Validation

- `vp test apps/web/src/state/desktopSshHosts.test.ts` (3 tests)
- `vp check`
- `vp run typecheck`

## Overlap

No open pull request currently touches either desktopSshHosts state file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-model refactor in desktop SSH discovery state with new tests; no auth, data, or broad API surface changes.
> 
> **Overview**
> Desktop SSH host discovery now returns **two distinct tagged errors** instead of one generic failure: `DesktopSshDiscoveryBridgeUnavailableError` when `window.desktopBridge` is missing, and `DesktopSshDiscoveryError` when `discoverSshHosts()` rejects.
> 
> Discovery failures use a **fixed user-facing message** (`Failed to discover SSH hosts.`) while the **original rejection is stored on `cause`** (required `Schema.Defect()`), so callers can branch on `_tag` or inspect the underlying error without leaking parse details into `message`.
> 
> Tests cover both failure paths via the state atom.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313b61cdb153a4745bc358af80fbee4157b00455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure desktop SSH host discovery failures into distinct error types
> - Introduces `DesktopSshDiscoveryBridgeUnavailableError` for when the desktop bridge is absent, and updates `DesktopSshDiscoveryError` to always carry the original failure as `cause` with a fixed message.
> - The atom in [desktopSshHosts.ts](https://github.com/pingdotgg/t3code/pull/3323/files#diff-c075edf61388cc5028aa80bced1ff08ce0e36c4b9645f72900d4d2cbb5a1eba4) now yields different error tags for "bridge unavailable" vs. "discovery failure", making error handling more precise for callers.
> - Behavioral Change: `DesktopSshDiscoveryError` no longer embeds the cause message in its own message; callers that inspected the error message directly will now always see `'Failed to discover SSH hosts.'` and must read `error.cause` for details.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 313b61c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->