### PR TITLE
[codex] Structure empty mobile pairing payload errors

### DIFF
--- a/apps/mobile/src/features/connection/pairing.test.ts
+++ b/apps/mobile/src/features/connection/pairing.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { extractPairingUrlFromQrPayload, parsePairingUrl } from "./pairing";
+import {
+  extractPairingUrlFromQrPayload,
+  PairingQrPayloadEmptyError,
+  parsePairingUrl,
+} from "./pairing";
 
 describe("extractPairingUrlFromQrPayload", () => {
   it("trims raw pairing urls from qr payloads", () => {
@@ -18,7 +22,8 @@ describe("extractPairingUrlFromQrPayload", () => {
   });
 
   it("rejects empty qr payloads", () => {
-    expect(() => extractPairingUrlFromQrPayload("   ")).toThrow(
+    expect(() => extractPairingUrlFromQrPayload("   ")).toThrowError(PairingQrPayloadEmptyError);
+    expect(() => extractPairingUrlFromQrPayload("   ")).toThrowError(
       "Scanned QR code did not contain a pairing URL.",
     );
   });

--- a/apps/mobile/src/features/connection/pairing.ts
+++ b/apps/mobile/src/features/connection/pairing.ts
@@ -1,6 +1,16 @@
 import { readHostedPairingRequest } from "@t3tools/shared/remote";
+import * as Schema from "effect/Schema";
 
 const MOBILE_PAIRING_URL_PARAM = "pairingUrl";
+
+export class PairingQrPayloadEmptyError extends Schema.TaggedErrorClass<PairingQrPayloadEmptyError>()(
+  "PairingQrPayloadEmptyError",
+  {},
+) {
+  override get message(): string {
+    return "Scanned QR code did not contain a pairing URL.";
+  }
+}
 
 export function buildPairingUrl(host: string, code: string): string {
   const h = host.trim();
@@ -48,7 +58,7 @@ export function parsePairingUrl(url: string): { host: string; code: string } {
 export function extractPairingUrlFromQrPayload(payload: string): string {
   const trimmed = payload.trim();
   if (!trimmed) {
-    throw new Error("Scanned QR code did not contain a pairing URL.");
+    throw new PairingQrPayloadEmptyError({});
   }
 
   try {


### PR DESCRIPTION
## Summary
- replace the generic empty QR payload `Error` with a distinct Schema-tagged error
- preserve the existing user-facing message
- keep pure validation free of synthetic causes

## Validation
- `pnpm vp test apps/mobile/src/features/connection/pairing.test.ts`
- `pnpm vp check` (20 pre-existing warnings)
- `pnpm vp run typecheck`
- `pnpm vp run lint:mobile`

No active open PR modifies these files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized pairing validation change with no auth or data-path impact; UI still relies on the same error message.
> 
> **Overview**
> Empty or whitespace-only QR scan input in **`extractPairingUrlFromQrPayload`** now throws **`PairingQrPayloadEmptyError`**, a `effect/Schema` **`TaggedErrorClass`**, instead of a generic **`Error`**. The user-facing message is unchanged.
> 
> Tests assert both the error type and the same message string. Call sites that read **`error.message`** (e.g. the new-connection QR handler) keep the same behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f96c917b1a96a5c9c71ca7b494704b57c95a76ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic `Error` with `PairingQrPayloadEmptyError` in `extractPairingUrlFromQrPayload`
> Introduces `PairingQrPayloadEmptyError`, a tagged error class (via `effect/Schema`) in [pairing.ts](https://github.com/pingdotgg/t3code/pull/3372/files#diff-f8dd0ceabf9233f24f8dbef1bcfa23856b70a5d29687d58548a1e1d6366a65e3), replacing the generic `Error` thrown when an empty or whitespace-only QR payload is detected. The error message is unchanged. Tests in [pairing.test.ts](https://github.com/pingdotgg/t3code/pull/3372/files#diff-7bbc5362a2451772e9caf8016b78586b887ce4a8da8c3cf7ba20b9bd78479506) are updated to assert the specific error class is thrown.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f96c917.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->