### PR TITLE
[codex] structure workspace search failures

### DIFF
--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -67,17 +67,20 @@ it.effect("preserves search and refresh failures with operation context", () =>
       vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
 
       const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
-      const searchError = yield* Effect.flip(searchIndex.search("needle", 3));
+      const query = "authorization: Bearer secret-token";
+      const searchError = yield* Effect.flip(searchIndex.search(query, 3));
       const refreshError = yield* Effect.flip(searchIndex.refresh());
 
       expect(searchError).toMatchObject({
         _tag: "WorkspaceSearchIndexSearchFailed",
         cwd: "/workspace/project",
-        query: "needle",
+        queryLength: query.length,
         pageSize: 4,
         reason: "FileFinder.mixedSearch threw unexpectedly.",
         cause: searchCause,
       });
+      expect(searchError).not.toHaveProperty("query");
+      expect(searchError.message).not.toMatch(/Bearer|secret-token/);
       expect(refreshError).toMatchObject({
         _tag: "WorkspaceSearchIndexRefreshFailed",
         cwd: "/workspace/project",
@@ -100,16 +103,19 @@ it.effect("keeps returned search diagnostics out of the cause chain", () =>
       vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
 
       const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
-      const searchError = yield* Effect.flip(searchIndex.search("needle", 3));
+      const query = "authorization: Bearer secret-token";
+      const searchError = yield* Effect.flip(searchIndex.search(query, 3));
       const refreshError = yield* Effect.flip(searchIndex.refresh());
 
       expect(searchError).toMatchObject({
         _tag: "WorkspaceSearchIndexSearchFailed",
         cwd: "/workspace/project",
-        query: "needle",
+        queryLength: query.length,
         pageSize: 4,
         reason: "native query rejected",
       });
+      expect(searchError).not.toHaveProperty("query");
+      expect(searchError.message).not.toMatch(/Bearer|secret-token/);
       expect(searchError.cause).toBeUndefined();
       expect(refreshError).toMatchObject({
         _tag: "WorkspaceSearchIndexRefreshFailed",

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -29,6 +29,26 @@ it.effect("preserves unexpected FileFinder creation failures", () =>
   }),
 );
 
+it.effect("keeps returned FileFinder creation diagnostics out of the cause chain", () =>
+  Effect.gen(function* () {
+    vi.spyOn(FileFinder, "create").mockReturnValueOnce({
+      ok: false,
+      error: "native index rejected the directory",
+    });
+
+    const error = yield* Effect.flip(
+      Effect.scoped(WorkspaceSearchIndex.make("/workspace/project")),
+    );
+
+    expect(error).toMatchObject({
+      _tag: "WorkspaceSearchIndexCreateFailed",
+      cwd: "/workspace/project",
+      reason: "native index rejected the directory",
+    });
+    expect(error.cause).toBeUndefined();
+  }),
+);
+
 it.effect("preserves search and refresh failures with operation context", () =>
   Effect.scoped(
     Effect.gen(function* () {
@@ -64,6 +84,39 @@ it.effect("preserves search and refresh failures with operation context", () =>
         reason: "FileFinder.scanFiles threw unexpectedly.",
         cause: refreshCause,
       });
+    }),
+  ),
+);
+
+it.effect("keeps returned search diagnostics out of the cause chain", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const finder = {
+        destroy: vi.fn(),
+        isScanning: vi.fn(() => false),
+        mixedSearch: vi.fn(() => ({ ok: false, error: "native query rejected" })),
+        scanFiles: vi.fn(() => ({ ok: false, error: "native refresh rejected" })),
+      } as unknown as FileFinder;
+      vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+
+      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
+      const searchError = yield* Effect.flip(searchIndex.search("needle", 3));
+      const refreshError = yield* Effect.flip(searchIndex.refresh());
+
+      expect(searchError).toMatchObject({
+        _tag: "WorkspaceSearchIndexSearchFailed",
+        cwd: "/workspace/project",
+        query: "needle",
+        pageSize: 4,
+        reason: "native query rejected",
+      });
+      expect(searchError.cause).toBeUndefined();
+      expect(refreshError).toMatchObject({
+        _tag: "WorkspaceSearchIndexRefreshFailed",
+        cwd: "/workspace/project",
+        reason: "native refresh rejected",
+      });
+      expect(refreshError.cause).toBeUndefined();
     }),
   ),
 );

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -1,0 +1,69 @@
+import { FileFinder } from "@ff-labs/fff-node";
+import { afterEach, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import { vi } from "vite-plus/test";
+
+import * as WorkspaceSearchIndex from "./WorkspaceSearchIndex.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it.effect("preserves unexpected FileFinder creation failures", () =>
+  Effect.gen(function* () {
+    const cause = new Error("native initialization failed");
+    vi.spyOn(FileFinder, "create").mockImplementationOnce(() => {
+      throw cause;
+    });
+
+    const error = yield* Effect.flip(
+      Effect.scoped(WorkspaceSearchIndex.make("/workspace/project")),
+    );
+
+    expect(error).toMatchObject({
+      _tag: "WorkspaceSearchIndexCreateFailed",
+      cwd: "/workspace/project",
+      reason: "FileFinder.create threw unexpectedly.",
+      cause,
+    });
+  }),
+);
+
+it.effect("preserves search and refresh failures with operation context", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const searchCause = new Error("native search failed");
+      const refreshCause = new Error("native scan failed");
+      const finder = {
+        destroy: vi.fn(),
+        isScanning: vi.fn(() => false),
+        mixedSearch: vi.fn(() => {
+          throw searchCause;
+        }),
+        scanFiles: vi.fn(() => {
+          throw refreshCause;
+        }),
+      } as unknown as FileFinder;
+      vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+
+      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
+      const searchError = yield* Effect.flip(searchIndex.search("needle", 3));
+      const refreshError = yield* Effect.flip(searchIndex.refresh());
+
+      expect(searchError).toMatchObject({
+        _tag: "WorkspaceSearchIndexSearchFailed",
+        cwd: "/workspace/project",
+        query: "needle",
+        pageSize: 4,
+        reason: "FileFinder.mixedSearch threw unexpectedly.",
+        cause: searchCause,
+      });
+      expect(refreshError).toMatchObject({
+        _tag: "WorkspaceSearchIndexRefreshFailed",
+        cwd: "/workspace/project",
+        reason: "FileFinder.scanFiles threw unexpectedly.",
+        cause: refreshCause,
+      });
+    }),
+  ),
+);

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -47,7 +47,7 @@ export class WorkspaceSearchIndexSearchFailed extends Schema.TaggedErrorClass<Wo
   "WorkspaceSearchIndexSearchFailed",
   {
     cwd: Schema.String,
-    query: Schema.String,
+    queryLength: Schema.Number,
     pageSize: Schema.Number,
     reason: Schema.String,
     cause: Schema.optional(Schema.Defect()),
@@ -223,7 +223,7 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
       catch: (cause) =>
         new WorkspaceSearchIndexSearchFailed({
           cwd,
-          query,
+          queryLength: query.length,
           pageSize,
           reason: "FileFinder.mixedSearch threw unexpectedly.",
           cause,
@@ -232,7 +232,7 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
     if (!result.ok) {
       return yield* new WorkspaceSearchIndexSearchFailed({
         cwd,
-        query,
+        queryLength: query.length,
         pageSize,
         reason: result.error,
       });

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -23,7 +23,7 @@ export class WorkspaceSearchIndexCreateFailed extends Schema.TaggedErrorClass<Wo
   {
     cwd: Schema.String,
     reason: Schema.String,
-    cause: Schema.Defect(),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
@@ -50,7 +50,7 @@ export class WorkspaceSearchIndexSearchFailed extends Schema.TaggedErrorClass<Wo
     query: Schema.String,
     pageSize: Schema.Number,
     reason: Schema.String,
-    cause: Schema.Defect(),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
@@ -63,7 +63,7 @@ export class WorkspaceSearchIndexRefreshFailed extends Schema.TaggedErrorClass<W
   {
     cwd: Schema.String,
     reason: Schema.String,
-    cause: Schema.Defect(),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
@@ -179,7 +179,6 @@ const createFinder = Effect.fn("WorkspaceSearchIndex.createFinder")(function* (c
   return yield* new WorkspaceSearchIndexCreateFailed({
     cwd,
     reason: result.error,
-    cause: result.error,
   });
 });
 
@@ -236,7 +235,6 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
         query,
         pageSize,
         reason: result.error,
-        cause: result.error,
       });
     }
     return result.value;
@@ -258,7 +256,6 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
       return yield* new WorkspaceSearchIndexRefreshFailed({
         cwd,
         reason: result.error,
-        cause: result.error,
       });
     }
     yield* waitForScan(

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -23,10 +23,11 @@ export class WorkspaceSearchIndexCreateFailed extends Schema.TaggedErrorClass<Wo
   {
     cwd: Schema.String,
     reason: Schema.String,
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to create the workspace search index for '${this.cwd}': ${this.reason}`;
+    return `Failed to create the workspace search index for '${this.cwd}'.`;
   }
 }
 
@@ -46,11 +47,14 @@ export class WorkspaceSearchIndexSearchFailed extends Schema.TaggedErrorClass<Wo
   "WorkspaceSearchIndexSearchFailed",
   {
     cwd: Schema.String,
+    query: Schema.String,
+    pageSize: Schema.Number,
     reason: Schema.String,
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Workspace search failed for '${this.cwd}': ${this.reason}`;
+    return `Workspace search failed for '${this.cwd}'.`;
   }
 }
 
@@ -59,10 +63,11 @@ export class WorkspaceSearchIndexRefreshFailed extends Schema.TaggedErrorClass<W
   {
     cwd: Schema.String,
     reason: Schema.String,
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to refresh the workspace search index for '${this.cwd}': ${this.reason}`;
+    return `Failed to refresh the workspace search index for '${this.cwd}'.`;
   }
 }
 
@@ -153,23 +158,36 @@ function withDirectoryAncestors(entries: ReadonlyArray<ProjectEntry>): ProjectEn
 }
 
 const createFinder = Effect.fn("WorkspaceSearchIndex.createFinder")(function* (cwd: string) {
-  const result = FileFinder.create({
-    basePath: cwd,
-    disableMmapCache: true,
-    disableContentIndexing: true,
-    aiMode: false,
-    enableFsRootScanning: true,
-    enableHomeDirScanning: true,
+  const result = yield* Effect.try({
+    try: () =>
+      FileFinder.create({
+        basePath: cwd,
+        disableMmapCache: true,
+        disableContentIndexing: true,
+        aiMode: false,
+        enableFsRootScanning: true,
+        enableHomeDirScanning: true,
+      }),
+    catch: (cause) =>
+      new WorkspaceSearchIndexCreateFailed({
+        cwd,
+        reason: "FileFinder.create threw unexpectedly.",
+        cause,
+      }),
   });
   if (result.ok) return result.value;
-  return yield* new WorkspaceSearchIndexCreateFailed({ cwd, reason: result.error });
+  return yield* new WorkspaceSearchIndexCreateFailed({
+    cwd,
+    reason: result.error,
+    cause: result.error,
+  });
 });
 
-const waitForScan = Effect.fn("WorkspaceSearchIndex.waitForScan")(function* (
-  cwd: string,
-  finder: FileFinder,
-) {
-  yield* Effect.sync(() => finder.isScanning()).pipe(
+const waitForScan = <E>(cwd: string, finder: FileFinder, onFailure: (cause: unknown) => E) =>
+  Effect.try({
+    try: () => finder.isScanning(),
+    catch: onFailure,
+  }).pipe(
     Effect.repeat({
       while: (scanning) => scanning,
       schedule: Schedule.spaced(WORKSPACE_INDEX_SCAN_POLL_INTERVAL),
@@ -179,22 +197,47 @@ const waitForScan = Effect.fn("WorkspaceSearchIndex.waitForScan")(function* (
       orElse: () =>
         new WorkspaceSearchIndexScanTimedOut({ cwd, timeout: WORKSPACE_INDEX_SCAN_TIMEOUT }),
     }),
+    Effect.withSpan("WorkspaceSearchIndex.waitForScan"),
   );
-});
 
 export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: string) {
   const finder = yield* Effect.acquireRelease(createFinder(cwd), (finder) =>
     Effect.sync(() => finder.destroy()),
   );
-  yield* waitForScan(cwd, finder);
+  yield* waitForScan(
+    cwd,
+    finder,
+    (cause) =>
+      new WorkspaceSearchIndexCreateFailed({
+        cwd,
+        reason: "FileFinder.isScanning threw while creating the index.",
+        cause,
+      }),
+  );
 
   const runMixedSearch = Effect.fn("WorkspaceSearchIndex.runMixedSearch")(function* (
     query: string,
     pageSize: number,
   ) {
-    const result = yield* Effect.sync(() => finder.mixedSearch(query, { pageSize }));
+    const result = yield* Effect.try({
+      try: () => finder.mixedSearch(query, { pageSize }),
+      catch: (cause) =>
+        new WorkspaceSearchIndexSearchFailed({
+          cwd,
+          query,
+          pageSize,
+          reason: "FileFinder.mixedSearch threw unexpectedly.",
+          cause,
+        }),
+    });
     if (!result.ok) {
-      return yield* new WorkspaceSearchIndexSearchFailed({ cwd, reason: result.error });
+      return yield* new WorkspaceSearchIndexSearchFailed({
+        cwd,
+        query,
+        pageSize,
+        reason: result.error,
+        cause: result.error,
+      });
     }
     return result.value;
   });
@@ -202,11 +245,32 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: strin
   const refresh: WorkspaceSearchIndex["Service"]["refresh"] = Effect.fn(
     "WorkspaceSearchIndex.refresh",
   )(function* () {
-    const result = yield* Effect.sync(() => finder.scanFiles());
+    const result = yield* Effect.try({
+      try: () => finder.scanFiles(),
+      catch: (cause) =>
+        new WorkspaceSearchIndexRefreshFailed({
+          cwd,
+          reason: "FileFinder.scanFiles threw unexpectedly.",
+          cause,
+        }),
+    });
     if (!result.ok) {
-      return yield* new WorkspaceSearchIndexRefreshFailed({ cwd, reason: result.error });
+      return yield* new WorkspaceSearchIndexRefreshFailed({
+        cwd,
+        reason: result.error,
+        cause: result.error,
+      });
     }
-    yield* waitForScan(cwd, finder);
+    yield* waitForScan(
+      cwd,
+      finder,
+      (cause) =>
+        new WorkspaceSearchIndexRefreshFailed({
+          cwd,
+          reason: "FileFinder.isScanning threw while refreshing the index.",
+          cause,
+        }),
+    );
   });
 
   const list: WorkspaceSearchIndex["Service"]["list"] = Effect.fn("WorkspaceSearchIndex.list")(


### PR DESCRIPTION
## Summary
- capture thrown FileFinder create/search/scan failures as typed errors with exact causes
- add query and effective page-size context to search failures
- retain compatibility reason details while keeping domain messages independent of opaque failure text

## Verification
- `vp test apps/server/src/workspace/WorkspaceSearchIndex.test.ts` (2 tests)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`


<!-- sensitive-context-follow-up -->
## Sensitive-context follow-up\n- workspace search failures retain query length and effective page size rather than the raw query\n- cwd, reason, and exact thrown cause behavior remain unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling and observability changes in workspace search; behavior on success is unchanged aside from shorter public error messages.
> 
> **Overview**
> **Workspace search index errors are now typed and safer to log.** `FileFinder.create`, `mixedSearch`, `scanFiles`, and `isScanning` are wrapped in `Effect.try` so thrown failures become tagged errors with an optional `cause`; native `ok: false` results still set `reason` but leave `cause` unset.
> 
> **Search failures carry `queryLength` and `pageSize` instead of the query string**, and user-facing `message` strings no longer embed `reason` (details stay on the error fields). `waitForScan` is generalized with an `onFailure` hook so create vs refresh can map `isScanning` throws to the right error type.
> 
> New **Effect/Vitest** coverage asserts cause preservation, returned-error handling, and that secrets in queries never appear on errors or messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 897e185cbfeabcf94664324a11a15209f700f474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure workspace search failures by catching raw exceptions as typed errors
> - Wraps `FileFinder.create`, `mixedSearch`, `scanFiles`, and `isScanning` in `Effect.try` so unexpected thrown exceptions are converted into `WorkspaceSearchIndexCreateFailed`, `WorkspaceSearchIndexSearchFailed`, or `WorkspaceSearchIndexRefreshFailed` instead of propagating as raw defects.
> - Adds optional `cause` field to all three error classes, and adds `queryLength`/`pageSize` fields to `WorkspaceSearchIndexSearchFailed` for contextual debugging.
> - Removes the internal `reason` detail from error message getters so sensitive query content is not exposed in error messages.
> - Adds tests in [`WorkspaceSearchIndex.test.ts`](https://github.com/pingdotgg/t3code/pull/3352/files#diff-a7ed586ccb0e703854e76107ba2f29105acaa431d7fbe8b9fad34c98a8547c59) covering error shaping, cause inclusion/exclusion, and message sanitization for create, search, and refresh operations.
> - Behavioral Change: error messages for all three failure types are now generic (no reason text); exceptions that previously escaped as defects are now surfaced as structured typed errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 897e185.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->