### PR TITLE
[codex] Add structured asset access context

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -87,6 +87,14 @@ describe("AssetAccess", () => {
         workspaceRoot: root,
       }).pipe(Effect.flip);
       expect(error.message).toBe("Workspace file path must be relative to the project root.");
+      expect(error).toMatchObject({
+        operation: "validate-workspace-path",
+        resource: {
+          _tag: "workspace-file",
+          threadId: "thread-1",
+          path: htmlPath,
+        },
+      });
       expect(error.cause).toBeInstanceOf(WorkspacePaths.WorkspacePathOutsideRootError);
     }).pipe(Effect.provide(testLayer)),
   );
@@ -121,6 +129,14 @@ describe("AssetAccess", () => {
       }).pipe(Effect.provideService(FileSystem.FileSystem, failingFileSystem), Effect.flip);
 
       expect(error.message).toBe("Failed to inspect the workspace asset.");
+      expect(error).toMatchObject({
+        operation: "inspect-workspace-asset",
+        resource: {
+          _tag: "workspace-file",
+          threadId: "thread-1",
+          path: htmlPath,
+        },
+      });
       expect(error.cause).toBe(cause);
     }).pipe(Effect.provide(testLayer)),
   );

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -165,12 +165,18 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
   switch (input.resource._tag) {
     case "workspace-file": {
       if (!input.workspaceRoot) {
-        return yield* new AssetAccessError({ message: "Workspace context was not found." });
+        return yield* new AssetAccessError({
+          operation: "resolve-workspace-context",
+          resource: input.resource,
+          message: "Workspace context was not found.",
+        });
       }
       const workspaceRoot = yield* workspacePaths.normalizeWorkspaceRoot(input.workspaceRoot).pipe(
         Effect.mapError(
           (cause) =>
             new AssetAccessError({
+              operation: "normalize-workspace-root",
+              resource: input.resource,
               message: "Failed to normalize the workspace root.",
               cause,
             }),
@@ -185,6 +191,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
           Effect.mapError(
             (cause) =>
               new AssetAccessError({
+                operation: "validate-workspace-path",
+                resource: input.resource,
                 message: "Workspace file path must be relative to the project root.",
                 cause,
               }),
@@ -192,6 +200,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         );
       if (!isWorkspacePreviewEntryPath(resolved.relativePath)) {
         return yield* new AssetAccessError({
+          operation: "validate-preview-type",
+          resource: input.resource,
           message: "Only browser documents and images can be previewed.",
         });
       }
@@ -202,18 +212,26 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         Effect.mapError(
           (cause) =>
             new AssetAccessError({
+              operation: "inspect-workspace-asset",
+              resource: input.resource,
               message: "Failed to inspect the workspace asset.",
               cause,
             }),
         ),
       );
       if (!canonicalFile) {
-        return yield* new AssetAccessError({ message: "Workspace asset was not found." });
+        return yield* new AssetAccessError({
+          operation: "locate-workspace-asset",
+          resource: input.resource,
+          message: "Workspace asset was not found.",
+        });
       }
       const canonicalWorkspaceRoot = yield* fileSystem.realPath(workspaceRoot).pipe(
         Effect.mapError(
           (cause) =>
             new AssetAccessError({
+              operation: "resolve-workspace",
+              resource: input.resource,
               message: "Failed to resolve workspace.",
               cause,
             }),
@@ -244,7 +262,11 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         attachmentId: input.resource.attachmentId,
       });
       if (!attachmentPath) {
-        return yield* new AssetAccessError({ message: "Attachment was not found." });
+        return yield* new AssetAccessError({
+          operation: "locate-attachment",
+          resource: input.resource,
+          message: "Attachment was not found.",
+        });
       }
       claims = {
         version: 1,
@@ -260,6 +282,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         Effect.mapError(
           (cause) =>
             new AssetAccessError({
+              operation: "normalize-workspace-root",
+              resource: input.resource,
               message: "Failed to normalize the workspace root.",
               cause,
             }),
@@ -270,6 +294,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         Effect.mapError(
           (cause) =>
             new AssetAccessError({
+              operation: "resolve-project-favicon",
+              resource: input.resource,
               message: "Failed to resolve project favicon.",
               cause,
             }),
@@ -282,13 +308,19 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
           Effect.mapError(
             (cause) =>
               new AssetAccessError({
+                operation: "inspect-project-favicon",
+                resource: input.resource,
                 message: "Failed to inspect the project favicon.",
                 cause,
               }),
           ),
         ))
       ) {
-        return yield* new AssetAccessError({ message: "Project favicon was not found." });
+        return yield* new AssetAccessError({
+          operation: "locate-project-favicon",
+          resource: input.resource,
+          message: "Project favicon was not found.",
+        });
       }
       claims = {
         version: 1,
@@ -297,6 +329,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
           Effect.mapError(
             (cause) =>
               new AssetAccessError({
+                operation: "resolve-workspace",
+                resource: input.resource,
                 message: "Failed to resolve workspace.",
                 cause,
               }),
@@ -315,6 +349,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
     Effect.mapError(
       (cause) =>
         new AssetAccessError({
+          operation: "load-signing-key",
+          resource: input.resource,
           message: "Failed to load the asset signing key.",
           cause,
         }),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1341,6 +1341,8 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
                   Effect.mapError(
                     (cause) =>
                       new AssetAccessError({
+                        operation: "resolve-workspace-context",
+                        resource: input.resource,
                         message: "Failed to resolve workspace context.",
                         cause,
                       }),
@@ -1348,6 +1350,8 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
                 );
               if (Option.isNone(thread)) {
                 return yield* new AssetAccessError({
+                  operation: "resolve-workspace-context",
+                  resource: input.resource,
                   message: "Workspace context was not found.",
                 });
               }
@@ -1357,6 +1361,8 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
                   Effect.mapError(
                     (cause) =>
                       new AssetAccessError({
+                        operation: "resolve-workspace-context",
+                        resource: input.resource,
                         message: "Failed to resolve workspace context.",
                         cause,
                       }),
@@ -1364,6 +1370,8 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
                 );
               if (Option.isNone(project)) {
                 return yield* new AssetAccessError({
+                  operation: "resolve-workspace-context",
+                  resource: input.resource,
                   message: "Workspace context was not found.",
                 });
               }

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -29,9 +29,27 @@ export const AssetCreateUrlResult = Schema.Struct({
 });
 export type AssetCreateUrlResult = typeof AssetCreateUrlResult.Type;
 
+export const AssetAccessOperation = Schema.Literals([
+  "resolve-workspace-context",
+  "normalize-workspace-root",
+  "validate-workspace-path",
+  "validate-preview-type",
+  "inspect-workspace-asset",
+  "locate-workspace-asset",
+  "resolve-workspace",
+  "locate-attachment",
+  "resolve-project-favicon",
+  "inspect-project-favicon",
+  "locate-project-favicon",
+  "load-signing-key",
+]);
+export type AssetAccessOperation = typeof AssetAccessOperation.Type;
+
 export class AssetAccessError extends Schema.TaggedErrorClass<AssetAccessError>()(
   "AssetAccessError",
   {
+    operation: AssetAccessOperation,
+    resource: AssetResource,
     message: TrimmedNonEmptyString,
     cause: Schema.optional(Schema.Defect()),
   },


### PR DESCRIPTION
## Summary
- add typed asset operations and the full requested resource to `AssetAccessError`
- retain the existing user-facing messages and exact causes
- make thread IDs, file paths, attachment IDs, and favicon roots available without parsing message text

## Validation
- `pnpm vp test apps/server/src/assets/AssetAccess.test.ts` (7 tests)
- `pnpm vp check` (20 pre-existing warnings)
- `pnpm vp run typecheck`

Stacked on #3369, which is stacked on #3342, so it extends the existing asset error work rather than conflicting with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Contract change requires every AssetAccessError construction to include new fields; behavior is unchanged but touches asset-access error paths that are security-adjacent.
> 
> **Overview**
> **`AssetAccessError` now carries typed `operation` and `resource` fields** alongside existing `message` and optional `cause`, via a new `AssetAccessOperation` literal union in contracts.
> 
> Every failure path in **`issueAssetUrl`** (workspace files, attachments, project favicons, signing key) and in the WebSocket **`assetsCreateUrl`** workspace-context resolution now sets a specific operation (e.g. `validate-workspace-path`, `inspect-workspace-asset`, `resolve-workspace-context`) and echoes the requested **`AssetResource`**.
> 
> User-facing messages and underlying causes are unchanged; tests assert the new fields on representative path-validation and inspection failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeacdc51ffb21dbe5ad3c01d426146a3fa4a3994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured `operation` and `resource` fields to `AssetAccessError`
> - Extends `AssetAccessError` in [`packages/contracts/src/assets.ts`](https://github.com/pingdotgg/t3code/pull/3378/files#diff-be151844cc8699bd23b42fc4d6d73c29e32170c1b03cb89b86296402f2c40359) with two required fields: `operation` (a constrained `AssetAccessOperation` literal) and `resource` (the `AssetResource` being processed).
> - Updates all error construction sites in [`AssetAccess.issueAssetUrl`](https://github.com/pingdotgg/t3code/pull/3378/files#diff-7106051c89d4fb8e7cebeee854e81bb55fdf03ec154089eb8c7499ef78ae51c1) and the workspace RPC handler in [`ws.ts`](https://github.com/pingdotgg/t3code/pull/3378/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) to populate these fields with operation-specific literals.
> - Risk: `AssetAccessError` construction is now a breaking change — all call sites must supply `operation` and `resource` or the schema validation will fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eeacdc5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->