### PR TITLE
[codex] Type malformed Clerk public config failures

### DIFF
--- a/apps/server/src/cloud/publicConfig.test.ts
+++ b/apps/server/src/cloud/publicConfig.test.ts
@@ -1,6 +1,7 @@
 import { assert, it } from "@effect/vitest";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
 
 import {
   makeCloudCliOAuthConfig,
@@ -86,6 +87,27 @@ it.effect("requires Clerk OAuth config when the server bundle has no injected va
     clerkPublishableKeyFallback: "",
     clerkCliOAuthClientIdFallback: "",
   }).pipe(provideEnv({}), Effect.flip),
+);
+
+it.effect("reports malformed Clerk publishable keys as typed configuration failures", () =>
+  Effect.gen(function* () {
+    const result = yield* makeCloudCliOAuthConfig({
+      clerkPublishableKeyFallback: "pk_test_not-base64!!",
+      clerkCliOAuthClientIdFallback: "oauth_client_embedded",
+    }).pipe(provideEnv({}), Effect.result);
+
+    assert.isTrue(Result.isFailure(result));
+    if (Result.isFailure(result)) {
+      assert.equal(result.failure.cause._tag, "SourceError");
+      if (result.failure.cause._tag === "SourceError") {
+        assert.equal(
+          result.failure.cause.message,
+          "Failed to derive Clerk Frontend API URL from the publishable key.",
+        );
+        assert.instanceOf(result.failure.cause.cause, Error);
+      }
+    }
+  }),
 );
 
 it("resolves relay client tracing from runtime config with build-time fallback", () => {

--- a/apps/server/src/cloud/publicConfig.ts
+++ b/apps/server/src/cloud/publicConfig.ts
@@ -1,6 +1,7 @@
 import { clerkFrontendApiUrlFromPublishableKey } from "@t3tools/shared/relayAuth";
 import { normalizeSecureRelayUrl } from "@t3tools/shared/relayUrl";
 import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
@@ -131,16 +132,29 @@ export function makeCloudCliOAuthConfig({
       clerkCliOAuthClientIdFallback,
     ),
   }).pipe(
-    Config.map(({ clerkPublishableKey, clientId }) => {
-      const clerkFrontendApiUrl = clerkFrontendApiUrlFromPublishableKey(clerkPublishableKey);
-      return {
-        authorizationEndpoint: `${clerkFrontendApiUrl}/oauth/authorize`,
-        tokenEndpoint: `${clerkFrontendApiUrl}/oauth/token`,
-        clientId,
-        redirectUri: CLOUD_CLI_OAUTH_REDIRECT_URI,
-        scopes: CLOUD_CLI_OAUTH_SCOPES,
-      } satisfies CloudCliOAuthConfig;
-    }),
+    Config.mapOrFail(({ clerkPublishableKey, clientId }) =>
+      Effect.try({
+        try: () => clerkFrontendApiUrlFromPublishableKey(clerkPublishableKey),
+        catch: (cause) =>
+          new Config.ConfigError(
+            new ConfigProvider.SourceError({
+              message: "Failed to derive Clerk Frontend API URL from the publishable key.",
+              cause,
+            }),
+          ),
+      }).pipe(
+        Effect.map(
+          (clerkFrontendApiUrl) =>
+            ({
+              authorizationEndpoint: `${clerkFrontendApiUrl}/oauth/authorize`,
+              tokenEndpoint: `${clerkFrontendApiUrl}/oauth/token`,
+              clientId,
+              redirectUri: CLOUD_CLI_OAUTH_REDIRECT_URI,
+              scopes: CLOUD_CLI_OAUTH_SCOPES,
+            }) satisfies CloudCliOAuthConfig,
+        ),
+      ),
+    ),
   );
 }
 


### PR DESCRIPTION
## Summary

- move Clerk publishable-key derivation from `Config.map` into a typed `Config.mapOrFail` boundary
- preserve the original decode/validation exception as the `SourceError.cause`
- verify malformed public config fails through the typed channel instead of dying

## Validation

- `vp test apps/server/src/cloud/publicConfig.test.ts`
- `vp check` (passes with existing repository warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Clerk OAuth config loading error handling; happy-path OAuth endpoints are unchanged, and callers already consume config as Effect failures.
> 
> **Overview**
> **Clerk CLI OAuth public config** now treats invalid publishable keys as **typed config failures** instead of letting `clerkFrontendApiUrlFromPublishableKey` throw inside a plain `Config.map`.
> 
> `makeCloudCliOAuthConfig` uses **`Config.mapOrFail`** with `Effect.try`: decode errors become a **`Config.ConfigError`** wrapping **`ConfigProvider.SourceError`** with the message *"Failed to derive Clerk Frontend API URL from the publishable key."* and the **original exception** on `cause`. Successful keys still build the same OAuth endpoint URLs.
> 
> A new test asserts a malformed embedded key surfaces **`SourceError`** through **`Effect.result`** / **`Result.isFailure`**, matching how other public config (e.g. relay URL) already fails in the Effect config channel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e27ff7ec5426ae313cff1e6e1ae277dcbeb2801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Return typed `Config.ConfigError` for malformed Clerk publishable keys in `makeCloudCliOAuthConfig`
> Replaces `Config.map` with `Config.mapOrFail` in [`publicConfig.ts`](https://github.com/pingdotgg/t3code/pull/3422/files#diff-5baa0423a6b8d9a40adcb4aceb7391880c39be179f04f0558871533429671d76) so that an invalid Clerk publishable key produces a `ConfigProvider.SourceError` with the message "Failed to derive Clerk Frontend API URL from the publishable key." rather than an untyped exception. A corresponding test in [`publicConfig.test.ts`](https://github.com/pingdotgg/t3code/pull/3422/files#diff-9f0c81b838e5dc097ccba194e2a3c93ff3f7c971694c7868c2af2cf4ba1e0936) verifies the typed failure shape.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3e27ff7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->