### PR TITLE
[codex] Preserve terminal preview link failure context

### DIFF
--- a/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
@@ -1,0 +1,109 @@
+import type { LocalApi, PreviewSessionSnapshot, ScopedThreadRef } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  openTerminalLinkInPreview,
+  TerminalLinkContextMenuShowError,
+  TerminalLinkPreviewOpenError,
+} from "./openTerminalLinkInPreview";
+
+vi.mock("~/previewStateStore", () => ({
+  applyPreviewServerSnapshot: vi.fn(),
+  isPreviewSupportedInRuntime: () => true,
+}));
+
+vi.mock("~/rightPanelStore", () => ({
+  useRightPanelStore: {
+    getState: () => ({ openBrowser: vi.fn() }),
+  },
+}));
+
+const threadRef = {
+  environmentId: "local" as ScopedThreadRef["environmentId"],
+  threadId: "thread-1" as ScopedThreadRef["threadId"],
+};
+
+const snapshot: PreviewSessionSnapshot = {
+  threadId: threadRef.threadId,
+  tabId: "tab-1",
+  navStatus: { _tag: "Idle" },
+  canGoBack: false,
+  canGoForward: false,
+  updatedAt: "2026-06-20T00:00:00.000Z",
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("openTerminalLinkInPreview", () => {
+  it("preserves context-menu failures with terminal link context before falling back", async () => {
+    const cause = new Error("menu unavailable");
+    const fallbackToBrowser = vi.fn();
+    const openPreview = vi.fn(async () => AsyncResult.success(snapshot));
+    const reportError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await openTerminalLinkInPreview({
+      url: "http://localhost:3000/path?token=secret",
+      position: { x: 12, y: 34 },
+      threadRef,
+      openPreview,
+      localApi: {
+        contextMenu: {
+          show: vi.fn(async () => {
+            throw cause;
+          }),
+        },
+      } as unknown as LocalApi,
+      fallbackToBrowser,
+    });
+
+    expect(fallbackToBrowser).toHaveBeenCalledOnce();
+    expect(openPreview).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledOnce();
+    const error = reportError.mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(TerminalLinkContextMenuShowError);
+    expect(error).toMatchObject({
+      environmentId: "local",
+      threadId: "thread-1",
+      targetOrigin: "http://localhost:3000",
+      cause,
+    });
+    expect(error.message).not.toContain("menu unavailable");
+    expect(error.targetOrigin).not.toContain("secret");
+  });
+
+  it("preserves the complete preview failure cause before falling back", async () => {
+    const rpcError = new Error("preview unavailable");
+    const cause = Cause.combine(Cause.fail(rpcError), Cause.die("preview defect"));
+    const fallbackToBrowser = vi.fn();
+    const reportError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await openTerminalLinkInPreview({
+      url: "http://127.0.0.1:5173/",
+      position: { x: 12, y: 34 },
+      threadRef,
+      openPreview: async () => AsyncResult.failure(cause),
+      localApi: {
+        contextMenu: {
+          show: vi.fn(async () => "open-in-preview"),
+        },
+      } as unknown as LocalApi,
+      fallbackToBrowser,
+    });
+
+    expect(fallbackToBrowser).toHaveBeenCalledOnce();
+    expect(reportError).toHaveBeenCalledOnce();
+    const error = reportError.mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(TerminalLinkPreviewOpenError);
+    expect(error).toMatchObject({
+      environmentId: "local",
+      threadId: "thread-1",
+      targetOrigin: "http://127.0.0.1:5173",
+      cause,
+    });
+    expect(error.message).not.toContain("preview unavailable");
+  });
+});

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.test.ts
@@ -106,4 +106,25 @@ describe("openTerminalLinkInPreview", () => {
     });
     expect(error.message).not.toContain("preview unavailable");
   });
+
+  it("does not report or fall back when opening the preview is interrupted", async () => {
+    const fallbackToBrowser = vi.fn();
+    const reportError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await openTerminalLinkInPreview({
+      url: "http://localhost:5173/",
+      position: { x: 12, y: 34 },
+      threadRef,
+      openPreview: async () => AsyncResult.failure(Cause.interrupt()),
+      localApi: {
+        contextMenu: {
+          show: vi.fn(async () => "open-in-preview"),
+        },
+      } as unknown as LocalApi,
+      fallbackToBrowser,
+    });
+
+    expect(reportError).not.toHaveBeenCalled();
+    expect(fallbackToBrowser).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -1,4 +1,5 @@
 import type { LocalApi, ScopedThreadRef } from "@t3tools/contracts";
+import { isAtomCommandInterrupted } from "@t3tools/client-runtime/state/runtime";
 import { isPreviewableUrl } from "@t3tools/shared/preview";
 import * as Schema from "effect/Schema";
 
@@ -85,6 +86,9 @@ export async function openTerminalLinkInPreview<E>(
       input: { threadId: input.threadRef.threadId, url: input.url },
     });
     if (result._tag === "Failure") {
+      if (isAtomCommandInterrupted(result)) {
+        return;
+      }
       console.error(
         new TerminalLinkPreviewOpenError({
           ...errorContext,

--- a/apps/web/src/components/preview/openTerminalLinkInPreview.ts
+++ b/apps/web/src/components/preview/openTerminalLinkInPreview.ts
@@ -1,9 +1,35 @@
 import type { LocalApi, ScopedThreadRef } from "@t3tools/contracts";
 import { isPreviewableUrl } from "@t3tools/shared/preview";
+import * as Schema from "effect/Schema";
 
 import type { OpenPreviewMutation } from "~/browser/openFileInPreview";
 import { applyPreviewServerSnapshot, isPreviewSupportedInRuntime } from "~/previewStateStore";
 import { useRightPanelStore } from "~/rightPanelStore";
+
+const terminalLinkErrorContext = {
+  environmentId: Schema.String,
+  threadId: Schema.String,
+  targetOrigin: Schema.String,
+  cause: Schema.Defect(),
+};
+
+export class TerminalLinkContextMenuShowError extends Schema.TaggedErrorClass<TerminalLinkContextMenuShowError>()(
+  "TerminalLinkContextMenuShowError",
+  terminalLinkErrorContext,
+) {
+  override get message(): string {
+    return `Failed to show the context menu for terminal link ${this.targetOrigin}.`;
+  }
+}
+
+export class TerminalLinkPreviewOpenError extends Schema.TaggedErrorClass<TerminalLinkPreviewOpenError>()(
+  "TerminalLinkPreviewOpenError",
+  terminalLinkErrorContext,
+) {
+  override get message(): string {
+    return `Failed to open terminal link ${this.targetOrigin} in preview for thread ${this.threadId}.`;
+  }
+}
 
 interface OpenTerminalLinkInPreviewInput<E> {
   readonly url: string;
@@ -27,6 +53,12 @@ export async function openTerminalLinkInPreview<E>(
     return;
   }
 
+  const errorContext = {
+    environmentId: input.threadRef.environmentId,
+    threadId: input.threadRef.threadId,
+    targetOrigin: new URL(input.url).origin,
+  };
+
   let choice: "open-in-preview" | "open-in-browser" | null;
   try {
     choice = await input.localApi.contextMenu.show(
@@ -36,7 +68,13 @@ export async function openTerminalLinkInPreview<E>(
       ],
       input.position,
     );
-  } catch {
+  } catch (cause) {
+    console.error(
+      new TerminalLinkContextMenuShowError({
+        ...errorContext,
+        cause,
+      }),
+    );
     input.fallbackToBrowser();
     return;
   }
@@ -47,6 +85,12 @@ export async function openTerminalLinkInPreview<E>(
       input: { threadId: input.threadRef.threadId, url: input.url },
     });
     if (result._tag === "Failure") {
+      console.error(
+        new TerminalLinkPreviewOpenError({
+          ...errorContext,
+          cause: result.cause,
+        }),
+      );
       input.fallbackToBrowser();
       return;
     }


### PR DESCRIPTION
## Summary
- replace swallowed terminal-link context-menu failures with a structured schema error
- preserve complete preview command causes while retaining browser fallback behavior
- attach environment, thread, and sanitized target-origin context without logging URL credentials or query data
- cover both fallback boundaries with focused tests

## Validation
- `vp test apps/web/src/components/preview/openTerminalLinkInPreview.test.ts`
- `vp check` (passes with existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in preview link handling with preserved fallback behavior; interrupt handling slightly changes UX by not opening the browser.
> 
> **Overview**
> Terminal link preview no longer swallows failures when showing the context menu or opening preview. Both paths now **`console.error`** tagged Effect schema errors (`TerminalLinkContextMenuShowError`, `TerminalLinkPreviewOpenError`) that carry `environmentId`, `threadId`, the full **`cause`**, and **`targetOrigin`** derived from `URL.origin` so messages avoid path/query secrets.
> 
> User-facing fallback to the external browser is unchanged for real failures. **Interrupted** preview commands are treated differently: no error log and no browser fallback.
> 
> New unit tests cover context-menu errors, combined preview failure causes, sanitized origins, and the interrupt path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 799e00576b8ab74873a510a3ad731eb917ac00aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve terminal preview link failure context with structured error reporting
> - Adds two new tagged error classes, `TerminalLinkContextMenuShowError` and `TerminalLinkPreviewOpenError`, each carrying `environmentId`, `threadId`, `targetOrigin` (sanitized to URL origin), and the original failure cause.
> - Updates `openTerminalLinkInPreview` to catch context menu and preview open failures, log the appropriate structured error via `console.error`, and call `fallbackToBrowser`.
> - If the preview open failure is an interrupt (detected via `isAtomCommandInterrupted`), the function returns silently without logging or falling back to the browser.
> - Adds tests covering the context menu failure path, the preview open failure path, and the interrupt suppression path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 799e005.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->