### PR TITLE
[codex] Structure preview session key errors

### DIFF
--- a/apps/web/src/components/preview/usePreviewSession.ts
+++ b/apps/web/src/components/preview/usePreviewSession.ts
@@ -4,6 +4,7 @@ import { useAtomValue } from "@effect/atom-react";
 import { parseScopedThreadKey, scopedThreadKey } from "@t3tools/client-runtime/environment";
 import { runAtomCommand } from "@t3tools/client-runtime/state/runtime";
 import type { ScopedThreadRef } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
 
 import {
@@ -13,10 +14,19 @@ import {
 } from "~/previewStateStore";
 import { previewEnvironment } from "~/state/preview";
 
+class PreviewSessionThreadKeyParseError extends Schema.TaggedErrorClass<PreviewSessionThreadKeyParseError>()(
+  "PreviewSessionThreadKeyParseError",
+  { threadKey: Schema.String },
+) {
+  override get message(): string {
+    return `Invalid scoped preview thread key: ${this.threadKey}`;
+  }
+}
+
 const previewSessionSyncAtom = Atom.family((threadKey: string) => {
   const threadRef = parseScopedThreadKey(threadKey);
-  if (!threadRef) {
-    throw new Error(`Invalid scoped preview thread key: ${threadKey}`);
+  if (threadRef === null) {
+    throw new PreviewSessionThreadKeyParseError({ threadKey });
   }
 
   const sessionsAtom = previewEnvironment.list({


### PR DESCRIPTION
## Summary

The preview-session atom rejected malformed scoped thread keys with a generic `Error`. Although the message included the raw key, the failure had no stable tag or structured field, so telemetry and error inspection could not distinguish this invariant from unrelated exceptions without parsing text.

This change replaces that generic throw with a `Schema.TaggedErrorClass` carrying the malformed `threadKey`. The message remains the same and is derived from that field. The validation and construction stay inline at the existing failure boundary, avoiding a constructor-only wrapper or an extra helper module.

No behavior test was added for this pure internal-invariant refactor.

## Validation

- `pnpm vp check` (passes with existing repository warnings)
- `pnpm vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal error-shape refactor only; same message and failure timing with no auth, data, or API behavior changes.
> 
> **Overview**
> Malformed scoped thread keys in **`previewSessionSyncAtom`** now throw **`PreviewSessionThreadKeyParseError`** (Effect **`Schema.TaggedErrorClass`**) with a structured **`threadKey`** field instead of a plain **`Error`**.
> 
> The user-facing message is unchanged; the null check is tightened to **`threadRef === null`**. Validation still happens at the same inline boundary in **`usePreviewSession.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0455679db0db48e4849e5b10ab3ccb82a91a5279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic Error with typed `PreviewSessionThreadKeyParseError` for invalid preview thread keys
> Introduces `PreviewSessionThreadKeyParseError`, a tagged error class (via `effect/Schema`) with a structured shape and message, to replace the generic `Error` thrown when an invalid scoped preview thread key is encountered in `previewSessionSyncAtom`. Also tightens the invalid key check from a falsy guard to an explicit `=== null` check.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0455679.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->