### PR TITLE
[codex] Correlate protocol request failures

### DIFF
--- a/packages/effect-acp/src/_internal/shared.ts
+++ b/packages/effect-acp/src/_internal/shared.ts
@@ -12,7 +12,7 @@ export const callRpc = <A>(
 ): Effect.Effect<A, AcpError.AcpError> =>
   effect.pipe(
     Effect.catchIf(isError, (error) =>
-      Effect.fail(AcpError.AcpRequestError.fromProtocolError(error)),
+      Effect.fail(AcpError.AcpRequestError.fromProtocolError(error, { method })),
     ),
     Effect.catchTags({
       RpcClientError: (cause) =>

--- a/packages/effect-acp/src/errors.test.ts
+++ b/packages/effect-acp/src/errors.test.ts
@@ -51,6 +51,8 @@ describe("effect-acp errors", () => {
         code: -32602,
         errorMessage: "Invalid params",
         data: { field: "sessionId" },
+        method: "session/load",
+        operation: "receive-response",
       });
     });
   });

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -5,8 +5,11 @@ import * as AcpSchema from "./_generated/schema.gen.ts";
 
 export const AcpRequestOperation = Schema.Literals([
   "decode-extension-request-payload",
+  "encode-extension-response",
   "handle-request",
   "handle-extension-request",
+  "receive-response",
+  "receive-streaming-response",
 ]);
 export type AcpRequestOperation = typeof AcpRequestOperation.Type;
 
@@ -65,6 +68,7 @@ const schemaIssueDiagnostics = (root: SchemaIssue.Issue): AcpSchemaIssueDiagnost
 
 export interface AcpRequestDiagnostics {
   readonly method?: string;
+  readonly requestId?: string;
   readonly operation?: AcpRequestOperation;
   readonly cause?: unknown;
   readonly issueCount?: number;
@@ -109,6 +113,7 @@ export class AcpProtocolParseError extends Schema.TaggedErrorClass<AcpProtocolPa
   {
     operation: AcpProtocolParseOperation,
     method: Schema.optionalKey(Schema.String),
+    requestId: Schema.optionalKey(Schema.String),
     issueCount: Schema.optionalKey(Schema.Number),
     issueKinds: Schema.optionalKey(Schema.Array(AcpSchemaIssueKind)),
     maximumPathDepth: Schema.optionalKey(Schema.Number),
@@ -129,6 +134,19 @@ export class AcpProtocolParseError extends Schema.TaggedErrorClass<AcpProtocolPa
       operation,
       method,
       ...schemaIssueDiagnostics(cause.issue),
+      cause,
+    });
+  }
+
+  static fromEncodingError(
+    method: string | undefined,
+    requestId: string | undefined,
+    cause: unknown,
+  ) {
+    return new AcpProtocolParseError({
+      operation: "encode-message",
+      ...(method === undefined ? {} : { method }),
+      ...(requestId === undefined ? {} : { requestId }),
       cause,
     });
   }
@@ -167,6 +185,7 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
   errorMessage: Schema.String,
   data: Schema.optional(Schema.Unknown),
   method: Schema.optionalKey(Schema.String),
+  requestId: Schema.optionalKey(Schema.String),
   operation: Schema.optionalKey(AcpRequestOperation),
   issueCount: Schema.optionalKey(Schema.Number),
   issueKinds: Schema.optionalKey(Schema.Array(AcpSchemaIssueKind)),
@@ -177,12 +196,57 @@ export class AcpRequestError extends Schema.TaggedErrorClass<AcpRequestError>()(
     return this.errorMessage;
   }
 
-  static fromProtocolError(error: AcpSchema.Error) {
+  static fromProtocolError(
+    error: AcpSchema.Error,
+    context: {
+      readonly method: string;
+      readonly requestId?: string;
+      readonly cause?: unknown;
+    },
+  ) {
     return new AcpRequestError({
       code: error.code,
       errorMessage: error.message,
       ...(error.data !== undefined ? { data: error.data } : {}),
+      method: context.method,
+      ...(context.requestId === undefined ? {} : { requestId: context.requestId }),
+      operation: "receive-response",
+      cause: context.cause ?? error,
     });
+  }
+
+  static fromExtensionResponseFailure(method: string, requestId: string, cause: unknown) {
+    return AcpRequestError.internalError("Extension request failed", undefined, {
+      method,
+      requestId,
+      operation: "receive-response",
+      cause,
+    });
+  }
+
+  static fromExtensionResponseEncodingError(
+    method: string,
+    requestId: string,
+    cause: AcpProtocolParseError,
+  ) {
+    return AcpRequestError.internalError("Internal error", undefined, {
+      method,
+      requestId,
+      operation: "encode-extension-response",
+      cause,
+    });
+  }
+
+  static unsupportedStreamingResponse(method: string, requestId: string) {
+    return AcpRequestError.internalError(
+      "Streaming extension responses are not supported",
+      undefined,
+      {
+        method,
+        requestId,
+        operation: "receive-streaming-response",
+      },
+    );
   }
 
   static fromCoreHandlerError(error: AcpError, method: string) {

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -260,15 +260,33 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
       const bigintError = yield* transport.notify("x/test", 1n).pipe(Effect.flip);
       assert.instanceOf(bigintError, AcpError.AcpProtocolParseError);
       assert.equal(bigintError.operation, "encode-message");
+      assert.equal(bigintError.method, "x/test");
       assert.instanceOf(bigintError.cause, TypeError);
-      assert.equal(bigintError.message, "ACP protocol operation 'encode-message' failed.");
+      assert.equal(
+        bigintError.message,
+        "ACP protocol operation 'encode-message' failed for method 'x/test'.",
+      );
 
       const circular: Record<string, unknown> = {};
       circular.self = circular;
       const circularError = yield* transport.notify("x/test", circular).pipe(Effect.flip);
       assert.instanceOf(circularError, AcpError.AcpProtocolParseError);
       assert.equal(circularError.operation, "encode-message");
+      assert.equal(circularError.method, "x/test");
       assert.instanceOf(circularError.cause, TypeError);
+
+      const requestError = yield* transport.request("x/request", 1n).pipe(
+        Effect.match({
+          onFailure: (error) => error,
+          onSuccess: () => assert.fail("Expected request encoding to fail"),
+        }),
+      );
+      assert.instanceOf(requestError, AcpError.AcpProtocolParseError);
+      assert.deepInclude(requestError, {
+        operation: "encode-message",
+        method: "x/request",
+        requestId: "1",
+      });
     }),
   );
 
@@ -307,6 +325,60 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
 
       const resolved = yield* Fiber.join(response);
       assert.deepEqual(resolved, { ok: true });
+    }),
+  );
+
+  it.effect("correlates extension response errors with the originating request", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const transport = yield* AcpProtocol.makeAcpPatchedProtocol({
+        stdio,
+        serverRequestMethods: new Set(),
+      });
+
+      const response = yield* transport
+        .request("x/private", { hello: "world" })
+        .pipe(Effect.forkScoped);
+      yield* Queue.take(output);
+      yield* Queue.offer(
+        input,
+        encoder.encode(
+          `${encodeUnknownJsonString({
+            jsonrpc: "2.0",
+            id: 1,
+            error: {
+              _tag: "Cause",
+              code: -32602,
+              message: "Invalid params",
+              data: [
+                {
+                  _tag: "Fail",
+                  error: {
+                    code: -32602,
+                    message: "Invalid params",
+                    data: { field: "hello" },
+                  },
+                },
+              ],
+            },
+          })}\n`,
+        ),
+      );
+
+      const error = yield* Fiber.join(response).pipe(
+        Effect.match({
+          onFailure: (error) => error,
+          onSuccess: () => assert.fail("Expected extension request to fail"),
+        }),
+      );
+      assert.instanceOf(error, AcpError.AcpRequestError);
+      assert.deepInclude(error, {
+        code: -32602,
+        errorMessage: "Invalid params",
+        method: "x/private",
+        requestId: "1",
+        operation: "receive-response",
+      });
     }),
   );
 

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -66,6 +66,11 @@ export interface AcpPatchedProtocol {
   readonly notify: (method: string, payload: unknown) => Effect.Effect<void, AcpError.AcpError>;
 }
 
+interface AcpPendingRequest {
+  readonly deferred: Deferred.Deferred<unknown, AcpError.AcpError>;
+  readonly method: string;
+}
+
 const decodeSessionUpdate = Schema.decodeUnknownEffect(AcpSchema.SessionNotification);
 const decodeElicitationComplete = Schema.decodeUnknownEffect(
   AcpSchema.ElicitationCompleteNotification,
@@ -83,9 +88,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
   const outgoing = yield* Queue.unbounded<string | Uint8Array, Cause.Done<void>>();
   const nextRequestId = yield* Ref.make(1n);
   const terminationHandled = yield* Ref.make(false);
-  const extPending = yield* Ref.make(
-    new Map<string, Deferred.Deferred<unknown, AcpError.AcpError>>(),
-  );
+  const extPending = yield* Ref.make(new Map<string, AcpPendingRequest>());
 
   const logProtocol = (event: AcpProtocolLogEvent) => {
     if (event.direction === "incoming" && !options.logIncoming) {
@@ -109,13 +112,17 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
       payload: message,
     });
 
+    const method = message._tag === "Request" ? message.tag : undefined;
+    const encodedRequestId =
+      message._tag === "Request"
+        ? message.id
+        : "requestId" in message
+          ? message.requestId
+          : undefined;
+    const requestId = encodedRequestId === "" ? undefined : encodedRequestId;
     const encoded = yield* Effect.try({
       try: () => parser.encode(message),
-      catch: (cause) =>
-        new AcpError.AcpProtocolParseError({
-          operation: "encode-message",
-          cause,
-        }),
+      catch: (cause) => AcpError.AcpProtocolParseError.fromEncodingError(method, requestId, cause),
     });
 
     if (encoded) {
@@ -131,16 +138,16 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
 
   const resolveExtPending = (
     requestId: string,
-    onFound: (deferred: Deferred.Deferred<unknown, AcpError.AcpError>) => Effect.Effect<void>,
+    onFound: (pendingRequest: AcpPendingRequest) => Effect.Effect<void>,
   ) =>
     Ref.modify(extPending, (pending) => {
-      const deferred = pending.get(requestId);
-      if (!deferred) {
+      const pendingRequest = pending.get(requestId);
+      if (!pendingRequest) {
         return [Effect.void, pending] as const;
       }
       const next = new Map(pending);
       next.delete(requestId);
-      return [onFound(deferred), next] as const;
+      return [onFound(pendingRequest), next] as const;
     }).pipe(Effect.flatten);
 
   const removeExtPending = (requestId: string) =>
@@ -154,15 +161,15 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
     });
 
   const completeExtPendingFailure = (requestId: string, error: AcpError.AcpError) =>
-    resolveExtPending(requestId, (deferred) => Deferred.fail(deferred, error));
+    resolveExtPending(requestId, ({ deferred }) => Deferred.fail(deferred, error));
 
   const completeExtPendingSuccess = (requestId: string, value: unknown) =>
-    resolveExtPending(requestId, (deferred) => Deferred.succeed(deferred, value));
+    resolveExtPending(requestId, ({ deferred }) => Deferred.succeed(deferred, value));
 
   const failAllExtPending = (error: AcpError.AcpError) =>
     Ref.getAndSet(extPending, new Map()).pipe(
       Effect.flatMap((pending) =>
-        Effect.forEach([...pending.values()], (deferred) => Deferred.fail(deferred, error), {
+        Effect.forEach([...pending.values()], ({ deferred }) => Deferred.fail(deferred, error), {
           discard: true,
         }),
       ),
@@ -303,7 +310,26 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
 
     if (!options.serverRequestMethods.has(message.tag)) {
       return handleExtRequest(message).pipe(
-        Effect.catch(() => respondWithError(message.id, AcpError.AcpRequestError.internalError())),
+        Effect.catchTags({
+          AcpProtocolParseError: (error) =>
+            Effect.logWarning(error).pipe(
+              Effect.annotateLogs({
+                method: message.tag,
+                requestId: message.id,
+                operation: error.operation,
+              }),
+              Effect.andThen(
+                respondWithError(
+                  message.id,
+                  AcpError.AcpRequestError.fromExtensionResponseEncodingError(
+                    message.tag,
+                    message.id,
+                    error,
+                  ),
+                ),
+              ),
+            ),
+        }),
         Effect.asVoid,
       );
     }
@@ -314,7 +340,8 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
   const handleExitEncoded = (message: RpcMessage.ResponseExitEncoded) =>
     Ref.get(extPending).pipe(
       Effect.flatMap((pending) => {
-        if (!pending.has(message.requestId)) {
+        const pendingRequest = pending.get(message.requestId);
+        if (!pendingRequest) {
           return Queue.offer(clientQueue, message).pipe(Effect.asVoid);
         }
         if (message.exit._tag === "Success") {
@@ -324,12 +351,20 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
         if (failure && isProtocolError(failure.error)) {
           return completeExtPendingFailure(
             message.requestId,
-            AcpError.AcpRequestError.fromProtocolError(failure.error),
+            AcpError.AcpRequestError.fromProtocolError(failure.error, {
+              method: pendingRequest.method,
+              requestId: message.requestId,
+              cause: message.exit.cause,
+            }),
           );
         }
         return completeExtPendingFailure(
           message.requestId,
-          AcpError.AcpRequestError.internalError("Extension request failed"),
+          AcpError.AcpRequestError.fromExtensionResponseFailure(
+            pendingRequest.method,
+            message.requestId,
+            message.exit.cause,
+          ),
         );
       }),
     );
@@ -344,16 +379,18 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
         return handleExitEncoded(message);
       case "Chunk":
         return Ref.get(extPending).pipe(
-          Effect.flatMap((pending) =>
-            pending.has(message.requestId)
+          Effect.flatMap((pending) => {
+            const pendingRequest = pending.get(message.requestId);
+            return pendingRequest
               ? completeExtPendingFailure(
                   message.requestId,
-                  AcpError.AcpRequestError.internalError(
-                    "Streaming extension responses are not supported",
+                  AcpError.AcpRequestError.unsupportedStreamingResponse(
+                    pendingRequest.method,
+                    message.requestId,
                   ),
                 )
-              : Queue.offer(clientQueue, message).pipe(Effect.asVoid),
-          ),
+              : Queue.offer(clientQueue, message).pipe(Effect.asVoid);
+          }),
         );
       case "Defect":
       case "ClientProtocolError":
@@ -401,6 +438,7 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
             payload: {
               operation: error.operation,
               ...(error.method === undefined ? {} : { method: error.method }),
+              ...(error.requestId === undefined ? {} : { requestId: error.requestId }),
               ...(error.issueCount === undefined ? {} : { issueCount: error.issueCount }),
               ...(error.issueKinds === undefined ? {} : { issueKinds: error.issueKinds }),
               ...(error.maximumPathDepth === undefined
@@ -494,18 +532,16 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
       (current) => [current, current + 1n] as const,
     );
     const deferred = yield* Deferred.make<unknown, AcpError.AcpError>();
-    yield* Ref.update(extPending, (pending) => new Map(pending).set(String(requestId), deferred));
+    yield* Ref.update(extPending, (pending) =>
+      new Map(pending).set(String(requestId), { deferred, method }),
+    );
     yield* offerOutgoing({
       _tag: "Request",
       id: String(requestId),
       tag: method,
       payload,
       headers: [],
-    }).pipe(
-      Effect.catch((error) =>
-        removeExtPending(String(requestId)).pipe(Effect.andThen(Effect.fail(error))),
-      ),
-    );
+    }).pipe(Effect.tapError(() => removeExtPending(String(requestId))));
     return yield* Deferred.await(deferred).pipe(
       Effect.onInterrupt(() => removeExtPending(String(requestId))),
     );

--- a/packages/effect-codex-app-server/src/errors.ts
+++ b/packages/effect-codex-app-server/src/errors.ts
@@ -5,6 +5,7 @@ export const CodexAppServerRequestOperation = Schema.Literals([
   "decode-payload",
   "encode-payload",
   "handle-request",
+  "receive-response",
 ]);
 export type CodexAppServerRequestOperation = typeof CodexAppServerRequestOperation.Type;
 
@@ -83,6 +84,7 @@ const payloadKind = (payload: unknown): CodexAppServerPayloadKind => {
 
 export interface CodexAppServerRequestDiagnostics {
   readonly method?: string;
+  readonly requestId?: string;
   readonly operation?: CodexAppServerRequestOperation;
   readonly cause?: unknown;
   readonly issueCount?: number;
@@ -154,6 +156,7 @@ export class CodexAppServerProtocolParseError extends Schema.TaggedErrorClass<Co
   {
     operation: CodexAppServerProtocolParseOperation,
     method: Schema.optionalKey(Schema.String),
+    requestId: Schema.optionalKey(Schema.String),
     detail: Schema.optionalKey(Schema.String),
     issueCount: Schema.optionalKey(Schema.Number),
     issueKinds: Schema.optionalKey(Schema.Array(CodexAppServerSchemaIssueKind)),
@@ -169,7 +172,7 @@ export class CodexAppServerProtocolParseError extends Schema.TaggedErrorClass<Co
   static fromSchemaError(
     operation: CodexAppServerProtocolParseOperation,
     cause: Schema.SchemaError,
-    context: { readonly method?: string } = {},
+    context: { readonly method?: string; readonly requestId?: string } = {},
   ) {
     return new CodexAppServerProtocolParseError({
       operation,
@@ -235,6 +238,7 @@ export class CodexAppServerRequestError extends Schema.TaggedErrorClass<CodexApp
     errorMessage: Schema.String,
     data: Schema.optional(Schema.Unknown),
     method: Schema.optionalKey(Schema.String),
+    requestId: Schema.optionalKey(Schema.String),
     operation: Schema.optionalKey(CodexAppServerRequestOperation),
     issueCount: Schema.optionalKey(Schema.Number),
     issueKinds: Schema.optionalKey(Schema.Array(CodexAppServerSchemaIssueKind)),
@@ -247,11 +251,19 @@ export class CodexAppServerRequestError extends Schema.TaggedErrorClass<CodexApp
     return this.errorMessage;
   }
 
-  static fromProtocolError(error: CodexAppServerProtocolErrorShape) {
+  static fromProtocolError(
+    error: CodexAppServerProtocolErrorShape,
+    method: string,
+    requestId: string,
+  ) {
     return new CodexAppServerRequestError({
       code: error.code,
       errorMessage: error.message,
       ...(error.data !== undefined ? { data: error.data } : {}),
+      method,
+      requestId,
+      operation: "receive-response",
+      cause: error,
     });
   }
 

--- a/packages/effect-codex-app-server/src/protocol.test.ts
+++ b/packages/effect-codex-app-server/src/protocol.test.ts
@@ -212,10 +212,11 @@ it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
       const bigintError = yield* transport.notify("x/test", 1n).pipe(Effect.flip);
       assert.instanceOf(bigintError, CodexError.CodexAppServerProtocolParseError);
       assert.equal(bigintError.operation, "encode-wire-message");
+      assert.equal(bigintError.method, "x/test");
       assert.exists(bigintError.cause);
       assert.equal(
         bigintError.message,
-        "Codex App Server protocol operation 'encode-wire-message' failed.",
+        "Codex App Server protocol operation 'encode-wire-message' failed for method 'x/test'.",
       );
 
       const circular: Record<string, unknown> = {};
@@ -223,7 +224,57 @@ it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
       const circularError = yield* transport.notify("x/test", circular).pipe(Effect.flip);
       assert.instanceOf(circularError, CodexError.CodexAppServerProtocolParseError);
       assert.equal(circularError.operation, "encode-wire-message");
+      assert.equal(circularError.method, "x/test");
       assert.exists(circularError.cause);
+
+      const requestError = yield* transport.request("x/request", 1n).pipe(
+        Effect.match({
+          onFailure: (error) => error,
+          onSuccess: () => assert.fail("Expected request encoding to fail"),
+        }),
+      );
+      assert.instanceOf(requestError, CodexError.CodexAppServerProtocolParseError);
+      assert.deepInclude(requestError, {
+        operation: "encode-wire-message",
+        method: "x/request",
+        requestId: "1",
+      });
+    }),
+  );
+
+  it.effect("correlates response errors with the originating request", () =>
+    Effect.gen(function* () {
+      const { stdio, input, output } = yield* makeInMemoryStdio();
+      const transport = yield* CodexProtocol.makeCodexAppServerPatchedProtocol({ stdio });
+
+      const response = yield* transport.request("thread/start", {}).pipe(Effect.forkScoped);
+      yield* Queue.take(output);
+      yield* Queue.offer(
+        input,
+        encodeJsonl({
+          id: 1,
+          error: {
+            code: -32602,
+            message: "Invalid params",
+            data: { field: "cwd" },
+          },
+        }),
+      );
+
+      const error = yield* Fiber.join(response).pipe(
+        Effect.match({
+          onFailure: (error) => error,
+          onSuccess: () => assert.fail("Expected Codex App Server request to fail"),
+        }),
+      );
+      assert.instanceOf(error, CodexError.CodexAppServerRequestError);
+      assert.deepInclude(error, {
+        code: -32602,
+        errorMessage: "Invalid params",
+        method: "thread/start",
+        requestId: "1",
+        operation: "receive-response",
+      });
     }),
   );
 

--- a/packages/effect-codex-app-server/src/protocol.ts
+++ b/packages/effect-codex-app-server/src/protocol.ts
@@ -67,6 +67,11 @@ export interface CodexAppServerPatchedProtocol {
   ) => Effect.Effect<void, CodexError.CodexAppServerError>;
 }
 
+interface CodexAppServerPendingRequest {
+  readonly deferred: Deferred.Deferred<unknown, CodexError.CodexAppServerError>;
+  readonly method: string;
+}
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -94,9 +99,21 @@ const encodeWireMessage = (
 ): Effect.Effect<string, CodexError.CodexAppServerProtocolParseError> =>
   encodeJsonString(message).pipe(
     Effect.map((encoded) => `${encoded}\n`),
-    Effect.mapError((cause) =>
-      CodexError.CodexAppServerProtocolParseError.fromSchemaError("encode-wire-message", cause),
-    ),
+    Effect.mapError((cause) => {
+      const method = typeof message.method === "string" ? message.method : undefined;
+      const requestId =
+        typeof message.id === "string" || typeof message.id === "number"
+          ? String(message.id)
+          : undefined;
+      return CodexError.CodexAppServerProtocolParseError.fromSchemaError(
+        "encode-wire-message",
+        cause,
+        {
+          ...(method === undefined ? {} : { method }),
+          ...(requestId === undefined ? {} : { requestId }),
+        },
+      );
+    }),
   );
 
 const decodeWireMessage = (
@@ -138,9 +155,7 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
     const outgoing = yield* Queue.unbounded<string, Cause.Done<void>>();
     const incomingNotifications = yield* Queue.unbounded<CodexAppServerIncomingNotification>();
     const incomingRequests = yield* Queue.unbounded<CodexAppServerIncomingRequest>();
-    const pending = yield* Ref.make(
-      new Map<string, Deferred.Deferred<unknown, CodexError.CodexAppServerError>>(),
-    );
+    const pending = yield* Ref.make(new Map<string, CodexAppServerPendingRequest>());
     const nextRequestId = yield* Ref.make(1);
     const remainder = yield* Ref.make("");
     const terminationHandled = yield* Ref.make(false);
@@ -161,7 +176,7 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
     const failAllPending = (error: CodexError.CodexAppServerError) =>
       Ref.get(pending).pipe(
         Effect.flatMap((current) =>
-          Effect.forEach([...current.values()], (deferred) => Deferred.fail(deferred, error), {
+          Effect.forEach([...current.values()], ({ deferred }) => Deferred.fail(deferred, error), {
             discard: true,
           }),
         ),
@@ -214,18 +229,16 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
 
     const resolvePending = (
       requestId: string,
-      handler: (
-        deferred: Deferred.Deferred<unknown, CodexError.CodexAppServerError>,
-      ) => Effect.Effect<void>,
+      handler: (pendingRequest: CodexAppServerPendingRequest) => Effect.Effect<void>,
     ) =>
       Ref.modify(pending, (current) => {
-        const deferred = current.get(requestId);
-        if (!deferred) {
+        const pendingRequest = current.get(requestId);
+        if (!pendingRequest) {
           return [Effect.void, current] as const;
         }
         const next = new Map(current);
         next.delete(requestId);
-        return [handler(deferred), next] as const;
+        return [handler(pendingRequest), next] as const;
       }).pipe(Effect.flatten);
 
     const respond = (requestId: string | number, result: unknown) =>
@@ -240,14 +253,20 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
       const requestId = String(response.id);
       const protocolError = response.error;
       if (protocolError !== undefined) {
-        return resolvePending(requestId, (deferred) =>
+        return resolvePending(requestId, ({ deferred, method }) =>
           Deferred.fail(
             deferred,
-            CodexError.CodexAppServerRequestError.fromProtocolError(protocolError),
+            CodexError.CodexAppServerRequestError.fromProtocolError(
+              protocolError,
+              method,
+              requestId,
+            ),
           ),
         );
       }
-      return resolvePending(requestId, (deferred) => Deferred.succeed(deferred, response.result));
+      return resolvePending(requestId, ({ deferred }) =>
+        Deferred.succeed(deferred, response.result),
+      );
     };
 
     const handleRequest = (request: CodexAppServerIncomingRequest) =>
@@ -322,6 +341,7 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
             payload: {
               operation: error.operation,
               ...(error.method === undefined ? {} : { method: error.method }),
+              ...(error.requestId === undefined ? {} : { requestId: error.requestId }),
               ...(error.issueCount === undefined ? {} : { issueCount: error.issueCount }),
               ...(error.issueKinds === undefined ? {} : { issueKinds: error.issueKinds }),
               ...(error.maximumPathDepth === undefined
@@ -375,16 +395,14 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
           (current) => [current, current + 1] as const,
         );
         const deferred = yield* Deferred.make<unknown, CodexError.CodexAppServerError>();
-        yield* Ref.update(pending, (current) => new Map(current).set(String(requestId), deferred));
+        yield* Ref.update(pending, (current) =>
+          new Map(current).set(String(requestId), { deferred, method }),
+        );
         yield* offerOutgoing({
           id: requestId,
           method,
           ...(payload !== undefined ? { params: payload } : {}),
-        }).pipe(
-          Effect.catch((error) =>
-            removePending(String(requestId)).pipe(Effect.andThen(Effect.fail(error))),
-          ),
-        );
+        }).pipe(Effect.tapError(() => removePending(String(requestId))));
         return yield* Deferred.await(deferred).pipe(
           Effect.onInterrupt(() => removePending(String(requestId))),
         );


### PR DESCRIPTION
## Summary

- attach method, request ID, and operation diagnostics to ACP and Codex App Server request/response failures
- retain complete encoded ACP failure causes while deriving stable protocol-facing messages
- preserve pending-request method context and clean it up without widening catch semantics
- centralize protocol error transformations on the error classes

## Validation

- vp test packages/effect-acp/src/errors.test.ts packages/effect-acp/src/protocol.test.ts packages/effect-codex-app-server/src/protocol.test.ts (26 tests)
- vp check (0 errors; existing warnings only)
- vp run typecheck
- independent read-only review found no remaining actionable issues

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core JSON-RPC error mapping and pending-request lifecycle in two protocol packages; behavior is mostly additive diagnostics but changes error shapes and ACP extension error handling semantics.
> 
> **Overview**
> **ACP** and **Codex App Server** now attach **method**, **request ID**, and **operation** (`receive-response`, encoding failures, etc.) when outbound encoding fails or when a client request gets an error response, so failures can be tied to the call that caused them.
> 
> Pending outbound requests keep **method** alongside the deferred (not just ID), and protocol layers use that when mapping JSON-RPC errors into `AcpRequestError` / `CodexAppServerRequestError`. **ACP** also adds focused factories for extension response failures, response encoding errors, and unsupported streaming chunks, keeps full exit **cause** on protocol errors where relevant, and tightens extension-handler error handling to `AcpProtocolParseError` instead of a blanket catch. Encode/decode failure logging can include **requestId** where available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 878b3a68ce28e756e240c7184c717b527af075a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Correlate protocol request failures with originating RPC method and request ID
> - Adds `method` and `requestId` metadata to `AcpRequestError` and `CodexAppServerRequestError` so that protocol-level failures can be traced back to the originating request.
> - Introduces `AcpPendingRequest` and `CodexAppServerPendingRequest` interfaces that store `method` alongside the deferred, enabling correlation when responses arrive.
> - New factory methods (`fromProtocolError`, `fromExtensionResponseFailure`, `fromExtensionResponseEncodingError`, `unsupportedStreamingResponse`) produce structured errors tagged with specific `operation` values (`receive-response`, `encode-extension-response`, `receive-streaming-response`).
> - Encoding failures in `offerOutgoing` and `encodeWireMessage` now propagate `method` and `requestId` into `AcpProtocolParseError` / `CodexAppServerProtocolParseError`.
> - Pending entries are now cleaned up via `tapError` on send failure rather than swallowing the error path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 878b3a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->