### PR TITLE
[codex] Structure relay deploy output errors

### DIFF
--- a/infra/relay/scripts/deploy.test.ts
+++ b/infra/relay/scripts/deploy.test.ts
@@ -11,6 +11,7 @@ import {
   reconcileRootEnvPublicConfig,
   reconcileRootEnvRelayUrl,
   RelayDeployError,
+  RelayDeployPublicConfigUnavailableError,
   serializeGithubOutput,
   serializeRelayClientTracingEnvironment,
 } from "./deploy.ts";
@@ -43,16 +44,15 @@ describe("RelayDeployError", () => {
     );
   });
 
-  it("includes the GitHub environment output path", () => {
-    const error = new RelayDeployError({
-      source: "deploy_outcome",
+  it("distinguishes deploy results that do not produce public config", () => {
+    const error = new RelayDeployPublicConfigUnavailableError({
+      result: "dry-run",
       stage: "production",
       outputPath: "/tmp/relay-client.env",
-      missingFields: ["clientTracingUrl", "clientTracingDataset", "clientTracingToken"],
     });
 
     expect(error.message).toBe(
-      "Relay deploy output from 'deploy_outcome' for stage 'production' at output path '/tmp/relay-client.env' is missing required public config fields: clientTracingUrl, clientTracingDataset, clientTracingToken",
+      "Relay deploy result 'dry-run' for stage 'production' did not produce public config required by GitHub environment output '/tmp/relay-client.env'.",
     );
   });
 });

--- a/infra/relay/scripts/deploy.test.ts
+++ b/infra/relay/scripts/deploy.test.ts
@@ -6,12 +6,56 @@ import * as Path from "effect/Path";
 
 import {
   hasDeployChanges,
+  missingRelayPublicConfigFields,
   publicConfigFromOutput,
   reconcileRootEnvPublicConfig,
   reconcileRootEnvRelayUrl,
+  RelayDeployError,
   serializeGithubOutput,
   serializeRelayClientTracingEnvironment,
 } from "./deploy.ts";
+
+describe("RelayDeployError", () => {
+  it("reports the incomplete state source, stage, and missing fields", () => {
+    const missingFields = missingRelayPublicConfigFields({
+      url: "https://relay.example.test",
+      mobileTracingUrl: "https://api.axiom.co/v1/traces",
+    });
+    const error = new RelayDeployError({
+      source: "alchemy_state",
+      stage: "production",
+      missingFields,
+    });
+
+    expect(error).toMatchObject({
+      source: "alchemy_state",
+      stage: "production",
+      missingFields: [
+        "mobileTracingDataset",
+        "mobileTracingToken",
+        "clientTracingUrl",
+        "clientTracingDataset",
+        "clientTracingToken",
+      ],
+    });
+    expect(error.message).toBe(
+      "Relay deploy output from 'alchemy_state' for stage 'production' is missing required public config fields: mobileTracingDataset, mobileTracingToken, clientTracingUrl, clientTracingDataset, clientTracingToken",
+    );
+  });
+
+  it("includes the GitHub environment output path", () => {
+    const error = new RelayDeployError({
+      source: "deploy_outcome",
+      stage: "production",
+      outputPath: "/tmp/relay-client.env",
+      missingFields: ["clientTracingUrl", "clientTracingDataset", "clientTracingToken"],
+    });
+
+    expect(error.message).toBe(
+      "Relay deploy output from 'deploy_outcome' for stage 'production' at output path '/tmp/relay-client.env' is missing required public config fields: clientTracingUrl, clientTracingDataset, clientTracingToken",
+    );
+  });
+});
 
 describe("hasDeployChanges", () => {
   it("detects resource, binding, and deletion changes", () => {

--- a/infra/relay/scripts/deploy.ts
+++ b/infra/relay/scripts/deploy.ts
@@ -44,18 +44,38 @@ const relayDeployOutputFields = [
 export const RelayDeployOutputField = Schema.Literals(relayDeployOutputFields);
 export type RelayDeployOutputField = typeof RelayDeployOutputField.Type;
 
+export const RelayDeployResult = Schema.Literals([
+  "applied",
+  "noop",
+  "dry-run",
+  "cancelled",
+  "state",
+]);
+export type RelayDeployResult = typeof RelayDeployResult.Type;
+
 export class RelayDeployError extends Schema.TaggedErrorClass<RelayDeployError>()(
   "RelayDeployError",
   {
-    source: Schema.Literals(["deploy_outcome", "alchemy_state", "alchemy_apply"]),
+    source: Schema.Literals(["alchemy_state", "alchemy_apply"]),
     stage: Schema.String,
-    outputPath: Schema.optional(Schema.String),
     missingFields: Schema.Array(RelayDeployOutputField),
   },
 ) {
   override get message(): string {
-    const outputPath = this.outputPath ? ` at output path '${this.outputPath}'` : "";
-    return `Relay deploy output from '${this.source}' for stage '${this.stage}'${outputPath} is missing required public config fields: ${this.missingFields.join(", ")}`;
+    return `Relay deploy output from '${this.source}' for stage '${this.stage}' is missing required public config fields: ${this.missingFields.join(", ")}`;
+  }
+}
+
+export class RelayDeployPublicConfigUnavailableError extends Schema.TaggedErrorClass<RelayDeployPublicConfigUnavailableError>()(
+  "RelayDeployPublicConfigUnavailableError",
+  {
+    result: RelayDeployResult,
+    stage: Schema.String,
+    outputPath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Relay deploy result '${this.result}' for stage '${this.stage}' did not produce public config required by GitHub environment output '${this.outputPath}'.`;
   }
 }
 
@@ -135,8 +155,6 @@ export function hasDeployChanges(plan: Plan.Plan): boolean {
     )
   );
 }
-
-export type RelayDeployResult = "applied" | "noop" | "dry-run" | "cancelled" | "state";
 
 export interface RelayDeployOutcome {
   readonly result: RelayDeployResult;
@@ -226,11 +244,10 @@ const writeGithubEnvFile = Effect.fn("relay.deploy.writeGithubEnvFile")(function
   stage: string,
 ) {
   if (Option.isNone(outcome.publicConfig)) {
-    return yield* new RelayDeployError({
-      source: "deploy_outcome",
+    return yield* new RelayDeployPublicConfigUnavailableError({
+      result: outcome.result,
       stage,
       outputPath,
-      missingFields: ["clientTracingUrl", "clientTracingDataset", "clientTracingToken"],
     });
   }
   const fs = yield* FileSystem.FileSystem;

--- a/infra/relay/scripts/deploy.ts
+++ b/infra/relay/scripts/deploy.ts
@@ -19,21 +19,45 @@ import { PlatformServices } from "alchemy/Util/PlatformServices";
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Console from "effect/Console";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
 import { Command, Flag, Prompt } from "effect/unstable/cli";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 
 import RelayStack from "../alchemy.run.ts";
 
-export class RelayDeployError extends Data.TaggedError("RelayDeployError")<{
-  readonly message: string;
-}> {}
+const relayDeployOutputFields = [
+  "url",
+  "mobileTracingUrl",
+  "mobileTracingDataset",
+  "mobileTracingToken",
+  "clientTracingUrl",
+  "clientTracingDataset",
+  "clientTracingToken",
+] as const;
+
+export const RelayDeployOutputField = Schema.Literals(relayDeployOutputFields);
+export type RelayDeployOutputField = typeof RelayDeployOutputField.Type;
+
+export class RelayDeployError extends Schema.TaggedErrorClass<RelayDeployError>()(
+  "RelayDeployError",
+  {
+    source: Schema.Literals(["deploy_outcome", "alchemy_state", "alchemy_apply"]),
+    stage: Schema.String,
+    outputPath: Schema.optional(Schema.String),
+    missingFields: Schema.Array(RelayDeployOutputField),
+  },
+) {
+  override get message(): string {
+    const outputPath = this.outputPath ? ` at output path '${this.outputPath}'` : "";
+    return `Relay deploy output from '${this.source}' for stage '${this.stage}'${outputPath} is missing required public config fields: ${this.missingFields.join(", ")}`;
+  }
+}
 
 export interface RelayDeployOptions {
   readonly dryRun: boolean;
@@ -199,10 +223,14 @@ const writeGithubOutput = Effect.fn("relay.deploy.writeGithubOutput")(function* 
 const writeGithubEnvFile = Effect.fn("relay.deploy.writeGithubEnvFile")(function* (
   outcome: RelayDeployOutcome,
   outputPath: string,
+  stage: string,
 ) {
   if (Option.isNone(outcome.publicConfig)) {
     return yield* new RelayDeployError({
-      message: "Relay public client config is unavailable for the GitHub environment file",
+      source: "deploy_outcome",
+      stage,
+      outputPath,
+      missingFields: ["clientTracingUrl", "clientTracingDataset", "clientTracingToken"],
     });
   }
   const fs = yield* FileSystem.FileSystem;
@@ -224,44 +252,71 @@ const deployBaseServices = Layer.mergeAll(
 );
 const deployServices = deployBaseServices;
 
-export function publicConfigFromOutput(output: unknown): RelayPublicConfig | null {
+function relayPublicConfigValues(
+  output: unknown,
+): Readonly<Record<RelayDeployOutputField, string | undefined>> {
   if (typeof output !== "object" || output === null) {
-    return null;
+    return {
+      url: undefined,
+      mobileTracingUrl: undefined,
+      mobileTracingDataset: undefined,
+      mobileTracingToken: undefined,
+      clientTracingUrl: undefined,
+      clientTracingDataset: undefined,
+      clientTracingToken: undefined,
+    };
   }
   const value = output as Record<string, unknown>;
-  const text = (name: string) => (typeof value[name] === "string" ? value[name] : undefined);
+  const text = (name: string) => {
+    const candidate = value[name];
+    return typeof candidate === "string" && candidate.length > 0 ? candidate : undefined;
+  };
   const secret = (name: string): string | undefined => {
     const candidate = value[name];
     if (!Redacted.isRedacted(candidate)) {
       return text(name);
     }
     const redacted = Redacted.value(candidate);
-    return typeof redacted === "string" ? redacted : undefined;
+    return typeof redacted === "string" && redacted.length > 0 ? redacted : undefined;
   };
-  const relayUrl = text("url");
-  const mobileTracingUrl = text("mobileTracingUrl");
-  const mobileTracingDataset = text("mobileTracingDataset");
-  const mobileTracingToken = secret("mobileTracingToken");
-  const clientTracingUrl = text("clientTracingUrl");
-  const clientTracingDataset = text("clientTracingDataset");
-  const clientTracingToken = secret("clientTracingToken");
-  return relayUrl &&
-    mobileTracingUrl &&
-    mobileTracingDataset &&
-    mobileTracingToken &&
-    clientTracingUrl &&
-    clientTracingDataset &&
-    clientTracingToken
-    ? {
-        relayUrl,
-        mobileTracingUrl,
-        mobileTracingDataset,
-        mobileTracingToken,
-        clientTracingUrl,
-        clientTracingDataset,
-        clientTracingToken,
-      }
-    : null;
+  return {
+    url: text("url"),
+    mobileTracingUrl: text("mobileTracingUrl"),
+    mobileTracingDataset: text("mobileTracingDataset"),
+    mobileTracingToken: secret("mobileTracingToken"),
+    clientTracingUrl: text("clientTracingUrl"),
+    clientTracingDataset: text("clientTracingDataset"),
+    clientTracingToken: secret("clientTracingToken"),
+  };
+}
+
+export function missingRelayPublicConfigFields(
+  output: unknown,
+): ReadonlyArray<RelayDeployOutputField> {
+  const values = relayPublicConfigValues(output);
+  return relayDeployOutputFields.filter((field) => values[field] === undefined);
+}
+
+function hasCompleteRelayPublicConfigValues(
+  values: Readonly<Record<RelayDeployOutputField, string | undefined>>,
+): values is Readonly<Record<RelayDeployOutputField, string>> {
+  return relayDeployOutputFields.every((field) => values[field] !== undefined);
+}
+
+export function publicConfigFromOutput(output: unknown): RelayPublicConfig | null {
+  const values = relayPublicConfigValues(output);
+  if (!hasCompleteRelayPublicConfigValues(values)) {
+    return null;
+  }
+  return {
+    relayUrl: values.url,
+    mobileTracingUrl: values.mobileTracingUrl,
+    mobileTracingDataset: values.mobileTracingDataset,
+    mobileTracingToken: values.mobileTracingToken,
+    clientTracingUrl: values.clientTracingUrl,
+    clientTracingDataset: values.clientTracingDataset,
+    clientTracingToken: values.clientTracingToken,
+  };
 }
 
 const readRelayPublicConfig = Effect.fn("relay.deploy.readState")(function* (stage: string) {
@@ -271,7 +326,9 @@ const readRelayPublicConfig = Effect.fn("relay.deploy.readState")(function* (sta
   const publicConfig = publicConfigFromOutput(output);
   if (publicConfig === null) {
     return yield* new RelayDeployError({
-      message: `Alchemy relay state for stage ${stage} did not include complete public client config`,
+      source: "alchemy_state",
+      stage,
+      missingFields: missingRelayPublicConfigFields(output),
     });
   }
   return {
@@ -285,7 +342,7 @@ const runRelayDeploy = Effect.fn("relay.deploy.run")(
   function* (
     options: RelayDeployOptions,
     _configProvider: ConfigProvider.ConfigProvider,
-    _stage: string,
+    stage: string,
   ) {
     const stack = yield* RelayStack;
     const cli = yield* Cli;
@@ -318,31 +375,18 @@ const runRelayDeploy = Effect.fn("relay.deploy.run")(
       }
     }
     const output = yield* Apply.apply(plan).pipe(Effect.provide(stack.services));
-    if (
-      output.url === undefined ||
-      output.mobileTracingUrl === undefined ||
-      output.mobileTracingDataset === undefined ||
-      output.mobileTracingToken === undefined ||
-      output.clientTracingUrl === undefined ||
-      output.clientTracingDataset === undefined ||
-      output.clientTracingToken === undefined
-    ) {
+    const publicConfig = publicConfigFromOutput(output);
+    if (publicConfig === null) {
       return yield* new RelayDeployError({
-        message: "Alchemy relay deploy output did not include complete public client config",
+        source: "alchemy_apply",
+        stage,
+        missingFields: missingRelayPublicConfigFields(output),
       });
     }
     return {
       result: changed ? "applied" : "noop",
       changed,
-      publicConfig: Option.some({
-        relayUrl: output.url,
-        mobileTracingUrl: output.mobileTracingUrl,
-        mobileTracingDataset: output.mobileTracingDataset,
-        mobileTracingToken: Redacted.value(output.mobileTracingToken),
-        clientTracingUrl: output.clientTracingUrl,
-        clientTracingDataset: output.clientTracingDataset,
-        clientTracingToken: Redacted.value(output.clientTracingToken),
-      }),
+      publicConfig: Option.some(publicConfig),
     } satisfies RelayDeployOutcome;
   },
   (effect, options, configProvider, stage) =>
@@ -379,7 +423,7 @@ export const deploy = Effect.fn("relay.deploy")(function* (options: RelayDeployO
     yield* writeGithubOutput(outcome);
   }
   if (Option.isSome(options.githubEnvFile)) {
-    yield* writeGithubEnvFile(outcome, options.githubEnvFile.value);
+    yield* writeGithubEnvFile(outcome, options.githubEnvFile.value, stage);
   }
 });
 


### PR DESCRIPTION
## Summary

- replace the message-only deploy error with a Schema error carrying source, stage, output path, and missing fields
- report exact missing Alchemy output fields for state reads and applies
- reuse the parsed deploy output so validation and public config construction cannot drift

## Validation

- `vp test infra/relay/scripts/deploy.test.ts --no-cache`
- `vp check`
- `vp run typecheck`
- `vpr typecheck`

## Overlap audit

- no active service/error-refactor PR overlaps these files; #2925 is an unrelated broad feature branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the relay deploy script’s error types and output validation; behavior on success is unchanged aside from stricter rejection of empty config values.
> 
> **Overview**
> Relay deploy failures now surface **structured errors** instead of generic message strings, so CI and operators can see *where* output broke (Alchemy state vs apply), the **stage**, and **which public config fields** are missing.
> 
> `RelayDeployError` moves from `Data.TaggedError` to **Effect Schema** tagged errors with `source`, `stage`, and `missingFields`, plus a derived message listing missing fields. A separate **`RelayDeployPublicConfigUnavailableError`** covers cases like dry-run or cancel when `--github-env-file` is set but no public config exists (includes `result`, `stage`, `outputPath`).
> 
> Public config parsing is centralized: **`missingRelayPublicConfigFields`**, shared value extraction, and **`publicConfigFromOutput`** now treat **empty strings** as incomplete and reuse the same path for state reads and apply output—replacing duplicated inline field checks after deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0897348af5117f4aa076db6c3312838547c253f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure relay deploy output errors with typed fields and distinct error classes
> - Replaces `Data.TaggedError`-based `RelayDeployError` with a `Schema.TaggedErrorClass` carrying structured `source`, `stage`, and `missingFields` properties, with a deterministic message listing missing public config fields.
> - Adds `RelayDeployPublicConfigUnavailableError`, a new error class thrown by `writeGithubEnvFile` when public config is absent, including `result`, `stage`, and `outputPath` context.
> - Adds `missingRelayPublicConfigFields` and `hasCompleteRelayPublicConfigValues` helpers to validate required deploy output fields; `publicConfigFromOutput` now rejects empty strings and handles `Redacted` values consistently.
> - Propagates `stage` through `writeGithubEnvFile` and `runRelayDeploy` so all error paths include stage context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0897348.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->