### PR TITLE
[codex] structure Bitbucket API failures

### DIFF
--- a/apps/server/src/sourceControl/BitbucketApi.test.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.test.ts
@@ -6,8 +6,14 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http";
+import {
+  HttpClient,
+  HttpClientError,
+  HttpClientRequest,
+  HttpClientResponse,
+} from "effect/unstable/http";
 
+import { GitCommandError } from "@t3tools/contracts";
 import * as BitbucketApi from "./BitbucketApi.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
 import * as VcsDriverRegistry from "../vcs/VcsDriverRegistry.ts";
@@ -53,10 +59,15 @@ const repositoryJson = {
 
 function makeLayer(input: {
   readonly response: (request: HttpClientRequest.HttpClientRequest) => Response;
+  readonly requestFailure?: (
+    request: HttpClientRequest.HttpClientRequest,
+  ) => HttpClientError.HttpClientError;
   readonly git?: Partial<GitVcsDriver.GitVcsDriver["Service"]>;
 }) {
   const execute = vi.fn((request: HttpClientRequest.HttpClientRequest) =>
-    Effect.succeed(HttpClientResponse.fromWeb(request, input.response(request))),
+    input.requestFailure
+      ? Effect.fail(input.requestFailure(request))
+      : Effect.succeed(HttpClientResponse.fromWeb(request, input.response(request))),
   );
   const gitMock = {
     readConfigValue: vi.fn<GitVcsDriver.GitVcsDriver["Service"]["readConfigValue"]>(() =>
@@ -497,6 +508,42 @@ it.effect("reports auth status through the Bitbucket REST /user endpoint", () =>
   }).pipe(Effect.provide(layer));
 });
 
+it.effect("preserves the HTTP client failure without deriving the domain message from it", () => {
+  const transportCause = new Error("socket reset by peer");
+  let requestFailure: HttpClientError.HttpClientError | undefined;
+  const { layer } = makeLayer({
+    response: () => Response.json({}),
+    requestFailure: (request) => {
+      requestFailure = new HttpClientError.HttpClientError({
+        reason: new HttpClientError.TransportError({
+          request,
+          cause: transportCause,
+        }),
+      });
+      return requestFailure;
+    },
+  });
+
+  return Effect.gen(function* () {
+    const bitbucket = yield* BitbucketApi.BitbucketApi;
+    const error = yield* Effect.flip(
+      bitbucket.getPullRequest({
+        cwd: "/repo",
+        reference: "42",
+      }),
+    );
+
+    assert.strictEqual(error.operation, "getPullRequest");
+    assert.strictEqual(error.detail, "Failed to send the Bitbucket request.");
+    assert.strictEqual(
+      error.message,
+      "Bitbucket API failed in getPullRequest: Failed to send the Bitbucket request.",
+    );
+    assert.strictEqual(error.cause, requestFailure);
+    assert.strictEqual(requestFailure?.cause, transportCause);
+  }).pipe(Effect.provide(layer));
+});
+
 it.effect("checks out same-repository pull requests with the existing Bitbucket remote", () => {
   const { git, layer } = makeLayer({
     response: () =>
@@ -546,6 +593,50 @@ it.effect("checks out same-repository pull requests with the existing Bitbucket 
       cwd: "/repo",
       refName: "feature/source-control",
     });
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("preserves Git checkout failures without deriving the domain message from them", () => {
+  const gitCause = new GitCommandError({
+    operation: "fetchRemoteBranch",
+    command: "git fetch origin feature/source-control",
+    cwd: "/repo",
+    detail: "remote rejected the request",
+  });
+  const { layer } = makeLayer({
+    response: () =>
+      Response.json({
+        ...bitbucketPullRequest,
+        source: {
+          branch: { name: "feature/source-control" },
+          repository: {
+            full_name: "pingdotgg/t3code",
+            workspace: { slug: "pingdotgg" },
+          },
+        },
+      }),
+    git: {
+      fetchRemoteBranch: () => Effect.fail(gitCause),
+    },
+  });
+
+  return Effect.gen(function* () {
+    const bitbucket = yield* BitbucketApi.BitbucketApi;
+    const error = yield* Effect.flip(
+      bitbucket.checkoutPullRequest({
+        cwd: "/repo",
+        reference: "42",
+        force: true,
+      }),
+    );
+
+    assert.strictEqual(error.operation, "checkoutPullRequest");
+    assert.strictEqual(error.detail, "Failed to check out the Bitbucket pull request.");
+    assert.strictEqual(
+      error.message,
+      "Bitbucket API failed in checkoutPullRequest: Failed to check out the Bitbucket pull request.",
+    );
+    assert.strictEqual(error.cause, gitCause);
   }).pipe(Effect.provide(layer));
 });
 

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -338,14 +338,6 @@ function authFromConfig(
   };
 }
 
-function requestError(operation: string, cause: unknown): BitbucketApiError {
-  return new BitbucketApiError({
-    operation,
-    detail: cause instanceof Error ? cause.message : String(cause),
-    cause,
-  });
-}
-
 function responseError(
   operation: string,
   response: HttpClientResponse.HttpClientResponse,
@@ -412,7 +404,14 @@ export const make = Effect.gen(function* () {
     schema: S,
   ): Effect.Effect<S["Type"], BitbucketApiError, S["DecodingServices"]> =>
     httpClient.execute(withAuth(request.pipe(HttpClientRequest.acceptJson))).pipe(
-      Effect.mapError((cause) => requestError(operation, cause)),
+      Effect.mapError(
+        (cause) =>
+          new BitbucketApiError({
+            operation,
+            detail: "Failed to send the Bitbucket request.",
+            cause,
+          }),
+      ),
       Effect.flatMap((response) => decodeResponse(operation, schema, response)),
     );
 
@@ -746,7 +745,7 @@ export const make = Effect.gen(function* () {
             ? cause
             : new BitbucketApiError({
                 operation: "checkoutPullRequest",
-                detail: cause instanceof Error ? cause.message : String(cause),
+                detail: "Failed to check out the Bitbucket pull request.",
                 cause,
               }),
         ),


### PR DESCRIPTION
## Summary
- remove the valueless Bitbucket request-error constructor wrapper
- keep request and checkout messages derived from structural operation context instead of nested cause text
- preserve exact HTTP and Git failures as `cause` and cover both chains with regression tests

## Validation
- `vp test apps/server/src/sourceControl/BitbucketApi.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-shaping in Bitbucket integration with clearer messages and unchanged failure propagation via `cause`; covered by new unit tests.
> 
> **Overview**
> **Bitbucket API errors** now use stable, operation-specific `detail` text instead of copying nested failure messages into the domain layer.
> 
> HTTP transport failures from `executeJson` are wrapped as `BitbucketApiError` with *"Failed to send the Bitbucket request."* while the original `HttpClientError` stays on `cause`. Checkout failures that are not already `BitbucketApiError` use *"Failed to check out the Bitbucket pull request."* with the underlying Git error preserved on `cause`. The redundant `requestError` helper is removed.
> 
> Regression tests cover both chains: transport errors on `getPullRequest` and `GitCommandError` on `checkoutPullRequest`, asserting fixed `detail`/`message` and identity of `cause`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfca5e1d7f07532f79b69503f73f66c65d81516b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `BitbucketApi` to use fixed error details instead of deriving them from cause messages
> - HTTP execution failures in `executeJson` now produce `BitbucketApiError` with a fixed detail `'Failed to send the Bitbucket request.'` instead of deriving the message from the underlying cause.
> - Checkout failures in `checkoutPullRequest` now produce `BitbucketApiError` with a fixed detail `'Failed to check out the Bitbucket pull request.'` instead of forwarding the raw error message.
> - Both paths preserve the original cause on the error for downstream inspection.
> - Tests are added to assert these fixed messages and that causes (including transport-level errors and `GitCommandError`) are preserved.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bfca5e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->