### PR TITLE
[codex] Preserve cloud disconnect diagnostics

### DIFF
--- a/apps/server/src/cli/connect.test.ts
+++ b/apps/server/src/cli/connect.test.ts
@@ -1,9 +1,14 @@
 import * as RelayClient from "@t3tools/shared/relayClient";
 import { assert, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
+import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
+import * as References from "effect/References";
 
-import { acquireRelayClientForLink } from "./connect.ts";
+import { acquireRelayClientForLink, reportCloudDisconnectResults } from "./connect.ts";
 
 const managedExecutable = {
   status: "available",
@@ -100,3 +105,51 @@ it.effect("reuses an available relay client executable without prompting", () =>
     assert.equal(promptCalls, 0);
   }),
 );
+
+it.effect("keeps disconnect causes in structured logs and out of console warnings", () => {
+  const warnings: ReadonlyArray<unknown>[] = [];
+  const logs: Readonly<Record<string, unknown>>[] = [];
+  const testConsole = {
+    ...globalThis.console,
+    warn: (...args: ReadonlyArray<unknown>) => {
+      warnings.push(args);
+    },
+  } satisfies Console.Console;
+  const logger = Logger.make(({ fiber }) => {
+    logs.push(fiber.getRef(References.CurrentLogAnnotations));
+  });
+  const liveFailure = "live unlink private diagnostic";
+  const relayFailure = "relay revoke private diagnostic";
+
+  return reportCloudDisconnectResults({
+    clearAuthorization: true,
+    liveResult: {
+      status: "failed",
+      cause: Cause.fail(new Error(liveFailure)),
+    },
+    relayResult: Exit.failCause(Cause.die(new Error(relayFailure))),
+  }).pipe(
+    Effect.provideService(Console.Console, testConsole),
+    Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
+    Effect.tap(() =>
+      Effect.sync(() => {
+        assert.lengthOf(warnings, 2);
+        const warningText = warnings.flat().map(String).join("\n");
+        assert.include(warningText, "running server could not stop its tunnel");
+        assert.include(warningText, "Could not revoke the relay-side environment record");
+        assert.notInclude(warningText, liveFailure);
+        assert.notInclude(warningText, relayFailure);
+        assert.deepEqual(
+          logs.map(({ operation, clearAuthorization }) => ({ operation, clearAuthorization })),
+          [
+            { operation: "live-server-unlink", clearAuthorization: true },
+            { operation: "relay-environment-unlink", clearAuthorization: true },
+          ],
+        );
+        const loggedCauses = logs.map((log) => String(log.cause)).join("\n");
+        assert.include(loggedCauses, liveFailure);
+        assert.include(loggedCauses, relayFailure);
+      }),
+    ),
+  );
+});

--- a/apps/server/src/cli/connect.ts
+++ b/apps/server/src/cli/connect.ts
@@ -7,6 +7,7 @@ import {
 import { RelayOkResponse } from "@t3tools/contracts/relay";
 import * as RelayClient from "@t3tools/shared/relayClient";
 import { withRelayClientTracing } from "@t3tools/shared/relayTracing";
+import * as Cause from "effect/Cause";
 import * as Console from "effect/Console";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
@@ -179,7 +180,7 @@ const withCloudCliSessionToken = <A, E, R>(
 type LiveCloudActionResult =
   | { readonly status: "not-running" }
   | { readonly status: "succeeded" }
-  | { readonly status: "failed"; readonly cause: unknown };
+  | { readonly status: "failed"; readonly cause: Cause.Cause<unknown> };
 
 const runLiveCloudUnlink = Effect.fn("cloud.cli.run_live_unlink")(function* () {
   const config = yield* ServerConfig.ServerConfig;
@@ -211,6 +212,21 @@ type RelayUnlinkResult =
   | { readonly status: "revoked" }
   | { readonly status: "not-linked" };
 
+type CloudDisconnectOperation = "live-server-unlink" | "relay-environment-unlink";
+
+const logCloudDisconnectFailure = (
+  operation: CloudDisconnectOperation,
+  clearAuthorization: boolean,
+  cause: Cause.Cause<unknown>,
+) =>
+  Effect.logWarning("T3 Connect disconnect operation failed.").pipe(
+    Effect.annotateLogs({
+      operation,
+      clearAuthorization,
+      cause: Cause.pretty(cause),
+    }),
+  );
+
 const unlinkRelayEnvironment = Effect.fn("cloud.cli.unlink_relay_environment")(function* () {
   const tokens = yield* CliTokenManager.CloudCliTokenManager;
   const token = yield* tokens.getExisting;
@@ -236,6 +252,42 @@ const unlinkRelayEnvironment = Effect.fn("cloud.cli.unlink_relay_environment")(f
     : ({ status: "not-linked" } satisfies RelayUnlinkResult);
 });
 
+export const reportCloudDisconnectResults = Effect.fn("cloud.cli.report_disconnect_results")(
+  function* (input: {
+    readonly clearAuthorization: boolean;
+    readonly liveResult: LiveCloudActionResult;
+    readonly relayResult: Exit.Exit<RelayUnlinkResult, unknown>;
+  }) {
+    if (input.liveResult.status === "failed") {
+      yield* logCloudDisconnectFailure(
+        "live-server-unlink",
+        input.clearAuthorization,
+        input.liveResult.cause,
+      );
+      yield* Console.warn(
+        "T3 Connect is disabled, but the running server could not stop its tunnel.\nRestart that server to stop the connector.",
+      );
+    } else {
+      yield* Console.log("T3 Connect is disabled locally.");
+    }
+
+    if (Exit.isFailure(input.relayResult)) {
+      yield* logCloudDisconnectFailure(
+        "relay-environment-unlink",
+        input.clearAuthorization,
+        input.relayResult.cause,
+      );
+      yield* Console.warn(
+        input.clearAuthorization
+          ? "Could not revoke the relay-side environment record before signing out.\nThe stored CLI authorization was still removed locally."
+          : "Could not revoke the relay-side environment record yet.\nRun `t3 connect unlink` again when the relay is reachable.",
+      );
+    } else if (input.relayResult.value.status === "revoked") {
+      yield* Console.log("Revoked the relay-side environment record.");
+    }
+  },
+);
+
 const disconnectCloud = Effect.fn("cloud.cli.disconnect")(function* (options: {
   readonly clearAuthorization: boolean;
 }) {
@@ -249,23 +301,11 @@ const disconnectCloud = Effect.fn("cloud.cli.disconnect")(function* (options: {
     yield* tokens.clear;
   }
 
-  if (liveResult.status === "failed") {
-    yield* Console.warn(
-      `T3 Connect is disabled, but the running server could not stop its tunnel: ${String(liveResult.cause)}\nRestart that server to stop the connector.`,
-    );
-  } else {
-    yield* Console.log("T3 Connect is disabled locally.");
-  }
-
-  if (Exit.isFailure(relayResult)) {
-    yield* Console.warn(
-      options.clearAuthorization
-        ? `Could not revoke the relay-side environment record before signing out: ${String(relayResult.cause)}\nThe stored CLI authorization was still removed locally.`
-        : `Could not revoke the relay-side environment record yet: ${String(relayResult.cause)}\nRun \`t3 connect unlink\` again when the relay is reachable.`,
-    );
-  } else if (relayResult.value.status === "revoked") {
-    yield* Console.log("Revoked the relay-side environment record.");
-  }
+  yield* reportCloudDisconnectResults({
+    clearAuthorization: options.clearAuthorization,
+    liveResult,
+    relayResult,
+  });
 
   if (options.clearAuthorization) {
     yield* Console.log("Signed out of T3 Connect locally.");


### PR DESCRIPTION
## Summary
- keep cloud disconnect warnings stable and free of internal cause text
- preserve full Effect causes in structured warning logs with operation and authorization context
- add behavioral coverage for diagnostic correlation and user-facing redaction

## Validation
- `vp test apps/server/src/cli/connect.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only messaging and logging changes during unlink/logout; no auth or relay protocol changes.
> 
> **Overview**
> **T3 Connect disconnect** no longer prints internal failure text in `Console.warn` messages. Live-server unlink and relay revoke failures still show the same stable guidance, while full Effect causes are recorded via `Effect.logWarning` with `operation`, `clearAuthorization`, and `Cause.pretty(cause)`.
> 
> `disconnectCloud` delegates user messaging to a new exported **`reportCloudDisconnectResults`**, and live unlink failures now carry **`Cause.Cause<unknown>`** instead of opaque `unknown`. A test asserts private diagnostic strings appear only in structured logs, not in console warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 870f4d7b7675bf625458fe9384076b2c4ff8e3f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve cloud disconnect failure causes in structured logs instead of console warnings
> - Adds `reportCloudDisconnectResults` in [`connect.ts`](https://github.com/pingdotgg/t3code/pull/3437/files#diff-369ea07c1ac5b161aaf3838766eade272006cee25413a596386e01aa6d2b9aa0) to separate user-facing console output from detailed failure diagnostics.
> - Failure causes are now recorded as structured log annotations (operation, clearAuthorization, pretty-printed cause) via a new `logCloudDisconnectFailure` helper, rather than interpolated directly into console warnings.
> - The `disconnect` function is updated to call `reportCloudDisconnectResults` instead of inlining console logging logic.
> - Behavioral Change: Console warnings no longer include raw cause strings; detailed causes are only visible in structured logs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 870f4d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->