### PR TITLE
[codex] Preserve desktop update state read failures

### DIFF
--- a/apps/web/src/state/desktopUpdate.test.ts
+++ b/apps/web/src/state/desktopUpdate.test.ts
@@ -1,7 +1,7 @@
 import type { DesktopUpdateState } from "@t3tools/contracts";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { AtomRegistry } from "effect/unstable/reactivity";
-import { describe, expect, it, vi } from "vite-plus/test";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import { createDesktopUpdateStateAtom } from "./desktopUpdate";
 
@@ -21,6 +21,10 @@ const baseState: DesktopUpdateState = {
   errorContext: null,
   canRetry: false,
 };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 describe("desktopUpdateStateAtom", () => {
   it("loads once, retains state, and follows desktop update events", async () => {
@@ -91,8 +95,11 @@ describe("desktopUpdateStateAtom", () => {
 
   it("keeps listening when the initial desktop state read fails", async () => {
     let listener: ((state: DesktopUpdateState) => void) | undefined;
+    const cause = new Error("IPC unavailable");
+    const reportError = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const getUpdateState = vi.fn(async () => Promise.reject(cause));
     const atom = createDesktopUpdateStateAtom(() => ({
-      getUpdateState: async () => Promise.reject(new Error("IPC unavailable")),
+      getUpdateState,
       onUpdateState: (nextListener) => {
         listener = nextListener;
         return () => undefined;
@@ -102,6 +109,18 @@ describe("desktopUpdateStateAtom", () => {
     registry.mount(atom);
 
     await vi.waitFor(() => expect(listener).toBeDefined());
+    await vi.waitFor(() => expect(reportError).toHaveBeenCalledOnce());
+    expect(getUpdateState).toHaveBeenCalledTimes(3);
+    const [, errorMessage, errorContext] = reportError.mock.calls[0] ?? [];
+    expect(errorMessage).toBe("Failed to read the initial desktop update state after 3 attempts.");
+    expect(errorContext).toMatchObject({
+      error: {
+        _tag: "DesktopUpdateStateReadError",
+        attemptCount: 3,
+        cause,
+      },
+    });
+
     listener?.(baseState);
     await vi.waitFor(() => {
       expect(AsyncResult.getOrElse(registry.get(atom), () => null)).toEqual(baseState);

--- a/apps/web/src/state/desktopUpdate.test.ts
+++ b/apps/web/src/state/desktopUpdate.test.ts
@@ -114,12 +114,11 @@ describe("desktopUpdateStateAtom", () => {
     const [, errorMessage, errorContext] = reportError.mock.calls[0] ?? [];
     expect(errorMessage).toBe("Failed to read the initial desktop update state after 3 attempts.");
     expect(errorContext).toMatchObject({
-      error: {
-        _tag: "DesktopUpdateStateReadError",
-        attemptCount: 3,
-        cause,
-      },
+      errorTag: "DesktopUpdateStateReadError",
+      attemptCount: 3,
     });
+    expect(errorContext).not.toHaveProperty("error");
+    expect(errorContext).not.toHaveProperty("cause");
 
     listener?.(baseState);
     await vi.waitFor(() => {

--- a/apps/web/src/state/desktopUpdate.ts
+++ b/apps/web/src/state/desktopUpdate.ts
@@ -2,11 +2,26 @@ import { useAtomValue } from "@effect/atom-react";
 import type { DesktopBridge, DesktopUpdateState } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import * as Queue from "effect/Queue";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { Atom } from "effect/unstable/reactivity";
 
 type DesktopUpdateBridge = Pick<DesktopBridge, "getUpdateState" | "onUpdateState">;
+
+const INITIAL_STATE_READ_ATTEMPT_COUNT = 3;
+
+export class DesktopUpdateStateReadError extends Schema.TaggedErrorClass<DesktopUpdateStateReadError>()(
+  "DesktopUpdateStateReadError",
+  {
+    attemptCount: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read the initial desktop update state after ${this.attemptCount} attempts.`;
+  }
+}
 
 function getDesktopUpdateBridge(): DesktopUpdateBridge | undefined {
   return typeof window === "undefined" ? undefined : window.desktopBridge;
@@ -32,9 +47,19 @@ export function createDesktopUpdateStateAtom(getBridge: () => DesktopUpdateBridg
         (unsubscribe) => Effect.sync(unsubscribe),
       );
 
-      const initialState = yield* Effect.tryPromise(() => bridge.getUpdateState()).pipe(
-        Effect.retry({ times: 2 }),
-        Effect.orElseSucceed(() => null),
+      const initialState = yield* Effect.tryPromise({
+        try: () => bridge.getUpdateState(),
+        catch: (cause) =>
+          new DesktopUpdateStateReadError({
+            attemptCount: INITIAL_STATE_READ_ATTEMPT_COUNT,
+            cause,
+          }),
+      }).pipe(
+        Effect.retry({ times: INITIAL_STATE_READ_ATTEMPT_COUNT - 1 }),
+        Effect.catchTags({
+          DesktopUpdateStateReadError: (error) =>
+            Effect.logError(error.message, { error }).pipe(Effect.as(null)),
+        }),
       );
       if (!receivedUpdate && initialState !== null) {
         Queue.offerUnsafe(queue, initialState);

--- a/apps/web/src/state/desktopUpdate.ts
+++ b/apps/web/src/state/desktopUpdate.ts
@@ -58,7 +58,11 @@ export function createDesktopUpdateStateAtom(getBridge: () => DesktopUpdateBridg
         Effect.retry({ times: INITIAL_STATE_READ_ATTEMPT_COUNT - 1 }),
         Effect.catchTags({
           DesktopUpdateStateReadError: (error) =>
-            Effect.logError(error.message, { error }).pipe(Effect.as(null)),
+            Effect.logError(error.message, {
+              errorTag: error._tag,
+              attemptCount: error.attemptCount,
+              stack: error.stack,
+            }).pipe(Effect.as(null)),
         }),
       );
       if (!receivedUpdate && initialState !== null) {


### PR DESCRIPTION
## Summary
- replace the silent initial desktop update state fallback with a structured Schema error
- retain the exact bridge rejection cause and final retry count
- recover through tagged catch semantics so the update event listener remains active
- verify retries, structured logging, cause forwarding, and listener recovery

## Validation
- `vp test apps/web/src/state/desktopUpdate.test.ts`
- `vp check` (passes with existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop update atom bootstrap and logging; behavior on success is unchanged and failure still falls back to null while keeping the listener active.
> 
> **Overview**
> Replaces the **silent** initial `getUpdateState` failure path in `createDesktopUpdateStateAtom` with a **`DesktopUpdateStateReadError`** tagged error, **three retries**, and **`Effect.logError`** using structured fields (`errorTag`, `attemptCount`, `stack`) before continuing with `null` so the update listener stays subscribed.
> 
> Tests add **`afterEach` mock restoration** and assert **three bridge read attempts**, the **exact log message**, and that logged context **does not leak** raw `error`/`cause` payloads while **later events** still update atom state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775fe69186b68ccf12d448a0cc36cb122a447f94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log errors when desktop update state read fails after 3 attempts
> - Wraps the initial desktop update state fetch in `Effect.tryPromise`, retrying up to 3 times (via `INITIAL_STATE_READ_ATTEMPT_COUNT`) before falling back to a `null` initial state.
> - Introduces `DesktopUpdateStateReadError`, a tagged error class that captures `attemptCount` and `cause`, replacing the previous silent `orElseSucceed(null)` fallback.
> - On final failure, logs the error tag, attempt count, and stack before proceeding, making read failures observable.
> - Adds test coverage in [desktopUpdate.test.ts](https://github.com/pingdotgg/t3code/pull/3370/files#diff-19c23c83917a99b99930645b2661b856efdac4c618c3b92903bb18d3ecdd25d0) asserting the retry count, error shape, and logged context structure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 775fe69.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->