### PR TITLE
[codex] Structure MCP snapshot failures

### DIFF
--- a/apps/server/src/mcp/McpHttpServer.test.ts
+++ b/apps/server/src/mcp/McpHttpServer.test.ts
@@ -49,6 +49,62 @@ it("normalizes empty successful notification responses to accepted", () => {
   expect(resultResponse.status).toBe(200);
 });
 
+it.effect("returns bounded structural preview snapshot failures", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const server = yield* McpServer.McpServer;
+      const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+      const requests = yield* broker.connect({
+        clientId: "mcp-failure-client",
+        environmentId,
+        threadId,
+        tabId,
+        visible: true,
+        supportsAutomation: true,
+        focusedAt: "2026-06-11T00:00:00.000Z",
+      });
+      yield* Stream.runForEach(requests, (request) =>
+        broker.respond({
+          requestId: request.requestId,
+          ok: false,
+          error: {
+            _tag: "PreviewAutomationExecutionError",
+            message: "sensitive renderer failure",
+            detail: { consoleOutput: "sensitive browser output" },
+          },
+        }),
+      ).pipe(Effect.forkScoped);
+      yield* Effect.yieldNow;
+      yield* broker.reportOwner({
+        clientId: "mcp-failure-client",
+        environmentId,
+        threadId,
+        tabId,
+        visible: true,
+        supportsAutomation: true,
+        focusedAt: "2026-06-11T00:00:00.000Z",
+      });
+
+      const snapshot = yield* server
+        .callTool({ name: "preview_snapshot", arguments: {} })
+        .pipe(
+          Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+          Effect.provideService(McpSchema.McpServerClient, client),
+        );
+
+      expect(snapshot.isError).toBe(true);
+      expect(snapshot.content).toEqual([{ type: "text", text: "Preview snapshot failed." }]);
+      expect(snapshot.structuredContent).toEqual({
+        error: {
+          _tag: "PreviewAutomationExecutionError",
+          operation: "snapshot",
+          failureCount: 1,
+        },
+      });
+    }),
+  ).pipe(Effect.provide(TestLayer)),
+);
+
 it.effect("terminates HTTP MCP sessions with DELETE", () =>
   Effect.scoped(
     Effect.gen(function* () {

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -88,6 +88,37 @@ const McpAuthMiddlewareLive = HttpRouter.middleware<{
   provides: McpInvocationContext.McpInvocationContext;
 }>()(makeMcpAuthMiddleware).layer;
 
+const previewSnapshotFailure = <E>(cause: Cause.Cause<E>) => {
+  if (Cause.hasInterrupts(cause) || cause.reasons.some(Cause.isDieReason)) {
+    return Effect.failCause(cause).pipe(Effect.orDie);
+  }
+  const failures = cause.reasons.filter(Cause.isFailReason);
+  const firstFailure = failures[0]?.error;
+  const errorTag =
+    typeof firstFailure === "object" &&
+    firstFailure !== null &&
+    "_tag" in firstFailure &&
+    typeof firstFailure._tag === "string"
+      ? firstFailure._tag
+      : "PreviewSnapshotError";
+  const result = new McpSchema.CallToolResult({
+    isError: true,
+    structuredContent: {
+      error: {
+        _tag: errorTag,
+        operation: "snapshot",
+        failureCount: failures.length,
+      },
+    },
+    content: [{ type: "text", text: "Preview snapshot failed." }],
+  });
+  return Effect.logWarning("preview snapshot failed", {
+    operation: "snapshot",
+    errorTag,
+    failureCount: failures.length,
+  }).pipe(Effect.as(result));
+};
+
 const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot")(function* () {
   const server = yield* McpServer.McpServer;
   const broker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
@@ -122,12 +153,8 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
           Effect.flatMap(Effect.fromOption),
           Effect.provideService(PreviewAutomationBroker.PreviewAutomationBroker, broker),
           Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
-          Effect.matchCause({
-            onFailure: (cause) =>
-              new McpSchema.CallToolResult({
-                isError: true,
-                content: [{ type: "text", text: Cause.pretty(cause) }],
-              }),
+          Effect.matchCauseEffect({
+            onFailure: previewSnapshotFailure,
             onSuccess: ({ encodedResult }) => {
               const snapshot = encodedResult as {
                 readonly screenshot: {
@@ -147,18 +174,20 @@ const registerPreviewSnapshot = Effect.fn("McpHttpServer.registerPreviewSnapshot
                   height: screenshot.height,
                 },
               };
-              return new McpSchema.CallToolResult({
-                isError: false,
-                structuredContent: metadata,
-                content: [
-                  { type: "text", text: JSON.stringify(metadata) },
-                  {
-                    type: "image",
-                    data: new Uint8Array(Buffer.from(screenshot.data, "base64")),
-                    mimeType: screenshot.mimeType,
-                  },
-                ],
-              });
+              return Effect.succeed(
+                new McpSchema.CallToolResult({
+                  isError: false,
+                  structuredContent: metadata,
+                  content: [
+                    { type: "text", text: JSON.stringify(metadata) },
+                    {
+                      type: "image",
+                      data: new Uint8Array(Buffer.from(screenshot.data, "base64")),
+                      mimeType: screenshot.mimeType,
+                    },
+                  ],
+                }),
+              );
             },
           }),
         );


### PR DESCRIPTION
## Summary
- stop returning rendered Effect causes and internal browser details to MCP snapshot callers
- return a stable message plus bounded operation, tag, and failure-count metadata for typed failures
- re-propagate interruptions and defects instead of converting them into successful tool-call transport results

## Validation
- `vp test apps/server/src/mcp/McpHttpServer.test.ts`
- `vp check` (20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP tool error handling for preview_snapshot; behavior is safer for clients but alters what external integrators see on failure.
> 
> **Overview**
> **`preview_snapshot` MCP errors no longer expose rendered Effect causes or internal browser/renderer details** to callers.
> 
> Failures are mapped to a fixed text message (`Preview snapshot failed.`) plus **`structuredContent.error`** with `_tag`, `operation: "snapshot"`, and `failureCount`. Interrupts and defects are **re-failed** instead of being turned into successful tool-call payloads. A test asserts that rich broker error fields (e.g. console output) are not returned to MCP clients.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0898668683ef9c534b2132ab62a67333b934af9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure `preview_snapshot` MCP tool failures with bounded error responses
> - Adds a `previewSnapshotFailure` helper in [McpHttpServer.ts](https://github.com/pingdotgg/t3code/pull/3423/files#diff-d5ed4053027686ef86dbdd41eb8a839268f0c99d955c7f22f62516a976c4d2b8) that converts a `Cause` into a structured `CallToolResult` with `structuredContent` containing `{ _tag, operation: 'snapshot', failureCount }` and a fixed `'Preview snapshot failed.'` text, plus a warning log.
> - Replaces the raw `Cause.pretty` string error response in `registerPreviewSnapshot` with this new helper via `Effect.matchCauseEffect`.
> - Interrupt and die causes still propagate and terminate the fiber; only expected failures are caught and structured.
> - Adds a test covering the new structured failure shape in [McpHttpServer.test.ts](https://github.com/pingdotgg/t3code/pull/3423/files#diff-552121f7256046a957f60f7f3476debc694a83547a2f5f9874be39fe468aa5f6).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0898668.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->