### PR TITLE
[codex] Structure process resource sampling failures

### DIFF
--- a/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.test.ts
@@ -111,7 +111,7 @@ describe("ProcessResourceMonitor", () => {
         readAtMs: DateTime.toEpochMillis(secondAt),
         windowMs: 60_000,
         bucketMs: 10_000,
-        lastError: null,
+        lastFailure: null,
       });
 
       expect(Option.isNone(result.error)).toBe(true);
@@ -171,7 +171,7 @@ describe("ProcessResourceMonitor", () => {
         readAtMs: DateTime.toEpochMillis(secondAt),
         windowMs: 60_000,
         bucketMs: 10_000,
-        lastError: null,
+        lastFailure: null,
       });
 
       expect(result.topProcesses).toHaveLength(1);
@@ -218,11 +218,38 @@ describe("ProcessResourceMonitor", () => {
         readAtMs: DateTime.toEpochMillis(sampledAt),
         windowMs: 60_000,
         bucketMs: 10_000,
-        lastError: null,
+        lastFailure: null,
       });
 
       expect(result.topProcesses).toHaveLength(36);
       expect(result.topProcesses.some((process) => process.command === "worker 34")).toBe(true);
+    }),
+  );
+
+  it.effect("exposes bounded failure diagnostics while retaining the exact cause", () =>
+    Effect.sync(() => {
+      const readAt = DateTime.makeUnsafe("2026-05-05T10:00:00.000Z");
+      const cause = new Error("stderr included credential=secret-value");
+      const failure = new ProcessResourceMonitor.ProcessResourceSamplingError({
+        failureTag: "ProcessDiagnosticsQueryFailedError",
+        cause,
+      });
+
+      const result = ProcessResourceMonitor.aggregateProcessResourceHistory({
+        samples: [],
+        readAt,
+        readAtMs: DateTime.toEpochMillis(readAt),
+        windowMs: 60_000,
+        bucketMs: 10_000,
+        lastFailure: failure,
+      });
+
+      expect(failure.cause).toBe(cause);
+      expect(Option.getOrThrow(result.error)).toEqual({
+        failureTag: "ProcessDiagnosticsQueryFailedError",
+        message: "Failed to sample process resources (ProcessDiagnosticsQueryFailedError).",
+      });
+      expect(Option.getOrThrow(result.error).message).not.toContain("secret-value");
     }),
   );
 });

--- a/apps/server/src/diagnostics/ProcessResourceMonitor.ts
+++ b/apps/server/src/diagnostics/ProcessResourceMonitor.ts
@@ -1,8 +1,10 @@
-import type {
-  ServerProcessResourceHistoryBucket,
-  ServerProcessResourceHistoryInput,
-  ServerProcessResourceHistoryResult,
-  ServerProcessResourceHistorySummary,
+import {
+  ServerProcessResourceHistoryFailureTag,
+  type ServerProcessResourceHistoryBucket,
+  type ServerProcessResourceHistoryFailureTag as ServerProcessResourceHistoryFailureTagType,
+  type ServerProcessResourceHistoryInput,
+  type ServerProcessResourceHistoryResult,
+  type ServerProcessResourceHistorySummary,
 } from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -10,6 +12,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as ProcessDiagnostics from "./ProcessDiagnostics.ts";
@@ -31,9 +34,21 @@ export interface ProcessResourceSample {
   readonly isServerRoot: boolean;
 }
 
+export class ProcessResourceSamplingError extends Schema.TaggedErrorClass<ProcessResourceSamplingError>()(
+  "ProcessResourceSamplingError",
+  {
+    failureTag: ServerProcessResourceHistoryFailureTag,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to sample process resources (${this.failureTag}).`;
+  }
+}
+
 interface MonitorState {
   readonly samples: ReadonlyArray<ProcessResourceSample>;
-  readonly lastError: string | null;
+  readonly lastFailure: ProcessResourceSamplingError | null;
 }
 
 export class ProcessResourceMonitor extends Context.Service<
@@ -218,7 +233,7 @@ export function aggregateProcessResourceHistory(input: {
   readonly readAtMs: number;
   readonly windowMs: number;
   readonly bucketMs: number;
-  readonly lastError: string | null;
+  readonly lastFailure: ProcessResourceSamplingError | null;
 }): ServerProcessResourceHistoryResult {
   const windowMs = Math.max(1_000, input.windowMs);
   const bucketMs = Math.max(1_000, input.bucketMs);
@@ -239,13 +254,29 @@ export function aggregateProcessResourceHistory(input: {
     totalCpuSecondsApprox,
     buckets: buildBuckets({ samples, nowMs: input.readAtMs, windowMs, bucketMs }),
     topProcesses,
-    error: input.lastError ? Option.some({ message: input.lastError }) : Option.none(),
+    error: input.lastFailure
+      ? Option.some({
+          failureTag: input.lastFailure.failureTag,
+          message: input.lastFailure.message,
+        })
+      : Option.none(),
   };
 }
 
 export const make = Effect.gen(function* () {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-  const state = yield* Ref.make<MonitorState>({ samples: [], lastError: null });
+  const state = yield* Ref.make<MonitorState>({ samples: [], lastFailure: null });
+
+  const recordSamplingFailure = (cause: {
+    readonly _tag: ServerProcessResourceHistoryFailureTagType;
+  }) =>
+    Ref.update(state, (current) => ({
+      ...current,
+      lastFailure: new ProcessResourceSamplingError({
+        failureTag: cause._tag,
+        cause,
+      }),
+    }));
 
   const sampleOnce = Effect.gen(function* () {
     const sampledAt = yield* DateTime.now;
@@ -261,15 +292,16 @@ export const make = Effect.gen(function* () {
     });
     yield* Ref.update(state, (current) => ({
       samples: trimSamples([...current.samples, ...samples], sampledAtMs),
-      lastError: null,
+      lastFailure: null,
     }));
   }).pipe(
-    Effect.catch((error: unknown) =>
-      Ref.update(state, (current) => ({
-        ...current,
-        lastError: error instanceof Error ? error.message : "Failed to sample process resources.",
-      })),
-    ),
+    Effect.catchTags({
+      ProcessDiagnosticsQueryTimeoutError: recordSamplingFailure,
+      ProcessDiagnosticsQueryFailedError: recordSamplingFailure,
+      ProcessDiagnosticsServerProcessSignalError: recordSamplingFailure,
+      ProcessDiagnosticsNotDescendantError: recordSamplingFailure,
+      ProcessDiagnosticsSignalFailedError: recordSamplingFailure,
+    }),
   );
 
   yield* Effect.forever(sampleOnce.pipe(Effect.andThen(Effect.sleep(SAMPLE_INTERVAL_MS)))).pipe(
@@ -287,7 +319,7 @@ export const make = Effect.gen(function* () {
         readAtMs,
         windowMs: input.windowMs,
         bucketMs: input.bucketMs,
-        lastError: current.lastError,
+        lastFailure: current.lastFailure,
       });
     });
 

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -364,6 +364,16 @@ export const ServerProcessResourceHistorySummary = Schema.Struct({
 });
 export type ServerProcessResourceHistorySummary = typeof ServerProcessResourceHistorySummary.Type;
 
+export const ServerProcessResourceHistoryFailureTag = Schema.Literals([
+  "ProcessDiagnosticsQueryTimeoutError",
+  "ProcessDiagnosticsQueryFailedError",
+  "ProcessDiagnosticsServerProcessSignalError",
+  "ProcessDiagnosticsNotDescendantError",
+  "ProcessDiagnosticsSignalFailedError",
+]);
+export type ServerProcessResourceHistoryFailureTag =
+  typeof ServerProcessResourceHistoryFailureTag.Type;
+
 export const ServerProcessResourceHistoryResult = Schema.Struct({
   readAt: Schema.DateTimeUtc,
   windowMs: NonNegativeInt,
@@ -375,6 +385,7 @@ export const ServerProcessResourceHistoryResult = Schema.Struct({
   topProcesses: Schema.Array(ServerProcessResourceHistorySummary),
   error: Schema.Option(
     Schema.Struct({
+      failureTag: ServerProcessResourceHistoryFailureTag,
       message: TrimmedNonEmptyString,
     }),
   ),


### PR DESCRIPTION
## Summary
- retain the exact typed ProcessDiagnostics failure as the sampling error cause
- replace broad catch handling with exhaustive `Effect.catchTags`
- expose a bounded failure tag and derived safe message through process resource history instead of raw child-process messages
- cover exact cause retention and diagnostic redaction

## Validation
- `vp test apps/server/src/diagnostics/ProcessResourceMonitor.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Contract change to history `error` shape and altered failure handling on the diagnostics sampling path; low blast radius but clients must handle `failureTag` and no longer see raw stderr in `message`.
> 
> **Overview**
> Process resource history no longer surfaces raw sampling error strings (e.g. child-process stderr). Failures are stored as **`ProcessResourceSamplingError`** with a typed **`failureTag`** and the original **`ProcessDiagnostics`** error kept as **`cause`**, while the API returns a fixed safe **`message`** plus **`failureTag`**.
> 
> The sampling loop replaces a broad **`catch`** that persisted **`Error.message`** with exhaustive **`Effect.catchTags`** for the known diagnostics failure tags. **`ServerProcessResourceHistoryResult.error`** in contracts gains **`failureTag`** alongside **`message`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 125bf91740c76ca4ff5d824092cb53e7f8a7a00c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure process resource sampling failures with typed errors and bounded messages
> - Introduces `ProcessResourceSamplingError` in [`ProcessResourceMonitor.ts`](https://github.com/pingdotgg/t3code/pull/3415/files#diff-531add2e9c8cf312f695a676a24b959ff83264a563fac3914620ab8e1f516d6b), a tagged error class that carries an explicit `failureTag` and a bounded message without exposing internal cause details.
> - Replaces the `lastError: string | null` state field with `lastFailure: ProcessResourceSamplingError | null`, and only records failures for known `ProcessDiagnostics`-tagged errors via `catchTags`.
> - Updates `aggregateProcessResourceHistory` to return a structured error object with `failureTag` and bounded message; arbitrary error strings are no longer propagated to callers.
> - Adds `ServerProcessResourceHistoryFailureTag` to [`packages/contracts/src/server.ts`](https://github.com/pingdotgg/t3code/pull/3415/files#diff-e575e7eac4053ca860f2d99f4f5bf09331b4e959961ac7bfed0562e916fc5dbb), enumerating the allowed failure tags and adding a `failureTag` field to the result's error schema.
> - Behavioral Change: the error object in `ServerProcessResourceHistoryResult` now includes a `failureTag` field, which is a breaking schema change for any consumers reading the error shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 125bf91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->