### PR TITLE
[codex] Structure OpenCode text generation failures

### DIFF
--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
@@ -1,4 +1,4 @@
-import { OpenCodeSettings, ProviderInstanceId } from "@t3tools/contracts";
+import { OpenCodeSettings, ProviderInstanceId, TextGenerationError } from "@t3tools/contracts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { it } from "@effect/vitest";
 import * as Duration from "effect/Duration";
@@ -11,8 +11,8 @@ import { beforeEach, expect } from "vite-plus/test";
 
 import * as ServerConfig from "../config.ts";
 import * as OpenCodeRuntime from "../provider/opencodeRuntime.ts";
+import * as OpenCodeTextGeneration from "./OpenCodeTextGeneration.ts";
 import * as TextGeneration from "./TextGeneration.ts";
-import { makeOpenCodeTextGeneration } from "./OpenCodeTextGeneration.ts";
 
 const runtimeMock = {
   state: {
@@ -20,6 +20,9 @@ const runtimeMock = {
     promptUrls: [] as string[],
     authHeaders: [] as Array<string | null>,
     closeCalls: [] as string[],
+    sessionCreateError: undefined as unknown,
+    sessionResult: undefined as { data?: { id: string } } | undefined,
+    promptRequestError: undefined as unknown,
     promptResult: undefined as
       | { data?: { info?: { error?: unknown }; parts?: Array<{ type: string; text?: string }> } }
       | undefined,
@@ -29,6 +32,9 @@ const runtimeMock = {
     this.state.promptUrls.length = 0;
     this.state.authHeaders.length = 0;
     this.state.closeCalls.length = 0;
+    this.state.sessionCreateError = undefined;
+    this.state.sessionResult = undefined;
+    this.state.promptRequestError = undefined;
     this.state.promptResult = undefined;
   },
 };
@@ -61,12 +67,20 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntime.OpenCodeRuntimeShape = {
   createOpenCodeSdkClient: ({ baseUrl, serverPassword }) =>
     ({
       session: {
-        create: async () => ({ data: { id: `${baseUrl}/session` } }),
+        create: async () => {
+          if (runtimeMock.state.sessionCreateError !== undefined) {
+            throw runtimeMock.state.sessionCreateError;
+          }
+          return runtimeMock.state.sessionResult ?? { data: { id: `${baseUrl}/session` } };
+        },
         prompt: async () => {
           runtimeMock.state.promptUrls.push(baseUrl);
           runtimeMock.state.authHeaders.push(
             serverPassword ? `Basic ${btoa(`opencode:${serverPassword}`)}` : null,
           );
+          if (runtimeMock.state.promptRequestError !== undefined) {
+            throw runtimeMock.state.promptRequestError;
+          }
           return (
             runtimeMock.state.promptResult ?? {
               data: {
@@ -98,6 +112,13 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntime.OpenCodeRuntimeShape = {
 const DEFAULT_TEST_MODEL_SELECTION = {
   instanceId: ProviderInstanceId.make("opencode"),
   model: "openai/gpt-5",
+};
+const DEFAULT_COMMIT_MESSAGE_INPUT = {
+  cwd: process.cwd(),
+  branch: "feature/opencode-reuse",
+  stagedSummary: "M README.md",
+  stagedPatch: "diff --git a/README.md b/README.md",
+  modelSelection: DEFAULT_TEST_MODEL_SELECTION,
 };
 
 const OPENCODE_TEXT_GENERATION_IDLE_TTL_MS = 30_000;
@@ -142,7 +163,7 @@ function withOpenCodeTextGeneration<A, E, R>(
   effectFn: (textGeneration: TextGeneration.TextGeneration["Service"]) => Effect.Effect<A, E, R>,
 ) {
   return Effect.gen(function* () {
-    const textGeneration = yield* makeOpenCodeTextGeneration(settings);
+    const textGeneration = yield* OpenCodeTextGeneration.makeOpenCodeTextGeneration(settings);
     return yield* effectFn(textGeneration);
   }).pipe(Effect.scoped);
 }
@@ -221,22 +242,95 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGeneration", (it) => {
     ).pipe(Effect.provide(TestClock.layer())),
   );
 
+  it.effect("preserves the SDK cause when session creation fails", () =>
+    withOpenCodeTextGeneration(DEFAULT_OPENCODE_SETTINGS, (textGeneration) =>
+      Effect.gen(function* () {
+        const sdkCause = new Error("session endpoint unavailable");
+        runtimeMock.state.sessionCreateError = sdkCause;
+
+        const error = yield* textGeneration
+          .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(TextGenerationError);
+        expect(error.message).toContain("OpenCode session.create request failed.");
+        expect(error.cause).toMatchObject({
+          _tag: "OpenCodeTextGenerationSessionRequestError",
+          operation: "generateCommitMessage",
+          cwd: process.cwd(),
+          cause: sdkCause,
+        });
+        expect((error.cause as { cause: unknown }).cause).toBe(sdkCause);
+      }),
+    ),
+  );
+
+  it.effect("reports a missing session payload without manufacturing a cause", () =>
+    withOpenCodeTextGeneration(DEFAULT_OPENCODE_SETTINGS, (textGeneration) =>
+      Effect.gen(function* () {
+        runtimeMock.state.sessionResult = {};
+
+        const error = yield* textGeneration
+          .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
+          .pipe(Effect.flip);
+
+        expect(error.message).toContain("OpenCode session.create returned no session payload.");
+        expect(error.cause).toMatchObject({
+          _tag: "OpenCodeTextGenerationSessionPayloadError",
+          operation: "generateCommitMessage",
+          cwd: process.cwd(),
+        });
+        expect(error.cause).not.toHaveProperty("cause");
+      }),
+    ),
+  );
+
+  it.effect("preserves the SDK cause and request context when prompting fails", () =>
+    withOpenCodeTextGeneration(DEFAULT_OPENCODE_SETTINGS, (textGeneration) =>
+      Effect.gen(function* () {
+        const sdkCause = new Error("prompt endpoint unavailable");
+        runtimeMock.state.promptRequestError = sdkCause;
+
+        const error = yield* textGeneration
+          .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
+          .pipe(Effect.flip);
+
+        expect(error.message).toContain("OpenCode session.prompt request failed.");
+        expect(error.cause).toMatchObject({
+          _tag: "OpenCodeTextGenerationPromptRequestError",
+          operation: "generateCommitMessage",
+          cwd: process.cwd(),
+          sessionId: "http://127.0.0.1:4301/session",
+          providerId: "openai",
+          modelId: "gpt-5",
+          cause: sdkCause,
+        });
+        expect((error.cause as { cause: unknown }).cause).toBe(sdkCause);
+      }),
+    ),
+  );
+
   it.effect("returns a typed empty-output error when OpenCode returns no text parts", () =>
     withOpenCodeTextGeneration(DEFAULT_OPENCODE_SETTINGS, (textGeneration) =>
       Effect.gen(function* () {
         runtimeMock.state.promptResult = { data: {} };
 
         const error = yield* textGeneration
-          .generateCommitMessage({
-            cwd: process.cwd(),
-            branch: "feature/opencode-reuse",
-            stagedSummary: "M README.md",
-            stagedPatch: "diff --git a/README.md b/README.md",
-            modelSelection: DEFAULT_TEST_MODEL_SELECTION,
-          })
+          .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
           .pipe(Effect.flip);
 
         expect(error.message).toContain("OpenCode returned empty output.");
+        expect(error.cause).toMatchObject({
+          _tag: "OpenCodeTextGenerationEmptyOutputError",
+          operation: "generateCommitMessage",
+          cwd: process.cwd(),
+          sessionId: "http://127.0.0.1:4301/session",
+          providerId: "openai",
+          modelId: "gpt-5",
+          responsePartCount: 0,
+          textPartCount: 0,
+        });
+        expect(error.cause).not.toHaveProperty("cause");
       }),
     ),
   );
@@ -289,16 +383,21 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGeneration", (it) => {
         };
 
         const error = yield* textGeneration
-          .generateCommitMessage({
-            cwd: process.cwd(),
-            branch: "feature/opencode-reuse",
-            stagedSummary: "M README.md",
-            stagedPatch: "diff --git a/README.md b/README.md",
-            modelSelection: DEFAULT_TEST_MODEL_SELECTION,
-          })
+          .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
           .pipe(Effect.flip);
 
         expect(error.message).toContain("Model did not produce structured output");
+        expect(error.cause).toMatchObject({
+          _tag: "OpenCodeTextGenerationPromptResponseError",
+          operation: "generateCommitMessage",
+          cwd: process.cwd(),
+          sessionId: "http://127.0.0.1:4301/session",
+          providerId: "openai",
+          modelId: "gpt-5",
+          providerErrorName: "StructuredOutputError",
+          providerMessage: "Model did not produce structured output",
+        });
+        expect(error.cause).not.toHaveProperty("cause");
       }),
     ),
   );

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts
@@ -24,7 +24,7 @@ const runtimeMock = {
     sessionResult: undefined as { data?: { id: string } } | undefined,
     promptRequestError: undefined as unknown,
     promptResult: undefined as
-      | { data?: { info?: { error?: unknown }; parts?: Array<{ type: string; text?: string }> } }
+      | { data?: { info?: { error?: unknown }; parts?: Array<unknown> } }
       | undefined,
   },
   reset() {
@@ -310,10 +310,14 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGeneration", (it) => {
     ),
   );
 
-  it.effect("returns a typed empty-output error when OpenCode returns no text parts", () =>
+  it.effect("returns a typed empty-output error for malformed and blank response parts", () =>
     withOpenCodeTextGeneration(DEFAULT_OPENCODE_SETTINGS, (textGeneration) =>
       Effect.gen(function* () {
-        runtimeMock.state.promptResult = { data: {} };
+        runtimeMock.state.promptResult = {
+          data: {
+            parts: [null, { type: "tool" }, { type: "text", text: "   " }],
+          },
+        };
 
         const error = yield* textGeneration
           .generateCommitMessage(DEFAULT_COMMIT_MESSAGE_INPUT)
@@ -327,8 +331,8 @@ it.layer(OpenCodeTextGenerationTestLayer)("OpenCodeTextGeneration", (it) => {
           sessionId: "http://127.0.0.1:4301/session",
           providerId: "openai",
           modelId: "gpt-5",
-          responsePartCount: 0,
-          textPartCount: 0,
+          responsePartCount: 3,
+          textPartCount: 1,
         });
         expect(error.cause).not.toHaveProperty("cause");
       }),

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -6,6 +6,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 
 import {
+  NonNegativeInt,
   TextGenerationError,
   type ChatAttachment,
   type ModelSelection,
@@ -33,11 +34,101 @@ import * as OpenCodeRuntime from "../provider/opencodeRuntime.ts";
 
 const OPENCODE_TEXT_GENERATION_IDLE_TTL = "30 seconds";
 
-function getOpenCodePromptErrorMessage(error: unknown): string | null {
+const OpenCodeTextGenerationOperation = Schema.Literals([
+  "generateCommitMessage",
+  "generatePrContent",
+  "generateBranchName",
+  "generateThreadTitle",
+]);
+
+type OpenCodeTextGenerationOperation = typeof OpenCodeTextGenerationOperation.Type;
+
+const openCodeTextGenerationErrorContext = {
+  operation: OpenCodeTextGenerationOperation,
+  cwd: Schema.String,
+};
+
+export class OpenCodeTextGenerationSessionRequestError extends Schema.TaggedErrorClass<OpenCodeTextGenerationSessionRequestError>()(
+  "OpenCodeTextGenerationSessionRequestError",
+  {
+    ...openCodeTextGenerationErrorContext,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `OpenCode session creation request failed for ${this.operation} in ${this.cwd}.`;
+  }
+}
+
+export class OpenCodeTextGenerationSessionPayloadError extends Schema.TaggedErrorClass<OpenCodeTextGenerationSessionPayloadError>()(
+  "OpenCodeTextGenerationSessionPayloadError",
+  openCodeTextGenerationErrorContext,
+) {
+  override get message(): string {
+    return `OpenCode session.create returned no session payload for ${this.operation} in ${this.cwd}.`;
+  }
+}
+
+const openCodePromptErrorContext = {
+  ...openCodeTextGenerationErrorContext,
+  sessionId: Schema.String,
+  providerId: Schema.String,
+  modelId: Schema.String,
+};
+
+export class OpenCodeTextGenerationPromptRequestError extends Schema.TaggedErrorClass<OpenCodeTextGenerationPromptRequestError>()(
+  "OpenCodeTextGenerationPromptRequestError",
+  {
+    ...openCodePromptErrorContext,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `OpenCode prompt request failed for ${this.operation} in ${this.cwd} using ${this.providerId}/${this.modelId} (session ${this.sessionId}).`;
+  }
+}
+
+export class OpenCodeTextGenerationPromptResponseError extends Schema.TaggedErrorClass<OpenCodeTextGenerationPromptResponseError>()(
+  "OpenCodeTextGenerationPromptResponseError",
+  {
+    ...openCodePromptErrorContext,
+    providerErrorName: Schema.optional(Schema.String),
+    providerMessage: Schema.String,
+  },
+) {
+  override get message(): string {
+    const providerError = this.providerErrorName ? ` ${this.providerErrorName}` : "";
+    return `OpenCode prompt${providerError} failed for ${this.operation} in ${this.cwd} using ${this.providerId}/${this.modelId} (session ${this.sessionId}): ${this.providerMessage}`;
+  }
+}
+
+export class OpenCodeTextGenerationEmptyOutputError extends Schema.TaggedErrorClass<OpenCodeTextGenerationEmptyOutputError>()(
+  "OpenCodeTextGenerationEmptyOutputError",
+  {
+    ...openCodePromptErrorContext,
+    responsePartCount: NonNegativeInt,
+    textPartCount: NonNegativeInt,
+  },
+) {
+  override get message(): string {
+    return `OpenCode returned empty output for ${this.operation} in ${this.cwd} using ${this.providerId}/${this.modelId} (session ${this.sessionId}, ${this.responsePartCount} response parts, ${this.textPartCount} text parts).`;
+  }
+}
+
+interface OpenCodePromptFailure {
+  readonly name?: string;
+  readonly message: string;
+}
+
+function getOpenCodePromptFailure(error: unknown): OpenCodePromptFailure | null {
   if (!error || typeof error !== "object") {
     return null;
   }
 
+  const name =
+    "name" in error && typeof error.name === "string" && error.name.trim().length > 0
+      ? error.name.trim()
+      : undefined;
   const message =
     "data" in error &&
     error.data &&
@@ -47,12 +138,14 @@ function getOpenCodePromptErrorMessage(error: unknown): string | null {
       ? error.data.message.trim()
       : "";
   if (message.length > 0) {
-    return message;
+    return {
+      ...(name ? { name } : {}),
+      message,
+    };
   }
 
-  if ("name" in error && typeof error.name === "string") {
-    const name = error.name.trim();
-    return name.length > 0 ? name : null;
+  if (name) {
+    return { name, message: name };
   }
 
   return null;
@@ -260,11 +353,7 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
   );
 
   const runOpenCodeJson = Effect.fn("runOpenCodeJson")(function* <S extends Schema.Top>(input: {
-    readonly operation:
-      | "generateCommitMessage"
-      | "generatePrContent"
-      | "generateBranchName"
-      | "generateThreadTitle";
+    readonly operation: OpenCodeTextGenerationOperation;
     readonly cwd: string;
     readonly prompt: string;
     readonly outputSchemaJson: S;
@@ -285,54 +374,123 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
         resolveAttachmentPath({ attachmentsDir: serverConfig.attachmentsDir, attachment }),
     });
 
-    const runAgainstServer = (server: Pick<OpenCodeRuntime.OpenCodeServerConnection, "url">) =>
-      Effect.tryPromise({
-        try: async () => {
-          const client = openCodeRuntime.createOpenCodeSdkClient({
-            baseUrl: server.url,
-            directory: input.cwd,
-            ...(openCodeSettings.serverUrl.length > 0 && openCodeSettings.serverPassword
-              ? { serverPassword: openCodeSettings.serverPassword }
-              : {}),
-          });
-          const session = await client.session.create({
-            title: `T3 Code ${input.operation}`,
-            permission: [{ permission: "*", pattern: "*", action: "deny" }],
-          });
-          if (!session.data) {
-            throw new Error("OpenCode session.create returned no session payload.");
-          }
-          const selectedAgent = getModelSelectionStringOptionValue(input.modelSelection, "agent");
-          const selectedVariant = getModelSelectionStringOptionValue(
-            input.modelSelection,
-            "variant",
-          );
-
-          const result = await client.session.prompt({
-            sessionID: session.data.id,
-            model: parsedModel,
-            ...(selectedAgent ? { agent: selectedAgent } : {}),
-            ...(selectedVariant ? { variant: selectedVariant } : {}),
-            parts: [{ type: "text", text: input.prompt }, ...fileParts],
-          });
-          const info = result.data?.info;
-          const errorMessage = getOpenCodePromptErrorMessage(info?.error);
-          if (errorMessage) {
-            throw new Error(errorMessage);
-          }
-          const rawText = getOpenCodeTextResponse(result.data?.parts);
-          if (rawText.length === 0) {
-            throw new Error("OpenCode returned empty output.");
-          }
-          return rawText;
-        },
-        catch: (cause) =>
-          new TextGenerationError({
+    const runAgainstServer = Effect.fn("runOpenCodeJson.runAgainstServer")(
+      function* (server: Pick<OpenCodeRuntime.OpenCodeServerConnection, "url">) {
+        const client = openCodeRuntime.createOpenCodeSdkClient({
+          baseUrl: server.url,
+          directory: input.cwd,
+          ...(openCodeSettings.serverUrl.length > 0 && openCodeSettings.serverPassword
+            ? { serverPassword: openCodeSettings.serverPassword }
+            : {}),
+        });
+        const session = yield* Effect.tryPromise({
+          try: () =>
+            client.session.create({
+              title: `T3 Code ${input.operation}`,
+              permission: [{ permission: "*", pattern: "*", action: "deny" }],
+            }),
+          catch: (cause) =>
+            new OpenCodeTextGenerationSessionRequestError({
+              operation: input.operation,
+              cwd: input.cwd,
+              cause,
+            }),
+        });
+        if (!session.data) {
+          return yield* new OpenCodeTextGenerationSessionPayloadError({
             operation: input.operation,
-            detail: OpenCodeRuntime.openCodeRuntimeErrorDetail(cause),
-            cause,
-          }),
-      });
+            cwd: input.cwd,
+          });
+        }
+        const selectedAgent = getModelSelectionStringOptionValue(input.modelSelection, "agent");
+        const selectedVariant = getModelSelectionStringOptionValue(input.modelSelection, "variant");
+        const promptContext = {
+          operation: input.operation,
+          cwd: input.cwd,
+          sessionId: session.data.id,
+          providerId: parsedModel.providerID,
+          modelId: parsedModel.modelID,
+        };
+
+        const result = yield* Effect.tryPromise({
+          try: () =>
+            client.session.prompt({
+              sessionID: session.data.id,
+              model: parsedModel,
+              ...(selectedAgent ? { agent: selectedAgent } : {}),
+              ...(selectedVariant ? { variant: selectedVariant } : {}),
+              parts: [{ type: "text", text: input.prompt }, ...fileParts],
+            }),
+          catch: (cause) =>
+            new OpenCodeTextGenerationPromptRequestError({
+              ...promptContext,
+              cause,
+            }),
+        });
+        const promptFailure = getOpenCodePromptFailure(result.data?.info?.error);
+        if (promptFailure) {
+          return yield* new OpenCodeTextGenerationPromptResponseError({
+            ...promptContext,
+            ...(promptFailure.name ? { providerErrorName: promptFailure.name } : {}),
+            providerMessage: promptFailure.message,
+          });
+        }
+        const responseParts = result.data?.parts ?? [];
+        const rawText = getOpenCodeTextResponse(responseParts);
+        if (rawText.length === 0) {
+          return yield* new OpenCodeTextGenerationEmptyOutputError({
+            ...promptContext,
+            responsePartCount: responseParts.length,
+            textPartCount: responseParts.filter(
+              (part) => part.type === "text" && typeof part.text === "string",
+            ).length,
+          });
+        }
+        return rawText;
+      },
+      Effect.catchTags({
+        OpenCodeTextGenerationSessionRequestError: (cause) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: cause.operation,
+              detail: "OpenCode session.create request failed.",
+              cause,
+            }),
+          ),
+        OpenCodeTextGenerationSessionPayloadError: (cause) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: cause.operation,
+              detail: "OpenCode session.create returned no session payload.",
+              cause,
+            }),
+          ),
+        OpenCodeTextGenerationPromptRequestError: (cause) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: cause.operation,
+              detail: "OpenCode session.prompt request failed.",
+              cause,
+            }),
+          ),
+        OpenCodeTextGenerationPromptResponseError: (cause) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: cause.operation,
+              detail: cause.providerMessage,
+              cause,
+            }),
+          ),
+        OpenCodeTextGenerationEmptyOutputError: (cause) =>
+          Effect.fail(
+            new TextGenerationError({
+              operation: cause.operation,
+              detail: "OpenCode returned empty output.",
+              cause,
+            }),
+          ),
+      }),
+    );
 
     const rawOutput =
       openCodeSettings.serverUrl.length > 0

--- a/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
+++ b/apps/server/src/textGeneration/OpenCodeTextGeneration.ts
@@ -120,6 +120,11 @@ interface OpenCodePromptFailure {
   readonly message: string;
 }
 
+interface OpenCodeTextPart {
+  readonly type: "text";
+  readonly text: string;
+}
+
 function getOpenCodePromptFailure(error: unknown): OpenCodePromptFailure | null {
   if (!error || typeof error !== "object") {
     return null;
@@ -151,20 +156,21 @@ function getOpenCodePromptFailure(error: unknown): OpenCodePromptFailure | null 
   return null;
 }
 
+function isOpenCodeTextPart(part: unknown): part is OpenCodeTextPart {
+  return (
+    part !== null &&
+    typeof part === "object" &&
+    "type" in part &&
+    part.type === "text" &&
+    "text" in part &&
+    typeof part.text === "string"
+  );
+}
+
 function getOpenCodeTextResponse(parts: ReadonlyArray<unknown> | undefined): string {
   return (parts ?? [])
-    .flatMap((part) => {
-      if (!part || typeof part !== "object") {
-        return [];
-      }
-      if (!("type" in part) || part.type !== "text") {
-        return [];
-      }
-      if (!("text" in part) || typeof part.text !== "string") {
-        return [];
-      }
-      return [part.text];
-    })
+    .filter(isOpenCodeTextPart)
+    .map((part) => part.text)
     .join("")
     .trim();
 }
@@ -441,9 +447,7 @@ export const makeOpenCodeTextGeneration = Effect.fn("makeOpenCodeTextGeneration"
           return yield* new OpenCodeTextGenerationEmptyOutputError({
             ...promptContext,
             responsePartCount: responseParts.length,
-            textPartCount: responseParts.filter(
-              (part) => part.type === "text" && typeof part.text === "string",
-            ).length,
+            textPartCount: responseParts.filter(isOpenCodeTextPart).length,
           });
         }
         return rawText;


### PR DESCRIPTION
OpenCode text generation handled session creation, prompt requests, provider-declared failures, and empty output inside one `tryPromise`. Semantic failures were converted into raw `Error` values, so the public `TextGenerationError` retained only a string and an artificial stack frame. Transport failures were also indistinguishable by phase.

This change introduces phase-specific Schema tagged errors for session requests, missing session payloads, prompt requests, provider-declared prompt failures, and empty output. They retain safe correlation fields such as the text-generation operation, cwd, session id, provider/model ids, and response part counts without retaining prompt or output bodies. SDK request failures keep the exact thrown cause; response-shape failures intentionally have no manufactured cause.

The SDK work is split into Effect operations and the known internal tags are mapped to the existing public `TextGenerationError` with `catchTags`. Existing user-facing details for missing payloads, provider-declared failures, and empty output remain unchanged.

Validation:

- `vp test apps/server/src/textGeneration/OpenCodeTextGeneration.test.ts` (9 tests)
- `vp check` (passes; repository has 20 pre-existing warnings)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error propagation on a shared text-generation path used for commit messages and related flows; behavior is intended to stay the same at the API surface but failure typing and cause chains differ internally.
> 
> **Overview**
> **OpenCode text generation** no longer wraps session create, prompt, and response handling in one `tryPromise` that turned semantic failures into generic `Error`s. The SDK path is split into Effect steps that fail with **phase-specific tagged errors** (`SessionRequest`, `SessionPayload`, `PromptRequest`, `PromptResponse`, `EmptyOutput`), carrying safe correlation fields (operation, `cwd`, session id, provider/model, part counts) and **preserving the real SDK throw** only for transport failures.
> 
> Those tags are mapped to the existing public **`TextGenerationError`** via `catchTags`, keeping the same user-facing detail strings for missing payloads, provider errors, and empty output. Provider-side failures are parsed with **`getOpenCodePromptFailure`** (`{ name?, message }`) instead of a single string helper.
> 
> Tests extend the runtime mock for session/prompt failures and assert structured `error.cause` tags and fields across each failure mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ab986c6a620996c8d64a43f817f95bb64df6f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure OpenCode text generation failures as typed errors with contextual detail
> - Introduces six tagged error classes in [OpenCodeTextGeneration.ts](https://github.com/pingdotgg/t3code/pull/3472/files#diff-69fc85c05aed321735eba7f35bbdfa8200cdfc2c3a52a905e8dacf1ddacbd777) covering session creation failure, missing session payload, prompt request failure, provider-surfaced errors, and empty/malformed output.
> - Refactors `makeOpenCodeTextGeneration.runOpenCodeJson` to map each failure point to its typed error, then re-wrap as `TextGenerationError` with a specific detail string and the typed error preserved as `cause`.
> - Replaces `getOpenCodePromptErrorMessage` with `getOpenCodePromptFailure`, which extracts both an optional provider error name and a message from the error shape.
> - Adds a stricter `isOpenCodeTextPart` type-guard so malformed response parts are silently dropped rather than processed.
> - Expands tests in [OpenCodeTextGeneration.test.ts](https://github.com/pingdotgg/t3code/pull/3472/files#diff-22c4f5630402f0a604b3a25b1318d606121e19fd7f8da841dc99cabe2c842007) to assert on `error.cause` structure for each new failure path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ab986c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->