### PR TITLE
[codex] Restore T3 Connect account controls

### DIFF
--- a/apps/web/src/cloud/linkEnvironment.test.ts
+++ b/apps/web/src/cloud/linkEnvironment.test.ts
@@ -33,6 +33,7 @@ import {
   readPrimaryCloudLinkState,
   type CloudLinkTarget,
   unlinkPrimaryEnvironmentFromCloud,
+  updatePrimaryCloudPreferences,
 } from "./linkEnvironment";
 
 const TARGET: CloudLinkTarget = {
@@ -249,6 +250,38 @@ describe("web cloud link environment client", () => {
       const request = new Request(fetchMock.mock.calls[0]?.[0], fetchMock.mock.calls[0]?.[1]);
       expect(request.credentials).not.toBe("include");
       expect(request.headers.get("authorization")).toBe("Bearer desktop-bearer-token");
+    }),
+  );
+
+  it.effect("updates agent activity publishing for the explicit primary target", () =>
+    Effect.gen(function* () {
+      const fetchMock = vi.fn().mockResolvedValue(
+        Response.json({
+          linked: true,
+          cloudUserId: "user-1",
+          relayUrl: "https://relay.example.test",
+          relayIssuer: "https://relay.example.test",
+          publishAgentActivity: true,
+        }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      const state = yield* withServices(
+        updatePrimaryCloudPreferences({
+          target: TARGET,
+          publishAgentActivity: true,
+        }),
+      );
+
+      expect(state.publishAgentActivity).toBe(true);
+      expect(String(fetchMock.mock.calls[0]?.[0])).toBe(
+        "http://127.0.0.1:3000/api/connect/preferences",
+      );
+      expect(fetchMock.mock.calls[0]?.[1]?.method).toBe("POST");
+      // @effect-diagnostics-next-line preferSchemaOverJson:off
+      expect(JSON.parse(bodyText(fetchMock.mock.calls[0]?.[1]?.body))).toEqual({
+        publishAgentActivity: true,
+      });
     }),
   );
 

--- a/apps/web/src/cloud/linkEnvironmentAtoms.ts
+++ b/apps/web/src/cloud/linkEnvironmentAtoms.ts
@@ -8,6 +8,7 @@ import {
   linkPrimaryEnvironmentToCloud,
   type CloudLinkTarget,
   unlinkPrimaryEnvironmentFromCloud,
+  updatePrimaryCloudPreferences,
 } from "./linkEnvironment";
 
 const cloudLinkScheduler = createAtomCommandScheduler();
@@ -30,4 +31,12 @@ export const unlinkPrimaryEnvironment = createRuntimeCommand(connectionAtomRunti
   concurrency: cloudLinkConcurrency,
   execute: (input: { readonly target: CloudLinkTarget; readonly clerkToken: string | null }) =>
     unlinkPrimaryEnvironmentFromCloud(input),
+});
+
+export const updatePrimaryEnvironmentPreferences = createRuntimeCommand(connectionAtomRuntime, {
+  label: "web:cloud:update-primary-environment-preferences",
+  scheduler: cloudLinkScheduler,
+  concurrency: cloudLinkConcurrency,
+  execute: (input: { readonly target: CloudLinkTarget; readonly publishAgentActivity: boolean }) =>
+    updatePrimaryCloudPreferences(input),
 });

--- a/apps/web/src/components/clerk/MobileClientsUserProfilePage.logic.test.ts
+++ b/apps/web/src/components/clerk/MobileClientsUserProfilePage.logic.test.ts
@@ -1,0 +1,65 @@
+import type { RelayClientDeviceRecord } from "@t3tools/contracts/relay";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  mobileClientNotificationDetail,
+  mobileClientPlatformLabel,
+  mobileClientUpdatedAtLabel,
+} from "./MobileClientsUserProfilePage.logic";
+
+function device(overrides: Partial<RelayClientDeviceRecord> = {}): RelayClientDeviceRecord {
+  return {
+    deviceId: "device-1",
+    label: "Julius’s iPhone",
+    platform: "ios",
+    iosMajorVersion: 18,
+    appVersion: "1.2.3",
+    notifications: {
+      enabled: true,
+      notifyOnApproval: true,
+      notifyOnInput: false,
+      notifyOnCompletion: true,
+      notifyOnFailure: false,
+    },
+    liveActivities: { enabled: true },
+    updatedAt: "2026-06-21T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("mobile client presentation", () => {
+  it("describes the client platform and enabled notification events", () => {
+    const client = device();
+
+    expect(mobileClientPlatformLabel(client)).toBe("iOS 18 · T3 Code 1.2.3");
+    expect(mobileClientNotificationDetail(client)).toBe(
+      "Alerts enabled for approvals, completions.",
+    );
+  });
+
+  it("distinguishes disabled notifications from an empty event selection", () => {
+    expect(
+      mobileClientNotificationDetail(
+        device({ notifications: { ...device().notifications, enabled: false } }),
+      ),
+    ).toBe("Push notifications are disabled on this device.");
+    expect(
+      mobileClientNotificationDetail(
+        device({
+          notifications: {
+            enabled: true,
+            notifyOnApproval: false,
+            notifyOnInput: false,
+            notifyOnCompletion: false,
+            notifyOnFailure: false,
+          },
+        }),
+      ),
+    ).toBe("Push notifications are enabled, but no alert types are selected.");
+  });
+
+  it("handles missing app versions and invalid update timestamps", () => {
+    expect(mobileClientPlatformLabel(device({ appVersion: null }))).toBe("iOS 18");
+    expect(mobileClientUpdatedAtLabel("not-a-date")).toBe("Update time unavailable");
+  });
+});

--- a/apps/web/src/components/clerk/MobileClientsUserProfilePage.logic.ts
+++ b/apps/web/src/components/clerk/MobileClientsUserProfilePage.logic.ts
@@ -1,0 +1,39 @@
+import type { RelayClientDeviceRecord } from "@t3tools/contracts/relay";
+
+const mobileClientUpdatedAtFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "short",
+});
+
+const NOTIFICATION_PREFERENCES = [
+  ["notifyOnApproval", "approvals"],
+  ["notifyOnInput", "input requests"],
+  ["notifyOnCompletion", "completions"],
+  ["notifyOnFailure", "failures"],
+] as const satisfies ReadonlyArray<
+  readonly [keyof RelayClientDeviceRecord["notifications"], string]
+>;
+
+export function mobileClientPlatformLabel(device: RelayClientDeviceRecord): string {
+  return `iOS ${device.iosMajorVersion}${device.appVersion ? ` · T3 Code ${device.appVersion}` : ""}`;
+}
+
+export function mobileClientNotificationDetail(device: RelayClientDeviceRecord): string {
+  if (!device.notifications.enabled) {
+    return "Push notifications are disabled on this device.";
+  }
+
+  const enabledPreferences = NOTIFICATION_PREFERENCES.flatMap(([preference, label]) =>
+    device.notifications[preference] ? [label] : [],
+  );
+  return enabledPreferences.length > 0
+    ? `Alerts enabled for ${enabledPreferences.join(", ")}.`
+    : "Push notifications are enabled, but no alert types are selected.";
+}
+
+export function mobileClientUpdatedAtLabel(updatedAt: string): string {
+  const date = new Date(updatedAt);
+  return Number.isNaN(date.getTime())
+    ? "Update time unavailable"
+    : `Updated ${mobileClientUpdatedAtFormatter.format(date)}`;
+}

--- a/apps/web/src/components/clerk/MobileClientsUserProfilePage.tsx
+++ b/apps/web/src/components/clerk/MobileClientsUserProfilePage.tsx
@@ -1,0 +1,164 @@
+import type { RelayClientDeviceRecord } from "@t3tools/contracts/relay";
+import { RefreshCwIcon, SmartphoneIcon } from "lucide-react";
+
+import { useManagedRelayDevices } from "../../cloud/managedRelayState";
+import { cn } from "../../lib/utils";
+import { Badge } from "../ui/badge";
+import { Button } from "../ui/button";
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from "../ui/empty";
+import { Skeleton } from "../ui/skeleton";
+import {
+  mobileClientNotificationDetail,
+  mobileClientPlatformLabel,
+  mobileClientUpdatedAtLabel,
+} from "./MobileClientsUserProfilePage.logic";
+
+const MOBILE_CLIENT_SKELETON_ROWS = ["primary", "secondary"] as const;
+
+function MobileClientStatusBadge({
+  enabled,
+  label,
+}: {
+  readonly enabled: boolean;
+  readonly label: string;
+}) {
+  return (
+    <Badge variant={enabled ? "success" : "outline"}>
+      {label}: {enabled ? "On" : "Off"}
+    </Badge>
+  );
+}
+
+function MobileClientRow({ device }: { readonly device: RelayClientDeviceRecord }) {
+  return (
+    <li className="rounded-xl border bg-card p-4 text-card-foreground shadow-sm/4">
+      <div className="flex items-start gap-3">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border bg-muted/40 text-muted-foreground">
+          <SmartphoneIcon className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between sm:gap-3">
+            <div className="min-w-0">
+              <h3 className="truncate text-sm font-semibold text-foreground">{device.label}</h3>
+              <p className="text-xs text-muted-foreground">{mobileClientPlatformLabel(device)}</p>
+            </div>
+            <p className="shrink-0 text-[11px] text-muted-foreground/75">
+              {mobileClientUpdatedAtLabel(device.updatedAt)}
+            </p>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-1.5">
+            <MobileClientStatusBadge
+              enabled={device.notifications.enabled}
+              label="Push notifications"
+            />
+            <MobileClientStatusBadge
+              enabled={device.liveActivities.enabled}
+              label="Live Activities"
+            />
+          </div>
+          <p className="mt-2 text-xs leading-relaxed text-muted-foreground/80">
+            {mobileClientNotificationDetail(device)}
+          </p>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function MobileClientsSkeleton() {
+  return (
+    <div aria-label="Loading mobile clients" className="space-y-3" role="status">
+      {MOBILE_CLIENT_SKELETON_ROWS.map((row) => (
+        <div key={row} className="rounded-xl border p-4">
+          <div className="flex gap-3">
+            <Skeleton className="size-9 shrink-0 rounded-lg" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-3 w-28" />
+              <div className="flex gap-2 pt-1">
+                <Skeleton className="h-5 w-28" />
+                <Skeleton className="h-5 w-24" />
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyMobileClients() {
+  return (
+    <Empty className="min-h-72 rounded-xl border border-dashed bg-muted/15">
+      <EmptyMedia variant="icon">
+        <SmartphoneIcon />
+      </EmptyMedia>
+      <EmptyHeader>
+        <EmptyTitle>No mobile clients</EmptyTitle>
+        <EmptyDescription>
+          Sign in to T3 Code on your iPhone to register it for push notifications and Live
+          Activities.
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}
+
+export function MobileClientsUserProfilePage() {
+  const devicesState = useManagedRelayDevices();
+  const devices = devicesState.data ?? [];
+  const isInitialLoad = devicesState.data === null && !devicesState.error;
+
+  return (
+    <div className="flex min-h-[30rem] w-full flex-col bg-background text-foreground">
+      <header className="flex flex-col gap-4 border-b px-6 py-5 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-base font-semibold tracking-[-0.01em]">Mobile clients</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Devices registered to receive T3 Connect activity from your environments.
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          disabled={devicesState.isPending}
+          onClick={devicesState.refresh}
+        >
+          <RefreshCwIcon className={cn("size-3.5", devicesState.isPending && "animate-spin")} />
+          Refresh
+        </Button>
+      </header>
+
+      <div className="flex-1 p-6">
+        {devicesState.error ? (
+          <div
+            className="mb-4 flex flex-col gap-3 rounded-lg border border-destructive/25 bg-destructive/5 p-3 text-sm sm:flex-row sm:items-center sm:justify-between"
+            role="alert"
+          >
+            <div>
+              <p className="font-medium text-destructive-foreground">
+                Could not load mobile clients
+              </p>
+              <p className="mt-0.5 text-xs text-muted-foreground">{devicesState.error}</p>
+            </div>
+            <Button size="xs" variant="outline" onClick={devicesState.refresh}>
+              Try again
+            </Button>
+          </div>
+        ) : null}
+
+        {isInitialLoad ? (
+          <MobileClientsSkeleton />
+        ) : devices.length > 0 ? (
+          <ul className="space-y-3">
+            {devices.map((device) => (
+              <MobileClientRow key={device.deviceId} device={device} />
+            ))}
+          </ul>
+        ) : (
+          <EmptyMobileClients />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/clerk/MobileClientsUserProfilePage.tsx
+++ b/apps/web/src/components/clerk/MobileClientsUserProfilePage.tsx
@@ -107,7 +107,9 @@ function EmptyMobileClients() {
 export function MobileClientsUserProfilePage() {
   const devicesState = useManagedRelayDevices();
   const devices = devicesState.data ?? [];
-  const isInitialLoad = devicesState.data === null && !devicesState.error;
+  const isInitialLoad =
+    !devicesState.accountId || (devicesState.data === null && !devicesState.error);
+  const hasErrorWithoutData = devicesState.error !== null && devicesState.data === null;
 
   return (
     <div className="flex min-h-[30rem] w-full flex-col bg-background text-foreground">
@@ -149,7 +151,7 @@ export function MobileClientsUserProfilePage() {
 
         {isInitialLoad ? (
           <MobileClientsSkeleton />
-        ) : devices.length > 0 ? (
+        ) : hasErrorWithoutData ? null : devices.length > 0 ? (
           <ul className="space-y-3">
             {devices.map((device) => (
               <MobileClientRow key={device.deviceId} device={device} />

--- a/apps/web/src/components/clerk/T3ConnectSidebarSignIn.tsx
+++ b/apps/web/src/components/clerk/T3ConnectSidebarSignIn.tsx
@@ -1,8 +1,9 @@
 import { UserButton, useAuth } from "@clerk/react";
-import { LogInIcon } from "lucide-react";
+import { LogInIcon, SmartphoneIcon } from "lucide-react";
 
 import { hasCloudPublicConfig } from "../../cloud/publicConfig";
 import { SidebarMenu, SidebarMenuButton, SidebarMenuItem } from "../ui/sidebar";
+import { MobileClientsUserProfilePage } from "./MobileClientsUserProfilePage";
 import { useT3ConnectAuthPrompt } from "./useT3ConnectAuthPrompt";
 
 export function T3ConnectSidebarSignIn() {
@@ -30,7 +31,15 @@ function ConfiguredT3ConnectSidebarAvatar() {
           userButtonTrigger: "rounded-lg p-1 hover:bg-sidebar-accent",
         },
       }}
-    />
+    >
+      <UserButton.UserProfilePage
+        label="Mobile clients"
+        labelIcon={<SmartphoneIcon className="size-4" />}
+        url="mobile-clients"
+      >
+        <MobileClientsUserProfilePage />
+      </UserButton.UserProfilePage>
+    </UserButton>
   );
 }
 

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -118,6 +118,7 @@ import { hasCloudPublicConfig } from "~/cloud/publicConfig";
 import {
   linkPrimaryEnvironment as linkPrimaryEnvironmentAtom,
   unlinkPrimaryEnvironment as unlinkPrimaryEnvironmentAtom,
+  updatePrimaryEnvironmentPreferences as updatePrimaryEnvironmentPreferencesAtom,
 } from "~/cloud/linkEnvironmentAtoms";
 import { authEnvironment } from "~/state/auth";
 import { environmentCatalog } from "~/connection/catalog";
@@ -1432,7 +1433,7 @@ function SavedBackendListRow({
       : null;
   const metadataBits = [
     sshTarget ? `SSH ${formatDesktopSshTarget(sshTarget)}` : null,
-    environment.relayManaged ? "T3 Cloud" : null,
+    environment.relayManaged ? "T3 Connect" : null,
   ].filter((value): value is string => value !== null);
 
   return (
@@ -1550,7 +1551,7 @@ function CloudLinkSwitch({
 }) {
   const control = (
     <Switch
-      aria-label="Enable T3 Cloud"
+      aria-label="Enable T3 Connect"
       checked={checked}
       disabled={disabled}
       {...(onCheckedChange ? { onCheckedChange } : {})}
@@ -1577,18 +1578,23 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
   const unlinkPrimaryEnvironment = useAtomCommand(unlinkPrimaryEnvironmentAtom, {
     reportFailure: false,
   });
+  const updatePrimaryEnvironmentPreferences = useAtomCommand(
+    updatePrimaryEnvironmentPreferencesAtom,
+    { reportFailure: false },
+  );
   const primaryCloudLinkState = usePrimaryCloudLinkState();
   const [operationError, setOperationError] = useState<string | null>(null);
   const [isUpdating, setIsUpdating] = useState(false);
+  const [isUpdatingPreference, setIsUpdatingPreference] = useState(false);
 
   const reportUpdateFailure = (cause: unknown) => {
-    const message = cause instanceof Error ? cause.message : "Could not update T3 Cloud access.";
+    const message = cause instanceof Error ? cause.message : "Could not update T3 Connect access.";
     const traceId = findErrorTraceId(cause);
-    console.error("[t3-cloud] Could not update T3 Cloud", { message, traceId, cause });
+    console.error("[t3-connect] Could not update T3 Connect", { message, traceId, cause });
     setOperationError(traceId ? `${message} Trace ID: ${traceId}` : message);
     toastManager.add({
       type: "error",
-      title: "Could not update T3 Cloud",
+      title: "Could not update T3 Connect",
       description: message,
       data: traceId
         ? {
@@ -1618,9 +1624,7 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
       return;
     }
     if (enabled && !tokenResult.value) {
-      reportUpdateFailure(
-        new Error("Sign in from T3 Cloud settings before linking this environment."),
-      );
+      reportUpdateFailure(new Error("Sign in to T3 Connect before linking this environment."));
       setIsUpdating(false);
       return;
     }
@@ -1655,38 +1659,95 @@ function ConfiguredCloudLinkRow({ canManageRelay }: { readonly canManageRelay: b
 
     toastManager.add({
       type: "success",
-      title: enabled ? "T3 Cloud linked" : "T3 Cloud unlinked",
+      title: enabled ? "T3 Connect linked" : "T3 Connect unlinked",
       description: enabled
-        ? "This environment is available through T3 Cloud."
-        : "This environment is no longer available through T3 Cloud.",
+        ? "This environment is available through T3 Connect."
+        : "This environment is no longer available through T3 Connect.",
     });
     setIsUpdating(false);
   };
+
+  const updatePublishAgentActivity = async (enabled: boolean) => {
+    const target = primaryCloudLinkState.target;
+    if (!target) {
+      reportUpdateFailure(new Error("Local environment is not ready yet."));
+      return;
+    }
+
+    setIsUpdatingPreference(true);
+    setOperationError(null);
+    const updateResult = await updatePrimaryEnvironmentPreferences({
+      target,
+      publishAgentActivity: enabled,
+    });
+    if (updateResult._tag === "Failure") {
+      if (!isAtomCommandInterrupted(updateResult)) {
+        reportUpdateFailure(squashAtomCommandFailure(updateResult));
+      }
+      setIsUpdatingPreference(false);
+      return;
+    }
+
+    primaryCloudLinkState.refresh();
+    toastManager.add({
+      type: "success",
+      title: enabled ? "Agent activity enabled" : "Agent activity disabled",
+      description: enabled
+        ? "This environment can publish agent activity to your mobile clients."
+        : "This environment will stop publishing agent activity.",
+    });
+    setIsUpdatingPreference(false);
+  };
   const disabledReason = !isSignedIn
-    ? "Sign in from T3 Cloud settings to manage this environment."
+    ? "Sign in to T3 Connect to manage this environment."
     : !canManageRelay
-      ? "Your session does not have permission to manage T3 Cloud access."
+      ? "Your session does not have permission to manage T3 Connect access."
       : null;
   const linked = primaryCloudLinkState.data?.linked ?? false;
 
   return (
-    <SettingsRow
-      title="T3 Cloud"
-      description={
-        linked
-          ? "This environment is available to your other devices through T3 Cloud."
-          : "Make this environment available to your other devices through T3 Cloud."
-      }
-      status={operationError ?? primaryCloudLinkState.error}
-      control={
-        <CloudLinkSwitch
-          checked={linked}
-          disabled={!canManageRelay || !isSignedIn || primaryCloudLinkState.isPending || isUpdating}
-          disabledReason={disabledReason}
-          onCheckedChange={(enabled) => void updateLink(enabled)}
+    <>
+      <SettingsRow
+        title="T3 Connect"
+        description={
+          linked
+            ? "This environment is available to your other devices through T3 Connect."
+            : "Make this environment available to your other devices through T3 Connect."
+        }
+        status={operationError ?? primaryCloudLinkState.error}
+        control={
+          <CloudLinkSwitch
+            checked={linked}
+            disabled={
+              !canManageRelay || !isSignedIn || primaryCloudLinkState.isPending || isUpdating
+            }
+            disabledReason={disabledReason}
+            onCheckedChange={(enabled) => void updateLink(enabled)}
+          />
+        }
+      />
+      {linked ? (
+        <SettingsRow
+          title="Publish agent activity"
+          description="Send activity from this environment to your mobile clients for push notifications and Live Activities."
+          className="bg-muted/20 pl-7 sm:pl-8"
+          control={
+            <Switch
+              aria-label="Publish agent activity to mobile clients"
+              checked={primaryCloudLinkState.data?.publishAgentActivity ?? false}
+              disabled={
+                !canManageRelay ||
+                !isSignedIn ||
+                primaryCloudLinkState.isPending ||
+                isUpdating ||
+                isUpdatingPreference
+              }
+              onCheckedChange={(enabled) => void updatePublishAgentActivity(enabled)}
+            />
+          }
         />
-      }
-    />
+      ) : null}
+    </>
   );
 }
 
@@ -1704,7 +1765,7 @@ function EmptyRemoteEnvironments({ cloudEnabled = true }: { readonly cloudEnable
         <EmptyTitle>No saved remote environments</EmptyTitle>
         <EmptyDescription>
           {cloudEnabled
-            ? "Click “Add environment” to pair another environment, or connect one from T3 Cloud."
+            ? "Click “Add environment” to pair another environment, or connect one from T3 Connect."
             : "Click “Add environment” to pair another environment."}
         </EmptyDescription>
       </EmptyHeader>
@@ -1769,7 +1830,7 @@ function ConfiguredCloudRemoteEnvironmentRows({
       toastManager.add({
         type: "success",
         title: "Environment connected",
-        description: `${environment.label} is available through T3 Cloud.`,
+        description: `${environment.label} is available through T3 Connect.`,
       });
       return;
     }
@@ -1778,9 +1839,9 @@ function ConfiguredCloudRemoteEnvironmentRows({
     }
     const cause = squashAtomCommandFailure(result);
     const message =
-      cause instanceof Error ? cause.message : "Could not connect the T3 Cloud environment.";
+      cause instanceof Error ? cause.message : "Could not connect the T3 Connect environment.";
     const traceId = findErrorTraceId(cause);
-    console.error("[t3-cloud] Could not connect environment", { message, traceId, cause });
+    console.error("[t3-connect] Could not connect environment", { message, traceId, cause });
     toastManager.add({
       type: "error",
       title: "Could not connect environment",


### PR DESCRIPTION
## Summary

- add a Clerk `UserButton.UserProfilePage` for account-level mobile clients
- show each registered client's push notification, Live Activity, app version, and notification-event status
- restore `Publish agent activity` as a nested setting under the local environment's T3 Connect exposure switch
- serialize preference changes with link/unlink operations and restore stale T3 Connect naming

## Root cause

The dedicated cloud settings page originally owned both notification-device status and the activity publication preference. The T3 Connect rebrand removed that page without moving the device view into Clerk. A later connection architecture rewrite also replaced the T3 Connect exposure row and dropped its nested publication toggle, while leaving the relay device APIs and server preference endpoint intact.

## Impact

Signed-in users can inspect registered mobile clients from the Clerk account component again. Linked server environments can explicitly opt into publishing agent activity so mobile push notifications and Live Activities receive updates.

## Validation

- `vp test run apps/web/src/components/clerk/MobileClientsUserProfilePage.logic.test.ts apps/web/src/cloud/linkEnvironment.test.ts`
- `vp check`
- `vp run typecheck`
- `vp run --filter @t3tools/web build`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore T3 Connect account controls with mobile client management and agent activity toggle
> - Renames all user-facing copy from "T3 Cloud" to "T3 Connect" across [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/3492/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9) and related components.
> - Adds a new toggle in the T3 Connect settings row to enable/disable publishing agent activity to mobile clients via the new `updatePrimaryEnvironmentPreferences` atom command.
> - Adds a "Mobile clients" page to the Clerk user profile (avatar menu) that lists managed relay devices with platform, notification, and Live Activities status using new formatting helpers in [MobileClientsUserProfilePage.logic.ts](https://github.com/pingdotgg/t3code/pull/3492/files#diff-98b856d11e65d666b8f8a946dc3dbc08caf3baa2aeb2737423719daac84f7afd).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fddeca8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cloud link preferences and what activity is published to mobile clients, but reuses existing connect APIs and serializes preference updates with link/unlink operations.
> 
> **Overview**
> Restores **T3 Connect** account and connection settings that were dropped during the rebrand and connection UI rewrite.
> 
> User-facing copy in **Connections** is updated from “T3 Cloud” to **T3 Connect**. When a local environment is linked, a nested **Publish agent activity** switch calls `updatePrimaryEnvironmentPreferences` (serialized with link/unlink) so the primary environment can opt in or out of sending activity to mobile push and Live Activities.
> 
> A **Mobile clients** tab is added to the Clerk `UserButton` profile. It lists relay-registered iOS devices (push/Live Activity badges, notification detail, refresh and error retry) via `useManagedRelayDevices`, with small presentation helpers and unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fddeca8a42b75bda12ffe468b4bd83568705a8cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->