### PR TITLE
[codex] Structure missing provider command failures

### DIFF
--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vite-plus/test";
 import { ProviderDriverKind, type ModelCapabilities } from "@t3tools/contracts";
 import { createModelCapabilities } from "@t3tools/shared/model";
 
-import { providerModelsFromSettings } from "./providerSnapshot.ts";
+import {
+  isCommandMissingCause,
+  ProviderCommandNotFoundError,
+  providerModelsFromSettings,
+} from "./providerSnapshot.ts";
 
 const OPENCODE_CUSTOM_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
   optionDescriptors: [
@@ -40,5 +44,24 @@ describe("providerModelsFromSettings", () => {
         capabilities: OPENCODE_CUSTOM_MODEL_CAPABILITIES,
       },
     ]);
+  });
+});
+
+describe("ProviderCommandNotFoundError", () => {
+  it("retains the failed command result as structured diagnostics", () => {
+    const error = new ProviderCommandNotFoundError({
+      binaryPath: "C:\\tools\\codex.cmd",
+      exitCode: 9009,
+      stdout: "",
+      stderr: "'codex' is not recognized as an internal or external command",
+    });
+
+    expect(error.binaryPath).toBe("C:\\tools\\codex.cmd");
+    expect(error.exitCode).toBe(9009);
+    expect(error.stderr).toContain("not recognized");
+    expect(error.message).toBe(
+      "Provider command C:\\tools\\codex.cmd was not found (exit code 9009).",
+    );
+    expect(isCommandMissingCause(error)).toBe(true);
   });
 });

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -4,6 +4,7 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { createModelCapabilities } from "@t3tools/shared/model";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -54,6 +55,20 @@ describe("providerModelsFromSettings", () => {
 });
 
 describe("ProviderCommandNotFoundError", () => {
+  it("classifies normalized platform failures without parsing messages", () => {
+    expect(
+      isCommandMissingCause(
+        PlatformError.systemError({
+          _tag: "NotFound",
+          module: "ChildProcess",
+          method: "spawn",
+          description: "arbitrary host detail",
+        }),
+      ),
+    ).toBe(true);
+    expect(isCommandMissingCause(new Error("spawn provider ENOENT"))).toBe(false);
+  });
+
   it.effect("retains safe failed-command diagnostics without process output", () => {
     const stderr = "'codex' is not recognized: secret-token-value";
     const spawner = ChildProcessSpawner.make(() =>

--- a/apps/server/src/provider/providerSnapshot.test.ts
+++ b/apps/server/src/provider/providerSnapshot.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it } from "vite-plus/test";
+import { describe, expect, it } from "@effect/vitest";
 import { ProviderDriverKind, type ModelCapabilities } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { createModelCapabilities } from "@t3tools/shared/model";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   isCommandMissingCause,
-  ProviderCommandNotFoundError,
   providerModelsFromSettings,
+  spawnAndCollect,
 } from "./providerSnapshot.ts";
 
 const OPENCODE_CUSTOM_MODEL_CAPABILITIES: ModelCapabilities = createModelCapabilities({
@@ -48,20 +54,50 @@ describe("providerModelsFromSettings", () => {
 });
 
 describe("ProviderCommandNotFoundError", () => {
-  it("retains the failed command result as structured diagnostics", () => {
-    const error = new ProviderCommandNotFoundError({
-      binaryPath: "C:\\tools\\codex.cmd",
-      exitCode: 9009,
-      stdout: "",
-      stderr: "'codex' is not recognized as an internal or external command",
-    });
-
-    expect(error.binaryPath).toBe("C:\\tools\\codex.cmd");
-    expect(error.exitCode).toBe(9009);
-    expect(error.stderr).toContain("not recognized");
-    expect(error.message).toBe(
-      "Provider command C:\\tools\\codex.cmd was not found (exit code 9009).",
+  it.effect("retains safe failed-command diagnostics without process output", () => {
+    const stderr = "'codex' is not recognized: secret-token-value";
+    const spawner = ChildProcessSpawner.make(() =>
+      Effect.succeed(
+        ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(1),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(9009)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          unref: Effect.succeed(Effect.void),
+          stdin: Sink.drain,
+          stdout: Stream.empty,
+          stderr: Stream.encodeText(Stream.make(stderr)),
+          all: Stream.empty,
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+        }),
+      ),
     );
-    expect(isCommandMissingCause(error)).toBe(true);
+    return Effect.gen(function* () {
+      const error = yield* spawnAndCollect(
+        "C:\\tools\\codex.cmd",
+        ChildProcess.make("codex", ["--version"]),
+      ).pipe(
+        Effect.provide(Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner)),
+        Effect.provideService(HostProcessPlatform, "win32"),
+        Effect.flip,
+      );
+
+      if (error._tag !== "ProviderCommandNotFoundError") {
+        throw new Error(`Unexpected error: ${error._tag}`);
+      }
+
+      expect(error.binaryPath).toBe("C:\\tools\\codex.cmd");
+      expect(error.exitCode).toBe(9009);
+      expect(error.stdoutLength).toBe(0);
+      expect(error.stderrLength).toBe(stderr.length);
+      expect(error.message).toBe(
+        "Provider command C:\\tools\\codex.cmd was not found (exit code 9009).",
+      );
+      expect(isCommandMissingCause(error)).toBe(true);
+      expect(error).not.toHaveProperty("stdout");
+      expect(error).not.toHaveProperty("stderr");
+      expect(error.message).not.toContain("secret-token-value");
+    });
   });
 });

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -32,8 +32,8 @@ export class ProviderCommandNotFoundError extends Schema.TaggedErrorClass<Provid
   {
     binaryPath: Schema.String,
     exitCode: Schema.Number,
-    stdout: Schema.String,
-    stderr: Schema.String,
+    stdoutLength: Schema.Number,
+    stderrLength: Schema.Number,
   },
 ) {
   override get message(): string {
@@ -90,8 +90,8 @@ export const spawnAndCollect = (binaryPath: string, command: ChildProcess.Comman
       return yield* new ProviderCommandNotFoundError({
         binaryPath,
         exitCode,
-        stdout,
-        stderr,
+        stdoutLength: stdout.length,
+        stderrLength: stderr.length,
       });
     }
     return result;

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -9,6 +9,7 @@ import type {
   ServerProviderState,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -66,10 +67,9 @@ export function nonEmptyTrimmed(value: string | undefined): string | undefined {
   return trimmed.length > 0 ? trimmed : undefined;
 }
 
-export function isCommandMissingCause(error: { readonly message: string }): boolean {
+export function isCommandMissingCause(error: unknown): boolean {
   if (isProviderCommandNotFoundError(error)) return true;
-  const lower = error.message.toLowerCase();
-  return lower.includes("enoent") || lower.includes("notfound");
+  return error instanceof PlatformError.PlatformError && error.reason._tag === "NotFound";
 }
 
 export const spawnAndCollect = (binaryPath: string, command: ChildProcess.Command) =>

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -9,7 +9,7 @@ import type {
   ServerProviderState,
 } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
-import * as Data from "effect/Data";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 import { normalizeModelSlug } from "@t3tools/shared/model";
@@ -27,11 +27,21 @@ export interface CommandResult {
   readonly code: number;
 }
 
-export class ProviderCommandExecutionError extends Data.TaggedError(
-  "ProviderCommandExecutionError",
-)<{
-  readonly message: string;
-}> {}
+export class ProviderCommandNotFoundError extends Schema.TaggedErrorClass<ProviderCommandNotFoundError>()(
+  "ProviderCommandNotFoundError",
+  {
+    binaryPath: Schema.String,
+    exitCode: Schema.Number,
+    stdout: Schema.String,
+    stderr: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Provider command ${this.binaryPath} was not found (exit code ${this.exitCode}).`;
+  }
+}
+
+const isProviderCommandNotFoundError = Schema.is(ProviderCommandNotFoundError);
 
 export interface ProviderProbeResult {
   readonly installed: boolean;
@@ -57,6 +67,7 @@ export function nonEmptyTrimmed(value: string | undefined): string | undefined {
 }
 
 export function isCommandMissingCause(error: { readonly message: string }): boolean {
+  if (isProviderCommandNotFoundError(error)) return true;
   const lower = error.message.toLowerCase();
   return lower.includes("enoent") || lower.includes("notfound");
 }
@@ -76,7 +87,12 @@ export const spawnAndCollect = (binaryPath: string, command: ChildProcess.Comman
 
     const result: CommandResult = { stdout, stderr, code: exitCode };
     if (yield* isWindowsCommandNotFound(exitCode, stderr)) {
-      return yield* new ProviderCommandExecutionError({ message: `spawn ${binaryPath} ENOENT` });
+      return yield* new ProviderCommandNotFoundError({
+        binaryPath,
+        exitCode,
+        stdout,
+        stderr,
+      });
     }
     return result;
   }).pipe(Effect.scoped);


### PR DESCRIPTION
## Summary
- replace the message-only provider command execution error with a schema-backed missing-command error
- retain binary path, exit code, and stdout/stderr lengths without storing subprocess output
- keep missing-command classification compatible with ordinary spawn errors

## Validation
- `vp test apps/server/src/provider/providerSnapshot.test.ts` (2 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized provider probe error typing and classification; behavior for callers using `isCommandMissingCause` is tightened but still covers platform NotFound and the new tagged error.
> 
> **Overview**
> Replaces the message-only **`ProviderCommandExecutionError`** with a schema-backed **`ProviderCommandNotFoundError`** when a provider CLI is missing (e.g. Windows exit **9009**). The error carries **`binaryPath`**, **`exitCode`**, and **stdout/stderr lengths** only—no subprocess text on the failure object, so diagnostics stay safe for logs/UI.
> 
> **`spawnAndCollect`** now fails with this type instead of a generic `spawn … ENOENT` string. **`isCommandMissingCause`** recognizes the tagged error and **`PlatformError`** `NotFound` spawn failures, and no longer treats arbitrary message substrings (e.g. legacy `ENOENT` strings) as missing-command signals.
> 
> New tests cover classification and that sensitive stderr is not exposed on the error or its message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 507eee50a39d54b8541b27ef51d764b8f73c036f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure provider command-not-found failures into a typed `ProviderCommandNotFoundError`
> - Introduces `ProviderCommandNotFoundError` in [providerSnapshot.ts](https://github.com/pingdotgg/t3code/pull/3384/files#diff-62373f674410fb63637739f0efeb07b9ef79b579393ae2adf51567de0b812b26), a schema-tagged error with `binaryPath`, `exitCode`, `stdoutLength`, and `stderrLength` fields and a stable message getter.
> - Updates `isCommandMissingCause` to classify errors by normalized platform error type (`PlatformError` with reason `NotFound`) instead of parsing message strings; generic `Error` instances containing `ENOENT` no longer match.
> - Updates `spawnAndCollect` to emit `ProviderCommandNotFoundError` (with structured diagnostics) instead of a message-only `ProviderCommandExecutionError` on Windows command-not-found exits.
> - Adds tests in [providerSnapshot.test.ts](https://github.com/pingdotgg/t3code/pull/3384/files#diff-c5e88b12d16b3ee7eb8f204cfbe9a8ab2473bc4646a2fa967ad57a57370ce741) verifying classification behavior and that sensitive output (e.g. tokens in stderr) is not leaked in the error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 507eee5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->