### PR TITLE
[codex] Sanitize provider config decode diagnostics

### DIFF
--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryDiagnostics.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryDiagnostics.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from "@effect/vitest";
+import {
+  ProviderDriverKind,
+  type ProviderInstanceConfigMap,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+
+import type { ProviderDriver } from "../ProviderDriver.ts";
+import { makeProviderInstanceRegistry } from "./ProviderInstanceRegistryLive.ts";
+
+const SensitiveProviderConfig = Schema.Struct({
+  serverPassword: Schema.String,
+});
+
+const sensitiveDriverKind = ProviderDriverKind.make("sensitiveTestDriver");
+const sensitiveDriver: ProviderDriver<typeof SensitiveProviderConfig.Type> = {
+  driverKind: sensitiveDriverKind,
+  metadata: { displayName: "Sensitive test driver" },
+  configSchema: SensitiveProviderConfig,
+  defaultConfig: () => ({ serverPassword: "" }),
+  create: () => Effect.die("invalid provider config must not reach driver creation"),
+};
+
+it.live("keeps rejected provider config values out of unavailable diagnostics", () =>
+  Effect.gen(function* () {
+    const secret = "provider-config-secret-sentinel";
+    const instanceId = ProviderInstanceId.make("sensitive_test");
+    const configMap: ProviderInstanceConfigMap = {
+      [instanceId]: {
+        driver: sensitiveDriverKind,
+        config: { serverPassword: { secret } },
+      },
+    };
+
+    const { registry } = yield* makeProviderInstanceRegistry({
+      drivers: [sensitiveDriver],
+      configMap,
+    });
+    const unavailable = yield* registry.listUnavailable;
+
+    expect(unavailable).toHaveLength(1);
+    expect(unavailable[0]?.unavailableReason).toContain("Invalid type");
+    expect(unavailable[0]?.unavailableReason).toContain('["serverPassword"]');
+    expect(unavailable[0]?.unavailableReason).not.toContain(secret);
+  }),
+);

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.ts
@@ -40,6 +40,7 @@ import {
   type ProviderDriverKind,
   type ServerProvider,
 } from "@t3tools/contracts";
+import { formatSchemaIssue } from "@t3tools/shared/schemaJson";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Equal from "effect/Equal";
@@ -137,12 +138,13 @@ const buildEntry = <R>(input: {
     const decoder = Schema.decodeUnknownEffect(driver.configSchema);
     const decodeResult = yield* decoder(entry.config ?? driver.defaultConfig()).pipe(Effect.result);
     if (decodeResult._tag === "Failure") {
-      const issue = decodeResult.failure;
-      const detail = issue.message ?? String(issue);
+      const error = decodeResult.failure;
+      const issue = formatSchemaIssue(error.issue);
       yield* Effect.logError("Failed to decode provider instance config", {
         instanceId: rawInstanceId,
         driver: entry.driver,
-        detail,
+        errorTag: error._tag,
+        issue,
       });
       return {
         kind: "unavailable" as const,
@@ -151,7 +153,7 @@ const buildEntry = <R>(input: {
           instanceId,
           displayName: entry.displayName,
           accentColor: entry.accentColor,
-          reason: `Invalid config for instance '${rawInstanceId}': ${detail}`,
+          reason: `Invalid config for instance '${rawInstanceId}': ${issue}`,
         }),
       };
     }

--- a/packages/shared/src/schemaJson.ts
+++ b/packages/shared/src/schemaJson.ts
@@ -106,6 +106,30 @@ function collectSchemaDiagnosticIssues(
   return 1;
 }
 
+function formatCollectedSchemaDiagnostics(
+  issues: ReadonlyArray<SchemaDiagnosticIssue>,
+  issueCount: number,
+  fallback: string,
+): string {
+  if (issues.length === 0) {
+    return fallback;
+  }
+
+  const omittedIssueCount = issueCount - issues.length;
+  const formatted = issues.map(formatDiagnosticIssue).join("\n");
+  if (omittedIssueCount === 0) {
+    return truncateDiagnostic(formatted, MAX_SCHEMA_DIAGNOSTIC_LENGTH);
+  }
+  const suffix = `\n... and ${omittedIssueCount} more issue(s)`;
+  return truncateDiagnostic(formatted, MAX_SCHEMA_DIAGNOSTIC_LENGTH - suffix.length) + suffix;
+}
+
+export const formatSchemaIssue = (issue: SchemaIssue.Issue): string => {
+  const issues: Array<SchemaDiagnosticIssue> = [];
+  const issueCount = collectSchemaDiagnosticIssues(issue, [], issues);
+  return formatCollectedSchemaDiagnostics(issues, issueCount, "Schema validation failed.");
+};
+
 export const decodeJsonResult = <S extends Schema.Codec<unknown, unknown, never, never>>(
   schema: S,
 ) => {
@@ -156,17 +180,11 @@ export const formatSchemaError = (cause: Cause.Cause<Schema.SchemaError>) => {
     }
   }
 
-  if (issues.length === 0) {
-    return `Schema validation failed (failureCount=${failureCount}, defectCount=${defectCount}, interruptionCount=${interruptionCount}).`;
-  }
-
-  const omittedIssueCount = issueCount - issues.length;
-  const formatted = issues.map(formatDiagnosticIssue).join("\n");
-  if (omittedIssueCount === 0) {
-    return truncateDiagnostic(formatted, MAX_SCHEMA_DIAGNOSTIC_LENGTH);
-  }
-  const suffix = `\n... and ${omittedIssueCount} more issue(s)`;
-  return truncateDiagnostic(formatted, MAX_SCHEMA_DIAGNOSTIC_LENGTH - suffix.length) + suffix;
+  return formatCollectedSchemaDiagnostics(
+    issues,
+    issueCount,
+    `Schema validation failed (failureCount=${failureCount}, defectCount=${defectCount}, interruptionCount=${interruptionCount}).`,
+  );
 };
 
 /**


### PR DESCRIPTION
## Summary

- replace raw provider config SchemaError messages with bounded structural issue diagnostics
- reuse the shared schema diagnostic formatter directly from SchemaIssue without manufacturing a Cause
- add a focused regression test proving unavailable-provider diagnostics retain the field path without exposing rejected secrets

## Validation

- `vp test apps/server/src/provider/Layers/ProviderInstanceRegistryDiagnostics.test.ts packages/shared/src/schemaJson.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how validation errors are exposed across server/UI boundaries; the change reduces leakage risk but incorrect formatting could still hide useful debug detail.
> 
> **Overview**
> **Unavailable provider diagnostics** no longer surface raw schema decode errors that can include rejected config values. When instance config fails decode, reasons are built with the shared **bounded structural formatter** (`formatSchemaIssue`) so messages keep issue kinds and field paths without echoing secrets.
> 
> In **`schemaJson`**, diagnostic string assembly is centralized in `formatCollectedSchemaDiagnostics`, exposed as **`formatSchemaIssue`** for a single `SchemaIssue`, and **`formatSchemaError`** now reuses that helper instead of duplicating truncation/omission logic.
> 
> A **live regression test** asserts invalid config still reports paths like `["serverPassword"]` while omitting a sentinel secret from `unavailableReason`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40bef00f2bff132a693e5f0f098ab4b49fa9502a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Sanitize provider config decode diagnostics to exclude raw secret values
> - When provider instance config decoding fails in [`ProviderInstanceRegistryLive`](https://github.com/pingdotgg/t3code/pull/3434/files#diff-831d50ba546b3d7c46d1e235290f0666bb4ee8bf2d8459b347ac0bdfc2c925ae), logged errors and `unavailableReason` now use structured schema diagnostics instead of raw failure messages that could expose secret values.
> - Adds `formatSchemaIssue` to [`schemaJson.ts`](https://github.com/pingdotgg/t3code/pull/3434/files#diff-d79129a7d12059ea757ac16209eb5470e9f1a538e909adadefe5cf684b995a88) to convert a single Schema issue into a truncated, sanitized diagnostic string; `formatSchemaError` is refactored to share the same formatting logic via a new `formatCollectedSchemaDiagnostics` helper.
> - Behavioral Change: callers reading `unavailableReason` will see formatted schema issue strings (e.g. type/path references) instead of the previous raw error detail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 40bef00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->