### PR TITLE
[codex] Structure mobile file rendering errors

### DIFF
--- a/apps/mobile/src/features/files/sourceHighlightingState.test.ts
+++ b/apps/mobile/src/features/files/sourceHighlightingState.test.ts
@@ -1,9 +1,12 @@
+import * as Cause from "effect/Cause";
+import * as Option from "effect/Option";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
 import {
   createSourceHighlightAtomFamily,
+  isSourceHighlightError,
   type SourceHighlightTokens,
 } from "./sourceHighlightingState";
 
@@ -101,8 +104,9 @@ describe("sourceHighlightingState", () => {
   });
 
   it("exposes highlighter errors as a failed async result", async () => {
+    const cause = new Error("highlight failed");
     const highlight = vi.fn(async () => {
-      throw new Error("highlight failed");
+      throw cause;
     });
     const sourceHighlightAtom = createSourceHighlightAtomFamily({ highlight });
     const registry = AtomRegistry.make();
@@ -113,8 +117,17 @@ describe("sourceHighlightingState", () => {
     });
     const unmount = registry.mount(atom);
 
-    await vi.waitFor(() => {
-      expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
+    await vi.waitFor(() => expect(AsyncResult.isFailure(registry.get(atom))).toBe(true));
+    const result = registry.get(atom);
+    const error = AsyncResult.isFailure(result)
+      ? Option.getOrUndefined(Cause.findErrorOption(result.cause))
+      : undefined;
+
+    expect(isSourceHighlightError(error)).toBe(true);
+    expect(error).toMatchObject({
+      path: "src/example.ts",
+      theme: "light",
+      cause,
     });
 
     unmount();

--- a/apps/mobile/src/features/files/sourceHighlightingState.ts
+++ b/apps/mobile/src/features/files/sourceHighlightingState.ts
@@ -1,5 +1,6 @@
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { Atom } from "effect/unstable/reactivity";
 
 import {
@@ -22,9 +23,20 @@ type SourceHighlighter = (input: SourceHighlightInput) => Promise<SourceHighligh
 
 class SourceHighlightCacheKey extends Data.Class<SourceHighlightInput> {}
 
-class SourceHighlightError extends Data.TaggedError("SourceHighlightError")<{
-  readonly cause: unknown;
-}> {}
+export class SourceHighlightError extends Schema.TaggedErrorClass<SourceHighlightError>()(
+  "SourceHighlightError",
+  {
+    path: Schema.String,
+    theme: Schema.Literals(["light", "dark"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to highlight ${this.path} with the ${this.theme} theme.`;
+  }
+}
+
+export const isSourceHighlightError = Schema.is(SourceHighlightError);
 
 export function createSourceHighlightAtomFamily(options?: {
   readonly highlight?: SourceHighlighter;
@@ -36,7 +48,8 @@ export function createSourceHighlightAtomFamily(options?: {
     Atom.make(
       Effect.tryPromise({
         try: () => highlight(request),
-        catch: (cause) => new SourceHighlightError({ cause }),
+        catch: (cause) =>
+          new SourceHighlightError({ path: request.path, theme: request.theme, cause }),
       }),
     ).pipe(
       Atom.setIdleTTL(idleTtlMs),

--- a/apps/mobile/src/features/files/workspace-file-image-cache.test.ts
+++ b/apps/mobile/src/features/files/workspace-file-image-cache.test.ts
@@ -53,7 +53,27 @@ describe("workspaceFileImageAtom", () => {
     registry.dispose();
   });
 
-  it("exposes prefetch failures", async () => {
+  it("exposes a false native prefetch result", async () => {
+    const imageAtom = createWorkspaceFileImageAtomFamily({ prefetch: async () => false });
+    const registry = AtomRegistry.make();
+    const atom = imageAtom("https://example.test/missing.png");
+    const unmount = registry.mount(atom);
+
+    await vi.waitFor(() => expect(AsyncResult.isFailure(registry.get(atom))).toBe(true));
+    const result = registry.get(atom);
+    const error = AsyncResult.isFailure(result)
+      ? Option.getOrUndefined(Cause.findErrorOption(result.cause))
+      : undefined;
+
+    expect(isWorkspaceImagePrefetchError(error)).toBe(true);
+    expect(error).toMatchObject({ uri: "https://example.test/missing.png" });
+    expect(error).not.toHaveProperty("cause");
+
+    unmount();
+    registry.dispose();
+  });
+
+  it("preserves thrown prefetch causes", async () => {
     const cause = new Error("native image prefetch failed");
     const imageAtom = createWorkspaceFileImageAtomFamily({
       prefetch: async () => {

--- a/apps/mobile/src/features/files/workspace-file-image-cache.test.ts
+++ b/apps/mobile/src/features/files/workspace-file-image-cache.test.ts
@@ -1,8 +1,13 @@
+import * as Cause from "effect/Cause";
+import * as Option from "effect/Option";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { describe, expect, it, vi } from "vite-plus/test";
 
-import { createWorkspaceFileImageAtomFamily } from "./workspace-file-image-cache";
+import {
+  createWorkspaceFileImageAtomFamily,
+  isWorkspaceImagePrefetchError,
+} from "./workspace-file-image-cache";
 
 describe("workspaceFileImageAtom", () => {
   it("reuses a prefetched image across route remounts", async () => {
@@ -49,13 +54,26 @@ describe("workspaceFileImageAtom", () => {
   });
 
   it("exposes prefetch failures", async () => {
-    const imageAtom = createWorkspaceFileImageAtomFamily({ prefetch: async () => false });
+    const cause = new Error("native image prefetch failed");
+    const imageAtom = createWorkspaceFileImageAtomFamily({
+      prefetch: async () => {
+        throw cause;
+      },
+    });
     const registry = AtomRegistry.make();
     const atom = imageAtom("https://example.test/missing.png");
     const unmount = registry.mount(atom);
 
-    await vi.waitFor(() => {
-      expect(AsyncResult.isFailure(registry.get(atom))).toBe(true);
+    await vi.waitFor(() => expect(AsyncResult.isFailure(registry.get(atom))).toBe(true));
+    const result = registry.get(atom);
+    const error = AsyncResult.isFailure(result)
+      ? Option.getOrUndefined(Cause.findErrorOption(result.cause))
+      : undefined;
+
+    expect(isWorkspaceImagePrefetchError(error)).toBe(true);
+    expect(error).toMatchObject({
+      uri: "https://example.test/missing.png",
+      cause,
     });
 
     unmount();

--- a/apps/mobile/src/features/files/workspace-file-image-cache.ts
+++ b/apps/mobile/src/features/files/workspace-file-image-cache.ts
@@ -1,5 +1,6 @@
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { Atom } from "effect/unstable/reactivity";
 
 const WORKSPACE_IMAGE_IDLE_TTL_MS = 30 * 60_000;
@@ -8,10 +9,19 @@ type ImagePrefetch = (uri: string) => Promise<boolean>;
 
 class WorkspaceImageCacheKey extends Data.Class<{ readonly uri: string }> {}
 
-export class WorkspaceImagePrefetchError extends Data.TaggedError("WorkspaceImagePrefetchError")<{
-  readonly cause?: unknown;
-  readonly uri: string;
-}> {}
+export class WorkspaceImagePrefetchError extends Schema.TaggedErrorClass<WorkspaceImagePrefetchError>()(
+  "WorkspaceImagePrefetchError",
+  {
+    uri: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Failed to prefetch workspace image ${this.uri}.`;
+  }
+}
+
+export const isWorkspaceImagePrefetchError = Schema.is(WorkspaceImagePrefetchError);
 
 async function prefetchWithNativeImage(uri: string): Promise<boolean> {
   const { Image } = await import("react-native");
@@ -35,7 +45,7 @@ export function createWorkspaceFileImageAtomFamily(options?: {
           return key.uri;
         },
         catch: (cause) =>
-          cause instanceof WorkspaceImagePrefetchError
+          isWorkspaceImagePrefetchError(cause)
             ? cause
             : new WorkspaceImagePrefetchError({ uri: key.uri, cause }),
       }),


### PR DESCRIPTION
## Summary\n\n- convert mobile source-highlighting and image-prefetch failures to Schema errors\n- attach source path/theme context without retaining file contents\n- preserve exact native highlighter and image-prefetch causes\n- replace schema-error instanceof checks with exported Schema.is predicates\n\n## Validation\n\n- pnpm vp test apps/mobile/src/features/files/sourceHighlightingState.test.ts apps/mobile/src/features/files/workspace-file-image-cache.test.ts\n- pnpm vp check\n- pnpm vp run typecheck\n- pnpm vp run lint:mobile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of error types and catch handling in two mobile file-rendering caches, with expanded unit tests and no auth or data-path changes.
> 
> **Overview**
> Mobile **source highlighting** and **workspace image prefetch** failures now use **`Schema.TaggedErrorClass`** instead of `Data.TaggedError`, with validated fields and user-facing `message` getters.
> 
> **`SourceHighlightError`** carries `path`, `theme`, and `cause` (file contents are not stored on the error). **`WorkspaceImagePrefetchError`** carries `uri` and an optional `cause`; a `false` prefetch result still fails with uri only. Catch paths use exported **`Schema.is`** guards (`isSourceHighlightError`, `isWorkspaceImagePrefetchError`) instead of `instanceof`.
> 
> Tests assert the structured error shape via **`Cause.findErrorOption`**, including separate cases for boolean prefetch failure vs thrown native errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cb9811e93380fe5489e3dc0d4d89582fb5f6cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure mobile file rendering errors with typed `SourceHighlightError` and `WorkspaceImagePrefetchError`
> - Replaces `Data.TaggedError` with `Schema.TaggedErrorClass` for `SourceHighlightError` and `WorkspaceImagePrefetchError`, adding structured fields (path, theme, uri) and an optional defect cause to each.
> - Exports `isSourceHighlightError` and `isWorkspaceImagePrefetchError` type guards via `Schema.is` to replace `instanceof` checks.
> - Error messages now include contextual metadata (path/theme for highlight errors, uri for image prefetch errors).
> - Tests are updated to extract failures via `Cause.findErrorOption` and assert error shape and preserved cause using the new type guards.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1cb9811.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->