### PR TITLE
[codex] Preserve native SQLite failure context

### DIFF
--- a/apps/server/src/persistence/Layers/Sqlite.ts
+++ b/apps/server/src/persistence/Layers/Sqlite.ts
@@ -3,6 +3,7 @@ import * as Layer from "effect/Layer";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
+import type { SqlError } from "effect/unstable/sql/SqlError";
 
 import { runMigrations } from "../Migrations.ts";
 import { ServerConfig } from "../../config.ts";
@@ -13,7 +14,7 @@ type RuntimeSqliteLayerConfig = {
 };
 
 type Loader = {
-  layer: (config: RuntimeSqliteLayerConfig) => Layer.Layer<SqlClient.SqlClient>;
+  layer: (config: RuntimeSqliteLayerConfig) => Layer.Layer<SqlClient.SqlClient, SqlError>;
 };
 const defaultSqliteClientLoaders = {
   bun: () => import("@effect/sql-sqlite-bun/SqliteClient"),

--- a/apps/server/src/persistence/NodeSqliteClient.test.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.test.ts
@@ -1,5 +1,6 @@
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as SqlClient from "effect/unstable/sql/SqlClient";
 
 import * as SqliteClient from "./NodeSqliteClient.ts";
@@ -27,4 +28,25 @@ layer("NodeSqliteClient", (it) => {
       assert.equal(values[1]?.[1], "beta");
     }),
   );
+
+  it.effect("returns a typed failure when an unprepared statement cannot be prepared", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const error = yield* Effect.flip(sql.unsafe("SELECT FROM").unprepared);
+
+      assert.equal(error._tag, "SqlError");
+      assert.equal(error.reason.operation, "prepare");
+    }),
+  );
 });
+
+it.effect("returns a typed failure when the database cannot be opened", () =>
+  Effect.gen(function* () {
+    const error = yield* Effect.flip(
+      Layer.build(SqliteClient.layer({ filename: "\0" })).pipe(Effect.scoped),
+    );
+
+    assert.equal(error._tag, "SqlError");
+    assert.equal(error.reason.operation, "open");
+  }),
+);

--- a/apps/server/src/persistence/NodeSqliteClient.ts
+++ b/apps/server/src/persistence/NodeSqliteClient.ts
@@ -13,6 +13,7 @@ import * as Effect from "effect/Effect";
 import * as Fiber from "effect/Fiber";
 import { identity } from "effect/Function";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import * as Context from "effect/Context";
@@ -45,6 +46,27 @@ export interface SqliteMemoryClientConfig extends Omit<
   "filename" | "readonly"
 > {}
 
+export class UnsupportedNodeSqliteVersionError extends Schema.TaggedErrorClass<UnsupportedNodeSqliteVersionError>()(
+  "UnsupportedNodeSqliteVersionError",
+  {
+    nodeVersion: Schema.String,
+    requirement: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Node.js ${this.nodeVersion} is missing required node:sqlite APIs. Upgrade to ${this.requirement}.`;
+  }
+}
+
+export class UnsupportedNodeSqliteOperationError extends Schema.TaggedErrorClass<UnsupportedNodeSqliteOperationError>()(
+  "UnsupportedNodeSqliteOperationError",
+  {},
+) {
+  override get message(): string {
+    return "Node SQLite does not support executeStream.";
+  }
+}
+
 /**
  * Verify that the current Node.js version includes the `node:sqlite` APIs
  * used by `NodeSqliteClient` — specifically `StatementSync.columns()` (added
@@ -60,8 +82,10 @@ const checkNodeSqliteCompat = () => {
 
   if (!supported) {
     return Effect.die(
-      `Node.js ${process.versions.node} is missing required node:sqlite APIs ` +
-        `(StatementSync.columns). Upgrade to Node.js >=22.16, >=23.11, or >=24.`,
+      new UnsupportedNodeSqliteVersionError({
+        nodeVersion: process.versions.node,
+        requirement: "Node.js >=22.16, >=23.11, or >=24",
+      }),
     );
   }
   return Effect.void;
@@ -70,7 +94,7 @@ const checkNodeSqliteCompat = () => {
 const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
   options: SqliteClientConfig,
   openDatabase: () => NodeSqlite.DatabaseSync,
-): Effect.fn.Return<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> {
+): Effect.fn.Return<Client.SqlClient, SqlError, Scope.Scope | Reactivity.Reactivity> {
   yield* checkNodeSqliteCompat();
 
   const compiler = Statement.makeCompilerSqlite(options.transformQueryNames);
@@ -80,10 +104,28 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
 
   const makeConnection = Effect.gen(function* () {
     const scope = yield* Effect.scope;
-    const db = openDatabase();
+    const db = yield* Effect.try({
+      try: openDatabase,
+      catch: (cause) =>
+        new SqlError({
+          reason: classifySqliteError(cause, {
+            message: "Failed to open database",
+            operation: "open",
+          }),
+        }),
+    });
     yield* Scope.addFinalizer(
       scope,
-      Effect.sync(() => db.close()),
+      Effect.try({
+        try: () => db.close(),
+        catch: (cause) =>
+          new SqlError({
+            reason: classifySqliteError(cause, {
+              message: "Failed to close database",
+              operation: "close",
+            }),
+          }),
+      }).pipe(Effect.orDie),
     );
 
     const statementReaderCache = new WeakMap<NodeSqlite.StatementSync, boolean>();
@@ -119,8 +161,8 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
       raw: boolean,
     ) =>
       Effect.withFiber<ReadonlyArray<any>, SqlError>((fiber) => {
-        statement.setReadBigInts(Boolean(Context.get(fiber.context, Client.SafeIntegers)));
         try {
+          statement.setReadBigInts(Boolean(Context.get(fiber.context, Client.SafeIntegers)));
           if (hasRows(statement)) {
             return Effect.succeed(statement.all(...(params as any)));
           }
@@ -166,11 +208,20 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
               }),
           }),
         (statement) =>
-          Effect.sync(() => {
-            if (hasRows(statement)) {
-              statement.setReturnArrays(false);
-            }
-          }),
+          Effect.try({
+            try: () => {
+              if (hasRows(statement)) {
+                statement.setReturnArrays(false);
+              }
+            },
+            catch: (cause) =>
+              new SqlError({
+                reason: classifySqliteError(cause, {
+                  message: "Failed to reset statement result mode",
+                  operation: "resetResultMode",
+                }),
+              }),
+          }).pipe(Effect.orDie),
       );
 
     return identity<Connection>({
@@ -184,11 +235,20 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
         return runValues(sql, params);
       },
       executeUnprepared(sql, params, rowTransform) {
-        const effect = runStatement(db.prepare(sql), params ?? [], false);
+        const effect = Effect.try({
+          try: () => db.prepare(sql),
+          catch: (cause) =>
+            new SqlError({
+              reason: classifySqliteError(cause, {
+                message: "Failed to prepare statement",
+                operation: "prepare",
+              }),
+            }),
+        }).pipe(Effect.flatMap((statement) => runStatement(statement, params ?? [], false)));
         return rowTransform ? Effect.map(effect, rowTransform) : effect;
       },
       executeStream(_sql, _params) {
-        return Stream.die("executeStream not implemented");
+        return Stream.die(new UnsupportedNodeSqliteOperationError());
       },
     });
   });
@@ -220,7 +280,7 @@ const makeWithDatabase = Effect.fn("makeWithDatabase")(function* (
 
 const make = (
   options: SqliteClientConfig,
-): Effect.Effect<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<Client.SqlClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
   makeWithDatabase(
     options,
     () =>
@@ -232,7 +292,7 @@ const make = (
 
 const makeMemory = (
   config: SqliteMemoryClientConfig = {},
-): Effect.Effect<Client.SqlClient, never, Scope.Scope | Reactivity.Reactivity> =>
+): Effect.Effect<Client.SqlClient, SqlError, Scope.Scope | Reactivity.Reactivity> =>
   makeWithDatabase(
     {
       ...config,
@@ -249,13 +309,15 @@ const makeMemory = (
 
 export const layerConfig = (
   config: Config.Wrap<SqliteClientConfig>,
-): Layer.Layer<Client.SqlClient, Config.ConfigError> =>
+): Layer.Layer<Client.SqlClient, Config.ConfigError | SqlError> =>
   Layer.effect(Client.SqlClient, Config.unwrap(config).pipe(Effect.flatMap(make))).pipe(
     Layer.provide(Reactivity.layer),
   );
 
-export const layer = (config: SqliteClientConfig): Layer.Layer<Client.SqlClient> =>
+export const layer = (config: SqliteClientConfig): Layer.Layer<Client.SqlClient, SqlError> =>
   Layer.effect(Client.SqlClient, make(config)).pipe(Layer.provide(Reactivity.layer));
 
-export const layerMemory = (config: SqliteMemoryClientConfig = {}): Layer.Layer<Client.SqlClient> =>
+export const layerMemory = (
+  config: SqliteMemoryClientConfig = {},
+): Layer.Layer<Client.SqlClient, SqlError> =>
   Layer.effect(Client.SqlClient, makeMemory(config)).pipe(Layer.provide(Reactivity.layer));


### PR DESCRIPTION
## Summary

- return native database-open and unprepared-statement preparation failures through the typed SqlError channel
- preserve structured causes for native cleanup failures and replace bare unsupported-runtime defects with Schema errors
- propagate SqlError through the runtime SQLite loader

## Validation

- vp test apps/server/src/persistence/NodeSqliteClient.test.ts
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how database startup and query failures surface (defects → `SqlError`), which can affect error handling at persistence boundaries without altering successful query behavior.
> 
> **Overview**
> **`NodeSqliteClient`** now routes native SQLite failures through the typed **`SqlError`** channel instead of untyped defects, so callers can handle open, prepare, and execute problems explicitly.
> 
> Database open, close, prepare (including unprepared queries), and related setup paths are wrapped with **`classifySqliteError`** and labeled operations such as **`open`**, **`prepare`**, and **`close`**. Unsupported Node versions and **`executeStream`** use new **`Schema.TaggedErrorClass`** types instead of string defects. Factory functions and **`layer` / `layerMemory` / `layerConfig`** declare **`SqlError`** on their error channel; the runtime SQLite loader in **`Sqlite.ts`** is updated to match.
> 
> Tests assert invalid SQL preparation and invalid filenames fail with **`SqlError`** and the expected **`reason.operation`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfd2f78fac0bd117e3ab2b80af3e41dfdaf18c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface typed `SqlError` failures from the Node.js SQLite client layer
> - Wraps database open, statement prepare, and execute operations in `Effect.try` in [NodeSqliteClient.ts](https://github.com/pingdotgg/t3code/pull/3428/files#diff-cf61d9fd2d48cc7f6a5d0ebaaa66f8c39d982f536913a6fb92196591465087aa), mapping native errors to typed `SqlError` values with a `reason.operation` field.
> - Introduces `UnsupportedNodeSqliteVersionError` and `UnsupportedNodeSqliteOperationError` tagged error classes to replace untyped `Effect.die` strings for compatibility and `executeStream` failures.
> - Updates the `Loader` type alias and all exported layers (`layer`, `layerMemory`, `layerConfig`) to include `SqlError` in their error channel.
> - Adds tests covering typed failures on bad SQL (`reason.operation === "prepare"`) and unopenable databases (`reason.operation === "open"`).
> - Behavioral Change: layers that previously defected on open/prepare failures now surface them as typed errors in the failure channel.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfd2f78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->