### PR TITLE
[codex] Structure process diagnostics failures

### DIFF
--- a/apps/server/src/diagnostics/ProcessDiagnostics.test.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.test.ts
@@ -220,7 +220,7 @@ describe("ProcessDiagnostics", () => {
     }),
   );
 
-  it.effect("keeps command diagnostics when the process query exits unsuccessfully", () =>
+  it.effect("keeps bounded command diagnostics when the process query exits unsuccessfully", () =>
     Effect.gen(function* () {
       const spawnerLayer = Layer.succeed(
         ChildProcessSpawner.ChildProcessSpawner,
@@ -244,14 +244,16 @@ describe("ProcessDiagnostics", () => {
       expect(error).toMatchObject({
         _tag: "ProcessDiagnosticsQueryFailedError",
         command: "ps",
-        args: ["-axo", "pid=,ppid=,pgid=,stat=,pcpu=,rss=,etime=,command="],
+        argCount: 2,
         cwd: process.cwd(),
         exitCode: 17,
-        stdout: "partial process output",
-        stderr: "process access denied",
+        stdoutBytes: 22,
+        stderrBytes: 21,
+        stdoutTruncated: false,
+        stderrTruncated: false,
       });
       expect(error.message).toBe(
-        `Process diagnostics query 'ps' failed with exit code 17 in '${process.cwd()}': process access denied`,
+        `Process diagnostics query 'ps' failed with exit code 17 in '${process.cwd()}'.`,
       );
     }),
   );

--- a/apps/server/src/diagnostics/ProcessDiagnostics.test.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.test.ts
@@ -6,6 +6,7 @@ import * as Option from "effect/Option";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import * as ProcessDiagnostics from "./ProcessDiagnostics.ts";
 
@@ -216,6 +217,42 @@ describe("ProcessDiagnostics", () => {
           args: ["-axo", "pid=,ppid=,pgid=,stat=,pcpu=,rss=,etime=,command="],
         },
       ]);
+    }),
+  );
+
+  it.effect("keeps command diagnostics when the process query exits unsuccessfully", () =>
+    Effect.gen(function* () {
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.succeed(
+            mockHandle({
+              code: 17,
+              stdout: "partial process output",
+              stderr: "process access denied",
+            }),
+          ),
+        ),
+      );
+
+      const error = yield* ProcessDiagnostics.readProcessRows.pipe(
+        Effect.provide(spawnerLayer),
+        Effect.provideService(HostProcessPlatform, "linux"),
+        Effect.flip,
+      );
+
+      expect(error).toMatchObject({
+        _tag: "ProcessDiagnosticsQueryFailedError",
+        command: "ps",
+        args: ["-axo", "pid=,ppid=,pgid=,stat=,pcpu=,rss=,etime=,command="],
+        cwd: process.cwd(),
+        exitCode: 17,
+        stdout: "partial process output",
+        stderr: "process access denied",
+      });
+      expect(error.message).toBe(
+        `Process diagnostics query 'ps' failed with exit code 17 in '${process.cwd()}': process access denied`,
+      );
     }),
   );
 

--- a/apps/server/src/diagnostics/ProcessDiagnostics.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.ts
@@ -45,10 +45,15 @@ export class ProcessDiagnostics extends Context.Service<
 
 class ProcessDiagnosticsQueryTimeoutError extends Schema.TaggedErrorClass<ProcessDiagnosticsQueryTimeoutError>()(
   "ProcessDiagnosticsQueryTimeoutError",
-  { command: Schema.String },
+  {
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    cwd: Schema.String,
+    timeoutMillis: Schema.Number,
+  },
 ) {
   override get message(): string {
-    return `Process diagnostics query '${this.command}' timed out.`;
+    return `Process diagnostics query '${this.command}' timed out after ${this.timeoutMillis}ms in '${this.cwd}'.`;
   }
 }
 
@@ -56,12 +61,19 @@ class ProcessDiagnosticsQueryFailedError extends Schema.TaggedErrorClass<Process
   "ProcessDiagnosticsQueryFailedError",
   {
     command: Schema.String,
+    args: Schema.Array(Schema.String),
+    cwd: Schema.String,
+    exitCode: Schema.optional(Schema.Number),
+    stdout: Schema.optional(Schema.String),
     stderr: Schema.optional(Schema.String),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return this.stderr?.trim() || `Failed to query process diagnostics with '${this.command}'.`;
+    const exitCode = this.exitCode === undefined ? "" : ` with exit code ${this.exitCode}`;
+    const stderr = this.stderr?.trim();
+    const detail = stderr === undefined || stderr.length === 0 ? "" : `: ${stderr}`;
+    return `Process diagnostics query '${this.command}' failed${exitCode} in '${this.cwd}'${detail}`;
   }
 }
 
@@ -76,7 +88,10 @@ class ProcessDiagnosticsServerProcessSignalError extends Schema.TaggedErrorClass
 
 class ProcessDiagnosticsNotDescendantError extends Schema.TaggedErrorClass<ProcessDiagnosticsNotDescendantError>()(
   "ProcessDiagnosticsNotDescendantError",
-  { pid: Schema.Number },
+  {
+    pid: Schema.Number,
+    serverPid: Schema.Number,
+  },
 ) {
   override get message(): string {
     return `Process ${this.pid} is not a live descendant of the T3 server.`;
@@ -312,20 +327,25 @@ function makeResult(input: {
 }
 
 interface ProcessOutput {
+  readonly cwd: string;
   readonly exitCode: number;
   readonly stdout: string;
   readonly stderr: string;
 }
 
-const runProcess = Effect.fn("runProcess")(
-  function* (input: { readonly command: string; readonly args: ReadonlyArray<string> }) {
+const runProcess = Effect.fn("runProcess")(function* (input: {
+  readonly command: string;
+  readonly args: ReadonlyArray<string>;
+}) {
+  const cwd = process.cwd();
+  return yield* Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
     // `ps` and `powershell.exe` are real executables; spawning through cmd.exe
     // shell mode would re-tokenize the PowerShell `-Command` payload (which
     // contains pipes) before PowerShell ever sees it.
     const child = yield* spawner.spawn(
       ChildProcess.make(input.command, input.args, {
-        cwd: process.cwd(),
+        cwd,
       }),
     );
     const [stdout, stderr, exitCode] = yield* Effect.all(
@@ -346,36 +366,40 @@ const runProcess = Effect.fn("runProcess")(
     );
 
     return {
+      cwd,
       exitCode,
       stdout: stdout.text,
       stderr: stderr.text,
     } satisfies ProcessOutput;
-  },
-  (effect, input) =>
-    effect.pipe(
-      Effect.scoped,
-      Effect.timeoutOption(Duration.millis(PROCESS_QUERY_TIMEOUT_MS)),
-      Effect.flatMap((result) =>
-        Option.match(result, {
-          onNone: () =>
-            Effect.fail(
-              new ProcessDiagnosticsQueryTimeoutError({
-                command: input.command,
-              }),
-            ),
-          onSome: Effect.succeed,
-        }),
-      ),
-      Effect.mapError((cause) =>
-        isProcessDiagnosticsError(cause)
-          ? cause
-          : new ProcessDiagnosticsQueryFailedError({
+  }).pipe(
+    Effect.scoped,
+    Effect.timeoutOption(Duration.millis(PROCESS_QUERY_TIMEOUT_MS)),
+    Effect.flatMap((result) =>
+      Option.match(result, {
+        onNone: () =>
+          Effect.fail(
+            new ProcessDiagnosticsQueryTimeoutError({
               command: input.command,
-              cause,
+              args: [...input.args],
+              cwd,
+              timeoutMillis: PROCESS_QUERY_TIMEOUT_MS,
             }),
-      ),
+          ),
+        onSome: Effect.succeed,
+      }),
     ),
-);
+    Effect.mapError((cause) =>
+      isProcessDiagnosticsError(cause)
+        ? cause
+        : new ProcessDiagnosticsQueryFailedError({
+            command: input.command,
+            args: [...input.args],
+            cwd,
+            cause,
+          }),
+    ),
+  );
+});
 
 function readPosixProcessRows(): Effect.Effect<
   ReadonlyArray<ProcessRow>,
@@ -391,6 +415,10 @@ function readPosixProcessRows(): Effect.Effect<
         ? Effect.fail(
             new ProcessDiagnosticsQueryFailedError({
               command: "ps",
+              args: ["-axo", POSIX_PROCESS_QUERY_COMMAND],
+              cwd: result.cwd,
+              exitCode: result.exitCode,
+              stdout: result.stdout,
               stderr: result.stderr.trim() || "ps failed.",
             }),
           )
@@ -421,6 +449,10 @@ function readWindowsProcessRows(): Effect.Effect<
         ? Effect.fail(
             new ProcessDiagnosticsQueryFailedError({
               command: "powershell.exe",
+              args: ["-NoProfile", "-NonInteractive", "-Command", command],
+              cwd: result.cwd,
+              exitCode: result.exitCode,
+              stdout: result.stdout,
               stderr: result.stderr.trim() || "PowerShell process query failed.",
             }),
           )
@@ -464,6 +496,7 @@ function assertDescendantPid(
         : Effect.fail(
             new ProcessDiagnosticsNotDescendantError({
               pid,
+              serverPid: process.pid,
             }),
           );
     }),

--- a/apps/server/src/diagnostics/ProcessDiagnostics.ts
+++ b/apps/server/src/diagnostics/ProcessDiagnostics.ts
@@ -47,7 +47,7 @@ class ProcessDiagnosticsQueryTimeoutError extends Schema.TaggedErrorClass<Proces
   "ProcessDiagnosticsQueryTimeoutError",
   {
     command: Schema.String,
-    args: Schema.Array(Schema.String),
+    argCount: Schema.Number,
     cwd: Schema.String,
     timeoutMillis: Schema.Number,
   },
@@ -61,19 +61,19 @@ class ProcessDiagnosticsQueryFailedError extends Schema.TaggedErrorClass<Process
   "ProcessDiagnosticsQueryFailedError",
   {
     command: Schema.String,
-    args: Schema.Array(Schema.String),
+    argCount: Schema.Number,
     cwd: Schema.String,
     exitCode: Schema.optional(Schema.Number),
-    stdout: Schema.optional(Schema.String),
-    stderr: Schema.optional(Schema.String),
+    stdoutBytes: Schema.optional(Schema.Number),
+    stderrBytes: Schema.optional(Schema.Number),
+    stdoutTruncated: Schema.optional(Schema.Boolean),
+    stderrTruncated: Schema.optional(Schema.Boolean),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
     const exitCode = this.exitCode === undefined ? "" : ` with exit code ${this.exitCode}`;
-    const stderr = this.stderr?.trim();
-    const detail = stderr === undefined || stderr.length === 0 ? "" : `: ${stderr}`;
-    return `Process diagnostics query '${this.command}' failed${exitCode} in '${this.cwd}'${detail}`;
+    return `Process diagnostics query '${this.command}' failed${exitCode} in '${this.cwd}'.`;
   }
 }
 
@@ -330,7 +330,11 @@ interface ProcessOutput {
   readonly cwd: string;
   readonly exitCode: number;
   readonly stdout: string;
+  readonly stdoutBytes: number;
+  readonly stdoutTruncated: boolean;
   readonly stderr: string;
+  readonly stderrBytes: number;
+  readonly stderrTruncated: boolean;
 }
 
 const runProcess = Effect.fn("runProcess")(function* (input: {
@@ -369,7 +373,11 @@ const runProcess = Effect.fn("runProcess")(function* (input: {
       cwd,
       exitCode,
       stdout: stdout.text,
+      stdoutBytes: stdout.bytes,
+      stdoutTruncated: stdout.truncated,
       stderr: stderr.text,
+      stderrBytes: stderr.bytes,
+      stderrTruncated: stderr.truncated,
     } satisfies ProcessOutput;
   }).pipe(
     Effect.scoped,
@@ -380,7 +388,7 @@ const runProcess = Effect.fn("runProcess")(function* (input: {
           Effect.fail(
             new ProcessDiagnosticsQueryTimeoutError({
               command: input.command,
-              args: [...input.args],
+              argCount: input.args.length,
               cwd,
               timeoutMillis: PROCESS_QUERY_TIMEOUT_MS,
             }),
@@ -393,7 +401,7 @@ const runProcess = Effect.fn("runProcess")(function* (input: {
         ? cause
         : new ProcessDiagnosticsQueryFailedError({
             command: input.command,
-            args: [...input.args],
+            argCount: input.args.length,
             cwd,
             cause,
           }),
@@ -415,11 +423,13 @@ function readPosixProcessRows(): Effect.Effect<
         ? Effect.fail(
             new ProcessDiagnosticsQueryFailedError({
               command: "ps",
-              args: ["-axo", POSIX_PROCESS_QUERY_COMMAND],
+              argCount: 2,
               cwd: result.cwd,
               exitCode: result.exitCode,
-              stdout: result.stdout,
-              stderr: result.stderr.trim() || "ps failed.",
+              stdoutBytes: result.stdoutBytes,
+              stderrBytes: result.stderrBytes,
+              stdoutTruncated: result.stdoutTruncated,
+              stderrTruncated: result.stderrTruncated,
             }),
           )
         : Effect.succeed(parsePosixProcessRows(result.stdout)),
@@ -449,11 +459,13 @@ function readWindowsProcessRows(): Effect.Effect<
         ? Effect.fail(
             new ProcessDiagnosticsQueryFailedError({
               command: "powershell.exe",
-              args: ["-NoProfile", "-NonInteractive", "-Command", command],
+              argCount: 4,
               cwd: result.cwd,
               exitCode: result.exitCode,
-              stdout: result.stdout,
-              stderr: result.stderr.trim() || "PowerShell process query failed.",
+              stdoutBytes: result.stdoutBytes,
+              stderrBytes: result.stderrBytes,
+              stdoutTruncated: result.stdoutTruncated,
+              stderrTruncated: result.stderrTruncated,
             }),
           )
         : Effect.succeed(parseWindowsProcessRows(result.stdout)),


### PR DESCRIPTION
## Summary\n- attach bounded command metadata, working directory, timeout, exit status, and output byte/truncation counts to diagnostics failures\n- preserve exact spawn causes without deriving messages from them or retaining raw process streams\n- include both target and server PIDs when rejecting non-descendant processes

## Tests
- `vp test apps/server/src/diagnostics/ProcessDiagnostics.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to diagnostics error shaping and messages; behavior of successful reads/signals is unchanged, though alert rules matching old error strings may need updates.
> 
> **Overview**
> Process diagnostics failures now carry **structured fields** instead of relying on stderr text for messages.
> 
> **Query errors** (`ProcessDiagnosticsQueryTimeoutError`, `ProcessDiagnosticsQueryFailedError`) gain `argCount`, `cwd`, and (for timeouts) `timeoutMillis`; failed queries also record `exitCode` plus **bounded** stdout/stderr **byte counts** and truncation flags. User-facing messages mention cwd, timeout, and exit code—not raw stderr.
> 
> `runProcess` captures cwd and stream collection metadata once and threads it into both POSIX (`ps`) and Windows (`powershell.exe`) failure paths. **`ProcessDiagnosticsNotDescendantError`** now includes `serverPid` alongside the target `pid`.
> 
> A new test asserts failed `ps` exits produce the expected structured error and message format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44734fa79e68459217ab9f086104b590e81cc8eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure process diagnostics errors with bounded command metadata
> - `ProcessDiagnosticsQueryFailedError` is extended with `argCount`, `cwd`, `exitCode`, `stdoutBytes`, `stderrBytes`, `stdoutTruncated`, and `stderrTruncated` fields; the raw stderr string is removed from the error.
> - `ProcessDiagnosticsQueryTimeoutError` gains `argCount`, `cwd`, and `timeoutMillis` fields with an updated message format.
> - `ProcessDiagnosticsNotDescendantError` gains a `serverPid` field.
> - The `ProcessOutput` interface and `runProcess` function in [ProcessDiagnostics.ts](https://github.com/pingdotgg/t3code/pull/3389/files#diff-3976428399caa24c646f345343c779cdea0f12d571dd49a947e677d81f460ced) now capture `cwd` and output byte counts/truncation flags on every execution.
> - Behavioral Change: error message formats for timeout and failure errors have changed; callers inspecting the `stderr` field of `ProcessDiagnosticsQueryFailedError` will need to use `stderrBytes` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44734fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
