### PR TITLE
[codex] fix: guard trace ID clipboard copy

### DIFF
--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -1423,6 +1423,31 @@ function SavedBackendListRow({
           : "bg-muted-foreground/40";
   const statusTooltip = connectionStatusText(environment.connection);
   const errorTraceId = environment.connection.traceId;
+  const { copyToClipboard: copyTraceIdToClipboard } = useCopyToClipboard<{ traceId: string }>({
+    target: "trace ID",
+    onCopy: ({ traceId }) => {
+      toastManager.add({
+        type: "success",
+        title: "Trace ID copied",
+        description: traceId,
+      });
+    },
+    onError: (error) => {
+      toastManager.add(
+        stackedThreadToast({
+          type: "error",
+          title: "Could not copy trace ID",
+          description: error.message,
+        }),
+      );
+    },
+  });
+  const copyTraceId = useCallback(
+    (traceId: string) => {
+      copyTraceIdToClipboard(traceId, { traceId });
+    },
+    [copyTraceIdToClipboard],
+  );
   const versionMismatch = resolveServerConfigVersionMismatch(environment.serverConfig);
   const sshTarget =
     environment.entry.target._tag === "SshConnectionTarget" &&
@@ -1468,7 +1493,7 @@ function SavedBackendListRow({
                 <button
                   type="button"
                   className="shrink-0 underline underline-offset-2"
-                  onClick={() => void navigator.clipboard.writeText(errorTraceId)}
+                  onClick={() => copyTraceId(errorTraceId)}
                 >
                   Copy trace ID
                 </button>


### PR DESCRIPTION
## Summary

- Route the saved backend row trace ID copy action through the existing guarded clipboard hook.
- Show success feedback when the trace ID is copied.
- Show the hook-provided clipboard error message when the Clipboard API is unavailable or write fails.

## Root cause

The saved backend row called `navigator.clipboard.writeText(errorTraceId)` directly, so unsupported clipboard contexts or rejected writes could fail without the existing user-visible error handling.

## Impact

Users keep the same `Copy trace ID` action, but failures now surface as an error toast and successful copies confirm the copied trace ID.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

`vp check` reports the repository existing unrelated warnings and no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI handler change in Connections settings with no auth, data, or API impact.
> 
> **Overview**
> **Copy trace ID** on saved remote backend rows (when a connection error includes a trace ID) no longer calls `navigator.clipboard.writeText` directly.
> 
> It now goes through `useCopyToClipboard` with `target: "trace ID"`, matching pairing-link copy behavior: a success toast shows the copied ID, and unavailable or failed clipboard writes surface an error toast via `stackedThreadToast`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44464e95bae9fcf72b5c1c8d1e789bf147bddfc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Guard trace ID clipboard copy in `SavedBackendListRow` with success and error toasts
> Replaces the direct `navigator.clipboard.writeText` call with a `useCopyToClipboard` helper in [ConnectionsSettings.tsx](https://github.com/pingdotgg/t3code/pull/3505/files#diff-8d3463be4371da0f55c5b65bb143b023e8c0ea0ee1db0816b2a21f11f3a1fce9). On success, a 'Trace ID copied' toast displays the copied ID; on failure, an error toast is shown via `stackedThreadToast` instead of silently failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 44464e9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->