### PR TITLE
[codex] Structure web local API failures

### DIFF
--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -75,20 +75,27 @@ describe("LocalApi", () => {
 
   it("preserves desktop bridge failures when opening external URLs", async () => {
     const cause = new Error("shell rejected request");
+    const url =
+      "https://user:password@example.com/pull/42?access_token=signed-secret-token#private";
     testWindow().desktopBridge = {
       openExternal: vi.fn().mockRejectedValue(cause),
     } as unknown as DesktopBridge;
 
     const { createLocalApi } = await import("./localApi");
-    const promise = createLocalApi().shell.openExternal("https://example.com/pull/42");
+    const promise = createLocalApi().shell.openExternal(url);
 
-    await expect(promise).rejects.toMatchObject({
+    const error = await promise.catch((error: unknown) => error);
+    expect(error).toMatchObject({
       _tag: "LocalExternalUrlOpenError",
-      url: "https://example.com/pull/42",
+      urlHostname: "example.com",
+      urlLength: url.length,
+      urlProtocol: "https:",
       cause,
-      message:
-        "Unable to open external URL https://example.com/pull/42 through the desktop bridge.",
+      message: `Unable to open an external URL for example.com through the desktop bridge (https:, input length ${url.length}).`,
     });
+    expect(error).not.toHaveProperty("url");
+    expect(String(error)).not.toContain("user:password");
+    expect(String(error)).not.toContain("signed-secret-token");
   });
 
   it("uses the browser context-menu fallback without a desktop bridge", async () => {

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -86,7 +86,8 @@ describe("LocalApi", () => {
       _tag: "LocalExternalUrlOpenError",
       url: "https://example.com/pull/42",
       cause,
-      message: "Unable to open external URL https://example.com/pull/42 through the desktop bridge.",
+      message:
+        "Unable to open external URL https://example.com/pull/42 through the desktop bridge.",
     });
   });
 

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -85,9 +85,8 @@ describe("LocalApi", () => {
     await expect(promise).rejects.toMatchObject({
       _tag: "LocalExternalUrlOpenError",
       url: "https://example.com/pull/42",
-      transport: "desktop-bridge",
       cause,
-      message: "Unable to open external URL https://example.com/pull/42 through desktop-bridge.",
+      message: "Unable to open external URL https://example.com/pull/42 through the desktop bridge.",
     });
   });
 

--- a/apps/web/src/localApi.test.ts
+++ b/apps/web/src/localApi.test.ts
@@ -62,15 +62,33 @@ afterEach(() => {
 
 describe("LocalApi", () => {
   it("keeps backend operations unavailable in the browser facade", async () => {
-    const { createLocalApi } = await import("./localApi");
+    const { createLocalApi, LocalBackendUnavailableError } = await import("./localApi");
     const api = createLocalApi();
 
-    await expect(api.server.getConfig()).rejects.toThrow(
-      "Local backend API is unavailable before a backend is paired.",
+    await expect(api.server.getConfig()).rejects.toEqual(
+      new LocalBackendUnavailableError({ operation: "get-config" }),
     );
-    await expect(api.shell.openInEditor("/tmp", "cursor")).rejects.toThrow(
-      "Local backend API is unavailable before a backend is paired.",
+    await expect(api.shell.openInEditor("/tmp", "cursor")).rejects.toEqual(
+      new LocalBackendUnavailableError({ operation: "open-in-editor" }),
     );
+  });
+
+  it("preserves desktop bridge failures when opening external URLs", async () => {
+    const cause = new Error("shell rejected request");
+    testWindow().desktopBridge = {
+      openExternal: vi.fn().mockRejectedValue(cause),
+    } as unknown as DesktopBridge;
+
+    const { createLocalApi } = await import("./localApi");
+    const promise = createLocalApi().shell.openExternal("https://example.com/pull/42");
+
+    await expect(promise).rejects.toMatchObject({
+      _tag: "LocalExternalUrlOpenError",
+      url: "https://example.com/pull/42",
+      transport: "desktop-bridge",
+      cause,
+      message: "Unable to open external URL https://example.com/pull/42 through desktop-bridge.",
+    });
   });
 
   it("uses the browser context-menu fallback without a desktop bridge", async () => {

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -1,4 +1,5 @@
 import type { ContextMenuItem, LocalApi } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 
 import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
 import { showContextMenuFallback } from "./contextMenuFallback";
@@ -6,8 +7,53 @@ import { readBrowserClientSettings, writeBrowserClientSettings } from "./clientP
 
 let cachedApi: LocalApi | undefined;
 
-function unavailableLocalBackendError(): Error {
-  return new Error("Local backend API is unavailable before a backend is paired.");
+export class LocalBackendUnavailableError extends Schema.TaggedErrorClass<LocalBackendUnavailableError>()(
+  "LocalBackendUnavailableError",
+  {
+    operation: Schema.Literals([
+      "open-in-editor",
+      "get-config",
+      "refresh-providers",
+      "update-provider",
+      "upsert-keybinding",
+      "remove-keybinding",
+      "get-settings",
+      "update-settings",
+      "discover-source-control",
+      "get-trace-diagnostics",
+      "get-process-diagnostics",
+      "get-process-resource-history",
+      "signal-process",
+    ]),
+  },
+) {
+  override get message(): string {
+    return `Local backend operation ${this.operation} is unavailable before a backend is paired.`;
+  }
+}
+
+export class LocalExternalUrlOpenError extends Schema.TaggedErrorClass<LocalExternalUrlOpenError>()(
+  "LocalExternalUrlOpenError",
+  {
+    url: Schema.String,
+    transport: Schema.Literal("desktop-bridge"),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Unable to open external URL ${this.url} through ${this.transport}.`;
+  }
+}
+
+export class LocalApiUnavailableError extends Schema.TaggedErrorClass<LocalApiUnavailableError>()(
+  "LocalApiUnavailableError",
+  {
+    runtime: Schema.Literal("server"),
+  },
+) {
+  override get message(): string {
+    return `Local API is unavailable in the ${this.runtime} runtime.`;
+  }
 }
 
 function createBrowserLocalApi(): LocalApi {
@@ -25,12 +71,25 @@ function createBrowserLocalApi(): LocalApi {
       },
     },
     shell: {
-      openInEditor: () => Promise.reject(unavailableLocalBackendError()),
+      openInEditor: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "open-in-editor" })),
       openExternal: async (url) => {
         if (window.desktopBridge) {
-          const opened = await window.desktopBridge.openExternal(url);
+          let opened: boolean;
+          try {
+            opened = await window.desktopBridge.openExternal(url);
+          } catch (cause) {
+            throw new LocalExternalUrlOpenError({
+              url,
+              transport: "desktop-bridge",
+              cause,
+            });
+          }
           if (!opened) {
-            throw new Error("Unable to open link.");
+            throw new LocalExternalUrlOpenError({
+              url,
+              transport: "desktop-bridge",
+            });
           }
           return;
         }
@@ -64,18 +123,32 @@ function createBrowserLocalApi(): LocalApi {
       },
     },
     server: {
-      getConfig: () => Promise.reject(unavailableLocalBackendError()),
-      refreshProviders: () => Promise.reject(unavailableLocalBackendError()),
-      updateProvider: () => Promise.reject(unavailableLocalBackendError()),
-      upsertKeybinding: () => Promise.reject(unavailableLocalBackendError()),
-      removeKeybinding: () => Promise.reject(unavailableLocalBackendError()),
-      getSettings: () => Promise.reject(unavailableLocalBackendError()),
-      updateSettings: () => Promise.reject(unavailableLocalBackendError()),
-      discoverSourceControl: () => Promise.reject(unavailableLocalBackendError()),
-      getTraceDiagnostics: () => Promise.reject(unavailableLocalBackendError()),
-      getProcessDiagnostics: () => Promise.reject(unavailableLocalBackendError()),
-      getProcessResourceHistory: () => Promise.reject(unavailableLocalBackendError()),
-      signalProcess: () => Promise.reject(unavailableLocalBackendError()),
+      getConfig: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "get-config" })),
+      refreshProviders: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "refresh-providers" })),
+      updateProvider: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "update-provider" })),
+      upsertKeybinding: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "upsert-keybinding" })),
+      removeKeybinding: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "remove-keybinding" })),
+      getSettings: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "get-settings" })),
+      updateSettings: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "update-settings" })),
+      discoverSourceControl: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "discover-source-control" })),
+      getTraceDiagnostics: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "get-trace-diagnostics" })),
+      getProcessDiagnostics: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "get-process-diagnostics" })),
+      getProcessResourceHistory: () =>
+        Promise.reject(
+          new LocalBackendUnavailableError({ operation: "get-process-resource-history" }),
+        ),
+      signalProcess: () =>
+        Promise.reject(new LocalBackendUnavailableError({ operation: "signal-process" })),
     },
   };
 }
@@ -100,7 +173,7 @@ export function readLocalApi(): LocalApi | undefined {
 export function ensureLocalApi(): LocalApi {
   const api = readLocalApi();
   if (!api) {
-    throw new Error("Local API not found");
+    throw new LocalApiUnavailableError({ runtime: "server" });
   }
   return api;
 }

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -36,23 +36,20 @@ export class LocalExternalUrlOpenError extends Schema.TaggedErrorClass<LocalExte
   "LocalExternalUrlOpenError",
   {
     url: Schema.String,
-    transport: Schema.Literal("desktop-bridge"),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return `Unable to open external URL ${this.url} through ${this.transport}.`;
+    return `Unable to open external URL ${this.url} through the desktop bridge.`;
   }
 }
 
 export class LocalApiUnavailableError extends Schema.TaggedErrorClass<LocalApiUnavailableError>()(
   "LocalApiUnavailableError",
-  {
-    runtime: Schema.Literal("server"),
-  },
+  {},
 ) {
   override get message(): string {
-    return `Local API is unavailable in the ${this.runtime} runtime.`;
+    return "Local API is unavailable in the server runtime.";
   }
 }
 
@@ -81,14 +78,12 @@ function createBrowserLocalApi(): LocalApi {
           } catch (cause) {
             throw new LocalExternalUrlOpenError({
               url,
-              transport: "desktop-bridge",
               cause,
             });
           }
           if (!opened) {
             throw new LocalExternalUrlOpenError({
               url,
-              transport: "desktop-bridge",
             });
           }
           return;
@@ -173,7 +168,7 @@ export function readLocalApi(): LocalApi | undefined {
 export function ensureLocalApi(): LocalApi {
   const api = readLocalApi();
   if (!api) {
-    throw new LocalApiUnavailableError({ runtime: "server" });
+    throw new LocalApiUnavailableError();
   }
   return api;
 }

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -35,12 +35,14 @@ export class LocalBackendUnavailableError extends Schema.TaggedErrorClass<LocalB
 export class LocalExternalUrlOpenError extends Schema.TaggedErrorClass<LocalExternalUrlOpenError>()(
   "LocalExternalUrlOpenError",
   {
-    url: Schema.String,
+    urlHostname: Schema.NullOr(Schema.String),
+    urlLength: Schema.Number,
+    urlProtocol: Schema.NullOr(Schema.String),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return `Unable to open external URL ${this.url} through the desktop bridge.`;
+    return `Unable to open an external URL for ${this.urlHostname ?? "an unknown host"} through the desktop bridge (${this.urlProtocol ?? "unknown protocol"}, input length ${this.urlLength}).`;
   }
 }
 
@@ -51,6 +53,23 @@ export class LocalApiUnavailableError extends Schema.TaggedErrorClass<LocalApiUn
   override get message(): string {
     return "Local API is unavailable in the server runtime.";
   }
+}
+
+function describeExternalUrl(url: string) {
+  let urlHostname: string | null = null;
+  let urlProtocol: string | null = null;
+  try {
+    const parsed = new URL(url);
+    urlHostname = parsed.hostname || null;
+    urlProtocol = parsed.protocol || null;
+  } catch {
+    // Invalid URLs still retain their nonsecret input length for diagnostics.
+  }
+  return {
+    urlHostname,
+    urlLength: url.length,
+    urlProtocol,
+  };
 }
 
 function createBrowserLocalApi(): LocalApi {
@@ -77,14 +96,12 @@ function createBrowserLocalApi(): LocalApi {
             opened = await window.desktopBridge.openExternal(url);
           } catch (cause) {
             throw new LocalExternalUrlOpenError({
-              url,
+              ...describeExternalUrl(url),
               cause,
             });
           }
           if (!opened) {
-            throw new LocalExternalUrlOpenError({
-              url,
-            });
+            throw new LocalExternalUrlOpenError(describeExternalUrl(url));
           }
           return;
         }

--- a/apps/web/src/localApi.ts
+++ b/apps/web/src/localApi.ts
@@ -1,4 +1,5 @@
 import type { ContextMenuItem, LocalApi } from "@t3tools/contracts";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Schema from "effect/Schema";
 
 import { resetRequestLatencyStateForTests } from "./rpc/requestLatencyState";
@@ -56,19 +57,11 @@ export class LocalApiUnavailableError extends Schema.TaggedErrorClass<LocalApiUn
 }
 
 function describeExternalUrl(url: string) {
-  let urlHostname: string | null = null;
-  let urlProtocol: string | null = null;
-  try {
-    const parsed = new URL(url);
-    urlHostname = parsed.hostname || null;
-    urlProtocol = parsed.protocol || null;
-  } catch {
-    // Invalid URLs still retain their nonsecret input length for diagnostics.
-  }
+  const diagnostics = getUrlDiagnostics(url);
   return {
-    urlHostname,
-    urlLength: url.length,
-    urlProtocol,
+    urlHostname: diagnostics.hostname ?? null,
+    urlLength: diagnostics.inputLength,
+    urlProtocol: diagnostics.protocol ?? null,
   };
 }
 


### PR DESCRIPTION
## Summary

- replace generic local API failures with structured errors keyed by the unavailable operation
- preserve the exact desktop bridge rejection cause for external URL opens
- retain only safe URL diagnostics (hostname, protocol, and input length), excluding credentials, path/query/fragment payloads, and the raw URL
- cover credential and token redaction in the local API tests

## Validation

- `vp test apps/web/src/localApi.test.ts`
- `vp check`
- `vp run typecheck`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic errors with typed error classes in the web local API
> - Introduces three typed error classes in [localApi.ts](https://github.com/pingdotgg/t3code/pull/3338/files#diff-75efdcd889ced82f7f5ce4977d3e67c293986a4024762b6d5c1a5bda4b9452da): `LocalBackendUnavailableError` (with a specific operation name), `LocalExternalUrlOpenError` (with sanitized URL diagnostics), and `LocalApiUnavailableError`.
> - Browser-facade backend operations (e.g. `server.getConfig`, `shell.openInEditor`) now reject with `LocalBackendUnavailableError` instead of a generic `Error`.
> - `shell.openExternal` wraps the desktop bridge call and throws `LocalExternalUrlOpenError` on failure or a `false` return, including hostname, protocol, and URL length while omitting the raw URL.
> - `ensureLocalApi` throws `LocalApiUnavailableError` instead of a generic `Error('Local API not found')`.
> - Behavioral Change: all callers that previously caught a generic `Error` must now handle the new tagged error types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70e9b69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Callers that matched plain `Error` messages or `instanceof Error` for local API failures must handle new tagged types; external URL error paths are security-sensitive but deliberately avoid leaking secrets.
> 
> **Overview**
> Replaces generic `Error` throws in the web **local API** facade with **Effect Schema tagged error classes**: `LocalBackendUnavailableError` (per-operation literal), `LocalExternalUrlOpenError` (safe hostname/protocol/length + optional `cause`), and `LocalApiUnavailableError` from `ensureLocalApi`.
> 
> **`shell.openExternal`** on the desktop bridge now wraps rejections and “not opened” outcomes in `LocalExternalUrlOpenError` using shared **`getUrlDiagnostics`** (`@t3tools/shared/urlDiagnostics`), so errors and messages never carry the raw URL, credentials, or query tokens.
> 
> Adds **`redactDpopRequestTarget`** in shared DPoP utilities (scheme/host/port/path only) with tests; exports **`urlDiagnostics`** from `@t3tools/shared`. Local API tests assert structured backend-unavailable errors and credential/token redaction for external URL failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70e9b69c77a3f108d32e6353818ec195977a3bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->