### PR TITLE
[codex] Use structural Git status semantics

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -638,6 +638,7 @@ function makeManager(input?: {
   ghScenario?: FakeGhScenario;
   textGeneration?: Partial<FakeGitTextGeneration>;
   setupScriptRunner?: ProjectSetupScriptRunner.ProjectSetupScriptRunner["Service"];
+  vcsDriverLayer?: Layer.Layer<GitVcsDriver.GitVcsDriver>;
 }) {
   const { service: gitHubCli, ghCalls } = createGitHubCliWithFakeGh(input?.ghScenario);
   const textGeneration = createTextGeneration(input?.textGeneration);
@@ -647,11 +648,13 @@ function makeManager(input?: {
 
   const serverSettingsLayer = ServerSettings.ServerSettingsService.layerTest();
 
-  const vcsDriverLayer = GitVcsDriver.layer.pipe(
-    Layer.provideMerge(VcsProcess.layer),
-    Layer.provideMerge(NodeServices.layer),
-    Layer.provideMerge(serverConfigLayer),
-  );
+  const vcsDriverLayer =
+    input?.vcsDriverLayer ??
+    GitVcsDriver.layer.pipe(
+      Layer.provideMerge(VcsProcess.layer),
+      Layer.provideMerge(NodeServices.layer),
+      Layer.provideMerge(serverConfigLayer),
+    );
   const sourceControlRegistryLayer = Layer.effect(
     SourceControlProviderRegistry.SourceControlProviderRegistry,
     GitHubSourceControlProvider.make.pipe(
@@ -931,6 +934,30 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         aheadOfDefaultCount: 0,
         pr: null,
       });
+    }),
+  );
+
+  it.effect("does not classify Git command failures from message text", () =>
+    Effect.gen(function* () {
+      const cwd = "/workspace";
+      const cause = new Error("spawn failed");
+      const commandError = new GitCommandError({
+        operation: "GitVcsDriver.statusDetails.status",
+        command: "git",
+        cwd,
+        detail: "not a git repository",
+        cause,
+      });
+      const { manager } = yield* makeManager({
+        vcsDriverLayer: Layer.mock(GitVcsDriver.GitVcsDriver)({
+          statusDetailsLocal: () => Effect.fail(commandError),
+        }),
+      });
+
+      const error = yield* manager.localStatus({ cwd }).pipe(Effect.flip);
+
+      expect(error).toBe(commandError);
+      expect(error.cause).toBe(cause);
     }),
   );
 

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -15,7 +15,6 @@ import * as Ref from "effect/Ref";
 import {
   GitActionProgressEvent,
   GitActionProgressPhase,
-  GitCommandError,
   GitPreparePullRequestThreadInput,
   GitPreparePullRequestThreadResult,
   GitPullRequestRefInput,
@@ -98,10 +97,6 @@ const STATUS_RESULT_CACHE_CAPACITY = 2_048;
 type StripProgressContext<T> = T extends any ? Omit<T, "actionId" | "cwd" | "action"> : never;
 type GitActionProgressPayload = StripProgressContext<GitActionProgressEvent>;
 type GitActionProgressEmitter = (event: GitActionProgressPayload) => Effect.Effect<void, never>;
-
-function isNotGitRepositoryError(error: GitCommandError): boolean {
-  return error.message.toLowerCase().includes("not a git repository");
-}
 
 interface OpenPrInfo {
   number: number;
@@ -727,25 +722,8 @@ export const make = Effect.gen(function* () {
   const canonicalizeExistingPath = (value: string) =>
     fileSystem.realPath(value).pipe(Effect.orElseSucceed(() => value));
   const normalizeStatusCacheKey = canonicalizeExistingPath;
-  const nonRepositoryStatusDetails = {
-    isRepo: false,
-    hasOriginRemote: false,
-    isDefaultBranch: false,
-    branch: null,
-    upstreamRef: null,
-    hasWorkingTreeChanges: false,
-    workingTree: { files: [], insertions: 0, deletions: 0 },
-    hasUpstream: false,
-    aheadCount: 0,
-    behindCount: 0,
-    aheadOfDefaultCount: 0,
-  } satisfies GitVcsDriver.GitStatusDetails;
   const readLocalStatus = Effect.fn("readLocalStatus")(function* (cwd: string) {
-    const details = yield* gitCore
-      .statusDetailsLocal(cwd)
-      .pipe(
-        Effect.catchIf(isNotGitRepositoryError, () => Effect.succeed(nonRepositoryStatusDetails)),
-      );
+    const details = yield* gitCore.statusDetailsLocal(cwd);
     const hostingProvider = details.isRepo
       ? yield* resolveHostingProvider(cwd, details.branch)
       : null;
@@ -772,9 +750,7 @@ export const make = Effect.gen(function* () {
     cwd: string,
     options?: GitVcsDriver.GitRemoteStatusOptions,
   ) {
-    const details = yield* gitCore
-      .statusDetailsRemote(cwd, options)
-      .pipe(Effect.catchIf(isNotGitRepositoryError, () => Effect.succeed(null)));
+    const details = yield* gitCore.statusDetailsRemote(cwd, options);
     if (details === null || !details.isRepo) {
       return null;
     }


### PR DESCRIPTION
## Summary
- remove GitManager fallback logic that classified failures by matching `error.message`
- rely on GitVcsDriver’s explicit non-repository status results
- preserve unrelated Git command errors and their cause chains

## Verification
- `vp test apps/server/src/git/GitManager.test.ts` (60 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error propagation for git status APIs; callers that assumed silent fallbacks on command failure may now see errors, though non-repo paths remain handled structurally in the driver.
> 
> **Overview**
> **GitManager** no longer treats `GitCommandError` as a non-repo case by matching error message text (`isNotGitRepositoryError`). `readLocalStatus` and `readRemoteStatus` call `gitCore.statusDetailsLocal` / `statusDetailsRemote` directly and let failures surface instead of returning synthetic `isRepo: false` status or swallowing remote errors as `null`.
> 
> Non-git directories still get explicit empty status when **GitVcsDriver** returns structural `isRepo: false` results; only real command failures change behavior—`localStatus` / `remoteStatus` callers now receive the underlying `GitCommandError` (with cause preserved).
> 
> Tests allow injecting a mocked `GitVcsDriver` layer and assert a failure whose detail says "not a git repository" is **not** misclassified as a benign non-repo outcome.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4945aad2753b5c0bd27dc3d84caeede2f2f4e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Propagate Git errors structurally in `readLocalStatus` and `readRemoteStatus`
> - Removes text-based error classification (`isNotGitRepositoryError`) from [GitManager.ts](https://github.com/pingdotgg/t3code/pull/3455/files#diff-cd0cda31b0a40baa44db979a23ee89f041c9bae39aa597513a8628cccebd0337); errors from `gitCore.statusDetailsLocal` and `gitCore.statusDetailsRemote` now propagate directly instead of being swallowed.
> - `readLocalStatus` previously caught errors matching 'not a git repository' and returned a synthetic `isRepo: false` status; it now lets those errors fail the effect.
> - `readRemoteStatus` previously returned `null` on any caught error; it now only returns `null` on a successful call that yields no repo, and propagates errors otherwise.
> - Behavioral Change: callers of `manager.localStatus` and `manager.remoteStatus` will now receive the underlying `GitCommandError` instead of a fallback status or `null` when git commands fail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4945aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->