### PR TITLE
[codex] Structure mobile thread outbox failures

### DIFF
--- a/apps/mobile/src/state/thread-outbox-manager.ts
+++ b/apps/mobile/src/state/thread-outbox-manager.ts
@@ -1,4 +1,5 @@
-import type { EnvironmentId, MessageId } from "@t3tools/contracts";
+import { EnvironmentId, MessageId, ThreadId } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import { Atom, type AtomRegistry } from "effect/unstable/reactivity";
 
 import {
@@ -7,6 +8,27 @@ import {
   type QueuedThreadMessage,
 } from "./thread-outbox-model";
 import type { ThreadOutboxStorage } from "./thread-outbox-storage";
+
+export class ThreadOutboxManagerError extends Schema.TaggedErrorClass<ThreadOutboxManagerError>()(
+  "ThreadOutboxManagerError",
+  {
+    operation: Schema.Literals([
+      "load",
+      "enqueue",
+      "remove",
+      "clear-environment-load",
+      "clear-environment-remove",
+    ]),
+    environmentId: Schema.NullOr(EnvironmentId),
+    threadId: Schema.NullOr(ThreadId),
+    messageId: Schema.NullOr(MessageId),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Thread outbox operation ${this.operation} failed for environment ${this.environmentId ?? "unknown"}, thread ${this.threadId ?? "unknown"}, message ${this.messageId ?? "unknown"}.`;
+  }
+}
 
 export interface ThreadOutboxManagerOptions {
   readonly registry: AtomRegistry.AtomRegistry;
@@ -49,22 +71,51 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
     loadPromise = serialize(async () => {
       const persistedMessages = await options.storage.load();
       setMessages([...persistedMessages, ...currentMessages()]);
-    }).catch((error) => {
+    }).catch((cause) => {
       loadPromise = null;
-      warn("[thread-outbox] failed to load persisted messages", error);
+      warn(
+        "[thread-outbox] failed to load persisted messages",
+        new ThreadOutboxManagerError({
+          operation: "load",
+          environmentId: null,
+          threadId: null,
+          messageId: null,
+          cause,
+        }),
+      );
     });
     return loadPromise;
   };
 
   const enqueue = (message: QueuedThreadMessage): Promise<void> =>
     serialize(async () => {
-      await options.storage.write(message);
+      try {
+        await options.storage.write(message);
+      } catch (cause) {
+        throw new ThreadOutboxManagerError({
+          operation: "enqueue",
+          environmentId: message.environmentId,
+          threadId: message.threadId,
+          messageId: message.messageId,
+          cause,
+        });
+      }
       setMessages([...currentMessages(), message]);
     });
 
   const remove = (message: QueuedThreadMessage): Promise<void> =>
     serialize(async () => {
-      await options.storage.remove(message);
+      try {
+        await options.storage.remove(message);
+      } catch (cause) {
+        throw new ThreadOutboxManagerError({
+          operation: "remove",
+          environmentId: message.environmentId,
+          threadId: message.threadId,
+          messageId: message.messageId,
+          cause,
+        });
+      }
       setMessages(
         currentMessages().filter((candidate) => candidate.messageId !== message.messageId),
       );
@@ -72,8 +123,17 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
 
   const clearEnvironment = (environmentId: EnvironmentId): Promise<void> =>
     serialize(async () => {
-      const persisted = await options.storage.load().catch((error) => {
-        warn("[thread-outbox] failed to load messages while clearing environment", error);
+      const persisted = await options.storage.load().catch((cause) => {
+        warn(
+          "[thread-outbox] failed to load messages while clearing environment",
+          new ThreadOutboxManagerError({
+            operation: "clear-environment-load",
+            environmentId,
+            threadId: null,
+            messageId: null,
+            cause,
+          }),
+        );
         return [];
       });
       const allMessages = flattenQueuedThreadMessages(
@@ -88,8 +148,17 @@ export function createThreadOutboxManager(options: ThreadOutboxManagerOptions) {
             try {
               await options.storage.remove(message);
               removedMessageIds.add(message.messageId);
-            } catch (error) {
-              warn("[thread-outbox] failed to clear persisted message", error);
+            } catch (cause) {
+              warn(
+                "[thread-outbox] failed to clear persisted message",
+                new ThreadOutboxManagerError({
+                  operation: "clear-environment-remove",
+                  environmentId: message.environmentId,
+                  threadId: message.threadId,
+                  messageId: message.messageId,
+                  cause,
+                }),
+              );
             }
           }),
       );

--- a/apps/mobile/src/state/thread-outbox-storage.ts
+++ b/apps/mobile/src/state/thread-outbox-storage.ts
@@ -1,4 +1,5 @@
-import type { MessageId } from "@t3tools/contracts";
+import { EnvironmentId, MessageId, ThreadId } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 
 import {
   decodeQueuedThreadMessage,
@@ -7,6 +8,22 @@ import {
 } from "./thread-outbox-model";
 
 const THREAD_OUTBOX_DIRECTORY = "thread-outbox";
+
+export class ThreadOutboxStorageError extends Schema.TaggedErrorClass<ThreadOutboxStorageError>()(
+  "ThreadOutboxStorageError",
+  {
+    operation: Schema.Literals(["load", "read-message", "write", "remove"]),
+    environmentId: Schema.NullOr(EnvironmentId),
+    threadId: Schema.NullOr(ThreadId),
+    messageId: Schema.NullOr(MessageId),
+    fileName: Schema.NullOr(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Thread outbox storage operation ${this.operation} failed for environment ${this.environmentId ?? "unknown"}, thread ${this.threadId ?? "unknown"}, message ${this.messageId ?? "unknown"}, file ${this.fileName ?? "unknown"}.`;
+  }
+}
 
 export interface ThreadOutboxStorage {
   readonly load: () => Promise<ReadonlyArray<QueuedThreadMessage>>;
@@ -32,33 +49,78 @@ async function getMessageFile(messageId: MessageId) {
 
 export const expoThreadOutboxStorage: ThreadOutboxStorage = {
   load: async () => {
-    const { File } = await import("expo-file-system");
-    const directory = await getOutboxDirectory();
     const messages: QueuedThreadMessage[] = [];
+    try {
+      const { File } = await import("expo-file-system");
+      const directory = await getOutboxDirectory();
 
-    for (const entry of directory.list()) {
-      if (!(entry instanceof File) || !entry.name.endsWith(".json")) {
-        continue;
+      for (const entry of directory.list()) {
+        if (!(entry instanceof File) || !entry.name.endsWith(".json")) {
+          continue;
+        }
+        try {
+          messages.push(decodeQueuedThreadMessage(JSON.parse(await entry.text()) as unknown));
+        } catch (cause) {
+          console.warn(
+            "[thread-outbox] ignored invalid persisted message",
+            new ThreadOutboxStorageError({
+              operation: "read-message",
+              environmentId: null,
+              threadId: null,
+              messageId: null,
+              fileName: entry.name,
+              cause,
+            }),
+          );
+        }
       }
-      try {
-        messages.push(decodeQueuedThreadMessage(JSON.parse(await entry.text()) as unknown));
-      } catch (error) {
-        console.warn("[thread-outbox] ignored invalid persisted message", entry.name, error);
-      }
+    } catch (cause) {
+      throw new ThreadOutboxStorageError({
+        operation: "load",
+        environmentId: null,
+        threadId: null,
+        messageId: null,
+        fileName: null,
+        cause,
+      });
     }
     return messages;
   },
   write: async (message) => {
-    const file = await getMessageFile(message.messageId);
-    if (!file.exists) {
-      file.create({ intermediates: true, overwrite: true });
+    const fileName = messageFileName(message.messageId);
+    try {
+      const file = await getMessageFile(message.messageId);
+      if (!file.exists) {
+        file.create({ intermediates: true, overwrite: true });
+      }
+      file.write(JSON.stringify(encodeQueuedThreadMessage(message)));
+    } catch (cause) {
+      throw new ThreadOutboxStorageError({
+        operation: "write",
+        environmentId: message.environmentId,
+        threadId: message.threadId,
+        messageId: message.messageId,
+        fileName,
+        cause,
+      });
     }
-    file.write(JSON.stringify(encodeQueuedThreadMessage(message)));
   },
   remove: async (message) => {
-    const file = await getMessageFile(message.messageId);
-    if (file.exists) {
-      file.delete();
+    const fileName = messageFileName(message.messageId);
+    try {
+      const file = await getMessageFile(message.messageId);
+      if (file.exists) {
+        file.delete();
+      }
+    } catch (cause) {
+      throw new ThreadOutboxStorageError({
+        operation: "remove",
+        environmentId: message.environmentId,
+        threadId: message.threadId,
+        messageId: message.messageId,
+        fileName,
+        cause,
+      });
     }
   },
 };

--- a/apps/mobile/src/state/thread-outbox.test.ts
+++ b/apps/mobile/src/state/thread-outbox.test.ts
@@ -10,7 +10,7 @@ import {
   threadOutboxRetryDelayMs,
   type QueuedThreadMessage,
 } from "./thread-outbox-model";
-import { createThreadOutboxManager } from "./thread-outbox-manager";
+import { createThreadOutboxManager, ThreadOutboxManagerError } from "./thread-outbox-manager";
 import type { ThreadOutboxStorage } from "./thread-outbox-storage";
 
 function queuedMessage(input: {
@@ -149,9 +149,48 @@ describe("thread outbox", () => {
     registry.dispose();
   });
 
+  it("reports structured load failures and permits a retry", async () => {
+    const registry = AtomRegistry.make();
+    const loadCause = new Error("storage unavailable");
+    const warnings: Array<{ message: string; error: unknown }> = [];
+    let loadCalls = 0;
+    const manager = createThreadOutboxManager({
+      registry,
+      storage: {
+        load: async () => {
+          loadCalls += 1;
+          if (loadCalls === 1) throw loadCause;
+          return [];
+        },
+        write: async () => undefined,
+        remove: async () => undefined,
+      },
+      warn: (message, error) => warnings.push({ message, error }),
+    });
+
+    await manager.load();
+    expect(warnings).toEqual([
+      {
+        message: "[thread-outbox] failed to load persisted messages",
+        error: new ThreadOutboxManagerError({
+          operation: "load",
+          environmentId: null,
+          threadId: null,
+          messageId: null,
+          cause: loadCause,
+        }),
+      },
+    ]);
+
+    await manager.load();
+    expect(loadCalls).toBe(2);
+    registry.dispose();
+  });
+
   it("keeps atom state aligned with durable writes and removals", async () => {
     const registry = AtomRegistry.make();
     const stored = new Map<MessageId, QueuedThreadMessage>();
+    const removalCause = new Error("remove failed");
     let failRemoval = true;
     const storage: ThreadOutboxStorage = {
       load: async () => [...stored.values()],
@@ -160,7 +199,7 @@ describe("thread outbox", () => {
       },
       remove: async (message) => {
         if (failRemoval) {
-          throw new Error("remove failed");
+          throw removalCause;
         }
         stored.delete(message.messageId);
       },
@@ -176,7 +215,15 @@ describe("thread outbox", () => {
       "environment-1:thread-1": [message],
     });
 
-    await expect(manager.remove(message)).rejects.toThrow("remove failed");
+    await expect(manager.remove(message)).rejects.toEqual(
+      new ThreadOutboxManagerError({
+        operation: "remove",
+        environmentId: message.environmentId,
+        threadId: message.threadId,
+        messageId: message.messageId,
+        cause: removalCause,
+      }),
+    );
     expect(registry.get(manager.queuedMessagesByThreadKeyAtom)).toEqual({
       "environment-1:thread-1": [message],
     });


### PR DESCRIPTION
## Summary
- attach storage operation, file, environment, thread, and message identity to outbox filesystem and decode failures
- preserve exact storage causes when manager operations warn or reject
- retain existing retry, durable-state ordering, and invalid-file recovery behavior

## Verification
- `vp test apps/mobile/src/state/thread-outbox.test.ts`
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Error-shape and logging changes only; durable ordering, retries, and invalid-file recovery behavior are unchanged.
> 
> **Overview**
> Mobile thread outbox **manager** and **Expo filesystem storage** now surface failures through Effect `Schema.TaggedErrorClass` types instead of raw errors.
> 
> **`ThreadOutboxStorageError`** wraps load, per-file read/decode, write, and remove failures with `operation`, optional environment/thread/message IDs, `fileName` where relevant, and the original **`cause`**. Invalid JSON files are still skipped on load, but warnings carry the structured error.
> 
> **`ThreadOutboxManagerError`** does the same for manager operations (`load`, `enqueue`, `remove`, and clear-environment load/remove paths). Load and partial clear failures still **warn** and allow retry; enqueue/remove **reject** with the tagged error while keeping in-memory state unchanged on failed removes.
> 
> Tests assert structured load warnings, retry after failed load, and `remove` rejections matching `ThreadOutboxManagerError` with the underlying cause preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba258ca093ff5c06982ba1c561bd5e60c689c0d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure mobile thread outbox failures with typed error classes
> - Introduces `ThreadOutboxStorageError` and `ThreadOutboxManagerError` as tagged error classes with structured metadata fields (operation, environmentId, threadId, messageId, cause).
> - Storage-layer methods (`load`, `write`, `remove`) in [thread-outbox-storage.ts](https://github.com/pingdotgg/t3code/pull/3341/files#diff-f0e4dbff3b700e09ca49dec390d6c6b2835050368b5f8958d16407c91bfef2a9) now throw `ThreadOutboxStorageError` instead of raw errors.
> - Manager-layer methods in [thread-outbox-manager.ts](https://github.com/pingdotgg/t3code/pull/3341/files#diff-8761ed0ec0414d025a4ec6d247ce9b47563b6c741fc707dbf506e9671fdd3045) wrap storage errors in `ThreadOutboxManagerError` before throwing or passing to warn callbacks.
> - Tests in [thread-outbox.test.ts](https://github.com/pingdotgg/t3code/pull/3341/files#diff-72c27bc8fd8aafae9a96593859117a27e1d454f06dd58bc981343e1243768f79) are updated to assert structured error types on load warnings and remove rejections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba258ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->