### PR TITLE
[codex] Structure server CLI failures

### DIFF
--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Logger from "effect/Logger";
@@ -20,6 +19,7 @@ import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
 import { fromYaml } from "@t3tools/shared/schemaYaml";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import serverPackageJson from "../package.json" with { type: "json" };
+import * as CliErrors from "./cliErrors.ts";
 
 interface PackageJson {
   name: string;
@@ -47,11 +47,6 @@ const WorkspaceConfig = Schema.Struct({
 type WorkspaceConfig = typeof WorkspaceConfig.Type;
 const decodeWorkspaceConfig = Schema.decodeEffect(fromYaml(WorkspaceConfig));
 
-class CliError extends Data.TaggedError("CliError")<{
-  readonly message: string;
-  readonly cause?: unknown;
-}> {}
-
 const RepoRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("../../..", import.meta.url))),
 );
@@ -70,9 +65,7 @@ const runCommand = Effect.fn("runCommand")(function* (command: ChildProcess.Comm
   const exitCode = yield* child.exitCode;
 
   if (exitCode !== 0) {
-    return yield* new CliError({
-      message: `Command exited with non-zero exit code (${exitCode})`,
-    });
+    return yield* new CliErrors.ServerCliCommandExitError({ exitCode });
   }
 });
 
@@ -95,14 +88,10 @@ const applyPublishIconOverrides = Effect.fn("applyPublishIconOverrides")(functio
     const backupPath = `${targetPath}.publish-bak`;
 
     if (!(yield* fs.exists(sourcePath))) {
-      return yield* new CliError({
-        message: `Missing publish icon source: ${sourcePath}`,
-      });
+      return yield* new CliErrors.ServerCliPublishIconSourceMissingError({ sourcePath });
     }
     if (!(yield* fs.exists(targetPath))) {
-      return yield* new CliError({
-        message: `Missing publish icon target: ${targetPath}. Run the build subcommand first.`,
-      });
+      return yield* new CliErrors.ServerCliPublishIconTargetMissingError({ targetPath });
     }
 
     yield* fs.copyFile(targetPath, backupPath);
@@ -138,14 +127,10 @@ const applyDevelopmentIconOverrides = Effect.fn("applyDevelopmentIconOverrides")
     const targetPath = path.join(serverDir, override.targetRelativePath);
 
     if (!(yield* fs.exists(sourcePath))) {
-      return yield* new CliError({
-        message: `Missing development icon source: ${sourcePath}`,
-      });
+      return yield* new CliErrors.ServerCliDevelopmentIconSourceMissingError({ sourcePath });
     }
     if (!(yield* fs.exists(targetPath))) {
-      return yield* new CliError({
-        message: `Missing development icon target: ${targetPath}. Build web first.`,
-      });
+      return yield* new CliErrors.ServerCliDevelopmentIconTargetMissingError({ targetPath });
     }
 
     yield* fs.copyFile(sourcePath, targetPath);
@@ -245,9 +230,7 @@ const publishCmd = Command.make(
       for (const relPath of ["dist/bin.mjs", "dist/client/index.html"]) {
         const abs = path.join(serverDir, relPath);
         if (!(yield* fs.exists(abs))) {
-          return yield* new CliError({
-            message: `Missing build asset: ${abs}. Run the build subcommand first.`,
-          });
+          return yield* new CliErrors.ServerCliBuildAssetMissingError({ assetPath: abs });
         }
       }
 

--- a/apps/server/scripts/cli.ts
+++ b/apps/server/scripts/cli.ts
@@ -19,7 +19,14 @@ import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
 import { fromYaml } from "@t3tools/shared/schemaYaml";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import serverPackageJson from "../package.json" with { type: "json" };
-import * as CliErrors from "./cliErrors.ts";
+import {
+  ServerCliBuildAssetMissingError,
+  ServerCliCommandExitError,
+  ServerCliDevelopmentIconSourceMissingError,
+  ServerCliDevelopmentIconTargetMissingError,
+  ServerCliPublishIconSourceMissingError,
+  ServerCliPublishIconTargetMissingError,
+} from "./cliErrors.ts";
 
 interface PackageJson {
   name: string;
@@ -59,13 +66,18 @@ const readWorkspaceConfig = Effect.fn("readWorkspaceConfig")(function* () {
   return yield* decodeWorkspaceConfig(workspaceYaml);
 });
 
-const runCommand = Effect.fn("runCommand")(function* (command: ChildProcess.Command) {
+const runCommand = Effect.fn("runCommand")(function* (command: ChildProcess.StandardCommand) {
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const child = yield* spawner.spawn(command);
   const exitCode = yield* child.exitCode;
 
   if (exitCode !== 0) {
-    return yield* new CliErrors.ServerCliCommandExitError({ exitCode });
+    return yield* new ServerCliCommandExitError({
+      command: command.command,
+      args: command.args,
+      cwd: command.options.cwd,
+      exitCode,
+    });
   }
 });
 
@@ -88,10 +100,10 @@ const applyPublishIconOverrides = Effect.fn("applyPublishIconOverrides")(functio
     const backupPath = `${targetPath}.publish-bak`;
 
     if (!(yield* fs.exists(sourcePath))) {
-      return yield* new CliErrors.ServerCliPublishIconSourceMissingError({ sourcePath });
+      return yield* new ServerCliPublishIconSourceMissingError({ sourcePath });
     }
     if (!(yield* fs.exists(targetPath))) {
-      return yield* new CliErrors.ServerCliPublishIconTargetMissingError({ targetPath });
+      return yield* new ServerCliPublishIconTargetMissingError({ targetPath });
     }
 
     yield* fs.copyFile(targetPath, backupPath);
@@ -127,10 +139,10 @@ const applyDevelopmentIconOverrides = Effect.fn("applyDevelopmentIconOverrides")
     const targetPath = path.join(serverDir, override.targetRelativePath);
 
     if (!(yield* fs.exists(sourcePath))) {
-      return yield* new CliErrors.ServerCliDevelopmentIconSourceMissingError({ sourcePath });
+      return yield* new ServerCliDevelopmentIconSourceMissingError({ sourcePath });
     }
     if (!(yield* fs.exists(targetPath))) {
-      return yield* new CliErrors.ServerCliDevelopmentIconTargetMissingError({ targetPath });
+      return yield* new ServerCliDevelopmentIconTargetMissingError({ targetPath });
     }
 
     yield* fs.copyFile(sourcePath, targetPath);
@@ -230,7 +242,7 @@ const publishCmd = Command.make(
       for (const relPath of ["dist/bin.mjs", "dist/client/index.html"]) {
         const abs = path.join(serverDir, relPath);
         if (!(yield* fs.exists(abs))) {
-          return yield* new CliErrors.ServerCliBuildAssetMissingError({ assetPath: abs });
+          return yield* new ServerCliBuildAssetMissingError({ assetPath: abs });
         }
       }
 

--- a/apps/server/scripts/cliErrors.test.ts
+++ b/apps/server/scripts/cliErrors.test.ts
@@ -1,0 +1,66 @@
+import { assert, describe, it } from "@effect/vitest";
+
+import * as CliErrors from "./cliErrors.ts";
+
+describe("server CLI errors", () => {
+  it("preserves the failed command exit code", () => {
+    const error = new CliErrors.ServerCliCommandExitError({ exitCode: 17 });
+
+    assert.equal(error._tag, "ServerCliCommandExitError");
+    assert.equal(error.exitCode, 17);
+    assert.equal(error.message, "Command exited with non-zero exit code (17)");
+  });
+
+  it("preserves missing paths and exact caller-facing messages", () => {
+    const failures = [
+      {
+        error: new CliErrors.ServerCliPublishIconSourceMissingError({
+          sourcePath: "/repo/icons/publish.png",
+        }),
+        tag: "ServerCliPublishIconSourceMissingError",
+        path: "/repo/icons/publish.png",
+        message: "Missing publish icon source: /repo/icons/publish.png",
+      },
+      {
+        error: new CliErrors.ServerCliPublishIconTargetMissingError({
+          targetPath: "/repo/dist/client/icon.png",
+        }),
+        tag: "ServerCliPublishIconTargetMissingError",
+        path: "/repo/dist/client/icon.png",
+        message:
+          "Missing publish icon target: /repo/dist/client/icon.png. Run the build subcommand first.",
+      },
+      {
+        error: new CliErrors.ServerCliDevelopmentIconSourceMissingError({
+          sourcePath: "/repo/icons/development.png",
+        }),
+        tag: "ServerCliDevelopmentIconSourceMissingError",
+        path: "/repo/icons/development.png",
+        message: "Missing development icon source: /repo/icons/development.png",
+      },
+      {
+        error: new CliErrors.ServerCliDevelopmentIconTargetMissingError({
+          targetPath: "/repo/dist/client/icon.png",
+        }),
+        tag: "ServerCliDevelopmentIconTargetMissingError",
+        path: "/repo/dist/client/icon.png",
+        message: "Missing development icon target: /repo/dist/client/icon.png. Build web first.",
+      },
+      {
+        error: new CliErrors.ServerCliBuildAssetMissingError({
+          assetPath: "/repo/apps/server/dist/bin.mjs",
+        }),
+        tag: "ServerCliBuildAssetMissingError",
+        path: "/repo/apps/server/dist/bin.mjs",
+        message:
+          "Missing build asset: /repo/apps/server/dist/bin.mjs. Run the build subcommand first.",
+      },
+    ] as const;
+
+    for (const failure of failures) {
+      assert.equal(failure.error._tag, failure.tag);
+      assert.equal(failure.error.message, failure.message);
+      assert.include(Object.values(failure.error), failure.path);
+    }
+  });
+});

--- a/apps/server/scripts/cliErrors.test.ts
+++ b/apps/server/scripts/cliErrors.test.ts
@@ -1,66 +1,31 @@
 import { assert, describe, it } from "@effect/vitest";
 
-import * as CliErrors from "./cliErrors.ts";
+import { ServerCliBuildAssetMissingError, ServerCliCommandExitError } from "./cliErrors.ts";
 
 describe("server CLI errors", () => {
-  it("preserves the failed command exit code", () => {
-    const error = new CliErrors.ServerCliCommandExitError({ exitCode: 17 });
+  it("preserves failed command context without changing its message", () => {
+    const error = new ServerCliCommandExitError({
+      command: "vp",
+      args: ["pm", "publish"],
+      cwd: "/repo",
+      exitCode: 17,
+    });
 
     assert.equal(error._tag, "ServerCliCommandExitError");
+    assert.equal(error.command, "vp");
+    assert.deepEqual(error.args, ["pm", "publish"]);
+    assert.equal(error.cwd, "/repo");
     assert.equal(error.exitCode, 17);
     assert.equal(error.message, "Command exited with non-zero exit code (17)");
   });
 
-  it("preserves missing paths and exact caller-facing messages", () => {
-    const failures = [
-      {
-        error: new CliErrors.ServerCliPublishIconSourceMissingError({
-          sourcePath: "/repo/icons/publish.png",
-        }),
-        tag: "ServerCliPublishIconSourceMissingError",
-        path: "/repo/icons/publish.png",
-        message: "Missing publish icon source: /repo/icons/publish.png",
-      },
-      {
-        error: new CliErrors.ServerCliPublishIconTargetMissingError({
-          targetPath: "/repo/dist/client/icon.png",
-        }),
-        tag: "ServerCliPublishIconTargetMissingError",
-        path: "/repo/dist/client/icon.png",
-        message:
-          "Missing publish icon target: /repo/dist/client/icon.png. Run the build subcommand first.",
-      },
-      {
-        error: new CliErrors.ServerCliDevelopmentIconSourceMissingError({
-          sourcePath: "/repo/icons/development.png",
-        }),
-        tag: "ServerCliDevelopmentIconSourceMissingError",
-        path: "/repo/icons/development.png",
-        message: "Missing development icon source: /repo/icons/development.png",
-      },
-      {
-        error: new CliErrors.ServerCliDevelopmentIconTargetMissingError({
-          targetPath: "/repo/dist/client/icon.png",
-        }),
-        tag: "ServerCliDevelopmentIconTargetMissingError",
-        path: "/repo/dist/client/icon.png",
-        message: "Missing development icon target: /repo/dist/client/icon.png. Build web first.",
-      },
-      {
-        error: new CliErrors.ServerCliBuildAssetMissingError({
-          assetPath: "/repo/apps/server/dist/bin.mjs",
-        }),
-        tag: "ServerCliBuildAssetMissingError",
-        path: "/repo/apps/server/dist/bin.mjs",
-        message:
-          "Missing build asset: /repo/apps/server/dist/bin.mjs. Run the build subcommand first.",
-      },
-    ] as const;
+  it("preserves a representative missing asset path", () => {
+    const error = new ServerCliBuildAssetMissingError({ assetPath: "/repo/server.mjs" });
 
-    for (const failure of failures) {
-      assert.equal(failure.error._tag, failure.tag);
-      assert.equal(failure.error.message, failure.message);
-      assert.include(Object.values(failure.error), failure.path);
-    }
+    assert.equal(error.assetPath, "/repo/server.mjs");
+    assert.equal(
+      error.message,
+      "Missing build asset: /repo/server.mjs. Run the build subcommand first.",
+    );
   });
 });

--- a/apps/server/scripts/cliErrors.ts
+++ b/apps/server/scripts/cliErrors.ts
@@ -1,0 +1,67 @@
+import * as Schema from "effect/Schema";
+
+export class ServerCliCommandExitError extends Schema.TaggedErrorClass<ServerCliCommandExitError>()(
+  "ServerCliCommandExitError",
+  {
+    exitCode: Schema.Int,
+  },
+) {
+  override get message(): string {
+    return `Command exited with non-zero exit code (${this.exitCode})`;
+  }
+}
+
+export class ServerCliPublishIconSourceMissingError extends Schema.TaggedErrorClass<ServerCliPublishIconSourceMissingError>()(
+  "ServerCliPublishIconSourceMissingError",
+  {
+    sourcePath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Missing publish icon source: ${this.sourcePath}`;
+  }
+}
+
+export class ServerCliPublishIconTargetMissingError extends Schema.TaggedErrorClass<ServerCliPublishIconTargetMissingError>()(
+  "ServerCliPublishIconTargetMissingError",
+  {
+    targetPath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Missing publish icon target: ${this.targetPath}. Run the build subcommand first.`;
+  }
+}
+
+export class ServerCliDevelopmentIconSourceMissingError extends Schema.TaggedErrorClass<ServerCliDevelopmentIconSourceMissingError>()(
+  "ServerCliDevelopmentIconSourceMissingError",
+  {
+    sourcePath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Missing development icon source: ${this.sourcePath}`;
+  }
+}
+
+export class ServerCliDevelopmentIconTargetMissingError extends Schema.TaggedErrorClass<ServerCliDevelopmentIconTargetMissingError>()(
+  "ServerCliDevelopmentIconTargetMissingError",
+  {
+    targetPath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Missing development icon target: ${this.targetPath}. Build web first.`;
+  }
+}
+
+export class ServerCliBuildAssetMissingError extends Schema.TaggedErrorClass<ServerCliBuildAssetMissingError>()(
+  "ServerCliBuildAssetMissingError",
+  {
+    assetPath: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Missing build asset: ${this.assetPath}. Run the build subcommand first.`;
+  }
+}

--- a/apps/server/scripts/cliErrors.ts
+++ b/apps/server/scripts/cliErrors.ts
@@ -3,6 +3,9 @@ import * as Schema from "effect/Schema";
 export class ServerCliCommandExitError extends Schema.TaggedErrorClass<ServerCliCommandExitError>()(
   "ServerCliCommandExitError",
   {
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    cwd: Schema.optional(Schema.String),
     exitCode: Schema.Int,
   },
 ) {


### PR DESCRIPTION
## Summary

- replace the arbitrary-message server script `CliError` with six distinct schema error tags
- retain the exact existing caller-facing messages while attaching structural paths or exit codes
- keep constructors inline at failure sites and add focused error-shape coverage

## Why

The previous catch-all error could only be correlated through free-form message text. These failures now expose stable tags and the relevant path or exit code without adding redundant operation fields or constructor wrappers.

## Validation

- `vp check`
- `vp run typecheck`
- `vp test apps/server/scripts/cliErrors.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor limited to internal server scripts CLI error types and messages; no runtime server or auth paths touched.
> 
> **Overview**
> Replaces the scripts CLI’s single **`CliError`** with **six `Schema.TaggedErrorClass` types** in `cliErrors.ts`, each with stable `_tag` fields and structured context (paths, or command/args/cwd/exitCode for subprocess failures). **User-facing `message` strings stay the same** via overridden getters.
> 
> `cli.ts` now fails with the specific error at each site (build assets, publish/dev icon overrides, non-zero `runCommand` exits) and types spawned commands as **`ChildProcess.StandardCommand`**. Adds **`cliErrors.test.ts`** to lock in tags, fields, and messages for representative cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df592344066676ab32e4f72aa5a1a80fcc622b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic `CliError` with structured error classes in server CLI scripts
> - Adds six typed error classes in [cliErrors.ts](https://github.com/pingdotgg/t3code/pull/3450/files#diff-7114a1e6b354045a6092e5b632c44555d778724cdbfc1568912b77cc698843d7): `ServerCliCommandExitError`, `ServerCliBuildAssetMissingError`, and four icon-related errors, each carrying relevant context fields (e.g. `exitCode`, `assetPath`, `sourcePath`).
> - Replaces all `CliError` usages in [cli.ts](https://github.com/pingdotgg/t3code/pull/3450/files#diff-e8442ce95db64bad13cb361a5638bd82e8723d4a0aa5833a7d0b81b4fc91ccf9) with the appropriate specific error class, preserving existing error messages.
> - Adds a vitest suite in [cliErrors.test.ts](https://github.com/pingdotgg/t3code/pull/3450/files#diff-1221592353fe12465906a19d8e518559118d5bc82b3070c1cb92babaf011c8d3) verifying that context fields and messages are preserved on the new error classes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df59234.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->