### PR TITLE
[codex] Structure missing client cloud config errors

### DIFF
--- a/apps/mobile/src/features/cloud/publicConfig.test.ts
+++ b/apps/mobile/src/features/cloud/publicConfig.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { hasTracingPublicConfig, resolveCloudPublicConfig } from "./publicConfig";
+import {
+  CloudPublicConfigMissingError,
+  hasTracingPublicConfig,
+  resolveCloudPublicConfig,
+  resolveRelayClerkTokenOptions,
+} from "./publicConfig";
 
 vi.mock("expo-constants", () => ({
   default: {
@@ -11,6 +16,12 @@ vi.mock("expo-constants", () => ({
 }));
 
 describe("resolveCloudPublicConfig", () => {
+  it("reports the missing Clerk JWT template as structured configuration", () => {
+    expect(() => resolveRelayClerkTokenOptions()).toThrowError(
+      new CloudPublicConfigMissingError({ key: "T3CODE_CLERK_JWT_TEMPLATE" }),
+    );
+  });
+
   it("returns no cloud configuration for an unconfigured build", () => {
     expect(resolveCloudPublicConfig({})).toEqual({
       clerk: {

--- a/apps/mobile/src/features/cloud/publicConfig.ts
+++ b/apps/mobile/src/features/cloud/publicConfig.ts
@@ -1,6 +1,18 @@
 import Constants from "expo-constants";
 import { relayClerkTokenOptions } from "@t3tools/shared/relayAuth";
 import { normalizeSecureRelayUrl } from "@t3tools/shared/relayUrl";
+import * as Schema from "effect/Schema";
+
+export class CloudPublicConfigMissingError extends Schema.TaggedErrorClass<CloudPublicConfigMissingError>()(
+  "CloudPublicConfigMissingError",
+  {
+    key: Schema.Literal("T3CODE_CLERK_JWT_TEMPLATE"),
+  },
+) {
+  override get message(): string {
+    return `${this.key} is not configured.`;
+  }
+}
 
 export interface CloudPublicConfig {
   readonly clerk: {
@@ -87,7 +99,7 @@ export function hasTracingPublicConfig(
 export function resolveRelayClerkTokenOptions() {
   const { jwtTemplate } = resolveCloudPublicConfig().clerk;
   if (!jwtTemplate) {
-    throw new Error("T3CODE_CLERK_JWT_TEMPLATE is not configured.");
+    throw new CloudPublicConfigMissingError({ key: "T3CODE_CLERK_JWT_TEMPLATE" });
   }
   return relayClerkTokenOptions(jwtTemplate);
 }

--- a/apps/web/src/cloud/publicConfig.test.ts
+++ b/apps/web/src/cloud/publicConfig.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { hasCloudPublicConfig } from "./publicConfig.ts";
+import {
+  CloudPublicConfigMissingError,
+  hasCloudPublicConfig,
+  resolveRelayClerkTokenOptions,
+} from "./publicConfig.ts";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -29,5 +33,13 @@ describe("hasCloudPublicConfig", () => {
     vi.stubEnv("VITE_T3CODE_RELAY_URL", "http://relay.example.test");
 
     expect(hasCloudPublicConfig()).toBe(false);
+  });
+
+  it("reports the missing Clerk JWT template as structured configuration", () => {
+    vi.stubEnv("VITE_CLERK_JWT_TEMPLATE", "");
+
+    expect(() => resolveRelayClerkTokenOptions()).toThrowError(
+      new CloudPublicConfigMissingError({ key: "T3CODE_CLERK_JWT_TEMPLATE" }),
+    );
   });
 });

--- a/apps/web/src/cloud/publicConfig.ts
+++ b/apps/web/src/cloud/publicConfig.ts
@@ -1,5 +1,17 @@
 import { relayClerkTokenOptions } from "@t3tools/shared/relayAuth";
 import { normalizeSecureRelayUrl } from "@t3tools/shared/relayUrl";
+import * as Schema from "effect/Schema";
+
+export class CloudPublicConfigMissingError extends Schema.TaggedErrorClass<CloudPublicConfigMissingError>()(
+  "CloudPublicConfigMissingError",
+  {
+    key: Schema.Literal("T3CODE_CLERK_JWT_TEMPLATE"),
+  },
+) {
+  override get message(): string {
+    return `${this.key} is not configured.`;
+  }
+}
 
 export interface CloudPublicConfig {
   readonly clerkPublishableKey: string | null;
@@ -65,7 +77,7 @@ export function hasCloudPublicConfig(): boolean {
 export function resolveRelayClerkTokenOptions() {
   const { clerkJwtTemplate } = resolveCloudPublicConfig();
   if (!clerkJwtTemplate) {
-    throw new Error("T3CODE_CLERK_JWT_TEMPLATE is not configured.");
+    throw new CloudPublicConfigMissingError({ key: "T3CODE_CLERK_JWT_TEMPLATE" });
   }
   return relayClerkTokenOptions(clerkJwtTemplate);
 }


### PR DESCRIPTION
## Summary

- replace generic missing Clerk JWT template throws in web and mobile with Schema-tagged configuration errors
- carry the missing public configuration key as structured data while preserving the existing message
- avoid inventing a cause for a deterministic configuration validation failure
- cover both client boundaries with focused tests

## Validation

- pnpm vp test apps/web/src/cloud/publicConfig.test.ts apps/mobile/src/features/cloud/publicConfig.test.ts (9 tests)
- pnpm vp check (passes with existing repository warnings)
- pnpm vp run typecheck
- pnpm vp run lint:mobile

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic errors with structured `CloudPublicConfigMissingError` in web and mobile cloud config
> Introduces `CloudPublicConfigMissingError`, a tagged error class (via `effect/Schema`), in both the web and mobile `publicConfig` modules. When `resolveRelayClerkTokenOptions` cannot find the Clerk JWT template, it now throws this structured error instead of a plain `Error`. Tests are added for both platforms to verify the new error type is thrown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized adbdcc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->