### PR TITLE
[codex] Structure APNs delivery queue errors

### DIFF
--- a/infra/relay/src/agentActivity/ApnsDeliveryQueue.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveryQueue.test.ts
@@ -1,0 +1,79 @@
+import * as NodeCryptoLayer from "@effect/platform-node/NodeCrypto";
+import { describe, expect, it } from "@effect/vitest";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+
+import * as RelayConfiguration from "../Config.ts";
+import * as ApnsDeliveryQueue from "./ApnsDeliveryQueue.ts";
+
+const config: RelayConfiguration.RelayConfiguration["Service"] = {
+  relayIssuer: "https://relay.example.com",
+  apns: {
+    teamId: "team-1",
+    keyId: "key-1",
+    privateKey: Redacted.make("apns-private-key"),
+    bundleId: "com.t3tools.test",
+    environment: "sandbox",
+  },
+  clerkSecretKey: Redacted.make("clerk-secret"),
+  clerkPublishableKey: "pk_test_test",
+  clerkJwtAudience: "t3-code-relay",
+  apnsDeliveryJobSigningSecret: Redacted.make("apns-job-secret"),
+  cloudMintPrivateKey: Redacted.make("cloud-private-key"),
+  cloudMintPublicKey: "cloud-public-key",
+  managedEndpointBaseDomain: undefined,
+  managedEndpointNamespace: undefined,
+};
+
+describe("ApnsDeliveryQueue", () => {
+  it.effect("preserves job identity and the queue sender cause", () => {
+    const cause = new Error("queue unavailable");
+    const senderCause = new Cloudflare.QueueSendError({
+      message: cause.message,
+      cause,
+    });
+    const layer = ApnsDeliveryQueue.layer.pipe(
+      Layer.provide(NodeCryptoLayer.layer),
+      Layer.provide(RelayConfiguration.layer(config)),
+      Layer.provide(
+        Layer.succeed(ApnsDeliveryQueue.ApnsDeliveryQueueSender, {
+          send: () => Effect.fail(senderCause),
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const queue = yield* ApnsDeliveryQueue.ApnsDeliveryQueue;
+      const error = yield* Effect.flip(
+        queue.enqueuePushNotification({
+          userId: "user-1",
+          deviceId: "device-1",
+          token: "push-token",
+          notification: {
+            title: "Thread",
+            body: "Input: Project",
+            environmentId: "env-1",
+            threadId: "thread-1",
+            deepLink: "/threads/env-1/thread-1",
+          },
+        }),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "ApnsDeliveryQueueSendError",
+        operation: "send",
+        jobId: expect.any(String),
+        kind: "push_notification",
+        userId: "user-1",
+        deviceId: "device-1",
+        cause: senderCause,
+      });
+      expect(senderCause.cause).toBe(cause);
+      expect(error.message).toBe(
+        "Failed to enqueue APNs push notification delivery during send for device device-1.",
+      );
+    }).pipe(Effect.provide(layer));
+  });
+});

--- a/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveryQueue.ts
@@ -7,7 +7,10 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
 
-import type { RelayDeliveryResult } from "@t3tools/contracts/relay";
+import {
+  RelayDeliveryKind as RelayDeliveryKindSchema,
+  type RelayDeliveryResult,
+} from "@t3tools/contracts/relay";
 
 import {
   sanitizeAgentActivityAggregateState,
@@ -24,10 +27,17 @@ import * as RelayConfiguration from "../Config.ts";
 
 export class ApnsDeliveryQueueSendError extends Schema.TaggedErrorClass<ApnsDeliveryQueueSendError>()(
   "ApnsDeliveryQueueSendError",
-  { cause: Schema.Defect() },
+  {
+    operation: Schema.Literals(["generate-job-id", "send"]),
+    jobId: Schema.NullOr(Schema.String),
+    kind: RelayDeliveryKindSchema,
+    userId: Schema.String,
+    deviceId: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to enqueue APNs delivery";
+    return `Failed to enqueue APNs ${this.kind.replaceAll("_", " ")} delivery during ${this.operation} for device ${this.deviceId}.`;
   }
 }
 
@@ -36,7 +46,7 @@ export type ApnsDeliveryQueueError = ApnsDeliveryQueueSendError;
 export class ApnsDeliveryQueueSender extends Context.Service<
   ApnsDeliveryQueueSender,
   {
-    readonly send: (body: SignedApnsDeliveryJob) => Effect.Effect<void, ApnsDeliveryQueueSendError>;
+    readonly send: (body: SignedApnsDeliveryJob) => Effect.Effect<void, Cloudflare.QueueSendError>;
   }
 >()("t3code-relay/agentActivity/ApnsDeliveryQueue/ApnsDeliveryQueueSender") {}
 
@@ -73,7 +83,17 @@ export const make = Effect.gen(function* () {
         });
         const now = yield* DateTime.now;
         const jobId = yield* crypto.randomUUIDv4.pipe(
-          Effect.mapError((cause) => new ApnsDeliveryQueueSendError({ cause })),
+          Effect.mapError(
+            (cause) =>
+              new ApnsDeliveryQueueSendError({
+                operation: "generate-job-id",
+                jobId: null,
+                kind: input.kind,
+                userId: input.userId,
+                deviceId: input.deviceId,
+                cause,
+              }),
+          ),
         );
         yield* Effect.annotateCurrentSpan({ "relay.delivery.job_id": jobId });
         const payload = makeApnsDeliveryJobPayload({
@@ -88,7 +108,19 @@ export const make = Effect.gen(function* () {
           secret: config.apnsDeliveryJobSigningSecret,
           payload,
         });
-        yield* sender.send(signed);
+        yield* sender.send(signed).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ApnsDeliveryQueueSendError({
+                operation: "send",
+                jobId,
+                kind: input.kind,
+                userId: input.userId,
+                deviceId: input.deviceId,
+                cause,
+              }),
+          ),
+        );
         return {
           deviceId: input.deviceId,
           kind: input.kind,
@@ -110,7 +142,17 @@ export const make = Effect.gen(function* () {
         });
         const now = yield* DateTime.now;
         const jobId = yield* crypto.randomUUIDv4.pipe(
-          Effect.mapError((cause) => new ApnsDeliveryQueueSendError({ cause })),
+          Effect.mapError(
+            (cause) =>
+              new ApnsDeliveryQueueSendError({
+                operation: "generate-job-id",
+                jobId: null,
+                kind: "push_notification",
+                userId: input.userId,
+                deviceId: input.deviceId,
+                cause,
+              }),
+          ),
         );
         yield* Effect.annotateCurrentSpan({ "relay.delivery.job_id": jobId });
         const payload = makeApnsDeliveryJobPayload({
@@ -128,7 +170,19 @@ export const make = Effect.gen(function* () {
           secret: config.apnsDeliveryJobSigningSecret,
           payload,
         });
-        yield* sender.send(signed);
+        yield* sender.send(signed).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ApnsDeliveryQueueSendError({
+                operation: "send",
+                jobId,
+                kind: "push_notification",
+                userId: input.userId,
+                deviceId: input.deviceId,
+                cause,
+              }),
+          ),
+        );
         return {
           deviceId: input.deviceId,
           kind: "push_notification" as const,
@@ -155,10 +209,9 @@ export const layerCloudflareQueues = (
         ApnsDeliveryQueueSender,
         ApnsDeliveryQueueSender.of({
           send: (body) =>
-            sender.send(body).pipe(
-              Effect.mapError((cause) => new ApnsDeliveryQueueSendError({ cause })),
-              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
-            ),
+            sender
+              .send(body)
+              .pipe(Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext)),
         }),
       ),
     ),


### PR DESCRIPTION
## Summary
- add operation, job, delivery kind, user, and device context to APNs queue failures
- preserve the Cloudflare queue error and its underlying cause instead of wrapping it prematurely in the adapter
- distinguish UUID generation from queue send failures through a diagnostic operation field while preserving the existing public error tag

## Tests
- `vp test infra/relay/src/agentActivity/ApnsDeliveryQueue.test.ts infra/relay/src/agentActivity/MobileRegistrations.test.ts infra/relay/src/agentActivity/ApnsDeliveries.test.ts --no-cache`
- `vp check`
- `vp run typecheck`
- `vpr typecheck`

## Overlap audit
- No active error-audit/service-refactor PR overlaps these files.
- Draft feature PRs #3135 and #2925 also touch the queue module; their scope is unrelated and was reviewed as acceptable overlap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only change to error shape and wrapping; the public error tag is unchanged and delivery behavior is unaffected.
> 
> **Overview**
> **`ApnsDeliveryQueueSendError`** now carries **`operation`** (`generate-job-id` vs `send`), **`jobId`**, delivery **`kind`**, **`userId`**, and **`deviceId`**, with messages that spell out which step failed for which device.
> 
> Queue send failures are wrapped at the **enqueue** paths (live activity and push notification) instead of in the Cloudflare adapter, so **`cause`** can stay the raw **`Cloudflare.QueueSendError`** (and its underlying error) rather than being double-wrapped. UUID generation failures get the same structured error with **`jobId: null`**.
> 
> A new unit test asserts that a failed push enqueue preserves **`jobId`**, metadata, and the sender **`cause`** chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f969219a10d7f199e86fc6dcfc58175bf38d21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure APNs delivery queue errors with operation context and metadata
> - `ApnsDeliveryQueueSendError` now carries structured fields: `operation` (`'generate-job-id'` or `'send'`), `jobId`, `kind`, `userId`, `deviceId`, and `cause`, replacing the previous generic error.
> - `enqueuePushNotification` and `enqueueLiveActivity` in [ApnsDeliveryQueue.ts](https://github.com/pingdotgg/t3code/pull/3326/files#diff-9ffbaa4661c6421201e29d1a746765e77cd57b09f777adf0f8353ebaa98224e7) map failures at each step into this structured error with the appropriate `operation` field and available context.
> - `ApnsDeliveryQueueSender.send` now surfaces `Cloudflare.QueueSendError` directly; error mapping into `ApnsDeliveryQueueSendError` is deferred to the call sites in each enqueue handler rather than in the Cloudflare layer.
> - New tests in [ApnsDeliveryQueue.test.ts](https://github.com/pingdotgg/t3code/pull/3326/files#diff-914820b42cc87555104b6554a5b4b140d885a9d4f20768b0aa342ed61ad307e1) verify metadata population and cause preservation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2f9692.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->