### PR TITLE
[codex] structure VCS process errors

### DIFF
--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -6,7 +6,11 @@ import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
 import { TestClock } from "effect/testing";
 
-import { VcsProcessExitError, VcsProcessTimeoutError } from "@t3tools/contracts";
+import {
+  VcsProcessExitError,
+  VcsProcessSpawnError,
+  VcsProcessTimeoutError,
+} from "@t3tools/contracts";
 import * as VcsProcess from "./VcsProcess.ts";
 
 const run = (input: VcsProcess.VcsProcessInput) =>
@@ -61,14 +65,53 @@ describe("VcsProcess.run", () => {
 
   it.effect("fails with VcsProcessExitError for non-zero exits by default", () =>
     Effect.gen(function* () {
+      const secretArgument = "--token=super-secret-token";
+      const secretStderr = "remote rejected super-secret-token";
       const error = yield* run({
         operation: "test.exit",
         command: "node",
-        args: ["-e", "process.stderr.write('boom'); process.exit(2)"],
+        args: [
+          "-e",
+          "process.stderr.write(process.argv[1]); process.exit(2)",
+          secretStderr,
+          secretArgument,
+        ],
         cwd: process.cwd(),
       }).pipe(Effect.flip);
 
       expect(error).toBeInstanceOf(VcsProcessExitError);
+      expect(error).toMatchObject({
+        operation: "test.exit",
+        command: "node",
+        argumentCount: 4,
+        exitCode: 2,
+        detail: "Process exited with a non-zero status.",
+        stderrLength: secretStderr.length,
+        stderrTruncated: false,
+      });
+      expect(error.message).not.toContain(secretArgument);
+      expect(error.message).not.toContain(secretStderr);
+    }).pipe(provideLive),
+  );
+
+  it.effect("retains spawn causes without exposing process arguments in the error message", () =>
+    Effect.gen(function* () {
+      const secretArgument = "--token=super-secret-token";
+      const error = yield* run({
+        operation: "test.spawn",
+        command: "definitely-not-a-t3code-executable",
+        args: [secretArgument],
+        cwd: process.cwd(),
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(VcsProcessSpawnError);
+      expect(error).toMatchObject({
+        operation: "test.spawn",
+        command: "definitely-not-a-t3code-executable",
+        argumentCount: 1,
+      });
+      expect(error).toHaveProperty("cause");
+      expect(error.message).not.toContain(secretArgument);
     }).pipe(provideLive),
   );
 

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -86,11 +86,37 @@ describe("VcsProcess.run", () => {
         argumentCount: 4,
         exitCode: 2,
         detail: "Process exited with a non-zero status.",
+        failureKind: "command-failed",
         stderrLength: secretStderr.length,
         stderrTruncated: false,
       });
       expect(error.message).not.toContain(secretArgument);
       expect(error.message).not.toContain(secretStderr);
+    }).pipe(provideLive),
+  );
+
+  it.effect("classifies authentication failures without retaining stderr", () =>
+    Effect.gen(function* () {
+      const secretStderr = "authentication failed for token super-secret-token";
+      const error = yield* run({
+        operation: "test.authentication",
+        command: "node",
+        args: ["-e", "process.stderr.write(process.argv[1]); process.exit(1)", secretStderr],
+        cwd: process.cwd(),
+      }).pipe(Effect.flip);
+
+      expect(error).toBeInstanceOf(VcsProcessExitError);
+      expect(error).toMatchObject({
+        operation: "test.authentication",
+        command: "node",
+        exitCode: 1,
+        detail: "Authentication failed.",
+        failureKind: "authentication",
+        stderrLength: secretStderr.length,
+        stderrTruncated: false,
+      });
+      expect(error.message).not.toContain(secretStderr);
+      expect(error.message).not.toContain("super-secret-token");
     }).pipe(provideLive),
   );
 

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -8,6 +8,7 @@ import {
   VcsOutputDecodeError,
   type VcsError,
   VcsProcessExitError,
+  type VcsProcessExitFailureKind,
   VcsProcessSpawnError,
   VcsProcessTimeoutError,
 } from "@t3tools/contracts";
@@ -45,6 +46,42 @@ export class VcsProcess extends Context.Service<
 const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
+
+const classifyNonZeroExit = (command: string, stderr: string): VcsProcessExitFailureKind => {
+  const normalized = stderr.toLowerCase();
+
+  if (
+    normalized.includes("authentication failed") ||
+    normalized.includes("not logged in") ||
+    normalized.includes("gh auth login") ||
+    normalized.includes("glab auth login") ||
+    normalized.includes("az devops login") ||
+    normalized.includes("please run az login") ||
+    normalized.includes("no oauth token") ||
+    normalized.includes("unauthorized")
+  ) {
+    return "authentication";
+  }
+
+  if (
+    (command === "gh" &&
+      (normalized.includes("could not resolve to a pullrequest") ||
+        normalized.includes("repository.pullrequest") ||
+        normalized.includes("no pull requests found for branch") ||
+        normalized.includes("pull request not found"))) ||
+    (command === "glab" &&
+      (normalized.includes("merge request not found") ||
+        normalized.includes("not found") ||
+        normalized.includes("404"))) ||
+    (command === "az" &&
+      normalized.includes("pull request") &&
+      (normalized.includes("not found") || normalized.includes("does not exist")))
+  ) {
+    return "not-found";
+  }
+
+  return "command-failed";
+};
 
 export const make = Effect.gen(function* () {
   const processRunner = yield* ProcessRunner.ProcessRunner;
@@ -93,13 +130,15 @@ export const make = Effect.gen(function* () {
     }
 
     if (!input.allowNonZeroExit && result.code !== 0) {
-      return yield* new VcsProcessExitError({
-        ...baseError,
-        exitCode: result.code,
-        detail: "Process exited with a non-zero status.",
-        stderrLength: result.stderr.length,
-        stderrTruncated: result.stderrTruncated,
-      });
+      return yield* VcsProcessExitError.fromProcessExit(
+        baseError,
+        {
+          exitCode: result.code,
+          stderr: result.stderr,
+          stderrTruncated: result.stderrTruncated,
+        },
+        classifyNonZeroExit(input.command, result.stderr),
+      );
     }
 
     return {

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -46,19 +46,15 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
 
-function commandLabel(command: string, args: ReadonlyArray<string>): string {
-  return [command, ...args].join(" ");
-}
-
 export const make = Effect.gen(function* () {
   const processRunner = yield* ProcessRunner.ProcessRunner;
 
   const run = Effect.fn("VcsProcess.run")(function* (input: VcsProcessInput) {
-    const label = commandLabel(input.command, input.args);
     const baseError = {
       operation: input.operation,
-      command: label,
+      command: input.command,
       cwd: input.cwd,
+      argumentCount: input.args.length,
     };
 
     const result = yield* processRunner
@@ -98,11 +94,11 @@ export const make = Effect.gen(function* () {
 
     if (!input.allowNonZeroExit && result.code !== 0) {
       return yield* new VcsProcessExitError({
-        operation: input.operation,
-        command: label,
-        cwd: input.cwd,
+        ...baseError,
         exitCode: result.code,
-        detail: result.stderr.trim() || `${label} exited with code ${result.code}.`,
+        detail: "Process exited with a non-zero status.",
+        stderrLength: result.stderr.length,
+        stderrTruncated: result.stderrTruncated,
       });
     }
 

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -1,5 +1,5 @@
 import * as Schema from "effect/Schema";
-import { TrimmedNonEmptyString } from "./baseSchemas.ts";
+import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
 
 export const VcsDriverKind = Schema.Literals(["git", "jj", "unknown"]);
 export type VcsDriverKind = typeof VcsDriverKind.Type;
@@ -62,6 +62,7 @@ export interface VcsProcessErrorContext {
   readonly operation: string;
   readonly command: string;
   readonly cwd: string;
+  readonly argumentCount?: number;
 }
 
 export interface VcsProcessSpawnFailure {
@@ -92,6 +93,7 @@ export class VcsProcessSpawnError extends Schema.TaggedErrorClass<VcsProcessSpaw
     operation: Schema.String,
     command: Schema.String,
     cwd: Schema.String,
+    argumentCount: Schema.optional(NonNegativeInt),
     cause: Schema.Defect(),
   },
 ) {
@@ -113,8 +115,11 @@ export class VcsProcessExitError extends Schema.TaggedErrorClass<VcsProcessExitE
     operation: Schema.String,
     command: Schema.String,
     cwd: Schema.String,
+    argumentCount: Schema.optional(NonNegativeInt),
     exitCode: Schema.Number,
     detail: Schema.String,
+    stderrLength: Schema.optional(NonNegativeInt),
+    stderrTruncated: Schema.optional(Schema.Boolean),
   },
 ) {
   override get message(): string {
@@ -128,6 +133,7 @@ export class VcsProcessTimeoutError extends Schema.TaggedErrorClass<VcsProcessTi
     operation: Schema.String,
     command: Schema.String,
     cwd: Schema.String,
+    argumentCount: Schema.optional(NonNegativeInt),
     timeoutMs: Schema.Number,
   },
 ) {
@@ -149,6 +155,7 @@ export class VcsOutputDecodeError extends Schema.TaggedErrorClass<VcsOutputDecod
     operation: Schema.String,
     command: Schema.String,
     cwd: Schema.String,
+    argumentCount: Schema.optional(NonNegativeInt),
     detail: Schema.String,
     cause: Schema.optional(Schema.Defect()),
   },

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -87,6 +87,19 @@ export interface VcsProcessTimeoutFailure {
   readonly timeoutMs: number;
 }
 
+export const VcsProcessExitFailureKind = Schema.Literals([
+  "authentication",
+  "not-found",
+  "command-failed",
+]);
+export type VcsProcessExitFailureKind = typeof VcsProcessExitFailureKind.Type;
+
+export interface VcsProcessExitFailure {
+  readonly exitCode: number;
+  readonly stderr: string;
+  readonly stderrTruncated: boolean;
+}
+
 export class VcsProcessSpawnError extends Schema.TaggedErrorClass<VcsProcessSpawnError>()(
   "VcsProcessSpawnError",
   {
@@ -118,12 +131,39 @@ export class VcsProcessExitError extends Schema.TaggedErrorClass<VcsProcessExitE
     argumentCount: Schema.optional(NonNegativeInt),
     exitCode: Schema.Number,
     detail: Schema.String,
+    failureKind: Schema.optional(VcsProcessExitFailureKind),
     stderrLength: Schema.optional(NonNegativeInt),
     stderrTruncated: Schema.optional(Schema.Boolean),
   },
 ) {
   override get message(): string {
     return `VCS process failed in ${this.operation}: ${this.command} (${this.cwd}) exited with ${this.exitCode} - ${this.detail}`;
+  }
+
+  static fromProcessExit(
+    context: VcsProcessErrorContext,
+    error: VcsProcessExitFailure,
+    failureKind: VcsProcessExitFailureKind,
+  ) {
+    const detail =
+      failureKind === "authentication"
+        ? "Authentication failed."
+        : failureKind === "not-found"
+          ? context.command === "glab"
+            ? "Merge request not found."
+            : context.command === "gh" || context.command === "az"
+              ? "Pull request not found."
+              : "VCS resource not found."
+          : "Process exited with a non-zero status.";
+
+    return new VcsProcessExitError({
+      ...context,
+      exitCode: error.exitCode,
+      detail,
+      failureKind,
+      stderrLength: error.stderr.length,
+      stderrTruncated: error.stderrTruncated,
+    });
   }
 }
 


### PR DESCRIPTION
## What changed

- keep VCS command arguments and stderr contents out of process errors
- add argument count, stderr length, and truncation metadata for correlation
- retain exact spawn causes while keeping public messages stable
- remove the command-label helper that joined raw arguments into diagnostics

## Why

VCS arguments and stderr can contain credentials, repository URLs, and arbitrary remote output. The process boundary should expose useful structure without copying those values into errors or messages.

## Validation

- `vp test apps/server/src/vcs/VcsProcess.test.ts` (8 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error shape and messaging for all VCS subprocess failures; callers matching on full `command` or stderr in `detail` may need updates, but behavior is intentional for security.
> 
> **Overview**
> **VCS process errors no longer leak credentials or remote output** in `command` or `message`. Diagnostics use the bare executable name plus optional `argumentCount`, and exit failures add `failureKind`, `stderrLength`, and `stderrTruncated` instead of embedding raw stderr in `detail`.
> 
> Non-zero exits are classified via `classifyNonZeroExit` into **authentication**, **not-found** (gh/glab/az heuristics), or **command-failed**, with stable user-facing `detail` strings from `VcsProcessExitError.fromProcessExit`. Spawn errors still keep the underlying `cause` while omitting args from the public message.
> 
> **Breaking for callers** that relied on joined `command` labels or stderr text in `detail`/`message`; tests assert secrets never appear in messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7aa6a8585bc041ee0b8dc5507e6234d77968461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure VCS process errors with failure classification and secret redaction
> - `VcsProcessExitError` now carries a `failureKind` (`authentication`, `not-found`, `command-failed`), `stderrLength`, `stderrTruncated`, and `argumentCount`, with a standardized `detail` message; stderr contents are no longer stored in the error instance.
> - Adds `classifyNonZeroExit` in [`VcsProcess.ts`](https://github.com/pingdotgg/t3code/pull/3408/files#diff-42ce5a28bf0b16d9cc4fdfbca0e82279f369588e696972ab8b199fe9df69336d) to detect auth and not-found failures from stderr for `gh`, `glab`, and `az` CLIs.
> - `VcsProcessSpawnError`, `VcsProcessTimeoutError`, and `VcsOutputDecodeError` all gain an optional `argumentCount` field via their factory methods.
> - Behavioral Change: process arguments are no longer included in error messages or command labels, preventing accidental secret leakage in logs or error reporting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c7aa6a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->