### PR TITLE
[codex] fix: reject credentials in advertised endpoint URLs

### DIFF
--- a/packages/client-runtime/src/environment/endpoint.test.ts
+++ b/packages/client-runtime/src/environment/endpoint.test.ts
@@ -22,6 +22,25 @@ describe("advertised endpoint helpers", () => {
     expect(deriveWsBaseUrl("http://127.0.0.1:3773")).toBe("ws://127.0.0.1:3773/");
   });
 
+  it("rejects endpoint URLs with credentials", () => {
+    expect(() => normalizeHttpBaseUrl("https://user:password@example.com/path?x=1#hash")).toThrow(
+      "Endpoint URL must not include credentials.",
+    );
+    expect(() => normalizeHttpBaseUrl("wss://user@example.com/socket")).toThrow(
+      "Endpoint URL must not include credentials.",
+    );
+    expect(() =>
+      createAdvertisedEndpoint({
+        id: "lan:https://user@example.com",
+        label: "LAN",
+        provider: coreProvider,
+        httpBaseUrl: "https://user@example.com",
+        reachability: "lan",
+        source: "desktop-core",
+      }),
+    ).toThrow("Endpoint URL must not include credentials.");
+  });
+
   it("marks HTTP endpoints as blocked from hosted HTTPS apps", () => {
     expect(classifyHostedHttpsCompatibility("http://192.168.1.44:3773")).toBe(
       "mixed-content-blocked",

--- a/packages/shared/src/advertisedEndpoint.ts
+++ b/packages/shared/src/advertisedEndpoint.ts
@@ -33,6 +33,10 @@ export function normalizeHttpBaseUrl(rawValue: string): string {
     throw new Error(`Endpoint must use HTTP or HTTPS. Received ${url.protocol}`);
   }
 
+  if (url.username.length > 0 || url.password.length > 0) {
+    throw new Error("Endpoint URL must not include credentials.");
+  }
+
   url.pathname = "/";
   url.search = "";
   url.hash = "";


### PR DESCRIPTION
## Summary
- Reject advertised endpoint URLs that contain userinfo credentials.
- Keep downstream connection handling from accepting credential-bearing endpoint strings.

## Why
URLs with embedded credentials should not be accepted as advertised endpoints because they can leak secrets through display, logging, or transport boundaries.

## Impact
Credential-bearing advertised endpoints are rejected before they can be stored or used.

## Validation
- `PATH="$HOME/.vite-plus/bin:$PATH" vp test packages/client-runtime/src/environment/endpoint.test.ts`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run -r --concurrency-limit 1 typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small input-validation hardening on endpoint URLs; only affects credential-bearing URLs that should not be advertised.
> 
> **Overview**
> **Advertised endpoint URLs with embedded userinfo are now rejected** during normalization instead of being accepted and propagated.
> 
> `normalizeHttpBaseUrl` in `advertisedEndpoint.ts` throws `"Endpoint URL must not include credentials."` when `url.username` or `url.password` is non-empty, before path/query/hash normalization. That applies to HTTP/HTTPS and ws/wss inputs (after protocol coercion), so **`createAdvertisedEndpoint`**, **`deriveWsBaseUrl`**, and other callers that normalize through this helper fail early. Connection onboarding that normalizes `httpBaseUrl` surfaces the same error as invalid configuration.
> 
> Tests cover `https://user:password@…`, `wss://user@…`, and credential-bearing `createAdvertisedEndpoint` inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13861a1ae7b8917b3ff194f9ef25eb2e40b7743a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject credentials embedded in advertised endpoint URLs
> Adds a credentials check to `normalizeHttpBaseUrl` in [advertisedEndpoint.ts](https://github.com/pingdotgg/t3code/pull/3516/files#diff-ed9930290d8ef6983316943458a7fd71c6a08472e556e8b0643b05b703c4e099). If the URL contains a non-empty `username` or `password`, the function throws `"Endpoint URL must not include credentials."` before any normalization occurs. Behavioral Change: callers passing URLs with embedded credentials will now receive an error instead of silently proceeding.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 13861a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->