### PR TITLE
Remove provider error constructor wrappers

### DIFF
--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -74,18 +74,6 @@ const ProviderRollbackConversationInput = Schema.Struct({
   numTurns: NonNegativeInt,
 });
 
-function toValidationError(
-  operation: string,
-  issue: string,
-  cause?: unknown,
-): ProviderValidationError {
-  return new ProviderValidationError({
-    operation,
-    issue,
-    ...(cause !== undefined ? { cause } : {}),
-  });
-}
-
 const decodeInputOrValidationError = <S extends Schema.Top>(input: {
   readonly operation: string;
   readonly schema: S;
@@ -248,12 +236,12 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     payload.providerInstanceId !== undefined
       ? Effect.succeed(payload.providerInstanceId)
       : Effect.fail(
-          toValidationError(
+          new ProviderValidationError({
             operation,
-            payload.provider
+            issue: payload.provider
               ? `Provider instance id is required for provider '${payload.provider}'.`
               : "Provider instance id is required.",
-          ),
+          }),
         );
 
   const upsertSessionBinding = (
@@ -388,10 +376,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       }
 
       if (!hasResumeCursor) {
-        return yield* toValidationError(
-          input.operation,
-          `Cannot recover thread '${input.binding.threadId}' because no provider resume state is persisted.`,
-        );
+        return yield* new ProviderValidationError({
+          operation: input.operation,
+          issue: `Cannot recover thread '${input.binding.threadId}' because no provider resume state is persisted.`,
+        });
       }
 
       const persistedCwd = readPersistedCwd(input.binding.runtimePayload);
@@ -411,10 +399,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         .pipe(Effect.onError(() => clearMcpSession(input.binding.threadId)));
       if (resumed.provider !== adapter.provider) {
         yield* clearMcpSession(input.binding.threadId);
-        return yield* toValidationError(
-          input.operation,
-          `Adapter/provider mismatch while recovering thread '${input.binding.threadId}'. Expected '${adapter.provider}', received '${resumed.provider}'.`,
-        );
+        return yield* new ProviderValidationError({
+          operation: input.operation,
+          issue: `Adapter/provider mismatch while recovering thread '${input.binding.threadId}'. Expected '${adapter.provider}', received '${resumed.provider}'.`,
+        });
       }
 
       yield* upsertSessionBinding(
@@ -445,10 +433,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
     const bindingOption = yield* directory.getBinding(input.threadId);
     const binding = Option.getOrUndefined(bindingOption);
     if (!binding) {
-      return yield* toValidationError(
-        input.operation,
-        `Cannot route thread '${input.threadId}' because no persisted provider binding exists.`,
-      );
+      return yield* new ProviderValidationError({
+        operation: input.operation,
+        issue: `Cannot route thread '${input.threadId}' because no persisted provider binding exists.`,
+      });
     }
     const instanceId = yield* requireBindingInstanceId(input.operation, binding);
     const adapter = yield* registry.getByInstance(instanceId);
@@ -543,10 +531,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         const resolvedProvider = instanceInfo.driverKind;
         metricProvider = resolvedProvider;
         if (parsed.provider !== undefined && parsed.provider !== resolvedProvider) {
-          return yield* toValidationError(
-            "ProviderService.startSession",
-            `Provider instance '${resolvedInstanceId}' belongs to driver '${resolvedProvider}', not '${parsed.provider}'.`,
-          );
+          return yield* new ProviderValidationError({
+            operation: "ProviderService.startSession",
+            issue: `Provider instance '${resolvedInstanceId}' belongs to driver '${resolvedProvider}', not '${parsed.provider}'.`,
+          });
         }
         const input = {
           ...parsed,
@@ -554,10 +542,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           provider: resolvedProvider,
         };
         if (!instanceInfo.enabled) {
-          return yield* toValidationError(
-            "ProviderService.startSession",
-            `Provider instance '${resolvedInstanceId}' is disabled in T3 Code settings.`,
-          );
+          return yield* new ProviderValidationError({
+            operation: "ProviderService.startSession",
+            issue: `Provider instance '${resolvedInstanceId}' is disabled in T3 Code settings.`,
+          });
         }
         const persistedBinding = Option.getOrUndefined(yield* directory.getBinding(threadId));
         const effectiveResumeCursor =
@@ -602,10 +590,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
 
         if (session.provider !== adapter.provider) {
           yield* clearMcpSession(threadId);
-          return yield* toValidationError(
-            "ProviderService.startSession",
-            `Adapter/provider mismatch: requested '${adapter.provider}', received '${session.provider}'.`,
-          );
+          return yield* new ProviderValidationError({
+            operation: "ProviderService.startSession",
+            issue: `Adapter/provider mismatch: requested '${adapter.provider}', received '${session.provider}'.`,
+          });
         }
         const sessionWithInstance = {
           ...session,
@@ -654,10 +642,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       attachments: parsed.attachments ?? [],
     };
     if (!input.input && input.attachments.length === 0) {
-      return yield* toValidationError(
-        "ProviderService.sendTurn",
-        "Either input text or at least one attachment is required",
-      );
+      return yield* new ProviderValidationError({
+        operation: "ProviderService.sendTurn",
+        issue: "Either input text or at least one attachment is required",
+      });
     }
     yield* Effect.annotateCurrentSpan({
       "provider.operation": "send-turn",

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -15,15 +15,6 @@ import {
 } from "../Services/ProviderSessionDirectory.ts";
 const decodeProviderDriverKindValue = Schema.decodeUnknownEffect(ProviderDriverKind);
 
-function toPersistenceError(operation: string) {
-  return (cause: unknown) =>
-    new ProviderSessionDirectoryPersistenceError({
-      operation,
-      detail: `Failed to execute ${operation}.`,
-      cause,
-    });
-}
-
 function decodeProviderDriverKind(
   providerName: string,
   operation: string,
@@ -88,7 +79,14 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
 
   const getBinding = (threadId: ThreadId) =>
     repository.getByThreadId({ threadId }).pipe(
-      Effect.mapError(toPersistenceError("ProviderSessionDirectory.getBinding:getByThreadId")),
+      Effect.mapError(
+        (cause) =>
+          new ProviderSessionDirectoryPersistenceError({
+            operation: "ProviderSessionDirectory.getBinding:getByThreadId",
+            detail: "Failed to execute ProviderSessionDirectory.getBinding:getByThreadId.",
+            cause,
+          }),
+      ),
       Effect.flatMap((runtime) =>
         Option.match(runtime, {
           onNone: () => Effect.succeed(Option.none<ProviderRuntimeBinding>()),
@@ -101,9 +99,16 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
     );
 
   const upsert: ProviderSessionDirectoryShape["upsert"] = Effect.fn(function* (binding) {
-    const existing = yield* repository
-      .getByThreadId({ threadId: binding.threadId })
-      .pipe(Effect.mapError(toPersistenceError("ProviderSessionDirectory.upsert:getByThreadId")));
+    const existing = yield* repository.getByThreadId({ threadId: binding.threadId }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderSessionDirectoryPersistenceError({
+            operation: "ProviderSessionDirectory.upsert:getByThreadId",
+            detail: "Failed to execute ProviderSessionDirectory.upsert:getByThreadId.",
+            cause,
+          }),
+      ),
+    );
 
     const existingRuntime = Option.getOrUndefined(existing);
     const resolvedThreadId = binding.threadId ?? existingRuntime?.threadId;
@@ -145,7 +150,16 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
           binding.runtimePayload,
         ),
       })
-      .pipe(Effect.mapError(toPersistenceError("ProviderSessionDirectory.upsert:upsert")));
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderSessionDirectoryPersistenceError({
+              operation: "ProviderSessionDirectory.upsert:upsert",
+              detail: "Failed to execute ProviderSessionDirectory.upsert:upsert.",
+              cause,
+            }),
+        ),
+      );
   });
 
   const getProvider: ProviderSessionDirectoryShape["getProvider"] = (threadId) =>
@@ -166,13 +180,27 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
 
   const listThreadIds: ProviderSessionDirectoryShape["listThreadIds"] = () =>
     repository.list().pipe(
-      Effect.mapError(toPersistenceError("ProviderSessionDirectory.listThreadIds:list")),
+      Effect.mapError(
+        (cause) =>
+          new ProviderSessionDirectoryPersistenceError({
+            operation: "ProviderSessionDirectory.listThreadIds:list",
+            detail: "Failed to execute ProviderSessionDirectory.listThreadIds:list.",
+            cause,
+          }),
+      ),
       Effect.map((rows) => rows.map((row) => row.threadId)),
     );
 
   const listBindings: ProviderSessionDirectoryShape["listBindings"] = () =>
     repository.list().pipe(
-      Effect.mapError(toPersistenceError("ProviderSessionDirectory.listBindings:list")),
+      Effect.mapError(
+        (cause) =>
+          new ProviderSessionDirectoryPersistenceError({
+            operation: "ProviderSessionDirectory.listBindings:list",
+            detail: "Failed to execute ProviderSessionDirectory.listBindings:list.",
+            cause,
+          }),
+      ),
       Effect.flatMap((rows) =>
         Effect.forEach(
           rows,
@@ -195,7 +223,3 @@ export const ProviderSessionDirectoryLive = Layer.effect(
   ProviderSessionDirectory,
   makeProviderSessionDirectory,
 );
-
-export function makeProviderSessionDirectoryLive() {
-  return Layer.effect(ProviderSessionDirectory, makeProviderSessionDirectory);
-}


### PR DESCRIPTION
Removes valueless provider error constructor wrappers so each failure site shows its structured operation, diagnostic detail, and cause directly. Also removes the unused ProviderSessionDirectory layer factory that duplicated the exported layer.

Validation:
- vp test apps/server/src/provider/Layers/ProviderSessionDirectory.test.ts apps/server/src/provider/Layers/ProviderService.test.ts
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with no behavior change; error messages and structure stay the same at each call site.
> 
> **Overview**
> Removes thin `toValidationError` and `toPersistenceError` helpers in the provider layer and constructs `ProviderValidationError` / `ProviderSessionDirectoryPersistenceError` at each failure site with explicit `operation`, `issue`/`detail`, and `cause` where applicable.
> 
> Also deletes the unused `makeProviderSessionDirectoryLive` factory that duplicated `ProviderSessionDirectoryLive`; wiring continues to use the exported layer only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aaafc61b666095206de6200fbb6a3128ca7615b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove error constructor wrapper functions from provider layers
> Replaces `toValidationError` in [`ProviderService.ts`](https://github.com/pingdotgg/t3code/pull/3396/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775) and `toPersistenceError` in [`ProviderSessionDirectory.ts`](https://github.com/pingdotgg/t3code/pull/3396/files#diff-0ca581a6030196f89d4a3b84a4699e4eb24dd0d70432ebcd642b6b1ca88851ab) with direct construction of their respective error types at each call site.
>
> - All error creation in `makeProviderService` and `resolveRoutableSession` now instantiates `ProviderValidationError` directly with inline arguments.
> - All `Effect.mapError(toPersistenceError(...))` usages in `makeProviderSessionDirectory` are replaced with inline `ProviderSessionDirectoryPersistenceError` construction.
> - The exported `makeProviderSessionDirectoryLive` function is removed; callers must use the `ProviderSessionDirectoryLive` constant instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1aaafc6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->