### PR TITLE
[codex] Structure terminal adapter startup defects

### DIFF
--- a/apps/server/src/terminal/BunPtyAdapter.test.ts
+++ b/apps/server/src/terminal/BunPtyAdapter.test.ts
@@ -1,9 +1,13 @@
-import { expect, it } from "@effect/vitest";
+import { assert, expect, it } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 
-import { BunPtyOperationUnavailableError } from "./BunPtyAdapter.ts";
+import * as BunPtyAdapter from "./BunPtyAdapter.ts";
 
 it("describes unavailable Bun PTY operations structurally", () => {
-  const error = new BunPtyOperationUnavailableError({
+  const error = new BunPtyAdapter.BunPtyOperationUnavailableError({
     operation: "resize",
     pid: 42,
   });
@@ -15,3 +19,26 @@ it("describes unavailable Bun PTY operations structurally", () => {
   });
   expect(error.message).toBe("Bun PTY resize is unavailable for process 42.");
 });
+
+it.effect("reports unsupported platforms with a structured startup defect", () =>
+  Effect.gen(function* () {
+    const exit = yield* BunPtyAdapter.make().pipe(
+      Effect.provideService(HostProcessPlatform, "win32"),
+      Effect.exit,
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Cause.hasDies(exit.cause)).toBe(true);
+      const error = Cause.squash(exit.cause);
+      assert.instanceOf(error, BunPtyAdapter.BunPtyUnsupportedPlatformError);
+      expect(error).toMatchObject({
+        _tag: "BunPtyUnsupportedPlatformError",
+        platform: "win32",
+      });
+      expect(error.message).toBe(
+        "Bun PTY terminal support is unavailable on win32. Please use Node.js (e.g. by running `npx t3`) instead.",
+      );
+    }
+  }),
+);

--- a/apps/server/src/terminal/BunPtyAdapter.ts
+++ b/apps/server/src/terminal/BunPtyAdapter.ts
@@ -7,6 +7,17 @@ import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import * as PtyAdapter from "./PtyAdapter.ts";
 
+export class BunPtyUnsupportedPlatformError extends Schema.TaggedErrorClass<BunPtyUnsupportedPlatformError>()(
+  "BunPtyUnsupportedPlatformError",
+  {
+    platform: Schema.Literal("win32"),
+  },
+) {
+  override get message(): string {
+    return `Bun PTY terminal support is unavailable on ${this.platform}. Please use Node.js (e.g. by running \`npx t3\`) instead.`;
+  }
+}
+
 export class BunPtyOperationUnavailableError extends Schema.TaggedErrorClass<BunPtyOperationUnavailableError>()(
   "BunPtyOperationUnavailableError",
   {
@@ -109,9 +120,7 @@ class BunPtyProcess implements PtyAdapter.PtyProcess {
 export const make = Effect.fn("BunPtyAdapter.make")(function* () {
   const platform = yield* HostProcessPlatform;
   if (platform === "win32") {
-    return yield* Effect.die(
-      "Bun PTY terminal support is unavailable on Windows. Please use Node.js (e.g. by running `npx t3`) instead.",
-    );
+    return yield* Effect.die(new BunPtyUnsupportedPlatformError({ platform }));
   }
   return PtyAdapter.PtyAdapter.of({
     spawn: (input) =>

--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -1,7 +1,9 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import { vi } from "vite-plus/test";
 
@@ -55,4 +57,32 @@ it.effect("spawns through the public adapter with the provided host references",
       },
     ]);
   }).pipe(Effect.provide(testLayer)),
+);
+
+it.effect("reports native module load failures as structured startup defects", () =>
+  Effect.gen(function* () {
+    const cause = new Error("native binding could not be loaded");
+    const exit = yield* NodePtyAdapter.make(() => Promise.reject(cause)).pipe(Effect.exit);
+
+    assert.isTrue(Exit.isFailure(exit));
+    if (Exit.isFailure(exit)) {
+      assert.isTrue(Cause.hasDies(exit.cause));
+      const error = Cause.squash(exit.cause);
+      assert.instanceOf(error, NodePtyAdapter.NodePtyModuleLoadError);
+      assert.deepInclude(error, {
+        _tag: "NodePtyModuleLoadError",
+        platform: "win32",
+        architecture: "x64",
+      });
+      assert.equal(error.message, "Failed to load node-pty for win32-x64.");
+    }
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        NodeServices.layer,
+        Layer.succeed(HostProcessPlatform, "win32"),
+        Layer.succeed(HostProcessArchitecture, "x64"),
+      ),
+    ),
+  ),
 );

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -4,9 +4,25 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import * as PtyAdapter from "./PtyAdapter.ts";
+
+export class NodePtyModuleLoadError extends Schema.TaggedErrorClass<NodePtyModuleLoadError>()(
+  "NodePtyModuleLoadError",
+  {
+    platform: Schema.String,
+    architecture: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to load node-pty for ${this.platform}-${this.architecture}.`;
+  }
+}
+
+type NodePtyModuleLoader = () => Promise<typeof import("node-pty")>;
 
 let didEnsureSpawnHelperExecutable = false;
 
@@ -94,13 +110,23 @@ class NodePtyProcess implements PtyAdapter.PtyProcess {
   }
 }
 
-export const make = Effect.fn("NodePtyAdapter.make")(function* () {
+export const make = Effect.fn("NodePtyAdapter.make")(function* (
+  loadNodePtyModule: NodePtyModuleLoader = () => import("node-pty"),
+) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const platform = yield* HostProcessPlatform;
   const architecture = yield* HostProcessArchitecture;
 
-  const nodePty = yield* Effect.promise(() => import("node-pty"));
+  const nodePty = yield* Effect.tryPromise({
+    try: loadNodePtyModule,
+    catch: (cause) =>
+      new NodePtyModuleLoadError({
+        platform,
+        architecture,
+        cause,
+      }),
+  }).pipe(Effect.orDie);
 
   const ensureNodePtySpawnHelperExecutableCached = yield* Effect.cached(
     ensureNodePtySpawnHelperExecutable().pipe(


### PR DESCRIPTION
## Summary

Terminal adapter startup failures were not consistently diagnosable. Bun's unsupported Windows path died with a bare string, while a rejected `node-pty` native-module import surfaced as an unstructured defect without host context.

This change preserves the existing fatal startup semantics while making both defects structured. The Bun defect records the unsupported platform. The Node defect records platform and architecture and retains the exact module-load rejection as `cause`, keeping the original stack chain intact. The external module loader is injectable so the failure boundary can be tested without mocking core logic.

## Validation

- `vp test apps/server/src/terminal/BunPtyAdapter.test.ts apps/server/src/terminal/NodePtyAdapter.test.ts`
- `vp check` (passes with existing repository warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior remains fatal startup defects; changes are limited to error shape, diagnostics, and testability in terminal adapters.
> 
> **Overview**
> Terminal adapter startup still **fails fatally** on unsupported Bun hosts and when `node-pty` cannot load, but those paths now die with **typed `Schema.TaggedErrorClass` defects** instead of bare strings or unstructured rejections.
> 
> **Bun:** `BunPtyAdapter.make` on `win32` dies with `BunPtyUnsupportedPlatformError` (platform + user-facing message). **Node:** `NodePtyAdapter.make` wraps a failed dynamic import in `NodePtyModuleLoadError` (platform, architecture, original `cause`) via `Effect.tryPromise` + `orDie`. An optional **`NodePtyModuleLoader`** hook lets tests simulate load failure without mocking internals.
> 
> New effect tests assert the squashed defect shape for both adapters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5681b5c2c971bb4238c97c94469f9ae80a899c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure terminal adapter startup defects with typed error classes
> - Adds `BunPtyUnsupportedPlatformError` to [BunPtyAdapter.ts](https://github.com/pingdotgg/t3code/pull/3425/files#diff-88cb34eb67677dedcd1e71d0c1c76c410778beed9b0a5ed74021c9375f217d67): a tagged Schema error with a `platform` field, replacing the plain string die on win32.
> - Adds `NodePtyModuleLoadError` to [NodePtyAdapter.ts](https://github.com/pingdotgg/t3code/pull/3425/files#diff-d570dd97f4978bc04d9ac7a64120d33a2a8c3fdcbf395a2c2d9f974a7ba699bb): a tagged Schema error carrying `platform`, `architecture`, and the underlying cause, thrown when `node-pty` fails to load.
> - `NodePtyAdapter.make` now accepts an optional module loader, enabling the new load-failure path to be tested without native modules.
> - Behavioral Change: callers catching defects from either adapter must now handle structured error types instead of plain strings or untyped rejections.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5681b5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->