### PR TITLE
[codex] Structure desktop local auth failures

### DIFF
--- a/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.test.ts
+++ b/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, it } from "@effect/vitest";
+import { RemoteEnvironmentAuthInvalidJsonError } from "@t3tools/client-runtime/authorization";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -28,12 +29,29 @@ const config: DesktopBackendManager.DesktopBackendStartConfig = {
   captureOutput: true,
 };
 
+const managerLayer = Layer.succeed(DesktopBackendManager.DesktopBackendManager, {
+  start: Effect.void,
+  stop: () => Effect.void,
+  currentConfig: Effect.succeed(Option.some(config)),
+  snapshot: Effect.succeed({
+    desiredRunning: true,
+    ready: true,
+    activePid: Option.none(),
+    restartAttempt: 0,
+    restartScheduled: false,
+  }),
+});
+
+const testLayer = (httpClient: HttpClient.HttpClient) =>
+  DesktopLocalEnvironmentAuth.layer.pipe(
+    Layer.provide(Layer.mergeAll(managerLayer, Layer.succeed(HttpClient.HttpClient, httpClient))),
+  );
+
 describe("DesktopLocalEnvironmentAuth", () => {
   it.effect("exchanges the desktop bootstrap credential only once", () =>
     Effect.gen(function* () {
       const requestCount = yield* Ref.make(0);
-      const httpClientLayer = Layer.succeed(
-        HttpClient.HttpClient,
+      const layer = testLayer(
         HttpClient.make((request) =>
           Ref.update(requestCount, (count) => count + 1).pipe(
             Effect.as(
@@ -54,30 +72,41 @@ describe("DesktopLocalEnvironmentAuth", () => {
           ),
         ),
       );
-      const managerLayer = Layer.succeed(DesktopBackendManager.DesktopBackendManager, {
-        start: Effect.void,
-        stop: () => Effect.void,
-        currentConfig: Effect.succeed(Option.some(config)),
-        snapshot: Effect.succeed({
-          desiredRunning: true,
-          ready: true,
-          activePid: Option.none(),
-          restartAttempt: 0,
-          restartScheduled: false,
-        }),
-      });
-      const testLayer = DesktopLocalEnvironmentAuth.layer.pipe(
-        Layer.provide(Layer.mergeAll(managerLayer, httpClientLayer)),
-      );
 
       const [first, second] = yield* Effect.gen(function* () {
         const auth = yield* DesktopLocalEnvironmentAuth.DesktopLocalEnvironmentAuth;
         return yield* Effect.all([auth.getBearerToken, auth.getBearerToken]);
-      }).pipe(Effect.provide(testLayer));
+      }).pipe(Effect.provide(layer));
 
       assert.strictEqual(first, "desktop-bearer-token");
       assert.strictEqual(second, "desktop-bearer-token");
       assert.strictEqual(yield* Ref.get(requestCount), 1);
+    }),
+  );
+
+  it.effect("preserves the backend origin and bootstrap failure cause", () =>
+    Effect.gen(function* () {
+      const layer = testLayer(
+        HttpClient.make((request) =>
+          Effect.succeed(HttpClientResponse.fromWeb(request, Response.json({ unexpected: true }))),
+        ),
+      );
+
+      const error = yield* Effect.gen(function* () {
+        const auth = yield* DesktopLocalEnvironmentAuth.DesktopLocalEnvironmentAuth;
+        return yield* auth.getBearerToken;
+      }).pipe(Effect.provide(layer), Effect.flip);
+
+      assert.instanceOf(
+        error,
+        DesktopLocalEnvironmentAuth.DesktopLocalEnvironmentAuthSessionBootstrapError,
+      );
+      assert.strictEqual(error.backendOrigin, "http://127.0.0.1:3773");
+      assert.strictEqual(
+        error.message,
+        "Failed to create the local desktop bearer session for http://127.0.0.1:3773.",
+      );
+      assert.instanceOf(error.cause, RemoteEnvironmentAuthInvalidJsonError);
     }),
   );
 });

--- a/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.ts
+++ b/apps/desktop/src/backend/DesktopLocalEnvironmentAuth.ts
@@ -21,10 +21,13 @@ export class DesktopLocalEnvironmentAuthBackendNotConfiguredError extends Schema
 
 export class DesktopLocalEnvironmentAuthSessionBootstrapError extends Schema.TaggedErrorClass<DesktopLocalEnvironmentAuthSessionBootstrapError>()(
   "DesktopLocalEnvironmentAuthSessionBootstrapError",
-  { cause: Schema.Defect() },
+  {
+    backendOrigin: Schema.String,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to create the local desktop bearer session.";
+    return `Failed to create the local desktop bearer session for ${this.backendOrigin}.`;
   }
 }
 
@@ -60,6 +63,7 @@ export const make = Effect.gen(function* () {
           return yield* new DesktopLocalEnvironmentAuthBackendNotConfiguredError();
         }
         const config = configOption.value;
+        const backendOrigin = config.httpBaseUrl.origin;
         const session = yield* bootstrapRemoteBearerSession({
           httpBaseUrl: config.httpBaseUrl.href,
           credential: config.bootstrap.desktopBootstrapToken,
@@ -72,6 +76,7 @@ export const make = Effect.gen(function* () {
           Effect.mapError(
             (cause) =>
               new DesktopLocalEnvironmentAuthSessionBootstrapError({
+                backendOrigin,
                 cause,
               }),
           ),


### PR DESCRIPTION
## Summary

Desktop local bearer-session bootstrap failures previously identified only the operation and the nested cause. When multiple desktop backends or ports are involved, that leaves logs without the endpoint needed to correlate the failure.

This change records the sanitized backend origin on `DesktopLocalEnvironmentAuthSessionBootstrapError` and derives its message from that structured field. It continues forwarding the exact `RemoteEnvironmentAuthError` as `cause`, so the complete failure chain and stack remain available without embedding cause text into the public message.

The focused failure-path test now verifies both the backend origin and the concrete nested invalid-response error. Shared test layer setup keeps the coverage small and avoids duplicating service scaffolding.

## Validation

- `vp test apps/desktop/src/backend/DesktopLocalEnvironmentAuth.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to error shape and messages; bootstrap and caching behavior are unchanged.
> 
> **Overview**
> **Desktop local bearer bootstrap failures** now carry a **`backendOrigin`** field on `DesktopLocalEnvironmentAuthSessionBootstrapError`, populated from `config.httpBaseUrl.origin` when token exchange fails. The public error message includes that origin so logs can distinguish backends/ports; the nested **`RemoteEnvironmentAuthError`** is still exposed unchanged as **`cause`**.
> 
> Tests hoist shared **`managerLayer`** / **`testLayer`** setup and add a failure-path case that asserts origin, message text, and a concrete **`RemoteEnvironmentAuthInvalidJsonError`** cause.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9878545ccb7e6618d131f565f5ccd37dec7a0b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `backendOrigin` field to `DesktopLocalEnvironmentAuthSessionBootstrapError`
> Extends `DesktopLocalEnvironmentAuthSessionBootstrapError` in [`DesktopLocalEnvironmentAuth.ts`](https://github.com/pingdotgg/t3code/pull/3401/files#diff-56b085d163dfd1df193fa070e0d181923c56370508e50e75751aea1bb7c9807b) to include a `backendOrigin` string field derived from `config.httpBaseUrl.origin`, and updates the error message to include that origin. Adds a test asserting that bootstrap failures carry the correct `backendOrigin` and a `cause` of type `RemoteEnvironmentAuthInvalidJsonError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9878545.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->