### PR TITLE
[codex] Sanitize YAML schema diagnostics

### DIFF
--- a/packages/shared/src/schemaYaml.test.ts
+++ b/packages/shared/src/schemaYaml.test.ts
@@ -50,9 +50,45 @@ tags:
     expect(decodeYaml("answer: 42\n")).toEqual({ answer: 42 });
   });
 
-  it("rejects malformed YAML", () => {
+  it("reports malformed YAML with safe structural diagnostics", () => {
     const decodeYaml = Schema.decodeUnknownSync(fromYaml(Schema.Unknown));
+    const secret = "credential=secret-value";
+    let error: unknown;
 
-    expect(() => decodeYaml("name: ok\n  bad-indent: nope\n")).toThrow();
+    try {
+      decodeYaml(`name: ${secret}\n  bad-indent: nope\n`);
+    } catch (cause) {
+      error = cause;
+    }
+
+    expect(Schema.isSchemaError(error)).toBe(true);
+    if (!Schema.isSchemaError(error)) {
+      throw new Error("Expected a schema error");
+    }
+    expect(error.message).toBe("Invalid YAML (code=BLOCK_AS_IMPLICIT_KEY, line=1, column=7).");
+    expect(error.message).not.toContain(secret);
+  });
+
+  it("does not expose stringify failure details", () => {
+    const encodeYaml = Schema.encodeSync(fromYaml(Schema.Unknown));
+    const secret = "credential=secret-value";
+    let error: unknown;
+
+    try {
+      encodeYaml({
+        toJSON() {
+          throw new Error(secret);
+        },
+      });
+    } catch (cause) {
+      error = cause;
+    }
+
+    expect(Schema.isSchemaError(error)).toBe(true);
+    if (!Schema.isSchemaError(error)) {
+      throw new Error("Expected a schema error");
+    }
+    expect(error.message).toBe("Failed to stringify YAML.");
+    expect(error.message).not.toContain(secret);
   });
 });

--- a/packages/shared/src/schemaYaml.ts
+++ b/packages/shared/src/schemaYaml.ts
@@ -5,6 +5,7 @@ import * as SchemaGetter from "effect/SchemaGetter";
 import * as SchemaIssue from "effect/SchemaIssue";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 import {
+  YAMLParseError,
   parse as parseYamlString,
   stringify as stringifyYamlValue,
   type CreateNodeOptions,
@@ -22,8 +23,14 @@ export type YamlStringifyOptions = DocumentOptions &
   CreateNodeOptions &
   ToStringOptions;
 
-function formatYamlError(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+function formatYamlParseError(error: unknown): string {
+  if (!(error instanceof YAMLParseError)) {
+    return "Invalid YAML.";
+  }
+
+  const position = error.linePos?.[0];
+  const location = position === undefined ? "" : `, line=${position.line}, column=${position.col}`;
+  return `Invalid YAML (code=${error.code}${location}).`;
 }
 
 /**
@@ -56,7 +63,7 @@ export function parseYaml<E extends string>(
     Effect.try({
       try: () => parseYamlString(input, options) as unknown,
       catch: (error) =>
-        new SchemaIssue.InvalidValue(Option.some(input), { message: formatYamlError(error) }),
+        new SchemaIssue.InvalidValue(Option.none(), { message: formatYamlParseError(error) }),
     }),
   );
 }
@@ -90,8 +97,8 @@ export function stringifyYaml(
   return SchemaGetter.transformOrFail((input: unknown) =>
     Effect.try({
       try: () => stringifyYamlValue(input, options),
-      catch: (error) =>
-        new SchemaIssue.InvalidValue(Option.some(input), { message: formatYamlError(error) }),
+      catch: () =>
+        new SchemaIssue.InvalidValue(Option.none(), { message: "Failed to stringify YAML." }),
     }),
   );
 }


### PR DESCRIPTION
## Summary
- replace raw YAML source excerpts with parser code and line/column diagnostics
- prevent arbitrary stringify exceptions from becoming schema error messages
- cover parse and encode failures with behavior tests that verify sensitive values stay out of rendered diagnostics

`SchemaGetter` failures are constrained to `SchemaIssue.Issue`, which has no cause channel; this preserves the safe structural context that representation supports without leaking third-party messages.

## Validation
- `vp test packages/shared/src/schemaJson.test.ts packages/shared/src/schemaYaml.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared validation error surfaces where secrets could have leaked; behavior is intentionally narrower but may reduce debug detail for operators.
> 
> **Overview**
> YAML schema helpers no longer surface raw parser messages, input snippets, or stringify exception text in `SchemaIssue` diagnostics.
> 
> **Parse failures** use a new `formatYamlParseError` that reports only `YAMLParseError` `code` plus optional line/column, and `parseYaml` attaches `Option.none()` instead of the offending string to `InvalidValue`. **Encode failures** always use the fixed message `Failed to stringify YAML.` with no underlying error text.
> 
> Tests assert malformed YAML and `toJSON` throw paths keep embedded secrets out of `error.message`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b4c1ae115f16575b61c5e29ff90433233fa63ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sanitize YAML schema diagnostics to prevent leaking raw input or error details
> - `parseYaml` now emits a sanitized message `Invalid YAML (code=..., line=..., column=...)` and excludes the original input from the `SchemaIssue` when parsing fails.
> - `stringifyYaml` now emits a fixed message `Failed to stringify YAML.` and excludes the input value when stringification fails.
> - A new `formatYamlParseError` helper returns `Invalid YAML.` for non-`YAMLParseError` inputs and a structured sanitized message for `YAMLParseError`.
> - Tests in [schemaYaml.test.ts](https://github.com/pingdotgg/t3code/pull/3427/files#diff-81aa9091f5fc6e66cbdc099dde59f78f8fc0287d03a8f0c243bbf81816b2e65e) verify that secret values are not present in error output for both parse and stringify failures.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7b4c1ae.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->