### PR TITLE
[codex] fix: retry transient shell subscription failures

### DIFF
--- a/packages/client-runtime/src/state/shell-sync.test.ts
+++ b/packages/client-runtime/src/state/shell-sync.test.ts
@@ -8,8 +8,10 @@ import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
+import * as Ref from "effect/Ref";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
+import * as TestClock from "effect/testing/TestClock";
 
 import {
   AVAILABLE_CONNECTION_STATE,
@@ -46,6 +48,37 @@ function session(client: WsRpcProtocolClient): RpcSession.RpcSession {
   };
 }
 
+function makeTestShellState(client: WsRpcProtocolClient) {
+  return Effect.gen(function* () {
+    const supervisorState = yield* SubscriptionRef.make(AVAILABLE_CONNECTION_STATE);
+    const activeSession = yield* SubscriptionRef.make<Option.Option<RpcSession.RpcSession>>(
+      Option.some(session(client)),
+    );
+    const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
+      target: TARGET,
+      state: supervisorState,
+      session: activeSession,
+      prepared: yield* SubscriptionRef.make(Option.none<PreparedConnection>()),
+      connect: Effect.void,
+      disconnect: Effect.void,
+      retryNow: Effect.void,
+    } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
+    const cache = Persistence.EnvironmentCacheStore.of({
+      loadShell: () => Effect.succeed(Option.none()),
+      saveShell: () => Effect.never,
+      loadThread: () => Effect.succeed(Option.none()),
+      saveThread: () => Effect.void,
+      removeThread: () => Effect.void,
+      clear: () => Effect.void,
+    });
+    const shellState = yield* makeEnvironmentShellState().pipe(
+      Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
+      Effect.provideService(Persistence.EnvironmentCacheStore, cache),
+    );
+    return { shellState, supervisorState };
+  });
+}
+
 describe("environment shell synchronization", () => {
   it.effect("publishes live state before persistence and preserves it when ready", () =>
     Effect.gen(function* () {
@@ -53,31 +86,7 @@ describe("environment shell synchronization", () => {
       const client = {
         [ORCHESTRATION_WS_METHODS.subscribeShell]: () => Stream.fromQueue(events),
       } as unknown as WsRpcProtocolClient;
-      const supervisorState = yield* SubscriptionRef.make(AVAILABLE_CONNECTION_STATE);
-      const activeSession = yield* SubscriptionRef.make<Option.Option<RpcSession.RpcSession>>(
-        Option.some(session(client)),
-      );
-      const supervisor = EnvironmentSupervisor.EnvironmentSupervisor.of({
-        target: TARGET,
-        state: supervisorState,
-        session: activeSession,
-        prepared: yield* SubscriptionRef.make(Option.none<PreparedConnection>()),
-        connect: Effect.void,
-        disconnect: Effect.void,
-        retryNow: Effect.void,
-      } satisfies EnvironmentSupervisor.EnvironmentSupervisor["Service"]);
-      const cache = Persistence.EnvironmentCacheStore.of({
-        loadShell: () => Effect.succeed(Option.none()),
-        saveShell: () => Effect.never,
-        loadThread: () => Effect.succeed(Option.none()),
-        saveThread: () => Effect.void,
-        removeThread: () => Effect.void,
-        clear: () => Effect.void,
-      });
-      const shellState = yield* makeEnvironmentShellState().pipe(
-        Effect.provideService(EnvironmentSupervisor.EnvironmentSupervisor, supervisor),
-        Effect.provideService(Persistence.EnvironmentCacheStore, cache),
-      );
+      const { shellState, supervisorState } = yield* makeTestShellState(client);
 
       yield* SubscriptionRef.set(supervisorState, {
         desired: true,
@@ -115,6 +124,51 @@ describe("environment shell synchronization", () => {
       const state = yield* SubscriptionRef.get(shellState);
       expect(state.status).toBe("live");
       expect(Option.getOrThrow(state.snapshot)).toEqual(LIVE_SHELL_SNAPSHOT);
+    }),
+  );
+
+  it.effect("retries expected subscription failures and accepts the next live snapshot", () =>
+    Effect.gen(function* () {
+      const events = yield* Queue.unbounded<OrchestrationShellStreamItem>();
+      const attempts = yield* Ref.make(0);
+      const client = {
+        [ORCHESTRATION_WS_METHODS.subscribeShell]: () =>
+          Stream.unwrap(
+            Ref.getAndUpdate(attempts, (count) => count + 1).pipe(
+              Effect.map((attempt) =>
+                attempt === 0
+                  ? Stream.fail(new Error("transient shell failure"))
+                  : Stream.fromQueue(events),
+              ),
+            ),
+          ),
+      } as unknown as WsRpcProtocolClient;
+      const { shellState } = yield* makeTestShellState(client);
+
+      yield* SubscriptionRef.changes(shellState).pipe(
+        Stream.filter((state) => Option.isSome(state.error)),
+        Stream.runHead,
+      );
+      const failedState = yield* SubscriptionRef.get(shellState);
+      expect(failedState.status).toBe("empty");
+      expect(Option.getOrThrow(failedState.error)).toBe("Could not synchronize environment data.");
+      expect(yield* Ref.get(attempts)).toBe(1);
+
+      yield* TestClock.adjust("250 millis");
+      yield* Queue.offer(events, {
+        kind: "snapshot",
+        snapshot: LIVE_SHELL_SNAPSHOT,
+      });
+      yield* SubscriptionRef.changes(shellState).pipe(
+        Stream.filter((state) => state.status === "live"),
+        Stream.runHead,
+      );
+
+      const liveState = yield* SubscriptionRef.get(shellState);
+      expect(yield* Ref.get(attempts)).toBe(2);
+      expect(liveState.status).toBe("live");
+      expect(liveState.error).toEqual(Option.none());
+      expect(Option.getOrThrow(liveState.snapshot)).toEqual(LIVE_SHELL_SNAPSHOT);
     }),
   );
 });

--- a/packages/client-runtime/src/state/shell.ts
+++ b/packages/client-runtime/src/state/shell.ts
@@ -152,6 +152,7 @@ export const makeEnvironmentShellState = Effect.fn("EnvironmentShellState.make")
     {},
     {
       onExpectedFailure: (cause) => setStreamError(Cause.squash(cause)),
+      retryExpectedFailureAfter: "250 millis",
     },
   ).pipe(Stream.runForEach(applyItem), Effect.forkScoped);
   yield* SubscriptionRef.changes(supervisor.state).pipe(


### PR DESCRIPTION
## Summary

- Retry handled shell subscription failures after the same 250 ms delay used by thread detail sync.
- Add shell sync regression coverage for recovering from an expected subscription failure without replacing the session.

## Root cause

Shell state handled expected subscription failures by surfacing a synchronization error, but it did not request a retry from the shared durable subscription helper. After a transient domain failure, shell sync could stay dormant until a session replacement.

## Impact

Transient expected shell subscription failures now resubscribe and can recover to a live snapshot, clearing the shell synchronization error once fresh shell data arrives.

## Validation

- `PATH="$HOME/.vite-plus/bin:$PATH" vp test packages/client-runtime/src/state/shell-sync.test.ts`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp check`
- `PATH="$HOME/.vite-plus/bin:$PATH" vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in client shell sync using an existing RPC subscribe retry option; covered by a new unit test.
> 
> **Overview**
> Environment shell sync now passes **`retryExpectedFailureAfter: "250 millis"`** on `subscribeShell`, aligning with thread detail sync so **expected** subscription failures still surface the sync error via `onExpectedFailure` but automatically resubscribe instead of staying dormant until the session is replaced.
> 
> **`shell-sync.test.ts`** extracts shared supervisor/cache setup into **`makeTestShellState`** and adds a regression test: first subscribe attempt fails, state shows the synchronization error, after **250 ms** a retry runs, and the next snapshot clears the error and reaches **`live`** status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60a25cd3359e8f54965b120cf94937ad5de917e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Retry transient shell subscription failures after 250ms in `makeEnvironmentShellState`
> Adds `retryExpectedFailureAfter: "250 millis"` to the `subscribeShell` call in [shell.ts](https://github.com/pingdotgg/t3code/pull/3528/files#diff-538b14bdf595ee51e55aaaa249aab3e8505b533401c51b92360b4d9c37251c83) so that expected subscription failures trigger an automatic retry after a 250ms delay, while still recording the error via `onExpectedFailure`. A new test in [shell-sync.test.ts](https://github.com/pingdotgg/t3code/pull/3528/files#diff-10e996028edc036253dd0536d0730bd97e31c36d26448202f9a37443324c4c6d) verifies the retry behavior and successful transition to live state after the next snapshot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60a25cd.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->