### PR TITLE
[codex] Structure release output failures

### DIFF
--- a/scripts/resolve-nightly-release.test.ts
+++ b/scripts/resolve-nightly-release.test.ts
@@ -1,5 +1,7 @@
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { assert, it } from "@effect/vitest";
+import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -10,6 +12,7 @@ import {
   resolveNightlyBaseVersion,
   resolveNightlyReleaseMetadata,
   resolveNightlyTargetVersion,
+  writeNightlyReleaseOutput,
 } from "./resolve-nightly-release.ts";
 
 it("strips prerelease and build metadata when deriving the nightly base version", () => {
@@ -47,6 +50,29 @@ it("derives nightly metadata including the short commit sha in the release name"
       shortSha: "abcdef123456",
     },
   );
+});
+
+it.effect("preserves the GITHUB_OUTPUT configuration cause", () => {
+  const metadata = resolveNightlyReleaseMetadata("1.2.4", "20260620", 42, "abcdef1234567890");
+  const configCause = new ConfigProvider.SourceError({ message: "environment unavailable" });
+
+  return Effect.gen(function* () {
+    const configError = yield* writeNightlyReleaseOutput(metadata, true).pipe(
+      Effect.provideService(FileSystem.FileSystem, FileSystem.makeNoop({})),
+      Effect.provideService(
+        ConfigProvider.ConfigProvider,
+        ConfigProvider.make(() => Effect.fail(configCause)),
+      ),
+      Effect.flip,
+    );
+
+    if (configError._tag !== "NightlyReleaseGitHubOutputConfigError") {
+      return assert.fail(`Unexpected error: ${configError._tag}`);
+    }
+    assert.instanceOf(configError.cause, Config.ConfigError);
+    assert.strictEqual(configError.cause.cause, configCause);
+    assert.notInclude(configError.message, configCause.message);
+  });
 });
 
 it.layer(NodeServices.layer)("readDesktopBaseVersion", (it) => {

--- a/scripts/resolve-nightly-release.ts
+++ b/scripts/resolve-nightly-release.ts
@@ -11,7 +11,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { Command, Flag } from "effect/unstable/cli";
 
-interface NightlyReleaseMetadata {
+export interface NightlyReleaseMetadata {
   readonly baseVersion: string;
   readonly version: string;
   readonly tag: string;
@@ -50,6 +50,29 @@ export class NightlyReleaseDesktopPackageError extends Schema.TaggedErrorClass<N
 ) {
   override get message(): string {
     return `Failed to ${this.operation} desktop package metadata at ${this.packageJsonPath}.`;
+  }
+}
+
+export class NightlyReleaseGitHubOutputConfigError extends Schema.TaggedErrorClass<NightlyReleaseGitHubOutputConfigError>()(
+  "NightlyReleaseGitHubOutputConfigError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to resolve the GITHUB_OUTPUT path for nightly release metadata.";
+  }
+}
+
+export class NightlyReleaseGitHubOutputAppendError extends Schema.TaggedErrorClass<NightlyReleaseGitHubOutputAppendError>()(
+  "NightlyReleaseGitHubOutputAppendError",
+  {
+    outputPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to append nightly release metadata to ${this.outputPath}.`;
   }
 }
 
@@ -120,7 +143,7 @@ export const readDesktopBaseVersion = Effect.fn("readDesktopBaseVersion")(functi
   return yield* resolveNightlyTargetVersion(packageJson.version);
 });
 
-const writeOutput = Effect.fn("writeOutput")(function* (
+export const writeNightlyReleaseOutput = Effect.fn("writeNightlyReleaseOutput")(function* (
   metadata: NightlyReleaseMetadata,
   writeGithubOutput: boolean,
 ) {
@@ -135,9 +158,24 @@ const writeOutput = Effect.fn("writeOutput")(function* (
   ] as const;
 
   if (writeGithubOutput) {
-    const githubOutputPath = yield* Config.nonEmptyString("GITHUB_OUTPUT");
+    const githubOutputPath = yield* Config.nonEmptyString("GITHUB_OUTPUT").pipe(
+      Effect.mapError(
+        (cause) =>
+          new NightlyReleaseGitHubOutputConfigError({
+            cause,
+          }),
+      ),
+    );
     const serialized = entries.map(([key, value]) => `${key}=${value}\n`).join("");
-    yield* fs.writeFileString(githubOutputPath, serialized, { flag: "a" });
+    yield* fs.writeFileString(githubOutputPath, serialized, { flag: "a" }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new NightlyReleaseGitHubOutputAppendError({
+            outputPath: githubOutputPath,
+            cause,
+          }),
+      ),
+    );
   } else {
     for (const [key, value] of entries) {
       yield* Console.log(`${key}=${value}`);
@@ -172,7 +210,7 @@ const command = Command.make(
   ({ date, runNumber, sha, githubOutput, root }) =>
     readDesktopBaseVersion(Option.getOrUndefined(root)).pipe(
       Effect.map((baseVersion) => resolveNightlyReleaseMetadata(baseVersion, date, runNumber, sha)),
-      Effect.flatMap((metadata) => writeOutput(metadata, githubOutput)),
+      Effect.flatMap((metadata) => writeNightlyReleaseOutput(metadata, githubOutput)),
     ),
 ).pipe(Command.withDescription("Resolve nightly release version metadata."));
 

--- a/scripts/resolve-previous-release-tag.test.ts
+++ b/scripts/resolve-previous-release-tag.test.ts
@@ -1,11 +1,17 @@
 import { assert, it } from "@effect/vitest";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as PlatformError from "effect/PlatformError";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
-import { listGitTags, resolvePreviousReleaseTag } from "./resolve-previous-release-tag.ts";
+import {
+  listGitTags,
+  resolvePreviousReleaseTag,
+  writePreviousReleaseTagOutput,
+} from "./resolve-previous-release-tag.ts";
 
 const encoder = new TextEncoder();
 
@@ -13,6 +19,8 @@ function mockHandle(options: {
   readonly exitCode: number;
   readonly stdout?: string;
   readonly stderr?: string;
+  readonly stdoutError?: PlatformError.PlatformError;
+  readonly stderrError?: PlatformError.PlatformError;
 }) {
   return ChildProcessSpawner.makeHandle({
     pid: ChildProcessSpawner.ProcessId(1),
@@ -21,8 +29,12 @@ function mockHandle(options: {
     kill: () => Effect.void,
     unref: Effect.succeed(Effect.void),
     stdin: Sink.drain,
-    stdout: Stream.make(encoder.encode(options.stdout ?? "")),
-    stderr: Stream.make(encoder.encode(options.stderr ?? "")),
+    stdout: options.stdoutError
+      ? Stream.fail(options.stdoutError)
+      : Stream.make(encoder.encode(options.stdout ?? "")),
+    stderr: options.stderrError
+      ? Stream.fail(options.stderrError)
+      : Stream.make(encoder.encode(options.stderr ?? "")),
     all: Stream.empty,
     getInputFd: () => Sink.drain,
     getOutputFd: () => Stream.empty,
@@ -95,6 +107,43 @@ it.effect("preserves git tag spawn context and the exact platform cause", () => 
   });
 });
 
+it.effect("distinguishes stdout and stderr read failures", () =>
+  Effect.gen(function* () {
+    for (const [stream, operation] of [
+      ["stdout", "read-stdout"],
+      ["stderr", "read-stderr"],
+    ] as const) {
+      const cause = PlatformError.systemError({
+        _tag: "Unknown",
+        module: "ChildProcess",
+        method: stream,
+        description: `${stream} unavailable`,
+      });
+      const error = yield* listGitTags("/repo").pipe(
+        Effect.scoped,
+        Effect.provideService(
+          ChildProcessSpawner.ChildProcessSpawner,
+          ChildProcessSpawner.make(() =>
+            Effect.succeed(
+              mockHandle({
+                exitCode: 0,
+                ...(stream === "stdout" ? { stdoutError: cause } : { stderrError: cause }),
+              }),
+            ),
+          ),
+        ),
+        Effect.flip,
+      );
+
+      if (error._tag !== "ReleaseTagListProcessError") {
+        return assert.fail(`Unexpected error: ${error._tag}`);
+      }
+      assert.equal(error.operation, operation);
+      assert.strictEqual(error.cause, cause);
+    }
+  }),
+);
+
 it.effect("reports git tag non-zero exits without manufacturing a cause", () =>
   Effect.gen(function* () {
     const error = yield* listGitTags("/repo").pipe(
@@ -128,3 +177,37 @@ it.effect("reports git tag non-zero exits without manufacturing a cause", () =>
     assert.notProperty(error, "stderr");
   }),
 );
+
+it.effect("preserves the GITHUB_OUTPUT append path and exact cause", () => {
+  const outputPath = "/tmp/previous-tag-github-output";
+  const appendCause = PlatformError.systemError({
+    _tag: "PermissionDenied",
+    module: "FileSystem",
+    method: "writeFileString",
+    pathOrDescriptor: outputPath,
+  });
+
+  return Effect.gen(function* () {
+    const appendError = yield* writePreviousReleaseTagOutput("v1.2.3", true).pipe(
+      Effect.provideService(
+        FileSystem.FileSystem,
+        FileSystem.makeNoop({
+          writeFileString: () => Effect.fail(appendCause),
+        }),
+      ),
+      Effect.provideService(
+        ConfigProvider.ConfigProvider,
+        ConfigProvider.fromEnv({ env: { GITHUB_OUTPUT: outputPath } }),
+      ),
+      Effect.flip,
+    );
+
+    if (appendError._tag !== "PreviousReleaseTagGitHubOutputAppendError") {
+      return assert.fail(`Unexpected error: ${appendError._tag}`);
+    }
+    assert.equal(appendError.outputPath, outputPath);
+    assert.strictEqual(appendError.cause, appendCause);
+    assert.notProperty(appendError, "contents");
+    assert.notInclude(appendError.message, appendCause.message);
+  });
+});

--- a/scripts/resolve-previous-release-tag.ts
+++ b/scripts/resolve-previous-release-tag.ts
@@ -26,9 +26,11 @@ export class InvalidReleaseTagError extends Schema.TaggedErrorClass<InvalidRelea
   }
 }
 
+const NonNegativeInt = Schema.Int.check(Schema.isGreaterThanOrEqualTo(0));
+
 const releaseTagListProcessContext = {
   executable: Schema.Literal("git"),
-  argumentCount: Schema.Number,
+  argumentCount: NonNegativeInt,
   cwd: Schema.String,
 };
 
@@ -36,7 +38,7 @@ export class ReleaseTagListProcessError extends Schema.TaggedErrorClass<ReleaseT
   "ReleaseTagListProcessError",
   {
     ...releaseTagListProcessContext,
-    operation: Schema.Literals(["spawn", "communicate", "wait-for-exit"]),
+    operation: Schema.Literals(["spawn", "read-stdout", "read-stderr", "wait-for-exit"]),
     cause: Schema.Defect(),
   },
 ) {
@@ -50,12 +52,35 @@ export class ReleaseTagListProcessExitError extends Schema.TaggedErrorClass<Rele
   {
     ...releaseTagListProcessContext,
     exitCode: Schema.Number,
-    stdoutLength: Schema.Number,
-    stderrLength: Schema.Number,
+    stdoutLength: NonNegativeInt,
+    stderrLength: NonNegativeInt,
   },
 ) {
   override get message(): string {
     return `Release tag listing exited with code ${this.exitCode}.`;
+  }
+}
+
+export class PreviousReleaseTagGitHubOutputConfigError extends Schema.TaggedErrorClass<PreviousReleaseTagGitHubOutputConfigError>()(
+  "PreviousReleaseTagGitHubOutputConfigError",
+  {
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Failed to resolve the GITHUB_OUTPUT path for the previous release tag.";
+  }
+}
+
+export class PreviousReleaseTagGitHubOutputAppendError extends Schema.TaggedErrorClass<PreviousReleaseTagGitHubOutputAppendError>()(
+  "PreviousReleaseTagGitHubOutputAppendError",
+  {
+    outputPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to append the previous release tag to ${this.outputPath}.`;
   }
 }
 
@@ -238,7 +263,7 @@ export const listGitTags = Effect.fn("listGitTags")(function* (cwd = process.cwd
           (cause) =>
             new ReleaseTagListProcessError({
               ...context,
-              operation: "communicate",
+              operation: "read-stdout",
               cause,
             }),
         ),
@@ -248,7 +273,7 @@ export const listGitTags = Effect.fn("listGitTags")(function* (cwd = process.cwd
           (cause) =>
             new ReleaseTagListProcessError({
               ...context,
-              operation: "communicate",
+              operation: "read-stderr",
               cause,
             }),
         ),
@@ -280,7 +305,7 @@ export const listGitTags = Effect.fn("listGitTags")(function* (cwd = process.cwd
   return stdout.split(/\r?\n/).map(String.trim).filter(String.isNonEmpty);
 });
 
-const writeOutput = Effect.fn("writeOutput")(function* (
+export const writePreviousReleaseTagOutput = Effect.fn("writePreviousReleaseTagOutput")(function* (
   previousTag: string | undefined,
   writeGithubOutput: boolean,
 ) {
@@ -288,8 +313,23 @@ const writeOutput = Effect.fn("writeOutput")(function* (
 
   if (writeGithubOutput) {
     const fs = yield* FileSystem.FileSystem;
-    const githubOutputPath = yield* Config.nonEmptyString("GITHUB_OUTPUT");
-    yield* fs.writeFileString(githubOutputPath, entry, { flag: "a" });
+    const githubOutputPath = yield* Config.nonEmptyString("GITHUB_OUTPUT").pipe(
+      Effect.mapError(
+        (cause) =>
+          new PreviousReleaseTagGitHubOutputConfigError({
+            cause,
+          }),
+      ),
+    );
+    yield* fs.writeFileString(githubOutputPath, entry, { flag: "a" }).pipe(
+      Effect.mapError(
+        (cause) =>
+          new PreviousReleaseTagGitHubOutputAppendError({
+            outputPath: githubOutputPath,
+            cause,
+          }),
+      ),
+    );
     return;
   }
 
@@ -313,7 +353,7 @@ const command = Command.make(
   ({ channel, currentTag, githubOutput }) =>
     listGitTags().pipe(
       Effect.flatMap((tags) => resolvePreviousReleaseTag(channel, currentTag, tags)),
-      Effect.flatMap((previousTag) => writeOutput(previousTag, githubOutput)),
+      Effect.flatMap((previousTag) => writePreviousReleaseTagOutput(previousTag, githubOutput)),
     ),
 ).pipe(Command.withDescription("Resolve the previous release tag for a stable or nightly series."));
 


### PR DESCRIPTION
## Summary

- wrap GITHUB_OUTPUT configuration and append failures with structured Schema errors that preserve their exact causes
- retain output paths for failed appends without retaining serialized output contents
- distinguish git stdout and stderr read failures and constrain counts and lengths to non-negative integers

## Validation

- `vp test scripts/resolve-nightly-release.test.ts scripts/resolve-previous-release-tag.test.ts`
- `vp check` (passes with existing repository warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI release scripts and error typing; no runtime app, auth, or data-path behavior changes.
> 
> **Overview**
> Release helper scripts now surface **GITHUB_OUTPUT** failures as tagged Schema errors instead of raw Effect failures, while keeping the original **cause** (and **outputPath** on append failures) without leaking serialized output into error messages.
> 
> **`resolve-nightly-release`** exports **`writeNightlyReleaseOutput`** and adds **`NightlyReleaseGitHubOutputConfigError`** / **`NightlyReleaseGitHubOutputAppendError`** around config lookup and file append.
> 
> **`resolve-previous-release-tag`** does the same for **`writePreviousReleaseTagOutput`** with **`PreviousReleaseTagGitHubOutput*`** errors. **`listGitTags`** maps stdout vs stderr read failures to **`read-stdout`** / **`read-stderr`** (replacing a single **`communicate`**), and constrains argument counts and stream lengths with **non-negative integers**.
> 
> Tests assert cause preservation and that user-facing messages do not echo underlying platform/config text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a7f9832bcd5c4df038bef2b83ef0ecbed11fedf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add structured tagged errors to release output failure paths in nightly and previous-release-tag scripts
> - Exports `writeNightlyReleaseOutput` and `writePreviousReleaseTagOutput` (previously internal `writeOutput`) with structured tagged errors for `GITHUB_OUTPUT` config resolution failures and file append failures, each preserving the underlying cause.
> - Adds `NightlyReleaseGitHubOutputConfigError`, `NightlyReleaseGitHubOutputAppendError`, `PreviousReleaseTagGitHubOutputConfigError`, and `PreviousReleaseTagGitHubOutputAppendError` error classes.
> - Expands `ReleaseTagListProcessError` operation literals to distinguish `read-stdout` vs `read-stderr` failures in `listGitTags`.
> - Adds tests verifying error types, preserved causes, and output paths for both config and append failure scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a7f983.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->