### PR TITLE
[codex] Preserve VCS project config error causes

### DIFF
--- a/apps/server/src/vcs/VcsProjectConfig.test.ts
+++ b/apps/server/src/vcs/VcsProjectConfig.test.ts
@@ -96,16 +96,19 @@ describe("VcsProjectConfig", () => {
         const kind = yield* config.resolveKind({ cwd });
 
         assert.equal(kind, "jj");
-        const [message, context] = messages[0] as [string, Record<string, unknown>];
         const failedCandidate = path.join(cwd, ".t3code", "vcs.json");
-        assert.equal(message, "Failed to inspect VCS project config at " + failedCandidate + ".");
-        assert.deepInclude(context, {
+        const [error] = messages[0] as ReadonlyArray<unknown>;
+        assert.instanceOf(error, VcsProjectConfig.VcsProjectConfigError);
+        assert.equal(
+          error.message,
+          "Failed to inspect VCS project config at " + failedCandidate + ".",
+        );
+        assert.deepInclude(error, {
           operation: "inspect",
           cwd,
           configPath: failedCandidate,
-          errorTag: "VcsProjectConfigError",
+          _tag: "VcsProjectConfigError",
         });
-        assert.equal("cause" in context, false);
       }).pipe(Effect.provide(Logger.layer([logger], { mergeWithExisting: false })));
     });
   });
@@ -146,18 +149,19 @@ describe("VcsProjectConfig", () => {
         const kind = yield* config.resolveKind({ cwd: root });
 
         assert.equal(kind, "auto");
-        const [message, context] = messages[0] as [string, Record<string, unknown>];
+        const [error] = messages[0] as ReadonlyArray<unknown>;
+        assert.instanceOf(error, VcsProjectConfig.VcsProjectConfigError);
         assert.equal(
-          message,
+          error.message,
           "Failed to decode VCS project config at " + path.join(configDir, "vcs.json") + ".",
         );
-        assert.deepInclude(context, {
+        assert.deepInclude(error.cause, { _tag: "SchemaError" });
+        assert.deepInclude(error, {
           operation: "decode",
           cwd: root,
           configPath: path.join(configDir, "vcs.json"),
-          errorTag: "VcsProjectConfigError",
+          _tag: "VcsProjectConfigError",
         });
-        assert.equal("cause" in context, false);
       }).pipe(Effect.provide(Logger.layer([logger], { mergeWithExisting: false })));
     });
   });
@@ -182,15 +186,16 @@ describe("VcsProjectConfig", () => {
         const kind = yield* config.resolveKind({ cwd: root });
 
         assert.equal(kind, "auto");
-        const [message, context] = messages[0] as [string, Record<string, unknown>];
-        assert.equal(message, "Failed to read VCS project config at " + configPath + ".");
-        assert.deepInclude(context, {
+        const [error] = messages[0] as ReadonlyArray<unknown>;
+        assert.instanceOf(error, VcsProjectConfig.VcsProjectConfigError);
+        assert.equal(error.message, "Failed to read VCS project config at " + configPath + ".");
+        assert.deepInclude(error.cause, { _tag: "PlatformError" });
+        assert.deepInclude(error, {
           operation: "read",
           cwd: root,
           configPath,
-          errorTag: "VcsProjectConfigError",
+          _tag: "VcsProjectConfigError",
         });
-        assert.equal("cause" in context, false);
       }).pipe(Effect.provide(Logger.layer([logger], { mergeWithExisting: false })));
     });
   });

--- a/apps/server/src/vcs/VcsProjectConfig.ts
+++ b/apps/server/src/vcs/VcsProjectConfig.ts
@@ -55,13 +55,14 @@ function configuredKind(config: ProjectVcsConfigFile): VcsDriverKindType | "auto
 }
 
 const logVcsProjectConfigError = (error: VcsProjectConfigError) =>
-  Effect.logWarning(error.message, {
-    operation: error.operation,
-    cwd: error.cwd,
-    configPath: error.configPath,
-    errorTag: error._tag,
-    stack: error.stack,
-  });
+  Effect.logWarning(error).pipe(
+    Effect.annotateLogs({
+      operation: error.operation,
+      cwd: error.cwd,
+      configPath: error.configPath,
+      errorTag: error._tag,
+    }),
+  );
 
 export const make = Effect.gen(function* () {
   const fileSystem = yield* FileSystem.FileSystem;


### PR DESCRIPTION
VCS project configuration discovery intentionally recovers from inspect, read, and decode failures so repositories remain usable with the automatic provider fallback. The recovery logger previously flattened `VcsProjectConfigError` into its message and copied fields, which discarded the original platform or schema cause and its stack before the error was swallowed.

This change logs the structured `VcsProjectConfigError` itself and retains the existing safe operation, working-directory, config-path, and error-tag annotations. Recovery behavior remains unchanged: failed candidate inspection continues walking parent directories, while read and decode failures still resolve to `auto`. No configuration contents or credentials are added to logging.

The existing focused recovery tests now verify that inspect, read, and decode fallbacks observe the structured error object and retain its nested platform or schema cause.

Validation:

- `vp test run apps/server/src/vcs/VcsProjectConfig.test.ts` (8 tests)
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to warning logs during existing auto-fallback paths; no change to config resolution or credentials in logs.
> 
> **Overview**
> VCS config discovery still swallows inspect/read/decode failures and falls back to **`auto`**; this PR only changes **what gets logged** on those recovery paths.
> 
> **`logVcsProjectConfigError`** now passes the full **`VcsProjectConfigError`** to **`Effect.logWarning`** and adds **`operation`**, **`cwd`**, **`configPath`**, and **`errorTag`** via **`Effect.annotateLogs`**, instead of logging the message string plus a copied context object. That keeps the wrapped **`cause`** (e.g. **`PlatformError`**, **`SchemaError`**) available in logs. **`stack`** is no longer duplicated in log annotations.
> 
> Tests for inspect, read, and decode recovery now assert the logger receives a **`VcsProjectConfigError`** instance (with **`_tag`** and **`cause`**) rather than a **`[message, context]`** tuple.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89f06d218c7590396e362dffab2cf07f7a7a278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve error causes in `logVcsProjectConfigError` by logging the error object directly
> Changes `logVcsProjectConfigError` in [VcsProjectConfig.ts](https://github.com/pingdotgg/t3code/pull/3474/files#diff-2b9514199f9a3bef51b173b0b758e4966b3fa18a88781540ab4d2d546e30c90b) to pass the full error object to `Effect.logWarning` instead of a message string with a context object. Metadata (`operation`, `cwd`, `configPath`, `errorTag`) is now attached via `Effect.annotateLogs`. Tests in [VcsProjectConfig.test.ts](https://github.com/pingdotgg/t3code/pull/3474/files#diff-b3ae3446988fbc49c10a4ebf96fef9073080375a2933513c22d6b9e6e8be134c) are updated to assert on the logged `VcsProjectConfigError` instance and its `cause` rather than a string message and context tuple.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e89f06d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->