### PR TITLE
[codex] Structure release package updater failures

### DIFF
--- a/scripts/update-release-package-versions.test.ts
+++ b/scripts/update-release-package-versions.test.ts
@@ -1,16 +1,21 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
+import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Path from "effect/Path";
+import * as PlatformError from "effect/PlatformError";
 import * as Schema from "effect/Schema";
 import { Command, CliError } from "effect/unstable/cli";
 import * as TestConsole from "effect/testing/TestConsole";
 import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
 
 import {
+  ReleaseGitHubOutputConfigurationError,
+  ReleaseGitHubOutputWriteError,
+  ReleasePackageManifestError,
   releasePackageFiles,
   updateReleasePackageVersions,
   updateReleasePackageVersionsCommand,
@@ -103,6 +108,73 @@ it.layer(ScriptTestLayer)("update-release-package-versions", (it) => {
     }),
   );
 
+  it.effect("preserves manifest read context and the filesystem cause", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "update-release-package-versions-read-error-",
+      });
+      const filePath = path.join(baseDir, releasePackageFiles[0]);
+
+      const error = yield* updateReleasePackageVersions("1.2.3", {
+        rootDir: baseDir,
+      }).pipe(Effect.flip);
+
+      assert.instanceOf(error, ReleasePackageManifestError);
+      assert.equal(error.operation, "read");
+      assert.equal(error.filePath, filePath);
+      assert.instanceOf(error.cause, PlatformError.PlatformError);
+      assert.equal(error.message, `Failed to read release package manifest '${filePath}'.`);
+    }),
+  );
+
+  it.effect("preserves manifest decode context and the schema cause", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "update-release-package-versions-decode-error-",
+      });
+      const filePath = path.join(baseDir, releasePackageFiles[0]);
+
+      yield* writePackageJsonFixtures(baseDir, "0.0.1");
+      yield* fs.writeFileString(filePath, "not json");
+
+      const error = yield* updateReleasePackageVersions("1.2.3", {
+        rootDir: baseDir,
+      }).pipe(Effect.flip);
+
+      assert.equal(error.operation, "decode");
+      assert.equal(error.filePath, filePath);
+      assert.isTrue(Schema.isSchemaError(error.cause));
+      assert.equal(error.message, `Failed to decode release package manifest '${filePath}'.`);
+    }),
+  );
+
+  it.effect("preserves manifest write context and the filesystem cause", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const baseDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "update-release-package-versions-write-error-",
+      });
+      const filePath = path.join(baseDir, releasePackageFiles[0]);
+
+      yield* writePackageJsonFixtures(baseDir, "0.0.1");
+      yield* fs.chmod(filePath, 0o400);
+
+      const error = yield* updateReleasePackageVersions("1.2.3", {
+        rootDir: baseDir,
+      }).pipe(Effect.flip, Effect.ensuring(fs.chmod(filePath, 0o600).pipe(Effect.orDie)));
+
+      assert.equal(error.operation, "write");
+      assert.equal(error.filePath, filePath);
+      assert.instanceOf(error.cause, PlatformError.PlatformError);
+      assert.equal(error.message, `Failed to write release package manifest '${filePath}'.`);
+    }),
+  );
+
   it.effect("accepts flags before the version positional and appends changed output", () =>
     Effect.gen(function* () {
       const fs = yield* FileSystem.FileSystem;
@@ -164,9 +236,43 @@ it.layer(ScriptTestLayer)("update-release-package-versions", (it) => {
         Effect.flip,
       );
 
+      assert.instanceOf(error, ReleaseGitHubOutputConfigurationError);
+      assert.instanceOf(error.cause, Config.ConfigError);
       assert.equal(
         error.message,
-        'SchemaError(Expected string, got undefined\n  at ["GITHUB_OUTPUT"])',
+        "Failed to resolve GITHUB_OUTPUT for release package version output.",
+      );
+    }),
+  );
+
+  it.effect("preserves GITHUB_OUTPUT write context and the filesystem cause", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const baseDir = yield* fs.makeTempDirectoryScoped({
+        prefix: "update-release-package-versions-cli-output-error-",
+      });
+
+      yield* writePackageJsonFixtures(baseDir, "0.0.1");
+
+      const error = yield* runCli(["4.0.0", "--root", baseDir, "--github-output"]).pipe(
+        Effect.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromEnv({
+              env: {
+                GITHUB_OUTPUT: baseDir,
+              },
+            }),
+          ),
+        ),
+        Effect.flip,
+      );
+
+      assert.instanceOf(error, ReleaseGitHubOutputWriteError);
+      assert.equal(error.filePath, baseDir);
+      assert.instanceOf(error.cause, PlatformError.PlatformError);
+      assert.equal(
+        error.message,
+        `Failed to append release package version output to '${baseDir}'.`,
       );
     }),
   );

--- a/scripts/update-release-package-versions.ts
+++ b/scripts/update-release-package-versions.ts
@@ -12,6 +12,40 @@ import * as Schema from "effect/Schema";
 import { Argument, Command, Flag } from "effect/unstable/cli";
 import { fromJsonStringPretty } from "@t3tools/shared/schemaJson";
 
+export class ReleasePackageManifestError extends Schema.TaggedErrorClass<ReleasePackageManifestError>()(
+  "ReleasePackageManifestError",
+  {
+    operation: Schema.Literals(["read", "decode", "encode", "write"]),
+    filePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to ${this.operation} release package manifest '${this.filePath}'.`;
+  }
+}
+
+export class ReleaseGitHubOutputConfigurationError extends Schema.TaggedErrorClass<ReleaseGitHubOutputConfigurationError>()(
+  "ReleaseGitHubOutputConfigurationError",
+  { cause: Schema.Defect() },
+) {
+  override get message(): string {
+    return "Failed to resolve GITHUB_OUTPUT for release package version output.";
+  }
+}
+
+export class ReleaseGitHubOutputWriteError extends Schema.TaggedErrorClass<ReleaseGitHubOutputWriteError>()(
+  "ReleaseGitHubOutputWriteError",
+  {
+    filePath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to append release package version output to '${this.filePath}'.`;
+  }
+}
+
 export const releasePackageFiles = [
   "apps/server/package.json",
   "apps/desktop/package.json",
@@ -39,13 +73,50 @@ export const updateReleasePackageVersions = Effect.fn("updateReleasePackageVersi
 
   for (const relativePath of releasePackageFiles) {
     const filePath = path.join(rootDir, relativePath);
-    const packageJson = yield* fs.readFileString(filePath).pipe(Effect.flatMap(decodePackageJson));
+    const packageJsonText = yield* fs.readFileString(filePath).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ReleasePackageManifestError({
+            operation: "read",
+            filePath,
+            cause,
+          }),
+      ),
+    );
+    const packageJson = yield* decodePackageJson(packageJsonText).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ReleasePackageManifestError({
+            operation: "decode",
+            filePath,
+            cause,
+          }),
+      ),
+    );
     if (packageJson.version === version) {
       continue;
     }
 
-    const packageJsonString = yield* encodePackageJson({ ...packageJson, version });
-    yield* fs.writeFileString(filePath, `${packageJsonString}\n`);
+    const packageJsonString = yield* encodePackageJson({ ...packageJson, version }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ReleasePackageManifestError({
+            operation: "encode",
+            filePath,
+            cause,
+          }),
+      ),
+    );
+    yield* fs.writeFileString(filePath, `${packageJsonString}\n`).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ReleasePackageManifestError({
+            operation: "write",
+            filePath,
+            cause,
+          }),
+      ),
+    );
     changed = true;
   }
 
@@ -54,8 +125,23 @@ export const updateReleasePackageVersions = Effect.fn("updateReleasePackageVersi
 
 const writeGithubOutput = Effect.fn("writeGithubOutput")(function* (changed: boolean) {
   const fs = yield* FileSystem.FileSystem;
-  const githubOutputPath = yield* Config.nonEmptyString("GITHUB_OUTPUT");
-  yield* fs.writeFileString(githubOutputPath, `changed=${changed}\n`, { flag: "a" });
+  const githubOutputPath = yield* Config.nonEmptyString("GITHUB_OUTPUT").pipe(
+    Effect.mapError(
+      (cause) =>
+        new ReleaseGitHubOutputConfigurationError({
+          cause,
+        }),
+    ),
+  );
+  yield* fs.writeFileString(githubOutputPath, `changed=${changed}\n`, { flag: "a" }).pipe(
+    Effect.mapError(
+      (cause) =>
+        new ReleaseGitHubOutputWriteError({
+          filePath: githubOutputPath,
+          cause,
+        }),
+    ),
+  );
 });
 
 export const updateReleasePackageVersionsCommand = Command.make(


### PR DESCRIPTION
Summary:
- attach manifest operation and file-path context to read, decode, encode, and write failures while preserving each immediate cause
- distinguish GITHUB_OUTPUT configuration and append failures with stable release-step messages
- cover filesystem, schema, configuration, and output-write boundaries with focused tests

Validation:
- vp test scripts/update-release-package-versions.test.ts
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the release version update script and its tests; no production app paths or security-sensitive logic.
> 
> **Overview**
> The release package version script now maps **read/decode/encode/write** manifest failures to **`ReleasePackageManifestError`**, carrying **`operation`**, **`filePath`**, and the original **`cause`** instead of leaking raw platform/schema errors.
> 
> **`GITHUB_OUTPUT`** handling is split into **`ReleaseGitHubOutputConfigurationError`** (missing/invalid env) and **`ReleaseGitHubOutputWriteError`** (append failures), with stable user-facing messages. CLI behavior for a missing **`GITHUB_OUTPUT`** with **`--github-output`** changes from a raw **`SchemaError`** to the configuration error type.
> 
> Tests cover manifest read/decode/write boundaries and GitHub output config/write failures, asserting error class, context fields, and preserved causes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 884eaa35bc3c41cee30af4adcaec998761c488b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add typed error classes for release package updater failures
> - Introduces `ReleasePackageManifestError`, `ReleaseGitHubOutputConfigurationError`, and `ReleaseGitHubOutputWriteError` tagged error classes in [update-release-package-versions.ts](https://github.com/pingdotgg/t3code/pull/3468/files#diff-ddfa181071d7a646d96564b3ceeb72326808a0bb87f995350e25aea02b118362).
> - Maps raw filesystem and schema errors to typed errors with `operation`, `filePath`, and `cause` fields for easier diagnostics.
> - Adds test cases in [update-release-package-versions.test.ts](https://github.com/pingdotgg/t3code/pull/3468/files#diff-809b88a2f198c454837cdd0afb2a25761ccf76d56e4f91cf871d05f53310b63b) to verify error type, operation, filePath, and cause are preserved across read/decode/write paths.
> - Behavioral Change: CLI output for missing `GITHUB_OUTPUT` now surfaces `ReleaseGitHubOutputConfigurationError` instead of a raw `SchemaError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 884eaa3.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->