### PR TITLE
[codex] Structure web diff worker failures

### DIFF
--- a/apps/web/src/components/DiffWorkerPoolProvider.tsx
+++ b/apps/web/src/components/DiffWorkerPoolProvider.tsx
@@ -1,8 +1,19 @@
 import { WorkerPoolContextProvider, useWorkerPool } from "@pierre/diffs/react";
 import DiffsWorker from "@pierre/diffs/worker/worker.js?worker";
+import * as Schema from "effect/Schema";
 import { useEffect, useMemo, type ReactNode } from "react";
 import { useTheme } from "../hooks/useTheme";
 import { resolveDiffThemeName, type DiffThemeName } from "../lib/diffRendering";
+
+export class DiffWorkerError extends Schema.TaggedErrorClass<DiffWorkerError>()("DiffWorkerError", {
+  operation: Schema.Literals(["create-worker", "get-render-options", "set-render-options"]),
+  themeName: Schema.Literals(["pierre-light", "pierre-dark"]),
+  cause: Schema.Defect(),
+}) {
+  override get message(): string {
+    return `Diff worker operation ${this.operation} failed for theme ${this.themeName}.`;
+  }
+}
 
 function DiffWorkerThemeSync({ themeName }: { themeName: DiffThemeName }) {
   const workerPool = useWorkerPool();
@@ -12,17 +23,23 @@ function DiffWorkerThemeSync({ themeName }: { themeName: DiffThemeName }) {
       return;
     }
 
-    const current = workerPool.getDiffRenderOptions();
-    if (current.theme === themeName) {
-      return;
-    }
+    let operation: DiffWorkerError["operation"] = "get-render-options";
+    void (async () => {
+      try {
+        const current = workerPool.getDiffRenderOptions();
+        if (current.theme === themeName) {
+          return;
+        }
 
-    void workerPool
-      .setRenderOptions({
-        ...current,
-        theme: themeName,
-      })
-      .catch(() => undefined);
+        operation = "set-render-options";
+        await workerPool.setRenderOptions({
+          ...current,
+          theme: themeName,
+        });
+      } catch (cause) {
+        console.error(new DiffWorkerError({ operation, themeName, cause }));
+      }
+    })();
   }, [themeName, workerPool]);
 
   return null;
@@ -40,7 +57,17 @@ export function DiffWorkerPoolProvider({ children }: { children?: ReactNode }) {
   return (
     <WorkerPoolContextProvider
       poolOptions={{
-        workerFactory: () => new DiffsWorker(),
+        workerFactory: () => {
+          try {
+            return new DiffsWorker();
+          } catch (cause) {
+            throw new DiffWorkerError({
+              operation: "create-worker",
+              themeName: diffThemeName,
+              cause,
+            });
+          }
+        },
         poolSize: workerPoolSize,
         totalASTLRUCacheSize: 240,
       }}


### PR DESCRIPTION
## Summary
- add a structured diff worker error with operation, theme, and exact cause
- distinguish worker construction, render-option reads, and theme updates
- preserve the existing UI behavior while making rejected theme synchronization observable

Adjacent diff parsing and syntax-language fallbacks remain unchanged because they are intentional rendering fallbacks rather than discarded worker failures.

## Verification
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small observability change in diff rendering setup; no auth, data, or user-facing behavior changes beyond richer error logging.
> 
> **Overview**
> Introduces **`DiffWorkerError`** (Effect `Schema.TaggedErrorClass`) so Pierre diff worker problems carry **`operation`**, **`themeName`**, and the underlying **`cause`**.
> 
> **Worker creation** in `workerFactory` now wraps `new DiffsWorker()` and rethrows failures as `create-worker` errors instead of a bare exception.
> 
> **Theme sync** in `DiffWorkerThemeSync` tracks whether failure happened during `get-render-options` or `set-render-options`, runs the update in an async IIFE with try/catch, and **`console.error`s** a `DiffWorkerError` instead of swallowing rejections via `.catch(() => undefined)`—user-visible behavior stays the same, but failed theme updates are observable in the console.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a09ab7104243c202651726379644b3d0e38d2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure diff worker failures with a typed `DiffWorkerError` class
> - Adds `DiffWorkerError` (via `effect/Schema`) with fields for `operation`, `themeName`, and `cause` to give worker failures a consistent shape.
> - `DiffWorkerPoolProvider` now throws `DiffWorkerError` (operation: `create-worker`) when `new DiffsWorker()` fails, replacing an untyped error.
> - `DiffWorkerThemeSync` now awaits `setRenderOptions` and logs a `DiffWorkerError` on failure instead of silently swallowing errors.
> - Behavioral Change: errors during `setRenderOptions` are now logged to `console.error` rather than discarded.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8a09ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->