### PR TITLE
[codex] Structure mobile native static-check failures

### DIFF
--- a/scripts/mobile-native-static-check.test.ts
+++ b/scripts/mobile-native-static-check.test.ts
@@ -1,18 +1,142 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as HostProcess from "@t3tools/shared/hostProcess";
 import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { NativeStaticCheckCommandError } from "./mobile-native-static-check.ts";
+import { collectSources, runCommand } from "./mobile-native-static-check.ts";
 
-it("describes failed native static-analysis commands structurally", () => {
-  const error = new NativeStaticCheckCommandError({
-    command: "swiftlint",
-    args: ["lint", "--strict"],
-    cwd: "/repo/apps/mobile",
-    exitCode: 2,
+const processHandle = (
+  exitCode: Effect.Effect<ChildProcessSpawner.ExitCode, PlatformError.PlatformError>,
+) =>
+  ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode,
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.drain,
+    stdout: Stream.empty,
+    stderr: Stream.empty,
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
   });
 
-  assert.equal(error.command, "swiftlint");
-  assert.deepStrictEqual(error.args, ["lint", "--strict"]);
-  assert.equal(error.cwd, "/repo/apps/mobile");
-  assert.equal(error.exitCode, 2);
-  assert.equal(error.message, "Native static check command 'swiftlint' exited with code 2.");
+const provideSpawner = (spawn: ChildProcessSpawner.ChildProcessSpawner["Service"]["spawn"]) =>
+  Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, ChildProcessSpawner.make(spawn));
+
+const runSwiftLint = runCommand("swiftlint", ["lint", "--strict"], "/repo/apps/mobile").pipe(
+  Effect.provideService(HostProcess.HostProcessPlatform, "linux"),
+);
+
+it.layer(NodeServices.layer)("mobile native source discovery", (it) => {
+  it.effect("preserves the failed discovery operation, path, and exact cause", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const root = yield* fs.makeTempDirectoryScoped({ prefix: "mobile-native-static-check-" });
+      const missingDirectory = path.join(root, "missing");
+
+      const error = yield* collectSources(missingDirectory, root).pipe(Effect.flip);
+
+      assert.equal(error._tag, "NativeStaticCheckSourceDiscoveryError");
+      assert.equal(error.operation, "read-directory");
+      assert.equal(error.path, missingDirectory);
+      assert.instanceOf(error.cause, PlatformError.PlatformError);
+      assert.equal(error.message, "Native source discovery operation 'read-directory' failed.");
+    }),
+  );
 });
+
+it.effect("preserves process spawn context and the exact cause", () => {
+  const cause = PlatformError.systemError({
+    _tag: "NotFound",
+    module: "ChildProcess",
+    method: "spawn",
+    description: "swiftlint was not found",
+  });
+
+  return Effect.gen(function* () {
+    const error = yield* runSwiftLint.pipe(
+      Effect.provide(provideSpawner(() => Effect.fail(cause))),
+      Effect.flip,
+    );
+
+    if (error._tag !== "NativeStaticCheckProcessError") {
+      return assert.fail(`Unexpected error: ${error._tag}`);
+    }
+    assert.equal(error.operation, "spawn");
+    assert.equal(error.command, "swiftlint");
+    assert.equal(error.argumentCount, 2);
+    assert.equal(error.cwd, "/repo/apps/mobile");
+    assert.equal(error.shell, false);
+    assert.equal(error.cause, cause);
+    assert.equal(
+      error.message,
+      "Native static check process operation 'spawn' failed for command 'swiftlint'.",
+    );
+    assert.notProperty(error, "args");
+  });
+});
+
+it.effect("preserves process wait context and the exact cause", () => {
+  const cause = PlatformError.systemError({
+    _tag: "Unknown",
+    module: "ChildProcess",
+    method: "exitCode",
+    description: "status unavailable",
+  });
+
+  return Effect.gen(function* () {
+    const error = yield* runSwiftLint.pipe(
+      Effect.provide(provideSpawner(() => Effect.succeed(processHandle(Effect.fail(cause))))),
+      Effect.flip,
+    );
+
+    if (error._tag !== "NativeStaticCheckProcessError") {
+      return assert.fail(`Unexpected error: ${error._tag}`);
+    }
+    assert.equal(error.operation, "wait-for-exit");
+    assert.equal(error.command, "swiftlint");
+    assert.equal(error.argumentCount, 2);
+    assert.equal(error.cwd, "/repo/apps/mobile");
+    assert.equal(error.shell, false);
+    assert.equal(error.cause, cause);
+    assert.equal(
+      error.message,
+      "Native static check process operation 'wait-for-exit' failed for command 'swiftlint'.",
+    );
+    assert.notProperty(error, "args");
+  });
+});
+
+it.effect("reports non-zero exits without manufacturing a cause", () =>
+  Effect.gen(function* () {
+    const error = yield* runSwiftLint.pipe(
+      Effect.provide(
+        provideSpawner(() =>
+          Effect.succeed(processHandle(Effect.succeed(ChildProcessSpawner.ExitCode(2)))),
+        ),
+      ),
+      Effect.flip,
+    );
+
+    if (error._tag !== "NativeStaticCheckCommandError") {
+      return assert.fail(`Unexpected error: ${error._tag}`);
+    }
+    assert.equal(error.command, "swiftlint");
+    assert.equal(error.argumentCount, 2);
+    assert.equal(error.cwd, "/repo/apps/mobile");
+    assert.equal(error.shell, false);
+    assert.equal(error.exitCode, 2);
+    assert.notProperty(error, "cause");
+    assert.notProperty(error, "args");
+  }),
+);

--- a/scripts/mobile-native-static-check.ts
+++ b/scripts/mobile-native-static-check.ts
@@ -8,7 +8,6 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Logger from "effect/Logger";
 import * as Path from "effect/Path";
-import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import { Command } from "effect/unstable/cli";
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
@@ -18,12 +17,44 @@ interface NativeStaticTool {
   readonly installHint: string;
 }
 
+const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0));
+
+export class NativeStaticCheckSourceDiscoveryError extends Schema.TaggedErrorClass<NativeStaticCheckSourceDiscoveryError>()(
+  "NativeStaticCheckSourceDiscoveryError",
+  {
+    operation: Schema.Literals(["resolve-root", "read-directory", "stat-entry"]),
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Native source discovery operation '${this.operation}' failed.`;
+  }
+}
+
+export class NativeStaticCheckProcessError extends Schema.TaggedErrorClass<NativeStaticCheckProcessError>()(
+  "NativeStaticCheckProcessError",
+  {
+    operation: Schema.Literals(["spawn", "wait-for-exit"]),
+    command: Schema.String,
+    argumentCount: NonNegativeInt,
+    cwd: Schema.String,
+    shell: Schema.Boolean,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Native static check process operation '${this.operation}' failed for command '${this.command}'.`;
+  }
+}
+
 export class NativeStaticCheckCommandError extends Schema.TaggedErrorClass<NativeStaticCheckCommandError>()(
   "NativeStaticCheckCommandError",
   {
     command: Schema.String,
-    args: Schema.Array(Schema.String),
+    argumentCount: NonNegativeInt,
     cwd: Schema.String,
+    shell: Schema.Boolean,
     exitCode: Schema.Int,
   },
 ) {
@@ -59,8 +90,17 @@ const excludedDirectories = new Set([
 ]);
 const generatedNativeProjectDirectories = new Set(["android", "ios"]);
 
+const mobileAppRootUrl = new URL("../apps/mobile", import.meta.url);
 const appRoot = Effect.service(Path.Path).pipe(
-  Effect.flatMap((path) => path.fromFileUrl(new URL("../apps/mobile", import.meta.url))),
+  Effect.flatMap((path) => path.fromFileUrl(mobileAppRootUrl)),
+  Effect.mapError(
+    (cause) =>
+      new NativeStaticCheckSourceDiscoveryError({
+        operation: "resolve-root",
+        path: mobileAppRootUrl.pathname,
+        cause,
+      }),
+  ),
 );
 
 const commandOutputOptions = {
@@ -77,7 +117,7 @@ const warnMissingTool = (tool: NativeStaticTool, checkName: string) =>
     `${tool.command} is not installed; skipping ${checkName}. Install it with '${tool.installHint}' or run 'brew bundle install --file apps/mobile/Brewfile'.`,
   );
 
-const runCommand = Effect.fn("runCommand")(function* (
+export const runCommand = Effect.fn("runCommand")(function* (
   command: string,
   args: ReadonlyArray<string>,
   cwd: string,
@@ -85,42 +125,86 @@ const runCommand = Effect.fn("runCommand")(function* (
   yield* Console.log(`$ ${[command, ...args].join(" ")}`);
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const spawnCommand = yield* resolveSpawnCommand(command, args);
-  const child = yield* spawner.spawn(
-    ChildProcess.make(spawnCommand.command, spawnCommand.args, {
-      cwd,
-      ...commandOutputOptions,
-      shell: spawnCommand.shell,
-    }),
+  const processContext = {
+    command,
+    argumentCount: spawnCommand.args.length,
+    cwd,
+    shell: spawnCommand.shell,
+  } as const;
+  const child = yield* spawner
+    .spawn(
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        cwd,
+        ...commandOutputOptions,
+        shell: spawnCommand.shell,
+      }),
+    )
+    .pipe(
+      Effect.mapError(
+        (cause) =>
+          new NativeStaticCheckProcessError({
+            ...processContext,
+            operation: "spawn",
+            cause,
+          }),
+      ),
+    );
+  const exitCode = Number(
+    yield* child.exitCode.pipe(
+      Effect.mapError(
+        (cause) =>
+          new NativeStaticCheckProcessError({
+            ...processContext,
+            operation: "wait-for-exit",
+            cause,
+          }),
+      ),
+    ),
   );
-  const exitCode = Number(yield* child.exitCode);
 
   if (exitCode !== 0) {
     return yield* new NativeStaticCheckCommandError({
-      command,
-      args,
-      cwd,
+      ...processContext,
       exitCode,
     });
   }
 });
 
-function collectSources(
+export function collectSources(
   directory: string,
   root: string,
 ): Effect.Effect<
   ReadonlyArray<string>,
-  PlatformError.PlatformError,
+  NativeStaticCheckSourceDiscoveryError,
   FileSystem.FileSystem | Path.Path
 > {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const path = yield* Path.Path;
-    const entries = yield* fs.readDirectory(directory);
+    const entries = yield* fs.readDirectory(directory).pipe(
+      Effect.mapError(
+        (cause) =>
+          new NativeStaticCheckSourceDiscoveryError({
+            operation: "read-directory",
+            path: directory,
+            cause,
+          }),
+      ),
+    );
     const sources: Array<string> = [];
 
     for (const entry of entries) {
       const entryPath = path.join(directory, entry);
-      const stat = yield* fs.stat(entryPath);
+      const stat = yield* fs.stat(entryPath).pipe(
+        Effect.mapError(
+          (cause) =>
+            new NativeStaticCheckSourceDiscoveryError({
+              operation: "stat-entry",
+              path: entryPath,
+              cause,
+            }),
+        ),
+      );
 
       if (stat.type === "Directory") {
         const isGeneratedNativeProjectDirectory =


### PR DESCRIPTION
Summary:
- preserve source-discovery operation/path context and the immediate filesystem cause
- preserve spawn/wait command context and the immediate process cause
- keep non-zero exits cause-free while replacing raw argument arrays with argumentCount

Validation:
- vp test scripts/mobile-native-static-check.test.ts
- vp check
- vp run typecheck
- vp run lint:mobile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to a dev script and its tests; the only outward contract shift is `NativeStaticCheckCommandError` dropping `args` in favor of `argumentCount`.
> 
> **Overview**
> **Restructures** how the `mobile-native-static-check` script reports failures so each stage carries stable, typed context instead of raw `PlatformError` or bare exit metadata.
> 
> **Source discovery** (`collectSources`, app root resolution) now fails with `NativeStaticCheckSourceDiscoveryError`, recording the operation (`resolve-root`, `read-directory`, `stat-entry`), the path, and the underlying cause.
> 
> **Process execution** (`runCommand`) maps spawn and wait-for-exit failures to `NativeStaticCheckProcessError` (operation, command, `argumentCount`, cwd, shell, cause). Non-zero exits still use `NativeStaticCheckCommandError` but **no longer include the full `args` array**—callers get `argumentCount` and `shell` instead, with no synthetic `cause`.
> 
> **Tests** replace a single structural assertion with Effect-based coverage: real temp-dir discovery failure, mocked spawner for spawn/wait errors, and non-zero exit shape (including absence of `args`/`cause` where applicable). `runCommand` and `collectSources` are **exported** to support those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d95dfeceacf6c5ddada27850570f57b46e39c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured error types to mobile native static-check failures
> - Introduces `NativeStaticCheckSourceDiscoveryError`, `NativeStaticCheckProcessError`, and `NativeStaticCheckCommandError` tagged error classes with structured context fields (operation, path, command, argumentCount, shell, exitCode) in [mobile-native-static-check.ts](https://github.com/pingdotgg/t3code/pull/3464/files#diff-bf82146cd22581df064bfdf7f7976e8ae0ba18a655c5ceedcd0003f978f3d0fc).
> - `runCommand` now maps spawn and wait-for-exit failures to `NativeStaticCheckProcessError`; non-zero exits produce `NativeStaticCheckCommandError` with `argumentCount` and `shell` instead of the raw args array.
> - `collectSources` wraps `readDirectory` and `stat` failures as `NativeStaticCheckSourceDiscoveryError` with the failing path and operation name.
> - Adds effect-based tests in [mobile-native-static-check.test.ts](https://github.com/pingdotgg/t3code/pull/3464/files#diff-8f40ae6139a4821725818aca6ca89d2cb42142f10059af103b107d71b8888e02) covering structured error contracts for source discovery, spawn failures, wait-for-exit failures, and non-zero exit handling.
> - Behavioral Change: `NativeStaticCheckCommandError` no longer includes the full args array; callers inspecting error fields will see `argumentCount` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07d95df.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->