### PR TITLE
[codex] Structure Bitbucket API errors

### DIFF
--- a/apps/server/src/sourceControl/BitbucketApi.test.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.test.ts
@@ -533,14 +533,67 @@ it.effect("preserves the HTTP client failure without deriving the domain message
       }),
     );
 
+    assert.instanceOf(error, BitbucketApi.BitbucketRequestError);
     assert.strictEqual(error.operation, "getPullRequest");
-    assert.strictEqual(error.detail, "Failed to send the Bitbucket request.");
     assert.strictEqual(
       error.message,
       "Bitbucket API failed in getPullRequest: Failed to send the Bitbucket request.",
     );
     assert.strictEqual(error.cause, requestFailure);
     assert.strictEqual(requestFailure?.cause, transportCause);
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("preserves structured Bitbucket HTTP failures through checkout", () => {
+  const responseBody = '{"error":{"message":"forbidden"}}';
+  const { layer } = makeLayer({
+    response: () => new Response(responseBody, { status: 403 }),
+  });
+
+  return Effect.gen(function* () {
+    const bitbucket = yield* BitbucketApi.BitbucketApi;
+    const error = yield* bitbucket
+      .checkoutPullRequest({ cwd: "/repo", reference: "42" })
+      .pipe(Effect.flip);
+
+    assert.instanceOf(error, BitbucketApi.BitbucketResponseError);
+    assert.strictEqual(error.operation, "getPullRequest");
+    assert.strictEqual(error.status, 403);
+    assert.strictEqual(error.responseBody, responseBody);
+    assert.strictEqual(
+      error.message,
+      `Bitbucket API failed in getPullRequest: Bitbucket returned HTTP 403: ${responseBody}`,
+    );
+  }).pipe(Effect.provide(layer));
+});
+
+it.effect("preserves Bitbucket response body read failures as their immediate cause", () => {
+  const cause = new Error("response stream failed");
+  const { layer } = makeLayer({
+    response: () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          start: (controller) => controller.error(cause),
+        }),
+        { status: 502 },
+      ),
+  });
+
+  return Effect.gen(function* () {
+    const bitbucket = yield* BitbucketApi.BitbucketApi;
+    const error = yield* bitbucket
+      .getPullRequest({ cwd: "/repo", reference: "42" })
+      .pipe(Effect.flip);
+
+    assert.instanceOf(error, BitbucketApi.BitbucketResponseBodyReadError);
+    assert.strictEqual(error.operation, "getPullRequest");
+    assert.strictEqual(error.status, 502);
+    assert.instanceOf(error.cause, HttpClientError.HttpClientError);
+    assert.strictEqual(error.cause.cause, cause);
+    assert.strictEqual(
+      error.message,
+      "Bitbucket API failed in getPullRequest: Bitbucket returned HTTP 502.",
+    );
   }).pipe(Effect.provide(layer));
 });
 
@@ -630,8 +683,9 @@ it.effect("preserves Git checkout failures without deriving the domain message f
       }),
     );
 
-    assert.strictEqual(error.operation, "checkoutPullRequest");
-    assert.strictEqual(error.detail, "Failed to check out the Bitbucket pull request.");
+    assert.instanceOf(error, BitbucketApi.BitbucketCheckoutError);
+    assert.strictEqual(error.cwd, "/repo");
+    assert.strictEqual(error.reference, "42");
     assert.strictEqual(
       error.message,
       "Bitbucket API failed in checkoutPullRequest: Failed to check out the Bitbucket pull request.",

--- a/apps/server/src/sourceControl/BitbucketApi.test.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.test.ts
@@ -544,8 +544,8 @@ it.effect("preserves the HTTP client failure without deriving the domain message
   }).pipe(Effect.provide(layer));
 });
 
-it.effect("preserves structured Bitbucket HTTP failures through checkout", () => {
-  const responseBody = '{"error":{"message":"forbidden"}}';
+it.effect("keeps Bitbucket response bodies out of checkout diagnostics", () => {
+  const responseBody = '{"error":{"message":"credential=secret-value"}}';
   const { layer } = makeLayer({
     response: () => new Response(responseBody, { status: 403 }),
   });
@@ -559,11 +559,13 @@ it.effect("preserves structured Bitbucket HTTP failures through checkout", () =>
     assert.instanceOf(error, BitbucketApi.BitbucketResponseError);
     assert.strictEqual(error.operation, "getPullRequest");
     assert.strictEqual(error.status, 403);
-    assert.strictEqual(error.responseBody, responseBody);
+    assert.strictEqual(error.responseBodyLength, responseBody.length);
+    assert.notProperty(error, "responseBody");
     assert.strictEqual(
       error.message,
-      `Bitbucket API failed in getPullRequest: Bitbucket returned HTTP 403: ${responseBody}`,
+      "Bitbucket API failed in getPullRequest: Bitbucket returned HTTP 403.",
     );
+    assert.notInclude(error.message, "secret-value");
   }).pipe(Effect.provide(layer));
 });
 

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -36,20 +36,159 @@ const BitbucketApiEnvConfig = Config.all({
   apiToken: Config.string("T3CODE_BITBUCKET_API_TOKEN").pipe(Config.option),
 });
 
-export class BitbucketApiError extends Schema.TaggedErrorClass<BitbucketApiError>()(
-  "BitbucketApiError",
+const BitbucketApiOperation = Schema.Literals([
+  "resolveRepository",
+  "getRepository",
+  "getBranchingModel",
+  "getPullRequest",
+  "listPullRequests",
+  "createRepository",
+  "createPullRequest",
+  "probeAuth",
+  "checkoutPullRequest",
+]);
+type BitbucketApiOperation = typeof BitbucketApiOperation.Type;
+
+export class BitbucketRepositoryLocatorError extends Schema.TaggedErrorClass<BitbucketRepositoryLocatorError>()(
+  "BitbucketRepositoryLocatorError",
   {
-    operation: Schema.String,
-    detail: Schema.String,
-    status: Schema.optional(Schema.Number),
-    cause: Schema.optional(Schema.Defect()),
+    repository: Schema.String,
   },
 ) {
   override get message(): string {
-    return `Bitbucket API failed in ${this.operation}: ${this.detail}`;
+    return "Bitbucket API failed in createRepository: Bitbucket repositories must be specified as workspace/repository.";
   }
 }
-const isBitbucketApiError = Schema.is(BitbucketApiError);
+
+export class BitbucketRequestError extends Schema.TaggedErrorClass<BitbucketRequestError>()(
+  "BitbucketRequestError",
+  {
+    operation: BitbucketApiOperation,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Bitbucket API failed in ${this.operation}: Failed to send the Bitbucket request.`;
+  }
+}
+
+export class BitbucketResponseError extends Schema.TaggedErrorClass<BitbucketResponseError>()(
+  "BitbucketResponseError",
+  {
+    operation: BitbucketApiOperation,
+    status: Schema.Int,
+    responseBody: Schema.String,
+  },
+) {
+  override get message(): string {
+    const body = this.responseBody.trim();
+    return body.length > 0
+      ? `Bitbucket API failed in ${this.operation}: Bitbucket returned HTTP ${this.status}: ${body}`
+      : `Bitbucket API failed in ${this.operation}: Bitbucket returned HTTP ${this.status}.`;
+  }
+}
+
+export class BitbucketResponseBodyReadError extends Schema.TaggedErrorClass<BitbucketResponseBodyReadError>()(
+  "BitbucketResponseBodyReadError",
+  {
+    operation: BitbucketApiOperation,
+    status: Schema.Int,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Bitbucket API failed in ${this.operation}: Bitbucket returned HTTP ${this.status}.`;
+  }
+}
+
+export class BitbucketResponseDecodeError extends Schema.TaggedErrorClass<BitbucketResponseDecodeError>()(
+  "BitbucketResponseDecodeError",
+  {
+    operation: BitbucketApiOperation,
+    status: Schema.Int,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Bitbucket API failed in ${this.operation}: Bitbucket returned invalid JSON for the requested resource.`;
+  }
+}
+
+export class BitbucketRepositoryVcsResolveError extends Schema.TaggedErrorClass<BitbucketRepositoryVcsResolveError>()(
+  "BitbucketRepositoryVcsResolveError",
+  {
+    cwd: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Bitbucket API failed in resolveRepository: Failed to resolve VCS repository for ${this.cwd}.`;
+  }
+}
+
+export class BitbucketRepositoryRemotesListError extends Schema.TaggedErrorClass<BitbucketRepositoryRemotesListError>()(
+  "BitbucketRepositoryRemotesListError",
+  {
+    cwd: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Bitbucket API failed in resolveRepository: Failed to list remotes for ${this.cwd}.`;
+  }
+}
+
+export class BitbucketRepositoryRemoteNotFoundError extends Schema.TaggedErrorClass<BitbucketRepositoryRemoteNotFoundError>()(
+  "BitbucketRepositoryRemoteNotFoundError",
+  {
+    cwd: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Bitbucket API failed in resolveRepository: No Bitbucket repository remote was detected for ${this.cwd}.`;
+  }
+}
+
+export class BitbucketPullRequestBodyReadError extends Schema.TaggedErrorClass<BitbucketPullRequestBodyReadError>()(
+  "BitbucketPullRequestBodyReadError",
+  {
+    cwd: Schema.String,
+    bodyFile: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Bitbucket API failed in createPullRequest: Failed to read pull request body file ${this.bodyFile}.`;
+  }
+}
+
+export class BitbucketCheckoutError extends Schema.TaggedErrorClass<BitbucketCheckoutError>()(
+  "BitbucketCheckoutError",
+  {
+    cwd: Schema.String,
+    reference: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Bitbucket API failed in checkoutPullRequest: Failed to check out the Bitbucket pull request.";
+  }
+}
+
+export const BitbucketApiError = Schema.Union([
+  BitbucketRepositoryLocatorError,
+  BitbucketRequestError,
+  BitbucketResponseError,
+  BitbucketResponseBodyReadError,
+  BitbucketResponseDecodeError,
+  BitbucketRepositoryVcsResolveError,
+  BitbucketRepositoryRemotesListError,
+  BitbucketRepositoryRemoteNotFoundError,
+  BitbucketPullRequestBodyReadError,
+  BitbucketCheckoutError,
+]);
+export type BitbucketApiError = typeof BitbucketApiError.Type;
+export const isBitbucketApiError = Schema.is(BitbucketApiError);
 
 const RawBitbucketRepositorySchema = Schema.Struct({
   full_name: TrimmedNonEmptyString,
@@ -209,16 +348,14 @@ function parseBitbucketRepositorySlug(value: string): BitbucketRepositoryLocator
 }
 
 function requireRepositoryLocator(
-  operation: string,
   repository: string,
 ): Effect.Effect<BitbucketRepositoryLocator, BitbucketApiError> {
   const locator = parseBitbucketRepositorySlug(repository);
   return locator
     ? Effect.succeed(locator)
     : Effect.fail(
-        new BitbucketApiError({
-          operation,
-          detail: "Bitbucket repositories must be specified as workspace/repository.",
+        new BitbucketRepositoryLocatorError({
+          repository,
         }),
       );
 }
@@ -339,20 +476,24 @@ function authFromConfig(
 }
 
 function responseError(
-  operation: string,
+  operation: BitbucketApiOperation,
   response: HttpClientResponse.HttpClientResponse,
 ): Effect.Effect<never, BitbucketApiError> {
   return response.text.pipe(
-    Effect.orElseSucceed(() => ""),
-    Effect.flatMap((body) =>
-      Effect.fail(
-        new BitbucketApiError({
+    Effect.mapError(
+      (cause) =>
+        new BitbucketResponseBodyReadError({
           operation,
           status: response.status,
-          detail:
-            body.trim().length > 0
-              ? `Bitbucket returned HTTP ${response.status}: ${body.trim()}`
-              : `Bitbucket returned HTTP ${response.status}.`,
+          cause,
+        }),
+    ),
+    Effect.flatMap((body) =>
+      Effect.fail(
+        new BitbucketResponseError({
+          operation,
+          status: response.status,
+          responseBody: body,
         }),
       ),
     ),
@@ -379,7 +520,7 @@ export const make = Effect.gen(function* () {
   };
 
   const decodeResponse = <S extends Schema.Top>(
-    operation: string,
+    operation: BitbucketApiOperation,
     schema: S,
     response: HttpClientResponse.HttpClientResponse,
   ): Effect.Effect<S["Type"], BitbucketApiError, S["DecodingServices"]> =>
@@ -388,9 +529,9 @@ export const make = Effect.gen(function* () {
         HttpClientResponse.schemaBodyJson(schema)(success).pipe(
           Effect.mapError(
             (cause) =>
-              new BitbucketApiError({
+              new BitbucketResponseDecodeError({
                 operation,
-                detail: "Bitbucket returned invalid JSON for the requested resource.",
+                status: success.status,
                 cause,
               }),
           ),
@@ -399,16 +540,15 @@ export const make = Effect.gen(function* () {
     })(response);
 
   const executeJson = <S extends Schema.Top>(
-    operation: string,
+    operation: BitbucketApiOperation,
     request: HttpClientRequest.HttpClientRequest,
     schema: S,
   ): Effect.Effect<S["Type"], BitbucketApiError, S["DecodingServices"]> =>
     httpClient.execute(withAuth(request.pipe(HttpClientRequest.acceptJson))).pipe(
       Effect.mapError(
         (cause) =>
-          new BitbucketApiError({
+          new BitbucketRequestError({
             operation,
-            detail: "Failed to send the Bitbucket request.",
             cause,
           }),
       ),
@@ -433,9 +573,8 @@ export const make = Effect.gen(function* () {
     const handle = yield* vcsRegistry.resolve({ cwd: input.cwd }).pipe(
       Effect.mapError(
         (cause) =>
-          new BitbucketApiError({
-            operation: "resolveRepository",
-            detail: `Failed to resolve VCS repository for ${input.cwd}.`,
+          new BitbucketRepositoryVcsResolveError({
+            cwd: input.cwd,
             cause,
           }),
       ),
@@ -443,9 +582,8 @@ export const make = Effect.gen(function* () {
     const remotes = yield* handle.driver.listRemotes(input.cwd).pipe(
       Effect.mapError(
         (cause) =>
-          new BitbucketApiError({
-            operation: "resolveRepository",
-            detail: `Failed to list remotes for ${input.cwd}.`,
+          new BitbucketRepositoryRemotesListError({
+            cwd: input.cwd,
             cause,
           }),
       ),
@@ -457,9 +595,8 @@ export const make = Effect.gen(function* () {
       if (parsed) return parsed;
     }
 
-    return yield* new BitbucketApiError({
-      operation: "resolveRepository",
-      detail: `No Bitbucket repository remote was detected for ${input.cwd}.`,
+    return yield* new BitbucketRepositoryRemoteNotFoundError({
+      cwd: input.cwd,
     });
   });
 
@@ -600,7 +737,7 @@ export const make = Effect.gen(function* () {
     getRepositoryCloneUrls: (input) =>
       getRepository(input).pipe(Effect.map(normalizeRepositoryCloneUrls)),
     createRepository: (input) =>
-      requireRepositoryLocator("createRepository", input.repository).pipe(
+      requireRepositoryLocator(input.repository).pipe(
         Effect.flatMap((repository) =>
           executeJson(
             "createRepository",
@@ -625,9 +762,9 @@ export const make = Effect.gen(function* () {
         const description = yield* fileSystem.readFileString(input.bodyFile).pipe(
           Effect.mapError(
             (cause) =>
-              new BitbucketApiError({
-                operation: "createPullRequest",
-                detail: `Failed to read pull request body file ${input.bodyFile}.`,
+              new BitbucketPullRequestBodyReadError({
+                cwd: input.cwd,
+                bodyFile: input.bodyFile,
                 cause,
               }),
           ),
@@ -743,9 +880,9 @@ export const make = Effect.gen(function* () {
         Effect.mapError((cause) =>
           isBitbucketApiError(cause)
             ? cause
-            : new BitbucketApiError({
-                operation: "checkoutPullRequest",
-                detail: "Failed to check out the Bitbucket pull request.",
+            : new BitbucketCheckoutError({
+                cwd: input.cwd,
+                reference: input.reference,
                 cause,
               }),
         ),

--- a/apps/server/src/sourceControl/BitbucketApi.ts
+++ b/apps/server/src/sourceControl/BitbucketApi.ts
@@ -6,6 +6,7 @@ import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import {
+  NonNegativeInt,
   TrimmedNonEmptyString,
   type SourceControlProviderAuth,
   type SourceControlRepositoryCloneUrls,
@@ -77,14 +78,11 @@ export class BitbucketResponseError extends Schema.TaggedErrorClass<BitbucketRes
   {
     operation: BitbucketApiOperation,
     status: Schema.Int,
-    responseBody: Schema.String,
+    responseBodyLength: NonNegativeInt,
   },
 ) {
   override get message(): string {
-    const body = this.responseBody.trim();
-    return body.length > 0
-      ? `Bitbucket API failed in ${this.operation}: Bitbucket returned HTTP ${this.status}: ${body}`
-      : `Bitbucket API failed in ${this.operation}: Bitbucket returned HTTP ${this.status}.`;
+    return `Bitbucket API failed in ${this.operation}: Bitbucket returned HTTP ${this.status}.`;
   }
 }
 
@@ -493,7 +491,7 @@ function responseError(
         new BitbucketResponseError({
           operation,
           status: response.status,
-          responseBody: body,
+          responseBodyLength: body.length,
         }),
       ),
     ),

--- a/apps/server/src/sourceControl/BitbucketSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/BitbucketSourceControlProvider.test.ts
@@ -53,11 +53,10 @@ it.effect("maps Bitbucket PR summaries into provider-neutral change requests", (
 
 it.effect("adds repository context while retaining Bitbucket API causes", () =>
   Effect.gen(function* () {
-    const cause = new BitbucketApi.BitbucketApiError({
+    const upstreamCause = new Error("raw upstream failure");
+    const cause = new BitbucketApi.BitbucketRequestError({
       operation: "getRepository",
-      detail: "upstream detail that should remain in the cause",
-      status: 503,
-      cause: new Error("raw upstream failure"),
+      cause: upstreamCause,
     });
     const provider = yield* makeProvider({
       getRepositoryCloneUrls: () => Effect.fail(cause),
@@ -86,7 +85,7 @@ it.effect("adds repository context while retaining Bitbucket API causes", () =>
       },
     );
     assert.strictEqual(error.cause, cause);
-    assert.equal(error.message.includes(cause.detail), false);
+    assert.equal(error.message.includes(upstreamCause.message), false);
   }),
 );
 


### PR DESCRIPTION
## Summary

- replace the free-form `BitbucketApiError.detail` bucket with distinct Schema error classes for transport, HTTP response, body-read, decode, repository resolution, locator, body-file, and checkout failures
- expose the union and its `Schema.is` predicate so checkout preserves already-structured Bitbucket failures by tag
- retain the existing user-facing messages while attaching operation-specific context, HTTP status/body diagnostics, and immediate causes
- update the existing Bitbucket API and provider tests with focused coverage for response diagnostics, body-read cause chains, and checkout tag preservation

## Validation

- `vp test run apps/server/src/sourceControl/BitbucketApi.test.ts apps/server/src/sourceControl/BitbucketSourceControlProvider.test.ts`
- `vp check` (passes with 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error shapes and HTTP failure messaging (no embedded API bodies); callers matching on `detail` or the old single class need updates, but user-facing messages stay stable and leakage risk is reduced.
> 
> **Overview**
> Replaces the monolithic `BitbucketApiError` (with free-form `detail`) with **tagged Schema error classes** and a `BitbucketApiError` union plus `isBitbucketApiError` for narrowing.
> 
> Failures are split by kind: transport (`BitbucketRequestError`), HTTP status (`BitbucketResponseError` with `responseBodyLength` only—**no response body text in messages or fields**), body read (`BitbucketResponseBodyReadError`), JSON decode, repository resolution/locator, PR body file read, and checkout (`BitbucketCheckoutError` with `cwd`/`reference`). `checkoutPullRequest` re-throws existing union members via `isBitbucketApiError` instead of re-wrapping.
> 
> Tests assert specific error classes, redaction of secrets from diagnostics, body-read cause chains, and provider-layer cause preservation without leaking upstream messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0ebe0dfb630c8455d08a276cfd2058722989477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic Bitbucket API errors with typed error classes
> - Introduces specific tagged error classes (`BitbucketRequestError`, `BitbucketResponseError`, `BitbucketResponseBodyReadError`, `BitbucketResponseDecodeError`, `BitbucketCheckoutError`, `BitbucketRepositoryLocatorError`, etc.) replacing the previous single `BitbucketApiError` class in [BitbucketApi.ts](https://github.com/pingdotgg/t3code/pull/3457/files#diff-0f26cbc52f3a4bd71850ee2ab91de644c5e26ecd24de9283ea456101105b01e8).
> - Each error class captures structured context (e.g. `operation`, `status`, `responseBodyLength`, `cwd`, `reference`) rather than freeform `detail` strings.
> - Non-2xx response bodies are no longer included in error objects; only the body length is recorded, preventing sensitive content from leaking into diagnostics.
> - `BitbucketApiError` is now a `Schema.Union` of all specific error types with an exported `isBitbucketApiError` predicate.
> - Behavioral Change: callers that previously matched on `BitbucketApiError` with `detail`/`operation` fields must migrate to the new specific error types and their respective fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0ebe0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->