### PR TITLE
[codex] Preserve detached desktop action causes

### DIFF
--- a/apps/desktop/src/app/DesktopDetachedActionErrors.test.ts
+++ b/apps/desktop/src/app/DesktopDetachedActionErrors.test.ts
@@ -1,0 +1,37 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+
+import { DesktopLifecycleRelaunchError } from "./DesktopLifecycle.ts";
+import { DesktopApplicationMenuActionError } from "../window/DesktopApplicationMenu.ts";
+
+describe("desktop detached action errors", () => {
+  it("preserves the complete relaunch failure cause and reason", () => {
+    const cause = Cause.combine(
+      Cause.fail(new Error("shutdown failed")),
+      Cause.die(new Error("relaunch defect")),
+    );
+    const error = new DesktopLifecycleRelaunchError({
+      reason: "apply update",
+      cause,
+    });
+
+    assert.strictEqual(error.cause, cause);
+    assert.equal(error.reason, "apply update");
+    assert.equal(error.message, 'Desktop relaunch failed for reason "apply update".');
+  });
+
+  it("preserves the complete menu action failure cause and action", () => {
+    const cause = Cause.combine(
+      Cause.fail(new Error("window unavailable")),
+      Cause.die(new Error("dispatch defect")),
+    );
+    const error = new DesktopApplicationMenuActionError({
+      action: "open-settings",
+      cause,
+    });
+
+    assert.strictEqual(error.cause, cause);
+    assert.equal(error.action, "open-settings");
+    assert.equal(error.message, 'Desktop menu action "open-settings" failed.');
+  });
+});

--- a/apps/desktop/src/app/DesktopLifecycle.ts
+++ b/apps/desktop/src/app/DesktopLifecycle.ts
@@ -1,8 +1,8 @@
-import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 
 import type * as Electron from "electron";
@@ -14,6 +14,18 @@ import * as ElectronApp from "../electron/ElectronApp.ts";
 import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as DesktopState from "./DesktopState.ts";
 import * as DesktopWindow from "../window/DesktopWindow.ts";
+
+export class DesktopLifecycleRelaunchError extends Schema.TaggedErrorClass<DesktopLifecycleRelaunchError>()(
+  "DesktopLifecycleRelaunchError",
+  {
+    reason: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Desktop relaunch failed for reason "${this.reason}".`;
+  }
+}
 
 export type DesktopLifecycleRuntimeServices =
   | DesktopEnvironment.DesktopEnvironment
@@ -142,11 +154,10 @@ export const make = DesktopLifecycle.of({
       });
       yield* electronApp.exit(0);
     }).pipe(
-      Effect.catchCause((cause) =>
-        logLifecycleError("desktop relaunch failed", {
-          cause: Cause.pretty(cause),
-        }),
-      ),
+      Effect.catchCause((cause) => {
+        const error = new DesktopLifecycleRelaunchError({ reason, cause });
+        return logLifecycleError(error.message, { error });
+      }),
       Effect.forkDetach,
       Effect.asVoid,
     );

--- a/apps/desktop/src/window/DesktopApplicationMenu.ts
+++ b/apps/desktop/src/window/DesktopApplicationMenu.ts
@@ -1,8 +1,8 @@
-import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import type * as Electron from "electron";
 
@@ -13,6 +13,18 @@ import * as ElectronMenu from "../electron/ElectronMenu.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopUpdates from "../updates/DesktopUpdates.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
+
+export class DesktopApplicationMenuActionError extends Schema.TaggedErrorClass<DesktopApplicationMenuActionError>()(
+  "DesktopApplicationMenuActionError",
+  {
+    action: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Desktop menu action "${this.action}" failed.`;
+  }
+}
 
 export class DesktopApplicationMenu extends Context.Service<
   DesktopApplicationMenu,
@@ -100,12 +112,10 @@ export const make = Effect.gen(function* () {
       effect.pipe(
         Effect.annotateLogs({ action }),
         Effect.withSpan("desktop.menu.action"),
-        Effect.catchCause((cause) =>
-          logMenuError("desktop menu action failed", {
-            action,
-            cause: Cause.pretty(cause),
-          }),
-        ),
+        Effect.catchCause((cause) => {
+          const error = new DesktopApplicationMenuActionError({ action, cause });
+          return logMenuError(error.message, { error });
+        }),
       ),
     );
   };


### PR DESCRIPTION
## Summary
- replace preformatted Effect causes in detached relaunch and native-menu handlers with structured Schema errors
- retain relaunch reason or menu action together with the complete Cause object
- derive stable messages from those structural attributes without reading cause text
- cover both error contracts with combined fail/defect causes

## Validation
- `vp test apps/desktop/src/app/DesktopDetachedActionErrors.test.ts apps/desktop/src/window/DesktopApplicationMenu.test.ts`
- `vp check` (passes with existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in forked/detached error handlers; no change to relaunch or menu success paths.
> 
> **Overview**
> Detached **relaunch** and **native menu** failure handlers no longer log only a preformatted `Cause.pretty` string. They now build **Schema tagged errors** (`DesktopLifecycleRelaunchError`, `DesktopApplicationMenuActionError`) that keep the full `Cause`, plus **reason** or **menu action**, and log with a stable message derived from those fields.
> 
> New unit tests assert combined fail/defect causes are retained on both error types and that messages match the structural attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4055656f5aab8e7f4f7deac25a0a7689c6ce5327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve structured causes in detached desktop action errors
> - Introduces `DesktopLifecycleRelaunchError` and `DesktopApplicationMenuActionError` tagged error classes, each carrying a structured `cause` (defect) and an identifying field (`reason` or `action`).
> - Replaces pretty-printed cause strings in log output with structured error objects, so the full cause chain is preserved in logs.
> - Behavioral Change: log message format and log field names change — `{cause: string}` becomes `{error: <structured error>}` for both relaunch and menu action failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4055656.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->