### PR TITLE
[codex] Preserve desktop backend output read failures

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -389,6 +389,46 @@ describe("DesktopBackendManager", () => {
     }),
   );
 
+  it.effect("reports output stream failures with process and stream context", () =>
+    Effect.gen(function* () {
+      const outputCause = PlatformError.systemError({
+        _tag: "BadResource",
+        module: "ChildProcess",
+        method: "stdout",
+        description: "output-stream-secret-sentinel",
+      });
+      const reported = yield* Deferred.make<DesktopBackendManager.BackendProcessOutputReadError>();
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.succeed(
+            makeProcess({
+              stdout: Stream.fail(outputCause),
+              exitCode: Deferred.await(reported).pipe(Effect.as(ChildProcessSpawner.ExitCode(0))),
+            }),
+          ),
+        ),
+      );
+
+      const exit = yield* DesktopBackendManager.runBackendProcess({
+        ...baseConfig,
+        onOutputFailure: (error) => Deferred.succeed(reported, error).pipe(Effect.asVoid),
+      }).pipe(Effect.scoped, Effect.provide(Layer.merge(spawnerLayer, healthyHttpClientLayer)));
+      const error = yield* Deferred.await(reported);
+
+      assert.equal(exit.code.pipe(Option.getOrUndefined), 0);
+      assert.equal(error.executablePath, "/electron");
+      assert.equal(error.entryPath, "/server/bin.mjs");
+      assert.equal(error.cwd, "/server");
+      assert.equal(error.httpBaseUrl.href, "http://127.0.0.1:3773/");
+      assert.equal(error.pid, 123);
+      assert.equal(error.streamName, "stdout");
+      assert.strictEqual(error.cause, outputCause);
+      assert.equal(error.message, "Failed to read stdout from desktop backend process 123.");
+      assert.notInclude(error.message, "output-stream-secret-sentinel");
+    }),
+  );
+
   it.effect("retries HTTP readiness before reporting the backend ready", () =>
     Effect.gen(function* () {
       const requestUrls: Array<string> = [];

--- a/apps/desktop/src/backend/DesktopBackendManager.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.test.ts
@@ -59,8 +59,8 @@ const configWithObservability: DesktopBackendBootstrapValue = {
 };
 
 function makeProcess(options?: {
-  readonly stdout?: Stream.Stream<Uint8Array>;
-  readonly stderr?: Stream.Stream<Uint8Array>;
+  readonly stdout?: Stream.Stream<Uint8Array, PlatformError.PlatformError>;
+  readonly stderr?: Stream.Stream<Uint8Array, PlatformError.PlatformError>;
   readonly exitCode?: Effect.Effect<ChildProcessSpawner.ExitCode, PlatformError.PlatformError>;
   readonly kill?: ChildProcessSpawner.ChildProcessHandle["kill"];
 }): ChildProcessSpawner.ChildProcessHandle {
@@ -397,7 +397,7 @@ describe("DesktopBackendManager", () => {
         method: "stdout",
         description: "output-stream-secret-sentinel",
       });
-      const reported = yield* Deferred.make<DesktopBackendManager.BackendProcessOutputReadError>();
+      const reported = yield* Deferred.make<DesktopBackendManager.BackendProcessOutputError>();
       const spawnerLayer = Layer.succeed(
         ChildProcessSpawner.ChildProcessSpawner,
         ChildProcessSpawner.make(() =>
@@ -417,6 +417,9 @@ describe("DesktopBackendManager", () => {
       const error = yield* Deferred.await(reported);
 
       assert.equal(exit.code.pipe(Option.getOrUndefined), 0);
+      if (error._tag !== "BackendProcessOutputReadError") {
+        return assert.fail(`Expected output read error, received ${error._tag}`);
+      }
       assert.equal(error.executablePath, "/electron");
       assert.equal(error.entryPath, "/server/bin.mjs");
       assert.equal(error.cwd, "/server");
@@ -426,6 +429,50 @@ describe("DesktopBackendManager", () => {
       assert.strictEqual(error.cause, outputCause);
       assert.equal(error.message, "Failed to read stdout from desktop backend process 123.");
       assert.notInclude(error.message, "output-stream-secret-sentinel");
+    }),
+  );
+
+  it.effect("reports output handler failures separately from stream read failures", () =>
+    Effect.gen(function* () {
+      const chunk = new TextEncoder().encode("backend output");
+      const outputCause = new Error("output-handler-secret-sentinel");
+      const reported = yield* Deferred.make<DesktopBackendManager.BackendProcessOutputError>();
+      const spawnerLayer = Layer.succeed(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.succeed(
+            makeProcess({
+              stdout: Stream.make(chunk),
+              exitCode: Deferred.await(reported).pipe(Effect.as(ChildProcessSpawner.ExitCode(0))),
+            }),
+          ),
+        ),
+      );
+
+      const exit = yield* DesktopBackendManager.runBackendProcess({
+        ...baseConfig,
+        onOutput: () => Effect.fail(outputCause),
+        onOutputFailure: (error) => Deferred.succeed(reported, error).pipe(Effect.asVoid),
+      }).pipe(Effect.scoped, Effect.provide(Layer.merge(spawnerLayer, healthyHttpClientLayer)));
+      const error = yield* Deferred.await(reported);
+
+      assert.equal(exit.code.pipe(Option.getOrUndefined), 0);
+      if (error._tag !== "BackendProcessOutputHandlingError") {
+        return assert.fail(`Expected output handling error, received ${error._tag}`);
+      }
+      assert.equal(error.executablePath, "/electron");
+      assert.equal(error.entryPath, "/server/bin.mjs");
+      assert.equal(error.cwd, "/server");
+      assert.equal(error.httpBaseUrl.href, "http://127.0.0.1:3773/");
+      assert.equal(error.pid, 123);
+      assert.equal(error.streamName, "stdout");
+      assert.equal(error.chunkByteLength, chunk.byteLength);
+      assert.strictEqual(error.cause, outputCause);
+      assert.equal(
+        error.message,
+        `Failed to handle ${chunk.byteLength} bytes from stdout of desktop backend process 123.`,
+      );
+      assert.notInclude(error.message, "output-handler-secret-sentinel");
     }),
   );
 

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -119,6 +119,25 @@ export class BackendProcessOutputReadError extends Schema.TaggedErrorClass<Backe
   }
 }
 
+export class BackendProcessOutputHandlingError extends Schema.TaggedErrorClass<BackendProcessOutputHandlingError>()(
+  "BackendProcessOutputHandlingError",
+  {
+    ...backendProcessContextSchema,
+    pid: Schema.Number,
+    streamName: Schema.Literals(["stdout", "stderr"]),
+    chunkByteLength: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to handle ${this.chunkByteLength} bytes from ${this.streamName} of desktop backend process ${this.pid}.`;
+  }
+}
+
+export type BackendProcessOutputError =
+  | BackendProcessOutputReadError
+  | BackendProcessOutputHandlingError;
+
 export class BackendProcessExitStatusError extends Schema.TaggedErrorClass<BackendProcessExitStatusError>()(
   "BackendProcessExitStatusError",
   {
@@ -160,8 +179,8 @@ interface RunBackendProcessOptions extends DesktopBackendStartConfig {
   readonly onOutput?: (
     streamName: BackendProcessOutputStream,
     chunk: Uint8Array,
-  ) => Effect.Effect<void>;
-  readonly onOutputFailure?: (error: BackendProcessOutputReadError) => Effect.Effect<void>;
+  ) => Effect.Effect<void, Error>;
+  readonly onOutputFailure?: (error: BackendProcessOutputError) => Effect.Effect<void>;
 }
 
 export interface DesktopBackendSnapshot {
@@ -272,12 +291,14 @@ function drainBackendOutput(
   context: BackendProcessContext & { readonly pid: number },
   streamName: BackendProcessOutputStream,
   stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>,
-  onOutput: (streamName: BackendProcessOutputStream, chunk: Uint8Array) => Effect.Effect<void>,
-  onOutputFailure: (error: BackendProcessOutputReadError) => Effect.Effect<void>,
+  onOutput: (
+    streamName: BackendProcessOutputStream,
+    chunk: Uint8Array,
+  ) => Effect.Effect<void, Error>,
+  onOutputFailure: (error: BackendProcessOutputError) => Effect.Effect<void>,
 ): Effect.Effect<void> {
   return stream.pipe(
-    Stream.runForEach((chunk) => onOutput(streamName, chunk)),
-    Effect.mapError(
+    Stream.mapError(
       (cause) =>
         new BackendProcessOutputReadError({
           ...context,
@@ -285,8 +306,22 @@ function drainBackendOutput(
           cause,
         }),
     ),
+    Stream.runForEach((chunk) =>
+      onOutput(streamName, chunk).pipe(
+        Effect.mapError(
+          (cause) =>
+            new BackendProcessOutputHandlingError({
+              ...context,
+              streamName,
+              chunkByteLength: chunk.byteLength,
+              cause,
+            }),
+        ),
+      ),
+    ),
     Effect.catchTags({
       BackendProcessOutputReadError: onOutputFailure,
+      BackendProcessOutputHandlingError: onOutputFailure,
     }),
   );
 }

--- a/apps/desktop/src/backend/DesktopBackendManager.ts
+++ b/apps/desktop/src/backend/DesktopBackendManager.ts
@@ -105,6 +105,20 @@ export class BackendProcessSpawnError extends Schema.TaggedErrorClass<BackendPro
   }
 }
 
+export class BackendProcessOutputReadError extends Schema.TaggedErrorClass<BackendProcessOutputReadError>()(
+  "BackendProcessOutputReadError",
+  {
+    ...backendProcessContextSchema,
+    pid: Schema.Number,
+    streamName: Schema.Literals(["stdout", "stderr"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to read ${this.streamName} from desktop backend process ${this.pid}.`;
+  }
+}
+
 export class BackendProcessExitStatusError extends Schema.TaggedErrorClass<BackendProcessExitStatusError>()(
   "BackendProcessExitStatusError",
   {
@@ -147,6 +161,7 @@ interface RunBackendProcessOptions extends DesktopBackendStartConfig {
     streamName: BackendProcessOutputStream,
     chunk: Uint8Array,
   ) => Effect.Effect<void>;
+  readonly onOutputFailure?: (error: BackendProcessOutputReadError) => Effect.Effect<void>;
 }
 
 export interface DesktopBackendSnapshot {
@@ -254,13 +269,25 @@ export const waitForHttpReady = Effect.fn("desktop.backendManager.waitForHttpRea
 });
 
 function drainBackendOutput(
+  context: BackendProcessContext & { readonly pid: number },
   streamName: BackendProcessOutputStream,
   stream: Stream.Stream<Uint8Array, PlatformError.PlatformError>,
   onOutput: (streamName: BackendProcessOutputStream, chunk: Uint8Array) => Effect.Effect<void>,
+  onOutputFailure: (error: BackendProcessOutputReadError) => Effect.Effect<void>,
 ): Effect.Effect<void> {
   return stream.pipe(
     Stream.runForEach((chunk) => onOutput(streamName, chunk)),
-    Effect.ignore,
+    Effect.mapError(
+      (cause) =>
+        new BackendProcessOutputReadError({
+          ...context,
+          streamName,
+          cause,
+        }),
+    ),
+    Effect.catchTags({
+      BackendProcessOutputReadError: onOutputFailure,
+    }),
   );
 }
 
@@ -321,8 +348,28 @@ export const runBackendProcess = Effect.fn("runBackendProcess")(function* (
 
   yield* options.onStarted?.(handle.pid) ?? Effect.void;
   if (options.captureOutput) {
-    yield* drainBackendOutput("stdout", handle.stdout, onOutput).pipe(Effect.forkScoped);
-    yield* drainBackendOutput("stderr", handle.stderr, onOutput).pipe(Effect.forkScoped);
+    const outputContext = {
+      executablePath: options.executablePath,
+      entryPath: options.entryPath,
+      cwd: options.cwd,
+      httpBaseUrl: options.httpBaseUrl,
+      pid: Number(handle.pid),
+    };
+    const onOutputFailure = options.onOutputFailure ?? (() => Effect.void);
+    yield* drainBackendOutput(
+      outputContext,
+      "stdout",
+      handle.stdout,
+      onOutput,
+      onOutputFailure,
+    ).pipe(Effect.forkScoped);
+    yield* drainBackendOutput(
+      outputContext,
+      "stderr",
+      handle.stderr,
+      onOutput,
+      onOutputFailure,
+    ).pipe(Effect.forkScoped);
   }
   yield* waitForHttpReady({
     executablePath: options.executablePath,
@@ -560,6 +607,7 @@ export const make = Effect.gen(function* () {
               error,
             }),
           onOutput: (streamName, chunk) => backendOutputLog.writeOutputChunk(streamName, chunk),
+          onOutputFailure: (error) => logBackendManagerError(error.message, { error }),
         }).pipe(
           Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
           Effect.provideService(HttpClient.HttpClient, httpClient),


### PR DESCRIPTION
Desktop backend stdout and stderr streams were drained with `Effect.ignore`, so a failed pipe or child-process read silently disappeared while the backend lifecycle continued.

This change preserves that fail-open lifecycle behavior while making failures observable. Stream failures are mapped to `BackendProcessOutputReadError`; callback failures are mapped separately to `BackendProcessOutputHandlingError`, including the chunk size. Both schema-backed errors carry executable, entrypoint, working directory, HTTP URL, PID, stream name, and original cause. The manager handles them with `catchTags` and sends the complete structured error to its existing diagnostic logger.

Behavioral tests drive both a failing output stream and a failing output callback. They verify that the process can still exit normally, each failure keeps its distinct tag and structured context, the original cause remains attached, and public messages are derived only from structural attributes.

Validation:
- `vp test apps/desktop/src/backend/DesktopBackendManager.test.ts` (12 passed)
- `vp check` (passes with 20 existing warnings)
- `vp run typecheck` (passes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes failure handling on the desktop backend child-process output path; behavior stays fail-open for lifecycle but alters observability and error typing in core desktop infrastructure.
> 
> **Overview**
> Desktop backend **stdout/stderr** draining no longer swallows failures via `Effect.ignore`. **`drainBackendOutput`** now maps pipe/read failures to **`BackendProcessOutputReadError`** and **`onOutput`** callback failures to **`BackendProcessOutputHandlingError`**, each carrying process context (paths, HTTP URL, PID, stream name, and for handlers chunk byte length). A new optional **`onOutputFailure`** hook receives these errors; the manager wires it to **`logBackendManagerError`** while the scoped drain fibers still run in the background so the backend lifecycle can continue.
> 
> Tests cover a failing output stream and a failing output handler, asserting distinct error tags, stable public messages (no cause leakage), and that the process can still exit normally.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d0f2cf755347885c8fa36ff976e0b20c4c8e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve and report desktop backend output read and handling failures with structured errors
> - Adds `BackendProcessOutputReadError` and `BackendProcessOutputHandlingError` tagged error classes to [`DesktopBackendManager.ts`](https://github.com/pingdotgg/t3code/pull/3444/files#diff-45848e60bcec64dd7239fc34379d23407c47d0ade3f351e89a4efc7f6b42757f), carrying process context (pid, stream name, cwd, URLs) for each failure type.
> - Refactors `drainBackendOutput` to map stream read errors and `onOutput` handler errors into these structured types, forwarding them to a new `onOutputFailure` callback instead of silently dropping them.
> - The `make` factory wires `onOutputFailure` to log errors via `logBackendManagerError`; callers can now supply their own handler.
> - Adds two new tests covering stream read failures and handler failures, asserting correct error shape and that secrets are not leaked in messages.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3d0f2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->