### PR TITLE
[codex] Model asset access failures with distinct errors

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -88,7 +88,7 @@ describe("AssetAccess", () => {
       }).pipe(Effect.flip);
       expect(error.message).toBe("Workspace file path must be relative to the project root.");
       expect(error).toMatchObject({
-        operation: "validate-workspace-path",
+        _tag: "AssetWorkspacePathValidationError",
         resource: {
           _tag: "workspace-file",
           threadId: "thread-1",
@@ -130,7 +130,7 @@ describe("AssetAccess", () => {
 
       expect(error.message).toBe("Failed to inspect the workspace asset.");
       expect(error).toMatchObject({
-        operation: "inspect-workspace-asset",
+        _tag: "AssetWorkspaceAssetInspectionError",
         resource: {
           _tag: "workspace-file",
           threadId: "thread-1",
@@ -268,6 +268,7 @@ describe("AssetAccess", () => {
       );
 
       expect(error.message).toBe("Failed to resolve project favicon.");
+      expect(error._tag).toBe("AssetProjectFaviconResolutionError");
       expect(error.cause).toBe(resolutionCause);
     }).pipe(Effect.provide(testLayer)),
   );

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -1,5 +1,18 @@
 import type { AssetResource } from "@t3tools/contracts";
-import { AssetAccessError } from "@t3tools/contracts";
+import {
+  AssetAttachmentNotFoundError,
+  AssetPreviewTypeValidationError,
+  AssetProjectFaviconInspectionError,
+  AssetProjectFaviconNotFoundError,
+  AssetProjectFaviconResolutionError,
+  AssetSigningKeyLoadError,
+  AssetWorkspaceAssetInspectionError,
+  AssetWorkspaceAssetNotFoundError,
+  AssetWorkspaceContextNotFoundError,
+  AssetWorkspacePathValidationError,
+  AssetWorkspaceResolutionError,
+  AssetWorkspaceRootNormalizationError,
+} from "@t3tools/contracts";
 import {
   isWorkspaceImagePreviewPath,
   isWorkspacePreviewEntryPath,
@@ -165,19 +178,15 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
   switch (input.resource._tag) {
     case "workspace-file": {
       if (!input.workspaceRoot) {
-        return yield* new AssetAccessError({
-          operation: "resolve-workspace-context",
+        return yield* new AssetWorkspaceContextNotFoundError({
           resource: input.resource,
-          message: "Workspace context was not found.",
         });
       }
       const workspaceRoot = yield* workspacePaths.normalizeWorkspaceRoot(input.workspaceRoot).pipe(
         Effect.mapError(
           (cause) =>
-            new AssetAccessError({
-              operation: "normalize-workspace-root",
+            new AssetWorkspaceRootNormalizationError({
               resource: input.resource,
-              message: "Failed to normalize the workspace root.",
               cause,
             }),
         ),
@@ -190,19 +199,15 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         .pipe(
           Effect.mapError(
             (cause) =>
-              new AssetAccessError({
-                operation: "validate-workspace-path",
+              new AssetWorkspacePathValidationError({
                 resource: input.resource,
-                message: "Workspace file path must be relative to the project root.",
                 cause,
               }),
           ),
         );
       if (!isWorkspacePreviewEntryPath(resolved.relativePath)) {
-        return yield* new AssetAccessError({
-          operation: "validate-preview-type",
+        return yield* new AssetPreviewTypeValidationError({
           resource: input.resource,
-          message: "Only browser documents and images can be previewed.",
         });
       }
       const canonicalFile = yield* resolveCanonicalWorkspaceFile({
@@ -211,28 +216,22 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       }).pipe(
         Effect.mapError(
           (cause) =>
-            new AssetAccessError({
-              operation: "inspect-workspace-asset",
+            new AssetWorkspaceAssetInspectionError({
               resource: input.resource,
-              message: "Failed to inspect the workspace asset.",
               cause,
             }),
         ),
       );
       if (!canonicalFile) {
-        return yield* new AssetAccessError({
-          operation: "locate-workspace-asset",
+        return yield* new AssetWorkspaceAssetNotFoundError({
           resource: input.resource,
-          message: "Workspace asset was not found.",
         });
       }
       const canonicalWorkspaceRoot = yield* fileSystem.realPath(workspaceRoot).pipe(
         Effect.mapError(
           (cause) =>
-            new AssetAccessError({
-              operation: "resolve-workspace",
+            new AssetWorkspaceResolutionError({
               resource: input.resource,
-              message: "Failed to resolve workspace.",
               cause,
             }),
         ),
@@ -262,10 +261,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         attachmentId: input.resource.attachmentId,
       });
       if (!attachmentPath) {
-        return yield* new AssetAccessError({
-          operation: "locate-attachment",
+        return yield* new AssetAttachmentNotFoundError({
           resource: input.resource,
-          message: "Attachment was not found.",
         });
       }
       claims = {
@@ -281,10 +278,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       const workspaceRoot = yield* workspacePaths.normalizeWorkspaceRoot(input.resource.cwd).pipe(
         Effect.mapError(
           (cause) =>
-            new AssetAccessError({
-              operation: "normalize-workspace-root",
+            new AssetWorkspaceRootNormalizationError({
               resource: input.resource,
-              message: "Failed to normalize the workspace root.",
               cause,
             }),
         ),
@@ -293,10 +288,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
       const faviconPath = yield* faviconResolver.resolvePath(workspaceRoot).pipe(
         Effect.mapError(
           (cause) =>
-            new AssetAccessError({
-              operation: "resolve-project-favicon",
+            new AssetProjectFaviconResolutionError({
               resource: input.resource,
-              message: "Failed to resolve project favicon.",
               cause,
             }),
         ),
@@ -307,19 +300,15 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         !(yield* resolveCanonicalWorkspaceFile({ workspaceRoot, relativePath }).pipe(
           Effect.mapError(
             (cause) =>
-              new AssetAccessError({
-                operation: "inspect-project-favicon",
+              new AssetProjectFaviconInspectionError({
                 resource: input.resource,
-                message: "Failed to inspect the project favicon.",
                 cause,
               }),
           ),
         ))
       ) {
-        return yield* new AssetAccessError({
-          operation: "locate-project-favicon",
+        return yield* new AssetProjectFaviconNotFoundError({
           resource: input.resource,
-          message: "Project favicon was not found.",
         });
       }
       claims = {
@@ -328,10 +317,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
         workspaceRoot: yield* fileSystem.realPath(workspaceRoot).pipe(
           Effect.mapError(
             (cause) =>
-              new AssetAccessError({
-                operation: "resolve-workspace",
+              new AssetWorkspaceResolutionError({
                 resource: input.resource,
-                message: "Failed to resolve workspace.",
                 cause,
               }),
           ),
@@ -348,10 +335,8 @@ export const issueAssetUrl = Effect.fn("AssetAccess.issueAssetUrl")(function* (i
   const signingSecret = yield* secretStore.getOrCreateRandom(SIGNING_SECRET_NAME, 32).pipe(
     Effect.mapError(
       (cause) =>
-        new AssetAccessError({
-          operation: "load-signing-key",
+        new AssetSigningKeyLoadError({
           resource: input.resource,
-          message: "Failed to load the asset signing key.",
           cause,
         }),
     ),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -46,7 +46,8 @@ import {
   OrchestrationReplayEventsError,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
-  AssetAccessError,
+  AssetWorkspaceContextNotFoundError,
+  AssetWorkspaceContextResolutionError,
   EnvironmentAuthorizationError,
   ThreadId,
   type TerminalAttachStreamEvent,
@@ -1413,19 +1414,15 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
                 .pipe(
                   Effect.mapError(
                     (cause) =>
-                      new AssetAccessError({
-                        operation: "resolve-workspace-context",
+                      new AssetWorkspaceContextResolutionError({
                         resource: input.resource,
-                        message: "Failed to resolve workspace context.",
                         cause,
                       }),
                   ),
                 );
               if (Option.isNone(thread)) {
-                return yield* new AssetAccessError({
-                  operation: "resolve-workspace-context",
+                return yield* new AssetWorkspaceContextNotFoundError({
                   resource: input.resource,
-                  message: "Workspace context was not found.",
                 });
               }
               const project = yield* projectionSnapshotQuery
@@ -1433,19 +1430,15 @@ const makeWsRpcLayer = (currentSession: EnvironmentAuth.AuthenticatedSession) =>
                 .pipe(
                   Effect.mapError(
                     (cause) =>
-                      new AssetAccessError({
-                        operation: "resolve-workspace-context",
+                      new AssetWorkspaceContextResolutionError({
                         resource: input.resource,
-                        message: "Failed to resolve workspace context.",
                         cause,
                       }),
                   ),
                 );
               if (Option.isNone(project)) {
-                return yield* new AssetAccessError({
-                  operation: "resolve-workspace-context",
+                return yield* new AssetWorkspaceContextNotFoundError({
                   resource: input.resource,
-                  message: "Workspace context was not found.",
                 });
               }
               return yield* issueAssetUrl({

--- a/packages/contracts/src/assets.ts
+++ b/packages/contracts/src/assets.ts
@@ -29,28 +29,170 @@ export const AssetCreateUrlResult = Schema.Struct({
 });
 export type AssetCreateUrlResult = typeof AssetCreateUrlResult.Type;
 
-export const AssetAccessOperation = Schema.Literals([
-  "resolve-workspace-context",
-  "normalize-workspace-root",
-  "validate-workspace-path",
-  "validate-preview-type",
-  "inspect-workspace-asset",
-  "locate-workspace-asset",
-  "resolve-workspace",
-  "locate-attachment",
-  "resolve-project-favicon",
-  "inspect-project-favicon",
-  "locate-project-favicon",
-  "load-signing-key",
-]);
-export type AssetAccessOperation = typeof AssetAccessOperation.Type;
-
-export class AssetAccessError extends Schema.TaggedErrorClass<AssetAccessError>()(
-  "AssetAccessError",
+export class AssetWorkspaceContextNotFoundError extends Schema.TaggedErrorClass<AssetWorkspaceContextNotFoundError>()(
+  "AssetWorkspaceContextNotFoundError",
   {
-    operation: AssetAccessOperation,
     resource: AssetResource,
-    message: TrimmedNonEmptyString,
-    cause: Schema.optional(Schema.Defect()),
   },
-) {}
+) {
+  override get message(): string {
+    return "Workspace context was not found.";
+  }
+}
+
+export class AssetWorkspaceContextResolutionError extends Schema.TaggedErrorClass<AssetWorkspaceContextResolutionError>()(
+  "AssetWorkspaceContextResolutionError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to resolve workspace context.";
+  }
+}
+
+export class AssetWorkspaceRootNormalizationError extends Schema.TaggedErrorClass<AssetWorkspaceRootNormalizationError>()(
+  "AssetWorkspaceRootNormalizationError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to normalize the workspace root.";
+  }
+}
+
+export class AssetWorkspacePathValidationError extends Schema.TaggedErrorClass<AssetWorkspacePathValidationError>()(
+  "AssetWorkspacePathValidationError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Workspace file path must be relative to the project root.";
+  }
+}
+
+export class AssetPreviewTypeValidationError extends Schema.TaggedErrorClass<AssetPreviewTypeValidationError>()(
+  "AssetPreviewTypeValidationError",
+  {
+    resource: AssetResource,
+  },
+) {
+  override get message(): string {
+    return "Only browser documents and images can be previewed.";
+  }
+}
+
+export class AssetWorkspaceAssetInspectionError extends Schema.TaggedErrorClass<AssetWorkspaceAssetInspectionError>()(
+  "AssetWorkspaceAssetInspectionError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to inspect the workspace asset.";
+  }
+}
+
+export class AssetWorkspaceAssetNotFoundError extends Schema.TaggedErrorClass<AssetWorkspaceAssetNotFoundError>()(
+  "AssetWorkspaceAssetNotFoundError",
+  {
+    resource: AssetResource,
+  },
+) {
+  override get message(): string {
+    return "Workspace asset was not found.";
+  }
+}
+
+export class AssetWorkspaceResolutionError extends Schema.TaggedErrorClass<AssetWorkspaceResolutionError>()(
+  "AssetWorkspaceResolutionError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to resolve workspace.";
+  }
+}
+
+export class AssetAttachmentNotFoundError extends Schema.TaggedErrorClass<AssetAttachmentNotFoundError>()(
+  "AssetAttachmentNotFoundError",
+  {
+    resource: AssetResource,
+  },
+) {
+  override get message(): string {
+    return "Attachment was not found.";
+  }
+}
+
+export class AssetProjectFaviconResolutionError extends Schema.TaggedErrorClass<AssetProjectFaviconResolutionError>()(
+  "AssetProjectFaviconResolutionError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to resolve project favicon.";
+  }
+}
+
+export class AssetProjectFaviconInspectionError extends Schema.TaggedErrorClass<AssetProjectFaviconInspectionError>()(
+  "AssetProjectFaviconInspectionError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to inspect the project favicon.";
+  }
+}
+
+export class AssetProjectFaviconNotFoundError extends Schema.TaggedErrorClass<AssetProjectFaviconNotFoundError>()(
+  "AssetProjectFaviconNotFoundError",
+  {
+    resource: AssetResource,
+  },
+) {
+  override get message(): string {
+    return "Project favicon was not found.";
+  }
+}
+
+export class AssetSigningKeyLoadError extends Schema.TaggedErrorClass<AssetSigningKeyLoadError>()(
+  "AssetSigningKeyLoadError",
+  {
+    resource: AssetResource,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to load the asset signing key.";
+  }
+}
+
+export const AssetAccessError = Schema.Union([
+  AssetWorkspaceContextNotFoundError,
+  AssetWorkspaceContextResolutionError,
+  AssetWorkspaceRootNormalizationError,
+  AssetWorkspacePathValidationError,
+  AssetPreviewTypeValidationError,
+  AssetWorkspaceAssetInspectionError,
+  AssetWorkspaceAssetNotFoundError,
+  AssetWorkspaceResolutionError,
+  AssetAttachmentNotFoundError,
+  AssetProjectFaviconResolutionError,
+  AssetProjectFaviconInspectionError,
+  AssetProjectFaviconNotFoundError,
+  AssetSigningKeyLoadError,
+]);
+export type AssetAccessError = typeof AssetAccessError.Type;


### PR DESCRIPTION
## Summary
- replace the message-driven `AssetAccessError` with distinct Schema error tags for each semantic failure
- preserve the original caller-facing messages while retaining structured resources and immediate causes
- expose the RPC failure surface as an `AssetAccessError` Schema union

## Tests
- `vp test run apps/server/src/assets/AssetAccess.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the RPC/contract error shape (drops `operation`, adds multiple `_tag` variants), which can break clients that matched on `operation` even though messages and asset-issuance logic stay the same.
> 
> **Overview**
> Replaces the single **`AssetAccessError`** (with an `operation` string and inline `message`) with **per-failure tagged Schema error classes** in `packages/contracts/src/assets.ts`. Each variant keeps the same user-facing text via a **`message` getter**, plus `resource` and optional `cause`; **`AssetAccessError`** is now a **`Schema.Union`** of those types for the `assetsCreateUrl` RPC.
> 
> **`issueAssetUrl`** in `AssetAccess.ts` and the workspace-file path in **`ws.ts`** now return the specific error at each failure site (e.g. path validation, preview type, favicon resolution). WebSocket workspace context handling additionally distinguishes **`AssetWorkspaceContextResolutionError`** (projection lookup failed) from **`AssetWorkspaceContextNotFoundError`** (thread/project missing).
> 
> Tests assert **`error._tag`** instead of **`operation`**. Callers that branched on `operation` must switch to **`_tag`**; serialized error shape changes accordingly while success paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 431a05f0c442109500aef0587f9192ac06e86564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic `AssetAccessError` with distinct tagged error classes for asset access failures
> - Removes the single `AssetAccessError` class (with `operation` field) from [contracts/src/assets.ts](https://github.com/pingdotgg/t3code/pull/3448/files#diff-be151844cc8699bd23b42fc4d6d73c29e32170c1b03cb89b86296402f2c40359) and replaces it with 12 dedicated tagged error classes (e.g. `AssetWorkspaceContextNotFoundError`, `AssetProjectFaviconResolutionError`). `AssetAccessError` is re-exported as a `Schema.Union` of these types.
> - Updates [AssetAccess.ts](https://github.com/pingdotgg/t3code/pull/3448/files#diff-7106051c89d4fb8e7cebeee854e81bb55fdf03ec154089eb8c7499ef78ae51c1) and [ws.ts](https://github.com/pingdotgg/t3code/pull/3448/files#diff-7f2100e8ffa23a58d9bf425c5b3ceafc39239911ae33bc569291a00ecb8e9125) to construct the appropriate specific error class at each failure site instead of the generic error.
> - Callers can now branch on `error._tag` to handle individual failure modes rather than inspecting an `operation` string.
> - Behavioral Change: error objects no longer carry explicit `message` or `operation` fields; messages are provided by each class's getter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 431a05f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->