### PR TITLE
[codex] Preserve supervisor unexpected causes

### DIFF
--- a/packages/client-runtime/src/connection/supervisor.ts
+++ b/packages/client-runtime/src/connection/supervisor.ts
@@ -187,6 +187,7 @@ function failureFromExit<A>(
       error: new ConnectionTransientError({
         reason: "transport",
         detail: `${target.label} connection failed unexpectedly.`,
+        cause: exit.cause,
       }),
       attemptSpan: Option.none(),
     },


### PR DESCRIPTION
## Summary
- preserve the complete Effect `Cause` when the connection supervisor converts an unexpected, non-interrupt exit into a transient connection error
- leave typed failures and interrupt-only exits unchanged

## Why
The supervisor previously replaced the original defect tree with a generic error, losing the causal chain needed for diagnostics and stack traces.

## Validation
- `vp test run src/connection/supervisor.test.ts` (from `packages/client-runtime`): 25 passed
- `vp check`
- `vp run typecheck`

Stacked on #3403 because that PR adds the structured optional `cause` field to `ConnectionTransientError`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field wiring in error mapping with no behavior change to retry, interrupt, or typed failure paths.
> 
> **Overview**
> When the environment connection supervisor maps an **unexpected** connection exit (not a typed `ConnectionAttemptError` and not interrupt-only) into a retryable `ConnectionTransientError`, it now attaches the original Effect **`exit.cause`** on that error instead of dropping the defect tree.
> 
> Typed failures and interrupt-only outcomes are unchanged; this only improves diagnostics and stack traces for unexpected transport defects during connect or while connected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17d882b609bd42875c1a258116f2206ce081c506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve original cause in `failureFromExit` transient errors
> When `failureFromExit` in [supervisor.ts](https://github.com/pingdotgg/t3code/pull/3438/files#diff-9cea0e0ed5756232bad1eb5801220443f2c1a6cbabaedc22ad335b39a79c7de9) cannot find a typed failure reason, it now attaches `exit.cause` to the constructed `ConnectionTransientError`. This makes the underlying cause available for debugging rather than silently discarding it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17d882b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->