### PR TITLE
[codex] fix: sync provider environment rows

### DIFF
--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -4,6 +4,7 @@ import type { ProviderInstanceEnvironmentVariable, ServerProviderModel } from "@
 import {
   deriveProviderModelsForDisplay,
   getProviderEnvironmentContentKey,
+  isPublishedProviderEnvironmentAcknowledgedByPersisted,
   mergeEnvironmentDraftRowsForPersistedUpdate,
 } from "./ProviderInstanceCard";
 
@@ -250,6 +251,65 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
     ]);
   });
 
+  it("consumes an acknowledged sensitive save when persisted content stays redacted", () => {
+    const previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+      {
+        name: "API_KEY",
+        value: "",
+        sensitive: true,
+        valueRedacted: true,
+      },
+    ];
+    const publishedEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+      {
+        name: "API_KEY",
+        value: "updated-secret",
+        sensitive: true,
+        valueRedacted: false,
+      },
+    ];
+    const redactedSaveEcho: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+      {
+        name: "API_KEY",
+        value: "",
+        sensitive: true,
+        valueRedacted: true,
+      },
+    ];
+
+    expect(
+      isPublishedProviderEnvironmentAcknowledgedByPersisted({
+        publishedEnvironment,
+        persistedEnvironment: redactedSaveEcho,
+      }),
+    ).toBe(true);
+
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "0:API_KEY",
+          name: "API_KEY",
+          value: "updated-secret",
+          sensitive: true,
+          valueRedacted: false,
+        },
+      ],
+      previousEnvironment,
+      nextEnvironment: redactedSaveEcho,
+      publishedEnvironment,
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:API_KEY",
+        name: "API_KEY",
+        value: "",
+        sensitive: true,
+        valueRedacted: true,
+      },
+    ]);
+  });
+
   it("keeps a sensitive plaintext draft when a sibling persisted row changes", () => {
     const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
       rows: [
@@ -341,10 +401,52 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
           sensitive: true,
         },
       ],
-      locallyDeletedEnvironmentVariableNames: new Set(["API_KEY"]),
+      locallyDeletedEnvironmentVariables: new Map([
+        [
+          "API_KEY",
+          {
+            name: "API_KEY",
+            value: "old",
+            sensitive: true,
+          },
+        ],
+      ]),
     });
 
     expect(rows).toEqual([]);
+  });
+
+  it("keeps a same-name server re-add when it differs from the deleted variable", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [],
+      previousEnvironment: [],
+      nextEnvironment: [
+        {
+          name: "API_KEY",
+          value: "new",
+          sensitive: true,
+        },
+      ],
+      locallyDeletedEnvironmentVariables: new Map([
+        [
+          "API_KEY",
+          {
+            name: "API_KEY",
+            value: "old",
+            sensitive: true,
+          },
+        ],
+      ]),
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:API_KEY",
+        name: "API_KEY",
+        value: "new",
+        sensitive: true,
+      },
+    ]);
   });
 
   it("keeps a new persisted row when a different previous-index draft row was deleted", () => {

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -178,6 +178,39 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
     ]);
   });
 
+  it("consumes a new sensitive row when its persisted save echo is redacted", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "provider-env-1",
+          name: "API_KEY",
+          value: "typed-secret",
+          sensitive: true,
+          valueRedacted: false,
+        },
+      ],
+      previousEnvironment: [],
+      nextEnvironment: [
+        {
+          name: "API_KEY",
+          value: "",
+          sensitive: true,
+          valueRedacted: true,
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:API_KEY",
+        name: "API_KEY",
+        value: "",
+        sensitive: true,
+        valueRedacted: true,
+      },
+    ]);
+  });
+
   it("preserves a local deletion when a stale persisted echo still contains the row", () => {
     const previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
       {
@@ -220,6 +253,64 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
         id: "0:BASE_URL",
         name: "BASE_URL",
         value: "https://example.test",
+        sensitive: false,
+      },
+    ]);
+  });
+
+  it("keeps reordered persisted rows when another variable has a local edit", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "0:A",
+          name: "A",
+          value: "local-edit",
+          sensitive: false,
+        },
+        {
+          id: "1:B",
+          name: "B",
+          value: "b",
+          sensitive: false,
+        },
+      ],
+      previousEnvironment: [
+        {
+          name: "A",
+          value: "a",
+          sensitive: false,
+        },
+        {
+          name: "B",
+          value: "b",
+          sensitive: false,
+        },
+      ],
+      nextEnvironment: [
+        {
+          name: "B",
+          value: "b",
+          sensitive: false,
+        },
+        {
+          name: "A",
+          value: "a",
+          sensitive: false,
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:B",
+        name: "B",
+        value: "b",
+        sensitive: false,
+      },
+      {
+        id: "0:A",
+        name: "A",
+        value: "local-edit",
         sensitive: false,
       },
     ]);

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -178,36 +178,6 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
     ]);
   });
 
-  it("drops a local add row once the persisted save echo arrives", () => {
-    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
-      rows: [
-        {
-          id: "provider-env-1",
-          name: "API_KEY",
-          value: "new-secret",
-          sensitive: true,
-        },
-      ],
-      previousEnvironment: [],
-      nextEnvironment: [
-        {
-          name: "API_KEY",
-          value: "new-secret",
-          sensitive: true,
-        },
-      ],
-    });
-
-    expect(rows).toEqual([
-      {
-        id: "0:API_KEY",
-        name: "API_KEY",
-        value: "new-secret",
-        sensitive: true,
-      },
-    ]);
-  });
-
   it("preserves a local deletion when a stale persisted echo still contains the row", () => {
     const previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
       {
@@ -251,42 +221,6 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
         name: "BASE_URL",
         value: "https://example.test",
         sensitive: false,
-      },
-    ]);
-  });
-
-  it("matches a renamed variable save echo without duplicating the draft row", () => {
-    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
-      rows: [
-        {
-          id: "0:OLD_API_KEY",
-          name: "NEW_API_KEY",
-          value: "secret",
-          sensitive: true,
-        },
-      ],
-      previousEnvironment: [
-        {
-          name: "OLD_API_KEY",
-          value: "secret",
-          sensitive: true,
-        },
-      ],
-      nextEnvironment: [
-        {
-          name: "NEW_API_KEY",
-          value: "secret",
-          sensitive: true,
-        },
-      ],
-    });
-
-    expect(rows).toEqual([
-      {
-        id: "0:NEW_API_KEY",
-        name: "NEW_API_KEY",
-        value: "secret",
-        sensitive: true,
       },
     ]);
   });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -226,6 +226,35 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
     expect(rows).toEqual([]);
   });
 
+  it("keeps a new persisted row when a different previous-index draft row was deleted", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [],
+      previousEnvironment: [
+        {
+          name: "API_KEY",
+          value: "old",
+          sensitive: true,
+        },
+      ],
+      nextEnvironment: [
+        {
+          name: "BASE_URL",
+          value: "https://example.test",
+          sensitive: false,
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:BASE_URL",
+        name: "BASE_URL",
+        value: "https://example.test",
+        sensitive: false,
+      },
+    ]);
+  });
+
   it("matches a renamed variable save echo without duplicating the draft row", () => {
     const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
       rows: [

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -211,6 +211,46 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
     ]);
   });
 
+  it("consumes an existing sensitive row when its persisted save echo is redacted", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "0:API_KEY",
+          name: "API_KEY",
+          value: "updated-secret",
+          sensitive: true,
+          valueRedacted: false,
+        },
+      ],
+      previousEnvironment: [
+        {
+          name: "API_KEY",
+          value: "",
+          sensitive: true,
+          valueRedacted: true,
+        },
+      ],
+      nextEnvironment: [
+        {
+          name: "API_KEY",
+          value: "",
+          sensitive: true,
+          valueRedacted: true,
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:API_KEY",
+        name: "API_KEY",
+        value: "",
+        sensitive: true,
+        valueRedacted: true,
+      },
+    ]);
+  });
+
   it("preserves a local deletion when a stale persisted echo still contains the row", () => {
     const previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
       {
@@ -224,6 +264,23 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
       rows: [],
       previousEnvironment,
       nextEnvironment: previousEnvironment,
+    });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("preserves a confirmed empty local deletion when a stale persisted echo restores the row", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [],
+      previousEnvironment: [],
+      nextEnvironment: [
+        {
+          name: "API_KEY",
+          value: "old",
+          sensitive: true,
+        },
+      ],
+      locallyDeletedEnvironmentVariableNames: new Set(["API_KEY"]),
     });
 
     expect(rows).toEqual([]);

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vite-plus/test";
-import type { ServerProviderModel } from "@t3tools/contracts";
+import type { ProviderInstanceEnvironmentVariable, ServerProviderModel } from "@t3tools/contracts";
 
-import { deriveProviderModelsForDisplay } from "./ProviderInstanceCard";
+import {
+  deriveProviderModelsForDisplay,
+  getProviderEnvironmentContentKey,
+} from "./ProviderInstanceCard";
 
 describe("deriveProviderModelsForDisplay", () => {
   it("uses current config custom models instead of stale live custom rows", () => {
@@ -32,5 +35,53 @@ describe("deriveProviderModelsForDisplay", () => {
         customModels: ["kept-custom"],
       }).map((model) => model.slug),
     ).toEqual(["server-model", "kept-custom"]);
+  });
+});
+
+describe("getProviderEnvironmentContentKey", () => {
+  const secretVariable: ProviderInstanceEnvironmentVariable = {
+    name: "API_KEY",
+    value: "stored-secret",
+    sensitive: true,
+    valueRedacted: true,
+  };
+  const baseUrlVariable: ProviderInstanceEnvironmentVariable = {
+    name: "BASE_URL",
+    value: "https://example.test",
+    sensitive: false,
+  };
+  const environment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+    secretVariable,
+    baseUrlVariable,
+  ];
+
+  it("keeps the same key for the same persisted content in a different array", () => {
+    expect(getProviderEnvironmentContentKey(environment)).toBe(
+      getProviderEnvironmentContentKey(environment.map((variable) => ({ ...variable }))),
+    );
+  });
+
+  it("changes the key when persisted values change", () => {
+    expect(getProviderEnvironmentContentKey(environment)).not.toBe(
+      getProviderEnvironmentContentKey([
+        { ...secretVariable, value: "updated-secret" },
+        baseUrlVariable,
+      ]),
+    );
+  });
+
+  it("changes the key when persisted rows are removed", () => {
+    expect(getProviderEnvironmentContentKey(environment)).not.toBe(
+      getProviderEnvironmentContentKey(environment.slice(0, 1)),
+    );
+  });
+
+  it("changes the key when persisted redaction state changes", () => {
+    expect(getProviderEnvironmentContentKey(environment)).not.toBe(
+      getProviderEnvironmentContentKey([
+        { ...secretVariable, valueRedacted: false },
+        baseUrlVariable,
+      ]),
+    );
   });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -177,4 +177,88 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
       },
     ]);
   });
+
+  it("drops a local add row once the persisted save echo arrives", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "provider-env-1",
+          name: "API_KEY",
+          value: "new-secret",
+          sensitive: true,
+        },
+      ],
+      previousEnvironment: [],
+      nextEnvironment: [
+        {
+          name: "API_KEY",
+          value: "new-secret",
+          sensitive: true,
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:API_KEY",
+        name: "API_KEY",
+        value: "new-secret",
+        sensitive: true,
+      },
+    ]);
+  });
+
+  it("preserves a local deletion when a stale persisted echo still contains the row", () => {
+    const previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+      {
+        name: "API_KEY",
+        value: "old",
+        sensitive: true,
+      },
+    ];
+
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [],
+      previousEnvironment,
+      nextEnvironment: previousEnvironment,
+    });
+
+    expect(rows).toEqual([]);
+  });
+
+  it("matches a renamed variable save echo without duplicating the draft row", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "0:OLD_API_KEY",
+          name: "NEW_API_KEY",
+          value: "secret",
+          sensitive: true,
+        },
+      ],
+      previousEnvironment: [
+        {
+          name: "OLD_API_KEY",
+          value: "secret",
+          sensitive: true,
+        },
+      ],
+      nextEnvironment: [
+        {
+          name: "NEW_API_KEY",
+          value: "secret",
+          sensitive: true,
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:NEW_API_KEY",
+        name: "NEW_API_KEY",
+        value: "secret",
+        sensitive: true,
+      },
+    ]);
+  });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -4,6 +4,7 @@ import type { ProviderInstanceEnvironmentVariable, ServerProviderModel } from "@
 import {
   deriveProviderModelsForDisplay,
   getProviderEnvironmentContentKey,
+  mergeEnvironmentDraftRowsForPersistedUpdate,
 } from "./ProviderInstanceCard";
 
 describe("deriveProviderModelsForDisplay", () => {
@@ -83,5 +84,97 @@ describe("getProviderEnvironmentContentKey", () => {
         baseUrlVariable,
       ]),
     );
+  });
+});
+
+describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
+  it("keeps a newer local draft when an older persisted echo arrives", () => {
+    const previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+      {
+        name: "API_KEY",
+        value: "old",
+        sensitive: true,
+      },
+    ];
+    const olderEcho: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+      {
+        name: "API_KEY",
+        value: "first-edit",
+        sensitive: true,
+      },
+    ];
+
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "0:API_KEY",
+          name: "API_KEY",
+          value: "second-edit",
+          sensitive: true,
+        },
+      ],
+      previousEnvironment,
+      nextEnvironment: olderEcho,
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:API_KEY",
+        name: "API_KEY",
+        value: "second-edit",
+        sensitive: true,
+      },
+    ]);
+  });
+
+  it("keeps unpublished add rows when persisted settings change", () => {
+    const previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+      {
+        name: "API_KEY",
+        value: "old",
+        sensitive: true,
+      },
+    ];
+    const nextEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable> = [
+      {
+        name: "API_KEY",
+        value: "new",
+        sensitive: true,
+      },
+    ];
+
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "0:API_KEY",
+          name: "API_KEY",
+          value: "old",
+          sensitive: true,
+        },
+        {
+          id: "provider-env-1",
+          name: "",
+          value: "",
+          sensitive: true,
+        },
+      ],
+      previousEnvironment,
+      nextEnvironment,
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:API_KEY",
+        name: "API_KEY",
+        value: "new",
+        sensitive: true,
+      },
+      {
+        id: "provider-env-1",
+        name: "",
+        value: "",
+        sensitive: true,
+      },
+    ]);
   });
 });

--- a/apps/web/src/components/settings/ProviderInstanceCard.test.ts
+++ b/apps/web/src/components/settings/ProviderInstanceCard.test.ts
@@ -225,9 +225,8 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
       previousEnvironment: [
         {
           name: "API_KEY",
-          value: "",
+          value: "previous-secret",
           sensitive: true,
-          valueRedacted: true,
         },
       ],
       nextEnvironment: [
@@ -247,6 +246,68 @@ describe("mergeEnvironmentDraftRowsForPersistedUpdate", () => {
         value: "",
         sensitive: true,
         valueRedacted: true,
+      },
+    ]);
+  });
+
+  it("keeps a sensitive plaintext draft when a sibling persisted row changes", () => {
+    const rows = mergeEnvironmentDraftRowsForPersistedUpdate({
+      rows: [
+        {
+          id: "0:API_KEY",
+          name: "API_KEY",
+          value: "typed-secret",
+          sensitive: true,
+          valueRedacted: false,
+        },
+        {
+          id: "1:BASE_URL",
+          name: "BASE_URL",
+          value: "https://old.example.test",
+          sensitive: false,
+        },
+      ],
+      previousEnvironment: [
+        {
+          name: "API_KEY",
+          value: "",
+          sensitive: true,
+          valueRedacted: true,
+        },
+        {
+          name: "BASE_URL",
+          value: "https://old.example.test",
+          sensitive: false,
+        },
+      ],
+      nextEnvironment: [
+        {
+          name: "API_KEY",
+          value: "",
+          sensitive: true,
+          valueRedacted: true,
+        },
+        {
+          name: "BASE_URL",
+          value: "https://new.example.test",
+          sensitive: false,
+        },
+      ],
+    });
+
+    expect(rows).toEqual([
+      {
+        id: "0:API_KEY",
+        name: "API_KEY",
+        value: "typed-secret",
+        sensitive: true,
+        valueRedacted: false,
+      },
+      {
+        id: "1:BASE_URL",
+        name: "BASE_URL",
+        value: "https://new.example.test",
+        sensitive: false,
       },
     ]);
   });

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -101,9 +101,26 @@ function isEnvironmentDraftRowEqualToPersisted(
   );
 }
 
+function isEnvironmentDraftRowAcknowledgedByPersisted(
+  row: EnvironmentDraftRow,
+  variable: ProviderInstanceEnvironmentVariable,
+  previousVariable: ProviderInstanceEnvironmentVariable | undefined,
+): boolean {
+  if (isEnvironmentDraftRowEqualToPersisted(row, variable)) return true;
+  return (
+    previousVariable === undefined &&
+    row.name === variable.name &&
+    row.sensitive === true &&
+    variable.sensitive === true &&
+    variable.value === "" &&
+    variable.valueRedacted === true &&
+    row.valueRedacted !== true
+  );
+}
+
 function isSameEnvironmentVariable(
-  previousVariable: ProviderInstanceEnvironmentVariable,
-  nextVariable: ProviderInstanceEnvironmentVariable,
+  previousVariable: Pick<ProviderInstanceEnvironmentVariable, "name">,
+  nextVariable: Pick<ProviderInstanceEnvironmentVariable, "name">,
 ): boolean {
   return previousVariable.name === nextVariable.name;
 }
@@ -126,10 +143,22 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
   const consumeRow = (row: EnvironmentDraftRow) => {
     consumedRowIds.add(row.id);
   };
-  const findMatchingCurrentRow = (variable: ProviderInstanceEnvironmentVariable) =>
-    input.rows.find(
-      (row) => !consumedRowIds.has(row.id) && isEnvironmentDraftRowEqualToPersisted(row, variable),
-    );
+  const findAcknowledgedCurrentRow = (variable: ProviderInstanceEnvironmentVariable) =>
+    input.rows.find((row) => {
+      if (consumedRowIds.has(row.id)) return false;
+      return isEnvironmentDraftRowAcknowledgedByPersisted(row, variable, previousById.get(row.id));
+    });
+  const findChangedCurrentRowForSameVariable = (variable: ProviderInstanceEnvironmentVariable) =>
+    input.rows.find((row) => {
+      if (consumedRowIds.has(row.id) || !isSameEnvironmentVariable(row, variable)) {
+        return false;
+      }
+      const previousVariable = previousById.get(row.id);
+      return (
+        previousVariable !== undefined &&
+        isEnvironmentDraftRowChangedFromPersisted(row, previousVariable)
+      );
+    });
 
   const nextRows = input.nextEnvironment.flatMap((variable, index) => {
     const nextRow = makeEnvironmentDraftRow(variable, index);
@@ -146,7 +175,9 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
       isEnvironmentDraftRowChangedFromPersisted(currentRow, previousVariable)
     ) {
       consumeRow(currentRow);
-      return isEnvironmentDraftRowEqualToPersisted(currentRow, variable) ? [nextRow] : [currentRow];
+      return isEnvironmentDraftRowAcknowledgedByPersisted(currentRow, variable, previousVariable)
+        ? [nextRow]
+        : [currentRow];
     }
 
     if (currentRow !== undefined) {
@@ -154,25 +185,16 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
       return [nextRow];
     }
 
-    if (
-      currentRowAtPreviousIndex !== undefined &&
-      previousRowAtIndex !== undefined &&
-      !consumedRowIds.has(currentRowAtPreviousIndex.id) &&
-      isEnvironmentDraftRowChangedFromPersisted(
-        currentRowAtPreviousIndex,
-        previousById.get(previousRowAtIndex.id) ?? variable,
-      )
-    ) {
-      consumeRow(currentRowAtPreviousIndex);
-      return isEnvironmentDraftRowEqualToPersisted(currentRowAtPreviousIndex, variable)
-        ? [nextRow]
-        : [currentRowAtPreviousIndex];
+    const acknowledgedCurrentRow = findAcknowledgedCurrentRow(variable);
+    if (acknowledgedCurrentRow !== undefined) {
+      consumeRow(acknowledgedCurrentRow);
+      return [nextRow];
     }
 
-    const matchingCurrentRow = findMatchingCurrentRow(variable);
-    if (matchingCurrentRow !== undefined) {
-      consumeRow(matchingCurrentRow);
-      return [nextRow];
+    const changedCurrentRow = findChangedCurrentRowForSameVariable(variable);
+    if (changedCurrentRow !== undefined) {
+      consumeRow(changedCurrentRow);
+      return [changedCurrentRow];
     }
 
     if (

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -101,6 +101,13 @@ function isEnvironmentDraftRowEqualToPersisted(
   );
 }
 
+function isSameEnvironmentVariable(
+  previousVariable: ProviderInstanceEnvironmentVariable,
+  nextVariable: ProviderInstanceEnvironmentVariable,
+): boolean {
+  return previousVariable.name === nextVariable.name;
+}
+
 export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
   readonly rows: ReadonlyArray<EnvironmentDraftRow>;
   readonly previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
@@ -170,7 +177,9 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
 
     if (
       previousVariable !== undefined ||
-      (previousRowAtIndex !== undefined && currentRowAtPreviousIndex === undefined)
+      (previousRowAtIndex !== undefined &&
+        currentRowAtPreviousIndex === undefined &&
+        isSameEnvironmentVariable(previousRowAtIndex, variable))
     ) {
       return [];
     }

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -113,12 +113,49 @@ function isProviderEnvironmentVariableEqual(
   );
 }
 
+function isProviderEnvironmentVariableAcknowledgedByPersisted(
+  publishedVariable: ProviderInstanceEnvironmentVariable,
+  persistedVariable: ProviderInstanceEnvironmentVariable,
+): boolean {
+  if (isProviderEnvironmentVariableEqual(publishedVariable, persistedVariable)) return true;
+  return (
+    publishedVariable.name === persistedVariable.name &&
+    publishedVariable.sensitive === true &&
+    publishedVariable.valueRedacted !== true &&
+    persistedVariable.sensitive === true &&
+    persistedVariable.value === "" &&
+    persistedVariable.valueRedacted === true
+  );
+}
+
+export function isPublishedProviderEnvironmentAcknowledgedByPersisted(input: {
+  readonly publishedEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
+  readonly persistedEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
+}): boolean {
+  if (input.publishedEnvironment.length !== input.persistedEnvironment.length) return false;
+  return input.publishedEnvironment.every((publishedVariable, index) => {
+    const persistedVariable = input.persistedEnvironment[index];
+    return (
+      persistedVariable !== undefined &&
+      isProviderEnvironmentVariableAcknowledgedByPersisted(publishedVariable, persistedVariable)
+    );
+  });
+}
+
 function isEnvironmentDraftRowAcknowledgedByPersisted(
   row: EnvironmentDraftRow,
   variable: ProviderInstanceEnvironmentVariable,
   previousVariable: ProviderInstanceEnvironmentVariable | undefined,
+  publishedVariable: ProviderInstanceEnvironmentVariable | undefined,
 ): boolean {
   if (isEnvironmentDraftRowEqualToPersisted(row, variable)) return true;
+  if (
+    publishedVariable !== undefined &&
+    isEnvironmentDraftRowEqualToPersisted(row, publishedVariable) &&
+    isProviderEnvironmentVariableAcknowledgedByPersisted(publishedVariable, variable)
+  ) {
+    return true;
+  }
   if (
     row.name !== variable.name ||
     row.sensitive !== true ||
@@ -150,7 +187,11 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
   readonly rows: ReadonlyArray<EnvironmentDraftRow>;
   readonly previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
   readonly nextEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
-  readonly locallyDeletedEnvironmentVariableNames?: ReadonlySet<string>;
+  readonly publishedEnvironment?: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
+  readonly locallyDeletedEnvironmentVariables?: ReadonlyMap<
+    string,
+    ProviderInstanceEnvironmentVariable
+  >;
 }): ReadonlyArray<EnvironmentDraftRow> {
   const previousById = new Map(
     input.previousEnvironment.map((variable, index) => [
@@ -160,6 +201,9 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
   );
   const previousRowsByIndex = input.previousEnvironment.map(makeEnvironmentDraftRow);
   const rowsById = new Map(input.rows.map((row) => [row.id, row]));
+  const publishedByName = new Map(
+    input.publishedEnvironment?.map((variable) => [variable.name, variable]) ?? [],
+  );
   const nextIds = new Set<string>();
   const consumedRowIds = new Set<string>();
   const consumeRow = (row: EnvironmentDraftRow) => {
@@ -168,7 +212,12 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
   const findAcknowledgedCurrentRow = (variable: ProviderInstanceEnvironmentVariable) =>
     input.rows.find((row) => {
       if (consumedRowIds.has(row.id)) return false;
-      return isEnvironmentDraftRowAcknowledgedByPersisted(row, variable, previousById.get(row.id));
+      return isEnvironmentDraftRowAcknowledgedByPersisted(
+        row,
+        variable,
+        previousById.get(row.id),
+        publishedByName.get(variable.name),
+      );
     });
   const findChangedCurrentRowForSameVariable = (variable: ProviderInstanceEnvironmentVariable) =>
     input.rows.find((row) => {
@@ -197,7 +246,12 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
       isEnvironmentDraftRowChangedFromPersisted(currentRow, previousVariable)
     ) {
       consumeRow(currentRow);
-      return isEnvironmentDraftRowAcknowledgedByPersisted(currentRow, variable, previousVariable)
+      return isEnvironmentDraftRowAcknowledgedByPersisted(
+        currentRow,
+        variable,
+        previousVariable,
+        publishedByName.get(variable.name),
+      )
         ? [nextRow]
         : [currentRow];
     }
@@ -219,7 +273,13 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
       return [changedCurrentRow];
     }
 
-    if (input.locallyDeletedEnvironmentVariableNames?.has(variable.name)) {
+    const locallyDeletedEnvironmentVariable = input.locallyDeletedEnvironmentVariables?.get(
+      variable.name,
+    );
+    if (
+      locallyDeletedEnvironmentVariable !== undefined &&
+      isProviderEnvironmentVariableEqual(locallyDeletedEnvironmentVariable, variable)
+    ) {
       return [];
     }
 
@@ -345,13 +405,29 @@ function ProviderEnvironmentSection(props: {
   const persistedEnvironmentContentKey = getProviderEnvironmentContentKey(props.environment);
   const previousPersistedEnvironment = useRef(props.environment);
   const previousPersistedEnvironmentContentKey = useRef(persistedEnvironmentContentKey);
-  const locallyDeletedEnvironmentVariableNames = useRef<Set<string>>(new Set());
+  const pendingPublishedEnvironment = useRef<
+    ReadonlyArray<ProviderInstanceEnvironmentVariable> | undefined
+  >(undefined);
+  const locallyDeletedEnvironmentVariables = useRef<
+    Map<string, ProviderInstanceEnvironmentVariable>
+  >(new Map());
   const [rows, setRows] = useState<ReadonlyArray<EnvironmentDraftRow>>(() =>
     props.environment.map(makeEnvironmentDraftRow),
   );
 
   useEffect(() => {
-    if (previousPersistedEnvironmentContentKey.current === persistedEnvironmentContentKey) {
+    const acknowledgedPublishedEnvironment =
+      pendingPublishedEnvironment.current !== undefined &&
+      isPublishedProviderEnvironmentAcknowledgedByPersisted({
+        publishedEnvironment: pendingPublishedEnvironment.current,
+        persistedEnvironment: props.environment,
+      })
+        ? pendingPublishedEnvironment.current
+        : undefined;
+    if (
+      previousPersistedEnvironmentContentKey.current === persistedEnvironmentContentKey &&
+      acknowledgedPublishedEnvironment === undefined
+    ) {
       return;
     }
     previousPersistedEnvironmentContentKey.current = persistedEnvironmentContentKey;
@@ -360,13 +436,19 @@ function ProviderEnvironmentSection(props: {
         rows: currentRows,
         previousEnvironment: previousPersistedEnvironment.current,
         nextEnvironment: props.environment,
-        locallyDeletedEnvironmentVariableNames: locallyDeletedEnvironmentVariableNames.current,
+        ...(acknowledgedPublishedEnvironment !== undefined
+          ? { publishedEnvironment: acknowledgedPublishedEnvironment }
+          : {}),
+        locallyDeletedEnvironmentVariables: locallyDeletedEnvironmentVariables.current,
       });
       for (const row of nextRows) {
-        locallyDeletedEnvironmentVariableNames.current.delete(row.name);
+        locallyDeletedEnvironmentVariables.current.delete(row.name);
       }
       return nextRows;
     });
+    if (acknowledgedPublishedEnvironment !== undefined) {
+      pendingPublishedEnvironment.current = undefined;
+    }
     previousPersistedEnvironment.current = props.environment;
   }, [persistedEnvironmentContentKey, props.environment]);
 
@@ -388,12 +470,13 @@ function ProviderEnvironmentSection(props: {
       const { id: _id, ...rest } = row;
       published.push({ ...rest, name });
     }
+    pendingPublishedEnvironment.current = published;
     props.onChange(published);
   };
 
   const updateVariable = (id: string, patch: Partial<Omit<EnvironmentDraftRow, "id">>) => {
     if (patch.name !== undefined) {
-      locallyDeletedEnvironmentVariableNames.current.delete(patch.name.trim());
+      locallyDeletedEnvironmentVariables.current.delete(patch.name.trim());
     }
     const nextRows = rows.map((row) =>
       row.id === id
@@ -414,8 +497,14 @@ function ProviderEnvironmentSection(props: {
       (variable, index) => makeEnvironmentDraftRow(variable, index).id === id,
     );
     if (removedRow !== undefined && previousVariable !== undefined) {
-      locallyDeletedEnvironmentVariableNames.current.add(previousVariable.name);
-      locallyDeletedEnvironmentVariableNames.current.add(removedRow.name.trim());
+      locallyDeletedEnvironmentVariables.current.set(previousVariable.name, previousVariable);
+      const removedName = removedRow.name.trim();
+      if (removedName.length > 0) {
+        locallyDeletedEnvironmentVariables.current.set(removedName, {
+          ...previousVariable,
+          name: removedName,
+        });
+      }
     }
     const nextRows = rows.filter((row) => row.id !== id);
     setRows(nextRows);

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -107,14 +107,21 @@ function isEnvironmentDraftRowAcknowledgedByPersisted(
   previousVariable: ProviderInstanceEnvironmentVariable | undefined,
 ): boolean {
   if (isEnvironmentDraftRowEqualToPersisted(row, variable)) return true;
+  if (
+    row.name !== variable.name ||
+    row.sensitive !== true ||
+    variable.sensitive !== true ||
+    variable.value !== "" ||
+    variable.valueRedacted !== true ||
+    row.valueRedacted === true
+  ) {
+    return false;
+  }
+
+  if (previousVariable === undefined) return true;
+
   return (
-    previousVariable === undefined &&
-    row.name === variable.name &&
-    row.sensitive === true &&
-    variable.sensitive === true &&
-    variable.value === "" &&
-    variable.valueRedacted === true &&
-    row.valueRedacted !== true
+    isSameEnvironmentVariable(previousVariable, variable) && previousVariable.sensitive === true
   );
 }
 
@@ -129,6 +136,7 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
   readonly rows: ReadonlyArray<EnvironmentDraftRow>;
   readonly previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
   readonly nextEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
+  readonly locallyDeletedEnvironmentVariableNames?: ReadonlySet<string>;
 }): ReadonlyArray<EnvironmentDraftRow> {
   const previousById = new Map(
     input.previousEnvironment.map((variable, index) => [
@@ -195,6 +203,10 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
     if (changedCurrentRow !== undefined) {
       consumeRow(changedCurrentRow);
       return [changedCurrentRow];
+    }
+
+    if (input.locallyDeletedEnvironmentVariableNames?.has(variable.name)) {
+      return [];
     }
 
     if (
@@ -319,6 +331,7 @@ function ProviderEnvironmentSection(props: {
   const persistedEnvironmentContentKey = getProviderEnvironmentContentKey(props.environment);
   const previousPersistedEnvironment = useRef(props.environment);
   const previousPersistedEnvironmentContentKey = useRef(persistedEnvironmentContentKey);
+  const locallyDeletedEnvironmentVariableNames = useRef<Set<string>>(new Set());
   const [rows, setRows] = useState<ReadonlyArray<EnvironmentDraftRow>>(() =>
     props.environment.map(makeEnvironmentDraftRow),
   );
@@ -328,13 +341,18 @@ function ProviderEnvironmentSection(props: {
       return;
     }
     previousPersistedEnvironmentContentKey.current = persistedEnvironmentContentKey;
-    setRows((currentRows) =>
-      mergeEnvironmentDraftRowsForPersistedUpdate({
+    setRows((currentRows) => {
+      const nextRows = mergeEnvironmentDraftRowsForPersistedUpdate({
         rows: currentRows,
         previousEnvironment: previousPersistedEnvironment.current,
         nextEnvironment: props.environment,
-      }),
-    );
+        locallyDeletedEnvironmentVariableNames: locallyDeletedEnvironmentVariableNames.current,
+      });
+      for (const row of nextRows) {
+        locallyDeletedEnvironmentVariableNames.current.delete(row.name);
+      }
+      return nextRows;
+    });
     previousPersistedEnvironment.current = props.environment;
   }, [persistedEnvironmentContentKey, props.environment]);
 
@@ -360,6 +378,9 @@ function ProviderEnvironmentSection(props: {
   };
 
   const updateVariable = (id: string, patch: Partial<Omit<EnvironmentDraftRow, "id">>) => {
+    if (patch.name !== undefined) {
+      locallyDeletedEnvironmentVariableNames.current.delete(patch.name.trim());
+    }
     const nextRows = rows.map((row) =>
       row.id === id
         ? {
@@ -374,6 +395,14 @@ function ProviderEnvironmentSection(props: {
   };
 
   const removeVariable = (id: string) => {
+    const removedRow = rows.find((row) => row.id === id);
+    const previousVariable = previousPersistedEnvironment.current.find(
+      (variable, index) => makeEnvironmentDraftRow(variable, index).id === id,
+    );
+    if (removedRow !== undefined && previousVariable !== undefined) {
+      locallyDeletedEnvironmentVariableNames.current.add(previousVariable.name);
+      locallyDeletedEnvironmentVariableNames.current.add(removedRow.name.trim());
+    }
     const nextRows = rows.filter((row) => row.id !== id);
     setRows(nextRows);
     publishRows(nextRows);

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -101,6 +101,18 @@ function isEnvironmentDraftRowEqualToPersisted(
   );
 }
 
+function isProviderEnvironmentVariableEqual(
+  left: ProviderInstanceEnvironmentVariable,
+  right: ProviderInstanceEnvironmentVariable,
+): boolean {
+  return (
+    left.name === right.name &&
+    left.value === right.value &&
+    left.sensitive === right.sensitive &&
+    left.valueRedacted === right.valueRedacted
+  );
+}
+
 function isEnvironmentDraftRowAcknowledgedByPersisted(
   row: EnvironmentDraftRow,
   variable: ProviderInstanceEnvironmentVariable,
@@ -121,7 +133,9 @@ function isEnvironmentDraftRowAcknowledgedByPersisted(
   if (previousVariable === undefined) return true;
 
   return (
-    isSameEnvironmentVariable(previousVariable, variable) && previousVariable.sensitive === true
+    isSameEnvironmentVariable(previousVariable, variable) &&
+    previousVariable.sensitive === true &&
+    !isProviderEnvironmentVariableEqual(previousVariable, variable)
   );
 }
 

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -77,6 +77,61 @@ function makeEnvironmentDraftRow(
   };
 }
 
+function isEnvironmentDraftRowChangedFromPersisted(
+  row: EnvironmentDraftRow,
+  variable: ProviderInstanceEnvironmentVariable,
+): boolean {
+  return (
+    row.name !== variable.name ||
+    row.value !== variable.value ||
+    row.sensitive !== variable.sensitive ||
+    row.valueRedacted !== variable.valueRedacted
+  );
+}
+
+export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
+  readonly rows: ReadonlyArray<EnvironmentDraftRow>;
+  readonly previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
+  readonly nextEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
+}): ReadonlyArray<EnvironmentDraftRow> {
+  const previousById = new Map(
+    input.previousEnvironment.map((variable, index) => [
+      makeEnvironmentDraftRow(variable, index).id,
+      variable,
+    ]),
+  );
+  const rowsById = new Map(input.rows.map((row) => [row.id, row]));
+  const nextIds = new Set<string>();
+  const nextRows = input.nextEnvironment.map((variable, index) => {
+    const nextRow = makeEnvironmentDraftRow(variable, index);
+    nextIds.add(nextRow.id);
+
+    const currentRow = rowsById.get(nextRow.id);
+    const previousVariable = previousById.get(nextRow.id);
+    if (
+      currentRow !== undefined &&
+      previousVariable !== undefined &&
+      isEnvironmentDraftRowChangedFromPersisted(currentRow, previousVariable)
+    ) {
+      return currentRow;
+    }
+
+    return nextRow;
+  });
+
+  const localRows = input.rows.filter((row) => {
+    if (nextIds.has(row.id)) return false;
+
+    const previousVariable = previousById.get(row.id);
+    return (
+      previousVariable === undefined ||
+      isEnvironmentDraftRowChangedFromPersisted(row, previousVariable)
+    );
+  });
+
+  return [...nextRows, ...localRows];
+}
+
 export function getProviderEnvironmentContentKey(
   environment: ReadonlyArray<ProviderInstanceEnvironmentVariable>,
 ): string {
@@ -171,6 +226,7 @@ function ProviderEnvironmentSection(props: {
   readonly onChange: (environment: ReadonlyArray<ProviderInstanceEnvironmentVariable>) => void;
 }) {
   const persistedEnvironmentContentKey = getProviderEnvironmentContentKey(props.environment);
+  const previousPersistedEnvironment = useRef(props.environment);
   const previousPersistedEnvironmentContentKey = useRef(persistedEnvironmentContentKey);
   const [rows, setRows] = useState<ReadonlyArray<EnvironmentDraftRow>>(() =>
     props.environment.map(makeEnvironmentDraftRow),
@@ -181,7 +237,14 @@ function ProviderEnvironmentSection(props: {
       return;
     }
     previousPersistedEnvironmentContentKey.current = persistedEnvironmentContentKey;
-    setRows(props.environment.map(makeEnvironmentDraftRow));
+    setRows((currentRows) =>
+      mergeEnvironmentDraftRowsForPersistedUpdate({
+        rows: currentRows,
+        previousEnvironment: previousPersistedEnvironment.current,
+        nextEnvironment: props.environment,
+      }),
+    );
+    previousPersistedEnvironment.current = props.environment;
   }, [persistedEnvironmentContentKey, props.environment]);
 
   const publishRows = (nextRows: ReadonlyArray<EnvironmentDraftRow>) => {

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -12,7 +12,7 @@ import {
 } from "lucide-react";
 import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import {
   isProviderDriverKind,
   type ProviderInstanceConfig,
@@ -75,6 +75,19 @@ function makeEnvironmentDraftRow(
     sensitive: variable.sensitive,
     ...(variable.valueRedacted !== undefined ? { valueRedacted: variable.valueRedacted } : {}),
   };
+}
+
+export function getProviderEnvironmentContentKey(
+  environment: ReadonlyArray<ProviderInstanceEnvironmentVariable>,
+): string {
+  return JSON.stringify(
+    environment.map((variable) => [
+      variable.name,
+      variable.value,
+      variable.sensitive,
+      variable.valueRedacted,
+    ]),
+  );
 }
 
 /**
@@ -157,9 +170,19 @@ function ProviderEnvironmentSection(props: {
   readonly environment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
   readonly onChange: (environment: ReadonlyArray<ProviderInstanceEnvironmentVariable>) => void;
 }) {
+  const persistedEnvironmentContentKey = getProviderEnvironmentContentKey(props.environment);
+  const previousPersistedEnvironmentContentKey = useRef(persistedEnvironmentContentKey);
   const [rows, setRows] = useState<ReadonlyArray<EnvironmentDraftRow>>(() =>
     props.environment.map(makeEnvironmentDraftRow),
   );
+
+  useEffect(() => {
+    if (previousPersistedEnvironmentContentKey.current === persistedEnvironmentContentKey) {
+      return;
+    }
+    previousPersistedEnvironmentContentKey.current = persistedEnvironmentContentKey;
+    setRows(props.environment.map(makeEnvironmentDraftRow));
+  }, [persistedEnvironmentContentKey, props.environment]);
 
   const publishRows = (nextRows: ReadonlyArray<EnvironmentDraftRow>) => {
     const published: ProviderInstanceEnvironmentVariable[] = [];

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -89,6 +89,18 @@ function isEnvironmentDraftRowChangedFromPersisted(
   );
 }
 
+function isEnvironmentDraftRowEqualToPersisted(
+  row: EnvironmentDraftRow,
+  variable: ProviderInstanceEnvironmentVariable,
+): boolean {
+  return (
+    row.name === variable.name &&
+    row.value === variable.value &&
+    row.sensitive === variable.sensitive &&
+    row.valueRedacted === variable.valueRedacted
+  );
+}
+
 export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
   readonly rows: ReadonlyArray<EnvironmentDraftRow>;
   readonly previousEnvironment: ReadonlyArray<ProviderInstanceEnvironmentVariable>;
@@ -100,26 +112,74 @@ export function mergeEnvironmentDraftRowsForPersistedUpdate(input: {
       variable,
     ]),
   );
+  const previousRowsByIndex = input.previousEnvironment.map(makeEnvironmentDraftRow);
   const rowsById = new Map(input.rows.map((row) => [row.id, row]));
   const nextIds = new Set<string>();
-  const nextRows = input.nextEnvironment.map((variable, index) => {
+  const consumedRowIds = new Set<string>();
+  const consumeRow = (row: EnvironmentDraftRow) => {
+    consumedRowIds.add(row.id);
+  };
+  const findMatchingCurrentRow = (variable: ProviderInstanceEnvironmentVariable) =>
+    input.rows.find(
+      (row) => !consumedRowIds.has(row.id) && isEnvironmentDraftRowEqualToPersisted(row, variable),
+    );
+
+  const nextRows = input.nextEnvironment.flatMap((variable, index) => {
     const nextRow = makeEnvironmentDraftRow(variable, index);
     nextIds.add(nextRow.id);
 
     const currentRow = rowsById.get(nextRow.id);
     const previousVariable = previousById.get(nextRow.id);
+    const previousRowAtIndex = previousRowsByIndex[index];
+    const currentRowAtPreviousIndex =
+      previousRowAtIndex !== undefined ? rowsById.get(previousRowAtIndex.id) : undefined;
     if (
       currentRow !== undefined &&
       previousVariable !== undefined &&
       isEnvironmentDraftRowChangedFromPersisted(currentRow, previousVariable)
     ) {
-      return currentRow;
+      consumeRow(currentRow);
+      return isEnvironmentDraftRowEqualToPersisted(currentRow, variable) ? [nextRow] : [currentRow];
     }
 
-    return nextRow;
+    if (currentRow !== undefined) {
+      consumeRow(currentRow);
+      return [nextRow];
+    }
+
+    if (
+      currentRowAtPreviousIndex !== undefined &&
+      previousRowAtIndex !== undefined &&
+      !consumedRowIds.has(currentRowAtPreviousIndex.id) &&
+      isEnvironmentDraftRowChangedFromPersisted(
+        currentRowAtPreviousIndex,
+        previousById.get(previousRowAtIndex.id) ?? variable,
+      )
+    ) {
+      consumeRow(currentRowAtPreviousIndex);
+      return isEnvironmentDraftRowEqualToPersisted(currentRowAtPreviousIndex, variable)
+        ? [nextRow]
+        : [currentRowAtPreviousIndex];
+    }
+
+    const matchingCurrentRow = findMatchingCurrentRow(variable);
+    if (matchingCurrentRow !== undefined) {
+      consumeRow(matchingCurrentRow);
+      return [nextRow];
+    }
+
+    if (
+      previousVariable !== undefined ||
+      (previousRowAtIndex !== undefined && currentRowAtPreviousIndex === undefined)
+    ) {
+      return [];
+    }
+
+    return [nextRow];
   });
 
   const localRows = input.rows.filter((row) => {
+    if (consumedRowIds.has(row.id)) return false;
     if (nextIds.has(row.id)) return false;
 
     const previousVariable = previousById.get(row.id);


### PR DESCRIPTION
## Summary
- Sync provider environment draft rows when persisted environment content changes while the settings card stays mounted.
- Add focused unit coverage for the persisted environment content key.

## Root cause
- `ProviderEnvironmentSection` initialized local rows from props once and did not reconcile them when refreshed or reset provider environment props changed underneath the mounted card.
- Array identity alone is not a safe signal because callers may pass fresh empty arrays on unrelated renders.

## Impact
- Provider environment rows now refresh after external settings reset or refresh without wiping local draft rows on unrelated renders.
- The existing publish behavior is preserved: invalid non-empty rows block publish, and blank default rows are skipped.

## Validation
- `PATH="$HOME/.vite-plus/bin:$PATH" vp test run apps/web/src/components/settings/ProviderInstanceCard.test.ts --project unit` reports no configured project named `unit` in this checkout before running tests.
- `PATH="$HOME/.vite-plus/bin:$PATH" vp test run apps/web/src/components/settings/ProviderInstanceCard.test.ts` passes: 1 file, 5 tests.
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check` passes with existing warnings outside this change.
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Non-trivial client state around sensitive environment variables; regressions could drop edits, resurrect deleted rows, or mishandle redacted secret UX, though server persistence is unchanged.
> 
> **Overview**
> Fixes provider environment variable rows going stale when persisted settings refresh or reset while the settings card stays mounted, without treating new array references as real data changes.
> 
> **`ProviderEnvironmentSection`** now keys sync off **`getProviderEnvironmentContentKey`** (serialized name/value/sensitive/redaction) and runs **`mergeEnvironmentDraftRowsForPersistedUpdate`** in a `useEffect` so incoming persisted snapshots merge with local drafts instead of replacing them blindly.
> 
> The merge keeps in-progress edits and blank “add” rows, honors local deletions (including stale server echoes via a locally-deleted map), handles reordering, and treats redacted sensitive save echoes as acknowledged when they match what was just published. Edits clear redaction on value change; deletes record removed variables before publish.
> 
> Adds broad unit coverage for the content key and merge edge cases in **`ProviderInstanceCard.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d42fee8103283c13110daa4cec59d28659419ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix provider environment variable sync to preserve local edits across persisted updates
> - Adds `mergeEnvironmentDraftRowsForPersistedUpdate` in [ProviderInstanceCard.tsx](https://github.com/pingdotgg/t3code/pull/3524/files#diff-abfacda8242e42a51ed23d2b21b91d4822ff52c2dfb6650be36af9d8c82302e9) to merge incoming persisted environment updates with local draft rows, preserving in-progress edits, unpublished adds, and local deletions.
> - Handles sensitive variable acknowledgement: when the server echoes a redacted empty value, the UI recognizes the save as confirmed rather than overwriting local state.
> - Tracks locally deleted variables so stale server echoes or conflicting re-adds don't resurrect removed rows.
> - Adds `getProviderEnvironmentContentKey` to detect when the persisted environment has actually changed content, gating the merge effect.
> - Extends the test suite in [ProviderInstanceCard.test.ts](https://github.com/pingdotgg/t3code/pull/3524/files#diff-b51111b812bafe455aefa256626abafc9a1e5d548cabde62df463bab2aaa04e8) with coverage for key stability, redaction semantics, reordering, and conflict resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d42fee.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->