### PR TITLE
[codex] Structure pairing grant failures

### DIFF
--- a/apps/server/src/auth/PairingGrantStore.test.ts
+++ b/apps/server/src/auth/PairingGrantStore.test.ts
@@ -3,9 +3,12 @@ import { expect, it } from "@effect/vitest";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as TestClock from "effect/testing/TestClock";
 
 import * as ServerConfig from "../config.ts";
+import * as AuthPairingLinks from "../persistence/AuthPairingLinks.ts";
+import { PersistenceSqlError } from "../persistence/Errors.ts";
 import { SqlitePersistenceMemory } from "../persistence/Layers/Sqlite.ts";
 import * as PairingGrantStore from "./PairingGrantStore.ts";
 
@@ -31,6 +34,26 @@ const makePairingGrantStoreLayer = (
   PairingGrantStore.layer.pipe(
     Layer.provide(SqlitePersistenceMemory),
     Layer.provide(makeServerConfigLayer(overrides)),
+  );
+
+const makePairingGrantStoreTestLayer = (
+  overrides: Partial<AuthPairingLinks.AuthPairingLinkRepository["Service"]>,
+) =>
+  Layer.effect(PairingGrantStore.PairingGrantStore, PairingGrantStore.make).pipe(
+    Layer.provide(
+      Layer.succeed(
+        AuthPairingLinks.AuthPairingLinkRepository,
+        AuthPairingLinks.AuthPairingLinkRepository.of({
+          create: () => Effect.void,
+          consumeAvailable: () => Effect.succeed(Option.none()),
+          listActive: () => Effect.succeed([]),
+          revoke: () => Effect.succeed(false),
+          getByCredential: () => Effect.succeed(Option.none()),
+          ...overrides,
+        }),
+      ),
+    ),
+    Layer.provide(makeServerConfigLayer()),
   );
 
 it.layer(NodeServices.layer)("PairingGrantStore.layer", (it) => {
@@ -186,4 +209,28 @@ it.layer(NodeServices.layer)("PairingGrantStore.layer", (it) => {
       expect(revokedConsume._tag).toBe("UnavailableBootstrapCredentialError");
     }).pipe(Effect.provide(makePairingGrantStoreLayer())),
   );
+
+  it.effect("identifies consume-available failures and preserves their cause", () => {
+    const repositoryFailure = new PersistenceSqlError({
+      operation: "consume-pairing-link",
+      detail: "Database unavailable",
+      cause: new Error("database unavailable"),
+    });
+
+    return Effect.gen(function* () {
+      const pairingGrants = yield* PairingGrantStore.PairingGrantStore;
+      const error = yield* Effect.flip(pairingGrants.consume("credential"));
+
+      if (error._tag !== "BootstrapCredentialConsumeAvailableError") {
+        return yield* Effect.die(error);
+      }
+      expect(error.cause).toBe(repositoryFailure);
+    }).pipe(
+      Effect.provide(
+        makePairingGrantStoreTestLayer({
+          consumeAvailable: () => Effect.fail(repositoryFailure),
+        }),
+      ),
+    );
+  });
 });

--- a/apps/server/src/auth/PairingGrantStore.ts
+++ b/apps/server/src/auth/PairingGrantStore.ts
@@ -88,22 +88,38 @@ export class ActivePairingLinksLoadError extends Schema.TaggedErrorClass<ActiveP
 export class PairingLinkRevokeError extends Schema.TaggedErrorClass<PairingLinkRevokeError>()(
   "PairingLinkRevokeError",
   {
+    pairingLinkId: Schema.String,
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return "Failed to revoke pairing link.";
+    return `Failed to revoke pairing link '${this.pairingLinkId}'.`;
   }
 }
 
 export class PairingCredentialIssueError extends Schema.TaggedErrorClass<PairingCredentialIssueError>()(
   "PairingCredentialIssueError",
   {
+    pairingLinkId: Schema.String,
+    subject: Schema.String,
+    label: Schema.optional(Schema.String),
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return "Failed to issue pairing credential.";
+    return `Failed to issue pairing credential '${this.pairingLinkId}' for '${this.subject}'.`;
+  }
+}
+
+export class PairingCredentialRandomGenerationError extends Schema.TaggedErrorClass<PairingCredentialRandomGenerationError>()(
+  "PairingCredentialRandomGenerationError",
+  {
+    operation: Schema.Literals(["generate-id", "generate-token"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to generate pairing credential data during '${this.operation}'.`;
   }
 }
 
@@ -118,11 +134,36 @@ export class BootstrapCredentialConsumeError extends Schema.TaggedErrorClass<Boo
   }
 }
 
+export class BootstrapCredentialConsumeAvailableError extends Schema.TaggedErrorClass<BootstrapCredentialConsumeAvailableError>()(
+  "BootstrapCredentialConsumeAvailableError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to atomically consume an available bootstrap credential.";
+  }
+}
+
+export class BootstrapCredentialLookupError extends Schema.TaggedErrorClass<BootstrapCredentialLookupError>()(
+  "BootstrapCredentialLookupError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to look up bootstrap credential state.";
+  }
+}
+
 export const BootstrapCredentialInternalError = Schema.Union([
   ActivePairingLinksLoadError,
   PairingLinkRevokeError,
   PairingCredentialIssueError,
+  PairingCredentialRandomGenerationError,
   BootstrapCredentialConsumeError,
+  BootstrapCredentialConsumeAvailableError,
+  BootstrapCredentialLookupError,
 ]);
 export type BootstrapCredentialInternalError = typeof BootstrapCredentialInternalError.Type;
 export const isBootstrapCredentialInternalError = Schema.is(BootstrapCredentialInternalError);
@@ -207,7 +248,14 @@ export const make = Effect.gen(function* () {
   const generatePairingToken = Effect.gen(function* () {
     let credential = "";
     while (credential.length < PAIRING_TOKEN_LENGTH) {
-      const bytes = yield* crypto.randomBytes(PAIRING_TOKEN_LENGTH);
+      const bytes = yield* crypto
+        .randomBytes(PAIRING_TOKEN_LENGTH)
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new PairingCredentialRandomGenerationError({ operation: "generate-token", cause }),
+          ),
+        );
       for (const byte of bytes) {
         if (byte >= PAIRING_TOKEN_REJECTION_LIMIT) {
           continue;
@@ -287,58 +335,73 @@ export const make = Effect.gen(function* () {
   const revoke: PairingGrantStore["Service"]["revoke"] = Effect.fn("PairingGrantStore.revoke")(
     function* (id) {
       const revokedAt = yield* DateTime.now;
-      const revoked = yield* pairingLinks.revoke({
-        id,
-        revokedAt,
-      });
+      const revoked = yield* pairingLinks
+        .revoke({
+          id,
+          revokedAt,
+        })
+        .pipe(Effect.mapError((cause) => new PairingLinkRevokeError({ pairingLinkId: id, cause })));
       if (revoked) {
         yield* emitRemoved(id);
       }
       return revoked;
     },
-    Effect.mapError((cause) => new PairingLinkRevokeError({ cause })),
   );
 
   const issueOneTimeToken: PairingGrantStore["Service"]["issueOneTimeToken"] = Effect.fn(
     "PairingGrantStore.issueOneTimeToken",
-  )(
-    function* (input) {
-      const id = yield* crypto.randomUUIDv4;
-      const credential = yield* generatePairingToken;
-      const ttl = input?.ttl ?? DEFAULT_ONE_TIME_TOKEN_TTL_MINUTES;
-      const now = yield* DateTime.now;
-      const expiresAt = DateTime.add(now, { milliseconds: Duration.toMillis(ttl) });
-      const issued: IssuedBootstrapCredential = {
-        id,
-        credential,
-        ...(input?.label ? { label: input.label } : {}),
-        ...(input?.proofKeyThumbprint ? { proofKeyThumbprint: input.proofKeyThumbprint } : {}),
-        expiresAt,
-      };
-      yield* pairingLinks.create({
+  )(function* (input) {
+    const id = yield* crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) => new PairingCredentialRandomGenerationError({ operation: "generate-id", cause }),
+      ),
+    );
+    const credential = yield* generatePairingToken;
+    const ttl = input?.ttl ?? DEFAULT_ONE_TIME_TOKEN_TTL_MINUTES;
+    const now = yield* DateTime.now;
+    const expiresAt = DateTime.add(now, { milliseconds: Duration.toMillis(ttl) });
+    const issued: IssuedBootstrapCredential = {
+      id,
+      credential,
+      ...(input?.label ? { label: input.label } : {}),
+      ...(input?.proofKeyThumbprint ? { proofKeyThumbprint: input.proofKeyThumbprint } : {}),
+      expiresAt,
+    };
+    const subject = input?.subject ?? "one-time-token";
+    yield* pairingLinks
+      .create({
         id,
         credential,
         method: "one-time-token",
         scopes: input?.scopes ?? AuthStandardClientScopes,
-        subject: input?.subject ?? "one-time-token",
+        subject,
         label: input?.label ?? null,
         proofKeyThumbprint: input?.proofKeyThumbprint ?? null,
         createdAt: now,
         expiresAt: expiresAt,
-      });
-      yield* emitUpsert({
-        id,
-        credential,
-        scopes: input?.scopes ?? AuthStandardClientScopes,
-        subject: input?.subject ?? "one-time-token",
-        ...(input?.label ? { label: input.label } : {}),
-        createdAt: now,
-        expiresAt,
-      });
-      return issued;
-    },
-    Effect.mapError((cause) => new PairingCredentialIssueError({ cause })),
-  );
+      })
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new PairingCredentialIssueError({
+              pairingLinkId: id,
+              subject,
+              ...(input?.label ? { label: input.label } : {}),
+              cause,
+            }),
+        ),
+      );
+    yield* emitUpsert({
+      id,
+      credential,
+      scopes: input?.scopes ?? AuthStandardClientScopes,
+      subject: input?.subject ?? "one-time-token",
+      ...(input?.label ? { label: input.label } : {}),
+      createdAt: now,
+      expiresAt,
+    });
+    return issued;
+  });
 
   const consume: PairingGrantStore["Service"]["consume"] = Effect.fn("PairingGrantStore.consume")(
     function* (credential, input) {
@@ -420,12 +483,14 @@ export const make = Effect.gen(function* () {
         return yield* seededResult.error;
       }
 
-      const consumed = yield* pairingLinks.consumeAvailable({
-        credential,
-        proofKeyThumbprint: input?.proofKeyThumbprint ?? null,
-        consumedAt: now,
-        now,
-      });
+      const consumed = yield* pairingLinks
+        .consumeAvailable({
+          credential,
+          proofKeyThumbprint: input?.proofKeyThumbprint ?? null,
+          consumedAt: now,
+          now,
+        })
+        .pipe(Effect.mapError((cause) => new BootstrapCredentialConsumeAvailableError({ cause })));
 
       if (Option.isSome(consumed)) {
         yield* emitRemoved(consumed.value.id);
@@ -441,7 +506,9 @@ export const make = Effect.gen(function* () {
         } satisfies BootstrapGrant;
       }
 
-      const matching = yield* pairingLinks.getByCredential({ credential });
+      const matching = yield* pairingLinks
+        .getByCredential({ credential })
+        .pipe(Effect.mapError((cause) => new BootstrapCredentialLookupError({ cause })));
       if (Option.isNone(matching)) {
         return yield* new UnknownBootstrapCredentialError({});
       }
@@ -467,9 +534,6 @@ export const make = Effect.gen(function* () {
 
       return yield* new UnavailableBootstrapCredentialError({});
     },
-    Effect.mapError((cause) =>
-      isBootstrapCredentialError(cause) ? cause : new BootstrapCredentialConsumeError({ cause }),
-    ),
   );
 
   return PairingGrantStore.of({


### PR DESCRIPTION
## Summary
- retain pairing-link identity and requested subject when persistence fails
- distinguish random credential generation, atomic consumption, and state lookup failures
- preserve the exact repository or platform cause through every error boundary

## Tests
- `vp test apps/server/src/auth/PairingGrantStore.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bootstrap/pairing credential consumption in auth; behavior on success paths is unchanged but failure types and wrapping differ, which may affect downstream error mapping and logging.
> 
> **Overview**
> **Pairing grant persistence and crypto failures** are now surfaced as specific tagged errors instead of generic wrappers, with **pairing link id**, **subject**, and optional **label** on issue/revoke failures and separate types for **random generation**, **atomic consume**, and **credential lookup**.
> 
> `consume` maps `consumeAvailable` and `getByCredential` failures to `BootstrapCredentialConsumeAvailableError` and `BootstrapCredentialLookupError` respectively, and drops the previous catch-all that re-wrapped unknown errors as `BootstrapCredentialConsumeError`. Repository/platform **causes** are attached at each `mapError` site.
> 
> Tests add a **mock `AuthPairingLinkRepository` layer** and assert that a failed `consumeAvailable` yields `BootstrapCredentialConsumeAvailableError` with the original `PersistenceSqlError` as `cause`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6438a45e2a7631c5b456cbb87b9e40dd381f64cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure pairing grant failures with typed errors in `PairingGrantStore`
> - Adds `BootstrapCredentialConsumeAvailableError` and `BootstrapCredentialLookupError` to distinguish repository failures in `PairingGrantStore.consume`, preserving the underlying cause in each.
> - Adds `PairingCredentialRandomGenerationError` for failures in random ID or token generation within `issueOneTimeToken` and `generatePairingToken`.
> - Enriches existing `PairingLinkRevokeError` and `PairingCredentialIssueError` with contextual fields (`pairingLinkId`, `subject`, `label`) and updates their messages accordingly.
> - Extends the `BootstrapCredentialInternalError` union to include all new error types.
> - Behavioral Change: `consume` no longer wraps all unrecognized failures into `BootstrapCredentialConsumeError`; callers that matched on that catch-all will need to handle the new error types.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6438a45.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->