### PR TITLE
[codex] Structure remote pairing input errors

### DIFF
--- a/packages/shared/src/remote.test.ts
+++ b/packages/shared/src/remote.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { resolveRemotePairingTarget } from "./remote.ts";
+import {
+  RemoteBackendUrlInvalidError,
+  RemoteBackendUrlMissingError,
+  RemotePairingCodeMissingError,
+  RemotePairingTokenMissingError,
+  RemotePairingUrlInvalidError,
+  resolveRemotePairingTarget,
+} from "./remote.ts";
 
 describe("remote", () => {
   it("derives backend urls and token from a pairing url", () => {
@@ -64,5 +71,36 @@ describe("remote", () => {
       httpBaseUrl: "https://myserver.com:3000/",
       wsBaseUrl: "wss://myserver.com:3000/",
     });
+  });
+
+  it("uses distinct structural errors for missing pairing inputs", () => {
+    expect(() => resolveRemotePairingTarget({})).toThrowError(RemoteBackendUrlMissingError);
+    expect(() =>
+      resolveRemotePairingTarget({ pairingUrl: "https://remote.example.com/pair" }),
+    ).toThrowError(RemotePairingTokenMissingError);
+    expect(() => resolveRemotePairingTarget({ host: "remote.example.com" })).toThrowError(
+      RemotePairingCodeMissingError,
+    );
+  });
+
+  it("preserves URL parsing causes with their input source", () => {
+    let pairingUrlError: unknown;
+    try {
+      resolveRemotePairingTarget({ pairingUrl: "not a url" });
+    } catch (cause) {
+      pairingUrlError = cause;
+    }
+    expect(pairingUrlError).toBeInstanceOf(RemotePairingUrlInvalidError);
+    expect((pairingUrlError as RemotePairingUrlInvalidError).cause).toBeInstanceOf(TypeError);
+
+    let hostError: unknown;
+    try {
+      resolveRemotePairingTarget({ host: "https://[invalid", pairingCode: "pairing-token" });
+    } catch (cause) {
+      hostError = cause;
+    }
+    expect(hostError).toBeInstanceOf(RemoteBackendUrlInvalidError);
+    expect(hostError).toMatchObject({ source: "direct-host" });
+    expect((hostError as RemoteBackendUrlInvalidError).cause).toBeInstanceOf(TypeError);
   });
 });

--- a/packages/shared/src/remote.test.ts
+++ b/packages/shared/src/remote.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   RemoteBackendUrlInvalidError,
   RemoteBackendUrlMissingError,
-  RemotePairingCodeMissingError,
   RemotePairingTokenMissingError,
   RemotePairingUrlInvalidError,
   resolveRemotePairingTarget,
@@ -78,8 +77,15 @@ describe("remote", () => {
     expect(() =>
       resolveRemotePairingTarget({ pairingUrl: "https://remote.example.com/pair" }),
     ).toThrowError(RemotePairingTokenMissingError);
-    expect(() => resolveRemotePairingTarget({ host: "remote.example.com" })).toThrowError(
-      RemotePairingCodeMissingError,
+    expect(() =>
+      resolveRemotePairingTarget({
+        host: "https://user:secret@remote.example.com/path?token=sensitive#fragment",
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        _tag: "RemotePairingCodeMissingError",
+        host: "remote.example.com",
+      }),
     );
   });
 

--- a/packages/shared/src/remote.ts
+++ b/packages/shared/src/remote.ts
@@ -1,3 +1,5 @@
+import * as Schema from "effect/Schema";
+
 const PAIRING_TOKEN_PARAM = "token";
 const HOSTED_PAIRING_HOST_PARAM = "host";
 const HOSTED_PAIRING_LABEL_PARAM = "label";
@@ -5,17 +7,82 @@ const HOSTED_PAIRING_LABEL_PARAM = "label";
 const readHashParams = (url: URL): URLSearchParams =>
   new URLSearchParams(url.hash.startsWith("#") ? url.hash.slice(1) : url.hash);
 
-const normalizeRemoteBaseUrl = (rawValue: string): URL => {
+export class RemoteBackendUrlMissingError extends Schema.TaggedErrorClass<RemoteBackendUrlMissingError>()(
+  "RemoteBackendUrlMissingError",
+  {},
+) {
+  override get message(): string {
+    return "Enter a backend URL.";
+  }
+}
+
+export class RemotePairingUrlInvalidError extends Schema.TaggedErrorClass<RemotePairingUrlInvalidError>()(
+  "RemotePairingUrlInvalidError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Pairing URL is invalid.";
+  }
+}
+
+export class RemoteBackendUrlInvalidError extends Schema.TaggedErrorClass<RemoteBackendUrlInvalidError>()(
+  "RemoteBackendUrlInvalidError",
+  {
+    source: Schema.Literals(["direct-host", "hosted-pairing-host"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Backend URL is invalid.";
+  }
+}
+
+export class RemotePairingTokenMissingError extends Schema.TaggedErrorClass<RemotePairingTokenMissingError>()(
+  "RemotePairingTokenMissingError",
+  { host: Schema.String },
+) {
+  override get message(): string {
+    return "Pairing URL is missing its token.";
+  }
+}
+
+export class RemotePairingCodeMissingError extends Schema.TaggedErrorClass<RemotePairingCodeMissingError>()(
+  "RemotePairingCodeMissingError",
+  { host: Schema.String },
+) {
+  override get message(): string {
+    return "Enter a pairing code.";
+  }
+}
+
+export const RemotePairingTargetError = Schema.Union([
+  RemoteBackendUrlMissingError,
+  RemotePairingUrlInvalidError,
+  RemoteBackendUrlInvalidError,
+  RemotePairingTokenMissingError,
+  RemotePairingCodeMissingError,
+]);
+export type RemotePairingTargetError = typeof RemotePairingTargetError.Type;
+
+const normalizeRemoteBaseUrl = (
+  rawValue: string,
+  source: RemoteBackendUrlInvalidError["source"],
+): URL => {
   const trimmed = rawValue.trim();
   if (!trimmed) {
-    throw new Error("Enter a backend URL.");
+    throw new RemoteBackendUrlMissingError();
   }
 
   const normalizedInput =
     /^[a-zA-Z][a-zA-Z\d+-]*:\/\//.test(trimmed) || trimmed.startsWith("//")
       ? trimmed
       : `https://${trimmed}`;
-  const url = new URL(normalizedInput);
+  let url: URL;
+  try {
+    url = new URL(normalizedInput);
+  } catch (cause) {
+    throw new RemoteBackendUrlInvalidError({ source, cause });
+  }
   url.pathname = "/";
   url.search = "";
   url.hash = "";
@@ -111,10 +178,18 @@ export const resolveRemotePairingTarget = (input: {
 }): ResolvedRemotePairingTarget => {
   const pairingUrl = input.pairingUrl?.trim() ?? "";
   if (pairingUrl.length > 0) {
-    const url = new URL(pairingUrl);
+    let url: URL;
+    try {
+      url = new URL(pairingUrl);
+    } catch (cause) {
+      throw new RemotePairingUrlInvalidError({ cause });
+    }
     const hostedPairingRequest = readHostedPairingRequest(url);
     if (hostedPairingRequest) {
-      const hostedBackendUrl = normalizeRemoteBaseUrl(hostedPairingRequest.host);
+      const hostedBackendUrl = normalizeRemoteBaseUrl(
+        hostedPairingRequest.host,
+        "hosted-pairing-host",
+      );
       return {
         credential: hostedPairingRequest.token,
         httpBaseUrl: toHttpBaseUrl(hostedBackendUrl),
@@ -124,7 +199,7 @@ export const resolveRemotePairingTarget = (input: {
 
     const credential = getPairingTokenFromUrl(url) ?? "";
     if (!credential) {
-      throw new Error("Pairing URL is missing its token.");
+      throw new RemotePairingTokenMissingError({ host: url.host });
     }
     return {
       credential,
@@ -136,13 +211,13 @@ export const resolveRemotePairingTarget = (input: {
   const host = input.host?.trim() ?? "";
   const pairingCode = input.pairingCode?.trim() ?? "";
   if (!host) {
-    throw new Error("Enter a backend URL.");
+    throw new RemoteBackendUrlMissingError();
   }
   if (!pairingCode) {
-    throw new Error("Enter a pairing code.");
+    throw new RemotePairingCodeMissingError({ host });
   }
 
-  const normalizedHost = normalizeRemoteBaseUrl(host);
+  const normalizedHost = normalizeRemoteBaseUrl(host, "direct-host");
   return {
     credential: pairingCode,
     httpBaseUrl: toHttpBaseUrl(normalizedHost),

--- a/packages/shared/src/remote.ts
+++ b/packages/shared/src/remote.ts
@@ -213,11 +213,11 @@ export const resolveRemotePairingTarget = (input: {
   if (!host) {
     throw new RemoteBackendUrlMissingError();
   }
+  const normalizedHost = normalizeRemoteBaseUrl(host, "direct-host");
   if (!pairingCode) {
-    throw new RemotePairingCodeMissingError({ host });
+    throw new RemotePairingCodeMissingError({ host: normalizedHost.host });
   }
 
-  const normalizedHost = normalizeRemoteBaseUrl(host, "direct-host");
   return {
     credential: pairingCode,
     httpBaseUrl: toHttpBaseUrl(normalizedHost),


### PR DESCRIPTION
## Summary
- replace raw remote-pairing input errors with distinct schema error classes
- retain URL parsing causes and classify backend URL source
- attach safe host context to missing token/code failures without exposing credentials

## Validation
- `vp test packages/shared/src/remote.test.ts`
- `vp check`
- `vp run typecheck`
- `vpr typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized validation refactor in shared remote pairing; user-facing messages are unchanged and success paths are the same, though error instances are no longer plain `Error`.
> 
> **Overview**
> Replaces generic `Error` throws in `resolveRemotePairingTarget` and `normalizeRemoteBaseUrl` with **Effect Schema tagged error classes** for missing/invalid pairing URLs, backend URLs, tokens, and pairing codes, plus a `RemotePairingTargetError` union.
> 
> Invalid URL parsing now wraps the original `TypeError` as `cause`, and backend URL failures record **`source`** (`direct-host` vs `hosted-pairing-host`). Missing token/code errors include a **normalized `host`** (e.g. no credentials from messy host strings). Tests assert the new error types and preserved causes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f32b4edbd7b8f1758087ee46d1d042da49284b08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic errors with structured tagged error classes in remote pairing input validation
> - Introduces five new `TaggedErrorClass` types in [remote.ts](https://github.com/pingdotgg/t3code/pull/3393/files#diff-0498d83e26080527d6445d335b3995ac3381148c1f4ae356399fa65e857fcb77): `RemoteBackendUrlMissingError`, `RemoteBackendUrlInvalidError`, `RemotePairingUrlInvalidError`, `RemotePairingTokenMissingError`, and `RemotePairingCodeMissingError`.
> - `RemoteBackendUrlInvalidError` carries a `source` field (`'direct-host'` | `'hosted-pairing-host'`) to identify the origin of the invalid input; all error classes with a cause preserve the original `TypeError`.
> - `normalizeRemoteBaseUrl` and `resolveRemotePairingTarget` now throw these structured errors instead of generic `Error` instances, with structured metadata (host, source, cause) attached.
> - Behavioral Change: callers catching errors from these functions must now handle tagged error types rather than plain `Error` objects.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f32b4ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->