### PR TITLE
[codex] Structure OTLP export diagnostics

### DIFF
--- a/apps/server/src/http.test.ts
+++ b/apps/server/src/http.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vite-plus/test";
 
-import { isLoopbackHostname, resolveDevRedirectUrl } from "./http.ts";
+import {
+  BrowserOtlpTraceCollectionError,
+  BrowserOtlpTraceDecodeError,
+  BrowserOtlpTraceExportError,
+  isLoopbackHostname,
+  resolveDevRedirectUrl,
+} from "./http.ts";
 
 describe("http dev routing", () => {
   it("treats localhost and loopback addresses as local", () => {
@@ -23,5 +29,75 @@ describe("http dev routing", () => {
     expect(resolveDevRedirectUrl(devUrl, requestUrl)).toBe(
       "http://127.0.0.1:5173/pair?token=test-token",
     );
+  });
+});
+
+describe("browser OTLP diagnostics", () => {
+  it("retains decode causes without retaining the trace payload", () => {
+    const cause = new Error("private trace payload detail");
+    const error = BrowserOtlpTraceDecodeError.fromPayload({ resourceSpans: [] }, cause);
+
+    expect(error).toMatchObject({
+      resourceSpanCount: 0,
+      cause,
+      message: "Failed to decode browser OTLP payload with 0 resource spans.",
+    });
+    expect(error.cause).toBe(cause);
+    expect(error).not.toHaveProperty("bodyJson");
+  });
+
+  it("describes malformed trace payloads without inspecting unsafe fields", () => {
+    const cause = new Error("private malformed trace payload detail");
+    const error = BrowserOtlpTraceDecodeError.fromPayload(
+      { resourceSpans: "private malformed resource spans" },
+      cause,
+    );
+
+    expect(error).toMatchObject({
+      resourceSpanCount: 0,
+      cause,
+      message: "Failed to decode browser OTLP payload with 0 resource spans.",
+    });
+    expect(error.cause).toBe(cause);
+    expect(error).not.toHaveProperty("resourceSpans");
+  });
+
+  it("retains local collection causes with a structural record count", () => {
+    const records = [{ type: "private trace record" }];
+    const cause = new Error("private local collector detail");
+    const error = BrowserOtlpTraceCollectionError.fromRecords(records, cause);
+
+    expect(error).toMatchObject({
+      recordCount: 1,
+      cause,
+      message: "Failed to collect 1 browser OTLP trace records locally.",
+    });
+    expect(error.cause).toBe(cause);
+    expect(error).not.toHaveProperty("records");
+  });
+
+  it("redacts collector URL credentials while retaining the exact cause", () => {
+    const collectorUrl =
+      "https://collector-user:collector-password@traces.example.test/private/v1/traces?access_token=collector-secret#collector-fragment";
+    const cause = new Error("collector transport failed");
+    const error = BrowserOtlpTraceExportError.fromCollectorUrl(collectorUrl, cause);
+
+    expect(error).toMatchObject({
+      collectorUrlInputLength: collectorUrl.length,
+      collectorUrlProtocol: "https:",
+      collectorUrlHostname: "traces.example.test",
+      cause,
+    });
+    expect(error.cause).toBe(cause);
+    expect(error).not.toHaveProperty("collectorUrl");
+    for (const secret of [
+      "collector-user",
+      "collector-password",
+      "/private/v1/traces",
+      "collector-secret",
+      "collector-fragment",
+    ]) {
+      expect(error.message).not.toContain(secret);
+    }
   });
 });

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -5,12 +5,13 @@ import {
   EnvironmentHttpApi,
 } from "@t3tools/contracts";
 import { decodeOtlpTraceRecords } from "@t3tools/shared/observability";
-import * as Data from "effect/Data";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
 import { cast } from "effect/Function";
 import {
   HttpBody,
@@ -108,10 +109,95 @@ export const serverEnvironmentHttpApiLayer = HttpApiBuilder.group(
   }),
 );
 
-class DecodeOtlpTraceRecordsError extends Data.TaggedError("DecodeOtlpTraceRecordsError")<{
-  readonly cause: unknown;
-  readonly bodyJson: OtlpTracer.TraceData;
-}> {}
+function errorDiagnosticTag(cause: unknown): string {
+  if (
+    typeof cause === "object" &&
+    cause !== null &&
+    "_tag" in cause &&
+    typeof cause._tag === "string"
+  ) {
+    return cause._tag;
+  }
+  if (cause instanceof Error) return cause.name;
+  return typeof cause;
+}
+
+export class BrowserOtlpTraceDecodeError extends Schema.TaggedErrorClass<BrowserOtlpTraceDecodeError>()(
+  "BrowserOtlpTraceDecodeError",
+  {
+    resourceSpanCount: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  static fromPayload(payload: unknown, cause: unknown): BrowserOtlpTraceDecodeError {
+    const resourceSpanCount =
+      typeof payload === "object" &&
+      payload !== null &&
+      "resourceSpans" in payload &&
+      Array.isArray(payload.resourceSpans)
+        ? payload.resourceSpans.length
+        : 0;
+
+    return new BrowserOtlpTraceDecodeError({
+      resourceSpanCount,
+      cause,
+    });
+  }
+
+  override get message(): string {
+    return `Failed to decode browser OTLP payload with ${this.resourceSpanCount} resource spans.`;
+  }
+}
+
+export class BrowserOtlpTraceCollectionError extends Schema.TaggedErrorClass<BrowserOtlpTraceCollectionError>()(
+  "BrowserOtlpTraceCollectionError",
+  {
+    recordCount: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  static fromRecords(
+    records: ReadonlyArray<unknown>,
+    cause: unknown,
+  ): BrowserOtlpTraceCollectionError {
+    return new BrowserOtlpTraceCollectionError({
+      recordCount: records.length,
+      cause,
+    });
+  }
+
+  override get message(): string {
+    return `Failed to collect ${this.recordCount} browser OTLP trace records locally.`;
+  }
+}
+
+export class BrowserOtlpTraceExportError extends Schema.TaggedErrorClass<BrowserOtlpTraceExportError>()(
+  "BrowserOtlpTraceExportError",
+  {
+    collectorUrlInputLength: Schema.Number,
+    collectorUrlProtocol: Schema.optionalKey(Schema.String),
+    collectorUrlHostname: Schema.optionalKey(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  static fromCollectorUrl(collectorUrl: string, cause: unknown): BrowserOtlpTraceExportError {
+    const diagnostics = getUrlDiagnostics(collectorUrl);
+    return new BrowserOtlpTraceExportError({
+      collectorUrlInputLength: diagnostics.inputLength,
+      ...(diagnostics.protocol === undefined ? {} : { collectorUrlProtocol: diagnostics.protocol }),
+      ...(diagnostics.hostname === undefined ? {} : { collectorUrlHostname: diagnostics.hostname }),
+      cause,
+    });
+  }
+
+  override get message(): string {
+    const collector =
+      this.collectorUrlHostname === undefined
+        ? "the configured collector"
+        : this.collectorUrlHostname;
+    return `Failed to export browser OTLP traces to ${collector} (collector URL input length ${this.collectorUrlInputLength}).`;
+  }
+}
 
 export const otlpTracesProxyRouteLayer = HttpRouter.add(
   "POST",
@@ -127,15 +213,31 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
 
     yield* Effect.try({
       try: () => decodeOtlpTraceRecords(bodyJson),
-      catch: (cause) => new DecodeOtlpTraceRecordsError({ cause, bodyJson }),
+      catch: (cause) => BrowserOtlpTraceDecodeError.fromPayload(bodyJson, cause),
     }).pipe(
-      Effect.flatMap((records) => browserTraceCollector.record(records)),
-      Effect.catch((cause) =>
-        Effect.logWarning("Failed to decode browser OTLP traces", {
-          cause,
-          bodyJson,
-        }),
+      Effect.flatMap((records) =>
+        browserTraceCollector
+          .record(records)
+          .pipe(
+            Effect.catchDefect((cause) =>
+              Effect.fail(BrowserOtlpTraceCollectionError.fromRecords(records, cause)),
+            ),
+          ),
       ),
+      Effect.catchTags({
+        BrowserOtlpTraceDecodeError: (error) =>
+          Effect.logWarning(error.message, {
+            errorTag: error._tag,
+            resourceSpanCount: error.resourceSpanCount,
+            causeTag: errorDiagnosticTag(error.cause),
+          }),
+        BrowserOtlpTraceCollectionError: (error) =>
+          Effect.logWarning(error.message, {
+            errorTag: error._tag,
+            recordCount: error.recordCount,
+            causeTag: errorDiagnosticTag(error.cause),
+          }),
+      }),
     );
 
     if (otlpTracesUrl === undefined) {
@@ -149,15 +251,23 @@ export const otlpTracesProxyRouteLayer = HttpRouter.add(
       .pipe(
         Effect.flatMap(HttpClientResponse.filterStatusOk),
         Effect.as(HttpServerResponse.empty({ status: 204 })),
-        Effect.tapError((cause) =>
-          Effect.logWarning("Failed to export browser OTLP traces", {
-            cause,
-            otlpTracesUrl,
-          }),
+        Effect.mapError((cause) =>
+          BrowserOtlpTraceExportError.fromCollectorUrl(otlpTracesUrl, cause),
         ),
-        Effect.orElseSucceed(() =>
-          HttpServerResponse.text("Trace export failed.", { status: 502 }),
-        ),
+        Effect.catchTags({
+          BrowserOtlpTraceExportError: (error) =>
+            Effect.logWarning(error.message, {
+              errorTag: error._tag,
+              collectorUrlInputLength: error.collectorUrlInputLength,
+              ...(error.collectorUrlProtocol === undefined
+                ? {}
+                : { collectorUrlProtocol: error.collectorUrlProtocol }),
+              ...(error.collectorUrlHostname === undefined
+                ? {}
+                : { collectorUrlHostname: error.collectorUrlHostname }),
+              causeTag: errorDiagnosticTag(error.cause),
+            }).pipe(Effect.as(HttpServerResponse.text("Trace export failed.", { status: 502 }))),
+        }),
       );
   }).pipe(
     Effect.catchTags({

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4026,6 +4026,31 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("continues browser OTLP requests when local trace collection defects", () =>
+    Effect.gen(function* () {
+      const payload = yield* makeBrowserOtlpPayload("client.test");
+
+      yield* buildAppUnderTest({
+        layers: {
+          browserTraceCollector: {
+            record: () => Effect.die(new Error("private local collector failure")),
+          },
+        },
+      });
+
+      const response = yield* HttpClient.post("/api/observability/v1/traces", {
+        headers: {
+          cookie: yield* getAuthenticatedSessionCookieHeader(),
+          "content-type": "application/json",
+        },
+        // @effect-diagnostics-next-line preferSchemaOverJson:off
+        body: HttpBody.text(JSON.stringify(payload), "application/json"),
+      });
+
+      assert.equal(response.status, 204);
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("routes websocket rpc server.upsertKeybinding", () =>
     Effect.gen(function* () {
       const rule: KeybindingRule = {


### PR DESCRIPTION
## Problem

Browser OTLP decode and export failures were logged with raw request payloads, collector URLs, and nested causes. Those values can contain credentials or private path, query, and fragment data, and the ad hoc errors did not expose stable structural diagnostics.

## Changes

- replace the unstructured decode failure with a schema error carrying resource-span count and the original cause
- add a schema export error that derives safe collector URL diagnostics while preserving the exact cause chain
- use `catchTags` for the two distinct failures
- log only stable error/cause tags and redacted URL diagnostics; never serialize raw payloads, collector URLs, or nested HTTP causes
- keep the derivation logic on value-adding static error mappers

## Validation

- `vp check`
- `vp test apps/server/src/http.test.ts`
- `vp run typecheck`

Tests cover exact cause identity and sentinel credentials, private path, query, and fragment redaction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches observability proxy logging and error handling on an authenticated route; behavior for clients is intended to stay the same but mis-handled defects could affect trace collection visibility.
> 
> **Overview**
> Browser OTLP decode, local collection, and export failures now use **schema tagged errors** instead of ad hoc `Data.TaggedError` types that held full request bodies or collector URLs.
> 
> **Decode** failures map to `BrowserOtlpTraceDecodeError` with `resourceSpanCount` and the original cause only; **local `browserTraceCollector.record` defects** become `BrowserOtlpTraceCollectionError` with `recordCount` and cause. The proxy logs warnings via `Effect.catchTags` using stable fields (`errorTag`, `causeTag`) and does not serialize payloads or records.
> 
> **Export** failures map to `BrowserOtlpTraceExportError`, which stores redacted URL metadata from `getUrlDiagnostics` (protocol, hostname, input length) while preserving the cause chain; logs omit credentials, paths, query, and fragments. HTTP behavior is unchanged: decode/collection issues are logged and the handler continues (still **204** when no upstream URL); export failure still returns **502** with `"Trace export failed."`
> 
> Unit tests assert cause identity and redaction; an integration test confirms OTLP requests still return **204** when local collection dies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ab9c61ced12e010f08846f100e88c0000c6c189. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure OTLP export diagnostics with redacted, typed errors in the browser trace handler
> - Introduces three typed error classes (`BrowserOtlpTraceDecodeError`, `BrowserOtlpTraceCollectionError`, `BrowserOtlpTraceExportError`) in [http.ts](https://github.com/pingdotgg/t3code/pull/3407/files#diff-55fb49cf72ecef123d8f2fa7061526dadb37cf93f8e9dd9e7f0d4f8cd4ff9f6d) to replace broad, unstructured error handling in the `POST /api/observability/v1/traces` handler.
> - Each error class captures only safe diagnostic fields (span/record counts, redacted URL components) and omits raw payloads, records, and collector URLs from logs.
> - Adds `errorDiagnosticTag` helper to derive a `causeTag` from error causes for structured log output.
> - Wraps local trace collection defects with `Effect.catchDefect` so the handler continues and returns 204 even when `BrowserTraceCollector.record` throws.
> - Behavioral Change: warning logs for decode, collection, and export failures now emit structured fields instead of raw values; the handler no longer logs `bodyJson` or `otlpTracesUrl`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ab9c61.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->