### PR TITLE
[codex] Structure unavailable environment RPC errors

### DIFF
--- a/packages/client-runtime/src/rpc/client.test.ts
+++ b/packages/client-runtime/src/rpc/client.test.ts
@@ -25,7 +25,13 @@ import {
 import * as EnvironmentSupervisor from "../connection/supervisor.ts";
 import * as RpcSession from "../rpc/session.ts";
 import type { WsRpcProtocolClient } from "../rpc/protocol.ts";
-import { EnvironmentRpcRequestObserver, request, runStream, subscribe } from "./client.ts";
+import {
+  EnvironmentRpcRequestObserver,
+  EnvironmentRpcUnavailableError,
+  request,
+  runStream,
+  subscribe,
+} from "./client.ts";
 
 const TARGET = new PrimaryConnectionTarget({
   environmentId: EnvironmentId.make("environment-1"),
@@ -77,6 +83,25 @@ const makeHarness = Effect.fn("TestEnvironmentRpc.makeHarness")(function* () {
 });
 
 describe("environment RPC", () => {
+  it.effect("describes unavailable environments from structured context", () =>
+    Effect.gen(function* () {
+      const { supervisor } = yield* makeHarness();
+
+      const error = yield* request(WS_METHODS.cloudGetRelayClientStatus, {}).pipe(
+        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+        Effect.flip,
+      );
+
+      expect(error).toEqual(
+        new EnvironmentRpcUnavailableError({
+          environmentId: TARGET.environmentId,
+          environmentLabel: TARGET.label,
+        }),
+      );
+      expect(error.message).toBe("Test environment is not connected.");
+    }),
+  );
+
   it.effect("observes unary requests until they complete", () =>
     Effect.gen(function* () {
       const observations: string[] = [];

--- a/packages/client-runtime/src/rpc/client.ts
+++ b/packages/client-runtime/src/rpc/client.ts
@@ -16,9 +16,13 @@ export class EnvironmentRpcUnavailableError extends Schema.TaggedErrorClass<Envi
   "EnvironmentRpcUnavailableError",
   {
     environmentId: Schema.String,
-    message: Schema.String,
+    environmentLabel: Schema.String,
   },
-) {}
+) {
+  override get message(): string {
+    return `${this.environmentLabel} is not connected.`;
+  }
+}
 
 export interface EnvironmentRpcRequestObservation {
   readonly environmentId: string;
@@ -94,7 +98,7 @@ const currentSession = Effect.fn("EnvironmentRpc.currentSession")(function* () {
           Effect.fail(
             new EnvironmentRpcUnavailableError({
               environmentId: supervisor.target.environmentId,
-              message: `${supervisor.target.label} is not connected.`,
+              environmentLabel: supervisor.target.label,
             }),
           ),
         onSome: Effect.succeed,


### PR DESCRIPTION
## Summary
- derive unavailable-environment messages from structured label data
- preserve environment identity for correlation
- cover the disconnected unary RPC path

## Validation
- `vp test packages/client-runtime/src/rpc/client.test.ts`
- `vp check` (20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-shape change in client-runtime RPC helpers with a focused test; no auth, data, or connection logic beyond how the failure is constructed.
> 
> **Overview**
> **`EnvironmentRpcUnavailableError`** now carries **`environmentLabel`** (with **`environmentId`** unchanged) instead of a stored **`message`** string. The user-facing text is derived via a **`message`** getter as `'<label> is not connected.'`, so callers pass structured context rather than preformatted copy.
> 
> **`EnvironmentRpc.currentSession`** is updated to supply **`environmentLabel`** from the supervisor target when no session is active. A new test covers the disconnected unary **`request`** path and asserts both the error fields and the derived message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d8c4912b4c05c47ea1803de94a8de7810c72b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure `EnvironmentRpcUnavailableError` with `environmentLabel` instead of `message`
> Replaces the `message` data field on `EnvironmentRpcUnavailableError` with `environmentLabel`, and adds an override getter that computes `error.message` as `'<label> is not connected.'`. The failure site in `EnvironmentRpc.currentSession` is updated to pass `environmentLabel` from `supervisor.target.label`. A new test asserts the structured fields and derived message are correct.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3d8c49.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->