### PR TITLE
[codex] Structure desktop backend settings read errors

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.test.ts
@@ -3,6 +3,8 @@ import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
@@ -19,6 +21,10 @@ const PersistedServerObservabilitySettingsDocument = Schema.Struct({
 
 const encodePersistedServerObservabilitySettingsDocument = Schema.encodeEffect(
   Schema.fromJsonString(PersistedServerObservabilitySettingsDocument),
+);
+
+const isDesktopBackendObservabilitySettingsReadError = Schema.is(
+  DesktopBackendConfiguration.DesktopBackendObservabilitySettingsReadError,
 );
 
 const serverExposureLayer = Layer.succeed(DesktopServerExposure.DesktopServerExposure, {
@@ -164,6 +170,62 @@ describe("DesktopBackendConfiguration", () => {
         assert.isUndefined(config.bootstrap.otlpMetricsUrl);
       }),
     ),
+  );
+
+  it.effect("logs structured context when persisted observability settings cannot be read", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const baseDir = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-desktop-backend-config-test-",
+      });
+      const settingsPath = `${baseDir}/userdata/settings.json`;
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "readFileString",
+        pathOrDescriptor: settingsPath,
+      });
+      const messages: Array<unknown> = [];
+      const logger = Logger.make(({ message }) => {
+        messages.push(message);
+      });
+      const failingFileSystemLayer = Layer.succeed(
+        FileSystem.FileSystem,
+        FileSystem.makeNoop({
+          readFileString: () => Effect.fail(cause),
+        }),
+      );
+
+      const config = yield* Effect.gen(function* () {
+        const configuration = yield* DesktopBackendConfiguration.DesktopBackendConfiguration;
+        return yield* configuration.resolve;
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            DesktopBackendConfiguration.layer.pipe(
+              Layer.provideMerge(serverExposureLayer),
+              Layer.provideMerge(makeEnvironmentLayer(baseDir)),
+              Layer.provideMerge(failingFileSystemLayer),
+            ),
+            Logger.layer([logger], { mergeWithExisting: false }),
+          ),
+        ),
+      );
+
+      assert.isUndefined(config.bootstrap.otlpTracesUrl);
+      assert.isUndefined(config.bootstrap.otlpMetricsUrl);
+
+      const error = messages
+        .flatMap((message) => (Array.isArray(message) ? message : [message]))
+        .find(isDesktopBackendObservabilitySettingsReadError);
+      assert.isDefined(error);
+      assert.equal(error.settingsPath, settingsPath);
+      assert.equal(error.cause, cause);
+      assert.equal(
+        error.message,
+        `Failed to read persisted backend observability settings at ${settingsPath}.`,
+      );
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
   it.effect("captures backend output in development so child process logs can be persisted", () =>

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -8,11 +8,23 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as PlatformError from "effect/PlatformError";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 
 import * as DesktopBackendManager from "./DesktopBackendManager.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
-import * as DesktopObservability from "../app/DesktopObservability.ts";
 import * as DesktopServerExposure from "./DesktopServerExposure.ts";
+
+export class DesktopBackendObservabilitySettingsReadError extends Schema.TaggedErrorClass<DesktopBackendObservabilitySettingsReadError>()(
+  "DesktopBackendObservabilitySettingsReadError",
+  {
+    settingsPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read persisted backend observability settings at ${this.settingsPath}.`;
+  }
+}
 
 export class DesktopBackendConfiguration extends Context.Service<
   DesktopBackendConfiguration,
@@ -50,25 +62,34 @@ const DESKTOP_BACKEND_ENV_NAMES = [
 const backendChildEnvPatch = (): Record<string, string | undefined> =>
   Object.fromEntries(DESKTOP_BACKEND_ENV_NAMES.map((name) => [name, undefined]));
 
-const { logWarning: logBackendConfigurationWarning } = DesktopObservability.makeComponentLogger(
-  "desktop-backend-configuration",
-);
+const logBackendObservabilitySettingsReadFailure = (
+  settingsPath: string,
+  cause: PlatformError.PlatformError,
+) => {
+  const error = new DesktopBackendObservabilitySettingsReadError({ settingsPath, cause });
+  return Effect.logWarning(error).pipe(
+    Effect.annotateLogs({
+      component: "desktop-backend-configuration",
+      error,
+    }),
+  );
+};
 
 const readPersistedBackendObservabilitySettings = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;
   const environment = yield* DesktopEnvironment.DesktopEnvironment;
-  const exists = yield* fileSystem
-    .exists(environment.serverSettingsPath)
-    .pipe(Effect.orElseSucceed(() => false));
-  if (!exists) {
-    return emptyBackendObservabilitySettings;
-  }
-
-  const raw = yield* fileSystem.readFileString(environment.serverSettingsPath).pipe(Effect.option);
+  const raw = yield* fileSystem.readFileString(environment.serverSettingsPath).pipe(
+    Effect.map(Option.some),
+    Effect.catchTags({
+      PlatformError: (cause) =>
+        cause.reason._tag === "NotFound"
+          ? Effect.succeed(Option.none())
+          : logBackendObservabilitySettingsReadFailure(environment.serverSettingsPath, cause).pipe(
+              Effect.as(Option.none()),
+            ),
+    }),
+  );
   if (Option.isNone(raw)) {
-    yield* logBackendConfigurationWarning(
-      "failed to read persisted backend observability settings",
-    );
     return emptyBackendObservabilitySettings;
   }
 


### PR DESCRIPTION
## Summary
- replace the exists/read fallback pair with one race-free read
- treat only NotFound as an expected missing settings file
- log other read failures as a structured Schema error with the settings path and exact platform cause while preserving the existing defaults fallback

## Verification
- `vp test apps/desktop/src/backend/DesktopBackendConfiguration.test.ts` (5 passed)
- `vp check` (passes; 20 existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop bootstrap config read path; behavior on missing files is unchanged and failures still degrade to defaults with better observability.
> 
> **Overview**
> **Desktop backend config** now loads persisted OTLP settings with a single `readFileString` instead of `exists` plus read, avoiding a race when the file appears or disappears between checks.
> 
> **Missing settings** are handled only when the read fails with **`NotFound`**; other filesystem errors (e.g. permission denied) emit a **structured `DesktopBackendObservabilitySettingsReadError`** via `Effect.logWarning` with `component`, `settingsPath`, and the platform cause, then still fall back to empty observability defaults so startup is unchanged.
> 
> A new test asserts that behavior on read failure: bootstrap URLs stay undefined and the logged error matches the path and cause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc020f59e6423cbc9a79f4c932ca86cab7ddcb0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure desktop backend observability settings read errors with `DesktopBackendObservabilitySettingsReadError`
> - Adds a new `DesktopBackendObservabilitySettingsReadError` Schema tagged error class in [DesktopBackendConfiguration.ts](https://github.com/pingdotgg/t3code/pull/3379/files#diff-8a9cd9d84f556b82ed8678110af5a99dea2cc1cfe1e6c6c46dc3a2e3bcb1f94c) with `settingsPath` and `cause` fields, replacing the previous generic string warning log.
> - When reading persisted observability settings fails, non-`NotFound` errors (e.g. `PermissionDenied`) now log a structured warning annotated with `component: desktop-backend-configuration`; `NotFound` errors return empty settings silently.
> - Removes the `FileSystem.exists` pre-check, instead attempting `readFileString` directly and branching on the error reason tag.
> - Adds a test in [DesktopBackendConfiguration.test.ts](https://github.com/pingdotgg/t3code/pull/3379/files#diff-1249037d55046a0fac1534a735fd14f75f78cff314f170b0305116ad2e443614) that injects a failing `FileSystem` layer and asserts the structured error is logged with the expected fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc020f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->