### PR TITLE
[codex] Preserve mobile composer input failures

### DIFF
--- a/apps/mobile/src/lib/composerImages.test.ts
+++ b/apps/mobile/src/lib/composerImages.test.ts
@@ -94,7 +94,7 @@ describe("native pasted image cleanup", () => {
   });
 
   it("reports structured context when reading a pasted image fails", async () => {
-    const uri = "file:///private/var/mobile/photos/missing.png";
+    const uri = "file:///private/var/mobile/photos/signed-secret-token/missing.png?token=private";
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
 
     await expect(
@@ -105,11 +105,16 @@ describe("native pasted image cleanup", () => {
       expect.objectContaining({
         _tag: "ComposerImageOperationError",
         operation: "read-pasted-image",
-        uri,
+        uriLength: uri.length,
+        uriProtocol: "file:",
         cause: missingFileCause,
-        message: `Composer image operation read-pasted-image failed for ${uri}.`,
+        message: `Composer image operation read-pasted-image failed for a file: URI (length ${uri.length}).`,
       }),
     );
+    const error = warn.mock.calls[0]?.[1];
+    expect(error).not.toHaveProperty("uri");
+    expect(String(error)).not.toContain("signed-secret-token");
+    expect(String(error)).not.toContain("token=private");
 
     warn.mockRestore();
   });

--- a/apps/mobile/src/lib/composerImages.test.ts
+++ b/apps/mobile/src/lib/composerImages.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { PROVIDER_SEND_TURN_MAX_ATTACHMENTS } from "@t3tools/contracts";
 
+const missingFileCause = new Error("missing file");
 const files = new Map<string, { base64: string; deleted: boolean }>();
 
 vi.mock("expo-file-system", () => ({
@@ -18,7 +19,7 @@ vi.mock("expo-file-system", () => ({
     async base64(): Promise<string> {
       const entry = files.get(this.uri);
       if (!entry || entry.deleted) {
-        throw new Error("missing file");
+        throw missingFileCause;
       }
       return entry.base64;
     }
@@ -90,5 +91,26 @@ describe("native pasted image cleanup", () => {
     expect(files.get(rejected)?.deleted).toBe(true);
     expect(files.get(overflow)?.deleted).toBe(true);
     expect(files.get(userOwned)?.deleted).toBe(false);
+  });
+
+  it("reports structured context when reading a pasted image fails", async () => {
+    const uri = "file:///private/var/mobile/photos/missing.png";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(
+      convertPastedImagesToAttachments({ uris: [uri], existingCount: 0 }),
+    ).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      "[composer-images] failed to read pasted image",
+      expect.objectContaining({
+        _tag: "ComposerImageOperationError",
+        operation: "read-pasted-image",
+        uri,
+        cause: missingFileCause,
+        message: `Composer image operation read-pasted-image failed for ${uri}.`,
+      }),
+    );
+
+    warn.mockRestore();
   });
 });

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -3,6 +3,7 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
   type UploadChatImageAttachment,
 } from "@t3tools/contracts";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Schema from "effect/Schema";
 import { uuidv4 } from "./uuid";
 
@@ -298,15 +299,10 @@ export function isOwnedPastedImageUri(uri: string): boolean {
 }
 
 function describeComposerImageUri(uri: string) {
-  let uriProtocol: string | undefined;
-  try {
-    uriProtocol = new URL(uri).protocol || undefined;
-  } catch {
-    // Malformed URIs still retain a nonsecret input length for diagnostics.
-  }
+  const diagnostics = getUrlDiagnostics(uri);
   return {
-    uriLength: uri.length,
-    ...(uriProtocol === undefined ? {} : { uriProtocol }),
+    uriLength: diagnostics.inputLength,
+    ...(diagnostics.protocol === undefined ? {} : { uriProtocol: diagnostics.protocol }),
   };
 }
 

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -28,12 +28,13 @@ export class ComposerImageOperationError extends Schema.TaggedErrorClass<Compose
       "read-pasted-image",
       "remove-pasted-image",
     ]),
-    uri: Schema.NullOr(Schema.String),
+    uriLength: Schema.optional(Schema.Number),
+    uriProtocol: Schema.optional(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Composer image operation ${this.operation} failed${this.uri === null ? "" : ` for ${this.uri}`}.`;
+    return `Composer image operation ${this.operation} failed${this.uriLength === undefined ? "" : ` for a ${this.uriProtocol ?? "unknown-protocol"} URI (length ${this.uriLength})`}.`;
   }
 }
 
@@ -48,7 +49,6 @@ async function loadImagePicker() {
   } catch (cause) {
     throw new ComposerImageOperationError({
       operation: "load-image-picker",
-      uri: null,
       cause,
     });
   }
@@ -60,7 +60,6 @@ async function loadClipboard() {
   } catch (cause) {
     throw new ComposerImageOperationError({
       operation: "load-clipboard",
-      uri: null,
       cause,
     });
   }
@@ -92,7 +91,6 @@ export async function pickComposerImages(input: { readonly existingCount: number
   const permission = await imagePicker.requestMediaLibraryPermissionsAsync().catch((cause) => {
     throw new ComposerImageOperationError({
       operation: "request-media-library-permission",
-      uri: null,
       cause,
     });
   });
@@ -114,7 +112,6 @@ export async function pickComposerImages(input: { readonly existingCount: number
     .catch((cause) => {
       throw new ComposerImageOperationError({
         operation: "launch-image-library",
-        uri: null,
         cause,
       });
     });
@@ -187,7 +184,6 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
   const hasImage = await clipboard.hasImageAsync().catch((cause) => {
     throw new ComposerImageOperationError({
       operation: "check-clipboard-image",
-      uri: null,
       cause,
     });
   });
@@ -202,7 +198,6 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
     const image = await clipboard.getImageAsync({ format: "png" }).catch((cause) => {
       throw new ComposerImageOperationError({
         operation: "read-clipboard-image",
-        uri: null,
         cause,
       });
     });
@@ -244,7 +239,6 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
   const hasText = await clipboard.hasStringAsync().catch((cause) => {
     throw new ComposerImageOperationError({
       operation: "check-clipboard-text",
-      uri: null,
       cause,
     });
   });
@@ -252,7 +246,6 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
     const text = await clipboard.getStringAsync().catch((cause) => {
       throw new ComposerImageOperationError({
         operation: "read-clipboard-text",
-        uri: null,
         cause,
       });
     });
@@ -304,6 +297,19 @@ export function isOwnedPastedImageUri(uri: string): boolean {
   }
 }
 
+function describeComposerImageUri(uri: string) {
+  let uriProtocol: string | undefined;
+  try {
+    uriProtocol = new URL(uri).protocol || undefined;
+  } catch {
+    // Malformed URIs still retain a nonsecret input length for diagnostics.
+  }
+  return {
+    uriLength: uri.length,
+    ...(uriProtocol === undefined ? {} : { uriProtocol }),
+  };
+}
+
 export async function convertPastedImagesToAttachments(input: {
   readonly uris: ReadonlyArray<string>;
   readonly existingCount: number;
@@ -339,7 +345,7 @@ export async function convertPastedImagesToAttachments(input: {
         "[composer-images] failed to read pasted image",
         new ComposerImageOperationError({
           operation: "read-pasted-image",
-          uri,
+          ...describeComposerImageUri(uri),
           cause,
         }),
       );
@@ -355,7 +361,7 @@ export async function convertPastedImagesToAttachments(input: {
             "[composer-images] failed to remove temporary pasted image",
             new ComposerImageOperationError({
               operation: "remove-pasted-image",
-              uri,
+              ...describeComposerImageUri(uri),
               cause,
             }),
           );

--- a/apps/mobile/src/lib/composerImages.ts
+++ b/apps/mobile/src/lib/composerImages.ts
@@ -3,6 +3,7 @@ import {
   PROVIDER_SEND_TURN_MAX_IMAGE_BYTES,
   type UploadChatImageAttachment,
 } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import { uuidv4 } from "./uuid";
 
 export interface DraftComposerImageAttachment extends UploadChatImageAttachment {
@@ -12,6 +13,30 @@ export interface DraftComposerImageAttachment extends UploadChatImageAttachment 
 
 const OWNED_PASTED_IMAGE_DIRECTORY = "t3-composer-paste";
 
+export class ComposerImageOperationError extends Schema.TaggedErrorClass<ComposerImageOperationError>()(
+  "ComposerImageOperationError",
+  {
+    operation: Schema.Literals([
+      "load-image-picker",
+      "request-media-library-permission",
+      "launch-image-library",
+      "load-clipboard",
+      "check-clipboard-image",
+      "read-clipboard-image",
+      "check-clipboard-text",
+      "read-clipboard-text",
+      "read-pasted-image",
+      "remove-pasted-image",
+    ]),
+    uri: Schema.NullOr(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Composer image operation ${this.operation} failed${this.uri === null ? "" : ` for ${this.uri}`}.`;
+  }
+}
+
 function estimateBase64ByteSize(base64: string): number {
   const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
   return Math.floor((base64.length * 3) / 4) - padding;
@@ -20,16 +45,24 @@ function estimateBase64ByteSize(base64: string): number {
 async function loadImagePicker() {
   try {
     return await import("expo-image-picker");
-  } catch (error) {
-    throw new Error("Image attachments are unavailable right now.", { cause: error });
+  } catch (cause) {
+    throw new ComposerImageOperationError({
+      operation: "load-image-picker",
+      uri: null,
+      cause,
+    });
   }
 }
 
 async function loadClipboard() {
   try {
     return await import("expo-clipboard");
-  } catch (error) {
-    throw new Error("Clipboard paste is unavailable right now.", { cause: error });
+  } catch (cause) {
+    throw new ComposerImageOperationError({
+      operation: "load-clipboard",
+      uri: null,
+      cause,
+    });
   }
 }
 
@@ -49,14 +82,20 @@ export async function pickComposerImages(input: { readonly existingCount: number
   try {
     imagePicker = await loadImagePicker();
   } catch (error) {
+    console.warn("[composer-images] image picker unavailable", error);
     return {
       images: [],
-      error:
-        error instanceof Error ? error.message : "Image attachments are unavailable right now.",
+      error: "Image attachments are unavailable right now.",
     };
   }
 
-  const permission = await imagePicker.requestMediaLibraryPermissionsAsync();
+  const permission = await imagePicker.requestMediaLibraryPermissionsAsync().catch((cause) => {
+    throw new ComposerImageOperationError({
+      operation: "request-media-library-permission",
+      uri: null,
+      cause,
+    });
+  });
   if (!permission.granted) {
     return {
       images: [],
@@ -64,13 +103,21 @@ export async function pickComposerImages(input: { readonly existingCount: number
     };
   }
 
-  const result = await imagePicker.launchImageLibraryAsync({
-    mediaTypes: ["images"],
-    allowsMultipleSelection: true,
-    selectionLimit: remainingSlots,
-    base64: true,
-    quality: 1,
-  });
+  const result = await imagePicker
+    .launchImageLibraryAsync({
+      mediaTypes: ["images"],
+      allowsMultipleSelection: true,
+      selectionLimit: remainingSlots,
+      base64: true,
+      quality: 1,
+    })
+    .catch((cause) => {
+      throw new ComposerImageOperationError({
+        operation: "launch-image-library",
+        uri: null,
+        cause,
+      });
+    });
 
   if (result.canceled) {
     return {
@@ -127,16 +174,24 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
   try {
     clipboard = await loadClipboard();
   } catch (error) {
+    console.warn("[composer-images] clipboard unavailable", error);
     return {
       images: [],
       text: null,
-      error: error instanceof Error ? error.message : "Clipboard paste is unavailable right now.",
+      error: "Clipboard paste is unavailable right now.",
     };
   }
 
   const remainingSlots = PROVIDER_SEND_TURN_MAX_ATTACHMENTS - input.existingCount;
 
-  if (await clipboard.hasImageAsync()) {
+  const hasImage = await clipboard.hasImageAsync().catch((cause) => {
+    throw new ComposerImageOperationError({
+      operation: "check-clipboard-image",
+      uri: null,
+      cause,
+    });
+  });
+  if (hasImage) {
     if (remainingSlots <= 0) {
       return {
         images: [],
@@ -144,7 +199,13 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
         error: `You can attach up to ${PROVIDER_SEND_TURN_MAX_ATTACHMENTS} images per message.`,
       };
     }
-    const image = await clipboard.getImageAsync({ format: "png" });
+    const image = await clipboard.getImageAsync({ format: "png" }).catch((cause) => {
+      throw new ComposerImageOperationError({
+        operation: "read-clipboard-image",
+        uri: null,
+        cause,
+      });
+    });
     if (!image) {
       return {
         images: [],
@@ -180,8 +241,21 @@ export async function pasteComposerClipboard(input: { readonly existingCount: nu
     };
   }
 
-  if (await clipboard.hasStringAsync()) {
-    const text = await clipboard.getStringAsync();
+  const hasText = await clipboard.hasStringAsync().catch((cause) => {
+    throw new ComposerImageOperationError({
+      operation: "check-clipboard-text",
+      uri: null,
+      cause,
+    });
+  });
+  if (hasText) {
+    const text = await clipboard.getStringAsync().catch((cause) => {
+      throw new ComposerImageOperationError({
+        operation: "read-clipboard-text",
+        uri: null,
+        cause,
+      });
+    });
     return {
       images: [],
       text: text.length > 0 ? text : null,
@@ -260,8 +334,15 @@ export async function convertPastedImagesToAttachments(input: {
         dataUrl: `data:${mimeType};base64,${base64}`,
         previewUri: ownedTemporaryFile ? `data:${mimeType};base64,${base64}` : uri,
       });
-    } catch (error) {
-      console.warn("Failed to read pasted image", uri, error);
+    } catch (cause) {
+      console.warn(
+        "[composer-images] failed to read pasted image",
+        new ComposerImageOperationError({
+          operation: "read-pasted-image",
+          uri,
+          cause,
+        }),
+      );
     } finally {
       if (ownedTemporaryFile) {
         try {
@@ -269,8 +350,15 @@ export async function convertPastedImagesToAttachments(input: {
           if (file.exists) {
             file.delete();
           }
-        } catch (error) {
-          console.warn("Failed to remove temporary pasted image", uri, error);
+        } catch (cause) {
+          console.warn(
+            "[composer-images] failed to remove temporary pasted image",
+            new ComposerImageOperationError({
+              operation: "remove-pasted-image",
+              uri,
+              cause,
+            }),
+          );
         }
       }
     }


### PR DESCRIPTION
## Summary

- replace image-picker, clipboard, and pasted-file failures with a structured operation error
- preserve the exact upstream cause while retaining only URI protocol and input length for pasted-image diagnostics
- keep existing friendly fallback messages, per-file recovery, and temporary-file cleanup behavior
- cover file-path and query-token redaction in structured warning payloads

## Stack dependency

- Based on #3403 for `@t3tools/shared/urlDiagnostics`.

## Validation

- `vp test run apps/mobile/src/lib/composerImages.test.ts` (4 tests)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and error-shaping only; user-visible success/fallback behavior is largely unchanged aside from fixed messages on picker/clipboard load failure instead of upstream `error.message`.
> 
> **Overview**
> Mobile composer image flows now use a **`ComposerImageOperationError`** tagged error (operation, optional URI length/protocol, preserved `cause`) instead of generic errors or logging raw pasted-image URIs.
> 
> **Image picker, clipboard, and pasted-file paths** wrap dynamic imports and async steps in this error type; load failures still return the same user-facing fallback strings but **`console.warn`** with structured payloads. Pasted-image diagnostics use **`getUrlDiagnostics`** (new `@t3tools/shared/urlDiagnostics` export) so logs keep protocol and length only—paths and query tokens stay out of warnings.
> 
> **Shared** also adds **`redactDpopRequestTarget`** for safe DPoP URL logging (scheme/host/port/path, no credentials/query/fragment), with tests; it is not wired into composer code in this PR.
> 
> A new test asserts read failures emit structured warnings without sensitive URI fragments in the error object or string form.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f2c8459cff18da10f9455aec9a8aed614d1be90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve structured error context for mobile composer image input failures
> - Adds `ComposerImageOperationError`, a tagged error class in [`composerImages.ts`](https://github.com/pingdotgg/t3code/pull/3343/files#diff-8723c2d87dbdbb196075db6f79088889d3a7f72c0b472d71bc669adc4b533e51) with fields for operation name, URI length, and URI protocol — without exposing the raw URI.
> - Replaces generic `Error` throws and raw URI logging in `pickComposerImages`, `pasteComposerClipboard`, and `convertPastedImagesToAttachments` with structured `ComposerImageOperationError` instances.
> - Adds a `describeComposerImageUri` helper to extract safe URI diagnostics (length and protocol) for use in error construction.
> - Adds a test verifying that pasted image read failures log a structured error and do not leak sensitive URI tokens.
> - Behavioral Change: import failures for the image picker and clipboard now log a warning and return a generic user-facing error string instead of propagating the raw error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3f2c845.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->