### PR TITLE
[codex] Report preview action failures

### DIFF
--- a/apps/web/src/components/preview/PreviewMoreMenu.tsx
+++ b/apps/web/src/components/preview/PreviewMoreMenu.tsx
@@ -7,6 +7,7 @@ import { Menu, MenuItem, MenuPopup, MenuSeparator, MenuTrigger } from "~/compone
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
 
 import { previewBridge } from "./previewBridge";
+import { reportPreviewActionFailure } from "./reportPreviewActionFailure";
 
 interface Props {
   /** Active preview tab id. Tab-targeting actions are disabled without it. */
@@ -30,9 +31,11 @@ export function PreviewMoreMenu({ tabId, hasWebContents, zoomFactor }: Props) {
   if (!previewBridge) return null;
   const bridge = previewBridge;
   const tabDisabled = !tabId || !hasWebContents;
-  const callTab = (op: (tabId: string) => Promise<void>) => () => {
+  const callTab = (operation: string, op: (tabId: string) => Promise<void>) => () => {
     if (!tabId) return;
-    void op(tabId).catch(() => undefined);
+    void op(tabId).catch((cause) => {
+      reportPreviewActionFailure({ operation, tabId }, cause);
+    });
   };
 
   const zoomLabel = `${Math.round(zoomFactor * 100)}%`;
@@ -53,10 +56,10 @@ export function PreviewMoreMenu({ tabId, hasWebContents, zoomFactor }: Props) {
         <TooltipPopup>More</TooltipPopup>
       </Tooltip>
       <MenuPopup align="end" sideOffset={6} className="min-w-56">
-        <MenuItem onClick={callTab(bridge.hardReload)} disabled={tabDisabled}>
+        <MenuItem onClick={callTab("hard-reload", bridge.hardReload)} disabled={tabDisabled}>
           Hard reload
         </MenuItem>
-        <MenuItem onClick={callTab(bridge.openDevTools)} disabled={tabDisabled}>
+        <MenuItem onClick={callTab("open-devtools", bridge.openDevTools)} disabled={tabDisabled}>
           Open DevTools
         </MenuItem>
         {/*
@@ -75,7 +78,7 @@ export function PreviewMoreMenu({ tabId, hasWebContents, zoomFactor }: Props) {
               variant="outline"
               size="icon-xs"
               type="button"
-              onClick={callTab(bridge.zoomOut)}
+              onClick={callTab("zoom-out", bridge.zoomOut)}
               aria-label="Zoom out"
               disabled={tabDisabled}
             >
@@ -88,7 +91,7 @@ export function PreviewMoreMenu({ tabId, hasWebContents, zoomFactor }: Props) {
               variant="outline"
               size="icon-xs"
               type="button"
-              onClick={callTab(bridge.zoomIn)}
+              onClick={callTab("zoom-in", bridge.zoomIn)}
               aria-label="Zoom in"
               disabled={tabDisabled}
             >
@@ -98,7 +101,7 @@ export function PreviewMoreMenu({ tabId, hasWebContents, zoomFactor }: Props) {
               variant="ghost"
               size="icon-xs"
               type="button"
-              onClick={callTab(bridge.resetZoom)}
+              onClick={callTab("reset-zoom", bridge.resetZoom)}
               aria-label="Reset zoom"
               disabled={tabDisabled}
             >
@@ -107,10 +110,22 @@ export function PreviewMoreMenu({ tabId, hasWebContents, zoomFactor }: Props) {
           </span>
         </MenuItem>
         <MenuSeparator />
-        <MenuItem onClick={() => void bridge.clearCookies().catch(() => undefined)}>
+        <MenuItem
+          onClick={() =>
+            void bridge.clearCookies().catch((cause) => {
+              reportPreviewActionFailure({ operation: "clear-cookies" }, cause);
+            })
+          }
+        >
           Clear cookies
         </MenuItem>
-        <MenuItem onClick={() => void bridge.clearCache().catch(() => undefined)}>
+        <MenuItem
+          onClick={() =>
+            void bridge.clearCache().catch((cause) => {
+              reportPreviewActionFailure({ operation: "clear-cache" }, cause);
+            })
+          }
+        >
           Clear cache
         </MenuItem>
       </MenuPopup>

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { scopedThreadKey } from "@t3tools/client-runtime/environment";
+import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { type ScopedThreadRef } from "@t3tools/contracts";
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -109,11 +110,17 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
           rememberPreviewUrl(threadRef, resolvedUrl);
         } else {
           operation = "open-session";
-          await openPreviewSession({
+          const result = await openPreviewSession({
             openPreview: open,
             threadRef,
             url: resolvedUrl,
           });
+          if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
+            reportPreviewActionFailure(
+              { operation, threadKey, ...(tabId ? { tabId } : {}), url: targetUrl },
+              result.cause,
+            );
+          }
         }
       } catch (cause) {
         reportPreviewActionFailure(

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -20,6 +20,7 @@ import { PreviewChromeRow } from "./PreviewChromeRow";
 import { formatPreviewUrl } from "./previewUrlPresentation";
 import { PreviewEmptyState } from "./PreviewEmptyState";
 import { PreviewMoreMenu } from "./PreviewMoreMenu";
+import { reportPreviewActionFailure } from "./reportPreviewActionFailure";
 import { PreviewUnreachable } from "./PreviewUnreachable";
 import { revealInFileExplorerLabel } from "./fileExplorerLabel";
 import { shouldShowPreviewEmptyState } from "./previewEmptyStateLogic";
@@ -91,58 +92,91 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
           environmentHttpBaseUrl,
         }) ?? undefined)
       : undefined;
+  const threadKey = scopedThreadKey(threadRef);
 
   const handleSubmitUrl = useCallback(
     async (next: string) => {
+      let operation = "resolve-url";
+      let targetUrl = next;
       try {
         const resolvedUrl = resolveDiscoveredServerUrl(threadRef.environmentId, next);
+        targetUrl = resolvedUrl;
         if (tabId && previewBridge) {
           // Drive the webview imperatively; `usePreviewBridge` mirrors the
           // resolved URL back to the server so other clients stay in sync.
+          operation = "navigate";
           await previewBridge.navigate(tabId, resolvedUrl);
           rememberPreviewUrl(threadRef, resolvedUrl);
         } else {
+          operation = "open-session";
           await openPreviewSession({
             openPreview: open,
             threadRef,
             url: resolvedUrl,
           });
         }
-      } catch {
+      } catch (cause) {
+        reportPreviewActionFailure(
+          { operation, threadKey, ...(tabId ? { tabId } : {}), url: targetUrl },
+          cause,
+        );
         // Server-side `failed` event renders the unreachable view.
       }
     },
-    [open, tabId, threadRef],
+    [open, tabId, threadKey, threadRef],
   );
 
   const handleRefresh = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.refresh(tabId);
-  }, [tabId]);
+    if (!previewBridge || !tabId) return;
+    void previewBridge.refresh(tabId).catch((cause) => {
+      reportPreviewActionFailure({ operation: "refresh", threadKey, tabId }, cause);
+    });
+  }, [tabId, threadKey]);
 
   const handleZoomIn = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.zoomIn(tabId);
-  }, [tabId]);
+    if (!previewBridge || !tabId) return;
+    void previewBridge.zoomIn(tabId).catch((cause) => {
+      reportPreviewActionFailure({ operation: "zoom-in", threadKey, tabId }, cause);
+    });
+  }, [tabId, threadKey]);
 
   const handleZoomOut = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.zoomOut(tabId);
-  }, [tabId]);
+    if (!previewBridge || !tabId) return;
+    void previewBridge.zoomOut(tabId).catch((cause) => {
+      reportPreviewActionFailure({ operation: "zoom-out", threadKey, tabId }, cause);
+    });
+  }, [tabId, threadKey]);
 
   const handleResetZoom = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.resetZoom(tabId);
-  }, [tabId]);
+    if (!previewBridge || !tabId) return;
+    void previewBridge.resetZoom(tabId).catch((cause) => {
+      reportPreviewActionFailure({ operation: "reset-zoom", threadKey, tabId }, cause);
+    });
+  }, [tabId, threadKey]);
 
   const handleBack = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.goBack(tabId);
-  }, [tabId]);
+    if (!previewBridge || !tabId) return;
+    void previewBridge.goBack(tabId).catch((cause) => {
+      reportPreviewActionFailure({ operation: "go-back", threadKey, tabId }, cause);
+    });
+  }, [tabId, threadKey]);
 
   const handleForward = useCallback(() => {
-    if (previewBridge && tabId) void previewBridge.goForward(tabId);
-  }, [tabId]);
+    if (!previewBridge || !tabId) return;
+    void previewBridge.goForward(tabId).catch((cause) => {
+      reportPreviewActionFailure({ operation: "go-forward", threadKey, tabId }, cause);
+    });
+  }, [tabId, threadKey]);
 
   const handleOpenInBrowser = useCallback(() => {
     if (!localApi || !url) return;
-    void localApi.shell.openExternal(url).catch(() => undefined);
-  }, [url]);
+    void localApi.shell.openExternal(url).catch((cause) => {
+      reportPreviewActionFailure(
+        { operation: "open-external", threadKey, ...(tabId ? { tabId } : {}), url },
+        cause,
+      );
+    });
+  }, [tabId, threadKey, url]);
 
   const handleCapture = useCallback(
     (record: boolean) => {
@@ -180,6 +214,15 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
                   }, 2_000);
                 },
                 (error) => {
+                  reportPreviewActionFailure(
+                    {
+                      operation: "copy-recording-path",
+                      threadKey,
+                      tabId,
+                      artifactPath: artifact.path,
+                    },
+                    error,
+                  );
                   toastManager.update(
                     toastId,
                     stackedThreadToast({
@@ -195,7 +238,18 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
 
             const revealAction = {
               children: revealInFileExplorerLabel(navigator.platform),
-              onClick: () => void bridge.revealArtifact(artifact.path),
+              onClick: () =>
+                void bridge.revealArtifact(artifact.path).catch((cause) => {
+                  reportPreviewActionFailure(
+                    {
+                      operation: "reveal-recording",
+                      threadKey,
+                      tabId,
+                      artifactPath: artifact.path,
+                    },
+                    cause,
+                  );
+                }),
             };
             const updateRecordingToast = () => {
               toastManager.update(
@@ -232,6 +286,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
             );
           },
           (error) => {
+            reportPreviewActionFailure({ operation: "stop-recording", threadKey, tabId }, error);
             toastManager.add({
               type: "error",
               title: "Unable to stop recording",
@@ -251,6 +306,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
           return;
         }
         void startBrowserRecording(tabId).catch((error) => {
+          reportPreviewActionFailure({ operation: "start-recording", threadKey, tabId }, error);
           toastManager.add({
             type: "error",
             title: "Unable to start recording",
@@ -263,7 +319,18 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         (artifact) => {
           const revealAction = {
             children: revealInFileExplorerLabel(navigator.platform),
-            onClick: () => void bridge.revealArtifact(artifact.path),
+            onClick: () =>
+              void bridge.revealArtifact(artifact.path).catch((cause) => {
+                reportPreviewActionFailure(
+                  {
+                    operation: "reveal-screenshot",
+                    threadKey,
+                    tabId,
+                    artifactPath: artifact.path,
+                  },
+                  cause,
+                );
+              }),
           };
           let pathCopied = false;
           let imageCopied = false;
@@ -325,6 +392,15 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
                 }, 2_000);
               },
               (error) => {
+                reportPreviewActionFailure(
+                  {
+                    operation: "copy-screenshot-path",
+                    threadKey,
+                    tabId,
+                    artifactPath: artifact.path,
+                  },
+                  error,
+                );
                 updateScreenshotToast(
                   "error",
                   "Unable to copy screenshot path",
@@ -345,6 +421,15 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
                 }, 2_000);
               },
               (error) => {
+                reportPreviewActionFailure(
+                  {
+                    operation: "copy-screenshot-image",
+                    threadKey,
+                    tabId,
+                    artifactPath: artifact.path,
+                  },
+                  error,
+                );
                 updateScreenshotToast(
                   "error",
                   "Unable to copy screenshot",
@@ -381,6 +466,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
           );
         },
         (error) => {
+          reportPreviewActionFailure({ operation: "capture-screenshot", threadKey, tabId }, error);
           toastManager.add({
             type: "error",
             title: "Unable to capture screenshot",
@@ -389,13 +475,18 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         },
       );
     },
-    [activeRecordingTabId, tabId],
+    [activeRecordingTabId, tabId, threadKey],
   );
 
   const handlePickElement = useCallback(() => {
     if (!previewBridge || !tabId) return;
     if (pickActiveRef.current) {
-      void previewBridge.cancelPickElement(tabId).catch(() => undefined);
+      void previewBridge.cancelPickElement(tabId).catch((cause) => {
+        reportPreviewActionFailure(
+          { operation: "cancel-element-picker", threadKey, tabId, trigger: "toggle" },
+          cause,
+        );
+      });
       return;
     }
     // Snapshot whatever the user was focused on (typically the chat
@@ -408,12 +499,18 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
     pickActiveRef.current = true;
     setPickActive(true);
     void (async () => {
+      let operation = "pick-element";
+      let annotationId: string | undefined;
       try {
         const annotation = await previewBridge.pickElement(tabId);
         if (!annotation) return;
+        annotationId = annotation.id;
+        operation = "add-preview-annotation";
         addPreviewAnnotation(threadRef, annotation);
+        operation = "prepare-annotation-screenshot";
         const screenshotFile = await previewAnnotationScreenshotFile(annotation);
         if (screenshotFile && annotation.screenshot) {
+          operation = "attach-annotation-screenshot";
           addImage(threadRef, {
             type: "image",
             id: annotation.id,
@@ -424,8 +521,17 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
             file: screenshotFile,
           });
         }
-      } catch {
-        // Picker failed (e.g. webview navigated). Treat as silent cancel.
+      } catch (cause) {
+        reportPreviewActionFailure(
+          {
+            operation,
+            threadKey,
+            tabId,
+            ...(annotationId ? { annotationId } : {}),
+          },
+          cause,
+        );
+        // Keep picker failures silent in the UI; navigating during a pick is expected.
       } finally {
         pickActiveRef.current = false;
         // Avoid `setState on unmounted component` if the panel/thread closed
@@ -447,7 +553,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
         }
       }
     })();
-  }, [addImage, addPreviewAnnotation, tabId, threadRef]);
+  }, [addImage, addPreviewAnnotation, tabId, threadKey, threadRef]);
 
   // If the active tab changes mid-pick (close, thread switch, hot restart),
   // tell main to tear down the in-flight session AND reset our local toggle
@@ -457,11 +563,16 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
       if (!pickActiveRef.current) return;
       pickActiveRef.current = false;
       if (previewBridge && tabId) {
-        void previewBridge.cancelPickElement(tabId).catch(() => undefined);
+        void previewBridge.cancelPickElement(tabId).catch((cause) => {
+          reportPreviewActionFailure(
+            { operation: "cancel-element-picker", threadKey, tabId, trigger: "tab-change" },
+            cause,
+          );
+        });
       }
       if (isMountedRef.current) setPickActive(false);
     };
-  }, [tabId]);
+  }, [tabId, threadKey]);
 
   // Subscribe only while visible; `toggle-panel` is owned by ChatView's
   // URL-aware handler regardless of whether the panel is currently mounted.
@@ -491,10 +602,7 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
   }, [handleRefresh, handleResetZoom, handleZoomIn, handleZoomOut, visible]);
 
   return (
-    <div
-      className="flex min-h-0 flex-1 flex-col bg-background"
-      data-thread-key={scopedThreadKey(threadRef)}
-    >
+    <div className="flex min-h-0 flex-1 flex-col bg-background" data-thread-key={threadKey}>
       <PreviewChromeRow
         url={url}
         displayUrl={displayUrl}

--- a/apps/web/src/components/preview/PreviewView.tsx
+++ b/apps/web/src/components/preview/PreviewView.tsx
@@ -21,7 +21,7 @@ import { PreviewChromeRow } from "./PreviewChromeRow";
 import { formatPreviewUrl } from "./previewUrlPresentation";
 import { PreviewEmptyState } from "./PreviewEmptyState";
 import { PreviewMoreMenu } from "./PreviewMoreMenu";
-import { reportPreviewActionFailure } from "./reportPreviewActionFailure";
+import { previewUrlFailureContext, reportPreviewActionFailure } from "./reportPreviewActionFailure";
 import { PreviewUnreachable } from "./PreviewUnreachable";
 import { revealInFileExplorerLabel } from "./fileExplorerLabel";
 import { shouldShowPreviewEmptyState } from "./previewEmptyStateLogic";
@@ -117,14 +117,24 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
           });
           if (result._tag === "Failure" && !isAtomCommandInterrupted(result)) {
             reportPreviewActionFailure(
-              { operation, threadKey, ...(tabId ? { tabId } : {}), url: targetUrl },
+              {
+                operation,
+                threadKey,
+                ...(tabId ? { tabId } : {}),
+                ...previewUrlFailureContext(targetUrl),
+              },
               result.cause,
             );
           }
         }
       } catch (cause) {
         reportPreviewActionFailure(
-          { operation, threadKey, ...(tabId ? { tabId } : {}), url: targetUrl },
+          {
+            operation,
+            threadKey,
+            ...(tabId ? { tabId } : {}),
+            ...previewUrlFailureContext(targetUrl),
+          },
           cause,
         );
         // Server-side `failed` event renders the unreachable view.
@@ -179,7 +189,12 @@ export function PreviewView({ threadRef, tabId: requestedTabId, configuredUrls, 
     if (!localApi || !url) return;
     void localApi.shell.openExternal(url).catch((cause) => {
       reportPreviewActionFailure(
-        { operation: "open-external", threadKey, ...(tabId ? { tabId } : {}), url },
+        {
+          operation: "open-external",
+          threadKey,
+          ...(tabId ? { tabId } : {}),
+          ...previewUrlFailureContext(url),
+        },
         cause,
       );
     });

--- a/apps/web/src/components/preview/reportPreviewActionFailure.test.ts
+++ b/apps/web/src/components/preview/reportPreviewActionFailure.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { previewUrlFailureContext, reportPreviewActionFailure } from "./reportPreviewActionFailure";
+
+describe("reportPreviewActionFailure", () => {
+  it("logs safe preview target metadata without credentials or URL parameters", () => {
+    const url =
+      "https://user:password@example.com/preview/signed-secret-token?access_token=private#fragment";
+    const cause = new Error("navigation failed");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    reportPreviewActionFailure(
+      {
+        operation: "navigate",
+        ...previewUrlFailureContext(url),
+      },
+      cause,
+    );
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[preview] action failed",
+      {
+        operation: "navigate",
+        urlHostname: "example.com",
+        urlLength: url.length,
+        urlProtocol: "https:",
+      },
+      cause,
+    );
+    const loggedContext = consoleError.mock.calls[0]?.[1];
+    expect(loggedContext).not.toHaveProperty("url");
+    expect(JSON.stringify(loggedContext)).not.toContain("signed-secret-token");
+    expect(JSON.stringify(loggedContext)).not.toContain("access_token=private");
+
+    consoleError.mockRestore();
+  });
+});

--- a/apps/web/src/components/preview/reportPreviewActionFailure.ts
+++ b/apps/web/src/components/preview/reportPreviewActionFailure.ts
@@ -2,10 +2,29 @@ export interface PreviewActionFailureContext {
   readonly operation: string;
   readonly threadKey?: string;
   readonly tabId?: string;
-  readonly url?: string;
+  readonly urlHostname?: string;
+  readonly urlLength?: number;
+  readonly urlProtocol?: string;
   readonly artifactPath?: string;
   readonly annotationId?: string;
   readonly trigger?: string;
+}
+
+export function previewUrlFailureContext(url: string) {
+  let urlHostname: string | undefined;
+  let urlProtocol: string | undefined;
+  try {
+    const parsed = new URL(url);
+    urlHostname = parsed.hostname || undefined;
+    urlProtocol = parsed.protocol || undefined;
+  } catch {
+    // Invalid targets still retain a nonsecret input length for diagnostics.
+  }
+  return {
+    urlLength: url.length,
+    ...(urlHostname === undefined ? {} : { urlHostname }),
+    ...(urlProtocol === undefined ? {} : { urlProtocol }),
+  };
 }
 
 export function reportPreviewActionFailure(

--- a/apps/web/src/components/preview/reportPreviewActionFailure.ts
+++ b/apps/web/src/components/preview/reportPreviewActionFailure.ts
@@ -1,0 +1,16 @@
+export interface PreviewActionFailureContext {
+  readonly operation: string;
+  readonly threadKey?: string;
+  readonly tabId?: string;
+  readonly url?: string;
+  readonly artifactPath?: string;
+  readonly annotationId?: string;
+  readonly trigger?: string;
+}
+
+export function reportPreviewActionFailure(
+  context: PreviewActionFailureContext,
+  cause: unknown,
+): void {
+  console.error("[preview] action failed", context, cause);
+}

--- a/apps/web/src/components/preview/reportPreviewActionFailure.ts
+++ b/apps/web/src/components/preview/reportPreviewActionFailure.ts
@@ -1,3 +1,5 @@
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
+
 export interface PreviewActionFailureContext {
   readonly operation: string;
   readonly threadKey?: string;
@@ -11,19 +13,11 @@ export interface PreviewActionFailureContext {
 }
 
 export function previewUrlFailureContext(url: string) {
-  let urlHostname: string | undefined;
-  let urlProtocol: string | undefined;
-  try {
-    const parsed = new URL(url);
-    urlHostname = parsed.hostname || undefined;
-    urlProtocol = parsed.protocol || undefined;
-  } catch {
-    // Invalid targets still retain a nonsecret input length for diagnostics.
-  }
+  const diagnostics = getUrlDiagnostics(url);
   return {
-    urlLength: url.length,
-    ...(urlHostname === undefined ? {} : { urlHostname }),
-    ...(urlProtocol === undefined ? {} : { urlProtocol }),
+    urlLength: diagnostics.inputLength,
+    ...(diagnostics.hostname === undefined ? {} : { urlHostname: diagnostics.hostname }),
+    ...(diagnostics.protocol === undefined ? {} : { urlProtocol: diagnostics.protocol }),
   };
 }
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -103,6 +103,10 @@
       "types": "./src/dpopCommon.ts",
       "import": "./src/dpopCommon.ts"
     },
+    "./urlDiagnostics": {
+      "types": "./src/urlDiagnostics.ts",
+      "import": "./src/urlDiagnostics.ts"
+    },
     "./relayAuth": {
       "types": "./src/relayAuth.ts",
       "import": "./src/relayAuth.ts"

--- a/packages/shared/src/dpop.test.ts
+++ b/packages/shared/src/dpop.test.ts
@@ -6,6 +6,7 @@ import {
   computeDpopAccessTokenHash,
   computeDpopJwkThumbprint,
   normalizeDpopHtu,
+  redactDpopRequestTarget,
   type DpopPublicJwk,
   verifyDpopProof,
 } from "./dpop.ts";
@@ -40,6 +41,18 @@ function signDpopProof(input: {
   }).toString("base64url");
   return `${header}.${payload}.${signature}`;
 }
+
+describe("redactDpopRequestTarget", () => {
+  it("retains the scheme, host, port, and path while removing sensitive URL components", () => {
+    const url = "https://user:password@example.com:8443/oauth/token?code=secret#fragment";
+
+    assert.equal(redactDpopRequestTarget(url), "https://example.com:8443/oauth/token");
+  });
+
+  it("returns a safe sentinel for invalid input", () => {
+    assert.equal(redactDpopRequestTarget("not a URL?token=secret"), "<invalid-url>");
+  });
+});
 
 describe("verifyDpopProof", () => {
   const { privateKey, publicKey } = NodeCrypto.generateKeyPairSync("ec", {

--- a/packages/shared/src/dpop.ts
+++ b/packages/shared/src/dpop.ts
@@ -88,6 +88,15 @@ export function normalizeDpopHtu(url: string): string | null {
   }
 }
 
+export function redactDpopRequestTarget(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+  } catch {
+    return "<invalid-url>";
+  }
+}
+
 export function computeDpopJwkThumbprint(jwk: DpopPublicJwk): string {
   return Encoding.encodeBase64Url(sha256(new TextEncoder().encode(dpopThumbprintInput(jwk))));
 }

--- a/packages/shared/src/urlDiagnostics.test.ts
+++ b/packages/shared/src/urlDiagnostics.test.ts
@@ -1,0 +1,24 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import { getUrlDiagnostics } from "./urlDiagnostics.ts";
+
+describe("getUrlDiagnostics", () => {
+  it("retains only input length, protocol, and hostname for valid URLs", () => {
+    const input =
+      "https://user:password@example.com:8443/private/path?access_token=secret#fragment";
+
+    assert.deepStrictEqual(getUrlDiagnostics(input), {
+      inputLength: input.length,
+      protocol: "https:",
+      hostname: "example.com",
+    });
+  });
+
+  it("returns only input length for invalid URLs", () => {
+    const input = "not a URL?access_token=secret";
+
+    assert.deepStrictEqual(getUrlDiagnostics(input), {
+      inputLength: input.length,
+    });
+  });
+});

--- a/packages/shared/src/urlDiagnostics.ts
+++ b/packages/shared/src/urlDiagnostics.ts
@@ -1,0 +1,19 @@
+export interface UrlDiagnostics {
+  readonly inputLength: number;
+  readonly protocol?: string;
+  readonly hostname?: string;
+}
+
+export function getUrlDiagnostics(input: string): UrlDiagnostics {
+  const inputLength = input.length;
+  try {
+    const url = new URL(input);
+    return {
+      inputLength,
+      protocol: url.protocol,
+      hostname: url.hostname,
+    };
+  } catch {
+    return { inputLength };
+  }
+}


### PR DESCRIPTION
## Summary

- report previously swallowed preview bridge and local API failures with operation, thread, tab, artifact, and annotation context
- preserve the exact upstream cause so original stack chains remain available
- replace raw preview URLs in logged context with hostname, protocol, and input length
- cover credential, path-token, query-token, and fragment redaction with a focused regression test

## Stack dependency

- Based on #3403 for `@t3tools/shared/urlDiagnostics`.

## Validation

- `vp test run apps/web/src/components/preview/reportPreviewActionFailure.test.ts` (1 test)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change: user-visible behavior and toasts are largely unchanged except more console noise on failures. URL redaction reduces accidental credential leakage in logs.
> 
> **Overview**
> Preview bridge and related failures are no longer swallowed with empty `.catch()` handlers. A shared **`reportPreviewActionFailure`** helper logs **`[preview] action failed`** to `console.error` with structured context (operation, `threadKey`, `tabId`, artifact/annotation ids where relevant) and passes through the original cause.
> 
> **`PreviewView`** and **`PreviewMoreMenu`** now route navigation, zoom, history, refresh, DevTools, cache/cookies, recordings, screenshots, clipboard, element picker, and open-external errors through that helper. URL-related context uses **`previewUrlFailureContext`**, backed by new **`getUrlDiagnostics`** in `@t3tools/shared/urlDiagnostics`, so logs keep hostname, protocol, and length only—not full URLs, credentials, or query tokens. **`openPreviewSession`** atom failures are reported when not interrupted; picker failures stay silent in the UI but are logged.
> 
> Shared also adds **`redactDpopRequestTarget`** (scheme/host/path only) with tests; it is not wired into callers in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fe62591f6c5f696ed1f4274d6a1dde6f89c3f35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Report preview action failures via console.error with sanitized context
> - Adds `reportPreviewActionFailure` in [reportPreviewActionFailure.ts](https://github.com/pingdotgg/t3code/pull/3351/files#diff-f868a553da55d40430855f5a355ab6d436b00704cd6e384cc32856a84b6de8e5) that logs a structured `console.error` with operation name and context, replacing silent error swallowing across preview components.
> - Adds `previewUrlFailureContext` to derive sanitized URL diagnostics (hostname, protocol, input length) without leaking raw URLs, credentials, or query params.
> - Wires failure reporting into [PreviewView.tsx](https://github.com/pingdotgg/t3code/pull/3351/files#diff-c02d770e873143915b2b12f22b2539bd0111c82465ae9e385583be2391fbcad5) for URL submission phases, navigation, session open, zoom, refresh, recording, screenshots, and element picking flows.
> - Wires failure reporting into [PreviewMoreMenu.tsx](https://github.com/pingdotgg/t3code/pull/3351/files#diff-60b81fe77cec9920eec66a2cbd6b6f9f28c90e252379508a02dc54be8803609a) for hard reload, devtools, zoom, cookie/cache clearing operations.
> - Behavioral Change: previously silent failures in preview actions now emit `console.error` entries with structured metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8fe6259.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->