### PR TITLE
[codex] Structure primary environment request failures

### DIFF
--- a/apps/web/src/authBootstrap.test.ts
+++ b/apps/web/src/authBootstrap.test.ts
@@ -290,22 +290,38 @@ describe("resolveInitialServerAuthGateState", () => {
   });
 
   it("surfaces a friendly error message when an invalid pairing token is submitted", async () => {
+    const cause = new EnvironmentAuthInvalidError({
+      code: "auth_invalid",
+      reason: "invalid_credential",
+      traceId: "trace-invalid-credential",
+    });
     const testApi = await installAuthApi({
-      browserSession: () =>
-        Effect.fail(
-          new EnvironmentAuthInvalidError({
-            code: "auth_invalid",
-            reason: "invalid_credential",
-            traceId: "trace-invalid-credential",
-          }),
-        ),
+      browserSession: () => Effect.fail(cause),
     });
 
-    const { submitServerAuthCredential } = await import("./environments/primary");
+    const { isPrimaryEnvironmentRequestError, submitServerAuthCredential } =
+      await import("./environments/primary");
 
-    await expect(submitServerAuthCredential("bad-token")).rejects.toThrow(
-      "Invalid pairing token. Check the token and try again.",
+    const error = await submitServerAuthCredential("bad-token").then(
+      () => null,
+      (failure: unknown) => failure,
     );
+    expect(error).toMatchObject({
+      _tag: "PrimaryEnvironmentRequestError",
+      operation: "exchange-bootstrap-credential",
+      status: 401,
+      detail: "Invalid pairing token. Check the token and try again.",
+    });
+    expect(isPrimaryEnvironmentRequestError(error)).toBe(true);
+    if (!isPrimaryEnvironmentRequestError(error)) {
+      throw new Error("Expected a structured primary environment request error.");
+    }
+    expect(error.cause).toMatchObject({
+      _tag: "EnvironmentAuthInvalidError",
+      code: "auth_invalid",
+      reason: "invalid_credential",
+      traceId: "trace-invalid-credential",
+    });
     expect(testApi.calls.browserSession).toEqual([{ credential: "bad-token" }]);
   });
 

--- a/apps/web/src/environments/primary/auth.ts
+++ b/apps/web/src/environments/primary/auth.ts
@@ -21,15 +21,57 @@ import {
 
 import { PrimaryEnvironmentHttpClient } from "./httpClient";
 import { runPrimaryHttp } from "../../lib/runtime";
-import * as Data from "effect/Data";
-import * as Predicate from "effect/Predicate";
 
-export class BootstrapHttpError extends Data.TaggedError("BootstrapHttpError")<{
-  readonly message: string;
-  readonly status: number;
-}> {}
-const isBootstrapHttpError = (u: unknown): u is BootstrapHttpError =>
-  Predicate.isTagged(u, "BootstrapHttpError");
+const PrimaryEnvironmentRequestOperation = Schema.Literals([
+  "fetch-session-state",
+  "exchange-bootstrap-credential",
+  "fetch-environment-descriptor",
+  "create-pairing-credential",
+  "list-pairing-links",
+  "revoke-pairing-link",
+  "list-client-sessions",
+  "revoke-client-session",
+  "revoke-other-client-sessions",
+]);
+type PrimaryEnvironmentRequestOperation = typeof PrimaryEnvironmentRequestOperation.Type;
+
+export class PrimaryEnvironmentRequestError extends Schema.TaggedErrorClass<PrimaryEnvironmentRequestError>()(
+  "PrimaryEnvironmentRequestError",
+  {
+    operation: PrimaryEnvironmentRequestOperation,
+    status: Schema.Number,
+    detail: Schema.String,
+    pairingLinkId: Schema.optional(Schema.String),
+    sessionId: Schema.optional(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  static fromCause(input: {
+    readonly operation: PrimaryEnvironmentRequestOperation;
+    readonly cause: unknown;
+    readonly fallbackMessage: (status: number) => string;
+    readonly formatDetail?: (detail: string, status: number) => string;
+    readonly pairingLinkId?: string;
+    readonly sessionId?: string;
+  }): PrimaryEnvironmentRequestError {
+    const status = readHttpApiStatus(input.cause) ?? 500;
+    const rawDetail = readHttpApiErrorMessage(input.cause, input.fallbackMessage(status));
+    return new PrimaryEnvironmentRequestError({
+      operation: input.operation,
+      status,
+      detail: input.formatDetail?.(rawDetail, status) ?? rawDetail,
+      ...(input.pairingLinkId !== undefined ? { pairingLinkId: input.pairingLinkId } : {}),
+      ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+      cause: input.cause,
+    });
+  }
+
+  override get message(): string {
+    return this.detail;
+  }
+}
+
+export const isPrimaryEnvironmentRequestError = Schema.is(PrimaryEnvironmentRequestError);
 const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
 
 export interface ServerPairingLinkRecord {
@@ -106,10 +148,10 @@ export async function fetchSessionState(): Promise<AuthSessionState> {
         ),
       );
     } catch (error) {
-      const status = readHttpApiStatus(error);
-      throw new BootstrapHttpError({
-        message: `Failed to load server auth session state (${status ?? "unknown"}).`,
-        status: status ?? 500,
+      throw PrimaryEnvironmentRequestError.fromCause({
+        operation: "fetch-session-state",
+        cause: error,
+        fallbackMessage: (status) => `Failed to load server auth session state (${status}).`,
       });
     }
   });
@@ -183,11 +225,11 @@ async function exchangeBootstrapCredential(credential: string): Promise<AuthBrow
         ),
       );
     } catch (error) {
-      const status = readHttpApiStatus(error) ?? 500;
-      const message = toFriendlyBootstrapErrorMessage(status, readHttpApiErrorMessage(error, ""));
-      throw new BootstrapHttpError({
-        message: message || `Failed to bootstrap auth session (${status}).`,
-        status,
+      throw PrimaryEnvironmentRequestError.fromCause({
+        operation: "exchange-bootstrap-credential",
+        cause: error,
+        fallbackMessage: (status) => `Failed to bootstrap auth session (${status}).`,
+        formatDetail: (detail, status) => toFriendlyBootstrapErrorMessage(status, detail),
       });
     }
   });
@@ -240,7 +282,7 @@ function waitForBootstrapRetry(delayMs: number): Promise<void> {
 }
 
 function isTransientBootstrapError(error: unknown): boolean {
-  if (isBootstrapHttpError(error)) {
+  if (isPrimaryEnvironmentRequestError(error)) {
     return TRANSIENT_BOOTSTRAP_STATUS_CODES.has(error.status);
   }
 
@@ -310,13 +352,11 @@ export async function createServerPairingCredential(input?: {
       ),
     );
   } catch (error) {
-    throw new Error(
-      readHttpApiErrorMessage(
-        error,
-        `Failed to create pairing credential (${readHttpApiStatus(error) ?? "unknown"}).`,
-      ),
-      { cause: error },
-    );
+    throw PrimaryEnvironmentRequestError.fromCause({
+      operation: "create-pairing-credential",
+      cause: error,
+      fallbackMessage: (status) => `Failed to create pairing credential (${status}).`,
+    });
   }
 }
 
@@ -353,13 +393,11 @@ export async function listServerPairingLinks(): Promise<ReadonlyArray<ServerPair
       };
     });
   } catch (error) {
-    throw new Error(
-      readHttpApiErrorMessage(
-        error,
-        `Failed to load pairing links (${readHttpApiStatus(error) ?? "unknown"}).`,
-      ),
-      { cause: error },
-    );
+    throw PrimaryEnvironmentRequestError.fromCause({
+      operation: "list-pairing-links",
+      cause: error,
+      fallbackMessage: (status) => `Failed to load pairing links (${status}).`,
+    });
   }
 }
 
@@ -371,13 +409,12 @@ export async function revokeServerPairingLink(id: string): Promise<void> {
       ),
     );
   } catch (error) {
-    throw new Error(
-      readHttpApiErrorMessage(
-        error,
-        `Failed to revoke pairing link (${readHttpApiStatus(error) ?? "unknown"}).`,
-      ),
-      { cause: error },
-    );
+    throw PrimaryEnvironmentRequestError.fromCause({
+      operation: "revoke-pairing-link",
+      pairingLinkId: id,
+      cause: error,
+      fallbackMessage: (status) => `Failed to revoke pairing link (${status}).`,
+    });
   }
 }
 
@@ -406,13 +443,11 @@ export async function listServerClientSessions(): Promise<
       current: clientSession.current,
     }));
   } catch (error) {
-    throw new Error(
-      readHttpApiErrorMessage(
-        error,
-        `Failed to load paired clients (${readHttpApiStatus(error) ?? "unknown"}).`,
-      ),
-      { cause: error },
-    );
+    throw PrimaryEnvironmentRequestError.fromCause({
+      operation: "list-client-sessions",
+      cause: error,
+      fallbackMessage: (status) => `Failed to load paired clients (${status}).`,
+    });
   }
 }
 
@@ -426,13 +461,12 @@ export async function revokeServerClientSession(sessionId: AuthSessionId): Promi
       ),
     );
   } catch (error) {
-    throw new Error(
-      readHttpApiErrorMessage(
-        error,
-        `Failed to revoke client session (${readHttpApiStatus(error) ?? "unknown"}).`,
-      ),
-      { cause: error },
-    );
+    throw PrimaryEnvironmentRequestError.fromCause({
+      operation: "revoke-client-session",
+      sessionId,
+      cause: error,
+      fallbackMessage: (status) => `Failed to revoke client session (${status}).`,
+    });
   }
 }
 
@@ -445,13 +479,11 @@ export async function revokeOtherServerClientSessions(): Promise<number> {
     );
     return result.revokedCount;
   } catch (error) {
-    throw new Error(
-      readHttpApiErrorMessage(
-        error,
-        `Failed to revoke other client sessions (${readHttpApiStatus(error) ?? "unknown"}).`,
-      ),
-      { cause: error },
-    );
+    throw PrimaryEnvironmentRequestError.fromCause({
+      operation: "revoke-other-client-sessions",
+      cause: error,
+      fallbackMessage: (status) => `Failed to revoke other client sessions (${status}).`,
+    });
   }
 }
 

--- a/apps/web/src/environments/primary/context.ts
+++ b/apps/web/src/environments/primary/context.ts
@@ -5,9 +5,8 @@ import {
 } from "@t3tools/client-runtime/environment";
 import type { ExecutionEnvironmentDescriptor } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
-import { HttpClientError } from "effect/unstable/http";
 
-import { BootstrapHttpError, retryTransientBootstrap } from "./auth";
+import { PrimaryEnvironmentRequestError, retryTransientBootstrap } from "./auth";
 import { PrimaryEnvironmentHttpClient } from "./httpClient";
 
 import { runPrimaryHttp } from "../../lib/runtime";
@@ -44,13 +43,10 @@ async function fetchPrimaryEnvironmentDescriptor(): Promise<ExecutionEnvironment
         PrimaryEnvironmentHttpClient.pipe(Effect.flatMap((client) => client.metadata.descriptor())),
       );
     } catch (error) {
-      const status =
-        HttpClientError.isHttpClientError(error) && error.response !== undefined
-          ? error.response.status
-          : 500;
-      throw new BootstrapHttpError({
-        message: `Failed to load server environment descriptor (${status}).`,
-        status,
+      throw PrimaryEnvironmentRequestError.fromCause({
+        operation: "fetch-environment-descriptor",
+        cause: error,
+        fallbackMessage: (status) => `Failed to load server environment descriptor (${status}).`,
       });
     }
 

--- a/apps/web/src/environments/primary/index.ts
+++ b/apps/web/src/environments/primary/index.ts
@@ -16,9 +16,11 @@ export {
 export {
   createServerPairingCredential,
   fetchSessionState,
+  isPrimaryEnvironmentRequestError,
   listServerClientSessions,
   listServerPairingLinks,
   peekPairingTokenFromUrl,
+  PrimaryEnvironmentRequestError,
   resolveInitialServerAuthGateState,
   revokeOtherServerClientSessions,
   revokeServerClientSession,


### PR DESCRIPTION
## Summary
- replace unstructured primary-environment HTTP failures with one schema error carrying operation, status, relevant resource identifiers, and the exact cause
- keep user-facing messages derived from safe structured HTTP error fields or code-owned fallbacks
- centralize the meaningful HTTP-to-request-error mapping on the error class and export its schema predicate

## Validation
- `vp test apps/web/src/authBootstrap.test.ts apps/web/src/environments/primary/bootstrap.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth bootstrap, session/pairing APIs, and error types callers may catch; behavior should stay similar but failure objects and predicates changed.
> 
> **Overview**
> Replaces ad-hoc `BootstrapHttpError` and generic `Error` throws with a single **`PrimaryEnvironmentRequestError`** (Effect Schema tagged error) for primary-environment HTTP calls.
> 
> Each failure now carries **`operation`** (e.g. `exchange-bootstrap-credential`, `list-pairing-links`), **`status`**, user-facing **`detail`**, optional **`pairingLinkId`** / **`sessionId`**, and the original **`cause`**. Mapping is centralized in **`PrimaryEnvironmentRequestError.fromCause`**, which derives status and messages from structured HTTP errors or code-owned fallbacks; bootstrap credential exchange still applies friendly pairing-token copy via **`formatDetail`**.
> 
> **`isTransientBootstrapError`** now treats transient retries using the new error’s **`status`**. **`context.ts`** descriptor fetch uses the same error type. Public exports add **`PrimaryEnvironmentRequestError`** and **`isPrimaryEnvironmentRequestError`**.
> 
> The invalid-pairing-token test now asserts the structured error shape (including preserved **`EnvironmentAuthInvalidError`** cause) instead of only matching a thrown message string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee2f35a6dfd055425cf2a95dc24fffcbbb4593a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace ad-hoc errors with structured `PrimaryEnvironmentRequestError` in primary environment auth
> - Introduces `PrimaryEnvironmentRequestError`, a tagged error class with `operation`, `status`, `detail`, optional `pairingLinkId`/`sessionId`, and `cause` fields, replacing generic `Error` and `BootstrapHttpError` across all primary environment request functions in [`auth.ts`](https://github.com/pingdotgg/t3code/pull/3409/files#diff-890ed82ba4e0838569b58c8c7aff7ce2995879306e5287324879a4a91b33e27c) and [`context.ts`](https://github.com/pingdotgg/t3code/pull/3409/files#diff-1991ea7dc3bf72806740f3cd9bbaa76f0a749dba781021f754e0f13b162efd44).
> - Exports `isPrimaryEnvironmentRequestError` type guard from the primary environment module so callers can discriminate errors by operation and status.
> - Updates `isTransientBootstrapError` to use `isPrimaryEnvironmentRequestError` instead of the now-removed `isBootstrapHttpError`.
> - Behavioral Change: All primary environment request failures now reject with `PrimaryEnvironmentRequestError` instead of `BootstrapHttpError` or generic `Error`; callers that catch and inspect error types will need to update their checks.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eee2f35.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->