### PR TITLE
[codex] Preserve APNs delivery failure context

### DIFF
--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -10,7 +10,6 @@ import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import * as Redacted from "effect/Redacted";
 import * as References from "effect/References";
-import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import {
   FetchHttpClient,
   HttpClient,
@@ -139,58 +138,6 @@ const target: LiveActivities.TargetRow = {
   last_live_activity_delivery_at: null,
 };
 
-function makeTransportFailureProbe(cause: Error) {
-  const transportErrors: Array<ApnsDeliveries.ApnsDeliveryTransportError> = [];
-  const requestFailures: Array<HttpClientError.HttpClientError> = [];
-  const logger = Logger.make(({ fiber }) => {
-    const redactedError = fiber.getRef(References.CurrentLogAnnotations).error;
-    const error = Redacted.isRedacted(redactedError) ? Redacted.value(redactedError) : undefined;
-    if (ApnsDeliveries.isApnsDeliveryTransportError(error)) {
-      transportErrors.push(error);
-    }
-  });
-  return {
-    cause,
-    requestFailures,
-    transportErrors,
-    loggerLayer: Logger.layer([logger], { mergeWithExisting: false }),
-    execute: (request: HttpClientRequest.HttpClientRequest) => {
-      const requestFailure = new HttpClientError.HttpClientError({
-        reason: new HttpClientError.TransportError({ request, cause }),
-      });
-      requestFailures.push(requestFailure);
-      return Effect.fail(requestFailure);
-    },
-  };
-}
-
-function expectTransportFailure(
-  probe: ReturnType<typeof makeTransportFailureProbe>,
-  expected: {
-    readonly kind: "live_activity_update" | "push_notification";
-    readonly sourceJobId: string;
-    readonly requestKind: "live-activity" | "push-notification";
-    readonly event: ApnsClient.ApnsLiveActivityEvent | null;
-  },
-) {
-  const error = probe.transportErrors[0]!;
-  expect(error).toMatchObject({
-    deviceId: target.device_id,
-    kind: expected.kind,
-    sourceJobId: expected.sourceJobId,
-    apnsErrorTag: "ApnsHttpRequestError",
-    requestStage: "send",
-    cause: {
-      _tag: "ApnsHttpRequestError",
-      requestKind: expected.requestKind,
-      event: expected.event,
-      stage: "send",
-    },
-  });
-  expect((error.cause as ApnsClient.ApnsHttpRequestError).cause).toBe(probe.requestFailures[0]);
-  expect(probe.requestFailures[0]?.reason).toMatchObject({ cause: probe.cause });
-}
-
 function makeLayer(input: {
   readonly attempts: Array<DeliveryAttempts.DeliveryAttemptInput>;
   readonly sourceJobClaims?: ReadonlyMap<string, DeliveryAttempts.DeliverySourceJobClaimResult>;
@@ -211,7 +158,7 @@ function makeLayer(input: {
   readonly config?: RelayConfiguration.RelayConfiguration["Service"];
   readonly execute?: (
     request: HttpClientRequest.HttpClientRequest,
-  ) => Effect.Effect<HttpClientResponse.HttpClientResponse, HttpClientError.HttpClientError>;
+  ) => Effect.Effect<HttpClientResponse.HttpClientResponse>;
 }) {
   return ApnsDeliveries.layer.pipe(
     Layer.provide(ApnsClient.layer),
@@ -684,8 +631,18 @@ describe("ApnsDeliveries", () => {
 
   it.effect("processes signed jobs through APNs and records attempts", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
-    const httpCause = new Error("network unavailable");
-    const failure = makeTransportFailureProbe(httpCause);
+    const transportErrors: Array<ApnsDeliveries.ApnsDeliveryTransportError> = [];
+    const logger = Logger.make(({ fiber }) => {
+      const annotation = fiber.getRef(References.CurrentLogAnnotations).error;
+      if (!Redacted.isRedacted(annotation)) {
+        return;
+      }
+      const error = Redacted.value(annotation);
+      // @effect-diagnostics-next-line instanceOfSchema:off
+      if (error instanceof ApnsDeliveries.ApnsDeliveryTransportError) {
+        transportErrors.push(error);
+      }
+    });
     const payload = makeApnsDeliveryJobPayload({
       kind: "live_activity_update",
       userId: target.user_id,
@@ -707,30 +664,33 @@ describe("ApnsDeliveries", () => {
 
       expect(result.kind).toBe("live_activity_update");
       expect(result.ok).toBe(false);
-      expect(result.apnsReason).toBe("APNs live-activity request failed during send in sandbox.");
       expect(attempts).toMatchObject([
         {
           kind: "live_activity_update",
           sourceJobId: "job-1",
           token: "activity-token",
-          transportError: "APNs live-activity request failed during send in sandbox.",
         },
       ]);
-      expectTransportFailure(failure, {
+      expect(transportErrors).toHaveLength(1);
+      const error = transportErrors[0]!;
+      expect(error).toMatchObject({
+        deviceId: target.device_id,
         kind: "live_activity_update",
         sourceJobId: "job-1",
-        requestKind: "live-activity",
-        event: "update",
+        apnsErrorTag: "ApnsJwtSigningError",
+        requestStage: null,
       });
+      expect(error.cause).toBeInstanceOf(ApnsClient.ApnsJwtSigningError);
+      expect(error.cause).toMatchObject({
+        teamId: "team-id",
+        keyId: "key-id",
+      });
+      expect((error.cause as ApnsClient.ApnsJwtSigningError).cause).toBeDefined();
     }).pipe(
       Effect.provide(
         Layer.mergeAll(
-          makeLayer({
-            attempts,
-            config: signingConfig,
-            execute: failure.execute,
-          }),
-          failure.loggerLayer,
+          makeLayer({ attempts }),
+          Logger.layer([logger], { mergeWithExisting: false }),
         ),
       ),
     );
@@ -793,68 +753,6 @@ describe("ApnsDeliveries", () => {
           config: signingConfig,
           execute,
         }),
-      ),
-    );
-  });
-
-  it.effect("preserves push notification transport failures while recording the result", () => {
-    const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
-    const httpCause = new Error("connection reset");
-    const failure = makeTransportFailureProbe(httpCause);
-
-    return Effect.gen(function* () {
-      const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
-      const result = yield* deliveries.sendPushNotification({
-        target: {
-          user_id: target.user_id,
-          device_id: target.device_id,
-        },
-        token: "apns-device-token",
-        sourceJobId: "job-push-transport",
-        notification: {
-          title: "Thread",
-          body: "Input: Project",
-          environmentId: "env",
-          threadId: "thread",
-          deepLink: "/",
-        },
-      });
-
-      expect(result).toMatchObject({
-        kind: "push_notification",
-        ok: false,
-        apnsStatus: null,
-        apnsReason: "APNs push-notification request failed during send in sandbox.",
-      });
-      expect(attempts).toMatchObject([
-        {
-          kind: "push_notification",
-          sourceJobId: "job-push-transport",
-          transportError: "APNs push-notification request failed during send in sandbox.",
-        },
-      ]);
-      expectTransportFailure(failure, {
-        kind: "push_notification",
-        sourceJobId: "job-push-transport",
-        requestKind: "push-notification",
-        event: null,
-      });
-    }).pipe(
-      Effect.provide(
-        Layer.mergeAll(
-          makeLayer({
-            attempts,
-            currentTargets: [
-              {
-                ...target,
-                push_token: "apns-device-token",
-              },
-            ],
-            config: signingConfig,
-            execute: failure.execute,
-          }),
-          failure.loggerLayer,
-        ),
       ),
     );
   });

--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -638,8 +638,7 @@ describe("ApnsDeliveries", () => {
         return;
       }
       const error = Redacted.value(annotation);
-      // @effect-diagnostics-next-line instanceOfSchema:off
-      if (error instanceof ApnsDeliveries.ApnsDeliveryTransportError) {
+      if (ApnsDeliveries.isApnsDeliveryTransportError(error)) {
         transportErrors.push(error);
       }
     });

--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -7,7 +7,10 @@ import { describe, expect, it } from "@effect/vitest";
 import * as NodeCrypto from "node:crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Redacted from "effect/Redacted";
+import * as References from "effect/References";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import {
   FetchHttpClient,
   HttpClient,
@@ -136,6 +139,58 @@ const target: LiveActivities.TargetRow = {
   last_live_activity_delivery_at: null,
 };
 
+function makeTransportFailureProbe(cause: Error) {
+  const transportErrors: Array<ApnsDeliveries.ApnsDeliveryTransportError> = [];
+  const requestFailures: Array<HttpClientError.HttpClientError> = [];
+  const logger = Logger.make(({ fiber }) => {
+    const redactedError = fiber.getRef(References.CurrentLogAnnotations).error;
+    const error = Redacted.isRedacted(redactedError) ? Redacted.value(redactedError) : undefined;
+    if (ApnsDeliveries.isApnsDeliveryTransportError(error)) {
+      transportErrors.push(error);
+    }
+  });
+  return {
+    cause,
+    requestFailures,
+    transportErrors,
+    loggerLayer: Logger.layer([logger], { mergeWithExisting: false }),
+    execute: (request: HttpClientRequest.HttpClientRequest) => {
+      const requestFailure = new HttpClientError.HttpClientError({
+        reason: new HttpClientError.TransportError({ request, cause }),
+      });
+      requestFailures.push(requestFailure);
+      return Effect.fail(requestFailure);
+    },
+  };
+}
+
+function expectTransportFailure(
+  probe: ReturnType<typeof makeTransportFailureProbe>,
+  expected: {
+    readonly kind: "live_activity_update" | "push_notification";
+    readonly sourceJobId: string;
+    readonly requestKind: "live-activity" | "push-notification";
+    readonly event: ApnsClient.ApnsLiveActivityEvent | null;
+  },
+) {
+  const error = probe.transportErrors[0]!;
+  expect(error).toMatchObject({
+    deviceId: target.device_id,
+    kind: expected.kind,
+    sourceJobId: expected.sourceJobId,
+    apnsErrorTag: "ApnsHttpRequestError",
+    requestStage: "send",
+    cause: {
+      _tag: "ApnsHttpRequestError",
+      requestKind: expected.requestKind,
+      event: expected.event,
+      stage: "send",
+    },
+  });
+  expect((error.cause as ApnsClient.ApnsHttpRequestError).cause).toBe(probe.requestFailures[0]);
+  expect(probe.requestFailures[0]?.reason).toMatchObject({ cause: probe.cause });
+}
+
 function makeLayer(input: {
   readonly attempts: Array<DeliveryAttempts.DeliveryAttemptInput>;
   readonly sourceJobClaims?: ReadonlyMap<string, DeliveryAttempts.DeliverySourceJobClaimResult>;
@@ -156,7 +211,7 @@ function makeLayer(input: {
   readonly config?: RelayConfiguration.RelayConfiguration["Service"];
   readonly execute?: (
     request: HttpClientRequest.HttpClientRequest,
-  ) => Effect.Effect<HttpClientResponse.HttpClientResponse>;
+  ) => Effect.Effect<HttpClientResponse.HttpClientResponse, HttpClientError.HttpClientError>;
 }) {
   return ApnsDeliveries.layer.pipe(
     Layer.provide(ApnsClient.layer),
@@ -629,6 +684,8 @@ describe("ApnsDeliveries", () => {
 
   it.effect("processes signed jobs through APNs and records attempts", () => {
     const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
+    const httpCause = new Error("network unavailable");
+    const failure = makeTransportFailureProbe(httpCause);
     const payload = makeApnsDeliveryJobPayload({
       kind: "live_activity_update",
       userId: target.user_id,
@@ -650,14 +707,33 @@ describe("ApnsDeliveries", () => {
 
       expect(result.kind).toBe("live_activity_update");
       expect(result.ok).toBe(false);
+      expect(result.apnsReason).toBe("APNs live-activity request failed during send in sandbox.");
       expect(attempts).toMatchObject([
         {
           kind: "live_activity_update",
           sourceJobId: "job-1",
           token: "activity-token",
+          transportError: "APNs live-activity request failed during send in sandbox.",
         },
       ]);
-    }).pipe(Effect.provide(makeLayer({ attempts })));
+      expectTransportFailure(failure, {
+        kind: "live_activity_update",
+        sourceJobId: "job-1",
+        requestKind: "live-activity",
+        event: "update",
+      });
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          makeLayer({
+            attempts,
+            config: signingConfig,
+            execute: failure.execute,
+          }),
+          failure.loggerLayer,
+        ),
+      ),
+    );
   });
 
   it.effect("processes signed push notification jobs through APNs and records attempts", () => {
@@ -717,6 +793,68 @@ describe("ApnsDeliveries", () => {
           config: signingConfig,
           execute,
         }),
+      ),
+    );
+  });
+
+  it.effect("preserves push notification transport failures while recording the result", () => {
+    const attempts: Array<DeliveryAttempts.DeliveryAttemptInput> = [];
+    const httpCause = new Error("connection reset");
+    const failure = makeTransportFailureProbe(httpCause);
+
+    return Effect.gen(function* () {
+      const deliveries = yield* ApnsDeliveries.ApnsDeliveries;
+      const result = yield* deliveries.sendPushNotification({
+        target: {
+          user_id: target.user_id,
+          device_id: target.device_id,
+        },
+        token: "apns-device-token",
+        sourceJobId: "job-push-transport",
+        notification: {
+          title: "Thread",
+          body: "Input: Project",
+          environmentId: "env",
+          threadId: "thread",
+          deepLink: "/",
+        },
+      });
+
+      expect(result).toMatchObject({
+        kind: "push_notification",
+        ok: false,
+        apnsStatus: null,
+        apnsReason: "APNs push-notification request failed during send in sandbox.",
+      });
+      expect(attempts).toMatchObject([
+        {
+          kind: "push_notification",
+          sourceJobId: "job-push-transport",
+          transportError: "APNs push-notification request failed during send in sandbox.",
+        },
+      ]);
+      expectTransportFailure(failure, {
+        kind: "push_notification",
+        sourceJobId: "job-push-transport",
+        requestKind: "push-notification",
+        event: null,
+      });
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          makeLayer({
+            attempts,
+            currentTargets: [
+              {
+                ...target,
+                push_token: "apns-device-token",
+              },
+            ],
+            config: signingConfig,
+            execute: failure.execute,
+          }),
+          failure.loggerLayer,
+        ),
       ),
     );
   });

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -109,8 +109,6 @@ export class ApnsDeliveryTransportError extends Schema.TaggedErrorClass<ApnsDeli
   }
 }
 
-export const isApnsDeliveryTransportError = Schema.is(ApnsDeliveryTransportError);
-
 const decodeRelayAgentActivityAggregateStateJson = Schema.decodeUnknownOption(
   Schema.fromJsonString(RelayAgentActivityAggregateStateSchema),
 );

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -7,12 +7,14 @@ import type {
 import {
   RelayAgentActivityAggregateState as RelayAgentActivityAggregateStateSchema,
   RelayAgentAwarenessPreferences as RelayAgentAwarenessPreferencesSchema,
+  RelayDeliveryKind as RelayDeliveryKindSchema,
 } from "@t3tools/contracts/relay";
 import * as Context from "effect/Context";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 
 import {
@@ -86,6 +88,28 @@ export class ApnsDeliveryJobClaimInFlight extends Schema.TaggedErrorClass<ApnsDe
     return `APNs delivery job '${this.sourceJobId}' is already in flight`;
   }
 }
+
+export class ApnsDeliveryTransportError extends Schema.TaggedErrorClass<ApnsDeliveryTransportError>()(
+  "ApnsDeliveryTransportError",
+  {
+    deviceId: Schema.String,
+    kind: RelayDeliveryKindSchema,
+    sourceJobId: Schema.NullOr(Schema.String),
+    apnsErrorTag: Schema.Literals([
+      "ApnsJwtEncodingError",
+      "ApnsJwtSigningError",
+      "ApnsHttpRequestError",
+    ]),
+    requestStage: Schema.NullOr(Schema.Literals(["send", "read-response"])),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `APNs ${this.kind} delivery failed for device ${this.deviceId}.`;
+  }
+}
+
+export const isApnsDeliveryTransportError = Schema.is(ApnsDeliveryTransportError);
 
 const decodeRelayAgentActivityAggregateStateJson = Schema.decodeUnknownOption(
   Schema.fromJsonString(RelayAgentActivityAggregateStateSchema),
@@ -302,6 +326,42 @@ function deliveryAttemptOutcome(result: Apns.ApnsDeliveryResult) {
   };
 }
 
+const recoverApnsDeliveryTransportError = (
+  input: {
+    readonly deviceId: string;
+    readonly kind: RelayDeliveryKind;
+    readonly sourceJobId: string | null;
+  },
+  cause: Apns.ApnsError,
+): Effect.Effect<Apns.ApnsDeliveryResult> => {
+  const error = new ApnsDeliveryTransportError({
+    deviceId: input.deviceId,
+    kind: input.kind,
+    sourceJobId: input.sourceJobId,
+    apnsErrorTag: cause._tag,
+    requestStage: cause._tag === "ApnsHttpRequestError" ? cause.stage : null,
+    cause,
+  });
+  return Effect.logError(error.message).pipe(
+    Effect.annotateLogs({
+      error: Redacted.make(error, { label: error._tag }),
+      "error.type": error._tag,
+      "error.apns_error_tag": error.apnsErrorTag,
+      ...(error.requestStage === null ? {} : { "error.request_stage": error.requestStage }),
+      ...(error.stack === undefined ? {} : { "error.stack": error.stack }),
+      "relay.mobile.device_id": error.deviceId,
+      "relay.delivery.kind": error.kind,
+      ...(error.sourceJobId === null ? {} : { "relay.delivery.job_id": error.sourceJobId }),
+    }),
+    Effect.as({
+      ok: false,
+      status: 0,
+      reason: cause.message,
+      apnsId: null,
+    }),
+  );
+};
+
 interface LiveActivityDeliveryTarget {
   readonly user_id: string;
   readonly device_id: string;
@@ -440,6 +500,15 @@ export const make = Effect.gen(function* () {
       { ...input, aggregate } as SendLiveActivityDeliveryInput,
       now,
     );
+    const recoverTransportError = (cause: Apns.ApnsError) =>
+      recoverApnsDeliveryTransportError(
+        {
+          deviceId: input.target.device_id,
+          kind: input.kind,
+          sourceJobId: input.sourceJobId ?? null,
+        },
+        cause,
+      );
     if (input.sourceJobId) {
       const claim = yield* attempts.claimSourceJob({
         userId: input.target.user_id,
@@ -476,14 +545,11 @@ export const make = Effect.gen(function* () {
         issuedAtUnixSeconds: epochSeconds,
       })
       .pipe(
-        Effect.catch((error) =>
-          Effect.succeed({
-            ok: false,
-            status: 0,
-            reason: error.message,
-            apnsId: null,
-          }),
-        ),
+        Effect.catchTags({
+          ApnsJwtEncodingError: recoverTransportError,
+          ApnsJwtSigningError: recoverTransportError,
+          ApnsHttpRequestError: recoverTransportError,
+        }),
       );
     if (result.ok) {
       yield* liveActivities.markDelivery({
@@ -551,6 +617,15 @@ export const make = Effect.gen(function* () {
       token: input.token,
       notification,
     });
+    const recoverTransportError = (cause: Apns.ApnsError) =>
+      recoverApnsDeliveryTransportError(
+        {
+          deviceId: input.target.device_id,
+          kind: "push_notification",
+          sourceJobId: input.sourceJobId ?? null,
+        },
+        cause,
+      );
     if (input.sourceJobId) {
       const claim = yield* attempts.claimSourceJob({
         userId: input.target.user_id,
@@ -593,14 +668,11 @@ export const make = Effect.gen(function* () {
         issuedAtUnixSeconds: epochSeconds,
       })
       .pipe(
-        Effect.catch((error) =>
-          Effect.succeed({
-            ok: false,
-            status: 0,
-            reason: error.message,
-            apnsId: null,
-          }),
-        ),
+        Effect.catchTags({
+          ApnsJwtEncodingError: recoverTransportError,
+          ApnsJwtSigningError: recoverTransportError,
+          ApnsHttpRequestError: recoverTransportError,
+        }),
       );
     if (isPermanentApnsTokenFailure(result)) {
       yield* liveActivities.invalidateDeliveryToken({

--- a/infra/relay/src/agentActivity/ApnsDeliveries.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.ts
@@ -109,6 +109,8 @@ export class ApnsDeliveryTransportError extends Schema.TaggedErrorClass<ApnsDeli
   }
 }
 
+export const isApnsDeliveryTransportError = Schema.is(ApnsDeliveryTransportError);
+
 const decodeRelayAgentActivityAggregateStateJson = Schema.decodeUnknownOption(
   Schema.fromJsonString(RelayAgentActivityAggregateStateSchema),
 );


### PR DESCRIPTION
## Summary
- retain APNs client failures as structured delivery errors with device, delivery kind, job, and request-stage context
- log exact cause chains behind a redacted annotation while exposing only safe queryable fields
- preserve existing status-0 results, retry/claim behavior, and delivery-attempt persistence

## Verification
- vp test infra/relay/src/agentActivity/ApnsDeliveries.test.ts (21 tests)
- vp check
- vp run typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to known `Apns` error tags with unchanged delivery outcomes and attempt persistence; only observability and error shape change on the relay push path.
> 
> **Overview**
> APNs transport failures (JWT encoding/signing and HTTP request errors) are now wrapped in **`ApnsDeliveryTransportError`** with device, delivery kind, job id, APNs error tag, and HTTP stage, while the original client error stays on **`cause`**.
> 
> **`recoverApnsDeliveryTransportError`** logs via **`Effect.logError`** with structured fields and a **redacted** `error` annotation holding the full object; callers still get the same **`ok: false`**, status-0 delivery result and existing claim/retry/attempt recording paths.
> 
> Live Activity and push notification sends switch from a broad **`Effect.catch`** to **`Effect.catchTags`** for the three **`Apns`** error types. Tests assert the redacted log payload for a JWT signing failure during signed job processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a510a0a71f5af2ffb7e1b34d7f9b4ba15692c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve APNs delivery failure context with structured `ApnsDeliveryTransportError` logging
> - Introduces `ApnsDeliveryTransportError`, a schema-tagged error class in [`ApnsDeliveries.ts`](https://github.com/pingdotgg/t3code/pull/3475/files#diff-b5f76b7b901b1e00d834ecfbecbc61c1b181e71f588fb216a5c94d753dca03e6) that captures `deviceId`, `kind`, `sourceJobId`, `apnsErrorTag`, `requestStage`, and `cause` for APNs transport/auth failures.
> - Adds `recoverApnsDeliveryTransportError`, a helper that logs the error with structured, redacted annotations and maps it to a standardized `ApnsDeliveryResult` with `ok=false`.
> - Replaces broad `Effect.catch` handlers in `sendLiveActivity` and `sendPushNotification` with `Effect.catchTags` scoped to `ApnsJwtEncodingError`, `ApnsJwtSigningError`, and `ApnsHttpRequestError`.
> - Risk: other unexpected errors in the APNs send path now propagate instead of being coerced into a delivery failure result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17a510a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
