### PR TITLE
[codex] Redact SSH tunnel diagnostics

### DIFF
--- a/packages/ssh/src/command.ts
+++ b/packages/ssh/src/command.ts
@@ -350,7 +350,10 @@ export const resolveSshTarget = Effect.fn("ssh/command.resolveSshTarget")(functi
       Effect.logDebug("ssh.target.resolve.succeeded", sshTargetLogFields(target)),
     ),
     Effect.catch((cause) =>
-      Effect.logDebug("ssh.target.resolve.fallback", { alias: trimmedAlias, cause }).pipe(
+      Effect.logDebug("ssh.target.resolve.fallback", {
+        alias: trimmedAlias,
+        failureTag: cause._tag,
+      }).pipe(
         Effect.as({
           alias: trimmedAlias,
           hostname: trimmedAlias,

--- a/packages/ssh/src/tunnel.test.ts
+++ b/packages/ssh/src/tunnel.test.ts
@@ -5,12 +5,14 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as PlatformError from "effect/PlatformError";
 import * as Result from "effect/Result";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import * as TestClock from "effect/testing/TestClock";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
@@ -21,6 +23,7 @@ import {
   SshHttpBridgeMissingUrlError,
   SshHttpBridgeNonLoopbackUrlError,
   SshPairingOutputParseError,
+  SshReadinessProbeError,
   SshReadinessProbeTimeoutError,
   SshReadinessTimeoutError,
 } from "./errors.ts";
@@ -86,6 +89,14 @@ const testNetService = NetService.NetService.of({
 
 function commandArgs(command: ChildProcess.Command): ReadonlyArray<string> {
   return command._tag === "StandardCommand" ? command.args : [];
+}
+
+function flattenedLogText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (typeof value !== "object" || value === null) return String(value);
+  return Object.entries(value)
+    .flatMap(([key, nested]) => [key, flattenedLogText(nested)])
+    .join("\n");
 }
 
 describe("ssh tunnel scripts", () => {
@@ -255,13 +266,22 @@ describe("ssh tunnel scripts", () => {
     assert.include(SshTunnel.REMOTE_PICK_PORT_SCRIPT, 'const filePath = process.argv[2] ?? "";');
   });
 
-  it.effect("bounds each HTTP readiness probe so retries cannot hang on one request", () =>
-    Effect.gen(function* () {
+  it.effect("bounds each HTTP readiness probe so retries cannot hang on one request", () => {
+    const baseUrl =
+      "http://ssh-user:ssh-password@127.0.0.1:41773/private/base?token=base-secret#base-fragment";
+    const path = "/ready/private?credential=request-secret#request-fragment";
+    const requestUrl = new URL(path, baseUrl).toString();
+    const capturedLogs: Array<ReadonlyArray<unknown>> = [];
+    const logger = Logger.make(({ message }) => {
+      capturedLogs.push(Array.isArray(message) ? message : [message]);
+    });
+
+    return Effect.gen(function* () {
       const fiber = yield* Effect.forkChild(
         Effect.result(
           SshTunnel.waitForHttpReady({
-            baseUrl: "http://127.0.0.1:41773/?token=base-secret#fragment",
-            path: "/ready?credential=request-secret#fragment",
+            baseUrl,
+            path,
             timeoutMs: 1_000,
             intervalMs: 100,
             probeTimeoutMs: 250,
@@ -281,8 +301,8 @@ describe("ssh tunnel scripts", () => {
           protocol: "http:",
           hostname: "127.0.0.1",
           port: "41773",
-          urlLength: 50,
-          pathnameLength: 1,
+          urlLength: baseUrl.length,
+          pathnameLength: new TextEncoder().encode(new URL(baseUrl).pathname).length,
           hasQuery: true,
           hasFragment: true,
         });
@@ -290,8 +310,8 @@ describe("ssh tunnel scripts", () => {
           protocol: "http:",
           hostname: "127.0.0.1",
           port: "41773",
-          urlLength: 63,
-          pathnameLength: 6,
+          urlLength: requestUrl.length,
+          pathnameLength: new TextEncoder().encode(new URL(requestUrl).pathname).length,
           hasQuery: true,
           hasFragment: true,
         });
@@ -311,13 +331,91 @@ describe("ssh tunnel scripts", () => {
         const probeTimeout = timeoutError.cause as SshReadinessProbeTimeoutError;
         assert.equal(probeTimeout.attempt, timeoutError.attempts);
         assert.isFalse("cause" in probeTimeout);
+
+        const logText = flattenedLogText(capturedLogs);
+        assert.include(logText, "127.0.0.1");
+        assert.notInclude(logText, "ssh-user");
+        assert.notInclude(logText, "ssh-password");
+        assert.notInclude(logText, "/private/base");
+        assert.notInclude(logText, "base-secret");
+        assert.notInclude(logText, "/ready/private");
+        assert.notInclude(logText, "request-secret");
+        assert.notInclude(logText, "base-fragment");
+        assert.notInclude(logText, "request-fragment");
       }
     }).pipe(
       Effect.provide(
-        Layer.merge(TestClock.layer(), Layer.succeed(HttpClient.HttpClient, hangingHttpClient)),
+        Layer.mergeAll(
+          TestClock.layer(),
+          Layer.succeed(HttpClient.HttpClient, hangingHttpClient),
+          Logger.layer([logger], { mergeWithExisting: false }),
+        ),
       ),
-    ),
-  );
+    );
+  });
+
+  it.effect("preserves the exact HTTP transport cause without logging request secrets", () => {
+    const baseUrl =
+      "http://transport-user:transport-password@127.0.0.1:41773/private?token=transport-secret#fragment";
+    const transportCause = new Error("socket closed");
+    const clientErrors: Array<HttpClientError.HttpClientError> = [];
+    const failingHttpClient = HttpClient.make((request) => {
+      const error = new HttpClientError.HttpClientError({
+        reason: new HttpClientError.TransportError({ request, cause: transportCause }),
+      });
+      clientErrors.push(error);
+      return Effect.fail(error);
+    });
+    const capturedLogs: Array<ReadonlyArray<unknown>> = [];
+    const logger = Logger.make(({ message }) => {
+      capturedLogs.push(Array.isArray(message) ? message : [message]);
+    });
+
+    return Effect.gen(function* () {
+      const fiber = yield* Effect.forkChild(
+        Effect.result(
+          SshTunnel.waitForHttpReady({
+            baseUrl,
+            timeoutMs: 300,
+            intervalMs: 100,
+            probeTimeoutMs: 250,
+          }),
+        ),
+      );
+      yield* Effect.yieldNow;
+      yield* TestClock.adjust(Duration.millis(300));
+
+      const result = yield* Fiber.join(fiber);
+      assert.isTrue(Result.isFailure(result));
+      if (Result.isFailure(result)) {
+        assert.instanceOf(result.failure, SshReadinessTimeoutError);
+        const timeoutError = result.failure as SshReadinessTimeoutError;
+        assert.instanceOf(timeoutError.cause, SshReadinessProbeError);
+        const probeError = timeoutError.cause as SshReadinessProbeError;
+        assert.strictEqual(probeError.cause, clientErrors.at(-1));
+        assert.strictEqual(
+          (probeError.cause as HttpClientError.HttpClientError).reason.cause,
+          transportCause,
+        );
+
+        const logText = flattenedLogText(capturedLogs);
+        assert.include(logText, "HttpClientError");
+        assert.include(logText, "TransportError");
+        assert.notInclude(logText, "transport-user");
+        assert.notInclude(logText, "transport-password");
+        assert.notInclude(logText, "/private");
+        assert.notInclude(logText, "transport-secret");
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          TestClock.layer(),
+          Layer.succeed(HttpClient.HttpClient, failingHttpClient),
+          Logger.layer([logger], { mergeWithExisting: false }),
+        ),
+      ),
+    );
+  });
 
   it.effect("preserves forwarded HTTP URL error messages", () =>
     Effect.gen(function* () {
@@ -363,6 +461,10 @@ describe("ssh tunnel scripts", () => {
         cause: { type: "string" },
       },
     );
+
+    const cyclicCause: { readonly _tag: string; cause?: unknown } = { _tag: "CyclicCause" };
+    cyclicCause.cause = cyclicCause;
+    assert.include(flattenedLogText(SshTunnel.describeReadinessCause(cyclicCause)), "truncated");
   });
 
   it("preserves structured readiness attributes in diagnostic output", () => {
@@ -542,6 +644,10 @@ describe("ssh tunnel scripts", () => {
     const spawnedCommands: Array<ReadonlyArray<string>> = [];
     let tunnelKillCount = 0;
     let stopCommandCount = 0;
+    const capturedLogs: Array<ReadonlyArray<unknown>> = [];
+    const logger = Logger.make(({ message }) => {
+      capturedLogs.push(Array.isArray(message) ? message : [message]);
+    });
     const spawner = ChildProcessSpawner.make((command) =>
       Effect.sync(() => {
         const args = commandArgs(command);
@@ -568,6 +674,7 @@ describe("ssh tunnel scripts", () => {
       Layer.succeed(NetService.NetService, testNetService),
       SshAuth.disabledLayer,
       SshTunnel.layer(),
+      Logger.layer([logger], { mergeWithExisting: false }),
     );
     const target = {
       alias: "devbox",
@@ -590,6 +697,10 @@ describe("ssh tunnel scripts", () => {
 
       assert.equal(spawnedCommands.filter((args) => args.includes("-N")).length, 2);
       assert.equal(tunnelKillCount, 1);
+
+      const logText = flattenedLogText(capturedLogs);
+      assert.include(logText, "httpBaseUrlDiagnostics");
+      assert.notInclude(logText, "httpBaseUrl\nhttp://");
     }).pipe(Effect.provide(layer), Effect.scoped);
   });
 });

--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -5,6 +5,8 @@ import type {
 import * as NetService from "@t3tools/shared/Net";
 import { extractJsonObject, fromLenientJson } from "@t3tools/shared/schemaJson";
 import { satisfiesSemverRange } from "@t3tools/shared/semver";
+import { getUrlDiagnostics } from "@t3tools/shared/urlDiagnostics";
+import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Deferred from "effect/Deferred";
 import * as Duration from "effect/Duration";
@@ -243,7 +245,24 @@ function applyScriptPlaceholders(
   return result;
 }
 
-export function describeReadinessCause(cause: unknown): unknown {
+const SSH_FAILURE_DIAGNOSTIC_DEPTH = 6;
+
+function describeReadinessCauseAtDepth(cause: unknown, depth: number): unknown {
+  if (depth >= SSH_FAILURE_DIAGNOSTIC_DEPTH) return { truncated: true };
+  const describeNested = (nested: unknown) => describeReadinessCauseAtDepth(nested, depth + 1);
+  if (Cause.isCause(cause)) {
+    return {
+      reasons: cause.reasons.map((reason) => {
+        if (Cause.isFailReason(reason)) {
+          return { _tag: reason._tag, error: describeNested(reason.error) };
+        }
+        if (Cause.isDieReason(reason)) {
+          return { _tag: reason._tag, defect: describeNested(reason.defect) };
+        }
+        return { _tag: reason._tag, fiberId: reason.fiberId };
+      }),
+    };
+  }
   if (isSshReadinessError(cause)) {
     const { cause: nestedCause, ...attributes } = cause as SshReadinessError & {
       readonly cause?: unknown;
@@ -251,13 +270,15 @@ export function describeReadinessCause(cause: unknown): unknown {
     return {
       ...attributes,
       message: cause.message,
-      ...(nestedCause === undefined ? {} : { cause: describeReadinessCause(nestedCause) }),
+      ...(nestedCause === undefined ? {} : { cause: describeNested(nestedCause) }),
     };
   }
   if (cause instanceof Error) {
+    const tagged = cause as Error & { readonly _tag?: unknown; readonly reason?: unknown };
     return {
-      name: cause.name,
-      ...(cause.cause === undefined ? {} : { cause: describeReadinessCause(cause.cause) }),
+      ...(typeof tagged._tag === "string" ? { _tag: tagged._tag } : { name: cause.name }),
+      ...(tagged.reason === undefined ? {} : { reason: describeNested(tagged.reason) }),
+      ...(cause.cause === undefined ? {} : { cause: describeNested(cause.cause) }),
     };
   }
   if (typeof cause !== "object" || cause === null) {
@@ -267,17 +288,23 @@ export function describeReadinessCause(cause: unknown): unknown {
   const record = cause as Readonly<Record<string, unknown>>;
   return {
     ...(typeof record._tag === "string" ? { _tag: record._tag } : {}),
-    ...(record.reason === undefined ? {} : { reason: describeReadinessCause(record.reason) }),
-    ...(record.cause === undefined ? {} : { cause: describeReadinessCause(record.cause) }),
+    ...(record.reason === undefined ? {} : { reason: describeNested(record.reason) }),
+    ...(record.cause === undefined ? {} : { cause: describeNested(record.cause) }),
   };
 }
 
-function readinessUrlDiagnostics(url: URL, urlLength: number) {
+export function describeReadinessCause(cause: unknown): unknown {
+  return describeReadinessCauseAtDepth(cause, 0);
+}
+
+function readinessUrlDiagnostics(input: string) {
+  const url = new URL(input);
+  const diagnostics = getUrlDiagnostics(input);
   return {
-    protocol: url.protocol,
-    hostname: url.hostname,
+    protocol: diagnostics.protocol ?? url.protocol,
+    hostname: diagnostics.hostname ?? url.hostname,
     ...(url.port === "" ? {} : { port: url.port }),
-    urlLength,
+    urlLength: diagnostics.inputLength,
     pathnameLength: utf8ByteLength(url.pathname),
     hasQuery: url.search !== "",
     hasFragment: url.hash !== "",
@@ -900,8 +927,8 @@ export const waitForHttpReady = Effect.fn("ssh/tunnel.waitForHttpReady")(functio
   const baseUrl = new URL(input.baseUrl);
   const request = new URL(input.path ?? "/", baseUrl);
   const requestUrl = request.toString();
-  const base = readinessUrlDiagnostics(baseUrl, utf8ByteLength(input.baseUrl));
-  const requestDiagnostics = readinessUrlDiagnostics(request, utf8ByteLength(requestUrl));
+  const base = readinessUrlDiagnostics(input.baseUrl);
+  const requestDiagnostics = readinessUrlDiagnostics(requestUrl);
   const client = yield* HttpClient.HttpClient;
   const lastProbeFailure = yield* Ref.make<unknown>(null);
   let attempt = 0;
@@ -1088,6 +1115,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
   const sshCommand = yield* resolveSshCommand;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const scope = yield* Scope.Scope;
+  const httpBaseUrlDiagnostics = getUrlDiagnostics(input.httpBaseUrl);
   yield* Effect.logDebug("ssh.tunnel.spawn.start", {
     ...sshTargetLogFields(input.resolvedTarget),
     command: sshCommand,
@@ -1095,7 +1123,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     localPort: input.localPort,
     remotePort: input.remotePort,
     remoteServerKind: input.remoteServerKind,
-    httpBaseUrl: input.httpBaseUrl,
+    httpBaseUrlDiagnostics,
   });
   const child = yield* spawner
     .spawn(
@@ -1128,7 +1156,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
     pid: child.pid,
     localPort: input.localPort,
     remotePort: input.remotePort,
-    httpBaseUrl: input.httpBaseUrl,
+    httpBaseUrlDiagnostics,
   });
   const tunnelEntry: SshTunnelEntry = {
     key: input.key,
@@ -1171,7 +1199,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
         pid: child.pid,
         localPort: input.localPort,
         remotePort: input.remotePort,
-        httpBaseUrl: input.httpBaseUrl,
+        httpBaseUrlDiagnostics,
         exitCode,
         stderrBytes: utf8ByteLength(stderr),
       }).pipe(Effect.andThen(Effect.fail(error)));
@@ -1192,7 +1220,7 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
         pid: child.pid,
         localPort: input.localPort,
         remotePort: input.remotePort,
-        httpBaseUrl: input.httpBaseUrl,
+        httpBaseUrlDiagnostics,
       }),
     ),
     Effect.tapError((cause) =>
@@ -1220,19 +1248,19 @@ const startSshTunnel = Effect.fn("ssh/tunnel.startSshTunnel")(function* (input: 
           processRunning,
           ...(Exit.isSuccess(processRunningExit)
             ? {}
-            : { processRunningError: processRunningExit.cause }),
+            : { processRunningFailure: describeReadinessCause(processRunningExit.cause) }),
           localPort: input.localPort,
           localPortListening: localPortAvailable === null ? null : !localPortAvailable,
           remotePort: input.remotePort,
-          httpBaseUrl: input.httpBaseUrl,
+          httpBaseUrlDiagnostics,
           ...(Exit.isSuccess(localPortAvailableExit)
             ? {}
-            : { localPortProbeError: localPortAvailableExit.cause }),
+            : { localPortProbeFailure: describeReadinessCause(localPortAvailableExit.cause) }),
           ...(remoteLogTail === null ? {} : { remoteLogTailBytes: utf8ByteLength(remoteLogTail) }),
           ...(Exit.isSuccess(remoteLogTailExit)
             ? {}
-            : { remoteLogTailError: remoteLogTailExit.cause }),
-          cause,
+            : { remoteLogTailFailure: describeReadinessCause(remoteLogTailExit.cause) }),
+          failure: describeReadinessCause(cause),
         });
       }),
     ),
@@ -1370,7 +1398,7 @@ export const make = Effect.fn("ssh/tunnel.SshEnvironmentManager.make")(function*
         ...sshTargetLogFields(input.target),
         key: input.key,
         promptCount: input.promptCount,
-        cause: input.error,
+        failure: describeReadinessCause(input.error),
       });
       const promptService = yield* SshAuth.SshPasswordPrompt;
       if (!promptService.isAvailable) {
@@ -1569,7 +1597,7 @@ export const make = Effect.fn("ssh/tunnel.SshEnvironmentManager.make")(function*
         key,
         localPort: entry.localPort,
         remotePort: entry.remotePort,
-        cause: readinessExit.cause,
+        failure: describeReadinessCause(readinessExit.cause),
       });
       yield* closeTunnelEntry(entry);
       yield* cancelPendingTunnelEntry(key, resolvedTarget);
@@ -1597,7 +1625,7 @@ export const make = Effect.fn("ssh/tunnel.SshEnvironmentManager.make")(function*
         Effect.logWarning("ssh.environment.tunnel.create.failed", {
           ...sshTargetLogFields(resolvedTarget),
           key,
-          cause,
+          failure: describeReadinessCause(cause),
         }),
       ),
       Effect.onExit((exit) =>


### PR DESCRIPTION
## Problem

SSH tunnel readiness and lifecycle logs included complete forwarded URLs and nested causes. A forwarded request can contain credentials and private path, query, or fragment data, while HTTP client causes retain the complete request. Logging those objects directly leaks the values that structured errors intentionally preserve for the cause chain.

## Changes

- derive URL diagnostics through the shared safe URL helper and replace raw forwarded URL log fields
- preserve the exact HTTP transport cause on the structured readiness error chain
- convert nested causes and Effect causes into bounded structural diagnostics before logging them
- remove direct cause logging from SSH authentication, stale tunnel, tunnel creation, and target-resolution fallbacks
- retain useful correlation fields such as protocol, hostname, input/path length, query/fragment presence, ports, attempts, and error tags

## Validation

- `vp check`
- `vp test packages/ssh/src/command.test.ts packages/ssh/src/tunnel.test.ts`
- `vp run typecheck`

The focused tests use credentials plus private path, query, and fragment sentinels and verify exact cause identity without serializing those values into logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SSH tunnel readiness, auth retry, and diagnostic paths where mis-redaction could hide debugging signal or mishandle causes; behavior is heavily test-covered but still security-sensitive logging.
> 
> **Overview**
> **SSH tunnel and command logging no longer emit full forwarded URLs or raw nested errors**, reducing leakage of credentials, paths, query params, and fragments that structured errors still keep on the in-memory cause chain.
> 
> Tunnel lifecycle and readiness logs now use **`getUrlDiagnostics`** / **`readinessUrlDiagnostics`** (protocol, hostname, lengths, query/fragment flags) instead of `httpBaseUrl` strings. **`describeReadinessCause`** walks Effect causes and errors with a depth cap, strips arbitrary messages, and surfaces tags/structure for log fields renamed from `cause` to **`failure`** (auth, stale tunnels, ready failures, target-resolve fallback logs only **`failureTag`**).
> 
> Tests assert secrets stay out of captured logs while **HTTP transport causes remain identical** on `SshReadinessProbeError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9591bea5f341bb422dcb095da9fc591190262fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Redact sensitive data from SSH tunnel diagnostic logs
> - Replaces raw URLs, cause objects, and error details in SSH tunnel logs with structured, redacted diagnostics using a new `describeReadinessCauseAtDepth` helper in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/3412/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072).
> - `describeReadinessCauseAtDepth` produces depth-bounded (max depth 6) descriptions of Effect Cause trees, preventing infinite recursion on cyclic structures and avoiding exposure of secrets in logs.
> - URL diagnostics are now derived via `getUrlDiagnostics()` and `readinessUrlDiagnostics()`, stripping userinfo, query, fragment, and path details from emitted log fields.
> - In `startSshTunnel` and `SshEnvironmentManager`, raw `cause` fields are replaced with `failure: describeReadinessCause(...)` and raw `httpBaseUrl` is replaced with `httpBaseUrlDiagnostics`.
> - In [command.ts](https://github.com/pingdotgg/t3code/pull/3412/files#diff-4f1aef4b11679d8551404a853942f04f47c3a80c050bc25b784d2b0c48ec9e5e), the `resolveSshTarget` error log now emits only `failureTag` instead of the full cause object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9591bea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->