### PR TITLE
[codex] sanitize ACP native event diagnostics

### DIFF
--- a/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.test.ts
@@ -6,8 +6,12 @@ import * as NodePath from "node:path";
 import { ThreadId } from "@t3tools/contracts";
 import { assert, describe, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Logger from "effect/Logger";
+import * as Schema from "effect/Schema";
 
 import { makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+
+const encodeUnknownJson = Schema.encodeUnknownSync(Schema.UnknownFromJsonString);
 
 function parseLogLine(line: string) {
   const match = /^\[([^\]]+)\] ([A-Z]+): (.+)$/.exec(line);
@@ -29,6 +33,38 @@ function parseLogLine(line: string) {
 }
 
 describe("EventNdjsonLogger", () => {
+  it.effect("logs bounded diagnostics when an event cannot be serialized", () => {
+    const messages: Array<unknown> = [];
+    const logCapture = Logger.make<unknown, void>(({ message }) => {
+      if (Array.isArray(message)) {
+        messages.push(...message);
+      } else {
+        messages.push(message);
+      }
+    });
+    const secret = "secret-circular-event-value";
+
+    return Effect.gen(function* () {
+      const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));
+      const basePath = NodePath.join(tempDir, "provider-native.ndjson");
+      const circular: Record<string, unknown> = { secret };
+      circular.self = circular;
+
+      try {
+        const logger = yield* makeEventNdjsonLogger(basePath, { stream: "native" });
+        assert.exists(logger);
+        if (!logger) return;
+        yield* logger.write(circular, ThreadId.make("thread-1"));
+
+        const serialized = encodeUnknownJson(messages);
+        assert.notInclude(serialized, secret);
+        assert.include(serialized, '"errorTag":"SchemaError"');
+      } finally {
+        NodeFS.rmSync(tempDir, { recursive: true, force: true });
+      }
+    }).pipe(Effect.provide(Logger.layer([logCapture], { mergeWithExisting: false })));
+  });
+
   it.effect("writes effect-style lines to thread-scoped files", () =>
     Effect.gen(function* () {
       const tempDir = NodeFS.mkdtempSync(NodePath.join(NodeOS.tmpdir(), "t3-provider-log-"));

--- a/apps/server/src/provider/Layers/EventNdjsonLogger.ts
+++ b/apps/server/src/provider/Layers/EventNdjsonLogger.ts
@@ -11,6 +11,7 @@ import * as NodePath from "node:path";
 
 import type { ThreadId } from "@t3tools/contracts";
 import { RotatingFileSink } from "@t3tools/shared/logging";
+import { errorTag } from "@t3tools/shared/observability";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Logger from "effect/Logger";
@@ -31,8 +32,8 @@ export type EventNdjsonStream = "native" | "canonical" | "orchestration";
 
 export interface EventNdjsonLogger {
   readonly filePath: string;
-  write: (event: unknown, threadId: ThreadId | null) => Effect.Effect<void>;
-  close: () => Effect.Effect<void>;
+  write: (event: unknown, threadId: ThreadId | null) => Effect.Effect<void, never, never>;
+  close: () => Effect.Effect<void, never, never>;
 }
 
 export interface EventNdjsonLoggerOptions {
@@ -91,9 +92,9 @@ const toLogMessage = Effect.fn("toLogMessage")(function* (
 ): Effect.fn.Return<string | undefined> {
   return yield* encodeUnknownJsonString(event).pipe(
     Effect.catch((error) =>
-      logWarning("failed to serialize provider event log record", { error }).pipe(
-        Effect.as(undefined),
-      ),
+      logWarning("failed to serialize provider event log record", {
+        errorTag: errorTag(error),
+      }).pipe(Effect.as(undefined)),
     ),
   );
 });
@@ -124,7 +125,7 @@ const makeThreadWriter = Effect.fn("makeThreadWriter")(function* (input: {
   if (!sinkResult.ok) {
     yield* logWarning("failed to initialize provider thread log file", {
       filePath: input.filePath,
-      error: sinkResult.error,
+      errorTag: errorTag(sinkResult.error),
     });
     return undefined;
   }
@@ -149,7 +150,7 @@ const makeThreadWriter = Effect.fn("makeThreadWriter")(function* (input: {
       if (!flushResult.ok) {
         yield* logWarning("provider event log batch flush failed", {
           filePath: input.filePath,
-          error: flushResult.error,
+          errorTag: errorTag(flushResult.error),
         });
       }
     }),
@@ -187,7 +188,7 @@ export const makeEventNdjsonLogger = Effect.fn("makeEventNdjsonLogger")(function
   if (directoryReady !== true) {
     yield* logWarning("failed to create provider event log directory", {
       filePath,
-      error: directoryReady.error,
+      errorTag: errorTag(directoryReady.error),
     });
     return undefined;
   }

--- a/apps/server/src/provider/acp/AcpNativeLogging.test.ts
+++ b/apps/server/src/provider/acp/AcpNativeLogging.test.ts
@@ -1,0 +1,137 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { ProviderDriverKind, ThreadId } from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Logger from "effect/Logger";
+import * as Schema from "effect/Schema";
+import * as AcpErrors from "effect-acp/errors";
+
+import type { EventNdjsonLogger } from "../Layers/EventNdjsonLogger.ts";
+import { makeAcpNativeLoggerFactory } from "./AcpNativeLogging.ts";
+
+const nodeServicesIt = it.layer(NodeServices.layer);
+const encodeUnknownJson = Schema.encodeUnknownSync(Schema.UnknownFromJsonString);
+
+nodeServicesIt("ACP native logging", (it) => {
+  it.effect("records bounded request and protocol diagnostics without raw payloads", () =>
+    Effect.gen(function* () {
+      const records: Array<unknown> = [];
+      const nativeEventLogger: EventNdjsonLogger = {
+        filePath: "/tmp/provider-native.ndjson",
+        write: (event) => Effect.sync(() => void records.push(event)),
+        close: () => Effect.void,
+      };
+      const makeLogger = yield* makeAcpNativeLoggerFactory();
+      const logger = makeLogger({
+        nativeEventLogger,
+        provider: ProviderDriverKind.make("cursor"),
+        threadId: ThreadId.make("thread-1"),
+      });
+      const secret = "secret-token-value";
+      const requestLogger = logger.requestLogger;
+      const protocolLogger = logger.protocolLogging?.logger;
+      assert.exists(requestLogger);
+      assert.exists(protocolLogger);
+      if (!requestLogger || !protocolLogger) return;
+
+      yield* requestLogger({
+        method: "session/prompt",
+        payload: { prompt: secret, sessionId: secret },
+        status: "failed",
+        cause: Cause.fail(AcpErrors.AcpRequestError.internalError(secret, { token: secret })),
+      });
+      yield* protocolLogger({
+        direction: "incoming",
+        stage: "raw",
+        payload: `{"token":"${secret}"}`,
+      });
+      yield* protocolLogger({
+        direction: "outgoing",
+        stage: "decoded",
+        payload: {
+          _tag: "Request",
+          tag: "session/prompt",
+          payload: { prompt: secret },
+        },
+      });
+
+      const serialized = encodeUnknownJson(records);
+      assert.notInclude(serialized, secret);
+      assert.include(serialized, '"method":"session/prompt"');
+      assert.include(serialized, '"errorTag":"AcpRequestError"');
+      assert.include(serialized, '"reasonCount":1');
+      assert.include(serialized, '"valueType":"string"');
+      assert.include(serialized, '"messageTag":"Request"');
+    }),
+  );
+
+  it.effect("logs a structural tag when the native writer defects", () => {
+    const messages: Array<unknown> = [];
+    const logCapture = Logger.make<unknown, void>(({ message }) => {
+      if (Array.isArray(message)) {
+        messages.push(...message);
+      } else {
+        messages.push(message);
+      }
+    });
+    const secret = "secret-writer-failure";
+
+    return Effect.gen(function* () {
+      const makeLogger = yield* makeAcpNativeLoggerFactory();
+      const logger = makeLogger({
+        nativeEventLogger: {
+          filePath: "/tmp/provider-native.ndjson",
+          write: () => Effect.die(new Error(secret)),
+          close: () => Effect.void,
+        },
+        provider: ProviderDriverKind.make("cursor"),
+        threadId: ThreadId.make("thread-1"),
+      });
+      const requestLogger = logger.requestLogger;
+      assert.exists(requestLogger);
+      if (!requestLogger) return;
+
+      yield* requestLogger({
+        method: "session/prompt",
+        payload: {},
+        status: "started",
+      });
+
+      const serialized = encodeUnknownJson(messages);
+      assert.notInclude(serialized, secret);
+      assert.include(serialized, '"errorTag":"Die"');
+      assert.include(serialized, '"reasonCount":1');
+    }).pipe(Effect.provide(Logger.layer([logCapture], { mergeWithExisting: false })));
+  });
+
+  it.effect("preserves native writer interruption", () =>
+    Effect.gen(function* () {
+      const makeLogger = yield* makeAcpNativeLoggerFactory();
+      const logger = makeLogger({
+        nativeEventLogger: {
+          filePath: "/tmp/provider-native.ndjson",
+          write: () => Effect.interrupt,
+          close: () => Effect.void,
+        },
+        provider: ProviderDriverKind.make("cursor"),
+        threadId: ThreadId.make("thread-1"),
+      });
+      const requestLogger = logger.requestLogger;
+      assert.exists(requestLogger);
+      if (!requestLogger) return;
+
+      const exit = yield* requestLogger({
+        method: "session/prompt",
+        payload: {},
+        status: "started",
+      }).pipe(Effect.exit);
+
+      assert.isTrue(Exit.isFailure(exit));
+      if (Exit.isFailure(exit)) {
+        assert.isTrue(Cause.hasInterruptsOnly(exit.cause));
+      }
+    }),
+  );
+});

--- a/apps/server/src/provider/acp/AcpNativeLogging.ts
+++ b/apps/server/src/provider/acp/AcpNativeLogging.ts
@@ -1,4 +1,5 @@
 import type { ProviderDriverKind, ThreadId } from "@t3tools/contracts";
+import { causeErrorTag, errorTag } from "@t3tools/shared/observability";
 import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
@@ -8,13 +9,58 @@ import type * as EffectAcpProtocol from "effect-acp/protocol";
 import type { EventNdjsonLogger } from "../Layers/EventNdjsonLogger.ts";
 import type * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
+function structuralMethod(value: string): string {
+  return value.length <= 128 && /^[A-Za-z][A-Za-z0-9._:/-]*$/.test(value) ? value : "unknown";
+}
+
+function summarizePayload(payload: unknown): Readonly<Record<string, unknown>> {
+  if (payload === null) return { valueType: "null" };
+  if (typeof payload === "string") {
+    return { valueType: "string", byteLength: new TextEncoder().encode(payload).byteLength };
+  }
+  if (payload instanceof Uint8Array) {
+    return { valueType: "bytes", byteLength: payload.byteLength };
+  }
+  if (Array.isArray(payload)) {
+    return { valueType: "array", itemCount: payload.length };
+  }
+  if (typeof payload !== "object") {
+    return { valueType: typeof payload };
+  }
+
+  try {
+    const record = payload as Record<string, unknown>;
+    return {
+      valueType: "object",
+      fieldCount: Object.keys(record).length,
+      ...(typeof record._tag === "string" ? { messageTag: errorTag(record) } : {}),
+      ...(typeof record.tag === "string" ? { method: structuralMethod(record.tag) } : {}),
+    };
+  } catch {
+    return { valueType: "object" };
+  }
+}
+
 function formatRequestLogPayload(event: AcpSessionRuntime.AcpSessionRequestLogEvent) {
   return {
-    method: event.method,
+    method: structuralMethod(event.method),
     status: event.status,
-    request: event.payload,
-    ...(event.result !== undefined ? { result: event.result } : {}),
-    ...(event.cause !== undefined ? { cause: Cause.pretty(event.cause) } : {}),
+    request: summarizePayload(event.payload),
+    ...(event.result !== undefined ? { result: summarizePayload(event.result) } : {}),
+    ...(event.cause !== undefined
+      ? {
+          errorTag: causeErrorTag(event.cause),
+          reasonCount: event.cause.reasons.length,
+        }
+      : {}),
+  };
+}
+
+function formatProtocolLogPayload(event: EffectAcpProtocol.AcpProtocolLogEvent) {
+  return {
+    direction: event.direction,
+    stage: event.stage,
+    payload: summarizePayload(event.payload),
   };
 }
 
@@ -47,12 +93,15 @@ export const makeAcpNativeLoggerFactory = Effect.fn("makeAcpNativeLoggerFactory"
           input.threadId,
         );
       }).pipe(
-        Effect.catch((cause) =>
-          Effect.logWarning("Failed to write native ACP event log.", {
-            cause,
-            provider: input.provider,
-            threadId: input.threadId,
-          }),
+        Effect.catchCause((cause) =>
+          Cause.hasInterrupts(cause)
+            ? Effect.interrupt
+            : Effect.logWarning("Failed to write native ACP event log.", {
+                errorTag: causeErrorTag(cause),
+                reasonCount: cause.reasons.length,
+                provider: input.provider,
+                threadId: input.threadId,
+              }),
         ),
       );
 
@@ -70,7 +119,7 @@ export const makeAcpNativeLoggerFactory = Effect.fn("makeAcpNativeLoggerFactory"
               logger: (event: EffectAcpProtocol.AcpProtocolLogEvent) =>
                 writeNativeAcpLog({
                   kind: "protocol",
-                  payload: event,
+                  payload: formatProtocolLogPayload(event),
                 }),
             } satisfies NonNullable<AcpSessionRuntime.AcpSessionRuntimeOptions["protocolLogging"]>,
           }

--- a/packages/shared/src/observability.test.ts
+++ b/packages/shared/src/observability.test.ts
@@ -15,10 +15,19 @@ import * as Tracer from "effect/Tracer";
 import {
   causeErrorTag,
   compactTraceAttributes,
+  errorTag,
   makeLocalFileTracer,
   makeTraceSink,
   type TraceRecord,
 } from "./observability.ts";
+
+describe("errorTag", () => {
+  it("reports structural tags without retaining arbitrary values", () => {
+    assert.equal(errorTag({ _tag: "AcpRequestError" }), "AcpRequestError");
+    assert.equal(errorTag(new TypeError("secret-token-value")), "TypeError");
+    assert.equal(errorTag({ _tag: "secret token value" }), "TaggedError");
+  });
+});
 
 describe("causeErrorTag", () => {
   it("reports the tagged failure value instead of the Cause reason wrapper", () => {

--- a/packages/shared/src/observability.ts
+++ b/packages/shared/src/observability.ts
@@ -73,18 +73,33 @@ export interface OtlpTraceRecord extends BaseTraceRecord {
 
 export type TraceRecord = EffectTraceRecord | OtlpTraceRecord;
 
-function taggedErrorName(error: unknown): string {
-  return typeof error === "object" && error !== null && "_tag" in error
-    ? String(error._tag)
-    : error instanceof Error
-      ? error.name
-      : typeof error;
+function isStructuralTag(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 128 &&
+    /^[A-Za-z][A-Za-z0-9._:/-]*$/.test(value)
+  );
+}
+
+export function errorTag(error: unknown): string {
+  try {
+    if (typeof error === "object" && error !== null && "_tag" in error) {
+      return isStructuralTag(error._tag) ? error._tag : "TaggedError";
+    }
+    if (error instanceof Error) {
+      return isStructuralTag(error.name) ? error.name : "Error";
+    }
+  } catch {
+    return "UnknownError";
+  }
+  return typeof error;
 }
 
 export function causeErrorTag(cause: Cause.Cause<unknown>): string {
   const failure = Cause.findErrorOption(cause);
   if (Option.isSome(failure)) {
-    return taggedErrorName(failure.value);
+    return errorTag(failure.value);
   }
   return cause.reasons[0]?._tag ?? "Empty";
 }


### PR DESCRIPTION
## Summary
- replace raw ACP request/result/protocol payload logging with bounded type, size, method, status, and failure-tag diagnostics
- stop serializing nested causes and filesystem/serialization defects into provider log warnings
- preserve logger interruption semantics while keeping best-effort writer defects non-fatal
- add a reusable bounded `errorTag` helper for untyped failures

## Validation
- `vp test packages/shared/src/observability.test.ts apps/server/src/provider/acp/AcpNativeLogging.test.ts apps/server/src/provider/Layers/EventNdjsonLogger.test.ts` (18 tests)
- `vp check` (passes with existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what gets persisted in provider observability logs (less detail for debugging) but reduces leakage of session/protocol secrets; write-path interrupt behavior is explicitly preserved.
> 
> **Overview**
> **Provider observability logs no longer carry raw ACP or filesystem failure details.** Native request/protocol records and NDJSON writer warnings are reduced to bounded metadata (payload shape, byte lengths, validated method names, `errorTag`, `reasonCount`) instead of full payloads, `Cause.pretty` output, or nested error objects.
> 
> ACP native logging adds **`summarizePayload`** / **`formatProtocolLogPayload`** so secrets in prompts, tokens, and wire JSON are not written to thread logs. Write failures are handled with **`catchCause`**: interruptions propagate; other defects log structural tags only. **`EventNdjsonLogger`** applies the same **`errorTag`** pattern for serialization and I/O warnings.
> 
> **`packages/shared`** exports **`errorTag`** with structural-tag validation (replacing inline tag/name extraction used by **`causeErrorTag`**). Tests assert secrets stay out of serialized log output and interruption semantics are preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3567ded68ebbd940a1cac4b06c4f5b7163e072e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sanitize ACP native event diagnostics by replacing raw error objects with bounded structural tags
> - Adds `errorTag` to [observability.ts](https://github.com/pingdotgg/t3code/pull/3417/files#diff-025893f041e950019e21bf1e931f71f4cb3a7af40582592438fba6869696cb17) that converts arbitrary error values into bounded structural tag strings (1–128 chars, `[A-Za-z][A-Za-z0-9._:/-]*`), used by `causeErrorTag`.
> - Updates [EventNdjsonLogger.ts](https://github.com/pingdotgg/t3code/pull/3417/files#diff-9e7861bc2eacfd2573bb80a1ee8844469e360556c2d989224c7af3771489937f) to log `errorTag(error)` instead of raw error objects on serialization, sink init, flush, and directory creation failures.
> - Updates [AcpNativeLogging.ts](https://github.com/pingdotgg/t3code/pull/3417/files#diff-03915e94a1e322a09e994555bf6971ef9746947f6946446144fe8e6419408540) to summarize request/protocol payloads (type, size, field count) and emit `errorTag`/`reasonCount` instead of raw payloads or `Cause.pretty` output.
> - Adds interruption preservation in `makeAcpNativeLoggerFactory`: interruptions propagate via `Effect.interrupt`; non-interrupt failures emit a bounded warning.
> - Behavioral Change: log records for ACP events and ndjson writer failures no longer contain raw error objects or payload content — only structural tags and size metadata.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3567de.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->