### PR TITLE
[codex] Bound relay registration replay diagnostics

### DIFF
--- a/infra/relay/src/agentActivity/MobileRegistrations.test.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.test.ts
@@ -7,6 +7,7 @@ import * as NodeCryptoLayer from "@effect/platform-node/NodeCrypto";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Redacted from "effect/Redacted";
 import { FetchHttpClient } from "effect/unstable/http";
 
@@ -232,6 +233,11 @@ describe("MobileRegistrations", () => {
   });
 
   it.effect("keeps device registration successful when activity replay fails", () => {
+    const messages: unknown[] = [];
+    const logger = Logger.make(({ message }) => {
+      messages.push(message);
+    });
+
     return Effect.gen(function* () {
       const result = yield* Effect.gen(function* () {
         const registrations = yield* MobileRegistrations.MobileRegistrations;
@@ -250,7 +256,7 @@ describe("MobileRegistrations", () => {
                       Effect.fail(
                         new AgentActivityRows.AgentActivityRowListPersistenceError({
                           userId: "dev:julius",
-                          cause: "replay failed",
+                          cause: "sensitive device replay detail",
                         }),
                       ),
                   }),
@@ -262,7 +268,11 @@ describe("MobileRegistrations", () => {
       );
 
       expect(result).toEqual({ ok: true });
-    });
+      expect(messages).toContainEqual([
+        "device registration activity replay failed",
+        { errorTag: "AgentActivityRowListPersistenceError" },
+      ]);
+    }).pipe(Effect.provide(Logger.layer([logger], { mergeWithExisting: false })));
   });
 
   it.effect("unregisters the current user's device", () => {

--- a/infra/relay/src/agentActivity/MobileRegistrations.ts
+++ b/infra/relay/src/agentActivity/MobileRegistrations.ts
@@ -51,8 +51,10 @@ export const make = Effect.gen(function* () {
           deviceId: input.payload.deviceId,
         })
         .pipe(
-          Effect.tapError((cause) =>
-            Effect.logWarning("device registration activity replay failed", { cause }),
+          Effect.tapError((error) =>
+            Effect.logWarning("device registration activity replay failed", {
+              errorTag: error._tag,
+            }),
           ),
           Effect.ignore,
         );
@@ -70,8 +72,10 @@ export const make = Effect.gen(function* () {
             deviceId: input.payload.deviceId,
           })
           .pipe(
-            Effect.tapError((cause) =>
-              Effect.logWarning("live activity registration replay failed", { cause }),
+            Effect.tapError((error) =>
+              Effect.logWarning("live activity registration replay failed", {
+                errorTag: error._tag,
+              }),
             ),
             Effect.ignore,
           );


### PR DESCRIPTION
## Summary
- replace nested typed replay failures in relay registration warnings with bounded error tags
- preserve best-effort registration behavior while keeping durable diagnostics structural
- extend the existing failure-path test to assert the observable warning shape

## Validation
- `vp test infra/relay/src/agentActivity/MobileRegistrations.test.ts`
- `vp check` (20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to warning log fields; registration success and best-effort replay behavior are unchanged.
> 
> **Overview**
> When **device** or **live activity** registration succeeds but post-registration activity replay fails, relay warnings no longer attach the full typed error (including nested `cause` strings). Warnings now log only **`errorTag`** from the Effect error’s `_tag`, while replay failures are still swallowed so registration returns `{ ok: true }`.
> 
> The failure-path test captures logger output and asserts the warning is `device registration activity replay failed` with `{ errorTag: "AgentActivityRowListPersistenceError" }`, not sensitive replay detail from the mock persistence error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c229f47612489cce8913554e84d529c5e06ad186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bound relay registration replay diagnostics to log only error tags
> When activity replay fails during device or live activity registration in `MobileRegistrations`, the warning log now emits `{ errorTag: error._tag }` instead of the full error cause object. Tests in [MobileRegistrations.test.ts](https://github.com/pingdotgg/t3code/pull/3420/files#diff-d1aea968ed5a972f204f7f825a476f3345ca52f3a58f904dcdd470dc85560bc6) are updated to assert on the `errorTag` field using a custom logger that captures emitted log messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c229f47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->