### PR TITLE
[codex] Structure preview automation failures

### DIFF
--- a/apps/web/src/components/preview/PreviewAutomationOwner.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationOwner.tsx
@@ -121,6 +121,10 @@ export class PreviewAutomationRecordingNotActiveError extends Schema.TaggedError
     tabId: PreviewTabId,
   },
 ) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError";
+  }
+
   override get message(): string {
     return `Preview automation request ${this.requestId} found no active recording for tab ${this.tabId} on environment ${this.environmentId} thread ${this.threadId}.`;
   }

--- a/apps/web/src/components/preview/PreviewAutomationOwner.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationOwner.tsx
@@ -2,14 +2,20 @@
 
 import { useAtomValue } from "@effect/atom-react";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
-import type {
-  PreviewAutomationNavigateInput,
-  PreviewAutomationOpenInput,
-  PreviewAutomationRequest,
-  PreviewAutomationOwner as PreviewAutomationOwnerState,
-  PreviewAutomationStatus,
-  ScopedThreadRef,
+import {
+  EnvironmentId,
+  type PreviewAutomationNavigateInput,
+  type PreviewAutomationOpenInput,
+  PreviewAutomationOperation,
+  type PreviewAutomationOwner as PreviewAutomationOwnerState,
+  type PreviewAutomationRequest,
+  type PreviewAutomationStatus,
+  PreviewTabId,
+  type ScopedThreadRef,
+  ThreadId,
+  TrimmedNonEmptyString,
 } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import { useCallback, useEffect, useEffectEvent, useId, useMemo, useRef, useState } from "react";
 
 import {
@@ -29,6 +35,96 @@ import {
   createLatestPreviewAutomationRequestHandler,
   createPreviewAutomationRequestConsumerAtom,
 } from "./previewAutomationRequestConsumer";
+
+export class PreviewAutomationOverlayTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationOverlayTimeoutError>()(
+  "PreviewAutomationOverlayTimeoutError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    timeoutMs: Schema.Int,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationTimeoutError";
+  }
+
+  override get message(): string {
+    return `Preview webview for request ${this.requestId} on environment ${this.environmentId} thread ${this.threadId} did not register within ${this.timeoutMs}ms.`;
+  }
+}
+
+export class PreviewAutomationNavigationTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationNavigationTimeoutError>()(
+  "PreviewAutomationNavigationTimeoutError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: PreviewTabId,
+    readiness: Schema.Literals(["domContentLoaded", "load"]),
+    timeoutMs: Schema.Int,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationTimeoutError";
+  }
+
+  override get message(): string {
+    return `Preview navigation for request ${this.requestId} on environment ${this.environmentId} thread ${this.threadId} tab ${this.tabId} did not reach ${this.readiness} readiness within ${this.timeoutMs}ms.`;
+  }
+}
+
+export class PreviewAutomationStaleOwnerError extends Schema.TaggedErrorClass<PreviewAutomationStaleOwnerError>()(
+  "PreviewAutomationStaleOwnerError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    expectedThreadId: ThreadId,
+    requestedThreadId: ThreadId,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationUnavailableError";
+  }
+
+  override get message(): string {
+    return `Preview automation request ${this.requestId} targeted thread ${this.requestedThreadId}, but the owner for environment ${this.environmentId} is attached to thread ${this.expectedThreadId}.`;
+  }
+}
+
+export class PreviewAutomationTargetUnavailableError extends Schema.TaggedErrorClass<PreviewAutomationTargetUnavailableError>()(
+  "PreviewAutomationTargetUnavailableError",
+  {
+    requestId: TrimmedNonEmptyString,
+    operation: PreviewAutomationOperation,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: Schema.NullOr(PreviewTabId),
+    bridgeAvailable: Schema.Boolean,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationTabNotFoundError";
+  }
+
+  override get message(): string {
+    return `Preview automation target for ${this.operation} request ${this.requestId} is unavailable on environment ${this.environmentId} thread ${this.threadId} (tab ${this.tabId ?? "unassigned"}, bridge ${this.bridgeAvailable ? "available" : "unavailable"}).`;
+  }
+}
+
+export class PreviewAutomationRecordingNotActiveError extends Schema.TaggedErrorClass<PreviewAutomationRecordingNotActiveError>()(
+  "PreviewAutomationRecordingNotActiveError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: PreviewTabId,
+  },
+) {
+  override get message(): string {
+    return `Preview automation request ${this.requestId} found no active recording for tab ${this.tabId} on environment ${this.environmentId} thread ${this.threadId}.`;
+  }
+}
 
 export function observeAutomationOwnerConnectedGeneration(
   previousGeneration: number | null,
@@ -51,6 +147,7 @@ export function observeAutomationOwnerConnectedGeneration(
 
 const waitForDesktopOverlay = async (
   threadRef: ScopedThreadRef,
+  requestId: string,
   timeoutMs: number,
 ): Promise<void> => {
   const deadline = Date.now() + timeoutMs;
@@ -63,20 +160,26 @@ const waitForDesktopOverlay = async (
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
   }
-  const error = new Error(`Preview webview did not register within ${timeoutMs}ms.`);
-  error.name = "PreviewAutomationTimeoutError";
-  throw error;
+  throw new PreviewAutomationOverlayTimeoutError({
+    requestId,
+    environmentId: threadRef.environmentId,
+    threadId: threadRef.threadId,
+    timeoutMs,
+  });
 };
 
 const waitForNavigationReadiness = async (
+  threadRef: ScopedThreadRef,
+  requestId: string,
   tabId: string,
   readiness: PreviewAutomationNavigateInput["readiness"],
   timeoutMs: number,
 ): Promise<void> => {
-  if (!previewBridge || readiness === "none") return;
+  const targetReadiness = readiness ?? "load";
+  if (!previewBridge || targetReadiness === "none") return;
   const deadline = Date.now() + timeoutMs;
   while (Date.now() <= deadline) {
-    if (readiness === "domContentLoaded") {
+    if (targetReadiness === "domContentLoaded") {
       const readyState = await previewBridge.automation.evaluate(tabId, {
         expression: "document.readyState",
       });
@@ -87,9 +190,14 @@ const waitForNavigationReadiness = async (
     }
     await new Promise<void>((resolve) => window.setTimeout(resolve, 50));
   }
-  const error = new Error(`Preview navigation did not become ready within ${timeoutMs}ms.`);
-  error.name = "PreviewAutomationTimeoutError";
-  throw error;
+  throw new PreviewAutomationNavigationTimeoutError({
+    requestId,
+    environmentId: threadRef.environmentId,
+    threadId: threadRef.threadId,
+    tabId,
+    readiness: targetReadiness,
+    timeoutMs,
+  });
 };
 
 const currentStatus = async (
@@ -111,12 +219,6 @@ const currentStatus = async (
     title: navStatus && navStatus._tag !== "Idle" ? navStatus.title : null,
     loading: navStatus?._tag === "Loading",
   };
-};
-
-const previewTabNotFoundError = (): Error => {
-  const error = new Error("Preview tab is not initialized.");
-  error.name = "PreviewAutomationTabNotFoundError";
-  return error;
 };
 
 export function PreviewAutomationOwner(props: {
@@ -182,12 +284,23 @@ export function PreviewAutomationOwner(props: {
   const handleRequest = useCallback(
     async (request: PreviewAutomationRequest): Promise<unknown> => {
       if (request.threadId !== threadRef.threadId) {
-        const error = new Error("Preview automation request targeted a stale thread owner.");
-        error.name = "PreviewAutomationUnavailableError";
-        throw error;
+        throw new PreviewAutomationStaleOwnerError({
+          requestId: request.requestId,
+          environmentId: threadRef.environmentId,
+          expectedThreadId: threadRef.threadId,
+          requestedThreadId: request.threadId,
+        });
       }
       const state = readThreadPreviewState(threadRef);
       const tabId = request.tabId ?? state.snapshot?.tabId ?? null;
+      const unavailableTarget = {
+        requestId: request.requestId,
+        operation: request.operation,
+        environmentId: threadRef.environmentId,
+        threadId: threadRef.threadId,
+        tabId,
+        bridgeAvailable: Boolean(previewBridge),
+      };
       switch (request.operation) {
         case "status":
           return currentStatus(threadRef, visible);
@@ -215,11 +328,13 @@ export function PreviewAutomationOwner(props: {
           if (input.show ?? true) {
             useRightPanelStore.getState().openBrowser(threadRef, activeTabId);
           }
-          await waitForDesktopOverlay(threadRef, request.timeoutMs);
+          await waitForDesktopOverlay(threadRef, request.requestId, request.timeoutMs);
           return currentStatus(threadRef, input.show ?? true);
         }
         case "navigate": {
-          if (!previewBridge || !tabId) throw previewTabNotFoundError();
+          if (!previewBridge || !tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           const input = request.input as PreviewAutomationNavigateInput;
           const resolution = resolveBrowserNavigationTarget(
             threadRef.environmentId,
@@ -227,6 +342,8 @@ export function PreviewAutomationOwner(props: {
           );
           await previewBridge.navigate(tabId, resolution.resolvedUrl);
           await waitForNavigationReadiness(
+            threadRef,
+            request.requestId,
             tabId,
             input.readiness ?? "load",
             input.timeoutMs ?? request.timeoutMs,
@@ -234,46 +351,62 @@ export function PreviewAutomationOwner(props: {
           return currentStatus(threadRef, visible);
         }
         case "snapshot":
-          if (!previewBridge || !tabId) throw previewTabNotFoundError();
+          if (!previewBridge || !tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           return previewBridge.automation.snapshot(tabId);
         case "click":
-          if (!previewBridge || !tabId) throw previewTabNotFoundError();
+          if (!previewBridge || !tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           return previewBridge.automation.click(
             tabId,
             request.input as Parameters<typeof previewBridge.automation.click>[1],
           );
         case "type":
-          if (!previewBridge || !tabId) throw previewTabNotFoundError();
+          if (!previewBridge || !tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           return previewBridge.automation.type(
             tabId,
             request.input as Parameters<typeof previewBridge.automation.type>[1],
           );
         case "press":
-          if (!previewBridge || !tabId) throw previewTabNotFoundError();
+          if (!previewBridge || !tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           return previewBridge.automation.press(
             tabId,
             request.input as Parameters<typeof previewBridge.automation.press>[1],
           );
         case "scroll":
-          if (!previewBridge || !tabId) throw previewTabNotFoundError();
+          if (!previewBridge || !tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           return previewBridge.automation.scroll(
             tabId,
             request.input as Parameters<typeof previewBridge.automation.scroll>[1],
           );
         case "evaluate":
-          if (!previewBridge || !tabId) throw previewTabNotFoundError();
+          if (!previewBridge || !tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           return previewBridge.automation.evaluate(
             tabId,
             request.input as Parameters<typeof previewBridge.automation.evaluate>[1],
           );
         case "waitFor":
-          if (!previewBridge || !tabId) throw previewTabNotFoundError();
+          if (!previewBridge || !tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           return previewBridge.automation.waitFor(
             tabId,
             request.input as Parameters<typeof previewBridge.automation.waitFor>[1],
           );
         case "recordingStart": {
-          if (!tabId) throw previewTabNotFoundError();
+          if (!tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           const startedAt = await startBrowserRecording(tabId);
           return {
             tabId,
@@ -282,9 +415,18 @@ export function PreviewAutomationOwner(props: {
           };
         }
         case "recordingStop": {
-          if (!tabId) throw previewTabNotFoundError();
+          if (!tabId) {
+            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+          }
           const artifact = await stopBrowserRecording(tabId);
-          if (!artifact) throw new Error("No active recording exists for this preview tab.");
+          if (!artifact) {
+            throw new PreviewAutomationRecordingNotActiveError({
+              requestId: request.requestId,
+              environmentId: threadRef.environmentId,
+              threadId: threadRef.threadId,
+              tabId,
+            });
+          }
           return artifact;
         }
       }

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -78,4 +78,24 @@ describe("previewAutomationRequestConsumer", () => {
       message: "No preview tab",
     });
   });
+
+  it("serializes structured automation context without leaking causes", () => {
+    const error = Object.assign(new Error("Preview target unavailable"), {
+      name: "PreviewAutomationTargetUnavailableError",
+      _tag: "PreviewAutomationTargetUnavailableError",
+      responseTag: "PreviewAutomationTabNotFoundError",
+      requestId: "request-1",
+      threadId: "thread-1",
+      cause: new Error("private bridge failure"),
+    });
+
+    expect(serializePreviewAutomationError(error)).toEqual({
+      _tag: "PreviewAutomationTabNotFoundError",
+      message: "Preview target unavailable",
+      detail: {
+        requestId: "request-1",
+        threadId: "thread-1",
+      },
+    });
+  });
 });

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.ts
@@ -21,14 +21,40 @@ export function serializePreviewAutomationError(
   error: unknown,
 ): NonNullable<PreviewAutomationResponse["error"]> {
   if (error instanceof Error) {
-    const detail =
+    const explicitDetail =
       "detail" in error && (error as { detail?: unknown }).detail !== undefined
         ? (error as { detail?: unknown }).detail
         : undefined;
+    const structuralDetail =
+      "_tag" in error &&
+      typeof (error as { _tag?: unknown })._tag === "string" &&
+      (error as { _tag: string })._tag.startsWith("PreviewAutomation")
+        ? Object.fromEntries(
+            Object.entries(error).filter(
+              ([key]) =>
+                key !== "_tag" &&
+                key !== "cause" &&
+                key !== "name" &&
+                key !== "message" &&
+                key !== "stack" &&
+                key !== "detail" &&
+                key !== "responseTag",
+            ),
+          )
+        : undefined;
+    const detail = explicitDetail ?? structuralDetail;
+    const responseTag =
+      "responseTag" in error &&
+      typeof (error as { responseTag?: unknown }).responseTag === "string" &&
+      (error as { responseTag: string }).responseTag.startsWith("PreviewAutomation")
+        ? (error as { responseTag: string }).responseTag
+        : undefined;
     return {
-      _tag: error.name.startsWith("PreviewAutomation")
-        ? error.name
-        : "PreviewAutomationExecutionError",
+      _tag:
+        responseTag ??
+        (error.name.startsWith("PreviewAutomation")
+          ? error.name
+          : "PreviewAutomationExecutionError"),
       message: error.message,
       ...(detail === undefined ? {} : { detail }),
     };


### PR DESCRIPTION
## Summary
- replace name-mutated generic automation errors and the tab-error constructor wrapper with schema-tagged errors carrying request, environment, thread, tab, operation, readiness, and timeout context
- keep wire compatibility by letting each specialized error map itself to the existing broker response tag
- serialize structured automation attributes as response detail while excluding causes and Error internals

## Verification
- `vp test apps/web/src/components/preview/PreviewAutomationOwner.test.ts apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts` (6 tests)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shape of automation error responses (structured detail) and all failure paths in the preview owner; wire tags are preserved via responseTag but clients parsing errors may need to handle new detail fields.
> 
> **Overview**
> Replaces ad-hoc `Error` objects (with mutated `name` fields) in preview automation handling with **Effect `Schema.TaggedErrorClass`** types that carry request/environment/thread/tab context and map to existing broker `_tag` values via **`responseTag`**.
> 
> **`PreviewAutomationOwner`** now throws dedicated errors for overlay timeouts, navigation readiness timeouts, stale thread owners, missing bridge/tab targets, and inactive recordings. Wait helpers take **`requestId`** (and thread context for navigation timeouts); navigation readiness defaults to **`load`** when omitted.
> 
> **`serializePreviewAutomationError`** prefers **`responseTag`** over `error.name`, builds **`detail`** from structured `PreviewAutomation*` error fields (excluding `cause`, stack, etc.), and adds a test asserting causes are not leaked on the wire.
> 
> Clients still see the same high-level response tags in most cases, but failures can include richer **`detail`** instead of generic messages only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c617f3daf99c0a3cdb5af20f540e571d76d1606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic errors with structured tagged error classes in preview automation
> - Adds five typed error classes (`PreviewAutomationOverlayTimeoutError`, `PreviewAutomationNavigationTimeoutError`, `PreviewAutomationStaleOwnerError`, `PreviewAutomationTargetUnavailableError`, `PreviewAutomationRecordingNotActiveError`) in [PreviewAutomationOwner.tsx](https://github.com/pingdotgg/t3code/pull/3333/files#diff-d910e8aa5c7895c71f0d40d2487477e0d69436114a0f882bcb52d143024f0a44), replacing generic `Error` instances with structured, tagged errors carrying contextual fields (requestId, environmentId, threadId, etc.).
> - Each error carries a `responseTag` that controls the serialized `_tag` emitted to consumers, decoupling the internal error type from the protocol-level error code.
> - `serializePreviewAutomationError` in [previewAutomationRequestConsumer.ts](https://github.com/pingdotgg/t3code/pull/3333/files#diff-87210ceefd89fe28a3f19951de9e7dba453a275aa1de4a6a21844fb46b713ba1) is extended to derive a `detail` object from enumerable error fields (excluding `cause`, `stack`, and other reserved keys) and to override `_tag` with `responseTag` when present.
> - Behavioral Change: serialized automation errors may now include a `detail` object and a different `_tag` than before; `cause` is explicitly excluded from serialized output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c617f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->