### PR TITLE
[codex] fix: guard DPoP fallback URL construction

### DIFF
--- a/apps/server/src/auth/dpop.test.ts
+++ b/apps/server/src/auth/dpop.test.ts
@@ -38,9 +38,9 @@ describe("mapDpopReplayStoreError", () => {
 });
 
 describe("requestAbsoluteUrl", () => {
-  it("returns null when fallback host URL construction is invalid", () => {
+  it("returns null when the request URL cannot be resolved", () => {
     const request = {
-      originalUrl: "/api/dpop",
+      url: "/api/dpop",
       headers: {
         host: "bad host",
       },

--- a/apps/server/src/auth/dpop.test.ts
+++ b/apps/server/src/auth/dpop.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vite-plus/test";
 import * as PlatformError from "effect/PlatformError";
-import type * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 
 import { SecretStorePersistError } from "./ServerSecretStore.ts";
-import { mapDpopReplayStoreError, requestAbsoluteUrl } from "./dpop.ts";
+import { mapDpopReplayStoreError } from "./dpop.ts";
 
 const storeFailure = (tag: "AlreadyExists" | "PermissionDenied") =>
   new SecretStorePersistError({
@@ -34,18 +33,5 @@ describe("mapDpopReplayStoreError", () => {
     if (error._tag === "ServerAuthDpopReplayStateRecordError") {
       expect(error.message).toBe("Failed to record DPoP proof replay state.");
     }
-  });
-});
-
-describe("requestAbsoluteUrl", () => {
-  it("returns null when the request URL cannot be resolved", () => {
-    const request = {
-      url: "/api/dpop",
-      headers: {
-        host: "bad host",
-      },
-    } as unknown as HttpServerRequest.HttpServerRequest;
-
-    expect(requestAbsoluteUrl(request)).toBeNull();
   });
 });

--- a/apps/server/src/auth/dpop.test.ts
+++ b/apps/server/src/auth/dpop.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vite-plus/test";
 import * as PlatformError from "effect/PlatformError";
+import type * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 
 import { SecretStorePersistError } from "./ServerSecretStore.ts";
-import { mapDpopReplayStoreError } from "./dpop.ts";
+import { mapDpopReplayStoreError, requestAbsoluteUrl } from "./dpop.ts";
 
 const storeFailure = (tag: "AlreadyExists" | "PermissionDenied") =>
   new SecretStorePersistError({
@@ -33,5 +34,18 @@ describe("mapDpopReplayStoreError", () => {
     if (error._tag === "ServerAuthDpopReplayStateRecordError") {
       expect(error.message).toBe("Failed to record DPoP proof replay state.");
     }
+  });
+});
+
+describe("requestAbsoluteUrl", () => {
+  it("returns null when fallback host URL construction is invalid", () => {
+    const request = {
+      originalUrl: "/api/dpop",
+      headers: {
+        host: "bad host",
+      },
+    } as unknown as HttpServerRequest.HttpServerRequest;
+
+    expect(requestAbsoluteUrl(request)).toBeNull();
   });
 });

--- a/apps/server/src/auth/dpop.ts
+++ b/apps/server/src/auth/dpop.ts
@@ -3,7 +3,8 @@ import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Encoding from "effect/Encoding";
-import type * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as Option from "effect/Option";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 
 import {
   ServerAuthDpopReplayKeyCalculationError,
@@ -13,24 +14,9 @@ import {
 } from "./EnvironmentAuth.ts";
 import * as ServerSecretStore from "./ServerSecretStore.ts";
 
-function firstHeaderValue(value: string | undefined): string | undefined {
-  const first = value?.split(",")[0]?.trim();
-  return first && first.length > 0 ? first : undefined;
-}
-
 export function requestAbsoluteUrl(request: HttpServerRequest.HttpServerRequest): string | null {
-  try {
-    return new URL(request.originalUrl).href;
-  } catch {
-    const host = firstHeaderValue(request.headers.host) ?? "127.0.0.1";
-    const forwardedProto = firstHeaderValue(request.headers["x-forwarded-proto"]);
-    const proto = forwardedProto === "https" || forwardedProto === "http" ? forwardedProto : "http";
-    try {
-      return new URL(request.originalUrl, `${proto}://${host}`).href;
-    } catch {
-      return null;
-    }
-  }
+  const url = HttpServerRequest.toURL(request);
+  return Option.isSome(url) ? url.value.href : null;
 }
 
 export const mapDpopReplayStoreError = (

--- a/apps/server/src/auth/dpop.ts
+++ b/apps/server/src/auth/dpop.ts
@@ -33,7 +33,7 @@ export const verifyRequestDpopProof = (input: {
 }) =>
   Effect.gen(function* () {
     const proof = input.request.headers.dpop;
-    const url = HttpServerRequest.toURL(input.request)
+    const url = HttpServerRequest.toURL(input.request);
     if (Option.isNone(url)) {
       return yield* new ServerAuthInvalidCredentialError({
         diagnostic: "Invalid DPoP request URL.",
@@ -43,7 +43,7 @@ export const verifyRequestDpopProof = (input: {
     const result = verifyDpopProof({
       proof,
       method: input.request.method,
-      url: url.value,
+      url: url.value.href,
       nowEpochSeconds: Math.floor(now.epochMilliseconds / 1_000),
       ...(input.expectedThumbprint ? { expectedThumbprint: input.expectedThumbprint } : {}),
       ...(input.expectedAccessToken ? { expectedAccessToken: input.expectedAccessToken } : {}),

--- a/apps/server/src/auth/dpop.ts
+++ b/apps/server/src/auth/dpop.ts
@@ -14,11 +14,6 @@ import {
 } from "./EnvironmentAuth.ts";
 import * as ServerSecretStore from "./ServerSecretStore.ts";
 
-export function requestAbsoluteUrl(request: HttpServerRequest.HttpServerRequest): string | null {
-  const url = HttpServerRequest.toURL(request);
-  return Option.isSome(url) ? url.value.href : null;
-}
-
 export const mapDpopReplayStoreError = (
   error: ServerSecretStore.SecretStoreError,
 ): ServerAuthInvalidCredentialError | ServerAuthInternalError =>
@@ -38,8 +33,8 @@ export const verifyRequestDpopProof = (input: {
 }) =>
   Effect.gen(function* () {
     const proof = input.request.headers.dpop;
-    const url = requestAbsoluteUrl(input.request);
-    if (url === null) {
+    const url = HttpServerRequest.toURL(input.request)
+    if (Option.isNone(url)) {
       return yield* new ServerAuthInvalidCredentialError({
         diagnostic: "Invalid DPoP request URL.",
       });
@@ -48,7 +43,7 @@ export const verifyRequestDpopProof = (input: {
     const result = verifyDpopProof({
       proof,
       method: input.request.method,
-      url,
+      url: url.value,
       nowEpochSeconds: Math.floor(now.epochMilliseconds / 1_000),
       ...(input.expectedThumbprint ? { expectedThumbprint: input.expectedThumbprint } : {}),
       ...(input.expectedAccessToken ? { expectedAccessToken: input.expectedAccessToken } : {}),

--- a/apps/server/src/auth/dpop.ts
+++ b/apps/server/src/auth/dpop.ts
@@ -18,14 +18,18 @@ function firstHeaderValue(value: string | undefined): string | undefined {
   return first && first.length > 0 ? first : undefined;
 }
 
-export function requestAbsoluteUrl(request: HttpServerRequest.HttpServerRequest): string {
+export function requestAbsoluteUrl(request: HttpServerRequest.HttpServerRequest): string | null {
   try {
     return new URL(request.originalUrl).href;
   } catch {
     const host = firstHeaderValue(request.headers.host) ?? "127.0.0.1";
     const forwardedProto = firstHeaderValue(request.headers["x-forwarded-proto"]);
     const proto = forwardedProto === "https" || forwardedProto === "http" ? forwardedProto : "http";
-    return new URL(request.originalUrl, `${proto}://${host}`).href;
+    try {
+      return new URL(request.originalUrl, `${proto}://${host}`).href;
+    } catch {
+      return null;
+    }
   }
 }
 
@@ -48,11 +52,17 @@ export const verifyRequestDpopProof = (input: {
 }) =>
   Effect.gen(function* () {
     const proof = input.request.headers.dpop;
+    const url = requestAbsoluteUrl(input.request);
+    if (url === null) {
+      return yield* new ServerAuthInvalidCredentialError({
+        diagnostic: "Invalid DPoP request URL.",
+      });
+    }
     const now = yield* DateTime.now;
     const result = verifyDpopProof({
       proof,
       method: input.request.method,
-      url: requestAbsoluteUrl(input.request),
+      url,
       nowEpochSeconds: Math.floor(now.epochMilliseconds / 1_000),
       ...(input.expectedThumbprint ? { expectedThumbprint: input.expectedThumbprint } : {}),
       ...(input.expectedAccessToken ? { expectedAccessToken: input.expectedAccessToken } : {}),


### PR DESCRIPTION
## Summary

- Guard DPoP fallback request URL construction so malformed Host or request URL values return null instead of throwing.
- Convert an unnormalizable DPoP request URL into an invalid-credentials auth failure before proof verification.

## Root cause

`requestAbsoluteUrl` caught invalid absolute `originalUrl` parsing, then built a fallback URL from `originalUrl` and `Host` without guarding that second `new URL(...)` call.

## Impact

Malformed Host values during DPoP auth now fail as `ServerAuthInvalidCredentialError` with `Invalid DPoP request URL.` instead of surfacing as a defect. Valid absolute URLs and existing relative URL fallback behavior are preserved.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp test apps/server/src/auth/dpop.test.ts`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and DPoP URL binding; malformed or previously edge-case URLs may now be rejected rather than verified or throwing at runtime.
> 
> **Overview**
> **DPoP proof verification** no longer builds request URLs locally. `verifyRequestDpopProof` now resolves the request URL with `HttpServerRequest.toURL` and, when that returns `None`, fails with `ServerAuthInvalidCredentialError` (`Invalid DPoP request URL.`) before calling `verifyDpopProof`.
> 
> This removes the previous `requestAbsoluteUrl` / `firstHeaderValue` fallback path that could still throw on a second `new URL(...)` when `Host` or related inputs were malformed. Valid absolute URLs and normal relative-URL resolution behavior are intended to stay the same; unresolvable URLs become explicit credential failures instead of defects or ambiguous verification input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1e04ed36dd62952f65956767a99acc38859fb16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard DPoP proof verification against unresolvable request URLs
> Replaces the local `requestAbsoluteUrl` helper in [dpop.ts](https://github.com/pingdotgg/t3code/pull/3503/files#diff-093e49c5bfc6ca71cc29c59db862f2b49bbbae2e34b282b89df6331d0edd2341) with `HttpServerRequest.toURL()` to derive the request URL for DPoP proof verification. When `toURL` returns `None`, `verifyRequestDpopProof` now rejects the request early with a `ServerAuthInvalidCredentialError` (diagnostic: "Invalid DPoP request URL.") instead of proceeding with a potentially malformed URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1e04ed.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->