### PR TITLE
[codex] Split project command failures

### DIFF
--- a/apps/server/src/cli/project.test.ts
+++ b/apps/server/src/cli/project.test.ts
@@ -2,7 +2,11 @@ import { assert, it } from "@effect/vitest";
 
 import { EnvironmentInternalError } from "@t3tools/contracts";
 
-import { ProjectCommandError } from "./project.ts";
+import {
+  ProjectLiveServerDeclaredResponseError,
+  ProjectLiveServerRequestError,
+  projectCommandErrorFromLiveServerRequest,
+} from "./project.ts";
 
 it("maps declared server failures into structural project command errors", () => {
   const cause = new EnvironmentInternalError({
@@ -11,8 +15,9 @@ it("maps declared server failures into structural project command errors", () =>
     traceId: "trace-123",
   });
 
-  const error = ProjectCommandError.fromLiveServerRequest(cause);
+  const error = projectCommandErrorFromLiveServerRequest(cause);
 
+  assert.instanceOf(error, ProjectLiveServerDeclaredResponseError);
   assert.strictEqual(error.operation, "callLiveServer");
   assert.strictEqual(error.code, "internal_error");
   assert.strictEqual(error.traceId, "trace-123");
@@ -23,10 +28,10 @@ it("maps declared server failures into structural project command errors", () =>
 it("preserves unexpected server failures without deriving the message from them", () => {
   const cause = new Error("credential abc123 was rejected");
 
-  const error = ProjectCommandError.fromLiveServerRequest(cause);
+  const error = projectCommandErrorFromLiveServerRequest(cause);
 
+  assert.instanceOf(error, ProjectLiveServerRequestError);
   assert.strictEqual(error.operation, "callLiveServer");
-  assert.strictEqual(error.detail, "Failed to call the running server.");
   assert.strictEqual(error.message, "Failed to call the running server.");
   assert.strictEqual(error.cause, cause);
 });

--- a/apps/server/src/cli/project.ts
+++ b/apps/server/src/cli/project.ts
@@ -51,62 +51,148 @@ type ProjectCliDispatchCommand = Extract<
 >;
 
 const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
-const ProjectCommandOperation = Schema.Literals([
-  "generateProjectCommandId",
-  "callLiveServer",
-  "validateProjectTitle",
-  "resolveProjectTarget",
-  "addProject",
-]);
 
-export class ProjectCommandError extends Schema.TaggedErrorClass<ProjectCommandError>()(
-  "ProjectCommandError",
+export class ProjectCommandIdGenerationError extends Schema.TaggedErrorClass<ProjectCommandIdGenerationError>()(
+  "ProjectCommandIdGenerationError",
   {
-    operation: ProjectCommandOperation,
-    detail: Schema.String,
-    code: Schema.optional(Schema.String),
-    traceId: Schema.optional(Schema.String),
-    status: Schema.optional(Schema.Number),
+    operation: Schema.Literal("generateProjectCommandId"),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to generate a project command identifier.";
+  }
+}
+
+export class ProjectLiveServerDeclaredResponseError extends Schema.TaggedErrorClass<ProjectLiveServerDeclaredResponseError>()(
+  "ProjectLiveServerDeclaredResponseError",
+  {
+    operation: Schema.Literal("callLiveServer"),
+    code: Schema.String,
+    traceId: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Server request failed (${this.code}, trace ${this.traceId}).`;
+  }
+}
+
+export class ProjectLiveServerUndeclaredStatusError extends Schema.TaggedErrorClass<ProjectLiveServerUndeclaredStatusError>()(
+  "ProjectLiveServerUndeclaredStatusError",
+  {
+    operation: Schema.Literal("callLiveServer"),
+    status: Schema.Int,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Server request failed with undeclared status ${this.status}.`;
+  }
+}
+
+export class ProjectLiveServerRequestError extends Schema.TaggedErrorClass<ProjectLiveServerRequestError>()(
+  "ProjectLiveServerRequestError",
+  {
+    operation: Schema.Literal("callLiveServer"),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to call the running server.";
+  }
+}
+
+export class ProjectTitleEmptyError extends Schema.TaggedErrorClass<ProjectTitleEmptyError>()(
+  "ProjectTitleEmptyError",
+  {
+    operation: Schema.Literal("validateProjectTitle"),
+    title: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "Project title cannot be empty.";
+  }
+}
+
+export class ProjectIdentifierEmptyError extends Schema.TaggedErrorClass<ProjectIdentifierEmptyError>()(
+  "ProjectIdentifierEmptyError",
+  {
+    operation: Schema.Literal("resolveProjectTarget"),
+    identifier: Schema.String,
+  },
+) {
+  override get message(): string {
+    return "Project identifier cannot be empty.";
+  }
+}
+
+export class ProjectNotFoundError extends Schema.TaggedErrorClass<ProjectNotFoundError>()(
+  "ProjectNotFoundError",
+  {
+    operation: Schema.Literal("resolveProjectTarget"),
+    identifier: Schema.String,
+    normalizedWorkspaceRoot: Schema.optional(Schema.String),
+    activeProjectCount: Schema.Number,
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
-  static fromLiveServerRequest(cause: unknown): ProjectCommandError {
-    if (isEnvironmentHttpCommonError(cause)) {
-      return new ProjectCommandError({
-        operation: "callLiveServer",
-        detail: `Server request failed (${cause.code}, trace ${cause.traceId}).`,
-        code: cause.code,
-        traceId: cause.traceId,
-        cause,
-      });
-    }
-    if (HttpClientError.isHttpClientError(cause) && cause.response !== undefined) {
-      return new ProjectCommandError({
-        operation: "callLiveServer",
-        detail: `Server request failed with undeclared status ${cause.response.status}.`,
-        status: cause.response.status,
-        cause,
-      });
-    }
-    return new ProjectCommandError({
+  override get message(): string {
+    return `No active project found for '${this.identifier}'.`;
+  }
+}
+
+export class ProjectAlreadyExistsError extends Schema.TaggedErrorClass<ProjectAlreadyExistsError>()(
+  "ProjectAlreadyExistsError",
+  {
+    operation: Schema.Literal("addProject"),
+    projectId: ProjectId,
+    workspaceRoot: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `An active project already exists for '${this.workspaceRoot}'.`;
+  }
+}
+
+export const ProjectCommandError = Schema.Union([
+  ProjectCommandIdGenerationError,
+  ProjectLiveServerDeclaredResponseError,
+  ProjectLiveServerUndeclaredStatusError,
+  ProjectLiveServerRequestError,
+  ProjectTitleEmptyError,
+  ProjectIdentifierEmptyError,
+  ProjectNotFoundError,
+  ProjectAlreadyExistsError,
+]);
+export type ProjectCommandError = typeof ProjectCommandError.Type;
+
+export function projectCommandErrorFromLiveServerRequest(cause: unknown): ProjectCommandError {
+  if (isEnvironmentHttpCommonError(cause)) {
+    return new ProjectLiveServerDeclaredResponseError({
       operation: "callLiveServer",
-      detail: "Failed to call the running server.",
+      code: cause.code,
+      traceId: cause.traceId,
+      cause,
+    });
+  }
+  if (HttpClientError.isHttpClientError(cause) && cause.response !== undefined) {
+    return new ProjectLiveServerUndeclaredStatusError({
+      operation: "callLiveServer",
+      status: cause.response.status,
       cause,
     });
   }
 
-  override get message(): string {
-    return this.detail;
-  }
+  return new ProjectLiveServerRequestError({ operation: "callLiveServer", cause });
 }
 
 const projectCommandUuid = Crypto.Crypto.pipe(
   Effect.flatMap((crypto) => crypto.randomUUIDv4),
   Effect.mapError(
     (cause) =>
-      new ProjectCommandError({
+      new ProjectCommandIdGenerationError({
         operation: "generateProjectCommandId",
-        detail: "Failed to generate a project command identifier.",
         cause,
       }),
   ),
@@ -158,9 +244,9 @@ const resolveProjectTitle = Effect.fn("resolveProjectTitle")(function* (
     if (trimmed.length > 0) {
       return trimmed;
     }
-    return yield* new ProjectCommandError({
+    return yield* new ProjectTitleEmptyError({
       operation: "validateProjectTitle",
-      detail: "Project title cannot be empty.",
+      title: explicitTitle,
     });
   }
 
@@ -175,9 +261,9 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
 }) {
   const trimmedIdentifier = input.identifier.trim();
   if (trimmedIdentifier.length === 0) {
-    return yield* new ProjectCommandError({
+    return yield* new ProjectIdentifierEmptyError({
       operation: "resolveProjectTarget",
-      detail: "Project identifier cannot be empty.",
+      identifier: input.identifier,
     });
   }
 
@@ -204,9 +290,11 @@ const findActiveProjectTarget = Effect.fn("findActiveProjectTarget")(function* (
 
   const resolved = exactWorkspaceMatch;
   if (!resolved) {
-    return yield* new ProjectCommandError({
+    return yield* new ProjectNotFoundError({
       operation: "resolveProjectTarget",
-      detail: `No active project found for '${trimmedIdentifier}'.`,
+      identifier: trimmedIdentifier,
+      activeProjectCount: activeProjects.length,
+      ...(normalizedWorkspaceRoot === null ? {} : { normalizedWorkspaceRoot }),
       ...(normalizedWorkspaceRootResult._tag === "Failure"
         ? { cause: normalizedWorkspaceRootResult.failure }
         : {}),
@@ -228,7 +316,7 @@ const fetchLiveOrchestrationSnapshot = (origin: string, bearerToken: string) =>
     });
   }).pipe(
     withProjectCliLiveServerTimeout,
-    Effect.mapError(ProjectCommandError.fromLiveServerRequest),
+    Effect.mapError(projectCommandErrorFromLiveServerRequest),
   );
 
 const dispatchLiveOrchestrationCommand = (
@@ -244,7 +332,7 @@ const dispatchLiveOrchestrationCommand = (
     } as Parameters<typeof client.orchestration.dispatch>[0]);
   }).pipe(
     withProjectCliLiveServerTimeout,
-    Effect.mapError(ProjectCommandError.fromLiveServerRequest),
+    Effect.mapError(projectCommandErrorFromLiveServerRequest),
   );
 
 const getOfflineSnapshot = Effect.fn("getOfflineSnapshot")(function* () {
@@ -376,9 +464,10 @@ const projectAddCommand = Command.make("add", {
           (project) => project.deletedAt === null && project.workspaceRoot === workspaceRoot,
         );
         if (existingProject) {
-          return yield* new ProjectCommandError({
+          return yield* new ProjectAlreadyExistsError({
             operation: "addProject",
-            detail: `An active project already exists for '${workspaceRoot}'.`,
+            projectId: existingProject.id,
+            workspaceRoot,
           });
         }
 


### PR DESCRIPTION
## Summary

- replace the free-form project command error with distinct Schema error classes for command-id generation, live-server responses, validation, lookup, and duplicate-project failures
- attach trace/status, raw inputs, normalized workspace context, active-project counts, existing project identity, and immediate causes where available
- preserve the existing caller-facing messages without deriving them from causes

## Validation

- `vp test apps/server/src/cli/project.test.ts`
- `vp check` (20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Callers that assumed a single `ProjectCommandError` class or read `detail` must handle the union; behavior is intended to stay the same at the message layer.
> 
> **Overview**
> Replaces the single **`ProjectCommandError`** tagged class (with a free-form `detail` string and optional fields) with a **`Schema.Union`** of eight operation-specific errors: command-id generation, three live-server failure shapes, title/identifier validation, not-found lookup, and duplicate project.
> 
> Live-server failures are classified by **`projectCommandErrorFromLiveServerRequest`** (replacing **`ProjectCommandError.fromLiveServerRequest`**) into declared HTTP errors, undeclared status responses, or a generic request error. Internal yields now attach structured context (e.g. **`traceId`**, **`status`**, raw **`title`/`identifier`**, **`activeProjectCount`**, existing **`projectId`**) while **`message`** getters keep the same user-facing text. Tests assert the concrete error classes for declared vs unexpected server causes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dd6af2ee193b94af9be4dc9b2d4a1427ae2f612. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `ProjectCommandError` into a discriminated union of specific error classes
> - Replaces the single generic `ProjectCommandError` class in [project.ts](https://github.com/pingdotgg/t3code/pull/3459/files#diff-44f1264ca9e5b2f3994c44291b5616390842fc6345021ca54e8447fd8dbbc1cd) with a `Schema.Union` of eight specific tagged error classes (`ProjectLiveServerDeclaredResponseError`, `ProjectLiveServerRequestError`, `ProjectLiveServerUndeclaredStatusError`, `ProjectCommandIdGenerationError`, `ProjectTitleEmptyError`, `ProjectIdentifierEmptyError`, `ProjectNotFoundError`, `ProjectAlreadyExistsError`).
> - Adds `projectCommandErrorFromLiveServerRequest` to classify live server failures into the appropriate union member based on the failure type.
> - Updates all internal call sites to yield specific error types with structured fields instead of a generic error with an optional `detail` string.
> - Behavioral Change: callers that pattern-match on `ProjectCommandError` must now handle the full discriminated union.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5dd6af2.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->