### PR TITLE
[codex] Structure mobile secure storage failures

### DIFF
--- a/apps/mobile/src/lib/storage.test.ts
+++ b/apps/mobile/src/lib/storage.test.ts
@@ -69,4 +69,35 @@ describe("mobile connection storage", () => {
       toStableSavedRemoteConnection(managedConnection),
     ]);
   });
+
+  it("preserves secure-storage read failures with operation and key context", async () => {
+    const cause = new Error("keychain unavailable");
+    mocks.getItemAsync.mockRejectedValueOnce(cause);
+
+    await expect(loadSavedConnections()).rejects.toMatchObject({
+      _tag: "MobileSecureStorageError",
+      operation: "read",
+      key: "t3code.connections",
+      cause,
+      message: "Mobile secure storage operation read failed for key t3code.connections.",
+    });
+  });
+
+  it("logs structured decode failures before using the empty fallback", async () => {
+    await mocks.setItemAsync("t3code.connections", "{");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(loadSavedConnections()).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      "[mobile-storage] ignored invalid JSON",
+      expect.objectContaining({
+        _tag: "MobileStorageDecodeError",
+        key: "t3code.connections",
+        cause: expect.any(SyntaxError),
+        message: "Failed to decode mobile storage value for key t3code.connections.",
+      }),
+    );
+
+    warn.mockRestore();
+  });
 });

--- a/apps/mobile/src/lib/storage.ts
+++ b/apps/mobile/src/lib/storage.ts
@@ -1,5 +1,6 @@
 import * as Arr from "effect/Array";
 import { pipe } from "effect/Function";
+import * as Schema from "effect/Schema";
 import * as SecureStore from "expo-secure-store";
 import { EnvironmentId } from "@t3tools/contracts";
 
@@ -12,21 +13,72 @@ import {
 const CONNECTIONS_KEY = "t3code.connections";
 const PREFERENCES_KEY = "t3code.preferences";
 const AGENT_AWARENESS_DEVICE_ID_KEY = "t3code.agent-awareness.device-id";
+const MobileStorageKey = Schema.Literals([
+  CONNECTIONS_KEY,
+  PREFERENCES_KEY,
+  AGENT_AWARENESS_DEVICE_ID_KEY,
+]);
+type MobileStorageKeyValue = typeof MobileStorageKey.Type;
+
+export class MobileSecureStorageError extends Schema.TaggedErrorClass<MobileSecureStorageError>()(
+  "MobileSecureStorageError",
+  {
+    operation: Schema.Literals(["read", "write", "generate-device-id"]),
+    key: MobileStorageKey,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Mobile secure storage operation ${this.operation} failed for key ${this.key}.`;
+  }
+}
+
+export class MobileStorageDecodeError extends Schema.TaggedErrorClass<MobileStorageDecodeError>()(
+  "MobileStorageDecodeError",
+  {
+    key: MobileStorageKey,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to decode mobile storage value for key ${this.key}.`;
+  }
+}
+
+export class MobileStorageEncodeError extends Schema.TaggedErrorClass<MobileStorageEncodeError>()(
+  "MobileStorageEncodeError",
+  {
+    key: MobileStorageKey,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to encode mobile storage value for key ${this.key}.`;
+  }
+}
 
 export interface Preferences {
   readonly liveActivitiesEnabled?: boolean;
   readonly terminalFontSize?: number;
 }
 
-async function readStorageItem(key: string): Promise<string | null> {
-  return await SecureStore.getItemAsync(key);
+async function readStorageItem(key: MobileStorageKeyValue): Promise<string | null> {
+  try {
+    return await SecureStore.getItemAsync(key);
+  } catch (cause) {
+    throw new MobileSecureStorageError({ operation: "read", key, cause });
+  }
 }
 
-async function writeStorageItem(key: string, value: string): Promise<void> {
-  await SecureStore.setItemAsync(key, value);
+async function writeStorageItem(key: MobileStorageKeyValue, value: string): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(key, value);
+  } catch (cause) {
+    throw new MobileSecureStorageError({ operation: "write", key, cause });
+  }
 }
 
-async function readJsonStorageItem<T>(key: string): Promise<T | null> {
+async function readJsonStorageItem<T>(key: MobileStorageKeyValue): Promise<T | null> {
   const raw = (await readStorageItem(key)) ?? "";
   if (!raw.trim()) {
     return null;
@@ -34,9 +86,23 @@ async function readJsonStorageItem<T>(key: string): Promise<T | null> {
 
   try {
     return JSON.parse(raw) as T;
-  } catch {
+  } catch (cause) {
+    console.warn(
+      "[mobile-storage] ignored invalid JSON",
+      new MobileStorageDecodeError({ key, cause }),
+    );
     return null;
   }
+}
+
+async function writeJsonStorageItem(key: MobileStorageKeyValue, value: unknown) {
+  let encoded: string;
+  try {
+    encoded = JSON.stringify(value);
+  } catch (cause) {
+    throw new MobileStorageEncodeError({ key, cause });
+  }
+  await writeStorageItem(key, encoded);
 }
 
 export async function loadSavedConnections(): Promise<ReadonlyArray<SavedRemoteConnection>> {
@@ -67,7 +133,7 @@ export async function saveConnection(connection: SavedRemoteConnection): Promise
       )
     : pipe(current, Arr.append(stableConnection));
 
-  await writeStorageItem(CONNECTIONS_KEY, JSON.stringify({ connections: next }));
+  await writeJsonStorageItem(CONNECTIONS_KEY, { connections: next });
 }
 
 export async function clearSavedConnection(environmentId: EnvironmentId): Promise<void> {
@@ -76,7 +142,7 @@ export async function clearSavedConnection(environmentId: EnvironmentId): Promis
     current,
     Arr.filter((entry) => entry.environmentId !== environmentId),
   );
-  await writeStorageItem(CONNECTIONS_KEY, JSON.stringify({ connections: next }));
+  await writeJsonStorageItem(CONNECTIONS_KEY, { connections: next });
 }
 
 export async function loadPreferences(): Promise<Preferences> {
@@ -106,7 +172,7 @@ export async function savePreferencesPatch(patch: Partial<Preferences>): Promise
     ...current,
     ...patch,
   };
-  await writeStorageItem(PREFERENCES_KEY, JSON.stringify(next));
+  await writeJsonStorageItem(PREFERENCES_KEY, next);
   return next;
 }
 
@@ -116,8 +182,15 @@ export async function loadOrCreateAgentAwarenessDeviceId(): Promise<string> {
     return existing;
   }
 
-  const { uuidv4 } = await import("./uuid");
-  const deviceId = uuidv4();
+  const deviceId = await import("./uuid")
+    .then(({ uuidv4 }) => uuidv4())
+    .catch((cause) => {
+      throw new MobileSecureStorageError({
+        operation: "generate-device-id",
+        key: AGENT_AWARENESS_DEVICE_ID_KEY,
+        cause,
+      });
+    });
   await writeStorageItem(AGENT_AWARENESS_DEVICE_ID_KEY, deviceId);
   return deviceId;
 }


### PR DESCRIPTION
## Summary
- attach secure-storage operation and key context to reads, writes, and device-ID generation while preserving exact causes
- distinguish JSON encode/decode failures from platform storage failures
- log corrupt persisted JSON structurally before retaining the existing empty fallback, without exposing stored values

## Verification
- `vp test apps/mobile/src/lib/storage.test.ts`
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the mobile local storage helper layer; corrupt-data behavior is unchanged aside from richer logging, though callers now see tagged errors on keychain failures instead of raw platform errors.
> 
> **Overview**
> Mobile secure storage now surfaces failures through **Effect Schema tagged errors** instead of silent or generic failures, with typed keys for the known `t3code.*` entries.
> 
> **SecureStore** read/write (and device-ID generation when the UUID module fails to load) throw `MobileSecureStorageError` with `operation`, `key`, and the original `cause`. JSON **encode** failures raise `MobileStorageEncodeError`; **decode** failures still return the same empty/null fallbacks but emit a structured `console.warn` with `MobileStorageDecodeError` (no stored value in logs). Connection and preference writes route through a shared `writeJsonStorageItem` helper.
> 
> Tests cover keychain read rejection propagating the new error shape and corrupt JSON logging before `loadSavedConnections` returns `[]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b6ccbfd667eba24d5683f5a711db18b0cfcab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure mobile secure storage failures with typed error classes
> - Adds three tagged error classes — `MobileSecureStorageError`, `MobileStorageDecodeError`, and `MobileStorageEncodeError` — to [storage.ts](https://github.com/pingdotgg/t3code/pull/3345/files#diff-88cde66d63934d3dcb84dc16a543dc88b914496ce9b91049148ace2eed73a6c9), replacing raw error propagation with structured errors that carry operation context and storage key.
> - `readStorageItem` and `writeStorageItem` now throw `MobileSecureStorageError` with `operation` and `key` fields on `SecureStore` failures.
> - JSON decode failures in `readJsonStorageItem` emit a `console.warn` with a `MobileStorageDecodeError` before returning `null`; encode failures in the new `writeJsonStorageItem` helper throw `MobileStorageEncodeError`.
> - All write callers (`saveConnection`, `clearSavedConnection`, `savePreferencesPatch`) are updated to use `writeJsonStorageItem`; `loadOrCreateAgentAwarenessDeviceId` wraps uuid import failures in `MobileSecureStorageError(generate-device-id, ...)`.
> - Behavioral Change: callers that previously received raw errors or silent failures now receive structured typed errors or structured console warnings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6b6ccb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->