### PR TITLE
[codex] Preserve desktop asset probe failures

### DIFF
--- a/apps/desktop/src/app/DesktopAssets.test.ts
+++ b/apps/desktop/src/app/DesktopAssets.test.ts
@@ -1,0 +1,57 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
+
+import * as DesktopAssets from "./DesktopAssets.ts";
+import * as DesktopConfig from "./DesktopConfig.ts";
+import * as DesktopEnvironment from "./DesktopEnvironment.ts";
+
+const environmentLayer = DesktopEnvironment.layer({
+  dirname: "/repo/apps/desktop/dist-electron",
+  homeDirectory: "/Users/alice",
+  platform: "darwin",
+  processArch: "arm64",
+  appVersion: "1.2.3",
+  appPath: "/Applications/T3 Code.app/Contents/Resources/app.asar",
+  isPackaged: true,
+  resourcesPath: "/Applications/T3 Code.app/Contents/Resources",
+  runningUnderArm64Translation: false,
+}).pipe(Layer.provide(Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({}))));
+
+describe("DesktopAssets", () => {
+  it.effect("preserves the failed asset candidate and filesystem cause", () =>
+    Effect.gen(function* () {
+      const fileName = "custom.bin";
+      const candidatePath = "/repo/apps/desktop/resources/custom.bin";
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "exists",
+        pathOrDescriptor: candidatePath,
+        description: "private filesystem diagnostic",
+      });
+      const fileSystemLayer = FileSystem.layerNoop({
+        exists: (path) => (path === candidatePath ? Effect.fail(cause) : Effect.succeed(false)),
+      });
+      const assetsLayer = DesktopAssets.layer.pipe(
+        Layer.provide(Layer.merge(fileSystemLayer, environmentLayer)),
+      );
+      const assets = yield* DesktopAssets.DesktopAssets.pipe(Effect.provide(assetsLayer));
+
+      const error = yield* assets.resolveResourcePath(fileName).pipe(Effect.flip);
+
+      assert.instanceOf(error, DesktopAssets.DesktopAssetProbeError);
+      assert.equal(error.fileName, fileName);
+      assert.equal(error.candidatePath, candidatePath);
+      assert.strictEqual(error.cause, cause);
+      assert.equal(
+        error.message,
+        `Failed to probe desktop asset "${fileName}" at ${candidatePath}.`,
+      );
+      assert.notInclude(error.message, "private filesystem diagnostic");
+    }),
+  );
+});

--- a/apps/desktop/src/app/DesktopAssets.ts
+++ b/apps/desktop/src/app/DesktopAssets.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 import * as DesktopEnvironment from "./DesktopEnvironment.ts";
 
@@ -12,11 +13,26 @@ export interface DesktopIconPaths {
   readonly png: Option.Option<string>;
 }
 
+export class DesktopAssetProbeError extends Schema.TaggedErrorClass<DesktopAssetProbeError>()(
+  "DesktopAssetProbeError",
+  {
+    fileName: Schema.String,
+    candidatePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to probe desktop asset "${this.fileName}" at ${this.candidatePath}.`;
+  }
+}
+
 export class DesktopAssets extends Context.Service<
   DesktopAssets,
   {
     readonly iconPaths: Effect.Effect<DesktopIconPaths>;
-    readonly resolveResourcePath: (fileName: string) => Effect.Effect<Option.Option<string>>;
+    readonly resolveResourcePath: (
+      fileName: string,
+    ) => Effect.Effect<Option.Option<string>, DesktopAssetProbeError>;
   }
 >()("@t3tools/desktop/app/DesktopAssets") {}
 
@@ -24,14 +40,20 @@ const resolveResourcePath = Effect.fn("desktop.assets.resolveResourcePath")(func
   fileName: string,
 ): Effect.fn.Return<
   Option.Option<string>,
-  never,
+  DesktopAssetProbeError,
   FileSystem.FileSystem | DesktopEnvironment.DesktopEnvironment
 > {
   const fileSystem = yield* FileSystem.FileSystem;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   const candidates = environment.resolveResourcePathCandidates(fileName);
   for (const candidate of candidates) {
-    const exists = yield* fileSystem.exists(candidate).pipe(Effect.orElseSucceed(() => false));
+    const exists = yield* fileSystem
+      .exists(candidate)
+      .pipe(
+        Effect.mapError(
+          (cause) => new DesktopAssetProbeError({ fileName, candidatePath: candidate, cause }),
+        ),
+      );
     if (exists) {
       return Option.some(candidate);
     }
@@ -43,16 +65,23 @@ const resolveIconPath = Effect.fn("desktop.assets.resolveIconPath")(function* (
   ext: keyof DesktopIconPaths,
 ): Effect.fn.Return<
   Option.Option<string>,
-  never,
+  DesktopAssetProbeError,
   FileSystem.FileSystem | DesktopEnvironment.DesktopEnvironment
 > {
   const fileSystem = yield* FileSystem.FileSystem;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
   if (environment.isDevelopment && environment.platform === "darwin" && ext === "png") {
     const developmentDockIconPath = environment.developmentDockIconPath;
-    const developmentDockIconExists = yield* fileSystem
-      .exists(developmentDockIconPath)
-      .pipe(Effect.orElseSucceed(() => false));
+    const developmentDockIconExists = yield* fileSystem.exists(developmentDockIconPath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new DesktopAssetProbeError({
+            fileName: "icon.png",
+            candidatePath: developmentDockIconPath,
+            cause,
+          }),
+      ),
+    );
     if (developmentDockIconExists) {
       return Option.some(developmentDockIconPath);
     }
@@ -61,7 +90,7 @@ const resolveIconPath = Effect.fn("desktop.assets.resolveIconPath")(function* (
   return yield* resolveResourcePath(`icon.${ext}`);
 });
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const context = yield* Effect.context<
     FileSystem.FileSystem | DesktopEnvironment.DesktopEnvironment
   >();


### PR DESCRIPTION
Desktop asset lookup no longer treats filesystem probe failures as missing files. The service now returns a structured error with the requested filename, candidate path, and exact underlying cause, while keeping a stable message independent of cause text.

Also exports make to match the single-file service convention.

Validation:
- vp test apps/desktop/src/app/DesktopAssets.test.ts
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Startup paths that load `iconPaths` can now fail on I/O errors instead of continuing with no icon; callers must handle `DesktopAssetProbeError` where they previously assumed infallible resolution.
> 
> **Overview**
> Desktop asset resolution no longer treats `FileSystem.exists` failures as “file not found.” **`resolveResourcePath`** and Darwin dev dock icon probing now **fail** with a new **`DesktopAssetProbeError`** that carries the requested filename, the candidate path, and the original cause, while exposing a **stable user-facing message** that does not leak cause text.
> 
> The **`DesktopAssets`** service typing is updated so these paths can error with **`DesktopAssetProbeError`**, and **`make`** is **exported** to align with other single-file Effect services. A unit test asserts the error shape and message behavior when a probe fails (e.g. permission denied).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36d521d5c970c2e2ea4e4628a5c8b28298963834. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve filesystem errors in `DesktopAssets.resolveResourcePath` as `DesktopAssetProbeError`
> - Introduces `DesktopAssetProbeError`, a structured tagged error carrying `fileName`, `candidatePath`, and the original filesystem `cause`, with a stable message format.
> - Changes `resolveResourcePath` and `resolveIconPath` to fail with `DesktopAssetProbeError` on filesystem errors instead of silently treating them as non-existence (previously via `orElseSucceed(() => false)`).
> - Adds a test in [DesktopAssets.test.ts](https://github.com/pingdotgg/t3code/pull/3373/files#diff-d0c47c1ce530f10d3dd73d77dc9d4c457cb2d48de5173dd1813d19d66e9c48a5) verifying the error preserves all fields and does not leak the cause in the message.
> - Risk: `DesktopAssets.make` can now fail during initialization if any icon probe encounters a filesystem error, and `resolveResourcePath` callers must now handle `DesktopAssetProbeError` in the error channel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36d521d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->