### PR TITLE
[codex] fix: show standalone element-pick context

### DIFF
--- a/apps/web/src/components/chat/MessagesTimeline.test.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.test.tsx
@@ -193,6 +193,33 @@ describe("MessagesTimeline", () => {
     expect(markup).toContain("Show full message");
   }, 20_000);
 
+  it("renders chips for standalone element-pick context messages", async () => {
+    const { MessagesTimeline } = await import("./MessagesTimeline");
+    const markup = renderToStaticMarkup(
+      <MessagesTimeline
+        {...buildProps()}
+        timelineEntries={[
+          buildUserTimelineEntry(
+            [
+              "<element_context>",
+              "- <SubmitButton> (Button.tsx:12):",
+              "  url: https://example.com/dashboard",
+              "  selector: button.submit",
+              "  source: /repo/src/Button.tsx:12:5",
+              "  html:",
+              '  <button class="submit">Save</button>',
+              "</element_context>",
+            ].join("\n"),
+          ),
+        ]}
+      />,
+    );
+
+    expect(markup).toContain("SubmitButton");
+    expect(markup).not.toContain("&lt;element_context");
+    expect(markup).not.toContain("<element_context");
+  });
+
   it("keeps the copy button for collapsed long user messages", async () => {
     const { MessagesTimeline } = await import("./MessagesTimeline");
     const markup = renderToStaticMarkup(

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -448,6 +448,10 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
     visibleText = extracted.promptText;
   }
   const elementContextState = extractTrailingElementContexts(visibleText);
+  const elementContexts = [
+    ...displayedUserMessage.elementContexts,
+    ...elementContextState.contexts,
+  ];
   const previewImages = userImages.filter((image) => image.name.startsWith("preview-annotation-"));
   const regularImages = userImages.filter((image) => !image.name.startsWith("preview-annotation-"));
   const canRevertAgentWork = typeof row.revertTurnCount === "number";
@@ -495,9 +499,9 @@ function UserTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "message" 
             image={previewImages[index] ?? null}
           />
         ))}
-        {elementContextState.contexts.length > 0 ? (
+        {elementContexts.length > 0 ? (
           <div className="mb-2 flex flex-wrap gap-1.5">
-            {elementContextState.contexts.map((context) => (
+            {elementContexts.map((context) => (
               <UserMessageElementContextChip
                 key={`${context.header}:${context.body}`}
                 context={context}


### PR DESCRIPTION
## Summary

- Render element-context chips parsed from the original sent user message state.
- Keep the existing preview-annotation stripping fallback so element blocks revealed after preview removal still render as chips.
- Add a focused regression test for messages that consist only of an `<element_context>` block.

## Root cause

`deriveDisplayedUserMessageState(row.message.text)` already strips trailing element-context blocks before timeline rendering, but `UserTimelineRow` only rendered contexts from a second extraction pass over the already-stripped visible text. Standalone element-pick messages therefore had no visible body and no rendered chip.

## Impact

Standalone element-pick sends now show their element chip in the transcript while preserving the raw sent prompt for copy. Messages where preview annotations are stripped before an element block becomes trailing still use the existing fallback extraction path.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp test apps/web/src/components/chat/MessagesTimeline.test.tsx`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change in chat message rendering with a focused test; no auth, data, or API impact.
> 
> **Overview**
> **User timeline rows** now render element-pick **chips** when the sent message is only an `<element_context>` block (or when contexts were already stripped from the visible prompt).
> 
> `UserTimelineRow` merges `displayedUserMessage.elementContexts` from `deriveDisplayedUserMessageState` with contexts from the existing trailing `extractTrailingElementContexts` pass on stripped visible text, so chips no longer depend solely on the second extraction. The collapsible body still uses `elementContextState.promptText`, and copy behavior stays on the full raw message.
> 
> A regression test asserts **SubmitButton** appears as a chip and raw `<element_context>` tags are not shown in the markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc8d14e789c5fa3530d85c40c1536ca00535c2e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix standalone element-pick context messages to render chips in `MessagesTimeline`
> Element context chips were not showing for standalone element-pick context messages because the chip rendering only used contexts parsed from the visible prompt text.
>
> - [MessagesTimeline.tsx](https://github.com/pingdotgg/t3code/pull/3527/files#diff-f2a34c4ad8d2b68c45657dbdcbf14afac4ea93e1fbd37007aaa2ccb8b41d2588) now merges `displayedUserMessage.elementContexts` with `elementContextState.contexts` so chips render from both sources.
> - A new test in [MessagesTimeline.test.tsx](https://github.com/pingdotgg/t3code/pull/3527/files#diff-ed3eb7f66cdae04c2cff32c0f2feb550aea5dddf9fe3af32adc68f50c0832a61) verifies chips appear and raw `<element_context>` tags are not leaked into the output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc8d14e.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->