### PR TITLE
[codex] Structure workspace search cleanup failures

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -151,20 +151,29 @@ export const make = Effect.gen(function* () {
       if (!(yield* RcMap.has(workspaceSearchIndexes.rcMap, normalizedCwd))) {
         return;
       }
+      const recoverRefreshFailure = (
+        cause:
+          | WorkspaceSearchIndex.WorkspaceSearchIndexCreateFailed
+          | WorkspaceSearchIndex.WorkspaceSearchIndexScanTimedOut
+          | WorkspaceSearchIndex.WorkspaceSearchIndexRefreshFailed,
+      ) =>
+        Effect.gen(function* () {
+          yield* Effect.logWarning("Failed to refresh workspace search index", {
+            cwd,
+            cause,
+          });
+          yield* workspaceSearchIndexes.invalidate(normalizedCwd);
+        });
       yield* Effect.gen(function* () {
         const searchIndex = yield* WorkspaceSearchIndex.WorkspaceSearchIndex;
         yield* searchIndex.refresh();
       }).pipe(
         Effect.provide(workspaceSearchIndexes.get(normalizedCwd)),
-        Effect.catch((cause) =>
-          Effect.gen(function* () {
-            yield* Effect.logWarning("Failed to refresh workspace search index", {
-              cwd,
-              cause,
-            });
-            yield* workspaceSearchIndexes.invalidate(normalizedCwd);
-          }),
-        ),
+        Effect.catchTags({
+          WorkspaceSearchIndexCreateFailed: recoverRefreshFailure,
+          WorkspaceSearchIndexScanTimedOut: recoverRefreshFailure,
+          WorkspaceSearchIndexRefreshFailed: recoverRefreshFailure,
+        }),
       );
     },
   );

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -1,6 +1,8 @@
 import { FileFinder } from "@ff-labs/fff-node";
 import { afterEach, expect, it } from "@effect/vitest";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import { vi } from "vite-plus/test";
 
 import * as WorkspaceSearchIndex from "./WorkspaceSearchIndex.ts";
@@ -46,6 +48,35 @@ it.effect("keeps returned FileFinder creation diagnostics out of the cause chain
       reason: "native index rejected the directory",
     });
     expect(error.cause).toBeUndefined();
+  }),
+);
+
+it.effect("preserves FileFinder destroy failures as structured defects", () =>
+  Effect.gen(function* () {
+    const cause = new Error("native destroy failed");
+    const finder = {
+      destroy: vi.fn(() => {
+        throw cause;
+      }),
+      isScanning: vi.fn(() => false),
+    } as unknown as FileFinder;
+    vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+
+    const exit = yield* Effect.scoped(WorkspaceSearchIndex.make("/workspace/project")).pipe(
+      Effect.exit,
+    );
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    if (Exit.isFailure(exit)) {
+      expect(Cause.hasDies(exit.cause)).toBe(true);
+      const error = Cause.squash(exit.cause);
+      expect(error).toBeInstanceOf(WorkspaceSearchIndex.WorkspaceSearchIndexDestroyFailed);
+      expect(error).toMatchObject({
+        _tag: "WorkspaceSearchIndexDestroyFailed",
+        cwd: "/workspace/project",
+        cause,
+      });
+    }
   }),
 );
 

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -71,6 +71,18 @@ export class WorkspaceSearchIndexRefreshFailed extends Schema.TaggedErrorClass<W
   }
 }
 
+export class WorkspaceSearchIndexDestroyFailed extends Schema.TaggedErrorClass<WorkspaceSearchIndexDestroyFailed>()(
+  "WorkspaceSearchIndexDestroyFailed",
+  {
+    cwd: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to destroy the workspace search index for '${this.cwd}'.`;
+  }
+}
+
 export type WorkspaceSearchIndexError =
   | WorkspaceSearchIndexCreateFailed
   | WorkspaceSearchIndexScanTimedOut
@@ -201,7 +213,10 @@ const waitForScan = <E>(cwd: string, finder: FileFinder, onFailure: (cause: unkn
 
 export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: string) {
   const finder = yield* Effect.acquireRelease(createFinder(cwd), (finder) =>
-    Effect.sync(() => finder.destroy()),
+    Effect.try({
+      try: () => finder.destroy(),
+      catch: (cause) => new WorkspaceSearchIndexDestroyFailed({ cwd, cause }),
+    }).pipe(Effect.orDie),
   );
   yield* waitForScan(
     cwd,


### PR DESCRIPTION
## Summary

- Preserve `FileFinder.destroy()` failures as `WorkspaceSearchIndexDestroyFailed` defects with the workspace path and immediate cause.
- Restrict workspace-index refresh recovery to the three expected tagged failures so defects and unexpected errors are not silently converted into cache invalidation.
- Add focused coverage for finalizer failure structure and cause preservation.

## Validation

- `vp test apps/server/src/workspace/WorkspaceSearchIndex.test.ts apps/server/src/workspace/WorkspaceEntries.test.ts` (21 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling and test changes in workspace search indexing; no auth, data, or API contract changes.
> 
> **Overview**
> **Workspace search cleanup** now turns `FileFinder.destroy()` failures into a tagged `WorkspaceSearchIndexDestroyFailed` defect (workspace path + cause) via `Effect.try`/`orDie` on the scoped release finalizer, instead of letting them escape as unstructured errors.
> 
> **Refresh recovery** in `WorkspaceEntries.refresh` is narrowed from a catch-all handler to `Effect.catchTags` on `WorkspaceSearchIndexCreateFailed`, `WorkspaceSearchIndexScanTimedOut`, and `WorkspaceSearchIndexRefreshFailed` only—so defects (e.g. destroy failures) and other unexpected errors are no longer logged and used to invalidate the index cache.
> 
> Tests add coverage that scoped teardown preserves destroy failure structure in the cause chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb6387a689b7e221de41e1149cf8593f12adfb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure workspace search index cleanup failures as typed defects
> - Adds `WorkspaceSearchIndexDestroyFailed` error class to [WorkspaceSearchIndex.ts](https://github.com/pingdotgg/t3code/pull/3465/files#diff-c11793234fa6d81f052147cd8ae0b62e4e60366837e340f42279225a76704093); when `FileFinder.destroy` throws during scope release, the scope now dies with this structured defect carrying `cwd` and the original cause instead of an unstructured exception.
> - Narrows error handling in [WorkspaceEntries.ts](https://github.com/pingdotgg/t3code/pull/3465/files#diff-26feb5e4175dd3c4b97bf023c259c336abef121574cd5665d06d3e4dbf1b15b8) from a broad `Effect.catch` to `Effect.catchTags` covering only `WorkspaceSearchIndexCreateFailed`, `WorkspaceSearchIndexScanTimedOut`, and `WorkspaceSearchIndexRefreshFailed`.
> - Adds a test in [WorkspaceSearchIndex.test.ts](https://github.com/pingdotgg/t3code/pull/3465/files#diff-a7ed586ccb0e703854e76107ba2f29105acaa431d7fbe8b9fad34c98a8547c59) asserting that `FileFinder.destroy` failures exit as `WorkspaceSearchIndexDestroyFailed` defects.
> - Behavioral Change: other failures from the refresh pipeline now propagate to the caller instead of being silently logged and invalidated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0cb6387.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->