### PR TITLE
[codex] Preserve connection persistence failure causes

### DIFF
--- a/apps/mobile/src/connection/catalog-store.ts
+++ b/apps/mobile/src/connection/catalog-store.ts
@@ -18,7 +18,8 @@ export const LEGACY_CONNECTIONS_KEY = "t3code.connections";
 function catalogError(operation: string, cause: unknown) {
   return new ConnectionTransientError({
     reason: "remote-unavailable",
-    detail: `Could not ${operation} the local connection catalog: ${String(cause)}`,
+    detail: `Could not ${operation} the local connection catalog.`,
+    cause,
   });
 }
 

--- a/apps/mobile/src/connection/storage.ts
+++ b/apps/mobile/src/connection/storage.ts
@@ -58,23 +58,8 @@ const LegacyStoredShellSnapshot = Schema.Struct({
 function catalogError(operation: string, cause: unknown) {
   return new ConnectionTransientError({
     reason: "remote-unavailable",
-    detail: `Could not ${operation} the local connection catalog: ${String(cause)}`,
-  });
-}
-
-function shellPersistenceError(
-  operation:
-    | "load-shell"
-    | "save-shell"
-    | "load-thread"
-    | "save-thread"
-    | "remove-thread"
-    | "clear-environment",
-  cause: unknown,
-) {
-  return new ConnectionPersistenceError({
-    operation,
-    message: `Could not ${operation.replaceAll("-", " ")}: ${String(cause)}`,
+    detail: `Could not ${operation} the local connection catalog.`,
+    cause,
   });
 }
 
@@ -100,7 +85,7 @@ const threadSnapshotDirectory = Effect.fn("mobile.connectionStorage.threadSnapsh
         }
         return directory;
       },
-      catch: (cause) => shellPersistenceError(operation, cause),
+      catch: (cause) => new ConnectionPersistenceError({ operation, cause }),
     });
   },
 );
@@ -116,16 +101,6 @@ const threadSnapshotFile = Effect.fn("mobile.connectionStorage.threadSnapshotFil
     threadSnapshotFileName(threadId),
   );
 });
-
-function targetPersistenceError(
-  operation: "list-targets" | "register-connection" | "remove-connection",
-  error: ConnectionTransientError,
-) {
-  return new ConnectionPersistenceError({
-    operation,
-    message: error.message,
-  });
-}
 
 const secureCatalogStorage: SecureCatalogStorage = {
   getItem: (key) =>
@@ -163,7 +138,7 @@ const shellSnapshotFileInDirectory = Effect.fn(
       directory.create({ idempotent: true, intermediates: true });
       return new File(directory, shellSnapshotFileName(environmentId));
     },
-    catch: (cause) => shellPersistenceError(operation, cause),
+    catch: (cause) => new ConnectionPersistenceError({ operation, cause }),
   });
 });
 
@@ -184,18 +159,29 @@ export const connectionStorageLayer = Layer.effectContext(
     const targetStore = ConnectionTargetStore.of({
       list: catalog.read.pipe(
         Effect.map((document) => document.targets),
-        Effect.mapError((error) => targetPersistenceError("list-targets", error)),
+        Effect.mapError(
+          (cause) => new ConnectionPersistenceError({ operation: "list-targets", cause }),
+        ),
       ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
       register: (registration) =>
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
-          .pipe(Effect.mapError((error) => targetPersistenceError("register-connection", error))),
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({ operation: "register-connection", cause }),
+            ),
+          ),
       remove: (target) =>
         catalog
           .update((document) => removeConnectionFromCatalog(document, target))
-          .pipe(Effect.mapError((error) => targetPersistenceError("remove-connection", error))),
+          .pipe(
+            Effect.mapError(
+              (cause) => new ConnectionPersistenceError({ operation: "remove-connection", cause }),
+            ),
+          ),
     });
     const profileStore = ProfileStore.make({
       get: (connectionId) =>
@@ -283,15 +269,19 @@ export const connectionStorageLayer = Layer.effectContext(
           if (file.exists) {
             const raw = yield* Effect.tryPromise({
               try: () => file.text(),
-              catch: (cause) => shellPersistenceError("load-shell", cause),
+              catch: (cause) => new ConnectionPersistenceError({ operation: "load-shell", cause }),
             });
             const parsed = yield* Effect.try({
               try: () => JSON.parse(raw) as unknown,
-              catch: (cause) => shellPersistenceError("load-shell", cause),
+              catch: (cause) => new ConnectionPersistenceError({ operation: "load-shell", cause }),
             });
             const stored = yield* Effect.fromResult(
               Schema.decodeUnknownResult(StoredShellSnapshot)(parsed),
-            ).pipe(Effect.mapError((cause) => shellPersistenceError("load-shell", cause)));
+            ).pipe(
+              Effect.mapError(
+                (cause) => new ConnectionPersistenceError({ operation: "load-shell", cause }),
+              ),
+            );
             return stored.environmentId === environmentId
               ? Option.some(stored.snapshot)
               : Option.none();
@@ -303,15 +293,19 @@ export const connectionStorageLayer = Layer.effectContext(
           }
           const legacyRaw = yield* Effect.tryPromise({
             try: () => legacyFile.text(),
-            catch: (cause) => shellPersistenceError("load-shell", cause),
+            catch: (cause) => new ConnectionPersistenceError({ operation: "load-shell", cause }),
           });
           const legacyParsed = yield* Effect.try({
             try: () => JSON.parse(legacyRaw) as unknown,
-            catch: (cause) => shellPersistenceError("load-shell", cause),
+            catch: (cause) => new ConnectionPersistenceError({ operation: "load-shell", cause }),
           });
           const legacyStored = yield* Effect.fromResult(
             Schema.decodeUnknownResult(LegacyStoredShellSnapshot)(legacyParsed),
-          ).pipe(Effect.mapError((cause) => shellPersistenceError("load-shell", cause)));
+          ).pipe(
+            Effect.mapError(
+              (cause) => new ConnectionPersistenceError({ operation: "load-shell", cause }),
+            ),
+          );
           return legacyStored.environmentId === environmentId
             ? Option.some(legacyStored.snapshot)
             : Option.none();
@@ -326,7 +320,11 @@ export const connectionStorageLayer = Layer.effectContext(
           } as const;
           const encoded = yield* Effect.fromResult(
             Schema.encodeUnknownResult(StoredShellSnapshot)(stored),
-          ).pipe(Effect.mapError((cause) => shellPersistenceError("save-shell", cause)));
+          ).pipe(
+            Effect.mapError(
+              (cause) => new ConnectionPersistenceError({ operation: "save-shell", cause }),
+            ),
+          );
           yield* Effect.try({
             try: () => {
               if (!file.exists) {
@@ -334,7 +332,7 @@ export const connectionStorageLayer = Layer.effectContext(
               }
               file.write(JSON.stringify(encoded));
             },
-            catch: (cause) => shellPersistenceError("save-shell", cause),
+            catch: (cause) => new ConnectionPersistenceError({ operation: "save-shell", cause }),
           });
         }),
       loadThread: (environmentId, threadId) =>
@@ -345,15 +343,19 @@ export const connectionStorageLayer = Layer.effectContext(
           }
           const raw = yield* Effect.tryPromise({
             try: () => file.text(),
-            catch: (cause) => shellPersistenceError("load-thread", cause),
+            catch: (cause) => new ConnectionPersistenceError({ operation: "load-thread", cause }),
           });
           const parsed = yield* Effect.try({
             try: () => JSON.parse(raw) as unknown,
-            catch: (cause) => shellPersistenceError("load-thread", cause),
+            catch: (cause) => new ConnectionPersistenceError({ operation: "load-thread", cause }),
           });
           const stored = yield* Effect.fromResult(
             Schema.decodeUnknownResult(StoredThreadSnapshot)(parsed),
-          ).pipe(Effect.mapError((cause) => shellPersistenceError("load-thread", cause)));
+          ).pipe(
+            Effect.mapError(
+              (cause) => new ConnectionPersistenceError({ operation: "load-thread", cause }),
+            ),
+          );
           return stored.environmentId === environmentId && stored.threadId === threadId
             ? Option.some(stored.thread)
             : Option.none();
@@ -368,7 +370,11 @@ export const connectionStorageLayer = Layer.effectContext(
               threadId: thread.id,
               thread,
             }),
-          ).pipe(Effect.mapError((cause) => shellPersistenceError("save-thread", cause)));
+          ).pipe(
+            Effect.mapError(
+              (cause) => new ConnectionPersistenceError({ operation: "save-thread", cause }),
+            ),
+          );
           yield* Effect.try({
             try: () => {
               if (!file.exists) {
@@ -376,7 +382,7 @@ export const connectionStorageLayer = Layer.effectContext(
               }
               file.write(JSON.stringify(encoded));
             },
-            catch: (cause) => shellPersistenceError("save-thread", cause),
+            catch: (cause) => new ConnectionPersistenceError({ operation: "save-thread", cause }),
           });
         }),
       removeThread: (environmentId, threadId) =>
@@ -389,7 +395,7 @@ export const connectionStorageLayer = Layer.effectContext(
           Effect.mapError((cause) =>
             cause._tag === "ConnectionPersistenceError"
               ? cause
-              : shellPersistenceError("remove-thread", cause),
+              : new ConnectionPersistenceError({ operation: "remove-thread", cause }),
           ),
         ),
       clear: (environmentId) =>
@@ -398,14 +404,16 @@ export const connectionStorageLayer = Layer.effectContext(
           if (file.exists) {
             yield* Effect.try({
               try: () => file.delete(),
-              catch: (cause) => shellPersistenceError("clear-environment", cause),
+              catch: (cause) =>
+                new ConnectionPersistenceError({ operation: "clear-environment", cause }),
             });
           }
           const legacyFile = yield* legacyShellSnapshotFile(environmentId, "clear-environment");
           if (legacyFile.exists) {
             yield* Effect.try({
               try: () => legacyFile.delete(),
-              catch: (cause) => shellPersistenceError("clear-environment", cause),
+              catch: (cause) =>
+                new ConnectionPersistenceError({ operation: "clear-environment", cause }),
             });
           }
           const threadDirectory = yield* threadSnapshotDirectory(
@@ -415,7 +423,8 @@ export const connectionStorageLayer = Layer.effectContext(
           if (threadDirectory.exists) {
             yield* Effect.try({
               try: () => threadDirectory.delete(),
-              catch: (cause) => shellPersistenceError("clear-environment", cause),
+              catch: (cause) =>
+                new ConnectionPersistenceError({ operation: "clear-environment", cause }),
             });
           }
         }),

--- a/apps/web/src/connection/storage.test.ts
+++ b/apps/web/src/connection/storage.test.ts
@@ -70,7 +70,10 @@ describe("makeCatalogBackend", () => {
       const error = yield* backend.write("{}").pipe(Effect.flip);
 
       expect(error).toBeInstanceOf(ConnectionTransientError);
-      expect(error.message).toContain("Desktop secure storage is unavailable");
+      expect(error.message).toBe("Could not save the local connection catalog.");
+      expect(error.cause).toEqual(
+        new Error("Desktop secure storage is unavailable in this system context."),
+      );
       expect(setConnectionCatalog).toHaveBeenCalledWith("{}");
     }),
   );

--- a/apps/web/src/connection/storage.ts
+++ b/apps/web/src/connection/storage.ts
@@ -63,26 +63,8 @@ const encodeStoredThreadSnapshot = Schema.encodeEffect(StoredThreadSnapshotJson)
 function catalogError(operation: string, cause: unknown) {
   return new ConnectionTransientError({
     reason: "remote-unavailable",
-    detail: `Could not ${operation} the local connection catalog: ${String(cause)}`,
-  });
-}
-
-function persistenceError(
-  operation:
-    | "list-targets"
-    | "register-connection"
-    | "remove-connection"
-    | "load-shell"
-    | "save-shell"
-    | "load-thread"
-    | "save-thread"
-    | "remove-thread"
-    | "clear-environment",
-  cause: unknown,
-) {
-  return new ConnectionPersistenceError({
-    operation,
-    message: `Could not ${operation.replaceAll("-", " ")}: ${String(cause)}`,
+    detail: `Could not ${operation} the local connection catalog.`,
+    cause,
   });
 }
 
@@ -233,7 +215,7 @@ export function makeCatalogBackend(database: IDBDatabase): CatalogBackend {
               : Effect.fail(
                   catalogError(
                     "save",
-                    "Desktop secure storage is unavailable in this system context.",
+                    new Error("Desktop secure storage is unavailable in this system context."),
                   ),
                 ),
           ),
@@ -330,18 +312,29 @@ export const connectionStorageLayer = Layer.effectContext(
     const targetStore = ConnectionTargetStore.of({
       list: catalog.read.pipe(
         Effect.map((document) => document.targets),
-        Effect.mapError((cause) => persistenceError("list-targets", cause)),
+        Effect.mapError(
+          (cause) => new ConnectionPersistenceError({ operation: "list-targets", cause }),
+        ),
       ),
     });
     const registrationStore = ConnectionRegistrationStore.of({
       register: (registration) =>
         catalog
           .update((document) => registerConnectionInCatalog(document, registration))
-          .pipe(Effect.mapError((cause) => persistenceError("register-connection", cause))),
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ConnectionPersistenceError({ operation: "register-connection", cause }),
+            ),
+          ),
       remove: (target) =>
         catalog
           .update((document) => removeConnectionFromCatalog(document, target))
-          .pipe(Effect.mapError((cause) => persistenceError("remove-connection", cause))),
+          .pipe(
+            Effect.mapError(
+              (cause) => new ConnectionPersistenceError({ operation: "remove-connection", cause }),
+            ),
+          ),
     });
     const profileStore = ProfileStore.make({
       get: (connectionId) =>
@@ -430,7 +423,9 @@ export const connectionStorageLayer = Layer.effectContext(
               return Effect.succeed(Option.none());
             }
             return decodeStoredShellSnapshot(raw).pipe(
-              Effect.mapError((cause) => persistenceError("load-shell", cause)),
+              Effect.mapError(
+                (cause) => new ConnectionPersistenceError({ operation: "load-shell", cause }),
+              ),
               Effect.map((stored) =>
                 stored.environmentId === environmentId
                   ? Option.some(stored.snapshot)
@@ -441,7 +436,7 @@ export const connectionStorageLayer = Layer.effectContext(
           Effect.mapError((cause) =>
             cause._tag === "ConnectionPersistenceError"
               ? cause
-              : persistenceError("load-shell", cause),
+              : new ConnectionPersistenceError({ operation: "load-shell", cause }),
           ),
         ),
       saveShell: (environmentId, snapshot) =>
@@ -450,13 +445,17 @@ export const connectionStorageLayer = Layer.effectContext(
             schemaVersion: SHELL_SNAPSHOT_CACHE_SCHEMA_VERSION,
             environmentId,
             snapshot,
-          }).pipe(Effect.mapError((cause) => persistenceError("save-shell", cause)));
+          }).pipe(
+            Effect.mapError(
+              (cause) => new ConnectionPersistenceError({ operation: "save-shell", cause }),
+            ),
+          );
           yield* writeDatabaseValue(database, SHELL_STORE_NAME, environmentId, encoded);
         }).pipe(
           Effect.mapError((cause) =>
             cause._tag === "ConnectionPersistenceError"
               ? cause
-              : persistenceError("save-shell", cause),
+              : new ConnectionPersistenceError({ operation: "save-shell", cause }),
           ),
         ),
       loadThread: (environmentId, threadId) =>
@@ -470,7 +469,9 @@ export const connectionStorageLayer = Layer.effectContext(
               return Effect.succeed(Option.none());
             }
             return decodeStoredThreadSnapshot(raw).pipe(
-              Effect.mapError((cause) => persistenceError("load-thread", cause)),
+              Effect.mapError(
+                (cause) => new ConnectionPersistenceError({ operation: "load-thread", cause }),
+              ),
               Effect.map((stored) =>
                 stored.environmentId === environmentId && stored.threadId === threadId
                   ? Option.some(stored.thread)
@@ -481,7 +482,7 @@ export const connectionStorageLayer = Layer.effectContext(
           Effect.mapError((cause) =>
             cause._tag === "ConnectionPersistenceError"
               ? cause
-              : persistenceError("load-thread", cause),
+              : new ConnectionPersistenceError({ operation: "load-thread", cause }),
           ),
         ),
       saveThread: (environmentId, thread) =>
@@ -491,7 +492,11 @@ export const connectionStorageLayer = Layer.effectContext(
             environmentId,
             threadId: thread.id,
             thread,
-          }).pipe(Effect.mapError((cause) => persistenceError("save-thread", cause)));
+          }).pipe(
+            Effect.mapError(
+              (cause) => new ConnectionPersistenceError({ operation: "save-thread", cause }),
+            ),
+          );
           yield* writeDatabaseValue(
             database,
             THREAD_STORE_NAME,
@@ -502,7 +507,7 @@ export const connectionStorageLayer = Layer.effectContext(
           Effect.mapError((cause) =>
             cause._tag === "ConnectionPersistenceError"
               ? cause
-              : persistenceError("save-thread", cause),
+              : new ConnectionPersistenceError({ operation: "save-thread", cause }),
           ),
         ),
       removeThread: (environmentId, threadId) =>
@@ -510,7 +515,11 @@ export const connectionStorageLayer = Layer.effectContext(
           database,
           THREAD_STORE_NAME,
           threadCacheKey(environmentId, threadId),
-        ).pipe(Effect.mapError((cause) => persistenceError("remove-thread", cause))),
+        ).pipe(
+          Effect.mapError(
+            (cause) => new ConnectionPersistenceError({ operation: "remove-thread", cause }),
+          ),
+        ),
       clear: (environmentId) =>
         Effect.all(
           [
@@ -522,7 +531,11 @@ export const connectionStorageLayer = Layer.effectContext(
             ),
           ],
           { concurrency: "unbounded", discard: true },
-        ).pipe(Effect.mapError((cause) => persistenceError("clear-environment", cause))),
+        ).pipe(
+          Effect.mapError(
+            (cause) => new ConnectionPersistenceError({ operation: "clear-environment", cause }),
+          ),
+        ),
     });
 
     return Context.make(ConnectionTargetStore, targetStore).pipe(

--- a/packages/client-runtime/src/connection/model.ts
+++ b/packages/client-runtime/src/connection/model.ts
@@ -81,6 +81,7 @@ export class ConnectionTransientError extends Schema.TaggedErrorClass<Connection
     reason: ConnectionTransientReason,
     detail: Schema.String,
     traceId: Schema.optionalKey(Schema.String),
+    cause: Schema.optionalKey(Schema.Defect()),
   },
 ) {
   override get message(): string {

--- a/packages/client-runtime/src/connection/registry.test.ts
+++ b/packages/client-runtime/src/connection/registry.test.ts
@@ -689,12 +689,13 @@ describe("EnvironmentRegistry", () => {
 
   it.effect("keeps the runtime registered when durable removal fails", () =>
     Effect.gen(function* () {
+      const persistenceCause = new Error("Storage is unavailable.");
       const harness = yield* makeHarness([RELAY_TARGET], [], [], {
         beforeRegistrationRemove: () =>
           Effect.fail(
             new Persistence.ConnectionPersistenceError({
               operation: "remove-connection",
-              message: "Storage is unavailable.",
+              cause: persistenceCause,
             }),
           ),
       });
@@ -711,6 +712,8 @@ describe("EnvironmentRegistry", () => {
         const error = yield* Effect.flip(registry.removeRelayEnvironments());
 
         expect(error._tag).toBe("ConnectionPersistenceError");
+        expect(error.message).toBe("Could not remove connection.");
+        expect(error.cause).toBe(persistenceCause);
         expect(yield* Ref.get(harness.releasedSessions)).toBe(0);
         expect((yield* SubscriptionRef.get(registry.entries)).has(RELAY_TARGET.environmentId)).toBe(
           true,

--- a/packages/client-runtime/src/platform/persistence.ts
+++ b/packages/client-runtime/src/platform/persistence.ts
@@ -26,9 +26,13 @@ export class ConnectionPersistenceError extends Schema.TaggedErrorClass<Connecti
       "remove-thread",
       "clear-environment",
     ]),
-    message: Schema.String,
+    cause: Schema.Defect(),
   },
-) {}
+) {
+  override get message(): string {
+    return `Could not ${this.operation.replaceAll("-", " ")}.`;
+  }
+}
 
 export class ConnectionTargetStore extends Context.Service<
   ConnectionTargetStore,


### PR DESCRIPTION
## Summary
- preserve immediate persistence and catalog causes instead of stringifying them into messages
- derive persistence messages from the structured operation
- remove valueless web and mobile persistence-error constructor wrappers

## Validation
- `vp test apps/web/src/connection/storage.test.ts apps/mobile/src/connection/storage.test.ts packages/client-runtime/src/connection/registry.test.ts`
- `vp check` (20 pre-existing warnings)
- `vp run typecheck`
- `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-model and mapping refactor in connection storage; user-visible messages stay operation-based, with improved debuggability via structured causes.
> 
> **Overview**
> Connection persistence and catalog failures now keep the **original underlying error** on structured error types instead of stringifying it into user-facing text.
> 
> **`ConnectionPersistenceError`** drops the free-form `message` field in favor of required `cause`, with **`message` derived from `operation`** (for example, “Could not remove connection.”). **`ConnectionTransientError`** gains an optional **`cause`** while catalog helpers use stable `detail` strings plus the attached cause.
> 
> Web and mobile connection storage **remove local persistence-error wrapper helpers** and map failures directly to `ConnectionPersistenceError({ operation, cause })`. Desktop catalog save failures pass an **`Error` instance as `cause`** rather than embedding desktop secure-storage text in the message. Tests assert the stable message and preserved **`cause`** separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7849fa7028ccf196f0eee977be5f00e65d09bf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve failure causes in connection persistence errors
> - `ConnectionPersistenceError` in [`persistence.ts`](https://github.com/pingdotgg/t3code/pull/3462/files#diff-911d79898a37f3b5cedb7bc5ef366c91355ef19d144eb9d27dc539af9f33e584) now stores a `cause` field (replacing the free-form `message` string) and synthesizes a standardized message from the `operation` field.
> - `ConnectionTransientError` in [`model.ts`](https://github.com/pingdotgg/t3code/pull/3462/files#diff-66cda97fd489ec4edb5b6ff01ef7a7084f47b6f60e511045bb4aae3f616395d6) gains an optional `cause` field so catalog errors can carry the underlying error.
> - All storage layers ([`apps/mobile`](https://github.com/pingdotgg/t3code/pull/3462/files#diff-940761525b81e4fc6f0119c072b9ced5fb0b0e38194aa610f5bab3a92161fb13), [`apps/web`](https://github.com/pingdotgg/t3code/pull/3462/files#diff-9217651f3dc353261c0a52088f12345f3ccb67a76ec3d2b127c3a6fe5c7291eb)) drop ad-hoc error-wrapping helpers and construct `ConnectionPersistenceError`/`ConnectionTransientError` directly with the originating cause attached.
> - Behavioral Change: callers that previously read a custom message from these errors will now receive a standardized message derived from the operation name; the original cause is accessible via `.cause`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7849fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->