### PR TITLE
[codex] Reject unsupported remote pairing protocols

### DIFF
--- a/packages/shared/src/remote.test.ts
+++ b/packages/shared/src/remote.test.ts
@@ -72,6 +72,52 @@ describe("remote", () => {
     });
   });
 
+  it("rejects unsupported direct pairing URL protocols", () => {
+    let pairingUrlError: unknown;
+    try {
+      resolveRemotePairingTarget({
+        pairingUrl: "ftp://remote.example.com/pair#token=pairing-token",
+      });
+    } catch (cause) {
+      pairingUrlError = cause;
+    }
+
+    expect(pairingUrlError).toBeInstanceOf(RemotePairingUrlInvalidError);
+    expect((pairingUrlError as RemotePairingUrlInvalidError).cause).toBeInstanceOf(Error);
+  });
+
+  it("rejects unsupported hosted pairing backend protocols", () => {
+    let hostError: unknown;
+    try {
+      resolveRemotePairingTarget({
+        pairingUrl:
+          "https://app.t3.codes/pair?host=ftp%3A%2F%2Fremote.example.com#token=pairing-token",
+      });
+    } catch (cause) {
+      hostError = cause;
+    }
+
+    expect(hostError).toBeInstanceOf(RemoteBackendUrlInvalidError);
+    expect(hostError).toMatchObject({ source: "hosted-pairing-host" });
+    expect((hostError as RemoteBackendUrlInvalidError).cause).toBeInstanceOf(Error);
+  });
+
+  it("rejects unsupported direct host protocols", () => {
+    let hostError: unknown;
+    try {
+      resolveRemotePairingTarget({
+        host: "ftp://remote.example.com",
+        pairingCode: "pairing-token",
+      });
+    } catch (cause) {
+      hostError = cause;
+    }
+
+    expect(hostError).toBeInstanceOf(RemoteBackendUrlInvalidError);
+    expect(hostError).toMatchObject({ source: "direct-host" });
+    expect((hostError as RemoteBackendUrlInvalidError).cause).toBeInstanceOf(Error);
+  });
+
   it("uses distinct structural errors for missing pairing inputs", () => {
     expect(() => resolveRemotePairingTarget({})).toThrowError(RemoteBackendUrlMissingError);
     expect(() =>

--- a/packages/shared/src/remote.test.ts
+++ b/packages/shared/src/remote.test.ts
@@ -83,7 +83,8 @@ describe("remote", () => {
     }
 
     expect(pairingUrlError).toBeInstanceOf(RemotePairingUrlInvalidError);
-    expect((pairingUrlError as RemotePairingUrlInvalidError).cause).toBeInstanceOf(Error);
+    expect(pairingUrlError).toMatchObject({ protocol: "ftp:" });
+    expect((pairingUrlError as RemotePairingUrlInvalidError).cause).toBeUndefined();
   });
 
   it("rejects unsupported hosted pairing backend protocols", () => {
@@ -98,8 +99,8 @@ describe("remote", () => {
     }
 
     expect(hostError).toBeInstanceOf(RemoteBackendUrlInvalidError);
-    expect(hostError).toMatchObject({ source: "hosted-pairing-host" });
-    expect((hostError as RemoteBackendUrlInvalidError).cause).toBeInstanceOf(Error);
+    expect(hostError).toMatchObject({ source: "hosted-pairing-host", protocol: "ftp:" });
+    expect((hostError as RemoteBackendUrlInvalidError).cause).toBeUndefined();
   });
 
   it("rejects unsupported direct host protocols", () => {
@@ -114,8 +115,8 @@ describe("remote", () => {
     }
 
     expect(hostError).toBeInstanceOf(RemoteBackendUrlInvalidError);
-    expect(hostError).toMatchObject({ source: "direct-host" });
-    expect((hostError as RemoteBackendUrlInvalidError).cause).toBeInstanceOf(Error);
+    expect(hostError).toMatchObject({ source: "direct-host", protocol: "ftp:" });
+    expect((hostError as RemoteBackendUrlInvalidError).cause).toBeUndefined();
   });
 
   it("uses distinct structural errors for missing pairing inputs", () => {

--- a/packages/shared/src/remote.ts
+++ b/packages/shared/src/remote.ts
@@ -3,6 +3,7 @@ import * as Schema from "effect/Schema";
 const PAIRING_TOKEN_PARAM = "token";
 const HOSTED_PAIRING_HOST_PARAM = "host";
 const HOSTED_PAIRING_LABEL_PARAM = "label";
+const SUPPORTED_REMOTE_BACKEND_PROTOCOLS = new Set(["http:", "https:", "ws:", "wss:"]);
 
 const readHashParams = (url: URL): URLSearchParams =>
   new URLSearchParams(url.hash.startsWith("#") ? url.hash.slice(1) : url.hash);
@@ -64,6 +65,12 @@ export const RemotePairingTargetError = Schema.Union([
 ]);
 export type RemotePairingTargetError = typeof RemotePairingTargetError.Type;
 
+const createUnsupportedRemoteBackendProtocolError = (url: URL): TypeError =>
+  new TypeError(`Unsupported remote backend URL protocol: ${url.protocol}`);
+
+const hasSupportedRemoteBackendProtocol = (url: URL): boolean =>
+  SUPPORTED_REMOTE_BACKEND_PROTOCOLS.has(url.protocol);
+
 const normalizeRemoteBaseUrl = (
   rawValue: string,
   source: RemoteBackendUrlInvalidError["source"],
@@ -82,6 +89,12 @@ const normalizeRemoteBaseUrl = (
     url = new URL(normalizedInput);
   } catch (cause) {
     throw new RemoteBackendUrlInvalidError({ source, cause });
+  }
+  if (!hasSupportedRemoteBackendProtocol(url)) {
+    throw new RemoteBackendUrlInvalidError({
+      source,
+      cause: createUnsupportedRemoteBackendProtocolError(url),
+    });
   }
   url.pathname = "/";
   url.search = "";
@@ -183,6 +196,11 @@ export const resolveRemotePairingTarget = (input: {
       url = new URL(pairingUrl);
     } catch (cause) {
       throw new RemotePairingUrlInvalidError({ cause });
+    }
+    if (!hasSupportedRemoteBackendProtocol(url)) {
+      throw new RemotePairingUrlInvalidError({
+        cause: createUnsupportedRemoteBackendProtocolError(url),
+      });
     }
     const hostedPairingRequest = readHostedPairingRequest(url);
     if (hostedPairingRequest) {

--- a/packages/shared/src/remote.ts
+++ b/packages/shared/src/remote.ts
@@ -19,7 +19,10 @@ export class RemoteBackendUrlMissingError extends Schema.TaggedErrorClass<Remote
 
 export class RemotePairingUrlInvalidError extends Schema.TaggedErrorClass<RemotePairingUrlInvalidError>()(
   "RemotePairingUrlInvalidError",
-  { cause: Schema.Defect() },
+  {
+    cause: Schema.optional(Schema.Defect()),
+    protocol: Schema.optional(Schema.String),
+  },
 ) {
   override get message(): string {
     return "Pairing URL is invalid.";
@@ -30,7 +33,8 @@ export class RemoteBackendUrlInvalidError extends Schema.TaggedErrorClass<Remote
   "RemoteBackendUrlInvalidError",
   {
     source: Schema.Literals(["direct-host", "hosted-pairing-host"]),
-    cause: Schema.Defect(),
+    cause: Schema.optional(Schema.Defect()),
+    protocol: Schema.optional(Schema.String),
   },
 ) {
   override get message(): string {
@@ -65,9 +69,6 @@ export const RemotePairingTargetError = Schema.Union([
 ]);
 export type RemotePairingTargetError = typeof RemotePairingTargetError.Type;
 
-const createUnsupportedRemoteBackendProtocolError = (url: URL): TypeError =>
-  new TypeError(`Unsupported remote backend URL protocol: ${url.protocol}`);
-
 const hasSupportedRemoteBackendProtocol = (url: URL): boolean =>
   SUPPORTED_REMOTE_BACKEND_PROTOCOLS.has(url.protocol);
 
@@ -93,7 +94,7 @@ const normalizeRemoteBaseUrl = (
   if (!hasSupportedRemoteBackendProtocol(url)) {
     throw new RemoteBackendUrlInvalidError({
       source,
-      cause: createUnsupportedRemoteBackendProtocolError(url),
+      protocol: url.protocol,
     });
   }
   url.pathname = "/";
@@ -199,7 +200,7 @@ export const resolveRemotePairingTarget = (input: {
     }
     if (!hasSupportedRemoteBackendProtocol(url)) {
       throw new RemotePairingUrlInvalidError({
-        cause: createUnsupportedRemoteBackendProtocolError(url),
+        protocol: url.protocol,
       });
     }
     const hostedPairingRequest = readHostedPairingRequest(url);


### PR DESCRIPTION
## Summary

- Reject unsupported remote backend protocols during remote pairing resolution.
- Keep accepted backend protocols to `http:`, `https:`, `ws:`, and `wss:` while preserving bare-host `https://` defaults.
- Add focused coverage for unsupported direct pairing URLs, hosted backend hosts, and direct host inputs.

## Root cause

Remote pairing URL parsing accepted any syntactically valid URL protocol. Unsupported schemes such as `ftp:` could pass through direct pairing resolution or normalized backend host resolution and produce backend base URLs that the app cannot use.

## Impact

Invalid remote pairing targets now fail early with the existing structured errors. Direct unsupported pairing URLs throw `RemotePairingUrlInvalidError`; unsupported hosted or direct backend host inputs throw `RemoteBackendUrlInvalidError` with their existing source metadata preserved.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp test packages/shared/src/remote.test.ts` passed: 1 file passed, 10 tests passed
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check` passed: 0 errors; 20 existing unrelated warnings
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck` passed: completed successfully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Input validation only in shared pairing URL parsing; behavior tightens for invalid schemes without changing auth or connection logic for supported protocols.
> 
> **Overview**
> Remote pairing resolution no longer accepts arbitrary URL schemes that parse successfully but cannot be used as HTTP/WebSocket backends.
> 
> **`resolveRemotePairingTarget`** and **`normalizeRemoteBaseUrl`** now allow only `http:`, `https:`, `ws:`, and `wss:` (bare hosts still default to `https://`). Unsupported schemes such as `ftp:` fail early with the existing **`RemotePairingUrlInvalidError`** or **`RemoteBackendUrlInvalidError`**, optionally carrying a **`protocol`** field; parse failures still attach a **`cause`** as before.
> 
> Tests cover unsupported protocols on direct pairing URLs, hosted pairing `host` parameters, and direct host inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43dca40d6500fec917884da8459b5d88c060f44e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject unsupported protocols in remote pairing and backend URL validation
> - Adds `SUPPORTED_REMOTE_BACKEND_PROTOCOLS` (`http:`, `https:`, `ws:`, `wss:`) as the allowlist for remote backend URLs in [remote.ts](https://github.com/pingdotgg/t3code/pull/3498/files#diff-0498d83e26080527d6445d335b3995ac3381148c1f4ae356399fa65e857fcb77).
> - `normalizeRemoteBaseUrl` now throws `RemoteBackendUrlInvalidError` (with `protocol`, no `cause`) when the parsed URL has an unsupported protocol.
> - `resolveRemotePairingTarget` now throws `RemotePairingUrlInvalidError` (with `protocol`, no `cause`) for unsupported pairing URL protocols; hosted pairing links with an unsupported backend host protocol surface as `RemoteBackendUrlInvalidError` with `source: 'hosted-pairing-host'`.
> - `cause` is now optional on both error classes, and both gain an optional `protocol` field.
> - Behavioral Change: URLs with protocols such as `ftp:` now throw structured errors instead of being accepted or failing with a generic parse error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 43dca40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->