### PR TITLE
[codex] Structure browser target resolution errors

### DIFF
--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -65,7 +65,9 @@ describe("browser target resolver", () => {
   });
 
   it("preserves invalid environment URL causes with connection context", async () => {
-    readPreparedConnection.mockReturnValue({ httpBaseUrl: "not a url" });
+    const sensitiveUrl =
+      "https://user:password@[invalid-host]/private/workspace?access_token=secret#fragment";
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: sensitiveUrl });
     const { BrowserTargetEnvironmentUrlInvalidError, resolveBrowserNavigationTarget } =
       await import("./browserTargetResolver");
 
@@ -79,11 +81,17 @@ describe("browser target resolver", () => {
       expect(error).toMatchObject({
         _tag: "BrowserTargetEnvironmentUrlInvalidError",
         environmentId: "environment-1",
-        httpBaseUrl: "not a url",
+        httpBaseUrlInputLength: sensitiveUrl.length,
         cause: expect.any(TypeError),
-        message: "Environment environment-1 has an invalid HTTP base URL: not a url.",
+        message: `Environment environment-1 has an invalid HTTP base URL input of length ${sensitiveUrl.length}.`,
       });
       expect(error).toBeInstanceOf(BrowserTargetEnvironmentUrlInvalidError);
+      expect(error).not.toHaveProperty("httpBaseUrl");
+      expect(error).not.toHaveProperty("httpBaseUrlProtocol");
+      expect(error).not.toHaveProperty("httpBaseUrlHostname");
+      expect(String((error as Error).message)).not.toMatch(
+        /user|password|private|workspace|access_token|secret|fragment/,
+      );
     }
   });
 

--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -28,12 +28,63 @@ describe("browser target resolver", () => {
   it("refuses public relay hosts until the authenticated gateway exists", async () => {
     readPreparedConnection.mockReturnValue({ httpBaseUrl: "https://relay.example.com" });
     const { resolveBrowserNavigationTarget } = await import("./browserTargetResolver");
-    expect(() =>
+
+    try {
       resolveBrowserNavigationTarget(EnvironmentId.make("environment-1"), {
         kind: "environment-port",
         port: 5173,
-      }),
-    ).toThrow(/authenticated preview gateway/);
+      });
+      expect.unreachable("Expected public environment host resolution to fail");
+    } catch (error) {
+      expect(error).toMatchObject({
+        _tag: "BrowserTargetPrivateNetworkRequiredError",
+        environmentId: "environment-1",
+        hostname: "relay.example.com",
+        message:
+          "Environment environment-1 host relay.example.com needs the planned authenticated preview gateway because it is not directly private-network reachable.",
+      });
+    }
+  });
+
+  it("identifies the disconnected environment", async () => {
+    const { resolveBrowserNavigationTarget } = await import("./browserTargetResolver");
+
+    try {
+      resolveBrowserNavigationTarget(EnvironmentId.make("environment-1"), {
+        kind: "environment-port",
+        port: 5173,
+      });
+      expect.unreachable("Expected disconnected environment resolution to fail");
+    } catch (error) {
+      expect(error).toMatchObject({
+        _tag: "BrowserTargetEnvironmentDisconnectedError",
+        environmentId: "environment-1",
+        message: "Environment environment-1 is not connected.",
+      });
+    }
+  });
+
+  it("preserves invalid environment URL causes with connection context", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "not a url" });
+    const { BrowserTargetEnvironmentUrlInvalidError, resolveBrowserNavigationTarget } =
+      await import("./browserTargetResolver");
+
+    try {
+      resolveBrowserNavigationTarget(EnvironmentId.make("environment-1"), {
+        kind: "environment-port",
+        port: 5173,
+      });
+      expect.unreachable("Expected browser target resolution to fail");
+    } catch (error) {
+      expect(error).toMatchObject({
+        _tag: "BrowserTargetEnvironmentUrlInvalidError",
+        environmentId: "environment-1",
+        httpBaseUrl: "not a url",
+        cause: expect.any(TypeError),
+        message: "Environment environment-1 has an invalid HTTP base URL: not a url.",
+      });
+      expect(error).toBeInstanceOf(BrowserTargetEnvironmentUrlInvalidError);
+    }
   });
 
   it("normalizes schemeless localhost server-picker values", async () => {

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -4,6 +4,7 @@ import {
   type PreviewUrlResolution,
 } from "@t3tools/contracts";
 import { isLoopbackHost, normalizePreviewUrl } from "@t3tools/shared/preview";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Schema from "effect/Schema";
 
 import { readPreparedConnection } from "~/state/session";
@@ -23,12 +24,14 @@ export class BrowserTargetEnvironmentUrlInvalidError extends Schema.TaggedErrorC
   "BrowserTargetEnvironmentUrlInvalidError",
   {
     environmentId: EnvironmentId,
-    httpBaseUrl: Schema.String,
+    httpBaseUrlInputLength: Schema.Number,
+    httpBaseUrlProtocol: Schema.optionalKey(Schema.String),
+    httpBaseUrlHostname: Schema.optionalKey(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Environment ${this.environmentId} has an invalid HTTP base URL: ${this.httpBaseUrl}.`;
+    return `Environment ${this.environmentId} has an invalid HTTP base URL input of length ${this.httpBaseUrlInputLength}.`;
   }
 }
 
@@ -81,9 +84,12 @@ export function resolveBrowserNavigationTarget(
   try {
     environmentUrl = new URL(connection.httpBaseUrl);
   } catch (cause) {
+    const diagnostics = getUrlDiagnostics(connection.httpBaseUrl);
     throw new BrowserTargetEnvironmentUrlInvalidError({
       environmentId,
-      httpBaseUrl: connection.httpBaseUrl,
+      httpBaseUrlInputLength: diagnostics.inputLength,
+      ...(diagnostics.protocol === undefined ? {} : { httpBaseUrlProtocol: diagnostics.protocol }),
+      ...(diagnostics.hostname === undefined ? {} : { httpBaseUrlHostname: diagnostics.hostname }),
       cause,
     });
   }

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -1,11 +1,48 @@
-import type {
-  BrowserNavigationTarget,
+import {
+  type BrowserNavigationTarget,
   EnvironmentId,
-  PreviewUrlResolution,
+  type PreviewUrlResolution,
 } from "@t3tools/contracts";
 import { isLoopbackHost, normalizePreviewUrl } from "@t3tools/shared/preview";
+import * as Schema from "effect/Schema";
 
 import { readPreparedConnection } from "~/state/session";
+
+export class BrowserTargetEnvironmentDisconnectedError extends Schema.TaggedErrorClass<BrowserTargetEnvironmentDisconnectedError>()(
+  "BrowserTargetEnvironmentDisconnectedError",
+  {
+    environmentId: EnvironmentId,
+  },
+) {
+  override get message(): string {
+    return `Environment ${this.environmentId} is not connected.`;
+  }
+}
+
+export class BrowserTargetEnvironmentUrlInvalidError extends Schema.TaggedErrorClass<BrowserTargetEnvironmentUrlInvalidError>()(
+  "BrowserTargetEnvironmentUrlInvalidError",
+  {
+    environmentId: EnvironmentId,
+    httpBaseUrl: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Environment ${this.environmentId} has an invalid HTTP base URL: ${this.httpBaseUrl}.`;
+  }
+}
+
+export class BrowserTargetPrivateNetworkRequiredError extends Schema.TaggedErrorClass<BrowserTargetPrivateNetworkRequiredError>()(
+  "BrowserTargetPrivateNetworkRequiredError",
+  {
+    environmentId: EnvironmentId,
+    hostname: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Environment ${this.environmentId} host ${this.hostname} needs the planned authenticated preview gateway because it is not directly private-network reachable.`;
+  }
+}
 
 const isPrivateNetworkHost = (host: string): boolean => {
   const normalized = host.toLowerCase().replace(/^\[|\]$/g, "");
@@ -37,12 +74,24 @@ export function resolveBrowserNavigationTarget(
     };
   }
   const connection = readPreparedConnection(environmentId);
-  if (!connection) throw new Error(`Environment ${environmentId} is not connected.`);
-  const environmentUrl = new URL(connection.httpBaseUrl);
+  if (!connection) {
+    throw new BrowserTargetEnvironmentDisconnectedError({ environmentId });
+  }
+  let environmentUrl: URL;
+  try {
+    environmentUrl = new URL(connection.httpBaseUrl);
+  } catch (cause) {
+    throw new BrowserTargetEnvironmentUrlInvalidError({
+      environmentId,
+      httpBaseUrl: connection.httpBaseUrl,
+      cause,
+    });
+  }
   if (!isPrivateNetworkHost(environmentUrl.hostname)) {
-    throw new Error(
-      "This environment port needs the planned authenticated preview gateway; its server address is not directly private-network reachable.",
-    );
+    throw new BrowserTargetPrivateNetworkRequiredError({
+      environmentId,
+      hostname: environmentUrl.hostname,
+    });
   }
   const protocol = target.protocol ?? "http";
   const path = target.path?.startsWith("/") ? target.path : `/${target.path ?? ""}`;


### PR DESCRIPTION
## Summary
- replace generic browser target failures with schema-tagged errors carrying environment and host context
- preserve the native URL parsing cause alongside the invalid environment base URL
- add focused coverage for disconnected, public-host, and malformed connection cases

## Verification
- `vp test apps/web/src/browser/browserTargetResolver.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized resolver and shared URL-redaction helpers; behavior is unchanged aside from error shape and safer diagnostics, with no auth or data-path changes in this diff.
> 
> **Overview**
> **`resolveBrowserNavigationTarget`** now throws three **Effect `Schema.TaggedErrorClass`** types instead of generic `Error`s: disconnected environment, invalid environment HTTP base URL (with native parse **`cause`**), and non–private-network host (with **`environmentId`** and **`hostname`**).
> 
> Invalid-base-URL failures use new **`getUrlDiagnostics`** (`@t3tools/shared/urlDiagnostics`) so errors expose only input length and optional protocol/hostname—tests assert messages and shapes never leak credentials or full URLs.
> 
> Shared **`redactDpopRequestTarget`** strips userinfo, query, and fragment from URLs for safe logging (invalid input → `"<invalid-url>"`), with tests only in this PR.
> 
> **Breaking for callers:** anything that matched generic error strings must handle tagged errors by **`_tag`** / type instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7db911984ba46566b5d950a349440fc08835c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic errors with structured tagged error classes in `resolveBrowserNavigationTarget`
> - Introduces three new tagged error classes in [`browserTargetResolver.ts`](https://github.com/pingdotgg/t3code/pull/3327/files#diff-d3c7988731a040ddf1171c7c3b826a4b211a89884507fdb562b4bb24fe5aba39): `BrowserTargetEnvironmentDisconnectedError`, `BrowserTargetEnvironmentUrlInvalidError`, and `BrowserTargetPrivateNetworkRequiredError`, each with structured properties and computed messages.
> - `BrowserTargetEnvironmentUrlInvalidError` uses a new `getUrlDiagnostics` helper (in [`packages/shared/src/urlDiagnostics.ts`](https://github.com/pingdotgg/t3code/pull/3327/files#diff-1c8198df49b2be099c916678220c6abc30f8130983b5efee4d72e2299511cceb)) to expose only non-sensitive diagnostics (input length, protocol, hostname) when a URL cannot be parsed.
> - Adds `redactDpopRequestTarget` to [`packages/shared/src/dpop.ts`](https://github.com/pingdotgg/t3code/pull/3327/files#diff-a70e3eceffb70848b1ea9f7dd87b2d3cd5f20af4faacba0e185745d8560ec50d) to produce redacted DPoP request targets without leaking user info, query, or fragment.
> - Behavioral Change: callers catching errors from `resolveBrowserNavigationTarget` will now receive typed tagged errors instead of generic `Error` instances.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7db911.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->