### PR TITLE
[codex] Structure mobile external link failures

### DIFF
--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   Markdown,
   type CustomRenderers,
@@ -144,12 +144,19 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
 
 export function FileMarkdownPreview(props: { readonly markdown: string }) {
   const styles = useMarkdownPreviewStyles();
+  const onLinkPress = useCallback((href: string) => {
+    void tryOpenExternalUrl(href, "markdown-link");
+  }, []);
 
   return (
     <ScrollView className="flex-1 bg-card" contentContainerStyle={{ padding: 18 }}>
       <View className="mx-auto w-full max-w-[760px]">
         {hasNativeSelectableMarkdownText() ? (
-          <SelectableMarkdownText markdown={props.markdown} textStyle={styles.nativeTextStyle} />
+          <SelectableMarkdownText
+            markdown={props.markdown}
+            onLinkPress={onLinkPress}
+            textStyle={styles.nativeTextStyle}
+          />
         ) : (
           <Markdown
             options={{ gfm: true }}

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -5,8 +5,9 @@ import {
   type NodeStyleOverrides,
   type PartialMarkdownTheme,
 } from "react-native-nitro-markdown";
-import { Linking, ScrollView, Text as NativeText, View } from "react-native";
+import { ScrollView, Text as NativeText, View } from "react-native";
 
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThemeColor } from "../../lib/useThemeColor";
 import {
@@ -38,7 +39,7 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
         <NativeText
           onPress={() => {
             if (href) {
-              void Linking.openURL(href);
+              void tryOpenExternalUrl(href, "markdown-link");
             }
           }}
           style={{

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -2,14 +2,7 @@ import Stack from "expo-router/stack";
 import { SymbolView } from "expo-symbols";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useCallback, useMemo, useRef, useState } from "react";
-import {
-  ActivityIndicator,
-  Linking,
-  Pressable,
-  ScrollView,
-  Text as RNText,
-  View,
-} from "react-native";
+import { ActivityIndicator, Pressable, ScrollView, Text as RNText, View } from "react-native";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 import {
   EnvironmentId,
@@ -23,6 +16,7 @@ import { CopyTextButton } from "../../components/CopyTextButton";
 import { EmptyState } from "../../components/EmptyState";
 import { LoadingScreen } from "../../components/LoadingScreen";
 import { cn } from "../../lib/cn";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { buildThreadFilesNavigation } from "../../lib/routes";
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThemeColor } from "../../lib/useThemeColor";
@@ -255,7 +249,7 @@ function FilePreviewHeader(props: {
               )}
               onPress={() => {
                 if (typeof props.externalPreviewUri === "string") {
-                  void Linking.openURL(props.externalPreviewUri);
+                  void tryOpenExternalUrl(props.externalPreviewUri, "file-preview");
                 }
               }}
             >

--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -1,11 +1,12 @@
 import * as Haptics from "expo-haptics";
 import { SymbolView } from "expo-symbols";
 import { useCallback, useEffect, useRef } from "react";
-import { ActivityIndicator, Linking, Pressable, View } from "react-native";
+import { ActivityIndicator, Pressable, View } from "react-native";
 import Animated, { FadeIn, FadeOut } from "react-native-reanimated";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { AppText as Text } from "../../components/AppText";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { GitActionProgress } from "../../state/use-vcs-action-state";
 
@@ -30,7 +31,7 @@ export function GitActionProgressOverlay(props: {
 
   const handlePress = useCallback(() => {
     if (progress.prUrl) {
-      void Linking.openURL(progress.prUrl);
+      void tryOpenExternalUrl(progress.prUrl, "pull-request");
       return;
     }
     if (progress.phase === "success" || progress.phase === "error") {

--- a/apps/mobile/src/features/threads/ThreadGitControls.tsx
+++ b/apps/mobile/src/features/threads/ThreadGitControls.tsx
@@ -13,8 +13,9 @@ import {
 import { useLocalSearchParams, useRouter } from "expo-router";
 import Stack from "expo-router/stack";
 import { useCallback, useMemo } from "react";
-import { Alert, Linking } from "react-native";
+import { Alert } from "react-native";
 import { buildThreadFilesNavigation, buildThreadReviewRoutePath } from "../../lib/routes";
+import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import {
   basename,
   getTerminalStatusLabel,
@@ -125,13 +126,8 @@ export function ThreadGitControls(props: {
       Alert.alert("No open PR", "This branch does not have an open pull request.");
       return;
     }
-    try {
-      await Linking.openURL(prUrl);
-    } catch (error) {
-      Alert.alert(
-        "Unable to open PR",
-        error instanceof Error ? error.message : "An error occurred.",
-      );
+    if (!(await tryOpenExternalUrl(prUrl, "pull-request"))) {
+      Alert.alert("Unable to open PR", "The pull request could not be opened.");
     }
   }, [gitStatus]);
 

--- a/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
@@ -8,11 +8,12 @@ import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { SymbolView } from "expo-symbols";
 import { useCallback, useEffect, useMemo } from "react";
-import { Alert, Linking, Pressable, ScrollView, View } from "react-native";
+import { Alert, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../../lib/useThemeColor";
 
 import { AppText as Text } from "../../../components/AppText";
+import { tryOpenExternalUrl } from "../../../lib/openExternalUrl";
 import { buildThreadReviewRoutePath } from "../../../lib/routes";
 import { useEnvironmentQuery } from "../../../state/query";
 import { useThreadSelection } from "../../../state/use-thread-selection";
@@ -83,13 +84,8 @@ export function GitOverviewSheet() {
       Alert.alert("No open PR", "This branch does not have an open pull request.");
       return;
     }
-    try {
-      await Linking.openURL(prUrl);
-    } catch (error) {
-      Alert.alert(
-        "Unable to open PR",
-        error instanceof Error ? error.message : "An error occurred.",
-      );
+    if (!(await tryOpenExternalUrl(prUrl, "pull-request"))) {
+      Alert.alert("Unable to open PR", "The pull request could not be opened.");
     }
   }, [gitStatus.data]);
 

--- a/apps/mobile/src/lib/openExternalUrl.test.ts
+++ b/apps/mobile/src/lib/openExternalUrl.test.ts
@@ -26,8 +26,8 @@ describe("tryOpenExternalUrl", () => {
     ).resolves.toBe(true);
   });
 
-  it("logs stable URL context with the exact opening failure", async () => {
-    const cause = new Error("browser unavailable");
+  it("logs stable URL context without exposing the opening failure", async () => {
+    const cause = new Error("browser-unavailable-secret-sentinel");
     openURL.mockRejectedValue(cause);
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
 
@@ -35,17 +35,24 @@ describe("tryOpenExternalUrl", () => {
       tryOpenExternalUrl("https://github.com/pingdotgg/t3code/pull/1?token=secret", "pull-request"),
     ).resolves.toBe(false);
 
-    expect(consoleError).toHaveBeenCalledWith(
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    const [message, attributes] = consoleError.mock.calls[0] ?? [];
+    expect(message).toBe("Failed to open pull-request URL with the https scheme.");
+    expect(attributes).toEqual(
       expect.objectContaining({
         _tag: "ExternalUrlOpenError",
         target: "pull-request",
         scheme: "https",
         host: "github.com",
-        cause,
+        stack: expect.stringContaining("ExternalUrlOpenError"),
       }),
     );
-    const loggedError = consoleError.mock.calls[0]?.[0];
-    expect(loggedError).not.toHaveProperty("url");
-    expect(JSON.stringify(loggedError)).not.toContain("token=secret");
+    expect(attributes).not.toHaveProperty("url");
+    expect(attributes).not.toHaveProperty("cause");
+    const diagnosticText = [message, ...Object.values(attributes as Record<string, unknown>)]
+      .map(String)
+      .join("\n");
+    expect(diagnosticText).not.toContain("token=secret");
+    expect(diagnosticText).not.toContain("browser-unavailable-secret-sentinel");
   });
 });

--- a/apps/mobile/src/lib/openExternalUrl.test.ts
+++ b/apps/mobile/src/lib/openExternalUrl.test.ts
@@ -1,0 +1,51 @@
+import { Linking } from "react-native";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { tryOpenExternalUrl } from "./openExternalUrl";
+
+vi.mock("react-native", () => ({
+  Linking: { openURL: vi.fn() },
+}));
+
+const openURL = vi.mocked(Linking.openURL);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("tryOpenExternalUrl", () => {
+  it("opens supported URLs", async () => {
+    openURL.mockResolvedValue(undefined);
+
+    await expect(
+      tryOpenExternalUrl("https://github.com/pingdotgg/t3code", "pull-request"),
+    ).resolves.toBe(true);
+  });
+
+  it("logs stable URL context with the exact opening failure", async () => {
+    const cause = new Error("browser unavailable");
+    openURL.mockRejectedValue(cause);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(
+      tryOpenExternalUrl("https://github.com/pingdotgg/t3code/pull/1?token=secret", "pull-request"),
+    ).resolves.toBe(false);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        _tag: "ExternalUrlOpenError",
+        target: "pull-request",
+        scheme: "https",
+        host: "github.com",
+        cause,
+      }),
+    );
+    const loggedError = consoleError.mock.calls[0]?.[0];
+    expect(loggedError).not.toHaveProperty("url");
+    expect(JSON.stringify(loggedError)).not.toContain("token=secret");
+  });
+});

--- a/apps/mobile/src/lib/openExternalUrl.ts
+++ b/apps/mobile/src/lib/openExternalUrl.ts
@@ -38,7 +38,14 @@ export async function tryOpenExternalUrl(url: string, target: ExternalUrlTarget)
     await Linking.openURL(url);
     return true;
   } catch (cause) {
-    console.error(new ExternalUrlOpenError({ target, ...externalUrlMetadata(url), cause }));
+    const error = new ExternalUrlOpenError({ target, ...externalUrlMetadata(url), cause });
+    console.error(error.message, {
+      _tag: error._tag,
+      target: error.target,
+      scheme: error.scheme,
+      host: error.host,
+      stack: error.stack,
+    });
     return false;
   }
 }

--- a/apps/mobile/src/lib/openExternalUrl.ts
+++ b/apps/mobile/src/lib/openExternalUrl.ts
@@ -1,0 +1,44 @@
+import * as Schema from "effect/Schema";
+import { Linking } from "react-native";
+
+const ExternalUrlTarget = Schema.Literals(["file-preview", "markdown-link", "pull-request"]);
+
+export type ExternalUrlTarget = typeof ExternalUrlTarget.Type;
+
+export class ExternalUrlOpenError extends Schema.TaggedErrorClass<ExternalUrlOpenError>()(
+  "ExternalUrlOpenError",
+  {
+    target: ExternalUrlTarget,
+    scheme: Schema.String,
+    host: Schema.optional(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to open ${this.target} URL with the ${this.scheme} scheme.`;
+  }
+}
+
+function externalUrlMetadata(url: string): { readonly scheme: string; readonly host?: string } {
+  try {
+    const parsed = new URL(url);
+    return {
+      scheme: parsed.protocol.replace(/:$/, "") || "unknown",
+      host: parsed.hostname || undefined,
+    };
+  } catch {
+    return {
+      scheme: /^([a-z][a-z\d+.-]*):/i.exec(url)?.[1]?.toLowerCase() ?? "unknown",
+    };
+  }
+}
+
+export async function tryOpenExternalUrl(url: string, target: ExternalUrlTarget): Promise<boolean> {
+  try {
+    await Linking.openURL(url);
+    return true;
+  } catch (cause) {
+    console.error(new ExternalUrlOpenError({ target, ...externalUrlMetadata(url), cause }));
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- route file previews, markdown links, and pull-request links through one best-effort mobile external-link boundary
- log a schema-tagged error with semantic target, URL scheme/host, and exact cause without retaining path/query/fragment data
- replace cause-derived PR alerts with a stable user-facing message while preventing unhandled `Linking.openURL` rejections

## Validation

- `vp test apps/mobile/src/lib/openExternalUrl.test.ts` (2 tests)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`
- `vp run lint:mobile`

## Overlap

- Exact current and prior filename scan found no open PR overlap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX and logging refactor around link opening; no auth or data-model changes, with explicit tests for log redaction.
> 
> **Overview**
> Adds **`tryOpenExternalUrl`** as the shared mobile boundary for opening links: it wraps `Linking.openURL`, returns success/failure, and on failure logs a schema-tagged **`ExternalUrlOpenError`** with semantic target (`file-preview`, `markdown-link`, `pull-request`), scheme, and host only—no full URL or raw cause in console output.
> 
> **File previews**, **markdown** (including native selectable links via `onLinkPress`), **Safari preview**, **git PR controls**, and the **git action overlay** now call this helper instead of `Linking.openURL` directly. **Open PR** flows in git sheets use a fixed **"Unable to open PR"** alert when the helper returns false, replacing error-message-derived alerts. Unit tests cover success and sanitized failure logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4a3d13884e7f218d2512ce182bddae4be05a71a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure mobile external link failures with a centralized `tryOpenExternalUrl` helper
> - Introduces `tryOpenExternalUrl` in [openExternalUrl.ts](https://github.com/pingdotgg/t3code/pull/3363/files#diff-a048a1a4e1a75ecd3c095f8da3c5f592309dca4a1bb664bdbd779e808bba80c9), a boolean-returning wrapper around `Linking.openURL` that logs a privacy-preserving diagnostic (scheme, host, target — no URL or error message) on failure.
> - Replaces direct `Linking.openURL` calls across markdown preview, file preview, and PR link handlers with `tryOpenExternalUrl`, each passing a typed `ExternalUrlTarget` string for structured logging.
> - PR open flows in `ThreadGitControls` and `GitOverviewSheet` now show a generic "Unable to open PR" alert on failure instead of surfacing raw error messages.
> - Adds unit tests verifying success behavior and that failure logs contain no sensitive URL or error content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4a3d13.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->