### PR TITLE
Fix: increase OpenCode server timeout to allow for slower OpenCode server startups

### DIFF
--- a/apps/server/src/provider/opencodeRuntime.ts
+++ b/apps/server/src/provider/opencodeRuntime.ts
@@ -37,7 +37,7 @@ const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.UnknownFromJ
 const OPENCODE_EMPTY_CONFIG_CONTENT = "{}";
 
 const OPENCODE_SERVER_READY_PREFIX = "opencode server listening";
-const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 5_000;
+const DEFAULT_OPENCODE_SERVER_TIMEOUT_MS = 20_000;
 const DEFAULT_HOSTNAME = "127.0.0.1";
 export interface OpenCodeServerProcess {
   readonly url: string;


### PR DESCRIPTION
## What Changed

Increases timeout for Opencode server to prevent abrupt failures for slower spawn times.

Fixes #2337

## Why

Currently, the OpenCode provider times out after 5 seconds before returning an error (`Failed to execute OpenCode CLI health check: Timed out waiting for OpenCode server start after 5000ms.`). Increase the timeout to 20 seconds to resolve the issue.

### Why 20 seconds?
In my testing, the OpenCode server takes about 9 seconds at best, and 12 seconds at worst, to restart (on a Linux PC). 20 seconds is basically some extra allowance in case of longer delays.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

## Verification
- `vp check`
- `vp run typecheck`
- `vp test run apps/server/src/provider/Layers/OpenCodeProvider.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change in provider startup timing with no auth, data, or API contract changes; worst case is slightly longer waits before failure.
> 
> **Overview**
> Raises the default wait for local OpenCode server startup from **5s to 20s** in `opencodeRuntime.ts` (`DEFAULT_OPENCODE_SERVER_TIMEOUT_MS`), so `startOpenCodeServerProcess` / `connectToOpenCodeServer` are less likely to fail with a health-check timeout when the CLI is slow to print `opencode server listening`.
> 
> Callers can still pass `timeoutMs` to override the default; only the fallback when that option is omitted changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0941e8ff4d14c6ea2c6022f166491d3d5ebd68ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Increase OpenCode server startup timeout from 5s to 20s
> Raises `DEFAULT_OPENCODE_SERVER_TIMEOUT_MS` in [opencodeRuntime.ts](https://github.com/pingdotgg/t3code/pull/3493/files#diff-b36408ac400332f121d5c4711ccfe4fd4049772d0f302343ee303670f4198ea8) from 5,000 ms to 20,000 ms to accommodate slower OpenCode server startups.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0941e8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->