### PR TITLE
[codex] Structure relay install confirmation conflicts

### DIFF
--- a/apps/web/src/cloud/relayClientInstallDialog.test.ts
+++ b/apps/web/src/cloud/relayClientInstallDialog.test.ts
@@ -4,6 +4,7 @@ import {
   completeRelayClientInstallDialogClose,
   finishRelayClientInstall,
   readRelayClientInstallDialogState,
+  RelayClientInstallConfirmationConflictError,
   reportRelayClientInstallProgress,
   requestRelayClientInstallConfirmation,
   resetRelayClientInstallDialogForTests,
@@ -66,5 +67,29 @@ describe("relay client install dialog coordinator", () => {
 
     completeRelayClientInstallDialogClose();
     expect(readRelayClientInstallDialogState()).toEqual({ status: "idle" });
+  });
+
+  it("rejects concurrent confirmation with the active install state", async () => {
+    const confirmation = requestRelayClientInstallConfirmation("2026.5.2");
+    respondToRelayClientInstallConfirmation(true);
+    await expect(confirmation).resolves.toBe(true);
+    reportRelayClientInstallProgress({ type: "progress", stage: "downloading" });
+
+    const error = await requestRelayClientInstallConfirmation("2026.6.0").then(
+      () => undefined,
+      (cause: unknown) => cause,
+    );
+
+    expect(error).toBeInstanceOf(RelayClientInstallConfirmationConflictError);
+    expect(error).toMatchObject({
+      requestedVersion: "2026.6.0",
+      activeVersion: "2026.5.2",
+      activeDialogStatus: "installing",
+      activeInstallStage: "downloading",
+    });
+    expect(error).not.toHaveProperty("cause");
+    expect((error as Error).message).toBe(
+      "Cannot confirm relay client installation 2026.6.0; installation 2026.5.2 has dialog status installing.",
+    );
   });
 });

--- a/apps/web/src/cloud/relayClientInstallDialog.ts
+++ b/apps/web/src/cloud/relayClientInstallDialog.ts
@@ -1,7 +1,23 @@
-import type {
-  RelayClientInstallProgressEvent,
-  RelayClientInstallProgressStage,
+import {
+  RelayClientInstallProgressStageSchema,
+  type RelayClientInstallProgressEvent,
+  type RelayClientInstallProgressStage,
 } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+export class RelayClientInstallConfirmationConflictError extends Schema.TaggedErrorClass<RelayClientInstallConfirmationConflictError>()(
+  "RelayClientInstallConfirmationConflictError",
+  {
+    requestedVersion: Schema.String,
+    activeVersion: Schema.String,
+    activeDialogStatus: Schema.Literals(["confirming", "installing", "closing"]),
+    activeInstallStage: Schema.optional(RelayClientInstallProgressStageSchema),
+  },
+) {
+  override get message(): string {
+    return `Cannot confirm relay client installation ${this.requestedVersion}; installation ${this.activeVersion} has dialog status ${this.activeDialogStatus}.`;
+  }
+}
 
 export type RelayClientInstallDialogState =
   | { readonly status: "idle" }
@@ -47,7 +63,17 @@ export function subscribeRelayClientInstallDialog(listener: () => void): () => v
 
 export function requestRelayClientInstallConfirmation(version: string): Promise<boolean> {
   if (state.status !== "idle") {
-    return Promise.reject(new Error("A relay client installation is already in progress."));
+    const activeInstall = state.status === "closing" ? state.view : state;
+    return Promise.reject(
+      new RelayClientInstallConfirmationConflictError({
+        requestedVersion: version,
+        activeVersion: activeInstall.version,
+        activeDialogStatus: state.status,
+        ...(activeInstall.status === "installing"
+          ? { activeInstallStage: activeInstall.stage }
+          : {}),
+      }),
+    );
   }
 
   publish({ status: "confirming", version });


### PR DESCRIPTION
## Summary
- replace the concurrent relay install confirmation `Error` with a Schema tagged error
- capture requested and active versions plus dialog lifecycle and install stage
- keep the state conflict cause-free instead of inventing a synthetic cause

## Verification
- `vp test apps/web/src/cloud/relayClientInstallDialog.test.ts`
- `vp check` (passes with existing warnings)
- `vp run typecheck`

## Overlap audit
- `gh pr list --limit 1000` found no other open PR touching either changed file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized dialog-coordinator error typing and messaging; callers that only checked generic Error messages may need to handle the new class.
> 
> **Overview**
> Concurrent relay client install confirmation requests now reject with **`RelayClientInstallConfirmationConflictError`** (Effect Schema tagged error) instead of a generic `Error`.
> 
> The rejection carries **requested vs active version**, **dialog status** (`confirming` / `installing` / `closing`), and **install stage** when the active flow is installing; **`closing`** still resolves the active version from the nested view. A coordinator test asserts the structured fields and that the error has **no `cause`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4fce97006c409aabc7ccb03cd56e118b4357af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic Error with structured `RelayClientInstallConfirmationConflictError` for install conflicts
> When `requestRelayClientInstallConfirmation` is called while the dialog is not idle, it now rejects with a new `RelayClientInstallConfirmationConflictError` instead of a generic `Error`. The structured error carries `requestedVersion`, `activeVersion`, `activeDialogStatus`, and optionally `activeInstallStage`, giving callers enough detail to handle conflicts programmatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d4fce9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->