### PR TITLE
[codex] Preserve relay trace error causes

### DIFF
--- a/packages/shared/src/relayTracing.test.ts
+++ b/packages/shared/src/relayTracing.test.ts
@@ -1,9 +1,16 @@
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Tracer from "effect/Tracer";
+import { FetchHttpClient } from "effect/unstable/http";
+import { vi } from "vite-plus/test";
 
-import { RelayClientTracer, withRelayClientTracing } from "./relayTracing.ts";
+import {
+  makeRelayClientTracingLayer,
+  RelayClientTracer,
+  withRelayClientTracing,
+} from "./relayTracing.ts";
 
 function collectingTracer(spans: Array<string>): Tracer.Tracer {
   return Tracer.make({
@@ -54,4 +61,44 @@ describe("withRelayClientTracing", () => {
       expect(userSpans).toEqual(["relay.operation"]);
     }),
   );
+
+  it.effect("preserves nested error causes in exported relay spans", () => {
+    const fetchFn = vi.fn<typeof fetch>(async () => new Response(null, { status: 202 }));
+    const httpClientLayer = FetchHttpClient.layer.pipe(
+      Layer.provide(Layer.succeed(FetchHttpClient.Fetch, fetchFn)),
+    );
+    const tracingLayer = makeRelayClientTracingLayer(
+      {
+        tracesUrl: "https://api.axiom.test/v1/traces",
+        tracesDataset: "relay-traces",
+        tracesToken: "public-ingest-token",
+      },
+      {
+        serviceName: "relay-test",
+        runtime: "test",
+        client: "test",
+      },
+    ).pipe(Layer.provide(httpClientLayer));
+    const rootCause = new Error("relay socket closed");
+    const failure = new Error("relay request failed", { cause: rootCause });
+    const tracedApplication = Layer.effectDiscard(
+      Effect.fail(failure).pipe(
+        Effect.withSpan("relay.failed-operation"),
+        withRelayClientTracing,
+        Effect.exit,
+      ),
+    ).pipe(Layer.provide(tracingLayer));
+
+    return Layer.build(tracedApplication).pipe(
+      Effect.scoped,
+      Effect.andThen(
+        Effect.sync(() => {
+          expect(fetchFn).toHaveBeenCalledOnce();
+          const payload = new TextDecoder().decode(fetchFn.mock.calls[0]?.[1]?.body as Uint8Array);
+          expect(payload).toContain("relay request failed");
+          expect(payload).toContain("relay socket closed");
+        }),
+      ),
+    );
+  });
 });

--- a/packages/shared/src/relayTracing.ts
+++ b/packages/shared/src/relayTracing.ts
@@ -41,7 +41,16 @@ export const withRelayClientTracing = <A, E, R>(
     ),
   );
 
-function traceSafeError(value: unknown): Error {
+function cleanTraceStack(error: Error): string {
+  const stack = error.stack ?? `${error.name}: ${error.message}`;
+  const lines = stack.split("\n");
+  const effectFrameIndex = lines.findIndex(
+    (line, index) => index > 0 && /(?:Generator\.next|~effect\/Effect)/.test(line),
+  );
+  return effectFrameIndex < 0 ? stack : lines.slice(0, effectFrameIndex).join("\n");
+}
+
+function traceSafeError(value: unknown, seen = new WeakSet<object>()): Error {
   const message =
     value instanceof Error
       ? value.message
@@ -51,12 +60,19 @@ function traceSafeError(value: unknown): Error {
           typeof value.message === "string"
         ? value.message
         : String(value);
-  const error = new Error(message);
+
+  let cause: Error | undefined;
+  if (typeof value === "object" && value !== null && !seen.has(value)) {
+    seen.add(value);
+    if ("cause" in value && value.cause !== undefined) {
+      cause = traceSafeError(value.cause, seen);
+    }
+  }
+
+  const error = new Error(message, cause ? { cause } : undefined);
   if (value instanceof Error) {
     error.name = value.name;
-    if (value.stack !== undefined) {
-      error.stack = value.stack;
-    }
+    error.stack = cleanTraceStack(value);
   } else if (
     typeof value === "object" &&
     value !== null &&
@@ -64,6 +80,9 @@ function traceSafeError(value: unknown): Error {
     typeof value.name === "string"
   ) {
     error.name = value.name;
+  }
+  if (cause) {
+    error.stack = `${error.stack ?? `${error.name}: ${error.message}`}\nCaused by: ${cause.stack ?? `${cause.name}: ${cause.message}`}`;
   }
   return error;
 }


### PR DESCRIPTION
## Summary
- preserve sanitized nested `cause` chains when relay failures are handed to the OTLP tracer
- retain each cause stack in the exported exception stack without changing the public failure value
- add an OTLP integration test covering the outer failure and root cause

## Testing
- `vp test packages/shared/src/relayTracing.test.ts`
- `vp check`
- `vp run typecheck`
- `vpr typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to best-effort telemetry sanitization in `nonInterferingTracer`; application exit/failure behavior is unchanged.
> 
> **Overview**
> Relay client tracing now **sanitizes failures for OTLP export** without changing the failure values the app sees. `traceSafeError` recursively walks `cause` chains (with cycle protection), trims Effect-internal frames via `cleanTraceStack`, and folds nested causes into the exported exception stack as a `Caused by:` section.
> 
> A new integration test builds the real tracing layer with a mocked HTTP client and asserts the ingest payload includes both the outer failure message and the root cause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e65854c55a83de2c118d07a7df93247a5c37b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve error causes and clean stack traces in `traceSafeError`
> - Expands `traceSafeError` in [relayTracing.ts](https://github.com/pingdotgg/t3code/pull/3377/files#diff-3a374d5d763bdc40c194a70fa27ccd365fd6b74a4b8f15c6267de9cbfbcb06bd) to propagate nested error causes, using a `WeakSet` to avoid cycles and appending a `Caused by:` section to the resulting stack.
> - Adds `cleanTraceStack` helper that strips internal Effect/Generator frames from stack traces.
> - Adds tests verifying that exported trace payloads include both the error message and its nested cause.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56e6585.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->