### PR TITLE
[codex] Structure client cloud cryptography errors

### DIFF
--- a/apps/mobile/src/features/cloud/dpop.test.ts
+++ b/apps/mobile/src/features/cloud/dpop.test.ts
@@ -95,7 +95,24 @@ describe("mobile DPoP", () => {
 
       const error = yield* loadOrCreateDpopProofKeyPair().pipe(Effect.flip);
 
-      expect(error.message).toBe("Stored DPoP proof key is invalid.");
+      expect(error).toMatchObject({
+        operation: "decode-key",
+        cause: expect.anything(),
+      });
+    }).pipe(Effect.provide(cryptoLayer)),
+  );
+
+  it.effect("reports invalid proof URLs as a structural operation failure", () =>
+    Effect.gen(function* () {
+      const proofKey = yield* generateDpopProofKeyPair();
+      const error = yield* createDpopProof({
+        method: "POST",
+        url: "not a URL",
+        proofKey,
+      }).pipe(Effect.flip);
+
+      expect(error).toMatchObject({ operation: "normalize-proof-url" });
+      expect(error.cause).toBeUndefined();
     }).pipe(Effect.provide(cryptoLayer)),
   );
 

--- a/apps/mobile/src/features/cloud/dpop.ts
+++ b/apps/mobile/src/features/cloud/dpop.ts
@@ -1,6 +1,5 @@
 import * as Clock from "effect/Clock";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
 import * as Result from "effect/Result";
@@ -16,13 +15,53 @@ import {
 } from "@t3tools/shared/dpop";
 import * as Layer from "effect/Layer";
 
-export class CloudDpopError extends Data.TaggedError("CloudDpopError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class CloudDpopError extends Schema.TaggedErrorClass<CloudDpopError>()("CloudDpopError", {
+  operation: Schema.Literals([
+    "generate-key-randomness",
+    "derive-public-key",
+    "read-key",
+    "decode-key",
+    "validate-key",
+    "encode-key",
+    "store-key",
+    "normalize-proof-url",
+    "import-private-key",
+    "generate-proof-id",
+    "encode-proof-header",
+    "encode-proof-payload",
+    "hash-signing-input",
+    "sign-proof",
+  ]),
+  cause: Schema.optional(Schema.Defect()),
+}) {
+  override get message(): string {
+    return `Cloud DPoP operation "${this.operation}" failed.`;
+  }
+}
 
-function cloudDpopError(message: string) {
-  return (cause: unknown) => new CloudDpopError({ message, cause });
+export class DpopPublicKeyFormatError extends Schema.TaggedErrorClass<DpopPublicKeyFormatError>()(
+  "DpopPublicKeyFormatError",
+  {
+    byteLength: Schema.Number,
+    firstByte: Schema.optional(Schema.Number),
+  },
+) {
+  override get message(): string {
+    const prefix =
+      this.firstByte === undefined
+        ? "no prefix byte"
+        : `prefix 0x${this.firstByte.toString(16).padStart(2, "0")}`;
+    return `Expected a 65-byte uncompressed P-256 public key beginning with 0x04; received ${this.byteLength} bytes with ${prefix}.`;
+  }
+}
+
+export class DpopStoredPublicKeyMismatchError extends Schema.TaggedErrorClass<DpopStoredPublicKeyMismatchError>()(
+  "DpopStoredPublicKeyMismatchError",
+  {},
+) {
+  override get message(): string {
+    return "Stored DPoP private and public key material do not match.";
+  }
 }
 
 const DpopPrivateJwkSchema = Schema.Struct({
@@ -97,29 +136,28 @@ function base64UrlToBytes(value: string): Uint8Array {
   return Result.getOrThrow(Encoding.decodeBase64Url(value));
 }
 
-function sha256Digest(
-  data: Uint8Array,
-  message: string,
-): Effect.Effect<Uint8Array, CloudDpopError, Crypto.Crypto> {
+function sha256Digest(data: Uint8Array): Effect.Effect<Uint8Array, CloudDpopError, Crypto.Crypto> {
   return Crypto.Crypto.pipe(
     Effect.flatMap((crypto) => crypto.digest("SHA-256", data)),
-    Effect.mapError(cloudDpopError(message)),
+    Effect.mapError((cause) => new CloudDpopError({ operation: "hash-signing-input", cause })),
   );
 }
 
 function secureRandomBytes(
   byteCount: number,
-  message: string,
 ): Effect.Effect<Uint8Array, CloudDpopError, Crypto.Crypto> {
   return Crypto.Crypto.pipe(
     Effect.flatMap((crypto) => crypto.randomBytes(byteCount)),
-    Effect.mapError(cloudDpopError(message)),
+    Effect.mapError((cause) => new CloudDpopError({ operation: "generate-key-randomness", cause })),
   );
 }
 
 function publicJwkFromUncompressedPublicKey(publicKey: Uint8Array): DpopPublicJwk {
   if (publicKey.length !== 65 || publicKey[0] !== 0x04) {
-    throw new Error("Generated DPoP public key is not an uncompressed P-256 point.");
+    throw new DpopPublicKeyFormatError({
+      byteLength: publicKey.length,
+      ...(publicKey[0] === undefined ? {} : { firstByte: publicKey[0] }),
+    });
   }
   return {
     kty: "EC",
@@ -144,14 +182,11 @@ export function generateDpopProofKeyPair(): Effect.Effect<
   return Effect.gen(function* () {
     let privateKey: Uint8Array;
     do {
-      privateKey = yield* secureRandomBytes(
-        p256.CURVE.nByteLength,
-        "Could not generate DPoP key pair randomness.",
-      );
+      privateKey = yield* secureRandomBytes(p256.CURVE.nByteLength);
     } while (!p256.utils.isValidPrivateKey(privateKey));
     const publicJwk = yield* Effect.try({
       try: () => publicJwkFromUncompressedPublicKey(p256.getPublicKey(privateKey, false)),
-      catch: cloudDpopError("Generated DPoP public key is invalid."),
+      catch: (cause) => new CloudDpopError({ operation: "derive-public-key", cause }),
     });
     const thumbprint = computeDpopJwkThumbprint(publicJwk);
     return {
@@ -170,11 +205,11 @@ export function loadOrCreateDpopProofKeyPair(): Effect.Effect<
   return Effect.gen(function* () {
     const stored = yield* Effect.tryPromise({
       try: () => SecureStore.getItemAsync(DPOP_PROOF_KEY_STORAGE_KEY),
-      catch: cloudDpopError("Could not read the DPoP proof key."),
+      catch: (cause) => new CloudDpopError({ operation: "read-key", cause }),
     });
     if (stored) {
       const storedPrivateJwk = yield* decodeDpopPrivateJwkJson(stored).pipe(
-        Effect.mapError(cloudDpopError("Stored DPoP proof key is invalid.")),
+        Effect.mapError((cause) => new CloudDpopError({ operation: "decode-key", cause })),
       );
       const restored = yield* Effect.try({
         try: () => {
@@ -183,11 +218,11 @@ export function loadOrCreateDpopProofKeyPair(): Effect.Effect<
             p256.getPublicKey(privateKey, false),
           );
           if (publicJwk.x !== storedPrivateJwk.x || publicJwk.y !== storedPrivateJwk.y) {
-            throw new Error("Stored DPoP key does not match its public key.");
+            throw new DpopStoredPublicKeyMismatchError();
           }
           return { privateJwk: storedPrivateJwk, publicJwk };
         },
-        catch: cloudDpopError("Stored DPoP proof key is invalid."),
+        catch: (cause) => new CloudDpopError({ operation: "validate-key", cause }),
       });
       return {
         ...restored,
@@ -196,11 +231,11 @@ export function loadOrCreateDpopProofKeyPair(): Effect.Effect<
     }
     const generated = yield* generateDpopProofKeyPair();
     const encodedPrivateJwk = yield* encodeDpopPrivateJwkJson(generated.privateJwk).pipe(
-      Effect.mapError(cloudDpopError("Could not encode the DPoP proof key.")),
+      Effect.mapError((cause) => new CloudDpopError({ operation: "encode-key", cause })),
     );
     yield* Effect.tryPromise({
       try: () => SecureStore.setItemAsync(DPOP_PROOF_KEY_STORAGE_KEY, encodedPrivateJwk),
-      catch: cloudDpopError("Could not store the DPoP proof key."),
+      catch: (cause) => new CloudDpopError({ operation: "store-key", cause }),
     });
     return generated;
   });
@@ -210,7 +245,7 @@ function normalizeHtu(url: string): Effect.Effect<string, CloudDpopError> {
   const normalized = normalizeDpopHtu(url);
   return normalized
     ? Effect.succeed(normalized)
-    : Effect.fail(new CloudDpopError({ message: "DPoP URL is invalid." }));
+    : Effect.fail(new CloudDpopError({ operation: "normalize-proof-url" }));
 }
 
 export function createDpopProof(input: {
@@ -227,12 +262,12 @@ export function createDpopProof(input: {
     const keyPair = input.proofKey ?? (yield* generateDpopProofKeyPair());
     const privateKey = yield* Effect.try({
       try: () => base64UrlToBytes(keyPair.privateJwk.d),
-      catch: cloudDpopError("Could not import DPoP private key."),
+      catch: (cause) => new CloudDpopError({ operation: "import-private-key", cause }),
     });
     const nowMs = yield* Clock.currentTimeMillis;
     const jti = yield* Crypto.Crypto.pipe(
       Effect.flatMap((crypto) => crypto.randomUUIDv4),
-      Effect.mapError(cloudDpopError("Could not generate DPoP proof identifier.")),
+      Effect.mapError((cause) => new CloudDpopError({ operation: "generate-proof-id", cause })),
     );
     const htu = yield* normalizeHtu(input.url);
     const header = yield* encodeDpopJwtHeaderJson({
@@ -241,7 +276,7 @@ export function createDpopProof(input: {
       jwk: keyPair.publicJwk,
     }).pipe(
       Effect.map(Encoding.encodeBase64Url),
-      Effect.mapError(cloudDpopError("Could not encode DPoP proof header.")),
+      Effect.mapError((cause) => new CloudDpopError({ operation: "encode-proof-header", cause })),
     );
     const ath = input.accessToken ? computeDpopAccessTokenHash(input.accessToken) : null;
     const payload = yield* encodeDpopJwtPayloadJson({
@@ -252,15 +287,14 @@ export function createDpopProof(input: {
       ...(ath ? { ath } : {}),
     }).pipe(
       Effect.map(Encoding.encodeBase64Url),
-      Effect.mapError(cloudDpopError("Could not encode DPoP proof payload.")),
+      Effect.mapError((cause) => new CloudDpopError({ operation: "encode-proof-payload", cause })),
     );
     const signatureInputHash = yield* sha256Digest(
       new TextEncoder().encode(`${header}.${payload}`),
-      "Could not hash DPoP signing input.",
     );
     const signature = yield* Effect.try({
       try: () => p256.sign(signatureInputHash, privateKey, { prehash: false }).toCompactRawBytes(),
-      catch: cloudDpopError("Could not sign DPoP proof."),
+      catch: (cause) => new CloudDpopError({ operation: "sign-proof", cause }),
     });
     return {
       proof: `${header}.${payload}.${Encoding.encodeBase64Url(signature)}`,

--- a/apps/mobile/src/features/cloud/managedRelayTokenStore.test.ts
+++ b/apps/mobile/src/features/cloud/managedRelayTokenStore.test.ts
@@ -1,5 +1,7 @@
 import { expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Logger from "effect/Logger";
+import * as References from "effect/References";
 import { vi } from "vite-plus/test";
 
 const secureStore = vi.hoisted(() => new Map<string, string>());
@@ -16,7 +18,10 @@ vi.mock("expo-secure-store", () => ({
   }),
 }));
 
-import { managedRelayAccessTokenStore } from "./managedRelayTokenStore";
+import {
+  isManagedRelayTokenStoreError,
+  managedRelayAccessTokenStore,
+} from "./managedRelayTokenStore";
 
 it.effect("round-trips and clears persisted managed relay access tokens", () =>
   Effect.gen(function* () {
@@ -45,7 +50,21 @@ it.effect("falls back to an empty cache when persisted data is invalid", () =>
   Effect.gen(function* () {
     secureStore.clear();
     secureStore.set("t3code.cloud.relay-access-tokens", "not-json");
+    const annotations: Array<Record<string, unknown>> = [];
+    const logger = Logger.make(({ fiber }) => {
+      annotations.push(fiber.getRef(References.CurrentLogAnnotations));
+    });
 
-    expect(yield* managedRelayAccessTokenStore.load).toEqual([]);
+    expect(
+      yield* managedRelayAccessTokenStore.load.pipe(
+        Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
+      ),
+    ).toEqual([]);
+    expect(annotations).toHaveLength(1);
+    expect(isManagedRelayTokenStoreError(annotations[0]?.error)).toBe(true);
+    expect(annotations[0]?.error).toMatchObject({
+      operation: "decode-cache",
+      cause: expect.anything(),
+    });
   }),
 );

--- a/apps/mobile/src/features/cloud/managedRelayTokenStore.ts
+++ b/apps/mobile/src/features/cloud/managedRelayTokenStore.ts
@@ -48,9 +48,12 @@ export class ManagedRelayTokenStoreError extends Schema.TaggedErrorClass<Managed
   }
 }
 
+export const isManagedRelayTokenStoreError = Schema.is(ManagedRelayTokenStoreError);
+
 function logStoreFailure(error: ManagedRelayTokenStoreError) {
   return Effect.logWarning(error.message).pipe(
     Effect.annotateLogs({
+      error,
       errorTag: error._tag,
       operation: error.operation,
     }),

--- a/apps/mobile/src/features/cloud/managedRelayTokenStore.ts
+++ b/apps/mobile/src/features/cloud/managedRelayTokenStore.ts
@@ -1,5 +1,4 @@
 import { ManagedRelay } from "@t3tools/client-runtime/relay";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as SecureStore from "expo-secure-store";
@@ -31,36 +30,45 @@ const decodeManagedRelayAccessTokenCache = Schema.decodeUnknownEffect(
 );
 const encodeManagedRelayAccessTokenCache = Schema.encodeEffect(ManagedRelayAccessTokenCacheSchema);
 
-export class ManagedRelayTokenStoreError extends Data.TaggedError("ManagedRelayTokenStoreError")<{
-  readonly message: string;
-  readonly cause: unknown;
-}> {}
+export class ManagedRelayTokenStoreError extends Schema.TaggedErrorClass<ManagedRelayTokenStoreError>()(
+  "ManagedRelayTokenStoreError",
+  {
+    operation: Schema.Literals([
+      "read-cache",
+      "decode-cache",
+      "encode-cache",
+      "write-cache",
+      "clear-cache",
+    ]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Managed relay token store operation "${this.operation}" failed.`;
+  }
+}
 
-const storeError =
-  (message: string) =>
-  (cause: unknown): ManagedRelayTokenStoreError =>
-    new ManagedRelayTokenStoreError({ message, cause });
-
-function logStoreFailure(operation: string) {
-  return (error: ManagedRelayTokenStoreError) =>
-    Effect.logWarning(`Managed relay token store ${operation} failed.`).pipe(
-      Effect.annotateLogs({
-        errorTag: error._tag,
-        message: error.message,
-      }),
-    );
+function logStoreFailure(error: ManagedRelayTokenStoreError) {
+  return Effect.logWarning(error.message).pipe(
+    Effect.annotateLogs({
+      errorTag: error._tag,
+      operation: error.operation,
+    }),
+  );
 }
 
 const loadManagedRelayAccessTokens = Effect.tryPromise({
   try: () => SecureStore.getItemAsync(MANAGED_RELAY_TOKEN_CACHE_KEY),
-  catch: storeError("Could not read persisted relay access tokens."),
+  catch: (cause) => new ManagedRelayTokenStoreError({ operation: "read-cache", cause }),
 }).pipe(
   Effect.flatMap((encoded) =>
     encoded === null
       ? Effect.succeed<ReadonlyArray<ManagedRelay.ManagedRelayAccessTokenCacheEntry>>([])
       : decodeManagedRelayAccessTokenCache(encoded).pipe(
           Effect.map((cache) => cache.entries),
-          Effect.mapError(storeError("Persisted relay access tokens are invalid.")),
+          Effect.mapError(
+            (cause) => new ManagedRelayTokenStoreError({ operation: "decode-cache", cause }),
+          ),
         ),
   ),
 );
@@ -72,34 +80,33 @@ const saveManagedRelayAccessTokens = (
     version: MANAGED_RELAY_TOKEN_CACHE_VERSION,
     entries,
   }).pipe(
-    Effect.mapError(storeError("Could not encode relay access tokens.")),
+    Effect.mapError(
+      (cause) => new ManagedRelayTokenStoreError({ operation: "encode-cache", cause }),
+    ),
     Effect.flatMap((encoded) =>
       Effect.tryPromise({
         try: () => SecureStore.setItemAsync(MANAGED_RELAY_TOKEN_CACHE_KEY, encoded),
-        catch: storeError("Could not persist relay access tokens."),
+        catch: (cause) => new ManagedRelayTokenStoreError({ operation: "write-cache", cause }),
       }),
     ),
   );
 
 const clearManagedRelayAccessTokens = Effect.tryPromise({
   try: () => SecureStore.deleteItemAsync(MANAGED_RELAY_TOKEN_CACHE_KEY),
-  catch: storeError("Could not clear persisted relay access tokens."),
+  catch: (cause) => new ManagedRelayTokenStoreError({ operation: "clear-cache", cause }),
 });
 
 export const managedRelayAccessTokenStore: ManagedRelay.ManagedRelayAccessTokenStore = {
   load: loadManagedRelayAccessTokens.pipe(
-    Effect.tapError(logStoreFailure("load")),
+    Effect.tapError(logStoreFailure),
     Effect.orElseSucceed(() => []),
     Effect.withSpan("mobile.managedRelayTokenStore.load"),
   ),
   save: Effect.fn("mobile.managedRelayTokenStore.save")((entries) =>
-    saveManagedRelayAccessTokens(entries).pipe(
-      Effect.tapError(logStoreFailure("save")),
-      Effect.ignore,
-    ),
+    saveManagedRelayAccessTokens(entries).pipe(Effect.tapError(logStoreFailure), Effect.ignore),
   ),
   clear: clearManagedRelayAccessTokens.pipe(
-    Effect.tapError(logStoreFailure("clear")),
+    Effect.tapError(logStoreFailure),
     Effect.ignore,
     Effect.withSpan("mobile.managedRelayTokenStore.clear"),
   ),

--- a/apps/web/src/cloud/dpop.test.ts
+++ b/apps/web/src/cloud/dpop.test.ts
@@ -4,9 +4,31 @@ import * as Effect from "effect/Effect";
 import { decodeJwt } from "jose";
 import { vi } from "vite-plus/test";
 
-import { browserCryptoLayer, createBrowserDpopProof, generateBrowserDpopKey } from "./dpop";
+import {
+  BrowserDpopError,
+  type BrowserDpopKey,
+  browserCryptoLayer,
+  createBrowserDpopProof,
+  generateBrowserDpopKey,
+} from "./dpop";
 
 describe("browser DPoP proofs", () => {
+  it.effect("reports URL normalization failures structurally with their cause", () =>
+    Effect.gen(function* () {
+      const error = yield* createBrowserDpopProof({
+        method: "POST",
+        url: "not a URL",
+        proofKey: {} as BrowserDpopKey,
+      }).pipe(Effect.provide(browserCryptoLayer), Effect.flip);
+
+      expect(error).toBeInstanceOf(BrowserDpopError);
+      expect(error).toMatchObject({
+        operation: "normalize-proof-url",
+        cause: expect.any(TypeError),
+      });
+    }),
+  );
+
   it.effect("signs relay resource proofs with an access-token hash", () =>
     Effect.gen(function* () {
       vi.stubGlobal("indexedDB", undefined);

--- a/apps/web/src/cloud/dpop.ts
+++ b/apps/web/src/cloud/dpop.ts
@@ -4,7 +4,6 @@ import {
   DpopPublicJwk,
 } from "@t3tools/shared/dpop";
 import * as Crypto from "effect/Crypto";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";
@@ -16,10 +15,31 @@ export interface BrowserDpopKey {
   readonly thumbprint: string;
 }
 
-export class BrowserDpopError extends Data.TaggedError("BrowserDpopError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
+export class BrowserDpopError extends Schema.TaggedErrorClass<BrowserDpopError>()(
+  "BrowserDpopError",
+  {
+    operation: Schema.Literals([
+      "open-key-storage",
+      "read-key",
+      "write-key",
+      "generate-key",
+      "export-private-key",
+      "export-public-key",
+      "decode-public-key",
+      "import-private-key",
+      "normalize-proof-url",
+      "generate-proof-id",
+      "sign-proof",
+    ]),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Browser DPoP operation "${this.operation}" failed.`;
+  }
+}
+
+export const isBrowserDpopError = Schema.is(BrowserDpopError);
 
 const DPOP_DATABASE_NAME = "t3code:cloud-auth";
 const DPOP_DATABASE_VERSION = 1;
@@ -40,16 +60,17 @@ export const browserCryptoLayer = Layer.succeed(
   }),
 );
 
-function dpopError(message: string, cause?: unknown) {
-  return new BrowserDpopError({ message, ...(cause === undefined ? {} : { cause }) });
-}
-
 function openDpopDatabase(): Effect.Effect<IDBDatabase, BrowserDpopError> {
   return Effect.callback<IDBDatabase, BrowserDpopError>((resume) => {
     const request = indexedDB.open(DPOP_DATABASE_NAME, DPOP_DATABASE_VERSION);
     request.addEventListener("error", () =>
       resume(
-        Effect.fail(dpopError("Could not open DPoP key storage.", request.error ?? undefined)),
+        Effect.fail(
+          new BrowserDpopError({
+            operation: "open-key-storage",
+            ...(request.error === null ? {} : { cause: request.error }),
+          }),
+        ),
       ),
     );
     request.addEventListener("upgradeneeded", () => {
@@ -74,7 +95,14 @@ export function readStoredBrowserDpopKey(): Effect.Effect<BrowserDpopKey | null,
           .objectStore(DPOP_KEY_STORE_NAME)
           .get(DPOP_KEY_ID);
         request.addEventListener("error", () =>
-          resume(Effect.fail(dpopError("Could not read DPoP key.", request.error ?? undefined))),
+          resume(
+            Effect.fail(
+              new BrowserDpopError({
+                operation: "read-key",
+                ...(request.error === null ? {} : { cause: request.error }),
+              }),
+            ),
+          ),
         );
         request.addEventListener("success", () =>
           resume(Effect.succeed((request.result as BrowserDpopKey | undefined) ?? null)),
@@ -97,7 +125,12 @@ export function writeStoredBrowserDpopKey(
         const transaction = database.transaction(DPOP_KEY_STORE_NAME, "readwrite");
         transaction.addEventListener("error", () =>
           resume(
-            Effect.fail(dpopError("Could not write DPoP key.", transaction.error ?? undefined)),
+            Effect.fail(
+              new BrowserDpopError({
+                operation: "write-key",
+                ...(transaction.error === null ? {} : { cause: transaction.error }),
+              }),
+            ),
           ),
         );
         transaction.addEventListener("complete", () => resume(Effect.void));
@@ -114,26 +147,26 @@ export const generateBrowserDpopKey = Effect.gen(function* () {
         "sign",
         "verify",
       ]) as Promise<CryptoKeyPair>,
-    catch: (cause) => dpopError("Could not generate DPoP proof key.", cause),
+    catch: (cause) => new BrowserDpopError({ operation: "generate-key", cause }),
   });
   const privateJwk = yield* Effect.tryPromise({
     try: () => crypto.subtle.exportKey("jwk", generated.privateKey),
-    catch: (cause) => dpopError("Could not export DPoP private key.", cause),
+    catch: (cause) => new BrowserDpopError({ operation: "export-private-key", cause }),
   });
   const publicJwk = yield* Effect.tryPromise({
     try: () => crypto.subtle.exportKey("jwk", generated.publicKey),
-    catch: (cause) => dpopError("Could not export DPoP public key.", cause),
+    catch: (cause) => new BrowserDpopError({ operation: "export-public-key", cause }),
   }).pipe(
     Effect.flatMap((jwk) => decodeDpopPublicJwk(jwk)),
     Effect.mapError((cause) =>
-      cause instanceof BrowserDpopError
+      isBrowserDpopError(cause)
         ? cause
-        : dpopError("Generated DPoP public key is invalid.", cause),
+        : new BrowserDpopError({ operation: "decode-public-key", cause }),
     ),
   );
   const privateKey = yield* Effect.tryPromise({
     try: () => importJWK(privateJwk as JWK, "ES256", { extractable: false }) as Promise<CryptoKey>,
-    catch: (cause) => dpopError("Could not import DPoP private key.", cause),
+    catch: (cause) => new BrowserDpopError({ operation: "import-private-key", cause }),
   });
   return {
     privateKey,
@@ -155,13 +188,13 @@ export function createBrowserDpopProof(input: {
   return Effect.gen(function* () {
     const normalizedUrl = yield* Effect.try({
       try: () => new URL(input.url),
-      catch: (cause) => dpopError("Could not normalize DPoP proof URL.", cause),
+      catch: (cause) => new BrowserDpopError({ operation: "normalize-proof-url", cause }),
     });
     normalizedUrl.search = "";
     normalizedUrl.hash = "";
     const jti = yield* Crypto.Crypto.pipe(
       Effect.flatMap((crypto) => crypto.randomUUIDv4),
-      Effect.mapError((cause) => dpopError("Could not generate DPoP proof identifier.", cause)),
+      Effect.mapError((cause) => new BrowserDpopError({ operation: "generate-proof-id", cause })),
     );
     const proof = yield* Effect.tryPromise({
       try: () =>
@@ -178,7 +211,7 @@ export function createBrowserDpopProof(input: {
           })
           .setIssuedAt()
           .sign(input.proofKey.privateKey),
-      catch: (cause) => dpopError("Could not sign DPoP proof.", cause),
+      catch: (cause) => new BrowserDpopError({ operation: "sign-proof", cause }),
     });
     return { proof, thumbprint: input.proofKey.thumbprint };
   });


### PR DESCRIPTION
## Summary\n\n- replace message-bearing DPoP errors with Schema errors carrying structured operation context\n- preserve exact lower-level causes and add typed key-format/mismatch causes for validation failures\n- remove valueless error constructor wrappers from web/mobile DPoP and mobile relay token storage\n- annotate best-effort token-store logging with the failing operation\n\n## Validation\n\n-  WARN  Unsupported engine: wanted: {"node":"^24.13.1"} (current: {"node":"v25.8.2","pnpm":"10.24.0"})
 RUN  /Users/julius/.codex/worktrees/client-cloud-crypto-errors


 Test Files  3 passed (3)
      Tests  10 passed (10)
   Start at  08:11:56
   Duration  376ms (transform 78ms, setup 0ms, import 632ms, tests 86ms, environment 0ms)\n-  WARN  Unsupported engine: wanted: {"node":"^24.13.1"} (current: {"node":"v25.8.2","pnpm":"10.24.0"})
[1m[94mpass:[39m[0m All 1848 files are correctly formatted [2m(775ms, 16 threads)[0m
! react(no-unstable-nested-components): Do not define components during render.
      ,-[apps/web/src/components/ChatMarkdown.tsx:1250:8]
 1249 |         () => ({
 1250 | ,->       p({ node: _node, children, ...props }) {
 1251 | |           return <p {...props}>{renderSkillInlineMarkdownChildren(children, skills)}</p>;
 1252 | `->       },
 1253 |           li({ node, children, ...props }) {
      `----
  help: Move this component definition out of the parent component `ChatMarkdown` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
      ,-[apps/web/src/components/ChatMarkdown.tsx:1253:9]
 1252 |           },
 1253 | ,->       li({ node, children, ...props }) {
 1254 | |           const listItemStart = node?.position?.start.offset;
 1255 | |           const markerOffset =
 1256 | |             typeof listItemStart === "number" ? findTaskListMarkerOffset(text, listItemStart) : null;
 1257 | |           return (
 1258 | |             <li {...props} data-task-marker-offset={markerOffset ?? undefined}>
 1259 | |               {renderSkillInlineMarkdownChildren(children, skills)}
 1260 | |             </li>
 1261 | |           );
 1262 | `->       },
 1263 |           input({ node: _node, type, checked, disabled: _disabled, ...props }) {
      `----
  help: Move this component definition out of the parent component `ChatMarkdown` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
      ,-[apps/web/src/components/ChatMarkdown.tsx:1263:12]
 1262 |           },
 1263 | ,->       input({ node: _node, type, checked, disabled: _disabled, ...props }) {
 1264 | |           if (type !== "checkbox" || !onTaskListChange) {
 1265 | |             return (
 1266 | |               <input
 1267 | |                 {...props}
 1268 | |                 type={type}
 1269 | |                 checked={checked}
 1270 | |                 disabled={_disabled}
 1271 | |                 readOnly={type === "checkbox"}
 1272 | |               />
 1273 | |             );
 1274 | |           }
 1275 | |           return (
 1276 | |             <input
 1277 | |               {...props}
 1278 | |               type="checkbox"
 1279 | |               name="markdown-task"
 1280 | |               aria-label="Toggle task"
 1281 | |               checked={checked}
 1282 | |               onChange={(event) => {
 1283 | |                 const markerOffset = Number(
 1284 | |                   event.currentTarget.closest("li")?.dataset.taskMarkerOffset,
 1285 | |                 );
 1286 | |                 if (!Number.isSafeInteger(markerOffset)) return;
 1287 | |                 onTaskListChange({ markerOffset, checked: event.currentTarget.checked });
 1288 | |               }}
 1289 | |             />
 1290 | |           );
 1291 | `->       },
 1292 |           a({ node, href, children, ...props }) {
      `----
  help: Move this component definition out of the parent component `ChatMarkdown` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
      ,-[apps/web/src/components/ChatMarkdown.tsx:1292:8]
 1291 |           },
 1292 | ,->       a({ node, href, children, ...props }) {
 1293 | |           const normalizedHref = href ? normalizeMarkdownLinkHrefKey(href) : "";
 1294 | |           const fileLinkMeta = normalizedHref ? markdownFileLinkMetaByHref.get(normalizedHref) : null;
 1295 | |           if (!fileLinkMeta) {
 1296 | |             const faviconHost = resolveExternalLinkHost(href);
 1297 | |             const isSameDocumentLink = href?.startsWith("#") ?? false;
 1298 | |             const onClick = props.onClick;
 1299 | |             const canOpenInPreview = Boolean(threadRef) && isPreviewSupportedInRuntime();
 1300 | |             const link = (
 1301 | |               <a
 1302 | |                 {...props}
 1303 | |                 href={href}
 1304 | |                 target={isSameDocumentLink ? undefined : "_blank"}
 1305 | |                 rel={isSameDocumentLink ? undefined : "noopener noreferrer"}
 1306 | |                 onClick={(event) => {
 1307 | |                   onClick?.(event);
 1308 | |                   if (isSameDocumentLink && href) {
 1309 | |                     handleMarkdownFragmentClick(event, href);
 1310 | |                   }
 1311 | |                 }}
 1312 | |                 onContextMenu={(event) => {
 1313 | |                   if (!canOpenInPreview || !href) return;
 1314 | |                   event.preventDefault();
 1315 | |                   event.stopPropagation();
 1316 | |                   const api = readLocalApi();
 1317 | |                   if (!api) return;
 1318 | |                   void api.contextMenu
 1319 | |                     .show(
 1320 | |                       [
 1321 | |                         { id: "open-in-browser", label: "Open in integrated browser" },
 1322 | |                         { id: "open-external", label: "Open in system browser" },
 1323 | |                       ] as const,
 1324 | |                       { x: event.clientX, y: event.clientY },
 1325 | |                     )
 1326 | |                     .then((clicked) => {
 1327 | |                       if (clicked === "open-in-browser") {
 1328 | |                         void openExternalLinkInPreview(href);
 1329 | |                         return;
 1330 | |                       }
 1331 | |                       if (clicked === "open-external") return api.shell.openExternal(href);
 1332 | |                     })
 1333 | |                     .catch(() => undefined);
 1334 | |                 }}
 1335 | |               >
 1336 | |                 {faviconHost ? (
 1337 | |                   <MarkdownExternalLinkContent host={faviconHost} plainText={plainHastText(node)}>
 1338 | |                     {children}
 1339 | |                   </MarkdownExternalLinkContent>
 1340 | |                 ) : (
 1341 | |                   children
 1342 | |                 )}
 1343 | |               </a>
 1344 | |             );
 1345 | |             if (!faviconHost || !href) {
 1346 | |               return link;
 1347 | |             }
 1348 | |             return (
 1349 | |               <Tooltip>
 1350 | |                 <TooltipTrigger render={link} />
 1351 | |                 <TooltipPopup
 1352 | |                   side="top"
 1353 | |                   className="max-w-[min(36rem,calc(100vw-2rem))] whitespace-normal leading-tight wrap-anywhere"
 1354 | |                 >
 1355 | |                   {href}
 1356 | |                 </TooltipPopup>
 1357 | |               </Tooltip>
 1358 | |             );
 1359 | |           }
 1360 | |   
 1361 | |           const parentSuffix = fileLinkParentSuffixByPath.get(fileLinkMeta.filePath);
 1362 | |           const labelParts = [fileLinkMeta.basename];
 1363 | |           if (typeof parentSuffix === "string" && parentSuffix.length > 0) {
 1364 | |             labelParts.push(parentSuffix);
 1365 | |           }
 1366 | |           if (fileLinkMeta.line) {
 1367 | |             labelParts.push(
 1368 | |               `L${fileLinkMeta.line}${fileLinkMeta.column ? `:C${fileLinkMeta.column}` : ""}`,
 1369 | |             );
 1370 | |           }
 1371 | |   
 1372 | |           return (
 1373 | |             <MarkdownFileLink
 1374 | |               href={fileLinkMeta.targetPath}
 1375 | |               targetPath={fileLinkMeta.targetPath}
 1376 | |               iconPath={fileLinkMeta.filePath}
 1377 | |               displayPath={fileLinkMeta.displayPath}
 1378 | |               workspaceRelativePath={fileLinkMeta.workspaceRelativePath}
 1379 | |               line={fileLinkMeta.line}
 1380 | |               label={labelParts.join(" · ")}
 1381 | |               copyMarkdown={`[${fileLinkMeta.basename}](${normalizedHref})`}
 1382 | |               theme={resolvedTheme}
 1383 | |               threadRef={threadRef}
 1384 | |               onOpen={openInPreferredEditor}
 1385 | |               onOpenInBrowser={
 1386 | |                 threadRef &&
 1387 | |                 isPreviewSupportedInRuntime() &&
 1388 | |                 isBrowserPreviewFile(fileLinkMeta.filePath)
 1389 | |                   ? () => openMarkdownFileInPreview(fileLinkMeta.filePath)
 1390 | |                   : undefined
 1391 | |               }
 1392 | |               className={props.className}
 1393 | |             />
 1394 | |           );
 1395 | `->       },
 1396 |           table({ node: _node, ...props }) {
      `----
  help: Move this component definition out of the parent component `ChatMarkdown` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
      ,-[apps/web/src/components/ChatMarkdown.tsx:1396:12]
 1395 |           },
 1396 | ,->       table({ node: _node, ...props }) {
 1397 | |           return <MarkdownTable {...props} />;
 1398 | `->       },
 1399 |           details({ node: _node, children, open: detailsOpen }) {
      `----
  help: Move this component definition out of the parent component `ChatMarkdown` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
      ,-[apps/web/src/components/ChatMarkdown.tsx:1399:14]
 1398 |           },
 1399 | ,->       details({ node: _node, children, open: detailsOpen }) {
 1400 | |           return <MarkdownDetails open={detailsOpen}>{children}</MarkdownDetails>;
 1401 | `->       },
 1402 |           pre({ node, children, ...props }) {
      `----
  help: Move this component definition out of the parent component `ChatMarkdown` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
      ,-[apps/web/src/components/ChatMarkdown.tsx:1402:10]
 1401 |           },
 1402 | ,->       pre({ node, children, ...props }) {
 1403 | |           const codeBlock = extractCodeBlock(children);
 1404 | |           if (!codeBlock) {
 1405 | |             return <pre {...props}>{children}</pre>;
 1406 | |           }
 1407 | |   
 1408 | |           const language = extractFenceLanguage(codeBlock.className);
 1409 | |           const fenceTitle = extractFenceTitle(extractPreCodeMeta(node));
 1410 | |           return (
 1411 | |             <MarkdownCodeBlock
 1412 | |               code={codeBlock.code}
 1413 | |               language={language}
 1414 | |               fenceTitle={fenceTitle}
 1415 | |               theme={resolvedTheme}
 1416 | |             >
 1417 | |               <CodeHighlightErrorBoundary fallback={<pre {...props}>{children}</pre>}>
 1418 | |                 <Suspense fallback={<pre {...props}>{children}</pre>}>
 1419 | |                   <SuspenseShikiCodeBlock
 1420 | |                     className={codeBlock.className}
 1421 | |                     code={codeBlock.code}
 1422 | |                     themeName={diffThemeName}
 1423 | |                     isStreaming={isStreaming}
 1424 | |                   />
 1425 | |                 </Suspense>
 1426 | |               </CodeHighlightErrorBoundary>
 1427 | |             </MarkdownCodeBlock>
 1428 | |           );
 1429 | `->       },
 1430 |         }),
      `----
  help: Move this component definition out of the parent component `ChatMarkdown` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
     ,-[apps/mobile/src/features/review/ReviewSheet.tsx:249:24]
 248 |               },
 249 | ,->           headerTitle: () => (
 250 | |               <View style={{ alignItems: "center" }}>
 251 | |                 <NativeText
 252 | |                   numberOfLines={1}
 253 | |                   style={{
 254 | |                     fontFamily: "DMSans_700Bold",
 255 | |                     fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
 256 | |                     fontWeight: "900",
 257 | |                     color: headerForeground,
 258 | |                     letterSpacing: -0.4,
 259 | |                   }}
 260 | |                 >
 261 | |                   Files Changed
 262 | |                 </NativeText>
 263 | |                 <View
 264 | |                   style={{
 265 | |                     flexDirection: "row",
 266 | |                     alignItems: "center",
 267 | |                     justifyContent: "center",
 268 | |                     gap: 6,
 269 | |                     flexWrap: "wrap",
 270 | |                   }}
 271 | |                 >
 272 | |                   {headerDiffSummary.additions && headerDiffSummary.deletions ? (
 273 | |                     <>
 274 | |                       <NativeText
 275 | |                         style={{
 276 | |                           fontFamily: "DMSans_700Bold",
 277 | |                           fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
 278 | |                           fontWeight: "700",
 279 | |                           color: "#16a34a",
 280 | |                         }}
 281 | |                       >
 282 | |                         {headerDiffSummary.additions}
 283 | |                       </NativeText>
 284 | |                       <NativeText
 285 | |                         style={{
 286 | |                           fontFamily: "DMSans_700Bold",
 287 | |                           fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
 288 | |                           fontWeight: "700",
 289 | |                           color: "#e11d48",
 290 | |                         }}
 291 | |                       >
 292 | |                         {headerDiffSummary.deletions}
 293 | |                       </NativeText>
 294 | |                       {pendingReviewCommentCount > 0 ? (
 295 | |                         <NativeText
 296 | |                           style={{
 297 | |                             fontFamily: "DMSans_700Bold",
 298 | |                             fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
 299 | |                             fontWeight: "700",
 300 | |                             color: "#b45309",
 301 | |                           }}
 302 | |                         >
 303 | |                           {pendingReviewCommentCount} pending
 304 | |                         </NativeText>
 305 | |                       ) : null}
 306 | |                     </>
 307 | |                   ) : (
 308 | |                     <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
 309 | |                       <NativeText
 310 | |                         numberOfLines={1}
 311 | |                         style={{
 312 | |                           fontFamily: "DMSans_700Bold",
 313 | |                           fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
 314 | |                           fontWeight: "700",
 315 | |                           color: headerMuted,
 316 | |                         }}
 317 | |                       >
 318 | |                         {selectedSection?.title ?? "Review changes"}
 319 | |                       </NativeText>
 320 | |                       {pendingReviewCommentCount > 0 ? (
 321 | |                         <NativeText
 322 | |                           style={{
 323 | |                             fontFamily: "DMSans_700Bold",
 324 | |                             fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
 325 | |                             fontWeight: "700",
 326 | |                             color: "#b45309",
 327 | |                           }}
 328 | |                         >
 329 | |                           {pendingReviewCommentCount} pending
 330 | |                         </NativeText>
 331 | |                       ) : null}
 332 | |                     </View>
 333 | |                   )}
 334 | |                 </View>
 335 | |               </View>
 336 | `->           ),
 337 |             }}
     `----
  help: Move this component definition out of the parent component `ReviewSheet` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
     ,-[apps/mobile/src/features/threads/ThreadRouteScreen.tsx:383:24]
 382 |               headerBackTitle: "",
 383 | ,->           headerTitle: () => (
 384 | |               <Pressable
 385 | |                 style={{ alignItems: "center", maxWidth: 200 }}
 386 | |                 onLongPress={() => {
 387 | |                   // TODO: trigger rename modal
 388 | |                 }}
 389 | |               >
 390 | |                 <RNText
 391 | |                   numberOfLines={1}
 392 | |                   style={{
 393 | |                     fontFamily: "DMSans_700Bold",
 394 | |                     fontSize: MOBILE_TYPOGRAPHY.headline.fontSize,
 395 | |                     fontWeight: "900",
 396 | |                     color: foregroundColor,
 397 | |                     letterSpacing: -0.4,
 398 | |                   }}
 399 | |                 >
 400 | |                   {selectedThread.title}
 401 | |                 </RNText>
 402 | |                 <RNText
 403 | |                   numberOfLines={1}
 404 | |                   style={{
 405 | |                     fontFamily: "DMSans_700Bold",
 406 | |                     fontSize: MOBILE_TYPOGRAPHY.label.fontSize,
 407 | |                     fontWeight: "700",
 408 | |                     color: secondaryFg,
 409 | |                     letterSpacing: 0.3,
 410 | |                   }}
 411 | |                 >
 412 | |                   {headerSubtitle}
 413 | |                 </RNText>
 414 | |               </Pressable>
 415 | `->           ),
 416 |             }}
     `----
  help: Move this component definition out of the parent component `ThreadRouteScreen` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
     ,-[apps/web/src/components/CommandPalette.tsx:612:15]
 611 |             valuePrefix: "project",
 612 | ,->         icon: (project) => (
 613 | |             <ProjectFavicon
 614 | |               environmentId={project.environmentId}
 615 | |               cwd={project.workspaceRoot}
 616 | |               className={ITEM_ICON_CLASS}
 617 | |             />
 618 | `->         ),
 619 |             runProject: openProjectFromSearch,
     `----
  help: Move this component definition out of the parent component `OpenCommandPaletteDialog` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
     ,-[apps/web/src/components/CommandPalette.tsx:630:15]
 629 |             shortcutCommand: "chat.new",
 630 | ,->         icon: (project) => (
 631 | |             <ProjectFavicon
 632 | |               environmentId={project.environmentId}
 633 | |               cwd={project.workspaceRoot}
 634 | |               className={ITEM_ICON_CLASS}
 635 | |             />
 636 | `->         ),
 637 |             runProject: async (project) => {
     `----
  help: Move this component definition out of the parent component `OpenCommandPaletteDialog` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
     ,-[apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx:911:24]
 910 |               title: "",
 911 | ,->           headerTitle: () => (
 912 | |               <View
 913 | |                 style={{
 914 | |                   alignItems: "center",
 915 | |                   gap: 1,
 916 | |                   maxWidth: 240,
 917 | |                 }}
 918 | |               >
 919 | |                 <RNText
 920 | |                   numberOfLines={1}
 921 | |                   style={{
 922 | |                     color: terminalTheme.foreground,
 923 | |                     fontFamily: "DMSans_700Bold",
 924 | |                     fontSize: MOBILE_TYPOGRAPHY.footnote.fontSize,
 925 | |                     lineHeight: 16,
 926 | |                   }}
 927 | |                 >
 928 | |                   {headerTitle.topLine}
 929 | |                 </RNText>
 930 | |                 <RNText
 931 | |                   ellipsizeMode="middle"
 932 | |                   numberOfLines={1}
 933 | |                   style={{
 934 | |                     color: terminalTheme.mutedForeground,
 935 | |                     fontFamily: "Menlo",
 936 | |                     fontSize: MOBILE_TYPOGRAPHY.caption.fontSize,
 937 | |                     lineHeight: 14,
 938 | |                   }}
 939 | |                 >
 940 | |                   {headerTitle.bottomLine}
 941 | |                 </RNText>
 942 | |               </View>
 943 | `->           ),
 944 |             }}
     `----
  help: Move this component definition out of the parent component `ThreadTerminalRouteScreen` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! react(no-unstable-nested-components): Do not define components during render.
     ,-[apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx:492:24]
 491 |           headerShadowVisible: false,
 492 |           headerTitle: () => <FilesHeaderTitle projectName={projectName} />,
     :                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 493 |           headerSearchBarOptions: {
     `----
  help: Move this component definition out of the parent component `ThreadFilesTreeScreen` and pass data as props. If you want to allow component creation in props, set `allowAsProps` option to true.

  ! t3code(no-inline-schema-compile): Hoist Schema.decodeUnknownResult(...) to module scope: the compiled function is rebuilt on every call. Move it to a module-level const.
     ,-[apps/mobile/src/connection/storage.ts:293:15]
 292 |             const stored = yield* Effect.fromResult(
 293 |               Schema.decodeUnknownResult(StoredShellSnapshot)(parsed),
     :               ^^^^^^^^^^^^^^^^^^^^^^^^^^
 294 |             ).pipe(Effect.mapError((cause) => shellPersistenceError("load-shell", cause)));
     `----

  ! t3code(no-inline-schema-compile): Hoist Schema.decodeUnknownResult(...) to module scope: the compiled function is rebuilt on every call. Move it to a module-level const.
     ,-[apps/mobile/src/connection/storage.ts:313:13]
 312 |           const legacyStored = yield* Effect.fromResult(
 313 |             Schema.decodeUnknownResult(LegacyStoredShellSnapshot)(legacyParsed),
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 314 |           ).pipe(Effect.mapError((cause) => shellPersistenceError("load-shell", cause)));
     `----

  ! t3code(no-inline-schema-compile): Hoist Schema.encodeUnknownResult(...) to module scope: the compiled function is rebuilt on every call. Move it to a module-level const.
     ,-[apps/mobile/src/connection/storage.ts:328:13]
 327 |           const encoded = yield* Effect.fromResult(
 328 |             Schema.encodeUnknownResult(StoredShellSnapshot)(stored),
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 329 |           ).pipe(Effect.mapError((cause) => shellPersistenceError("save-shell", cause)));
     `----

  ! t3code(no-inline-schema-compile): Hoist Schema.decodeUnknownResult(...) to module scope: the compiled function is rebuilt on every call. Move it to a module-level const.
     ,-[apps/mobile/src/connection/storage.ts:355:13]
 354 |           const stored = yield* Effect.fromResult(
 355 |             Schema.decodeUnknownResult(StoredThreadSnapshot)(parsed),
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 356 |           ).pipe(Effect.mapError((cause) => shellPersistenceError("load-thread", cause)));
     `----

  ! t3code(no-inline-schema-compile): Hoist Schema.encodeUnknownResult(...) to module scope: the compiled function is rebuilt on every call. Move it to a module-level const.
     ,-[apps/mobile/src/connection/storage.ts:365:13]
 364 |           const encoded = yield* Effect.fromResult(
 365 |             Schema.encodeUnknownResult(StoredThreadSnapshot)({
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 366 |               schemaVersion: THREAD_SNAPSHOT_CACHE_SCHEMA_VERSION,
     `----

  ! t3code(no-inline-schema-compile): Hoist Schema.decodeUnknownResult(...) to module scope: the compiled function is rebuilt on every call. Move it to a module-level const.
    ,-[apps/mobile/src/connection/catalog-store.ts:31:5]
 30 |   return yield* Effect.fromResult(
 31 |     Schema.decodeUnknownResult(ConnectionCatalogDocument)(parsed),
    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 32 |   ).pipe(Effect.mapError((cause) => catalogError("decode", cause)));
    `----

  ! t3code(no-inline-schema-compile): Hoist Schema.encodeUnknownResult(...) to module scope: the compiled function is rebuilt on every call. Move it to a module-level const.
    ,-[apps/mobile/src/connection/catalog-store.ts:39:5]
 38 |   const encoded = yield* Effect.fromResult(
 39 |     Schema.encodeUnknownResult(ConnectionCatalogDocument)(catalog),
    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^
 40 |   ).pipe(Effect.mapError((cause) => catalogError("encode", cause)));
    `----

Found 0 errors and 20 warnings in 1748 files (978ms, 16 threads)\n-  WARN  Unsupported engine: wanted: {"node":"^24.13.1"} (current: {"node":"v25.8.2","pnpm":"10.24.0"})
~/packages/contracts$ tsgo --noEmit ⊘ cache disabled
~/apps/marketing$ astro check ⊘ cache disabled

~/oxlint-plugin-t3code$ tsgo --noEmit ⊘ cache disabled

~/packages/effect-codex-app-server$ tsgo --noEmit ⊘ cache disabled
08:12:00 [WARN] [vite] warning: `optimizeDeps.esbuildOptions` option was specified by "astro:dev-toolbar" plugin. This option is deprecated, please use `optimizeDeps.rolldownOptions` instead.
08:12:00 [WARN] [vite] You or a plugin you are using have set `optimizeDeps.esbuildOptions` but this option is now deprecated. Vite now uses Rolldown to optimize the dependencies. Please use `optimizeDeps.rolldownOptions` instead.
08:12:00 [types] Generated 39ms
08:12:00 [check] Getting diagnostics for Astro files in /Users/julius/.codex/worktrees/client-cloud-crypto-errors/apps/marketing...
Result (10 files): 
- 0 errors
- 0 warnings
- 0 hints


~/packages/effect-acp$ tsgo --noEmit ⊘ cache disabled

~/packages/shared$ tsgo --noEmit ⊘ cache disabled

~/packages/client-runtime$ tsgo --noEmit ⊘ cache disabled

~/scripts$ tsgo --noEmit ⊘ cache disabled

~/packages/ssh$ tsgo --noEmit ⊘ cache disabled

~/packages/tailscale$ tsgo --noEmit ⊘ cache disabled

~/apps/web$ tsgo --noEmit ⊘ cache disabled

~/apps/mobile$ tsc --noEmit ⊘ cache disabled

~/infra/relay$ tsgo --noEmit ⊘ cache disabled

~/apps/desktop$ tsgo --noEmit ⊘ cache disabled

~/apps/server$ tsgo --noEmit ⊘ cache disabled


---
vp run: 0/15 cache hit (0%). (Run `vp run --last-details` for full details)\n-  WARN  Unsupported engine: wanted: {"node":"^24.13.1"} (current: {"node":"v25.8.2","pnpm":"10.24.0"})
$ node scripts/mobile-native-static-check.ts ⊘ cache disabled
Found 6 Swift and 2 Kotlin native source files.
$ swiftlint lint --config .swiftlint.yml --strict
$ ktlint modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt
$ detekt --config detekt.yml --input modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalModule.kt,modules/t3-terminal/android/src/main/java/expo/modules/t3terminal/T3TerminalView.kt --build-upon-default-config
Skipping generated native project folders: android/, ios/.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth-related DPoP and secure token cache paths; error shape and message text change for any caller matching on strings, though signing/storage behavior is unchanged.
> 
> **Overview**
> Replaces free-form `message` strings on mobile/web **DPoP** and mobile **managed relay token** failures with **Effect Schema** tagged errors that carry a discriminated **`operation`** literal and an optional **`cause`** (`Defect`), plus derived `message` getters.
> 
> On **mobile DPoP**, validation failures now use dedicated types (`DpopPublicKeyFormatError`, `DpopStoredPublicKeyMismatchError`) wrapped as `validate-key` / `derive-public-key` where appropriate; invalid proof URLs fail as `normalize-proof-url` **without** a cause. **Web DPoP** follows the same pattern (including `isBrowserDpopError` for decode chaining).
> 
> **Managed relay token store** errors are structured the same way; load/save/clear logging annotates the full error object and **`operation`** instead of a generic operation string. Tests assert **`operation`** (and causes where relevant) rather than fixed message text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df4f4d70e0f525b489ea50160df7cfd6ab8b272d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure cloud cryptography errors with operation-tagged `Schema.TaggedErrorClass` types
> - Replaces `Data.TaggedError` with `Schema.TaggedErrorClass` for `CloudDpopError`, `BrowserDpopError`, and `ManagedRelayTokenStoreError`, adding an `operation` literal discriminant and optional typed `cause` to each.
> - Each error class now exposes a `message` getter that formats the operation name, and new specific error types (`DpopPublicKeyFormatError`, `DpopStoredPublicKeyMismatchError`) are introduced for granular failure cases.
> - Exports `isBrowserDpopError` and `isManagedRelayTokenStoreError` type guards via `Schema.is`.
> - Log annotations in `managedRelayTokenStore` now include the structured error object and its operation field instead of a freeform string.
> - Behavioral Change: callers that previously matched on error message strings must now inspect the structured `operation` field.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df4f4d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->