### PR TITLE
[codex] Preserve checkpoint repository detection failures

### DIFF
--- a/apps/server/src/checkpointing/CheckpointStore.test.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.test.ts
@@ -93,6 +93,27 @@ function buildLargeText(lineCount = 5_000): string {
 }
 
 it.layer(TestLayer)("CheckpointStore.layer", (it) => {
+  describe("isGitRepository", () => {
+    it.effect("returns false when no Git repository is detected", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+
+        expect(yield* checkpointStore.isGitRepository(tmp)).toBe(false);
+      }),
+    );
+
+    it.effect("returns true when a Git repository is detected", () =>
+      Effect.gen(function* () {
+        const tmp = yield* makeTmpDir();
+        yield* initRepoWithCommit(tmp);
+        const checkpointStore = yield* CheckpointStore.CheckpointStore;
+
+        expect(yield* checkpointStore.isGitRepository(tmp)).toBe(true);
+      }),
+    );
+  });
+
   describe("diffCheckpoints", () => {
     it.effect("returns full oversized checkpoint diffs without truncation", () =>
       Effect.gen(function* () {

--- a/apps/server/src/checkpointing/CheckpointStore.ts
+++ b/apps/server/src/checkpointing/CheckpointStore.ts
@@ -115,10 +115,9 @@ export const make = Effect.gen(function* () {
   });
 
   const isGitRepository: CheckpointStore["Service"]["isGitRepository"] = (cwd) =>
-    vcsRegistry.resolve({ cwd, requestedKind: "git" }).pipe(
-      Effect.map(() => true),
-      Effect.orElseSucceed(() => false),
-    );
+    vcsRegistry
+      .detect({ cwd, requestedKind: "git" })
+      .pipe(Effect.map((repository) => repository !== null));
 
   const captureCheckpoint: CheckpointStore["Service"]["captureCheckpoint"] = Effect.fn(
     "captureCheckpoint",


### PR DESCRIPTION
## Summary
- use nullable VCS detection for the checkpoint repository predicate
- return `false` only when no Git repository is detected
- preserve typed VCS/process/filesystem failures in the service error channel
- cover Git and non-Git repository detection with the live implementation

## Verification
- `vp test apps/server/src/checkpointing/CheckpointStore.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in checkpoint Git detection with focused tests; no auth or data-path changes.
> 
> **Overview**
> **`CheckpointStore.isGitRepository`** no longer treats Git detection failures as “not a repo.” It now calls **`vcsRegistry.detect`** with `requestedKind: 'git'` and returns **`false` only when detection yields no repository** (`null`), instead of using **`resolve`** with **`orElseSucceed(() => false)`**, which collapsed errors into **`false`**.
> 
> Tests assert **`false`** in a plain temp directory and **`true`** after **`initRepoWithCommit`**, against the live stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87fb43375a6fc89095ebe0746d3705667b23d01e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `isGitRepository` to preserve detection failures in `CheckpointStore`
> Reimplements `isGitRepository` in [CheckpointStore.ts](https://github.com/pingdotgg/t3code/pull/3360/files#diff-81ee8314218d1cb6f56ad7eece6b007318c109b5fbcb1f3a83ef99c8eb581c9d) to use `vcsRegistry.detect` with `requestedKind: 'git'`, mapping the result to a boolean based on whether a non-null repository is returned. The previous approach used `orElseSucceed` to swallow errors, meaning resolution failures were indistinguishable from "no repo found". Adds tests covering both the no-repo and valid-repo cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 87fb433.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->