### PR TITLE
[codex] Structure desktop bridge state errors

### DIFF
--- a/apps/web/src/state/desktopNetworkAccess.test.ts
+++ b/apps/web/src/state/desktopNetworkAccess.test.ts
@@ -1,4 +1,5 @@
 import type { AdvertisedEndpoint, DesktopServerExposureState } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import { describe, expect, it, vi } from "vite-plus/test";
@@ -14,6 +15,8 @@ const serverExposureState: DesktopServerExposureState = {
 };
 
 const advertisedEndpoints: ReadonlyArray<AdvertisedEndpoint> = [];
+const serverExposureLoadCause = new Error("exposure failed");
+const advertisedEndpointsLoadCause = new Error("endpoints failed");
 
 describe("desktopNetworkAccessState", () => {
   it("retains the loaded snapshot when the settings screen remounts", async () => {
@@ -45,6 +48,40 @@ describe("desktopNetworkAccessState", () => {
     expect(getAdvertisedEndpoints).toHaveBeenCalledTimes(1);
 
     remount();
+    registry.dispose();
+  });
+
+  it.each([
+    {
+      cause: serverExposureLoadCause,
+      expectedTag: "DesktopServerExposureStateLoadError",
+      getAdvertisedEndpoints: async () => advertisedEndpoints,
+      getServerExposureState: async () => Promise.reject(serverExposureLoadCause),
+    },
+    {
+      cause: advertisedEndpointsLoadCause,
+      expectedTag: "DesktopAdvertisedEndpointsLoadError",
+      getAdvertisedEndpoints: async () => Promise.reject(advertisedEndpointsLoadCause),
+      getServerExposureState: async () => serverExposureState,
+    },
+  ])("retains the $expectedTag cause", async (testCase) => {
+    const atom = createDesktopNetworkAccessStateAtom(() => ({
+      getAdvertisedEndpoints: testCase.getAdvertisedEndpoints,
+      getServerExposureState: testCase.getServerExposureState,
+    }));
+    const registry = AtomRegistry.make();
+    registry.mount(atom);
+
+    await vi.waitFor(() => expect(AsyncResult.isFailure(registry.get(atom))).toBe(true));
+    const result = registry.get(atom);
+    if (!AsyncResult.isFailure(result)) throw new Error("Expected network access load to fail.");
+
+    expect(Cause.squash(result.cause)).toEqual(
+      expect.objectContaining({
+        _tag: testCase.expectedTag,
+        cause: testCase.cause,
+      }),
+    );
     registry.dispose();
   });
 });

--- a/apps/web/src/state/desktopNetworkAccess.ts
+++ b/apps/web/src/state/desktopNetworkAccess.ts
@@ -21,13 +21,32 @@ export interface DesktopNetworkAccessSnapshot {
   readonly serverExposureState: DesktopServerExposureState;
 }
 
-class DesktopNetworkAccessError extends Schema.TaggedErrorClass<DesktopNetworkAccessError>()(
-  "DesktopNetworkAccessError",
-  {
-    message: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
-  },
-) {}
+class DesktopNetworkAccessUnavailableError extends Schema.TaggedErrorClass<DesktopNetworkAccessUnavailableError>()(
+  "DesktopNetworkAccessUnavailableError",
+  {},
+) {
+  override get message(): string {
+    return "Desktop network access is unavailable.";
+  }
+}
+
+class DesktopServerExposureStateLoadError extends Schema.TaggedErrorClass<DesktopServerExposureStateLoadError>()(
+  "DesktopServerExposureStateLoadError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to load desktop server exposure state.";
+  }
+}
+
+class DesktopAdvertisedEndpointsLoadError extends Schema.TaggedErrorClass<DesktopAdvertisedEndpointsLoadError>()(
+  "DesktopAdvertisedEndpointsLoadError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to load advertised desktop endpoints.";
+  }
+}
 
 function getDesktopNetworkAccessBridge(): DesktopNetworkAccessBridge | undefined {
   return typeof window === "undefined" ? undefined : window.desktopBridge;
@@ -39,25 +58,25 @@ export function createDesktopNetworkAccessStateAtom(
   const loadDesktopNetworkAccess = Effect.fn("loadDesktopNetworkAccess")(function* () {
     const bridge = getBridge();
     if (!bridge) {
-      return yield* new DesktopNetworkAccessError({
-        message: "Desktop network access is unavailable.",
-      });
+      return yield* new DesktopNetworkAccessUnavailableError();
     }
-    return yield* Effect.tryPromise({
-      try: async (): Promise<DesktopNetworkAccessSnapshot> => {
-        const [serverExposureState, advertisedEndpoints] = await Promise.all([
-          bridge.getServerExposureState(),
-          bridge.getAdvertisedEndpoints(),
-        ]);
-        return { advertisedEndpoints, serverExposureState };
-      },
-      catch: (cause) =>
-        new DesktopNetworkAccessError({
-          message:
-            cause instanceof Error ? cause.message : "Failed to load desktop network access.",
-          cause,
+    const [serverExposureState, advertisedEndpoints] = yield* Effect.all(
+      [
+        Effect.tryPromise({
+          try: () => bridge.getServerExposureState(),
+          catch: (cause) => new DesktopServerExposureStateLoadError({ cause }),
         }),
-    });
+        Effect.tryPromise({
+          try: () => bridge.getAdvertisedEndpoints(),
+          catch: (cause) => new DesktopAdvertisedEndpointsLoadError({ cause }),
+        }),
+      ],
+      { concurrency: "unbounded" },
+    );
+    return {
+      advertisedEndpoints,
+      serverExposureState,
+    } satisfies DesktopNetworkAccessSnapshot;
   });
 
   return Atom.make(loadDesktopNetworkAccess()).pipe(

--- a/apps/web/src/state/desktopSshHosts.test.ts
+++ b/apps/web/src/state/desktopSshHosts.test.ts
@@ -1,4 +1,5 @@
 import type { DesktopDiscoveredSshHost } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { describe, expect, it, vi } from "vite-plus/test";
@@ -36,6 +37,27 @@ describe("desktopSshHostsState", () => {
     expect(discoverSshHosts).toHaveBeenCalledTimes(1);
 
     remount();
+    registry.dispose();
+  });
+
+  it("retains the desktop bridge failure as the discovery error cause", async () => {
+    const cause = new Error("ssh config unavailable");
+    const atom = createDesktopSshHostsStateAtom(() => ({
+      discoverSshHosts: async () => Promise.reject(cause),
+    }));
+    const registry = AtomRegistry.make();
+    registry.mount(atom);
+
+    await vi.waitFor(() => expect(AsyncResult.isFailure(registry.get(atom))).toBe(true));
+    const result = registry.get(atom);
+    if (!AsyncResult.isFailure(result)) throw new Error("Expected SSH host discovery to fail.");
+
+    expect(Cause.squash(result.cause)).toEqual(
+      expect.objectContaining({
+        _tag: "DesktopSshDiscoveryError",
+        cause,
+      }),
+    );
     registry.dispose();
   });
 });

--- a/apps/web/src/state/desktopSshHosts.ts
+++ b/apps/web/src/state/desktopSshHosts.ts
@@ -5,13 +5,23 @@ import { Atom } from "effect/unstable/reactivity";
 
 type DesktopSshDiscoveryBridge = Pick<DesktopBridge, "discoverSshHosts">;
 
+class DesktopSshDiscoveryUnavailableError extends Schema.TaggedErrorClass<DesktopSshDiscoveryUnavailableError>()(
+  "DesktopSshDiscoveryUnavailableError",
+  {},
+) {
+  override get message(): string {
+    return "Desktop SSH host discovery is unavailable.";
+  }
+}
+
 class DesktopSshDiscoveryError extends Schema.TaggedErrorClass<DesktopSshDiscoveryError>()(
   "DesktopSshDiscoveryError",
-  {
-    message: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
-  },
-) {}
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to discover SSH hosts.";
+  }
+}
 
 function getDesktopSshDiscoveryBridge(): DesktopSshDiscoveryBridge | undefined {
   return typeof window === "undefined" ? undefined : window.desktopBridge;
@@ -23,17 +33,11 @@ export function createDesktopSshHostsStateAtom(
   const discoverDesktopSshHosts = Effect.fn("discoverDesktopSshHosts")(function* () {
     const bridge = getBridge();
     if (!bridge) {
-      return yield* new DesktopSshDiscoveryError({
-        message: "Desktop SSH host discovery is unavailable.",
-      });
+      return yield* new DesktopSshDiscoveryUnavailableError();
     }
     return yield* Effect.tryPromise({
       try: (): Promise<ReadonlyArray<DesktopDiscoveredSshHost>> => bridge.discoverSshHosts(),
-      catch: (cause) =>
-        new DesktopSshDiscoveryError({
-          message: cause instanceof Error ? cause.message : "Failed to discover SSH hosts.",
-          cause,
-        }),
+      catch: (cause) => new DesktopSshDiscoveryError({ cause }),
     });
   });
 


### PR DESCRIPTION
## Summary
- split unavailable desktop bridges from bridge invocation failures with distinct schema error tags
- preserve the exact bridge rejection as `cause` instead of exposing `cause.message` as the domain error message
- identify server-exposure and advertised-endpoint failures separately while keeping both bridge calls concurrent

## Validation
- `pnpm vp test apps/web/src/state/desktopNetworkAccess.test.ts apps/web/src/state/desktopSshHosts.test.ts`
- `pnpm vp check`
- `pnpm vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b24999de686d257ce72771b8af7520a0921b4577. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure desktop bridge state errors into specific tagged error classes
> - Replaces the generic `DesktopNetworkAccessError` and `DesktopSshDiscoveryError` with specific tagged error classes: `DesktopNetworkAccessUnavailableError`, `DesktopServerExposureStateLoadError`, `DesktopAdvertisedEndpointsLoadError`, and `DesktopSshDiscoveryUnavailableError`.
> - Each error class includes the original cause (`Schema.Defect`) and a standardized message, making failure reasons distinguishable per sub-operation.
> - The network access atom now fetches server exposure state and advertised endpoints concurrently using `Effect.all` with `concurrency: 'unbounded'`.
> - Tests verify that `Cause.squash` on a failed atom contains the correct `_tag` and preserves the original cause.
> - Behavioral Change: callers inspecting error tags from these atoms will see new tag values instead of the previous generic tags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b24999d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->