### PR TITLE
[codex] Structure unroutable app-server messages

### DIFF
--- a/packages/effect-codex-app-server/src/errors.ts
+++ b/packages/effect-codex-app-server/src/errors.ts
@@ -82,6 +82,11 @@ const payloadKind = (payload: unknown): CodexAppServerPayloadKind => {
   return typeof payload;
 };
 
+const protocolMessageFields = ["id", "method", "params", "result", "error"] as const;
+
+export const CodexAppServerProtocolMessageField = Schema.Literals(protocolMessageFields);
+export type CodexAppServerProtocolMessageField = typeof CodexAppServerProtocolMessageField.Type;
+
 export interface CodexAppServerRequestDiagnostics {
   readonly method?: string;
   readonly requestId?: string;
@@ -157,7 +162,8 @@ export class CodexAppServerProtocolParseError extends Schema.TaggedErrorClass<Co
     operation: CodexAppServerProtocolParseOperation,
     method: Schema.optionalKey(Schema.String),
     requestId: Schema.optionalKey(Schema.String),
-    detail: Schema.optionalKey(Schema.String),
+    payloadKind: Schema.optionalKey(CodexAppServerPayloadKind),
+    presentFields: Schema.optionalKey(Schema.Array(CodexAppServerProtocolMessageField)),
     issueCount: Schema.optionalKey(Schema.Number),
     issueKinds: Schema.optionalKey(Schema.Array(CodexAppServerSchemaIssueKind)),
     maximumPathDepth: Schema.optionalKey(Schema.Number),
@@ -194,6 +200,31 @@ export class CodexAppServerProtocolParseError extends Schema.TaggedErrorClass<Co
       ...(cause.issueKinds === undefined ? {} : { issueKinds: cause.issueKinds }),
       ...(cause.maximumPathDepth === undefined ? {} : { maximumPathDepth: cause.maximumPathDepth }),
       cause,
+    });
+  }
+
+  static fromUnroutableMessage(message: unknown) {
+    const diagnostics = { payloadKind: payloadKind(message) };
+    if (typeof message !== "object" || message === null || Array.isArray(message)) {
+      return new CodexAppServerProtocolParseError({
+        operation: "route-wire-message",
+        ...diagnostics,
+      });
+    }
+
+    const presentFields = protocolMessageFields.filter((field) => field in message);
+    const method =
+      "method" in message && typeof message.method === "string" ? message.method : undefined;
+    const requestId =
+      "id" in message && (typeof message.id === "string" || typeof message.id === "number")
+        ? String(message.id)
+        : undefined;
+    return new CodexAppServerProtocolParseError({
+      operation: "route-wire-message",
+      ...diagnostics,
+      presentFields,
+      ...(method === undefined ? {} : { method }),
+      ...(requestId === undefined ? {} : { requestId }),
     });
   }
 }

--- a/packages/effect-codex-app-server/src/protocol.test.ts
+++ b/packages/effect-codex-app-server/src/protocol.test.ts
@@ -311,6 +311,36 @@ it.layer(NodeServices.layer)("effect-codex-app-server protocol", (it) => {
     }),
   );
 
+  it.effect("describes unroutable messages with safe structural diagnostics", () =>
+    Effect.gen(function* () {
+      const secret = "codex-unroutable-secret-sentinel";
+      const { stdio, input } = yield* makeInMemoryStdio();
+      const termination = yield* Deferred.make<CodexError.CodexAppServerError>();
+      yield* CodexProtocol.makeCodexAppServerPatchedProtocol({
+        stdio,
+        onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+      });
+
+      yield* Queue.offer(
+        input,
+        encodeJsonl({ id: true, method: "thread/start", params: { token: secret } }),
+      );
+
+      const error = yield* Deferred.await(termination);
+      assert.instanceOf(error, CodexError.CodexAppServerProtocolParseError);
+      assert.deepInclude(error, {
+        operation: "route-wire-message",
+        method: "thread/start",
+        payloadKind: "object",
+        presentFields: ["id", "method", "params"],
+      });
+      assert.isUndefined(error.requestId);
+      assert.notProperty(error, "detail");
+      assert.notProperty(error, "cause");
+      assert.notInclude(error.message, secret);
+    }),
+  );
+
   it.effect("classifies an input stream ending without inventing a cause", () =>
     Effect.gen(function* () {
       const { stdio, input } = yield* makeInMemoryStdio();

--- a/packages/effect-codex-app-server/src/protocol.ts
+++ b/packages/effect-codex-app-server/src/protocol.ts
@@ -310,10 +310,7 @@ export const makeCodexAppServerPatchedProtocol = Effect.fn("makeCodexAppServerPa
         return handleResponse(message);
       }
       return Effect.fail(
-        new CodexError.CodexAppServerProtocolParseError({
-          detail: "Received protocol message in an unknown shape",
-          operation: "route-wire-message",
-        }),
+        CodexError.CodexAppServerProtocolParseError.fromUnroutableMessage(message),
       );
     };
 


### PR DESCRIPTION
## Summary
- replace the free-form unroutable-message detail with safe payload and envelope-field diagnostics
- retain valid method and request identifiers without copying arbitrary payload contents
- centralize the structural mapping on the protocol error and cover malformed envelopes with a compact test

## Validation
- `vp test run packages/effect-codex-app-server/src/protocol.test.ts` (7 tests)
- `vp check` (0 errors; 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-shape and routing diagnostics for malformed protocol envelopes; no auth or transport behavior changes beyond safer failure metadata.
> 
> **Overview**
> When an inbound wire message decodes but cannot be routed (not a valid request, notification, or response), failures now use **structured diagnostics** instead of a free-form `detail` string.
> 
> `CodexAppServerProtocolParseError` drops `detail` and adds optional `payloadKind` and `presentFields` (which of `id`, `method`, `params`, `result`, `error` appear on the object). A new `fromUnroutableMessage` factory records `method` and stringified `requestId` only when types match—it does **not** copy `params` or other arbitrary payload values, so secrets in malformed envelopes are less likely to leak into errors or logs. Routing in `protocol.ts` calls this factory for unknown shapes.
> 
> A protocol test sends a message with a boolean `id` and sensitive `params`, asserting the expected structural fields and that the secret never appears in the error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b093935cfe230be759edb7eeeeb4cb3f1e938bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured diagnostics to `CodexAppServerProtocolParseError` for unroutable messages
> - Adds a static `fromUnroutableMessage` constructor to `CodexAppServerProtocolParseError` that extracts `payloadKind`, `presentFields`, `method`, and `requestId` from an unroutable message instead of using a generic detail string.
> - Updates the router in [protocol.ts](https://github.com/pingdotgg/t3code/pull/3463/files#diff-c2eebe727f23e219c63497172bee07fd14e21634903ec9de0e7d63bfc80571fd) to call `fromUnroutableMessage` when an incoming message cannot be routed.
> - Removes the `detail` field from the error and replaces it with typed schema fields (`payloadKind` and `presentFields`).
> - The new test verifies that secret values embedded in the payload are not included in the error message.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8b09393.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->