### PR TITLE
[codex] Fix terminal cwd error test construction

### DIFF
--- a/apps/server/src/project/ProjectSetupScriptRunner.test.ts
+++ b/apps/server/src/project/ProjectSetupScriptRunner.test.ts
@@ -153,9 +153,8 @@ describe("ProjectSetupScriptRunner", () => {
 
   it.effect("keeps terminal failures as the exact cause of a structured operation error", () => {
     const rootCause = new Error("stat failed");
-    const terminalError = new TerminalManager.TerminalCwdError({
+    const terminalError = new TerminalManager.TerminalCwdStatError({
       cwd: "/repo/worktrees/a",
-      reason: "statFailed",
       cause: rootCause,
     });
     const project = makeProject([


### PR DESCRIPTION
## Summary

- construct the concrete `TerminalCwdStatError` in the project setup runner test
- remove the obsolete `reason` field from the pre-union error shape

## Root cause

The terminal cwd failure was split into structured error classes and `TerminalCwdError` became a `Schema.Union`, but this test still attempted to instantiate the union directly. That broke the repository-wide typecheck on `main`.

## Validation

- `vp test run apps/server/src/project/ProjectSetupScriptRunner.test.ts` (3 tests)
- `vp check` (0 errors; existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production behavior impact.
> 
> **Overview**
> Updates **`ProjectSetupScriptRunner`** test setup so terminal cwd failures use the concrete **`TerminalCwdStatError`** class instead of constructing the **`TerminalCwdError`** union directly.
> 
> Removes the obsolete **`reason: "statFailed"`** field from the stub error so the test matches the split cwd error types used by **`TerminalManager`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2de01d12ec0a8c8e7ce6614e99a7392bba006a72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TerminalCwdStatError` construction in `ProjectSetupScriptRunner` tests
> Replaces `TerminalManager.TerminalCwdError` with `TerminalManager.TerminalCwdStatError` in [ProjectSetupScriptRunner.test.ts](https://github.com/pingdotgg/t3code/pull/3440/files#diff-f9024d08f14dae211fd7ccaee88dfc5e2bd216c0c25b992776c79018700cfad3), removing the `reason: "statFailed"` argument so the error is instantiated with only `cwd` and `cause`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2de01d1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->