### PR TITLE
[codex] Preserve review path resolution failures

### DIFF
--- a/apps/server/src/review/ReviewService.test.ts
+++ b/apps/server/src/review/ReviewService.test.ts
@@ -3,6 +3,7 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 
 import { ServerConfig } from "../config.ts";
 import * as GitVcsDriver from "../vcs/GitVcsDriver.ts";
@@ -71,6 +72,29 @@ describe("ReviewService", () => {
       assert.strictEqual(result.cwd, workspaceRoot);
       assert.deepStrictEqual(result.sources, []);
       assert.deepStrictEqual(detectCalls, [{ cwd: workspaceRoot }]);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("preserves unexpected path-resolution failures", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const workspaceRoot = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-workspace-" });
+      const baseDir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-review-base-" });
+      const invalidCwd = `${workspaceRoot}\0invalid`;
+      const detectCalls: Array<{ readonly cwd: string }> = [];
+
+      const error = yield* Effect.gen(function* () {
+        const review = yield* ReviewService.ReviewService;
+        return yield* review.getDiffPreview({ cwd: invalidCwd }).pipe(Effect.flip);
+      }).pipe(Effect.provide(makeLayer({ workspaceRoot, baseDir, detectCalls })));
+
+      assert.strictEqual(error._tag, "VcsRepositoryDetectionError");
+      if (error._tag !== "VcsRepositoryDetectionError") return;
+      assert.strictEqual(error.operation, "ReviewService.assertWorkspaceBoundCwd.canonicalizePath");
+      assert.strictEqual(error.cwd, invalidCwd);
+      assert.match(error.detail, /Failed to resolve a path/);
+      assert.instanceOf(error.cause, PlatformError.PlatformError);
+      assert.deepStrictEqual(detectCalls, []);
     }).pipe(Effect.provide(NodeServices.layer)),
   );
 });

--- a/apps/server/src/review/ReviewService.ts
+++ b/apps/server/src/review/ReviewService.ts
@@ -33,8 +33,24 @@ export const make = Effect.gen(function* () {
   const vcsRegistry = yield* VcsDriverRegistry.VcsDriverRegistry;
   const git = yield* GitVcsDriver.GitVcsDriver;
 
-  const canonicalizePath = (value: string) =>
-    fileSystem.realPath(path.resolve(value)).pipe(Effect.orElseSucceed(() => path.resolve(value)));
+  const canonicalizePath = (value: string) => {
+    const resolvedPath = path.resolve(value);
+    return fileSystem.realPath(resolvedPath).pipe(
+      Effect.catchTags({
+        PlatformError: (cause) =>
+          cause.reason._tag === "NotFound"
+            ? Effect.succeed(resolvedPath)
+            : Effect.fail(
+                new VcsRepositoryDetectionError({
+                  operation: "ReviewService.assertWorkspaceBoundCwd.canonicalizePath",
+                  cwd: resolvedPath,
+                  detail: "Failed to resolve a path while validating the review workspace.",
+                  cause,
+                }),
+              ),
+      }),
+    );
+  };
 
   const isWithinRoot = (candidate: string, root: string) => {
     const relative = path.relative(root, candidate);


### PR DESCRIPTION
## Summary
- only treat missing review paths as a lexical-path fallback
- surface other canonicalization failures as structured `VcsRepositoryDetectionError` values
- retain the exact platform error as `cause` and cover the failure path

## Verification
- `vp test apps/server/src/review/ReviewService.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how review `cwd` is canonicalized before workspace-boundary checks; misclassification could weaken validation or break legitimate previews, but scope is limited to review path resolution.
> 
> **Overview**
> **Review workspace path validation** no longer treats every `realPath` failure as a silent fallback to the lexical resolved path.
> 
> `canonicalizePath` in `ReviewService` now **only** falls back when the platform error is **`NotFound`** (path does not exist yet). Any other `PlatformError` during canonicalization **fails** with a structured **`VcsRepositoryDetectionError`** (`operation`: `ReviewService.assertWorkspaceBoundCwd.canonicalizePath`), a clear detail message, and the original **`PlatformError` preserved as `cause`**.
> 
> A new test drives an invalid `cwd` (embedded null) through `getDiffPreview` and asserts that failure shape, that **`PlatformError`** is on the cause, and that **VCS detect is not invoked** when canonicalization fails early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b28127bd72fc6b377a6e03caedcd8ac2e291cb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve non-NotFound path resolution failures in `ReviewService.canonicalizePath`
> Previously, `canonicalizePath` in [ReviewService.ts](https://github.com/pingdotgg/t3code/pull/3357/files#diff-df5ef885ed75ead172387058168fa6fd45dc2ce55a3fbecc53e3e039528642ce) silently swallowed all `realPath` errors by returning the resolved path. Now it only falls back on `NotFound` errors; any other `PlatformError` causes `getDiffPreview` to fail early with a `VcsRepositoryDetectionError` that includes the original error as `cause` and contextual metadata. A new test in [ReviewService.test.ts](https://github.com/pingdotgg/t3code/pull/3357/files#diff-c5999faf9c89c4069e4bd5afc09e31562c1c5a6347183a2677a0d032f2a429e1) covers this path using an invalid NUL-containing cwd.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b28127.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->