### PR TITLE
[codex] Structure relay domain label errors

### DIFF
--- a/infra/relay/src/deploymentConfig.test.ts
+++ b/infra/relay/src/deploymentConfig.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vite-plus/test";
+import * as Schema from "effect/Schema";
 
 import {
   managedEndpointDigestInput,
@@ -12,6 +13,8 @@ import {
   relayResourceNameForStage,
   relayStageSlug,
 } from "./deploymentConfig.ts";
+
+const isRelayPublicDomainLabelTooLongError = Schema.is(RelayPublicDomainLabelTooLongError);
 
 describe("relayStageSlug", () => {
   it("matches Alchemy physical-name sanitization for default developer stages", () => {
@@ -40,8 +43,7 @@ describe("relayPublicDomainForStage", () => {
       error = cause;
     }
 
-    expect(error).toBeInstanceOf(RelayPublicDomainLabelTooLongError);
-    if (!(error instanceof RelayPublicDomainLabelTooLongError)) {
+    if (!isRelayPublicDomainLabelTooLongError(error)) {
       throw error;
     }
     expect(error).toMatchObject({

--- a/infra/relay/src/deploymentConfig.test.ts
+++ b/infra/relay/src/deploymentConfig.test.ts
@@ -7,6 +7,7 @@ import {
   isManagedEndpointHostname,
   managedEndpointTunnelName,
   relayOwnsManagedEndpointZone,
+  RelayPublicDomainLabelTooLongError,
   relayPublicDomainForStage,
   relayResourceNameForStage,
   relayStageSlug,
@@ -26,6 +27,30 @@ describe("relayPublicDomainForStage", () => {
   it("isolates personal stages below the imported zone", () => {
     expect(relayPublicDomainForStage("dev_julius", "example.com")).toBe(
       "relay-dev-julius.example.com",
+    );
+  });
+
+  it("reports the stage and derived DNS label when the label is too long", () => {
+    const stage = `dev_${"x".repeat(60)}`;
+    let error: unknown;
+
+    try {
+      relayPublicDomainForStage(stage, "example.com");
+    } catch (cause) {
+      error = cause;
+    }
+
+    expect(error).toBeInstanceOf(RelayPublicDomainLabelTooLongError);
+    if (!(error instanceof RelayPublicDomainLabelTooLongError)) {
+      throw error;
+    }
+    expect(error).toMatchObject({
+      stage,
+      label: `relay-dev-${"x".repeat(60)}`,
+      maxLength: 63,
+    });
+    expect(error.message).toBe(
+      `Relay stage '${stage}' produces custom domain label 'relay-dev-${"x".repeat(60)}' (70 characters), exceeding the DNS label limit of 63.`,
     );
   });
 });

--- a/infra/relay/src/deploymentConfig.ts
+++ b/infra/relay/src/deploymentConfig.ts
@@ -1,9 +1,23 @@
 import type { RelayManagedEndpoint } from "@t3tools/contracts/relay";
+import * as Schema from "effect/Schema";
 
 const DNS_LABEL_MAX_LENGTH = 63;
 const MANAGED_ENDPOINT_HASH_LENGTH = 16;
 const MANAGED_ENDPOINT_TUNNEL_PREFIX = "t3coderelay-managedendpoint";
 export const MANAGED_ENDPOINT_ZONE_OWNER_STAGE = "prod";
+
+export class RelayPublicDomainLabelTooLongError extends Schema.TaggedErrorClass<RelayPublicDomainLabelTooLongError>()(
+  "RelayPublicDomainLabelTooLongError",
+  {
+    stage: Schema.String,
+    label: Schema.String,
+    maxLength: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Relay stage '${this.stage}' produces custom domain label '${this.label}' (${this.label.length} characters), exceeding the DNS label limit of ${this.maxLength}.`;
+  }
+}
 
 function normalizeZoneName(zoneName: string): string {
   return zoneName
@@ -62,7 +76,11 @@ export function relayPublicDomainForStage(stage: string, zoneName: string): stri
   const stageSlug = relayStageSlug(stage);
   const relayLabel = stage === "prod" ? "relay" : `relay-${stageSlug}`;
   if (relayLabel.length > DNS_LABEL_MAX_LENGTH) {
-    throw new Error(`Relay stage is too long for a custom domain: ${stage}`);
+    throw new RelayPublicDomainLabelTooLongError({
+      stage,
+      label: relayLabel,
+      maxLength: DNS_LABEL_MAX_LENGTH,
+    });
   }
   return `${relayLabel}.${normalizeZoneName(zoneName)}`;
 }


### PR DESCRIPTION
## Summary
- replace the generic long-stage throw with a schema-tagged domain error
- attach the original stage, derived DNS label, and provider maximum length
- derive the diagnostic message from those structured fields
- cover the oversized-label failure contract

## Validation
- `vp test infra/relay/src/deploymentConfig.test.ts --no-cache`
- `vp check`
- `vp run typecheck`
- `vpr typecheck`

## Overlap audit
No active error/service refactor touches these files. The only exact-file overlap is older broad draft feature PR #2925.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-type change in relay deployment config with no behavior change on the success path; only failure diagnostics and catchability improve.
> 
> **Overview**
> When `relayPublicDomainForStage` rejects an oversized derived DNS label, it now throws **`RelayPublicDomainLabelTooLongError`** (Effect `Schema.TaggedErrorClass`) instead of a plain `Error`.
> 
> The tagged error carries **`stage`**, **`label`**, and **`maxLength`**, with a **`message`** getter that reports label length vs the 63-character limit. A new test asserts the error shape and message for an overlong stage name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311099d881c85d9ee1375698e25c53f8f9a43846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic Error with structured `RelayPublicDomainLabelTooLongError` in `relayPublicDomainForStage`
> Introduces `RelayPublicDomainLabelTooLongError`, a tagged `Schema.TaggedErrorClass` in [deploymentConfig.ts](https://github.com/pingdotgg/t3code/pull/3347/files#diff-a4f5c11dfbc1691caffb11e7393674bebbe3ae71525325c27439161b65ef6a75) with fields `stage`, `label`, and `maxLength`, plus a detailed message. When the computed relay DNS label exceeds 63 characters, `relayPublicDomainForStage` now throws this structured error instead of a generic `Error`. Tests in [deploymentConfig.test.ts](https://github.com/pingdotgg/t3code/pull/3347/files#diff-700465a6e627409193f5b0170abdce58f88443c98fdab599a55dda6ada3a030f) verify the error tag, structured fields, and message content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 311099d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->