### PR TITLE
[codex] Structure preview capability errors

### DIFF
--- a/apps/server/src/mcp/McpInvocationContext.test.ts
+++ b/apps/server/src/mcp/McpInvocationContext.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from "@effect/vitest";
+import {
+  EnvironmentId,
+  PreviewAutomationUnavailableError,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+
+import * as McpInvocationContext from "./McpInvocationContext.ts";
+
+it.effect("reports the scoped credential context when preview capability is unavailable", () => {
+  const invocation: McpInvocationContext.McpInvocationScope = {
+    environmentId: EnvironmentId.make("environment-1"),
+    threadId: ThreadId.make("thread-1"),
+    providerSessionId: "provider-session-1",
+    providerInstanceId: ProviderInstanceId.make("codex"),
+    capabilities: new Set(),
+    issuedAt: 1,
+    expiresAt: 2,
+  };
+
+  return Effect.gen(function* () {
+    const error = yield* McpInvocationContext.requireMcpCapability("preview").pipe(
+      Effect.provideService(McpInvocationContext.McpInvocationContext, invocation),
+      Effect.flip,
+    );
+
+    expect(error).toBeInstanceOf(PreviewAutomationUnavailableError);
+    expect(error).toMatchObject({
+      capability: "preview",
+      environmentId: invocation.environmentId,
+      threadId: invocation.threadId,
+      providerSessionId: invocation.providerSessionId,
+      providerInstanceId: invocation.providerInstanceId,
+    });
+    expect(error.message).toBe("MCP credential does not grant the preview capability.");
+  });
+});

--- a/apps/server/src/mcp/McpInvocationContext.ts
+++ b/apps/server/src/mcp/McpInvocationContext.ts
@@ -1,5 +1,9 @@
-import type { EnvironmentId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
-import { PreviewAutomationUnavailableError } from "@t3tools/contracts";
+import {
+  type EnvironmentId,
+  PreviewAutomationUnavailableError,
+  type ProviderInstanceId,
+  type ThreadId,
+} from "@t3tools/contracts";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 
@@ -26,7 +30,11 @@ export const requireMcpCapability = Effect.fn("mcp.requireCapability")(function*
   const invocation = yield* McpInvocationContext;
   if (!invocation.capabilities.has(capability)) {
     return yield* new PreviewAutomationUnavailableError({
-      message: `MCP credential does not grant the ${capability} capability.`,
+      capability,
+      environmentId: invocation.environmentId,
+      threadId: invocation.threadId,
+      providerSessionId: invocation.providerSessionId,
+      providerInstanceId: invocation.providerInstanceId,
     });
   }
   return invocation;

--- a/packages/contracts/src/previewAutomation.ts
+++ b/packages/contracts/src/previewAutomation.ts
@@ -453,8 +453,18 @@ export type PreviewAutomationResponse = typeof PreviewAutomationResponse.Type;
 
 export class PreviewAutomationUnavailableError extends Schema.TaggedErrorClass<PreviewAutomationUnavailableError>()(
   "PreviewAutomationUnavailableError",
-  { message: Schema.String },
-) {}
+  {
+    capability: Schema.Literal("preview"),
+    environmentId: EnvironmentId,
+    threadId: ThreadId,
+    providerSessionId: TrimmedNonEmptyString,
+    providerInstanceId: ProviderInstanceId,
+  },
+) {
+  override get message(): string {
+    return `MCP credential does not grant the ${this.capability} capability.`;
+  }
+}
 
 const PreviewAutomationScopeErrorFields = {
   operation: PreviewAutomationOperation,


### PR DESCRIPTION
## Summary

- replace the free-form preview capability error message with structured capability and MCP invocation context
- derive the existing stable user-facing message from the capability field
- verify the server capability guard attaches the complete invocation context and preserves the exact message

The denial is a structural credential state rather than a wrapped failure, so it intentionally does not fabricate a `cause`. Remote preview availability failures continue to use their separate request-scoped error and preserve the remote response as their cause.

## Validation

- `vp test run apps/server/src/mcp/McpInvocationContext.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small contract shape change on one tagged error plus a capability guard; no auth or remote preview path changes, with behavior covered by a new unit test.
> 
> **Overview**
> **`PreviewAutomationUnavailableError`** no longer stores a free-form `message` field. It now carries structured **`capability`**, **`environmentId`**, **`threadId`**, **`providerSessionId`**, and **`providerInstanceId`**, aligned with other preview automation scope errors. The user-facing text is unchanged and comes from a **`message` getter** built from `capability`.
> 
> When **`requireMcpCapability`** denies access, it fills those fields from the current **`McpInvocationContext`** instead of passing a string. A new server test asserts the full context is attached and the message stays **`MCP credential does not grant the preview capability.`**
> 
> Callers that constructed or serialized the error with only `message` need to use the structured fields (or the getter); remote preview failures still use the separate request-scoped errors with their own causes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d23f0f0b10a2af688b576db1d1e114366890eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure `PreviewAutomationUnavailableError` with capability and session context fields
> - Replaces the single `message` field in `PreviewAutomationUnavailableError` with a structured schema containing `capability`, `environmentId`, `threadId`, `providerSessionId`, and `providerInstanceId`.
> - The error message is now derived via a getter: `"MCP credential does not grant the ${capability} capability."`
> - `requireMcpCapability` in [McpInvocationContext.ts](https://github.com/pingdotgg/t3code/pull/3454/files#diff-c9ff5695076b9f25fe2f8da017afff1cadcf471ba36168a447815596d29cb025) now populates all structured fields from the current invocation context when a capability is missing.
> - Behavioral Change: callers catching `PreviewAutomationUnavailableError` that previously read a `message` field must now use the getter or read the structured fields directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d23f0f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->