### PR TITLE
[codex] Structure preferred editor failures

### DIFF
--- a/apps/web/src/editorPreferences.ts
+++ b/apps/web/src/editorPreferences.ts
@@ -1,11 +1,11 @@
-import { EDITORS, EditorId, type EnvironmentId } from "@t3tools/contracts";
+import { EDITORS, EditorId, EnvironmentId } from "@t3tools/contracts";
 import {
   mapAtomCommandResult,
   type AtomCommandFailure,
   type AtomCommandResult,
 } from "@t3tools/client-runtime/state/runtime";
 import * as Cause from "effect/Cause";
-import * as Data from "effect/Data";
+import * as Schema from "effect/Schema";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { getLocalStorageItem, setLocalStorageItem, useLocalStorage } from "./hooks/useLocalStorage";
 import { useCallback, useMemo } from "react";
@@ -14,11 +14,29 @@ import { useAtomCommand } from "./state/use-atom-command";
 
 const LAST_EDITOR_KEY = "t3code:last-editor";
 
-export class PreferredEditorUnavailableError extends Data.TaggedError(
+export class PreferredEditorEnvironmentRequiredError extends Schema.TaggedErrorClass<PreferredEditorEnvironmentRequiredError>()(
+  "PreferredEditorEnvironmentRequiredError",
+  {
+    targetPath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Cannot open ${this.targetPath} because no environment is selected.`;
+  }
+}
+
+export class PreferredEditorUnavailableError extends Schema.TaggedErrorClass<PreferredEditorUnavailableError>()(
   "PreferredEditorUnavailableError",
-)<{
-  readonly message: string;
-}> {}
+  {
+    environmentId: EnvironmentId,
+    targetPath: Schema.String,
+    availableEditorIds: Schema.Array(EditorId),
+  },
+) {
+  override get message(): string {
+    return `No available editor can open ${this.targetPath} in environment ${this.environmentId}.`;
+  }
+}
 
 export function usePreferredEditor(availableEditors: ReadonlyArray<EditorId>) {
   const [lastEditor, setLastEditor] = useLocalStorage(LAST_EDITOR_KEY, null, EditorId);
@@ -55,13 +73,18 @@ export function useOpenInPreferredEditor(
     async (
       targetPath: string,
     ): Promise<
-      AtomCommandResult<EditorId, OpenInEditorError | PreferredEditorUnavailableError>
+      AtomCommandResult<
+        EditorId,
+        | OpenInEditorError
+        | PreferredEditorEnvironmentRequiredError
+        | PreferredEditorUnavailableError
+      >
     > => {
       if (environmentId === null) {
         return AsyncResult.failure(
           Cause.fail(
-            new PreferredEditorUnavailableError({
-              message: "No environment is selected.",
+            new PreferredEditorEnvironmentRequiredError({
+              targetPath,
             }),
           ),
         );
@@ -71,7 +94,9 @@ export function useOpenInPreferredEditor(
         return AsyncResult.failure(
           Cause.fail(
             new PreferredEditorUnavailableError({
-              message: "No available editors found.",
+              environmentId,
+              targetPath,
+              availableEditorIds: availableEditors,
             }),
           ),
         );


### PR DESCRIPTION
## Summary

Opening a path in the preferred editor represented two distinct precondition failures with one `Data.TaggedError` whose only field was caller-supplied message text. That made “no environment selected” and “no compatible editor available” indistinguishable except by parsing their messages, and discarded the path and editor-selection context at the async command boundary.

This change gives each failure its own Schema error type. The missing-environment error records the attempted path. The unavailable-editor error records the environment, attempted path, and reported editor IDs. Each message is derived from those fields, and the command error channel now exposes the distinct types directly. There are no reason switches or constructor wrappers.

No behavior test was added for this pure error-model refactor.

## Validation

- `pnpm vp check` (passes with existing repository warnings)
- `pnpm vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure error-model refactor in editor preferences with no runtime behavior change beyond richer failure payloads and messages.
> 
> **Overview**
> **Preferred-editor open failures** are no longer a single `Data.TaggedError` with a free-form `message`. They are split into two **Effect Schema** tagged error classes so callers can branch on type instead of parsing strings.
> 
> `PreferredEditorEnvironmentRequiredError` is returned when no environment is selected; it carries **`targetPath`**. `PreferredEditorUnavailableError` is returned when no compatible editor exists; it carries **`environmentId`**, **`targetPath`**, and **`availableEditorIds`**. User-facing text is computed from those fields via overridden **`message`** getters.
> 
> `useOpenInPreferredEditor`’s result error union is updated to expose both types explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d324bc282a88b665a1e7e96a5f30da053b8022. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure preferred editor failures into distinct typed errors in `useOpenInPreferredEditor`
> - Splits the single `PreferredEditorUnavailableError` into two distinct `Schema.TaggedErrorClass` types: `PreferredEditorEnvironmentRequiredError` (no environment selected) and `PreferredEditorUnavailableError` (no matching editor found).
> - `PreferredEditorEnvironmentRequiredError` carries `targetPath` and reports that no environment is selected.
> - `PreferredEditorUnavailableError` now carries structured fields: `environmentId`, `targetPath`, and `availableEditorIds`.
> - Both errors are defined using `effect/Schema` instead of `effect/Data`, enabling schema-based introspection of error fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09d324b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->