### PR TITLE
[codex] Preserve trace IDs across error causes

### DIFF
--- a/packages/client-runtime/src/errors/errorTrace.test.ts
+++ b/packages/client-runtime/src/errors/errorTrace.test.ts
@@ -1,3 +1,4 @@
+import * as Cause from "effect/Cause";
 import { describe, expect, it } from "vite-plus/test";
 
 import { findErrorTraceId } from "./errorTrace.ts";
@@ -21,5 +22,23 @@ describe("findErrorTraceId", () => {
     error.cause = error;
 
     expect(findErrorTraceId(error)).toBeNull();
+  });
+
+  it("finds trace metadata in Effect cause branches", () => {
+    const cause = Cause.fromReasons<unknown>([
+      Cause.makeFailReason(new Error("first failure")),
+      Cause.makeFailReason({ traceId: "trace-secondary" }),
+    ]);
+
+    expect(findErrorTraceId(cause)).toBe("trace-secondary");
+  });
+
+  it("finds trace metadata in aggregate error branches", () => {
+    const error = new AggregateError(
+      [new Error("first failure"), { traceId: "trace-aggregate" }],
+      "request failed",
+    );
+
+    expect(findErrorTraceId(error)).toBe("trace-aggregate");
   });
 });

--- a/packages/client-runtime/src/errors/errorTrace.ts
+++ b/packages/client-runtime/src/errors/errorTrace.ts
@@ -1,17 +1,49 @@
+import * as Cause from "effect/Cause";
+
+const MAX_ERROR_TRACE_NODES = 128;
+
 export function findErrorTraceId(error: unknown): string | null {
   const seen = new Set<object>();
-  let current: unknown = error;
+  const pending: Array<unknown> = [error];
+  let inspectedNodeCount = 0;
 
-  while (typeof current === "object" && current !== null && !seen.has(current)) {
+  while (pending.length > 0 && inspectedNodeCount < MAX_ERROR_TRACE_NODES) {
+    const current = pending.pop();
+    inspectedNodeCount += 1;
+    if (typeof current !== "object" || current === null || seen.has(current)) {
+      continue;
+    }
     seen.add(current);
     const record = current as {
       readonly cause?: unknown;
+      readonly errors?: unknown;
       readonly traceId?: unknown;
     };
     if (typeof record.traceId === "string" && record.traceId.trim().length > 0) {
       return record.traceId;
     }
-    current = record.cause;
+
+    if (Array.isArray(record.errors)) {
+      for (let index = record.errors.length - 1; index >= 0; index -= 1) {
+        pending.push(record.errors[index]);
+      }
+    }
+    if (Cause.isCause(current)) {
+      for (let index = current.reasons.length - 1; index >= 0; index -= 1) {
+        const reason = current.reasons[index];
+        switch (reason?._tag) {
+          case "Fail":
+            pending.push(reason.error);
+            break;
+          case "Die":
+            pending.push(reason.defect);
+            break;
+        }
+      }
+    }
+    if ("cause" in record) {
+      pending.push(record.cause);
+    }
   }
 
   return null;


### PR DESCRIPTION
## Summary
- traverse preserved `cause` chains, Effect `Cause` reasons, and aggregate error branches when finding a trace ID
- keep correlation lookup cycle-safe and bound it to 128 inspected nodes
- cover multi-branch Effect causes and aggregate errors with behavior tests

## Validation
- `vp test packages/client-runtime/src/errors/errorTrace.test.ts` (4 tests)
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to error introspection in client-runtime with added tests; no auth or data-path changes, only richer traversal of error shapes already passed into relay snapshot handling.
> 
> **Overview**
> **`findErrorTraceId`** no longer follows only a single `cause` pointer. It walks a bounded graph of error nodes (stack-based, max **128** nodes, cycle-safe via `seen`) so correlation IDs can be recovered when failures are wrapped in Effect **`Cause`** branches or **`AggregateError`**-style **`errors`** arrays.
> 
> Traversal order pushes **`errors`** and Effect **`Fail`/`Die`** payloads onto the pending stack (reverse order so earlier branches are visited first), then still follows **`cause`** when present. Existing linear `cause` chains and cyclic graphs behave as before; new tests cover multi-reason Effect causes and aggregate errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43372395fcccdb70a184dec29665ead41c201e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve trace IDs across error causes by traversing AggregateError and Effect Cause branches
> - Refactors `findErrorTraceId` in [errorTrace.ts](https://github.com/pingdotgg/t3code/pull/3426/files#diff-6a06f46c6f9349bc003f3582d88b52cad77da32fa797581fc923df495728e028) from a linear cause-chain loop into a bounded stack-based traversal with cycle detection via a `Set` of seen objects.
> - Traversal now inspects `AggregateError.errors` entries and Effect `Cause` reasons (`Fail.error`, `Die.defect`) in addition to the standard `.cause` chain.
> - Adds a `MAX_ERROR_TRACE_NODES` cap of 128 nodes to bound traversal cost.
> - Adds tests covering traceId discovery within Effect Cause and AggregateError branches.
> - Behavioral Change: traversal now returns the first `traceId` found across any branch rather than only following the linear cause chain.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f433723.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->