### PR TITLE
[codex] Remove project setup error constructor wrappers

### DIFF
--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -3,10 +3,15 @@ import { type OrchestrationProject, ProjectId } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
 import * as TerminalManager from "../terminal/Manager.ts";
 import * as ProjectSetupScriptRunner from "./ProjectSetupScriptRunner.ts";
+
+const isProjectSetupScriptOperationError = Schema.is(
+  ProjectSetupScriptRunner.ProjectSetupScriptOperationError,
+);
 
 const makeProject = (scripts: OrchestrationProject["scripts"]): OrchestrationProject => ({
   id: ProjectId.make("project-1"),
@@ -145,4 +150,50 @@ describe("ProjectSetupScriptRunner", () => {
       }).pipe(Effect.provide(testLayer(project, { open, write })));
     },
   );
+
+  it.effect("keeps terminal failures as the exact cause of a structured operation error", () => {
+    const rootCause = new Error("stat failed");
+    const terminalError = new TerminalManager.TerminalCwdError({
+      cwd: "/repo/worktrees/a",
+      reason: "statFailed",
+      cause: rootCause,
+    });
+    const project = makeProject([
+      {
+        id: "setup",
+        name: "Setup",
+        command: "bun install",
+        icon: "configure",
+        runOnWorktreeCreate: true,
+      },
+    ]);
+
+    return Effect.gen(function* () {
+      const runner = yield* ProjectSetupScriptRunner.ProjectSetupScriptRunner;
+      const error = yield* runner
+        .runForThread({
+          threadId: "thread-1",
+          projectId: "project-1",
+          worktreePath: "/repo/worktrees/a",
+        })
+        .pipe(Effect.flip);
+
+      expect(isProjectSetupScriptOperationError(error)).toBe(true);
+      if (isProjectSetupScriptOperationError(error)) {
+        expect(error.operation).toBe("openTerminal");
+        expect(error.threadId).toBe("thread-1");
+        expect(error.projectId).toBe("project-1");
+        expect(error.worktreePath).toBe("/repo/worktrees/a");
+        expect(error.cause).toBe(terminalError);
+        expect(terminalError.cause).toBe(rootCause);
+      }
+    }).pipe(
+      Effect.provide(
+        testLayer(project, {
+          open: () => Effect.fail(terminalError),
+          write: () => Effect.die("unexpected write"),
+        }),
+      ),
+    );
+  });
 });

--- a/apps/server/src/project/ProjectSetupScriptRunner.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.ts
@@ -59,7 +59,7 @@ export class ProjectSetupScriptProjectNotFoundError extends Schema.TaggedErrorCl
   },
 ) {
   override get message(): string {
-    return "Project was not found for setup script execution.";
+    return `Project was not found for setup script execution for thread '${this.threadId}' in '${this.worktreePath}'.`;
   }
 }
 
@@ -78,32 +78,6 @@ export class ProjectSetupScriptRunner extends Context.Service<
   }
 >()("t3/project/ProjectSetupScriptRunner") {}
 
-const isProjectSetupScriptRunnerError = Schema.is(ProjectSetupScriptRunnerError);
-
-function operationError(
-  input: ProjectSetupScriptRunnerInput,
-  operation: ProjectSetupScriptOperationError["operation"],
-  cause: unknown,
-): ProjectSetupScriptOperationError {
-  return new ProjectSetupScriptOperationError({
-    threadId: input.threadId,
-    worktreePath: input.worktreePath,
-    operation,
-    cause,
-    ...(input.projectId === undefined ? {} : { projectId: input.projectId }),
-    ...(input.projectCwd === undefined ? {} : { projectCwd: input.projectCwd }),
-  });
-}
-
-function mapRunnerError(
-  input: ProjectSetupScriptRunnerInput,
-  operation: ProjectSetupScriptOperationError["operation"],
-) {
-  return Effect.mapError((cause: unknown) =>
-    isProjectSetupScriptRunnerError(cause) ? cause : operationError(input, operation, cause),
-  );
-}
-
 export const make = Effect.gen(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
   const terminalManager = yield* TerminalManager.TerminalManager;
@@ -111,26 +85,43 @@ export const make = Effect.gen(function* () {
   const runForThread: ProjectSetupScriptRunner["Service"]["runForThread"] = Effect.fn(
     "ProjectSetupScriptRunner.runForThread",
   )(function* (input) {
+    const errorContext = {
+      threadId: input.threadId,
+      worktreePath: input.worktreePath,
+      ...(input.projectId === undefined ? {} : { projectId: input.projectId }),
+      ...(input.projectCwd === undefined ? {} : { projectCwd: input.projectCwd }),
+    };
     const projectById = input.projectId
-      ? yield* projectionSnapshotQuery
-          .getProjectShellById(ProjectId.make(input.projectId))
-          .pipe(Effect.map(Option.getOrUndefined), mapRunnerError(input, "resolveProject"))
+      ? yield* projectionSnapshotQuery.getProjectShellById(ProjectId.make(input.projectId)).pipe(
+          Effect.map(Option.getOrUndefined),
+          Effect.mapError(
+            (cause) =>
+              new ProjectSetupScriptOperationError({
+                ...errorContext,
+                operation: "resolveProject",
+                cause,
+              }),
+          ),
+        )
       : null;
     const project =
       projectById ??
       (input.projectCwd
-        ? yield* projectionSnapshotQuery
-            .getActiveProjectByWorkspaceRoot(input.projectCwd)
-            .pipe(Effect.map(Option.getOrUndefined), mapRunnerError(input, "resolveProject"))
+        ? yield* projectionSnapshotQuery.getActiveProjectByWorkspaceRoot(input.projectCwd).pipe(
+            Effect.map(Option.getOrUndefined),
+            Effect.mapError(
+              (cause) =>
+                new ProjectSetupScriptOperationError({
+                  ...errorContext,
+                  operation: "resolveProject",
+                  cause,
+                }),
+            ),
+          )
         : null);
 
     if (!project) {
-      return yield* new ProjectSetupScriptProjectNotFoundError({
-        threadId: input.threadId,
-        worktreePath: input.worktreePath,
-        ...(input.projectId === undefined ? {} : { projectId: input.projectId }),
-        ...(input.projectCwd === undefined ? {} : { projectCwd: input.projectCwd }),
-      });
+      return yield* new ProjectSetupScriptProjectNotFoundError(errorContext);
     }
 
     const script = setupProjectScript(project.scripts);
@@ -155,14 +146,32 @@ export const make = Effect.gen(function* () {
         worktreePath: input.worktreePath,
         env,
       })
-      .pipe(mapRunnerError(input, "openTerminal"));
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProjectSetupScriptOperationError({
+              ...errorContext,
+              operation: "openTerminal",
+              cause,
+            }),
+        ),
+      );
     yield* terminalManager
       .write({
         threadId: input.threadId,
         terminalId,
         data: `${script.command}\r`,
       })
-      .pipe(mapRunnerError(input, "writeCommand"));
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProjectSetupScriptOperationError({
+              ...errorContext,
+              operation: "writeCommand",
+              cause,
+            }),
+        ),
+      );
 
     return {
       status: "started",


### PR DESCRIPTION
## Summary
- remove the `operationError` and `mapRunnerError` constructor wrappers
- construct each structured operation error directly at the failing call site
- retain shared correlation context and the exact upstream cause
- derive the project-not-found message from thread and worktree context
- verify the terminal error chain remains intact

## Validation
- `vp test apps/server/src/project/ProjectSetupScriptRunner.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of error construction and messaging in ProjectSetupScriptRunner with added test coverage; no change to success paths or external APIs.
> 
> **Overview**
> Refactors **project setup script** error handling by removing the `operationError` / `mapRunnerError` helpers and building `ProjectSetupScriptOperationError` directly where `resolveProject`, `openTerminal`, and `writeCommand` fail, using a shared `errorContext` for thread/worktree (and optional project) fields.
> 
> `ProjectSetupScriptProjectNotFoundError` now reuses that same context object and its message includes **thread** and **worktree** identifiers. A new test asserts that terminal failures surface as structured operation errors with the **original terminal error** (and root cause) unchanged in the `cause` chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 402f2f1d7874902222b97b1ed4d2c39c6ef14c69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove error constructor wrappers in `ProjectSetupScriptRunner` and always wrap errors in `ProjectSetupScriptOperationError`
> - Removes helper functions `isProjectSetupScriptRunnerError`, `operationError`, and `mapRunnerError` from [ProjectSetupScriptRunner.ts](https://github.com/pingdotgg/t3code/pull/3329/files#diff-7ca99e864eafb76644d30338cec8869844b8c2d62113b7e4b348f829dd12bcf2), replacing them with inline `Effect.mapError` blocks per operation.
> - Each operation (`resolveProject`, `openTerminal`, `writeCommand`) now always wraps its error in a new `ProjectSetupScriptOperationError` with the original error as `cause`, rather than passing through existing `ProjectSetupScriptRunnerError` instances unwrapped.
> - Updates `ProjectSetupScriptProjectNotFoundError` message to include `threadId` and `worktreePath`.
> - Behavioral Change: previously, errors that were already `ProjectSetupScriptRunnerError` instances were forwarded without re-wrapping; they are now always wrapped in a new `ProjectSetupScriptOperationError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 402f2f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->