### PR TITLE
fix(cursor): default binary path to cursor-agent  PR Description

### DIFF
--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -1,4 +1,8 @@
-import { type CursorSettings, type ProviderOptionSelection } from "@t3tools/contracts";
+import {
+  DEFAULT_CURSOR_BINARY_PATH,
+  type CursorSettings,
+  type ProviderOptionSelection,
+} from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -36,7 +40,7 @@ export function buildCursorAcpSpawnInput(
   environment?: NodeJS.ProcessEnv,
 ): AcpSessionRuntime.AcpSpawnInput {
   return {
-    command: cursorSettings?.binaryPath || "cursor-agent",
+    command: cursorSettings?.binaryPath || DEFAULT_CURSOR_BINARY_PATH,
     args: [
       ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
       "acp",

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -1,8 +1,4 @@
-import {
-  DEFAULT_CURSOR_BINARY_PATH,
-  type CursorSettings,
-  type ProviderOptionSelection,
-} from "@t3tools/contracts";
+import { type CursorSettings, type ProviderOptionSelection } from "@t3tools/contracts";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -40,7 +36,7 @@ export function buildCursorAcpSpawnInput(
   environment?: NodeJS.ProcessEnv,
 ): AcpSessionRuntime.AcpSpawnInput {
   return {
-    command: cursorSettings?.binaryPath || DEFAULT_CURSOR_BINARY_PATH,
+    command: cursorSettings?.binaryPath || "cursor-agent",
     args: [
       ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
       "acp",

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -4,6 +4,7 @@ import * as Schema from "effect/Schema";
 import { ProviderInstanceId } from "./providerInstance.ts";
 import {
   ClientSettingsSchema,
+  CursorSettings,
   DEFAULT_SERVER_SETTINGS,
   ServerSettings,
   ServerSettingsPatch,
@@ -126,6 +127,24 @@ describe("ServerSettingsPatch.providerInstances", () => {
     });
     const ollamaId = ProviderInstanceId.make("ollama_local");
     expect(patch.providerInstances?.[ollamaId]?.driver).toBe("ollama");
+  });
+});
+
+describe("CursorSettings binary path", () => {
+  const decodeCursorSettings = Schema.decodeUnknownSync(CursorSettings);
+
+  it("defaults to cursor-agent", () => {
+    expect(decodeCursorSettings({}).binaryPath).toBe("cursor-agent");
+  });
+
+  it("maps the legacy agent binary name to cursor-agent", () => {
+    expect(decodeCursorSettings({ binaryPath: "agent" }).binaryPath).toBe("cursor-agent");
+  });
+
+  it("preserves explicit binary paths", () => {
+    expect(decodeCursorSettings({ binaryPath: "/usr/local/bin/agent" }).binaryPath).toBe(
+      "/usr/local/bin/agent",
+    );
   });
 });
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -114,6 +114,25 @@ const makeBinaryPathSetting = (fallback: string) =>
     Schema.withDecodingDefault(Effect.succeed(fallback)),
   );
 
+export const LEGACY_CURSOR_BINARY_PATH = "agent";
+export const DEFAULT_CURSOR_BINARY_PATH = "cursor-agent";
+
+export const normalizeCursorBinaryPath = (value: string): string =>
+  value === LEGACY_CURSOR_BINARY_PATH ? DEFAULT_CURSOR_BINARY_PATH : value;
+
+const makeCursorBinaryPathSetting = () =>
+  TrimmedString.pipe(
+    Schema.decodeTo(
+      Schema.String,
+      SchemaTransformation.transformOrFail({
+        decode: (value) =>
+          Effect.succeed(normalizeCursorBinaryPath(value || DEFAULT_CURSOR_BINARY_PATH)),
+        encode: (value) => Effect.succeed(value),
+      }),
+    ),
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_CURSOR_BINARY_PATH)),
+  );
+
 export type ProviderSettingsFormControl = "text" | "password" | "textarea" | "switch";
 
 export interface ProviderSettingsFormAnnotation {
@@ -252,7 +271,7 @@ export const CursorSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed(false)),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
-    binaryPath: makeBinaryPathSetting("cursor-agent").pipe(
+    binaryPath: makeCursorBinaryPathSetting().pipe(
       Schema.annotateKey({
         title: "Binary path",
         description: "Path to the Cursor agent binary.",


### PR DESCRIPTION
Fixes #3479

When Grok CLI is installed alongside Cursor, the shared `agent` command name resolves to Grok and breaks Cursor ACP discovery. Default Cursor to `cursor-agent`, map legacy `agent` configs on decode, and align update probes and spawn fallbacks with the new binary name.

## What Changed

- Changed the default Cursor `binaryPath` from `agent` to `cursor-agent`
- Added decode-time migration so existing configs with `binaryPath: "agent"` resolve to `cursor-agent` (explicit full paths are unchanged)
- Updated Cursor ACP spawn fallbacks, provider update probes, and related tests to use `cursor-agent`

## Why

T3 was invoking `agent acp` for Cursor provider discovery. On machines where both Grok CLI and Cursor are installed, `agent` often resolves to Grok first, causing Cursor ACP model discovery to fail with `AcpTransportError` even though `cursor-agent` works correctly.

`cursor-agent` is the correct Cursor CLI binary name and avoids this collision. Mapping legacy `"agent"` values preserves existing user configs without requiring a manual settings change.

## UI Changes

N/A — server-side provider discovery and settings default only. The settings placeholder now shows `cursor-agent` instead of `agent`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Cursor provider binary path defaults and decode-time normalization in settings; no auth, data, or broad behavioral changes beyond which executable is invoked.
> 
> **Overview**
> Cursor provider settings now default **`binaryPath`** to **`cursor-agent`** instead of **`agent`**, avoiding PATH collisions when Grok CLI also installs an `agent` command and breaking Cursor ACP discovery.
> 
> The contracts layer adds **`normalizeCursorBinaryPath`** and a dedicated decode path via **`makeCursorBinaryPathSetting`**: empty values default to **`cursor-agent`**, stored **`"agent"`** is rewritten to **`cursor-agent`** on read, and explicit paths (e.g. **`/usr/local/bin/agent`**) are left unchanged. The settings form placeholder is updated to **`cursor-agent`**. Unit tests cover default, legacy, and explicit-path behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 220eab8083108066bd8d17d49584487583d52ddc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default `CursorSettings.binaryPath` to `cursor-agent` and migrate legacy `agent` value
> Updates the `binaryPath` field in `CursorSettings` to use a new `makeCursorBinaryPathSetting()` builder in [settings.ts](https://github.com/pingdotgg/t3code/pull/3481/files#diff-82d7525e9c2a6a61cd5d416ceaeba40992140373eb7ac00fa3a91c2edd00bc3c). Missing or empty values decode to `'cursor-agent'`, and the legacy value `'agent'` is remapped to `'cursor-agent'`. Explicit absolute paths are preserved as-is.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 220eab8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->