### PR TITLE
[codex] Structure native view resolution failures

### DIFF
--- a/apps/mobile/src/features/diffs/nativeReviewDiffSurface.test.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffSurface.test.ts
@@ -58,10 +58,20 @@ describe("resolveNativeReviewDiffView", () => {
 
   it("returns null when the view manager cannot be required", async () => {
     setExpoViewConfigAvailable();
+    const cause = new Error("boom");
     expoMocks.requireNativeView.mockImplementation(() => {
-      throw new Error("boom");
+      throw cause;
     });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const { resolveNativeReviewDiffView } = await import("./nativeReviewDiffSurface");
+
     expect(resolveNativeReviewDiffView()).toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _tag: "NativeViewResolutionError",
+        nativeModuleName: "T3ReviewDiffSurface",
+        cause,
+      }),
+    );
   });
 });

--- a/apps/mobile/src/features/diffs/nativeReviewDiffSurface.test.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffSurface.test.ts
@@ -66,6 +66,8 @@ describe("resolveNativeReviewDiffView", () => {
     const { resolveNativeReviewDiffView } = await import("./nativeReviewDiffSurface");
 
     expect(resolveNativeReviewDiffView()).toBeNull();
+    expect(resolveNativeReviewDiffView()).toBeNull();
+    expect(expoMocks.requireNativeView).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith(
       expect.objectContaining({
         _tag: "NativeViewResolutionError",
@@ -73,5 +75,6 @@ describe("resolveNativeReviewDiffView", () => {
         cause,
       }),
     );
+    expect(consoleError).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/features/diffs/nativeReviewDiffSurface.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffSurface.ts
@@ -2,6 +2,8 @@ import type { ComponentType } from "react";
 import type { NativeSyntheticEvent, ViewProps } from "react-native";
 import { requireNativeView } from "expo";
 
+import { NativeViewResolutionError } from "../../native/nativeViewResolutionError";
+
 const NATIVE_REVIEW_DIFF_MODULE_NAME = "T3ReviewDiffSurface";
 
 interface ExpoGlobalWithViewConfig {
@@ -148,7 +150,13 @@ export function resolveNativeReviewDiffView(): ComponentType<NativeReviewDiffVie
     cachedNativeReviewDiffView = requireNativeView<NativeReviewDiffViewProps>(
       NATIVE_REVIEW_DIFF_MODULE_NAME,
     );
-  } catch {
+  } catch (cause) {
+    console.error(
+      new NativeViewResolutionError({
+        nativeModuleName: NATIVE_REVIEW_DIFF_MODULE_NAME,
+        cause,
+      }),
+    );
     return null;
   }
 

--- a/apps/mobile/src/features/diffs/nativeReviewDiffSurface.ts
+++ b/apps/mobile/src/features/diffs/nativeReviewDiffSurface.ts
@@ -130,6 +130,7 @@ export interface NativeReviewDiffViewProps extends ViewProps {
 }
 
 let cachedNativeReviewDiffView: ComponentType<NativeReviewDiffViewProps> | undefined;
+let nativeReviewDiffViewResolutionFailed = false;
 
 function getExpoViewConfig(moduleName: string) {
   return (globalThis as typeof globalThis & ExpoGlobalWithViewConfig).expo?.getViewConfig?.(
@@ -142,6 +143,10 @@ export function resolveNativeReviewDiffView(): ComponentType<NativeReviewDiffVie
     return cachedNativeReviewDiffView;
   }
 
+  if (nativeReviewDiffViewResolutionFailed) {
+    return null;
+  }
+
   if (getExpoViewConfig(NATIVE_REVIEW_DIFF_MODULE_NAME) == null) {
     return null;
   }
@@ -151,6 +156,7 @@ export function resolveNativeReviewDiffView(): ComponentType<NativeReviewDiffVie
       NATIVE_REVIEW_DIFF_MODULE_NAME,
     );
   } catch (cause) {
+    nativeReviewDiffViewResolutionFailed = true;
     console.error(
       new NativeViewResolutionError({
         nativeModuleName: NATIVE_REVIEW_DIFF_MODULE_NAME,

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.test.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.test.ts
@@ -51,6 +51,8 @@ describe("resolveNativeTerminalSurfaceView", () => {
     const { resolveNativeTerminalSurfaceView } = await import("./nativeTerminalModule");
 
     expect(resolveNativeTerminalSurfaceView()).toBeNull();
+    expect(resolveNativeTerminalSurfaceView()).toBeNull();
+    expect(expoMocks.requireNativeView).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith(
       expect.objectContaining({
         _tag: "NativeViewResolutionError",
@@ -58,5 +60,6 @@ describe("resolveNativeTerminalSurfaceView", () => {
         cause,
       }),
     );
+    expect(consoleError).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.test.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.test.ts
@@ -43,10 +43,20 @@ describe("resolveNativeTerminalSurfaceView", () => {
 
   it("returns null when the view manager cannot be required", async () => {
     setExpoViewConfigAvailable();
+    const cause = new Error("boom");
     expoMocks.requireNativeView.mockImplementation(() => {
-      throw new Error("boom");
+      throw cause;
     });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const { resolveNativeTerminalSurfaceView } = await import("./nativeTerminalModule");
+
     expect(resolveNativeTerminalSurfaceView()).toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _tag: "NativeViewResolutionError",
+        nativeModuleName: "T3TerminalSurface",
+        cause,
+      }),
+    );
   });
 });

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.ts
@@ -35,6 +35,7 @@ export interface NativeTerminalSurfaceProps extends ViewProps {
 }
 
 let cachedNativeTerminalSurfaceView: ComponentType<NativeTerminalSurfaceProps> | undefined;
+let nativeTerminalSurfaceViewResolutionFailed = false;
 
 function getExpoViewConfig(moduleName: string) {
   return (globalThis as typeof globalThis & ExpoGlobalWithViewConfig).expo?.getViewConfig?.(
@@ -47,6 +48,10 @@ export function resolveNativeTerminalSurfaceView(): ComponentType<NativeTerminal
     return cachedNativeTerminalSurfaceView;
   }
 
+  if (nativeTerminalSurfaceViewResolutionFailed) {
+    return null;
+  }
+
   if (getExpoViewConfig(NATIVE_TERMINAL_MODULE_NAME) == null) {
     return null;
   }
@@ -56,6 +61,7 @@ export function resolveNativeTerminalSurfaceView(): ComponentType<NativeTerminal
       NATIVE_TERMINAL_MODULE_NAME,
     );
   } catch (cause) {
+    nativeTerminalSurfaceViewResolutionFailed = true;
     console.error(
       new NativeViewResolutionError({
         nativeModuleName: NATIVE_TERMINAL_MODULE_NAME,

--- a/apps/mobile/src/features/terminal/nativeTerminalModule.ts
+++ b/apps/mobile/src/features/terminal/nativeTerminalModule.ts
@@ -2,6 +2,8 @@ import type { ComponentType } from "react";
 import type { NativeSyntheticEvent, ViewProps } from "react-native";
 import { requireNativeView } from "expo";
 
+import { NativeViewResolutionError } from "../../native/nativeViewResolutionError";
+
 const NATIVE_TERMINAL_MODULE_NAME = "T3TerminalSurface";
 
 interface ExpoGlobalWithViewConfig {
@@ -53,7 +55,13 @@ export function resolveNativeTerminalSurfaceView(): ComponentType<NativeTerminal
     cachedNativeTerminalSurfaceView = requireNativeView<NativeTerminalSurfaceProps>(
       NATIVE_TERMINAL_MODULE_NAME,
     );
-  } catch {
+  } catch (cause) {
+    console.error(
+      new NativeViewResolutionError({
+        nativeModuleName: NATIVE_TERMINAL_MODULE_NAME,
+        cause,
+      }),
+    );
     return null;
   }
 

--- a/apps/mobile/src/native/nativeViewResolutionError.ts
+++ b/apps/mobile/src/native/nativeViewResolutionError.ts
@@ -1,0 +1,13 @@
+import * as Schema from "effect/Schema";
+
+export class NativeViewResolutionError extends Schema.TaggedErrorClass<NativeViewResolutionError>()(
+  "NativeViewResolutionError",
+  {
+    nativeModuleName: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to resolve native view ${this.nativeModuleName}.`;
+  }
+}


### PR DESCRIPTION
## What Changed

- added a schema-backed native-view resolution error carrying the Expo module name and exact cause
- report failures to require the terminal and review-diff native views before retaining their existing `null` fallback
- extended the focused resolver tests to verify structured diagnostics and cause preservation

## Why

Both resolvers silently discarded `requireNativeView` failures. The UI fallback is intentional, but the failure now remains diagnosable without changing availability behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

## Validation

- `vp test apps/mobile/src/features/terminal/nativeTerminalModule.test.ts apps/mobile/src/features/diffs/nativeReviewDiffSurface.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and retry-avoidance only; public resolver return values and UI fallback paths are unchanged.
> 
> **Overview**
> Native Expo view resolvers for **review diff** and **terminal** surfaces no longer swallow `requireNativeView` failures. On error they log a **`NativeViewResolutionError`** (module name + original cause) via `console.error`, set a **one-shot failure flag** so later calls skip re-invoking `requireNativeView`, and still return **`null`** for the existing JS fallback.
> 
> Adds **`nativeViewResolutionError.ts`** as a shared Effect Schema tagged error. Resolver tests now assert structured logging, preserved cause, and that a second resolve attempt does not call `requireNativeView` again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b5ceb1cbb7cb0f257c37b8432eb5500ee20b897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure native view resolution failures with `NativeViewResolutionError` and memoized failure state
> - Adds a new [`NativeViewResolutionError`](https://github.com/pingdotgg/t3code/pull/3353/files#diff-f67b17d2166adddfcc372060587992c5eb12ae14d45f7c499147a7897e392db7) tagged error class (via `effect/Schema`) carrying `nativeModuleName` and `cause` fields.
> - Updates `resolveNativeReviewDiffView` and `resolveNativeTerminalSurfaceView` to catch failures, log a `NativeViewResolutionError` to `console.error`, and set a module-level flag so subsequent calls return `null` immediately without retrying.
> - Behavioral Change: after the first `requireNativeView` failure, the resolver short-circuits all subsequent calls rather than re-attempting resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4b5ceb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->