### PR TITLE
[codex] Structure command resolution failures

### DIFF
--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -3,6 +3,7 @@ import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 import { describe, expect, it, vi } from "vite-plus/test";
 
@@ -371,7 +372,46 @@ effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
     }),
   );
 
-  it.effect("preserves filesystem failures while probing PATH candidates", () =>
+  it.effect("continues past a failed PATH probe when a later executable exists", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDirectory = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-command-resolution-",
+      });
+      const blockedDirectory = path.join(baseDirectory, "blocked");
+      const workingDirectory = path.join(baseDirectory, "working");
+      const blockedCandidate = path.join(blockedDirectory, "available-command");
+      const workingCandidate = path.join(workingDirectory, "available-command");
+      yield* fileSystem.makeDirectory(blockedDirectory);
+      yield* fileSystem.makeDirectory(workingDirectory);
+      yield* fileSystem.writeFileString(workingCandidate, "#!/bin/sh\nexit 0\n");
+      yield* fileSystem.chmod(workingCandidate, 0o755);
+
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "stat",
+        pathOrDescriptor: blockedCandidate,
+      });
+      const failingFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        stat: (candidate) =>
+          candidate === blockedCandidate ? Effect.fail(cause) : fileSystem.stat(candidate),
+      });
+
+      const resolved = yield* resolveCommandPath("available-command", {
+        env: { PATH: `${blockedDirectory}:${workingDirectory}` },
+      }).pipe(
+        Effect.provideService(HostProcessPlatform, "linux"),
+        Effect.provideService(FileSystem.FileSystem, failingFileSystem),
+      );
+
+      expect(resolved).toBe(workingCandidate);
+    }),
+  );
+
+  it.effect("preserves filesystem failures after exhausting PATH candidates", () =>
     Effect.gen(function* () {
       const fileSystem = yield* FileSystem.FileSystem;
       const cause = PlatformError.systemError({

--- a/packages/shared/src/shell.test.ts
+++ b/packages/shared/src/shell.test.ts
@@ -2,12 +2,15 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it as effectIt } from "@effect/vitest";
 import { HostProcessEnvironment, HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as PlatformError from "effect/PlatformError";
 import { describe, expect, it, vi } from "vite-plus/test";
 
 import {
   extractPathFromShellOutput,
   CommandAvailability,
   type CommandAvailabilityChecker,
+  CommandResolutionError,
   isCommandAvailable,
   listLoginShellCandidates,
   mergePathEntries,
@@ -355,13 +358,45 @@ effectIt.layer(NodeServices.layer)("isCommandAvailable", (it) => {
 });
 
 effectIt.layer(NodeServices.layer)("resolveCommandPath", (it) => {
-  it.effect("fails when PATH is empty", () =>
+  it.effect("reports the unresolved command and platform when PATH is empty", () =>
     Effect.gen(function* () {
-      const result = yield* resolveCommandPath("definitely-not-installed", {
+      const error = yield* resolveCommandPath("definitely-not-installed", {
         env: { PATH: "", PATHEXT: ".COM;.EXE;.BAT;.CMD" },
-      }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.result);
+      }).pipe(Effect.provideService(HostProcessPlatform, "win32"), Effect.flip);
 
-      expect(result._tag).toBe("Failure");
+      expect(error).toBeInstanceOf(CommandResolutionError);
+      expect(error.command).toBe("definitely-not-installed");
+      expect(error.platform).toBe("win32");
+      expect(error.message).toBe('Could not resolve command "definitely-not-installed" on win32.');
+    }),
+  );
+
+  it.effect("preserves filesystem failures while probing PATH candidates", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const cause = PlatformError.systemError({
+        _tag: "PermissionDenied",
+        module: "FileSystem",
+        method: "stat",
+        pathOrDescriptor: "/bin/blocked-command",
+      });
+      const failingFileSystem = FileSystem.FileSystem.of({
+        ...fileSystem,
+        stat: () => Effect.fail(cause),
+      });
+
+      const error = yield* resolveCommandPath("blocked-command", {
+        env: { PATH: "/bin" },
+      }).pipe(
+        Effect.provideService(HostProcessPlatform, "linux"),
+        Effect.provideService(FileSystem.FileSystem, failingFileSystem),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(CommandResolutionError);
+      expect(error.command).toBe("blocked-command");
+      expect(error.platform).toBe("linux");
+      expect(error.cause).toBe(cause);
     }),
   );
 });

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -3,13 +3,14 @@ import * as NodeOS from "node:os";
 import * as NodePath from "node:path";
 import * as NodeChildProcess from "node:child_process";
 import * as NodeFS from "node:fs";
-import * as Data from "effect/Data";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as Schema from "effect/Schema";
 
 import { HostProcessEnvironment, HostProcessPlatform } from "./hostProcess.ts";
-import * as Context from "effect/Context";
 
 const PATH_CAPTURE_START = "__T3CODE_PATH_START__";
 const PATH_CAPTURE_END = "__T3CODE_PATH_END__";
@@ -17,6 +18,19 @@ const SHELL_ENV_NAME_PATTERN = /^[A-Z0-9_]+$/;
 const WINDOWS_PATH_DELIMITER = ";";
 const POSIX_PATH_DELIMITER = ":";
 const WINDOWS_SHELL_CANDIDATES = ["pwsh.exe", "powershell.exe"] as const;
+const ProcessPlatform = Schema.Literals([
+  "aix",
+  "android",
+  "darwin",
+  "freebsd",
+  "haiku",
+  "linux",
+  "openbsd",
+  "sunos",
+  "win32",
+  "cygwin",
+  "netbsd",
+]);
 
 type ExecFileSyncLike = (
   file: string,
@@ -43,10 +57,18 @@ export type CommandAvailabilityChecker = (
   options?: CommandAvailabilityOptions,
 ) => Effect.Effect<boolean, never, FileSystem.FileSystem | Path.Path>;
 
-export class CommandResolutionError extends Data.TaggedError("CommandResolutionError")<{
-  readonly command: string;
-  readonly reason: "not-found";
-}> {}
+export class CommandResolutionError extends Schema.TaggedErrorClass<CommandResolutionError>()(
+  "CommandResolutionError",
+  {
+    command: Schema.String,
+    platform: ProcessPlatform,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Could not resolve command ${JSON.stringify(this.command)} on ${this.platform}.`;
+  }
+}
 
 const WINDOWS_SHELL_META_CHARS = /([()\][%!^"`<>&|;, *?])/g;
 
@@ -495,10 +517,15 @@ const isExecutableFile = Effect.fn("shell.isExecutableFile")(function* (
   filePath: string,
   platform: NodeJS.Platform,
   windowsPathExtensions: ReadonlyArray<string>,
-): Effect.fn.Return<boolean, never, FileSystem.FileSystem | Path.Path> {
+): Effect.fn.Return<boolean, PlatformError.PlatformError, FileSystem.FileSystem | Path.Path> {
   const fileSystem = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
-  const stat = yield* fileSystem.stat(filePath).pipe(Effect.orElseSucceed(() => null));
+  const stat = yield* fileSystem.stat(filePath).pipe(
+    Effect.catchIf(
+      (error) => error.reason._tag === "NotFound",
+      () => Effect.succeed(null),
+    ),
+  );
   if (stat === null || stat.type !== "File") return false;
 
   if (platform === "win32") {
@@ -527,16 +554,20 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
 
   if (command.includes("/") || command.includes("\\")) {
     for (const candidate of commandCandidates) {
-      if (yield* isExecutableFile(candidate, platform, windowsPathExtensions)) {
+      if (
+        yield* isExecutableFile(candidate, platform, windowsPathExtensions).pipe(
+          Effect.mapError((cause) => new CommandResolutionError({ command, platform, cause })),
+        )
+      ) {
         return candidate;
       }
     }
-    return yield* new CommandResolutionError({ command, reason: "not-found" });
+    return yield* new CommandResolutionError({ command, platform });
   }
 
   const pathValue = resolvePathEnvironmentVariable(env);
   if (pathValue.length === 0) {
-    return yield* new CommandResolutionError({ command, reason: "not-found" });
+    return yield* new CommandResolutionError({ command, platform });
   }
   const pathEntries: string[] = [];
   for (const entry of pathValue.split(pathDelimiterForPlatform(platform))) {
@@ -549,12 +580,16 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
   for (const pathEntry of pathEntries) {
     for (const candidate of commandCandidates) {
       const candidatePath = path.join(pathEntry, candidate);
-      if (yield* isExecutableFile(candidatePath, platform, windowsPathExtensions)) {
+      if (
+        yield* isExecutableFile(candidatePath, platform, windowsPathExtensions).pipe(
+          Effect.mapError((cause) => new CommandResolutionError({ command, platform, cause })),
+        )
+      ) {
         return candidatePath;
       }
     }
   }
-  return yield* new CommandResolutionError({ command, reason: "not-found" });
+  return yield* new CommandResolutionError({ command, platform });
 });
 
 export const resolveCommandPath = Effect.fn("shell.resolveCommandPath")(function* (

--- a/packages/shared/src/shell.ts
+++ b/packages/shared/src/shell.ts
@@ -551,18 +551,26 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
     windowsPathExtensions,
     path.extname,
   );
+  let firstProbeFailure: PlatformError.PlatformError | undefined;
+  const probeCandidate = (candidatePath: string) =>
+    isExecutableFile(candidatePath, platform, windowsPathExtensions).pipe(
+      Effect.catch((cause) => {
+        firstProbeFailure ??= cause;
+        return Effect.succeed(false);
+      }),
+    );
 
   if (command.includes("/") || command.includes("\\")) {
     for (const candidate of commandCandidates) {
-      if (
-        yield* isExecutableFile(candidate, platform, windowsPathExtensions).pipe(
-          Effect.mapError((cause) => new CommandResolutionError({ command, platform, cause })),
-        )
-      ) {
+      if (yield* probeCandidate(candidate)) {
         return candidate;
       }
     }
-    return yield* new CommandResolutionError({ command, platform });
+    return yield* new CommandResolutionError({
+      command,
+      platform,
+      ...(firstProbeFailure === undefined ? {} : { cause: firstProbeFailure }),
+    });
   }
 
   const pathValue = resolvePathEnvironmentVariable(env);
@@ -580,16 +588,16 @@ const resolveCommandPathForPlatform = Effect.fn("shell.resolveCommandPathForPlat
   for (const pathEntry of pathEntries) {
     for (const candidate of commandCandidates) {
       const candidatePath = path.join(pathEntry, candidate);
-      if (
-        yield* isExecutableFile(candidatePath, platform, windowsPathExtensions).pipe(
-          Effect.mapError((cause) => new CommandResolutionError({ command, platform, cause })),
-        )
-      ) {
+      if (yield* probeCandidate(candidatePath)) {
         return candidatePath;
       }
     }
   }
-  return yield* new CommandResolutionError({ command, platform });
+  return yield* new CommandResolutionError({
+    command,
+    platform,
+    ...(firstProbeFailure === undefined ? {} : { cause: firstProbeFailure }),
+  });
 });
 
 export const resolveCommandPath = Effect.fn("shell.resolveCommandPath")(function* (


### PR DESCRIPTION
## Summary

- model command lookup failures as a schema-backed error with a derived message
- attach the command and host platform needed to correlate lookup failures
- preserve non-`NotFound` filesystem causes instead of treating every probe failure as an absent executable

## Root cause

Command probing converted every filesystem `stat` failure into a missing candidate. Permission and other system failures therefore lost their cause chain, while the exposed error carried a redundant single-value `reason` and no platform context.

## Validation

- `vp test packages/shared/src/shell.test.ts` (30 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared shell command resolution used for spawn/availability; probe failures behave differently and errors expose new fields, which may surface permission issues that were previously hidden.
> 
> **Overview**
> **`CommandResolutionError`** is now a schema-backed tagged error with **`command`**, **`platform`**, an optional **`cause`**, and a derived **`message`** (replacing the old `reason: "not-found"` shape).
> 
> **PATH probing** in **`resolveCommandPathForPlatform`** treats only **`NotFound`** **`stat`** results as “skip this candidate.” Other filesystem errors are recorded on the first failed probe, search continues, and if nothing resolves the failure is still **`CommandResolutionError`** but may include that **`cause`**. **`isExecutableFile`** was updated to match (no longer swallowing every **`stat`** failure).
> 
> Tests assert the new error fields, resolution when an earlier PATH entry errors but a later one works, and **`cause`** preservation when all probes fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e812b2813f7da5aedfda6cffa78e860c1599955. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure `CommandResolutionError` to include command, platform, and filesystem cause
> - `CommandResolutionError` in [shell.ts](https://github.com/pingdotgg/t3code/pull/3441/files#diff-89a91f85db41a9a0912bc86c336bf9429751f3797ee50a089248c68cde8489ce) is converted to a `Schema.TaggedErrorClass` with `command`, `platform`, and optional `cause` fields, plus a human-readable `message` getter.
> - `isExecutableFile` now propagates non-`NotFound` filesystem errors instead of silently treating them as non-executable.
> - `resolveCommandPathForPlatform` continues past probe failures, records the first failure cause, and attaches it to `CommandResolutionError` when no executable is found.
> - Behavioral Change: filesystem errors other than `NotFound` during path probing now surface to callers rather than being swallowed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6e812b2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->