### PR TITLE
Add Create PR base branch selector

### DIFF
--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -607,6 +607,8 @@ function runStackedAction(
     actionId?: string;
     commitMessage?: string;
     featureBranch?: boolean;
+    baseBranch?: string;
+    rememberBaseBranch?: boolean;
     filePaths?: readonly string[];
   },
   options?: Parameters<GitManager.GitManager["Service"]["runStackedAction"]>[1],
@@ -615,6 +617,8 @@ function runStackedAction(
     {
       ...input,
       actionId: input.actionId ?? "test-action-id",
+      ...(input.baseBranch ? { baseBranch: input.baseBranch } : {}),
+      ...(input.rememberBaseBranch ? { rememberBaseBranch: true } : {}),
     },
     options,
   );
@@ -2230,6 +2234,107 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
         ghCalls.some((call) => call.includes("pr create --base main --head feature-create-pr")),
       ).toBe(true);
       expect(ghCalls.some((call) => call.startsWith("pr view "))).toBe(false);
+    }),
+  );
+
+  it.effect("create_pr uses an explicitly selected base branch", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["branch", "dev"]);
+      yield* runGit(repoDir, ["push", "origin", "dev"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature-selected-pr-base"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "selected-pr-base.txt"), "change\n");
+      yield* runGit(repoDir, ["add", "selected-pr-base.txt"]);
+      yield* runGit(repoDir, ["commit", "-m", "Feature commit"]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature-selected-pr-base"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          defaultBranch: "main",
+          prListSequence: [
+            "[]",
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 89,
+                title: "Add selected PR base",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/89",
+                baseRefName: "dev",
+                headRefName: "feature-selected-pr-base",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "create_pr",
+        baseBranch: "dev",
+      });
+
+      expect(result.pr.status).toBe("created");
+      expect(result.pr.baseBranch).toBe("dev");
+      expect(
+        ghCalls.some((call) =>
+          call.includes("pr create --base dev --head feature-selected-pr-base"),
+        ),
+      ).toBe(true);
+    }),
+  );
+
+  it.effect("create_pr can remember the selected base branch for the repository", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const remoteDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "origin", remoteDir]);
+      yield* runGit(repoDir, ["branch", "dev"]);
+      yield* runGit(repoDir, ["push", "origin", "dev"]);
+      yield* runGit(repoDir, ["checkout", "-b", "feature-remember-pr-base"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "remember-pr-base.txt"), "change\n");
+      yield* runGit(repoDir, ["add", "remember-pr-base.txt"]);
+      yield* runGit(repoDir, ["commit", "-m", "Feature commit"]);
+      yield* runGit(repoDir, ["push", "-u", "origin", "feature-remember-pr-base"]);
+
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          defaultBranch: "main",
+          prListSequence: [
+            "[]",
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 90,
+                title: "Remember selected PR base",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/90",
+                baseRefName: "dev",
+                headRefName: "feature-remember-pr-base",
+              },
+            ]),
+          ],
+        },
+      });
+
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "create_pr",
+        baseBranch: "dev",
+        rememberBaseBranch: true,
+      });
+
+      expect(result.pr.status).toBe("created");
+      expect(result.pr.baseBranch).toBe("dev");
+      const remembered = yield* runGit(repoDir, ["config", "--get", "t3code.default-pr-base"]);
+      expect(remembered.stdout.trim()).toBe("dev");
+      expect(
+        ghCalls.some((call) =>
+          call.includes("pr create --base dev --head feature-remember-pr-base"),
+        ),
+      ).toBe(true);
     }),
   );
 

--- a/apps/server/src/git/GitManager.ts
+++ b/apps/server/src/git/GitManager.ts
@@ -1091,9 +1091,15 @@ export const make = Effect.gen(function* () {
     branch: string,
     upstreamRef: string | null,
     headContext: Pick<BranchHeadContext, "isCrossRepository" | "remoteName">,
+    explicitBaseBranch?: string,
   ) {
+    if (explicitBaseBranch) return explicitBaseBranch;
+
     const configured = yield* gitCore.readConfigValue(cwd, `branch.${branch}.gh-merge-base`);
     if (configured) return configured;
+
+    const repoDefault = yield* gitCore.readConfigValue(cwd, "t3code.default-pr-base");
+    if (repoDefault) return repoDefault;
 
     if (upstreamRef && !headContext.isCrossRepository) {
       const upstreamBranch = extractBranchNameFromRemoteRef(upstreamRef, {
@@ -1301,6 +1307,10 @@ export const make = Effect.gen(function* () {
     cwd: string,
     fallbackBranch: string | null,
     emit: GitActionProgressEmitter,
+    options?: {
+      readonly baseBranch?: string;
+      readonly rememberBaseBranch?: boolean;
+    },
   ) {
     const provider = yield* sourceControlProvider(cwd);
     const terms = getChangeRequestTerminologyForKind(provider.kind);
@@ -1338,7 +1348,16 @@ export const make = Effect.gen(function* () {
       };
     }
 
-    const baseBranch = yield* resolveBaseBranch(cwd, branch, details.upstreamRef, headContext);
+    const baseBranch = yield* resolveBaseBranch(
+      cwd,
+      branch,
+      details.upstreamRef,
+      headContext,
+      options?.baseBranch,
+    );
+    if (options?.rememberBaseBranch === true) {
+      yield* gitCore.setConfigValue(cwd, "t3code.default-pr-base", baseBranch);
+    }
     yield* emit({
       kind: "phase_started",
       phase: "pr",
@@ -1815,7 +1834,10 @@ export const make = Effect.gen(function* () {
               .pipe(
                 Effect.tap(() => Ref.set(currentPhase, Option.some("pr"))),
                 Effect.flatMap(() =>
-                  runPrStep(modelSelection, input.cwd, currentBranch, progress.emit),
+                  runPrStep(modelSelection, input.cwd, currentBranch, progress.emit, {
+                    ...(input.baseBranch ? { baseBranch: input.baseBranch } : {}),
+                    ...(input.rememberBaseBranch ? { rememberBaseBranch: true } : {}),
+                  }),
                 ),
               )
           : { status: "skipped_not_requested" as const };

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -225,6 +225,11 @@ export class GitVcsDriver extends Context.Service<
       cwd: string,
       key: string,
     ) => Effect.Effect<string | null, GitCommandError>;
+    readonly setConfigValue: (
+      cwd: string,
+      key: string,
+      value: string,
+    ) => Effect.Effect<void, GitCommandError>;
     readonly listRefs: (
       input: VcsListRefsInput,
     ) => Effect.Effect<VcsListRefsResult, GitCommandError>;

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -1980,6 +1980,12 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       Effect.map((trimmed) => (trimmed.length > 0 ? trimmed : null)),
     );
 
+  const setConfigValue: GitVcsDriver.GitVcsDriver["Service"]["setConfigValue"] = (
+    cwd,
+    key,
+    value,
+  ) => runGit("GitVcsDriver.setConfigValue", cwd, ["config", key, value]);
+
   const listRefs: GitVcsDriver.GitVcsDriver["Service"]["listRefs"] = Effect.fn("listRefs")(
     function* (input) {
       const branchRecencyPromise = readBranchRecency(input.cwd).pipe(
@@ -2542,6 +2548,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     readRangeContext,
     getReviewDiffPreview,
     readConfigValue,
+    setConfigValue,
     listRefs,
     createWorktree,
     fetchPullRequestBranch,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -65,6 +65,13 @@ import { Input } from "~/components/ui/input";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { Popover, PopoverPopup, PopoverTrigger } from "~/components/ui/popover";
 import { ScrollArea } from "~/components/ui/scroll-area";
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 import { Textarea } from "~/components/ui/textarea";
 import { stackedThreadToast, toastManager, type ThreadToastData } from "~/components/ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
@@ -131,6 +138,8 @@ interface RunGitActionWithToastInput {
   skipDefaultBranchPrompt?: boolean;
   statusOverride?: VcsStatusResult | null;
   featureBranch?: boolean;
+  baseBranch?: string;
+  rememberBaseBranch?: boolean;
   progressToastId?: GitActionToastId;
   filePaths?: string[];
 }
@@ -999,6 +1008,12 @@ export default function GitActionsControl({
   const [excludedFiles, setExcludedFiles] = useState<ReadonlySet<string>>(new Set());
   const [isEditingFiles, setIsEditingFiles] = useState(false);
   const [isPublishDialogOpen, setIsPublishDialogOpen] = useState(false);
+  const [isCreatePrDialogOpen, setIsCreatePrDialogOpen] = useState(false);
+  const [createPrDialogAction, setCreatePrDialogAction] = useState<"create_pr" | "commit_push_pr">(
+    "create_pr",
+  );
+  const [selectedPrBaseBranch, setSelectedPrBaseBranch] = useState("");
+  const [rememberPrBaseBranch, setRememberPrBaseBranch] = useState(false);
   const [pendingDefaultBranchAction, setPendingDefaultBranchAction] =
     useState<PendingDefaultBranchAction | null>(null);
   const activeGitActionProgressRef = useRef<ActiveGitActionProgress | null>(null);
@@ -1099,6 +1114,40 @@ export default function GitActionsControl({
   const isRepo = gitStatus?.isRepo ?? true;
   const hasPrimaryRemote = gitStatus?.hasPrimaryRemote ?? false;
   const gitStatusForActions = gitStatus;
+  const remoteBranchesQuery = useEnvironmentQuery(
+    activeEnvironmentId !== null && gitCwd !== null && hasPrimaryRemote
+      ? vcsEnvironment.listRefs({
+          environmentId: activeEnvironmentId,
+          input: {
+            cwd: gitCwd,
+            includeMatchingRemoteRefs: true,
+            refKind: "remote",
+            limit: 200,
+          },
+        })
+      : null,
+  );
+  const remoteBaseBranches = useMemo(() => {
+    const refs = remoteBranchesQuery.data?.refs ?? [];
+    const names = new Set<string>();
+    for (const ref of refs) {
+      if (!ref.isRemote || ref.remoteName !== "origin") {
+        continue;
+      }
+      const branchName = ref.name.startsWith("origin/")
+        ? ref.name.slice("origin/".length)
+        : ref.name;
+      if (branchName.length > 0 && branchName !== "HEAD") {
+        names.add(branchName);
+      }
+    }
+    return [...names].toSorted((left, right) => {
+      const score = (value: string) =>
+        value === "dev" ? 0 : value === "main" ? 1 : value === "master" ? 2 : 3;
+      const scoreDelta = score(left) - score(right);
+      return scoreDelta === 0 ? left.localeCompare(right) : scoreDelta;
+    });
+  }, [remoteBranchesQuery.data?.refs]);
 
   const allFiles = gitStatusForActions?.workingTree.files ?? [];
   const selectedFiles = allFiles.filter((f) => !excludedFiles.has(f.path));
@@ -1243,6 +1292,32 @@ export default function GitActionsControl({
     });
   }, [gitStatusForActions, threadToastData]);
 
+  const openCreatePrDialog = useCallback(
+    (action: "create_pr" | "commit_push_pr") => {
+      const fallbackBranch =
+        selectedPrBaseBranch ||
+        remoteBaseBranches.find((branch) => branch === "dev") ||
+        remoteBaseBranches.find((branch) => branch === "main") ||
+        remoteBaseBranches[0] ||
+        "";
+      setCreatePrDialogAction(action);
+      setSelectedPrBaseBranch(fallbackBranch);
+      setRememberPrBaseBranch(false);
+      setIsCreatePrDialogOpen(true);
+    },
+    [remoteBaseBranches, selectedPrBaseBranch],
+  );
+
+  const runCreatePrFromDialog = () => {
+    const baseBranch = selectedPrBaseBranch.trim();
+    setIsCreatePrDialogOpen(false);
+    void runGitActionWithToast({
+      action: createPrDialogAction,
+      ...(baseBranch ? { baseBranch } : {}),
+      ...(rememberPrBaseBranch ? { rememberBaseBranch: true } : {}),
+    });
+  };
+
   runGitActionWithToast = useEffectEvent(
     async ({
       action,
@@ -1253,6 +1328,8 @@ export default function GitActionsControl({
       featureBranch = false,
       progressToastId,
       filePaths,
+      baseBranch,
+      rememberBaseBranch,
     }: RunGitActionWithToastInput) => {
       const actionStatus = statusOverride ?? gitStatusForActions;
       const actionBranch = actionStatus?.refName ?? null;
@@ -1392,6 +1469,8 @@ export default function GitActionsControl({
         action,
         ...(commitMessage ? { commitMessage } : {}),
         ...(featureBranch ? { featureBranch } : {}),
+        ...(baseBranch ? { baseBranch } : {}),
+        ...(rememberBaseBranch ? { rememberBaseBranch } : {}),
         ...(filePaths ? { filePaths } : {}),
         onProgress: applyProgressEvent,
       });
@@ -1582,6 +1661,10 @@ export default function GitActionsControl({
       return;
     }
     if (quickAction.action) {
+      if (quickAction.action === "create_pr" || quickAction.action === "commit_push_pr") {
+        openCreatePrDialog(quickAction.action);
+        return;
+      }
       void runGitActionWithToast({ action: quickAction.action });
     }
   };
@@ -1597,7 +1680,7 @@ export default function GitActionsControl({
       return;
     }
     if (item.dialogAction === "create_pr") {
-      void runGitActionWithToast({ action: "create_pr" });
+      openCreatePrDialog("create_pr");
       return;
     }
     setExcludedFiles(new Set());
@@ -1814,6 +1897,79 @@ export default function GitActionsControl({
           </Menu>
         </Group>
       )}
+
+      <Dialog
+        open={isCreatePrDialogOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setIsCreatePrDialogOpen(false);
+          }
+        }}
+      >
+        <DialogPopup>
+          <DialogHeader>
+            <DialogTitle>{changeRequestTerminology.shortLabel}</DialogTitle>
+            <DialogDescription>
+              Choose the target branch for this {changeRequestTerminology.singular}.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-xs font-medium text-foreground" htmlFor="create-pr-base">
+                Create {changeRequestTerminology.shortLabel} to
+              </label>
+              <Select
+                value={selectedPrBaseBranch}
+                onValueChange={(value) => {
+                  if (value !== null) {
+                    setSelectedPrBaseBranch(value);
+                  }
+                }}
+              >
+                <SelectTrigger
+                  id="create-pr-base"
+                  className="w-full"
+                  aria-label={`${changeRequestTerminology.shortLabel} base branch`}
+                >
+                  <SelectValue>{selectedPrBaseBranch || "Select origin branch"}</SelectValue>
+                </SelectTrigger>
+                <SelectPopup alignItemWithTrigger={false}>
+                  {remoteBaseBranches.map((branch) => (
+                    <SelectItem key={branch} value={branch}>
+                      {branch}
+                    </SelectItem>
+                  ))}
+                </SelectPopup>
+              </Select>
+              {remoteBranchesQuery.isPending ? (
+                <p className="text-xs text-muted-foreground">Loading origin branches...</p>
+              ) : remoteBaseBranches.length === 0 ? (
+                <p className="text-xs text-warning">No origin branches were found.</p>
+              ) : null}
+            </div>
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <Checkbox
+                checked={rememberPrBaseBranch}
+                onCheckedChange={(checked) => setRememberPrBaseBranch(Boolean(checked))}
+                aria-label={`Use selected ${changeRequestTerminology.shortLabel} base as the default for this repo`}
+              />
+              Use as default for this repo
+            </label>
+          </DialogPanel>
+          <DialogFooter>
+            <Button variant="outline" size="sm" onClick={() => setIsCreatePrDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={runCreatePrFromDialog}
+              disabled={!selectedPrBaseBranch.trim() || remoteBaseBranches.length === 0}
+            >
+              Create {changeRequestTerminology.shortLabel}
+            </Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
 
       <Dialog
         open={isCommitDialogOpen}

--- a/apps/web/src/state/sourceControlActions.ts
+++ b/apps/web/src/state/sourceControlActions.ts
@@ -217,6 +217,8 @@ export function useGitStackedAction(scope: SourceControlActionScope) {
       action: GitStackedAction;
       commitMessage?: string;
       featureBranch?: boolean;
+      baseBranch?: string;
+      rememberBaseBranch?: boolean;
       filePaths?: string[];
       onProgress?: (event: GitActionProgressEvent) => void;
     }) => {
@@ -236,6 +238,8 @@ export function useGitStackedAction(scope: SourceControlActionScope) {
         action: input.action,
         ...(input.commitMessage ? { commitMessage: input.commitMessage } : {}),
         ...(input.featureBranch ? { featureBranch: true } : {}),
+        ...(input.baseBranch ? { baseBranch: input.baseBranch } : {}),
+        ...(input.rememberBaseBranch ? { rememberBaseBranch: true } : {}),
         ...(input.filePaths?.length ? { filePaths: input.filePaths } : {}),
         ...(input.onProgress ? { onProgress: input.onProgress } : {}),
       });

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -73,6 +73,8 @@ export interface RunVcsStackedActionInput {
   readonly action: GitStackedAction;
   readonly commitMessage?: string;
   readonly featureBranch?: boolean;
+  readonly baseBranch?: string;
+  readonly rememberBaseBranch?: boolean;
   readonly filePaths?: ReadonlyArray<string>;
   readonly onProgress?: (event: GitActionProgressEvent) => void;
 }
@@ -462,6 +464,8 @@ export function createVcsActionManager<R, E>(
           action: input.action,
           ...(input.commitMessage ? { commitMessage: input.commitMessage } : {}),
           ...(input.featureBranch ? { featureBranch: true } : {}),
+          ...(input.baseBranch ? { baseBranch: input.baseBranch } : {}),
+          ...(input.rememberBaseBranch ? { rememberBaseBranch: true } : {}),
           ...(input.filePaths?.length ? { filePaths: [...input.filePaths] } : {}),
         };
         return consumeVcsActionProgress(

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -115,6 +115,8 @@ export const GitRunStackedActionInput = Schema.Struct({
   action: GitStackedAction,
   commitMessage: Schema.optional(TrimmedNonEmptyStringSchema.check(Schema.isMaxLength(10_000))),
   featureBranch: Schema.optional(Schema.Boolean),
+  baseBranch: Schema.optional(TrimmedNonEmptyStringSchema),
+  rememberBaseBranch: Schema.optional(Schema.Boolean),
   filePaths: Schema.optional(
     Schema.Array(TrimmedNonEmptyStringSchema).check(Schema.isMinLength(1)),
   ),


### PR DESCRIPTION
## Summary
- add optional PR base branch fields to the stacked git action RPC
- show a Create PR target-branch selector populated from origin branches
- allow the selected base branch to be saved as a repo-local default via git config

## Notes
- preserves branch.<current-branch>.gh-merge-base as the first fallback when no explicit base is selected
- remembered repo defaults are stored in local git config as t3code.default-pr-base, not global app settings

## Test plan
- corepack pnpm exec vp test apps/server/src/git/GitManager.test.ts packages/contracts/src/git.test.ts packages/client-runtime/src/state/vcsAction.test.ts apps/web/src/components/GitActionsControl.logic.test.ts
- corepack pnpm run typecheck
- corepack pnpm exec vp fmt --check packages/contracts/src/git.ts packages/client-runtime/src/state/vcsAction.ts apps/web/src/state/sourceControlActions.ts apps/web/src/components/GitActionsControl.tsx apps/server/src/vcs/GitVcsDriver.ts apps/server/src/vcs/GitVcsDriverCore.ts apps/server/src/git/GitManager.ts apps/server/src/git/GitManager.test.ts
- corepack pnpm run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR creation base resolution and writes local git config; wrong base or config could target the wrong merge branch, but scope is limited to PR flows with tests.
> 
> **Overview**
> **Create PR** and **commit/push/PR** no longer run immediately with an inferred base; they open a dialog to pick the target branch from `origin` remotes (with `dev` / `main` favored in the list).
> 
> The stacked git action path gains optional `baseBranch` and `rememberBaseBranch` on the RPC/contracts/client stack. **GitManager** uses an explicit base when provided, otherwise falls back through `branch.*.gh-merge-base`, then new repo-local `t3code.default-pr-base`, then existing upstream/provider logic. **Remember** persists the choice via new `setConfigValue` on the git VCS driver.
> 
> Server tests cover explicit base and remembered config; the web control wires menu/quick actions through the dialog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e11de956d1a68567f3c6a07251cccb70f2a9fa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add base branch selector to the Create PR flow
> - Adds a dialog in [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/3538/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) that prompts users to select a base branch (populated from origin branches) before creating a PR via `create_pr` or `commit_push_pr` actions.
> - Adds an opt-in checkbox to persist the selected branch as the repository default, stored under the `t3code.default-pr-base` git config key.
> - Threads `baseBranch` and `rememberBaseBranch` through the full stack: RPC contract, client runtime, server action, and `GitManager.resolveBaseBranch`.
> - `resolveBaseBranch` now checks the caller-supplied branch first, then `t3code.default-pr-base`, then falls back to existing heuristics.
> - Adds `setConfigValue` to `GitVcsDriver` and `GitVcsDriverCore` to write git config values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0e11de9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->