### PR TITLE
[codex] Structure unavailable Bun PTY operations

### DIFF
--- a/apps/server/src/terminal/BunPtyAdapter.test.ts
+++ b/apps/server/src/terminal/BunPtyAdapter.test.ts
@@ -1,0 +1,17 @@
+import { expect, it } from "@effect/vitest";
+
+import { BunPtyOperationUnavailableError } from "./BunPtyAdapter.ts";
+
+it("describes unavailable Bun PTY operations structurally", () => {
+  const error = new BunPtyOperationUnavailableError({
+    operation: "resize",
+    pid: 42,
+  });
+
+  expect(error).toMatchObject({
+    _tag: "BunPtyOperationUnavailableError",
+    operation: "resize",
+    pid: 42,
+  });
+  expect(error.message).toBe("Bun PTY resize is unavailable for process 42.");
+});

--- a/apps/server/src/terminal/BunPtyAdapter.ts
+++ b/apps/server/src/terminal/BunPtyAdapter.ts
@@ -2,9 +2,22 @@
 
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import * as PtyAdapter from "./PtyAdapter.ts";
+
+export class BunPtyOperationUnavailableError extends Schema.TaggedErrorClass<BunPtyOperationUnavailableError>()(
+  "BunPtyOperationUnavailableError",
+  {
+    operation: Schema.Literals(["write", "resize"]),
+    pid: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Bun PTY ${this.operation} is unavailable for process ${this.pid}.`;
+  }
+}
 
 class BunPtyProcess implements PtyAdapter.PtyProcess {
   private readonly dataListeners = new Set<(data: string) => void>();
@@ -33,14 +46,14 @@ class BunPtyProcess implements PtyAdapter.PtyProcess {
 
   write(data: string): void {
     if (!this.process.terminal) {
-      throw new Error("Bun PTY terminal handle is unavailable");
+      throw new BunPtyOperationUnavailableError({ operation: "write", pid: this.pid });
     }
     this.process.terminal.write(data);
   }
 
   resize(cols: number, rows: number): void {
     if (!this.process.terminal?.resize) {
-      throw new Error("Bun PTY resize is unavailable");
+      throw new BunPtyOperationUnavailableError({ operation: "resize", pid: this.pid });
     }
     this.process.terminal.resize(cols, rows);
   }


### PR DESCRIPTION
## Summary
- replace generic Bun PTY write/resize defects with a structured tagged error
- include the unavailable operation and process id in diagnostics
- derive the message from those attributes

## Tests
- `vp test apps/server/src/terminal/BunPtyAdapter.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Bun PTY adapter error typing only; no auth, data, or broader terminal flow changes.
> 
> **Overview**
> When Bun’s PTY lacks a terminal handle or `resize`, **`BunPtyProcess`** no longer throws plain `Error` strings. It throws **`BunPtyOperationUnavailableError`**, an Effect **`Schema.TaggedErrorClass`** with `operation` (`write` | `resize`), `pid`, and a derived message.
> 
> A small test asserts the tag, fields, and message for the resize case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb36ed6d29708ba2b4d924f40222d8efc491df27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure unavailable Bun PTY errors with tagged `BunPtyOperationUnavailableError` class
> Replaces generic `Error` throws in `BunPtyProcess.write()` and `BunPtyProcess.resize()` with a new `Schema.TaggedErrorClass` named `BunPtyOperationUnavailableError`. The new error carries structured `operation` ('write' | 'resize') and `pid` fields, and formats a deterministic message like `'Bun PTY resize is unavailable for process 42.'`. A test in [BunPtyAdapter.test.ts](https://github.com/pingdotgg/t3code/pull/3394/files#diff-f50594a7e3f11686c9c5b2991d39f4fc409dacaac3eee0e3c779b6adad80e472) validates the structure and message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb36ed6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->