### PR TITLE
[codex] Structure managed endpoint allocation failures

### DIFF
--- a/infra/relay/src/environments/ManagedEndpointAllocations.ts
+++ b/infra/relay/src/environments/ManagedEndpointAllocations.ts
@@ -120,7 +120,7 @@ const whereAllocation = (input: ManagedEndpointAllocationKey) =>
     eq(relayManagedEndpointAllocations.environmentId, input.environmentId),
   );
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const db = yield* RelayDb.RelayDb;
 
   return ManagedEndpointAllocations.of({

--- a/infra/relay/src/environments/ManagedEndpointProvider.test.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.test.ts
@@ -133,7 +133,7 @@ function makeDnsClient(
             operation: "update-record",
             hostname: request.name,
             dnsRecordId,
-            cause: `DNS record ${dnsRecordId} does not exist.`,
+            cause: { _tag: "NotFound", dnsRecordId },
           });
         }
       }),
@@ -531,6 +531,59 @@ describe("ManagedEndpointProvider", () => {
     }).pipe(Effect.provide(layer));
   });
 
+  it.effect("does not hide non-not-found checkpoint update failures", () => {
+    const dnsCalls: DnsCall[] = [];
+    const failure = new ManagedEndpointProvider.ManagedEndpointDnsClientError({
+      operation: "update-record",
+      dnsRecordId: "created-record-id",
+      cause: new Error("Cloudflare DNS unavailable"),
+    });
+    let records: ReadonlyArray<{ readonly id: string }> = [];
+    const dnsClient = ManagedEndpointProvider.ManagedEndpointDnsClient.of({
+      listRecords: (hostname) =>
+        Effect.sync(() => {
+          dnsCalls.push({ operation: "listRecords", input: hostname });
+          return records;
+        }),
+      createRecord: (request) =>
+        Effect.sync(() => {
+          dnsCalls.push({ operation: "createRecord", input: request });
+          const record = { id: "created-record-id" };
+          records = [record];
+          return record;
+        }),
+      updateRecord: (dnsRecordId, request) =>
+        Effect.sync(() => {
+          dnsCalls.push({ operation: "updateRecord", input: { dnsRecordId, request } });
+        }).pipe(Effect.andThen(Effect.fail(failure))),
+      deleteRecord: () => Effect.void,
+    });
+    const layer = providerLayer(makePersistentTunnelClient(), dnsClient, makeAllocations());
+
+    return Effect.gen(function* () {
+      const provider = yield* ManagedEndpointProvider.ManagedEndpointProvider;
+      const request = {
+        userId: "user_ABC",
+        environmentId: "env_ABC",
+        origin: { localHttpHost: "127.0.0.1", localHttpPort: 3773 },
+      } as const;
+      yield* provider.provision(request);
+      const error = yield* Effect.flip(provider.provision(request));
+
+      expect(error).toMatchObject({
+        _tag: "ManagedEndpointProvisioningFailed",
+        stage: "ensure-dns-record",
+        userId: "user_ABC",
+        environmentId: "env_ABC",
+      });
+      expect(dnsCalls.map((call) => call.operation)).toEqual([
+        "listRecords",
+        "createRecord",
+        "updateRecord",
+      ]);
+    }).pipe(Effect.provide(layer));
+  });
+
   it.effect(
     "deprovisions checkpointed DNS and tunnel resources before removing the allocation",
     () => {
@@ -765,11 +818,11 @@ describe("ManagedEndpointProvider", () => {
     }).pipe(Effect.provide(providerLayer(makeTunnelClient(), dnsClient)));
   });
 
-  it.effect("reports malformed tunnel responses without manufacturing a cause", () => {
+  it.effect("reports mismatched tunnel responses without manufacturing a cause", () => {
     const dnsCalls: DnsCall[] = [];
     const tunnelClient = ManagedEndpointProvider.ManagedEndpointTunnelClient.of({
       ...makeTunnelClient(),
-      create: () => Effect.succeed({ id: "returned-tunnel-id", name: null }),
+      create: () => Effect.succeed({ id: "returned-tunnel-id", name: "unexpected-tunnel" }),
     });
 
     return Effect.gen(function* () {
@@ -790,6 +843,7 @@ describe("ManagedEndpointProvider", () => {
         hostname: expectedManagedHostname("env_ABC"),
         tunnelName: expectedManagedTunnelName("env_ABC"),
         returnedTunnelId: "returned-tunnel-id",
+        returnedTunnelName: "unexpected-tunnel",
       });
       if (error._tag === "ManagedEndpointProvisioningFailed") {
         expect(error.cause).toBeUndefined();

--- a/infra/relay/src/environments/ManagedEndpointProvider.ts
+++ b/infra/relay/src/environments/ManagedEndpointProvider.ts
@@ -192,11 +192,8 @@ export class ManagedEndpointTunnelClient extends Context.Service<
   }
 >()("t3code-relay/environments/ManagedEndpointProvider/ManagedEndpointTunnelClient") {}
 
-export const makeTunnelClient = (client: ManagedEndpointTunnelClient["Service"]) =>
-  ManagedEndpointTunnelClient.of(client);
-
 export const layerTunnelClient = (client: ManagedEndpointTunnelClient["Service"]) =>
-  Layer.succeed(ManagedEndpointTunnelClient, makeTunnelClient(client));
+  Layer.succeed(ManagedEndpointTunnelClient, client);
 
 interface ManagedEndpointCnameRecordInput {
   readonly type: "CNAME";
@@ -247,11 +244,8 @@ export class ManagedEndpointDnsClient extends Context.Service<
   }
 >()("t3code-relay/environments/ManagedEndpointProvider/ManagedEndpointDnsClient") {}
 
-export const makeDnsClient = (client: ManagedEndpointDnsClient["Service"]) =>
-  ManagedEndpointDnsClient.of(client);
-
 export const layerDnsClient = (client: ManagedEndpointDnsClient["Service"]) =>
-  Layer.succeed(ManagedEndpointDnsClient, makeDnsClient(client));
+  Layer.succeed(ManagedEndpointDnsClient, client);
 
 const requireCloudflareSettings = Effect.fnUntraced(function* (
   settings: RelayConfiguration.RelayConfiguration["Service"],
@@ -331,7 +325,7 @@ const ignoreNotFound = <A>(
     }),
   );
 
-const make = Effect.gen(function* () {
+export const make = Effect.gen(function* () {
   const config = yield* RelayConfiguration.RelayConfiguration;
   const crypto = yield* Crypto.Crypto;
   const tunnels = yield* ManagedEndpointTunnelClient;
@@ -366,7 +360,10 @@ const make = Effect.gen(function* () {
         .updateRecord(preferredDnsRecordId, dnsRecord)
         .pipe(
           Effect.as(true),
-          Effect.orElseSucceed(() => false),
+          Effect.catchTags({
+            ManagedEndpointDnsClientError: (error) =>
+              isNotFoundCause(error.cause) ? Effect.succeed(false) : Effect.fail(error),
+          }),
         );
       if (checkpointedRecordUpdated) {
         return preferredDnsRecordId;
@@ -550,7 +547,7 @@ const make = Effect.gen(function* () {
             }),
         ),
       );
-      if (!tunnelResponse.id || !tunnelResponse.name) {
+      if (!tunnelResponse.id || tunnelResponse.name !== tunnelName) {
         return yield* new ManagedEndpointProvisioningFailed({
           userId: input.userId,
           environmentId: input.environmentId,
@@ -712,131 +709,127 @@ export const layerCloudflareBindings = (
   layer.pipe(
     Layer.provide(
       Layer.mergeAll(
-        layerTunnelClient(
-          ManagedEndpointTunnelClient.of({
-            list: (request) =>
-              tunnelClient.list(request).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointTunnelClientError({
-                      operation: "list",
-                      tunnelName: request.name,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+        layerTunnelClient({
+          list: (request) =>
+            tunnelClient.list(request).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "list",
+                    tunnelName: request.name,
+                    cause,
+                  }),
               ),
-            create: (request) =>
-              tunnelClient.create(request).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointTunnelClientError({
-                      operation: "create",
-                      tunnelName: request.name,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          create: (request) =>
+            tunnelClient.create(request).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "create",
+                    tunnelName: request.name,
+                    cause,
+                  }),
               ),
-            putConfiguration: (tunnelId, config) =>
-              tunnelClient.putConfiguration(tunnelId, config).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointTunnelClientError({
-                      operation: "put-configuration",
-                      tunnelId,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          putConfiguration: (tunnelId, config) =>
+            tunnelClient.putConfiguration(tunnelId, config).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "put-configuration",
+                    tunnelId,
+                    cause,
+                  }),
               ),
-            getToken: (tunnelId) =>
-              tunnelClient.getToken(tunnelId).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointTunnelClientError({
-                      operation: "get-token",
-                      tunnelId,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          getToken: (tunnelId) =>
+            tunnelClient.getToken(tunnelId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "get-token",
+                    tunnelId,
+                    cause,
+                  }),
               ),
-            delete: (tunnelId) =>
-              tunnelClient.delete(tunnelId).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointTunnelClientError({
-                      operation: "delete",
-                      tunnelId,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          delete: (tunnelId) =>
+            tunnelClient.delete(tunnelId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointTunnelClientError({
+                    operation: "delete",
+                    tunnelId,
+                    cause,
+                  }),
               ),
-          }),
-        ),
-        layerDnsClient(
-          ManagedEndpointDnsClient.of({
-            listRecords: (hostname) =>
-              dnsClient.listDnsRecords({ search: hostname }).pipe(
-                Effect.map((response) =>
-                  response.result.filter(
-                    (record): record is typeof record & { readonly id: string } =>
-                      typeof record.id === "string" &&
-                      normalizeHostname(record.name) === normalizeHostname(hostname),
-                  ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+        }),
+        layerDnsClient({
+          listRecords: (hostname) =>
+            dnsClient.listDnsRecords({ search: hostname }).pipe(
+              Effect.map((response) =>
+                response.result.filter(
+                  (record): record is typeof record & { readonly id: string } =>
+                    typeof record.id === "string" &&
+                    normalizeHostname(record.name) === normalizeHostname(hostname),
                 ),
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointDnsClientError({
-                      operation: "list-records",
-                      hostname,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
               ),
-            createRecord: (request) =>
-              dnsClient.createDnsRecord(request).pipe(
-                Effect.map((response) => ({ id: response.id })),
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointDnsClientError({
-                      operation: "create-record",
-                      hostname: request.name,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointDnsClientError({
+                    operation: "list-records",
+                    hostname,
+                    cause,
+                  }),
               ),
-            updateRecord: (dnsRecordId, request) =>
-              dnsClient.updateDnsRecord(dnsRecordId, request).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointDnsClientError({
-                      operation: "update-record",
-                      hostname: request.name,
-                      dnsRecordId,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          createRecord: (request) =>
+            dnsClient.createDnsRecord(request).pipe(
+              Effect.map((response) => ({ id: response.id })),
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointDnsClientError({
+                    operation: "create-record",
+                    hostname: request.name,
+                    cause,
+                  }),
               ),
-            deleteRecord: (dnsRecordId) =>
-              dnsClient.deleteDnsRecord(dnsRecordId).pipe(
-                Effect.mapError(
-                  (cause) =>
-                    new ManagedEndpointDnsClientError({
-                      operation: "delete-record",
-                      dnsRecordId,
-                      cause,
-                    }),
-                ),
-                Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          updateRecord: (dnsRecordId, request) =>
+            dnsClient.updateDnsRecord(dnsRecordId, request).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointDnsClientError({
+                    operation: "update-record",
+                    hostname: request.name,
+                    dnsRecordId,
+                    cause,
+                  }),
               ),
-          }),
-        ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+          deleteRecord: (dnsRecordId) =>
+            dnsClient.deleteDnsRecord(dnsRecordId).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new ManagedEndpointDnsClientError({
+                    operation: "delete-record",
+                    dnsRecordId,
+                    cause,
+                  }),
+              ),
+              Effect.provideService(Alchemy.RuntimeContext, alchemyRuntimeContext),
+            ),
+        }),
       ),
     ),
   );


### PR DESCRIPTION
## Summary

- attach operation, user, environment, resource identifiers, and exact causes to managed-endpoint allocation, provisioning, deprovisioning, tunnel-client, and DNS-client failures
- replace the synthetic reserve `Error` and valueless persistence-error constructor wrapper with structural errors; invalid tunnel responses are a distinct cause-free error nested under the provisioning failure
- use `Effect.catchTags` for tunnel/DNS recovery and only treat structured nested `NotFound` failures as idempotent fallback
- preserve unrelated checkpoint update failures instead of silently retrying through a different DNS path
- export the real service `make` values

## Verification

- `vp test infra/relay/src/environments/ManagedEndpointAllocations.test.ts infra/relay/src/environments/ManagedEndpointProvider.test.ts` (19 passed)
- `vp check` (passes with 20 unrelated existing warnings)
- `vp run typecheck`

## Scope

Excludes relay orchestration/projection and files owned by #3331, #3334, #3335, and #3392.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live in Cloudflare tunnel/DNS provisioning paths; misclassified errors could break retries or hide outages, though behavior is narrowed and tested for non-not-found checkpoint failures.
> 
> **Overview**
> Tightens **managed endpoint provisioning** so transient DNS “not found” cases still fall back, but real failures surface correctly.
> 
> **Checkpoint DNS updates** no longer swallow every `updateRecord` error via `orElseSucceed`; only structured **`NotFound`** causes are treated as “record gone, reconcile elsewhere.” Other errors (e.g. Cloudflare outage) fail at **`ensure-dns-record`** instead of silently taking another DNS path—covered by a new test.
> 
> **Tunnel validation** now requires the created tunnel’s **name to match** the expected stable name (not merely non-null), with **`returnedTunnelName`** on the provisioning failure when it mismatches.
> 
> **Exports and layers**: `make` is exported on allocations and provider; tunnel/DNS `layer*` helpers pass client implementations directly without extra `of()` wrappers; Cloudflare binding layer is flattened accordingly. Test fakes use tagged **`NotFound`** causes for missing DNS records.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10793eb2d2d6148d10f7d47cee7e1fb5b5641e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden managed endpoint allocation failure handling in `ManagedEndpointProvider`
> - `ensureDnsRecord` now rethrows DNS `updateRecord` errors unless the cause is `NotFound`; previously all errors were swallowed and treated as a miss, masking real failures
> - Tunnel response validation now checks that the returned tunnel name matches the expected name, not just that it is truthy; mismatches fail with stage `validate-tunnel-response` and include `returnedTunnelName` in the error
> - Exports the `make` factory from both `ManagedEndpointProvider` and `ManagedEndpointAllocations` for external construction
> - Removes the `makeTunnelClient`/`makeDnsClient` wrapper functions; service objects are now passed directly to `layerTunnelClient`/`layerDnsClient`
> - Risk: the `ensureDnsRecord` change is a behavioral breaking change — callers that previously succeeded despite DNS update errors will now see failures propagated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 10793eb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->