### PR TITLE
[codex] fix: ignore stale shell reducer events

### DIFF
--- a/packages/client-runtime/src/state/shellReducer.test.ts
+++ b/packages/client-runtime/src/state/shellReducer.test.ts
@@ -44,6 +44,26 @@ const stubThread = {
 } as const;
 
 describe("applyShellStreamEvent", () => {
+  it("ignores stale project upserts without mutating the snapshot", () => {
+    const snapshotWithProject: OrchestrationShellSnapshot = {
+      ...baseSnapshot,
+      snapshotSequence: 4,
+      projects: [stubProject],
+    };
+
+    for (const sequence of [3, 4]) {
+      const next = applyShellStreamEvent(snapshotWithProject, {
+        kind: "project-upserted",
+        sequence,
+        project: { ...stubProject, title: "Stale Title" },
+      });
+
+      expect(next).toBe(snapshotWithProject);
+      expect(next.snapshotSequence).toBe(4);
+      expect(next.projects[0]?.title).toBe("Test Project");
+    }
+  });
+
   describe("project-upserted", () => {
     it("adds a new project", () => {
       const event: OrchestrationShellStreamEvent = {

--- a/packages/client-runtime/src/state/shellReducer.ts
+++ b/packages/client-runtime/src/state/shellReducer.ts
@@ -13,6 +13,8 @@ export function applyShellStreamEvent(
   snapshot: OrchestrationShellSnapshot,
   event: OrchestrationShellStreamEvent,
 ): OrchestrationShellSnapshot {
+  if (event.sequence <= snapshot.snapshotSequence) return snapshot;
+
   switch (event.kind) {
     case "project-upserted": {
       const projects = snapshot.projects.some((p) => p.id === event.project.id)


### PR DESCRIPTION
## Summary
- Ignore stale shell reducer events whose sequence is older than the current shell state.
- Preserve newer shell state when out-of-order lifecycle events arrive.

## Root cause
The reducer accepted older sequence events after newer state had already been applied.

## Impact
Out-of-order shell events no longer regress current shell state.

## Validation
- `PATH="$HOME/.vite-plus/bin:$PATH" vp test packages/client-runtime/src/state/shellReducer.test.ts`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, pure reducer guard with targeted tests; shared by web/mobile but behavior is strictly more conservative on stale events.
> 
> **Overview**
> **`applyShellStreamEvent`** now bails out before the event `switch` when `event.sequence` is less than or equal to the snapshot’s **`snapshotSequence`**, returning the **same snapshot reference** with no project/thread updates.
> 
> That stops duplicate or out-of-order orchestration shell stream events (e.g. late **`project-upserted`**) from overwriting newer local shell state on web and mobile. A unit test covers sequences **3** and **4** against a snapshot already at **4**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8757ca5accb760dc90deb23696669029c438867d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `applyShellStreamEvent` to ignore stale shell reducer events
> Adds an early return in [`applyShellStreamEvent`](https://github.com/pingdotgg/t3code/pull/3517/files#diff-e0890280f52f603e546fa3829b85035fbb9453ab2901a389f94c11ecc64cd0e7) that skips any event whose sequence number is less than or equal to the current `snapshotSequence`, returning the original snapshot reference unchanged. This prevents out-of-order or duplicate events from incorrectly mutating state.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8757ca5.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->