### PR TITLE
[codex] Structure legacy connection migration errors

### DIFF
--- a/apps/mobile/src/connection/migration.test.ts
+++ b/apps/mobile/src/connection/migration.test.ts
@@ -75,4 +75,30 @@ describe("migrateLegacyConnectionCatalog", () => {
       expect(catalog.targets).toEqual([]);
     }),
   );
+
+  it.effect("preserves the JSON parse failure", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(migrateLegacyConnectionCatalog("{"));
+
+      expect(error).toMatchObject({
+        _tag: "LegacyConnectionDocumentParseError",
+        cause: expect.any(SyntaxError),
+      });
+      expect(error.message).toBe("Could not parse the legacy mobile connection catalog.");
+    }),
+  );
+
+  it.effect("preserves the schema decode failure", () =>
+    Effect.gen(function* () {
+      const error = yield* Effect.flip(
+        migrateLegacyConnectionCatalog(JSON.stringify({ connections: "invalid" })),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "LegacyConnectionDocumentDecodeError",
+        cause: { _tag: "SchemaError" },
+      });
+      expect(error.message).toBe("Could not decode the legacy mobile connection catalog.");
+    }),
+  );
 });

--- a/apps/mobile/src/connection/migration.ts
+++ b/apps/mobile/src/connection/migration.ts
@@ -33,12 +33,23 @@ const LegacyConnectionDocument = Schema.Struct({
 });
 const decodeLegacyConnectionDocument = Schema.decodeUnknownEffect(LegacyConnectionDocument);
 
-export class LegacyConnectionMigrationError extends Schema.TaggedErrorClass<LegacyConnectionMigrationError>()(
-  "LegacyConnectionMigrationError",
-  {
-    message: Schema.String,
-  },
-) {}
+export class LegacyConnectionDocumentParseError extends Schema.TaggedErrorClass<LegacyConnectionDocumentParseError>()(
+  "LegacyConnectionDocumentParseError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Could not parse the legacy mobile connection catalog.";
+  }
+}
+
+export class LegacyConnectionDocumentDecodeError extends Schema.TaggedErrorClass<LegacyConnectionDocumentDecodeError>()(
+  "LegacyConnectionDocumentDecodeError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Could not decode the legacy mobile connection catalog.";
+  }
+}
 
 function isRelayManaged(connection: typeof LegacySavedRemoteConnection.Type): boolean {
   return connection.relayManaged === true || connection.authenticationMethod === "dpop";
@@ -92,18 +103,10 @@ export const migrateLegacyConnectionCatalog = Effect.fn(
 )(function* (raw: string) {
   const parsed = yield* Effect.try({
     try: () => JSON.parse(raw) as unknown,
-    catch: (cause) =>
-      new LegacyConnectionMigrationError({
-        message: `Could not parse the legacy mobile connection catalog: ${String(cause)}`,
-      }),
+    catch: (cause) => new LegacyConnectionDocumentParseError({ cause }),
   });
   const legacy = yield* decodeLegacyConnectionDocument(parsed).pipe(
-    Effect.mapError(
-      (cause) =>
-        new LegacyConnectionMigrationError({
-          message: `Could not decode the legacy mobile connection catalog: ${String(cause)}`,
-        }),
-    ),
+    Effect.mapError((cause) => new LegacyConnectionDocumentDecodeError({ cause })),
   );
 
   return (legacy.connections ?? []).reduce(migrateConnection, EMPTY_CONNECTION_CATALOG_DOCUMENT);


### PR DESCRIPTION
## Summary
- split legacy mobile catalog parse and schema-decode failures into distinct schema errors
- preserve the exact JSON or schema failure as `cause`
- keep stable caller-facing messages independent of defect text and avoid retaining the credential-bearing raw document

## Validation
- `pnpm vp test apps/mobile/src/connection/migration.test.ts`
- `pnpm vp check`
- `pnpm vp run typecheck`
- `pnpm vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-model refactor in legacy migration with no change to successful migration behavior; callers must handle new error tags if they matched on the old type.
> 
> **Overview**
> Replaces the single **`LegacyConnectionMigrationError`** with two tagged schema errors: **`LegacyConnectionDocumentParseError`** (invalid JSON) and **`LegacyConnectionDocumentDecodeError`** (schema validation). Each carries the underlying failure in **`cause`** via **`Schema.Defect()`**, while **`message`** is a fixed string that no longer embeds defect text (avoiding leaking raw catalog content in error strings).
> 
> **`migrateLegacyConnectionCatalog`** maps **`JSON.parse`** and decode failures to the matching error type. Tests assert tags, preserved causes, and stable messages for malformed JSON and invalid **`connections`** shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b98359c8ba1870850ba6436b35b5cac6d075525. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split legacy connection migration errors into distinct parse and decode error types
> Replaces the single `LegacyConnectionMigrationError` class in [migration.ts](https://github.com/pingdotgg/t3code/pull/3382/files#diff-1caa3214adf0469c28b2314139e8dc5af6ae49469bde44f328bbdc6364e2c8e9) with two distinct tagged error classes: `LegacyConnectionDocumentParseError` for JSON parse failures and `LegacyConnectionDocumentDecodeError` for schema decode failures. Each class preserves the original exception as a `cause` field and returns a fixed message string. Behavioral Change: callers handling `LegacyConnectionMigrationError` will no longer match these errors and must be updated to handle the two new tags.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b98359.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->