### PR TITLE
[codex] Structure release metadata failures

### DIFF
--- a/scripts/resolve-nightly-release.test.ts
+++ b/scripts/resolve-nightly-release.test.ts
@@ -1,7 +1,12 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 
 import {
+  readDesktopBaseVersion,
   resolveNightlyBaseVersion,
   resolveNightlyReleaseMetadata,
   resolveNightlyTargetVersion,
@@ -41,5 +46,51 @@ it("derives nightly metadata including the short commit sha in the release name"
       name: "T3 Code Nightly 9.9.10-nightly.20260413.321 (abcdef123456)",
       shortSha: "abcdef123456",
     },
+  );
+});
+
+it.layer(NodeServices.layer)("readDesktopBaseVersion", (it) => {
+  it.effect("preserves desktop package read context and its platform cause", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const rootDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "resolve-nightly-release-read-",
+      });
+      const packageJsonPath = path.join(rootDir, "apps/desktop/package.json");
+
+      const error = yield* readDesktopBaseVersion(rootDir).pipe(Effect.flip);
+
+      if (error._tag !== "NightlyReleaseDesktopPackageError") {
+        return assert.fail(`Unexpected error: ${error._tag}`);
+      }
+      assert.equal(error.operation, "read");
+      assert.equal(error.packageJsonPath, packageJsonPath);
+      assert.instanceOf(error.cause, PlatformError.PlatformError);
+      assert.notInclude(error.message, String((error.cause as Error).message));
+    }),
+  );
+
+  it.effect("preserves desktop package decode context and its schema cause", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const rootDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "resolve-nightly-release-decode-",
+      });
+      const packageJsonPath = path.join(rootDir, "apps/desktop/package.json");
+      yield* fs.makeDirectory(path.dirname(packageJsonPath), { recursive: true });
+      yield* fs.writeFileString(packageJsonPath, "{");
+
+      const error = yield* readDesktopBaseVersion(rootDir).pipe(Effect.flip);
+
+      if (error._tag !== "NightlyReleaseDesktopPackageError") {
+        return assert.fail(`Unexpected error: ${error._tag}`);
+      }
+      assert.equal(error.operation, "decode");
+      assert.equal(error.packageJsonPath, packageJsonPath);
+      assert.ok(error.cause !== undefined);
+      assert.notInclude(error.message, String((error.cause as Error).message));
+    }),
   );
 });

--- a/scripts/resolve-nightly-release.ts
+++ b/scripts/resolve-nightly-release.ts
@@ -40,6 +40,19 @@ export class InvalidDesktopPackageVersionError extends Schema.TaggedErrorClass<I
   }
 }
 
+export class NightlyReleaseDesktopPackageError extends Schema.TaggedErrorClass<NightlyReleaseDesktopPackageError>()(
+  "NightlyReleaseDesktopPackageError",
+  {
+    operation: Schema.Literals(["read", "decode"]),
+    packageJsonPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to ${this.operation} desktop package metadata at ${this.packageJsonPath}.`;
+  }
+}
+
 const RepoRoot = Effect.service(Path.Path).pipe(
   Effect.flatMap((path) => path.fromFileUrl(new URL("..", import.meta.url))),
 );
@@ -77,16 +90,33 @@ export const resolveNightlyReleaseMetadata = (
   };
 };
 
-const readDesktopBaseVersion = Effect.fn("readDesktopBaseVersion")(function* (
+export const readDesktopBaseVersion = Effect.fn("readDesktopBaseVersion")(function* (
   rootDir: string | undefined,
 ) {
   const fs = yield* FileSystem.FileSystem;
   const path = yield* Path.Path;
   const workspaceRoot = rootDir ? path.resolve(rootDir) : yield* RepoRoot;
   const packageJsonPath = path.join(workspaceRoot, "apps/desktop/package.json");
-  const packageJson = yield* fs
-    .readFileString(packageJsonPath)
-    .pipe(Effect.flatMap(decodeDesktopPackageJson));
+  const packageJsonSource = yield* fs.readFileString(packageJsonPath).pipe(
+    Effect.mapError(
+      (cause) =>
+        new NightlyReleaseDesktopPackageError({
+          operation: "read",
+          packageJsonPath,
+          cause,
+        }),
+    ),
+  );
+  const packageJson = yield* decodeDesktopPackageJson(packageJsonSource).pipe(
+    Effect.mapError(
+      (cause) =>
+        new NightlyReleaseDesktopPackageError({
+          operation: "decode",
+          packageJsonPath,
+          cause,
+        }),
+    ),
+  );
   return yield* resolveNightlyTargetVersion(packageJson.version);
 });
 

--- a/scripts/resolve-previous-release-tag.test.ts
+++ b/scripts/resolve-previous-release-tag.test.ts
@@ -1,7 +1,33 @@
 import { assert, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as PlatformError from "effect/PlatformError";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { resolvePreviousReleaseTag } from "./resolve-previous-release-tag.ts";
+import { listGitTags, resolvePreviousReleaseTag } from "./resolve-previous-release-tag.ts";
+
+const encoder = new TextEncoder();
+
+function mockHandle(options: {
+  readonly exitCode: number;
+  readonly stdout?: string;
+  readonly stderr?: string;
+}) {
+  return ChildProcessSpawner.makeHandle({
+    pid: ChildProcessSpawner.ProcessId(1),
+    exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(options.exitCode)),
+    isRunning: Effect.succeed(false),
+    kill: () => Effect.void,
+    unref: Effect.succeed(Effect.void),
+    stdin: Sink.drain,
+    stdout: Stream.make(encoder.encode(options.stdout ?? "")),
+    stderr: Stream.make(encoder.encode(options.stderr ?? "")),
+    all: Stream.empty,
+    getInputFd: () => Sink.drain,
+    getOutputFd: () => Stream.empty,
+  });
+}
 
 it.effect("selects the latest earlier stable tag and ignores nightlies", () =>
   Effect.gen(function* () {
@@ -35,5 +61,70 @@ it.effect("reports the invalid tag with its release channel", () =>
     assert.equal(error.channel, "nightly");
     assert.equal(error.currentTag, "v1.2.0");
     assert.equal(error.message, "Invalid nightly release tag 'v1.2.0'.");
+  }),
+);
+
+it.effect("preserves git tag spawn context and the exact platform cause", () => {
+  const cause = PlatformError.systemError({
+    _tag: "NotFound",
+    module: "ChildProcess",
+    method: "spawn",
+    description: "git was not found",
+  });
+
+  return Effect.gen(function* () {
+    const error = yield* listGitTags("/repo").pipe(
+      Effect.scoped,
+      Effect.provideService(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() => Effect.fail(cause)),
+      ),
+      Effect.flip,
+    );
+
+    if (error._tag !== "ReleaseTagListProcessError") {
+      return assert.fail(`Unexpected error: ${error._tag}`);
+    }
+    assert.equal(error.operation, "spawn");
+    assert.equal(error.executable, "git");
+    assert.equal(error.argumentCount, 2);
+    assert.equal(error.cwd, "/repo");
+    assert.strictEqual(error.cause, cause);
+    assert.notProperty(error, "args");
+    assert.notInclude(error.message, cause.message);
+  });
+});
+
+it.effect("reports git tag non-zero exits without manufacturing a cause", () =>
+  Effect.gen(function* () {
+    const error = yield* listGitTags("/repo").pipe(
+      Effect.scoped,
+      Effect.provideService(
+        ChildProcessSpawner.ChildProcessSpawner,
+        ChildProcessSpawner.make(() =>
+          Effect.succeed(
+            mockHandle({
+              exitCode: 17,
+              stdout: "v1.2.3\n",
+              stderr: "fatal: repository unavailable\n",
+            }),
+          ),
+        ),
+      ),
+      Effect.flip,
+    );
+
+    if (error._tag !== "ReleaseTagListProcessExitError") {
+      return assert.fail(`Unexpected error: ${error._tag}`);
+    }
+    assert.equal(error.executable, "git");
+    assert.equal(error.argumentCount, 2);
+    assert.equal(error.cwd, "/repo");
+    assert.equal(error.exitCode, 17);
+    assert.equal(error.stdoutLength, 7);
+    assert.equal(error.stderrLength, 30);
+    assert.notProperty(error, "cause");
+    assert.notProperty(error, "stdout");
+    assert.notProperty(error, "stderr");
   }),
 );

--- a/scripts/resolve-previous-release-tag.ts
+++ b/scripts/resolve-previous-release-tag.ts
@@ -2,7 +2,6 @@
 
 import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
 import * as NodeServices from "@effect/platform-node/NodeServices";
-import * as Array from "effect/Array";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -24,6 +23,39 @@ export class InvalidReleaseTagError extends Schema.TaggedErrorClass<InvalidRelea
 ) {
   override get message(): string {
     return `Invalid ${this.channel} release tag '${this.currentTag}'.`;
+  }
+}
+
+const releaseTagListProcessContext = {
+  executable: Schema.Literal("git"),
+  argumentCount: Schema.Number,
+  cwd: Schema.String,
+};
+
+export class ReleaseTagListProcessError extends Schema.TaggedErrorClass<ReleaseTagListProcessError>()(
+  "ReleaseTagListProcessError",
+  {
+    ...releaseTagListProcessContext,
+    operation: Schema.Literals(["spawn", "communicate", "wait-for-exit"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to list release tags during process operation "${this.operation}".`;
+  }
+}
+
+export class ReleaseTagListProcessExitError extends Schema.TaggedErrorClass<ReleaseTagListProcessExitError>()(
+  "ReleaseTagListProcessExitError",
+  {
+    ...releaseTagListProcessContext,
+    exitCode: Schema.Number,
+    stdoutLength: Schema.Number,
+    stderrLength: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return `Release tag listing exited with code ${this.exitCode}.`;
   }
 }
 
@@ -172,20 +204,80 @@ export const resolvePreviousReleaseTag = (
     return candidates[0]?.tag;
   });
 
-const listGitTags = Effect.fn("listGitTags")(function* () {
-  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
-  const child = yield* spawner.spawn(ChildProcess.make("git", ["tag", "--list"]));
-  const tags = yield* child.stdout.pipe(
+const collectStreamAsString = <E>(stream: Stream.Stream<Uint8Array, E>): Effect.Effect<string, E> =>
+  stream.pipe(
     Stream.decodeText(),
     Stream.runFold(
       () => "",
       (acc, chunk) => acc + chunk,
     ),
-    Effect.map(String.split(/\r?\n/)),
-    Effect.map(Array.map(String.trim)),
-    Effect.map(Array.filter(String.isNonEmpty)),
   );
-  return tags;
+
+export const listGitTags = Effect.fn("listGitTags")(function* (cwd = process.cwd()) {
+  const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const args = ["tag", "--list"] as const;
+  const context = {
+    executable: "git",
+    argumentCount: args.length,
+    cwd,
+  } as const;
+  const child = yield* spawner.spawn(ChildProcess.make("git", args, { cwd })).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ReleaseTagListProcessError({
+          ...context,
+          operation: "spawn",
+          cause,
+        }),
+    ),
+  );
+  const [stdout, stderr, exitCode] = yield* Effect.all(
+    [
+      collectStreamAsString(child.stdout).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ReleaseTagListProcessError({
+              ...context,
+              operation: "communicate",
+              cause,
+            }),
+        ),
+      ),
+      collectStreamAsString(child.stderr).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ReleaseTagListProcessError({
+              ...context,
+              operation: "communicate",
+              cause,
+            }),
+        ),
+      ),
+      child.exitCode.pipe(
+        Effect.map(Number),
+        Effect.mapError(
+          (cause) =>
+            new ReleaseTagListProcessError({
+              ...context,
+              operation: "wait-for-exit",
+              cause,
+            }),
+        ),
+      ),
+    ],
+    { concurrency: "unbounded" },
+  );
+
+  if (exitCode !== 0) {
+    return yield* new ReleaseTagListProcessExitError({
+      ...context,
+      exitCode,
+      stdoutLength: stdout.length,
+      stderrLength: stderr.length,
+    });
+  }
+
+  return stdout.split(/\r?\n/).map(String.trim).filter(String.isNonEmpty);
 });
 
 const writeOutput = Effect.fn("writeOutput")(function* (


### PR DESCRIPTION
## Summary

- preserve desktop package read and decode context with the immediate cause
- preserve git tag process spawn, stream, and exit diagnostics without retaining command output
- reject non-zero git tag listing exits without manufacturing a cause

## Why

The release metadata scripts exposed low-level failures without enough domain context, and git tag listing did not inspect the process exit code. This keeps stable messages separate from causes while retaining the full error chain and safe structured attributes.

## Validation

- `vp test scripts/resolve-nightly-release.test.ts scripts/resolve-previous-release-tag.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI/release helper scripts and error shaping; success paths for tag listing and version resolution stay the same aside from failing when git exits non-zero.
> 
> **Overview**
> Release metadata scripts now wrap low-level failures in **tagged domain errors** with stable messages and preserved `cause` chains, instead of surfacing raw platform/schema/process errors.
> 
> **Nightly (`readDesktopBaseVersion`)** adds `NightlyReleaseDesktopPackageError` for **read** vs **decode** of `apps/desktop/package.json`, exports the helper, and maps file/JSON failures without folding the underlying message into the top-level text.
> 
> **Previous tag (`listGitTags`)** is exported, runs `git tag --list` with an explicit **cwd**, and classifies failures as `ReleaseTagListProcessError` (spawn / communicate / wait-for-exit with the original cause) or `ReleaseTagListProcessExitError` on **non-zero exit** (exit code plus stdout/stderr **lengths only**—no command output on the error). Tests cover desktop read/decode errors and mocked git spawn/exit behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0715b854af2f6726b7bf8f702daf141ca35f3fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure release metadata failures with typed errors in nightly release scripts
> - Introduces `NightlyReleaseDesktopPackageError` in [resolve-nightly-release.ts](https://github.com/pingdotgg/t3code/pull/3467/files#diff-908efcd86c90341a4fcec11bc6327f78b5b1fada44e1dd8802dfd10ea628e618) with `operation` ('read' | 'decode') and `packageJsonPath` fields, replacing raw platform/schema errors from `readDesktopBaseVersion`.
> - Introduces `ReleaseTagListProcessError` and `ReleaseTagListProcessExitError` in [resolve-previous-release-tag.ts](https://github.com/pingdotgg/t3code/pull/3467/files#diff-7a8a5b092210685ad9f73b267b7c772922541c68b703084bf0573acd46d92633) to wrap spawn, communication, and non-zero exit failures from `listGitTags`.
> - Both `readDesktopBaseVersion` and `listGitTags` are now exported and include structured context (operation, path, exit code, output lengths) without leaking raw cause messages.
> - Adds tests verifying that error wrapping preserves cause context and does not echo internal error messages to callers.
> - Behavioral Change: callers of `readDesktopBaseVersion` and `listGitTags` now receive typed tagged errors instead of raw platform or schema errors.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0715b85.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->