### PR TITLE
Remove persistence error constructor wrappers

### DIFF
--- a/apps/server/src/persistence/AuthPairingLinks.ts
+++ b/apps/server/src/persistence/AuthPairingLinks.ts
@@ -10,8 +10,8 @@ import { AuthEnvironmentScopes } from "@t3tools/contracts";
 
 import {
   type AuthPairingLinkRepositoryError,
-  toPersistenceDecodeError,
-  toPersistenceSqlError,
+  PersistenceDecodeError,
+  PersistenceSqlError,
 } from "./Errors.ts";
 
 export const AuthPairingLinkRecord = Schema.Struct({
@@ -90,8 +90,8 @@ export class AuthPairingLinkRepository extends Context.Service<
 function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: string) {
   return (cause: unknown): AuthPairingLinkRepositoryError =>
     Schema.isSchemaError(cause)
-      ? toPersistenceDecodeError(decodeOperation)(cause)
-      : toPersistenceSqlError(sqlOperation)(cause);
+      ? PersistenceDecodeError.fromSchemaError(decodeOperation, cause)
+      : new PersistenceSqlError({ operation: sqlOperation, cause });
 }
 
 export const make = Effect.gen(function* () {

--- a/apps/server/src/persistence/AuthSessions.ts
+++ b/apps/server/src/persistence/AuthSessions.ts
@@ -15,8 +15,8 @@ import {
 
 import {
   type AuthSessionRepositoryError,
-  toPersistenceDecodeError,
-  toPersistenceSqlError,
+  PersistenceDecodeError,
+  PersistenceSqlError,
 } from "./Errors.ts";
 
 export const AuthSessionClientMetadataRecord = Schema.Struct({
@@ -146,8 +146,8 @@ function toAuthSessionRecord(row: typeof AuthSessionDbRow.Type): AuthSessionReco
 function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: string) {
   return (cause: unknown): AuthSessionRepositoryError =>
     Schema.isSchemaError(cause)
-      ? toPersistenceDecodeError(decodeOperation)(cause)
-      : toPersistenceSqlError(sqlOperation)(cause);
+      ? PersistenceDecodeError.fromSchemaError(decodeOperation, cause)
+      : new PersistenceSqlError({ operation: sqlOperation, cause });
 }
 
 export const make = Effect.gen(function* () {

--- a/apps/server/src/persistence/Errors.test.ts
+++ b/apps/server/src/persistence/Errors.test.ts
@@ -4,7 +4,13 @@ import * as Schema from "effect/Schema";
 
 import { PersistenceDecodeError, PersistenceSqlError } from "./Errors.ts";
 
-const decodeString = Schema.decodeUnknownEffect(Schema.String);
+const decodeRuntimePayload = Schema.decodeUnknownEffect(
+  Schema.Struct({
+    runtimePayload: Schema.Struct({
+      attempt: Schema.Number,
+    }),
+  }),
+);
 
 it("keeps SQL operation context without a tautological detail", () => {
   const cause = new Error("database unavailable");
@@ -19,9 +25,16 @@ it("keeps SQL operation context without a tautological detail", () => {
   assert.equal(error.message, "SQL error in AuthSessionRepository.list:query");
 });
 
-it.effect("maps schema errors with their formatted issue and exact cause", () =>
+it.effect("maps schema errors without copying rejected payloads into diagnostics", () =>
   Effect.gen(function* () {
-    const cause = yield* Effect.flip(decodeString(42));
+    const rejectedPayload = "runtime-payload-secret-sentinel";
+    const cause = yield* Effect.flip(
+      decodeRuntimePayload({
+        runtimePayload: {
+          attempt: rejectedPayload,
+        },
+      }),
+    );
     const error = PersistenceDecodeError.fromSchemaError(
       "ProviderSessionRuntimeRepository.list:decodeRows",
       cause,
@@ -29,6 +42,8 @@ it.effect("maps schema errors with their formatted issue and exact cause", () =>
 
     assert.equal(error.operation, "ProviderSessionRuntimeRepository.list:decodeRows");
     assert.equal(error.cause, cause);
-    assert.include(error.issue, "Expected string");
+    assert.notInclude(error.issue, rejectedPayload);
+    assert.notInclude(error.message, rejectedPayload);
+    assert.include(error.issue, "InvalidType");
   }),
 );

--- a/apps/server/src/persistence/Errors.test.ts
+++ b/apps/server/src/persistence/Errors.test.ts
@@ -1,0 +1,34 @@
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import { PersistenceDecodeError, PersistenceSqlError } from "./Errors.ts";
+
+const decodeString = Schema.decodeUnknownEffect(Schema.String);
+
+it("keeps SQL operation context without a tautological detail", () => {
+  const cause = new Error("database unavailable");
+  const error = new PersistenceSqlError({
+    operation: "AuthSessionRepository.list:query",
+    cause,
+  });
+
+  assert.equal(error.operation, "AuthSessionRepository.list:query");
+  assert.equal(error.detail, undefined);
+  assert.equal(error.cause, cause);
+  assert.equal(error.message, "SQL error in AuthSessionRepository.list:query");
+});
+
+it.effect("maps schema errors with their formatted issue and exact cause", () =>
+  Effect.gen(function* () {
+    const cause = yield* Effect.flip(decodeString(42));
+    const error = PersistenceDecodeError.fromSchemaError(
+      "ProviderSessionRuntimeRepository.list:decodeRows",
+      cause,
+    );
+
+    assert.equal(error.operation, "ProviderSessionRuntimeRepository.list:decodeRows");
+    assert.equal(error.cause, cause);
+    assert.include(error.issue, "Expected string");
+  }),
+);

--- a/apps/server/src/persistence/Errors.ts
+++ b/apps/server/src/persistence/Errors.ts
@@ -1,7 +1,19 @@
 import * as Schema from "effect/Schema";
 import * as SchemaIssue from "effect/SchemaIssue";
 
-const formatSchemaIssue = SchemaIssue.makeFormatterDefault();
+function summarizeSchemaIssue(issue: SchemaIssue.Issue): string {
+  switch (issue._tag) {
+    case "Filter":
+    case "Encoding":
+    case "Pointer":
+      return `${issue._tag}(${summarizeSchemaIssue(issue.issue)})`;
+    case "Composite":
+    case "AnyOf":
+      return `${issue._tag}(${issue.issues.map(summarizeSchemaIssue).join(",")})`;
+    default:
+      return issue._tag;
+  }
+}
 
 // ===============================
 // Core Persistence Errors
@@ -33,7 +45,7 @@ export class PersistenceDecodeError extends Schema.TaggedErrorClass<PersistenceD
   static fromSchemaError(operation: string, cause: Schema.SchemaError): PersistenceDecodeError {
     return new PersistenceDecodeError({
       operation,
-      issue: formatSchemaIssue(cause.issue),
+      issue: summarizeSchemaIssue(cause.issue),
       cause,
     });
   }

--- a/apps/server/src/persistence/Errors.ts
+++ b/apps/server/src/persistence/Errors.ts
@@ -1,6 +1,8 @@
 import * as Schema from "effect/Schema";
 import * as SchemaIssue from "effect/SchemaIssue";
 
+const formatSchemaIssue = SchemaIssue.makeFormatterDefault();
+
 // ===============================
 // Core Persistence Errors
 // ===============================
@@ -9,12 +11,14 @@ export class PersistenceSqlError extends Schema.TaggedErrorClass<PersistenceSqlE
   "PersistenceSqlError",
   {
     operation: Schema.String,
-    detail: Schema.String,
+    detail: Schema.optional(Schema.String),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return `SQL error in ${this.operation}: ${this.detail}`;
+    return this.detail === undefined
+      ? `SQL error in ${this.operation}`
+      : `SQL error in ${this.operation}: ${this.detail}`;
   }
 }
 
@@ -26,6 +30,14 @@ export class PersistenceDecodeError extends Schema.TaggedErrorClass<PersistenceD
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
+  static fromSchemaError(operation: string, cause: Schema.SchemaError): PersistenceDecodeError {
+    return new PersistenceDecodeError({
+      operation,
+      issue: formatSchemaIssue(cause.issue),
+      cause,
+    });
+  }
+
   override get message(): string {
     return `Decode error in ${this.operation}: ${this.issue}`;
   }
@@ -33,6 +45,7 @@ export class PersistenceDecodeError extends Schema.TaggedErrorClass<PersistenceD
 const isPersistenceSqlError = Schema.is(PersistenceSqlError);
 const isPersistenceDecodeError = Schema.is(PersistenceDecodeError);
 
+// Kept for orchestration/projection call sites, which are being revamped separately.
 export function toPersistenceSqlError(operation: string) {
   return (cause: unknown): PersistenceSqlError =>
     new PersistenceSqlError({
@@ -42,22 +55,10 @@ export function toPersistenceSqlError(operation: string) {
     });
 }
 
+// Kept for orchestration/projection call sites, which are being revamped separately.
 export function toPersistenceDecodeError(operation: string) {
-  return (error: Schema.SchemaError): PersistenceDecodeError =>
-    new PersistenceDecodeError({
-      operation,
-      issue: SchemaIssue.makeFormatterDefault()(error.issue),
-      cause: error,
-    });
-}
-
-export function toPersistenceDecodeCauseError(operation: string) {
-  return (cause: unknown): PersistenceDecodeError =>
-    new PersistenceDecodeError({
-      operation,
-      issue: `Failed to execute ${operation}`,
-      cause,
-    });
+  return (cause: Schema.SchemaError): PersistenceDecodeError =>
+    PersistenceDecodeError.fromSchemaError(operation, cause);
 }
 
 export const isPersistenceError = (u: unknown) =>

--- a/apps/server/src/persistence/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/ProviderSessionRuntime.ts
@@ -16,9 +16,9 @@ import {
 } from "@t3tools/contracts";
 
 import {
+  PersistenceDecodeError,
+  PersistenceSqlError,
   type ProviderSessionRuntimeRepositoryError,
-  toPersistenceDecodeError,
-  toPersistenceSqlError,
 } from "./Errors.ts";
 
 /**
@@ -117,8 +117,8 @@ const DeleteRuntimeRequestSchema = GetRuntimeRequestSchema;
 function toPersistenceSqlOrDecodeError(sqlOperation: string, decodeOperation: string) {
   return (cause: unknown): ProviderSessionRuntimeRepositoryError =>
     Schema.isSchemaError(cause)
-      ? toPersistenceDecodeError(decodeOperation)(cause)
-      : toPersistenceSqlError(sqlOperation)(cause);
+      ? PersistenceDecodeError.fromSchemaError(decodeOperation, cause)
+      : new PersistenceSqlError({ operation: sqlOperation, cause });
 }
 
 export const make = Effect.gen(function* () {
@@ -235,9 +235,10 @@ export const make = Effect.gen(function* () {
           onNone: () => Effect.succeed(Option.none()),
           onSome: (row) =>
             decodeRuntime(row).pipe(
-              Effect.mapError(
-                toPersistenceDecodeError(
+              Effect.mapError((cause) =>
+                PersistenceDecodeError.fromSchemaError(
                   "ProviderSessionRuntimeRepository.getByThreadId:rowToRuntime",
+                  cause,
                 ),
               ),
               Effect.map((runtime) => Option.some(runtime)),
@@ -259,8 +260,11 @@ export const make = Effect.gen(function* () {
           rows,
           (row) =>
             decodeRuntime(row).pipe(
-              Effect.mapError(
-                toPersistenceDecodeError("ProviderSessionRuntimeRepository.list:rowToRuntime"),
+              Effect.mapError((cause) =>
+                PersistenceDecodeError.fromSchemaError(
+                  "ProviderSessionRuntimeRepository.list:rowToRuntime",
+                  cause,
+                ),
               ),
             ),
           { concurrency: "unbounded" },
@@ -273,7 +277,11 @@ export const make = Effect.gen(function* () {
   ) =>
     deleteRuntimeByThreadId(input).pipe(
       Effect.mapError(
-        toPersistenceSqlError("ProviderSessionRuntimeRepository.deleteByThreadId:query"),
+        (cause) =>
+          new PersistenceSqlError({
+            operation: "ProviderSessionRuntimeRepository.deleteByThreadId:query",
+            cause,
+          }),
       ),
     );
 


### PR DESCRIPTION
Removes the valueless persistence error constructor wrappers and constructs SQL errors directly where operation and cause are known. Generic duplicated detail text is dropped; specific detail remains supported. SchemaError conversion moves to the valueful PersistenceDecodeError.fromSchemaError mapper.

Validation:
- vp test persistence Errors, projection repositories, event store, and orchestration engine suites (19 tests)
- vp test server and SessionStore suites (104 tests)
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized persistence error construction and logging shape changes; no auth or data-path logic changes, with tests covering message and diagnostic behavior.
> 
> **Overview**
> Persistence repositories now build **`PersistenceSqlError`** and **`PersistenceDecodeError`** directly instead of going through thin `toPersistence*` wrappers. **`PersistenceSqlError.detail`** is optional, so messages like `SQL error in <operation>` no longer append a generic “Failed to execute …” suffix when only operation and cause are known.
> 
> Schema failures are mapped via **`PersistenceDecodeError.fromSchemaError()`**, which summarizes issues with a small **`summarizeSchemaIssue`** helper (issue tags only) rather than the full default formatter—so rejected row/payload values are not copied into **`issue`** or **`message`**. **`toPersistenceDecodeCauseError`** is removed; legacy **`toPersistenceSqlError`** / **`toPersistenceDecodeError`** remain for orchestration/projection call sites. New tests lock in SQL message shape and decode diagnostics that exclude sensitive rejected data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd36e2698dea15da20050d6b200784f09fcd2390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove persistence error constructor wrapper functions in favor of direct error instantiation
> - Replaces `toPersistenceDecodeError` and `toPersistenceSqlError` helper calls with direct construction via `PersistenceDecodeError.fromSchemaError(operation, cause)` and `new PersistenceSqlError({ operation, cause })` across persistence repositories.
> - Adds `summarizeSchemaIssue` in [Errors.ts](https://github.com/pingdotgg/t3code/pull/3398/files#diff-a49007546447945afb00362617c4fe342b8a0113ab70f400117cb1fe2c48ed61) to produce compact issue strings from `SchemaIssue.Issue`, avoiding rejected payload values leaking into error diagnostics.
> - Makes `PersistenceSqlError.detail` optional; messages now read `'SQL error in <operation>'` when no detail is provided (previously always included a detail string).
> - Behavioral Change: decode error messages now use summarized issue strings instead of the full `SchemaIssue` formatter output; SQL errors constructed via the new path omit the `'Failed to execute <operation>'` detail string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd36e26.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->