### PR TITLE
[codex] Structure preview automation boundary failures

### DIFF
--- a/apps/web/src/components/preview/PreviewAutomationOwner.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationOwner.tsx
@@ -3,19 +3,13 @@
 import { useAtomValue } from "@effect/atom-react";
 import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
 import {
-  EnvironmentId,
   type PreviewAutomationNavigateInput,
   type PreviewAutomationOpenInput,
-  PreviewAutomationOperation,
   type PreviewAutomationOwner as PreviewAutomationOwnerState,
   type PreviewAutomationRequest,
   type PreviewAutomationStatus,
-  PreviewTabId,
   type ScopedThreadRef,
-  ThreadId,
-  TrimmedNonEmptyString,
 } from "@t3tools/contracts";
-import * as Schema from "effect/Schema";
 import { useCallback, useEffect, useEffectEvent, useId, useMemo, useRef, useState } from "react";
 
 import {
@@ -32,103 +26,17 @@ import { useAtomCommand } from "~/state/use-atom-command";
 
 import { previewBridge } from "./previewBridge";
 import {
+  PreviewAutomationNavigationTimeoutError,
+  PreviewAutomationOperationError,
+  PreviewAutomationOverlayTimeoutError,
+  PreviewAutomationRecordingNotActiveError,
+  PreviewAutomationStaleOwnerError,
+  PreviewAutomationTargetUnavailableError,
+} from "./previewAutomationErrors";
+import {
   createLatestPreviewAutomationRequestHandler,
   createPreviewAutomationRequestConsumerAtom,
 } from "./previewAutomationRequestConsumer";
-
-export class PreviewAutomationOverlayTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationOverlayTimeoutError>()(
-  "PreviewAutomationOverlayTimeoutError",
-  {
-    requestId: TrimmedNonEmptyString,
-    environmentId: EnvironmentId,
-    threadId: ThreadId,
-    timeoutMs: Schema.Int,
-  },
-) {
-  get responseTag() {
-    return "PreviewAutomationTimeoutError";
-  }
-
-  override get message(): string {
-    return `Preview webview for request ${this.requestId} on environment ${this.environmentId} thread ${this.threadId} did not register within ${this.timeoutMs}ms.`;
-  }
-}
-
-export class PreviewAutomationNavigationTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationNavigationTimeoutError>()(
-  "PreviewAutomationNavigationTimeoutError",
-  {
-    requestId: TrimmedNonEmptyString,
-    environmentId: EnvironmentId,
-    threadId: ThreadId,
-    tabId: PreviewTabId,
-    readiness: Schema.Literals(["domContentLoaded", "load"]),
-    timeoutMs: Schema.Int,
-  },
-) {
-  get responseTag() {
-    return "PreviewAutomationTimeoutError";
-  }
-
-  override get message(): string {
-    return `Preview navigation for request ${this.requestId} on environment ${this.environmentId} thread ${this.threadId} tab ${this.tabId} did not reach ${this.readiness} readiness within ${this.timeoutMs}ms.`;
-  }
-}
-
-export class PreviewAutomationStaleOwnerError extends Schema.TaggedErrorClass<PreviewAutomationStaleOwnerError>()(
-  "PreviewAutomationStaleOwnerError",
-  {
-    requestId: TrimmedNonEmptyString,
-    environmentId: EnvironmentId,
-    expectedThreadId: ThreadId,
-    requestedThreadId: ThreadId,
-  },
-) {
-  get responseTag() {
-    return "PreviewAutomationUnavailableError";
-  }
-
-  override get message(): string {
-    return `Preview automation request ${this.requestId} targeted thread ${this.requestedThreadId}, but the owner for environment ${this.environmentId} is attached to thread ${this.expectedThreadId}.`;
-  }
-}
-
-export class PreviewAutomationTargetUnavailableError extends Schema.TaggedErrorClass<PreviewAutomationTargetUnavailableError>()(
-  "PreviewAutomationTargetUnavailableError",
-  {
-    requestId: TrimmedNonEmptyString,
-    operation: PreviewAutomationOperation,
-    environmentId: EnvironmentId,
-    threadId: ThreadId,
-    tabId: Schema.NullOr(PreviewTabId),
-    bridgeAvailable: Schema.Boolean,
-  },
-) {
-  get responseTag() {
-    return "PreviewAutomationTabNotFoundError";
-  }
-
-  override get message(): string {
-    return `Preview automation target for ${this.operation} request ${this.requestId} is unavailable on environment ${this.environmentId} thread ${this.threadId} (tab ${this.tabId ?? "unassigned"}, bridge ${this.bridgeAvailable ? "available" : "unavailable"}).`;
-  }
-}
-
-export class PreviewAutomationRecordingNotActiveError extends Schema.TaggedErrorClass<PreviewAutomationRecordingNotActiveError>()(
-  "PreviewAutomationRecordingNotActiveError",
-  {
-    requestId: TrimmedNonEmptyString,
-    environmentId: EnvironmentId,
-    threadId: ThreadId,
-    tabId: PreviewTabId,
-  },
-) {
-  get responseTag() {
-    return "PreviewAutomationExecutionError";
-  }
-
-  override get message(): string {
-    return `Preview automation request ${this.requestId} found no active recording for tab ${this.tabId} on environment ${this.environmentId} thread ${this.threadId}.`;
-  }
-}
 
 export function observeAutomationOwnerConnectedGeneration(
   previousGeneration: number | null,
@@ -287,152 +195,166 @@ export function PreviewAutomationOwner(props: {
 
   const handleRequest = useCallback(
     async (request: PreviewAutomationRequest): Promise<unknown> => {
-      if (request.threadId !== threadRef.threadId) {
-        throw new PreviewAutomationStaleOwnerError({
+      let tabId = request.tabId ?? null;
+      try {
+        if (request.threadId !== threadRef.threadId) {
+          throw new PreviewAutomationStaleOwnerError({
+            requestId: request.requestId,
+            environmentId: threadRef.environmentId,
+            expectedThreadId: threadRef.threadId,
+            requestedThreadId: request.threadId,
+          });
+        }
+        const state = readThreadPreviewState(threadRef);
+        tabId = request.tabId ?? state.snapshot?.tabId ?? null;
+        const unavailableTarget = {
           requestId: request.requestId,
+          operation: request.operation,
           environmentId: threadRef.environmentId,
-          expectedThreadId: threadRef.threadId,
-          requestedThreadId: request.threadId,
-        });
-      }
-      const state = readThreadPreviewState(threadRef);
-      const tabId = request.tabId ?? state.snapshot?.tabId ?? null;
-      const unavailableTarget = {
-        requestId: request.requestId,
-        operation: request.operation,
-        environmentId: threadRef.environmentId,
-        threadId: threadRef.threadId,
-        tabId,
-        bridgeAvailable: Boolean(previewBridge),
-      };
-      switch (request.operation) {
-        case "status":
-          return currentStatus(threadRef, visible);
-        case "open": {
-          const input = request.input as PreviewAutomationOpenInput;
-          let activeTabId =
-            (input.reuseExistingTab ?? true) ? (state.snapshot?.tabId ?? null) : null;
-          if (!activeTabId) {
-            const result = await open({
-              environmentId: threadRef.environmentId,
-              input: {
-                threadId: threadRef.threadId,
-                ...(input.url ? { url: input.url } : {}),
-              },
-            });
-            if (result._tag === "Failure") {
-              throw squashAtomCommandFailure(result);
+          threadId: threadRef.threadId,
+          tabId,
+          bridgeAvailable: Boolean(previewBridge),
+        };
+        switch (request.operation) {
+          case "status":
+            return await currentStatus(threadRef, visible);
+          case "open": {
+            const input = request.input as PreviewAutomationOpenInput;
+            let activeTabId =
+              (input.reuseExistingTab ?? true) ? (state.snapshot?.tabId ?? null) : null;
+            tabId = activeTabId;
+            if (!activeTabId) {
+              const result = await open({
+                environmentId: threadRef.environmentId,
+                input: {
+                  threadId: threadRef.threadId,
+                  ...(input.url ? { url: input.url } : {}),
+                },
+              });
+              if (result._tag === "Failure") {
+                throw squashAtomCommandFailure(result);
+              }
+              const snapshot = result.value;
+              applyPreviewServerSnapshot(threadRef, snapshot);
+              activeTabId = snapshot.tabId;
+              tabId = activeTabId;
+            } else if (input.url && previewBridge) {
+              await previewBridge.navigate(activeTabId, input.url);
             }
-            const snapshot = result.value;
-            applyPreviewServerSnapshot(threadRef, snapshot);
-            activeTabId = snapshot.tabId;
-          } else if (input.url && previewBridge) {
-            await previewBridge.navigate(activeTabId, input.url);
+            if (input.show ?? true) {
+              useRightPanelStore.getState().openBrowser(threadRef, activeTabId);
+            }
+            await waitForDesktopOverlay(threadRef, request.requestId, request.timeoutMs);
+            return await currentStatus(threadRef, input.show ?? true);
           }
-          if (input.show ?? true) {
-            useRightPanelStore.getState().openBrowser(threadRef, activeTabId);
-          }
-          await waitForDesktopOverlay(threadRef, request.requestId, request.timeoutMs);
-          return currentStatus(threadRef, input.show ?? true);
-        }
-        case "navigate": {
-          if (!previewBridge || !tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          const input = request.input as PreviewAutomationNavigateInput;
-          const resolution = resolveBrowserNavigationTarget(
-            threadRef.environmentId,
-            input.target ?? { kind: "url", url: input.url! },
-          );
-          await previewBridge.navigate(tabId, resolution.resolvedUrl);
-          await waitForNavigationReadiness(
-            threadRef,
-            request.requestId,
-            tabId,
-            input.readiness ?? "load",
-            input.timeoutMs ?? request.timeoutMs,
-          );
-          return currentStatus(threadRef, visible);
-        }
-        case "snapshot":
-          if (!previewBridge || !tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          return previewBridge.automation.snapshot(tabId);
-        case "click":
-          if (!previewBridge || !tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          return previewBridge.automation.click(
-            tabId,
-            request.input as Parameters<typeof previewBridge.automation.click>[1],
-          );
-        case "type":
-          if (!previewBridge || !tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          return previewBridge.automation.type(
-            tabId,
-            request.input as Parameters<typeof previewBridge.automation.type>[1],
-          );
-        case "press":
-          if (!previewBridge || !tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          return previewBridge.automation.press(
-            tabId,
-            request.input as Parameters<typeof previewBridge.automation.press>[1],
-          );
-        case "scroll":
-          if (!previewBridge || !tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          return previewBridge.automation.scroll(
-            tabId,
-            request.input as Parameters<typeof previewBridge.automation.scroll>[1],
-          );
-        case "evaluate":
-          if (!previewBridge || !tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          return previewBridge.automation.evaluate(
-            tabId,
-            request.input as Parameters<typeof previewBridge.automation.evaluate>[1],
-          );
-        case "waitFor":
-          if (!previewBridge || !tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          return previewBridge.automation.waitFor(
-            tabId,
-            request.input as Parameters<typeof previewBridge.automation.waitFor>[1],
-          );
-        case "recordingStart": {
-          if (!tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          const startedAt = await startBrowserRecording(tabId);
-          return {
-            tabId,
-            recording: true,
-            startedAt,
-          };
-        }
-        case "recordingStop": {
-          if (!tabId) {
-            throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
-          }
-          const artifact = await stopBrowserRecording(tabId);
-          if (!artifact) {
-            throw new PreviewAutomationRecordingNotActiveError({
-              requestId: request.requestId,
-              environmentId: threadRef.environmentId,
-              threadId: threadRef.threadId,
+          case "navigate": {
+            if (!previewBridge || !tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            const input = request.input as PreviewAutomationNavigateInput;
+            const resolution = resolveBrowserNavigationTarget(
+              threadRef.environmentId,
+              input.target ?? { kind: "url", url: input.url! },
+            );
+            await previewBridge.navigate(tabId, resolution.resolvedUrl);
+            await waitForNavigationReadiness(
+              threadRef,
+              request.requestId,
               tabId,
-            });
+              input.readiness ?? "load",
+              input.timeoutMs ?? request.timeoutMs,
+            );
+            return await currentStatus(threadRef, visible);
           }
-          return artifact;
+          case "snapshot":
+            if (!previewBridge || !tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            return await previewBridge.automation.snapshot(tabId);
+          case "click":
+            if (!previewBridge || !tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            return await previewBridge.automation.click(
+              tabId,
+              request.input as Parameters<typeof previewBridge.automation.click>[1],
+            );
+          case "type":
+            if (!previewBridge || !tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            return await previewBridge.automation.type(
+              tabId,
+              request.input as Parameters<typeof previewBridge.automation.type>[1],
+            );
+          case "press":
+            if (!previewBridge || !tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            return await previewBridge.automation.press(
+              tabId,
+              request.input as Parameters<typeof previewBridge.automation.press>[1],
+            );
+          case "scroll":
+            if (!previewBridge || !tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            return await previewBridge.automation.scroll(
+              tabId,
+              request.input as Parameters<typeof previewBridge.automation.scroll>[1],
+            );
+          case "evaluate":
+            if (!previewBridge || !tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            return await previewBridge.automation.evaluate(
+              tabId,
+              request.input as Parameters<typeof previewBridge.automation.evaluate>[1],
+            );
+          case "waitFor":
+            if (!previewBridge || !tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            return await previewBridge.automation.waitFor(
+              tabId,
+              request.input as Parameters<typeof previewBridge.automation.waitFor>[1],
+            );
+          case "recordingStart": {
+            if (!tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            const startedAt = await startBrowserRecording(tabId);
+            return {
+              tabId,
+              recording: true,
+              startedAt,
+            };
+          }
+          case "recordingStop": {
+            if (!tabId) {
+              throw new PreviewAutomationTargetUnavailableError(unavailableTarget);
+            }
+            const artifact = await stopBrowserRecording(tabId);
+            if (!artifact) {
+              throw new PreviewAutomationRecordingNotActiveError({
+                requestId: request.requestId,
+                environmentId: threadRef.environmentId,
+                threadId: threadRef.threadId,
+                tabId,
+              });
+            }
+            return artifact;
+          }
         }
+      } catch (cause) {
+        throw PreviewAutomationOperationError.fromCause({
+          requestId: request.requestId,
+          operation: request.operation,
+          environmentId: threadRef.environmentId,
+          threadId: threadRef.threadId,
+          tabId,
+          cause,
+        });
       }
     },
     [open, threadRef, visible],
@@ -448,6 +370,7 @@ export function PreviewAutomationOwner(props: {
     () =>
       createPreviewAutomationRequestConsumerAtom({
         requestsAtom: automationRequestsAtom,
+        environmentId: threadRef.environmentId,
         handleRequest: requestHandler.handle,
         respond: (response) =>
           respondToAutomation({

--- a/apps/web/src/components/preview/previewAutomationErrors.ts
+++ b/apps/web/src/components/preview/previewAutomationErrors.ts
@@ -1,0 +1,169 @@
+import {
+  EnvironmentId,
+  type PreviewAutomationOwner,
+  PreviewAutomationOperation,
+  type PreviewAutomationRequest,
+  type PreviewAutomationResponse,
+  PreviewTabId,
+  ThreadId,
+  TrimmedNonEmptyString,
+} from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
+
+export interface PreviewAutomationOperationContext {
+  readonly requestId: PreviewAutomationRequest["requestId"];
+  readonly operation: PreviewAutomationRequest["operation"];
+  readonly environmentId: PreviewAutomationOwner["environmentId"];
+  readonly threadId: PreviewAutomationRequest["threadId"];
+  readonly tabId: Exclude<PreviewAutomationRequest["tabId"], undefined> | null;
+}
+
+export class PreviewAutomationOverlayTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationOverlayTimeoutError>()(
+  "PreviewAutomationOverlayTimeoutError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    timeoutMs: Schema.Int,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationTimeoutError" as const;
+  }
+
+  override get message(): string {
+    return `Preview webview for request ${this.requestId} on environment ${this.environmentId} thread ${this.threadId} did not register within ${this.timeoutMs}ms.`;
+  }
+}
+
+export class PreviewAutomationNavigationTimeoutError extends Schema.TaggedErrorClass<PreviewAutomationNavigationTimeoutError>()(
+  "PreviewAutomationNavigationTimeoutError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: PreviewTabId,
+    readiness: Schema.Literals(["domContentLoaded", "load"]),
+    timeoutMs: Schema.Int,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationTimeoutError" as const;
+  }
+
+  override get message(): string {
+    return `Preview navigation for request ${this.requestId} on environment ${this.environmentId} thread ${this.threadId} tab ${this.tabId} did not reach ${this.readiness} readiness within ${this.timeoutMs}ms.`;
+  }
+}
+
+export class PreviewAutomationStaleOwnerError extends Schema.TaggedErrorClass<PreviewAutomationStaleOwnerError>()(
+  "PreviewAutomationStaleOwnerError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    expectedThreadId: ThreadId,
+    requestedThreadId: ThreadId,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationUnavailableError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation request ${this.requestId} targeted thread ${this.requestedThreadId}, but the owner for environment ${this.environmentId} is attached to thread ${this.expectedThreadId}.`;
+  }
+}
+
+export class PreviewAutomationTargetUnavailableError extends Schema.TaggedErrorClass<PreviewAutomationTargetUnavailableError>()(
+  "PreviewAutomationTargetUnavailableError",
+  {
+    requestId: TrimmedNonEmptyString,
+    operation: PreviewAutomationOperation,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: Schema.NullOr(PreviewTabId),
+    bridgeAvailable: Schema.Boolean,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationTabNotFoundError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation target for ${this.operation} request ${this.requestId} is unavailable on environment ${this.environmentId} thread ${this.threadId} (tab ${this.tabId ?? "unassigned"}, bridge ${this.bridgeAvailable ? "available" : "unavailable"}).`;
+  }
+}
+
+export class PreviewAutomationRecordingNotActiveError extends Schema.TaggedErrorClass<PreviewAutomationRecordingNotActiveError>()(
+  "PreviewAutomationRecordingNotActiveError",
+  {
+    requestId: TrimmedNonEmptyString,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: PreviewTabId,
+  },
+) {
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation request ${this.requestId} found no active recording for tab ${this.tabId} on environment ${this.environmentId} thread ${this.threadId}.`;
+  }
+}
+
+export class PreviewAutomationOperationError extends Schema.TaggedErrorClass<PreviewAutomationOperationError>()(
+  "PreviewAutomationOperationError",
+  {
+    requestId: TrimmedNonEmptyString,
+    operation: PreviewAutomationOperation,
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    tabId: Schema.NullOr(PreviewTabId),
+    cause: Schema.Defect(),
+  },
+) {
+  static fromCause(
+    input: PreviewAutomationOperationContext & { readonly cause: unknown },
+  ): PreviewAutomationOwnerError {
+    return isPreviewAutomationOwnerError(input.cause)
+      ? input.cause
+      : new PreviewAutomationOperationError(input);
+  }
+
+  get responseTag() {
+    return "PreviewAutomationExecutionError" as const;
+  }
+
+  override get message(): string {
+    return `Preview automation ${this.operation} request ${this.requestId} failed on environment ${this.environmentId} thread ${this.threadId} (tab ${this.tabId ?? "unassigned"}).`;
+  }
+}
+
+export const PreviewAutomationOwnerError = Schema.Union([
+  PreviewAutomationOverlayTimeoutError,
+  PreviewAutomationNavigationTimeoutError,
+  PreviewAutomationStaleOwnerError,
+  PreviewAutomationTargetUnavailableError,
+  PreviewAutomationRecordingNotActiveError,
+  PreviewAutomationOperationError,
+]);
+export type PreviewAutomationOwnerError = typeof PreviewAutomationOwnerError.Type;
+
+export const isPreviewAutomationOwnerError = Schema.is(PreviewAutomationOwnerError);
+
+export function serializePreviewAutomationOwnerError(
+  error: PreviewAutomationOwnerError,
+): NonNullable<PreviewAutomationResponse["error"]> {
+  const detail = Object.fromEntries(
+    Object.entries(error).filter(
+      ([key]) =>
+        key !== "_tag" && key !== "cause" && key !== "name" && key !== "message" && key !== "stack",
+    ),
+  );
+  return {
+    _tag: error.responseTag,
+    message: error.message,
+    ...(Object.keys(detail).length === 0 ? {} : { detail }),
+  };
+}

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.test.ts
@@ -1,19 +1,33 @@
-import type { PreviewAutomationRequest, PreviewAutomationResponse } from "@t3tools/contracts";
-import { ThreadId } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  type PreviewAutomationRequest,
+  type PreviewAutomationResponse,
+  PreviewTabId,
+  ThreadId,
+} from "@t3tools/contracts";
 import { AsyncResult, Atom, AtomRegistry } from "effect/unstable/reactivity";
 import { describe, expect, it, vi } from "vite-plus/test";
 
+import { PreviewAutomationTargetUnavailableError } from "./previewAutomationErrors";
 import {
   createPreviewAutomationRequestConsumerAtom,
   serializePreviewAutomationError,
 } from "./previewAutomationRequestConsumer";
 
-const request = (requestId: string): PreviewAutomationRequest => ({
+const environmentId = EnvironmentId.make("environment-1");
+const threadId = ThreadId.make("thread-1");
+const tabId = PreviewTabId.make("tab-1");
+
+const request = (
+  requestId: string,
+  overrides: Partial<PreviewAutomationRequest> = {},
+): PreviewAutomationRequest => ({
   requestId,
-  threadId: ThreadId.make("thread-1"),
+  threadId,
   operation: "status",
   input: {},
   timeoutMs: 15_000,
+  ...overrides,
 });
 
 describe("previewAutomationRequestConsumer", () => {
@@ -30,6 +44,7 @@ describe("previewAutomationRequestConsumer", () => {
     });
     const consumerAtom = createPreviewAutomationRequestConsumerAtom({
       requestsAtom,
+      environmentId,
       handleRequest,
       respond,
       label: "test:preview-automation-consumer",
@@ -56,6 +71,7 @@ describe("previewAutomationRequestConsumer", () => {
     const respond = vi.fn(async (_response: PreviewAutomationResponse) => undefined);
     const consumerAtom = createPreviewAutomationRequestConsumerAtom({
       requestsAtom,
+      environmentId,
       handleRequest: async () => undefined,
       respond,
       label: "test:preview-automation-initial-request",
@@ -69,33 +85,112 @@ describe("previewAutomationRequestConsumer", () => {
     registry.dispose();
   });
 
-  it("preserves typed automation errors in responses", () => {
-    const error = new Error("No preview tab");
-    error.name = "PreviewAutomationTabNotFoundError";
+  it("preserves tagged automation errors and their structured diagnostics", () => {
+    const error = new PreviewAutomationTargetUnavailableError({
+      requestId: "request-1",
+      operation: "click",
+      environmentId,
+      threadId,
+      tabId,
+      bridgeAvailable: false,
+    });
 
-    expect(serializePreviewAutomationError(error)).toEqual({
+    expect(
+      serializePreviewAutomationError(error, {
+        requestId: "request-1",
+        operation: "click",
+        environmentId,
+        threadId,
+        tabId,
+      }),
+    ).toEqual({
       _tag: "PreviewAutomationTabNotFoundError",
-      message: "No preview tab",
+      message:
+        "Preview automation target for click request request-1 is unavailable on environment environment-1 thread thread-1 (tab tab-1, bridge unavailable).",
+      detail: {
+        requestId: "request-1",
+        operation: "click",
+        environmentId: "environment-1",
+        threadId: "thread-1",
+        tabId: "tab-1",
+        bridgeAvailable: false,
+      },
     });
   });
 
-  it("serializes structured automation context without leaking causes", () => {
-    const error = Object.assign(new Error("Preview target unavailable"), {
-      name: "PreviewAutomationTargetUnavailableError",
-      _tag: "PreviewAutomationTargetUnavailableError",
-      responseTag: "PreviewAutomationTabNotFoundError",
-      requestId: "request-1",
-      threadId: "thread-1",
-      cause: new Error("private bridge failure"),
-    });
+  it("correlates unexpected failures without exposing cause details", () => {
+    const cause = new Error("private bridge token: preview-secret");
+    const context = {
+      requestId: "request-2",
+      operation: "snapshot" as const,
+      environmentId,
+      threadId,
+      tabId,
+    };
+    const response = serializePreviewAutomationError(cause, context);
 
-    expect(serializePreviewAutomationError(error)).toEqual({
-      _tag: "PreviewAutomationTabNotFoundError",
-      message: "Preview target unavailable",
+    expect(response).toEqual({
+      _tag: "PreviewAutomationExecutionError",
+      message:
+        "Preview automation snapshot request request-2 failed on environment environment-1 thread thread-1 (tab tab-1).",
       detail: {
-        requestId: "request-1",
+        requestId: "request-2",
+        operation: "snapshot",
+        environmentId: "environment-1",
         threadId: "thread-1",
+        tabId: "tab-1",
       },
     });
+    expect(JSON.stringify(response)).not.toContain("preview-secret");
+  });
+
+  it("sanitizes unexpected handler failures at the response boundary", async () => {
+    const requestsAtom = Atom.make<AsyncResult.AsyncResult<PreviewAutomationRequest, Error>>(
+      AsyncResult.initial<PreviewAutomationRequest, Error>(false),
+    );
+    const responses: PreviewAutomationResponse[] = [];
+    const consumerAtom = createPreviewAutomationRequestConsumerAtom({
+      requestsAtom,
+      environmentId,
+      handleRequest: async () => {
+        throw new Error("desktop IPC secret: do-not-return");
+      },
+      respond: async (response) => {
+        responses.push(response);
+      },
+      label: "test:preview-automation-failure-boundary",
+    });
+    const registry = AtomRegistry.make();
+    registry.mount(consumerAtom);
+
+    registry.set(
+      requestsAtom,
+      AsyncResult.success(
+        request("request-failed", {
+          operation: "click",
+          tabId,
+        }),
+      ),
+    );
+
+    await vi.waitFor(() => expect(responses).toHaveLength(1));
+    expect(responses[0]).toEqual({
+      requestId: "request-failed",
+      ok: false,
+      error: {
+        _tag: "PreviewAutomationExecutionError",
+        message:
+          "Preview automation click request request-failed failed on environment environment-1 thread thread-1 (tab tab-1).",
+        detail: {
+          requestId: "request-failed",
+          operation: "click",
+          environmentId: "environment-1",
+          threadId: "thread-1",
+          tabId: "tab-1",
+        },
+      },
+    });
+    expect(JSON.stringify(responses[0])).not.toContain("do-not-return");
+    registry.dispose();
   });
 });

--- a/apps/web/src/components/preview/previewAutomationRequestConsumer.ts
+++ b/apps/web/src/components/preview/previewAutomationRequestConsumer.ts
@@ -1,5 +1,15 @@
-import type { PreviewAutomationRequest, PreviewAutomationResponse } from "@t3tools/contracts";
+import type {
+  PreviewAutomationOwner,
+  PreviewAutomationRequest,
+  PreviewAutomationResponse,
+} from "@t3tools/contracts";
 import { AsyncResult, Atom } from "effect/unstable/reactivity";
+
+import {
+  PreviewAutomationOperationError,
+  type PreviewAutomationOperationContext,
+  serializePreviewAutomationOwnerError,
+} from "./previewAutomationErrors";
 
 type AutomationRequestResult<E> = AsyncResult.AsyncResult<PreviewAutomationRequest, E>;
 type AutomationRequestHandler = (request: PreviewAutomationRequest) => Promise<unknown>;
@@ -19,54 +29,16 @@ export function createLatestPreviewAutomationRequestHandler(initial: AutomationR
 
 export function serializePreviewAutomationError(
   error: unknown,
+  context: PreviewAutomationOperationContext,
 ): NonNullable<PreviewAutomationResponse["error"]> {
-  if (error instanceof Error) {
-    const explicitDetail =
-      "detail" in error && (error as { detail?: unknown }).detail !== undefined
-        ? (error as { detail?: unknown }).detail
-        : undefined;
-    const structuralDetail =
-      "_tag" in error &&
-      typeof (error as { _tag?: unknown })._tag === "string" &&
-      (error as { _tag: string })._tag.startsWith("PreviewAutomation")
-        ? Object.fromEntries(
-            Object.entries(error).filter(
-              ([key]) =>
-                key !== "_tag" &&
-                key !== "cause" &&
-                key !== "name" &&
-                key !== "message" &&
-                key !== "stack" &&
-                key !== "detail" &&
-                key !== "responseTag",
-            ),
-          )
-        : undefined;
-    const detail = explicitDetail ?? structuralDetail;
-    const responseTag =
-      "responseTag" in error &&
-      typeof (error as { responseTag?: unknown }).responseTag === "string" &&
-      (error as { responseTag: string }).responseTag.startsWith("PreviewAutomation")
-        ? (error as { responseTag: string }).responseTag
-        : undefined;
-    return {
-      _tag:
-        responseTag ??
-        (error.name.startsWith("PreviewAutomation")
-          ? error.name
-          : "PreviewAutomationExecutionError"),
-      message: error.message,
-      ...(detail === undefined ? {} : { detail }),
-    };
-  }
-  return {
-    _tag: "PreviewAutomationExecutionError",
-    message: String(error),
-  };
+  return serializePreviewAutomationOwnerError(
+    PreviewAutomationOperationError.fromCause({ ...context, cause: error }),
+  );
 }
 
 export function createPreviewAutomationRequestConsumerAtom<E>(options: {
   readonly requestsAtom: Atom.Atom<AutomationRequestResult<E>>;
+  readonly environmentId: PreviewAutomationOwner["environmentId"];
   readonly handleRequest: (request: PreviewAutomationRequest) => Promise<unknown>;
   readonly respond: (response: PreviewAutomationResponse) => Promise<unknown>;
   readonly label: string;
@@ -89,7 +61,13 @@ export function createPreviewAutomationRequestConsumerAtom<E>(options: {
           options.respond({
             requestId: request.requestId,
             ok: false,
-            error: serializePreviewAutomationError(error),
+            error: serializePreviewAutomationError(error, {
+              requestId: request.requestId,
+              operation: request.operation,
+              environmentId: options.environmentId,
+              threadId: request.threadId,
+              tabId: request.tabId ?? null,
+            }),
           }),
       );
     };


### PR DESCRIPTION
## Summary

- move the preview-owner error model into a dedicated module and add a structured operation boundary error
- preserve existing tagged preview failures while wrapping unexpected open, bridge, IPC, and recording failures with request, operation, environment, thread, and tab context
- keep the immediate failure as `cause` while returning only attribute-derived messages and bounded structural detail to the remote caller
- sanitize unexpected handler rejections at the final response boundary instead of collapsing them through `String(error)`

## Why

Unexpected preview automation failures previously escaped as raw errors. The response serializer could expose their messages while dropping the request context needed to correlate the failure. This keeps the diagnostic chain locally and sends a predictable, non-cause-derived response upstream.

## Validation

- `vp test run src/components/preview/previewAutomationRequestConsumer.test.ts --project unit` (from `apps/web`)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how automation errors are surfaced to remote callers; behavior is intentional sanitization but affects debugging and any consumers expecting raw error text.
> 
> **Overview**
> Preview automation failures are centralized in **`previewAutomationErrors.ts`**, with tagged errors, a **`PreviewAutomationOperationError`** wrapper, and **`serializePreviewAutomationOwnerError`** so remote responses use stable tags/messages and bounded **`detail`** without leaking **`cause`**.
> 
> **`PreviewAutomationOwner`** wraps the request handler in **try/catch**, tracks **`tabId`** through operations, and rethrows via **`PreviewAutomationOperationError.fromCause`** (known tagged errors pass through). The request consumer now takes **`environmentId`** and serializes failures with full operation context instead of inferring from raw **`Error`** names/messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ba73d347e158c8cc278f6d32972e70871b90ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Standardize preview automation boundary failures into structured tagged errors
> - Extracts all error classes (`PreviewAutomationOverlayTimeoutError`, `PreviewAutomationNavigationTimeoutError`, `PreviewAutomationStaleOwnerError`, `PreviewAutomationTargetUnavailableError`, `PreviewAutomationRecordingNotActiveError`) into [previewAutomationErrors.ts](https://github.com/pingdotgg/t3code/pull/3436/files#diff-41ba4b5577ed316e261c951845f012efe78d5c552c6bd09ffa8a23e2d12105e9) with rich contextual fields (requestId, environmentId, threadId, tabId).
> - Adds `PreviewAutomationOperationError` as a catch-all wrapper for unexpected failures, with a static `fromCause` that preserves known owner errors or wraps unknown ones, and a `serializePreviewAutomationOwnerError` function that converts errors to safe response payloads.
> - Updates `PreviewAutomationOwner.handleRequest` in [PreviewAutomationOwner.tsx](https://github.com/pingdotgg/t3code/pull/3436/files#diff-d910e8aa5c7895c71f0d40d2487477e0d69436114a0f882bcb52d143024f0a44) to wrap all operation branches in a try/catch and rethrow via `PreviewAutomationOperationError.fromCause`, and consistently awaits async calls.
> - Updates `serializePreviewAutomationError` in [previewAutomationRequestConsumer.ts](https://github.com/pingdotgg/t3code/pull/3436/files#diff-87210ceefd89fe28a3f19951de9e7dba453a275aa1de4a6a21844fb46b713ba1) to accept operation context and always produce a standardized, sanitized error response.
> - Behavioral Change: `createPreviewAutomationRequestConsumerAtom` now requires `environmentId`; all error responses include structured context and raw causes are never leaked.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b4ba73d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->