### PR TITLE
[codex] Preserve child process termination context

### DIFF
--- a/packages/effect-acp/src/_internal/stdio.test.ts
+++ b/packages/effect-acp/src/_internal/stdio.test.ts
@@ -1,0 +1,45 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as PlatformError from "effect/PlatformError";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as AcpError from "../errors.ts";
+import { makeTerminationError } from "./stdio.ts";
+
+describe("ACP child process termination", () => {
+  it.effect("retains the process identifier with the exit code", () =>
+    Effect.gen(function* () {
+      const error = yield* makeTerminationError({
+        pid: ChildProcessSpawner.ProcessId(41),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(7)),
+      });
+
+      assert.instanceOf(error, AcpError.AcpProcessExitedError);
+      assert.equal(error.pid, 41);
+      assert.equal(error.code, 7);
+      assert.equal(error.message, "ACP process exited with code 7");
+    }),
+  );
+
+  it.effect("retains the process identifier and exact exit-status cause", () =>
+    Effect.gen(function* () {
+      const rootCause = new Error("private process diagnostics");
+      const cause = PlatformError.systemError({
+        _tag: "Unknown",
+        module: "ChildProcess",
+        method: "exitCode",
+        cause: rootCause,
+      });
+      const error = yield* makeTerminationError({
+        pid: ChildProcessSpawner.ProcessId(42),
+        exitCode: Effect.fail(cause),
+      });
+
+      assert.instanceOf(error, AcpError.AcpTransportError);
+      assert.equal(error.pid, 42);
+      assert.strictEqual(error.cause, cause);
+      assert.equal(error.message, "ACP transport operation read-process-exit-status failed.");
+      assert.notInclude(error.message, rootCause.message);
+    }),
+  );
+});

--- a/packages/effect-acp/src/_internal/stdio.ts
+++ b/packages/effect-acp/src/_internal/stdio.ts
@@ -44,14 +44,20 @@ export const makeInMemoryStdio = Effect.fn("makeInMemoryStdio")(function* () {
   };
 });
 
+type ChildProcessTerminationHandle = Pick<
+  ChildProcessSpawner.ChildProcessHandle,
+  "exitCode" | "pid"
+>;
+
 export const makeTerminationError = (
-  handle: ChildProcessSpawner.ChildProcessHandle,
+  handle: ChildProcessTerminationHandle,
 ): Effect.Effect<AcpError.AcpError> =>
   Effect.match(handle.exitCode, {
     onFailure: (cause) =>
       new AcpError.AcpTransportError({
         operation: "read-process-exit-status",
+        pid: handle.pid,
         cause,
       }),
-    onSuccess: (code) => new AcpError.AcpProcessExitedError({ code }),
+    onSuccess: (code) => new AcpError.AcpProcessExitedError({ code, pid: handle.pid }),
   });

--- a/packages/effect-acp/src/errors.ts
+++ b/packages/effect-acp/src/errors.ts
@@ -91,6 +91,7 @@ export class AcpProcessExitedError extends Schema.TaggedErrorClass<AcpProcessExi
   "AcpProcessExitedError",
   {
     code: Schema.optional(Schema.Number),
+    pid: Schema.optionalKey(Schema.Int),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
@@ -160,6 +161,7 @@ export class AcpTransportError extends Schema.TaggedErrorClass<AcpTransportError
     ),
     method: Schema.optional(Schema.String),
     detail: Schema.optional(Schema.String),
+    pid: Schema.optionalKey(Schema.Int),
     cause: Schema.Defect(),
   },
 ) {

--- a/packages/effect-codex-app-server/src/_internal/stdio.test.ts
+++ b/packages/effect-codex-app-server/src/_internal/stdio.test.ts
@@ -1,0 +1,48 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as PlatformError from "effect/PlatformError";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import * as CodexError from "../errors.ts";
+import { makeTerminationError } from "./stdio.ts";
+
+describe("Codex App Server child process termination", () => {
+  it.effect("retains the process identifier with the exit code", () =>
+    Effect.gen(function* () {
+      const error = yield* makeTerminationError({
+        pid: ChildProcessSpawner.ProcessId(51),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(9)),
+      });
+
+      assert.instanceOf(error, CodexError.CodexAppServerProcessExitedError);
+      assert.equal(error.pid, 51);
+      assert.equal(error.code, 9);
+      assert.equal(error.message, "Codex App Server process exited with code 9");
+    }),
+  );
+
+  it.effect("retains the process identifier and exact exit-status cause", () =>
+    Effect.gen(function* () {
+      const rootCause = new Error("private process diagnostics");
+      const cause = PlatformError.systemError({
+        _tag: "Unknown",
+        module: "ChildProcess",
+        method: "exitCode",
+        cause: rootCause,
+      });
+      const error = yield* makeTerminationError({
+        pid: ChildProcessSpawner.ProcessId(52),
+        exitCode: Effect.fail(cause),
+      });
+
+      assert.instanceOf(error, CodexError.CodexAppServerTransportError);
+      assert.equal(error.pid, 52);
+      assert.strictEqual(error.cause, cause);
+      assert.equal(
+        error.message,
+        "Codex App Server transport operation 'read-process-exit-status' failed.",
+      );
+      assert.notInclude(error.message, rootCause.message);
+    }),
+  );
+});

--- a/packages/effect-codex-app-server/src/_internal/stdio.ts
+++ b/packages/effect-codex-app-server/src/_internal/stdio.ts
@@ -44,14 +44,20 @@ export const makeInMemoryStdio = Effect.fn("makeInMemoryStdio")(function* () {
   };
 });
 
+type ChildProcessTerminationHandle = Pick<
+  ChildProcessSpawner.ChildProcessHandle,
+  "exitCode" | "pid"
+>;
+
 export const makeTerminationError = (
-  handle: ChildProcessSpawner.ChildProcessHandle,
+  handle: ChildProcessTerminationHandle,
 ): Effect.Effect<CodexError.CodexAppServerError> =>
   Effect.match(handle.exitCode, {
     onFailure: (cause) =>
       new CodexError.CodexAppServerTransportError({
         operation: "read-process-exit-status",
+        pid: handle.pid,
         cause,
       }),
-    onSuccess: (code) => new CodexError.CodexAppServerProcessExitedError({ code }),
+    onSuccess: (code) => new CodexError.CodexAppServerProcessExitedError({ code, pid: handle.pid }),
   });

--- a/packages/effect-codex-app-server/src/errors.ts
+++ b/packages/effect-codex-app-server/src/errors.ts
@@ -146,6 +146,7 @@ export class CodexAppServerProcessExitedError extends Schema.TaggedErrorClass<Co
   "CodexAppServerProcessExitedError",
   {
     code: Schema.optional(Schema.Number),
+    pid: Schema.optionalKey(Schema.Int),
     cause: Schema.optional(Schema.Defect()),
   },
 ) {
@@ -233,6 +234,7 @@ export class CodexAppServerTransportError extends Schema.TaggedErrorClass<CodexA
   "CodexAppServerTransportError",
   {
     operation: CodexAppServerTransportOperation,
+    pid: Schema.optionalKey(Schema.Int),
     cause: Schema.Defect(),
   },
 ) {


### PR DESCRIPTION
## Summary

- attach the child process PID to ACP and Codex App Server termination errors
- retain the exact exit-status read failure as the transport error cause
- keep normal process exits cause-free while preserving their exit code
- cover both symmetric adapters with compact focused tests

## Why

Termination failures previously retained the exit code or read failure but not the process identity, which made concurrent child-process failures harder to correlate. The existing termination helper remains because it performs an effectful status read and selects between distinct error types; it is not a constructor-only wrapper.

## Validation

- vp test across all effect-acp and effect-codex-app-server test files: 47 passed
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional fields on error types and clearer diagnostics; no changes to auth, data handling, or core transport behavior beyond enriched error payloads.
> 
> **Overview**
> **Child process termination errors now carry the process ID** in both `effect-acp` and `effect-codex-app-server`. `makeTerminationError` passes `handle.pid` into `AcpProcessExitedError` / `CodexAppServerProcessExitedError` on normal exit and into the corresponding transport error when reading exit status fails; the exit-status failure still uses the original `cause` unchanged.
> 
> The termination helper now accepts a narrowed `ChildProcessTerminationHandle` (`pid` + `exitCode` only). Error schemas gain an optional `pid` field on process-exited and read-exit-status transport types. New `stdio.test.ts` files assert PID retention, cause identity, and that user-facing messages stay free of nested diagnostic text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f751e75dc9564790a1c0ace17f341e03afcd4212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve child process PID in termination errors for ACP and Codex App Server
> - Adds an optional `pid` field to `AcpProcessExitedError`, `AcpTransportError`, `CodexAppServerProcessExitedError`, and `CodexAppServerTransportError` schema classes.
> - Updates `makeTerminationError` in both packages to accept a `ChildProcessTerminationHandle` (typed as `Pick<ChildProcessHandle, 'exitCode' | 'pid'>`) and populate `pid` on all produced errors.
> - Adds test suites in both packages verifying PID propagation and correct error messages for both exit-code success and failure cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f751e75.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->