### PR TITLE
[codex] Structure Tailscale status parse diagnostics

### DIFF
--- a/packages/tailscale/src/tailscale.test.ts
+++ b/packages/tailscale/src/tailscale.test.ts
@@ -108,10 +108,15 @@ describe("tailscale", () => {
 
   it.effect("preserves status decoding failures without exposing cause text", () =>
     Effect.gen(function* () {
-      const error = yield* parseTailscaleStatus("{not-json").pipe(Effect.flip);
+      const malformedStatus = "{not-json";
+      const error = yield* parseTailscaleStatus(malformedStatus).pipe(Effect.flip);
 
       assert.instanceOf(error, TailscaleStatusParseError);
-      assert.equal(error.message, "Failed to decode tailscale status JSON.");
+      assert.equal(error.inputLength, malformedStatus.length);
+      assert.equal(
+        error.message,
+        `Failed to decode ${malformedStatus.length}-character tailscale status JSON.`,
+      );
       assert.isDefined(error.cause);
       assert.notInclude(error.message, String(error.cause));
     }),

--- a/packages/tailscale/src/tailscale.ts
+++ b/packages/tailscale/src/tailscale.ts
@@ -84,10 +84,13 @@ export type TailscaleCommandError = typeof TailscaleCommandError.Type;
 
 export class TailscaleStatusParseError extends Schema.TaggedErrorClass<TailscaleStatusParseError>()(
   "TailscaleStatusParseError",
-  { cause: Schema.Defect() },
+  {
+    inputLength: Schema.Number,
+    cause: Schema.Defect(),
+  },
 ) {
   override get message(): string {
-    return "Failed to decode tailscale status JSON.";
+    return `Failed to decode ${this.inputLength}-character tailscale status JSON.`;
   }
 }
 
@@ -135,7 +138,9 @@ export const parseTailscaleMagicDnsName = (
   rawStatusJson: string,
 ): Effect.Effect<string | null, TailscaleStatusParseError> =>
   decodeTailscaleStatusJson(rawStatusJson).pipe(
-    Effect.mapError((cause) => new TailscaleStatusParseError({ cause })),
+    Effect.mapError(
+      (cause) => new TailscaleStatusParseError({ inputLength: rawStatusJson.length, cause }),
+    ),
     Effect.map(normalizeMagicDnsName),
   );
 
@@ -161,7 +166,9 @@ export const parseTailscaleStatus = (
   rawStatusJson: string,
 ): Effect.Effect<TailscaleStatus, TailscaleStatusParseError> =>
   decodeTailscaleStatusJson(rawStatusJson).pipe(
-    Effect.mapError((cause) => new TailscaleStatusParseError({ cause })),
+    Effect.mapError(
+      (cause) => new TailscaleStatusParseError({ inputLength: rawStatusJson.length, cause }),
+    ),
     Effect.map((parsed) => {
       const rawIps = parsed.Self?.TailscaleIPs;
       const tailnetIpv4Addresses: Array<string> = [];


### PR DESCRIPTION
## Summary

- attach the safe input length to Tailscale status decode failures
- derive the error message from that structural context while retaining the exact schema decode cause
- extend the existing focused failure test without adding a separate refactor-only test

## Validation

- `vp test packages/tailscale/src/tailscale.test.ts` (12 passed)
- `vp check` (baseline warnings only)
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to error shape and messaging in the tailscale package with no security or behavioral changes to parsing logic.
> 
> **Overview**
> **`TailscaleStatusParseError`** now carries **`inputLength`** (bytes/chars of the raw status JSON) and builds its public message from that count, e.g. `Failed to decode N-character tailscale status JSON.`
> 
> Both **`parseTailscaleStatus`** and **`parseTailscaleMagicDnsName`** pass **`rawStatusJson.length`** when mapping decode failures; the underlying schema **`cause`** is unchanged and still kept out of the message. The existing parse-failure test asserts **`inputLength`** and the new message wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72591c08a933f98d5c43e7f966da602f0752b4ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `inputLength` field to `TailscaleStatusParseError` and include it in the error message
> Extends `TailscaleStatusParseError` in [`tailscale.ts`](https://github.com/pingdotgg/t3code/pull/3477/files#diff-580f62662917cf32d498487b66719be157805c6a8b3cd04d84bb278fef541e43) with a numeric `inputLength` field set to the length of the raw JSON string that failed to parse. The error message now interpolates this value instead of returning a constant string. Both `parseTailscaleStatus` and `parseTailscaleMagicDnsName` pass `inputLength` when constructing the error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72591c0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->