### PR TITLE
[codex] Keep PTY spawn errors structural

### DIFF
--- a/apps/server/src/terminal/PtyAdapter.test.ts
+++ b/apps/server/src/terminal/PtyAdapter.test.ts
@@ -1,0 +1,34 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Schema from "effect/Schema";
+
+import * as PtyAdapter from "./PtyAdapter.ts";
+
+const isPtySpawnError = Schema.is(PtyAdapter.PtySpawnError);
+
+describe("PtySpawnError", () => {
+  it("derives messages from structural context while preserving the full cause chain", () => {
+    const spawnCause = new Error("spawn /bin/zsh ENOENT");
+    const adapterError = new PtyAdapter.PtySpawnError({
+      adapter: "node-pty",
+      shell: "/bin/zsh",
+      cause: spawnCause,
+    });
+    const managerError = new PtyAdapter.PtySpawnError({
+      adapter: "terminal-manager",
+      attemptedShells: ["/bin/zsh -o nopromptsp", "/bin/bash"],
+      cause: adapterError,
+    });
+
+    assert(isPtySpawnError(managerError));
+    assert.strictEqual(
+      managerError.message,
+      "Failed to spawn PTY process with terminal-manager. Tried shells: /bin/zsh -o nopromptsp, /bin/bash.",
+    );
+    assert.strictEqual(
+      adapterError.message,
+      "Failed to spawn PTY process '/bin/zsh' with node-pty.",
+    );
+    assert.strictEqual(managerError.cause, adapterError);
+    assert.strictEqual(adapterError.cause, spawnCause);
+  });
+});

--- a/apps/server/src/terminal/PtyAdapter.ts
+++ b/apps/server/src/terminal/PtyAdapter.ts
@@ -25,9 +25,7 @@ export class PtySpawnError extends Schema.TaggedErrorClass<PtySpawnError>()("Pty
       this.attemptedShells === undefined || this.attemptedShells.length === 0
         ? ""
         : ` Tried shells: ${this.attemptedShells.join(", ")}.`;
-    const causeMessage =
-      this.cause instanceof Error && this.cause.message.length > 0 ? ` ${this.cause.message}` : "";
-    return `Failed to spawn PTY process${shell} with ${this.adapter}.${attemptedShells}${causeMessage}`;
+    return `Failed to spawn PTY process${shell} with ${this.adapter}.${attemptedShells}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- derive `PtySpawnError.message` exclusively from adapter and shell context
- retain the exact nested spawn cause for stack traces and diagnostics without copying its message
- add a focused regression test for the structural messages and full cause chain

## Validation
- `vp test apps/server/src/terminal/PtyAdapter.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to error string formatting for PTY spawn failures; cause chaining and spawn behavior are unchanged.
> 
> **Overview**
> **`PtySpawnError.message`** no longer appends the nested **`cause`**’s error text. User-facing strings are built only from **`adapter`**, optional **`shell`**, and optional **`attemptedShells`** (e.g. terminal-manager retry lists).
> 
> The **`cause`** field is unchanged and still chains the original spawn failure for stacks and diagnostics—only the duplicated message in **`message`** is removed.
> 
> Adds **`PtyAdapter.test.ts`** to lock in those messages and assert **`managerError.cause → adapterError.cause → spawnCause`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeefcaa6bb0c826f492935dfcc5ee98c132a8e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove cause message concatenation from `PtySpawnError.message`
> `PtySpawnError.message` previously appended the underlying cause's message string, mixing structured error context with raw exception text. The message now includes only the adapter, shell, and attemptedShells fields; the full cause chain remains accessible via the `cause` property. Tests in [PtyAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/3325/files#diff-2642613bad2f53cd50e6398ace8be43ac42ea94fabebd575958f94cf964bf9f1) verify the new message format and cause chain behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eeefcaa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->