### PR TITLE
[codex] Structure relay device persistence errors

### DIFF
--- a/infra/relay/src/agentActivity/Devices.test.ts
+++ b/infra/relay/src/agentActivity/Devices.test.ts
@@ -223,4 +223,82 @@ describe("Devices", () => {
       Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
     );
   });
+
+  it.effect("identifies the failed device registration stage", () => {
+    const cause = new Error("push-token claim failed");
+    const fakeDb = {
+      update: () => ({
+        set: (values: Record<string, unknown>) => ({
+          where: () => ("pushToken" in values ? Effect.fail(cause) : Effect.void),
+        }),
+      }),
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const devices = yield* Devices.Devices;
+      const error = yield* devices.register({ userId: "user-2", registration }).pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        userId: "user-2",
+        deviceId: "device-1",
+        stage: "claim-push-token",
+      });
+      expect(error.cause).toBe(cause);
+      expect(error.message).toBe(
+        "Failed to persist mobile device registration for user-2/device-1 during claim-push-token.",
+      );
+    }).pipe(
+      Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
+    );
+  });
+
+  it.effect("identifies the failed device unregistration stage", () => {
+    const cause = new Error("live activity delete failed");
+    const fakeDb = {
+      delete: (table: unknown) => ({
+        where: () => (table === relayLiveActivities ? Effect.fail(cause) : Effect.void),
+      }),
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const devices = yield* Devices.Devices;
+      const error = yield* devices
+        .unregister({ userId: "user-2", deviceId: "device-1" })
+        .pipe(Effect.flip);
+
+      expect(error).toMatchObject({
+        userId: "user-2",
+        deviceId: "device-1",
+        stage: "delete-live-activity",
+      });
+      expect(error.cause).toBe(cause);
+      expect(error.message).toBe(
+        "Failed to unregister mobile device user-2/device-1 during delete-live-activity.",
+      );
+    }).pipe(
+      Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
+    );
+  });
+
+  it.effect("attaches the user to device list failures", () => {
+    const cause = new Error("device list failed");
+    const fakeDb = {
+      select: () => ({
+        from: () => ({
+          where: () => Effect.fail(cause),
+        }),
+      }),
+    } as unknown as RelayDb.RelayDb["Service"];
+
+    return Effect.gen(function* () {
+      const devices = yield* Devices.Devices;
+      const error = yield* devices.listForUser({ userId: "user-2" }).pipe(Effect.flip);
+
+      expect(error).toMatchObject({ userId: "user-2" });
+      expect(error.cause).toBe(cause);
+      expect(error.message).toBe("Failed to list mobile devices for user-2.");
+    }).pipe(
+      Effect.provide(Devices.layer.pipe(Layer.provide(Layer.succeed(RelayDb.RelayDb, fakeDb)))),
+    );
+  });
 });

--- a/infra/relay/src/agentActivity/Devices.ts
+++ b/infra/relay/src/agentActivity/Devices.ts
@@ -15,28 +15,41 @@ import { relayLiveActivities, relayMobileDevices } from "../persistence/schema.t
 
 export class DeviceRegistrationPersistenceError extends Schema.TaggedErrorClass<DeviceRegistrationPersistenceError>()(
   "DeviceRegistrationPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    userId: Schema.String,
+    deviceId: Schema.String,
+    stage: Schema.Literals(["claim-push-token", "claim-push-to-start-token", "upsert-device"]),
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to persist mobile device registration";
+    return `Failed to persist mobile device registration for ${this.userId}/${this.deviceId} during ${this.stage}.`;
   }
 }
 
 export class DeviceUnregistrationPersistenceError extends Schema.TaggedErrorClass<DeviceUnregistrationPersistenceError>()(
   "DeviceUnregistrationPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    userId: Schema.String,
+    deviceId: Schema.String,
+    stage: Schema.Literals(["delete-live-activity", "delete-device"]),
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to unregister mobile device";
+    return `Failed to unregister mobile device ${this.userId}/${this.deviceId} during ${this.stage}.`;
   }
 }
 
 export class DeviceListPersistenceError extends Schema.TaggedErrorClass<DeviceListPersistenceError>()(
   "DeviceListPersistenceError",
-  { cause: Schema.Defect() },
+  {
+    userId: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to list mobile devices";
+    return `Failed to list mobile devices for ${this.userId}.`;
   }
 }
 
@@ -61,130 +74,181 @@ export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
 
   return Devices.of({
-    register: Effect.fn("relay.devices.register")(
-      function* (input) {
-        yield* Effect.annotateCurrentSpan({
-          "relay.mobile.device_id": input.registration.deviceId,
-        });
-        const updatedAt = DateTime.formatIso(yield* DateTime.now);
-        const registration = input.registration;
+    register: Effect.fn("relay.devices.register")(function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "relay.mobile.device_id": input.registration.deviceId,
+      });
+      const updatedAt = DateTime.formatIso(yield* DateTime.now);
+      const registration = input.registration;
 
-        yield* Effect.all(
-          [
-            registration.pushToken
-              ? db
-                  .update(relayMobileDevices)
-                  .set({ pushToken: null, updatedAt })
-                  .where(eq(relayMobileDevices.pushToken, registration.pushToken))
-              : Effect.void,
-            registration.pushToStartToken
-              ? db
-                  .update(relayMobileDevices)
-                  .set({ pushToStartToken: null, updatedAt })
-                  .where(eq(relayMobileDevices.pushToStartToken, registration.pushToStartToken))
-              : Effect.void,
-          ],
-          { concurrency: 2, discard: true },
-        );
+      yield* Effect.all(
+        [
+          registration.pushToken
+            ? db
+                .update(relayMobileDevices)
+                .set({ pushToken: null, updatedAt })
+                .where(eq(relayMobileDevices.pushToken, registration.pushToken))
+                .pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new DeviceRegistrationPersistenceError({
+                        userId: input.userId,
+                        deviceId: registration.deviceId,
+                        stage: "claim-push-token",
+                        cause,
+                      }),
+                  ),
+                )
+            : Effect.void,
+          registration.pushToStartToken
+            ? db
+                .update(relayMobileDevices)
+                .set({ pushToStartToken: null, updatedAt })
+                .where(eq(relayMobileDevices.pushToStartToken, registration.pushToStartToken))
+                .pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new DeviceRegistrationPersistenceError({
+                        userId: input.userId,
+                        deviceId: registration.deviceId,
+                        stage: "claim-push-to-start-token",
+                        cause,
+                      }),
+                  ),
+                )
+            : Effect.void,
+        ],
+        { concurrency: 2, discard: true },
+      );
 
-        yield* db
-          .insert(relayMobileDevices)
-          .values({
-            userId: input.userId,
-            deviceId: registration.deviceId,
-            label: registration.label,
+      yield* db
+        .insert(relayMobileDevices)
+        .values({
+          userId: input.userId,
+          deviceId: registration.deviceId,
+          label: registration.label,
+          platform: registration.platform,
+          iosMajorVersion: registration.iosMajorVersion,
+          appVersion: registration.appVersion ?? null,
+          pushToken: registration.pushToken ?? null,
+          pushToStartToken: registration.pushToStartToken ?? null,
+          preferencesJson: registration.preferences,
+          createdAt: updatedAt,
+          updatedAt,
+        })
+        .onConflictDoUpdate({
+          target: [relayMobileDevices.userId, relayMobileDevices.deviceId],
+          set: {
             platform: registration.platform,
+            label: registration.label,
             iosMajorVersion: registration.iosMajorVersion,
             appVersion: registration.appVersion ?? null,
-            pushToken: registration.pushToken ?? null,
-            pushToStartToken: registration.pushToStartToken ?? null,
-            preferencesJson: registration.preferences,
-            createdAt: updatedAt,
-            updatedAt,
-          })
-          .onConflictDoUpdate({
-            target: [relayMobileDevices.userId, relayMobileDevices.deviceId],
-            set: {
-              platform: registration.platform,
-              label: registration.label,
-              iosMajorVersion: registration.iosMajorVersion,
-              appVersion: registration.appVersion ?? null,
-              pushToken: sql`coalesce(excluded.push_token, ${relayMobileDevices.pushToken})`,
-              pushToStartToken: sql`coalesce(
+            pushToken: sql`coalesce(excluded.push_token, ${relayMobileDevices.pushToken})`,
+            pushToStartToken: sql`coalesce(
                 excluded.push_to_start_token,
                 ${relayMobileDevices.pushToStartToken}
               )`,
-              preferencesJson: registration.preferences,
-              updatedAt,
-            },
-          });
-      },
-      Effect.mapError((cause) => new DeviceRegistrationPersistenceError({ cause })),
-    ),
-    unregister: Effect.fn("relay.devices.unregister")(
-      function* (input) {
-        yield* Effect.annotateCurrentSpan({
-          "relay.mobile.device_id": input.deviceId,
-        });
-        yield* Effect.all(
-          [
-            db
-              .delete(relayLiveActivities)
-              .where(
-                and(
-                  eq(relayLiveActivities.userId, input.userId),
-                  eq(relayLiveActivities.deviceId, input.deviceId),
-                ),
-              ),
-            db
-              .delete(relayMobileDevices)
-              .where(
-                and(
-                  eq(relayMobileDevices.userId, input.userId),
-                  eq(relayMobileDevices.deviceId, input.deviceId),
-                ),
-              ),
-          ],
-          { concurrency: 2, discard: true },
+            preferencesJson: registration.preferences,
+            updatedAt,
+          },
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new DeviceRegistrationPersistenceError({
+                userId: input.userId,
+                deviceId: registration.deviceId,
+                stage: "upsert-device",
+                cause,
+              }),
+          ),
         );
-      },
-      Effect.mapError((cause) => new DeviceUnregistrationPersistenceError({ cause })),
-    ),
-    listForUser: Effect.fn("relay.devices.listForUser")(
-      function* (input) {
-        const rows = yield* db
-          .select({
-            deviceId: relayMobileDevices.deviceId,
-            label: relayMobileDevices.label,
-            platform: relayMobileDevices.platform,
-            iosMajorVersion: relayMobileDevices.iosMajorVersion,
-            appVersion: relayMobileDevices.appVersion,
-            preferences: relayMobileDevices.preferencesJson,
-            updatedAt: relayMobileDevices.updatedAt,
-          })
-          .from(relayMobileDevices)
-          .where(eq(relayMobileDevices.userId, input.userId));
-        return rows.map((row) => ({
-          deviceId: row.deviceId,
-          label: row.label,
-          platform: row.platform,
-          iosMajorVersion: row.iosMajorVersion,
-          appVersion: row.appVersion,
-          notifications: {
-            enabled: row.preferences.notificationsEnabled,
-            notifyOnApproval: row.preferences.notifyOnApproval,
-            notifyOnInput: row.preferences.notifyOnInput,
-            notifyOnCompletion: row.preferences.notifyOnCompletion,
-            notifyOnFailure: row.preferences.notifyOnFailure,
-          },
-          liveActivities: {
-            enabled: row.preferences.liveActivitiesEnabled,
-          },
-          updatedAt: row.updatedAt,
-        }));
-      },
-      Effect.mapError((cause) => new DeviceListPersistenceError({ cause })),
-    ),
+    }),
+    unregister: Effect.fn("relay.devices.unregister")(function* (input) {
+      yield* Effect.annotateCurrentSpan({
+        "relay.mobile.device_id": input.deviceId,
+      });
+      yield* Effect.all(
+        [
+          db
+            .delete(relayLiveActivities)
+            .where(
+              and(
+                eq(relayLiveActivities.userId, input.userId),
+                eq(relayLiveActivities.deviceId, input.deviceId),
+              ),
+            )
+            .pipe(
+              Effect.mapError(
+                (cause) =>
+                  new DeviceUnregistrationPersistenceError({
+                    userId: input.userId,
+                    deviceId: input.deviceId,
+                    stage: "delete-live-activity",
+                    cause,
+                  }),
+              ),
+            ),
+          db
+            .delete(relayMobileDevices)
+            .where(
+              and(
+                eq(relayMobileDevices.userId, input.userId),
+                eq(relayMobileDevices.deviceId, input.deviceId),
+              ),
+            )
+            .pipe(
+              Effect.mapError(
+                (cause) =>
+                  new DeviceUnregistrationPersistenceError({
+                    userId: input.userId,
+                    deviceId: input.deviceId,
+                    stage: "delete-device",
+                    cause,
+                  }),
+              ),
+            ),
+        ],
+        { concurrency: 2, discard: true },
+      );
+    }),
+    listForUser: Effect.fn("relay.devices.listForUser")(function* (input) {
+      const rows = yield* db
+        .select({
+          deviceId: relayMobileDevices.deviceId,
+          label: relayMobileDevices.label,
+          platform: relayMobileDevices.platform,
+          iosMajorVersion: relayMobileDevices.iosMajorVersion,
+          appVersion: relayMobileDevices.appVersion,
+          preferences: relayMobileDevices.preferencesJson,
+          updatedAt: relayMobileDevices.updatedAt,
+        })
+        .from(relayMobileDevices)
+        .where(eq(relayMobileDevices.userId, input.userId))
+        .pipe(
+          Effect.mapError(
+            (cause) => new DeviceListPersistenceError({ userId: input.userId, cause }),
+          ),
+        );
+      return rows.map((row) => ({
+        deviceId: row.deviceId,
+        label: row.label,
+        platform: row.platform,
+        iosMajorVersion: row.iosMajorVersion,
+        appVersion: row.appVersion,
+        notifications: {
+          enabled: row.preferences.notificationsEnabled,
+          notifyOnApproval: row.preferences.notifyOnApproval,
+          notifyOnInput: row.preferences.notifyOnInput,
+          notifyOnCompletion: row.preferences.notifyOnCompletion,
+          notifyOnFailure: row.preferences.notifyOnFailure,
+        },
+        liveActivities: {
+          enabled: row.preferences.liveActivitiesEnabled,
+        },
+        updatedAt: row.updatedAt,
+      }));
+    }),
   });
 });
 

--- a/infra/relay/src/agentActivity/Devices.ts
+++ b/infra/relay/src/agentActivity/Devices.ts
@@ -118,7 +118,7 @@ export const make = Effect.gen(function* () {
                 )
             : Effect.void,
         ],
-        { concurrency: 2, discard: true },
+        { discard: true },
       );
 
       yield* db
@@ -209,7 +209,7 @@ export const make = Effect.gen(function* () {
               ),
             ),
         ],
-        { concurrency: 2, discard: true },
+        { discard: true },
       );
     }),
     listForUser: Effect.fn("relay.devices.listForUser")(function* (input) {


### PR DESCRIPTION
## Summary
- attach user and device identifiers to relay device persistence failures
- identify the exact registration or unregistration database stage that failed
- preserve the original database cause and derive messages from structured fields
- cover registration, unregistration, and list failure diagnostics

## Validation
- `vp test infra/relay/src/agentActivity/Devices.test.ts --no-cache`
- `vp check`
- `vp run typecheck`
- `vpr typecheck`

## Overlap audit
No active error/service refactor touches these files. The only exact-file overlaps are older broad draft feature PRs #2925 and #3135.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and error-shape changes only; persistence behavior is unchanged aside from dropping explicit concurrency on parallel claim/delete steps.
> 
> **Overview**
> Relay mobile device persistence failures now carry **structured context** (`userId`, `deviceId`, and a **`stage`** label) instead of a generic message plus `cause`.
> 
> **Registration** errors tag which step failed: `claim-push-token`, `claim-push-to-start-token`, or `upsert-device`. **Unregistration** errors distinguish `delete-live-activity` vs `delete-device`. **List** failures include `userId`. Each DB step uses its own `Effect.mapError` instead of one wrapper on the whole `register`/`unregister`/`listForUser` effect, so the reported stage matches the failing operation. Error messages are derived from those fields.
> 
> Tests assert stage, identifiers, preserved `cause`, and message text for register, unregister, and list failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 142db89571352da45abda83b5428fc2aa5504679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure relay device persistence errors with userId, deviceId, and stage context
> - Expands `DeviceRegistrationPersistenceError`, `DeviceUnregistrationPersistenceError`, and `DeviceListPersistenceError` in [Devices.ts](https://github.com/pingdotgg/t3code/pull/3344/files#diff-f39a06e479fec1cc961b5149366557d207ac1c06eef4f7a27da3013d0b8f0695) to carry `userId`, `deviceId`, `stage`, and `cause` fields, and updates their message getters to include these values.
> - Refactors `Devices.register`, `Devices.unregister`, and `Devices.listForUser` to map errors at each individual database operation stage (e.g. `'claim-push-token'`, `'delete-live-activity'`) rather than wrapping the whole pipeline.
> - Removes explicit `{ concurrency: 2 }` from `Effect.all` calls in `register` and `unregister`, leaving only `{ discard: true }`.
> - Adds tests in [Devices.test.ts](https://github.com/pingdotgg/t3code/pull/3344/files#diff-0eda8aca345655021e499dab08c7caaeabd78554abbe18f08ab7db91cdc27327) that verify each error class carries the correct fields and stage when the underlying database call fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 142db89.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->