### PR TITLE
[codex] Preserve mobile composer draft failures

### DIFF
--- a/apps/mobile/src/state/use-composer-drafts.ts
+++ b/apps/mobile/src/state/use-composer-drafts.ts
@@ -1,5 +1,6 @@
 import { useAtomValue } from "@effect/atom-react";
 import type { EnvironmentId } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import { useEffect } from "react";
 import { Atom } from "effect/unstable/reactivity";
 
@@ -10,6 +11,20 @@ const COMPOSER_DRAFTS_SCHEMA_VERSION = 1;
 const COMPOSER_DRAFTS_DIRECTORY = "composer-drafts";
 const COMPOSER_DRAFTS_FILE = "drafts.json";
 const PERSIST_DEBOUNCE_MS = 200;
+
+export class ComposerDraftPersistenceError extends Schema.TaggedErrorClass<ComposerDraftPersistenceError>()(
+  "ComposerDraftPersistenceError",
+  {
+    operation: Schema.Literals(["open", "read", "decode", "encode", "write", "hydrate"]),
+    directory: Schema.String,
+    fileName: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Composer draft persistence operation ${this.operation} failed for ${this.directory}/${this.fileName}.`;
+  }
+}
 
 export interface ComposerDraft {
   readonly text: string;
@@ -56,12 +71,16 @@ async function getComposerDraftsFile() {
 }
 
 async function loadPersistedComposerDrafts(): Promise<Record<string, ComposerDraft>> {
+  let operation: ComposerDraftPersistenceError["operation"] = "open";
   try {
     const file = await getComposerDraftsFile();
     if (!file.exists) {
       return {};
     }
-    const parsed = JSON.parse(await file.text()) as Partial<PersistedComposerDrafts>;
+    operation = "read";
+    const raw = await file.text();
+    operation = "decode";
+    const parsed = JSON.parse(raw) as Partial<PersistedComposerDrafts>;
     if (parsed.schemaVersion !== COMPOSER_DRAFTS_SCHEMA_VERSION || !parsed.drafts) {
       return {};
     }
@@ -75,30 +94,53 @@ async function loadPersistedComposerDrafts(): Promise<Record<string, ComposerDra
         );
       }),
     );
-  } catch {
+  } catch (cause) {
+    console.warn(
+      "[composer-drafts] ignored persisted draft failure",
+      new ComposerDraftPersistenceError({
+        operation,
+        directory: COMPOSER_DRAFTS_DIRECTORY,
+        fileName: COMPOSER_DRAFTS_FILE,
+        cause,
+      }),
+    );
     return {};
   }
 }
 
 async function writePersistedComposerDrafts(drafts: Record<string, ComposerDraft>): Promise<void> {
-  const file = await getComposerDraftsFile();
-  const nonEmptyDrafts = Object.fromEntries(
-    Object.entries(drafts).filter(([, draft]) => !isEmptyDraft(draft)),
-  );
-  const document: PersistedComposerDrafts = {
-    schemaVersion: COMPOSER_DRAFTS_SCHEMA_VERSION,
-    drafts: nonEmptyDrafts,
-  };
-  if (!file.exists) {
-    file.create({ intermediates: true, overwrite: true });
+  let operation: ComposerDraftPersistenceError["operation"] = "open";
+  try {
+    const file = await getComposerDraftsFile();
+    operation = "encode";
+    const nonEmptyDrafts = Object.fromEntries(
+      Object.entries(drafts).filter(([, draft]) => !isEmptyDraft(draft)),
+    );
+    const document: PersistedComposerDrafts = {
+      schemaVersion: COMPOSER_DRAFTS_SCHEMA_VERSION,
+      drafts: nonEmptyDrafts,
+    };
+    const encoded = JSON.stringify(document);
+    operation = "write";
+    if (!file.exists) {
+      file.create({ intermediates: true, overwrite: true });
+    }
+    file.write(encoded);
+  } catch (cause) {
+    throw new ComposerDraftPersistenceError({
+      operation,
+      directory: COMPOSER_DRAFTS_DIRECTORY,
+      fileName: COMPOSER_DRAFTS_FILE,
+      cause,
+    });
   }
-  file.write(JSON.stringify(document));
 }
 
 async function savePersistedComposerDrafts(drafts: Record<string, ComposerDraft>): Promise<void> {
   try {
     await writePersistedComposerDrafts(drafts);
-  } catch {
+  } catch (error) {
+    console.warn("[composer-drafts] failed to persist drafts", error);
     // Draft persistence is best-effort; in-memory drafts still keep working.
   }
 }
@@ -128,7 +170,16 @@ export function ensureComposerDraftsLoaded(): void {
         ...current,
       });
     })
-    .catch(() => {
+    .catch((cause) => {
+      console.warn(
+        "[composer-drafts] failed to hydrate drafts",
+        new ComposerDraftPersistenceError({
+          operation: "hydrate",
+          directory: COMPOSER_DRAFTS_DIRECTORY,
+          fileName: COMPOSER_DRAFTS_FILE,
+          cause,
+        }),
+      );
       // Draft loading is best-effort; in-memory drafts still keep working.
     });
 }


### PR DESCRIPTION
## Summary
- add structured composer-draft persistence errors with operation and storage path context
- preserve exact causes for read, JSON, write, and hydration failures
- retain best-effort draft behavior while making ignored failures observable

## Verification
- `vp test apps/mobile/src/state/use-composer-drafts.test.ts`
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes to local draft file handling; no change to user-facing draft semantics or security-sensitive flows.
> 
> **Overview**
> Adds **`ComposerDraftPersistenceError`** (Effect `Schema.TaggedErrorClass`) so mobile composer draft file I/O failures carry **operation** (`open`, `read`, `decode`, `encode`, `write`, `hydrate`), **storage path**, and the **original cause**.
> 
> Load, debounced save, and hydration paths still **fail open** (empty drafts / in-memory state unchanged), but **silent `catch` blocks are replaced** with `console.warn` that logs the tagged error. Writes now wrap failures in the structured error before the existing best-effort save handler logs them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0adc3f67f47d8703ed6392eb916d4a3318034d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve mobile composer draft failures with structured error logging
> - Introduces `ComposerDraftPersistenceError`, a tagged error class with fields for operation, directory, fileName, and cause, thrown by `writePersistedComposerDrafts` on open/encode/write failures.
> - `loadPersistedComposerDrafts` now catches and wraps failures in `ComposerDraftPersistenceError` and emits a console warning, still returning an empty object on failure.
> - `savePersistedComposerDrafts` and `ensureComposerDraftsLoaded` log console warnings on failure but continue to treat persistence as best-effort and do not rethrow.
> - Changes are isolated to [use-composer-drafts.ts](https://github.com/pingdotgg/t3code/pull/3348/files#diff-6acb6f89d59b03b7738cacfb4cec712073b5d8c6b8d2abcd3cde1acee04f818e).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0adc3f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->