### PR TITLE
Restore right panel inset when maximized

### DIFF
--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -347,7 +347,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           "workspace-topbar gap-1 pl-2",
           props.mode === "inline" ? "pr-28" : "pr-3",
           ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
-          ownsDesktopTitleBar && props.maximized && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
+          props.mode === "inline" && props.maximized && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
         )}
         data-right-panel-tabbar
       >

--- a/apps/web/src/components/RightPanelTabs.tsx
+++ b/apps/web/src/components/RightPanelTabs.tsx
@@ -20,6 +20,7 @@ import { Menu, MenuItem, MenuPopup, MenuTrigger } from "~/components/ui/menu";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { faviconUrlForOrigin } from "~/lib/favicon";
 import { useTheme } from "~/hooks/useTheme";
+import { COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS } from "~/workspaceTitlebar";
 
 import { PreviewPanelShell, type PreviewPanelMode } from "./preview/PreviewPanelShell";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
@@ -346,6 +347,7 @@ export function RightPanelTabs(props: RightPanelTabsProps) {
           "workspace-topbar gap-1 pl-2",
           props.mode === "inline" ? "pr-28" : "pr-3",
           ownsDesktopTitleBar && "wco:pr-[calc(var(--workspace-native-controls-inset)+6rem)]",
+          ownsDesktopTitleBar && props.maximized && COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS,
         )}
         data-right-panel-tabbar
       >


### PR DESCRIPTION
## Summary
- Restores the right panel tab bar inset when the workspace is maximized.
- Reuses the collapsed sidebar titlebar inset class so native controls and right-panel traffic no longer overlap.

## Testing
- Not run (PR content only; no code changes made in this step).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional CSS class on the right panel top bar; no auth, data, or API changes.
> 
> **Overview**
> Restores correct **left padding** on the right panel tab bar when the inline panel is **maximized** in the desktop app, so tabs no longer sit under the collapsed-sidebar / native titlebar region.
> 
> `RightPanelTabs` now applies the shared `COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS` (already used on the main chat and empty-thread headers) only when `mode === "inline"` and `maximized` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c76fccac45e12596eb87323ee994d56dc384192. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore right panel inset styling when maximized in inline mode
> In [RightPanelTabs.tsx](https://github.com/pingdotgg/t3code/pull/3555/files#diff-1580fd0e52935869fd626dd71bcb2484b765e9b216e92c55d09960e870986b91), the topbar div now conditionally applies `COLLAPSED_SIDEBAR_TITLEBAR_INSET_CLASS` when the panel is in inline mode and maximized, restoring the correct inset appearance under those conditions.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c76fcc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->