### PR TITLE
[codex] Structure pull request link failures

### DIFF
--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -88,6 +88,7 @@ import { resolvePathLinkTarget } from "~/terminal-links";
 import { type DraftId, useComposerDraftStore } from "~/composerDraftStore";
 import { readLocalApi } from "~/localApi";
 import { getSourceControlPresentation } from "~/sourceControlPresentation";
+import { openPullRequestLink } from "~/lib/openPullRequestLink";
 
 interface GitActionsControlProps {
   gitCwd: string | null;
@@ -1229,7 +1230,8 @@ export default function GitActionsControl({
       });
       return;
     }
-    void api.shell.openExternal(prUrl).catch((err: unknown) => {
+    void openPullRequestLink(api.shell, prUrl).catch((err: unknown) => {
+      console.error(err);
       toastManager.add(
         stackedThreadToast({
           type: "error",

--- a/apps/web/src/lib/openPullRequestLink.test.ts
+++ b/apps/web/src/lib/openPullRequestLink.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { openPullRequestLink, PullRequestLinkOpenError } from "./openPullRequestLink";
+
+describe("openPullRequestLink", () => {
+  it("opens the requested pull request URL", async () => {
+    const openExternal = vi.fn(async () => undefined);
+    const targetUrl = "https://github.com/pingdotgg/t3code/pull/123";
+
+    await openPullRequestLink({ openExternal }, targetUrl);
+
+    expect(openExternal).toHaveBeenCalledExactlyOnceWith(targetUrl);
+  });
+
+  it("reports bridge failures with a safe target origin", async () => {
+    const cause = new Error("desktop shell unavailable");
+    const targetUrl = "https://github.com/pingdotgg/t3code/pull/123?token=secret";
+    const openExternal = vi.fn(async () => Promise.reject(cause));
+
+    const result = openPullRequestLink({ openExternal }, targetUrl);
+
+    await expect(result).rejects.toEqual(
+      new PullRequestLinkOpenError({
+        targetOrigin: "https://github.com",
+        cause,
+      }),
+    );
+    await expect(result).rejects.not.toHaveProperty("message", expect.stringContaining("secret"));
+  });
+});

--- a/apps/web/src/lib/openPullRequestLink.ts
+++ b/apps/web/src/lib/openPullRequestLink.ts
@@ -1,7 +1,44 @@
+import type { LocalApi } from "@t3tools/contracts";
+import * as Schema from "effect/Schema";
 import { type MouseEvent, useCallback } from "react";
 
 import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { readLocalApi } from "../localApi";
+
+export class PullRequestLinkOpenError extends Schema.TaggedErrorClass<PullRequestLinkOpenError>()(
+  "PullRequestLinkOpenError",
+  {
+    targetOrigin: Schema.NullOr(Schema.String),
+    cause: Schema.Defect(),
+  },
+) {
+  static fromCause(targetUrl: string, cause: unknown): PullRequestLinkOpenError {
+    let targetOrigin: string | null = null;
+    try {
+      targetOrigin = new URL(targetUrl).origin;
+    } catch {
+      // Keep malformed URLs out of diagnostics while preserving the open failure below.
+    }
+    return new PullRequestLinkOpenError({ targetOrigin, cause });
+  }
+
+  override get message(): string {
+    return this.targetOrigin === null
+      ? "Unable to open pull request link."
+      : `Unable to open pull request link at ${this.targetOrigin}.`;
+  }
+}
+
+export async function openPullRequestLink(
+  shell: Pick<LocalApi["shell"], "openExternal">,
+  targetUrl: string,
+): Promise<void> {
+  try {
+    await shell.openExternal(targetUrl);
+  } catch (cause) {
+    throw PullRequestLinkOpenError.fromCause(targetUrl, cause);
+  }
+}
 
 /**
  * Returns a click handler that opens a pull request URL in the system browser.
@@ -24,7 +61,8 @@ export function useOpenPrLink() {
       return;
     }
 
-    void api.shell.openExternal(prUrl).catch((error) => {
+    void openPullRequestLink(api.shell, prUrl).catch((error) => {
+      console.error(error);
       toastManager.add(
         stackedThreadToast({
           type: "error",


### PR DESCRIPTION
## Summary
- translate pull-request link bridge rejections into a structured error at the external-open boundary
- retain the original cause while correlating diagnostics with only the safe target origin
- use the shared operation from both pull-request link entry points and log the structured failure before showing the existing toast

## Root cause
The two pull-request link entry points called the bridge independently and reduced rejected operations to toast text. That discarded the cause chain and provided no safe URL correlation for diagnostics.

## Validation
- `vp test apps/web/src/lib/openPullRequestLink.test.ts` (2 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX/diagnostics refactor around external link opening; no auth or data-path changes, with tests for error redaction.
> 
> **Overview**
> Pull request links no longer call `shell.openExternal` directly at each UI entry point. A shared **`openPullRequestLink`** helper wraps the bridge call and turns rejections into a **`PullRequestLinkOpenError`** that keeps the original **cause** while exposing only a **safe `targetOrigin`** (no full URL or query secrets) in user-facing messages.
> 
> **`useOpenPrLink`** and **`GitActionsControl`**’s open-existing-PR path now use that helper; failures are **`console.error`**’d before the existing error toasts. Unit tests cover successful opens and failure shaping (including URLs with sensitive query params).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d120aa72990c0886f104c65c218fee04112572a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure pull request link open failures into `PullRequestLinkOpenError`
> - Introduces [`openPullRequestLink.ts`](https://github.com/pingdotgg/t3code/pull/3445/files#diff-953140e01f1329a36fe8f5606c9027215b588e76537644ab9819a9a618d000ae) with a `PullRequestLinkOpenError` tagged error class that wraps raw shell failures, exposing only the URL origin (not full URL with query params) in its message.
> - Adds `openPullRequestLink(shell, url)` utility that throws `PullRequestLinkOpenError` on failure, used by both `GitActionsControl` and `useOpenPrLink`.
> - Failures are now logged to the console via `console.error` before surfacing a toast, and the toast message reflects the sanitized error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d120aa7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->