### PR TITLE
[codex] Structure loopback port errors

### DIFF
--- a/packages/shared/src/Net.test.ts
+++ b/packages/shared/src/Net.test.ts
@@ -102,32 +102,38 @@ it.layer(NetService.layer)("NetService", (it) => {
       });
     });
 
-    it.effect("preserves address-read context when closing an unusable reservation", () => {
-      const probe = NodeNet.createServer();
-      const cause = new Error("close failed");
-      probe.unref = (() => probe) as typeof probe.unref;
-      probe.address = (() => null) as typeof probe.address;
-      probe.listen = ((_port: number, _host: string, listeningListener: () => void) => {
-        listeningListener();
-        return probe;
-      }) as typeof probe.listen;
-      probe.close = (() => {
-        probe.emit("error", cause);
-        return probe;
-      }) as typeof probe.close;
-      const net = NetService.make({ createServer: () => probe });
+    it.effect("preserves address context when an unusable reservation errors during close", () =>
+      Effect.gen(function* () {
+        for (const invalidPort of [null, 43.5, 65_536]) {
+          const probe = NodeNet.createServer();
+          const cause = new Error("close failed");
+          probe.unref = (() => probe) as typeof probe.unref;
+          probe.address = (() => ({
+            address: "127.0.0.1",
+            family: "IPv4",
+            port: invalidPort,
+          })) as unknown as typeof probe.address;
+          probe.listen = ((_port: number, _host: string, listeningListener: () => void) => {
+            listeningListener();
+            return probe;
+          }) as typeof probe.listen;
+          probe.close = (() => {
+            probe.emit("error", cause);
+            return probe;
+          }) as typeof probe.close;
+          const net = NetService.make({ createServer: () => probe });
 
-      return Effect.gen(function* () {
-        const error = yield* net.reserveLoopbackPort().pipe(Effect.flip);
+          const error = yield* net.reserveLoopbackPort().pipe(Effect.flip);
 
-        assert(isLoopbackPortAddressUnavailableError(error));
-        assert.equal(error.host, "127.0.0.1");
-        assert.equal(error.address, null);
-        assert.equal(error.family, null);
-        assert.equal(error.port, null);
-        assert.strictEqual(error.cause, cause);
-      });
-    });
+          assert(isLoopbackPortAddressUnavailableError(error));
+          assert.equal(error.host, "127.0.0.1");
+          assert.equal(error.address, "127.0.0.1");
+          assert.equal(error.family, "IPv4");
+          assert.equal(error.port, invalidPort);
+          assert.strictEqual(error.cause, cause);
+        }
+      }),
+    );
 
     it.effect("rejects missing and non-finite ports returned by the server", () =>
       Effect.gen(function* () {

--- a/packages/shared/src/Net.test.ts
+++ b/packages/shared/src/Net.test.ts
@@ -2,8 +2,11 @@ import * as NodeNet from "node:net";
 
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 
 import * as NetService from "./Net.ts";
+
+const isLoopbackPortListenError = Schema.is(NetService.LoopbackPortListenError);
 
 const closeServer = (server: NodeNet.Server) =>
   Effect.sync(() => {
@@ -19,19 +22,19 @@ const getPort = (server: NodeNet.Server): number => {
   return typeof address === "object" && address !== null ? address.port : 0;
 };
 
-const openServer = (host?: string): Effect.Effect<NodeNet.Server, NetService.NetError> =>
-  Effect.callback<NodeNet.Server, NetService.NetError>((resume) => {
+const openServer = (host?: string): Effect.Effect<NodeNet.Server, Error> =>
+  Effect.callback<NodeNet.Server, Error>((resume) => {
     const server = NodeNet.createServer();
     let settled = false;
 
-    const settle = (effect: Effect.Effect<NodeNet.Server, NetService.NetError>) => {
+    const settle = (effect: Effect.Effect<NodeNet.Server, Error>) => {
       if (settled) return;
       settled = true;
       resume(effect);
     };
 
     server.once("error", (cause) => {
-      settle(Effect.fail(new NetService.NetError({ host: host ?? "localhost", cause })));
+      settle(Effect.fail(cause));
     });
 
     if (host) {
@@ -45,17 +48,24 @@ const openServer = (host?: string): Effect.Effect<NodeNet.Server, NetService.Net
 
 it.layer(NetService.layer)("NetService", (it) => {
   describe("Net helpers", () => {
-    it("preserves the loopback reservation error message", () => {
-      const error = new NetService.NetError({ host: "127.0.0.1" });
-      assert.equal(error.message, "Failed to reserve loopback port");
-    });
-
     it.effect("reserveLoopbackPort returns a positive loopback port", () =>
       Effect.gen(function* () {
         const net = yield* NetService.NetService;
         const port = yield* net.reserveLoopbackPort();
 
         assert.ok(port > 0);
+      }),
+    );
+
+    it.effect("retains the host and listen cause when reservation fails", () =>
+      Effect.gen(function* () {
+        const net = yield* NetService.NetService;
+        const error = yield* net.reserveLoopbackPort("256.256.256.256").pipe(Effect.flip);
+
+        assert(isLoopbackPortListenError(error));
+        assert.equal(error.host, "256.256.256.256");
+        assert.match(error.message, /256\.256\.256\.256/u);
+        assert.equal((error.cause as NodeJS.ErrnoException).code, "ENOTFOUND");
       }),
     );
 

--- a/packages/shared/src/Net.test.ts
+++ b/packages/shared/src/Net.test.ts
@@ -7,6 +7,9 @@ import * as Schema from "effect/Schema";
 import * as NetService from "./Net.ts";
 
 const isLoopbackPortListenError = Schema.is(NetService.LoopbackPortListenError);
+const isLoopbackPortAddressUnavailableError = Schema.is(
+  NetService.LoopbackPortAddressUnavailableError,
+);
 const isLoopbackPortReleaseError = Schema.is(NetService.LoopbackPortReleaseError);
 
 const closeServer = (server: NodeNet.Server) =>
@@ -95,6 +98,33 @@ it.layer(NetService.layer)("NetService", (it) => {
         assert(isLoopbackPortReleaseError(error));
         assert.equal(error.host, "127.0.0.1");
         assert.equal(error.port, 43123);
+        assert.strictEqual(error.cause, cause);
+      });
+    });
+
+    it.effect("preserves address-read context when closing an unusable reservation", () => {
+      const probe = NodeNet.createServer();
+      const cause = new Error("close failed");
+      probe.unref = (() => probe) as typeof probe.unref;
+      probe.address = (() => null) as typeof probe.address;
+      probe.listen = ((_port: number, _host: string, listeningListener: () => void) => {
+        listeningListener();
+        return probe;
+      }) as typeof probe.listen;
+      probe.close = (() => {
+        probe.emit("error", cause);
+        return probe;
+      }) as typeof probe.close;
+      const net = NetService.make({ createServer: () => probe });
+
+      return Effect.gen(function* () {
+        const error = yield* net.reserveLoopbackPort().pipe(Effect.flip);
+
+        assert(isLoopbackPortAddressUnavailableError(error));
+        assert.equal(error.host, "127.0.0.1");
+        assert.equal(error.address, null);
+        assert.equal(error.family, null);
+        assert.equal(error.port, null);
         assert.strictEqual(error.cause, cause);
       });
     });

--- a/packages/shared/src/Net.test.ts
+++ b/packages/shared/src/Net.test.ts
@@ -7,6 +7,7 @@ import * as Schema from "effect/Schema";
 import * as NetService from "./Net.ts";
 
 const isLoopbackPortListenError = Schema.is(NetService.LoopbackPortListenError);
+const isLoopbackPortReleaseError = Schema.is(NetService.LoopbackPortReleaseError);
 
 const closeServer = (server: NodeNet.Server) =>
   Effect.sync(() => {
@@ -68,6 +69,35 @@ it.layer(NetService.layer)("NetService", (it) => {
         assert.equal((error.cause as NodeJS.ErrnoException).code, "ENOTFOUND");
       }),
     );
+
+    it.effect("classifies server errors during close as release failures", () => {
+      const probe = NodeNet.createServer();
+      const cause = new Error("close failed");
+      probe.unref = (() => probe) as typeof probe.unref;
+      probe.address = (() => ({
+        address: "127.0.0.1",
+        family: "IPv4",
+        port: 43123,
+      })) as typeof probe.address;
+      probe.listen = ((_port: number, _host: string, listeningListener: () => void) => {
+        listeningListener();
+        return probe;
+      }) as typeof probe.listen;
+      probe.close = (() => {
+        probe.emit("error", cause);
+        return probe;
+      }) as typeof probe.close;
+      const net = NetService.make({ createServer: () => probe });
+
+      return Effect.gen(function* () {
+        const error = yield* net.reserveLoopbackPort().pipe(Effect.flip);
+
+        assert(isLoopbackPortReleaseError(error));
+        assert.equal(error.host, "127.0.0.1");
+        assert.equal(error.port, 43123);
+        assert.strictEqual(error.cause, cause);
+      });
+    });
 
     it.effect("isPortAvailableOnLoopback reports false for an occupied port", () =>
       Effect.acquireUseRelease(

--- a/packages/shared/src/Net.test.ts
+++ b/packages/shared/src/Net.test.ts
@@ -129,6 +129,35 @@ it.layer(NetService.layer)("NetService", (it) => {
       });
     });
 
+    it.effect("rejects missing and non-finite ports returned by the server", () =>
+      Effect.gen(function* () {
+        for (const invalidPort of [undefined, Number.NaN]) {
+          const probe = NodeNet.createServer();
+          probe.unref = (() => probe) as typeof probe.unref;
+          probe.address = (() => ({
+            address: "127.0.0.1",
+            family: "IPv4",
+            port: invalidPort,
+          })) as unknown as typeof probe.address;
+          probe.listen = ((_port: number, _host: string, listeningListener: () => void) => {
+            listeningListener();
+            return probe;
+          }) as typeof probe.listen;
+          probe.close = ((callback?: (cause?: Error) => void) => {
+            callback?.();
+            return probe;
+          }) as typeof probe.close;
+          const net = NetService.make({ createServer: () => probe });
+
+          const error = yield* net.reserveLoopbackPort().pipe(Effect.flip);
+
+          assert(isLoopbackPortAddressUnavailableError(error));
+          assert.equal(error.port, null);
+          assert.equal("cause" in error, false);
+        }
+      }),
+    );
+
     it.effect("isPortAvailableOnLoopback reports false for an occupied port", () =>
       Effect.acquireUseRelease(
         openServer("127.0.0.1"),

--- a/packages/shared/src/Net.ts
+++ b/packages/shared/src/Net.ts
@@ -62,6 +62,9 @@ const isErrnoExceptionWithCode = (
   Predicate.hasProperty(cause, "code") &&
   Predicate.isString(cause.code);
 
+const isUsablePort = (port: number | null): port is number =>
+  port !== null && Number.isInteger(port) && port > 0 && port <= 65_535;
+
 const closeServer = (server: NodeNet.Server) => {
   try {
     server.close();
@@ -218,7 +221,7 @@ export const make = (
           Effect.fail(
             addressDetails === undefined
               ? new LoopbackPortListenError({ host, cause })
-              : addressDetails.port !== null && addressDetails.port > 0
+              : isUsablePort(addressDetails.port)
                 ? new LoopbackPortReleaseError({ host, port: addressDetails.port, cause })
                 : new LoopbackPortAddressUnavailableError({
                     host,
@@ -251,7 +254,7 @@ export const make = (
 
           probe.close((cause) => {
             const port = resolvedAddressDetails.port;
-            if (port === null || !Number.isInteger(port) || port <= 0 || port > 65_535) {
+            if (!isUsablePort(port)) {
               settle(
                 Effect.fail(
                   new LoopbackPortAddressUnavailableError({

--- a/packages/shared/src/Net.ts
+++ b/packages/shared/src/Net.ts
@@ -6,14 +6,51 @@ import * as Layer from "effect/Layer";
 import * as Predicate from "effect/Predicate";
 import * as Schema from "effect/Schema";
 
-export class NetError extends Schema.TaggedErrorClass<NetError>()("NetError", {
-  host: Schema.String,
-  cause: Schema.optional(Schema.Defect()),
-}) {
+export class LoopbackPortListenError extends Schema.TaggedErrorClass<LoopbackPortListenError>()(
+  "LoopbackPortListenError",
+  {
+    host: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
   override get message(): string {
-    return "Failed to reserve loopback port";
+    return `Failed to listen for an ephemeral loopback port on ${this.host}.`;
   }
 }
+
+export class LoopbackPortAddressUnavailableError extends Schema.TaggedErrorClass<LoopbackPortAddressUnavailableError>()(
+  "LoopbackPortAddressUnavailableError",
+  {
+    host: Schema.String,
+    address: Schema.NullOr(Schema.String),
+    family: Schema.NullOr(Schema.String),
+    port: Schema.NullOr(Schema.Number),
+  },
+) {
+  override get message(): string {
+    return `Failed to read a usable ephemeral loopback port for ${this.host} (address ${this.address ?? "unavailable"}, family ${this.family ?? "unavailable"}, port ${this.port ?? "unavailable"}).`;
+  }
+}
+
+export class LoopbackPortReleaseError extends Schema.TaggedErrorClass<LoopbackPortReleaseError>()(
+  "LoopbackPortReleaseError",
+  {
+    host: Schema.String,
+    port: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to release ephemeral loopback port ${this.port} on ${this.host}.`;
+  }
+}
+
+export const NetError = Schema.Union([
+  LoopbackPortListenError,
+  LoopbackPortAddressUnavailableError,
+  LoopbackPortReleaseError,
+]);
+export type NetError = typeof NetError.Type;
 
 const isErrnoExceptionWithCode = (
   cause: unknown,
@@ -163,20 +200,55 @@ export const make = () => {
       };
 
       probe.once("error", (cause) => {
-        settle(Effect.fail(new NetError({ host, cause })));
+        settle(Effect.fail(new LoopbackPortListenError({ host, cause })));
       });
 
-      probe.listen(0, host, () => {
-        const address = probe.address();
-        const port = typeof address === "object" && address !== null ? address.port : 0;
-        probe.close(() => {
-          if (port > 0) {
-            settle(Effect.succeed(port));
-            return;
-          }
-          settle(Effect.fail(new NetError({ host })));
+      try {
+        probe.listen(0, host, () => {
+          const address = probe.address();
+          const addressDetails =
+            typeof address === "object" && address !== null
+              ? {
+                  address: address.address,
+                  family: address.family,
+                  port: address.port,
+                }
+              : {
+                  address,
+                  family: null,
+                  port: null,
+                };
+
+          probe.close((cause) => {
+            if (cause) {
+              settle(
+                Effect.fail(
+                  new LoopbackPortReleaseError({
+                    host,
+                    port: addressDetails.port ?? 0,
+                    cause,
+                  }),
+                ),
+              );
+              return;
+            }
+            if (addressDetails.port !== null && addressDetails.port > 0) {
+              settle(Effect.succeed(addressDetails.port));
+              return;
+            }
+            settle(
+              Effect.fail(
+                new LoopbackPortAddressUnavailableError({
+                  host,
+                  ...addressDetails,
+                }),
+              ),
+            );
+          });
         });
-      });
+      } catch (cause) {
+        settle(Effect.fail(new LoopbackPortListenError({ host, cause })));
+      }
 
       return Effect.sync(() => {
         closeServer(probe);

--- a/packages/shared/src/Net.ts
+++ b/packages/shared/src/Net.ts
@@ -237,7 +237,10 @@ export const make = (
               ? {
                   address: address.address,
                   family: address.family,
-                  port: address.port,
+                  port:
+                    typeof address.port === "number" && Number.isFinite(address.port)
+                      ? address.port
+                      : null,
                 }
               : {
                   address,
@@ -247,7 +250,8 @@ export const make = (
           addressDetails = resolvedAddressDetails;
 
           probe.close((cause) => {
-            if (resolvedAddressDetails.port === null || resolvedAddressDetails.port <= 0) {
+            const port = resolvedAddressDetails.port;
+            if (port === null || !Number.isInteger(port) || port <= 0 || port > 65_535) {
               settle(
                 Effect.fail(
                   new LoopbackPortAddressUnavailableError({
@@ -264,14 +268,14 @@ export const make = (
                 Effect.fail(
                   new LoopbackPortReleaseError({
                     host,
-                    port: resolvedAddressDetails.port,
+                    port,
                     cause,
                   }),
                 ),
               );
               return;
             }
-            settle(Effect.succeed(resolvedAddressDetails.port));
+            settle(Effect.succeed(port));
           });
         });
       } catch (cause) {

--- a/packages/shared/src/Net.ts
+++ b/packages/shared/src/Net.ts
@@ -97,7 +97,13 @@ export class NetService extends Context.Service<
   }
 >()("@t3tools/shared/Net/NetService") {}
 
-export const make = () => {
+export const make = (
+  options: {
+    readonly createServer?: () => NodeNet.Server;
+  } = {},
+) => {
+  const createServer = options.createServer ?? NodeNet.createServer;
+
   /**
    * Returns true when a TCP server can bind to {host, port}.
    * `EADDRNOTAVAIL` is treated as available so IPv6-absent hosts don't fail
@@ -105,7 +111,7 @@ export const make = () => {
    */
   const canListenOnHost = (port: number, host: string): Effect.Effect<boolean> =>
     Effect.callback<boolean>((resume) => {
-      const server = NodeNet.createServer();
+      const server = createServer();
       let settled = false;
 
       const settle = (value: boolean) => {
@@ -190,8 +196,9 @@ export const make = () => {
    */
   const reserveLoopbackPort = (host = "127.0.0.1"): Effect.Effect<number, NetError> =>
     Effect.callback<number, NetError>((resume) => {
-      const probe = NodeNet.createServer();
+      const probe = createServer();
       let settled = false;
+      let releasePort: number | undefined;
 
       const settle = (effect: Effect.Effect<number, NetError>) => {
         if (settled) return;
@@ -200,7 +207,13 @@ export const make = () => {
       };
 
       probe.once("error", (cause) => {
-        settle(Effect.fail(new LoopbackPortListenError({ host, cause })));
+        settle(
+          Effect.fail(
+            releasePort === undefined
+              ? new LoopbackPortListenError({ host, cause })
+              : new LoopbackPortReleaseError({ host, port: releasePort, cause }),
+          ),
+        );
       });
 
       try {
@@ -218,6 +231,8 @@ export const make = () => {
                   family: null,
                   port: null,
                 };
+          const port = addressDetails.port ?? 0;
+          releasePort = port;
 
           probe.close((cause) => {
             if (cause) {
@@ -225,7 +240,7 @@ export const make = () => {
                 Effect.fail(
                   new LoopbackPortReleaseError({
                     host,
-                    port: addressDetails.port ?? 0,
+                    port,
                     cause,
                   }),
                 ),

--- a/packages/shared/src/Net.ts
+++ b/packages/shared/src/Net.ts
@@ -25,6 +25,7 @@ export class LoopbackPortAddressUnavailableError extends Schema.TaggedErrorClass
     address: Schema.NullOr(Schema.String),
     family: Schema.NullOr(Schema.String),
     port: Schema.NullOr(Schema.Number),
+    cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
@@ -198,7 +199,13 @@ export const make = (
     Effect.callback<number, NetError>((resume) => {
       const probe = createServer();
       let settled = false;
-      let releasePort: number | undefined;
+      let addressDetails:
+        | {
+            readonly address: string | null;
+            readonly family: string | null;
+            readonly port: number | null;
+          }
+        | undefined;
 
       const settle = (effect: Effect.Effect<number, NetError>) => {
         if (settled) return;
@@ -209,9 +216,15 @@ export const make = (
       probe.once("error", (cause) => {
         settle(
           Effect.fail(
-            releasePort === undefined
+            addressDetails === undefined
               ? new LoopbackPortListenError({ host, cause })
-              : new LoopbackPortReleaseError({ host, port: releasePort, cause }),
+              : addressDetails.port !== null && addressDetails.port > 0
+                ? new LoopbackPortReleaseError({ host, port: addressDetails.port, cause })
+                : new LoopbackPortAddressUnavailableError({
+                    host,
+                    ...addressDetails,
+                    cause,
+                  }),
           ),
         );
       });
@@ -219,7 +232,7 @@ export const make = (
       try {
         probe.listen(0, host, () => {
           const address = probe.address();
-          const addressDetails =
+          const resolvedAddressDetails =
             typeof address === "object" && address !== null
               ? {
                   address: address.address,
@@ -231,34 +244,34 @@ export const make = (
                   family: null,
                   port: null,
                 };
-          const port = addressDetails.port ?? 0;
-          releasePort = port;
+          addressDetails = resolvedAddressDetails;
 
           probe.close((cause) => {
+            if (resolvedAddressDetails.port === null || resolvedAddressDetails.port <= 0) {
+              settle(
+                Effect.fail(
+                  new LoopbackPortAddressUnavailableError({
+                    host,
+                    ...resolvedAddressDetails,
+                    ...(cause === undefined ? {} : { cause }),
+                  }),
+                ),
+              );
+              return;
+            }
             if (cause) {
               settle(
                 Effect.fail(
                   new LoopbackPortReleaseError({
                     host,
-                    port,
+                    port: resolvedAddressDetails.port,
                     cause,
                   }),
                 ),
               );
               return;
             }
-            if (addressDetails.port !== null && addressDetails.port > 0) {
-              settle(Effect.succeed(addressDetails.port));
-              return;
-            }
-            settle(
-              Effect.fail(
-                new LoopbackPortAddressUnavailableError({
-                  host,
-                  ...addressDetails,
-                }),
-              ),
-            );
+            settle(Effect.succeed(resolvedAddressDetails.port));
           });
         });
       } catch (cause) {


### PR DESCRIPTION
## Summary

- replace the generic optional-cause `NetError` with distinct Schema errors for listen, address, and release failures
- retain the host, observed address details, reserved port, and immediate Node cause where one exists
- handle synchronous listen failures and close callback failures without inventing causes

## Validation

- `vp test packages/shared/src/Net.test.ts --no-cache`
- `vp check` (passes with pre-existing warnings)
- `vp run typecheck`
- `vpr typecheck`

## Overlap audit

No current open PR touches either changed path, including previous filenames.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for NetError shape and messages; reserveLoopbackPort failure typing affects startup port selection used by findAvailablePort.
> 
> **Overview**
> Replaces the single optional-cause **`NetError`** class with three Schema tagged errors—**`LoopbackPortListenError`**, **`LoopbackPortAddressUnavailableError`**, and **`LoopbackPortReleaseError`**—and exposes **`NetError`** as a union type for the same failure channel.
> 
> **`reserveLoopbackPort`** now classifies failures by phase: listen/sync listen throws, unreadable or invalid ephemeral ports (via **`isUsablePort`**), and close callback or server **`error`** after a valid port was observed. Errors carry **host**, address/family/port where relevant, and the Node **cause** when present (no synthetic causes for bad ports).
> 
> **`NetService.make`** accepts optional **`createServer`** for injection (used in new tests with mocked servers). Callers that matched on the old **`NetError`** tag or message must narrow on the new union members.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce790f395cd29b518a07dfcc3d429624d825932d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure loopback port errors into typed variants in `NetService`
> - Replaces the single generic `NetError` class with a discriminated union of three typed errors: `LoopbackPortListenError`, `LoopbackPortAddressUnavailableError`, and `LoopbackPortReleaseError`, each preserving host, port, address, and original cause fields.
> - Rewrites `reserveLoopbackPort` in [Net.ts](https://github.com/pingdotgg/t3code/pull/3358/files#diff-fe80effcaf0ecc4ab322310491fb5372fc77491af6fabf061873cadd19417dd1) to classify failures at each stage (listen, address resolution, close) and emit the appropriate typed error.
> - Adds an `isUsablePort` predicate to validate ports as integers in the 1–65535 range; invalid or non-finite ports yield `LoopbackPortAddressUnavailableError`.
> - Extends the `make` factory to accept an optional `createServer` injection for testing, used in [Net.test.ts](https://github.com/pingdotgg/t3code/pull/3358/files#diff-79bdd2bef716c557152c5fcaaa2d716f806dbaa5aa7d13644f377f01722425ab) to simulate server failure scenarios.
> - Behavioral Change: callers catching `NetError` must now handle a union type; the raw `Error` cause is preserved on each variant rather than wrapped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce790f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->