### PR TITLE
[codex] Structure VCS process boundary errors

### DIFF
--- a/apps/server/src/sourceControl/GitLabCli.ts
+++ b/apps/server/src/sourceControl/GitLabCli.ts
@@ -133,7 +133,10 @@ export class GitLabCliCommandError extends Schema.TaggedErrorClass<GitLabCliComm
         }
       },
       VcsProcessTimeoutError: (cause) => new GitLabCliCommandError({ ...context, cause }),
-      VcsOutputDecodeError: (cause) => new GitLabCliCommandError({ ...context, cause }),
+      VcsProcessStdinWriteError: (cause) => new GitLabCliCommandError({ ...context, cause }),
+      VcsProcessOutputReadError: (cause) => new GitLabCliCommandError({ ...context, cause }),
+      VcsProcessOutputLimitError: (cause) => new GitLabCliCommandError({ ...context, cause }),
+      VcsProcessMissingExitCodeError: (cause) => new GitLabCliCommandError({ ...context, cause }),
       VcsRepositoryDetectionError: (cause) => new GitLabCliCommandError({ ...context, cause }),
       VcsUnsupportedOperationError: (cause) => new GitLabCliCommandError({ ...context, cause }),
     });

--- a/apps/server/src/vcs/VcsProcess.test.ts
+++ b/apps/server/src/vcs/VcsProcess.test.ts
@@ -11,6 +11,7 @@ import {
   VcsProcessSpawnError,
   VcsProcessTimeoutError,
 } from "@t3tools/contracts";
+import * as ProcessRunner from "../processRunner.ts";
 import * as VcsProcess from "./VcsProcess.ts";
 
 const run = (input: VcsProcess.VcsProcessInput) =>
@@ -23,6 +24,25 @@ const liveLayer = VcsProcess.layer.pipe(Layer.provide(NodeServices.layer));
 
 const provideLive = <A, E, R>(effect: Effect.Effect<A, E, R | VcsProcess.VcsProcess>) =>
   effect.pipe(Effect.provide(liveLayer));
+
+const baseInput = {
+  operation: "test.process-boundary",
+  command: "git",
+  args: ["status", "--short"],
+  cwd: "/workspace",
+} satisfies VcsProcess.VcsProcessInput;
+
+const captureProcessResult = (
+  result: Effect.Effect<ProcessRunner.ProcessRunOutput, ProcessRunner.ProcessRunError>,
+) =>
+  VcsProcess.make.pipe(
+    Effect.provideService(
+      ProcessRunner.ProcessRunner,
+      ProcessRunner.ProcessRunner.of({ run: () => result }),
+    ),
+    Effect.flatMap((service) => service.run(baseInput)),
+    Effect.flip,
+  );
 
 describe("VcsProcess.run", () => {
   it.effect("collects stdout", () =>
@@ -139,6 +159,51 @@ describe("VcsProcess.run", () => {
       expect(error).toHaveProperty("cause");
       expect(error.message).not.toContain(secretArgument);
     }).pipe(provideLive),
+  );
+
+  it.effect("preserves real boundary causes without manufacturing structural ones", () =>
+    Effect.gen(function* () {
+      const cause = new Error("secret stdin failure");
+      const error = yield* captureProcessResult(
+        Effect.fail(
+          new ProcessRunner.ProcessStdinError({
+            command: baseInput.command,
+            argumentCount: baseInput.args.length,
+            cwd: baseInput.cwd,
+            stdinBytes: 47,
+            cause,
+          }),
+        ),
+      );
+
+      expect(error).toMatchObject({
+        _tag: "VcsProcessStdinWriteError",
+        operation: baseInput.operation,
+        stdinBytes: 47,
+        cause,
+      });
+      expect(error.message).not.toContain(cause.message);
+
+      const missingExitCodeError = yield* captureProcessResult(
+        Effect.succeed({
+          stdout: "",
+          stderr: "",
+          code: null,
+          timedOut: false,
+          stdoutTruncated: false,
+          stderrTruncated: false,
+        }),
+      );
+
+      expect(missingExitCodeError).toMatchObject({
+        _tag: "VcsProcessMissingExitCodeError",
+        operation: baseInput.operation,
+        command: baseInput.command,
+        cwd: baseInput.cwd,
+        argumentCount: baseInput.args.length,
+      });
+      expect(missingExitCodeError).not.toHaveProperty("cause");
+    }),
   );
 
   it.effect("returns output when non-zero exits are allowed", () =>

--- a/apps/server/src/vcs/VcsProcess.ts
+++ b/apps/server/src/vcs/VcsProcess.ts
@@ -5,11 +5,14 @@ import * as Match from "effect/Match";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
-  VcsOutputDecodeError,
   type VcsError,
   VcsProcessExitError,
   type VcsProcessExitFailureKind,
+  VcsProcessMissingExitCodeError,
+  VcsProcessOutputLimitError,
+  VcsProcessOutputReadError,
   VcsProcessSpawnError,
+  VcsProcessStdinWriteError,
   VcsProcessTimeoutError,
 } from "@t3tools/contracts";
 import * as ProcessRunner from "../processRunner.ts";
@@ -114,19 +117,32 @@ export const make = Effect.gen(function* () {
             ProcessSpawnError: (error) =>
               VcsProcessSpawnError.fromProcessSpawnError(baseError, error),
             ProcessOutputLimitError: (error) =>
-              VcsOutputDecodeError.fromProcessOutputLimitError(baseError, error),
+              new VcsProcessOutputLimitError({
+                ...baseError,
+                stream: error.stream,
+                maxBytes: error.maxBytes,
+                observedBytes: error.observedBytes,
+              }),
             ProcessTimeoutError: (error) =>
               VcsProcessTimeoutError.fromProcessTimeoutError(baseError, error),
             ProcessStdinError: (error) =>
-              VcsOutputDecodeError.fromProcessStdinError(baseError, error),
+              new VcsProcessStdinWriteError({
+                ...baseError,
+                stdinBytes: error.stdinBytes,
+                cause: error.cause,
+              }),
             ProcessReadError: (error) =>
-              VcsOutputDecodeError.fromProcessReadError(baseError, error),
+              new VcsProcessOutputReadError({
+                ...baseError,
+                stream: error.stream,
+                cause: error.cause,
+              }),
           }),
         ),
       );
 
     if (result.code === null) {
-      return yield* VcsOutputDecodeError.missingExitCode(baseError);
+      return yield* new VcsProcessMissingExitCodeError(baseError);
     }
 
     if (!input.allowNonZeroExit && result.code !== 0) {

--- a/packages/contracts/src/vcs.ts
+++ b/packages/contracts/src/vcs.ts
@@ -69,20 +69,6 @@ export interface VcsProcessSpawnFailure {
   readonly cause: unknown;
 }
 
-export interface VcsProcessStdinFailure {
-  readonly cause: unknown;
-}
-
-export interface VcsProcessReadFailure {
-  readonly stream: "stdout" | "stderr" | "exitCode";
-  readonly cause: unknown;
-}
-
-export interface VcsProcessOutputLimitFailure {
-  readonly stream: "stdout" | "stderr";
-  readonly maxBytes: number;
-}
-
 export interface VcsProcessTimeoutFailure {
   readonly timeoutMs: number;
 }
@@ -189,57 +175,69 @@ export class VcsProcessTimeoutError extends Schema.TaggedErrorClass<VcsProcessTi
   }
 }
 
-export class VcsOutputDecodeError extends Schema.TaggedErrorClass<VcsOutputDecodeError>()(
-  "VcsOutputDecodeError",
+const VcsProcessBoundaryErrorFields = {
+  operation: Schema.String,
+  command: Schema.String,
+  cwd: Schema.String,
+  argumentCount: Schema.optional(NonNegativeInt),
+};
+
+export class VcsProcessStdinWriteError extends Schema.TaggedErrorClass<VcsProcessStdinWriteError>()(
+  "VcsProcessStdinWriteError",
   {
-    operation: Schema.String,
-    command: Schema.String,
-    cwd: Schema.String,
-    argumentCount: Schema.optional(NonNegativeInt),
-    detail: Schema.String,
-    cause: Schema.optional(Schema.Defect()),
+    ...VcsProcessBoundaryErrorFields,
+    stdinBytes: NonNegativeInt,
+    cause: Schema.Defect(),
   },
 ) {
   override get message(): string {
-    return `VCS output decode failed in ${this.operation}: ${this.command} (${this.cwd}) - ${this.detail}`;
-  }
-
-  static fromProcessStdinError(context: VcsProcessErrorContext, error: VcsProcessStdinFailure) {
-    return new VcsOutputDecodeError({
-      ...context,
-      detail: "failed to write process stdin",
-      cause: error.cause,
-    });
-  }
-
-  static fromProcessReadError(context: VcsProcessErrorContext, error: VcsProcessReadFailure) {
-    return new VcsOutputDecodeError({
-      ...context,
-      detail:
-        error.stream === "exitCode"
-          ? "failed to read process exit code"
-          : `failed to read process ${error.stream}`,
-      cause: error.cause,
-    });
-  }
-
-  static fromProcessOutputLimitError(
-    context: VcsProcessErrorContext,
-    error: VcsProcessOutputLimitFailure,
-  ) {
-    return new VcsOutputDecodeError({
-      ...context,
-      detail: `process ${error.stream} exceeded ${error.maxBytes} bytes`,
-    });
-  }
-
-  static missingExitCode(context: VcsProcessErrorContext) {
-    return new VcsOutputDecodeError({
-      ...context,
-      detail: "process completed without an exit code",
-    });
+    return `VCS process failed to write ${this.stdinBytes} bytes to stdin in ${this.operation}: ${this.command} (${this.cwd})`;
   }
 }
+
+export class VcsProcessOutputReadError extends Schema.TaggedErrorClass<VcsProcessOutputReadError>()(
+  "VcsProcessOutputReadError",
+  {
+    ...VcsProcessBoundaryErrorFields,
+    stream: Schema.Literals(["stdout", "stderr", "exitCode"]),
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `VCS process failed to read ${this.stream} in ${this.operation}: ${this.command} (${this.cwd})`;
+  }
+}
+
+export class VcsProcessOutputLimitError extends Schema.TaggedErrorClass<VcsProcessOutputLimitError>()(
+  "VcsProcessOutputLimitError",
+  {
+    ...VcsProcessBoundaryErrorFields,
+    stream: Schema.Literals(["stdout", "stderr"]),
+    maxBytes: NonNegativeInt,
+    observedBytes: NonNegativeInt,
+  },
+) {
+  override get message(): string {
+    return `VCS process ${this.stream} produced ${this.observedBytes} bytes in ${this.operation}: ${this.command} (${this.cwd}), exceeding the ${this.maxBytes} byte limit`;
+  }
+}
+
+export class VcsProcessMissingExitCodeError extends Schema.TaggedErrorClass<VcsProcessMissingExitCodeError>()(
+  "VcsProcessMissingExitCodeError",
+  VcsProcessBoundaryErrorFields,
+) {
+  override get message(): string {
+    return `VCS process completed without an exit code in ${this.operation}: ${this.command} (${this.cwd})`;
+  }
+}
+
+export const VcsOutputDecodeError = Schema.Union([
+  VcsProcessStdinWriteError,
+  VcsProcessOutputReadError,
+  VcsProcessOutputLimitError,
+  VcsProcessMissingExitCodeError,
+]);
+export type VcsOutputDecodeError = typeof VcsOutputDecodeError.Type;
 
 export class VcsRepositoryDetectionError extends Schema.TaggedErrorClass<VcsRepositoryDetectionError>()(
   "VcsRepositoryDetectionError",
@@ -272,7 +270,10 @@ export const VcsError = Schema.Union([
   VcsProcessSpawnError,
   VcsProcessExitError,
   VcsProcessTimeoutError,
-  VcsOutputDecodeError,
+  VcsProcessStdinWriteError,
+  VcsProcessOutputReadError,
+  VcsProcessOutputLimitError,
+  VcsProcessMissingExitCodeError,
   VcsRepositoryDetectionError,
   VcsUnsupportedOperationError,
 ]);


### PR DESCRIPTION
## Problem

`VcsOutputDecodeError` grouped stdin writes, process reads, output limits, and missing exit codes behind one tag and a free-form `detail` string. That erased useful byte and stream diagnostics, made the message depend on manually manufactured text, and allowed real I/O causes and structural no-cause failures to share the same loose shape.

## Change

Replace the single error class with a `Schema.Union` of distinct tagged errors for stdin writes, output reads, output limits, and missing exit codes. The errors now expose safe structured fields such as `stream`, `stdinBytes`, `maxBytes`, and `observedBytes`; real stdin/read failures retain their exact underlying cause, while output-limit and missing-code conditions do not manufacture one. Messages derive only from those structured fields and never from a cause or captured output.

`VcsProcess` constructs the errors directly at the mapping boundary, and the exhaustive GitLab CLI mapper recognizes the new tags without changing its existing fallback behavior. The focused backend test verifies exact-cause identity, safe messages, and the absence of a synthetic cause for a missing exit code.

## Validation

- `vp test run apps/server/src/vcs/VcsProcess.test.ts apps/server/src/sourceControl/GitLabCli.test.ts` (18 tests)
- `vp check` (passes; existing unrelated warnings remain)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `@t3tools/contracts` error shapes and the core `VcsProcess` boundary; callers matching on `VcsError` tags must handle four tags instead of one, though the union alias preserves grouping.
> 
> **Overview**
> Replaces the single **`VcsOutputDecodeError`** (free-form `detail`) with four distinct tagged errors: **`VcsProcessStdinWriteError`**, **`VcsProcessOutputReadError`**, **`VcsProcessOutputLimitError`**, and **`VcsProcessMissingExitCodeError`**. Each exposes structured fields (`stdinBytes`, `stream`, `maxBytes`, `observedBytes`) and messages derived from those fields only; real I/O failures keep their underlying `cause`, while limit and missing-exit-code cases do not invent one.
> 
> **`VcsProcess`** maps `ProcessRunner` failures directly to these types instead of factory helpers on the old class. **`VcsError`** lists the four tags individually; **`VcsOutputDecodeError`** remains as a **`Schema.Union`** alias for backward grouping. **GitLab CLI**’s exhaustive `fromVcsError` matcher adds cases for each new tag, all falling through to **`GitLabCliCommandError`** like before.
> 
> Tests add a mocked **`ProcessRunner`** path to assert exact cause identity, safe messages, and no synthetic `cause` on missing exit code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6747ab7a4781d0a9192755d4bf6ebe6b631ae1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Structure VCS process boundary errors into granular error types
> - Replaces the single `VcsOutputDecodeError` class in [`vcs.ts`](https://github.com/pingdotgg/t3code/pull/3476/files#diff-4c8c2b37831e8d24699e4f86f07c837774b30d7a7a97bd52322ca8b08d92b80e) with four dedicated error classes: `VcsProcessStdinWriteError`, `VcsProcessOutputReadError`, `VcsProcessOutputLimitError`, and `VcsProcessMissingExitCodeError`, each with structured fields and specific tags.
> - Updates [`VcsProcess.ts`](https://github.com/pingdotgg/t3code/pull/3476/files#diff-42ce5a28bf0b16d9cc4fdfbca0e82279f369588e696972ab8b199fe9df69336d) to emit these granular types instead of the old `VcsOutputDecodeError` factory methods, preserving underlying causes for stdin/read failures.
> - Updates [`GitLabCli.ts`](https://github.com/pingdotgg/t3code/pull/3476/files#diff-89856450646a3d6128d2d758713ca3279cd16397b9535c8549f7a8b450f8c81d) to map each new error tag to a `GitLabCliCommandError` with the original cause preserved.
> - `VcsOutputDecodeError` is retained as a union type alias over the four new classes for backward compatibility with existing consumers.
> - Behavioral Change: `VcsError` consumers will now see distinct tags per boundary error type rather than a single generic `VcsOutputDecodeError` tag.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a6747ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->