### PR TITLE
[codex] Preserve Linux icon resize fallback failures

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -4,6 +4,9 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
   BuildScriptError,
@@ -14,6 +17,7 @@ import {
   InvalidMacPasskeyRpDomainError,
   InvalidMacPasskeyPublishableKeyError,
   isMacPasskeySigningConfigurationError,
+  LinuxIconResizeError,
   MissingMacPasskeyProvisioningProfileError,
   renderMacPasskeyEntitlements,
   resolveClerkPasskeyNativeArtifacts,
@@ -27,10 +31,48 @@ import {
   resolveGitHubPublishConfig,
   resolveMockUpdateServerPort,
   resolveMockUpdateServerUrl,
+  stageLinuxIconSize,
   STAGE_INSTALL_ARGS,
 } from "./build-desktop-artifact.ts";
 import { BRAND_ASSET_PATHS } from "./lib/brand-assets.ts";
 import { HostProcessArchitecture, HostProcessPlatform } from "@t3tools/shared/hostProcess";
+
+function mockProcess(exitCode: number) {
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exitCode)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.drain,
+    stdout: Stream.empty,
+    stderr: Stream.empty,
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
+}
+
+function iconResizeSpawnerLayer(
+  commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }>,
+  exitCodes: ReadonlyArray<number>,
+) {
+  let commandIndex = 0;
+  return Layer.succeed(
+    ChildProcessSpawner.ChildProcessSpawner,
+    ChildProcessSpawner.make((command) => {
+      const childProcess = command as unknown as {
+        readonly command: string;
+        readonly args: ReadonlyArray<string>;
+      };
+      commands.push({
+        command: childProcess.command,
+        args: childProcess.args,
+      });
+      return Effect.succeed(mockProcess(exitCodes[commandIndex++] ?? 0));
+    }),
+  );
+}
 
 it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
   it("resolves the dedicated nightly updater channel from nightly versions", () => {
@@ -182,6 +224,40 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
 
   it("unpacks the fff shared library for filesystem and FFI access", () => {
     assert.deepStrictEqual(DESKTOP_ASAR_UNPACK, ["node_modules/@ff-labs/fff-bin-*/**/*"]);
+  });
+
+  it.effect("preserves both Linux icon resize failures with structural context", () => {
+    const commands: Array<{ readonly command: string; readonly args: ReadonlyArray<string> }> = [];
+
+    return Effect.gen(function* () {
+      const error = yield* stageLinuxIconSize("source.png", "target.png", 512, false).pipe(
+        Effect.provide(iconResizeSpawnerLayer(commands, [1, 2])),
+        Effect.flip,
+      );
+
+      assert.instanceOf(error, LinuxIconResizeError);
+      assert.equal(error.operation, "resize");
+      assert.equal(error.iconSize, 512);
+      assert.equal(error.primaryTool, "magick");
+      assert.equal(error.fallbackTool, "convert");
+      assert.include(error.message, "512x512");
+      assert.include(error.message, "`magick`");
+      assert.include(error.message, "`convert`");
+      assert.notInclude(error.message, "non-zero exit code");
+
+      assert.instanceOf(error.cause, AggregateError);
+      const aggregateCause = error.cause as AggregateError;
+      assert.lengthOf(aggregateCause.errors, 2);
+      assert.strictEqual(aggregateCause.cause, aggregateCause.errors[0]);
+      assert.instanceOf(aggregateCause.errors[0], BuildScriptError);
+      assert.instanceOf(aggregateCause.errors[1], BuildScriptError);
+      assert.include((aggregateCause.errors[0] as BuildScriptError).message, "magick linux icon");
+      assert.include((aggregateCause.errors[1] as BuildScriptError).message, "convert linux icon");
+      assert.deepStrictEqual(
+        commands.map(({ command }) => command),
+        ["magick", "convert"],
+      );
+    });
   });
 
   it("derives macOS passkey signing configuration from the Clerk publishable key", () => {

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -142,6 +142,21 @@ export class BuildScriptError extends Data.TaggedError("BuildScriptError")<{
   }
 }
 
+export class LinuxIconResizeError extends Schema.TaggedErrorClass<LinuxIconResizeError>()(
+  "LinuxIconResizeError",
+  {
+    operation: Schema.Literal("resize"),
+    iconSize: Schema.Int,
+    primaryTool: Schema.Literal("magick"),
+    fallbackTool: Schema.Literal("convert"),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to ${this.operation} the Linux desktop icon to ${this.iconSize}x${this.iconSize} with \`${this.primaryTool}\` or \`${this.fallbackTool}\`. Install ImageMagick so either tool is available.`;
+  }
+}
+
 const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
   stream.pipe(
     Stream.decodeText(),
@@ -877,7 +892,7 @@ function stageLinuxIcons(stageResourcesDir: string, sourcePng: string, verbose: 
   });
 }
 
-function stageLinuxIconSize(
+export function stageLinuxIconSize(
   sourcePng: string,
   targetPng: string,
   iconSize: number,
@@ -890,13 +905,20 @@ function stageLinuxIconSize(
     );
 
   return resize("magick").pipe(
-    Effect.catch(() =>
+    Effect.catch((primaryCause) =>
       resize("convert").pipe(
         Effect.mapError(
-          () =>
-            new BuildScriptError({
-              message:
-                "ImageMagick is required to generate Linux desktop icon sizes. Install ImageMagick so either `magick` or `convert` is available.",
+          (fallbackCause) =>
+            new LinuxIconResizeError({
+              operation: "resize",
+              iconSize,
+              primaryTool: "magick",
+              fallbackTool: "convert",
+              cause: new AggregateError(
+                [primaryCause, fallbackCause],
+                "Both Linux icon resize tool attempts failed.",
+                { cause: primaryCause },
+              ),
             }),
         ),
       ),


### PR DESCRIPTION
## Summary
- add a structured Linux icon resize error with size and tool context
- preserve both the primary `magick` failure and fallback `convert` failure in the cause chain
- cover the dual-failure behavior without expanding the refactor test surface

## Tests
- `vp test run scripts/build-desktop-artifact.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to desktop build-script error reporting and tests; success paths are unchanged, but any handler expecting `BuildScriptError` on dual ImageMagick failure must be updated.
> 
> **Overview**
> When **both** `magick` and `convert` fail during Linux desktop icon resizing, the build script now fails with a structured **`LinuxIconResizeError`** instead of a generic **`BuildScriptError`**. The error carries icon size and tool names, and its **`cause`** is an **`AggregateError`** that keeps the primary and fallback command failures (with the primary failure as the aggregate’s linked cause).
> 
> **`stageLinuxIconSize`** is exported for direct testing. Tests mock **`ChildProcessSpawner`** to assert dual-failure shape, command order, and that the top-level message points at ImageMagick rather than a bare exit-code string.
> 
> **Behavioral note:** code that only catches **`BuildScriptError`** on this path will no longer see dual-tool failures; handle **`LinuxIconResizeError`** (or inspect **`cause`**) instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1213394b20b924c947321427dcebecfe88aae0cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve both Linux icon resize failures in structured `LinuxIconResizeError`
> - Introduces `LinuxIconResizeError`, a tagged error class with fields for `operation`, `iconSize`, `primaryTool` (`magick`), and `fallbackTool` (`convert`), replacing a generic `BuildScriptError` with a static message.
> - Updates `stageLinuxIconSize` in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/3447/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d) to catch the primary `magick` failure, retry with `convert`, and on second failure wrap both causes in an `AggregateError` embedded in `LinuxIconResizeError`.
> - Exports `stageLinuxIconSize` and `LinuxIconResizeError` for use in tests and external callers.
> - Adds a test in [build-desktop-artifact.test.ts](https://github.com/pingdotgg/t3code/pull/3447/files#diff-a199d37af35c35dd3b48cf71436cb06b23acccd6857a9fe74db6d48cb73c7663) that mocks the spawner with exit codes `[1, 2]` and asserts the full error structure, including both tool failures in the `AggregateError` cause.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1213394.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->