### PR TITLE
[codex] Structure thread archive blocked error

### DIFF
--- a/apps/web/src/hooks/useThreadActions.test.ts
+++ b/apps/web/src/hooks/useThreadActions.test.ts
@@ -1,0 +1,19 @@
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ThreadArchiveBlockedError } from "./useThreadActions";
+
+describe("ThreadArchiveBlockedError", () => {
+  it("keeps the blocked thread context with the fixed message", () => {
+    const error = new ThreadArchiveBlockedError({
+      environmentId: EnvironmentId.make("environment-1"),
+      threadId: ThreadId.make("thread-1"),
+    });
+
+    expect(error).toMatchObject({
+      environmentId: "environment-1",
+      threadId: "thread-1",
+    });
+    expect(error.message).toBe("Cannot archive a running thread.");
+  });
+});

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -4,9 +4,9 @@ import {
   scopeThreadRef,
 } from "@t3tools/client-runtime/environment";
 import { settlePromise, squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
-import { type ScopedThreadRef, ThreadId } from "@t3tools/contracts";
+import { EnvironmentId, type ScopedThreadRef, ThreadId } from "@t3tools/contracts";
 import * as Cause from "effect/Cause";
-import * as Data from "effect/Data";
+import * as Schema from "effect/Schema";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo, useRef } from "react";
@@ -27,9 +27,17 @@ import { stackedThreadToast, toastManager } from "../components/ui/toast";
 import { useClientSettings } from "./useSettings";
 import { useAtomCommand } from "../state/use-atom-command";
 
-export class ThreadArchiveBlockedError extends Data.TaggedError("ThreadArchiveBlockedError")<{
-  readonly message: string;
-}> {}
+export class ThreadArchiveBlockedError extends Schema.TaggedErrorClass<ThreadArchiveBlockedError>()(
+  "ThreadArchiveBlockedError",
+  {
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+  },
+) {
+  override get message(): string {
+    return "Cannot archive a running thread.";
+  }
+}
 
 export function useThreadActions() {
   const closeTerminal = useAtomCommand(terminalEnvironment.close);
@@ -89,7 +97,8 @@ export function useThreadActions() {
         return AsyncResult.failure(
           Cause.fail(
             new ThreadArchiveBlockedError({
-              message: "Cannot archive a running thread.",
+              environmentId: threadRef.environmentId,
+              threadId: threadRef.threadId,
             }),
           ),
         );


### PR DESCRIPTION
`ThreadArchiveBlockedError` accepted a caller-supplied `message` even though the archive guard has only one semantic failure. That made the error's meaning mutable at each construction site and kept it outside the schema-based error conventions used elsewhere.

This changes the error to an empty-shape `Schema.TaggedErrorClass` with the existing caller-visible text derived by a constant `message` getter. The archive guard now constructs the error without redundant message data.

A focused test locks down the exact message without adding a broad hook refactor test.

Validation:

- `vp test run apps/web/src/hooks/useThreadActions.test.ts`
- `vp check` (passes with 20 existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-type refactor in thread archive handling with no change to archive success paths or broader hook behavior.
> 
> **Overview**
> **`ThreadArchiveBlockedError`** is now a **`Schema.TaggedErrorClass`** with **`environmentId`** and **`threadId`** instead of a caller-supplied **`message`**. The user-facing text is fixed via a **`message`** getter (`"Cannot archive a running thread."`), matching other schema-based errors.
> 
> The running-thread archive guard constructs the error with **`threadRef`** ids only. A small unit test asserts the structured fields and exact message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7780446fc31d9148e6b127db95c0d79d2a4668cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `environmentId` and `threadId` fields to `ThreadArchiveBlockedError`
> Converts `ThreadArchiveBlockedError` from a `Data.TaggedError` to a `Schema.TaggedErrorClass` so it carries structured `environmentId` and `threadId` fields. The error message is now a fixed string via a getter rather than a passed-in argument. When archiving a running thread fails, these fields are populated from the current thread reference.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7780446.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->