### PR TITLE
[codex] Structure cross-client clipboard failures

### DIFF
--- a/apps/mobile/src/app/settings/environments.tsx
+++ b/apps/mobile/src/app/settings/environments.tsx
@@ -397,7 +397,7 @@ function CloudEnvironmentRowShell(props: {
                   className={cn("text-xs leading-[16px] underline", statusClassName)}
                   onLongPress={(event) => {
                     event.stopPropagation();
-                    copyTextWithHaptic(errorTraceId);
+                    copyTextWithHaptic(errorTraceId, { target: "connection-trace-id" });
                   }}
                   onPress={(event) => {
                     event.stopPropagation();
@@ -441,7 +441,7 @@ function CopyTraceIdButton(props: { readonly traceId: string }) {
     <Pressable
       accessibilityRole="button"
       onPress={() => {
-        copyTextWithHaptic(props.traceId);
+        copyTextWithHaptic(props.traceId, { target: "connection-trace-id" });
       }}
       className="self-start flex-row items-center gap-1.5 rounded-full bg-subtle px-3 py-2 active:opacity-70"
     >

--- a/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
+++ b/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
@@ -101,7 +101,7 @@ export function ConnectionEnvironmentRow(props: {
                     className="underline"
                     onLongPress={(event) => {
                       event.stopPropagation();
-                      copyTextWithHaptic(statusTraceId);
+                      copyTextWithHaptic(statusTraceId, { target: "connection-trace-id" });
                     }}
                     onPress={(event) => {
                       event.stopPropagation();

--- a/apps/mobile/src/features/connection/EnvironmentConnectionNotice.tsx
+++ b/apps/mobile/src/features/connection/EnvironmentConnectionNotice.tsx
@@ -85,7 +85,11 @@ export function EnvironmentConnectionNotice(props: {
                 accessibilityHint="Copies the trace ID"
                 accessibilityRole="button"
                 className="underline decoration-dotted"
-                onPress={() => copyTextWithHaptic(props.connection.traceId!)}
+                onPress={() =>
+                  copyTextWithHaptic(props.connection.traceId!, {
+                    target: "connection-trace-id",
+                  })
+                }
               >
                 {props.connection.traceId}
               </Text>

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -1,4 +1,3 @@
-import * as Clipboard from "expo-clipboard";
 import * as Haptics from "expo-haptics";
 import { KeyboardAvoidingLegendList } from "@legendapp/list/keyboard";
 import { type LegendListRef } from "@legendapp/list/react-native";
@@ -31,6 +30,7 @@ import { TouchableOpacity } from "react-native-gesture-handler";
 import ImageViewing from "react-native-image-viewing";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
+import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
 import {
   hasNativeSelectableMarkdownText,
   SelectableMarkdownText,
@@ -1321,8 +1321,10 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
   }, []);
 
   const onCopyWorkRow = useCallback((rowId: string, value: string) => {
-    void Clipboard.setStringAsync(value);
-    void Haptics.selectionAsync();
+    copyTextWithHaptic(value, {
+      target: "thread-work-row",
+      feedback: "selection",
+    });
     setInteractionState((current) => ({ ...current, copiedRowId: rowId }));
     if (copyFeedbackTimeoutRef.current) {
       clearTimeout(copyFeedbackTimeoutRef.current);

--- a/apps/mobile/src/lib/copyTextWithHaptic.test.ts
+++ b/apps/mobile/src/lib/copyTextWithHaptic.test.ts
@@ -73,7 +73,6 @@ describe("copyTextWithHaptic", () => {
     );
     expect(clipboardError).toBeInstanceOf(CopyTextClipboardWriteError);
     expect(clipboardError).toMatchObject({
-      operation: "write-clipboard",
       target: "connection-trace-id",
       cause: clipboardCause,
     });
@@ -82,7 +81,6 @@ describe("copyTextWithHaptic", () => {
     const hapticError = failures.find((failure) => failure instanceof CopyTextHapticFeedbackError);
     expect(hapticError).toBeInstanceOf(CopyTextHapticFeedbackError);
     expect(hapticError).toMatchObject({
-      operation: "trigger-haptic-feedback",
       target: "connection-trace-id",
       feedback: "light-impact",
       cause: hapticCause,

--- a/apps/mobile/src/lib/copyTextWithHaptic.test.ts
+++ b/apps/mobile/src/lib/copyTextWithHaptic.test.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 const mocks = vi.hoisted(() => ({
   impactAsync: vi.fn(),
+  selectionAsync: vi.fn(),
   setStringAsync: vi.fn(),
 }));
 
@@ -14,15 +15,25 @@ vi.mock("expo-haptics", () => ({
     Light: "light",
   },
   impactAsync: mocks.impactAsync,
+  selectionAsync: mocks.selectionAsync,
 }));
 
-import { copyTextWithHaptic } from "./copyTextWithHaptic";
+import {
+  CopyTextClipboardWriteError,
+  CopyTextHapticFeedbackError,
+  copyTextWithHaptic,
+} from "./copyTextWithHaptic";
 
 describe("copyTextWithHaptic", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.setStringAsync.mockReturnValue(new Promise<void>(() => undefined));
     mocks.impactAsync.mockResolvedValue(undefined);
+    mocks.selectionAsync.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("triggers haptic feedback without waiting for the clipboard promise", () => {
@@ -30,5 +41,52 @@ describe("copyTextWithHaptic", () => {
 
     expect(mocks.setStringAsync).toHaveBeenCalledWith("trace-123");
     expect(mocks.impactAsync).toHaveBeenCalledWith("light");
+  });
+
+  it("preserves selection feedback for thread work rows", () => {
+    copyTextWithHaptic("work output", {
+      target: "thread-work-row",
+      feedback: "selection",
+    });
+
+    expect(mocks.setStringAsync).toHaveBeenCalledWith("work output");
+    expect(mocks.selectionAsync).toHaveBeenCalledOnce();
+    expect(mocks.impactAsync).not.toHaveBeenCalled();
+  });
+
+  it("reports structured failures without including clipboard contents", async () => {
+    const clipboardCause = new Error("native clipboard failure");
+    const hapticCause = new Error("native haptic failure");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.setStringAsync.mockRejectedValueOnce(clipboardCause);
+    mocks.impactAsync.mockRejectedValueOnce(hapticCause);
+
+    copyTextWithHaptic("secret clipboard contents", { target: "connection-trace-id" });
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledTimes(2);
+    });
+
+    const failures = consoleError.mock.calls.map(([failure]) => failure);
+    const clipboardError = failures.find(
+      (failure) => failure instanceof CopyTextClipboardWriteError,
+    );
+    expect(clipboardError).toBeInstanceOf(CopyTextClipboardWriteError);
+    expect(clipboardError).toMatchObject({
+      operation: "write-clipboard",
+      target: "connection-trace-id",
+      cause: clipboardCause,
+    });
+    expect((clipboardError as Error).message).not.toContain("secret clipboard contents");
+
+    const hapticError = failures.find((failure) => failure instanceof CopyTextHapticFeedbackError);
+    expect(hapticError).toBeInstanceOf(CopyTextHapticFeedbackError);
+    expect(hapticError).toMatchObject({
+      operation: "trigger-haptic-feedback",
+      target: "connection-trace-id",
+      feedback: "light-impact",
+      cause: hapticCause,
+    });
+    expect((hapticError as Error).message).not.toContain("secret clipboard contents");
   });
 });

--- a/apps/mobile/src/lib/copyTextWithHaptic.ts
+++ b/apps/mobile/src/lib/copyTextWithHaptic.ts
@@ -5,7 +5,6 @@ import * as Haptics from "expo-haptics";
 export class CopyTextClipboardWriteError extends Schema.TaggedErrorClass<CopyTextClipboardWriteError>()(
   "CopyTextClipboardWriteError",
   {
-    operation: Schema.Literal("write-clipboard"),
     target: Schema.String,
     cause: Schema.Defect(),
   },
@@ -18,7 +17,6 @@ export class CopyTextClipboardWriteError extends Schema.TaggedErrorClass<CopyTex
 export class CopyTextHapticFeedbackError extends Schema.TaggedErrorClass<CopyTextHapticFeedbackError>()(
   "CopyTextHapticFeedbackError",
   {
-    operation: Schema.Literal("trigger-haptic-feedback"),
     target: Schema.String,
     feedback: Schema.Literals(["light-impact", "selection"]),
     cause: Schema.Defect(),
@@ -45,7 +43,6 @@ export function copyTextWithHaptic(
     } catch (cause) {
       console.error(
         new CopyTextClipboardWriteError({
-          operation: "write-clipboard",
           target,
           cause,
         }),
@@ -63,7 +60,6 @@ export function copyTextWithHaptic(
     } catch (cause) {
       console.error(
         new CopyTextHapticFeedbackError({
-          operation: "trigger-haptic-feedback",
           target,
           feedback,
           cause,

--- a/apps/mobile/src/lib/copyTextWithHaptic.ts
+++ b/apps/mobile/src/lib/copyTextWithHaptic.ts
@@ -1,7 +1,74 @@
+import * as Schema from "effect/Schema";
 import * as Clipboard from "expo-clipboard";
 import * as Haptics from "expo-haptics";
 
-export function copyTextWithHaptic(value: string): void {
-  void Clipboard.setStringAsync(value);
-  void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+export class CopyTextClipboardWriteError extends Schema.TaggedErrorClass<CopyTextClipboardWriteError>()(
+  "CopyTextClipboardWriteError",
+  {
+    operation: Schema.Literal("write-clipboard"),
+    target: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to copy ${this.target} to the clipboard.`;
+  }
+}
+
+export class CopyTextHapticFeedbackError extends Schema.TaggedErrorClass<CopyTextHapticFeedbackError>()(
+  "CopyTextHapticFeedbackError",
+  {
+    operation: Schema.Literal("trigger-haptic-feedback"),
+    target: Schema.String,
+    feedback: Schema.Literals(["light-impact", "selection"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to trigger ${this.feedback} haptic feedback after copying ${this.target}.`;
+  }
+}
+
+export function copyTextWithHaptic(
+  value: string,
+  options: {
+    readonly target?: string;
+    readonly feedback?: "light-impact" | "selection";
+  } = {},
+): void {
+  const target = options.target ?? "text";
+  const feedback = options.feedback ?? "light-impact";
+
+  void (async () => {
+    try {
+      await Clipboard.setStringAsync(value);
+    } catch (cause) {
+      console.error(
+        new CopyTextClipboardWriteError({
+          operation: "write-clipboard",
+          target,
+          cause,
+        }),
+      );
+    }
+  })();
+
+  void (async () => {
+    try {
+      if (feedback === "selection") {
+        await Haptics.selectionAsync();
+      } else {
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      }
+    } catch (cause) {
+      console.error(
+        new CopyTextHapticFeedbackError({
+          operation: "trigger-haptic-feedback",
+          target,
+          feedback,
+          cause,
+        }),
+      );
+    }
+  })();
 }

--- a/apps/web/src/components/PlanSidebar.tsx
+++ b/apps/web/src/components/PlanSidebar.tsx
@@ -83,7 +83,7 @@ const PlanSidebar = memo(function PlanSidebar({
   const writeProjectFile = useAtomCommand(projectEnvironment.writeFile, {
     reportFailure: false,
   });
-  const { copyToClipboard, isCopied } = useCopyToClipboard();
+  const { copyToClipboard, isCopied } = useCopyToClipboard({ target: "plan" });
 
   const planMarkdown = activeProposedPlan?.planMarkdown ?? null;
   const displayedPlanMarkdown = planMarkdown ? stripDisplayedPlanMarkdown(planMarkdown) : null;

--- a/apps/web/src/components/chat/ProposedPlanCard.tsx
+++ b/apps/web/src/components/chat/ProposedPlanCard.tsx
@@ -54,6 +54,7 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
     reportFailure: false,
   });
   const { copyToClipboard, isCopied } = useCopyToClipboard({
+    target: "plan",
     onError: (error) => {
       toastManager.add(
         stackedThreadToast({

--- a/apps/web/src/components/settings/DiagnosticsSettings.tsx
+++ b/apps/web/src/components/settings/DiagnosticsSettings.tsx
@@ -32,6 +32,7 @@ import {
 } from "../../state/server";
 import { shellEnvironment } from "../../state/shell";
 import { usePrimaryEnvironment } from "../../state/environments";
+import { useCopyToClipboard } from "../../hooks/useCopyToClipboard";
 import { Button } from "../ui/button";
 import { ScrollArea } from "../ui/scroll-area";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
@@ -246,16 +247,10 @@ function DiagnosticsTable({
 }
 
 function TraceIdCell({ traceId }: { traceId: string }) {
-  const [copied, setCopied] = useState(false);
-  const copyTraceId = useCallback(() => {
-    void navigator.clipboard
-      ?.writeText(traceId)
-      .then(() => {
-        setCopied(true);
-        window.setTimeout(() => setCopied(false), 1_200);
-      })
-      .catch(() => undefined);
-  }, [traceId]);
+  const { copyToClipboard, isCopied: copied } = useCopyToClipboard({
+    target: "trace ID",
+    timeout: 1_200,
+  });
 
   return (
     <div className="flex w-full min-w-0 max-w-full items-center gap-2">
@@ -281,7 +276,7 @@ function TraceIdCell({ traceId }: { traceId: string }) {
               type="button"
               className="inline-flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground"
               aria-label={copied ? "Copied trace ID" : "Copy trace ID"}
-              onClick={copyTraceId}
+              onClick={() => copyToClipboard(traceId)}
             >
               <CopyIcon className="size-3" />
             </button>

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -117,7 +117,7 @@ function handleToastDismissClick(
 }
 
 function CopyErrorButton({ text }: { text: string }) {
-  const { copyToClipboard, isCopied } = useCopyToClipboard();
+  const { copyToClipboard, isCopied } = useCopyToClipboard({ target: "error-message" });
   const label = isCopied ? "Copied error" : "Copy error";
 
   return (

--- a/apps/web/src/hooks/useCopyToClipboard.test.ts
+++ b/apps/web/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  ClipboardApiUnavailableError,
+  ClipboardWriteError,
+  writeTextToClipboard,
+} from "./useCopyToClipboard";
+
+describe("writeTextToClipboard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports unavailable clipboard support with structural context", async () => {
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", {});
+
+    const error = await writeTextToClipboard("plan contents", "plan").then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+
+    expect(error).toBeInstanceOf(ClipboardApiUnavailableError);
+    expect(error).toMatchObject({
+      operation: "resolve-clipboard-api",
+      target: "plan",
+    });
+    expect((error as Error).message).not.toContain("plan contents");
+  });
+
+  it("preserves the exact clipboard failure without exposing copied contents", async () => {
+    const cause = new Error("browser clipboard failure");
+    const writeText = vi.fn().mockRejectedValue(cause);
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    const error = await writeTextToClipboard("secret clipboard contents", "error-message").then(
+      () => undefined,
+      (failure: unknown) => failure,
+    );
+
+    expect(writeText).toHaveBeenCalledWith("secret clipboard contents");
+    expect(error).toBeInstanceOf(ClipboardWriteError);
+    expect(error).toMatchObject({
+      operation: "write-clipboard",
+      target: "error-message",
+      cause,
+    });
+    expect((error as Error).message).not.toContain("secret clipboard contents");
+  });
+
+  it("keeps empty values as a no-op when clipboard support is available", async () => {
+    const writeText = vi.fn();
+    vi.stubGlobal("window", {});
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+
+    await expect(writeTextToClipboard("", "plan")).resolves.toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useCopyToClipboard.test.ts
+++ b/apps/web/src/hooks/useCopyToClipboard.test.ts
@@ -22,7 +22,6 @@ describe("writeTextToClipboard", () => {
 
     expect(error).toBeInstanceOf(ClipboardApiUnavailableError);
     expect(error).toMatchObject({
-      operation: "resolve-clipboard-api",
       target: "plan",
     });
     expect((error as Error).message).not.toContain("plan contents");
@@ -42,7 +41,6 @@ describe("writeTextToClipboard", () => {
     expect(writeText).toHaveBeenCalledWith("secret clipboard contents");
     expect(error).toBeInstanceOf(ClipboardWriteError);
     expect(error).toMatchObject({
-      operation: "write-clipboard",
       target: "error-message",
       cause,
     });

--- a/apps/web/src/hooks/useCopyToClipboard.ts
+++ b/apps/web/src/hooks/useCopyToClipboard.ts
@@ -1,11 +1,65 @@
 import * as React from "react";
+import * as Schema from "effect/Schema";
+
+export class ClipboardApiUnavailableError extends Schema.TaggedErrorClass<ClipboardApiUnavailableError>()(
+  "ClipboardApiUnavailableError",
+  {
+    operation: Schema.Literal("resolve-clipboard-api"),
+    target: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Clipboard API is unavailable while copying ${this.target}.`;
+  }
+}
+
+export class ClipboardWriteError extends Schema.TaggedErrorClass<ClipboardWriteError>()(
+  "ClipboardWriteError",
+  {
+    operation: Schema.Literal("write-clipboard"),
+    target: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to copy ${this.target} to the clipboard.`;
+  }
+}
+
+export async function writeTextToClipboard(value: string, target = "text") {
+  if (
+    typeof window === "undefined" ||
+    typeof navigator === "undefined" ||
+    !navigator.clipboard?.writeText
+  ) {
+    throw new ClipboardApiUnavailableError({
+      operation: "resolve-clipboard-api",
+      target,
+    });
+  }
+
+  if (!value) return false;
+
+  try {
+    await navigator.clipboard.writeText(value);
+    return true;
+  } catch (cause) {
+    throw new ClipboardWriteError({
+      operation: "write-clipboard",
+      target,
+      cause,
+    });
+  }
+}
 
 export function useCopyToClipboard<TContext = void>({
   timeout = 2000,
+  target = "text",
   onCopy,
   onError,
 }: {
   timeout?: number;
+  target?: string;
   onCopy?: (ctx: TContext) => void;
   onError?: (error: Error, ctx: TContext) => void;
 } = {}): { copyToClipboard: (value: string, ctx: TContext) => void; isCopied: boolean } {
@@ -13,22 +67,18 @@ export function useCopyToClipboard<TContext = void>({
   const timeoutIdRef = React.useRef<NodeJS.Timeout | null>(null);
   const onCopyRef = React.useRef(onCopy);
   const onErrorRef = React.useRef(onError);
+  const targetRef = React.useRef(target);
   const timeoutRef = React.useRef(timeout);
 
   onCopyRef.current = onCopy;
   onErrorRef.current = onError;
+  targetRef.current = target;
   timeoutRef.current = timeout;
 
   const copyToClipboard = React.useCallback((value: string, ctx: TContext): void => {
-    if (typeof window === "undefined" || !navigator.clipboard?.writeText) {
-      onErrorRef.current?.(new Error("Clipboard API unavailable."), ctx);
-      return;
-    }
-
-    if (!value) return;
-
-    navigator.clipboard.writeText(value).then(
-      () => {
+    void writeTextToClipboard(value, targetRef.current).then(
+      (didCopy) => {
+        if (!didCopy) return;
         if (timeoutIdRef.current) {
           clearTimeout(timeoutIdRef.current);
         }
@@ -44,11 +94,8 @@ export function useCopyToClipboard<TContext = void>({
         }
       },
       (error) => {
-        if (onErrorRef.current) {
-          onErrorRef.current(error, ctx);
-        } else {
-          console.error(error);
-        }
+        console.error(error);
+        onErrorRef.current?.(error, ctx);
       },
     );
   }, []);

--- a/apps/web/src/hooks/useCopyToClipboard.ts
+++ b/apps/web/src/hooks/useCopyToClipboard.ts
@@ -4,7 +4,6 @@ import * as Schema from "effect/Schema";
 export class ClipboardApiUnavailableError extends Schema.TaggedErrorClass<ClipboardApiUnavailableError>()(
   "ClipboardApiUnavailableError",
   {
-    operation: Schema.Literal("resolve-clipboard-api"),
     target: Schema.String,
   },
 ) {
@@ -16,7 +15,6 @@ export class ClipboardApiUnavailableError extends Schema.TaggedErrorClass<Clipbo
 export class ClipboardWriteError extends Schema.TaggedErrorClass<ClipboardWriteError>()(
   "ClipboardWriteError",
   {
-    operation: Schema.Literal("write-clipboard"),
     target: Schema.String,
     cause: Schema.Defect(),
   },
@@ -33,7 +31,6 @@ export async function writeTextToClipboard(value: string, target = "text") {
     !navigator.clipboard?.writeText
   ) {
     throw new ClipboardApiUnavailableError({
-      operation: "resolve-clipboard-api",
       target,
     });
   }
@@ -45,7 +42,6 @@ export async function writeTextToClipboard(value: string, target = "text") {
     return true;
   } catch (cause) {
     throw new ClipboardWriteError({
-      operation: "write-clipboard",
       target,
       cause,
     });


### PR DESCRIPTION
## Summary
- add structured clipboard API, write, and haptic feedback errors with stable operation/target context
- retain exact underlying causes without including copied contents in diagnostics
- preserve mobile best-effort copy feedback, including thread work-row selection haptics
- add focused cross-client coverage for failure structure and behavior

## Verification
- `vp test apps/mobile/src/lib/copyTextWithHaptic.test.ts apps/web/src/hooks/useCopyToClipboard.test.ts`
- `vp check` (passes with existing warnings)
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX-focused clipboard error handling and logging; no auth, data persistence, or security-sensitive logic changes beyond avoiding sensitive text in diagnostics.
> 
> **Overview**
> Adds **structured clipboard/haptic errors** on mobile and web so failures carry a stable `target` label and underlying `cause`, without ever putting copied text in error messages.
> 
> On **mobile**, `copyTextWithHaptic` now accepts optional `target` and `feedback` (`light-impact` vs `selection`), logs `CopyTextClipboardWriteError` / `CopyTextHapticFeedbackError`, and still runs clipboard and haptics in parallel. Connection trace-ID copy sites pass `connection-trace-id`; thread work rows use `thread-work-row` + selection haptics via the shared helper instead of direct Expo clipboard/haptics.
> 
> On **web**, `writeTextToClipboard` centralizes clipboard writes with `ClipboardApiUnavailableError` and `ClipboardWriteError`. `useCopyToClipboard` takes a `target`, always `console.error`s failures, then optional `onError`. Call sites tag copies as `plan`, `trace ID`, or `error-message`; diagnostics trace-ID copy drops hand-rolled `navigator.clipboard` in favor of the hook.
> 
> New unit tests cover failure shape and the no-contents-in-messages rule on both clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa91438adf1c785ad09f737fb701488a48732415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured error logging to clipboard operations across mobile and web
> - Introduces `CopyTextClipboardWriteError`, `CopyTextHapticFeedbackError`, `ClipboardApiUnavailableError`, and `ClipboardWriteError` as Schema-based `TaggedError` classes with safe messages and target context, so clipboard failures never leak copied content in logs.
> - Updates [`copyTextWithHaptic`](https://github.com/pingdotgg/t3code/pull/3361/files#diff-e70e088b10bcb4d4eaff5d063326b6b8d811987ae75cc03bf449d0dcc73e07f4) to accept `target` and `feedback` options, and [`useCopyToClipboard`](https://github.com/pingdotgg/t3code/pull/3361/files#diff-974e1dc0bd8d7dd8989de9b385c2299f9bfe38c29926aaad1b80d22f942b9db8) to accept a `target` option; both now route failures through structured errors logged via `console.error`.
> - Propagates `target` tags (`"connection-trace-id"`, `"thread-work-row"`, `"plan"`, `"error-message"`) across all call sites on mobile and web.
> - Adds test coverage for structured error behavior, selection haptic mode, and empty-value no-ops.
> - Behavioral Change: empty values passed to `useCopyToClipboard` are now treated as no-ops and do not set the copied state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa91438.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->