### PR TITLE
[codex] Structure relay Clerk verification failures

### DIFF
--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -1,21 +1,30 @@
 import { createClerkClient, verifyToken } from "@clerk/backend";
 import { describe, expect, it } from "@effect/vitest";
 import { vi } from "vite-plus/test";
+import * as Cause from "effect/Cause";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Predicate from "effect/Predicate";
 import * as Redacted from "effect/Redacted";
+import * as References from "effect/References";
 import * as Tracer from "effect/Tracer";
 import * as HttpRouter from "effect/unstable/http/HttpRouter";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import { RelayEnvironmentAuth } from "@t3tools/contracts/relay";
+import {
+  RelayEnvironmentAuth,
+  RelayEnvironmentConnectNotAuthorizedError,
+  RelayInternalError,
+} from "@t3tools/contracts/relay";
 
 import {
   ClerkBearerTokenVerificationError,
   ClerkTokenVerificationError,
+  mapErrorTags,
+  mapRelayCommonApiErrors,
   relayCors,
   relayDocsRedirectRoute,
   relayEnvironmentAuthLayer,
@@ -27,6 +36,7 @@ import {
 } from "./Api.ts";
 import * as RelayConfiguration from "../Config.ts";
 import * as EnvironmentCredentials from "../environments/EnvironmentCredentials.ts";
+import * as EnvironmentConnector from "../environments/EnvironmentConnector.ts";
 
 vi.mock("@clerk/backend", () => ({
   createClerkClient: vi.fn(),
@@ -51,6 +61,19 @@ const relaySettings: RelayConfiguration.RelayConfiguration["Service"] = {
   managedEndpointBaseDomain: undefined,
   managedEndpointNamespace: undefined,
 };
+
+const projectionTraceId = "00000000000000000000000000000042";
+const projectionParentSpan = Tracer.externalSpan({
+  traceId: projectionTraceId,
+  spanId: "0000000000000042",
+  sampled: true,
+});
+
+interface CapturedLog {
+  readonly message: unknown;
+  readonly cause: Cause.Cause<unknown>;
+  readonly annotations: Readonly<Record<string, unknown>>;
+}
 
 describe("relay client authentication", () => {
   it.effect("preserves the existing Clerk session JWT path", () =>
@@ -242,6 +265,14 @@ describe("relay DPoP token exchange authentication", () => {
 
 describe("relay environment authentication", () => {
   it.effect("preserves credential lookup persistence failures as internal errors", () => {
+    const logs: CapturedLog[] = [];
+    const logger = Logger.make(({ cause, fiber, message }) => {
+      logs.push({
+        message,
+        cause,
+        annotations: fiber.getRef(References.CurrentLogAnnotations),
+      });
+    });
     const failure = new EnvironmentCredentials.EnvironmentCredentialAuthenticatePersistenceError({
       stage: "lookup-credential",
       cause: "database unavailable",
@@ -265,8 +296,25 @@ describe("relay environment authentication", () => {
       expect(Predicate.isTagged(error, "RelayInternalError")).toBe(true);
       if (Predicate.isTagged(error, "RelayInternalError")) {
         expect(error.reason).toBe("persistence_failed");
+        expect(error.traceId).toBe(projectionTraceId);
+        expect(error).not.toHaveProperty("cause");
       }
+      expect(logs).toEqual([
+        {
+          message: ["relay API failure projected to wire response"],
+          cause: Cause.fail(failure),
+          annotations: expect.objectContaining({
+            traceId: projectionTraceId,
+            sourceErrorTag: "EnvironmentCredentialAuthenticatePersistenceError",
+            responseErrorTag: "RelayInternalError",
+            responseCode: "internal_error",
+            responseReason: "persistence_failed",
+          }),
+        },
+      ]);
     }).pipe(
+      Effect.provideService(Tracer.ParentSpan, projectionParentSpan),
+      Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
       Effect.provideService(
         HttpServerRequest.HttpServerRequest,
         HttpServerRequest.fromWeb(new Request("https://relay.test/v1/server/link")),
@@ -282,6 +330,128 @@ describe("relay environment authentication", () => {
         ),
       ),
       Effect.scoped,
+    );
+  });
+});
+
+describe("relay API error projection", () => {
+  it.effect("logs common persistence failures with the wire response trace", () => {
+    const logs: CapturedLog[] = [];
+    const logger = Logger.make(({ cause, fiber, message }) => {
+      logs.push({
+        message,
+        cause,
+        annotations: fiber.getRef(References.CurrentLogAnnotations),
+      });
+    });
+    const databaseCause = new Error("database connection refused");
+    const failure = new EnvironmentCredentials.EnvironmentCredentialRevokePersistenceError({
+      environmentId: "env-test",
+      cause: databaseCause,
+    });
+
+    return Effect.gen(function* () {
+      const error = yield* Effect.fail(failure).pipe(
+        mapRelayCommonApiErrors("not_authorized"),
+        Effect.flip,
+      );
+
+      expect(error).toBeInstanceOf(RelayInternalError);
+      expect(error).toMatchObject({
+        code: "internal_error",
+        reason: "persistence_failed",
+        traceId: projectionTraceId,
+      });
+      expect(error).not.toHaveProperty("cause");
+      expect(logs).toEqual([
+        {
+          message: ["relay API failure projected to wire response"],
+          cause: Cause.fail(failure),
+          annotations: expect.objectContaining({
+            traceId: projectionTraceId,
+            sourceErrorTag: "EnvironmentCredentialRevokePersistenceError",
+            responseErrorTag: "RelayInternalError",
+            responseCode: "internal_error",
+            responseReason: "persistence_failed",
+          }),
+        },
+      ]);
+      expect(failure.cause).toBe(databaseCause);
+    }).pipe(
+      Effect.provideService(Tracer.ParentSpan, projectionParentSpan),
+      Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
+    );
+  });
+
+  it.effect("logs selected server failures but not expected authorization projections", () => {
+    const logs: CapturedLog[] = [];
+    const logger = Logger.make(({ cause, fiber, message }) => {
+      logs.push({
+        message,
+        cause,
+        annotations: fiber.getRef(References.CurrentLogAnnotations),
+      });
+    });
+    const serverCause = new Error("mint request transport failed");
+    const serverFailure = EnvironmentConnector.EnvironmentMintRequestFailed.fromEndpoint({
+      userId: "user-test",
+      environmentId: "env-test",
+      operation: "connect",
+      stage: "send_request",
+      httpBaseUrl: "https://environment.example.test",
+      cause: serverCause,
+    });
+    const authorizationFailure = new EnvironmentConnector.EnvironmentConnectNotAuthorized({
+      environmentId: "env-test",
+      operation: "connect",
+      reason: "environment_link_not_found",
+    });
+
+    return Effect.gen(function* () {
+      const serverError = yield* Effect.fail(serverFailure).pipe(
+        mapErrorTags({
+          EnvironmentMintRequestFailed: (_error, traceId) =>
+            new RelayInternalError({
+              code: "internal_error",
+              reason: "upstream_unavailable",
+              traceId,
+            }),
+        }),
+        Effect.flip,
+      );
+      const authorizationError = yield* Effect.fail(authorizationFailure).pipe(
+        mapErrorTags({
+          EnvironmentConnectNotAuthorized: (_error, traceId) =>
+            new RelayEnvironmentConnectNotAuthorizedError({
+              code: "environment_connect_not_authorized",
+              traceId,
+            }),
+        }),
+        Effect.flip,
+      );
+
+      expect(serverError).toMatchObject({
+        reason: "upstream_unavailable",
+        traceId: projectionTraceId,
+      });
+      expect(authorizationError.traceId).toBe(projectionTraceId);
+      expect(logs).toEqual([
+        {
+          message: ["relay API failure projected to wire response"],
+          cause: Cause.fail(serverFailure),
+          annotations: expect.objectContaining({
+            traceId: projectionTraceId,
+            sourceErrorTag: "EnvironmentMintRequestFailed",
+            responseErrorTag: "RelayInternalError",
+            responseCode: "internal_error",
+            responseReason: "upstream_unavailable",
+          }),
+        },
+      ]);
+      expect(serverFailure.cause).toBe(serverCause);
+    }).pipe(
+      Effect.provideService(Tracer.ParentSpan, projectionParentSpan),
+      Effect.provide(Logger.layer([logger], { mergeWithExisting: false })),
     );
   });
 });

--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -14,6 +14,8 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { RelayEnvironmentAuth } from "@t3tools/contracts/relay";
 
 import {
+  ClerkBearerTokenVerificationError,
+  ClerkTokenVerificationError,
   relayCors,
   relayDocsRedirectRoute,
   relayEnvironmentAuthLayer,
@@ -94,6 +96,87 @@ describe("relay client authentication", () => {
         secretKey: "clerk-secret-key",
         publishableKey: "pk_test_test",
       });
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          vi.mocked(verifyToken).mockReset();
+          vi.mocked(createClerkClient).mockReset();
+        }),
+      ),
+    ),
+  );
+
+  it.effect("preserves both Clerk failures when session and OAuth verification fail", () => {
+    const sessionCause = Object.assign(new Error("private session verification detail"), {
+      reason: "session_invalid",
+    });
+    const oauthCause = Object.assign(new Error("private OAuth verification detail"), {
+      reason: "oauth_invalid",
+    });
+
+    return Effect.gen(function* () {
+      vi.mocked(verifyToken).mockRejectedValue(sessionCause);
+      vi.mocked(createClerkClient).mockReturnValue({
+        authenticateRequest: vi.fn().mockRejectedValue(oauthCause),
+      } as never);
+
+      const error = yield* Effect.flip(
+        verifyRelayClientBearerToken(relaySettings, "invalid-token"),
+      );
+
+      expect(error).toBeInstanceOf(ClerkBearerTokenVerificationError);
+      expect(error.sessionFailure).toBeInstanceOf(ClerkTokenVerificationError);
+      expect(error.sessionFailure).toMatchObject({
+        stage: "session-token-verification",
+        reason: "session_invalid",
+        cause: sessionCause,
+      });
+      expect(error.cause).toBeInstanceOf(ClerkTokenVerificationError);
+      expect(error.cause).toMatchObject({
+        stage: "oauth-request-authentication",
+        reason: "oauth_invalid",
+        cause: oauthCause,
+      });
+      expect(error.message).toBe(
+        "Clerk bearer token verification failed after session stage 'session-token-verification' (session_invalid) and OAuth stage 'oauth-request-authentication' (oauth_invalid).",
+      );
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          vi.mocked(verifyToken).mockReset();
+          vi.mocked(createClerkClient).mockReset();
+        }),
+      ),
+    );
+  });
+
+  it.effect("models an unauthenticated Clerk OAuth state as a structured failure", () =>
+    Effect.gen(function* () {
+      vi.mocked(verifyToken).mockRejectedValue(
+        Object.assign(new Error("not a session JWT"), { reason: "session_invalid" }),
+      );
+      vi.mocked(createClerkClient).mockReturnValue({
+        authenticateRequest: vi.fn().mockResolvedValue({
+          isAuthenticated: false,
+          toAuth: () => ({ userId: null }),
+        }),
+      } as never);
+
+      const error = yield* Effect.flip(
+        verifyRelayClientBearerToken(relaySettings, "unauthenticated-token"),
+      );
+
+      expect(error).toBeInstanceOf(ClerkBearerTokenVerificationError);
+      expect(error.sessionFailure).toMatchObject({
+        stage: "session-token-verification",
+        reason: "session_invalid",
+      });
+      expect(error.cause).toBeInstanceOf(ClerkTokenVerificationError);
+      expect(error.cause).toMatchObject({
+        stage: "oauth-auth-state-validation",
+        reason: "not_authenticated",
+      });
+      expect(error.cause.cause).toBeUndefined();
     }).pipe(
       Effect.ensuring(
         Effect.sync(() => {

--- a/infra/relay/src/http/Api.test.ts
+++ b/infra/relay/src/http/Api.test.ts
@@ -21,6 +21,7 @@ import {
   relayEnvironmentAuthLayer,
   relayNotFoundRoute,
   traceRelayHttpRequestWith,
+  verifyRelayDpopTokenExchangeSubject,
   verifyRelayClientBearerToken,
   withoutCapturedParentSpan,
 } from "./Api.ts";
@@ -186,6 +187,57 @@ describe("relay client authentication", () => {
       ),
     ),
   );
+});
+
+describe("relay DPoP token exchange authentication", () => {
+  it.effect("records safe Clerk verification diagnostics before returning invalid bearer", () => {
+    const verificationCause = Object.assign(new Error("private token verification detail"), {
+      reason: "session_invalid",
+    });
+
+    return Effect.gen(function* () {
+      const spans: Array<Tracer.NativeSpan> = [];
+      const tracer = Tracer.make({
+        span: (options) => {
+          const span = new Tracer.NativeSpan(options);
+          spans.push(span);
+          return span;
+        },
+      });
+      vi.mocked(verifyToken).mockRejectedValue(verificationCause);
+
+      const error = yield* Effect.flip(
+        verifyRelayDpopTokenExchangeSubject(relaySettings, "private-subject-token").pipe(
+          Effect.provideService(Tracer.Tracer, tracer),
+        ),
+      );
+
+      expect(Predicate.isTagged(error, "RelayAuthInvalidError")).toBe(true);
+      if (Predicate.isTagged(error, "RelayAuthInvalidError")) {
+        expect(error.reason).toBe("invalid_bearer");
+      }
+      const exchangeSpan = spans.find(
+        (span) => span.name === "relay.auth.dpop_token_exchange_subject",
+      );
+      expect(exchangeSpan?.attributes.get("relay.auth.clerk_verification_failure")).toBe(
+        "session_invalid",
+      );
+      expect(exchangeSpan?.attributes.get("relay.auth.clerk_verification_stage")).toBe(
+        "session-token-verification",
+      );
+      for (const attribute of exchangeSpan?.attributes.values() ?? []) {
+        expect(String(attribute)).not.toContain("private-subject-token");
+        expect(String(attribute)).not.toContain("private token verification detail");
+      }
+    }).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          vi.mocked(verifyToken).mockReset();
+          vi.mocked(createClerkClient).mockReset();
+        }),
+      ),
+    );
+  });
 });
 
 describe("relay environment authentication", () => {

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -198,19 +198,18 @@ export const relayClientAuthLayer = Layer.effect(
         const token = readHttpAuthorizationCredential(credential);
         const verified = yield* verifyRelayClientBearerToken(config, token).pipe(
           Effect.tapError((error) =>
-            Effect.annotateCurrentSpan(
-              "relay.auth.clerk_verification_failure",
-              clerkVerificationFailureReason(error.cause),
-            ),
+            Effect.annotateCurrentSpan({
+              "relay.auth.clerk_verification_failure": error.cause.reason,
+              "relay.auth.clerk_session_failure_stage": error.sessionFailure.stage,
+              "relay.auth.clerk_session_failure_reason": error.sessionFailure.reason,
+              "relay.auth.clerk_oauth_failure_stage": error.cause.stage,
+              "relay.auth.clerk_oauth_failure_reason": error.cause.reason,
+            }),
           ),
-          Effect.catch(() => relayAuthInvalidError("invalid_bearer")),
+          Effect.catchTags({
+            ClerkBearerTokenVerificationError: () => relayAuthInvalidError("invalid_bearer"),
+          }),
         );
-        if (!verified.sub) {
-          yield* Effect.annotateCurrentSpan({
-            "relay.auth.clerk_verification_failure": "missing_subject",
-          });
-          return yield* relayAuthInvalidError("invalid_bearer");
-        }
         yield* Effect.annotateCurrentSpan({
           "relay.auth.mode": verified.mode,
           "relay.auth.subject": verified.sub,
@@ -861,14 +860,39 @@ export const serverApi = HttpApiBuilder.group(
   }),
 );
 
-class ClerkTokenVerificationFailed extends Schema.TaggedErrorClass<ClerkTokenVerificationFailed>()(
-  "ClerkTokenVerificationFailed",
+const ClerkTokenVerificationStage = Schema.Literals([
+  "session-token-verification",
+  "session-claims-validation",
+  "oauth-request-authentication",
+  "oauth-auth-state-validation",
+]);
+const ClerkTokenVerificationReason = Schema.String.check(
+  Schema.isMaxLength(64),
+  Schema.isPattern(/^[a-z0-9._-]+$/i),
+);
+
+export class ClerkTokenVerificationError extends Schema.TaggedErrorClass<ClerkTokenVerificationError>()(
+  "ClerkTokenVerificationError",
   {
-    cause: Schema.Defect(),
+    stage: ClerkTokenVerificationStage,
+    reason: ClerkTokenVerificationReason,
+    cause: Schema.optionalKey(Schema.Defect()),
   },
 ) {
   override get message(): string {
-    return "Clerk token verification failed";
+    return `Clerk token verification failed during '${this.stage}' (${this.reason}).`;
+  }
+}
+
+export class ClerkBearerTokenVerificationError extends Schema.TaggedErrorClass<ClerkBearerTokenVerificationError>()(
+  "ClerkBearerTokenVerificationError",
+  {
+    sessionFailure: ClerkTokenVerificationError,
+    cause: ClerkTokenVerificationError,
+  },
+) {
+  override get message(): string {
+    return `Clerk bearer token verification failed after session stage '${this.sessionFailure.stage}' (${this.sessionFailure.reason}) and OAuth stage '${this.cause.stage}' (${this.cause.reason}).`;
   }
 }
 
@@ -1008,7 +1032,7 @@ function resolveConnectClientKeyThumbprint(payload: RelayEnvironmentConnectReque
 }
 
 function safeAuthFailureReason(value: string): string {
-  return /^[a-z0-9._-]+$/i.test(value) ? value : "unknown";
+  return value.length <= 64 && /^[a-z0-9._-]+$/i.test(value) ? value : "unknown";
 }
 
 function clerkVerificationFailureReason(cause: unknown): string {
@@ -1041,14 +1065,19 @@ function hasExpectedClerkAudience(audience: unknown, expectedAudience: string): 
 function verifyClerkBearerToken(
   config: RelayConfiguration.RelayConfiguration["Service"],
   token: string,
-) {
+): Effect.Effect<Awaited<ReturnType<typeof verifyToken>>, ClerkTokenVerificationError> {
   return Effect.tryPromise({
     try: () =>
       verifyToken(token, {
         secretKey: Redacted.value(config.clerkSecretKey),
         audience: config.clerkJwtAudience,
       }),
-    catch: (cause) => new ClerkTokenVerificationFailed({ cause }),
+    catch: (cause) =>
+      new ClerkTokenVerificationError({
+        stage: "session-token-verification",
+        reason: clerkVerificationFailureReason(cause),
+        cause,
+      }),
   }).pipe(
     Effect.withSpan("verify_clerk_bearer_token", {
       attributes: { "relay.auth.token_length": token.length },
@@ -1059,44 +1088,104 @@ function verifyClerkBearerToken(
 function verifyClerkOAuthBearerToken(
   config: RelayConfiguration.RelayConfiguration["Service"],
   token: string,
-) {
+): Effect.Effect<{ readonly sub: string }, ClerkTokenVerificationError> {
   return Effect.tryPromise({
-    try: async () => {
+    try: () => {
       const client = createClerkClient({
         secretKey: Redacted.value(config.clerkSecretKey),
         publishableKey: config.clerkPublishableKey,
       });
-      const state = await client.authenticateRequest(
+      return client.authenticateRequest(
         new Request(config.relayIssuer, {
           headers: { authorization: `Bearer ${token}` },
         }),
         { acceptsToken: "oauth_token" },
       );
-      const auth = state.toAuth();
-      if (!state.isAuthenticated || !auth.userId) {
-        throw new Error("Clerk OAuth token is not authenticated.");
-      }
-      return { sub: auth.userId };
     },
-    catch: (cause) => new ClerkTokenVerificationFailed({ cause }),
-  });
+    catch: (cause) =>
+      new ClerkTokenVerificationError({
+        stage: "oauth-request-authentication",
+        reason: clerkVerificationFailureReason(cause),
+        cause,
+      }),
+  }).pipe(
+    Effect.flatMap((state) =>
+      Effect.try({
+        try: () => state.toAuth(),
+        catch: (cause) =>
+          new ClerkTokenVerificationError({
+            stage: "oauth-auth-state-validation",
+            reason: clerkVerificationFailureReason(cause),
+            cause,
+          }),
+      }).pipe(
+        Effect.flatMap((auth) => {
+          if (!state.isAuthenticated) {
+            return Effect.fail(
+              new ClerkTokenVerificationError({
+                stage: "oauth-auth-state-validation",
+                reason: "not_authenticated",
+              }),
+            );
+          }
+          if (!auth.userId) {
+            return Effect.fail(
+              new ClerkTokenVerificationError({
+                stage: "oauth-auth-state-validation",
+                reason: "missing_user_id",
+              }),
+            );
+          }
+          return Effect.succeed({ sub: auth.userId });
+        }),
+      ),
+    ),
+  );
 }
 
 export function verifyRelayClientBearerToken(
   config: RelayConfiguration.RelayConfiguration["Service"],
   token: string,
-) {
+): Effect.Effect<
+  {
+    readonly sub: string;
+    readonly mode: "clerk_session_bearer" | "clerk_oauth_bearer";
+  },
+  ClerkBearerTokenVerificationError
+> {
   return verifyClerkBearerToken(config, token).pipe(
-    Effect.flatMap((verified) =>
-      verified.sub && hasExpectedClerkAudience(verified.aud, config.clerkJwtAudience)
-        ? Effect.succeed({ sub: verified.sub, mode: "clerk_session_bearer" as const })
-        : Effect.fail(new ClerkTokenVerificationFailed({ cause: "missing_relay_audience" })),
-    ),
-    Effect.catch(() =>
-      verifyClerkOAuthBearerToken(config, token).pipe(
-        Effect.map((verified) => ({ ...verified, mode: "clerk_oauth_bearer" as const })),
-      ),
-    ),
+    Effect.flatMap((verified) => {
+      if (!verified.sub) {
+        return Effect.fail(
+          new ClerkTokenVerificationError({
+            stage: "session-claims-validation",
+            reason: "missing_subject",
+          }),
+        );
+      }
+      if (!hasExpectedClerkAudience(verified.aud, config.clerkJwtAudience)) {
+        return Effect.fail(
+          new ClerkTokenVerificationError({
+            stage: "session-claims-validation",
+            reason: "audience_mismatch",
+          }),
+        );
+      }
+      return Effect.succeed({ sub: verified.sub, mode: "clerk_session_bearer" as const });
+    }),
+    Effect.catchTags({
+      ClerkTokenVerificationError: (sessionFailure) =>
+        verifyClerkOAuthBearerToken(config, token).pipe(
+          Effect.map((verified) => ({ ...verified, mode: "clerk_oauth_bearer" as const })),
+          Effect.mapError(
+            (cause) =>
+              new ClerkBearerTokenVerificationError({
+                sessionFailure,
+                cause,
+              }),
+          ),
+        ),
+    }),
   );
 }
 

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -1,5 +1,6 @@
 import { createClerkClient, verifyToken } from "@clerk/backend";
 import { sql as drizzleSql } from "drizzle-orm";
+import * as Cause from "effect/Cause";
 import * as Crypto from "effect/Crypto";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
@@ -239,8 +240,8 @@ export const relayEnvironmentAuthLayer = Layer.effect(
         const token = readHttpAuthorizationCredential(credential);
         const principal = yield* credentials.authenticate(token).pipe(
           Effect.catchTags({
-            EnvironmentCredentialAuthenticatePersistenceError: () =>
-              relayInternalErrorResponse("persistence_failed"),
+            EnvironmentCredentialAuthenticatePersistenceError: (error) =>
+              relayInternalErrorResponse("persistence_failed", error),
           }),
         );
         if (principal._tag === "None") {
@@ -353,7 +354,7 @@ export const healthApi = HttpApiBuilder.group(
           yield* db.execute(drizzleSql`SELECT 1`);
           return { ok: true, service: "relay" as const };
         },
-        Effect.catch(() => relayInternalErrorResponse("database_unavailable")),
+        Effect.catch((error) => relayInternalErrorResponse("database_unavailable", error)),
       ),
     );
   }),
@@ -512,7 +513,7 @@ export const clientApi = HttpApiBuilder.group(
           const now = yield* DateTime.now;
           const expiresAt = DateTime.add(now, { minutes: 5 });
           const jti = yield* crypto.randomUUIDv4.pipe(
-            Effect.catch(() => relayInternalErrorResponse("internal_error")),
+            Effect.catch((error) => relayInternalErrorResponse("internal_error", error)),
           );
           const challenge = yield* relayTokens
             .issueLinkChallenge({
@@ -522,7 +523,7 @@ export const clientApi = HttpApiBuilder.group(
               issuedAtEpochSeconds: Math.floor(now.epochMilliseconds / 1_000),
               expiresAtEpochSeconds: Math.floor(expiresAt.epochMilliseconds / 1_000),
             })
-            .pipe(Effect.catch(() => relayInternalErrorResponse("internal_error")));
+            .pipe(Effect.catch((error) => relayInternalErrorResponse("internal_error", error)));
           return { challenge, expiresAt: DateTime.formatIso(expiresAt) };
         }, mapRelayCommonApiErrors("not_authorized")),
       )
@@ -536,7 +537,9 @@ export const clientApi = HttpApiBuilder.group(
               userId,
               environmentId: params.environmentId,
             })
-            .pipe(Effect.catch(() => relayInternalErrorResponse("upstream_unavailable")));
+            .pipe(
+              Effect.catch((error) => relayInternalErrorResponse("upstream_unavailable", error)),
+            );
           const link = yield* links.getForUser({
             userId,
             environmentId: params.environmentId,
@@ -596,7 +599,7 @@ export const tokenApi = HttpApiBuilder.group(
         const now = yield* DateTime.now;
         const expiresAt = DateTime.addDuration(now, RelayTokens.RELAY_DPOP_ACCESS_TOKEN_TTL);
         const jti = yield* crypto.randomUUIDv4.pipe(
-          Effect.catch(() => relayInternalErrorResponse("internal_error")),
+          Effect.catch((error) => relayInternalErrorResponse("internal_error", error)),
         );
         return {
           access_token: yield* relayTokens
@@ -609,7 +612,7 @@ export const tokenApi = HttpApiBuilder.group(
               clientId: args.payload.client_id,
               scopes: requestedScopes,
             })
-            .pipe(Effect.catch(() => relayInternalErrorResponse("internal_error"))),
+            .pipe(Effect.catch((error) => relayInternalErrorResponse("internal_error", error))),
           issued_token_type: RelayAccessTokenType,
           token_type: "DPoP" as const,
           expires_in: Duration.toSeconds(RelayTokens.RELAY_DPOP_ACCESS_TOKEN_TTL),
@@ -901,6 +904,50 @@ const currentTraceId = Effect.currentParentSpan.pipe(
   Effect.orElseSucceed(() => "unavailable"),
 );
 
+function relayApiErrorTag(error: unknown): string {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    typeof error._tag === "string"
+  ) {
+    return error._tag;
+  }
+  if (error instanceof Error && error.name.length > 0) {
+    return error.name;
+  }
+  return typeof error;
+}
+
+function safeRelayApiLogCode(value: unknown): string | undefined {
+  return typeof value === "string" && value.length <= 64 && /^[a-z0-9._-]+$/iu.test(value)
+    ? value
+    : undefined;
+}
+
+function relayApiProjectionResponseFields(error: unknown) {
+  if (typeof error !== "object" || error === null) {
+    return {};
+  }
+  const code = "code" in error ? safeRelayApiLogCode(error.code) : undefined;
+  const reason = "reason" in error ? safeRelayApiLogCode(error.reason) : undefined;
+  return {
+    ...(code === undefined ? {} : { responseCode: code }),
+    ...(reason === undefined ? {} : { responseReason: reason }),
+  };
+}
+
+function logRelayApiProjection(cause: unknown, responseError: unknown, traceId: string) {
+  return Effect.logError("relay API failure projected to wire response", Cause.fail(cause)).pipe(
+    Effect.annotateLogs({
+      traceId,
+      sourceErrorTag: relayApiErrorTag(cause),
+      responseErrorTag: relayApiErrorTag(responseError),
+      ...relayApiProjectionResponseFields(responseError),
+    }),
+  );
+}
+
 const RelayCommonPersistenceError = Schema.Union([
   Devices.DeviceRegistrationPersistenceError,
   Devices.DeviceUnregistrationPersistenceError,
@@ -930,15 +977,16 @@ type MapRelayCommonApiError<E> =
   | (Extract<E, HttpApiError.Unauthorized> extends never ? never : RelayAuthInvalidError)
   | (Extract<E, RelayCommonPersistenceError> extends never ? never : RelayInternalError);
 
-function relayInternalErrorResponse(reason: RelayInternalError["reason"]) {
-  return currentTraceId.pipe(
-    Effect.flatMap((traceId) =>
-      Effect.fail(new RelayInternalError({ code: "internal_error", reason, traceId })),
-    ),
-  );
+function relayInternalErrorResponse(reason: RelayInternalError["reason"], cause: unknown) {
+  return Effect.gen(function* () {
+    const traceId = yield* currentTraceId;
+    const responseError = new RelayInternalError({ code: "internal_error", reason, traceId });
+    yield* logRelayApiProjection(cause, responseError, traceId);
+    return yield* responseError;
+  });
 }
 
-function mapRelayCommonApiErrors(authReason: RelayAuthInvalidReason) {
+export function mapRelayCommonApiErrors(authReason: RelayAuthInvalidReason) {
   const mapError = Effect.fnUntraced(function* <E>(error: E) {
     const traceId = yield* currentTraceId;
     if (isHttpUnauthorized(error)) {
@@ -951,13 +999,13 @@ function mapRelayCommonApiErrors(authReason: RelayAuthInvalidReason) {
       );
     }
     if (isRelayCommonPersistenceError(error)) {
-      return yield* Effect.fail(
-        new RelayInternalError({
-          code: "internal_error",
-          reason: "persistence_failed",
-          traceId,
-        }) as MapRelayCommonApiError<E>,
-      );
+      const responseError = new RelayInternalError({
+        code: "internal_error",
+        reason: "persistence_failed",
+        traceId,
+      });
+      yield* logRelayApiProjection(error, responseError, traceId);
+      return yield* Effect.fail(responseError as MapRelayCommonApiError<E>);
     }
 
     return yield* Effect.fail(error as MapRelayCommonApiError<E>);
@@ -989,7 +1037,19 @@ type CatchTagCases<E, Cases> = {
   ) => Effect.Effect<never, MappedTagError<Cases>>;
 } & (unknown extends E ? {} : { readonly [K in Exclude<keyof Cases, TaggedErrorTag<E>>]: never });
 
-function mapErrorTags<
+const relayApiProjectedFailureLogTags = new Set([
+  "ManagedEndpointProvisioningNotConfigured",
+  "ManagedEndpointProvisioningFailed",
+  "EnvironmentLinkUpsertPersistenceError",
+  "EnvironmentCredentialCreatePersistenceError",
+  "DpopProofReplayPersistenceError",
+  "EnvironmentMintRequestFailed",
+  "EnvironmentMintRequestTimedOut",
+  "EnvironmentMintResponseInvalid",
+  "ApnsDeliveryQueueSendError",
+]);
+
+export function mapErrorTags<
   E,
   Cases extends MapErrorTagCases<E> &
     (unknown extends E ? {} : { readonly [K in Exclude<keyof Cases, TaggedErrorTag<E>>]: never }),
@@ -1000,7 +1060,15 @@ function mapErrorTags<
       (error: never, traceId: string) => MappedTagError<Cases>
     >,
     (makeError) => (error: never) =>
-      currentTraceId.pipe(Effect.flatMap((traceId) => Effect.fail(makeError(error, traceId)))),
+      currentTraceId.pipe(
+        Effect.flatMap((traceId) => {
+          const responseError = makeError(error, traceId);
+          const logProjection = relayApiProjectedFailureLogTags.has(relayApiErrorTag(error))
+            ? logRelayApiProjection(error, responseError, traceId)
+            : Effect.void;
+          return logProjection.pipe(Effect.andThen(Effect.fail(responseError)));
+        }),
+      ),
   ) as CatchTagCases<E, Cases>;
 
   return <A, R>(

--- a/infra/relay/src/http/Api.ts
+++ b/infra/relay/src/http/Api.ts
@@ -586,12 +586,10 @@ export const tokenApi = HttpApiBuilder.group(
           return yield* new HttpApiError.Unauthorized({});
         }
 
-        const verified = yield* verifyClerkBearerToken(config, args.payload.subject_token).pipe(
-          Effect.catch(() => relayAuthInvalidError("invalid_bearer")),
+        const userId = yield* verifyRelayDpopTokenExchangeSubject(
+          config,
+          args.payload.subject_token,
         );
-        if (!verified.sub || !hasExpectedClerkAudience(verified.aud, config.clerkJwtAudience)) {
-          return yield* relayAuthInvalidError("invalid_bearer");
-        }
         const proofKeyThumbprint = yield* requireDpopProof().pipe(
           Effect.provideService(DpopProofs.DpopProofReplay, dpopProofs),
         );
@@ -603,7 +601,7 @@ export const tokenApi = HttpApiBuilder.group(
         return {
           access_token: yield* relayTokens
             .issueDpopAccessToken({
-              userId: verified.sub,
+              userId,
               proofKeyThumbprint,
               jti,
               issuedAtEpochSeconds: Math.floor(now.epochMilliseconds / 1_000),
@@ -1061,6 +1059,26 @@ function hasExpectedClerkAudience(audience: unknown, expectedAudience: string): 
     : Array.isArray(audience) &&
         audience.some((entry) => typeof entry === "string" && entry === expectedAudience);
 }
+
+export const verifyRelayDpopTokenExchangeSubject = Effect.fn(
+  "relay.auth.dpop_token_exchange_subject",
+)(function* (config: RelayConfiguration.RelayConfiguration["Service"], token: string) {
+  const verified = yield* verifyClerkBearerToken(config, token).pipe(
+    Effect.tapErrorTag("ClerkTokenVerificationError", (error) =>
+      Effect.annotateCurrentSpan({
+        "relay.auth.clerk_verification_failure": error.reason,
+        "relay.auth.clerk_verification_stage": error.stage,
+      }),
+    ),
+    Effect.catchTags({
+      ClerkTokenVerificationError: () => relayAuthInvalidError("invalid_bearer"),
+    }),
+  );
+  if (!verified.sub || !hasExpectedClerkAudience(verified.aud, config.clerkJwtAudience)) {
+    return yield* relayAuthInvalidError("invalid_bearer");
+  }
+  return verified.sub;
+});
 
 function verifyClerkBearerToken(
   config: RelayConfiguration.RelayConfiguration["Service"],


### PR DESCRIPTION
## Summary
- model Clerk verification failures with structured stages and bounded diagnostic reasons
- preserve the session failure when OAuth fallback also fails, with OAuth as the immediate cause
- replace the unauthenticated OAuth plain exception with a semantic structured failure
- annotate relay auth spans with safe session and OAuth diagnostics

## Root cause
The previous fallback collapsed every Clerk failure into one opaque cause. When OAuth fallback also failed, the original session-verification context was discarded, and expected unauthenticated OAuth state was represented by a manufactured `Error`.

## Validation
- `vp test infra/relay/src/http/Api.test.ts` (8 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and error-mapping paths; client bearer now only catches tagged Clerk aggregate failures instead of all errors, which can change failure propagation for unexpected defects.
> 
> **Overview**
> Relay HTTP auth and error handling now use **structured Clerk verification failures** instead of a single opaque defect. Session JWT and OAuth fallback each record **stage** and bounded **reason**; when both paths fail, **`ClerkBearerTokenVerificationError`** keeps the session failure alongside the OAuth failure (expected unauthenticated OAuth is **`not_authenticated`**, not a synthetic `Error`).
> 
> **Client bearer** spans get separate session/OAuth diagnostics and only **`ClerkBearerTokenVerificationError`** maps to **`invalid_bearer`** (replacing a broad catch-all). **DPoP token exchange** uses **`verifyRelayDpopTokenExchangeSubject`** for subject/audience checks and safe span attributes (no tokens or raw error text).
> 
> **API error projection** logs internal/upstream/persistence mappings with **traceId**, source/response tags, and sanitized codes via **`relayInternalErrorResponse`**, **`mapRelayCommonApiErrors`**, and selective **`mapErrorTags`** logging; wire **`RelayInternalError`** responses still omit internal **cause** details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 986fe93d5b0201e652ead5b60c5d8328670a058f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure Clerk verification failures in the relay with typed errors and projection logging
> - Introduces `ClerkTokenVerificationError` and `ClerkBearerTokenVerificationError` to carry structured stage/reason metadata for session and OAuth token verification failures, replacing generic errors.
> - Reworks `verifyClerkBearerToken`, `verifyClerkOAuthBearerToken`, and `verifyRelayClientBearerToken` to return precise failure stages (e.g. `session-claims-validation`, `oauth-request-authentication`) and annotate tracing spans with safe failure metadata.
> - Adds `logRelayApiProjection` and related helpers to emit a single structured log entry (`relay API failure projected to wire response`) with traceId, source/response error tags, and reason whenever an error is mapped to a wire response.
> - Propagates concrete errors into `relayInternalErrorResponse` and `mapRelayCommonApiErrors` across handlers (health, DPoP exchange, environment link, unlink) so projection logs are emitted with trace context.
> - Extracts DPoP subject verification into `verifyRelayDpopTokenExchangeSubject` with centralized stage-aware error handling and span annotations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 986fe93.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->