### PR TITLE
[codex] Structure checkpoint diff failures

### DIFF
--- a/apps/server/src/checkpointing/CheckpointDiffQuery.test.ts
+++ b/apps/server/src/checkpointing/CheckpointDiffQuery.test.ts
@@ -9,6 +9,7 @@ import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSn
 import { checkpointRefForThreadTurn } from "./Utils.ts";
 import * as CheckpointDiffQuery from "./CheckpointDiffQuery.ts";
 import * as CheckpointStore from "./CheckpointStore.ts";
+import { CheckpointThreadNotFoundError } from "./Errors.ts";
 
 function makeThreadCheckpointContext(input: {
   readonly projectId: ProjectId;
@@ -412,7 +413,14 @@ describe("CheckpointDiffQuery.layer", () => {
         });
       }).pipe(Effect.provide(layer), Effect.flip);
 
-      expect(error.message).toContain("Thread 'thread-missing' not found.");
+      expect(error).toBeInstanceOf(CheckpointThreadNotFoundError);
+      expect(error).toMatchObject({
+        operation: "CheckpointDiffQuery.getTurnDiff",
+        threadId,
+      });
+      expect(error.message).toBe(
+        "Checkpoint invariant violation in CheckpointDiffQuery.getTurnDiff: Thread 'thread-missing' not found.",
+      );
     }),
   );
 });

--- a/apps/server/src/checkpointing/CheckpointDiffQuery.ts
+++ b/apps/server/src/checkpointing/CheckpointDiffQuery.ts
@@ -22,7 +22,13 @@ import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
 import * as ProjectionSnapshotQuery from "../orchestration/Services/ProjectionSnapshotQuery.ts";
-import { CheckpointInvariantError, CheckpointUnavailableError } from "./Errors.ts";
+import {
+  CheckpointDiffResultInvalidError,
+  CheckpointRefUnavailableError,
+  CheckpointThreadNotFoundError,
+  CheckpointTurnRangeUnavailableError,
+  CheckpointWorkspacePathMissingError,
+} from "./Errors.ts";
 import type { CheckpointServiceError } from "./Errors.ts";
 import { checkpointRefForThreadTurn } from "./Utils.ts";
 import * as CheckpointStore from "./CheckpointStore.ts";
@@ -92,9 +98,9 @@ export const make = Effect.gen(function* () {
           diff: "",
         };
         if (!isTurnDiffResult(emptyDiff)) {
-          return yield* new CheckpointInvariantError({
+          return yield* new CheckpointDiffResultInvalidError({
             operation,
-            detail: "Computed turn diff result does not satisfy contract schema.",
+            threadId: input.threadId,
           });
         }
         return emptyDiff;
@@ -104,9 +110,9 @@ export const make = Effect.gen(function* () {
         .getThreadCheckpointContext(input.threadId)
         .pipe(Effect.withSpan("checkpoint.turnDiff.lookupContext"));
       if (Option.isNone(threadContext)) {
-        return yield* new CheckpointInvariantError({
+        return yield* new CheckpointThreadNotFoundError({
           operation,
-          detail: `Thread '${input.threadId}' not found.`,
+          threadId: input.threadId,
         });
       }
 
@@ -115,18 +121,19 @@ export const make = Effect.gen(function* () {
         0,
       );
       if (input.toTurnCount > maxTurnCount) {
-        return yield* new CheckpointUnavailableError({
+        return yield* new CheckpointTurnRangeUnavailableError({
+          operation,
           threadId: input.threadId,
-          turnCount: input.toTurnCount,
-          detail: `Turn diff range exceeds current turn count: requested ${input.toTurnCount}, current ${maxTurnCount}.`,
+          requestedTurnCount: input.toTurnCount,
+          availableTurnCount: maxTurnCount,
         });
       }
 
       const workspaceCwd = threadContext.value.worktreePath ?? threadContext.value.workspaceRoot;
       if (!workspaceCwd) {
-        return yield* new CheckpointInvariantError({
+        return yield* new CheckpointWorkspacePathMissingError({
           operation,
-          detail: `Workspace path missing for thread '${input.threadId}' when computing turn diff.`,
+          threadId: input.threadId,
         });
       }
 
@@ -137,10 +144,11 @@ export const make = Effect.gen(function* () {
               (checkpoint) => checkpoint.checkpointTurnCount === input.fromTurnCount,
             )?.checkpointRef;
       if (!fromCheckpointRef) {
-        return yield* new CheckpointUnavailableError({
+        return yield* new CheckpointRefUnavailableError({
+          operation,
           threadId: input.threadId,
           turnCount: input.fromTurnCount,
-          detail: `Checkpoint ref is unavailable for turn ${input.fromTurnCount}.`,
+          checkpoint: "from",
         });
       }
 
@@ -148,10 +156,11 @@ export const make = Effect.gen(function* () {
         (checkpoint) => checkpoint.checkpointTurnCount === input.toTurnCount,
       )?.checkpointRef;
       if (!toCheckpointRef) {
-        return yield* new CheckpointUnavailableError({
+        return yield* new CheckpointRefUnavailableError({
+          operation,
           threadId: input.threadId,
           turnCount: input.toTurnCount,
-          detail: `Checkpoint ref is unavailable for turn ${input.toTurnCount}.`,
+          checkpoint: "to",
         });
       }
 
@@ -167,9 +176,9 @@ export const make = Effect.gen(function* () {
 
       const turnDiff = buildTurnDiffResult(input, diff);
       if (!isTurnDiffResult(turnDiff)) {
-        return yield* new CheckpointInvariantError({
+        return yield* new CheckpointDiffResultInvalidError({
           operation,
-          detail: "Computed turn diff result does not satisfy contract schema.",
+          threadId: input.threadId,
         });
       }
 
@@ -200,9 +209,9 @@ export const make = Effect.gen(function* () {
         "",
       );
       if (!isTurnDiffResult(emptyDiff)) {
-        return yield* new CheckpointInvariantError({
+        return yield* new CheckpointDiffResultInvalidError({
           operation,
-          detail: "Computed full thread diff result does not satisfy contract schema.",
+          threadId: input.threadId,
         });
       }
       return emptyDiff satisfies OrchestrationGetFullThreadDiffResult;
@@ -213,33 +222,35 @@ export const make = Effect.gen(function* () {
       .pipe(Effect.withSpan("checkpoint.fullThread.lookupContext"));
 
     if (Option.isNone(threadContext)) {
-      return yield* new CheckpointInvariantError({
+      return yield* new CheckpointThreadNotFoundError({
         operation,
-        detail: `Thread '${input.threadId}' not found.`,
+        threadId: input.threadId,
       });
     }
 
     if (input.toTurnCount > threadContext.value.latestCheckpointTurnCount) {
-      return yield* new CheckpointUnavailableError({
+      return yield* new CheckpointTurnRangeUnavailableError({
+        operation,
         threadId: input.threadId,
-        turnCount: input.toTurnCount,
-        detail: `Turn diff range exceeds current turn count: requested ${input.toTurnCount}, current ${threadContext.value.latestCheckpointTurnCount}.`,
+        requestedTurnCount: input.toTurnCount,
+        availableTurnCount: threadContext.value.latestCheckpointTurnCount,
       });
     }
 
     const workspaceCwd = threadContext.value.worktreePath ?? threadContext.value.workspaceRoot;
     if (!workspaceCwd) {
-      return yield* new CheckpointInvariantError({
+      return yield* new CheckpointWorkspacePathMissingError({
         operation,
-        detail: `Workspace path missing for thread '${input.threadId}' when computing full thread diff.`,
+        threadId: input.threadId,
       });
     }
 
     if (!threadContext.value.toCheckpointRef) {
-      return yield* new CheckpointUnavailableError({
+      return yield* new CheckpointRefUnavailableError({
+        operation,
         threadId: input.threadId,
         turnCount: input.toTurnCount,
-        detail: `Checkpoint ref is unavailable for turn ${input.toTurnCount}.`,
+        checkpoint: "to",
       });
     }
 
@@ -262,9 +273,9 @@ export const make = Effect.gen(function* () {
       diff,
     );
     if (!isTurnDiffResult(turnDiff)) {
-      return yield* new CheckpointInvariantError({
+      return yield* new CheckpointDiffResultInvalidError({
         operation,
-        detail: "Computed full thread diff result does not satisfy contract schema.",
+        threadId: input.threadId,
       });
     }
 

--- a/apps/server/src/checkpointing/Errors.test.ts
+++ b/apps/server/src/checkpointing/Errors.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from "@effect/vitest";
+import { ThreadId } from "@t3tools/contracts";
+
+import {
+  CheckpointRefUnavailableError,
+  CheckpointTurnRangeUnavailableError,
+  CheckpointWorkspacePathMissingError,
+} from "./Errors.ts";
+
+const threadId = ThreadId.make("thread-1");
+
+it("derives checkpoint messages from structured context", () => {
+  const range = new CheckpointTurnRangeUnavailableError({
+    operation: "CheckpointDiffQuery.getTurnDiff",
+    threadId,
+    requestedTurnCount: 4,
+    availableTurnCount: 2,
+  });
+  const checkpoint = new CheckpointRefUnavailableError({
+    operation: "CheckpointDiffQuery.getTurnDiff",
+    threadId,
+    turnCount: 2,
+    checkpoint: "to",
+  });
+  const workspace = new CheckpointWorkspacePathMissingError({
+    operation: "CheckpointDiffQuery.getFullThreadDiff",
+    threadId,
+  });
+
+  expect(range.message).toBe(
+    "Checkpoint unavailable for thread thread-1 turn 4: Turn diff range exceeds current turn count: requested 4, current 2.",
+  );
+  expect(checkpoint.message).toBe(
+    "Checkpoint unavailable for thread thread-1 turn 2: Checkpoint ref is unavailable for turn 2.",
+  );
+  expect(workspace.message).toBe(
+    "Checkpoint invariant violation in CheckpointDiffQuery.getFullThreadDiff: Workspace path missing for thread 'thread-1' when computing full thread diff.",
+  );
+});

--- a/apps/server/src/checkpointing/Errors.ts
+++ b/apps/server/src/checkpointing/Errors.ts
@@ -1,40 +1,94 @@
+import { NonNegativeInt, ThreadId, type VcsError } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
+
 import type { ProjectionRepositoryError } from "../persistence/Errors.ts";
-import type { VcsError } from "@t3tools/contracts";
 
-/**
- * CheckpointUnavailableError - Expected checkpoint does not exist.
- */
-export class CheckpointUnavailableError extends Schema.TaggedErrorClass<CheckpointUnavailableError>()(
-  "CheckpointUnavailableError",
+export const CheckpointDiffOperation = Schema.Literals([
+  "CheckpointDiffQuery.getTurnDiff",
+  "CheckpointDiffQuery.getFullThreadDiff",
+]);
+export type CheckpointDiffOperation = typeof CheckpointDiffOperation.Type;
+
+/** The computed result does not satisfy the checkpoint RPC contract. */
+export class CheckpointDiffResultInvalidError extends Schema.TaggedErrorClass<CheckpointDiffResultInvalidError>()(
+  "CheckpointDiffResultInvalidError",
   {
-    threadId: Schema.String,
-    turnCount: Schema.Number,
-    detail: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
+    operation: CheckpointDiffOperation,
+    threadId: ThreadId,
   },
 ) {
   override get message(): string {
-    return `Checkpoint unavailable for thread ${this.threadId} turn ${this.turnCount}: ${this.detail}`;
+    const result =
+      this.operation === "CheckpointDiffQuery.getTurnDiff" ? "turn diff" : "full thread diff";
+    return `Checkpoint invariant violation in ${this.operation}: Computed ${result} result does not satisfy contract schema.`;
   }
 }
 
-/**
- * CheckpointInvariantError - Inconsistent provider/filesystem/catalog state.
- */
-export class CheckpointInvariantError extends Schema.TaggedErrorClass<CheckpointInvariantError>()(
-  "CheckpointInvariantError",
+/** Projection state no longer contains the requested checkpoint thread. */
+export class CheckpointThreadNotFoundError extends Schema.TaggedErrorClass<CheckpointThreadNotFoundError>()(
+  "CheckpointThreadNotFoundError",
   {
-    operation: Schema.String,
-    detail: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
+    operation: CheckpointDiffOperation,
+    threadId: ThreadId,
   },
 ) {
   override get message(): string {
-    return `Checkpoint invariant violation in ${this.operation}: ${this.detail}`;
+    return `Checkpoint invariant violation in ${this.operation}: Thread '${this.threadId}' not found.`;
   }
 }
 
-export type CheckpointStoreError = VcsError | CheckpointInvariantError | CheckpointUnavailableError;
+/** The checkpoint thread has no workspace path from which to compute a diff. */
+export class CheckpointWorkspacePathMissingError extends Schema.TaggedErrorClass<CheckpointWorkspacePathMissingError>()(
+  "CheckpointWorkspacePathMissingError",
+  {
+    operation: CheckpointDiffOperation,
+    threadId: ThreadId,
+  },
+) {
+  override get message(): string {
+    const diff =
+      this.operation === "CheckpointDiffQuery.getTurnDiff" ? "turn diff" : "full thread diff";
+    return `Checkpoint invariant violation in ${this.operation}: Workspace path missing for thread '${this.threadId}' when computing ${diff}.`;
+  }
+}
 
-export type CheckpointServiceError = CheckpointStoreError | ProjectionRepositoryError;
+/** The requested turn lies beyond the latest available checkpoint. */
+export class CheckpointTurnRangeUnavailableError extends Schema.TaggedErrorClass<CheckpointTurnRangeUnavailableError>()(
+  "CheckpointTurnRangeUnavailableError",
+  {
+    operation: CheckpointDiffOperation,
+    threadId: ThreadId,
+    requestedTurnCount: NonNegativeInt,
+    availableTurnCount: NonNegativeInt,
+  },
+) {
+  override get message(): string {
+    return `Checkpoint unavailable for thread ${this.threadId} turn ${this.requestedTurnCount}: Turn diff range exceeds current turn count: requested ${this.requestedTurnCount}, current ${this.availableTurnCount}.`;
+  }
+}
+
+/** Expected checkpoint metadata does not contain the requested Git ref. */
+export class CheckpointRefUnavailableError extends Schema.TaggedErrorClass<CheckpointRefUnavailableError>()(
+  "CheckpointRefUnavailableError",
+  {
+    operation: CheckpointDiffOperation,
+    threadId: ThreadId,
+    turnCount: NonNegativeInt,
+    checkpoint: Schema.Literals(["from", "to"]),
+  },
+) {
+  override get message(): string {
+    return `Checkpoint unavailable for thread ${this.threadId} turn ${this.turnCount}: Checkpoint ref is unavailable for turn ${this.turnCount}.`;
+  }
+}
+
+export type CheckpointStoreError = VcsError;
+
+export type CheckpointServiceError =
+  | CheckpointStoreError
+  | ProjectionRepositoryError
+  | CheckpointDiffResultInvalidError
+  | CheckpointThreadNotFoundError
+  | CheckpointWorkspacePathMissingError
+  | CheckpointTurnRangeUnavailableError
+  | CheckpointRefUnavailableError;


### PR DESCRIPTION
## Summary
- replace generic checkpoint detail errors with distinct Schema-backed failure types
- attach operation, thread, turn-range, and checkpoint-position context
- keep existing caller-facing messages while narrowing store error types

## Validation
- `vp test apps/server/src/checkpointing/Errors.test.ts apps/server/src/checkpointing/CheckpointDiffQuery.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-model refactor in checkpoint diff query paths; behavior and messages are preserved and covered by tests, with no auth or data-path changes.
> 
> **Overview**
> Replaces **`CheckpointInvariantError`** and **`CheckpointUnavailableError`** with five Schema-backed tagged errors in **`Errors.ts`**: `CheckpointDiffResultInvalidError`, `CheckpointThreadNotFoundError`, `CheckpointWorkspacePathMissingError`, `CheckpointTurnRangeUnavailableError`, and `CheckpointRefUnavailableError`. Each carries **`operation`**, **`threadId`**, and scenario-specific fields (turn range, `from`/`to` checkpoint side) instead of free-form **`detail`** strings.
> 
> **`CheckpointDiffQuery`** now fails with the matching type at each validation step in **`getTurnDiff`** and **`getFullThreadDiff`**. User-facing **`message`** text is derived from that context and stays aligned with prior wording (including the “Checkpoint invariant violation in …” prefix where applicable).
> 
> **`CheckpointStoreError`** is narrowed to **`VcsError`** only; diff-layer failures are listed on **`CheckpointServiceError`**. Adds **`Errors.test.ts`** for message derivation and tightens the missing-thread test to assert **`CheckpointThreadNotFoundError`** shape and message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 779124a145c40abdba9c0d621e7f5502453e94ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic checkpoint errors with structured error classes in `CheckpointDiffQuery`
> - Introduces five new `TaggedError` subclasses in [Errors.ts](https://github.com/pingdotgg/t3code/pull/3453/files#diff-7408788e21feee3fe06538b3d857a706c7ebe81aa1821c6ad4e752aa130e6a5a): `CheckpointDiffResultInvalidError`, `CheckpointThreadNotFoundError`, `CheckpointWorkspacePathMissingError`, `CheckpointTurnRangeUnavailableError`, and `CheckpointRefUnavailableError`.
> - Each error carries structured fields (e.g. `operation`, `threadId`, `requestedTurnCount`, `availableTurnCount`, `checkpoint`) and derives a human-readable message from them.
> - `getTurnDiff` and `getFullThreadDiff` in [CheckpointDiffQuery.ts](https://github.com/pingdotgg/t3code/pull/3453/files#diff-54c22b3fa7d2e7e9bff934546f61145e3ab9d952d06cb5a212c6954cd6393619) now throw these specific errors instead of the removed generic `CheckpointInvariantError` and `CheckpointUnavailableError`.
> - `CheckpointServiceError` is updated to include the new error classes; `CheckpointStoreError` is narrowed to `VcsError` only.
> - Behavioral Change: callers catching `CheckpointInvariantError` or `CheckpointUnavailableError` will no longer match these error paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 779124a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->