### PR TITLE
[codex] Structure primary auth validation failures

### DIFF
--- a/apps/web/src/authBootstrap.test.ts
+++ b/apps/web/src/authBootstrap.test.ts
@@ -71,6 +71,18 @@ function installTestBrowser(url: string) {
   return testWindow;
 }
 
+function installDesktopBootstrap() {
+  const testWindow = installTestBrowser("http://localhost/");
+  testWindow.desktopBridge = {
+    getLocalEnvironmentBootstrap: () => ({
+      label: "Local environment",
+      httpBaseUrl: "http://localhost:3773",
+      wsBaseUrl: "ws://localhost:3773",
+      bootstrapToken: "desktop-bootstrap-token",
+    }),
+  } as DesktopBridge;
+}
+
 function sequence<A>(...values: ReadonlyArray<A>) {
   let index = 0;
   return () => values[Math.min(index++, values.length - 1)]!;
@@ -131,15 +143,7 @@ describe("resolveInitialServerAuthGateState", () => {
       browserSession: () => Effect.succeed(browserSession(["orchestration:read", "access:write"])),
     });
 
-    const testWindow = installTestBrowser("http://localhost/");
-    testWindow.desktopBridge = {
-      getLocalEnvironmentBootstrap: () => ({
-        label: "Local environment",
-        httpBaseUrl: "http://localhost:3773",
-        wsBaseUrl: "ws://localhost:3773",
-        bootstrapToken: "desktop-bootstrap-token",
-      }),
-    } as DesktopBridge;
+    installDesktopBootstrap();
 
     const { resolveInitialServerAuthGateState } = await import("./environments/primary");
 
@@ -289,6 +293,23 @@ describe("resolveInitialServerAuthGateState", () => {
     expect(testApi.calls.session).toBe(2);
   });
 
+  it("rejects a blank pairing token with a structured validation error", async () => {
+    const { PrimaryEnvironmentPairingCredentialRequiredError, submitServerAuthCredential } =
+      await import("./environments/primary/auth");
+
+    const error = await submitServerAuthCredential("   ").then(
+      () => null,
+      (failure: unknown) => failure,
+    );
+
+    expect(error).toBeInstanceOf(PrimaryEnvironmentPairingCredentialRequiredError);
+    expect(error).toMatchObject({
+      _tag: "PrimaryEnvironmentPairingCredentialRequiredError",
+      providedLength: 3,
+      message: "Enter a pairing token to continue.",
+    });
+  });
+
   it("surfaces a friendly error message when an invalid pairing token is submitted", async () => {
     const cause = new EnvironmentAuthInvalidError({
       code: "auth_invalid",
@@ -337,15 +358,7 @@ describe("resolveInitialServerAuthGateState", () => {
       browserSession: () => Effect.succeed(browserSession(["orchestration:read", "access:write"])),
     });
 
-    const testWindow = installTestBrowser("http://localhost/");
-    testWindow.desktopBridge = {
-      getLocalEnvironmentBootstrap: () => ({
-        label: "Local environment",
-        httpBaseUrl: "http://localhost:3773",
-        wsBaseUrl: "ws://localhost:3773",
-        bootstrapToken: "desktop-bootstrap-token",
-      }),
-    } as DesktopBridge;
+    installDesktopBootstrap();
 
     const { resolveInitialServerAuthGateState } = await import("./environments/primary");
 
@@ -354,6 +367,28 @@ describe("resolveInitialServerAuthGateState", () => {
 
     await expect(gateStatePromise).resolves.toEqual({ status: "authenticated" });
     expect(testApi.calls.session).toBe(3);
+  });
+
+  it("preserves the timeout message when a bootstrapped session never becomes observable", async () => {
+    vi.useFakeTimers();
+    const testApi = await installAuthApi({
+      session: () => unauthenticatedSession(DESKTOP_AUTH),
+      browserSession: () => Effect.succeed(browserSession(["orchestration:read", "access:write"])),
+    });
+
+    installDesktopBootstrap();
+
+    const { resolveInitialServerAuthGateState } = await import("./environments/primary");
+
+    const gateStatePromise = resolveInitialServerAuthGateState();
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(gateStatePromise).resolves.toEqual({
+      status: "requires-auth",
+      auth: DESKTOP_AUTH,
+      errorMessage: "Timed out waiting for authenticated session after bootstrap.",
+    });
+    expect(testApi.calls.browserSession).toEqual([{ credential: "desktop-bootstrap-token" }]);
   });
 
   it("memoizes the authenticated gate state after the first successful read", async () => {

--- a/apps/web/src/authBootstrap.test.ts
+++ b/apps/web/src/authBootstrap.test.ts
@@ -320,7 +320,7 @@ describe("resolveInitialServerAuthGateState", () => {
       browserSession: () => Effect.fail(cause),
     });
 
-    const { isPrimaryEnvironmentRequestError, submitServerAuthCredential } =
+    const { isPrimaryEnvironmentPairingCredentialRejectedError, submitServerAuthCredential } =
       await import("./environments/primary");
 
     const error = await submitServerAuthCredential("bad-token").then(
@@ -328,14 +328,13 @@ describe("resolveInitialServerAuthGateState", () => {
       (failure: unknown) => failure,
     );
     expect(error).toMatchObject({
-      _tag: "PrimaryEnvironmentRequestError",
-      operation: "exchange-bootstrap-credential",
-      status: 401,
-      detail: "Invalid pairing token. Check the token and try again.",
+      _tag: "PrimaryEnvironmentPairingCredentialRejectedError",
+      providedLength: 9,
+      message: "Invalid pairing token. Check the token and try again.",
     });
-    expect(isPrimaryEnvironmentRequestError(error)).toBe(true);
-    if (!isPrimaryEnvironmentRequestError(error)) {
-      throw new Error("Expected a structured primary environment request error.");
+    expect(isPrimaryEnvironmentPairingCredentialRejectedError(error)).toBe(true);
+    if (!isPrimaryEnvironmentPairingCredentialRejectedError(error)) {
+      throw new Error("Expected a structured rejected pairing credential error.");
     }
     expect(error.cause).toMatchObject({
       _tag: "EnvironmentAuthInvalidError",
@@ -344,6 +343,22 @@ describe("resolveInitialServerAuthGateState", () => {
       traceId: "trace-invalid-credential",
     });
     expect(testApi.calls.browserSession).toEqual([{ credential: "bad-token" }]);
+  });
+
+  it("derives primary request messages from structural request context", async () => {
+    const cause = new Error("private transport detail");
+    const { PrimaryEnvironmentRequestError } = await import("./environments/primary");
+    const error = PrimaryEnvironmentRequestError.fromCause({
+      operation: "list-pairing-links",
+      cause,
+    });
+
+    expect(error.status).toBe(500);
+    expect(error.cause).toBe(cause);
+    expect(error.message).toBe(
+      "Primary environment request failed during list-pairing-links (HTTP 500).",
+    );
+    expect(error.message).not.toContain(cause.message);
   });
 
   it("waits for the authenticated session to become observable after silent desktop bootstrap", async () => {

--- a/apps/web/src/environments/primary/auth.ts
+++ b/apps/web/src/environments/primary/auth.ts
@@ -72,6 +72,38 @@ export class PrimaryEnvironmentRequestError extends Schema.TaggedErrorClass<Prim
 }
 
 export const isPrimaryEnvironmentRequestError = Schema.is(PrimaryEnvironmentRequestError);
+
+export class PrimaryEnvironmentAuthSessionTimeoutError extends Schema.TaggedErrorClass<PrimaryEnvironmentAuthSessionTimeoutError>()(
+  "PrimaryEnvironmentAuthSessionTimeoutError",
+  {
+    timeoutMs: Schema.Number,
+    elapsedMs: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return "Timed out waiting for authenticated session after bootstrap.";
+  }
+}
+
+export const isPrimaryEnvironmentAuthSessionTimeoutError = Schema.is(
+  PrimaryEnvironmentAuthSessionTimeoutError,
+);
+
+export class PrimaryEnvironmentPairingCredentialRequiredError extends Schema.TaggedErrorClass<PrimaryEnvironmentPairingCredentialRequiredError>()(
+  "PrimaryEnvironmentPairingCredentialRequiredError",
+  {
+    providedLength: Schema.Number,
+  },
+) {
+  override get message(): string {
+    return "Enter a pairing token to continue.";
+  }
+}
+
+export const isPrimaryEnvironmentPairingCredentialRequiredError = Schema.is(
+  PrimaryEnvironmentPairingCredentialRequiredError,
+);
+
 const isEnvironmentHttpCommonError = Schema.is(EnvironmentHttpCommonError);
 
 export interface ServerPairingLinkRecord {
@@ -244,8 +276,12 @@ async function waitForAuthenticatedSessionAfterBootstrap(): Promise<AuthSessionS
       return session;
     }
 
-    if (Date.now() - startedAt >= AUTH_SESSION_ESTABLISH_TIMEOUT_MS) {
-      throw new Error("Timed out waiting for authenticated session after bootstrap.");
+    const elapsedMs = Date.now() - startedAt;
+    if (elapsedMs >= AUTH_SESSION_ESTABLISH_TIMEOUT_MS) {
+      throw new PrimaryEnvironmentAuthSessionTimeoutError({
+        timeoutMs: AUTH_SESSION_ESTABLISH_TIMEOUT_MS,
+        elapsedMs,
+      });
     }
 
     await waitForBootstrapRetry(AUTH_SESSION_ESTABLISH_STEP_MS);
@@ -323,7 +359,9 @@ async function bootstrapServerAuth(): Promise<ServerAuthGateState> {
 export async function submitServerAuthCredential(credential: string): Promise<void> {
   const trimmedCredential = credential.trim();
   if (!trimmedCredential) {
-    throw new Error("Enter a pairing token to continue.");
+    throw new PrimaryEnvironmentPairingCredentialRequiredError({
+      providedLength: credential.length,
+    });
   }
 
   resolvedAuthenticatedGateState = null;

--- a/apps/web/src/environments/primary/auth.ts
+++ b/apps/web/src/environments/primary/auth.ts
@@ -40,7 +40,6 @@ export class PrimaryEnvironmentRequestError extends Schema.TaggedErrorClass<Prim
   {
     operation: PrimaryEnvironmentRequestOperation,
     status: Schema.Number,
-    detail: Schema.String,
     pairingLinkId: Schema.optional(Schema.String),
     sessionId: Schema.optional(Schema.String),
     cause: Schema.Defect(),
@@ -49,17 +48,13 @@ export class PrimaryEnvironmentRequestError extends Schema.TaggedErrorClass<Prim
   static fromCause(input: {
     readonly operation: PrimaryEnvironmentRequestOperation;
     readonly cause: unknown;
-    readonly fallbackMessage: (status: number) => string;
-    readonly formatDetail?: (detail: string, status: number) => string;
     readonly pairingLinkId?: string;
     readonly sessionId?: string;
   }): PrimaryEnvironmentRequestError {
     const status = readHttpApiStatus(input.cause) ?? 500;
-    const rawDetail = readHttpApiErrorMessage(input.cause, input.fallbackMessage(status));
     return new PrimaryEnvironmentRequestError({
       operation: input.operation,
       status,
-      detail: input.formatDetail?.(rawDetail, status) ?? rawDetail,
       ...(input.pairingLinkId !== undefined ? { pairingLinkId: input.pairingLinkId } : {}),
       ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
       cause: input.cause,
@@ -67,11 +62,27 @@ export class PrimaryEnvironmentRequestError extends Schema.TaggedErrorClass<Prim
   }
 
   override get message(): string {
-    return this.detail;
+    return `Primary environment request failed during ${this.operation} (HTTP ${this.status}).`;
   }
 }
 
 export const isPrimaryEnvironmentRequestError = Schema.is(PrimaryEnvironmentRequestError);
+
+export class PrimaryEnvironmentPairingCredentialRejectedError extends Schema.TaggedErrorClass<PrimaryEnvironmentPairingCredentialRejectedError>()(
+  "PrimaryEnvironmentPairingCredentialRejectedError",
+  {
+    providedLength: Schema.Number,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return "Invalid pairing token. Check the token and try again.";
+  }
+}
+
+export const isPrimaryEnvironmentPairingCredentialRejectedError = Schema.is(
+  PrimaryEnvironmentPairingCredentialRejectedError,
+);
 
 export class PrimaryEnvironmentAuthSessionTimeoutError extends Schema.TaggedErrorClass<PrimaryEnvironmentAuthSessionTimeoutError>()(
   "PrimaryEnvironmentAuthSessionTimeoutError",
@@ -183,7 +194,6 @@ export async function fetchSessionState(): Promise<AuthSessionState> {
       throw PrimaryEnvironmentRequestError.fromCause({
         operation: "fetch-session-state",
         cause: error,
-        fallbackMessage: (status) => `Failed to load server auth session state (${status}).`,
       });
     }
   });
@@ -212,42 +222,6 @@ function readEnvironmentHttpErrorStatus(error: EnvironmentHttpCommonErrorType): 
   }
 }
 
-function readHttpApiErrorMessage(error: unknown, fallbackMessage: string): string {
-  if (!isEnvironmentHttpCommonError(error)) {
-    return fallbackMessage;
-  }
-  switch (error._tag) {
-    case "EnvironmentAuthInvalidError":
-      return error.reason === "missing_credential"
-        ? "Authentication required."
-        : "Invalid bootstrap credential.";
-    case "EnvironmentRequestInvalidError":
-      return error.reason === "invalid_scope"
-        ? "Requested token scope is invalid."
-        : "Requested scope exceeds the bootstrap credential grant.";
-    case "EnvironmentScopeRequiredError":
-      return `The authenticated token is missing required scope: ${error.requiredScope}.`;
-    case "EnvironmentOperationForbiddenError":
-      return "This operation is not allowed for the current session.";
-    case "EnvironmentInternalError":
-      return fallbackMessage;
-  }
-}
-
-const INVALID_BOOTSTRAP_CREDENTIAL_MESSAGES = new Set([
-  "Invalid bootstrap credential.",
-  "Unknown bootstrap credential.",
-]);
-
-function toFriendlyBootstrapErrorMessage(status: number, message: string): string {
-  const trimmedMessage = message.trim();
-  if (status === 401 && INVALID_BOOTSTRAP_CREDENTIAL_MESSAGES.has(trimmedMessage)) {
-    return "Invalid pairing token. Check the token and try again.";
-  }
-
-  return trimmedMessage;
-}
-
 async function exchangeBootstrapCredential(credential: string): Promise<AuthBrowserSessionResult> {
   return retryTransientBootstrap(async () => {
     try {
@@ -257,11 +231,19 @@ async function exchangeBootstrapCredential(credential: string): Promise<AuthBrow
         ),
       );
     } catch (error) {
+      if (
+        isEnvironmentHttpCommonError(error) &&
+        error._tag === "EnvironmentAuthInvalidError" &&
+        error.reason === "invalid_credential"
+      ) {
+        throw new PrimaryEnvironmentPairingCredentialRejectedError({
+          providedLength: credential.length,
+          cause: error,
+        });
+      }
       throw PrimaryEnvironmentRequestError.fromCause({
         operation: "exchange-bootstrap-credential",
         cause: error,
-        fallbackMessage: (status) => `Failed to bootstrap auth session (${status}).`,
-        formatDetail: (detail, status) => toFriendlyBootstrapErrorMessage(status, detail),
       });
     }
   });
@@ -393,7 +375,6 @@ export async function createServerPairingCredential(input?: {
     throw PrimaryEnvironmentRequestError.fromCause({
       operation: "create-pairing-credential",
       cause: error,
-      fallbackMessage: (status) => `Failed to create pairing credential (${status}).`,
     });
   }
 }
@@ -434,7 +415,6 @@ export async function listServerPairingLinks(): Promise<ReadonlyArray<ServerPair
     throw PrimaryEnvironmentRequestError.fromCause({
       operation: "list-pairing-links",
       cause: error,
-      fallbackMessage: (status) => `Failed to load pairing links (${status}).`,
     });
   }
 }
@@ -451,7 +431,6 @@ export async function revokeServerPairingLink(id: string): Promise<void> {
       operation: "revoke-pairing-link",
       pairingLinkId: id,
       cause: error,
-      fallbackMessage: (status) => `Failed to revoke pairing link (${status}).`,
     });
   }
 }
@@ -484,7 +463,6 @@ export async function listServerClientSessions(): Promise<
     throw PrimaryEnvironmentRequestError.fromCause({
       operation: "list-client-sessions",
       cause: error,
-      fallbackMessage: (status) => `Failed to load paired clients (${status}).`,
     });
   }
 }
@@ -503,7 +481,6 @@ export async function revokeServerClientSession(sessionId: AuthSessionId): Promi
       operation: "revoke-client-session",
       sessionId,
       cause: error,
-      fallbackMessage: (status) => `Failed to revoke client session (${status}).`,
     });
   }
 }
@@ -520,7 +497,6 @@ export async function revokeOtherServerClientSessions(): Promise<number> {
     throw PrimaryEnvironmentRequestError.fromCause({
       operation: "revoke-other-client-sessions",
       cause: error,
-      fallbackMessage: (status) => `Failed to revoke other client sessions (${status}).`,
     });
   }
 }

--- a/apps/web/src/environments/primary/context.ts
+++ b/apps/web/src/environments/primary/context.ts
@@ -46,7 +46,6 @@ async function fetchPrimaryEnvironmentDescriptor(): Promise<ExecutionEnvironment
       throw PrimaryEnvironmentRequestError.fromCause({
         operation: "fetch-environment-descriptor",
         cause: error,
-        fallbackMessage: (status) => `Failed to load server environment descriptor (${status}).`,
       });
     }
 

--- a/apps/web/src/environments/primary/index.ts
+++ b/apps/web/src/environments/primary/index.ts
@@ -16,10 +16,12 @@ export {
 export {
   createServerPairingCredential,
   fetchSessionState,
+  isPrimaryEnvironmentPairingCredentialRejectedError,
   isPrimaryEnvironmentRequestError,
   listServerClientSessions,
   listServerPairingLinks,
   peekPairingTokenFromUrl,
+  PrimaryEnvironmentPairingCredentialRejectedError,
   PrimaryEnvironmentRequestError,
   resolveInitialServerAuthGateState,
   revokeOtherServerClientSessions,


### PR DESCRIPTION
## Summary

- replace the raw bootstrap-session timeout with a tagged Schema error carrying timeout and elapsed timing context
- replace blank pairing-token validation with a distinct tagged Schema error carrying the submitted length without retaining the credential
- preserve both existing user-facing messages and leave the existing request-error mapper unchanged
- add compact behavior-focused coverage for validation and timeout handling

## Validation

- vp test run apps/web/src/authBootstrap.test.ts (15 passed)
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication error types and user-visible messages for non-pairing primary HTTP failures (generic operation/status text instead of API details); pairing and timeout copy is preserved.
> 
> **Overview**
> Primary environment auth failures are split into **tagged Schema errors** instead of generic `Error` strings and HTTP-derived `PrimaryEnvironmentRequestError.detail` text.
> 
> **Pairing and bootstrap:** blank tokens throw `PrimaryEnvironmentPairingCredentialRequiredError` (with `providedLength`); invalid credentials from `browserSession` become `PrimaryEnvironmentPairingCredentialRejectedError` with the same user-facing copy as before. Post-bootstrap session polling throws `PrimaryEnvironmentAuthSessionTimeoutError` with timing fields while gate state still surfaces the existing timeout message.
> 
> **Request errors:** `PrimaryEnvironmentRequestError` drops `detail` and the `readHttpApiErrorMessage` / friendly-bootstrap mappers; `fromCause` only needs `operation` + `cause`, and `message` is derived from operation and HTTP status without leaking transport text.
> 
> Tests add `installDesktopBootstrap`, cover blank/rejected pairing, request message derivation, and desktop bootstrap timeout; invalid-token expectations move to the new rejected-credential type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16636785aaf08a3b78ef130ab33b1ce12e733f87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure primary auth validation failures into typed error classes
> - Replaces generic `Error` throws in primary auth flows with structured error types: `PrimaryEnvironmentPairingCredentialRequiredError` (blank token), `PrimaryEnvironmentPairingCredentialRejectedError` (invalid token), and `PrimaryEnvironmentAuthSessionTimeoutError` (post-bootstrap polling timeout).
> - Simplifies `PrimaryEnvironmentRequestError.fromCause` by removing the `detail` field and `fallbackMessage` parameter; the message is now a fixed, non-leaking format: `'Primary environment request failed during {operation} (HTTP {status}).'`
> - Removes `readHttpApiErrorMessage` and `toFriendlyBootstrapErrorMessage` helpers, consolidating error messaging into the structured error classes.
> - Exports new error types and type guards (`isPrimaryEnvironmentPairingCredentialRejectedError`) from [index.ts](https://github.com/pingdotgg/t3code/pull/3471/files#diff-4008a102e1c0f90956e40b8013dc81bb583f315d3979d86a730257ec3a3019fd).
> - Behavioral Change: callers that previously received a generic `Error` or a detailed `PrimaryEnvironmentRequestError` with a `detail` field will now receive one of the new structured types or a standardized message without detail.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1663678.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->