### PR TITLE
[codex] Structure Codex schema generator errors

### DIFF
--- a/packages/effect-codex-app-server/package.json
+++ b/packages/effect-codex-app-server/package.json
@@ -31,6 +31,7 @@
     "probe": "node test/examples/codex-app-server-probe.ts"
   },
   "dependencies": {
+    "@t3tools/shared": "workspace:*",
     "effect": "catalog:"
   },
   "devDependencies": {

--- a/packages/effect-codex-app-server/scripts/generate.test.ts
+++ b/packages/effect-codex-app-server/scripts/generate.test.ts
@@ -47,6 +47,7 @@ describe("Codex schema generator errors", () => {
 
       assert(isGeneratorFetchError(error));
       expect(error.url).toBe(url);
+      expect(error.stage).toBe("request");
       expect(error.cause).toBeDefined();
       expect(error.message).toBe(`Failed to fetch ${url}.`);
     }),

--- a/packages/effect-codex-app-server/scripts/generate.test.ts
+++ b/packages/effect-codex-app-server/scripts/generate.test.ts
@@ -13,6 +13,10 @@ const isGeneratorSchemaDocumentDecodeError = Schema.is(
   Generator.GeneratorSchemaDocumentDecodeError,
 );
 const isGeneratorFormatExitError = Schema.is(Generator.GeneratorFormatExitError);
+const isGeneratorSchemaNameParseError = Schema.is(Generator.GeneratorSchemaNameParseError);
+const isGeneratorSchemaValueDeclarationMissingError = Schema.is(
+  Generator.GeneratorSchemaValueDeclarationMissingError,
+);
 
 const httpClient = (response: Response) =>
   HttpClient.make((request) => Effect.succeed(HttpClientResponse.fromWeb(request, response)));
@@ -56,7 +60,10 @@ describe("Codex schema generator errors", () => {
       expect(error.stage).toBe("request");
       expect(error.cause).toBeDefined();
       const { cause: _, ...directDiagnostics } = error;
-      expect(JSON.stringify(directDiagnostics)).not.toMatch(
+      expect(directDiagnostics).not.toHaveProperty("url");
+      expect(directDiagnostics.urlProtocol).toBe("https:");
+      expect(directDiagnostics.urlHostname).toBe("example.test");
+      expect(error.message).not.toMatch(
         /generator-user|generator-password|private|token|generator-secret|fragment/,
       );
     }),
@@ -132,4 +139,29 @@ describe("Codex schema generator errors", () => {
       expect(spawned?.args).toEqual(["fmt", generatedDir, "--write"]);
     }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
   });
+
+  it.effect("returns malformed generated schema declarations as typed failures", () =>
+    Effect.gen(function* () {
+      const missingValueError = yield* Generator.collectSchemaEntries(
+        "export type Session = string;",
+      ).pipe(Effect.flip);
+      assert(isGeneratorSchemaValueDeclarationMissingError(missingValueError));
+      expect(missingValueError).toMatchObject({
+        lineIndex: 0,
+        typeDeclarationLength: 29,
+        nextLinePresent: false,
+      });
+      expect(missingValueError).not.toHaveProperty("typeDeclaration");
+
+      const nameParseError = yield* Generator.collectSchemaEntries(
+        "export type @ = string;\nexport const invalid = Schema.String;",
+      ).pipe(Effect.flip);
+      assert(isGeneratorSchemaNameParseError(nameParseError));
+      expect(nameParseError).toMatchObject({
+        lineIndex: 0,
+        typeDeclarationLength: 23,
+      });
+      expect(nameParseError).not.toHaveProperty("typeDeclaration");
+    }),
+  );
 });

--- a/packages/effect-codex-app-server/scripts/generate.test.ts
+++ b/packages/effect-codex-app-server/scripts/generate.test.ts
@@ -34,9 +34,10 @@ function processHandle(exitCode: number) {
 }
 
 describe("Codex schema generator errors", () => {
-  it.effect("retains the requested URL and HTTP cause when fetching fails", () =>
+  it.effect("retains safe URL diagnostics and the HTTP cause when fetching fails", () =>
     Effect.gen(function* () {
-      const url = "https://example.test/schema.json";
+      const url =
+        "https://generator-user:generator-password@example.test/private/schema.json?token=generator-secret#fragment";
       const error = yield* Generator.fetchText(url).pipe(
         Effect.provideService(
           HttpClient.HttpClient,
@@ -46,10 +47,18 @@ describe("Codex schema generator errors", () => {
       );
 
       assert(isGeneratorFetchError(error));
-      expect(error.url).toBe(url);
+      expect(error).toMatchObject({
+        urlInputLength: url.length,
+        urlProtocol: "https:",
+        urlHostname: "example.test",
+      });
+      expect(error).not.toHaveProperty("url");
       expect(error.stage).toBe("request");
       expect(error.cause).toBeDefined();
-      expect(error.message).toBe(`Failed to fetch ${url}.`);
+      const { cause: _, ...directDiagnostics } = error;
+      expect(JSON.stringify(directDiagnostics)).not.toMatch(
+        /generator-user|generator-password|private|token|generator-secret|fragment/,
+      );
     }),
   );
 
@@ -65,7 +74,12 @@ describe("Codex schema generator errors", () => {
 
       assert(isGeneratorDirectoryDecodeError(error));
       expect(error.directoryPath).toBe("schema/json/v2");
-      expect(error.url).toContain("/schema/json/v2?ref=");
+      expect(error).toMatchObject({
+        urlProtocol: "https:",
+        urlHostname: "api.github.com",
+      });
+      expect(error.urlInputLength).toBeGreaterThan(0);
+      expect(error).not.toHaveProperty("url");
       expect(error.cause).toBeDefined();
       expect(error.message).toContain("schema/json/v2");
     }),
@@ -83,7 +97,12 @@ describe("Codex schema generator errors", () => {
 
       assert(isGeneratorSchemaDocumentDecodeError(error));
       expect(error.repositoryPath).toBe(repositoryPath);
-      expect(error.url).toBe(url);
+      expect(error).toMatchObject({
+        urlInputLength: url.length,
+        urlProtocol: "https:",
+        urlHostname: "raw.example.test",
+      });
+      expect(error).not.toHaveProperty("url");
       expect(error.cause).toBeDefined();
       expect(error.message).toContain(repositoryPath);
     }),
@@ -104,12 +123,13 @@ describe("Codex schema generator errors", () => {
 
       assert(isGeneratorFormatExitError(error));
       expect(error.command).toBe("vp");
-      expect(error.args).toEqual(["fmt", generatedDir, "--write"]);
+      expect(error.argumentCount).toBe(3);
+      expect(error).not.toHaveProperty("args");
       expect(error.generatedDir).toBe(generatedDir);
       expect(error.exitCode).toBe(17);
       expect(error.message).toContain("17");
       expect(spawned?.command).toBe("vp");
-      expect(spawned?.args).toEqual(error.args);
+      expect(spawned?.args).toEqual(["fmt", generatedDir, "--write"]);
     }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
   });
 });

--- a/packages/effect-codex-app-server/scripts/generate.test.ts
+++ b/packages/effect-codex-app-server/scripts/generate.test.ts
@@ -1,0 +1,114 @@
+import { assert, describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { HttpClient, HttpClientResponse } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import * as Generator from "./generate.ts";
+
+const isGeneratorFetchError = Schema.is(Generator.GeneratorFetchError);
+const isGeneratorDirectoryDecodeError = Schema.is(Generator.GeneratorDirectoryDecodeError);
+const isGeneratorSchemaDocumentDecodeError = Schema.is(
+  Generator.GeneratorSchemaDocumentDecodeError,
+);
+const isGeneratorFormatExitError = Schema.is(Generator.GeneratorFormatExitError);
+
+const httpClient = (response: Response) =>
+  HttpClient.make((request) => Effect.succeed(HttpClientResponse.fromWeb(request, response)));
+
+function processHandle(exitCode: number) {
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.drain,
+    stdout: Stream.empty,
+    stderr: Stream.empty,
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
+}
+
+describe("Codex schema generator errors", () => {
+  it.effect("retains the requested URL and HTTP cause when fetching fails", () =>
+    Effect.gen(function* () {
+      const url = "https://example.test/schema.json";
+      const error = yield* Generator.fetchText(url).pipe(
+        Effect.provideService(
+          HttpClient.HttpClient,
+          httpClient(new Response("unavailable", { status: 503 })),
+        ),
+        Effect.flip,
+      );
+
+      assert(isGeneratorFetchError(error));
+      expect(error.url).toBe(url);
+      expect(error.cause).toBeDefined();
+      expect(error.message).toBe(`Failed to fetch ${url}.`);
+    }),
+  );
+
+  it.effect("adds the GitHub directory path to listing decode failures", () =>
+    Effect.gen(function* () {
+      const error = yield* Generator.fetchDirectoryEntries("schema/json/v2").pipe(
+        Effect.provideService(
+          HttpClient.HttpClient,
+          httpClient(new Response("not-json", { status: 200 })),
+        ),
+        Effect.flip,
+      );
+
+      assert(isGeneratorDirectoryDecodeError(error));
+      expect(error.directoryPath).toBe("schema/json/v2");
+      expect(error.url).toContain("/schema/json/v2?ref=");
+      expect(error.cause).toBeDefined();
+      expect(error.message).toContain("schema/json/v2");
+    }),
+  );
+
+  it.effect("adds repository and download context to schema decode failures", () =>
+    Effect.gen(function* () {
+      const repositoryPath = "codex-rs/app-server-protocol/schema/json/v2/Thread.json";
+      const url = "https://raw.example.test/Thread.json";
+      const error = yield* Generator.decodeSchemaDocument({
+        repositoryPath,
+        url,
+        raw: "not-json",
+      }).pipe(Effect.flip);
+
+      assert(isGeneratorSchemaDocumentDecodeError(error));
+      expect(error.repositoryPath).toBe(repositoryPath);
+      expect(error.url).toBe(url);
+      expect(error.cause).toBeDefined();
+      expect(error.message).toContain(repositoryPath);
+    }),
+  );
+
+  it.effect("reports formatter commands and nonzero exit codes structurally", () => {
+    let spawned: ChildProcess.StandardCommand | undefined;
+    const spawner = ChildProcessSpawner.make((command) => {
+      if (ChildProcess.isStandardCommand(command)) {
+        spawned = command;
+      }
+      return Effect.succeed(processHandle(17));
+    });
+
+    return Effect.gen(function* () {
+      const generatedDir = "/tmp/codex-generated";
+      const error = yield* Generator.formatGeneratedFiles(generatedDir).pipe(Effect.flip);
+
+      assert(isGeneratorFormatExitError(error));
+      expect(error.command).toBe("vp");
+      expect(error.args).toEqual(["fmt", generatedDir, "--write"]);
+      expect(error.generatedDir).toBe(generatedDir);
+      expect(error.exitCode).toBe(17);
+      expect(error.message).toContain("17");
+      expect(spawned?.command).toBe("vp");
+      expect(spawned?.args).toEqual(error.args);
+    }).pipe(Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner));
+  });
+});

--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -149,19 +149,27 @@ export class GeneratorFormatExitError extends Schema.TaggedErrorClass<GeneratorF
 
 export class GeneratorSchemaValueDeclarationMissingError extends Schema.TaggedErrorClass<GeneratorSchemaValueDeclarationMissingError>()(
   "GeneratorSchemaValueDeclarationMissingError",
-  { typeDeclaration: Schema.String },
+  {
+    lineIndex: Schema.Number,
+    typeDeclarationLength: Schema.Number,
+    nextLinePresent: Schema.Boolean,
+    nextLineLength: Schema.optional(Schema.Number),
+  },
 ) {
   override get message(): string {
-    return `Generated schema type declaration has no following value declaration: ${this.typeDeclaration}`;
+    return `Generated schema type declaration at line ${this.lineIndex + 1} has no following value declaration.`;
   }
 }
 
 export class GeneratorSchemaNameParseError extends Schema.TaggedErrorClass<GeneratorSchemaNameParseError>()(
   "GeneratorSchemaNameParseError",
-  { typeDeclaration: Schema.String },
+  {
+    lineIndex: Schema.Number,
+    typeDeclarationLength: Schema.Number,
+  },
 ) {
   override get message(): string {
-    return `Could not extract a schema name from generated declaration: ${this.typeDeclaration}`;
+    return `Could not extract a schema name from generated declaration at line ${this.lineIndex + 1}.`;
   }
 }
 
@@ -383,9 +391,7 @@ export const formatGeneratedFiles = Effect.fn("formatGeneratedFiles")(function* 
   }
 });
 
-function collectSchemaEntries(
-  chunk: string,
-): ReadonlyArray<{ readonly name: string; readonly code: string }> {
+export const collectSchemaEntries = Effect.fn("collectSchemaEntries")(function* (chunk: string) {
   const lines = chunk
     .split("\n")
     .map((line) => line.trim())
@@ -400,12 +406,20 @@ function collectSchemaEntries(
 
     const constLine = lines[index + 1];
     if (!constLine?.startsWith("export const ")) {
-      throw new GeneratorSchemaValueDeclarationMissingError({ typeDeclaration: typeLine });
+      return yield* new GeneratorSchemaValueDeclarationMissingError({
+        lineIndex: index,
+        typeDeclarationLength: typeLine.length,
+        nextLinePresent: constLine !== undefined,
+        ...(constLine === undefined ? {} : { nextLineLength: constLine.length }),
+      });
     }
 
     const match = /^export type ([A-Za-z0-9_]+)/.exec(typeLine);
     if (!match?.[1]) {
-      throw new GeneratorSchemaNameParseError({ typeDeclaration: typeLine });
+      return yield* new GeneratorSchemaNameParseError({
+        lineIndex: index,
+        typeDeclarationLength: typeLine.length,
+      });
     }
 
     entries.push({
@@ -416,7 +430,7 @@ function collectSchemaEntries(
   }
 
   return entries;
-}
+});
 
 function normalizeNullableTypes(value: Schema.Json): Schema.Json {
   if (Array.isArray(value)) {
@@ -811,7 +825,8 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
   const generatedEntries = new Map<string, string>();
   const output = generator.generate("openapi-3.1", aggregateSchemas as never, false).trim();
   if (output.length > 0) {
-    for (const entry of collectSchemaEntries(output)) {
+    const schemaEntries = yield* collectSchemaEntries(output);
+    for (const entry of schemaEntries) {
       if (!generatedEntries.has(entry.name)) {
         generatedEntries.set(entry.name, entry.code);
       }

--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -66,6 +66,7 @@ export class GeneratorFetchError extends Schema.TaggedErrorClass<GeneratorFetchE
   "GeneratorFetchError",
   {
     url: Schema.String,
+    stage: Schema.Literals(["request", "read-response"]),
     cause: Schema.Defect(),
   },
 ) {
@@ -265,12 +266,14 @@ const ensureGeneratedDir = Effect.fn("ensureGeneratedDir")(function* () {
 });
 
 export const fetchText = Effect.fn("fetchText")(function* (url: string) {
-  return yield* HttpClientRequest.get(url).pipe(
+  const response = yield* HttpClientRequest.get(url).pipe(
     HttpClientRequest.setHeader("user-agent", USER_AGENT),
     HttpClient.execute,
     Effect.flatMap(HttpClientResponse.filterStatusOk),
-    Effect.flatMap((okResponse) => okResponse.text),
-    Effect.mapError((cause) => new GeneratorFetchError({ url, cause })),
+    Effect.mapError((cause) => new GeneratorFetchError({ url, stage: "request", cause })),
+  );
+  return yield* response.text.pipe(
+    Effect.mapError((cause) => new GeneratorFetchError({ url, stage: "read-response", cause })),
   );
 });
 

--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -59,14 +59,116 @@ interface JsonSchemaFile {
   readonly fileName: string;
   readonly downloadUrl: string;
   readonly qualifiedName: string;
+  readonly repositoryPath: string;
 }
 
-class GeneratorError extends Schema.TaggedErrorClass<GeneratorError>()("GeneratorError", {
-  detail: Schema.String,
-  cause: Schema.optional(Schema.Defect()),
-}) {
-  override get message() {
-    return this.detail;
+export class GeneratorFetchError extends Schema.TaggedErrorClass<GeneratorFetchError>()(
+  "GeneratorFetchError",
+  {
+    url: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to fetch ${this.url}.`;
+  }
+}
+
+export class GeneratorDirectoryDecodeError extends Schema.TaggedErrorClass<GeneratorDirectoryDecodeError>()(
+  "GeneratorDirectoryDecodeError",
+  {
+    directoryPath: Schema.String,
+    url: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to decode the GitHub directory listing for ${this.directoryPath} from ${this.url}.`;
+  }
+}
+
+export class GeneratorSchemaDocumentDecodeError extends Schema.TaggedErrorClass<GeneratorSchemaDocumentDecodeError>()(
+  "GeneratorSchemaDocumentDecodeError",
+  {
+    repositoryPath: Schema.String,
+    url: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to decode the Codex schema document ${this.repositoryPath} from ${this.url}.`;
+  }
+}
+
+export class GeneratorFormatProcessError extends Schema.TaggedErrorClass<GeneratorFormatProcessError>()(
+  "GeneratorFormatProcessError",
+  {
+    operation: Schema.Literals(["spawn", "wait-for-exit"]),
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    generatedDir: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Generator formatting command ${JSON.stringify([this.command, ...this.args])} failed during ${this.operation} for ${this.generatedDir}.`;
+  }
+}
+
+export class GeneratorFormatExitError extends Schema.TaggedErrorClass<GeneratorFormatExitError>()(
+  "GeneratorFormatExitError",
+  {
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    generatedDir: Schema.String,
+    exitCode: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Generator formatting command ${JSON.stringify([this.command, ...this.args])} exited with code ${this.exitCode} for ${this.generatedDir}.`;
+  }
+}
+
+export class GeneratorSchemaValueDeclarationMissingError extends Schema.TaggedErrorClass<GeneratorSchemaValueDeclarationMissingError>()(
+  "GeneratorSchemaValueDeclarationMissingError",
+  { typeDeclaration: Schema.String },
+) {
+  override get message(): string {
+    return `Generated schema type declaration has no following value declaration: ${this.typeDeclaration}`;
+  }
+}
+
+export class GeneratorSchemaNameParseError extends Schema.TaggedErrorClass<GeneratorSchemaNameParseError>()(
+  "GeneratorSchemaNameParseError",
+  { typeDeclaration: Schema.String },
+) {
+  override get message(): string {
+    return `Could not extract a schema name from generated declaration: ${this.typeDeclaration}`;
+  }
+}
+
+export class GeneratorSchemaTypeResolutionError extends Schema.TaggedErrorClass<GeneratorSchemaTypeResolutionError>()(
+  "GeneratorSchemaTypeResolutionError",
+  {
+    rawTypeName: Schema.String,
+    candidates: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    return `Unable to resolve schema type ${this.rawTypeName}; tried ${this.candidates.join(", ")}.`;
+  }
+}
+
+export class GeneratorExternalReferenceResolutionError extends Schema.TaggedErrorClass<GeneratorExternalReferenceResolutionError>()(
+  "GeneratorExternalReferenceResolutionError",
+  {
+    reference: Schema.String,
+    currentNamespace: Schema.NullOr(Schema.String),
+    candidates: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    return `Unable to rewrite external reference ${this.reference} in namespace ${this.currentNamespace ?? "<root>"}; tried ${this.candidates.join(", ")}.`;
   }
 }
 
@@ -162,25 +264,82 @@ const ensureGeneratedDir = Effect.fn("ensureGeneratedDir")(function* () {
   yield* fs.makeDirectory(generatedDir, { recursive: true });
 });
 
-const fetchText = Effect.fn("fetchText")(function* (url: string) {
+export const fetchText = Effect.fn("fetchText")(function* (url: string) {
   return yield* HttpClientRequest.get(url).pipe(
     HttpClientRequest.setHeader("user-agent", USER_AGENT),
     HttpClient.execute,
     Effect.flatMap(HttpClientResponse.filterStatusOk),
     Effect.flatMap((okResponse) => okResponse.text),
+    Effect.mapError((cause) => new GeneratorFetchError({ url, cause })),
+  );
+});
+
+export const fetchDirectoryEntries = Effect.fn("fetchDirectoryEntries")(function* (
+  directoryPath: string,
+) {
+  const url = `${GITHUB_API_BASE}/${directoryPath}?ref=${UPSTREAM_REF}`;
+  const raw = yield* fetchText(url);
+  return yield* decodeGithubContentEntries(raw).pipe(
+    Effect.mapError((cause) => new GeneratorDirectoryDecodeError({ directoryPath, url, cause })),
+  );
+});
+
+export const decodeSchemaDocument = Effect.fn("decodeSchemaDocument")(function* (input: {
+  readonly repositoryPath: string;
+  readonly url: string;
+  readonly raw: string;
+}) {
+  return yield* decodeJsonSchemaDocument(input.raw).pipe(
     Effect.mapError(
       (cause) =>
-        new GeneratorError({
-          detail: `Failed to fetch ${url}`,
+        new GeneratorSchemaDocumentDecodeError({
+          repositoryPath: input.repositoryPath,
+          url: input.url,
           cause,
         }),
     ),
   );
 });
 
-const fetchDirectoryEntries = Effect.fn("fetchDirectoryEntries")(function* (path: string) {
-  const raw = yield* fetchText(`${GITHUB_API_BASE}/${path}?ref=${UPSTREAM_REF}`);
-  return yield* decodeGithubContentEntries(raw);
+export const formatGeneratedFiles = Effect.fn("formatGeneratedFiles")(function* (
+  generatedDir: string,
+) {
+  const command = "vp";
+  const args = ["fmt", generatedDir, "--write"];
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const child = yield* spawner.spawn(ChildProcess.make(command, args)).pipe(
+    Effect.mapError(
+      (cause) =>
+        new GeneratorFormatProcessError({
+          operation: "spawn",
+          command,
+          args,
+          generatedDir,
+          cause,
+        }),
+    ),
+  );
+  const exitCode = yield* child.exitCode.pipe(
+    Effect.mapError(
+      (cause) =>
+        new GeneratorFormatProcessError({
+          operation: "wait-for-exit",
+          command,
+          args,
+          generatedDir,
+          cause,
+        }),
+    ),
+  );
+
+  if (exitCode !== 0) {
+    return yield* new GeneratorFormatExitError({
+      command,
+      args,
+      generatedDir,
+      exitCode,
+    });
+  }
 });
 
 function collectSchemaEntries(
@@ -200,12 +359,12 @@ function collectSchemaEntries(
 
     const constLine = lines[index + 1];
     if (!constLine?.startsWith("export const ")) {
-      throw new Error(`Malformed generator output near: ${typeLine}`);
+      throw new GeneratorSchemaValueDeclarationMissingError({ typeDeclaration: typeLine });
     }
 
     const match = /^export type ([A-Za-z0-9_]+)/.exec(typeLine);
     if (!match?.[1]) {
-      throw new Error(`Could not extract schema name from: ${typeLine}`);
+      throw new GeneratorSchemaNameParseError({ typeDeclaration: typeLine });
     }
 
     entries.push({
@@ -337,7 +496,7 @@ function resolveSchemaTypeName(
     }
   }
 
-  throw new Error(`Unable to resolve schema type name: ${rawTypeName}`);
+  throw new GeneratorSchemaTypeResolutionError({ rawTypeName, candidates });
 }
 
 function resolveResponseTypeName(
@@ -454,6 +613,7 @@ function buildJsonSchemaFiles(
           fileName: entry.name,
           downloadUrl: entry.download_url!,
           qualifiedName: relative.replace(/\.json$/, ""),
+          repositoryPath: entry.path,
         } satisfies JsonSchemaFile;
       }
       return {
@@ -461,6 +621,7 @@ function buildJsonSchemaFiles(
         fileName: entry.name,
         downloadUrl: entry.download_url!,
         qualifiedName: relative.replace(/\.json$/, ""),
+        repositoryPath: entry.path,
       } satisfies JsonSchemaFile;
     });
 }
@@ -504,7 +665,11 @@ function rewriteExternalRefs(
           .find((candidate) => candidate !== undefined);
 
         if (!rewritten) {
-          throw new Error(`Missing rewritten definition for ref: ${child}`);
+          throw new GeneratorExternalReferenceResolutionError({
+            reference: child,
+            currentNamespace: currentNamespace ?? null,
+            candidates,
+          });
         }
 
         return [key, `#/definitions/${rewritten}`];
@@ -545,7 +710,11 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
 
   for (const file of jsonSchemaFiles) {
     const raw = yield* fetchText(file.downloadUrl);
-    const parsed = yield* decodeJsonSchemaDocument(raw);
+    const parsed = yield* decodeSchemaDocument({
+      repositoryPath: file.repositoryPath,
+      url: file.downloadUrl,
+      raw,
+    });
     const localDefinitionNames = new Map(
       Object.keys(parsed.definitions ?? {}).map((definitionName) => [
         definitionName,
@@ -745,31 +914,19 @@ const generateFiles = Effect.fn("generateFiles")(function* () {
 
   yield* Effect.log(`Generated Codex App Server schemas from ${UPSTREAM_REF}`);
 
-  yield* Effect.service(ChildProcessSpawner.ChildProcessSpawner).pipe(
-    Effect.flatMap((spawner) =>
-      spawner.spawn(ChildProcess.make("vp", ["fmt", generatedDir, "--write"])),
-    ),
-    Effect.flatMap((child) => child.exitCode),
-    Effect.tap((code) =>
-      code === 0
-        ? Effect.void
-        : Effect.fail(
-            new GeneratorError({
-              detail: `vp fmt failed with exit code ${code}`,
-            }),
-          ),
-    ),
-  );
+  yield* formatGeneratedFiles(generatedDir);
 });
 
-generateFiles().pipe(
-  Effect.scoped,
-  Effect.provide(
-    Layer.mergeAll(
-      Logger.layer([Logger.consolePretty()]),
-      NodeServices.layer,
-      FetchHttpClient.layer,
+if (import.meta.main) {
+  generateFiles().pipe(
+    Effect.scoped,
+    Effect.provide(
+      Layer.mergeAll(
+        Logger.layer([Logger.consolePretty()]),
+        NodeServices.layer,
+        FetchHttpClient.layer,
+      ),
     ),
-  ),
-  NodeRuntime.runMain,
-);
+    NodeRuntime.runMain,
+  );
+}

--- a/packages/effect-codex-app-server/scripts/generate.ts
+++ b/packages/effect-codex-app-server/scripts/generate.ts
@@ -3,6 +3,7 @@
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { make as makeJsonSchemaGenerator } from "@effect/openapi-generator/JsonSchemaGenerator";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -62,16 +63,32 @@ interface JsonSchemaFile {
   readonly repositoryPath: string;
 }
 
+const urlDiagnosticsSchema = {
+  urlInputLength: Schema.Number,
+  urlProtocol: Schema.optionalKey(Schema.String),
+  urlHostname: Schema.optionalKey(Schema.String),
+};
+
+function urlDiagnosticFields(url: string) {
+  const diagnostics = getUrlDiagnostics(url);
+  return {
+    urlInputLength: diagnostics.inputLength,
+    ...(diagnostics.protocol === undefined ? {} : { urlProtocol: diagnostics.protocol }),
+    ...(diagnostics.hostname === undefined ? {} : { urlHostname: diagnostics.hostname }),
+  };
+}
+
 export class GeneratorFetchError extends Schema.TaggedErrorClass<GeneratorFetchError>()(
   "GeneratorFetchError",
   {
-    url: Schema.String,
+    ...urlDiagnosticsSchema,
     stage: Schema.Literals(["request", "read-response"]),
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to fetch ${this.url}.`;
+    const source = this.urlHostname === undefined ? "the configured source" : this.urlHostname;
+    return `Failed to fetch a Codex generator input from ${source} during ${this.stage}.`;
   }
 }
 
@@ -79,12 +96,12 @@ export class GeneratorDirectoryDecodeError extends Schema.TaggedErrorClass<Gener
   "GeneratorDirectoryDecodeError",
   {
     directoryPath: Schema.String,
-    url: Schema.String,
+    ...urlDiagnosticsSchema,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to decode the GitHub directory listing for ${this.directoryPath} from ${this.url}.`;
+    return `Failed to decode the GitHub directory listing for ${this.directoryPath}.`;
   }
 }
 
@@ -92,12 +109,12 @@ export class GeneratorSchemaDocumentDecodeError extends Schema.TaggedErrorClass<
   "GeneratorSchemaDocumentDecodeError",
   {
     repositoryPath: Schema.String,
-    url: Schema.String,
+    ...urlDiagnosticsSchema,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to decode the Codex schema document ${this.repositoryPath} from ${this.url}.`;
+    return `Failed to decode the Codex schema document ${this.repositoryPath}.`;
   }
 }
 
@@ -106,13 +123,13 @@ export class GeneratorFormatProcessError extends Schema.TaggedErrorClass<Generat
   {
     operation: Schema.Literals(["spawn", "wait-for-exit"]),
     command: Schema.String,
-    args: Schema.Array(Schema.String),
+    argumentCount: Schema.Number,
     generatedDir: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Generator formatting command ${JSON.stringify([this.command, ...this.args])} failed during ${this.operation} for ${this.generatedDir}.`;
+    return `Generator formatting command ${this.command} failed during ${this.operation} for ${this.generatedDir}.`;
   }
 }
 
@@ -120,13 +137,13 @@ export class GeneratorFormatExitError extends Schema.TaggedErrorClass<GeneratorF
   "GeneratorFormatExitError",
   {
     command: Schema.String,
-    args: Schema.Array(Schema.String),
+    argumentCount: Schema.Number,
     generatedDir: Schema.String,
     exitCode: Schema.Number,
   },
 ) {
   override get message(): string {
-    return `Generator formatting command ${JSON.stringify([this.command, ...this.args])} exited with code ${this.exitCode} for ${this.generatedDir}.`;
+    return `Generator formatting command ${this.command} exited with code ${this.exitCode} for ${this.generatedDir}.`;
   }
 }
 
@@ -270,10 +287,24 @@ export const fetchText = Effect.fn("fetchText")(function* (url: string) {
     HttpClientRequest.setHeader("user-agent", USER_AGENT),
     HttpClient.execute,
     Effect.flatMap(HttpClientResponse.filterStatusOk),
-    Effect.mapError((cause) => new GeneratorFetchError({ url, stage: "request", cause })),
+    Effect.mapError(
+      (cause) =>
+        new GeneratorFetchError({
+          ...urlDiagnosticFields(url),
+          stage: "request",
+          cause,
+        }),
+    ),
   );
   return yield* response.text.pipe(
-    Effect.mapError((cause) => new GeneratorFetchError({ url, stage: "read-response", cause })),
+    Effect.mapError(
+      (cause) =>
+        new GeneratorFetchError({
+          ...urlDiagnosticFields(url),
+          stage: "read-response",
+          cause,
+        }),
+    ),
   );
 });
 
@@ -283,7 +314,14 @@ export const fetchDirectoryEntries = Effect.fn("fetchDirectoryEntries")(function
   const url = `${GITHUB_API_BASE}/${directoryPath}?ref=${UPSTREAM_REF}`;
   const raw = yield* fetchText(url);
   return yield* decodeGithubContentEntries(raw).pipe(
-    Effect.mapError((cause) => new GeneratorDirectoryDecodeError({ directoryPath, url, cause })),
+    Effect.mapError(
+      (cause) =>
+        new GeneratorDirectoryDecodeError({
+          directoryPath,
+          ...urlDiagnosticFields(url),
+          cause,
+        }),
+    ),
   );
 });
 
@@ -297,7 +335,7 @@ export const decodeSchemaDocument = Effect.fn("decodeSchemaDocument")(function* 
       (cause) =>
         new GeneratorSchemaDocumentDecodeError({
           repositoryPath: input.repositoryPath,
-          url: input.url,
+          ...urlDiagnosticFields(input.url),
           cause,
         }),
     ),
@@ -316,7 +354,7 @@ export const formatGeneratedFiles = Effect.fn("formatGeneratedFiles")(function* 
         new GeneratorFormatProcessError({
           operation: "spawn",
           command,
-          args,
+          argumentCount: args.length,
           generatedDir,
           cause,
         }),
@@ -328,7 +366,7 @@ export const formatGeneratedFiles = Effect.fn("formatGeneratedFiles")(function* 
         new GeneratorFormatProcessError({
           operation: "wait-for-exit",
           command,
-          args,
+          argumentCount: args.length,
           generatedDir,
           cause,
         }),
@@ -338,7 +376,7 @@ export const formatGeneratedFiles = Effect.fn("formatGeneratedFiles")(function* 
   if (exitCode !== 0) {
     return yield* new GeneratorFormatExitError({
       command,
-      args,
+      argumentCount: args.length,
       generatedDir,
       exitCode,
     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -758,6 +758,9 @@ importers:
 
   packages/effect-codex-app-server:
     dependencies:
+      '@t3tools/shared':
+        specifier: workspace:*
+        version: link:../shared
       effect:
         specifier: 4.0.0-beta.78
         version: 4.0.0-beta.78(patch_hash=c502bc684210b707dfceb87d8fe6ad6843395af6e19cfc02cd65854898bde2c5)


### PR DESCRIPTION
## Summary

- replace the generator's free-form error and generic throws with structured Schema errors
- retain fetch, decode, and process causes while attaching URLs, repository paths, resolution candidates, commands, and exit codes
- cover fetch/decode/formatter failure boundaries with focused tests

## Validation

- `vp test packages/effect-codex-app-server/scripts/generate.test.ts --no-cache`
- `vp check` (passes with pre-existing warnings)
- `vp run typecheck`
- `vpr typecheck`

## Overlap audit

No current open PR touches either changed path, including previous filenames.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-time codegen script refactor with tests; no runtime app behavior change beyond safer import of `generate.ts`.
> 
> **Overview**
> Replaces the Codex schema generator’s single `GeneratorError` and ad-hoc `throw new Error` paths with **Effect `Schema.TaggedErrorClass` types** (fetch, directory/schema decode, formatter spawn/exit, generated declaration parsing, type and external-ref resolution). Network-related failures attach **redacted URL diagnostics** via `@t3tools/shared` `getUrlDiagnostics` (length, protocol, hostname—no raw URLs or secrets in messages).
> 
> **Exported** helpers (`fetchText`, `fetchDirectoryEntries`, `decodeSchemaDocument`, `formatGeneratedFiles`, `collectSchemaEntries`) so failures can be tested in isolation; **`formatGeneratedFiles`** centralizes `vp fmt` and maps nonzero exits to structured errors. Schema JSON handling threads **`repositoryPath`** into decode errors.
> 
> **`generateFiles` only runs when executed as the script** (`if (import.meta.main)`), so importing `generate.ts` no longer triggers generation. Adds **`generate.test.ts`** covering safe fetch diagnostics, decode context, formatter exit codes, and malformed generator output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9cb0c3c63c55d2004d4ee484fc4c7680f2ce0e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure Codex schema generator errors into typed, sanitized error classes
> - Replaces the single generic `GeneratorError` in [`generate.ts`](https://github.com/pingdotgg/t3code/pull/3354/files#diff-560473cbb6e8d5dcb7711cbe1b22019753b863e14f3d956a5a2e509fdedea368) with distinct tagged error classes for each failure mode: fetch, directory decode, schema decode, format process/exit, missing declarations, name parse, type resolution, and external reference resolution.
> - Each error class captures sanitized, structured fields (e.g. URL diagnostics without raw URLs, command args count, exit code, line index) instead of raw error messages.
> - Refactors `fetchText`, `fetchDirectoryEntries`, `decodeSchemaDocument`, `formatGeneratedFiles`, and `collectSchemaEntries` into exported `Effect.fn` functions that propagate typed failures.
> - Adds a comprehensive test suite in [`generate.test.ts`](https://github.com/pingdotgg/t3code/pull/3354/files#diff-2458322adf92c2643f8b764f27bec58993ada6968fe429eeb87fbe67407a9af4) covering error behavior for all new error classes using custom HTTP and process test doubles.
> - Wraps the CLI entrypoint in an `import.meta.main` guard so importing the module no longer triggers generation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c9cb0c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->