### PR TITLE
[codex] Diagnose desktop client settings read failures

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.diagnostics.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.diagnostics.test.ts
@@ -1,0 +1,129 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
+import * as References from "effect/References";
+
+import * as DesktopConfig from "../app/DesktopConfig.ts";
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as DesktopClientSettings from "./DesktopClientSettings.ts";
+
+interface LogRecord {
+  readonly message: unknown;
+  readonly annotations: Readonly<Record<string, unknown>>;
+}
+
+const baseDir = "/virtual-home";
+
+function makeLayer(fileSystemLayer: Layer.Layer<FileSystem.FileSystem>) {
+  const environmentLayer = DesktopEnvironment.layer({
+    dirname: "/repo/apps/desktop/src",
+    homeDirectory: baseDir,
+    platform: "darwin",
+    processArch: "x64",
+    appVersion: "1.2.3",
+    appPath: "/repo",
+    isPackaged: true,
+    resourcesPath: "/missing/resources",
+    runningUnderArm64Translation: false,
+  }).pipe(
+    Layer.provide(
+      Layer.mergeAll(NodeServices.layer, DesktopConfig.layerTest({ T3CODE_HOME: baseDir })),
+    ),
+  );
+
+  return DesktopClientSettings.layer.pipe(
+    Layer.provideMerge(Layer.mergeAll(environmentLayer, NodeServices.layer, fileSystemLayer)),
+  );
+}
+
+const readWithLogs = (fileSystemLayer: Layer.Layer<FileSystem.FileSystem>) => {
+  const records: Array<LogRecord> = [];
+  const logger = Logger.make(({ fiber, message }) => {
+    records.push({
+      message,
+      annotations: { ...fiber.getRef(References.CurrentLogAnnotations) },
+    });
+  });
+
+  return Effect.gen(function* () {
+    const environment = yield* DesktopEnvironment.DesktopEnvironment;
+    const settings = yield* DesktopClientSettings.DesktopClientSettings;
+    return {
+      result: yield* settings.get,
+      settingsPath: environment.clientSettingsPath,
+      records,
+    };
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        makeLayer(fileSystemLayer),
+        Logger.layer([logger], { mergeWithExisting: false }),
+      ),
+    ),
+  );
+};
+
+describe("DesktopClientSettings diagnostics", () => {
+  it.effect("treats a missing settings file as expected without warning", () =>
+    Effect.gen(function* () {
+      const result = yield* readWithLogs(FileSystem.layerNoop({}));
+
+      assert.isTrue(Option.isNone(result.result));
+      assert.deepEqual(result.records, []);
+    }),
+  );
+
+  it.effect("logs non-missing filesystem failures with the settings path", () => {
+    const permissionError = PlatformError.systemError({
+      _tag: "PermissionDenied",
+      module: "FileSystem",
+      method: "readFileString",
+      pathOrDescriptor: `${baseDir}/userdata/client-settings.json`,
+    });
+
+    return Effect.gen(function* () {
+      const result = yield* readWithLogs(
+        FileSystem.layerNoop({
+          readFileString: () => Effect.fail(permissionError),
+        }),
+      );
+
+      assert.isTrue(Option.isNone(result.result));
+      assert.equal(result.records.length, 1);
+      assert.deepEqual(result.records[0]?.message, [
+        "Could not read desktop client settings.",
+        permissionError,
+      ]);
+      assert.equal(result.records[0]?.annotations.settingsPath, result.settingsPath);
+    });
+  });
+
+  it.effect("logs malformed settings documents with the settings path", () =>
+    Effect.gen(function* () {
+      const result = yield* readWithLogs(
+        FileSystem.layerNoop({
+          readFileString: () => Effect.succeed("{not-json"),
+        }),
+      );
+
+      assert.isTrue(Option.isNone(result.result));
+      assert.equal(result.records.length, 1);
+      const message = result.records[0]?.message;
+      if (!Array.isArray(message)) {
+        return assert.fail("expected structured warning arguments");
+      }
+      assert.equal(message[0], "Could not decode desktop client settings.");
+      const schemaError = message[1];
+      if (schemaError === null || typeof schemaError !== "object") {
+        return assert.fail("expected the schema error in the warning");
+      }
+      assert.equal("_tag" in schemaError ? schemaError._tag : undefined, "SchemaError");
+      assert.equal(result.records[0]?.annotations.settingsPath, result.settingsPath);
+    }),
+  );
+});

--- a/apps/desktop/src/settings/DesktopClientSettings.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.ts
@@ -67,14 +67,29 @@ const readClientSettings = (
   settingsPath: string,
 ): Effect.Effect<Option.Option<ClientSettings>> =>
   fileSystem.readFileString(settingsPath).pipe(
-    Effect.option,
+    Effect.map(Option.some),
+    Effect.catchTags({
+      PlatformError: (cause) =>
+        cause.reason._tag === "NotFound"
+          ? Effect.succeed(Option.none<string>())
+          : Effect.logWarning("Could not read desktop client settings.", cause).pipe(
+              Effect.annotateLogs({ settingsPath }),
+              Effect.as(Option.none<string>()),
+            ),
+    }),
     Effect.flatMap(
       Option.match({
         onNone: () => Effect.succeed(Option.none<ClientSettings>()),
         onSome: (raw) =>
           decodeClientSettingsJson(raw).pipe(
             Effect.map((settings) => Option.some(settings)),
-            Effect.orElseSucceed(() => Option.none<ClientSettings>()),
+            Effect.catchTags({
+              SchemaError: (cause) =>
+                Effect.logWarning("Could not decode desktop client settings.", cause).pipe(
+                  Effect.annotateLogs({ settingsPath }),
+                  Effect.as(Option.none<ClientSettings>()),
+                ),
+            }),
           ),
       }),
     ),


### PR DESCRIPTION
Desktop client settings intentionally fall back to `None` when the settings file is missing or unusable, but the loader previously implemented that behavior with `Effect.option` and `Effect.orElseSucceed`. Those broad fallbacks also hid permission failures, other filesystem failures, and malformed settings documents without leaving any diagnostic evidence.

This change keeps the existing nonfatal API while making unexpected failures observable. A normalized `PlatformError` whose reason is `NotFound` remains an expected silent absence. Other filesystem failures produce a warning annotated with `settingsPath` and retain the original platform error in the log arguments. Schema failures likewise produce a path-annotated warning with the original `SchemaError` before returning `None`. Both recovery points use tagged catch semantics.

The diagnostics tests use an isolated test file because the established client-settings test is currently touched by feature work. They verify that missing files remain silent, permission failures remain nonfatal but observable, and malformed documents remain nonfatal but observable.

Validation:

- `vp test apps/desktop/src/settings/DesktopClientSettings.diagnostics.test.ts`
- `vp check` (passes with pre-existing repository warnings only)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior for callers (`get` still returns `Option`) is unchanged except that some previously hidden failures may now surface as Effect failures or logs; no auth or data-mutation paths.
> 
> **Overview**
> **Desktop client settings** still return `None` when the file is absent or unusable, but unexpected problems are no longer swallowed silently.
> 
> `readClientSettings` replaces broad `Effect.option` / `orElseSucceed` fallbacks with tagged handling: **`NotFound`** stays a quiet `None`; other **`PlatformError`** cases emit a warning (with **`settingsPath`**) and return `None`; **`SchemaError`** on decode gets the same treatment. Errors outside those tags are no longer converted to `None`.
> 
> Adds **`DesktopClientSettings.diagnostics.test.ts`** to assert missing file → no logs, permission/read failure → warning + path, malformed JSON → decode warning + path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 295cff22c194fcffcd76f8db8e800e7538995bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Diagnose desktop client settings read failures with targeted warning logs
> - Missing settings files return `None` silently (no log) in `readClientSettings`.
> - Non-missing filesystem read errors now emit a warning log annotated with `settingsPath` instead of silently returning `None`.
> - Schema decode failures now emit a warning log annotated with `settingsPath` instead of silently returning `None`.
> - Read or decode errors that are not `PlatformError`/`SchemaError` now propagate as failures rather than being swallowed.
> - Adds diagnostic tests in [DesktopClientSettings.diagnostics.test.ts](https://github.com/pingdotgg/t3code/pull/3432/files#diff-087431c75b7136e7baedfa036b3caa6cc363e68a416175e23548edb842c05c88) covering all three cases above.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 295cff2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->