### PR TITLE
[codex] Sanitize text generation CLI errors

### DIFF
--- a/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
+++ b/apps/server/src/textGeneration/TextGenerationPrompts.test.ts
@@ -190,4 +190,16 @@ describe("normalizeCliError", () => {
     expect(result).toBeInstanceOf(TextGenerationError);
     expect(result.detail).toBe("fallback");
   });
+
+  it("does not expose CLI failure details in the public error message", () => {
+    const result = normalizeCliError(
+      "codex",
+      "generateCommitMessage",
+      new Error("request failed with access_token=secret-token"),
+      "Failed to generate a commit message",
+    );
+
+    expect(result.detail).toBe("Failed to generate a commit message");
+    expect(result.message).not.toContain("secret-token");
+  });
 });

--- a/apps/server/src/textGeneration/TextGenerationUtils.ts
+++ b/apps/server/src/textGeneration/TextGenerationUtils.ts
@@ -99,7 +99,7 @@ export function normalizeCliError(
     }
     return new TextGenerationError({
       operation,
-      detail: `${fallback}: ${error.message}`,
+      detail: fallback,
       cause: error,
     });
   }


### PR DESCRIPTION
## Summary

- keep arbitrary CLI failure text in the underlying `cause`
- use the stable operation fallback as the public structured detail
- cover the behavior with a secret-bearing CLI error regression test

## Root cause

Generic CLI errors were copied into `TextGenerationError.detail`, so provider output and credentials embedded in a process error could surface in public error messages even though the original error was already retained as the cause.

## Validation

- `vp test apps/server/src/textGeneration/TextGenerationPrompts.test.ts` (14 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches error surfacing for text generation; reduces information leakage but may hide CLI failure text from default user-visible messages (still available via cause).
> 
> **Overview**
> **Stops leaking raw CLI stderr/process errors into user-facing text generation failures.**
> 
> `normalizeCliError` no longer appends the underlying `Error.message` to `TextGenerationError.detail` for generic CLI failures. The public `detail` (and derived `message`) now uses only the stable operation **fallback**, while the original error remains on **`cause`**. Missing-CLI-on-PATH handling is unchanged.
> 
> A regression test asserts that a Codex-style error containing `access_token=secret-token` does not appear in the public message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8be620d031e449bc439a7a4844703dd45f85e1ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sanitize `normalizeCliError` output to exclude sensitive CLI error details
> In [TextGenerationUtils.ts](https://github.com/pingdotgg/t3code/pull/3431/files#diff-d7cc46884f2a9f396346252876b2861a6ac0a0467c6695cc7f1321756d51d63c), `normalizeCliError` previously appended the original error message to the fallback string when constructing a `TextGenerationError` for non-ENOENT errors. This exposed internal CLI failure details in the public `detail` field. The fix sets `detail` to the fallback string only, dropping the original error message entirely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8be620d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->