### PR TITLE
[codex] Fix desktop preview event delivery errors

### DIFF
--- a/apps/desktop/src/ipc/methods/preview.ts
+++ b/apps/desktop/src/ipc/methods/preview.ts
@@ -19,37 +19,30 @@ import {
   PreviewAutomationSnapshot,
   PreviewAutomationStatus,
 } from "@t3tools/contracts";
-import { BrowserWindow } from "electron";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as NodeURL from "node:url";
 
+import * as ElectronWindow from "../../electron/ElectronWindow.ts";
 import * as PreviewManager from "../../preview/Manager.ts";
 import { PREVIEW_WEBVIEW_PREFERENCES } from "../../preview/WebviewPreferences.ts";
 import * as IpcChannels from "../channels.ts";
 import * as DesktopIpc from "../DesktopIpc.ts";
 
-const broadcast = (channel: string, ...args: ReadonlyArray<unknown>): void => {
-  for (const window of BrowserWindow.getAllWindows()) {
-    if (!window.isDestroyed()) {
-      window.webContents.send(channel, ...args);
-    }
-  }
-};
-
 export const installPreviewEventForwarding = Effect.fn(
   "desktop.ipc.preview.installEventForwarding",
 )(function* () {
+  const electronWindow = yield* ElectronWindow.ElectronWindow;
   const manager = yield* PreviewManager.PreviewManager;
-  yield* manager.subscribeStateChanges((tabId, state) => {
-    broadcast(IpcChannels.PREVIEW_STATE_CHANGE_CHANNEL, tabId, state);
-  });
-  yield* manager.subscribeRecordingFrames((frame) => {
-    broadcast(IpcChannels.PREVIEW_RECORDING_FRAME_CHANNEL, frame);
-  });
-  yield* manager.subscribePointerEvents((event) => {
-    broadcast(IpcChannels.PREVIEW_POINTER_EVENT_CHANNEL, event);
-  });
+  yield* manager.subscribeStateChanges((tabId, state) =>
+    electronWindow.sendAll(IpcChannels.PREVIEW_STATE_CHANGE_CHANNEL, tabId, state),
+  );
+  yield* manager.subscribeRecordingFrames((frame) =>
+    electronWindow.sendAll(IpcChannels.PREVIEW_RECORDING_FRAME_CHANNEL, frame),
+  );
+  yield* manager.subscribePointerEvents((event) =>
+    electronWindow.sendAll(IpcChannels.PREVIEW_POINTER_EVENT_CHANNEL, event),
+  );
 });
 
 export const createTab = DesktopIpc.makeIpcMethod({

--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -5,6 +5,7 @@ import * as Exit from "effect/Exit";
 import * as FileSystem from "effect/FileSystem";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
@@ -13,6 +14,7 @@ import { TestClock } from "effect/testing";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import * as BrowserSession from "./BrowserSession.ts";
 import * as PreviewManager from "./Manager.ts";
 
@@ -126,6 +128,72 @@ describe("PreviewManager", () => {
           loading: false,
         });
         expect(fromId).not.toHaveBeenCalled();
+      }),
+    ),
+  );
+
+  effectIt.effect("isolates failed state listeners and continues delivery", () => {
+    const loggedErrors: Array<unknown> = [];
+    const logger = Logger.make(({ message }) => {
+      for (const value of Array.isArray(message) ? message : [message]) {
+        if (typeof value === "object" && value !== null && "cause" in value) {
+          loggedErrors.push(Cause.squash(value.cause as Cause.Cause<never>));
+        }
+      }
+    });
+    const deliveryError = new ElectronWindow.ElectronWindowOperationError({
+      operation: "send-window-message",
+      platform: "darwin",
+      windowId: 42,
+      channel: "preview:state-change",
+      cause: new Error("renderer unavailable"),
+    });
+    const delivered = vi.fn();
+
+    return withManager((manager) =>
+      Effect.gen(function* () {
+        yield* manager.subscribeStateChanges(() => Effect.die(deliveryError));
+        yield* manager.subscribeStateChanges((tabId, state) =>
+          Effect.sync(() => {
+            delivered(tabId, state);
+          }),
+        );
+
+        const state = yield* manager.createTab("tab_listener_failure");
+
+        expect(delivered).toHaveBeenCalledOnce();
+        expect(delivered).toHaveBeenCalledWith("tab_listener_failure", state);
+        expect(loggedErrors).toHaveLength(1);
+        expect(loggedErrors[0]).toBeInstanceOf(ElectronWindow.ElectronWindowOperationError);
+        expect(loggedErrors[0]).toMatchObject({
+          operation: "send-window-message",
+          windowId: 42,
+          channel: "preview:state-change",
+        });
+      }),
+    ).pipe(
+      Effect.provide(
+        Logger.layer([logger], {
+          mergeWithExisting: false,
+        }),
+      ),
+    );
+  });
+
+  effectIt.effect("does not swallow state listener interruption", () =>
+    withManager((manager) =>
+      Effect.gen(function* () {
+        const exit = yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* manager.subscribeStateChanges(() => Effect.interrupt);
+            return yield* Effect.exit(manager.createTab("tab_interrupted_listener"));
+          }),
+        );
+
+        expect(Exit.isFailure(exit)).toBe(true);
+        if (Exit.isFailure(exit)) {
+          expect(Cause.hasInterrupts(exit.cause)).toBe(true);
+        }
       }),
     ),
   );
@@ -411,7 +479,11 @@ describe("PreviewManager", () => {
           },
         } as never);
 
-        yield* manager.subscribePointerEvents((event) => activity.push(event.phase));
+        yield* manager.subscribePointerEvents((event) =>
+          Effect.sync(() => {
+            activity.push(event.phase);
+          }),
+        );
         yield* manager.createTab("tab_1");
         yield* manager.registerWebview("tab_1", 42);
         const click = yield* manager

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -281,8 +281,8 @@ const nextZoomLevel = (current: number, direction: "in" | "out"): number => {
   return ZOOM_LEVELS[Math.max(step - 1, 0)] ?? current;
 };
 
-type Listener = (tabId: string, state: PreviewTabState) => void;
-type RecordingFrameListener = (frame: DesktopPreviewRecordingFrame) => void;
+type Listener = (tabId: string, state: PreviewTabState) => Effect.Effect<void>;
+type RecordingFrameListener = (frame: DesktopPreviewRecordingFrame) => Effect.Effect<void>;
 
 type PreviewInputSignal =
   | { readonly kind: "pointer"; readonly x: number; readonly y: number; readonly button: number }
@@ -313,7 +313,7 @@ interface BrowserDiagnostics {
   readonly requests: ReadonlyMap<string, { url: string; method: string }>;
 }
 
-type PointerEventListener = (event: DesktopPreviewPointerEvent) => void;
+type PointerEventListener = (event: DesktopPreviewPointerEvent) => Effect.Effect<void>;
 
 interface ExpectedAgentInput {
   readonly signal: PreviewInputSignal;
@@ -442,11 +442,28 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     return copy;
   };
 
+  const deliverEvent = (
+    eventKind: "state-change" | "recording-frame" | "pointer-event",
+    tabId: string,
+    delivery: () => Effect.Effect<void>,
+  ) =>
+    Effect.suspend(delivery).pipe(
+      Effect.catchCause((cause) =>
+        Cause.hasInterrupts(cause)
+          ? Effect.failCause(cause)
+          : Effect.logWarning("Desktop preview event listener failed.", {
+              eventKind,
+              tabId,
+              cause,
+            }),
+      ),
+    );
+
   const emit = Effect.fn("PreviewManager.emit")(function* (tabId: string, state: PreviewTabState) {
     const listeners = yield* Ref.get(listenersRef);
     yield* Effect.forEach(
       listeners,
-      (listener) => Effect.sync(() => listener(tabId, state)).pipe(Effect.ignore),
+      (listener) => deliverEvent("state-change", tabId, () => listener(tabId, state)),
       { discard: true },
     );
   });
@@ -739,7 +756,8 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
                   };
                   yield* Effect.forEach(
                     listeners,
-                    (listener) => Effect.sync(() => listener(frame)).pipe(Effect.ignore),
+                    (listener) =>
+                      deliverEvent("recording-frame", frame.tabId, () => listener(frame)),
                     { discard: true },
                   );
                 }
@@ -1918,7 +1936,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     const listeners = yield* Ref.get(pointerEventListenersRef);
     yield* Effect.forEach(
       listeners,
-      (listener) => Effect.sync(() => listener(event)).pipe(Effect.ignore),
+      (listener) => deliverEvent("pointer-event", event.tabId, () => listener(event)),
       { discard: true },
     );
   });


### PR DESCRIPTION
## Summary
- route preview event broadcasts through `ElectronWindow.sendAll` so list, inspection, and send failures keep structured window/channel diagnostics and their true causes
- make preview subscriptions effectful and isolate/log non-interruption listener failures without blocking later listeners
- preserve interruption and add behavioral coverage for continued delivery, structured logging, and interruption

## Validation
- `vp test run apps/desktop/src/preview/Manager.test.ts`
- `vp run --filter @t3tools/desktop test` (40 files, 218 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches main-process preview→renderer event plumbing; behavior changes around listener errors could affect UI updates if misconfigured, though failures are now contained and better logged.
> 
> **Overview**
> **Preview IPC** no longer loops `BrowserWindow` directly; state, recording, and pointer events are broadcast via **`ElectronWindow.sendAll`**, so send failures surface as structured `ElectronWindowOperationError` diagnostics (window id, channel, cause).
> 
> **PreviewManager** preview subscriptions are now **effectful** (`Effect<void>`). A shared **`deliverEvent`** path logs and isolates non-interruption listener failures so one bad subscriber does not block others, while **interruptions still propagate**. Tests cover continued delivery after a failing listener, structured logging, and non-swallowed interruption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bc6ab925a855364ddb597b85db4f50a05e72b0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop preview event delivery errors by making listeners effectful in `PreviewManager`
> - Changes the `Listener`, `RecordingFrameListener`, and `PointerEventListener` type aliases in [Manager.ts](https://github.com/pingdotgg/t3code/pull/3435/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53) to return `Effect.Effect<void>` instead of `void`, making all event delivery effectful.
> - Adds a `deliverEvent` helper that catches listener failures: non-interrupt failures are logged as warnings while delivery continues; interrupt causes are re-propagated.
> - Replaces direct `BrowserWindow` broadcasting in [preview.ts](https://github.com/pingdotgg/t3code/pull/3435/files#diff-8526df92d9957bd23a5f5ea2368417e8d6652ba67a1cdc59eed46edffaca82f8) with `ElectronWindow.sendAll` via the Effect environment.
> - Behavioral Change: event delivery no longer silently ignores listener failures — errors are now logged and interrupts propagate up.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9bc6ab9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->