### PR TITLE
[codex] Redact agent awareness relay diagnostics

### DIFF
--- a/apps/server/src/relay/AgentAwarenessRelay.test.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.test.ts
@@ -20,6 +20,7 @@ import { CommandId, ProviderInstanceId } from "@t3tools/contracts";
 import { RelayClientTracer } from "@t3tools/shared/relayTracing";
 import { RELAY_ACTIVITY_PUBLISH_TYP, verifyRelayJwt } from "@t3tools/shared/relayJwt";
 import { describe, expect, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -98,6 +99,50 @@ function makeMemorySecretStore() {
 }
 
 describe.sequential("signRelayAgentActivityPublishProof", () => {
+  it("redacts relay URL secrets from log attributes", () => {
+    const relayUrl =
+      "https://relay-user:relay-password@relay.example.test/private/path?token=relay-secret#fragment";
+    const attributes = AgentAwarenessRelay.relayUrlLogAttributes(relayUrl);
+
+    expect(attributes).toEqual({
+      relayUrlConfigured: true,
+      relayUrlInputLength: relayUrl.length,
+      relayUrlProtocol: "https:",
+      relayUrlHostname: "relay.example.test",
+    });
+    const renderedAttributes = Object.values(attributes).join(" ");
+    expect(renderedAttributes).not.toContain("relay-user");
+    expect(renderedAttributes).not.toContain("relay-password");
+    expect(renderedAttributes).not.toContain("private/path");
+    expect(renderedAttributes).not.toContain("relay-secret");
+    expect(renderedAttributes).not.toContain("fragment");
+  });
+
+  it("summarizes publish causes without serializing nested failures or defects", () => {
+    const privateFailureDetail = "private relay response body";
+    const privateDefectDetail = "private relay defect detail";
+    const cause = Cause.combine(
+      Cause.fail({
+        _tag: "RelayPublishError",
+        cause: new Error(privateFailureDetail),
+        detail: privateFailureDetail,
+      }),
+      Cause.die(new Error(privateDefectDetail)),
+    );
+    const attributes = AgentAwarenessRelay.relayPublishCauseLogAttributes(cause);
+
+    expect(attributes).toEqual({
+      causeReasonCount: 2,
+      causeFailureCount: 1,
+      causeDefectCount: 1,
+      causeInterruptionCount: 0,
+      causeFailureTags: ["RelayPublishError"],
+    });
+    const renderedAttributes = Object.values(attributes).join(" ");
+    expect(renderedAttributes).not.toContain(privateFailureDetail);
+    expect(renderedAttributes).not.toContain(privateDefectDetail);
+  });
+
   it("distinguishes pending link credentials from disabled publication", () => {
     expect(
       AgentAwarenessRelay.resolveAgentActivityPublishingStartupState({

--- a/apps/server/src/relay/AgentAwarenessRelay.ts
+++ b/apps/server/src/relay/AgentAwarenessRelay.ts
@@ -18,6 +18,7 @@ import {
   RELAY_ACTIVITY_PUBLISH_TYP,
   signRelayJwt,
 } from "@t3tools/shared/relayJwt";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
 import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Crypto from "effect/Crypto";
@@ -96,6 +97,44 @@ export function agentAwarenessPublishIdentity(state: RelayAgentActivityState | n
 
 export function isAgentActivityPublishingEnabled(value: string | null): boolean {
   return value === "true";
+}
+
+export function relayUrlLogAttributes(relayUrl: string | undefined) {
+  if (relayUrl === undefined) {
+    return { relayUrlConfigured: false };
+  }
+  const diagnostics = getUrlDiagnostics(relayUrl);
+  return {
+    relayUrlConfigured: true,
+    relayUrlInputLength: diagnostics.inputLength,
+    ...(diagnostics.protocol === undefined ? {} : { relayUrlProtocol: diagnostics.protocol }),
+    ...(diagnostics.hostname === undefined ? {} : { relayUrlHostname: diagnostics.hostname }),
+  };
+}
+
+export function relayPublishCauseLogAttributes(cause: Cause.Cause<unknown>) {
+  const failureTags = cause.reasons.flatMap((reason) => {
+    if (!Cause.isFailReason(reason)) {
+      return [];
+    }
+    const error = reason.error;
+    if (
+      typeof error !== "object" ||
+      error === null ||
+      !("_tag" in error) ||
+      typeof error._tag !== "string"
+    ) {
+      return [];
+    }
+    return [error._tag];
+  });
+  return {
+    causeReasonCount: cause.reasons.length,
+    causeFailureCount: cause.reasons.filter(Cause.isFailReason).length,
+    causeDefectCount: cause.reasons.filter(Cause.isDieReason).length,
+    causeInterruptionCount: cause.reasons.filter(Cause.isInterruptReason).length,
+    causeFailureTags: [...new Set(failureTags)],
+  };
 }
 
 export function resolveAgentActivityPublishingStartupState(input: {
@@ -417,12 +456,12 @@ export const make = Effect.gen(function* () {
 
   const publishThread: AgentAwarenessRelay["Service"]["publishThread"] = (threadId) =>
     publishThreadUnsafe(threadId).pipe(
-      Effect.catchCause((cause) => {
-        return Effect.logWarning("agent activity publish failed", {
+      Effect.catchCause((cause) =>
+        Effect.logWarning("agent activity publish failed", {
           threadId,
-          cause: Cause.pretty(cause),
-        });
-      }),
+          ...relayPublishCauseLogAttributes(cause),
+        }),
+      ),
       Effect.withSpan("AgentAwarenessRelay.publishThread"),
       withRelayClientTracing,
     );
@@ -467,7 +506,7 @@ export const make = Effect.gen(function* () {
           if (logEnabledWhenReady) {
             const relayConfig = yield* readRelayConfig.pipe(Effect.orElseSucceed(() => null));
             yield* Effect.logInfo("agent activity publishing enabled after link reconciliation", {
-              relayUrl: relayConfig?.url,
+              ...relayUrlLogAttributes(relayConfig?.url),
             });
           }
           return;
@@ -499,7 +538,7 @@ export const make = Effect.gen(function* () {
           break;
         case "enabled":
           yield* Effect.logInfo("agent activity publishing enabled", {
-            relayUrl: relayConfig?.url,
+            ...relayUrlLogAttributes(relayConfig?.url),
           });
           break;
       }


### PR DESCRIPTION
## Issue

Agent-awareness diagnostics exposed the complete configured relay URL, including any embedded credentials, path, query, and fragment. Publish failures also rendered the complete Effect cause into log attributes, which could serialize nested response bodies, defects, and other sensitive details.

## Root cause

The relay service passed configuration and `Cause.pretty` output directly to the logger instead of projecting them into bounded structural diagnostics.

## Fix

- Project relay URLs through the shared URL diagnostic helper and log only configuration state, input length, protocol, and hostname.
- Summarize publish causes by reason counts and typed failure tags without serializing failure values or defects.
- Keep `catchCause` at this boundary because the background publisher intentionally handles typed failures, defects, and interruptions together; the change does not construct or replace any cause.

This PR is stacked on #3403, which introduces the shared URL diagnostic helper.

## Validation

- `vp test apps/server/src/relay/AgentAwarenessRelay.test.ts` (13 tests)
- `vp check`
- `vp run typecheck`

Focused regression tests use sentinel credentials, path, query, fragment, nested failure detail, and defect detail to verify none reach the projected log attributes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change in the relay publisher; behavior and error handling boundaries are unchanged aside from what gets written to logs.
> 
> **Overview**
> Agent-awareness relay logging no longer emits full relay URLs or serialized Effect causes.
> 
> **Relay URL logging** now goes through `relayUrlLogAttributes`, which uses shared `getUrlDiagnostics` so logs only record whether a URL is configured, input length, protocol, and hostname—credentials, path, query, and fragment are omitted from startup and reconciliation info logs.
> 
> **Publish failure logging** replaces `Cause.pretty(cause)` with `relayPublishCauseLogAttributes`, which records reason/failure/defect/interruption counts and deduplicated `_tag` values from typed failures, without embedding nested error bodies or defect messages.
> 
> Regression tests assert sentinel secrets and private failure/defect strings never appear in the projected attribute payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd68a77343ae518abe08f0a9cc9aa764279ba8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redact relay URL and cause details in `AgentAwarenessRelay` logs
> - Adds `relayUrlLogAttributes` to replace raw relay URL strings in logs with safe attributes: configured flag, input length, protocol, and hostname.
> - Adds `relayPublishCauseLogAttributes` to replace `Cause.pretty` strings with structured summaries: reason counts by type and aggregated failure tags.
> - Both utilities are used in `AgentAwarenessRelay.make` for startup, enablement, and `publishThread` error logging.
> - Behavioral Change: warning logs for publish failures no longer include full pretty-printed cause details or raw URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dd68a77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->