### PR TITLE
[codex] fix: preserve localhost preview hosts

### DIFF
--- a/apps/web/src/browser/browserTargetResolver.test.ts
+++ b/apps/web/src/browser/browserTargetResolver.test.ts
@@ -47,6 +47,14 @@ describe("browser target resolver", () => {
     ).toBe("http://localhost:3000/app");
   });
 
+  it("preserves localhost server-picker values when the prepared base is 127.0.0.1", async () => {
+    readPreparedConnection.mockReturnValue({ httpBaseUrl: "http://127.0.0.1:3773" });
+    const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
+    expect(
+      resolveDiscoveredServerUrl(EnvironmentId.make("environment-1"), "localhost:5173/app?x=1#top"),
+    ).toBe("http://localhost:5173/app?x=1#top");
+  });
+
   it("normalizes public URLs without treating them as environment ports", async () => {
     const { resolveDiscoveredServerUrl } = await import("./browserTargetResolver");
     expect(resolveDiscoveredServerUrl(EnvironmentId.make("environment-1"), "example.com/app")).toBe(

--- a/apps/web/src/browser/browserTargetResolver.ts
+++ b/apps/web/src/browser/browserTargetResolver.ts
@@ -24,6 +24,11 @@ const isPrivateNetworkHost = (host: string): boolean => {
   );
 };
 
+const isLocalLoopbackHost = (host: string): boolean => {
+  const normalized = host.toLowerCase().replace(/^\[|\]$/g, "");
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+};
+
 export function resolveBrowserNavigationTarget(
   environmentId: EnvironmentId,
   target: BrowserNavigationTarget,
@@ -68,6 +73,12 @@ export function resolveDiscoveredServerUrl(environmentId: EnvironmentId, rawUrl:
     const normalizedUrl = normalizePreviewUrl(rawUrl);
     const parsed = new URL(normalizedUrl);
     if (!isLoopbackHost(parsed.hostname)) return normalizedUrl;
+    const connection = readPreparedConnection(environmentId);
+    if (!connection) throw new Error(`Environment ${environmentId} is not connected.`);
+    const environmentUrl = new URL(connection.httpBaseUrl);
+    if (parsed.hostname !== "0.0.0.0" && isLocalLoopbackHost(environmentUrl.hostname)) {
+      return normalizedUrl;
+    }
     const port = Number(parsed.port || (parsed.protocol === "https:" ? 443 : 80));
     return resolveBrowserNavigationTarget(environmentId, {
       kind: "environment-port",


### PR DESCRIPTION
## Summary

- Preserve normalized `localhost` discovered preview URLs when the prepared connection itself is local loopback.
- Keep `0.0.0.0` flowing through the existing environment-port normalization path.
- Keep private remote host remapping for discovered loopback ports.

## Root cause

`resolveDiscoveredServerUrl(...)` treated every loopback discovered URL as an environment-port target. When the prepared connection base was `http://127.0.0.1:<port>`, that remapped `localhost:<port>` onto `127.0.0.1:<port>`, even though the normalized user-visible URL should stay on `localhost`.

## Impact

Users opening a discovered `localhost` dev server from a local prepared environment keep the `localhost` host, which preserves host-specific API allowlists. Wildcard local hosts such as `0.0.0.0` still normalize to a concrete reachable host, and private remote environments still remap discovered loopback ports onto the private environment host.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp test apps/web/src/browser/browserTargetResolver.test.ts` passed: 1 file passed, 7 tests passed.
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check` passed: 0 errors; 20 existing unrelated warnings.
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck` passed: completed successfully.

Closes pingdotgg/t3code#3124

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to preview URL resolution in the web app with clear tests and no auth or data-path impact.
> 
> **Overview**
> **`resolveDiscoveredServerUrl`** no longer remaps discovered **`localhost`** URLs onto **`127.0.0.1`** when the prepared environment connection is itself a local loopback host (`localhost`, `127.0.0.1`, or `::1`). In that case it returns the normalized URL unchanged so host-specific API allowlists stay on **`localhost`**.
> 
> Discovered **`0.0.0.0`** URLs still go through environment-port normalization, and loopback discoveries against **private remote** prepared bases still remap ports onto the environment host as before. A new **`isLocalLoopbackHost`** helper drives the early-return branch, with a unit test covering **`127.0.0.1`** prepared base + **`localhost`** picker input including path, query, and hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e581f07f8d9b958fdb3f222b6759e95a4046b220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve localhost preview hosts in `resolveDiscoveredServerUrl`
> Previously, `resolveDiscoveredServerUrl` would rewrite loopback URLs through environment-port resolution even when both the discovered host and the prepared connection base host were local loopbacks. This adds a new `isLocalLoopbackHost` helper and an early-return path in `resolveDiscoveredServerUrl` that returns the normalized URL unchanged when both sides are loopback (localhost/127.0.0.1/::1) and the discovered host is not `0.0.0.0`. If no prepared connection exists, the function now returns the raw input instead of attempting port mapping.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e581f07.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->