### PR TITLE
Re-application of custom features on upstream branch

### DIFF
--- a/apps/server/src/cli/config.ts
+++ b/apps/server/src/cli/config.ts
@@ -24,6 +24,9 @@ import {
   type StartupPresentation,
 } from "../config.ts";
 import { expandHomePath, resolveBaseDir } from "../os-jank.ts";
+// EMPOWERRD:start - fork Jira server config
+import { resolveJiraServerConfig } from "../jira/config.ts";
+// EMPOWERRD:end
 
 export const modeFlag = Flag.choice("mode", RuntimeMode.literals).pipe(
   Flag.withDescription("Runtime mode. `desktop` keeps loopback defaults unless overridden."),
@@ -341,6 +344,10 @@ export const resolveServerConfig = (
     );
     const logLevel = Option.getOrElse(cliLogLevel, () => env.logLevel);
 
+    // EMPOWERRD:start - resolve fork Jira config from the environment
+    const jira = yield* resolveJiraServerConfig();
+    // EMPOWERRD:end
+
     const config: ServerConfigShape = {
       logLevel,
       traceMinLevel: env.traceMinLevel,
@@ -374,6 +381,9 @@ export const resolveServerConfig = (
       logWebSocketEvents,
       tailscaleServeEnabled,
       tailscaleServePort,
+      // EMPOWERRD:start
+      jira,
+      // EMPOWERRD:end
     };
 
     return config;

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -13,6 +13,9 @@ import * as LogLevel from "effect/LogLevel";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import * as Context from "effect/Context";
+// EMPOWERRD:start - fork Jira server config type
+import type { JiraServerConfig } from "./jira/config.ts";
+// EMPOWERRD:end
 
 export const DEFAULT_PORT = 3773;
 
@@ -73,6 +76,11 @@ export interface ServerConfigShape extends ServerDerivedPaths {
   readonly logWebSocketEvents: boolean;
   readonly tailscaleServeEnabled: boolean;
   readonly tailscaleServePort: number;
+  // EMPOWERRD:start - fork Jira settings (normalized at config assembly).
+  // Optional so upstream test fixtures that build ServerConfigShape inline
+  // don't need editing; production assembly always populates it.
+  readonly jira?: JiraServerConfig;
+  // EMPOWERRD:end
 }
 
 export const deriveServerPaths = Effect.fn(function* (
@@ -175,6 +183,9 @@ export class ServerConfig extends Context.Service<ServerConfig, ServerConfigShap
           devUrl,
           noBrowser: false,
           startupPresentation: "browser",
+          // EMPOWERRD:start
+          jira: { domain: null, projectKey: null },
+          // EMPOWERRD:end
         } satisfies ServerConfigShape;
       }),
     );

--- a/apps/server/src/jira/config.ts
+++ b/apps/server/src/jira/config.ts
@@ -1,0 +1,34 @@
+// EMPOWERRD: fork-owned Jira server config. Reads JIRA_DOMAIN / JIRA_PROJECT_KEY
+// from the environment at config-assembly time (not deep inside an RPC handler),
+// normalizes them, and warns on an invalid project key. The resolved values are
+// folded into ServerConfigShape and surfaced to the client via loadServerConfig.
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import { normalizeJiraDomain, normalizeJiraProjectKey } from "@t3tools/shared/jira";
+
+export interface JiraServerConfig {
+  readonly domain: string | null;
+  readonly projectKey: string | null;
+}
+
+const optionalEnv = (name: string) =>
+  Config.string(name).pipe(Config.option, Config.map(Option.getOrUndefined));
+
+export const resolveJiraServerConfig = Effect.fn("resolveJiraServerConfig")(function* () {
+  const rawDomain = yield* optionalEnv("JIRA_DOMAIN");
+  const rawProjectKey = yield* optionalEnv("JIRA_PROJECT_KEY");
+
+  const projectKey = normalizeJiraProjectKey(rawProjectKey);
+  if (rawProjectKey !== undefined && rawProjectKey.trim().length > 0 && projectKey === null) {
+    yield* Effect.logWarning(
+      `JIRA_PROJECT_KEY="${rawProjectKey}" is not a valid project key (must be A-Z/0-9 and start with a letter). The project-key constraint is disabled.`,
+    );
+  }
+
+  return {
+    domain: normalizeJiraDomain(rawDomain),
+    projectKey,
+  } satisfies JiraServerConfig;
+});

--- a/apps/server/src/jira/wsHandlers.test.ts
+++ b/apps/server/src/jira/wsHandlers.test.ts
@@ -1,0 +1,195 @@
+import {
+  CommandId,
+  type OrchestrationCommand,
+  type OrchestrationProjectShell,
+  type OrchestrationThreadShell,
+  ProjectId,
+  ThreadId,
+  type VcsStatusLocalResult,
+} from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import type { ProjectionThreadJira } from "../persistence/Services/ProjectionThreadJira.ts";
+import { type ForkJiraHandlerDeps, makeForkJiraHandlers } from "./wsHandlers.ts";
+
+const THREAD = ThreadId.make("thread-1");
+const PROJECT = ProjectId.make("project-1");
+
+const makeThreadShell = (over: {
+  readonly branch?: string | null;
+  readonly worktreePath?: string | null;
+  readonly title?: string;
+}): OrchestrationThreadShell =>
+  ({
+    id: THREAD,
+    projectId: PROJECT,
+    title: over.title ?? "Fix login flow",
+    branch: over.branch ?? null,
+    worktreePath: over.worktreePath ?? null,
+  }) as unknown as OrchestrationThreadShell;
+
+const makeProjectShell = (workspaceRoot: string): OrchestrationProjectShell =>
+  ({ id: PROJECT, workspaceRoot }) as unknown as OrchestrationProjectShell;
+
+const makeLocalStatus = (refName: string | null): VcsStatusLocalResult =>
+  ({ refName }) as unknown as VcsStatusLocalResult;
+
+interface Harness {
+  readonly deps: ForkJiraHandlerDeps;
+  readonly dispatched: Array<OrchestrationCommand>;
+  readonly upserts: Array<ProjectionThreadJira>;
+  readonly deletes: Array<ThreadId>;
+}
+
+const makeHarness = (over?: {
+  readonly projectKey?: string | null;
+  readonly thread?: OrchestrationThreadShell;
+  readonly localRefName?: string | null;
+}): Harness => {
+  const dispatched: Array<OrchestrationCommand> = [];
+  const upserts: Array<ProjectionThreadJira> = [];
+  const deletes: Array<ThreadId> = [];
+  const thread =
+    over?.thread ?? makeThreadShell({ worktreePath: "/wt", branch: "empcode/abcd1234" });
+
+  const deps: ForkJiraHandlerDeps = {
+    projectKey: over?.projectKey ?? null,
+    newCommandId: () => Effect.succeed(CommandId.make("server:test:cmd")),
+    gitWorkflow: {
+      localStatus: () => Effect.succeed(makeLocalStatus(over?.localRefName ?? "main")),
+      renameBranch: ({ newBranch }) => Effect.succeed({ branch: newBranch }),
+      invalidateStatus: () => Effect.void,
+    },
+    orchestrationEngine: {
+      dispatch: (command) =>
+        Effect.sync(() => {
+          dispatched.push(command);
+          return { sequence: dispatched.length };
+        }),
+    },
+    projectionSnapshotQuery: {
+      getThreadShellById: () => Effect.succeed(Option.some(thread)),
+      getProjectShellById: () => Effect.succeed(Option.some(makeProjectShell("/repo"))),
+    },
+    jiraRepository: {
+      upsert: (row) =>
+        Effect.sync(() => {
+          upserts.push(row);
+        }),
+      getByThreadId: () => Effect.succeed(Option.none()),
+      listAll: () => Effect.succeed([]),
+      deleteByThreadId: ({ threadId }) =>
+        Effect.sync(() => {
+          deletes.push(threadId);
+        }),
+    },
+  };
+
+  return { deps, dispatched, upserts, deletes };
+};
+
+it.effect("renames a temp worktree branch and persists the key", () =>
+  Effect.gen(function* () {
+    const h = makeHarness({
+      projectKey: "PLAT",
+      thread: makeThreadShell({
+        worktreePath: "/wt",
+        branch: "empcode/abcd1234",
+        title: "Fix login flow",
+      }),
+    });
+    const result = yield* makeForkJiraHandlers(h.deps).setThreadJiraKey({
+      threadId: THREAD,
+      jiraKey: "PLAT-1",
+      renameBranch: true,
+    });
+
+    assert.strictEqual(result.jiraKey, "PLAT-1");
+    assert.strictEqual(result.branch, "PLAT-1/fix-login-flow");
+    assert.deepStrictEqual(
+      h.dispatched.map((c) => c.type),
+      ["thread.meta.update"],
+    );
+    assert.strictEqual(h.upserts.length, 1);
+    assert.strictEqual(h.upserts[0]?.jiraKey, "PLAT-1");
+  }),
+);
+
+it.effect("rejects a key that does not match the configured project key", () =>
+  Effect.gen(function* () {
+    const h = makeHarness({ projectKey: "PLAT" });
+    const outcome = yield* Effect.result(
+      makeForkJiraHandlers(h.deps).setThreadJiraKey({
+        threadId: THREAD,
+        jiraKey: "OTHER-1",
+        renameBranch: false,
+      }),
+    );
+    assert.isTrue(outcome._tag === "Failure");
+    if (outcome._tag === "Failure") {
+      assert.include(outcome.failure.message, "Use a Jira key like PLAT-123.");
+    }
+    assert.strictEqual(h.upserts.length, 0);
+  }),
+);
+
+it.effect("blocks setting a key on a non-worktree thread checked out on main", () =>
+  Effect.gen(function* () {
+    const h = makeHarness({
+      thread: makeThreadShell({ worktreePath: null, branch: "main" }),
+      localRefName: "main",
+    });
+    const outcome = yield* Effect.result(
+      makeForkJiraHandlers(h.deps).setThreadJiraKey({
+        threadId: THREAD,
+        jiraKey: "PLAT-1",
+        renameBranch: false,
+      }),
+    );
+    assert.isTrue(outcome._tag === "Failure");
+    if (outcome._tag === "Failure") {
+      assert.include(
+        outcome.failure.message,
+        "worktree threads or when the current checkout is not main",
+      );
+    }
+    assert.strictEqual(h.upserts.length, 0);
+  }),
+);
+
+it.effect("allows a key on a non-worktree thread checked out on a feature branch", () =>
+  Effect.gen(function* () {
+    const h = makeHarness({
+      thread: makeThreadShell({ worktreePath: null, branch: "feature/foo" }),
+      localRefName: "feature/foo",
+    });
+    const result = yield* makeForkJiraHandlers(h.deps).setThreadJiraKey({
+      threadId: THREAD,
+      jiraKey: "ABC-7",
+      renameBranch: false,
+    });
+    assert.strictEqual(result.jiraKey, "ABC-7");
+    // renameBranch=false → no git rename / dispatch
+    assert.strictEqual(h.dispatched.length, 0);
+    assert.strictEqual(h.upserts.length, 1);
+  }),
+);
+
+it.effect("clearing a key deletes the row and never renames", () =>
+  Effect.gen(function* () {
+    const h = makeHarness({
+      thread: makeThreadShell({ worktreePath: "/wt", branch: "PLAT-1/fix-login-flow" }),
+    });
+    const result = yield* makeForkJiraHandlers(h.deps).setThreadJiraKey({
+      threadId: THREAD,
+      jiraKey: null,
+      renameBranch: true,
+    });
+    assert.strictEqual(result.jiraKey, null);
+    assert.strictEqual(h.deletes.length, 1);
+    assert.strictEqual(h.dispatched.length, 0);
+    assert.strictEqual(h.upserts.length, 0);
+  }),
+);

--- a/apps/server/src/jira/wsHandlers.ts
+++ b/apps/server/src/jira/wsHandlers.ts
@@ -1,0 +1,219 @@
+// EMPOWERRD: fork-owned WS RPC handlers for Jira.
+//
+// Supplied as a SEPARATE handler layer (ForkWsRpcGroup.toLayer) that is merged
+// into the /ws route's provide chain in ws.ts, so the upstream WsRpcGroup.of({…})
+// handler object is never edited.
+//
+// Design (Problem A): the Jira key lives in a fork-owned side-table written
+// directly here. The branch rename reuses the EXISTING `thread.meta.update`
+// command (no decider/projector/core-schema edits). The handler returns the
+// persisted key + resulting branch so the client store can update synchronously.
+//
+// The pure logic lives in `makeForkJiraHandlers` so it can be unit-tested with
+// plain mocks; the layer just resolves services and forwards them.
+import {
+  type CommandId,
+  CommandId as CommandIdSchema,
+  ForkWsRpcGroup,
+  JIRA_WS_METHODS,
+  JiraOperationError,
+  type ProjectId,
+  type SetThreadJiraKeyInput,
+  type ThreadId,
+  type ThreadJiraKey,
+  type ThreadJiraKeyList,
+} from "@t3tools/contracts";
+import {
+  buildRenamedJiraBranchName,
+  isMainOrMasterBranchName,
+  validateJiraKeyInput,
+} from "@t3tools/shared/jira";
+import * as Crypto from "effect/Crypto";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+
+import { ServerConfig } from "../config.ts";
+import { GitWorkflowService, type GitWorkflowServiceShape } from "../git/GitWorkflowService.ts";
+import {
+  OrchestrationEngineService,
+  type OrchestrationEngineShape,
+} from "../orchestration/Services/OrchestrationEngine.ts";
+import {
+  ProjectionSnapshotQuery,
+  type ProjectionSnapshotQueryShape,
+} from "../orchestration/Services/ProjectionSnapshotQuery.ts";
+import {
+  ProjectionThreadJiraRepository,
+  type ProjectionThreadJiraRepositoryShape,
+} from "../persistence/Services/ProjectionThreadJira.ts";
+
+const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+
+const failWith = (message: string, cause?: unknown) =>
+  new JiraOperationError({ message, ...(cause === undefined ? {} : { cause }) });
+
+export interface ForkJiraHandlerDeps {
+  readonly projectKey: string | null;
+  readonly newCommandId: (tag: string) => Effect.Effect<CommandId, JiraOperationError>;
+  readonly gitWorkflow: Pick<
+    GitWorkflowServiceShape,
+    "renameBranch" | "localStatus" | "invalidateStatus"
+  >;
+  readonly orchestrationEngine: Pick<OrchestrationEngineShape, "dispatch">;
+  readonly projectionSnapshotQuery: Pick<
+    ProjectionSnapshotQueryShape,
+    "getThreadShellById" | "getProjectShellById"
+  >;
+  readonly jiraRepository: ProjectionThreadJiraRepositoryShape;
+}
+
+export interface ForkJiraHandlers {
+  readonly setThreadJiraKey: (
+    input: SetThreadJiraKeyInput,
+  ) => Effect.Effect<ThreadJiraKey, JiraOperationError>;
+  readonly listThreadJiraKeys: () => Effect.Effect<ThreadJiraKeyList, JiraOperationError>;
+}
+
+export const makeForkJiraHandlers = (deps: ForkJiraHandlerDeps): ForkJiraHandlers => {
+  const { projectKey, newCommandId, gitWorkflow, orchestrationEngine, jiraRepository } = deps;
+  const { getThreadShellById, getProjectShellById } = deps.projectionSnapshotQuery;
+
+  const loadThreadShell = (threadId: ThreadId) =>
+    getThreadShellById(threadId).pipe(
+      Effect.mapError((cause) => failWith("Failed to load thread.", cause)),
+      Effect.flatMap(
+        Option.match({
+          onNone: () => Effect.fail(failWith("Thread not found.")),
+          onSome: (thread) => Effect.succeed(thread),
+        }),
+      ),
+    );
+
+  const loadProjectWorkspaceRoot = (projectId: ProjectId) =>
+    getProjectShellById(projectId).pipe(
+      Effect.mapError((cause) => failWith("Failed to load project.", cause)),
+      Effect.flatMap(
+        Option.match({
+          onNone: () => Effect.fail(failWith("Project not found.")),
+          onSome: (project) => Effect.succeed(project.workspaceRoot),
+        }),
+      ),
+    );
+
+  // Enforce: a Jira key may only be set for worktree threads, or when the
+  // project's current checkout is not main/master.
+  const ensureAllowedForContext = (thread: {
+    readonly projectId: ProjectId;
+    readonly branch: string | null;
+    readonly worktreePath: string | null;
+  }) =>
+    Effect.gen(function* () {
+      if (thread.worktreePath !== null) {
+        return;
+      }
+      const workspaceRoot = yield* loadProjectWorkspaceRoot(thread.projectId);
+      const local = yield* gitWorkflow
+        .localStatus({ cwd: workspaceRoot })
+        .pipe(Effect.mapError((cause) => failWith("Failed to read git status.", cause)));
+      const effectiveBranch = local.refName ?? thread.branch;
+      if (effectiveBranch !== null && !isMainOrMasterBranchName(effectiveBranch)) {
+        return;
+      }
+      return yield* failWith(
+        "Jira keys can only be set for worktree threads or when the current checkout is not main or master.",
+      );
+    });
+
+  const setThreadJiraKey: ForkJiraHandlers["setThreadJiraKey"] = (input) =>
+    Effect.gen(function* () {
+      const thread = yield* loadThreadShell(input.threadId);
+
+      // Clearing the key: just remove the row.
+      if (input.jiraKey === null) {
+        yield* jiraRepository
+          .deleteByThreadId({ threadId: input.threadId })
+          .pipe(Effect.mapError((cause) => failWith("Failed to clear Jira key.", cause)));
+        return { threadId: input.threadId, jiraKey: null, branch: thread.branch };
+      }
+
+      // Setting a key: validate (incl. project-key constraint) + context rule.
+      const validation = validateJiraKeyInput(input.jiraKey, projectKey);
+      if (validation.normalized === null) {
+        return yield* failWith(validation.error ?? "Invalid Jira key.");
+      }
+      const normalizedJiraKey = validation.normalized;
+      yield* ensureAllowedForContext(thread);
+
+      // Optionally rename the worktree branch, reusing the existing
+      // thread.meta.update command to persist the new branch.
+      let resultBranch = thread.branch;
+      if (input.renameBranch && thread.branch !== null) {
+        const cwd = thread.worktreePath ?? (yield* loadProjectWorkspaceRoot(thread.projectId));
+        const targetBranch = buildRenamedJiraBranchName({
+          currentBranch: thread.branch,
+          newJiraKey: normalizedJiraKey,
+          fallbackTitle: thread.title,
+        });
+        if (targetBranch !== thread.branch) {
+          const renamed = yield* gitWorkflow
+            .renameBranch({ cwd, oldBranch: thread.branch, newBranch: targetBranch })
+            .pipe(Effect.mapError((cause) => failWith("Failed to rename branch.", cause)));
+          resultBranch = renamed.branch;
+          yield* orchestrationEngine
+            .dispatch({
+              type: "thread.meta.update",
+              commandId: yield* newCommandId("jira-key-branch-rename"),
+              threadId: input.threadId,
+              branch: renamed.branch,
+            })
+            .pipe(Effect.mapError((cause) => failWith("Failed to update thread branch.", cause)));
+          yield* gitWorkflow.invalidateStatus(cwd);
+        }
+      }
+
+      const updatedAt = yield* nowIso;
+      yield* jiraRepository
+        .upsert({ threadId: input.threadId, jiraKey: normalizedJiraKey, updatedAt })
+        .pipe(Effect.mapError((cause) => failWith("Failed to save Jira key.", cause)));
+
+      return { threadId: input.threadId, jiraKey: normalizedJiraKey, branch: resultBranch };
+    });
+
+  const listThreadJiraKeys: ForkJiraHandlers["listThreadJiraKeys"] = () =>
+    jiraRepository.listAll().pipe(
+      Effect.mapError((cause) => failWith("Failed to list Jira keys.", cause)),
+      Effect.map((rows) => rows.map((row) => ({ threadId: row.threadId, jiraKey: row.jiraKey }))),
+    );
+
+  return { setThreadJiraKey, listThreadJiraKeys };
+};
+
+export const ForkJiraWsRpcLayer = ForkWsRpcGroup.toLayer(
+  Effect.gen(function* () {
+    const crypto = yield* Crypto.Crypto;
+    const config = yield* ServerConfig;
+    const gitWorkflow = yield* GitWorkflowService;
+    const orchestrationEngine = yield* OrchestrationEngineService;
+    const projectionSnapshotQuery = yield* ProjectionSnapshotQuery;
+    const jiraRepository = yield* ProjectionThreadJiraRepository;
+
+    const handlers = makeForkJiraHandlers({
+      projectKey: config.jira?.projectKey ?? null,
+      newCommandId: (tag) =>
+        crypto.randomUUIDv4.pipe(
+          Effect.mapError((cause) => failWith("Failed to generate command identifier.", cause)),
+          Effect.map((uuid) => CommandIdSchema.make(`server:${tag}:${uuid}`)),
+        ),
+      gitWorkflow,
+      orchestrationEngine,
+      projectionSnapshotQuery,
+      jiraRepository,
+    });
+
+    return ForkWsRpcGroup.of({
+      [JIRA_WS_METHODS.setThreadJiraKey]: handlers.setThreadJiraKey,
+      [JIRA_WS_METHODS.listThreadJiraKeys]: handlers.listThreadJiraKeys,
+    });
+  }),
+);

--- a/apps/server/src/orchestration/runtimeLayer.ts
+++ b/apps/server/src/orchestration/runtimeLayer.ts
@@ -5,6 +5,10 @@ import { OrchestrationEventStoreLive } from "../persistence/Layers/Orchestration
 import { OrchestrationEngineLive } from "./Layers/OrchestrationEngine.ts";
 import { OrchestrationProjectionPipelineLive } from "./Layers/ProjectionPipeline.ts";
 import { OrchestrationProjectionSnapshotQueryLive } from "./Layers/ProjectionSnapshotQuery.ts";
+// EMPOWERRD:start - fork-owned Jira side-table repository, exposed ambiently like
+// the other projection read services (SqlClient satisfied by PersistenceLayerLive)
+import { ProjectionThreadJiraRepositoryLive } from "../persistence/Layers/ProjectionThreadJira.ts";
+// EMPOWERRD:end
 
 export const OrchestrationEventInfrastructureLayerLive = Layer.mergeAll(
   OrchestrationEventStoreLive,
@@ -19,6 +23,9 @@ export const OrchestrationInfrastructureLayerLive = Layer.mergeAll(
   OrchestrationProjectionSnapshotQueryLive,
   OrchestrationEventInfrastructureLayerLive,
   OrchestrationProjectionPipelineLayerLive,
+  // EMPOWERRD:start
+  ProjectionThreadJiraRepositoryLive,
+  // EMPOWERRD:end
 );
 
 export const OrchestrationLayerLive = Layer.mergeAll(

--- a/apps/server/src/persistence/ForkMigrations.test.ts
+++ b/apps/server/src/persistence/ForkMigrations.test.ts
@@ -1,0 +1,65 @@
+// EMPOWERRD: regression test for the fork-migration tracking-table design.
+// Guards the auth-500 class of bug: a fork migration must NOT raise upstream's
+// effect_sql_migrations max-id pointer (which would silently skip later
+// upstream migrations). Fork migrations live in their own `fork_migrations`
+// table with their own max pointer.
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+import { migrationEntries, runMigrations } from "./Migrations.ts";
+import { forkMigrationEntries } from "./ForkMigrations.ts";
+import * as NodeSqliteClient from "./NodeSqliteClient.ts";
+
+const layer = it.layer(Layer.mergeAll(NodeSqliteClient.layerMemory()));
+
+const tableExists = (sql: SqlClient.SqlClient) => (name: string) =>
+  sql<{ readonly name: string }>`
+    SELECT name FROM sqlite_master WHERE type = 'table' AND name = ${name}
+  `.pipe(Effect.map((rows) => rows.length > 0));
+
+layer("ForkMigrations", (it) => {
+  it.effect("runs fork migrations in a separate tracking table without touching upstream's", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+      const exists = tableExists(sql);
+
+      yield* runMigrations();
+
+      // Fork side-table and both tracking tables exist.
+      assert.isTrue(yield* exists("projection_thread_jira"), "projection_thread_jira table exists");
+      assert.isTrue(yield* exists("effect_sql_migrations"), "upstream tracking table exists");
+      assert.isTrue(yield* exists("fork_migrations"), "fork tracking table exists");
+
+      // The fork migration did NOT bump upstream's max-id pointer. This is the
+      // invariant that lets future upstream migrations (33, 34, ...) still run.
+      const [upstream] = yield* sql<{ readonly maxId: number }>`
+        SELECT MAX(migration_id) AS "maxId" FROM effect_sql_migrations
+      `;
+      const upstreamMaxId = Math.max(...migrationEntries.map(([id]) => id));
+      assert.strictEqual(upstream?.maxId, upstreamMaxId);
+
+      // The fork tracking table has only its own ids.
+      const [fork] = yield* sql<{ readonly maxId: number }>`
+        SELECT MAX(migration_id) AS "maxId" FROM fork_migrations
+      `;
+      const forkMaxId = Math.max(...forkMigrationEntries.map(([id]) => id));
+      assert.strictEqual(fork?.maxId, forkMaxId);
+    }),
+  );
+
+  it.effect("is idempotent across repeated full runs", () =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient;
+
+      yield* runMigrations();
+      yield* runMigrations();
+
+      const [fork] = yield* sql<{ readonly count: number }>`
+        SELECT COUNT(*) AS "count" FROM fork_migrations
+      `;
+      assert.strictEqual(fork?.count, forkMigrationEntries.length);
+    }),
+  );
+});

--- a/apps/server/src/persistence/ForkMigrations.ts
+++ b/apps/server/src/persistence/ForkMigrations.ts
@@ -1,0 +1,28 @@
+/**
+ * EMPOWERRD: fork-owned migrations.
+ *
+ * These run through a SECOND Migrator instance against their own tracking table
+ * (`fork_migrations`). The Effect Migrator runs by MAX applied id, so sharing
+ * upstream's `effect_sql_migrations` table would make a high fork id silently
+ * skip later upstream migrations (and a low id collide with upstream's next
+ * additions). A separate tracking table gives the fork its own max pointer —
+ * fork ids start at 1 in their own namespace and never interfere with upstream.
+ *
+ * Mirrors the shape of the upstream `migrationEntries` / `makeMigrationLoader`
+ * in Migrations.ts so the wiring there is a single fenced call.
+ */
+import * as Migrator from "effect/unstable/sql/Migrator";
+
+import ForkMigration0001 from "./Migrations/fork/001_ProjectionThreadJira.ts";
+
+/** Tracking table name for fork-owned migrations (kept separate from upstream's). */
+export const FORK_MIGRATIONS_TABLE = "fork_migrations";
+
+export const forkMigrationEntries = [[1, "ProjectionThreadJira", ForkMigration0001]] as const;
+
+export const makeForkMigrationLoader = () =>
+  Migrator.fromRecord(
+    Object.fromEntries(
+      forkMigrationEntries.map(([id, name, migration]) => [`${id}_${name}`, migration]),
+    ),
+  );

--- a/apps/server/src/persistence/Layers/ProjectionThreadJira.test.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadJira.test.ts
@@ -1,0 +1,51 @@
+import { JiraKey, ThreadId } from "@t3tools/contracts";
+import { assert, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+
+import { ProjectionThreadJiraRepository } from "../Services/ProjectionThreadJira.ts";
+import { ProjectionThreadJiraRepositoryLive } from "./ProjectionThreadJira.ts";
+import { SqlitePersistenceMemory } from "./Sqlite.ts";
+
+const layer = it.layer(
+  ProjectionThreadJiraRepositoryLive.pipe(Layer.provideMerge(SqlitePersistenceMemory)),
+);
+
+layer("ProjectionThreadJiraRepository", (it) => {
+  it.effect("upserts, reads, lists, and deletes a thread's Jira key", () =>
+    Effect.gen(function* () {
+      const repository = yield* ProjectionThreadJiraRepository;
+      const threadId = ThreadId.make("thread-jira-1");
+
+      assert.isTrue(Option.isNone(yield* repository.getByThreadId({ threadId })));
+
+      yield* repository.upsert({
+        threadId,
+        jiraKey: JiraKey.make("PLAT-123"),
+        updatedAt: "2026-06-18T10:00:00.000Z",
+      });
+
+      const stored = yield* repository.getByThreadId({ threadId });
+      assert.isTrue(Option.isSome(stored));
+      assert.strictEqual(Option.getOrThrow(stored).jiraKey, "PLAT-123");
+
+      // Upsert overwrites the existing key.
+      yield* repository.upsert({
+        threadId,
+        jiraKey: JiraKey.make("PLAT-456"),
+        updatedAt: "2026-06-18T11:00:00.000Z",
+      });
+      const updated = yield* repository.getByThreadId({ threadId });
+      assert.strictEqual(Option.getOrThrow(updated).jiraKey, "PLAT-456");
+
+      const all = yield* repository.listAll();
+      assert.strictEqual(all.length, 1);
+      assert.strictEqual(all[0]?.threadId, threadId);
+
+      yield* repository.deleteByThreadId({ threadId });
+      assert.isTrue(Option.isNone(yield* repository.getByThreadId({ threadId })));
+      assert.strictEqual((yield* repository.listAll()).length, 0);
+    }),
+  );
+});

--- a/apps/server/src/persistence/Layers/ProjectionThreadJira.ts
+++ b/apps/server/src/persistence/Layers/ProjectionThreadJira.ts
@@ -1,0 +1,99 @@
+// EMPOWERRD: fork-owned side-table repository for thread Jira associations.
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+import * as SqlSchema from "effect/unstable/sql/SqlSchema";
+
+import { toPersistenceSqlError } from "../Errors.ts";
+import {
+  DeleteProjectionThreadJiraInput,
+  GetProjectionThreadJiraInput,
+  ProjectionThreadJira,
+  ProjectionThreadJiraRepository,
+  type ProjectionThreadJiraRepositoryShape,
+} from "../Services/ProjectionThreadJira.ts";
+
+const makeProjectionThreadJiraRepository = Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  const upsertRow = SqlSchema.void({
+    Request: ProjectionThreadJira,
+    execute: (row) => sql`
+      INSERT INTO projection_thread_jira (thread_id, jira_key, updated_at)
+      VALUES (${row.threadId}, ${row.jiraKey}, ${row.updatedAt})
+      ON CONFLICT (thread_id)
+      DO UPDATE SET
+        jira_key = excluded.jira_key,
+        updated_at = excluded.updated_at
+    `,
+  });
+
+  const getRowByThreadId = SqlSchema.findOneOption({
+    Request: GetProjectionThreadJiraInput,
+    Result: ProjectionThreadJira,
+    execute: ({ threadId }) => sql`
+      SELECT
+        thread_id AS "threadId",
+        jira_key AS "jiraKey",
+        updated_at AS "updatedAt"
+      FROM projection_thread_jira
+      WHERE thread_id = ${threadId}
+    `,
+  });
+
+  const listRows = SqlSchema.findAll({
+    Request: Schema.Void,
+    Result: ProjectionThreadJira,
+    execute: () => sql`
+      SELECT
+        thread_id AS "threadId",
+        jira_key AS "jiraKey",
+        updated_at AS "updatedAt"
+      FROM projection_thread_jira
+      ORDER BY updated_at DESC, thread_id ASC
+    `,
+  });
+
+  const deleteRowByThreadId = SqlSchema.void({
+    Request: DeleteProjectionThreadJiraInput,
+    execute: ({ threadId }) => sql`
+      DELETE FROM projection_thread_jira
+      WHERE thread_id = ${threadId}
+    `,
+  });
+
+  const upsert: ProjectionThreadJiraRepositoryShape["upsert"] = (row) =>
+    upsertRow(row).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionThreadJiraRepository.upsert:query")),
+    );
+
+  const getByThreadId: ProjectionThreadJiraRepositoryShape["getByThreadId"] = (input) =>
+    getRowByThreadId(input).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionThreadJiraRepository.getByThreadId:query")),
+    );
+
+  const listAll: ProjectionThreadJiraRepositoryShape["listAll"] = () =>
+    listRows(undefined).pipe(
+      Effect.mapError(toPersistenceSqlError("ProjectionThreadJiraRepository.listAll:query")),
+    );
+
+  const deleteByThreadId: ProjectionThreadJiraRepositoryShape["deleteByThreadId"] = (input) =>
+    deleteRowByThreadId(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlError("ProjectionThreadJiraRepository.deleteByThreadId:query"),
+      ),
+    );
+
+  return {
+    upsert,
+    getByThreadId,
+    listAll,
+    deleteByThreadId,
+  } satisfies ProjectionThreadJiraRepositoryShape;
+});
+
+export const ProjectionThreadJiraRepositoryLive = Layer.effect(
+  ProjectionThreadJiraRepository,
+  makeProjectionThreadJiraRepository,
+);

--- a/apps/server/src/persistence/Migrations.ts
+++ b/apps/server/src/persistence/Migrations.ts
@@ -45,6 +45,9 @@ import Migration0029 from "./Migrations/029_ProjectionThreadDetailOrderingIndexe
 import Migration0030 from "./Migrations/030_ProjectionThreadShellArchiveIndexes.ts";
 import Migration0031 from "./Migrations/031_AuthAuthorizationScopes.ts";
 import Migration0032 from "./Migrations/032_AuthPairingProofKeyThumbprint.ts";
+// EMPOWERRD:start - fork-owned migrations run against a separate tracking table
+import { FORK_MIGRATIONS_TABLE, makeForkMigrationLoader } from "./ForkMigrations.ts";
+// EMPOWERRD:end
 
 /**
  * Migration loader with all migrations defined inline.
@@ -129,6 +132,21 @@ export const runMigrations = Effect.fn("runMigrations")(function* ({
       : `Running migrations 1 through ${toMigrationInclusive}...`,
   );
   const executedMigrations = yield* run({ loader: makeMigrationLoader(toMigrationInclusive) });
+  // EMPOWERRD:start - run fork migrations through their own tracking table on a
+  // full migration. Skipped for partial (toMigrationInclusive) runs, which are
+  // upstream-boundary migration tests that should remain unaffected.
+  if (toMigrationInclusive === undefined) {
+    const executedForkMigrations = yield* run({
+      loader: makeForkMigrationLoader(),
+      table: FORK_MIGRATIONS_TABLE,
+    });
+    yield* Effect.log("Fork migrations ran successfully").pipe(
+      Effect.annotateLogs({
+        forkMigrations: executedForkMigrations.map(([id, name]) => `fork_${id}_${name}`),
+      }),
+    );
+  }
+  // EMPOWERRD:end
   yield* Effect.log("Migrations ran successfully").pipe(
     Effect.annotateLogs({ migrations: executedMigrations.map(([id, name]) => `${id}_${name}`) }),
   );

--- a/apps/server/src/persistence/Migrations/fork/001_ProjectionThreadJira.ts
+++ b/apps/server/src/persistence/Migrations/fork/001_ProjectionThreadJira.ts
@@ -1,0 +1,17 @@
+// EMPOWERRD: fork-owned migration. Tracked in a SEPARATE table ("fork_migrations")
+// so its id never collides with — or blocks — upstream's effect_sql_migrations
+// max-id pointer. See ForkMigrations.ts and the fenced edit in Migrations.ts.
+import * as Effect from "effect/Effect";
+import * as SqlClient from "effect/unstable/sql/SqlClient";
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient;
+
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS projection_thread_jira (
+      thread_id TEXT PRIMARY KEY,
+      jira_key TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    )
+  `;
+});

--- a/apps/server/src/persistence/Services/ProjectionThreadJira.ts
+++ b/apps/server/src/persistence/Services/ProjectionThreadJira.ts
@@ -1,0 +1,47 @@
+// EMPOWERRD: fork-owned side-table service for a thread's Jira association.
+// Mirrors the upstream ProjectionThreadProposedPlans pattern. The Jira key is
+// stored here (keyed by threadId), NOT on the core thread schema, and is
+// written directly by the fork RPC handler rather than the event projector.
+import { IsoDateTime, JiraKey, ThreadId } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import type * as Effect from "effect/Effect";
+import type * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import type { ProjectionRepositoryError } from "../Errors.ts";
+
+export const ProjectionThreadJira = Schema.Struct({
+  threadId: ThreadId,
+  jiraKey: JiraKey,
+  updatedAt: IsoDateTime,
+});
+export type ProjectionThreadJira = typeof ProjectionThreadJira.Type;
+
+export const GetProjectionThreadJiraInput = Schema.Struct({
+  threadId: ThreadId,
+});
+export type GetProjectionThreadJiraInput = typeof GetProjectionThreadJiraInput.Type;
+
+export const DeleteProjectionThreadJiraInput = Schema.Struct({
+  threadId: ThreadId,
+});
+export type DeleteProjectionThreadJiraInput = typeof DeleteProjectionThreadJiraInput.Type;
+
+export interface ProjectionThreadJiraRepositoryShape {
+  readonly upsert: (row: ProjectionThreadJira) => Effect.Effect<void, ProjectionRepositoryError>;
+  readonly getByThreadId: (
+    input: GetProjectionThreadJiraInput,
+  ) => Effect.Effect<Option.Option<ProjectionThreadJira>, ProjectionRepositoryError>;
+  readonly listAll: () => Effect.Effect<
+    ReadonlyArray<ProjectionThreadJira>,
+    ProjectionRepositoryError
+  >;
+  readonly deleteByThreadId: (
+    input: DeleteProjectionThreadJiraInput,
+  ) => Effect.Effect<void, ProjectionRepositoryError>;
+}
+
+export class ProjectionThreadJiraRepository extends Context.Service<
+  ProjectionThreadJiraRepository,
+  ProjectionThreadJiraRepositoryShape
+>()("t3/persistence/Services/ProjectionThreadJira/ProjectionThreadJiraRepository") {}

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -89,6 +89,9 @@ import {
   type ProjectionSnapshotQueryShape,
 } from "./orchestration/Services/ProjectionSnapshotQuery.ts";
 import { SqlitePersistenceMemory } from "./persistence/Layers/Sqlite.ts";
+// EMPOWERRD:start - fork Jira side-table repository (mocked in the app harness)
+import { ProjectionThreadJiraRepository } from "./persistence/Services/ProjectionThreadJira.ts";
+// EMPOWERRD:end
 import { PersistenceSqlError } from "./persistence/Errors.ts";
 import {
   ProviderRegistry,
@@ -726,7 +729,19 @@ const buildAppUnderTest = (options?: {
           getFirstActiveThreadIdByProjectId: () => Effect.succeed(Option.none()),
           getThreadCheckpointContext: () => Effect.succeed(Option.none()),
           ...options?.layers?.projectionSnapshotQuery,
-        }),
+          // EMPOWERRD: merge the fork Jira repo mock into this same provide() to
+          // avoid growing buildAppUnderTest's pipe arity (tsgo widens to unknown
+          // past its variadic-pipe overloads).
+        }).pipe(
+          Layer.merge(
+            Layer.mock(ProjectionThreadJiraRepository)({
+              upsert: () => Effect.void,
+              getByThreadId: () => Effect.succeed(Option.none()),
+              listAll: () => Effect.succeed([]),
+              deleteByThreadId: () => Effect.void,
+            }),
+          ),
+        ),
       ),
       Layer.provide(
         Layer.mock(CheckpointDiffQuery)({

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -51,6 +51,9 @@ import {
   type TerminalMetadataStreamEvent,
   WS_METHODS,
   WsRpcGroup,
+  // EMPOWERRD:start - merged protocol incl. fork Jira RPCs
+  AllWsRpcGroup,
+  // EMPOWERRD:end
 } from "@t3tools/contracts";
 import { clamp } from "effect/Number";
 import { HttpRouter, HttpServerRequest, HttpServerRespondable } from "effect/unstable/http";
@@ -84,6 +87,9 @@ import { WorkspacePathOutsideRootError } from "./workspace/Services/WorkspacePat
 import { VcsStatusBroadcaster } from "./vcs/VcsStatusBroadcaster.ts";
 import { VcsProvisioningService } from "./vcs/VcsProvisioningService.ts";
 import { GitWorkflowService } from "./git/GitWorkflowService.ts";
+// EMPOWERRD:start - fork Jira RPC handler layer
+import { ForkJiraWsRpcLayer } from "./jira/wsHandlers.ts";
+// EMPOWERRD:end
 import { ReviewService } from "./review/ReviewService.ts";
 import { ProjectSetupScriptRunner } from "./project/Services/ProjectSetupScriptRunner.ts";
 import { RepositoryIdentityResolver } from "./project/Services/RepositoryIdentityResolver.ts";
@@ -790,6 +796,9 @@ const makeWsRpcLayer = (currentSession: AuthenticatedSession) =>
             otlpMetricsEnabled: config.otlpMetricsUrl !== undefined,
           },
           settings,
+          // EMPOWERRD:start - surface fork Jira config to the client
+          jira: config.jira,
+          // EMPOWERRD:end
         };
       });
 
@@ -1653,11 +1662,13 @@ export const websocketRpcRouteLayer = Layer.unwrap(
             ServerAuthInternalError: (error) => failEnvironmentInternal("internal_error", error),
           }),
         );
-        const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(WsRpcGroup, {
+        const rpcWebSocketHttpEffect = yield* RpcServer.toHttpEffectWebsocket(AllWsRpcGroup, {
           disableTracing: true,
         }).pipe(
           Effect.provide(
-            makeWsRpcLayer(session).pipe(
+            // EMPOWERRD:start - merge the fork Jira handler layer into the route
+            Layer.merge(makeWsRpcLayer(session), ForkJiraWsRpcLayer).pipe(
+              // EMPOWERRD:end
               Layer.provideMerge(RpcSerialization.layerJson),
               Layer.provide(PreviewAutomationBroker.layer),
               Layer.provide(ProviderMaintenanceRunner.layer),

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -24,6 +24,11 @@ import {
 import { BranchToolbarBranchSelector } from "./BranchToolbarBranchSelector";
 import { BranchToolbarEnvironmentSelector } from "./BranchToolbarEnvironmentSelector";
 import { BranchToolbarEnvModeSelector } from "./BranchToolbarEnvModeSelector";
+// EMPOWERRD:start - Jira key control
+import { useAtomValue } from "@effect/atom-react";
+import { BranchToolbarJiraKeyControl } from "../jira/BranchToolbarJiraKeyControl";
+import { primaryServerConfigAtom } from "../state/server";
+// EMPOWERRD:end
 import { Button } from "./ui/button";
 import {
   Menu,
@@ -220,6 +225,9 @@ export const BranchToolbar = memo(function BranchToolbar({
       ? scopeProjectRef(draftThread.environmentId, draftThread.projectId)
       : null;
   const activeProject = useProject(activeProjectRef);
+  // EMPOWERRD:start - Jira config for the key control
+  const serverConfig = useAtomValue(primaryServerConfigAtom);
+  // EMPOWERRD:end
   const hasActiveThread = serverThread !== null || draftThread !== null;
   const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const effectiveEnvMode =
@@ -273,6 +281,21 @@ export const BranchToolbar = memo(function BranchToolbar({
           />
         </div>
       )}
+
+      {/* EMPOWERRD:start - Jira key control (server threads only) */}
+      {!isMobile && serverThread && (
+        <BranchToolbarJiraKeyControl
+          environmentId={environmentId}
+          threadId={threadId}
+          projectCwd={activeProject.workspaceRoot}
+          effectiveEnvMode={effectiveEnvMode}
+          jiraProjectKey={serverConfig?.jira?.projectKey ?? null}
+          currentBranch={serverThread.branch ?? null}
+          title={serverThread.title}
+          {...(onComposerFocusRequest ? { onComposerFocusRequest } : {})}
+        />
+      )}
+      {/* EMPOWERRD:end */}
 
       <BranchToolbarBranchSelector
         className="min-w-0 flex-1 justify-end md:ml-auto md:flex-none"

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -14,6 +14,9 @@ import ProjectScriptsControl, {
   type NewProjectScriptInput,
   type ProjectScriptActionResult,
 } from "../ProjectScriptsControl";
+// EMPOWERRD:start - Jira ticket deep-link button
+import { JiraTicketButton } from "~/jira/JiraTicketButton";
+// EMPOWERRD:end
 import { SidebarTrigger } from "../ui/sidebar";
 import { OpenInPicker } from "./OpenInPicker";
 import { usePrimaryEnvironmentId } from "../../state/environments";
@@ -113,6 +116,9 @@ export const ChatHeader = memo(function ChatHeader({
             onDeleteScript={onDeleteProjectScript}
           />
         )}
+        {/* EMPOWERRD:start - Jira ticket deep-link */}
+        <JiraTicketButton environmentId={activeThreadEnvironmentId} threadId={activeThreadId} />
+        {/* EMPOWERRD:end */}
         {showOpenInPicker && (
           <OpenInPicker
             environmentId={activeThreadEnvironmentId}

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -95,6 +95,44 @@ export function useThreadActions() {
         );
       }
 
+      // EMPOWERRD:start - when archiving the last thread linked to a worktree,
+      // prompt to delete the orphaned worktree (mirrors the delete flow's
+      // cleanup helpers + new state-entity reads).
+      const archiveThreads = readEnvironmentThreadRefs(threadRef.environmentId).flatMap((ref) => {
+        const shell = readThreadShell(ref);
+        return shell === null ? [] : [shell];
+      });
+      const archiveThreadProject = readProject({
+        environmentId: threadRef.environmentId,
+        projectId: thread.projectId,
+      });
+      const orphanedWorktreePath = getOrphanedWorktreePathForThread(
+        archiveThreads,
+        threadRef.threadId,
+      );
+      const displayWorktreePath = orphanedWorktreePath
+        ? formatWorktreePathForDisplay(orphanedWorktreePath)
+        : null;
+      const archiveLocalApi = readLocalApi();
+      let shouldDeleteWorktree = false;
+      if (orphanedWorktreePath !== null && archiveThreadProject !== null && archiveLocalApi) {
+        const confirmationResult = await settlePromise(() =>
+          archiveLocalApi.dialogs.confirm(
+            [
+              "This thread is the only one linked to this worktree:",
+              displayWorktreePath ?? orphanedWorktreePath,
+              "",
+              "Delete the worktree too?",
+            ].join("\n"),
+          ),
+        );
+        if (confirmationResult._tag === "Failure") {
+          return confirmationResult;
+        }
+        shouldDeleteWorktree = confirmationResult.value;
+      }
+      // EMPOWERRD:end
+
       const currentRouteThreadRef = getCurrentRouteThreadRef();
       const shouldNavigateToDraft =
         currentRouteThreadRef?.threadId === threadRef.threadId &&
@@ -106,6 +144,25 @@ export function useThreadActions() {
       if (archiveResult._tag === "Failure") {
         return archiveResult;
       }
+
+      // EMPOWERRD:start - remove the orphaned worktree once archive succeeds.
+      if (shouldDeleteWorktree && orphanedWorktreePath && archiveThreadProject) {
+        const removeResult = await removeWorktree({
+          environmentId: threadRef.environmentId,
+          input: {
+            cwd: archiveThreadProject.workspaceRoot,
+            path: orphanedWorktreePath,
+            force: true,
+          },
+        });
+        if (removeResult._tag === "Success") {
+          await refreshVcsStatus({
+            environmentId: threadRef.environmentId,
+            input: { cwd: archiveThreadProject.workspaceRoot },
+          });
+        }
+      }
+      // EMPOWERRD:end
 
       if (shouldNavigateToDraft) {
         const navigationResult = await settlePromise(() =>

--- a/apps/web/src/jira/BranchToolbarJiraKeyControl.tsx
+++ b/apps/web/src/jira/BranchToolbarJiraKeyControl.tsx
@@ -1,0 +1,276 @@
+// EMPOWERRD: branch-toolbar control to view/set/clear a thread's Jira key.
+//
+// Reads the current key from the fork `threadJiraKeysQuery` (Decision A: the key
+// is not on the core thread payload) and writes via the `setThreadJiraKeyCommand`
+// RPC. Branch rename behaviour: temp placeholder branches auto-rename; meaningful
+// branches prompt for confirmation; preview/validation reuse the shared helpers.
+import { squashAtomCommandFailure } from "@t3tools/client-runtime/state/runtime";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { isMainOrMasterBranchName, validateJiraKeyInput } from "@t3tools/shared/jira";
+import { useEffect, useState } from "react";
+
+import { Button } from "../components/ui/button";
+import {
+  Dialog,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogPanel,
+  DialogPopup,
+  DialogTitle,
+} from "../components/ui/dialog";
+import { Input } from "../components/ui/input";
+import { toastManager } from "../components/ui/toast";
+import { useEnvironmentQuery } from "../state/query";
+import { useAtomCommand } from "../state/use-atom-command";
+import { vcsEnvironment } from "../state/vcs";
+import { resolveJiraKeySavePlan } from "./savePlan.ts";
+import { setThreadJiraKeyCommand, threadJiraKeysQuery } from "./state.ts";
+
+export interface BranchToolbarJiraKeyControlProps {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+  readonly projectCwd: string;
+  readonly effectiveEnvMode: "local" | "worktree";
+  readonly jiraProjectKey: string | null;
+  readonly currentBranch: string | null;
+  readonly title: string;
+  readonly onComposerFocusRequest?: () => void;
+}
+
+export function BranchToolbarJiraKeyControl(props: BranchToolbarJiraKeyControlProps) {
+  const {
+    environmentId,
+    threadId,
+    projectCwd,
+    effectiveEnvMode,
+    jiraProjectKey,
+    currentBranch,
+    title,
+  } = props;
+
+  const jiraKeysQuery = useEnvironmentQuery(threadJiraKeysQuery({ environmentId, input: {} }));
+  const currentJiraKey =
+    jiraKeysQuery.data?.find((row) => row.threadId === threadId)?.jiraKey ?? null;
+  const setJiraKey = useAtomCommand(setThreadJiraKeyCommand, { reportFailure: false });
+
+  const vcsStatus = useEnvironmentQuery(
+    effectiveEnvMode === "worktree"
+      ? null
+      : vcsEnvironment.status({ environmentId, input: { cwd: projectCwd } }),
+  );
+  const resolvedLocalBranch = vcsStatus.data?.refName ?? currentBranch;
+  const jiraKeyAllowed =
+    effectiveEnvMode === "worktree" ||
+    (resolvedLocalBranch !== null && !isMainOrMasterBranchName(resolvedLocalBranch));
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [draftValue, setDraftValue] = useState(currentJiraKey ?? "");
+  const [isSaving, setIsSaving] = useState(false);
+  const [pendingRename, setPendingRename] = useState<{
+    readonly jiraKey: string;
+    readonly targetBranch: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!dialogOpen) {
+      setDraftValue(currentJiraKey ?? "");
+    }
+  }, [currentJiraKey, dialogOpen]);
+
+  const validation = validateJiraKeyInput(draftValue, jiraProjectKey);
+  const normalizedJiraKey = validation.normalized;
+  const isBlockedByGuardrail = normalizedJiraKey !== null && !jiraKeyAllowed;
+  const canSave =
+    !isSaving &&
+    validation.error === null &&
+    !isBlockedByGuardrail &&
+    normalizedJiraKey !== currentJiraKey;
+
+  const applyKey = async (jiraKey: string | null, renameBranch: boolean) => {
+    const result = await setJiraKey({ environmentId, input: { threadId, jiraKey, renameBranch } });
+    if (result._tag === "Failure") {
+      const error = squashAtomCommandFailure(result);
+      throw error instanceof Error ? error : new Error("Failed to save Jira key.");
+    }
+    jiraKeysQuery.refresh();
+  };
+
+  const handleSave = async () => {
+    if (!canSave) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      if (normalizedJiraKey === null) {
+        await applyKey(null, false);
+        setDialogOpen(false);
+        props.onComposerFocusRequest?.();
+        return;
+      }
+
+      const plan = resolveJiraKeySavePlan({ currentBranch, normalizedJiraKey, title });
+      if (plan.kind === "save") {
+        await applyKey(normalizedJiraKey, false);
+        setDialogOpen(false);
+        props.onComposerFocusRequest?.();
+        return;
+      }
+      if (plan.kind === "autoRename") {
+        await applyKey(normalizedJiraKey, true);
+        setDialogOpen(false);
+        props.onComposerFocusRequest?.();
+        return;
+      }
+
+      // Meaningful branch: save the key now (no rename), then ask the user.
+      await applyKey(normalizedJiraKey, false);
+      setPendingRename({ jiraKey: normalizedJiraKey, targetBranch: plan.targetBranch });
+      setDialogOpen(false);
+      setConfirmOpen(true);
+      props.onComposerFocusRequest?.();
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Failed to save Jira key",
+        description: error instanceof Error ? error.message : "An unexpected error occurred.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const confirmRename = async () => {
+    if (!pendingRename) {
+      return;
+    }
+    setIsSaving(true);
+    try {
+      await applyKey(pendingRename.jiraKey, true);
+      setConfirmOpen(false);
+      setPendingRename(null);
+      props.onComposerFocusRequest?.();
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Failed to rename branch",
+        description:
+          error instanceof Error
+            ? `${error.message} The Jira key was still saved.`
+            : "The Jira key was saved, but the branch rename failed.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleClear = async () => {
+    setIsSaving(true);
+    try {
+      await applyKey(null, false);
+      setDialogOpen(false);
+      props.onComposerFocusRequest?.();
+    } catch (error) {
+      toastManager.add({
+        type: "error",
+        title: "Failed to clear Jira key",
+        description: error instanceof Error ? error.message : "An unexpected error occurred.",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        size="xs"
+        variant="ghost"
+        className="font-medium text-muted-foreground/70"
+        onClick={() => setDialogOpen(true)}
+      >
+        {currentJiraKey ? `Jira: ${currentJiraKey}` : "Add Jira Key"}
+      </Button>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>{currentJiraKey ? "Edit Jira key" : "Add Jira key"}</DialogTitle>
+            <DialogDescription>
+              Save an optional Jira key to this thread and use it for worktree branch naming.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel>
+            <div className="space-y-2">
+              <Input
+                autoFocus
+                placeholder={`${jiraProjectKey ?? "ABC"}-123`}
+                value={draftValue}
+                onChange={(event) => setDraftValue(event.currentTarget.value)}
+              />
+              {validation.error ? (
+                <p className="text-destructive text-xs">{validation.error}</p>
+              ) : null}
+              {isBlockedByGuardrail ? (
+                <p className="text-destructive text-xs">
+                  Jira keys can only be set in a worktree or when the current checkout is not{" "}
+                  <code>main</code> or <code>master</code>.
+                </p>
+              ) : null}
+              <p className="text-muted-foreground text-xs">
+                Branches use <code>{normalizedJiraKey ?? "KEY"}/slug</code> when a Jira key is set.
+              </p>
+            </div>
+          </DialogPanel>
+          <DialogFooter variant="bare">
+            {currentJiraKey ? (
+              <Button variant="outline" disabled={isSaving} onClick={() => void handleClear()}>
+                Clear
+              </Button>
+            ) : null}
+            <Button variant="outline" disabled={isSaving} onClick={() => setDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button disabled={!canSave} onClick={() => void handleSave()}>
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>Rename branch to match Jira key?</DialogTitle>
+            <DialogDescription>
+              The Jira key has been saved. Rename the current branch to match it now?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel>
+            <div className="space-y-2 text-sm">
+              <p>Current branch: {currentBranch ?? "(none)"}</p>
+              <p>New branch: {pendingRename?.targetBranch ?? "(none)"}</p>
+            </div>
+          </DialogPanel>
+          <DialogFooter variant="bare">
+            <Button
+              variant="outline"
+              disabled={isSaving}
+              onClick={() => {
+                setConfirmOpen(false);
+                setPendingRename(null);
+                props.onComposerFocusRequest?.();
+              }}
+            >
+              Keep current branch
+            </Button>
+            <Button disabled={isSaving} onClick={() => void confirmRename()}>
+              Rename branch
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/jira/JiraTicketButton.tsx
+++ b/apps/web/src/jira/JiraTicketButton.tsx
@@ -1,0 +1,42 @@
+// EMPOWERRD: chat-header button that deep-links to Jira. Gated on JIRA_DOMAIN.
+// With a key set on the thread it opens the issue; otherwise the create-issue page.
+import { useAtomValue } from "@effect/atom-react";
+import type { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { buildJiraCreateTicketUrl, buildJiraTicketUrl } from "@t3tools/shared/jira";
+import { TicketIcon } from "lucide-react";
+
+import { Button } from "../components/ui/button";
+import { useEnvironmentQuery } from "../state/query";
+import { primaryServerConfigAtom } from "../state/server";
+import { threadJiraKeysQuery } from "./state.ts";
+
+export function JiraTicketButton(props: {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+}) {
+  const { environmentId, threadId } = props;
+  const config = useAtomValue(primaryServerConfigAtom);
+  const jiraDomain = config?.jira?.domain ?? null;
+  const jiraKeysQuery = useEnvironmentQuery(threadJiraKeysQuery({ environmentId, input: {} }));
+  const jiraKey = jiraKeysQuery.data?.find((row) => row.threadId === threadId)?.jiraKey ?? null;
+
+  if (!jiraDomain) {
+    return null;
+  }
+
+  const href = jiraKey
+    ? buildJiraTicketUrl(jiraDomain, jiraKey)
+    : buildJiraCreateTicketUrl(jiraDomain);
+  const label = jiraKey ? "Open Ticket" : "Create Ticket";
+
+  return (
+    <Button
+      size="xs"
+      variant="outline"
+      render={<a href={href} target="_blank" rel="noopener noreferrer" aria-label={label} />}
+    >
+      <TicketIcon aria-hidden="true" className="size-3.5" />
+      {label}
+    </Button>
+  );
+}

--- a/apps/web/src/jira/savePlan.test.ts
+++ b/apps/web/src/jira/savePlan.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { resolveJiraKeySavePlan } from "./savePlan.ts";
+
+describe("resolveJiraKeySavePlan", () => {
+  it("saves without renaming when there is no branch", () => {
+    expect(
+      resolveJiraKeySavePlan({ currentBranch: null, normalizedJiraKey: "PLAT-1", title: "x" }),
+    ).toEqual({ kind: "save" });
+  });
+
+  it("saves without renaming when the branch is already prefixed with the key", () => {
+    expect(
+      resolveJiraKeySavePlan({
+        currentBranch: "PLAT-1/foo",
+        normalizedJiraKey: "PLAT-1",
+        title: "x",
+      }),
+    ).toEqual({ kind: "save" });
+  });
+
+  it("auto-renames a temporary placeholder branch", () => {
+    expect(
+      resolveJiraKeySavePlan({
+        currentBranch: "empcode/abcd1234",
+        normalizedJiraKey: "JIRA-9",
+        title: "Fix login flow",
+      }),
+    ).toEqual({ kind: "autoRename" });
+  });
+
+  it("requests confirmation for a meaningful branch, preserving the suffix", () => {
+    expect(
+      resolveJiraKeySavePlan({
+        currentBranch: "feature/foo",
+        normalizedJiraKey: "JIRA-12",
+        title: "ignored",
+      }),
+    ).toEqual({ kind: "confirm", targetBranch: "JIRA-12/foo" });
+  });
+});

--- a/apps/web/src/jira/savePlan.ts
+++ b/apps/web/src/jira/savePlan.ts
@@ -1,0 +1,53 @@
+// EMPOWERRD: pure decision logic for what a Jira-key save should do to the
+// thread's branch. Extracted from the toolbar control so it can be unit-tested
+// without the React/RPC machinery.
+import {
+  buildRenamedJiraBranchName,
+  isTemporaryWorktreeBranchForAnyPrefix,
+  normalizeWorktreeBranchPrefix,
+} from "@t3tools/shared/jira";
+
+export type JiraKeySavePlan =
+  /** Persist the key without renaming the branch. */
+  | { readonly kind: "save" }
+  /** Branch is a throwaway placeholder — rename immediately, no confirmation. */
+  | { readonly kind: "autoRename" }
+  /** Branch is meaningful — persist the key, then ask before renaming. */
+  | { readonly kind: "confirm"; readonly targetBranch: string };
+
+/**
+ * Decide how assigning `normalizedJiraKey` should affect the thread's branch.
+ *
+ * - No branch, or the branch is already prefixed with the key → just save.
+ * - Temporary placeholder branch (`<prefix>/<8 hex>`) → auto-rename.
+ * - Otherwise → confirm a rename that preserves the existing suffix.
+ */
+export function resolveJiraKeySavePlan(input: {
+  readonly currentBranch: string | null;
+  readonly normalizedJiraKey: string;
+  readonly title: string;
+}): JiraKeySavePlan {
+  const { currentBranch, normalizedJiraKey, title } = input;
+  if (!currentBranch) {
+    return { kind: "save" };
+  }
+
+  const currentPrefix = currentBranch.split("/")[0] ?? "";
+  if (normalizeWorktreeBranchPrefix(currentPrefix) === normalizedJiraKey) {
+    return { kind: "save" };
+  }
+
+  if (isTemporaryWorktreeBranchForAnyPrefix(currentBranch)) {
+    return { kind: "autoRename" };
+  }
+
+  const targetBranch = buildRenamedJiraBranchName({
+    currentBranch,
+    newJiraKey: normalizedJiraKey,
+    fallbackTitle: title,
+  });
+  if (targetBranch === currentBranch) {
+    return { kind: "save" };
+  }
+  return { kind: "confirm", targetBranch };
+}

--- a/apps/web/src/jira/state.ts
+++ b/apps/web/src/jira/state.ts
@@ -1,0 +1,22 @@
+// EMPOWERRD: fork-owned environment atoms for the Jira RPCs. Built on the
+// generic RPC command/query factories so the fork plugs into the new web state
+// model (atom-command + environment query) exactly like vcs/threads do.
+import {
+  createEnvironmentRpcCommand,
+  createEnvironmentRpcQueryAtomFamily,
+} from "@t3tools/client-runtime/state/runtime";
+import { JIRA_WS_METHODS } from "@t3tools/contracts";
+
+import { connectionAtomRuntime } from "../connection/runtime";
+
+/** Mutation: set/clear a thread's Jira key (and optionally rename its branch). */
+export const setThreadJiraKeyCommand = createEnvironmentRpcCommand(connectionAtomRuntime, {
+  label: "jira set thread key",
+  tag: JIRA_WS_METHODS.setThreadJiraKey,
+});
+
+/** Query: list every thread's Jira key for an environment. */
+export const threadJiraKeysQuery = createEnvironmentRpcQueryAtomFamily(connectionAtomRuntime, {
+  label: "jira list thread keys",
+  tag: JIRA_WS_METHODS.listThreadJiraKeys,
+});

--- a/packages/client-runtime/src/rpc/protocol.ts
+++ b/packages/client-runtime/src/rpc/protocol.ts
@@ -1,8 +1,10 @@
-import { WsRpcGroup } from "@t3tools/contracts";
+// EMPOWERRD: use the merged protocol (upstream + fork Jira RPCs) so the generic
+// EnvironmentRpc.request(tag, ...) path can call jira.* methods.
+import { AllWsRpcGroup } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
 import { RpcClient } from "effect/unstable/rpc";
 
-export const makeWsRpcProtocolClient = RpcClient.make(WsRpcGroup);
+export const makeWsRpcProtocolClient = RpcClient.make(AllWsRpcGroup);
 type RpcClientFactory = typeof makeWsRpcProtocolClient;
 export type WsRpcProtocolClient =
   RpcClientFactory extends Effect.Effect<infer Client, any, any> ? Client : never;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -26,3 +26,7 @@ export * from "./review.ts";
 export * from "./preview.ts";
 export * from "./previewAutomation.ts";
 export * from "./rpc.ts";
+// EMPOWERRD:start - fork-owned Jira contracts
+export * from "./jira.ts";
+export * from "./rpcJira.ts";
+// EMPOWERRD:end

--- a/packages/contracts/src/jira.ts
+++ b/packages/contracts/src/jira.ts
@@ -1,0 +1,57 @@
+// EMPOWERRD: fork-owned Jira contracts. Kept in a dedicated module so upstream
+// syncs never touch it. Consumed by the fork RPC group (rpcJira.ts) and the
+// server/web Jira feature modules.
+import * as Schema from "effect/Schema";
+
+import { ThreadId, TrimmedNonEmptyString } from "./baseSchemas.ts";
+
+/** Canonical Jira issue-key shape, e.g. `PLAT-123`. */
+export const JIRA_KEY_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
+
+/** A validated, normalized Jira issue key. */
+export const JiraKey = TrimmedNonEmptyString.check(Schema.isPattern(JIRA_KEY_PATTERN));
+export type JiraKey = typeof JiraKey.Type;
+
+/** Input for the fork `jira.setThreadJiraKey` RPC. */
+export const SetThreadJiraKeyInput = Schema.Struct({
+  threadId: ThreadId,
+  jiraKey: Schema.NullOr(JiraKey),
+  renameBranch: Schema.Boolean,
+});
+export type SetThreadJiraKeyInput = typeof SetThreadJiraKeyInput.Type;
+
+/**
+ * A thread's Jira association as surfaced to the client. `branch` reflects the
+ * thread's branch after any rename performed by the handler.
+ */
+export const ThreadJiraKey = Schema.Struct({
+  threadId: ThreadId,
+  jiraKey: Schema.NullOr(JiraKey),
+  branch: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type ThreadJiraKey = typeof ThreadJiraKey.Type;
+
+/** Result of `jira.listThreadJiraKeys` — one row per thread that has a key. */
+export const ThreadJiraKeyList = Schema.Array(
+  Schema.Struct({
+    threadId: ThreadId,
+    jiraKey: JiraKey,
+  }),
+);
+export type ThreadJiraKeyList = typeof ThreadJiraKeyList.Type;
+
+/** Jira settings surfaced to the web client (each field null when unset). */
+export const ServerJiraConfig = Schema.Struct({
+  domain: Schema.NullOr(TrimmedNonEmptyString),
+  projectKey: Schema.NullOr(TrimmedNonEmptyString),
+});
+export type ServerJiraConfig = typeof ServerJiraConfig.Type;
+
+/** Failure surfaced by the fork Jira RPC handlers (validation, main/master rule, git rename). */
+export class JiraOperationError extends Schema.TaggedErrorClass<JiraOperationError>()(
+  "JiraOperationError",
+  {
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -1,6 +1,9 @@
 import * as Schema from "effect/Schema";
 import * as Rpc from "effect/unstable/rpc/Rpc";
 import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
+// EMPOWERRD:start - fork-owned Jira RPC group
+import { ForkWsRpcGroup } from "./rpcJira.ts";
+// EMPOWERRD:end
 
 import { ExternalLauncherError, LaunchEditorInput } from "./editor.ts";
 import {
@@ -748,3 +751,9 @@ export const WsRpcGroup = RpcGroup.make(
   WsOrchestrationSubscribeShellRpc,
   WsOrchestrationSubscribeThreadRpc,
 );
+
+// EMPOWERRD:start - merge the fork-owned Jira RPC group into the protocol.
+// `WsRpcGroup` above is left untouched (and still used for upstream handlers);
+// `AllWsRpcGroup` is what the server and client wire against.
+export const AllWsRpcGroup = WsRpcGroup.merge(ForkWsRpcGroup);
+// EMPOWERRD:end

--- a/packages/contracts/src/rpcJira.ts
+++ b/packages/contracts/src/rpcJira.ts
@@ -1,0 +1,32 @@
+// EMPOWERRD: fork-owned WS RPC group. Lives in its own module and is merged into
+// the protocol via `WsRpcGroup.merge(ForkWsRpcGroup)` in rpc.ts, so the upstream
+// WsRpcGroup definition (and the ws.ts handler object) are never edited.
+import * as Rpc from "effect/unstable/rpc/Rpc";
+import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
+import * as Schema from "effect/Schema";
+
+import {
+  JiraOperationError,
+  SetThreadJiraKeyInput,
+  ThreadJiraKey,
+  ThreadJiraKeyList,
+} from "./jira.ts";
+
+export const JIRA_WS_METHODS = {
+  setThreadJiraKey: "jira.setThreadJiraKey",
+  listThreadJiraKeys: "jira.listThreadJiraKeys",
+} as const;
+
+export const WsThreadSetJiraKeyRpc = Rpc.make(JIRA_WS_METHODS.setThreadJiraKey, {
+  payload: SetThreadJiraKeyInput,
+  success: ThreadJiraKey,
+  error: JiraOperationError,
+});
+
+export const WsThreadListJiraKeysRpc = Rpc.make(JIRA_WS_METHODS.listThreadJiraKeys, {
+  payload: Schema.Struct({}),
+  success: ThreadJiraKeyList,
+  error: JiraOperationError,
+});
+
+export const ForkWsRpcGroup = RpcGroup.make(WsThreadSetJiraKeyRpc, WsThreadListJiraKeysRpc);

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -18,6 +18,9 @@ import {
 } from "./keybindings.ts";
 import { EditorId } from "./editor.ts";
 import { ModelCapabilities } from "./model.ts";
+// EMPOWERRD:start - fork Jira config schema
+import { ServerJiraConfig } from "./jira.ts";
+// EMPOWERRD:end
 import { ProviderDriverKind, ProviderInstanceId } from "./providerInstance.ts";
 import { ServerSettings } from "./settings.ts";
 
@@ -406,6 +409,9 @@ export const ServerConfig = Schema.Struct({
   availableEditors: Schema.Array(EditorId),
   observability: ServerObservability,
   settings: ServerSettings,
+  // EMPOWERRD:start - fork Jira settings surfaced to the client
+  jira: Schema.optional(ServerJiraConfig),
+  // EMPOWERRD:end
 });
 export type ServerConfig = typeof ServerConfig.Type;
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -19,6 +19,10 @@
       "types": "./src/git.ts",
       "import": "./src/git.ts"
     },
+    "./jira": {
+      "types": "./src/jira.ts",
+      "import": "./src/jira.ts"
+    },
     "./sourceControl": {
       "types": "./src/sourceControl.ts",
       "import": "./src/sourceControl.ts"

--- a/packages/shared/src/git.ts
+++ b/packages/shared/src/git.ts
@@ -10,7 +10,9 @@ import * as Arr from "effect/Array";
 import * as Result from "effect/Result";
 import { detectSourceControlProviderFromRemoteUrl } from "./sourceControl.ts";
 
-export const WORKTREE_BRANCH_PREFIX = "t3code";
+// EMPOWERRD:start - default worktree branch prefix renamed from upstream "t3code"
+export const WORKTREE_BRANCH_PREFIX = "empcode";
+// EMPOWERRD:end
 const TEMP_WORKTREE_BRANCH_PATTERN = new RegExp(`^${WORKTREE_BRANCH_PREFIX}\\/[0-9a-f]{8}$`);
 
 /**

--- a/packages/shared/src/jira.test.ts
+++ b/packages/shared/src/jira.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  applyProjectKeyPrefix,
+  buildJiraCreateTicketUrl,
+  buildJiraTicketUrl,
+  buildRenamedJiraBranchName,
+  buildSemanticWorktreeBranchName,
+  DEFAULT_WORKTREE_BRANCH_PREFIX,
+  deriveWorktreeBranchSuffix,
+  isMainOrMasterBranchName,
+  isTemporaryWorktreeBranchForAnyPrefix,
+  normalizeJiraDomain,
+  normalizeJiraProjectKey,
+  normalizeWorktreeBranchPrefix,
+  validateJiraKeyInput,
+} from "./jira.ts";
+
+describe("isTemporaryWorktreeBranchForAnyPrefix", () => {
+  it("matches default-prefix temp branches", () => {
+    expect(isTemporaryWorktreeBranchForAnyPrefix("empcode/deadbeef")).toBe(true);
+    expect(isTemporaryWorktreeBranchForAnyPrefix(" empcode/DEADBEEF ")).toBe(true);
+  });
+
+  it("matches jira-prefixed temp branches", () => {
+    expect(isTemporaryWorktreeBranchForAnyPrefix("JIRA-123/deadbeef")).toBe(true);
+    expect(isTemporaryWorktreeBranchForAnyPrefix("ABC-1/abcd1234")).toBe(true);
+  });
+
+  it("rejects semantic branches even when the suffix is hex-shaped", () => {
+    expect(isTemporaryWorktreeBranchForAnyPrefix("JIRA-123/feature-name")).toBe(false);
+    // 8 hex chars but the prefix is neither default nor a jira key.
+    expect(isTemporaryWorktreeBranchForAnyPrefix("feature/abcdef12")).toBe(false);
+  });
+
+  it("rejects malformed branches", () => {
+    expect(isTemporaryWorktreeBranchForAnyPrefix("main")).toBe(false);
+    expect(isTemporaryWorktreeBranchForAnyPrefix("empcode/")).toBe(false);
+    expect(isTemporaryWorktreeBranchForAnyPrefix("/deadbeef")).toBe(false);
+    expect(isTemporaryWorktreeBranchForAnyPrefix("empcode/deadbeefxx")).toBe(false);
+  });
+});
+
+describe("buildRenamedJiraBranchName", () => {
+  it("uses the sanitized title when the current branch is a default-prefix temp", () => {
+    expect(
+      buildRenamedJiraBranchName({
+        currentBranch: "empcode/abcd1234",
+        newJiraKey: "JIRA-123",
+        fallbackTitle: "Fix login flow",
+      }),
+    ).toBe("JIRA-123/fix-login-flow");
+  });
+
+  it("uses the sanitized title when the current branch is a jira-prefix temp", () => {
+    expect(
+      buildRenamedJiraBranchName({
+        currentBranch: "OLD-9/abcd1234",
+        newJiraKey: "NEW-1",
+        fallbackTitle: "Patch payment bug",
+      }),
+    ).toBe("NEW-1/patch-payment-bug");
+  });
+
+  it("preserves the existing suffix when the current branch is semantic", () => {
+    expect(
+      buildRenamedJiraBranchName({
+        currentBranch: "feature/foo-bar",
+        newJiraKey: "JIRA-7",
+        fallbackTitle: "Title that should not be used",
+      }),
+    ).toBe("JIRA-7/foo-bar");
+  });
+
+  it("falls back to the title when the current branch has no suffix", () => {
+    expect(
+      buildRenamedJiraBranchName({
+        currentBranch: "main",
+        newJiraKey: "JIRA-9",
+        fallbackTitle: "Hotfix release",
+      }),
+    ).toBe("JIRA-9/hotfix-release");
+  });
+
+  it("normalizes lowercase Jira keys to uppercase", () => {
+    expect(
+      buildRenamedJiraBranchName({
+        currentBranch: "feature/refactor-auth",
+        newJiraKey: "abc-123",
+        fallbackTitle: "anything",
+      }),
+    ).toBe("ABC-123/refactor-auth");
+  });
+});
+
+describe("worktree branch helpers", () => {
+  it("uses empcode as the default worktree branch prefix", () => {
+    expect(DEFAULT_WORKTREE_BRANCH_PREFIX).toBe("empcode");
+    expect(normalizeWorktreeBranchPrefix(" EmpCode ")).toBe("empcode");
+  });
+
+  it("preserves jira-style prefixes in uppercase", () => {
+    expect(normalizeWorktreeBranchPrefix("abc-123")).toBe("ABC-123");
+  });
+
+  it("derives a suffix from the namespaced worktree branch", () => {
+    expect(deriveWorktreeBranchSuffix("ABC-123/fix-login-flow")).toBe("fix-login-flow");
+    expect(deriveWorktreeBranchSuffix("main")).toBeNull();
+  });
+
+  it("builds semantic jira worktree branches", () => {
+    expect(buildSemanticWorktreeBranchName("abc-123", "Fix login flow")).toBe(
+      "ABC-123/fix-login-flow",
+    );
+  });
+
+  it("identifies main and master as protected branch names", () => {
+    expect(isMainOrMasterBranchName("main")).toBe(true);
+    expect(isMainOrMasterBranchName("master")).toBe(true);
+    expect(isMainOrMasterBranchName("refs/heads/main")).toBe(true);
+    expect(isMainOrMasterBranchName("feature/main")).toBe(false);
+  });
+
+  it("validates jira keys against an optional configured project key", () => {
+    expect(validateJiraKeyInput("abc-123")).toEqual({ normalized: "ABC-123", error: null });
+    expect(validateJiraKeyInput("some-123", "SOME")).toEqual({
+      normalized: "SOME-123",
+      error: null,
+    });
+    expect(validateJiraKeyInput("other-123", "SOME")).toEqual({
+      normalized: null,
+      error: "Use a Jira key like SOME-123.",
+    });
+  });
+
+  it("normalizes jira domains and project keys", () => {
+    expect(normalizeJiraDomain("https://Example.atlassian.net/")).toBe("example");
+    expect(normalizeJiraProjectKey(" some ")).toBe("SOME");
+    expect(normalizeJiraProjectKey("1bad")).toBeNull();
+  });
+
+  it("builds jira issue and create-ticket urls", () => {
+    expect(buildJiraTicketUrl("example", "SOME-123")).toBe(
+      "https://example.atlassian.net/browse/SOME-123",
+    );
+    expect(buildJiraCreateTicketUrl("example")).toBe(
+      "https://example.atlassian.net/secure/CreateIssue.jspa",
+    );
+  });
+});
+
+describe("applyProjectKeyPrefix", () => {
+  it("prefixes a bare number with the configured project key", () => {
+    expect(applyProjectKeyPrefix("1234", "PLAT")).toBe("PLAT-1234");
+    expect(applyProjectKeyPrefix("12", "PLAT")).toBe("PLAT-12");
+  });
+
+  it("accepts a full key as-is and normalizes case (no double-prefix)", () => {
+    expect(applyProjectKeyPrefix("PLAT-1234", "PLAT")).toBe("PLAT-1234");
+    expect(applyProjectKeyPrefix("plat-1234", "PLAT")).toBe("PLAT-1234");
+  });
+
+  it("does not prefix when the project key alone is typed", () => {
+    expect(applyProjectKeyPrefix("PLAT", "PLAT")).toBe("PLAT");
+  });
+
+  it("leaves partial alpha input untouched mid-typing", () => {
+    expect(applyProjectKeyPrefix("pl", "PLAT")).toBe("pl");
+    expect(applyProjectKeyPrefix("ABC-9", "PLAT")).toBe("ABC-9");
+  });
+
+  it("returns empty input unchanged", () => {
+    expect(applyProjectKeyPrefix("", "PLAT")).toBe("");
+    expect(applyProjectKeyPrefix("   ", "PLAT")).toBe("");
+  });
+
+  it("does not prefix when no project key is configured", () => {
+    expect(applyProjectKeyPrefix("1234")).toBe("1234");
+    expect(applyProjectKeyPrefix("1234", null)).toBe("1234");
+  });
+
+  it("feeds into validateJiraKeyInput so bare numbers validate", () => {
+    expect(validateJiraKeyInput("1234", "PLAT")).toEqual({
+      normalized: "PLAT-1234",
+      error: null,
+    });
+  });
+});

--- a/packages/shared/src/jira.ts
+++ b/packages/shared/src/jira.ts
@@ -1,0 +1,204 @@
+// EMPOWERRD: fork-owned, pure Jira helpers. Isolated here so upstream syncs
+// never touch them. Reused by the server RPC handler, the web toolbar control,
+// and the header ticket button. The default worktree branch prefix is the
+// single upstream constant (renamed to "empcode" via a fenced edit in git.ts).
+import { sanitizeBranchFragment, WORKTREE_BRANCH_PREFIX } from "./git.ts";
+
+/** Default temporary-worktree branch prefix (mirrors the upstream constant). */
+export const DEFAULT_WORKTREE_BRANCH_PREFIX = WORKTREE_BRANCH_PREFIX;
+
+/** Canonical Jira issue-key shape, e.g. `PLAT-123`. */
+const JIRA_KEY_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
+/** Temporary-worktree branch suffix: an 8-char hex token. */
+const TEMPORARY_WORKTREE_BRANCH_SUFFIX_PATTERN = /^[0-9a-f]{8}$/i;
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Normalize a worktree branch prefix. Empty input falls back to the default
+ * temp prefix; Jira-style keys are uppercased; everything else is sanitized
+ * into a branch-safe fragment.
+ */
+export function normalizeWorktreeBranchPrefix(raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return DEFAULT_WORKTREE_BRANCH_PREFIX;
+  }
+
+  const normalizedUpper = trimmed.toUpperCase();
+  if (JIRA_KEY_PATTERN.test(normalizedUpper)) {
+    return normalizedUpper;
+  }
+
+  return sanitizeBranchFragment(trimmed);
+}
+
+/**
+ * Match any branch in temporary-worktree shape — `<prefix>/<8-hex>` — where
+ * the prefix is either the default temp prefix or a Jira-style key. Useful
+ * when the current branch's prefix may not equal the desired prefix (e.g. the
+ * user assigned a Jira key to a thread that already had an `empcode/...` temp
+ * branch).
+ */
+export function isTemporaryWorktreeBranchForAnyPrefix(branch: string): boolean {
+  const trimmed = branch.trim();
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+    return false;
+  }
+  const prefix = trimmed.slice(0, slashIndex);
+  const suffix = trimmed.slice(slashIndex + 1);
+  if (!TEMPORARY_WORKTREE_BRANCH_SUFFIX_PATTERN.test(suffix)) {
+    return false;
+  }
+  return prefix.toLowerCase() === DEFAULT_WORKTREE_BRANCH_PREFIX || JIRA_KEY_PATTERN.test(prefix);
+}
+
+/** Return the slash-separated suffix of a namespaced branch, or null. */
+export function deriveWorktreeBranchSuffix(branch: string): string | null {
+  const trimmed = branch.trim().replace(/^refs\/heads\//, "");
+  const slashIndex = trimmed.indexOf("/");
+  if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+    return null;
+  }
+  return trimmed.slice(slashIndex + 1);
+}
+
+/** Build a `<prefix>/<suffix>` branch name with both parts normalized. */
+export function buildSemanticWorktreeBranchName(prefix: string, suffix: string): string {
+  const normalizedPrefix = normalizeWorktreeBranchPrefix(prefix);
+  const normalizedSuffix = sanitizeBranchFragment(suffix);
+  return `${normalizedPrefix}/${normalizedSuffix.length > 0 ? normalizedSuffix : "update"}`;
+}
+
+/**
+ * Compute the target branch name when assigning a Jira key to an existing
+ * branch. Used by both the dialog preview on the client and the rename
+ * dispatch on the server, so the two stay in lockstep.
+ *
+ * - If the current branch is a temporary placeholder (any recognized prefix),
+ *   the random hex suffix is meaningless — replace it with a sanitized
+ *   fragment of the thread title.
+ * - Otherwise the existing suffix is preserved (just re-prefixed with the
+ *   new Jira key), which keeps user-meaningful branch names stable.
+ */
+export function buildRenamedJiraBranchName(input: {
+  readonly currentBranch: string;
+  readonly newJiraKey: string;
+  readonly fallbackTitle: string;
+}): string {
+  const isTemporary = isTemporaryWorktreeBranchForAnyPrefix(input.currentBranch);
+  const titleFragment = sanitizeBranchFragment(input.fallbackTitle);
+  const suffix = isTemporary
+    ? titleFragment
+    : (deriveWorktreeBranchSuffix(input.currentBranch) ?? titleFragment);
+  return buildSemanticWorktreeBranchName(input.newJiraKey, suffix);
+}
+
+/** True when a branch name resolves to `main` or `master` (never renamed). */
+export function isMainOrMasterBranchName(branch: string): boolean {
+  const normalized = branch
+    .trim()
+    .replace(/^refs\/heads\//, "")
+    .toLowerCase();
+  return normalized === "main" || normalized === "master";
+}
+
+/** Normalize a Jira domain to its bare subdomain (e.g. `example`). */
+export function normalizeJiraDomain(raw: string | null | undefined): string | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalized = trimmed
+    .replace(/^https?:\/\//i, "")
+    .replace(/\/+$/g, "")
+    .replace(/\.atlassian\.net$/i, "")
+    .toLowerCase();
+
+  return normalized.length > 0 ? normalized : null;
+}
+
+/** Normalize a Jira project key (uppercase, must start with a letter), or null. */
+export function normalizeJiraProjectKey(raw: string | null | undefined): string | null {
+  const trimmed = raw?.trim().toUpperCase();
+  if (!trimmed || !/^[A-Z][A-Z0-9]*$/.test(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
+/**
+ * Help the user reach a full Jira key when a project key is configured.
+ *
+ * - No (or invalid) project key → input unchanged.
+ * - Empty input → empty.
+ * - Already starts with `<KEY>-` (case-insensitive) → uppercase-normalize
+ *   (never double-prefix).
+ * - Bare number → `<KEY>-<number>`.
+ * - Otherwise (partial alpha mid-typing) → input unchanged.
+ */
+export function applyProjectKeyPrefix(input: string, projectKey?: string | null): string {
+  const normalizedProjectKey = normalizeJiraProjectKey(projectKey);
+  if (!normalizedProjectKey) {
+    return input;
+  }
+  const trimmed = input.trim();
+  if (trimmed.length === 0) {
+    return trimmed;
+  }
+  if (trimmed.toUpperCase().startsWith(`${normalizedProjectKey}-`)) {
+    return trimmed.toUpperCase();
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return `${normalizedProjectKey}-${trimmed}`;
+  }
+  return trimmed;
+}
+
+/**
+ * Validate and normalize a Jira key from raw input. Applies project-key
+ * auto-prefixing first, then validates against the configured project key (if
+ * any) or the generic Jira-key pattern. Empty input is valid (clears the key).
+ */
+export function validateJiraKeyInput(
+  raw: string,
+  projectKey?: string | null,
+): { normalized: string | null; error: string | null } {
+  const prefixed = applyProjectKeyPrefix(raw, projectKey);
+  const trimmed = prefixed.trim();
+  if (trimmed.length === 0) {
+    return { normalized: null, error: null };
+  }
+
+  const normalized = trimmed.toUpperCase();
+  const normalizedProjectKey = normalizeJiraProjectKey(projectKey);
+  const pattern = normalizedProjectKey
+    ? new RegExp(`^${escapeRegExp(normalizedProjectKey)}-\\d+$`)
+    : JIRA_KEY_PATTERN;
+  if (!pattern.test(normalized)) {
+    return {
+      normalized: null,
+      error: normalizedProjectKey
+        ? `Use a Jira key like ${normalizedProjectKey}-123.`
+        : "Use a Jira key like ABC-123.",
+    };
+  }
+
+  return { normalized, error: null };
+}
+
+/** Deep-link to an existing Jira issue. */
+export function buildJiraTicketUrl(domain: string, jiraKey: string): string {
+  const normalizedDomain = normalizeJiraDomain(domain);
+  return `https://${normalizedDomain}.atlassian.net/browse/${jiraKey}`;
+}
+
+/** Link to the Jira "create issue" page for a domain. */
+export function buildJiraCreateTicketUrl(domain: string): string {
+  const normalizedDomain = normalizeJiraDomain(domain);
+  return `https://${normalizedDomain}.atlassian.net/secure/CreateIssue.jspa`;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches WebSocket RPC wiring, SQLite migrations, and git branch rename/orchestration dispatch; fork migration isolation is tested but schema and git side effects need careful review on upgrade.
> 
> **Overview**
> Re-applies **EMPOWERRD** fork features on top of upstream: end-to-end **Jira** support for threads, plus a few related worktree/git tweaks.
> 
> **Jira (server + client)**  
> - Reads `JIRA_DOMAIN` / `JIRA_PROJECT_KEY` at startup, adds optional `jira` on server config, and exposes it on `loadServerConfig`.  
> - Adds fork RPCs (`jira.setThreadJiraKey`, `jira.listThreadJiraKeys`) via a merged `AllWsRpcGroup` and a separate `ForkJiraWsRpcLayer` (upstream `WsRpcGroup` handlers stay untouched).  
> - Persists thread→key associations in a new `projection_thread_jira` side table (not on core thread schema), with fork migrations tracked in **`fork_migrations`** so upstream `effect_sql_migrations` max IDs are not affected.  
> - Handlers validate keys (optional project-key constraint), block keys on `main`/`master` unless worktree or feature checkout, optionally **git-rename** branches and persist via existing `thread.meta.update`.
> 
> **Web UI**  
> - Branch toolbar **Jira key** control (set/clear, branch rename prompts) and chat header **Open/Create Ticket** when domain is configured.  
> - Archive flow can prompt to **delete an orphaned worktree** when archiving the last thread on that worktree.
> 
> **Shared**  
> - New `@t3tools/shared/jira` helpers (validation, URLs, branch naming).  
> - Default worktree temp branch prefix renamed from `t3code` to **`empcode`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ed568300b3b16125d0b052afac7e38f9108d6f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Jira key management to threads with branch-rename support and fork migration tracking
> - Introduces full Jira key CRUD for threads via new WebSocket RPCs (`jira.setThreadJiraKey`, `jira.listThreadJiraKeys`) wired through [`ForkJiraWsRpcLayer`](https://github.com/pingdotgg/t3code/pull/3529/files#diff-12713096b506568a2de47ce4707c2477a2c81a4b4fb672f6120111e39385abd2) and backed by a new [`projection_thread_jira`](https://github.com/pingdotgg/t3code/pull/3529/files#diff-329753a14bcbdda05b60bd2022094480cd88266c047acbb07039d417181f5c41) SQL table.
> - Adds a [`BranchToolbarJiraKeyControl`](https://github.com/pingdotgg/t3code/pull/3529/files#diff-9caaedd122c5daa516bcda828dfe2d97c2e5510ecc934c89f8bf9cac57b1d801) UI component to set/clear a thread's Jira key, with optional branch renaming (auto or confirm) based on [`resolveJiraKeySavePlan`](https://github.com/pingdotgg/t3code/pull/3529/files#diff-f4ab589321de486e1cf9b59ebf91b8d84799e72f2e1b4307e4580a3f1b7bf595) logic and a guardrail preventing key assignment on main/master outside worktrees.
> - Adds a [`JiraTicketButton`](https://github.com/pingdotgg/t3code/pull/3529/files#diff-f2e4107d7010e7c99231bad28502ebeebba3470259506055ffefea1657daec14) to the chat header linking to the thread's Jira ticket or the create-issue page when no key is set; hidden if no Jira domain is configured.
> - Introduces fork-owned migration infrastructure via [`ForkMigrations`](https://github.com/pingdotgg/t3code/pull/3529/files#diff-87aae589e23894b1e1ea0ec9082a729797f91f43f577d44cd178bb87af9e5ba4) using a separate `fork_migrations` tracking table so upstream `effect_sql_migrations` is unaffected.
> - Adds Jira helper utilities in [`packages/shared/src/jira.ts`](https://github.com/pingdotgg/t3code/pull/3529/files#diff-348bb4f53bd778cf396eb7b1319a08a94c8debef5418a9b7e14f33d680b2f62c) covering domain/key normalization, branch naming, URL building, and validation.
> - Behavioral Change: `WORKTREE_BRANCH_PREFIX` is renamed from `"t3code"` to `"empcode"`, changing which branches are recognized as temporary worktree branches.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7ed5683. 26 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->