### PR TITLE
[codex] fix: restore pending input keyboard activation

### DIFF
--- a/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
+++ b/apps/web/src/components/chat/ComposerPendingUserInputPanel.tsx
@@ -208,19 +208,17 @@ const ComposerPendingUserInputCard = memo(function ComposerPendingUserInputCard(
             </>
           );
           return (
-            <div
+            <button
               key={`${activeQuestion.id}:${option.label}`}
-              role="button"
-              tabIndex={isResponding ? -1 : 0}
-              aria-disabled={isResponding}
+              type="button"
+              disabled={isResponding}
               onClick={() => {
-                if (isResponding) return;
                 handleOptionSelection(activeQuestion.id, option.label);
               }}
               className={className}
             >
               {content}
-            </div>
+            </button>
           );
         })}
       </div>


### PR DESCRIPTION
## Summary

- Replaces pending user input option rows with native `button` elements.
- Preserves the existing selection styling, disabled/responding behavior, click handling, check icon, and number-key shortcut display.
- Keeps composer form behavior stable with `type="button"`.

## Root cause

The option rows used focusable `div role="button"` elements. They supported pointer selection and number-key shortcuts, but did not get browser-native Enter/Space activation when focused.

## Impact

Focused pending input options now use native button activation while preserving the existing pointer and number-key behavior.

## Validation

- Passed: `PATH="$HOME/.vite-plus/bin:$PATH" vp check` (0 errors; 20 existing unrelated warnings)
- Passed: `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck` (completed successfully)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/accessibility change in the chat composer with no auth, data, or API impact.
> 
> **Overview**
> Pending user input option rows in **`ComposerPendingUserInputPanel`** are now real **`<button type="button">`** elements instead of focusable **`div role="button"`** wrappers.
> 
> **Disabled** state uses the native **`disabled`** attribute (replacing **`aria-disabled`** and an early return in **`onClick`**), so focused options get standard **Enter/Space** activation while pointer clicks, styling, shortcuts, and **`type="button"`** inside the composer stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09bc6aa272c6b4d9edc15fba4723f64aa4baa78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix keyboard activation for pending input options in chat composer
> Replaces the `<div role="button">` wrapper for each option in [`ComposerPendingUserInputCard`](https://github.com/pingdotgg/t3code/pull/3501/files#diff-4d79f14a0bb3d90ecac6af885c54e9a485bcd9510c4a339f6bfdbcde568a0b0e) with a native `<button type="button">`. The `disabled` attribute now controls focusability and click suppression when `isResponding` is true, removing the need for manual `tabIndex`, `aria-disabled`, and `onClick` guard logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c09bc6a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->