### PR TITLE
[codex] Preserve mobile review highlighter failures

### DIFF
--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
@@ -8,12 +8,41 @@ import jsxLanguage from "@shikijs/langs/jsx";
 import tsxLanguage from "@shikijs/langs/tsx";
 import typescriptLanguage from "@shikijs/langs/typescript";
 import yamlLanguage from "@shikijs/langs/yaml";
+import * as Schema from "effect/Schema";
 
 import type { NativeReviewDiffFile, NativeReviewDiffLanguage } from "./nativeReviewDiffTypes";
 import type { NativeReviewDiffRow, NativeReviewDiffToken } from "./nativeReviewDiffSurface";
 
 export type NativeReviewDiffHighlightScheme = "light" | "dark";
 export type NativeReviewDiffHighlightEngine = "native" | "javascript";
+
+export class NativeReviewDiffHighlighterUnavailableError extends Schema.TaggedErrorClass<NativeReviewDiffHighlighterUnavailableError>()(
+  "NativeReviewDiffHighlighterUnavailableError",
+  {
+    requestedEngine: Schema.Literal("native"),
+  },
+) {
+  override get message(): string {
+    return `The ${this.requestedEngine} review diff highlighter is unavailable in this build.`;
+  }
+}
+
+export const isNativeReviewDiffHighlighterUnavailableError = Schema.is(
+  NativeReviewDiffHighlighterUnavailableError,
+);
+
+export class NativeReviewDiffHighlighterInitializationError extends Schema.TaggedErrorClass<NativeReviewDiffHighlighterInitializationError>()(
+  "NativeReviewDiffHighlighterInitializationError",
+  {
+    requestedEngine: Schema.Literals(["native", "javascript"]),
+    attemptedEngine: Schema.Literals(["native", "javascript"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to initialize the ${this.attemptedEngine} review diff highlighter requested as ${this.requestedEngine}.`;
+  }
+}
 
 export interface NativeReviewDiffHighlighterHandle {
   readonly engine: NativeReviewDiffHighlightEngine;
@@ -197,7 +226,7 @@ function normalizeTokens(
 async function createNativeReviewDiffHighlighter(): Promise<NativeReviewDiffHighlighterHandle> {
   const nativeEngineModule = await import("react-native-shiki-engine");
   if (!nativeEngineModule.isNativeEngineAvailable()) {
-    throw new Error("Native Shiki engine is not available in this build.");
+    throw new NativeReviewDiffHighlighterUnavailableError({ requestedEngine: "native" });
   }
 
   const highlighter = await createHighlighterCore({
@@ -229,18 +258,52 @@ export async function getNativeReviewDiffHighlighter(
   engine: NativeReviewDiffHighlightEngine = "native",
 ): Promise<NativeReviewDiffHighlighterHandle> {
   if (engine === "javascript") {
-    javascriptHighlighterPromise ??= createJavascriptReviewDiffHighlighter();
-    return javascriptHighlighterPromise;
+    try {
+      javascriptHighlighterPromise ??= createJavascriptReviewDiffHighlighter();
+      return await javascriptHighlighterPromise;
+    } catch (cause) {
+      javascriptHighlighterPromise = null;
+      throw new NativeReviewDiffHighlighterInitializationError({
+        requestedEngine: engine,
+        attemptedEngine: "javascript",
+        cause,
+      });
+    }
   }
 
-  nativeHighlighterPromise ??= createNativeReviewDiffHighlighter().catch((error: unknown) => {
-    console.warn("[debug-native-diff] native highlighter unavailable", {
-      error: error instanceof Error ? error.message : String(error),
+  nativeHighlighterPromise ??= createNativeReviewDiffHighlighter()
+    .catch(async (cause: unknown) => {
+      const nativeError = isNativeReviewDiffHighlighterUnavailableError(cause)
+        ? cause
+        : new NativeReviewDiffHighlighterInitializationError({
+            requestedEngine: engine,
+            attemptedEngine: "native",
+            cause,
+          });
+      console.warn("[debug-native-diff] native highlighter unavailable", {
+        error: nativeError,
+      });
+      try {
+        javascriptHighlighterPromise ??= createJavascriptReviewDiffHighlighter();
+        return await javascriptHighlighterPromise;
+      } catch (fallbackCause) {
+        javascriptHighlighterPromise = null;
+        throw new NativeReviewDiffHighlighterInitializationError({
+          requestedEngine: engine,
+          attemptedEngine: "javascript",
+          cause: new AggregateError(
+            [nativeError, fallbackCause],
+            "Native and JavaScript review diff highlighter initialization failed.",
+            { cause: nativeError },
+          ),
+        });
+      }
+    })
+    .catch((error) => {
+      nativeHighlighterPromise = null;
+      throw error;
     });
-    javascriptHighlighterPromise ??= createJavascriptReviewDiffHighlighter();
-    return javascriptHighlighterPromise;
-  });
-  return nativeHighlighterPromise;
+  return await nativeHighlighterPromise;
 }
 
 function isHighlightableLineRow(row: NativeReviewDiffRow): row is NativeReviewDiffLineRow {

--- a/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffHighlighter.ts
@@ -18,12 +18,10 @@ export type NativeReviewDiffHighlightEngine = "native" | "javascript";
 
 export class NativeReviewDiffHighlighterUnavailableError extends Schema.TaggedErrorClass<NativeReviewDiffHighlighterUnavailableError>()(
   "NativeReviewDiffHighlighterUnavailableError",
-  {
-    requestedEngine: Schema.Literal("native"),
-  },
+  {},
 ) {
   override get message(): string {
-    return `The ${this.requestedEngine} review diff highlighter is unavailable in this build.`;
+    return "The native review diff highlighter is unavailable in this build.";
   }
 }
 
@@ -226,7 +224,7 @@ function normalizeTokens(
 async function createNativeReviewDiffHighlighter(): Promise<NativeReviewDiffHighlighterHandle> {
   const nativeEngineModule = await import("react-native-shiki-engine");
   if (!nativeEngineModule.isNativeEngineAvailable()) {
-    throw new NativeReviewDiffHighlighterUnavailableError({ requestedEngine: "native" });
+    throw new NativeReviewDiffHighlighterUnavailableError();
   }
 
   const highlighter = await createHighlighterCore({

--- a/apps/mobile/src/features/review/reviewHighlighterState.test.ts
+++ b/apps/mobile/src/features/review/reviewHighlighterState.test.ts
@@ -53,11 +53,12 @@ it("initializes review highlighter state once", async () => {
 });
 
 it("stores initialization failures in atom state", async () => {
+  const cause = new Error("load failed");
   const manager = createReviewHighlighterManager({
     getRegistry: () => registry,
     loader: {
       prepare: async () => {
-        throw new Error("load failed");
+        throw cause;
       },
       prepareLanguages: async () => undefined,
       getEngine: async () => "javascript",
@@ -67,9 +68,23 @@ it("stores initialization failures in atom state", async () => {
   void manager.initialize();
   await flushAsyncWork();
 
-  assert.deepStrictEqual(manager.getSnapshot(), {
-    engine: null,
-    error: "load failed",
-    status: "error",
-  });
+  const snapshot = manager.getSnapshot();
+  assert.strictEqual(snapshot.engine, null);
+  assert.strictEqual(snapshot.status, "error");
+  assert.strictEqual(snapshot.error?._tag, "ReviewHighlighterManagerError");
+  assert.strictEqual(snapshot.error?.operation, "prepare");
+  assert.deepStrictEqual(snapshot.error?.languages, [
+    "typescript",
+    "tsx",
+    "javascript",
+    "jsx",
+    "json",
+    "yaml",
+    "bash",
+  ]);
+  assert.strictEqual(snapshot.error?.cause, cause);
+  assert.strictEqual(
+    snapshot.error?.message,
+    "Review highlighter operation prepare failed for languages typescript, tsx, javascript, jsx, json, yaml, bash.",
+  );
 });

--- a/apps/mobile/src/features/review/reviewHighlighterState.ts
+++ b/apps/mobile/src/features/review/reviewHighlighterState.ts
@@ -1,4 +1,5 @@
 import { useAtomValue } from "@effect/atom-react";
+import * as Schema from "effect/Schema";
 import { Atom, type AtomRegistry } from "effect/unstable/reactivity";
 import { useEffect } from "react";
 
@@ -12,9 +13,22 @@ import {
 
 export type ReviewHighlighterStatus = "idle" | "initializing" | "ready" | "error";
 
+export class ReviewHighlighterManagerError extends Schema.TaggedErrorClass<ReviewHighlighterManagerError>()(
+  "ReviewHighlighterManagerError",
+  {
+    operation: Schema.Literals(["prepare", "prepare-languages", "resolve-engine"]),
+    languages: Schema.Array(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Review highlighter operation ${this.operation} failed for languages ${this.languages.join(", ")}.`;
+  }
+}
+
 export interface ReviewHighlighterState {
   readonly engine: ReviewHighlighterEngine | null;
-  readonly error: string | null;
+  readonly error: ReviewHighlighterManagerError | null;
   readonly status: ReviewHighlighterStatus;
 }
 
@@ -101,24 +115,35 @@ export function createReviewHighlighterManager(config: {
 
     inFlight = (async () => {
       const startedAt = performance.now();
+      const languages = config.languages ?? REVIEW_INITIAL_LANGUAGES;
+      let operation: ReviewHighlighterManagerError["operation"] = "prepare";
+      let engine: ReviewHighlighterEngine;
       try {
         await config.loader.prepare();
-        await config.loader.prepareLanguages(config.languages ?? REVIEW_INITIAL_LANGUAGES);
-        const engine = await config.loader.getEngine();
-        const durationMs = Math.round(performance.now() - startedAt);
-        logReviewHighlighterProviderDiagnostic("initialized", {
-          durationMs,
-          engine,
+        operation = "prepare-languages";
+        await config.loader.prepareLanguages(languages);
+        operation = "resolve-engine";
+        engine = await config.loader.getEngine();
+      } catch (cause) {
+        const error = new ReviewHighlighterManagerError({
+          operation,
+          languages,
+          cause,
         });
-        setState({ engine, error: null, status: "ready" });
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        logReviewHighlighterProviderDiagnostic("initialization failed", { error: message });
-        setState({ engine: null, error: message, status: "error" });
-      } finally {
-        inFlight = null;
+        logReviewHighlighterProviderDiagnostic("initialization failed", { error });
+        setState({ engine: null, error, status: "error" });
+        return;
       }
-    })();
+
+      const durationMs = Math.round(performance.now() - startedAt);
+      logReviewHighlighterProviderDiagnostic("initialized", {
+        durationMs,
+        engine,
+      });
+      setState({ engine, error: null, status: "ready" });
+    })().finally(() => {
+      inFlight = null;
+    });
 
     return inFlight;
   }

--- a/apps/mobile/src/features/review/shikiReviewHighlighter.ts
+++ b/apps/mobile/src/features/review/shikiReviewHighlighter.ts
@@ -10,6 +10,7 @@ import yamlLanguage from "@shikijs/langs/yaml";
 import githubDarkDefault from "@shikijs/themes/github-dark-default";
 import githubLightDefault from "@shikijs/themes/github-light-default";
 import { getFiletypeFromFileName } from "@pierre/diffs/utils/getFiletypeFromFileName";
+import * as Schema from "effect/Schema";
 
 import {
   resolveReviewHighlighterEngine,
@@ -21,6 +22,19 @@ import { applyDiffRangesToTokens, computeWordAltDiffRanges } from "./reviewWordD
 
 export type ReviewDiffTheme = "light" | "dark";
 export type { ReviewHighlighterEngine };
+
+export class ReviewHighlighterEngineInitializationError extends Schema.TaggedErrorClass<ReviewHighlighterEngineInitializationError>()(
+  "ReviewHighlighterEngineInitializationError",
+  {
+    preferredEngine: Schema.Literals(["native", "javascript"]),
+    attemptedEngine: Schema.Literals(["native", "javascript"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to initialize the ${this.attemptedEngine} review highlighter with ${this.preferredEngine} preferred.`;
+  }
+}
 
 export interface ReviewHighlightedToken {
   content: string;
@@ -227,16 +241,6 @@ function logReviewHighlighterDiagnosticError(message: string, error: unknown): v
   if (!isReviewHighlighterDebugLoggingEnabled()) {
     return;
   }
-
-  if (error instanceof Error) {
-    console.error(`[review-highlighter] ${message}`, {
-      name: error.name,
-      message: error.message,
-      stack: error.stack,
-    });
-    return;
-  }
-
   console.error(`[review-highlighter] ${message}`, error);
 }
 
@@ -258,6 +262,7 @@ async function getHighlighter(): Promise<HighlighterCore> {
   if (!highlighterPromise) {
     const configuredHighlighterPromise = (async () => {
       let nativeEngineAvailable = false;
+      let nativeInitializationError: ReviewHighlighterEngineInitializationError | undefined;
 
       logReviewHighlighterDiagnostic("initializing", {
         configuredPreference: REVIEW_HIGHLIGHTER_ENGINE_ENV_VALUE,
@@ -289,9 +294,14 @@ async function getHighlighter(): Promise<HighlighterCore> {
             };
           }
         } catch (error) {
+          nativeInitializationError = new ReviewHighlighterEngineInitializationError({
+            preferredEngine: REVIEW_HIGHLIGHTER_ENGINE_PREFERENCE,
+            attemptedEngine: "native",
+            cause: error,
+          });
           logReviewHighlighterDiagnosticError(
             "native engine initialization failed; falling back to javascript",
-            error,
+            nativeInitializationError,
           );
           nativeEngineAvailable = false;
         }
@@ -305,11 +315,30 @@ async function getHighlighter(): Promise<HighlighterCore> {
         REVIEW_HIGHLIGHTER_ENGINE_PREFERENCE,
         nativeEngineAvailable,
       );
-      const highlighter = await createHighlighterCore({
-        themes,
-        langs: REVIEW_INITIAL_LANGUAGE_MODULES,
-        engine: createJavaScriptRegexEngine(),
-      });
+      let highlighter: HighlighterCore;
+      try {
+        highlighter = await createHighlighterCore({
+          themes,
+          langs: REVIEW_INITIAL_LANGUAGE_MODULES,
+          engine: createJavaScriptRegexEngine(),
+        });
+      } catch (cause) {
+        const javascriptError = new ReviewHighlighterEngineInitializationError({
+          preferredEngine: REVIEW_HIGHLIGHTER_ENGINE_PREFERENCE,
+          attemptedEngine: "javascript",
+          cause,
+        });
+        if (!nativeInitializationError) throw javascriptError;
+        throw new ReviewHighlighterEngineInitializationError({
+          preferredEngine: REVIEW_HIGHLIGHTER_ENGINE_PREFERENCE,
+          attemptedEngine: "javascript",
+          cause: new AggregateError(
+            [nativeInitializationError, javascriptError],
+            "Native and JavaScript review highlighter initialization failed.",
+            { cause: nativeInitializationError },
+          ),
+        });
+      }
       logReviewHighlighterDiagnostic("using javascript engine", {
         resolvedEngine: engine,
       });

--- a/apps/mobile/src/features/review/useNativeReviewDiffHighlighting.ts
+++ b/apps/mobile/src/features/review/useNativeReviewDiffHighlighting.ts
@@ -108,7 +108,11 @@ export function useNativeReviewDiffHighlighting(input: {
       } catch (error) {
         if (!abortController.signal.aborted) {
           logReviewDiffDiagnostic("native visible highlight failed", {
-            error: error instanceof Error ? error.message : String(error),
+            error,
+            resetKey,
+            scheme,
+            firstRowIndex: requestRange.firstRowIndex,
+            lastRowIndex: requestRange.lastRowIndex,
           });
         }
       }


### PR DESCRIPTION
## Summary
- replace string-only mobile review highlighter failures with schema errors carrying the attempted/preferred engine, operation, and language context
- preserve exact native and JavaScript initialization causes, including both failures when fallback initialization also fails
- retain error objects in state and diagnostics so stack/cause chains remain available

## Verification
- `vp test apps/mobile/src/features/review/reviewHighlighterState.test.ts apps/mobile/src/features/review/shikiReviewHighlighter.test.ts`
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public shape of `ReviewHighlighterState.error` from strings to tagged errors, which can break callers that assumed string messages; initialization and fallback behavior is more complex but still non-security-critical UI highlighting.
> 
> **Overview**
> Replaces **string-only** highlighter failure handling with **Effect Schema tagged errors** so initialization problems keep engine choice, operation step, language list, and original **cause** chains.
> 
> **Native diff highlighter** (`getNativeReviewDiffHighlighter`) now throws `NativeReviewDiffHighlighterUnavailableError` / `NativeReviewDiffHighlighterInitializationError` instead of generic `Error` messages. Native init failures still fall back to JavaScript, but if both paths fail the thrown error wraps an **`AggregateError`** of both causes. Failed init **clears cached promises** so later calls can retry.
> 
> **Review screen highlighter** mirrors that pattern via `ReviewHighlighterEngineInitializationError` in `shikiReviewHighlighter`, and the atom manager stores **`ReviewHighlighterManagerError`** (operation: prepare / prepare-languages / resolve-engine) rather than `error: string | null` in `ReviewHighlighterState`.
> 
> Diagnostics and the native visible-highlight hook log the **full error object** (plus scroll context) instead of only `.message`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f48bb5db2c4bcf4e4bc957ef465e5b415fa2482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve mobile review highlighter failures as structured errors
> - Adds tagged error classes (`NativeReviewDiffHighlighterUnavailableError`, `NativeReviewDiffHighlighterInitializationError`, `ReviewHighlighterEngineInitializationError`, `ReviewHighlighterManagerError`) to replace generic `Error` throws across the highlighter stack.
> - When both native and JS engine initialization fail, errors are aggregated into a single `AggregateError` wrapped in the structured type so callers get full context.
> - Cached promises (`nativeHighlighterPromise`, `inFlight`) are now reset on failure, allowing reattempts after an error.
> - `ReviewHighlighterState.error` changes from `string | null` to `ReviewHighlighterManagerError | null`.
> - Behavioral Change: any code reading `state.error` as a string will break; diagnostic logs now include the raw error object and additional context fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f48bb5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->