### PR TITLE
[codex] Structure OAuth scope encoding failures

### DIFF
--- a/packages/shared/src/oauthScope.test.ts
+++ b/packages/shared/src/oauthScope.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vite-plus/test";
+import * as Schema from "effect/Schema";
 
-import { encodeOAuthScope, parseAllowedOAuthScope, parseOAuthScope } from "./oauthScope.ts";
+import {
+  encodeOAuthScope,
+  OAuthScopeEncodingError,
+  parseAllowedOAuthScope,
+  parseOAuthScope,
+} from "./oauthScope.ts";
+
+const isOAuthScopeEncodingError = Schema.is(OAuthScopeEncodingError);
 
 describe("OAuth scopes", () => {
   it("parses an RFC 6749 space-delimited scope set without duplicating permissions", () => {
@@ -31,5 +39,23 @@ describe("OAuth scopes", () => {
         allowedScopes: new Set(["orchestration:read", "access:write"] as const),
       }),
     ).toBeNull();
+  });
+
+  it("reports invalid encoding input structurally", () => {
+    expect.assertions(5);
+
+    try {
+      encodeOAuthScope(["access:read", "invalid scope", "access:read"]);
+    } catch (error) {
+      expect(error).toBeInstanceOf(OAuthScopeEncodingError);
+      if (!isOAuthScopeEncodingError(error)) return;
+
+      expect(error.scopes).toEqual(["access:read", "invalid scope", "access:read"]);
+      expect(error.invalidScopes).toEqual(["invalid scope"]);
+      expect(error.duplicateScopes).toEqual(["access:read"]);
+      expect(error.message).toBe(
+        "OAuth scopes must be non-empty, syntactically valid, and unique.",
+      );
+    }
   });
 });

--- a/packages/shared/src/oauthScope.ts
+++ b/packages/shared/src/oauthScope.ts
@@ -1,4 +1,19 @@
+import * as Schema from "effect/Schema";
+
 const OAUTH_SCOPE_TOKEN = /^[\u0021\u0023-\u005b\u005d-\u007e]+$/u;
+
+export class OAuthScopeEncodingError extends Schema.TaggedErrorClass<OAuthScopeEncodingError>()(
+  "OAuthScopeEncodingError",
+  {
+    scopes: Schema.Array(Schema.String),
+    invalidScopes: Schema.Array(Schema.String),
+    duplicateScopes: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
+    return "OAuth scopes must be non-empty, syntactically valid, and unique.";
+  }
+}
 
 /**
  * Decodes an RFC 6749 `scope` value as a set while preserving its first-seen
@@ -18,12 +33,22 @@ export function parseOAuthScope(value: string): ReadonlyArray<string> | null {
 }
 
 export function encodeOAuthScope(scopes: ReadonlyArray<string>): string {
-  const encoded = scopes.join(" ");
-  const parsed = parseOAuthScope(encoded);
-  if (parsed === null || parsed.length !== scopes.length) {
-    throw new Error("OAuth scopes must be non-empty, valid, and unique.");
+  const invalidScopes = scopes.filter((scope) => !OAUTH_SCOPE_TOKEN.test(scope));
+  const seen = new Set<string>();
+  const duplicateScopes = new Set<string>();
+  for (const scope of scopes) {
+    if (seen.has(scope)) duplicateScopes.add(scope);
+    seen.add(scope);
   }
-  return encoded;
+
+  if (scopes.length === 0 || invalidScopes.length > 0 || duplicateScopes.size > 0) {
+    throw new OAuthScopeEncodingError({
+      scopes,
+      invalidScopes,
+      duplicateScopes: [...duplicateScopes],
+    });
+  }
+  return scopes.join(" ");
 }
 
 export function oauthScopeSetEquals(value: string, expectedScopes: ReadonlyArray<string>): boolean {


### PR DESCRIPTION
## Summary
- replace the opaque OAuth scope encoder exception with a schema-backed error carrying the original scopes plus invalid and duplicate entries
- validate the input scopes directly, fixing a case where an invalid scope containing a space could be accepted when deduplication happened to preserve the original array length
- keep the user-facing message generic and omit a synthetic cause for this pure validation failure

## Validation
- `pnpm vp test packages/shared/src/oauthScope.test.ts`
- `pnpm vp check` (passes with 20 existing warnings)
- `pnpm vp run typecheck`

## Overlap
- exact-file audit across all open PRs (`--limit 1000`) found no overlap

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized validation and error-shape change in shared OAuth scope helpers; successful encoding behavior is unchanged for valid inputs.
> 
> **Overview**
> **`encodeOAuthScope`** no longer round-trips through **`parseOAuthScope`** and a generic **`Error`**. It validates each scope token directly and throws a schema-backed **`OAuthScopeEncodingError`** that carries the original **`scopes`**, **`invalidScopes`**, and **`duplicateScopes`**, with the same generic user-facing message.
> 
> This closes a validation gap where an invalid scope containing a space could be accepted when joining and re-parsing happened to leave the array length unchanged after deduplication. Tests now assert the structured error fields via **`Schema.is(OAuthScopeEncodingError)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bfc53e338e3401d6e9df7e1c601bf9da1d2c83d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure OAuth scope encoding failures with `OAuthScopeEncodingError`
> - Introduces `OAuthScopeEncodingError`, a tagged error class carrying structured fields: `scopes`, `invalidScopes`, and `duplicateScopes`.
> - Rewrites `encodeOAuthScope` to explicitly validate tokens via `OAUTH_SCOPE_TOKEN`, detect duplicates with a `Set`, and reject empty input — replacing the previous round-trip through `parseOAuthScope`.
> - Behavioral Change: `encodeOAuthScope([])` now throws `OAuthScopeEncodingError` instead of returning an empty string; invalid or duplicate scope errors are now typed rather than generic `Error`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6bfc53e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->