### PR TITLE
[codex] Sanitize client runtime failure diagnostics

### DIFF
--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -26,6 +26,7 @@ import {
   type SupervisorConnectionState,
 } from "./model.ts";
 import * as RpcSession from "../rpc/session.ts";
+import { safeErrorLogAttributes } from "../errors/safeLog.ts";
 import * as ConnectionWakeups from "./wakeups.ts";
 
 const RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 16_000] as const;
@@ -503,11 +504,13 @@ export const make = Effect.fn("EnvironmentSupervisor.make")(function* (
         !establishment.exit.cause.reasons.some(Cause.isFailReason);
       const outcome = failureFromExit(target, establishment.exit, false, false);
       if (isUnexpectedDefect) {
+        const defect = establishment.exit.cause.reasons.find(Cause.isDieReason)?.defect;
         yield* Effect.logError("Connection attempt failed with an unexpected defect.").pipe(
           Effect.annotateLogs({
             "environment.id": target.environmentId,
             "environment.label": target.label,
-            cause: Cause.pretty(establishment.exit.cause),
+            "cause.reason_count": establishment.exit.cause.reasons.length,
+            ...safeErrorLogAttributes(defect),
           }),
         );
       }

--- a/packages/client-runtime/src/state/archivedThreads.test.ts
+++ b/packages/client-runtime/src/state/archivedThreads.test.ts
@@ -1,7 +1,10 @@
-import { EnvironmentId } from "@t3tools/contracts";
+import { EnvironmentId, type OrchestrationShellSnapshot } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 import { expect, it } from "vite-plus/test";
 
 import {
+  createArchivedThreadSnapshotsAtomFamily,
   makeArchivedThreadsEnvironmentKey,
   parseArchivedThreadsEnvironmentKey,
 } from "./archivedThreads.ts";
@@ -12,4 +15,26 @@ it("round-trips environment keys in sorted order", () => {
   const key = makeArchivedThreadsEnvironmentKey([envB, envA]);
 
   expect(parseArchivedThreadsEnvironmentKey(key)).toEqual([envA, envB]);
+});
+
+it("does not expose an archived snapshot failure message", () => {
+  const environmentId = EnvironmentId.make("env-sensitive");
+  const snapshotsAtom = createArchivedThreadSnapshotsAtomFamily<Error>({
+    getSnapshotAtom: () =>
+      Atom.make(
+        AsyncResult.failure<OrchestrationShellSnapshot, Error>(
+          Cause.fail(new Error("credential=secret-value")),
+        ),
+      ),
+    labelPrefix: "test:archived-thread-snapshots",
+  });
+  const registry = AtomRegistry.make();
+
+  expect(registry.get(snapshotsAtom(makeArchivedThreadsEnvironmentKey([environmentId])))).toEqual({
+    snapshots: [],
+    error: "Failed to load archived threads.",
+    isLoading: false,
+  });
+
+  registry.dispose();
 });

--- a/packages/client-runtime/src/state/archivedThreads.ts
+++ b/packages/client-runtime/src/state/archivedThreads.ts
@@ -1,6 +1,5 @@
 import { EnvironmentId, type OrchestrationShellSnapshot } from "@t3tools/contracts";
 import * as Arr from "effect/Array";
-import * as Cause from "effect/Cause";
 import { pipe } from "effect/Function";
 import * as Option from "effect/Option";
 import * as Order from "effect/Order";
@@ -60,11 +59,7 @@ export function createArchivedThreadSnapshotsAtomFamily<E>(options: {
         }
 
         if (error === null && result._tag === "Failure") {
-          const cause = Cause.squash(result.cause);
-          error =
-            cause instanceof Error && cause.message.trim().length > 0
-              ? cause.message
-              : "Failed to load archived threads.";
+          error = "Failed to load archived threads.";
         }
       }
 

--- a/packages/client-runtime/src/state/session.ts
+++ b/packages/client-runtime/src/state/session.ts
@@ -8,6 +8,7 @@ import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { EnvironmentRegistry } from "../connection/registry.ts";
 import type { PreparedConnection } from "../connection/model.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
+import { safeErrorLogAttributes } from "../errors/safeLog.ts";
 import { followStreamInEnvironment } from "./runtime.ts";
 
 export function initialConfigOption<E>(
@@ -16,9 +17,10 @@ export function initialConfigOption<E>(
   return initialConfig.pipe(
     Effect.map(Option.some),
     Effect.catch((error) =>
-      Effect.logWarning("Could not load the initial environment configuration.", {
-        error,
-      }).pipe(Effect.as(Option.none<ServerConfig>())),
+      Effect.logWarning("Could not load the initial environment configuration.").pipe(
+        Effect.annotateLogs({ ...safeErrorLogAttributes(error) }),
+        Effect.as(Option.none<ServerConfig>()),
+      ),
     ),
   );
 }

--- a/packages/client-runtime/src/state/shell.ts
+++ b/packages/client-runtime/src/state/shell.ts
@@ -16,6 +16,7 @@ import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import { EnvironmentRegistry } from "../connection/registry.ts";
 import { connectionProjectionPhase } from "../connection/model.ts";
 import { EnvironmentSupervisor } from "../connection/supervisor.ts";
+import { safeErrorLogAttributes } from "../errors/safeLog.ts";
 import { EnvironmentCacheStore } from "../platform/persistence.ts";
 import { subscribe } from "../rpc/client.ts";
 import { applyShellStreamEvent } from "./shellReducer.ts";
@@ -42,11 +43,7 @@ function shellStatusForSnapshot(
   return Option.isSome(snapshot) ? "cached" : "empty";
 }
 
-function formatShellError(error: unknown): string {
-  return error instanceof Error && error.message.trim().length > 0
-    ? error.message
-    : "Could not synchronize environment data.";
-}
+const SHELL_SYNCHRONIZATION_ERROR_MESSAGE = "Could not synchronize environment data.";
 
 export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")(function* () {
   const supervisor = yield* EnvironmentSupervisor;
@@ -57,7 +54,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
       Effect.logWarning("Could not load cached environment shell.").pipe(
         Effect.annotateLogs({
           environmentId,
-          error: error.message,
+          ...safeErrorLogAttributes(error),
         }),
         Effect.as(Option.none<OrchestrationShellSnapshot>()),
       ),
@@ -78,7 +75,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
         Effect.logWarning("Could not persist environment shell cache.").pipe(
           Effect.annotateLogs({
             environmentId,
-            error: error.message,
+            ...safeErrorLogAttributes(error),
           }),
         ),
       ),
@@ -110,11 +107,19 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
         },
   );
   const setStreamError = (error: unknown) =>
-    SubscriptionRef.update(state, (current) => ({
-      ...current,
-      status: shellStatusForSnapshot(current.snapshot),
-      error: Option.some(formatShellError(error)),
-    }));
+    Effect.logWarning("Could not synchronize the environment shell.").pipe(
+      Effect.annotateLogs({
+        environmentId,
+        ...safeErrorLogAttributes(error),
+      }),
+      Effect.andThen(
+        SubscriptionRef.update(state, (current) => ({
+          ...current,
+          status: shellStatusForSnapshot(current.snapshot),
+          error: Option.some(SHELL_SYNCHRONIZATION_ERROR_MESSAGE),
+        })),
+      ),
+    );
 
   const applyItem = Effect.fn("EnvironmentShellState.applyItem")(function* (
     item: OrchestrationShellStreamItem,


### PR DESCRIPTION
## Summary
- project shell cache, session bootstrap, and supervisor defects into the shared safe error-log attributes instead of serializing messages, nested errors, or `Cause.pretty` output
- keep archived-thread and shell synchronization UI failures generic rather than exposing remote or persistence error messages
- retain safe correlation data and stack frames through the shared projection

This is stacked on #3405 for the shared safe projection. The separate approved #3255 owns the connection error schema cause fields, so this PR intentionally avoids overlapping `connection/model.ts`.

## Validation
- `vp test packages/client-runtime/src/errors packages/client-runtime/src/state/archivedThreads.test.ts packages/client-runtime/src/state/session.test.ts packages/client-runtime/src/state/shell.test.ts packages/client-runtime/src/state/shell-sync.test.ts packages/client-runtime/src/connection/supervisor.test.ts` (46 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Intentional reduction of error detail in UI and logs; no auth or data-path logic changes, with tests covering archived-thread message sanitization.
> 
> **Overview**
> **Sanitizes client-runtime failure handling** so logs and reactive state no longer surface raw error messages, nested errors, or full `Cause.pretty` output.
> 
> Connection **supervisor** unexpected-defect logs now record `cause.reason_count` and **`safeErrorLogAttributes`** from the die defect instead of a pretty-printed cause. **Session** bootstrap and **shell** cache/persist/sync warnings use the same safe projection for structured logs; shell stream failures still log the real error safely but set UI state to the fixed message *"Could not synchronize environment data."* **Archived thread** snapshot failures always expose *"Failed to load archived threads."* in atom state, with a test asserting sensitive `Error.message` text is not leaked.
> 
> **Behavior change:** operators and users see generic copy where underlying persistence/remote messages used to appear; diagnostics remain in logs via sanitized type/name/tag/trace/stack fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a4c955fa9b5967ff91ecc62e8bbb06841a1860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sanitize client runtime failure diagnostics to avoid exposing raw error details
> - In [`supervisor.ts`](https://github.com/pingdotgg/t3code/pull/3411/files#diff-9cea0e0ed5756232bad1eb5801220443f2c1a6cbabaedc22ad335b39a79c7de9), replaces the pretty-printed cause in defect logs with `reason_count` and sanitized error attributes via `safeErrorLogAttributes`.
> - In [`archivedThreads.ts`](https://github.com/pingdotgg/t3code/pull/3411/files#diff-b14eb29d042575ba897c9a570e2ebd3a0d1962130cb18625406225a89effafa3), archived thread snapshot failures now always return the generic message `'Failed to load archived threads.'` instead of the underlying error message.
> - In [`session.ts`](https://github.com/pingdotgg/t3code/pull/3411/files#diff-5498c4d57f2882951bb3fbeeac8f353791b02b9610594e753ead02f7e808550b) and [`shell.ts`](https://github.com/pingdotgg/t3code/pull/3411/files#diff-538b14bdf595ee51e55aaaa249aab3e8505b533401c51b92360b4d9c37251c83), initial config load and shell sync error logs now use sanitized attributes instead of raw error objects.
> - Behavioral Change: error messages surfaced to callers and logs are now generic/sanitized; previously, raw error messages may have been exposed in state and structured logs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44a4c95.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->