### PR TITLE
[codex] Migrate desktop app errors to Schema

### DIFF
--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -1,8 +1,8 @@
 import * as Cause from "effect/Cause";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
 
 import * as NetService from "@t3tools/shared/Net";
 import * as Crypto from "effect/Crypto";
@@ -33,22 +33,24 @@ const makeDesktopRunId = Crypto.Crypto.pipe(
   Effect.map((value) => value.replaceAll("-", "").slice(0, 12)),
 );
 
-class DesktopBackendPortUnavailableError extends Data.TaggedError(
+export class DesktopBackendPortUnavailableError extends Schema.TaggedErrorClass<DesktopBackendPortUnavailableError>()(
   "DesktopBackendPortUnavailableError",
-)<{
-  readonly startPort: number;
-  readonly maxPort: number;
-  readonly hosts: readonly string[];
-}> {
-  override get message() {
+  {
+    startPort: Schema.Number,
+    maxPort: Schema.Number,
+    hosts: Schema.Array(Schema.String),
+  },
+) {
+  override get message(): string {
     return `No desktop backend port is available on hosts ${this.hosts.join(", ")} between ${this.startPort} and ${this.maxPort}.`;
   }
 }
 
-class DesktopDevelopmentBackendPortRequiredError extends Data.TaggedError(
+export class DesktopDevelopmentBackendPortRequiredError extends Schema.TaggedErrorClass<DesktopDevelopmentBackendPortRequiredError>()(
   "DesktopDevelopmentBackendPortRequiredError",
-)<{}> {
-  override get message() {
+  {},
+) {
+  override get message(): string {
     return "T3CODE_PORT is required in desktop development.";
   }
 }

--- a/apps/desktop/src/app/DesktopApp.ts
+++ b/apps/desktop/src/app/DesktopApp.ts
@@ -36,8 +36,8 @@ const makeDesktopRunId = Crypto.Crypto.pipe(
 export class DesktopBackendPortUnavailableError extends Schema.TaggedErrorClass<DesktopBackendPortUnavailableError>()(
   "DesktopBackendPortUnavailableError",
   {
-    startPort: Schema.Number,
-    maxPort: Schema.Number,
+    startPort: Schema.Int,
+    maxPort: Schema.Int,
     hosts: Schema.Array(Schema.String),
   },
 ) {

--- a/apps/desktop/src/app/DesktopAppErrors.test.ts
+++ b/apps/desktop/src/app/DesktopAppErrors.test.ts
@@ -1,0 +1,30 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import {
+  DesktopBackendPortUnavailableError,
+  DesktopDevelopmentBackendPortRequiredError,
+} from "./DesktopApp.ts";
+
+describe("DesktopApp errors", () => {
+  it("preserves unavailable backend port context", () => {
+    const error = new DesktopBackendPortUnavailableError({
+      startPort: 3_773,
+      maxPort: 65_535,
+      hosts: ["127.0.0.1", "0.0.0.0", "::"],
+    });
+
+    assert.equal(error.startPort, 3_773);
+    assert.equal(error.maxPort, 65_535);
+    assert.deepEqual(error.hosts, ["127.0.0.1", "0.0.0.0", "::"]);
+    assert.equal(
+      error.message,
+      "No desktop backend port is available on hosts 127.0.0.1, 0.0.0.0, :: between 3773 and 65535.",
+    );
+  });
+
+  it("reports the required development port", () => {
+    const error = new DesktopDevelopmentBackendPortRequiredError();
+
+    assert.equal(error.message, "T3CODE_PORT is required in desktop development.");
+  });
+});


### PR DESCRIPTION
## Summary

- migrate the two remaining `DesktopApp` `Data.TaggedError` classes to `Schema.TaggedErrorClass`
- preserve the existing structured port fields and user-facing messages
- add focused coverage for both error shapes

## Why

This removes the remaining non-schema error definitions in desktop startup and keeps their diagnostics consistent with the rest of the Effect error campaign.

## Validation

- `vp check`
- `vp run typecheck`
- `vp test apps/desktop/src/app/DesktopAppErrors.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical error-type migration with unchanged throw sites and messages; new unit tests cover shape and copy only.
> 
> **Overview**
> Replaces the last two desktop startup **`Data.TaggedError`** types in `DesktopApp.ts` with **`Schema.TaggedErrorClass`**, matching the rest of the desktop Effect error pattern.
> 
> **`DesktopBackendPortUnavailableError`** now declares **`startPort`**, **`maxPort`**, and **`hosts`** via Schema fields; **`DesktopDevelopmentBackendPortRequiredError`** stays tag-only. Both are **exported** and keep the same user-facing **`message`** strings. Startup still fails the same way when port scan exhausts or dev mode lacks **`T3CODE_PORT`**.
> 
> Adds **`DesktopAppErrors.test.ts`** to lock in structured fields and message text for both errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc6776e0f3369231f60abf33eee4ba6fe29e083. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Migrate desktop app error classes to `Schema.TaggedErrorClass`
> - Converts `DesktopBackendPortUnavailableError` and `DesktopDevelopmentBackendPortRequiredError` in [DesktopApp.ts](https://github.com/pingdotgg/t3code/pull/3449/files#diff-267cf20af5c499f356b88a4bc3d3dec61aa6c7a3398f93f8836975b3bcf764e9) from `Data.TaggedError` to `Schema.TaggedErrorClass`, with explicit field schemas for each.
> - Both error classes are now exported, making them available to external importers.
> - Adds [DesktopAppErrors.test.ts](https://github.com/pingdotgg/t3code/pull/3449/files#diff-f5db36e8d9ac97dae601b1879467c16eb4beb9ff7538a5a564a2c7f8a3705948) to verify constructor inputs are preserved and message getters return expected strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ddc6776.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->