### PR TITLE
[codex] Structure mobile waitlist enrollment failures

### DIFF
--- a/apps/mobile/src/features/cloud/CloudWaitlistEnrollment.tsx
+++ b/apps/mobile/src/features/cloud/CloudWaitlistEnrollment.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThemeColor } from "../../lib/useThemeColor";
+import { CloudWaitlistJoinRejectedError, joinCloudWaitlist } from "./cloudWaitlistJoin";
 
 export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }) {
   const { errors, fetchStatus, waitlist } = useWaitlist();
@@ -21,12 +22,14 @@ export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }
 
     setRequestError(null);
     try {
-      const { error } = await waitlist.join({ emailAddress: normalizedEmailAddress });
-      if (error) {
-        setRequestError("Could not join the waitlist. Check your email address and try again.");
-      }
-    } catch {
-      setRequestError("Could not join the waitlist. Check your connection and try again.");
+      await joinCloudWaitlist(waitlist, normalizedEmailAddress);
+    } catch (error) {
+      console.error(error);
+      setRequestError(
+        error instanceof CloudWaitlistJoinRejectedError
+          ? "Could not join the waitlist. Check your email address and try again."
+          : "Could not join the waitlist. Check your connection and try again.",
+      );
     }
   };
 

--- a/apps/mobile/src/features/cloud/cloudWaitlistJoin.test.ts
+++ b/apps/mobile/src/features/cloud/cloudWaitlistJoin.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import {
+  CloudWaitlistJoinRejectedError,
+  CloudWaitlistJoinRequestError,
+  joinCloudWaitlist,
+} from "./cloudWaitlistJoin";
+
+describe("joinCloudWaitlist", () => {
+  it("submits the provided email address", async () => {
+    const join = vi.fn().mockResolvedValue({ error: null });
+
+    await joinCloudWaitlist({ join }, "person@example.com");
+
+    expect(join).toHaveBeenCalledExactlyOnceWith({ emailAddress: "person@example.com" });
+  });
+
+  it("preserves Clerk rejection details without exposing the email address", async () => {
+    const cause = Object.assign(new Error("The enrollment was rejected."), {
+      code: "form_identifier_invalid",
+    });
+    const join = vi.fn().mockResolvedValue({ error: cause });
+
+    const failure = await joinCloudWaitlist({ join }, "secret@example.com").catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(CloudWaitlistJoinRejectedError);
+    expect(failure).toMatchObject({
+      code: "form_identifier_invalid",
+      cause,
+    });
+    expect(String(failure)).not.toContain("secret@example.com");
+  });
+
+  it("distinguishes request failures from rejected enrollments", async () => {
+    const cause = new Error("network unavailable");
+    const join = vi.fn().mockRejectedValue(cause);
+
+    const failure = await joinCloudWaitlist({ join }, "person@example.com").catch(
+      (error: unknown) => error,
+    );
+
+    expect(failure).toBeInstanceOf(CloudWaitlistJoinRequestError);
+    expect(failure).toMatchObject({ cause });
+    expect(failure).not.toBeInstanceOf(CloudWaitlistJoinRejectedError);
+  });
+});

--- a/apps/mobile/src/features/cloud/cloudWaitlistJoin.ts
+++ b/apps/mobile/src/features/cloud/cloudWaitlistJoin.ts
@@ -1,0 +1,46 @@
+import * as Schema from "effect/Schema";
+
+interface CloudWaitlistJoiner {
+  readonly join: (input: { emailAddress: string }) => Promise<{
+    readonly error: { readonly code: string } | null;
+  }>;
+}
+
+export class CloudWaitlistJoinRejectedError extends Schema.TaggedErrorClass<CloudWaitlistJoinRejectedError>()(
+  "CloudWaitlistJoinRejectedError",
+  {
+    code: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Cloud waitlist enrollment was rejected with code "${this.code}".`;
+  }
+}
+
+export class CloudWaitlistJoinRequestError extends Schema.TaggedErrorClass<CloudWaitlistJoinRequestError>()(
+  "CloudWaitlistJoinRequestError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Cloud waitlist enrollment request failed.";
+  }
+}
+
+export async function joinCloudWaitlist(
+  waitlist: CloudWaitlistJoiner,
+  emailAddress: string,
+): Promise<void> {
+  const result = await waitlist.join({ emailAddress }).catch((cause) => {
+    throw new CloudWaitlistJoinRequestError({ cause });
+  });
+
+  if (result.error) {
+    throw new CloudWaitlistJoinRejectedError({
+      code: result.error.code,
+      cause: result.error,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- distinguish Clerk enrollment rejections from request/transport failures
- retain the original failure cause and Clerk's stable error code without putting the submitted email in diagnostics
- keep the existing user-facing guidance while emitting the structured failure

## Why

Waitlist enrollment previously discarded both returned Clerk errors and thrown request causes. That made validation failures indistinguishable from connectivity failures in diagnostics and broke the underlying error chain.

## Validation

- `vp test run apps/mobile/src/features/cloud/cloudWaitlistJoin.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized refactor of waitlist enrollment error handling with unit tests; no auth or data-model changes beyond clearer logging and error typing.
> 
> **Overview**
> Waitlist join logic moves out of **`CloudWaitlistEnrollment`** into **`joinCloudWaitlist`**, which maps Clerk outcomes to two tagged errors: **`CloudWaitlistJoinRejectedError`** (returned `error` with stable `code` and preserved cause) and **`CloudWaitlistJoinRequestError`** (thrown transport failures).
> 
> The screen still shows the same two user-facing messages but picks them via `instanceof` on the rejection type, and **`console.error`** logs the structured failure for diagnostics. Error messages intentionally omit the submitted email while retaining Clerk codes and the original cause chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a10a6b1e6014478bb19b8248a0b072c219f79a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure cloud waitlist enrollment failures into typed error classes
> - Introduces `CloudWaitlistJoinRejectedError` and `CloudWaitlistJoinRequestError` in [`cloudWaitlistJoin.ts`](https://github.com/pingdotgg/t3code/pull/3446/files#diff-3bc9ebd568c98530eef8658f1166bfc450bf39a8ca85ea0c54672e8eb6d15ef9) to distinguish Clerk-level rejections from network/request failures.
> - Adds `joinCloudWaitlist`, a utility that wraps `waitlist.join`, throwing the appropriate typed error on failure.
> - Updates [`CloudWaitlistEnrollment.tsx`](https://github.com/pingdotgg/t3code/pull/3446/files#diff-1ffcd7a218eacc2b6fd6af4c160c2e119b396e6215675d0bc6b6fd4e04230dfc) to use `joinCloudWaitlist` with differentiated user-facing error messages per error type.
> - Adds unit tests covering email submission, Clerk rejection detail preservation, and error class differentiation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a10a6b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->