### PR TITLE
fix: auto-retry the startup error boundary on focus/online so a recovered backend un-sticks the app

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,6 +7,7 @@ import {
   type ErrorComponentProps,
   useLocation,
   useNavigate,
+  useRouter,
 } from "@tanstack/react-router";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
@@ -187,6 +188,36 @@ function HostedStaticEnvironmentBootstrap() {
 function RootRouteErrorView({ error, reset }: ErrorComponentProps) {
   const message = errorMessage(error);
   const details = errorDetails(error);
+
+  // The root error boundary is shown when beforeLoad's startup probe
+  // (resolveInitialServerAuthGateState -> fetchSessionState) throws. That failure
+  // is frequently transient (backend still starting, a flaky session call), but
+  // the boundary persists until a manual reload. Auto-retry when the window
+  // regains focus/visibility or the network returns, so a recovered backend
+  // un-sticks the app instead of stranding the user here. reset() only resets the
+  // boundary; router.invalidate() re-runs beforeLoad. See #3513.
+  const router = useRouter();
+  const retryingRef = useRef(false);
+  useEffect(() => {
+    const retry = () => {
+      if (retryingRef.current) return;
+      retryingRef.current = true;
+      void router.invalidate().finally(() => {
+        retryingRef.current = false;
+      });
+    };
+    const retryIfVisible = () => {
+      if (document.visibilityState === "visible") retry();
+    };
+    document.addEventListener("visibilitychange", retryIfVisible);
+    window.addEventListener("focus", retry);
+    window.addEventListener("online", retry);
+    return () => {
+      document.removeEventListener("visibilitychange", retryIfVisible);
+      window.removeEventListener("focus", retry);
+      window.removeEventListener("online", retry);
+    };
+  }, [router]);
 
   return (
     <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-4 py-10 text-foreground sm:px-6">


### PR DESCRIPTION
## Summary
The root route's `beforeLoad` runs a startup auth/session probe; if it throws, `RootRouteErrorView` is shown and **persists until a manual reload** (it does not re-run on focus). When that failure is transient (backend still starting, a flaky session call), the user is stranded on the error screen even after the backend recovers. This auto-retries the probe when the window regains focus/visibility or the network returns.

Scope: this addresses the **unrecoverable-overlay** aspect of #3513. The underlying session-store write failure and the renderer-side diagnosability gap are tracked there separately — this PR intentionally stays small and single-concern.

## Root cause
`RootRouteErrorView` only exposes `reset()` (resets the error boundary) and `window.location.reload()`. `reset()` does **not** re-run `beforeLoad`, so a transient startup-probe failure leaves a sticky dead-end until a manual reload. `router.invalidate()` re-runs matched routes' `beforeLoad`/loaders and resets the boundary.

## What changed
In `RootRouteErrorView`, on `visibilitychange`→visible, window `focus`, or `online`, call `router.invalidate()` — guarded by an in-flight ref so noisy (Electron) focus events don't stack concurrent retries. The retry is intentionally broad (it fires for any boundary error) and harmless: it's focus/online-gated and ref-locked, so a persistent failure just re-shows the error rather than looping. No behavior change on the success path.

## Validation
- `vp run --filter @t3tools/web typecheck` — clean
- `vp lint` — 0 errors
- `vp run --filter @t3tools/web test` — 1155/1155 pass

I didn't add a unit test: the web suite has no DOM-render harness (no jsdom/testing-library — components are tested by structural invocation), so a `window`-event effect test doesn't fit the current setup. Happy to add one if you point me at the preferred pattern for DOM/router-effect tests.

Refs #3513

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, error-boundary-only UX change with ref-gated retries; no changes to auth logic or the happy path.
> 
> **Overview**
> When the root route’s `beforeLoad` startup probe fails, **`RootRouteErrorView` used to stick until a full reload**—`reset()` does not re-run `beforeLoad`, so a transient backend or session failure could strand users even after recovery.
> 
> **`RootRouteErrorView` now auto-retries** by calling `router.invalidate()` when the tab becomes visible, the window gains focus, or the browser goes online. An in-flight ref prevents stacked retries from noisy focus events (e.g. Electron). Persistent failures still show the same error screen; the success path is unchanged.
> 
> Manual **Try again** / **Reload app** buttons are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4b0b8b2d724e7b03b6028f6bcbae469f101fd9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-retry the startup error boundary on focus, visibility, and network recovery
> When the root error boundary is shown, the app was stuck until a manual reload even if the backend recovered. The `RootRouteErrorView` component in [__root.tsx](https://github.com/pingdotgg/t3code/pull/3520/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) now registers listeners for `visibilitychange`, `focus`, and `online` events and calls `router.invalidate()` on each, re-running `beforeLoad` and exiting the error boundary automatically if the backend is healthy. A `retryingRef` guard prevents concurrent retry attempts.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4b0b8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->