### PR TITLE
[codex] Preserve desktop update state causes

### DIFF
--- a/apps/web/src/state/desktopUpdate.test.ts
+++ b/apps/web/src/state/desktopUpdate.test.ts
@@ -3,7 +3,7 @@ import * as AsyncResult from "effect/unstable/reactivity/AsyncResult";
 import { AtomRegistry } from "effect/unstable/reactivity";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 
-import { createDesktopUpdateStateAtom } from "./desktopUpdate";
+import { createDesktopUpdateStateAtom, DesktopUpdateStateReadError } from "./desktopUpdate";
 
 const baseState: DesktopUpdateState = {
   enabled: true,
@@ -117,8 +117,13 @@ describe("desktopUpdateStateAtom", () => {
       errorTag: "DesktopUpdateStateReadError",
       attemptCount: 3,
     });
-    expect(errorContext).not.toHaveProperty("error");
-    expect(errorContext).not.toHaveProperty("cause");
+    const loggedError = (errorContext as { readonly error: unknown }).error;
+    expect(loggedError).toBeInstanceOf(DesktopUpdateStateReadError);
+    expect(loggedError).toMatchObject({
+      _tag: "DesktopUpdateStateReadError",
+      attemptCount: 3,
+    });
+    expect((loggedError as DesktopUpdateStateReadError).cause).toBe(cause);
 
     listener?.(baseState);
     await vi.waitFor(() => {

--- a/apps/web/src/state/desktopUpdate.ts
+++ b/apps/web/src/state/desktopUpdate.ts
@@ -59,9 +59,9 @@ export function createDesktopUpdateStateAtom(getBridge: () => DesktopUpdateBridg
         Effect.catchTags({
           DesktopUpdateStateReadError: (error) =>
             Effect.logError(error.message, {
+              error,
               errorTag: error._tag,
               attemptCount: error.attemptCount,
-              stack: error.stack,
             }).pipe(Effect.as(null)),
         }),
       );


### PR DESCRIPTION
## Summary

- retain the structured `DesktopUpdateStateReadError` in terminal retry logs
- preserve its exact IPC cause and stack alongside the existing attempt metadata
- keep update retries, listener behavior, and the `null` fallback unchanged

## Root cause

The recovery boundary copied the error tag and attempt count into log attributes but retained only the wrapper stack. The original IPC cause was therefore unavailable after the read failure was swallowed.

## Validation

- `vp test apps/web/src/state/desktopUpdate.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to error log payload; no change to retry, subscription, or state fallback behavior.
> 
> **Overview**
> When the initial `getUpdateState` read fails after retries, terminal **`Effect.logError`** now attaches the full **`DesktopUpdateStateReadError`** (via an `error` field) instead of only copying **`error.stack`**.
> 
> That keeps the original IPC failure on **`error.cause`** in log context for debugging, while retry count, listener behavior, and the `null` fallback stay the same. Tests now assert the logged error is the tagged instance and that **`cause`** matches the rejected IPC error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37fe94b2fcd9c08dd9f8d946f5dc9c2c71fb8398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve error cause in desktop update state read failure logging
> In `createDesktopUpdateStateAtom`, the `Effect.catchTags` handler for `DesktopUpdateStateReadError` now includes the full error object in the log context instead of a separate `stack` field. This makes the original cause accessible when inspecting error logs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37fe94b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->