### PR TITLE
Add automatic provider instance fallback

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -9,6 +9,7 @@ import {
   type OrchestrationSession,
   ThreadId,
   type ProviderSession,
+  type ProviderSendTurnInput,
   type RuntimeMode,
   type TurnId,
 } from "@t3tools/contracts";
@@ -829,26 +830,31 @@ const make = Effect.gen(function* () {
 
     const attemptFallbackBeforeReporting = Effect.fnUntraced(function* (
       cause: Cause.Cause<unknown>,
+      attemptedSendTurnInput?: ProviderSendTurnInput,
     ) {
       const failure = classifyProviderServiceFailure(cause);
       if (!failure) return false;
-      const modelSelection = event.payload.modelSelection ?? thread.modelSelection;
+      const modelSelection =
+        attemptedSendTurnInput?.modelSelection ??
+        event.payload.modelSelection ??
+        thread.modelSelection;
+      const sendTurnInput: ProviderSendTurnInput = attemptedSendTurnInput ?? {
+        threadId: event.payload.threadId,
+        ...(toNonEmptyProviderInput(message.text)
+          ? { input: toNonEmptyProviderInput(message.text) }
+          : {}),
+        ...(message.attachments && message.attachments.length > 0
+          ? { attachments: message.attachments }
+          : {}),
+        modelSelection,
+        interactionMode: event.payload.interactionMode,
+      };
       const fallback = yield* attemptProviderFallback({
         threadId: event.payload.threadId,
-        currentInstanceId: modelSelection.instanceId,
+        failedInstanceId: modelSelection.instanceId,
         modelSelection,
         runtimeMode: event.payload.runtimeMode,
-        sendTurnInput: {
-          threadId: event.payload.threadId,
-          ...(toNonEmptyProviderInput(message.text)
-            ? { input: toNonEmptyProviderInput(message.text) }
-            : {}),
-          ...(message.attachments && message.attachments.length > 0
-            ? { attachments: message.attachments }
-            : {}),
-          modelSelection,
-          interactionMode: event.payload.interactionMode,
-        },
+        sendTurnInput,
         failure,
         requireCompatibleContinuation: !isFirstUserMessageTurn,
         createdAt: event.payload.createdAt,
@@ -856,8 +862,11 @@ const make = Effect.gen(function* () {
       return fallback.switched;
     });
 
-    const recoverTurnStartFailure = (cause: Cause.Cause<unknown>) =>
-      attemptFallbackBeforeReporting(cause).pipe(
+    const recoverTurnStartFailure = (
+      cause: Cause.Cause<unknown>,
+      attemptedSendTurnInput?: ProviderSendTurnInput,
+    ) =>
+      attemptFallbackBeforeReporting(cause, attemptedSendTurnInput).pipe(
         Effect.catchCause((fallbackCause) =>
           Effect.logWarning("provider command reactor fallback attempt failed", {
             eventType: event.type,
@@ -895,9 +904,10 @@ const make = Effect.gen(function* () {
       return;
     }
 
-    yield* providerService
-      .sendTurn(sendTurnRequest.value)
-      .pipe(Effect.catchCause(recoverTurnStartFailure), Effect.forkScoped);
+    yield* providerService.sendTurn(sendTurnRequest.value).pipe(
+      Effect.catchCause((cause) => recoverTurnStartFailure(cause, sendTurnRequest.value)),
+      Effect.forkScoped,
+    );
   });
 
   const processTurnInterruptRequested = Effect.fn("processTurnInterruptRequested")(function* (

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -44,6 +44,7 @@ import { ServerSettingsService } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
 import { attemptProviderFallback } from "../providerFallbackWorkflow.ts";
+import { completeProviderFallbackChain } from "../providerFallbackChain.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
 
@@ -772,6 +773,10 @@ const make = Effect.gen(function* () {
       });
       return;
     }
+
+    // A visible user turn starts a new fallback chain. Mid-task fallback turns
+    // bypass this reactor, so their attempted-instance history remains intact.
+    completeProviderFallbackChain(thread.id);
 
     const isFirstUserMessageTurn =
       thread.messages.filter((entry) => entry.role === "user").length === 1;

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -29,6 +29,7 @@ import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
 import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
 import type { ProviderServiceError } from "../../provider/Errors.ts";
+import { classifyProviderServiceFailure } from "../../provider/providerFallback.ts";
 import { TextGeneration } from "../../textGeneration/TextGeneration.ts";
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
 import { ProviderRegistry } from "../../provider/Services/ProviderRegistry.ts";
@@ -41,6 +42,7 @@ import {
 import { ServerSettingsService } from "../../serverSettings.ts";
 import { VcsStatusBroadcaster } from "../../vcs/VcsStatusBroadcaster.ts";
 import { GitWorkflowService } from "../../git/GitWorkflowService.ts";
+import { attemptProviderFallback } from "../providerFallbackWorkflow.ts";
 const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
 
@@ -825,8 +827,46 @@ const make = Effect.gen(function* () {
       );
     };
 
+    const attemptFallbackBeforeReporting = Effect.fnUntraced(function* (
+      cause: Cause.Cause<unknown>,
+    ) {
+      const failure = classifyProviderServiceFailure(cause);
+      if (!failure) return false;
+      const modelSelection = event.payload.modelSelection ?? thread.modelSelection;
+      const fallback = yield* attemptProviderFallback({
+        threadId: event.payload.threadId,
+        currentInstanceId: modelSelection.instanceId,
+        modelSelection,
+        runtimeMode: event.payload.runtimeMode,
+        sendTurnInput: {
+          threadId: event.payload.threadId,
+          ...(toNonEmptyProviderInput(message.text)
+            ? { input: toNonEmptyProviderInput(message.text) }
+            : {}),
+          ...(message.attachments && message.attachments.length > 0
+            ? { attachments: message.attachments }
+            : {}),
+          modelSelection,
+          interactionMode: event.payload.interactionMode,
+        },
+        failure,
+        requireCompatibleContinuation: !isFirstUserMessageTurn,
+        createdAt: event.payload.createdAt,
+      });
+      return fallback.switched;
+    });
+
     const recoverTurnStartFailure = (cause: Cause.Cause<unknown>) =>
-      handleTurnStartFailure(cause).pipe(
+      attemptFallbackBeforeReporting(cause).pipe(
+        Effect.catchCause((fallbackCause) =>
+          Effect.logWarning("provider command reactor fallback attempt failed", {
+            eventType: event.type,
+            threadId: event.payload.threadId,
+            cause: Cause.pretty(fallbackCause),
+            originalCause: Cause.pretty(cause),
+          }).pipe(Effect.as(false)),
+        ),
+        Effect.flatMap((switched) => (switched ? Effect.void : handleTurnStartFailure(cause))),
         Effect.catchCause((recoveryCause) =>
           Effect.logWarning("provider command reactor failed to recover turn start failure", {
             eventType: event.type,
@@ -848,7 +888,7 @@ const make = Effect.gen(function* () {
       createdAt: event.payload.createdAt,
     }).pipe(
       Effect.map(Option.some),
-      Effect.catchCause((cause) => handleTurnStartFailure(cause).pipe(Effect.as(Option.none()))),
+      Effect.catchCause((cause) => recoverTurnStartFailure(cause).pipe(Effect.as(Option.none()))),
     );
 
     if (Option.isNone(sendTurnRequest)) {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.test.ts
@@ -39,6 +39,7 @@ import {
   ProviderService,
   type ProviderServiceShape,
 } from "../../provider/Services/ProviderService.ts";
+import { makeProviderRegistryLayer } from "../../provider/testUtils/providerRegistryMock.ts";
 import * as RepositoryIdentityResolver from "../../project/RepositoryIdentityResolver.ts";
 import { OrchestrationEngineLive } from "./OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./ProjectionPipeline.ts";
@@ -238,6 +239,7 @@ describe("ProviderRuntimeIngestion", () => {
       Layer.provideMerge(projectionSnapshotLayer),
       Layer.provideMerge(SqlitePersistenceMemory),
       Layer.provideMerge(Layer.succeed(ProviderService, provider.service)),
+      Layer.provideMerge(makeProviderRegistryLayer([])),
       Layer.provideMerge(makeTestServerSettingsLayer(options?.serverSettings)),
       Layer.provideMerge(ServerConfig.layerTest(process.cwd(), process.cwd())),
       Layer.provideMerge(NodeServices.layer),

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -39,10 +39,9 @@ import {
   type ProviderRuntimeIngestionShape,
 } from "../Services/ProviderRuntimeIngestion.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
-import {
-  attemptProviderFallback,
-  isProviderFallbackTrialInstance,
-} from "../providerFallbackWorkflow.ts";
+import { attemptProviderFallback } from "../providerFallbackWorkflow.ts";
+import { decideProviderFallbackTrialEvent } from "../providerFallbackTrialGate.ts";
+import { completeProviderFallbackChain } from "../providerFallbackChain.ts";
 
 const providerTurnKey = (threadId: ThreadId, turnId: TurnId) => `${threadId}:${turnId}`;
 
@@ -1221,14 +1220,28 @@ const make = Effect.gen(function* () {
       const thread = yield* resolveThreadShell(event.threadId);
       if (!thread) return;
 
-      // Trial sessions can emit before a fallback handoff commits or after it
-      // rolls back. Ignore events from an instance that no longer owns the
-      // thread so stale trial output cannot overwrite the restored binding.
+      // A fallback candidate can emit before sendTurn confirms the handoff.
+      // Hold those events until the trial commits, or discard them if it rolls
+      // back, so provisional output never leaks into the thread projection.
+      const fallbackTrialDecision =
+        event.providerInstanceId === undefined
+          ? "not-trial"
+          : yield* decideProviderFallbackTrialEvent(
+              thread.id,
+              event.providerInstanceId,
+              event.createdAt,
+            );
+      if (fallbackTrialDecision === "reject") {
+        return;
+      }
+
+      // Ignore events from an instance that no longer owns the thread. A
+      // committed trial is accepted during the narrow projection handoff.
       if (
         event.providerInstanceId !== undefined &&
         thread.session?.providerInstanceId !== undefined &&
         event.providerInstanceId !== thread.session.providerInstanceId &&
-        !isProviderFallbackTrialInstance(thread.id, event.providerInstanceId)
+        fallbackTrialDecision !== "accept"
       ) {
         return;
       }
@@ -1284,6 +1297,14 @@ const make = Effect.gen(function* () {
           );
           if (fallback.switched) return;
         }
+      }
+
+      if (
+        !fallbackFailure &&
+        fallbackInstanceId !== undefined &&
+        (event.type === "turn.completed" || event.type === "session.exited")
+      ) {
+        completeProviderFallbackChain(thread.id, fallbackInstanceId);
       }
 
       const conflictsWithActiveTurn =

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -39,7 +39,10 @@ import {
   type ProviderRuntimeIngestionShape,
 } from "../Services/ProviderRuntimeIngestion.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
-import { attemptProviderFallback } from "../providerFallbackWorkflow.ts";
+import {
+  attemptProviderFallback,
+  isProviderFallbackTrialInstance,
+} from "../providerFallbackWorkflow.ts";
 
 const providerTurnKey = (threadId: ThreadId, turnId: TurnId) => `${threadId}:${turnId}`;
 
@@ -1224,7 +1227,8 @@ const make = Effect.gen(function* () {
       if (
         event.providerInstanceId !== undefined &&
         thread.session?.providerInstanceId !== undefined &&
-        event.providerInstanceId !== thread.session.providerInstanceId
+        event.providerInstanceId !== thread.session.providerInstanceId &&
+        !isProviderFallbackTrialInstance(thread.id, event.providerInstanceId)
       ) {
         return;
       }
@@ -1256,7 +1260,7 @@ const make = Effect.gen(function* () {
           yield* Cache.set(handledFallbackEvents, fallbackKey, true);
           const fallback = yield* attemptProviderFallback({
             threadId: thread.id,
-            currentInstanceId: fallbackInstanceId,
+            failedInstanceId: fallbackInstanceId,
             modelSelection: thread.modelSelection,
             runtimeMode: thread.runtimeMode,
             sendTurnInput: {

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -28,6 +28,7 @@ import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
 import { ProviderService } from "../../provider/Services/ProviderService.ts";
+import { classifyProviderRuntimeFailure } from "../../provider/providerFallback.ts";
 import { ProjectionTurnRepository } from "../../persistence/Services/ProjectionTurns.ts";
 import { ProjectionTurnRepositoryLive } from "../../persistence/Layers/ProjectionTurns.ts";
 import { isGitRepository } from "../../git/Utils.ts";
@@ -38,6 +39,7 @@ import {
   type ProviderRuntimeIngestionShape,
 } from "../Services/ProviderRuntimeIngestion.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
+import { attemptProviderFallback } from "../providerFallbackWorkflow.ts";
 
 const providerTurnKey = (threadId: ThreadId, turnId: TurnId) => `${threadId}:${turnId}`;
 
@@ -54,6 +56,8 @@ const BUFFERED_MESSAGE_TEXT_BY_MESSAGE_ID_TTL = Duration.minutes(120);
 const BUFFERED_PROPOSED_PLAN_BY_ID_CACHE_CAPACITY = 10_000;
 const BUFFERED_PROPOSED_PLAN_BY_ID_TTL = Duration.minutes(120);
 const MAX_BUFFERED_ASSISTANT_CHARS = 24_000;
+const HANDLED_FALLBACK_EVENT_CACHE_CAPACITY = 10_000;
+const HANDLED_FALLBACK_EVENT_TTL = Duration.minutes(120);
 const STRICT_PROVIDER_LIFECYCLE_GUARD = process.env.T3CODE_STRICT_PROVIDER_LIFECYCLE_GUARD !== "0";
 
 type TurnStartRequestedDomainEvent = Extract<
@@ -666,6 +670,12 @@ const make = Effect.gen(function* () {
     lookup: () => Effect.succeed({ text: "", createdAt: "" }),
   });
 
+  const handledFallbackEvents = yield* Cache.make<string, true>({
+    capacity: HANDLED_FALLBACK_EVENT_CACHE_CAPACITY,
+    timeToLive: HANDLED_FALLBACK_EVENT_TTL,
+    lookup: () => Effect.succeed(true),
+  });
+
   const resolveThreadDetail = Effect.fn("resolveThreadDetail")(function* (threadId: ThreadId) {
     return yield* projectionSnapshotQuery
       .getThreadDetailById(threadId)
@@ -1208,6 +1218,17 @@ const make = Effect.gen(function* () {
       const thread = yield* resolveThreadShell(event.threadId);
       if (!thread) return;
 
+      // Trial sessions can emit before a fallback handoff commits or after it
+      // rolls back. Ignore events from an instance that no longer owns the
+      // thread so stale trial output cannot overwrite the restored binding.
+      if (
+        event.providerInstanceId !== undefined &&
+        thread.session?.providerInstanceId !== undefined &&
+        event.providerInstanceId !== thread.session.providerInstanceId
+      ) {
+        return;
+      }
+
       let loadedThreadDetail: OrchestrationThread | null | undefined;
       const getLoadedThreadDetail = () =>
         Effect.gen(function* () {
@@ -1221,6 +1242,45 @@ const make = Effect.gen(function* () {
       const now = event.createdAt;
       const eventTurnId = toTurnId(event.turnId);
       const activeTurnId = thread.session?.activeTurnId ?? null;
+
+      const fallbackFailure = classifyProviderRuntimeFailure(event);
+      const fallbackInstanceId = event.providerInstanceId ?? thread.session?.providerInstanceId;
+      if (
+        fallbackFailure &&
+        fallbackInstanceId !== undefined &&
+        (activeTurnId !== null || eventTurnId !== undefined)
+      ) {
+        const fallbackKey = `${thread.id}:${fallbackInstanceId}:${eventTurnId ?? activeTurnId ?? event.eventId}`;
+        const handled = yield* Cache.getOption(handledFallbackEvents, fallbackKey);
+        if (Option.isNone(handled)) {
+          yield* Cache.set(handledFallbackEvents, fallbackKey, true);
+          const fallback = yield* attemptProviderFallback({
+            threadId: thread.id,
+            currentInstanceId: fallbackInstanceId,
+            modelSelection: thread.modelSelection,
+            runtimeMode: thread.runtimeMode,
+            sendTurnInput: {
+              threadId: thread.id,
+              input: "Continue.",
+              modelSelection: thread.modelSelection,
+              interactionMode: thread.interactionMode,
+            },
+            failure: fallbackFailure,
+            requireCompatibleContinuation: true,
+            createdAt: now,
+          }).pipe(
+            Effect.catchCause((cause) =>
+              Effect.logWarning("provider runtime fallback attempt failed", {
+                eventId: event.eventId,
+                eventType: event.type,
+                threadId: thread.id,
+                cause: Cause.pretty(cause),
+              }).pipe(Effect.as({ switched: false, skipped: [] })),
+            ),
+          );
+          if (fallback.switched) return;
+        }
+      }
 
       const conflictsWithActiveTurn =
         activeTurnId !== null && eventTurnId !== undefined && !sameId(activeTurnId, eventTurnId);

--- a/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
+++ b/apps/server/src/orchestration/Layers/ProviderRuntimeIngestion.ts
@@ -1292,10 +1292,16 @@ const make = Effect.gen(function* () {
                 eventType: event.type,
                 threadId: thread.id,
                 cause: Cause.pretty(cause),
-              }).pipe(Effect.as({ switched: false, skipped: [] })),
+              }).pipe(
+                Effect.as({
+                  switched: false,
+                  restoredOriginalInstance: false,
+                  skipped: [],
+                }),
+              ),
             ),
           );
-          if (fallback.switched) return;
+          if (fallback.switched || fallback.restoredOriginalInstance) return;
         }
       }
 

--- a/apps/server/src/orchestration/providerFallbackChain.test.ts
+++ b/apps/server/src/orchestration/providerFallbackChain.test.ts
@@ -1,0 +1,44 @@
+import { ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import {
+  beginProviderFallbackChain,
+  completeProviderFallbackChain,
+  markProviderFallbackInstanceAttempted,
+  resetProviderFallbackChainsForTest,
+} from "./providerFallbackChain.ts";
+
+const threadId = ThreadId.make("thread-1");
+const first = ProviderInstanceId.make("codex-first");
+const second = ProviderInstanceId.make("codex-second");
+const third = ProviderInstanceId.make("codex-third");
+
+afterEach(resetProviderFallbackChainsForTest);
+
+describe("provider fallback chain", () => {
+  it("retains every attempted instance across consecutive runtime failures", () => {
+    expect([...beginProviderFallbackChain(threadId, first)]).toEqual([first]);
+    markProviderFallbackInstanceAttempted(threadId, second);
+
+    expect([...beginProviderFallbackChain(threadId, second)]).toEqual([first, second]);
+    markProviderFallbackInstanceAttempted(threadId, third);
+
+    expect([...beginProviderFallbackChain(threadId, third)]).toEqual([first, second, third]);
+  });
+
+  it("starts a fresh chain after the active instance completes", () => {
+    beginProviderFallbackChain(threadId, first);
+    markProviderFallbackInstanceAttempted(threadId, second);
+    completeProviderFallbackChain(threadId, second);
+
+    expect([...beginProviderFallbackChain(threadId, second)]).toEqual([second]);
+  });
+
+  it("does not let a stale instance complete the current chain", () => {
+    beginProviderFallbackChain(threadId, first);
+    markProviderFallbackInstanceAttempted(threadId, second);
+    completeProviderFallbackChain(threadId, first);
+
+    expect([...beginProviderFallbackChain(threadId, second)]).toEqual([first, second]);
+  });
+});

--- a/apps/server/src/orchestration/providerFallbackChain.test.ts
+++ b/apps/server/src/orchestration/providerFallbackChain.test.ts
@@ -12,33 +12,61 @@ const threadId = ThreadId.make("thread-1");
 const first = ProviderInstanceId.make("codex-first");
 const second = ProviderInstanceId.make("codex-second");
 const third = ProviderInstanceId.make("codex-third");
+const origin = {
+  instanceId: first,
+  displayName: "Codex First",
+  failure: { kind: "rate-limit" as const, message: "Usage limit reached." },
+  modelSelection: { instanceId: first, model: "gpt-5" },
+  session: undefined,
+};
 
 afterEach(resetProviderFallbackChainsForTest);
 
 describe("provider fallback chain", () => {
   it("retains every attempted instance across consecutive runtime failures", () => {
-    expect([...beginProviderFallbackChain(threadId, first)]).toEqual([first]);
+    expect([...beginProviderFallbackChain(threadId, first, origin).attemptedInstanceIds]).toEqual([
+      first,
+    ]);
     markProviderFallbackInstanceAttempted(threadId, second);
 
-    expect([...beginProviderFallbackChain(threadId, second)]).toEqual([first, second]);
+    const secondAttempt = beginProviderFallbackChain(threadId, second, {
+      ...origin,
+      instanceId: second,
+    });
+    expect([...secondAttempt.attemptedInstanceIds]).toEqual([first, second]);
+    expect(secondAttempt.origin).toEqual(origin);
     markProviderFallbackInstanceAttempted(threadId, third);
 
-    expect([...beginProviderFallbackChain(threadId, third)]).toEqual([first, second, third]);
+    expect([...beginProviderFallbackChain(threadId, third, origin).attemptedInstanceIds]).toEqual([
+      first,
+      second,
+      third,
+    ]);
   });
 
   it("starts a fresh chain after the active instance completes", () => {
-    beginProviderFallbackChain(threadId, first);
+    beginProviderFallbackChain(threadId, first, origin);
     markProviderFallbackInstanceAttempted(threadId, second);
     completeProviderFallbackChain(threadId, second);
 
-    expect([...beginProviderFallbackChain(threadId, second)]).toEqual([second]);
+    expect([
+      ...beginProviderFallbackChain(threadId, second, {
+        ...origin,
+        instanceId: second,
+      }).attemptedInstanceIds,
+    ]).toEqual([second]);
   });
 
   it("does not let a stale instance complete the current chain", () => {
-    beginProviderFallbackChain(threadId, first);
+    beginProviderFallbackChain(threadId, first, origin);
     markProviderFallbackInstanceAttempted(threadId, second);
     completeProviderFallbackChain(threadId, first);
 
-    expect([...beginProviderFallbackChain(threadId, second)]).toEqual([first, second]);
+    expect([
+      ...beginProviderFallbackChain(threadId, second, {
+        ...origin,
+        instanceId: second,
+      }).attemptedInstanceIds,
+    ]).toEqual([first, second]);
   });
 });

--- a/apps/server/src/orchestration/providerFallbackChain.ts
+++ b/apps/server/src/orchestration/providerFallbackChain.ts
@@ -1,0 +1,65 @@
+import { type ProviderInstanceId, type ThreadId } from "@t3tools/contracts";
+
+interface ProviderFallbackChainState {
+  readonly attemptedInstanceIds: Set<ProviderInstanceId>;
+  activeInstanceId: ProviderInstanceId;
+}
+
+const PROVIDER_FALLBACK_CHAIN_CAPACITY = 10_000;
+const providerFallbackChains = new Map<ThreadId, ProviderFallbackChainState>();
+
+function makeRoomForProviderFallbackChain(): void {
+  if (providerFallbackChains.size < PROVIDER_FALLBACK_CHAIN_CAPACITY) return;
+  const oldestThreadId = providerFallbackChains.keys().next().value;
+  if (oldestThreadId !== undefined) {
+    providerFallbackChains.delete(oldestThreadId);
+  }
+}
+
+/**
+ * Starts a new chain or resumes the chain owned by the failing instance.
+ * Returning a copy prevents callers from mutating the tracked chain.
+ */
+export function beginProviderFallbackChain(
+  threadId: ThreadId,
+  failedInstanceId: ProviderInstanceId,
+): ReadonlySet<ProviderInstanceId> {
+  const existing = providerFallbackChains.get(threadId);
+  if (existing?.activeInstanceId === failedInstanceId) {
+    existing.attemptedInstanceIds.add(failedInstanceId);
+    return new Set(existing.attemptedInstanceIds);
+  }
+
+  makeRoomForProviderFallbackChain();
+  const attemptedInstanceIds = new Set([failedInstanceId]);
+  providerFallbackChains.set(threadId, {
+    attemptedInstanceIds,
+    activeInstanceId: failedInstanceId,
+  });
+  return new Set(attemptedInstanceIds);
+}
+
+export function markProviderFallbackInstanceAttempted(
+  threadId: ThreadId,
+  instanceId: ProviderInstanceId,
+): void {
+  const state = providerFallbackChains.get(threadId);
+  if (!state) return;
+  state.attemptedInstanceIds.add(instanceId);
+  state.activeInstanceId = instanceId;
+}
+
+export function completeProviderFallbackChain(
+  threadId: ThreadId,
+  activeInstanceId?: ProviderInstanceId,
+): void {
+  const state = providerFallbackChains.get(threadId);
+  if (!state || (activeInstanceId !== undefined && state.activeInstanceId !== activeInstanceId)) {
+    return;
+  }
+  providerFallbackChains.delete(threadId);
+}
+
+export function resetProviderFallbackChainsForTest(): void {
+  providerFallbackChains.clear();
+}

--- a/apps/server/src/orchestration/providerFallbackChain.ts
+++ b/apps/server/src/orchestration/providerFallbackChain.ts
@@ -1,7 +1,27 @@
-import { type ProviderInstanceId, type ThreadId } from "@t3tools/contracts";
+import {
+  type ModelSelection,
+  type ProviderInstanceId,
+  type ProviderSession,
+  type ThreadId,
+} from "@t3tools/contracts";
+import type { ProviderFallbackFailure } from "../provider/providerFallback.ts";
+
+export interface ProviderFallbackChainOrigin {
+  readonly instanceId: ProviderInstanceId;
+  readonly displayName: string;
+  readonly failure: ProviderFallbackFailure;
+  readonly modelSelection: ModelSelection;
+  readonly session: ProviderSession | undefined;
+}
+
+export interface ProviderFallbackChainSnapshot {
+  readonly attemptedInstanceIds: ReadonlySet<ProviderInstanceId>;
+  readonly origin: ProviderFallbackChainOrigin;
+}
 
 interface ProviderFallbackChainState {
   readonly attemptedInstanceIds: Set<ProviderInstanceId>;
+  readonly origin: ProviderFallbackChainOrigin;
   activeInstanceId: ProviderInstanceId;
 }
 
@@ -23,11 +43,15 @@ function makeRoomForProviderFallbackChain(): void {
 export function beginProviderFallbackChain(
   threadId: ThreadId,
   failedInstanceId: ProviderInstanceId,
-): ReadonlySet<ProviderInstanceId> {
+  origin: ProviderFallbackChainOrigin,
+): ProviderFallbackChainSnapshot {
   const existing = providerFallbackChains.get(threadId);
   if (existing?.activeInstanceId === failedInstanceId) {
     existing.attemptedInstanceIds.add(failedInstanceId);
-    return new Set(existing.attemptedInstanceIds);
+    return {
+      attemptedInstanceIds: new Set(existing.attemptedInstanceIds),
+      origin: existing.origin,
+    };
   }
 
   makeRoomForProviderFallbackChain();
@@ -35,8 +59,9 @@ export function beginProviderFallbackChain(
   providerFallbackChains.set(threadId, {
     attemptedInstanceIds,
     activeInstanceId: failedInstanceId,
+    origin,
   });
-  return new Set(attemptedInstanceIds);
+  return { attemptedInstanceIds: new Set(attemptedInstanceIds), origin };
 }
 
 export function markProviderFallbackInstanceAttempted(

--- a/apps/server/src/orchestration/providerFallbackTrialGate.test.ts
+++ b/apps/server/src/orchestration/providerFallbackTrialGate.test.ts
@@ -1,0 +1,63 @@
+import { ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "@effect/vitest";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+
+import {
+  beginProviderFallbackTrial,
+  completeProviderFallbackTrial,
+  decideProviderFallbackTrialEvent,
+} from "./providerFallbackTrialGate.ts";
+
+const threadId = ThreadId.make("thread-fallback-gate");
+const instanceId = ProviderInstanceId.make("codex-work");
+
+describe("provider fallback trial event gate", () => {
+  it.effect("holds provisional events and rejects them when the trial fails", () =>
+    Effect.gen(function* () {
+      const token = yield* beginProviderFallbackTrial(threadId, instanceId);
+      const decision = yield* decideProviderFallbackTrialEvent(
+        threadId,
+        instanceId,
+        DateTime.formatIso(DateTime.makeUnsafe(token.startedAtMs + 1)),
+      ).pipe(Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      yield* completeProviderFallbackTrial(token, "reject");
+
+      expect(yield* Fiber.join(decision)).toBe("reject");
+    }),
+  );
+
+  it.effect("releases provisional events only after the trial commits", () =>
+    Effect.gen(function* () {
+      const token = yield* beginProviderFallbackTrial(threadId, instanceId);
+      const decision = yield* decideProviderFallbackTrialEvent(
+        threadId,
+        instanceId,
+        DateTime.formatIso(DateTime.makeUnsafe(token.startedAtMs + 1)),
+      ).pipe(Effect.forkChild);
+
+      yield* Effect.yieldNow;
+      yield* completeProviderFallbackTrial(token, "accept");
+
+      expect(yield* Fiber.join(decision)).toBe("accept");
+    }),
+  );
+
+  it.effect("does not apply an old trial outcome to later events from the same instance", () =>
+    Effect.gen(function* () {
+      const token = yield* beginProviderFallbackTrial(threadId, instanceId);
+      yield* completeProviderFallbackTrial(token, "reject");
+
+      expect(
+        yield* decideProviderFallbackTrialEvent(
+          threadId,
+          instanceId,
+          DateTime.formatIso(DateTime.makeUnsafe(token.startedAtMs + 60_000)),
+        ),
+      ).toBe("not-trial");
+    }),
+  );
+});

--- a/apps/server/src/orchestration/providerFallbackTrialGate.ts
+++ b/apps/server/src/orchestration/providerFallbackTrialGate.ts
@@ -1,0 +1,105 @@
+import type { ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import * as Clock from "effect/Clock";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+
+export type ProviderFallbackTrialDecision = "accept" | "not-trial" | "reject";
+
+export interface ProviderFallbackTrialToken {
+  readonly key: string;
+  readonly threadId: ThreadId;
+  readonly startedAtMs: number;
+  readonly decision: Deferred.Deferred<"accept" | "reject">;
+}
+
+interface ProviderFallbackTrialState extends ProviderFallbackTrialToken {
+  completedAtMs: number | undefined;
+  outcome: "accept" | "reject" | undefined;
+}
+
+const TRIAL_OUTCOME_TTL_MS = 120_000;
+const TRIAL_OUTCOME_CAPACITY = 10_000;
+const trialStateByKey = new Map<string, ProviderFallbackTrialState>();
+
+const trialKey = (threadId: ThreadId, instanceId: ProviderInstanceId) =>
+  `${threadId}:${instanceId}`;
+
+function pruneTrialOutcomes(nowMs: number): void {
+  for (const [key, state] of trialStateByKey) {
+    if (state.completedAtMs !== undefined && nowMs - state.completedAtMs > TRIAL_OUTCOME_TTL_MS) {
+      trialStateByKey.delete(key);
+    }
+  }
+  while (trialStateByKey.size >= TRIAL_OUTCOME_CAPACITY) {
+    const oldestCompleted = [...trialStateByKey.entries()].find(
+      ([, state]) => state.completedAtMs !== undefined,
+    );
+    if (!oldestCompleted) break;
+    trialStateByKey.delete(oldestCompleted[0]);
+  }
+}
+
+export const beginProviderFallbackTrial = Effect.fn("beginProviderFallbackTrial")(function* (
+  threadId: ThreadId,
+  instanceId: ProviderInstanceId,
+) {
+  const startedAtMs = yield* Clock.currentTimeMillis;
+  const decision = yield* Deferred.make<"accept" | "reject">();
+  const token: ProviderFallbackTrialState = {
+    key: trialKey(threadId, instanceId),
+    threadId,
+    startedAtMs,
+    decision,
+    completedAtMs: undefined,
+    outcome: undefined,
+  };
+  pruneTrialOutcomes(startedAtMs);
+  trialStateByKey.set(token.key, token);
+  return token satisfies ProviderFallbackTrialToken;
+});
+
+export const completeProviderFallbackTrial = Effect.fn("completeProviderFallbackTrial")(function* (
+  token: ProviderFallbackTrialToken,
+  outcome: "accept" | "reject",
+) {
+  const state = trialStateByKey.get(token.key);
+  if (state !== token || state.outcome !== undefined) return;
+  state.outcome = outcome;
+  state.completedAtMs = yield* Clock.currentTimeMillis;
+  yield* Deferred.succeed(state.decision, outcome);
+});
+
+export const rejectPendingProviderFallbackTrials = Effect.fn("rejectPendingProviderFallbackTrials")(
+  function* (threadId: ThreadId) {
+    const pending = [...trialStateByKey.values()].filter(
+      (state) => state.threadId === threadId && state.outcome === undefined,
+    );
+    yield* Effect.forEach(pending, (state) => completeProviderFallbackTrial(state, "reject"), {
+      discard: true,
+    });
+  },
+);
+
+export const decideProviderFallbackTrialEvent = Effect.fn("decideProviderFallbackTrialEvent")(
+  function* (threadId: ThreadId, instanceId: ProviderInstanceId, eventCreatedAt: string) {
+    const state = trialStateByKey.get(trialKey(threadId, instanceId));
+    if (!state) return "not-trial" as const;
+
+    const eventTimeMs = Date.parse(eventCreatedAt);
+    if (Number.isFinite(eventTimeMs) && eventTimeMs < state.startedAtMs) {
+      return "not-trial" as const;
+    }
+
+    if (state.outcome === undefined) {
+      return yield* Deferred.await(state.decision);
+    }
+    if (
+      state.completedAtMs !== undefined &&
+      Number.isFinite(eventTimeMs) &&
+      eventTimeMs > state.completedAtMs
+    ) {
+      return "not-trial" as const;
+    }
+    return state.outcome;
+  },
+);

--- a/apps/server/src/orchestration/providerFallbackWorkflow.ts
+++ b/apps/server/src/orchestration/providerFallbackWorkflow.ts
@@ -26,6 +26,17 @@ import { ProviderService } from "../provider/Services/ProviderService.ts";
 import { ServerSettingsService } from "../serverSettings.ts";
 import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
 import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
+import {
+  beginProviderFallbackChain,
+  completeProviderFallbackChain,
+  markProviderFallbackInstanceAttempted,
+} from "./providerFallbackChain.ts";
+import {
+  beginProviderFallbackTrial,
+  completeProviderFallbackTrial,
+  rejectPendingProviderFallbackTrials,
+  type ProviderFallbackTrialToken,
+} from "./providerFallbackTrialGate.ts";
 
 export interface ProviderFallbackAttemptInput {
   readonly threadId: ThreadId;
@@ -51,22 +62,6 @@ interface ProviderFallbackLockEntry {
 }
 
 const fallbackLocks = new Map<ThreadId, ProviderFallbackLockEntry>();
-const fallbackTrialInstanceByThread = new Map<ThreadId, ProviderInstanceId>();
-
-export function isProviderFallbackTrialInstance(
-  threadId: ThreadId,
-  instanceId: ProviderInstanceId,
-): boolean {
-  return fallbackTrialInstanceByThread.get(threadId) === instanceId;
-}
-
-function clearFallbackTrialInstance(threadId: ThreadId, instanceId?: ProviderInstanceId) {
-  return Effect.sync(() => {
-    if (instanceId === undefined || fallbackTrialInstanceByThread.get(threadId) === instanceId) {
-      fallbackTrialInstanceByThread.delete(threadId);
-    }
-  });
-}
 
 function withProviderFallbackLock<E, R>(
   threadId: ThreadId,
@@ -156,12 +151,15 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
     return { switched: false, skipped: [] } satisfies ProviderFallbackAttemptResult;
   }
 
+  const attemptedInstanceIds = beginProviderFallbackChain(input.threadId, input.failedInstanceId);
+
   const plan = planProviderFallback({
     settings,
     providers,
     currentInstanceId: input.failedInstanceId,
     modelSelection: input.modelSelection,
     requireCompatibleContinuation: input.requireCompatibleContinuation,
+    excludedInstanceIds: attemptedInstanceIds,
   });
   const skipped: ProviderFallbackSkip[] = [...plan.skipped];
   const originalSession = (yield* providerService.listSessions()).find(
@@ -169,6 +167,7 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
   );
   let bindingChanged = false;
   let boundFallbackInstance: ProviderFallbackCandidate | undefined;
+  let currentTrialToken: ProviderFallbackTrialToken | undefined;
 
   const nextCommandId = (tag: string) =>
     crypto.randomUUIDv4.pipe(Effect.map((id) => CommandId.make(`server:${tag}:${id}`)));
@@ -228,9 +227,8 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
   });
 
   for (const candidate of plan.candidates) {
-    yield* Effect.sync(() => {
-      fallbackTrialInstanceByThread.set(input.threadId, candidate.instanceId);
-    });
+    markProviderFallbackInstanceAttempted(input.threadId, candidate.instanceId);
+    currentTrialToken = yield* beginProviderFallbackTrial(input.threadId, candidate.instanceId);
     const attempt = yield* Effect.gen(function* () {
       const started = yield* providerService.startSession(input.threadId, {
         threadId: input.threadId,
@@ -253,7 +251,8 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
     }).pipe(Effect.result);
 
     if (attempt._tag === "Failure") {
-      yield* clearFallbackTrialInstance(input.threadId, candidate.instanceId);
+      yield* completeProviderFallbackTrial(currentTrialToken, "reject");
+      currentTrialToken = undefined;
       skipped.push({
         instanceId: candidate.instanceId,
         displayName: candidate.displayName,
@@ -286,6 +285,8 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
       session,
       createdAt: input.createdAt,
     });
+    yield* completeProviderFallbackTrial(currentTrialToken, "accept");
+    currentTrialToken = undefined;
     yield* appendOutcomeActivity({
       kind: "provider.fallback.succeeded",
       summary: `Switched to ${candidate.displayName}`,
@@ -361,6 +362,7 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
     summary: "Automatic provider fallback failed",
     tone: "error",
   });
+  completeProviderFallbackChain(input.threadId);
   return { switched: false, skipped } satisfies ProviderFallbackAttemptResult;
 });
 
@@ -370,7 +372,12 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
   return yield* withProviderFallbackLock(
     input.threadId,
     attemptProviderFallbackUnlocked(input).pipe(
-      Effect.ensuring(clearFallbackTrialInstance(input.threadId)),
+      Effect.onError(() =>
+        Effect.sync(() => {
+          completeProviderFallbackChain(input.threadId);
+        }),
+      ),
+      Effect.ensuring(rejectPendingProviderFallbackTrials(input.threadId)),
     ),
   );
 });

--- a/apps/server/src/orchestration/providerFallbackWorkflow.ts
+++ b/apps/server/src/orchestration/providerFallbackWorkflow.ts
@@ -11,11 +11,13 @@ import {
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Semaphore from "effect/Semaphore";
 
 import { resolveThreadWorkspaceCwd } from "../checkpointing/Utils.ts";
 import {
   planProviderFallback,
   providerFallbackDisplayName,
+  type ProviderFallbackCandidate,
   type ProviderFallbackFailure,
   type ProviderFallbackSkip,
 } from "../provider/providerFallback.ts";
@@ -27,7 +29,7 @@ import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
 
 export interface ProviderFallbackAttemptInput {
   readonly threadId: ThreadId;
-  readonly currentInstanceId: ProviderInstanceId;
+  readonly failedInstanceId: ProviderInstanceId;
   readonly modelSelection: ModelSelection;
   readonly runtimeMode: RuntimeMode;
   readonly sendTurnInput: ProviderSendTurnInput;
@@ -39,6 +41,73 @@ export interface ProviderFallbackAttemptInput {
 export interface ProviderFallbackAttemptResult {
   readonly switched: boolean;
   readonly skipped: ReadonlyArray<ProviderFallbackSkip>;
+}
+
+interface ProviderFallbackLockEntry {
+  readonly semaphore: Semaphore.Semaphore;
+  users: number;
+  generation: number;
+  lastResult: ProviderFallbackAttemptResult | undefined;
+}
+
+const fallbackLocks = new Map<ThreadId, ProviderFallbackLockEntry>();
+const fallbackTrialInstanceByThread = new Map<ThreadId, ProviderInstanceId>();
+
+export function isProviderFallbackTrialInstance(
+  threadId: ThreadId,
+  instanceId: ProviderInstanceId,
+): boolean {
+  return fallbackTrialInstanceByThread.get(threadId) === instanceId;
+}
+
+function clearFallbackTrialInstance(threadId: ThreadId, instanceId?: ProviderInstanceId) {
+  return Effect.sync(() => {
+    if (instanceId === undefined || fallbackTrialInstanceByThread.get(threadId) === instanceId) {
+      fallbackTrialInstanceByThread.delete(threadId);
+    }
+  });
+}
+
+function withProviderFallbackLock<E, R>(
+  threadId: ThreadId,
+  effect: Effect.Effect<ProviderFallbackAttemptResult, E, R>,
+): Effect.Effect<ProviderFallbackAttemptResult, E, R> {
+  return Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const existing = fallbackLocks.get(threadId);
+      if (existing) {
+        existing.users += 1;
+        return { entry: existing, observedGeneration: existing.generation };
+      }
+      const entry: ProviderFallbackLockEntry = {
+        semaphore: Semaphore.makeUnsafe(1),
+        users: 1,
+        generation: 0,
+        lastResult: undefined,
+      };
+      fallbackLocks.set(threadId, entry);
+      return { entry, observedGeneration: 0 };
+    }),
+    ({ entry, observedGeneration }) =>
+      entry.semaphore.withPermits(1)(
+        Effect.gen(function* () {
+          if (entry.generation !== observedGeneration && entry.lastResult !== undefined) {
+            return entry.lastResult;
+          }
+          const result = yield* effect;
+          entry.generation += 1;
+          entry.lastResult = result;
+          return result;
+        }),
+      ),
+    ({ entry }) =>
+      Effect.sync(() => {
+        entry.users -= 1;
+        if (entry.users === 0 && fallbackLocks.get(threadId) === entry) {
+          fallbackLocks.delete(threadId);
+        }
+      }),
+  );
 }
 
 function formatFailure(error: unknown): string {
@@ -60,7 +129,7 @@ function sessionStatus(status: "connecting" | "ready" | "running" | "error" | "c
   }
 }
 
-export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(function* (
+const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlocked")(function* (
   input: ProviderFallbackAttemptInput,
 ) {
   const crypto = yield* Crypto.Crypto;
@@ -81,7 +150,7 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
   const cwd = resolveThreadWorkspaceCwd({ thread, projects: project ? [project] : [] });
   const providers = yield* providerRegistry.getProviders;
   const currentProvider = providers.find(
-    (provider) => provider.instanceId === input.currentInstanceId,
+    (provider) => provider.instanceId === input.failedInstanceId,
   );
   if (!currentProvider) {
     return { switched: false, skipped: [] } satisfies ProviderFallbackAttemptResult;
@@ -90,16 +159,16 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
   const plan = planProviderFallback({
     settings,
     providers,
-    currentInstanceId: input.currentInstanceId,
+    currentInstanceId: input.failedInstanceId,
     modelSelection: input.modelSelection,
     requireCompatibleContinuation: input.requireCompatibleContinuation,
   });
   const skipped: ProviderFallbackSkip[] = [...plan.skipped];
   const originalSession = (yield* providerService.listSessions()).find(
-    (session) =>
-      session.threadId === input.threadId && session.providerInstanceId === input.currentInstanceId,
+    (session) => session.threadId === input.threadId,
   );
   let bindingChanged = false;
+  let boundFallbackInstance: ProviderFallbackCandidate | undefined;
 
   const nextCommandId = (tag: string) =>
     crypto.randomUUIDv4.pipe(Effect.map((id) => CommandId.make(`server:${tag}:${id}`)));
@@ -122,7 +191,7 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
             kind: outcome.kind,
             summary: outcome.summary,
             payload: {
-              fromInstanceId: input.currentInstanceId,
+              fromInstanceId: input.failedInstanceId,
               fromDisplayName: providerFallbackDisplayName(currentProvider),
               ...(outcome.toInstanceId ? { toInstanceId: outcome.toInstanceId } : {}),
               ...(outcome.toDisplayName ? { toDisplayName: outcome.toDisplayName } : {}),
@@ -137,8 +206,31 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
         }),
       ),
     );
+  const stopFallbackSessionAndProject = Effect.fn("stopFallbackSessionAndProject")(function* () {
+    const bound = boundFallbackInstance;
+    yield* providerService.stopSession({ threadId: input.threadId }).pipe(Effect.ignore);
+    yield* engine.dispatch({
+      type: "thread.session.set",
+      commandId: yield* nextCommandId("provider-fallback-stop"),
+      threadId: input.threadId,
+      session: {
+        threadId: input.threadId,
+        status: "stopped",
+        providerName: bound?.provider.driver ?? currentProvider.driver,
+        providerInstanceId: bound?.instanceId ?? input.failedInstanceId,
+        runtimeMode: input.runtimeMode,
+        activeTurnId: null,
+        lastError: input.failure.message,
+        updatedAt: input.createdAt,
+      },
+      createdAt: input.createdAt,
+    });
+  });
 
   for (const candidate of plan.candidates) {
+    yield* Effect.sync(() => {
+      fallbackTrialInstanceByThread.set(input.threadId, candidate.instanceId);
+    });
     const attempt = yield* Effect.gen(function* () {
       const started = yield* providerService.startSession(input.threadId, {
         threadId: input.threadId,
@@ -152,6 +244,7 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
         runtimeMode: input.runtimeMode,
       });
       bindingChanged = true;
+      boundFallbackInstance = candidate;
       const turn = yield* providerService.sendTurn({
         ...input.sendTurnInput,
         modelSelection: candidate.modelSelection,
@@ -160,6 +253,7 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
     }).pipe(Effect.result);
 
     if (attempt._tag === "Failure") {
+      yield* clearFallbackTrialInstance(input.threadId, candidate.instanceId);
       skipped.push({
         instanceId: candidate.instanceId,
         displayName: candidate.displayName,
@@ -204,45 +298,61 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
 
   if (bindingChanged) {
     if (originalSession) {
-      const restored = yield* providerService
-        .startSession(input.threadId, {
-          threadId: input.threadId,
-          provider: originalSession.provider,
-          providerInstanceId: input.currentInstanceId,
-          ...(cwd ? { cwd } : {}),
-          modelSelection: input.modelSelection,
-          ...(originalSession.resumeCursor !== undefined
-            ? { resumeCursor: originalSession.resumeCursor }
-            : {}),
-          runtimeMode: input.runtimeMode,
-        })
-        .pipe(Effect.result);
-      if (restored._tag === "Success") {
-        yield* engine.dispatch({
-          type: "thread.session.set",
-          commandId: yield* nextCommandId("provider-fallback-restore"),
-          threadId: input.threadId,
-          session: {
-            threadId: input.threadId,
-            status: sessionStatus(restored.success.status),
-            providerName: restored.success.provider,
-            providerInstanceId: input.currentInstanceId,
-            runtimeMode: input.runtimeMode,
-            activeTurnId: null,
-            lastError: input.failure.message,
-            updatedAt: input.createdAt,
-          },
-          createdAt: input.createdAt,
-        });
-      } else {
+      const originalInstanceId = originalSession.providerInstanceId;
+      if (originalInstanceId === undefined) {
         skipped.push({
-          instanceId: input.currentInstanceId,
+          instanceId: input.failedInstanceId,
           displayName: providerFallbackDisplayName(currentProvider),
-          reason: `Could not restore the original instance: ${formatFailure(restored.failure)}`,
+          reason: "Could not restore the original session because its instance id is missing.",
         });
+        yield* stopFallbackSessionAndProject();
+      } else {
+        const originalModelSelection: ModelSelection = {
+          ...thread.modelSelection,
+          instanceId: originalInstanceId,
+          ...(originalSession.model !== undefined ? { model: originalSession.model } : {}),
+        };
+        const restored = yield* providerService
+          .startSession(input.threadId, {
+            threadId: input.threadId,
+            provider: originalSession.provider,
+            providerInstanceId: originalInstanceId,
+            ...(cwd ? { cwd } : {}),
+            modelSelection: originalModelSelection,
+            ...(originalSession.resumeCursor !== undefined
+              ? { resumeCursor: originalSession.resumeCursor }
+              : {}),
+            runtimeMode: input.runtimeMode,
+          })
+          .pipe(Effect.result);
+        if (restored._tag === "Success") {
+          yield* engine.dispatch({
+            type: "thread.session.set",
+            commandId: yield* nextCommandId("provider-fallback-restore"),
+            threadId: input.threadId,
+            session: {
+              threadId: input.threadId,
+              status: sessionStatus(restored.success.status),
+              providerName: restored.success.provider,
+              providerInstanceId: originalInstanceId,
+              runtimeMode: input.runtimeMode,
+              activeTurnId: null,
+              lastError: input.failure.message,
+              updatedAt: input.createdAt,
+            },
+            createdAt: input.createdAt,
+          });
+        } else {
+          skipped.push({
+            instanceId: originalInstanceId,
+            displayName: String(originalInstanceId),
+            reason: `Could not restore the original instance: ${formatFailure(restored.failure)}`,
+          });
+          yield* stopFallbackSessionAndProject();
+        }
       }
     } else {
-      yield* providerService.stopSession({ threadId: input.threadId }).pipe(Effect.ignore);
+      yield* stopFallbackSessionAndProject();
     }
   }
 
@@ -252,4 +362,15 @@ export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(func
     tone: "error",
   });
   return { switched: false, skipped } satisfies ProviderFallbackAttemptResult;
+});
+
+export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(function* (
+  input: ProviderFallbackAttemptInput,
+) {
+  return yield* withProviderFallbackLock(
+    input.threadId,
+    attemptProviderFallbackUnlocked(input).pipe(
+      Effect.ensuring(clearFallbackTrialInstance(input.threadId)),
+    ),
+  );
 });

--- a/apps/server/src/orchestration/providerFallbackWorkflow.ts
+++ b/apps/server/src/orchestration/providerFallbackWorkflow.ts
@@ -1,0 +1,255 @@
+import {
+  CommandId,
+  EventId,
+  type ModelSelection,
+  type OrchestrationSession,
+  type ProviderInstanceId,
+  type ProviderSendTurnInput,
+  type RuntimeMode,
+  type ThreadId,
+} from "@t3tools/contracts";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import { resolveThreadWorkspaceCwd } from "../checkpointing/Utils.ts";
+import {
+  planProviderFallback,
+  providerFallbackDisplayName,
+  type ProviderFallbackFailure,
+  type ProviderFallbackSkip,
+} from "../provider/providerFallback.ts";
+import { ProviderRegistry } from "../provider/Services/ProviderRegistry.ts";
+import { ProviderService } from "../provider/Services/ProviderService.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
+import { OrchestrationEngineService } from "./Services/OrchestrationEngine.ts";
+import { ProjectionSnapshotQuery } from "./Services/ProjectionSnapshotQuery.ts";
+
+export interface ProviderFallbackAttemptInput {
+  readonly threadId: ThreadId;
+  readonly currentInstanceId: ProviderInstanceId;
+  readonly modelSelection: ModelSelection;
+  readonly runtimeMode: RuntimeMode;
+  readonly sendTurnInput: ProviderSendTurnInput;
+  readonly failure: ProviderFallbackFailure;
+  readonly requireCompatibleContinuation: boolean;
+  readonly createdAt: string;
+}
+
+export interface ProviderFallbackAttemptResult {
+  readonly switched: boolean;
+  readonly skipped: ReadonlyArray<ProviderFallbackSkip>;
+}
+
+function formatFailure(error: unknown): string {
+  return error instanceof Error && error.message.trim().length > 0 ? error.message : String(error);
+}
+
+function sessionStatus(status: "connecting" | "ready" | "running" | "error" | "closed") {
+  switch (status) {
+    case "connecting":
+      return "starting" as const;
+    case "running":
+      return "running" as const;
+    case "error":
+      return "error" as const;
+    case "closed":
+      return "stopped" as const;
+    case "ready":
+      return "ready" as const;
+  }
+}
+
+export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(function* (
+  input: ProviderFallbackAttemptInput,
+) {
+  const crypto = yield* Crypto.Crypto;
+  const engine = yield* OrchestrationEngineService;
+  const projection = yield* ProjectionSnapshotQuery;
+  const providerRegistry = yield* ProviderRegistry;
+  const providerService = yield* ProviderService;
+  const settingsService = yield* ServerSettingsService;
+
+  const settings = yield* settingsService.getSettings;
+  if (!settings.providerFallback.enabled) {
+    return { switched: false, skipped: [] } satisfies ProviderFallbackAttemptResult;
+  }
+
+  const thread = Option.getOrUndefined(yield* projection.getThreadDetailById(input.threadId));
+  if (!thread) return { switched: false, skipped: [] } satisfies ProviderFallbackAttemptResult;
+  const project = Option.getOrUndefined(yield* projection.getProjectShellById(thread.projectId));
+  const cwd = resolveThreadWorkspaceCwd({ thread, projects: project ? [project] : [] });
+  const providers = yield* providerRegistry.getProviders;
+  const currentProvider = providers.find(
+    (provider) => provider.instanceId === input.currentInstanceId,
+  );
+  if (!currentProvider) {
+    return { switched: false, skipped: [] } satisfies ProviderFallbackAttemptResult;
+  }
+
+  const plan = planProviderFallback({
+    settings,
+    providers,
+    currentInstanceId: input.currentInstanceId,
+    modelSelection: input.modelSelection,
+    requireCompatibleContinuation: input.requireCompatibleContinuation,
+  });
+  const skipped: ProviderFallbackSkip[] = [...plan.skipped];
+  const originalSession = (yield* providerService.listSessions()).find(
+    (session) =>
+      session.threadId === input.threadId && session.providerInstanceId === input.currentInstanceId,
+  );
+  let bindingChanged = false;
+
+  const nextCommandId = (tag: string) =>
+    crypto.randomUUIDv4.pipe(Effect.map((id) => CommandId.make(`server:${tag}:${id}`)));
+  const appendOutcomeActivity = (outcome: {
+    readonly kind: "provider.fallback.failed" | "provider.fallback.succeeded";
+    readonly summary: string;
+    readonly tone: "error" | "info";
+    readonly toInstanceId?: ProviderInstanceId;
+    readonly toDisplayName?: string;
+  }) =>
+    Effect.all({ commandId: nextCommandId(outcome.kind), eventId: crypto.randomUUIDv4 }).pipe(
+      Effect.flatMap(({ commandId, eventId }) =>
+        engine.dispatch({
+          type: "thread.activity.append",
+          commandId,
+          threadId: input.threadId,
+          activity: {
+            id: EventId.make(eventId),
+            tone: outcome.tone,
+            kind: outcome.kind,
+            summary: outcome.summary,
+            payload: {
+              fromInstanceId: input.currentInstanceId,
+              fromDisplayName: providerFallbackDisplayName(currentProvider),
+              ...(outcome.toInstanceId ? { toInstanceId: outcome.toInstanceId } : {}),
+              ...(outcome.toDisplayName ? { toDisplayName: outcome.toDisplayName } : {}),
+              failureKind: input.failure.kind,
+              detail: input.failure.message,
+              skipped,
+            },
+            turnId: thread.session?.activeTurnId ?? null,
+            createdAt: input.createdAt,
+          },
+          createdAt: input.createdAt,
+        }),
+      ),
+    );
+
+  for (const candidate of plan.candidates) {
+    const attempt = yield* Effect.gen(function* () {
+      const started = yield* providerService.startSession(input.threadId, {
+        threadId: input.threadId,
+        provider: candidate.provider.driver,
+        providerInstanceId: candidate.instanceId,
+        ...(cwd ? { cwd } : {}),
+        modelSelection: candidate.modelSelection,
+        ...(input.requireCompatibleContinuation && originalSession?.resumeCursor !== undefined
+          ? { resumeCursor: originalSession.resumeCursor }
+          : {}),
+        runtimeMode: input.runtimeMode,
+      });
+      bindingChanged = true;
+      const turn = yield* providerService.sendTurn({
+        ...input.sendTurnInput,
+        modelSelection: candidate.modelSelection,
+      });
+      return { started, turn };
+    }).pipe(Effect.result);
+
+    if (attempt._tag === "Failure") {
+      skipped.push({
+        instanceId: candidate.instanceId,
+        displayName: candidate.displayName,
+        reason: formatFailure(attempt.failure),
+      });
+      continue;
+    }
+
+    const { started, turn } = attempt.success;
+    yield* engine.dispatch({
+      type: "thread.meta.update",
+      commandId: yield* nextCommandId("provider-fallback-model"),
+      threadId: input.threadId,
+      modelSelection: candidate.modelSelection,
+    });
+    const session: OrchestrationSession = {
+      threadId: input.threadId,
+      status: "running",
+      providerName: started.provider,
+      providerInstanceId: candidate.instanceId,
+      runtimeMode: input.runtimeMode,
+      activeTurnId: turn.turnId,
+      lastError: null,
+      updatedAt: input.createdAt,
+    };
+    yield* engine.dispatch({
+      type: "thread.session.set",
+      commandId: yield* nextCommandId("provider-fallback-session"),
+      threadId: input.threadId,
+      session,
+      createdAt: input.createdAt,
+    });
+    yield* appendOutcomeActivity({
+      kind: "provider.fallback.succeeded",
+      summary: `Switched to ${candidate.displayName}`,
+      tone: "info",
+      toInstanceId: candidate.instanceId,
+      toDisplayName: candidate.displayName,
+    });
+    return { switched: true, skipped } satisfies ProviderFallbackAttemptResult;
+  }
+
+  if (bindingChanged) {
+    if (originalSession) {
+      const restored = yield* providerService
+        .startSession(input.threadId, {
+          threadId: input.threadId,
+          provider: originalSession.provider,
+          providerInstanceId: input.currentInstanceId,
+          ...(cwd ? { cwd } : {}),
+          modelSelection: input.modelSelection,
+          ...(originalSession.resumeCursor !== undefined
+            ? { resumeCursor: originalSession.resumeCursor }
+            : {}),
+          runtimeMode: input.runtimeMode,
+        })
+        .pipe(Effect.result);
+      if (restored._tag === "Success") {
+        yield* engine.dispatch({
+          type: "thread.session.set",
+          commandId: yield* nextCommandId("provider-fallback-restore"),
+          threadId: input.threadId,
+          session: {
+            threadId: input.threadId,
+            status: sessionStatus(restored.success.status),
+            providerName: restored.success.provider,
+            providerInstanceId: input.currentInstanceId,
+            runtimeMode: input.runtimeMode,
+            activeTurnId: null,
+            lastError: input.failure.message,
+            updatedAt: input.createdAt,
+          },
+          createdAt: input.createdAt,
+        });
+      } else {
+        skipped.push({
+          instanceId: input.currentInstanceId,
+          displayName: providerFallbackDisplayName(currentProvider),
+          reason: `Could not restore the original instance: ${formatFailure(restored.failure)}`,
+        });
+      }
+    } else {
+      yield* providerService.stopSession({ threadId: input.threadId }).pipe(Effect.ignore);
+    }
+  }
+
+  yield* appendOutcomeActivity({
+    kind: "provider.fallback.failed",
+    summary: "Automatic provider fallback failed",
+    tone: "error",
+  });
+  return { switched: false, skipped } satisfies ProviderFallbackAttemptResult;
+});

--- a/apps/server/src/orchestration/providerFallbackWorkflow.ts
+++ b/apps/server/src/orchestration/providerFallbackWorkflow.ts
@@ -51,6 +51,7 @@ export interface ProviderFallbackAttemptInput {
 
 export interface ProviderFallbackAttemptResult {
   readonly switched: boolean;
+  readonly restoredOriginalInstance?: boolean;
   readonly skipped: ReadonlyArray<ProviderFallbackSkip>;
 }
 
@@ -151,7 +152,16 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
     return { switched: false, skipped: [] } satisfies ProviderFallbackAttemptResult;
   }
 
-  const attemptedInstanceIds = beginProviderFallbackChain(input.threadId, input.failedInstanceId);
+  const activeSession = (yield* providerService.listSessions()).find(
+    (session) => session.threadId === input.threadId,
+  );
+  const fallbackChain = beginProviderFallbackChain(input.threadId, input.failedInstanceId, {
+    instanceId: input.failedInstanceId,
+    displayName: providerFallbackDisplayName(currentProvider),
+    failure: input.failure,
+    modelSelection: input.modelSelection,
+    session: activeSession,
+  });
 
   const plan = planProviderFallback({
     settings,
@@ -159,13 +169,11 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
     currentInstanceId: input.failedInstanceId,
     modelSelection: input.modelSelection,
     requireCompatibleContinuation: input.requireCompatibleContinuation,
-    excludedInstanceIds: attemptedInstanceIds,
+    excludedInstanceIds: fallbackChain.attemptedInstanceIds,
   });
   const skipped: ProviderFallbackSkip[] = [...plan.skipped];
-  const originalSession = (yield* providerService.listSessions()).find(
-    (session) => session.threadId === input.threadId,
-  );
   let bindingChanged = false;
+  let restoredOriginalInstance = false;
   let boundFallbackInstance: ProviderFallbackCandidate | undefined;
   let currentTrialToken: ProviderFallbackTrialToken | undefined;
 
@@ -177,6 +185,7 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
     readonly tone: "error" | "info";
     readonly toInstanceId?: ProviderInstanceId;
     readonly toDisplayName?: string;
+    readonly useOriginalFailure?: boolean;
   }) =>
     Effect.all({ commandId: nextCommandId(outcome.kind), eventId: crypto.randomUUIDv4 }).pipe(
       Effect.flatMap(({ commandId, eventId }) =>
@@ -190,12 +199,21 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
             kind: outcome.kind,
             summary: outcome.summary,
             payload: {
-              fromInstanceId: input.failedInstanceId,
-              fromDisplayName: providerFallbackDisplayName(currentProvider),
+              fromInstanceId: outcome.useOriginalFailure
+                ? fallbackChain.origin.instanceId
+                : input.failedInstanceId,
+              fromDisplayName: outcome.useOriginalFailure
+                ? fallbackChain.origin.displayName
+                : providerFallbackDisplayName(currentProvider),
               ...(outcome.toInstanceId ? { toInstanceId: outcome.toInstanceId } : {}),
               ...(outcome.toDisplayName ? { toDisplayName: outcome.toDisplayName } : {}),
-              failureKind: input.failure.kind,
-              detail: input.failure.message,
+              failureKind: outcome.useOriginalFailure
+                ? fallbackChain.origin.failure.kind
+                : input.failure.kind,
+              detail: outcome.useOriginalFailure
+                ? fallbackChain.origin.failure.message
+                : input.failure.message,
+              ...(outcome.useOriginalFailure ? { restoredOriginalInstance: true } : {}),
               skipped,
             },
             turnId: thread.session?.activeTurnId ?? null,
@@ -236,8 +254,8 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
         providerInstanceId: candidate.instanceId,
         ...(cwd ? { cwd } : {}),
         modelSelection: candidate.modelSelection,
-        ...(input.requireCompatibleContinuation && originalSession?.resumeCursor !== undefined
-          ? { resumeCursor: originalSession.resumeCursor }
+        ...(input.requireCompatibleContinuation && activeSession?.resumeCursor !== undefined
+          ? { resumeCursor: activeSession.resumeCursor }
           : {}),
         runtimeMode: input.runtimeMode,
       });
@@ -297,7 +315,10 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
     return { switched: true, skipped } satisfies ProviderFallbackAttemptResult;
   }
 
-  if (bindingChanged) {
+  const originalSession = fallbackChain.origin.session;
+  const shouldRestoreOriginalInstance =
+    bindingChanged || fallbackChain.origin.instanceId !== input.failedInstanceId;
+  if (shouldRestoreOriginalInstance) {
     if (originalSession) {
       const originalInstanceId = originalSession.providerInstanceId;
       if (originalInstanceId === undefined) {
@@ -308,11 +329,7 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
         });
         yield* stopFallbackSessionAndProject();
       } else {
-        const originalModelSelection: ModelSelection = {
-          ...thread.modelSelection,
-          instanceId: originalInstanceId,
-          ...(originalSession.model !== undefined ? { model: originalSession.model } : {}),
-        };
+        const originalModelSelection: ModelSelection = fallbackChain.origin.modelSelection;
         const restored = yield* providerService
           .startSession(input.threadId, {
             threadId: input.threadId,
@@ -327,6 +344,12 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
           })
           .pipe(Effect.result);
         if (restored._tag === "Success") {
+          yield* engine.dispatch({
+            type: "thread.meta.update",
+            commandId: yield* nextCommandId("provider-fallback-restore-model"),
+            threadId: input.threadId,
+            modelSelection: originalModelSelection,
+          });
           yield* engine.dispatch({
             type: "thread.session.set",
             commandId: yield* nextCommandId("provider-fallback-restore"),
@@ -343,6 +366,14 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
             },
             createdAt: input.createdAt,
           });
+          const attemptedOriginSkip = skipped.findIndex(
+            (entry) =>
+              entry.instanceId === originalInstanceId &&
+              entry.reason ===
+                "This instance was already attempted during the current fallback chain.",
+          );
+          if (attemptedOriginSkip >= 0) skipped.splice(attemptedOriginSkip, 1);
+          restoredOriginalInstance = true;
         } else {
           skipped.push({
             instanceId: originalInstanceId,
@@ -361,9 +392,14 @@ const attemptProviderFallbackUnlocked = Effect.fn("attemptProviderFallbackUnlock
     kind: "provider.fallback.failed",
     summary: "Automatic provider fallback failed",
     tone: "error",
+    useOriginalFailure: restoredOriginalInstance,
   });
   completeProviderFallbackChain(input.threadId);
-  return { switched: false, skipped } satisfies ProviderFallbackAttemptResult;
+  return {
+    switched: false,
+    restoredOriginalInstance,
+    skipped,
+  } satisfies ProviderFallbackAttemptResult;
 });
 
 export const attemptProviderFallback = Effect.fn("attemptProviderFallback")(function* (

--- a/apps/server/src/provider/providerFallback.test.ts
+++ b/apps/server/src/provider/providerFallback.test.ts
@@ -92,6 +92,49 @@ describe("planProviderFallback", () => {
     expect(plan.candidates.map((entry) => entry.instanceId)).toEqual(["codex_enabled"]);
     expect(plan.skipped[0]?.reason).toBe("Automatic fallback is disabled for this instance.");
   });
+
+  it("never retries instances already attempted by the current fallback chain", () => {
+    const plan = planProviderFallback({
+      settings,
+      providers: [
+        provider({ id: "codex_first" }),
+        provider({ id: "codex_second" }),
+        provider({ id: "codex_third" }),
+      ],
+      currentInstanceId: ProviderInstanceId.make("codex_second"),
+      modelSelection: { instanceId: ProviderInstanceId.make("codex_second"), model: "gpt-5" },
+      requireCompatibleContinuation: false,
+      excludedInstanceIds: new Set([
+        ProviderInstanceId.make("codex_first"),
+        ProviderInstanceId.make("codex_second"),
+      ]),
+    });
+
+    expect(plan.candidates.map((entry) => entry.instanceId)).toEqual(["codex_third"]);
+    expect(plan.skipped).toEqual([
+      {
+        instanceId: "codex_first",
+        displayName: "codex_first",
+        reason: "This instance was already attempted during the current fallback chain.",
+      },
+    ]);
+  });
+
+  it("does not loop back to the first instance when both available instances fail", () => {
+    const first = ProviderInstanceId.make("codex_first");
+    const second = ProviderInstanceId.make("codex_second");
+    const plan = planProviderFallback({
+      settings,
+      providers: [provider({ id: first }), provider({ id: second })],
+      currentInstanceId: second,
+      modelSelection: { instanceId: second, model: "gpt-5" },
+      requireCompatibleContinuation: false,
+      excludedInstanceIds: new Set([first, second]),
+    });
+
+    expect(plan.candidates).toEqual([]);
+    expect(plan.skipped.map((entry) => entry.instanceId)).toEqual([first]);
+  });
 });
 
 describe("provider fallback failure classification", () => {

--- a/apps/server/src/provider/providerFallback.test.ts
+++ b/apps/server/src/provider/providerFallback.test.ts
@@ -1,0 +1,127 @@
+import {
+  EventId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  type ServerProvider,
+  type ServerSettings,
+} from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import { describe, expect, it } from "vite-plus/test";
+
+import { ProviderAdapterRequestError } from "./Errors.ts";
+import {
+  classifyProviderRuntimeFailure,
+  classifyProviderServiceFailure,
+  planProviderFallback,
+} from "./providerFallback.ts";
+
+const provider = (input: {
+  id: string;
+  models?: ReadonlyArray<string>;
+  continuation?: string;
+}): ServerProvider => ({
+  instanceId: ProviderInstanceId.make(input.id),
+  driver: ProviderDriverKind.make("codex"),
+  displayName: input.id,
+  ...(input.continuation ? { continuation: { groupKey: input.continuation } } : {}),
+  enabled: true,
+  installed: true,
+  version: "1.0.0",
+  status: "ready",
+  auth: { status: "authenticated", type: "test" },
+  checkedAt: "2026-06-21T00:00:00.000Z",
+  models: (input.models ?? ["gpt-5"]).map((slug) => ({
+    slug,
+    name: slug,
+    isCustom: false,
+    capabilities: null,
+  })),
+  slashCommands: [],
+  skills: [],
+});
+
+const settings = {
+  providerFallback: { enabled: true },
+  providerInstances: {},
+} as ServerSettings;
+
+describe("planProviderFallback", () => {
+  it("preserves provider order and explains model and continuation skips", () => {
+    const plan = planProviderFallback({
+      settings,
+      providers: [
+        provider({ id: "codex", continuation: "home:a" }),
+        provider({ id: "codex_missing", models: ["gpt-4"], continuation: "home:a" }),
+        provider({ id: "codex_other_home", continuation: "home:b" }),
+        provider({ id: "codex_work", continuation: "home:a" }),
+      ],
+      currentInstanceId: ProviderInstanceId.make("codex"),
+      modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5" },
+      requireCompatibleContinuation: true,
+    });
+
+    expect(plan.candidates.map((entry) => entry.instanceId)).toEqual(["codex_work"]);
+    expect(plan.skipped.map((entry) => entry.reason)).toEqual([
+      "Model 'gpt-5' was not found on this instance.",
+      "The provider home directory or continuation store does not match the active instance.",
+    ]);
+  });
+
+  it("defaults instance participation on and excludes explicitly opted-out instances", () => {
+    const plan = planProviderFallback({
+      settings: {
+        ...settings,
+        providerInstances: {
+          [ProviderInstanceId.make("codex_disabled")]: {
+            driver: ProviderDriverKind.make("codex"),
+            allowFallback: false,
+          },
+        },
+      },
+      providers: [
+        provider({ id: "codex" }),
+        provider({ id: "codex_enabled" }),
+        provider({ id: "codex_disabled" }),
+      ],
+      currentInstanceId: ProviderInstanceId.make("codex"),
+      modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5" },
+      requireCompatibleContinuation: false,
+    });
+
+    expect(plan.candidates.map((entry) => entry.instanceId)).toEqual(["codex_enabled"]);
+    expect(plan.skipped[0]?.reason).toBe("Automatic fallback is disabled for this instance.");
+  });
+});
+
+describe("provider fallback failure classification", () => {
+  it("accepts operational failures and rejects unrelated provider errors", () => {
+    const rateLimit = new ProviderAdapterRequestError({
+      provider: "codex",
+      method: "turn/start",
+      detail: "Usage limit reached for this account.",
+    });
+    const invalidPrompt = new ProviderAdapterRequestError({
+      provider: "codex",
+      method: "turn/start",
+      detail: "Prompt is invalid.",
+    });
+
+    expect(classifyProviderServiceFailure(Cause.fail(rateLimit))?.kind).toBe("rate-limit");
+    expect(classifyProviderServiceFailure(Cause.fail(invalidPrompt))).toBeUndefined();
+  });
+
+  it("classifies canonical transport errors without parsing provider-specific details", () => {
+    expect(
+      classifyProviderRuntimeFailure({
+        type: "runtime.error",
+        eventId: EventId.make("event-1"),
+        provider: ProviderDriverKind.make("codex"),
+        providerInstanceId: ProviderInstanceId.make("codex"),
+        threadId: ThreadId.make("thread-1"),
+        createdAt: "2026-06-21T00:00:00.000Z",
+        payload: { message: "Disconnected", class: "transport_error" },
+      })?.kind,
+    ).toBe("transport");
+  });
+});

--- a/apps/server/src/provider/providerFallback.ts
+++ b/apps/server/src/provider/providerFallback.ts
@@ -112,6 +112,7 @@ export function planProviderFallback(input: {
   readonly currentInstanceId: ProviderInstanceId;
   readonly modelSelection: ModelSelection;
   readonly requireCompatibleContinuation: boolean;
+  readonly excludedInstanceIds?: ReadonlySet<ProviderInstanceId>;
 }): ProviderFallbackPlan {
   const current = input.providers.find(
     (provider) => provider.instanceId === input.currentInstanceId,
@@ -126,6 +127,11 @@ export function planProviderFallback(input: {
     const skip = (reason: string) =>
       skipped.push({ instanceId: provider.instanceId, displayName, reason });
     const config = input.settings.providerInstances[provider.instanceId];
+
+    if (input.excludedInstanceIds?.has(provider.instanceId)) {
+      skip("This instance was already attempted during the current fallback chain.");
+      continue;
+    }
 
     if (config?.allowFallback === false) {
       skip("Automatic fallback is disabled for this instance.");

--- a/apps/server/src/provider/providerFallback.ts
+++ b/apps/server/src/provider/providerFallback.ts
@@ -1,0 +1,165 @@
+import {
+  isProviderAvailable,
+  type ModelSelection,
+  type ProviderInstanceId,
+  type ProviderRuntimeEvent,
+  type ServerProvider,
+  type ServerSettings,
+} from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
+import * as Schema from "effect/Schema";
+
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderUnsupportedError,
+  type ProviderServiceError,
+} from "./Errors.ts";
+
+export type ProviderFallbackFailureKind =
+  | "authentication"
+  | "process"
+  | "rate-limit"
+  | "transport"
+  | "unavailable";
+
+export interface ProviderFallbackFailure {
+  readonly kind: ProviderFallbackFailureKind;
+  readonly message: string;
+}
+
+export interface ProviderFallbackSkip {
+  readonly instanceId: ProviderInstanceId;
+  readonly displayName: string;
+  readonly reason: string;
+}
+
+export interface ProviderFallbackCandidate {
+  readonly instanceId: ProviderInstanceId;
+  readonly displayName: string;
+  readonly modelSelection: ModelSelection;
+  readonly provider: ServerProvider;
+}
+
+export interface ProviderFallbackPlan {
+  readonly candidates: ReadonlyArray<ProviderFallbackCandidate>;
+  readonly skipped: ReadonlyArray<ProviderFallbackSkip>;
+}
+
+const RATE_LIMIT_PATTERN =
+  /\b(?:rate[ -]?limit|usage limit|quota|too many requests|resource exhausted|credits? exhausted|limit reached)\b/i;
+const AUTH_PATTERN =
+  /\b(?:unauthenticated|authentication|not authenticated|invalid (?:api )?key|expired token|login required|unauthorized|forbidden)\b/i;
+const TRANSPORT_PATTERN =
+  /\b(?:connection (?:closed|lost|refused|reset)|network|socket|timed? out|timeout|transport|broken pipe|econnreset|econnrefused|service unavailable|bad gateway|gateway timeout|http 5\d\d)\b/i;
+const isProviderUnsupportedError = Schema.is(ProviderUnsupportedError);
+const isProviderAdapterProcessError = Schema.is(ProviderAdapterProcessError);
+const isProviderAdapterRequestError = Schema.is(ProviderAdapterRequestError);
+
+function classifyMessage(message: string): ProviderFallbackFailure | undefined {
+  if (RATE_LIMIT_PATTERN.test(message)) return { kind: "rate-limit", message };
+  if (AUTH_PATTERN.test(message)) return { kind: "authentication", message };
+  if (TRANSPORT_PATTERN.test(message)) return { kind: "transport", message };
+  return undefined;
+}
+
+export function classifyProviderServiceFailure(
+  cause: Cause.Cause<ProviderServiceError | unknown>,
+): ProviderFallbackFailure | undefined {
+  const failReason = cause.reasons.find(Cause.isFailReason);
+  const error = failReason?.error;
+  if (isProviderUnsupportedError(error)) {
+    return { kind: "unavailable", message: error.message };
+  }
+  if (isProviderAdapterProcessError(error)) {
+    return { kind: "process", message: error.detail };
+  }
+  if (isProviderAdapterRequestError(error)) {
+    return classifyMessage(error.detail);
+  }
+  return error instanceof Error
+    ? classifyMessage(error.message)
+    : classifyMessage(Cause.pretty(cause));
+}
+
+export function classifyProviderRuntimeFailure(
+  event: ProviderRuntimeEvent,
+): ProviderFallbackFailure | undefined {
+  if (event.type === "runtime.error") {
+    if (event.payload.class === "transport_error") {
+      return { kind: "transport", message: event.payload.message };
+    }
+    return classifyMessage(event.payload.message);
+  }
+  if (event.type === "session.exited" && event.payload.exitKind === "error") {
+    const message = event.payload.reason ?? "Provider process exited unexpectedly.";
+    return classifyMessage(message) ?? { kind: "process", message };
+  }
+  if (event.type === "turn.completed" && event.payload.state === "failed") {
+    const message = event.payload.errorMessage ?? "Provider turn failed.";
+    return classifyMessage(message);
+  }
+  return undefined;
+}
+
+export function providerFallbackDisplayName(provider: ServerProvider): string {
+  return provider.displayName?.trim() || String(provider.instanceId);
+}
+
+export function planProviderFallback(input: {
+  readonly settings: ServerSettings;
+  readonly providers: ReadonlyArray<ServerProvider>;
+  readonly currentInstanceId: ProviderInstanceId;
+  readonly modelSelection: ModelSelection;
+  readonly requireCompatibleContinuation: boolean;
+}): ProviderFallbackPlan {
+  const current = input.providers.find(
+    (provider) => provider.instanceId === input.currentInstanceId,
+  );
+  if (!current) return { candidates: [], skipped: [] };
+
+  const candidates: ProviderFallbackCandidate[] = [];
+  const skipped: ProviderFallbackSkip[] = [];
+  for (const provider of input.providers) {
+    if (provider.instanceId === current.instanceId || provider.driver !== current.driver) continue;
+    const displayName = providerFallbackDisplayName(provider);
+    const skip = (reason: string) =>
+      skipped.push({ instanceId: provider.instanceId, displayName, reason });
+    const config = input.settings.providerInstances[provider.instanceId];
+
+    if (config?.allowFallback === false) {
+      skip("Automatic fallback is disabled for this instance.");
+      continue;
+    }
+    if (!provider.enabled || provider.status === "disabled") {
+      skip("The instance is disabled.");
+      continue;
+    }
+    if (!provider.installed || !isProviderAvailable(provider) || provider.status === "error") {
+      skip(provider.unavailableReason ?? provider.message ?? "The instance is unavailable.");
+      continue;
+    }
+    if (!provider.models.some((model) => model.slug === input.modelSelection.model)) {
+      skip(`Model '${input.modelSelection.model}' was not found on this instance.`);
+      continue;
+    }
+    if (input.requireCompatibleContinuation) {
+      const currentGroup = current.continuation?.groupKey;
+      const candidateGroup = provider.continuation?.groupKey;
+      if (!currentGroup || !candidateGroup || currentGroup !== candidateGroup) {
+        skip(
+          "The provider home directory or continuation store does not match the active instance.",
+        );
+        continue;
+      }
+    }
+
+    candidates.push({
+      instanceId: provider.instanceId,
+      displayName,
+      modelSelection: { ...input.modelSelection, instanceId: provider.instanceId },
+      provider,
+    });
+  }
+  return { candidates, skipped };
+}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1736,9 +1736,18 @@ function ChatViewContent(props: ChatViewProps) {
           </ul>
         ) : undefined;
       const description =
-        activity.kind === "provider.fallback.succeeded" && detail
-          ? `Switched after “${from}” reported: ${detail}`
-          : detail;
+        activity.kind === "provider.fallback.succeeded" && detail ? (
+          <div className="grid gap-2">
+            <p>
+              Switched after <span className="font-medium text-foreground">“{from}”</span> reported:
+            </p>
+            <div className="whitespace-pre-wrap wrap-break-word rounded-md border border-border/70 bg-muted/40 px-2.5 py-2 font-mono text-[11px] leading-relaxed text-foreground/85 shadow-inner">
+              {detail}
+            </div>
+          </div>
+        ) : (
+          detail
+        );
 
       toastManager.add(
         stackedThreadToast({

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1684,6 +1684,86 @@ function ChatViewContent(props: ChatViewProps) {
   const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
   const phase = derivePhase(activeThread?.session ?? null);
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
+  const seenFallbackActivityIdsByThreadRef = useRef(new Map<string, Set<string>>());
+  useEffect(() => {
+    if (!activeThreadKey || !activeThreadRef) return;
+    const existing = seenFallbackActivityIdsByThreadRef.current.get(activeThreadKey);
+    if (!existing) {
+      seenFallbackActivityIdsByThreadRef.current.set(
+        activeThreadKey,
+        new Set(threadActivities.map((activity) => String(activity.id))),
+      );
+      return;
+    }
+
+    for (const activity of threadActivities) {
+      const activityId = String(activity.id);
+      if (existing.has(activityId)) continue;
+      existing.add(activityId);
+      if (
+        activity.kind !== "provider.fallback.succeeded" &&
+        activity.kind !== "provider.fallback.failed"
+      ) {
+        continue;
+      }
+      const payload =
+        activity.payload && typeof activity.payload === "object" && !Array.isArray(activity.payload)
+          ? (activity.payload as Record<string, unknown>)
+          : {};
+      const from =
+        typeof payload.fromDisplayName === "string" ? payload.fromDisplayName : "current instance";
+      const to = typeof payload.toDisplayName === "string" ? payload.toDisplayName : null;
+      const detail = typeof payload.detail === "string" ? payload.detail : undefined;
+      const skipped = Array.isArray(payload.skipped)
+        ? payload.skipped.filter(
+            (entry): entry is { instanceId: string; displayName: string; reason: string } =>
+              Boolean(entry) &&
+              typeof entry === "object" &&
+              typeof (entry as Record<string, unknown>).instanceId === "string" &&
+              typeof (entry as Record<string, unknown>).displayName === "string" &&
+              typeof (entry as Record<string, unknown>).reason === "string",
+          )
+        : [];
+      const expandableContent =
+        skipped.length > 0 ? (
+          <ul className="grid gap-1.5 text-xs text-muted-foreground">
+            {skipped.map((entry) => (
+              <li key={entry.instanceId}>
+                <span className="font-medium text-foreground">{entry.displayName}</span>:{" "}
+                {entry.reason}
+              </li>
+            ))}
+          </ul>
+        ) : undefined;
+      const description =
+        activity.kind === "provider.fallback.succeeded" && detail
+          ? `Switched after “${from}” reported: ${detail}`
+          : detail;
+
+      toastManager.add(
+        stackedThreadToast({
+          type: activity.kind === "provider.fallback.succeeded" ? "success" : "error",
+          title:
+            activity.kind === "provider.fallback.succeeded" && to
+              ? `Switched from ${from} to ${to}`
+              : `Could not switch from ${from}`,
+          ...(description ? { description } : {}),
+          data: {
+            threadRef: activeThreadRef,
+            ...(expandableContent
+              ? {
+                  expandableContent,
+                  expandableLabels: {
+                    expand: "Show skipped instances",
+                    collapse: "Hide skipped instances",
+                  },
+                }
+              : {}),
+          },
+        }),
+      );
+    }
+  }, [activeThreadKey, activeThreadRef, threadActivities]);
   const workLogEntries = useMemo(() => deriveWorkLogEntries(threadActivities), [threadActivities]);
   const pendingApprovals = useMemo(
     () => derivePendingApprovals(threadActivities),

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1714,6 +1714,7 @@ function ChatViewContent(props: ChatViewProps) {
         typeof payload.fromDisplayName === "string" ? payload.fromDisplayName : "current instance";
       const to = typeof payload.toDisplayName === "string" ? payload.toDisplayName : null;
       const detail = typeof payload.detail === "string" ? payload.detail : undefined;
+      const restoredOriginalInstance = payload.restoredOriginalInstance === true;
       const skipped = Array.isArray(payload.skipped)
         ? payload.skipped.filter(
             (entry): entry is { instanceId: string; displayName: string; reason: string } =>
@@ -1755,7 +1756,9 @@ function ChatViewContent(props: ChatViewProps) {
           title:
             activity.kind === "provider.fallback.succeeded" && to
               ? `Switched from ${from} to ${to}`
-              : `Could not switch from ${from}`,
+              : restoredOriginalInstance
+                ? "No fallback instance succeeded"
+                : `Could not switch from ${from}`,
           ...(description ? { description } : {}),
           data: {
             threadRef: activeThreadRef,

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -326,6 +326,7 @@ interface ProviderInstanceCardProps {
   readonly isExpanded: boolean;
   readonly onExpandedChange: (open: boolean) => void;
   readonly onUpdate: (nextInstance: ProviderInstanceConfig) => void;
+  readonly providerFallbackEnabled: boolean;
   /**
    * Pass `undefined` to hide the delete button entirely. Built-in default
    * instance slots use `undefined` — they can't be deleted without losing
@@ -383,6 +384,7 @@ export function ProviderInstanceCard({
   isExpanded,
   onExpandedChange,
   onUpdate,
+  providerFallbackEnabled,
   onDelete,
   headerAction,
   hiddenModels,
@@ -464,6 +466,10 @@ export function ProviderInstanceCard({
 
   const updateEnabled = (value: boolean) => {
     onUpdate({ ...instance, enabled: value });
+  };
+
+  const updateAllowFallback = (value: boolean) => {
+    onUpdate({ ...instance, allowFallback: value });
   };
 
   const updateAccentColor = (value: string) => {
@@ -745,6 +751,39 @@ export function ProviderInstanceCard({
                   Optional label shown in the provider list.
                 </span>
               </label>
+            </div>
+
+            <div className="border-t border-border/60 px-4 py-3 sm:px-5">
+              <div className="flex items-center justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="text-xs font-medium text-foreground">Use for automatic fallback</p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Allows this instance to receive compatible turns when another instance fails.
+                  </p>
+                </div>
+                <Tooltip>
+                  <TooltipTrigger
+                    render={
+                      <span
+                        className="inline-flex shrink-0"
+                        tabIndex={providerFallbackEnabled ? -1 : 0}
+                      />
+                    }
+                  >
+                    <Switch
+                      checked={instance.allowFallback ?? true}
+                      disabled={!providerFallbackEnabled}
+                      onCheckedChange={(checked) => updateAllowFallback(Boolean(checked))}
+                      aria-label={`Allow ${displayName} for automatic fallback`}
+                    />
+                  </TooltipTrigger>
+                  {!providerFallbackEnabled ? (
+                    <TooltipPopup side="top">
+                      Enable automatic provider fallback to change this setting.
+                    </TooltipPopup>
+                  ) : null}
+                </Tooltip>
+              </div>
             </div>
 
             <div className="border-t border-border/60 px-4 py-3 sm:px-5">

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1379,6 +1379,7 @@ export function ProviderSettingsPanel() {
                   updateProviderInstance(row, next);
                 }
               }}
+              providerFallbackEnabled={settings.providerFallback.enabled}
               onDelete={row.isDefault ? undefined : () => deleteProviderInstance(row.instanceId)}
               headerAction={headerAction}
               hiddenModels={modelPreferences.hiddenModels}
@@ -1413,6 +1414,24 @@ export function ProviderSettingsPanel() {
             />
           );
         })}
+      </SettingsSection>
+
+      <SettingsSection title="Automatic fallback">
+        <SettingsRow
+          title="Switch provider instances automatically"
+          description="When an operational provider failure occurs, try compatible instances of the same provider in order without exposing intermediate failures."
+          control={
+            <Switch
+              checked={settings.providerFallback.enabled}
+              onCheckedChange={(checked) =>
+                updateSettings({
+                  providerFallback: { enabled: Boolean(checked) },
+                })
+              }
+              aria-label="Enable automatic provider fallback"
+            />
+          }
+        />
       </SettingsSection>
 
       {isAddInstanceDialogOpen ? (

--- a/packages/contracts/src/providerInstance.ts
+++ b/packages/contracts/src/providerInstance.ts
@@ -127,6 +127,8 @@ export const ProviderInstanceConfig = Schema.Struct({
   accentColor: Schema.optional(TrimmedNonEmptyString),
   environment: Schema.optionalKey(ProviderInstanceEnvironment),
   enabled: Schema.optionalKey(Schema.Boolean),
+  /** Whether this instance may participate in automatic same-driver fallback. */
+  allowFallback: Schema.optionalKey(Schema.Boolean),
   config: Schema.optionalKey(Schema.Unknown),
 });
 export type ProviderInstanceConfig = typeof ProviderInstanceConfig.Type;

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -11,6 +11,7 @@ const encodeServerSettings = Schema.encodeSync(ServerSettings);
 describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   it("defaults to an empty record so legacy configs without the key still decode", () => {
     expect(DEFAULT_SERVER_SETTINGS.providerInstances).toEqual({});
+    expect(DEFAULT_SERVER_SETTINGS.providerFallback.enabled).toBe(false);
   });
 
   it("decodes a fully empty config (legacy on-disk shape) without complaint", () => {

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -386,6 +386,9 @@ export const ServerSettings = Schema.Struct({
       }),
     ),
   ),
+  providerFallback: Schema.Struct({
+    enabled: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
+  }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
 
   // Legacy single-instance-per-driver settings. Continues to be the source
   // of truth until `providerInstances` (below) lands per-driver migration
@@ -510,6 +513,11 @@ export const ServerSettingsPatch = Schema.Struct({
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),
   addProjectBaseDirectory: Schema.optionalKey(TrimmedString),
   textGenerationModelSelection: Schema.optionalKey(ModelSelectionPatch),
+  providerFallback: Schema.optionalKey(
+    Schema.Struct({
+      enabled: Schema.optionalKey(Schema.Boolean),
+    }),
+  ),
   observability: Schema.optionalKey(
     Schema.Struct({
       otlpTracesUrl: Schema.optionalKey(TrimmedString),


### PR DESCRIPTION
## What Changed

Adds opt-in automatic fallback between multiple instances of the same provider driver.

- Adds a global **Automatic fallback** setting, disabled by default.
- Adds a per-instance **Use for automatic fallback** setting, enabled by default. The control is disabled while global fallback is off and explains why on hover.
- Retries eligible provider instances in deterministic provider-list order and stops after the first successful attempt.
- Handles both initial request failures and operational failures that occur during an active task.
- Updates the thread's active instance and model selection only after a successful handoff.
- Reports one final success or failure toast, with skipped candidates and their reasons in expandable details.

## Why

A provider instance can become unusable because of a usage limit, expired authentication, process failure, transport failure, or temporary unavailability. Users with another configured instance of the same provider previously had to surface the error, switch instances manually, and restart or continue the task themselves.

This keeps those failures recoverable without changing normal behavior when the feature is disabled or when the error is not operational.

## How It Works

### Failure classification

Fallback is attempted only for operational failures:

- rate or usage limits, quotas, and exhausted credits
- authentication failures
- network, transport, timeout, and upstream 5xx failures
- provider process failures
- unavailable or unsupported provider runtimes

Validation errors, cancellation, permission decisions, malformed prompts, and unrelated provider errors continue through the existing error path.

### Candidate selection

Candidates are considered in provider-list order. An instance is skipped when:

- it belongs to a different provider driver
- its per-instance fallback setting is off
- it is disabled, not installed, unavailable, or in an error state
- it does not expose the exact model used by the current thread
- continuation compatibility is required and its provider home/continuation store differs from the active instance
- starting its session or sending the retry fails

Each skipped instance records a user-facing reason. The workflow stops immediately when one candidate accepts the turn; later candidates are not attempted.

### First request versus an active task

For the first user message, a compatible same-driver instance receives the original prompt, attachments, model, runtime mode, and interaction mode.

For an existing conversation or a failure during an active task, fallback additionally requires the same provider-native continuation group. It starts the candidate with the original native resume cursor and sends a hidden `Continue.` turn. No summary or synthesized context is inserted, so the provider resumes from its own conversation state.

### Success and total failure

On success, the server commits the candidate session and model selection, persists one fallback activity, and the UI shows:

> Switched from Original Instance to New Instance
>
> Switched after “Original Instance” reported: error details

Skipped candidates are available under expandable toast details.

If every candidate is skipped or fails, the server restores the original provider binding when necessary, preserves the original model selection, emits one fallback-failed activity, and then allows the original provider error to follow the existing error path. If fallback infrastructure itself fails unexpectedly, that failure is logged and the original error is still surfaced.

## UI Changes

Before this change, the Providers settings page had no fallback controls and operational provider errors surfaced immediately. The screenshots below show the new states.

### Global opt-in

![Providers settings with automatic fallback](https://raw.githubusercontent.com/edoedac0/t3code/5379b45b1248a7e1f99b3c41a2c83a4e20ec89d1/pr-assets/provider-instance-fallback/settings-overview.png)

### Per-instance participation

![Per-instance automatic fallback setting](https://raw.githubusercontent.com/edoedac0/t3code/5379b45b1248a7e1f99b3c41a2c83a4e20ec89d1/pr-assets/provider-instance-fallback/instance-enabled.png)

### Disabled control explanation

![Disabled per-instance setting tooltip](https://raw.githubusercontent.com/edoedac0/t3code/5379b45b1248a7e1f99b3c41a2c83a4e20ec89d1/pr-assets/provider-instance-fallback/instance-disabled-tooltip.png)

### Exhausted fallback details

![Fallback failure toast with skipped instance details](https://raw.githubusercontent.com/edoedac0/t3code/5379b45b1248a7e1f99b3c41a2c83a4e20ec89d1/pr-assets/provider-instance-fallback/fallback-failed-toast.png)

## Successful switching demo

The recording shows an operational failure on the active provider instance, the automatic handoff, the final switch toast, and the updated active instance/model selection.

https://raw.githubusercontent.com/edoedac0/t3code/7322c743ac3586fe82839bd25a8bda40b4019c39/pr-assets/provider-instance-fallback/successful-switch.mp4

## Validation

- `./node_modules/.bin/vp check` — passed (0 errors; 20 existing warnings)
- `./node_modules/.bin/vp run typecheck` — passed
- `./node_modules/.bin/vp test` — 536 files passed, 2 skipped; 4,073 tests passed, 7 skipped

## Checklist

- [x] This PR is focused on one provider reliability feature
- [x] I explained what changed and why
- [x] I included clear screenshots for the UI states
- [x] I included a video demonstrating the successful switching interaction


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add automatic provider instance fallback when a provider turn fails
> - Introduces a full fallback workflow ([providerFallbackWorkflow.ts](https://github.com/pingdotgg/t3code/pull/3482/files#diff-af24ec66db12611586afbad933a3e85a4ec3e1f47a76397d412efc0167863ec2)) that plans candidate provider instances, serializes concurrent attempts per thread, switches the session/model selection, and emits `provider.fallback.succeeded` or `provider.fallback.failed` activity records.
> - Adds [providerFallbackChain.ts](https://github.com/pingdotgg/t3code/pull/3482/files#diff-df29b3fd76455b56500dc02e34060d381489a90007c1f19b2c02173ae6ad7bb9) to track attempted instances across a chain per thread, and [providerFallbackTrialGate.ts](https://github.com/pingdotgg/t3code/pull/3482/files#diff-4ac643eabb99c5cf887e626fd11bec7c888423894b05763f22f4562391240ba1) to defer or reject runtime events from a candidate instance until the trial commits.
> - Updates [ProviderCommandReactor.ts](https://github.com/pingdotgg/t3code/pull/3482/files#diff-0630e9ad70d5dcd1c8586d29297f9b7d5f5436cc8e10fc88dc22acc511f1450d) and [ProviderRuntimeIngestion.ts](https://github.com/pingdotgg/t3code/pull/3482/files#diff-22a6c9818b956463b848a73a5b3e787b44a144bd003b1cc25fa2b1b3110cdea7) to trigger fallback on classified service and runtime failures, with deduplication and chain reset on new user turns.
> - Adds a global `providerFallback.enabled` server setting (default `false`) and a per-instance `allowFallback` flag so operators control participation.
> - The chat UI shows toasts summarizing fallback success or failure, including skipped instances, via [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/3482/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e).
> - Risk: fallback is off by default but once enabled, a failed turn triggers session replacement and model selection changes on the thread automatically.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43d4637.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core provider session binding, turn recovery, and runtime event ingestion; misclassification or trial/handoff bugs could hide errors, leak partial output, or leave threads on the wrong instance.
> 
> **Overview**
> Introduces **automatic provider instance fallback** (off by default) so threads can recover from operational failures by trying other **same-driver** instances before surfacing errors.
> 
> **Server orchestration** classifies service and runtime failures, plans candidates in provider-list order (model match, availability, per-instance `allowFallback`, continuation compatibility, no re-tries in the current chain), and runs `attemptProviderFallback` under a per-thread lock. Turn-start failures in `ProviderCommandReactor` attempt fallback before the usual failure activity; `ProviderRuntimeIngestion` does the same on mid-task failures with a hidden `Continue.` turn, filters stale instance events, and uses a **trial gate** so provisional candidate output is held until a handoff commits or is discarded.
> 
> **Contracts & UI**: `ServerSettings.providerFallback.enabled` and per-instance `allowFallback`; settings switches and **ChatView** toasts for `provider.fallback.succeeded` / `provider.fallback.failed` with skipped-instance details.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43d46373b183bbcb482a5addc89b71b0d958facb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->