### PR TITLE
[codex] Structure Azure DevOps CLI failures

### DIFF
--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -4,8 +4,9 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as PlatformError from "effect/PlatformError";
 import { ChildProcessSpawner } from "effect/unstable/process";
-import { VcsProcessExitError } from "@t3tools/contracts";
+import { VcsProcessExitError, VcsProcessSpawnError } from "@t3tools/contracts";
 
 import * as VcsProcess from "../vcs/VcsProcess.ts";
 import * as AzureDevOpsCli from "./AzureDevOpsCli.ts";
@@ -353,6 +354,34 @@ describe("AzureDevOpsCli.layer", () => {
       assert.strictEqual(error.detail, "Azure DevOps CLI command failed.");
       assert.strictEqual(error.cause, cause);
       assert.equal(error.message.includes("sensitive-upstream-detail"), false);
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("does not report a missing working directory as a missing Azure CLI", () =>
+    Effect.gen(function* () {
+      const cwd = "/missing/repo";
+      const platformCause = PlatformError.systemError({
+        _tag: "NotFound",
+        module: "ChildProcess",
+        method: "spawn",
+        syscall: "chdir",
+        pathOrDescriptor: cwd,
+      });
+      const cause = new VcsProcessSpawnError({
+        operation: "AzureDevOpsCli.execute",
+        command: "az",
+        cwd,
+        argumentCount: 2,
+        cause: platformCause,
+      });
+      mockRun.mockReturnValueOnce(Effect.fail(cause));
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      const error = yield* az.execute({ cwd, args: ["repos", "list"] }).pipe(Effect.flip);
+
+      assert.instanceOf(error, AzureDevOpsCli.AzureDevOpsCommandFailedError);
+      assert.strictEqual(error.cwd, cwd);
+      assert.strictEqual(error.cause, cause);
     }).pipe(Effect.provide(layer)),
   );
 

--- a/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.test.ts
@@ -345,11 +345,35 @@ describe("AzureDevOpsCli.layer", () => {
       const az = yield* AzureDevOpsCli.AzureDevOpsCli;
       const error = yield* az.execute({ cwd: "/repo", args: ["repos", "list"] }).pipe(Effect.flip);
 
+      assert.instanceOf(error, AzureDevOpsCli.AzureDevOpsCommandFailedError);
+      assert.strictEqual(error.operation, "execute");
       assert.strictEqual(error.command, "az");
       assert.strictEqual(error.cwd, "/repo");
+      assert.strictEqual(error.argumentCount, 2);
       assert.strictEqual(error.detail, "Azure DevOps CLI command failed.");
       assert.strictEqual(error.cause, cause);
       assert.equal(error.message.includes("sensitive-upstream-detail"), false);
+    }).pipe(Effect.provide(layer)),
+  );
+
+  it.effect("keeps invalid pull request output diagnostics structured", () =>
+    Effect.gen(function* () {
+      mockRun.mockReturnValueOnce(Effect.succeed(processOutput("not-json")));
+
+      const az = yield* AzureDevOpsCli.AzureDevOpsCli;
+      const error = yield* az.getPullRequest({ cwd: "/repo", reference: "42" }).pipe(Effect.flip);
+
+      assert.instanceOf(error, AzureDevOpsCli.AzureDevOpsPullRequestDecodeError);
+      assert.strictEqual(error.operation, "getPullRequest");
+      assert.strictEqual(error.command, "az");
+      assert.strictEqual(error.cwd, "/repo");
+      assert.strictEqual(error.outputLength, 8);
+      assert.strictEqual(error.detail, "Azure DevOps CLI returned invalid pull request JSON.");
+      assert.exists(error.cause);
+      assert.strictEqual(
+        error.message,
+        "Azure DevOps CLI failed in getPullRequest: Azure DevOps CLI returned invalid pull request JSON.",
+      );
     }).pipe(Effect.provide(layer)),
   );
 });

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -1,9 +1,11 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as PlatformError from "effect/PlatformError";
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import {
+  NonNegativeInt,
   TrimmedNonEmptyString,
   type SourceControlRepositoryVisibility,
   type VcsError,
@@ -19,16 +21,61 @@ import * as SourceControlProvider from "./SourceControlProvider.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
 
-export class AzureDevOpsCliError extends Schema.TaggedErrorClass<AzureDevOpsCliError>()(
-  "AzureDevOpsCliError",
-  {
-    operation: Schema.String,
-    command: Schema.String,
-    cwd: Schema.String,
-    detail: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
-  },
+const azureDevOpsCommandErrorFields = {
+  operation: Schema.Literal("execute"),
+  command: Schema.Literal("az"),
+  cwd: Schema.String,
+  argumentCount: NonNegativeInt,
+  cause: Schema.Defect(),
+};
+
+export class AzureDevOpsCliUnavailableError extends Schema.TaggedErrorClass<AzureDevOpsCliUnavailableError>()(
+  "AzureDevOpsCliUnavailableError",
+  azureDevOpsCommandErrorFields,
 ) {
+  get detail(): string {
+    return "Azure CLI (`az`) with the Azure DevOps extension is required but not available on PATH.";
+  }
+
+  override get message(): string {
+    return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class AzureDevOpsCliAuthenticationError extends Schema.TaggedErrorClass<AzureDevOpsCliAuthenticationError>()(
+  "AzureDevOpsCliAuthenticationError",
+  azureDevOpsCommandErrorFields,
+) {
+  get detail(): string {
+    return "Azure DevOps CLI is not authenticated. Run `az devops login` and retry.";
+  }
+
+  override get message(): string {
+    return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class AzureDevOpsPullRequestNotFoundError extends Schema.TaggedErrorClass<AzureDevOpsPullRequestNotFoundError>()(
+  "AzureDevOpsPullRequestNotFoundError",
+  azureDevOpsCommandErrorFields,
+) {
+  get detail(): string {
+    return "Pull request not found. Check the PR number or URL and try again.";
+  }
+
+  override get message(): string {
+    return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class AzureDevOpsCommandFailedError extends Schema.TaggedErrorClass<AzureDevOpsCommandFailedError>()(
+  "AzureDevOpsCommandFailedError",
+  azureDevOpsCommandErrorFields,
+) {
+  get detail(): string {
+    return "Azure DevOps CLI command failed.";
+  }
+
   override get message(): string {
     return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
   }
@@ -38,52 +85,106 @@ export class AzureDevOpsCliError extends Schema.TaggedErrorClass<AzureDevOpsCliE
       readonly operation: "execute";
       readonly command: "az";
       readonly cwd: string;
+      readonly argumentCount: number;
     },
-    error: VcsError | unknown,
+    cause: VcsError,
   ): AzureDevOpsCliError {
-    const lower = errorText(error).toLowerCase();
-
-    if (lower.includes("command not found: az") || lower.includes("enoent")) {
-      return new AzureDevOpsCliError({
-        ...context,
-        detail:
-          "Azure CLI (`az`) with the Azure DevOps extension is required but not available on PATH.",
-        cause: error,
-      });
-    }
+    const fields = { ...context, cause };
 
     if (
-      lower.includes("az devops login") ||
-      lower.includes("please run az login") ||
-      lower.includes("not logged in") ||
-      lower.includes("authentication failed") ||
-      lower.includes("unauthorized")
+      cause._tag === "VcsProcessSpawnError" &&
+      cause.cause instanceof PlatformError.PlatformError &&
+      cause.cause.reason._tag === "NotFound"
     ) {
-      return new AzureDevOpsCliError({
-        ...context,
-        detail: "Azure DevOps CLI is not authenticated. Run `az devops login` and retry.",
-        cause: error,
-      });
+      return new AzureDevOpsCliUnavailableError(fields);
     }
 
-    if (
-      lower.includes("pull request") &&
-      (lower.includes("not found") || lower.includes("does not exist"))
-    ) {
-      return new AzureDevOpsCliError({
-        ...context,
-        detail: "Pull request not found. Check the PR number or URL and try again.",
-        cause: error,
-      });
+    if (cause._tag === "VcsProcessExitError") {
+      if (cause.failureKind === "authentication") {
+        return new AzureDevOpsCliAuthenticationError(fields);
+      }
+      if (cause.failureKind === "not-found") {
+        return new AzureDevOpsPullRequestNotFoundError(fields);
+      }
     }
 
-    return new AzureDevOpsCliError({
-      ...context,
-      detail: "Azure DevOps CLI command failed.",
-      cause: error,
-    });
+    return new AzureDevOpsCommandFailedError(fields);
   }
 }
+
+const azureDevOpsDecodeErrorFields = {
+  command: Schema.Literal("az"),
+  cwd: Schema.String,
+  outputLength: NonNegativeInt,
+  cause: Schema.Defect(),
+};
+
+export class AzureDevOpsPullRequestListDecodeError extends Schema.TaggedErrorClass<AzureDevOpsPullRequestListDecodeError>()(
+  "AzureDevOpsPullRequestListDecodeError",
+  {
+    operation: Schema.Literal("listPullRequests"),
+    ...azureDevOpsDecodeErrorFields,
+  },
+) {
+  get detail(): string {
+    return "Azure DevOps CLI returned invalid PR list JSON.";
+  }
+
+  override get message(): string {
+    return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export class AzureDevOpsPullRequestDecodeError extends Schema.TaggedErrorClass<AzureDevOpsPullRequestDecodeError>()(
+  "AzureDevOpsPullRequestDecodeError",
+  {
+    operation: Schema.Literal("getPullRequest"),
+    ...azureDevOpsDecodeErrorFields,
+  },
+) {
+  get detail(): string {
+    return "Azure DevOps CLI returned invalid pull request JSON.";
+  }
+
+  override get message(): string {
+    return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+const AzureDevOpsRepositoryDecodeOperation = Schema.Literals([
+  "getRepositoryCloneUrls",
+  "getDefaultBranch",
+  "createRepository",
+]);
+
+export class AzureDevOpsRepositoryDecodeError extends Schema.TaggedErrorClass<AzureDevOpsRepositoryDecodeError>()(
+  "AzureDevOpsRepositoryDecodeError",
+  {
+    operation: AzureDevOpsRepositoryDecodeOperation,
+    ...azureDevOpsDecodeErrorFields,
+  },
+) {
+  get detail(): string {
+    return "Azure DevOps CLI returned invalid repository JSON.";
+  }
+
+  override get message(): string {
+    return `Azure DevOps CLI failed in ${this.operation}: ${this.detail}`;
+  }
+}
+
+export const AzureDevOpsCliError = Schema.Union([
+  AzureDevOpsCliUnavailableError,
+  AzureDevOpsCliAuthenticationError,
+  AzureDevOpsPullRequestNotFoundError,
+  AzureDevOpsCommandFailedError,
+  AzureDevOpsPullRequestListDecodeError,
+  AzureDevOpsPullRequestDecodeError,
+  AzureDevOpsRepositoryDecodeError,
+]);
+export type AzureDevOpsCliError = typeof AzureDevOpsCliError.Type;
+
+export const isAzureDevOpsCliError = Schema.is(AzureDevOpsCliError);
 
 export interface AzureDevOpsRepositoryCloneUrls {
   readonly nameWithOwner: string;
@@ -145,17 +246,6 @@ export class AzureDevOpsCli extends Context.Service<
     }) => Effect.Effect<void, AzureDevOpsCliError>;
   }
 >()("t3/sourceControl/AzureDevOpsCli") {}
-
-function errorText(error: VcsError | unknown): string {
-  if (typeof error === "object" && error !== null) {
-    const tag = "_tag" in error && typeof error._tag === "string" ? error._tag : "";
-    const detail = "detail" in error && typeof error.detail === "string" ? error.detail : "";
-    const message = "message" in error && typeof error.message === "string" ? error.message : "";
-    return [tag, detail, message].filter(Boolean).join("\n");
-  }
-
-  return String(error);
-}
 
 function normalizeChangeRequestId(reference: string): string {
   const trimmed = reference.trim().replace(/^#/, "");
@@ -225,19 +315,18 @@ function parseRepositorySpecifier(repository: string): {
 function decodeAzureDevOpsJson<S extends Schema.Top>(
   raw: string,
   schema: S,
-  operation: "getRepositoryCloneUrls" | "getDefaultBranch" | "createRepository",
-  invalidDetail: string,
+  operation: typeof AzureDevOpsRepositoryDecodeOperation.Type,
   cwd: string,
-): Effect.Effect<S["Type"], AzureDevOpsCliError, S["DecodingServices"]> {
+): Effect.Effect<S["Type"], AzureDevOpsRepositoryDecodeError, S["DecodingServices"]> {
   return Schema.decodeEffect(Schema.fromJsonString(schema))(raw).pipe(
     Effect.mapError(
-      (error) =>
-        new AzureDevOpsCliError({
+      (cause) =>
+        new AzureDevOpsRepositoryDecodeError({
           operation,
           command: "az",
           cwd,
-          detail: invalidDetail,
-          cause: error,
+          outputLength: raw.length,
+          cause,
         }),
     ),
   );
@@ -257,8 +346,13 @@ export const make = Effect.gen(function* () {
       })
       .pipe(
         Effect.mapError((error) =>
-          AzureDevOpsCliError.fromVcsError(
-            { operation: "execute", command: "az", cwd: input.cwd },
+          AzureDevOpsCommandFailedError.fromVcsError(
+            {
+              operation: "execute",
+              command: "az",
+              cwd: input.cwd,
+              argumentCount: input.args.length,
+            },
             error,
           ),
         ),
@@ -297,11 +391,11 @@ export const make = Effect.gen(function* () {
                 Effect.flatMap((decoded) => {
                   if (!Result.isSuccess(decoded)) {
                     return Effect.fail(
-                      new AzureDevOpsCliError({
+                      new AzureDevOpsPullRequestListDecodeError({
                         operation: "listPullRequests",
                         command: "az",
                         cwd: input.cwd,
-                        detail: "Azure DevOps CLI returned invalid PR list JSON.",
+                        outputLength: raw.length,
                         cause: decoded.failure,
                       }),
                     );
@@ -331,11 +425,11 @@ export const make = Effect.gen(function* () {
             Effect.flatMap((decoded) => {
               if (!Result.isSuccess(decoded)) {
                 return Effect.fail(
-                  new AzureDevOpsCliError({
+                  new AzureDevOpsPullRequestDecodeError({
                     operation: "getPullRequest",
                     command: "az",
                     cwd: input.cwd,
-                    detail: "Azure DevOps CLI returned invalid pull request JSON.",
+                    outputLength: raw.length,
                     cause: decoded.failure,
                   }),
                 );
@@ -357,7 +451,6 @@ export const make = Effect.gen(function* () {
             raw,
             RawAzureDevOpsRepositorySchema,
             "getRepositoryCloneUrls",
-            "Azure DevOps CLI returned invalid repository JSON.",
             input.cwd,
           ),
         ),
@@ -383,13 +476,7 @@ export const make = Effect.gen(function* () {
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
-          decodeAzureDevOpsJson(
-            raw,
-            RawAzureDevOpsRepositorySchema,
-            "createRepository",
-            "Azure DevOps CLI returned invalid repository JSON.",
-            input.cwd,
-          ),
+          decodeAzureDevOpsJson(raw, RawAzureDevOpsRepositorySchema, "createRepository", input.cwd),
         ),
         Effect.map(normalizeRepositoryCloneUrls),
       );
@@ -421,13 +508,7 @@ export const make = Effect.gen(function* () {
       }).pipe(
         Effect.map((result) => result.stdout.trim()),
         Effect.flatMap((raw) =>
-          decodeAzureDevOpsJson(
-            raw,
-            RawAzureDevOpsRepositorySchema,
-            "getDefaultBranch",
-            "Azure DevOps CLI returned invalid repository JSON.",
-            input.cwd,
-          ),
+          decodeAzureDevOpsJson(raw, RawAzureDevOpsRepositorySchema, "getDefaultBranch", input.cwd),
         ),
         Effect.map((repo) => normalizeDefaultBranch(repo.defaultBranch)),
       ),

--- a/apps/server/src/sourceControl/AzureDevOpsCli.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsCli.ts
@@ -94,7 +94,9 @@ export class AzureDevOpsCommandFailedError extends Schema.TaggedErrorClass<Azure
     if (
       cause._tag === "VcsProcessSpawnError" &&
       cause.cause instanceof PlatformError.PlatformError &&
-      cause.cause.reason._tag === "NotFound"
+      cause.cause.reason._tag === "NotFound" &&
+      cause.cause.reason.pathOrDescriptor !== context.cwd &&
+      cause.cause.reason.syscall !== "chdir"
     ) {
       return new AzureDevOpsCliUnavailableError(fields);
     }

--- a/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts
@@ -48,11 +48,11 @@ it.effect("maps Azure DevOps PR summaries into provider-neutral change requests"
 
 it.effect("adds change-request context while retaining Azure CLI causes", () =>
   Effect.gen(function* () {
-    const cause = new AzureDevOpsCli.AzureDevOpsCliError({
+    const cause = new AzureDevOpsCli.AzureDevOpsCommandFailedError({
       operation: "execute",
       command: "az",
       cwd: "/repo",
-      detail: "Azure DevOps CLI command failed.",
+      argumentCount: 2,
       cause: new Error("raw upstream detail that should remain in the cause"),
     });
     const provider = yield* makeProvider({


### PR DESCRIPTION
## Summary

- replace the free-form `AzureDevOpsCliError` detail field with distinct schema-tagged command and decode failures
- classify command failures from structured VCS error data while retaining the immediate cause
- keep provider-facing messages stable and expose a union predicate for the complete error domain

## Validation

- `vp test apps/server/src/sourceControl/AzureDevOpsCli.test.ts apps/server/src/sourceControl/AzureDevOpsSourceControlProvider.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Callers that matched on the old single error class must handle the new union tags; classification behavior changes slightly (e.g. chdir NotFound vs missing az).
> 
> **Overview**
> Replaces the single **`AzureDevOpsCliError`** with a **union of schema-tagged classes** (unavailable CLI, authentication, PR not found, generic command failure, and separate decode errors for PR list, PR view, and repository JSON).
> 
> **`fromVcsError`** now maps **`VcsError`** by structured fields (`failureKind`, spawn `NotFound` with `chdir` vs missing `az`) instead of parsing error strings. User-facing **`detail`** / **`message`** stay fixed per type; upstream text stays on **`cause`**. Command failures gain **`argumentCount`**; decode failures gain **`outputLength`**. **`isAzureDevOpsCliError`** is added for the union.
> 
> Tests assert the new types (including that a missing **cwd** is not misclassified as missing Azure CLI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 525210467f82da4990c4bb1644aedf06566f7980. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace generic Azure DevOps CLI errors with structured typed error classes
> - Introduces specific error classes (`AzureDevOpsCliUnavailableError`, `AzureDevOpsCliAuthenticationError`, `AzureDevOpsPullRequestNotFoundError`, `AzureDevOpsCommandFailedError`, and decode errors for PRs and repositories) in [AzureDevOpsCli.ts](https://github.com/pingdotgg/t3code/pull/3460/files#diff-7b5b9de7bc688c860c0ef1946cc45b4de0a7a75607ccf07af3a5bac053b562d0), replacing the previous single generic error type.
> - Rewrites `AzureDevOpsCommandFailedError.fromVcsError` to classify failures by structured fields (e.g. `failureKind`, spawn `NotFound` with/without `chdir` syscall) instead of string matching.
> - Adds `outputLength` and `argumentCount` to decode and command failure errors for richer diagnostics.
> - Updates tests in [AzureDevOpsCli.test.ts](https://github.com/pingdotgg/t3code/pull/3460/files#diff-b2ee80ff05c77875b314a46bd0f9c21969aa82755f2b342a84fd7cd3e0c03588) and [AzureDevOpsSourceControlProvider.test.ts](https://github.com/pingdotgg/t3code/pull/3460/files#diff-f2cc981cd7ee2d63c51b9191520c5384069a396a6561fee74c0df710c7859514) to assert on the new specific error classes and structured fields.
> - Behavioral Change: callers handling the previous single error type now receive one of several specific error types from the exported `AzureDevOpsCliError` union.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5252104.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->