### PR TITLE
[codex] Structure GitLab CLI failures

### DIFF
--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -331,12 +331,37 @@ layer("GitLabCli.layer", (it) => {
         });
       }).pipe(Effect.flip);
 
-      assert.equal(error.message.includes("Merge request not found"), true);
+      assert.equal(error.message.includes("Merge request 4888 was not found"), true);
       assert.strictEqual(error._tag, "GitLabMergeRequestNotFoundError");
       assert.strictEqual(error.command, "glab");
       assert.strictEqual(error.cwd, "/repo");
       assert.strictEqual(error.cause, cause);
       assert.equal(error.message.includes(cause.detail), false);
+    }),
+  );
+
+  it.effect("keeps non-merge-request not-found failures generic", () =>
+    Effect.gen(function* () {
+      const cause = new VcsProcessExitError({
+        operation: "GitLabCli.execute",
+        command: "glab",
+        cwd: "/repo",
+        exitCode: 1,
+        detail: "GET 404 project not found",
+        failureKind: "not-found",
+      });
+      mockedRun.mockReturnValueOnce(Effect.fail(cause));
+
+      const error = yield* Effect.gen(function* () {
+        const glab = yield* GitLabCli.GitLabCli;
+        return yield* glab.getRepositoryCloneUrls({
+          cwd: "/repo",
+          repository: "missing/project",
+        });
+      }).pipe(Effect.flip);
+
+      assert.strictEqual(error._tag, "GitLabCliCommandError");
+      assert.strictEqual(error.cause, cause);
     }),
   );
 });

--- a/apps/server/src/sourceControl/GitLabCli.test.ts
+++ b/apps/server/src/sourceControl/GitLabCli.test.ts
@@ -315,10 +315,11 @@ layer("GitLabCli.layer", (it) => {
     Effect.gen(function* () {
       const cause = new VcsProcessExitError({
         operation: "GitLabCli.execute",
-        command: "glab mr view 4888",
+        command: "glab",
         cwd: "/repo",
         exitCode: 1,
         detail: "GET 404 merge request not found",
+        failureKind: "not-found",
       });
       mockedRun.mockReturnValueOnce(Effect.fail(cause));
 
@@ -331,6 +332,7 @@ layer("GitLabCli.layer", (it) => {
       }).pipe(Effect.flip);
 
       assert.equal(error.message.includes("Merge request not found"), true);
+      assert.strictEqual(error._tag, "GitLabMergeRequestNotFoundError");
       assert.strictEqual(error.command, "glab");
       assert.strictEqual(error.cwd, "/repo");
       assert.strictEqual(error.cause, cause);

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
@@ -21,13 +22,66 @@ import type * as SourceControlProvider from "./SourceControlProvider.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-export class GitLabCliError extends Schema.TaggedErrorClass<GitLabCliError>()("GitLabCliError", {
-  operation: Schema.String,
-  command: Schema.String,
+const gitLabCliExecutionErrorContext = {
+  operation: Schema.Literal("execute"),
+  command: Schema.Literal("glab"),
   cwd: Schema.String,
-  detail: Schema.String,
-  cause: Schema.optional(Schema.Defect()),
-}) {
+  cause: Schema.Defect(),
+};
+
+const gitLabCliDecodeErrorContext = {
+  command: Schema.Literal("glab"),
+  cwd: Schema.String,
+  cause: Schema.Defect(),
+};
+
+export class GitLabCliUnavailableError extends Schema.TaggedErrorClass<GitLabCliUnavailableError>()(
+  "GitLabCliUnavailableError",
+  gitLabCliExecutionErrorContext,
+) {
+  get detail(): string {
+    return "GitLab CLI (`glab`) is required but not available on PATH.";
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class GitLabCliAuthenticationError extends Schema.TaggedErrorClass<GitLabCliAuthenticationError>()(
+  "GitLabCliAuthenticationError",
+  gitLabCliExecutionErrorContext,
+) {
+  get detail(): string {
+    return "GitLab CLI is not authenticated. Run `glab auth login` and retry.";
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class GitLabMergeRequestNotFoundError extends Schema.TaggedErrorClass<GitLabMergeRequestNotFoundError>()(
+  "GitLabMergeRequestNotFoundError",
+  gitLabCliExecutionErrorContext,
+) {
+  get detail(): string {
+    return "Merge request not found. Check the MR number or URL and try again.";
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class GitLabCliCommandError extends Schema.TaggedErrorClass<GitLabCliCommandError>()(
+  "GitLabCliCommandError",
+  gitLabCliExecutionErrorContext,
+) {
+  get detail(): string {
+    return "GitLab CLI command failed.";
+  }
+
   override get message(): string {
     return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
   }
@@ -38,50 +92,108 @@ export class GitLabCliError extends Schema.TaggedErrorClass<GitLabCliError>()("G
       readonly command: "glab";
       readonly cwd: string;
     },
-    error: VcsError | unknown,
+    error: VcsError,
   ): GitLabCliError {
-    const lower = errorText(error).toLowerCase();
-
-    if (lower.includes("command not found: glab") || isVcsProcessSpawnError(error)) {
-      return new GitLabCliError({
-        ...context,
-        detail: "GitLab CLI (`glab`) is required but not available on PATH.",
-        cause: error,
-      });
-    }
-
-    if (
-      lower.includes("authentication failed") ||
-      lower.includes("not logged in") ||
-      lower.includes("glab auth login") ||
-      lower.includes("token")
-    ) {
-      return new GitLabCliError({
-        ...context,
-        detail: "GitLab CLI is not authenticated. Run `glab auth login` and retry.",
-        cause: error,
-      });
-    }
-
-    if (
-      lower.includes("merge request not found") ||
-      lower.includes("not found") ||
-      lower.includes("404")
-    ) {
-      return new GitLabCliError({
-        ...context,
-        detail: "Merge request not found. Check the MR number or URL and try again.",
-        cause: error,
-      });
-    }
-
-    return new GitLabCliError({
-      ...context,
-      detail: "GitLab CLI command failed.",
-      cause: error,
+    return Match.valueTags(error, {
+      VcsProcessSpawnError: (cause) => new GitLabCliUnavailableError({ ...context, cause }),
+      VcsProcessExitError: (cause) => {
+        switch (cause.failureKind) {
+          case "authentication":
+            return new GitLabCliAuthenticationError({ ...context, cause });
+          case "not-found":
+            return new GitLabMergeRequestNotFoundError({ ...context, cause });
+          case "command-failed":
+          case undefined:
+            return new GitLabCliCommandError({ ...context, cause });
+        }
+      },
+      VcsProcessTimeoutError: (cause) => new GitLabCliCommandError({ ...context, cause }),
+      VcsOutputDecodeError: (cause) => new GitLabCliCommandError({ ...context, cause }),
+      VcsRepositoryDetectionError: (cause) => new GitLabCliCommandError({ ...context, cause }),
+      VcsUnsupportedOperationError: (cause) => new GitLabCliCommandError({ ...context, cause }),
     });
   }
 }
+
+export class GitLabMergeRequestListDecodeError extends Schema.TaggedErrorClass<GitLabMergeRequestListDecodeError>()(
+  "GitLabMergeRequestListDecodeError",
+  {
+    ...gitLabCliDecodeErrorContext,
+    operation: Schema.Literal("listMergeRequests"),
+  },
+) {
+  get detail(): string {
+    return "GitLab CLI returned invalid MR list JSON.";
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class GitLabMergeRequestDecodeError extends Schema.TaggedErrorClass<GitLabMergeRequestDecodeError>()(
+  "GitLabMergeRequestDecodeError",
+  {
+    ...gitLabCliDecodeErrorContext,
+    operation: Schema.Literal("getMergeRequest"),
+    reference: Schema.String,
+  },
+) {
+  get detail(): string {
+    return "GitLab CLI returned invalid merge request JSON.";
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class GitLabRepositoryDecodeError extends Schema.TaggedErrorClass<GitLabRepositoryDecodeError>()(
+  "GitLabRepositoryDecodeError",
+  {
+    ...gitLabCliDecodeErrorContext,
+    operation: Schema.Literals(["getRepositoryCloneUrls", "createRepository", "getDefaultBranch"]),
+    repository: Schema.optional(Schema.String),
+  },
+) {
+  get detail(): string {
+    return "GitLab CLI returned invalid repository JSON.";
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class GitLabNamespaceDecodeError extends Schema.TaggedErrorClass<GitLabNamespaceDecodeError>()(
+  "GitLabNamespaceDecodeError",
+  {
+    ...gitLabCliDecodeErrorContext,
+    operation: Schema.Literal("createRepository"),
+    namespacePath: Schema.String,
+  },
+) {
+  get detail(): string {
+    return "GitLab CLI returned invalid namespace JSON.";
+  }
+
+  override get message(): string {
+    return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export const GitLabCliError = Schema.Union([
+  GitLabCliUnavailableError,
+  GitLabCliAuthenticationError,
+  GitLabMergeRequestNotFoundError,
+  GitLabCliCommandError,
+  GitLabMergeRequestListDecodeError,
+  GitLabMergeRequestDecodeError,
+  GitLabRepositoryDecodeError,
+  GitLabNamespaceDecodeError,
+]);
+export type GitLabCliError = typeof GitLabCliError.Type;
+export const isGitLabCliError = Schema.is(GitLabCliError);
 
 export interface GitLabMergeRequestSummary {
   readonly number: number;
@@ -100,17 +212,6 @@ export interface GitLabRepositoryCloneUrls {
   readonly nameWithOwner: string;
   readonly url: string;
   readonly sshUrl: string;
-}
-
-function errorText(error: VcsError | unknown): string {
-  if (typeof error === "object" && error !== null) {
-    const tag = "_tag" in error && typeof error._tag === "string" ? error._tag : "";
-    const detail = "detail" in error && typeof error.detail === "string" ? error.detail : "";
-    const message = "message" in error && typeof error.message === "string" ? error.message : "";
-    return [tag, detail, message].filter(Boolean).join("\n");
-  }
-
-  return String(error);
 }
 
 export class GitLabCli extends Context.Service<
@@ -168,15 +269,6 @@ export class GitLabCli extends Context.Service<
   }
 >()("t3/sourceControl/GitLabCli") {}
 
-function isVcsProcessSpawnError(error: unknown): boolean {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "_tag" in error &&
-    error._tag === "VcsProcessSpawnError"
-  );
-}
-
 const RawGitLabRepositoryCloneUrlsSchema = Schema.Struct({
   path_with_namespace: TrimmedNonEmptyString,
   web_url: TrimmedNonEmptyString,
@@ -192,6 +284,14 @@ const RawGitLabNamespaceSchema = Schema.Struct({
   id: Schema.Number,
 });
 
+const decodeGitLabRepositoryCloneUrls = Schema.decodeEffect(
+  Schema.fromJsonString(RawGitLabRepositoryCloneUrlsSchema),
+);
+const decodeGitLabDefaultBranch = Schema.decodeEffect(
+  Schema.fromJsonString(RawGitLabDefaultBranchSchema),
+);
+const decodeGitLabNamespace = Schema.decodeEffect(Schema.fromJsonString(RawGitLabNamespaceSchema));
+
 function normalizeRepositoryCloneUrls(
   raw: Schema.Schema.Type<typeof RawGitLabRepositoryCloneUrlsSchema>,
 ): GitLabRepositoryCloneUrls {
@@ -200,27 +300,6 @@ function normalizeRepositoryCloneUrls(
     url: raw.web_url,
     sshUrl: raw.ssh_url_to_repo,
   };
-}
-
-function decodeGitLabJson<S extends Schema.Top>(
-  raw: string,
-  schema: S,
-  operation: "getRepositoryCloneUrls" | "getDefaultBranch" | "createRepository",
-  invalidDetail: string,
-  cwd: string,
-): Effect.Effect<S["Type"], GitLabCliError, S["DecodingServices"]> {
-  return Schema.decodeEffect(Schema.fromJsonString(schema))(raw).pipe(
-    Effect.mapError(
-      (error) =>
-        new GitLabCliError({
-          operation,
-          command: "glab",
-          cwd,
-          detail: invalidDetail,
-          cause: error,
-        }),
-    ),
-  );
 }
 
 function stateArgs(state: "open" | "closed" | "merged" | "all"): ReadonlyArray<string> {
@@ -294,7 +373,7 @@ export const make = Effect.gen(function* () {
       })
       .pipe(
         Effect.mapError((error) =>
-          GitLabCliError.fromVcsError(
+          GitLabCliCommandError.fromVcsError(
             { operation: "execute", command: "glab", cwd: input.cwd },
             error,
           ),
@@ -326,11 +405,10 @@ export const make = Effect.gen(function* () {
                 Effect.flatMap((decoded) => {
                   if (!Result.isSuccess(decoded)) {
                     return Effect.fail(
-                      new GitLabCliError({
+                      new GitLabMergeRequestListDecodeError({
                         operation: "listMergeRequests",
                         command: "glab",
                         cwd: input.cwd,
-                        detail: "GitLab CLI returned invalid MR list JSON.",
                         cause: decoded.failure,
                       }),
                     );
@@ -352,11 +430,11 @@ export const make = Effect.gen(function* () {
             Effect.flatMap((decoded) => {
               if (!Result.isSuccess(decoded)) {
                 return Effect.fail(
-                  new GitLabCliError({
+                  new GitLabMergeRequestDecodeError({
                     operation: "getMergeRequest",
                     command: "glab",
                     cwd: input.cwd,
-                    detail: "GitLab CLI returned invalid merge request JSON.",
+                    reference: input.reference,
                     cause: decoded.failure,
                   }),
                 );
@@ -374,12 +452,17 @@ export const make = Effect.gen(function* () {
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
-          decodeGitLabJson(
-            raw,
-            RawGitLabRepositoryCloneUrlsSchema,
-            "getRepositoryCloneUrls",
-            "GitLab CLI returned invalid repository JSON.",
-            input.cwd,
+          decodeGitLabRepositoryCloneUrls(raw).pipe(
+            Effect.mapError(
+              (cause) =>
+                new GitLabRepositoryDecodeError({
+                  operation: "getRepositoryCloneUrls",
+                  command: "glab",
+                  cwd: input.cwd,
+                  repository: input.repository,
+                  cause,
+                }),
+            ),
           ),
         ),
         Effect.map(normalizeRepositoryCloneUrls),
@@ -393,12 +476,17 @@ export const make = Effect.gen(function* () {
           }).pipe(
             Effect.map((result) => result.stdout.trim()),
             Effect.flatMap((raw) =>
-              decodeGitLabJson(
-                raw,
-                RawGitLabNamespaceSchema,
-                "createRepository",
-                "GitLab CLI returned invalid namespace JSON.",
-                input.cwd,
+              decodeGitLabNamespace(raw).pipe(
+                Effect.mapError(
+                  (cause) =>
+                    new GitLabNamespaceDecodeError({
+                      operation: "createRepository",
+                      command: "glab",
+                      cwd: input.cwd,
+                      namespacePath,
+                      cause,
+                    }),
+                ),
               ),
             ),
             Effect.map((namespace) => namespace.id),
@@ -428,12 +516,17 @@ export const make = Effect.gen(function* () {
         ),
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
-          decodeGitLabJson(
-            raw,
-            RawGitLabRepositoryCloneUrlsSchema,
-            "createRepository",
-            "GitLab CLI returned invalid repository JSON.",
-            input.cwd,
+          decodeGitLabRepositoryCloneUrls(raw).pipe(
+            Effect.mapError(
+              (cause) =>
+                new GitLabRepositoryDecodeError({
+                  operation: "createRepository",
+                  command: "glab",
+                  cwd: input.cwd,
+                  repository: input.repository,
+                  cause,
+                }),
+            ),
           ),
         ),
         Effect.map(normalizeRepositoryCloneUrls),
@@ -467,12 +560,16 @@ export const make = Effect.gen(function* () {
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
-          decodeGitLabJson(
-            raw,
-            RawGitLabDefaultBranchSchema,
-            "getDefaultBranch",
-            "GitLab CLI returned invalid repository JSON.",
-            input.cwd,
+          decodeGitLabDefaultBranch(raw).pipe(
+            Effect.mapError(
+              (cause) =>
+                new GitLabRepositoryDecodeError({
+                  operation: "getDefaultBranch",
+                  command: "glab",
+                  cwd: input.cwd,
+                  cause,
+                }),
+            ),
           ),
         ),
         Effect.map((value) => value.default_branch ?? null),

--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -63,14 +63,40 @@ export class GitLabCliAuthenticationError extends Schema.TaggedErrorClass<GitLab
 
 export class GitLabMergeRequestNotFoundError extends Schema.TaggedErrorClass<GitLabMergeRequestNotFoundError>()(
   "GitLabMergeRequestNotFoundError",
-  gitLabCliExecutionErrorContext,
+  {
+    ...gitLabCliExecutionErrorContext,
+    reference: Schema.String,
+  },
 ) {
   get detail(): string {
-    return "Merge request not found. Check the MR number or URL and try again.";
+    return `Merge request ${this.reference} was not found. Check the MR number or URL and try again.`;
   }
 
   override get message(): string {
     return `GitLab CLI failed in ${this.operation}: ${this.detail}`;
+  }
+
+  static fromVcsError(
+    context: {
+      readonly operation: "execute";
+      readonly command: "glab";
+      readonly cwd: string;
+      readonly reference: string;
+    },
+    error: VcsError,
+  ): GitLabCliError {
+    if (error._tag === "VcsProcessExitError" && error.failureKind === "not-found") {
+      return new GitLabMergeRequestNotFoundError({ ...context, cause: error });
+    }
+
+    return GitLabCliCommandError.fromVcsError(
+      {
+        operation: context.operation,
+        command: context.command,
+        cwd: context.cwd,
+      },
+      error,
+    );
   }
 }
 
@@ -101,7 +127,6 @@ export class GitLabCliCommandError extends Schema.TaggedErrorClass<GitLabCliComm
           case "authentication":
             return new GitLabCliAuthenticationError({ ...context, cause });
           case "not-found":
-            return new GitLabMergeRequestNotFoundError({ ...context, cause });
           case "command-failed":
           case undefined:
             return new GitLabCliCommandError({ ...context, cause });
@@ -362,7 +387,10 @@ function parseRepositoryPath(repository: string): {
 export const make = Effect.gen(function* () {
   const process = yield* VcsProcess.VcsProcess;
 
-  const execute: GitLabCli["Service"]["execute"] = (input) =>
+  const run = (
+    input: Parameters<GitLabCli["Service"]["execute"]>[0],
+    mapError: (error: VcsError) => GitLabCliError,
+  ) =>
     process
       .run({
         operation: "GitLabCli.execute",
@@ -371,14 +399,32 @@ export const make = Effect.gen(function* () {
         cwd: input.cwd,
         timeoutMs: input.timeoutMs ?? DEFAULT_TIMEOUT_MS,
       })
-      .pipe(
-        Effect.mapError((error) =>
-          GitLabCliCommandError.fromVcsError(
-            { operation: "execute", command: "glab", cwd: input.cwd },
-            error,
-          ),
-        ),
-      );
+      .pipe(Effect.mapError(mapError));
+
+  const execute: GitLabCli["Service"]["execute"] = (input) =>
+    run(input, (error) =>
+      GitLabCliCommandError.fromVcsError(
+        { operation: "execute", command: "glab", cwd: input.cwd },
+        error,
+      ),
+    );
+
+  const executeMergeRequest = (input: {
+    readonly cwd: string;
+    readonly reference: string;
+    readonly args: ReadonlyArray<string>;
+  }) =>
+    run(input, (error) =>
+      GitLabMergeRequestNotFoundError.fromVcsError(
+        {
+          operation: "execute",
+          command: "glab",
+          cwd: input.cwd,
+          reference: input.reference,
+        },
+        error,
+      ),
+    );
 
   return GitLabCli.of({
     execute,
@@ -420,8 +466,9 @@ export const make = Effect.gen(function* () {
         ),
       ),
     getMergeRequest: (input) =>
-      execute({
+      executeMergeRequest({
         cwd: input.cwd,
+        reference: input.reference,
         args: ["mr", "view", input.reference, "--output", "json"],
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
@@ -575,8 +622,9 @@ export const make = Effect.gen(function* () {
         Effect.map((value) => value.default_branch ?? null),
       ),
     checkoutMergeRequest: (input) =>
-      execute({
+      executeMergeRequest({
         cwd: input.cwd,
+        reference: input.reference,
         args: ["mr", "checkout", input.reference],
       }).pipe(Effect.asVoid),
   });

--- a/apps/server/src/sourceControl/GitLabSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitLabSourceControlProvider.test.ts
@@ -54,11 +54,10 @@ it.effect("maps GitLab MR summaries into provider-neutral change requests", () =
 
 it.effect("adds repository context while retaining GitLab CLI causes", () =>
   Effect.gen(function* () {
-    const cause = new GitLabCli.GitLabCliError({
+    const cause = new GitLabCli.GitLabCliCommandError({
       operation: "execute",
       command: "glab",
       cwd: "/repo",
-      detail: "GitLab CLI command failed.",
       cause: new Error("raw upstream detail that should remain in the cause"),
     });
     const provider = yield* makeProvider({


### PR DESCRIPTION
## Summary
- replace free-form GitLab CLI errors with distinct Schema error classes and a union predicate
- classify process failures from VCS tags and failure kinds instead of parsing error text
- retain immediate causes and attach operation-specific decode context

## Validation
- `vp test apps/server/src/sourceControl/GitLabCli.test.ts apps/server/src/sourceControl/GitLabSourceControlProvider.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all GitLab CLI failures are typed and surfaced; callers matching on the old single error shape or detail strings need updates, though behavior is covered by updated tests.
> 
> **Overview**
> Replaces the single free-form `GitLabCliError` with **tagged Schema error classes** (unavailable, authentication, MR not found, generic command failure, and operation-specific decode errors) plus a `GitLabCliError` union and `isGitLabCliError`.
> 
> **Process failures** are classified via `VcsError` tags and `failureKind` (`Match.valueTags`) instead of parsing stderr/detail strings; spawn → unavailable, auth → `GitLabCliAuthenticationError`, etc.
> 
> **MR-specific paths** (`getMergeRequest`, `checkoutMergeRequest`) use `executeMergeRequest` so `not-found` becomes `GitLabMergeRequestNotFoundError` with the MR reference in the message; other APIs (e.g. project 404) stay `GitLabCliCommandError`.
> 
> JSON decode failures now map to dedicated decode error types with structured `cause`; user-facing `message`/`detail` no longer leak raw upstream text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b7ee6d806c5b821fcbc89f983a61d3750cb6650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure GitLab CLI failures into typed error classes
> - Replaces the single generic `GitLabCliError` class with a union of specific typed errors: `GitLabCliUnavailableError`, `GitLabCliAuthenticationError`, `GitLabMergeRequestNotFoundError`, `GitLabCliCommandError`, and operation-specific decode errors.
> - MR operations (`getMergeRequest`, `checkoutMergeRequest`) now throw `GitLabMergeRequestNotFoundError` with a reference-specific message (e.g. "Merge request 4888 was not found") instead of a generic error.
> - Each `GitLabCli` method maps decode failures to a dedicated error class (e.g. `GitLabRepositoryDecodeError`, `GitLabNamespaceDecodeError`) rather than a shared generic decode error.
> - Error classification moves from heuristic string matching (`errorText`) to structured `VcsError` tag/`failureKind` matching via static `fromVcsError` methods.
> - Behavioral Change: callers catching `GitLabCliError` must update to use the new `isGitLabCliError` guard or handle individual error variants.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b7ee6d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->