### PR TITLE
[codex] Structure mobile notification setting failures

### DIFF
--- a/apps/mobile/src/features/agent-awareness/liveActivityPreferences.ts
+++ b/apps/mobile/src/features/agent-awareness/liveActivityPreferences.ts
@@ -1,4 +1,5 @@
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { HttpClient } from "effect/unstable/http";
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
 
@@ -6,6 +7,18 @@ import type { SavedRemoteConnection } from "../../lib/connection";
 import { savePreferencesPatch } from "../../lib/storage";
 import { linkEnvironmentToCloud } from "../cloud/linkEnvironment";
 import { refreshAgentAwarenessRegistration } from "./remoteRegistration";
+
+export class LiveActivityPreferenceSaveError extends Schema.TaggedErrorClass<LiveActivityPreferenceSaveError>()(
+  "LiveActivityPreferenceSaveError",
+  {
+    enabled: Schema.Boolean,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to save the Live Activity updates setting (enabled: ${this.enabled}).`;
+  }
+}
 
 export function setLiveActivityUpdatesEnabled(input: {
   readonly enabled: boolean;
@@ -15,7 +28,7 @@ export function setLiveActivityUpdatesEnabled(input: {
   return Effect.gen(function* () {
     yield* Effect.tryPromise({
       try: () => savePreferencesPatch({ liveActivitiesEnabled: input.enabled }),
-      catch: (error) => error,
+      catch: (cause) => new LiveActivityPreferenceSaveError({ enabled: input.enabled, cause }),
     });
 
     yield* refreshAgentAwarenessRegistration();

--- a/apps/mobile/src/features/agent-awareness/notificationPermissions.ts
+++ b/apps/mobile/src/features/agent-awareness/notificationPermissions.ts
@@ -1,5 +1,6 @@
 import * as Notifications from "expo-notifications";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { Platform } from "react-native";
 
 export type NotificationPermissionResult =
@@ -7,9 +8,33 @@ export type NotificationPermissionResult =
   | { readonly type: "granted" }
   | { readonly type: "denied"; readonly canAskAgain: boolean };
 
+export class NotificationPermissionReadError extends Schema.TaggedErrorClass<NotificationPermissionReadError>()(
+  "NotificationPermissionReadError",
+  {
+    platform: Schema.Literal("ios"),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read notification permissions on ${this.platform}.`;
+  }
+}
+
+export class NotificationPermissionRequestError extends Schema.TaggedErrorClass<NotificationPermissionRequestError>()(
+  "NotificationPermissionRequestError",
+  {
+    platform: Schema.Literal("ios"),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to request notification permissions on ${this.platform}.`;
+  }
+}
+
 export const requestAgentNotificationPermission: Effect.Effect<
   NotificationPermissionResult,
-  unknown
+  NotificationPermissionReadError | NotificationPermissionRequestError
 > = Effect.gen(function* () {
   if (Platform.OS !== "ios") {
     return { type: "unsupported" };
@@ -17,7 +42,7 @@ export const requestAgentNotificationPermission: Effect.Effect<
 
   const existing = yield* Effect.tryPromise({
     try: () => Notifications.getPermissionsAsync(),
-    catch: (error) => error,
+    catch: (cause) => new NotificationPermissionReadError({ platform: "ios", cause }),
   });
   if (existing.granted) {
     return { type: "granted" };
@@ -36,7 +61,7 @@ export const requestAgentNotificationPermission: Effect.Effect<
           allowSound: true,
         },
       }),
-    catch: (error) => error,
+    catch: (cause) => new NotificationPermissionRequestError({ platform: "ios", cause }),
   });
   return requested.granted
     ? { type: "granted" }

--- a/apps/mobile/src/features/agent-awareness/notificationPermissions.ts
+++ b/apps/mobile/src/features/agent-awareness/notificationPermissions.ts
@@ -11,24 +11,22 @@ export type NotificationPermissionResult =
 export class NotificationPermissionReadError extends Schema.TaggedErrorClass<NotificationPermissionReadError>()(
   "NotificationPermissionReadError",
   {
-    platform: Schema.Literal("ios"),
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to read notification permissions on ${this.platform}.`;
+    return "Failed to read notification permissions on iOS.";
   }
 }
 
 export class NotificationPermissionRequestError extends Schema.TaggedErrorClass<NotificationPermissionRequestError>()(
   "NotificationPermissionRequestError",
   {
-    platform: Schema.Literal("ios"),
     cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `Failed to request notification permissions on ${this.platform}.`;
+    return "Failed to request notification permissions on iOS.";
   }
 }
 
@@ -42,7 +40,7 @@ export const requestAgentNotificationPermission: Effect.Effect<
 
   const existing = yield* Effect.tryPromise({
     try: () => Notifications.getPermissionsAsync(),
-    catch: (cause) => new NotificationPermissionReadError({ platform: "ios", cause }),
+    catch: (cause) => new NotificationPermissionReadError({ cause }),
   });
   if (existing.granted) {
     return { type: "granted" };
@@ -61,7 +59,7 @@ export const requestAgentNotificationPermission: Effect.Effect<
           allowSound: true,
         },
       }),
-    catch: (cause) => new NotificationPermissionRequestError({ platform: "ios", cause }),
+    catch: (cause) => new NotificationPermissionRequestError({ cause }),
   });
   return requested.granted
     ? { type: "granted" }


### PR DESCRIPTION
## Summary

Mobile agent-awareness settings exposed raw `unknown` failures from three native or persistence boundaries: reading notification permission, requesting notification permission, and saving the Live Activity updates setting. Downstream settings commands could not reliably identify which operation failed, and the preference write discarded the requested setting value.

This change introduces distinct Schema errors for reading and requesting notification permissions. Both record the iOS platform and preserve the exact native cause. Live Activity preference persistence now has its own Schema error carrying the requested `enabled` value and exact storage cause. Messages are derived from those fields without reason switches, cause-derived text, or constructor wrappers.

No behavior tests were added for the pure error-model refactors; the existing Live Activity preference suite still passes.

## Validation

- `pnpm vp test apps/mobile/src/features/agent-awareness/liveActivityPreferences.test.ts` (4 tests)
- `pnpm vp check` (passes with existing repository warnings)
- `pnpm vp run typecheck`
- `pnpm vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure error-model refactor on settings paths; success paths and UI handling via existing failure squashing are unchanged.
> 
> **Overview**
> Replaces raw `unknown` failures on mobile agent-awareness settings with **Effect Schema tagged errors**, so callers can distinguish which boundary failed and inspect structured fields.
> 
> **Notification permissions** (`notificationPermissions.ts`): `requestAgentNotificationPermission` now fails with `NotificationPermissionReadError` or `NotificationPermissionRequestError` instead of `unknown`, each wrapping the native cause via `Schema.Defect()` and a fixed iOS-oriented message.
> 
> **Live Activity preference** (`liveActivityPreferences.ts`): `savePreferencesPatch` failures map to `LiveActivityPreferenceSaveError`, which carries the requested `enabled` value plus the storage cause.
> 
> Runtime behavior of permission checks and preference saves is unchanged; only the error channel typing and failure payloads change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f03667eb25279589516d86cc7f0804e272c267b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure mobile notification and live activity preference failures as typed errors
> - Wraps live activity preference save failures in a new `LiveActivityPreferenceSaveError` tagged error class (with `enabled` flag and original cause) in [liveActivityPreferences.ts](https://github.com/pingdotgg/t3code/pull/3391/files#diff-fd932b53c91418631111f4902693f36ec129cd684712312c24eb786ab0325470)
> - Wraps iOS notification permission failures in `NotificationPermissionReadError` or `NotificationPermissionRequestError` tagged error classes in [notificationPermissions.ts](https://github.com/pingdotgg/t3code/pull/3391/files#diff-19fecd4b2cb87c846ef684cab3c6cf25932eef3aaaf60397873edbaddb1fb8ae)
> - Both changes replace raw `unknown` errors with structured Effect error types, making failure handling explicit and type-safe.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f03667.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->