### PR TITLE
[codex] Split preferred editor precondition errors

### DIFF
--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -5,7 +5,7 @@ import {
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
 import * as Cause from "effect/Cause";
-import * as Data from "effect/Data";
+import * as Schema from "effect/Schema";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "./hooks/useLocalStorage";
 import { useCallback, useMemo } from "react";
@@ -14,11 +14,23 @@ import { useAtomCommand } from "./state/use-atom-command";
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
 
-export class PreferredEditorUnavailableError extends Data.TaggedError(
+export class OpenInEditorEnvironmentNotSelectedError extends Schema.TaggedErrorClass<OpenInEditorEnvironmentNotSelectedError>()(
+  "OpenInEditorEnvironmentNotSelectedError",
+  {},
+) {
+  override get message(): string {
+    return "No environment is selected.";
+  }
+}
+
+export class PreferredEditorUnavailableError extends Schema.TaggedErrorClass<PreferredEditorUnavailableError>()(
   "PreferredEditorUnavailableError",
-)<{
-  readonly message: string;
-}> {}
+  {},
+) {
+  override get message(): string {
+    return "No available editors found.";
+  }
+}
 
 export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
   const [lastEditor, setLastEditor] = useLocalStorage(LAST_EDITOR_KEY, null, EditorId);
@@ -55,26 +67,19 @@ export function useOpenInPreferredEditor(
     async (
       targetPath: string,
     ): Promise<
-      AtomCommandResult<EditorId, OpenInEditorError | PreferredEditorUnavailableError>
+      AtomCommandResult<
+        EditorId,
+        | OpenInEditorError
+        | OpenInEditorEnvironmentNotSelectedError
+        | PreferredEditorUnavailableError
+      >
     > => {
       if (environmentId === null) {
-        return AsyncResult.failure(
-          Cause.fail(
-            new PreferredEditorUnavailableError({
-              message: "No environment is selected.",
-            }),
-          ),
-        );
+        return AsyncResult.failure(Cause.fail(new OpenInEditorEnvironmentNotSelectedError()));
       }
       const editor = resolveAndPersistPreferredEditor(availableEditors);
       if (!editor) {
-        return AsyncResult.failure(
-          Cause.fail(
-            new PreferredEditorUnavailableError({
-              message: "No available editors found.",
-            }),
-          ),
-        );
+        return AsyncResult.failure(Cause.fail(new PreferredEditorUnavailableError()));
       }
       const result = await openInEditor({
         environmentId,

--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -1,4 +1,4 @@
-import { EDITORS, EditorId, type EnvironmentId } from "@t3tools/contracts";
+import { EDITORS, EditorId, EnvironmentId } from "@t3tools/contracts";
 import {
   mapAtomCommandResult,
   type AtomCommandFailure,
@@ -14,21 +14,27 @@ import { useAtomCommand } from "./state/use-atom-command";
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
 
-export class OpenInEditorEnvironmentNotSelectedError extends Schema.TaggedErrorClass<OpenInEditorEnvironmentNotSelectedError>()(
-  "OpenInEditorEnvironmentNotSelectedError",
-  {},
+export class PreferredEditorEnvironmentRequiredError extends Schema.TaggedErrorClass<PreferredEditorEnvironmentRequiredError>()(
+  "PreferredEditorEnvironmentRequiredError",
+  {
+    targetPath: Schema.String,
+  },
 ) {
   override get message(): string {
-    return "No environment is selected.";
+    return `Cannot open ${this.targetPath} because no environment is selected.`;
   }
 }
 
 export class PreferredEditorUnavailableError extends Schema.TaggedErrorClass<PreferredEditorUnavailableError>()(
   "PreferredEditorUnavailableError",
-  {},
+  {
+    environmentId: EnvironmentId,
+    targetPath: Schema.String,
+    availableEditorIds: Schema.Array(EditorId),
+  },
 ) {
   override get message(): string {
-    return "No available editors found.";
+    return `No available editor can open ${this.targetPath} in environment ${this.environmentId}.`;
   }
 }
 
@@ -70,16 +76,30 @@ export function useOpenInPreferredEditor(
       AtomCommandResult<
         EditorId,
         | OpenInEditorError
-        | OpenInEditorEnvironmentNotSelectedError
+        | PreferredEditorEnvironmentRequiredError
         | PreferredEditorUnavailableError
       >
     > => {
       if (environmentId === null) {
-        return AsyncResult.failure(Cause.fail(new OpenInEditorEnvironmentNotSelectedError()));
+        return AsyncResult.failure(
+          Cause.fail(
+            new PreferredEditorEnvironmentRequiredError({
+              targetPath,
+            }),
+          ),
+        );
       }
       const editor = resolveAndPersistPreferredEditor(availableEditors);
       if (!editor) {
-        return AsyncResult.failure(Cause.fail(new PreferredEditorUnavailableError()));
+        return AsyncResult.failure(
+          Cause.fail(
+            new PreferredEditorUnavailableError({
+              environmentId,
+              targetPath,
+              availableEditorIds: availableEditors,
+            }),
+          ),
+        );
       }
       const result = await openInEditor({
         environmentId,


### PR DESCRIPTION
## Summary

- split the two preferred-editor precondition failures into distinct Schema error tags
- attach attempted path, environment ID, and available editor IDs as structured fields
- derive stable messages from those fields so callers never need to parse arbitrary text
- keep the command result error channel structurally discriminable

No behavior test was added for this pure error-model refactor.

## Validation

- pnpm vp check (passes with existing repository warnings)
- pnpm vp run typecheck

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `useOpenInPreferredEditor` precondition errors into distinct typed errors
> - Adds `PreferredEditorEnvironmentRequiredError` for the case where no environment is selected, carrying `targetPath` and a specific message.
> - Refactors `PreferredEditorUnavailableError` into a `Schema.TaggedErrorClass` with structured fields: `environmentId`, `targetPath`, and `availableEditorIds`.
> - The `useOpenInPreferredEditor` hook now returns distinct error types for these two failure cases instead of reusing a single error class.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9f64e27.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to editor open preconditions in `editorPreferences.ts`; callers must handle an additional error tag if they pattern-match failures.
> 
> **Overview**
> **`useOpenInPreferredEditor`** now returns two discriminable precondition failures instead of one generic `PreferredEditorUnavailableError` with a free-form message.
> 
> When **`environmentId`** is null, callers get **`PreferredEditorEnvironmentRequiredError`** with `targetPath`. When no editor can be resolved, they get **`PreferredEditorUnavailableError`** carrying `environmentId`, `targetPath`, and `availableEditorIds`. Both types move from **`Data.TaggedError`** to **`Schema.TaggedErrorClass`**, with user-facing text from a **`message`** getter rather than caller-supplied strings.
> 
> The hook’s result error union is updated accordingly. Any code that only handled **`PreferredEditorUnavailableError`** for the “no environment” case must handle **`PreferredEditorEnvironmentRequiredError`** separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f64e276c12930a58b61ef11549809386285944c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->