### PR TITLE
[codex] Sanitize Bitbucket API failures

### DIFF
--- a/apps/server/src/sourceControl/BitbucketApi.test.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.test.ts
@@ -544,6 +544,68 @@ it.effect("preserves the HTTP client failure without deriving the domain message
   }).pipe(Effect.provide(layer));
 });
 
+it.effect("keeps Bitbucket HTTP response bodies out of diagnostics", () => {
+  const secretBody = '{"error":{"message":"credential=secret-value"}}';
+  const { layer } = makeLayer({
+    response: () => new Response(secretBody, { status: 403 }),
+  });
+
+  return Effect.gen(function* () {
+    const bitbucket = yield* BitbucketApi.BitbucketApi;
+    const error = yield* Effect.flip(
+      bitbucket.getPullRequest({
+        cwd: "/repo",
+        reference: "42",
+      }),
+    );
+
+    assert.strictEqual(error.operation, "getPullRequest");
+    assert.strictEqual(error.status, 403);
+    assert.strictEqual(error.responseBodyLength, secretBody.length);
+    assert.strictEqual(error.detail, "Bitbucket returned HTTP 403.");
+    assert.strictEqual(
+      error.message,
+      "Bitbucket API failed in getPullRequest: Bitbucket returned HTTP 403.",
+    );
+    assert.notInclude(error.message, "secret-value");
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("reports Bitbucket response-body read failures with stable diagnostics", () => {
+  const bodyReadCause = new Error("credential=secret-value");
+  const { layer } = makeLayer({
+    response: () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.error(bodyReadCause);
+          },
+        }),
+        { status: 502 },
+      ),
+  });
+
+  return Effect.gen(function* () {
+    const bitbucket = yield* BitbucketApi.BitbucketApi;
+    const error = yield* Effect.flip(
+      bitbucket.getPullRequest({
+        cwd: "/repo",
+        reference: "42",
+      }),
+    );
+
+    assert.strictEqual(error.operation, "getPullRequest");
+    assert.strictEqual(error.status, 502);
+    assert.strictEqual(error.responseBodyLength, undefined);
+    assert.strictEqual(error.detail, "Failed to read the Bitbucket error response body.");
+    assert.strictEqual(
+      error.message,
+      "Bitbucket API failed in getPullRequest: Failed to read the Bitbucket error response body.",
+    );
+    assert.notInclude(error.message, "secret-value");
+  }).pipe(Effect.provide(layer));
+});
+
 it.effect("checks out same-repository pull requests with the existing Bitbucket remote", () => {
   const { git, layer } = makeLayer({
     response: () =>

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -6,6 +6,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import {
+  NonNegativeInt,
   TrimmedNonEmptyString,
   type SourceControlProviderAuth,
   type SourceControlRepositoryCloneUrls,
@@ -42,6 +43,7 @@ export class BitbucketApiError extends Schema.TaggedErrorClass<BitbucketApiError
     operation: Schema.String,
     detail: Schema.String,
     status: Schema.optional(Schema.Number),
+    responseBodyLength: Schema.optional(NonNegativeInt),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
@@ -343,16 +345,22 @@ function responseError(
   response: HttpClientResponse.HttpClientResponse,
 ): Effect.Effect<never, BitbucketApiError> {
   return response.text.pipe(
-    Effect.orElseSucceed(() => ""),
+    Effect.mapError(
+      (cause) =>
+        new BitbucketApiError({
+          operation,
+          status: response.status,
+          detail: "Failed to read the Bitbucket error response body.",
+          cause,
+        }),
+    ),
     Effect.flatMap((body) =>
       Effect.fail(
         new BitbucketApiError({
           operation,
           status: response.status,
-          detail:
-            body.trim().length > 0
-              ? `Bitbucket returned HTTP ${response.status}: ${body.trim()}`
-              : `Bitbucket returned HTTP ${response.status}.`,
+          responseBodyLength: body.length,
+          detail: `Bitbucket returned HTTP ${response.status}.`,
         }),
       ),
     ),


### PR DESCRIPTION
## Summary
- keep raw Bitbucket error response bodies out of domain messages
- retain HTTP status and response body length as structured diagnostics
- preserve response-body read failures as causes behind a stable message

## Verification
- vp test apps/server/src/sourceControl/BitbucketApi.test.ts
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to error formatting in the Bitbucket client; reduces credential leakage risk with a small behavioral change for anyone relying on body text in error detail.
> 
> **Overview**
> **Bitbucket HTTP error handling no longer surfaces raw response bodies** in `BitbucketApiError` messages or `detail`, so API error payloads (which may contain secrets) are not leaked into logs or UI.
> 
> `responseError` now sets a generic `detail` (`Bitbucket returned HTTP <status>.`) and optional **`responseBodyLength`** instead of appending the body text. **`BitbucketApiError`** gains that structured field. When reading the error body fails, the failure is a dedicated **`BitbucketApiError`** with a stable detail string and the read error on **`cause`**, replacing the previous silent empty-body fallback.
> 
> New tests assert secrets stay out of **`message`** for both a 403 body and a failing response stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0debd790594655ce2100bb3c61b041b740f12d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sanitize Bitbucket API error responses to exclude response body content from diagnostics
> - `responseError` in [BitbucketApi.ts](https://github.com/pingdotgg/t3code/pull/3430/files#diff-0f26cbc52f3a4bd71850ee2ab91de644c5e26ecd24de9283ea456101105b01e8) no longer includes the raw response body in `BitbucketApiError.detail`; instead it logs a generic `"Bitbucket returned HTTP <status>."` message and records `responseBodyLength`.
> - If the response body cannot be read, the error now carries `"Failed to read the Bitbucket error response body."` as the detail with the underlying cause attached, rather than silently falling back to an empty string.
> - Tests cover both cases: a 403 with a secret-containing body and a 502 with a stream read failure.
> - Behavioral Change: callers that previously extracted error detail to surface response body content will now receive only the generic message and body length.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0debd7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->