### PR TITLE
[codex] structure project CLI failures

### DIFF
--- a/apps/server/src/cli/project.test.ts
+++ b/apps/server/src/cli/project.test.ts
@@ -1,0 +1,32 @@
+import { assert, it } from "@effect/vitest";
+
+import { EnvironmentInternalError } from "@t3tools/contracts";
+
+import { ProjectCommandError } from "./project.ts";
+
+it("maps declared server failures into structural project command errors", () => {
+  const cause = new EnvironmentInternalError({
+    code: "internal_error",
+    reason: "orchestration_snapshot_failed",
+    traceId: "trace-123",
+  });
+
+  const error = ProjectCommandError.fromLiveServerRequest(cause);
+
+  assert.strictEqual(error.operation, "callLiveServer");
+  assert.strictEqual(error.code, "internal_error");
+  assert.strictEqual(error.traceId, "trace-123");
+  assert.strictEqual(error.message, "Server request failed (internal_error, trace trace-123).");
+  assert.strictEqual(error.cause, cause);
+});
+
+it("preserves unexpected server failures without deriving the message from them", () => {
+  const cause = new Error("credential abc123 was rejected");
+
+  const error = ProjectCommandError.fromLiveServerRequest(cause);
+
+  assert.strictEqual(error.operation, "callLiveServer");
+  assert.strictEqual(error.detail, "Failed to call the running server.");
+  assert.strictEqual(error.message, "Failed to call the running server.");
+  assert.strictEqual(error.cause, cause);
+});

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -9,11 +9,9 @@ import {
 } from "@t3tools/contracts";
 import * as Console from "effect/Console";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as DateTime from "effect/DateTime";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
-import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -52,16 +50,64 @@ type ProjectCliDispatchCommand = Extract<
   { type: "project.create" | "project.meta.update" | "project.delete" }
 >;
 
-class ProjectCommandError extends Data.TaggedError("ProjectCommandError")<{
-  readonly message: string;
-}> {}
+const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
+const ProjectCommandOperation = Schema.Literals([
+  "generateProjectCommandId",
+  "callLiveServer",
+  "validateProjectTitle",
+  "resolveProjectTarget",
+  "addProject",
+]);
+
+export class ProjectCommandError extends Schema.TaggedErrorClass<ProjectCommandError>()(
+  "ProjectCommandError",
+  {
+    operation: ProjectCommandOperation,
+    detail: Schema.String,
+    code: Schema.optional(Schema.String),
+    traceId: Schema.optional(Schema.String),
+    status: Schema.optional(Schema.Number),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  static fromLiveServerRequest(cause: unknown): ProjectCommandError {
+    if (isEnvironmentHttpCommonError(cause)) {
+      return new ProjectCommandError({
+        operation: "callLiveServer",
+        detail: `Server request failed (${cause.code}, trace ${cause.traceId}).`,
+        code: cause.code,
+        traceId: cause.traceId,
+        cause,
+      });
+    }
+    if (HttpClientError.isHttpClientError(cause) && cause.response !== undefined) {
+      return new ProjectCommandError({
+        operation: "callLiveServer",
+        detail: `Server request failed with undeclared status ${cause.response.status}.`,
+        status: cause.response.status,
+        cause,
+      });
+    }
+    return new ProjectCommandError({
+      operation: "callLiveServer",
+      detail: "Failed to call the running server.",
+      cause,
+    });
+  }
+
+  override get message(): string {
+    return this.detail;
+  }
+}
 
 const projectCommandUuid = Crypto.Crypto.pipe(
   Effect.flatMap((crypto) => crypto.randomUUIDv4),
   Effect.mapError(
-    () =>
+    (cause) =>
       new ProjectCommandError({
-        message: "Failed to generate a project command identifier.",
+        operation: "generateProjectCommandId",
+        detail: "Failed to generate a project command identifier.",
+        cause,
       }),
   ),
 );
@@ -75,7 +121,6 @@ const ProjectCliRuntimeLive = Layer.mergeAll(
 );
 
 const PROJECT_CLI_LIVE_SERVER_TIMEOUT = Duration.seconds(1);
-const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
 const withProjectCliSessionToken = <A, E, R>(
   environmentAuth: EnvironmentAuth.EnvironmentAuth["Service"],
   run: (token: string) => Effect.Effect<A, E, R>,
@@ -91,28 +136,6 @@ const withProjectCliSessionToken = <A, E, R>(
 
 const withProjectCliLiveServerTimeout = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(Effect.timeout(PROJECT_CLI_LIVE_SERVER_TIMEOUT));
-
-const failLiveServerRequest = (cause: unknown) => {
-  if (isEnvironmentHttpCommonError(cause)) {
-    return Effect.fail(
-      new ProjectCommandError({
-        message: `Server request failed (${cause.code}, trace ${cause.traceId}).`,
-      }),
-    );
-  }
-  if (HttpClientError.isHttpClientError(cause) && cause.response !== undefined) {
-    return Effect.fail(
-      new ProjectCommandError({
-        message: `Server request failed with undeclared status ${cause.response.status}.`,
-      }),
-    );
-  }
-  return Effect.fail(
-    new ProjectCommandError({
-      message: `Failed to call running server: ${String(cause)}.`,
-    }),
-  );
-};
 
 const makeLiveServerClient = (origin: string) =>
   HttpApiClient.make(EnvironmentHttpApi, {
@@ -135,7 +158,10 @@ const resolveProjectTitle = Effect.fn("resolveProjectTitle")(function* (
     if (trimmed.length > 0) {
       return trimmed;
     }
-    return yield* new ProjectCommandError({ message: "Project title cannot be empty." });
+    return yield* new ProjectCommandError({
+      operation: "validateProjectTitle",
+      detail: "Project title cannot be empty.",
+    });
   }
 
   const path = yield* Path.Path;
@@ -149,7 +175,10 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
 }) {
   const trimmedIdentifier = input.identifier.trim();
   if (trimmedIdentifier.length === 0) {
-    return yield* new ProjectCommandError({ message: "Project identifier cannot be empty." });
+    return yield* new ProjectCommandError({
+      operation: "resolveProjectTarget",
+      detail: "Project identifier cannot be empty.",
+    });
   }
 
   const activeProjects = input.snapshot.projects.filter((project) => project.deletedAt === null);
@@ -162,12 +191,11 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
     } satisfies ProjectMutationTarget;
   }
 
-  const normalizedWorkspaceRootResult = yield* Effect.exit(
+  const normalizedWorkspaceRootResult = yield* Effect.result(
     normalizeWorkspaceRootForProjectCommand(trimmedIdentifier),
   );
-  const normalizedWorkspaceRoot = Exit.isSuccess(normalizedWorkspaceRootResult)
-    ? normalizedWorkspaceRootResult.value
-    : null;
+  const normalizedWorkspaceRoot =
+    normalizedWorkspaceRootResult._tag === "Success" ? normalizedWorkspaceRootResult.success : null;
 
   const exactWorkspaceMatch =
     normalizedWorkspaceRoot === null
@@ -177,7 +205,11 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
   const resolved = exactWorkspaceMatch;
   if (!resolved) {
     return yield* new ProjectCommandError({
-      message: `No active project found for '${trimmedIdentifier}'.`,
+      operation: "resolveProjectTarget",
+      detail: `No active project found for '${trimmedIdentifier}'.`,
+      ...(normalizedWorkspaceRootResult._tag === "Failure"
+        ? { cause: normalizedWorkspaceRootResult.failure }
+        : {}),
     });
   }
 
@@ -194,7 +226,10 @@ const fetchLiveOrchestrationSnapshot = (origin: string, bearerToken: string) =>
     return yield* client.orchestration.snapshot({
       headers: { authorization: `Bearer ${bearerToken}` },
     });
-  }).pipe(withProjectCliLiveServerTimeout, Effect.catch(failLiveServerRequest));
+  }).pipe(
+    withProjectCliLiveServerTimeout,
+    Effect.mapError(ProjectCommandError.fromLiveServerRequest),
+  );
 
 const dispatchLiveOrchestrationCommand = (
   origin: string,
@@ -207,7 +242,10 @@ const dispatchLiveOrchestrationCommand = (
       headers: { authorization: `Bearer ${bearerToken}` },
       payload: command,
     } as Parameters<typeof client.orchestration.dispatch>[0]);
-  }).pipe(withProjectCliLiveServerTimeout, Effect.catch(failLiveServerRequest));
+  }).pipe(
+    withProjectCliLiveServerTimeout,
+    Effect.mapError(ProjectCommandError.fromLiveServerRequest),
+  );
 
 const getOfflineSnapshot = Effect.fn("getOfflineSnapshot")(function* () {
   const projectionSnapshotQuery = yield* ProjectionSnapshotQuery.ProjectionSnapshotQuery;
@@ -232,11 +270,15 @@ const tryResolveLiveProjectExecutionMode = Effect.fn("tryResolveLiveProjectExecu
       ),
     );
 
-    const attempted = yield* Effect.exit(attempt);
-    if (Exit.isSuccess(attempted)) {
-      return Option.some(attempted.value);
+    const attempted = yield* Effect.result(attempt);
+    if (attempted._tag === "Success") {
+      return Option.some(attempted.success);
     }
 
+    yield* Effect.logDebug("Failed to connect to the persisted project CLI server.", {
+      origin: runtimeState.value.origin,
+      cause: attempted.failure,
+    });
     yield* clearPersistedServerRuntimeState(config.serverRuntimeStatePath);
     return Option.none<{ readonly origin: string }>();
   },
@@ -335,7 +377,8 @@ const projectAddCommand = Command.make("add", {
         );
         if (existingProject) {
           return yield* new ProjectCommandError({
-            message: `An active project already exists for '${workspaceRoot}'.`,
+            operation: "addProject",
+            detail: `An active project already exists for '${workspaceRoot}'.`,
           });
         }
 


### PR DESCRIPTION
## Summary
- replace the message-only project CLI error with a schema error carrying operation and server response context
- move live-server error mapping onto the error class, preserve exact causes, and use `mapError` rather than catch/re-fail wrappers
- retain normalization and live-server fallback failures in the cause chain or debug logs

## Validation
- `vp test apps/server/src/cli/project.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only error shaping and logging; no auth, persistence, or orchestration contract changes beyond safer user-facing messages for unexpected server errors.
> 
> **Overview**
> **Replaces** the project CLI’s message-only `ProjectCommandError` with a **schema-backed** error that records **`operation`**, **`detail`**, and optional server fields (`code`, `traceId`, `status`) plus an optional **`cause`**.
> 
> Live-server failures are centralized in **`ProjectCommandError.fromLiveServerRequest`**, wired via **`Effect.mapError`** instead of catch/re-fail helpers. Declared HTTP errors still surface code/trace in the user message; **unexpected** failures use a fixed generic message while keeping the original error in **`cause`** (avoiding leaking raw error text).
> 
> Other CLI failure paths (validation, target resolution, duplicate project) now tag an **`operation`** and use **`detail`** (exposed as **`message`**). Target resolution uses **`Effect.result`** and can attach normalization failures to **`cause`**; failed live-server probes log at **debug** with the failure before clearing persisted runtime state.
> 
> Adds unit tests for declared vs unexpected server error mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9d80b2dbc0390331d11fb60655bd72e80483c0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure project CLI failures into typed `ProjectCommandError` instances
> - Replaces the `Data.TaggedError`-based `ProjectCommandError` with a `Schema.TaggedErrorClass` carrying structured fields: `operation`, `detail`, optional `code`, `traceId`, `status`, and `cause`.
> - Adds a static `ProjectCommandError.fromLiveServerRequest` factory that normalizes server failures, extracting `code`/`traceId` from `EnvironmentHttpCommonError` and falling back to a generic message for unexpected errors.
> - Updates all error sites in [project.ts](https://github.com/pingdotgg/t3code/pull/3339/files#diff-44f1264ca9e5b2f3994c44291b5616390842fc6345021ca54e8447fd8dbbc1cd) to populate `operation` and `detail` fields; user-facing messages are unchanged.
> - Adds unit tests in [project.test.ts](https://github.com/pingdotgg/t3code/pull/3339/files#diff-c8b0563f4c9826dc9f2934b09f7c9840b6490e8f372536ac01e5985919676817) covering both declared server errors and unexpected failures.
> - Behavioral Change: callers receiving `ProjectCommandError` now get structured fields instead of a plain message string; the `message` getter is derived from `detail`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9d80b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->