### PR TITLE
[codex] structure source-control repository failures

### DIFF
--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -1,11 +1,13 @@
+import * as NodePath from "@effect/platform-node/NodePath";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { GitCommandError, type SourceControlProviderError } from "@t3tools/contracts";
+import { GitCommandError, SourceControlProviderError } from "@t3tools/contracts";
 
 import * as ServerConfig from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
@@ -54,8 +56,9 @@ function processOutput(): GitVcsDriver.ExecuteGitResult {
 function makeLayer(input: {
   readonly provider?: SourceControlProvider.SourceControlProvider["Service"];
   readonly git?: Partial<GitVcsDriver.GitVcsDriver["Service"]>;
+  readonly fileSystem?: FileSystem.FileSystem;
 }) {
-  return SourceControlRepositoryService.layer.pipe(
+  const serviceLayer = SourceControlRepositoryService.layer.pipe(
     Layer.provide(
       Layer.mock(SourceControlProviderRegistry.SourceControlProviderRegistry)({
         get: () => Effect.succeed(input.provider ?? makeProvider()),
@@ -75,9 +78,20 @@ function makeLayer(input: {
         ...input.git,
       }),
     ),
-    Layer.provide(ServerConfig.layerTest(process.cwd(), { prefix: "t3-source-control-repos-" })),
-    Layer.provideMerge(NodeServices.layer),
+    Layer.provide(
+      ServerConfig.layerTest(
+        process.cwd(),
+        input.fileSystem ? "/tmp/t3-source-control-repos" : { prefix: "t3-source-control-repos-" },
+      ),
+    ),
   );
+
+  return input.fileSystem
+    ? serviceLayer.pipe(
+        Layer.provide(Layer.succeed(FileSystem.FileSystem, input.fileSystem)),
+        Layer.provideMerge(NodePath.layer),
+      )
+    : serviceLayer.pipe(Layer.provideMerge(NodeServices.layer));
 }
 
 it.effect("looks up repositories through the requested provider without search", () => {
@@ -100,6 +114,37 @@ it.effect("looks up repositories through the requested provider without search",
 
     assert.deepStrictEqual(result, { provider: "github", ...CLONE_URLS });
     assert.deepStrictEqual(calls, [{ cwd: "/workspace", repository: "octocat/t3code" }]);
+  }).pipe(Effect.provide(makeLayer({ provider })));
+});
+
+it.effect("preserves provider failures without deriving the repository message from them", () => {
+  const providerCause = new SourceControlProviderError({
+    provider: "github",
+    operation: "getRepositoryCloneUrls",
+    detail: "credential token abc123 was rejected",
+  });
+  const provider = makeProvider({
+    getRepositoryCloneUrls: () => Effect.fail(providerCause),
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+    const error = yield* Effect.flip(
+      service.lookupRepository({
+        provider: "github",
+        repository: "octocat/t3code",
+        cwd: "/workspace",
+      }),
+    );
+
+    assert.strictEqual(error.provider, "github");
+    assert.strictEqual(error.operation, "lookupRepository");
+    assert.strictEqual(error.detail, "The source control operation could not be completed.");
+    assert.strictEqual(
+      error.message,
+      "Source control repository operation lookupRepository failed for github: The source control operation could not be completed.",
+    );
+    assert.strictEqual(error.cause, providerCause);
   }).pipe(Effect.provide(makeLayer({ provider })));
 });
 
@@ -147,6 +192,38 @@ it.effect("clones a looked-up repository into the requested destination", () =>
     );
   }).pipe(Effect.provide(NodeServices.layer)),
 );
+
+it.effect("preserves destination probe failures instead of treating them as missing paths", () => {
+  const fileSystemCause = PlatformError.systemError({
+    _tag: "PermissionDenied",
+    module: "FileSystem",
+    method: "exists",
+    pathOrDescriptor: "/restricted/t3code",
+  });
+
+  return Effect.gen(function* () {
+    const service = yield* SourceControlRepositoryService.SourceControlRepositoryService;
+    const error = yield* Effect.flip(
+      service.cloneRepository({
+        remoteUrl: CLONE_URLS.sshUrl,
+        destinationPath: "/restricted/t3code",
+      }),
+    );
+
+    assert.strictEqual(error.provider, "unknown");
+    assert.strictEqual(error.operation, "cloneRepository");
+    assert.strictEqual(error.cause, fileSystemCause);
+  }).pipe(
+    Effect.provide(
+      makeLayer({
+        fileSystem: FileSystem.makeNoop({
+          exists: () => Effect.fail(fileSystemCause),
+          makeDirectory: () => Effect.void,
+        }),
+      }),
+    ),
+  );
+});
 
 it.effect("publishes by creating the repository, adding a remote, and pushing upstream", () => {
   const createCalls: Array<{ cwd: string; repository: string; visibility: string }> = [];

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.test.ts
@@ -121,6 +121,8 @@ it.effect("preserves provider failures without deriving the repository message f
   const providerCause = new SourceControlProviderError({
     provider: "github",
     operation: "getRepositoryCloneUrls",
+    cwd: "/workspace",
+    repository: "octocat/t3code",
     detail: "credential token abc123 was rejected",
   });
   const provider = makeProvider({

--- a/apps/server/src/sourceControl/SourceControlRepositoryService.ts
+++ b/apps/server/src/sourceControl/SourceControlRepositoryService.ts
@@ -39,41 +39,14 @@ export class SourceControlRepositoryService extends Context.Service<
   }
 >()("t3/sourceControl/SourceControlRepositoryService") {}
 
-function detailFromUnknown(cause: unknown): string {
-  if (typeof cause === "object" && cause !== null) {
-    if ("detail" in cause && typeof cause.detail === "string" && cause.detail.length > 0) {
-      return cause.detail;
-    }
-    if ("message" in cause && typeof cause.message === "string" && cause.message.length > 0) {
-      return cause.message;
-    }
-  }
-
-  return "An unexpected source control error occurred.";
-}
-
-function repositoryError(input: {
-  readonly operation: string;
-  readonly provider: SourceControlProviderKind;
-  readonly detail: string;
-  readonly cause?: unknown;
-}): SourceControlRepositoryError {
-  return new SourceControlRepositoryError({
-    provider: input.provider,
-    operation: input.operation,
-    detail: input.detail,
-    ...(input.cause === undefined ? {} : { cause: input.cause }),
-  });
-}
-
 function mapRepositoryError(operation: string, provider: SourceControlProviderKind) {
   return Effect.mapError((cause: unknown) =>
     isSourceControlRepositoryError(cause)
       ? cause
-      : repositoryError({
+      : new SourceControlRepositoryError({
           operation,
           provider,
-          detail: detailFromUnknown(cause),
+          detail: "The source control operation could not be completed.",
           cause,
         }),
   );
@@ -130,7 +103,7 @@ export const make = Effect.gen(function* () {
     }
 
     return Effect.fail(
-      repositoryError({
+      new SourceControlRepositoryError({
         operation: input.operation,
         provider: input.provider,
         detail: "Choose a source control provider before continuing.",
@@ -157,7 +130,7 @@ export const make = Effect.gen(function* () {
     function* (destinationPath: string) {
       const trimmed = destinationPath.trim();
       if (trimmed.length === 0) {
-        return yield* repositoryError({
+        return yield* new SourceControlRepositoryError({
           operation: "cloneRepository",
           provider: "unknown",
           detail: "Choose a destination path before cloning.",
@@ -171,21 +144,22 @@ export const make = Effect.gen(function* () {
   const prepareDestination = Effect.fn("SourceControlRepositoryService.prepareDestination")(
     function* (destinationPath: string) {
       const normalizedDestination = yield* normalizeDestinationPath(destinationPath);
-      if (yield* fileSystem.exists(normalizedDestination).pipe(Effect.orElseSucceed(() => false))) {
+      if (yield* fileSystem.exists(normalizedDestination)) {
         const entries = yield* fileSystem
           .readDirectory(normalizedDestination, { recursive: false })
           .pipe(
-            Effect.mapError((cause) =>
-              repositoryError({
-                operation: "cloneRepository",
-                provider: "unknown",
-                detail: "Destination path already exists and is not a directory.",
-                cause,
-              }),
+            Effect.mapError(
+              (cause) =>
+                new SourceControlRepositoryError({
+                  operation: "cloneRepository",
+                  provider: "unknown",
+                  detail: "Destination path already exists and is not a directory.",
+                  cause,
+                }),
             ),
           );
         if (entries.length > 0) {
-          return yield* repositoryError({
+          return yield* new SourceControlRepositoryError({
             operation: "cloneRepository",
             provider: "unknown",
             detail: "Destination path already exists and is not empty.",
@@ -222,7 +196,7 @@ export const make = Effect.gen(function* () {
     }
 
     if (!remoteUrl) {
-      return yield* repositoryError({
+      return yield* new SourceControlRepositoryError({
         operation: "cloneRepository",
         provider,
         detail: "Enter a repository path or clone URL before cloning.",


### PR DESCRIPTION
## Summary
- remove the constructor-only repository error helper
- keep repository messages based on structural operation/provider fields instead of nested cause text
- preserve destination probe failures and exact provider/filesystem causes

## Validation
- `vp test apps/server/src/sourceControl/SourceControlRepositoryService.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes clone path handling and what clients see in error messages; incorrect mapping could hide real failures or leak less/more detail than intended.
> 
> **Overview**
> **Source control repository failures** now use a fixed user-facing `detail` when wrapping unknown causes, instead of copying nested provider or exception text into the message (so sensitive provider errors stay on `cause` only). The `repositoryError` / `detailFromUnknown` helpers are removed in favor of direct `SourceControlRepositoryError` construction.
> 
> **Clone destination preparation** no longer treats `FileSystem.exists` failures as “path missing”; permission and other probe errors fail the clone with the original cause attached.
> 
> Tests cover provider lookup wrapping and destination `exists` failures, and the test layer can inject a noop filesystem.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b66655f56e2d497ac7ed2ab0f9699c0b427b332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize source control repository error messages and propagate `FileSystem.exists` failures
> - Replaces dynamic error detail derivation in `mapRepositoryError` with a fixed string (`'The source control operation could not be completed.'`), so error messages no longer leak internal cause details.
> - Removes the `repositoryError` and `detailFromUnknown` helpers, replacing all call sites with direct `SourceControlRepositoryError` instantiation.
> - Behavioral Change: `prepareDestination` no longer swallows `FileSystem.exists` errors via `orElseSucceed`; permission errors and other failures now propagate instead of being treated as a missing path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b66655.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->