### PR TITLE
[codex] Fix Claude auth probe fallback

### DIFF
--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -3,8 +3,10 @@ import {
   type ModelCapabilities,
   type ModelSelection,
   ProviderDriverKind,
+  type ServerProviderAuth,
   type ServerProviderModel,
   type ServerProviderSlashCommand,
+  type ServerProviderState,
 } from "@t3tools/contracts";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
@@ -30,11 +32,14 @@ import {
   buildBooleanOptionDescriptor,
   buildSelectOptionDescriptor,
   buildServerProvider,
+  AUTH_PROBE_TIMEOUT_MS,
   DEFAULT_TIMEOUT_MS,
+  extractAuthBoolean,
   isCommandMissingCause,
   parseGenericCliVersion,
   providerModelsFromSettings,
   spawnAndCollect,
+  type CommandResult,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
 import { makeClaudeEnvironment } from "../Drivers/ClaudeHome.ts";
@@ -444,6 +449,81 @@ function claudeAuthMetadata(input: {
   return undefined;
 }
 
+function parseClaudeAuthStatusFromOutput(result: CommandResult): {
+  readonly status: Exclude<ServerProviderState, "disabled">;
+  readonly auth: Pick<ServerProviderAuth, "status">;
+  readonly message?: string;
+} {
+  const lowerOutput = `${result.stdout}\n${result.stderr}`.toLowerCase();
+
+  if (
+    lowerOutput.includes("unknown command") ||
+    lowerOutput.includes("unrecognized command") ||
+    lowerOutput.includes("unexpected argument")
+  ) {
+    return {
+      status: "warning",
+      auth: { status: "unknown" },
+      message:
+        "Claude Agent authentication status command is unavailable in this version of Claude.",
+    };
+  }
+
+  if (
+    lowerOutput.includes("not logged in") ||
+    lowerOutput.includes("login required") ||
+    lowerOutput.includes("authentication required") ||
+    lowerOutput.includes("run `claude login`") ||
+    lowerOutput.includes("run claude login")
+  ) {
+    return {
+      status: "error",
+      auth: { status: "unauthenticated" },
+      message: "Claude is not authenticated. Run `claude auth login` and try again.",
+    };
+  }
+
+  const trimmedStdout = result.stdout.trim();
+  let parsedAuth: boolean | undefined;
+  let parsedJson = false;
+  if (trimmedStdout.startsWith("{") || trimmedStdout.startsWith("[")) {
+    try {
+      parsedAuth = extractAuthBoolean(JSON.parse(trimmedStdout) as unknown);
+      parsedJson = true;
+    } catch {
+      // Fall through to the command exit status for non-JSON output.
+    }
+  }
+
+  if (parsedAuth === true) {
+    return { status: "ready", auth: { status: "authenticated" } };
+  }
+  if (parsedAuth === false) {
+    return {
+      status: "error",
+      auth: { status: "unauthenticated" },
+      message: "Claude is not authenticated. Run `claude auth login` and try again.",
+    };
+  }
+  if (parsedJson) {
+    return {
+      status: "warning",
+      auth: { status: "unknown" },
+      message:
+        "Could not verify Claude authentication status from JSON output (missing auth marker).",
+    };
+  }
+  if (result.code === 0) {
+    return { status: "ready", auth: { status: "authenticated" } };
+  }
+
+  return {
+    status: "warning",
+    auth: { status: "unknown" },
+    message: "Could not verify Claude authentication status.",
+  };
+}
+
 // ── SDK capability probe ────────────────────────────────────────────
 
 const CAPABILITIES_PROBE_TIMEOUT_MS = 8_000;
@@ -741,6 +821,34 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
   const dedupedSlashCommands = dedupeSlashCommands(slashCommands);
 
   if (!capabilities) {
+    const authProbe = yield* runClaudeCommand(
+      claudeSettings,
+      ["auth", "status"],
+      resolvedEnvironment,
+    ).pipe(Effect.timeoutOption(AUTH_PROBE_TIMEOUT_MS), Effect.result);
+
+    if (Result.isSuccess(authProbe) && Option.isSome(authProbe.success)) {
+      const parsedAuth = parseClaudeAuthStatusFromOutput(authProbe.success.value);
+      return buildServerProvider({
+        presentation: CLAUDE_PRESENTATION,
+        enabled: claudeSettings.enabled,
+        checkedAt,
+        models,
+        slashCommands: dedupedSlashCommands,
+        probe: {
+          installed: true,
+          version: parsedVersion,
+          status: parsedAuth.status,
+          auth: parsedAuth.auth,
+          ...(parsedAuth.message
+            ? { message: parsedAuth.message }
+            : versionUpgradeMessage
+              ? { message: versionUpgradeMessage }
+              : {}),
+        },
+      });
+    }
+
     return buildServerProvider({
       presentation: CLAUDE_PRESENTATION,
       enabled: claudeSettings.enabled,
@@ -752,7 +860,10 @@ export const checkClaudeProviderStatus = Effect.fn("checkClaudeProviderStatus")(
         version: parsedVersion,
         status: "warning",
         auth: { status: "unknown" },
-        message: "Could not verify Claude authentication status from initialization result.",
+        message:
+          Result.isSuccess(authProbe) && Option.isNone(authProbe.success)
+            ? "Could not verify Claude authentication status. Timed out while running command."
+            : "Could not verify Claude authentication status.",
       },
     });
   }

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1902,18 +1902,44 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
         );
       });
 
-      it.effect("returns warning when the Claude initialization result is unavailable", () =>
+      it.effect("falls back to CLI auth when the Claude initialization result is unavailable", () =>
         Effect.gen(function* () {
           const status = yield* checkClaudeProviderStatus(
             defaultClaudeSettings,
             noClaudeCapabilities,
           );
-          assert.strictEqual(status.status, "warning");
+          assert.strictEqual(status.status, "ready");
           assert.strictEqual(status.installed, true);
-          assert.strictEqual(status.auth.status, "unknown");
+          assert.strictEqual(status.auth.status, "authenticated");
+        }).pipe(
+          Effect.provide(
+            mockSpawnerLayer((args) => {
+              const joined = args.join(" ");
+              if (joined === "--version") return { stdout: "1.0.0\n", stderr: "", code: 0 };
+              if (joined === "auth status")
+                return {
+                  stdout: '{"loggedIn":true,"authMethod":"third_party","apiProvider":"bedrock"}\n',
+                  stderr: "",
+                  code: 0,
+                };
+              throw new Error(`Unexpected args: ${joined}`);
+            }),
+          ),
+        ),
+      );
+
+      it.effect("returns unauthenticated when the CLI auth fallback reports logged out", () =>
+        Effect.gen(function* () {
+          const status = yield* checkClaudeProviderStatus(
+            defaultClaudeSettings,
+            noClaudeCapabilities,
+          );
+          assert.strictEqual(status.status, "error");
+          assert.strictEqual(status.installed, true);
+          assert.strictEqual(status.auth.status, "unauthenticated");
           assert.strictEqual(
             status.message,
-            "Could not verify Claude authentication status from initialization result.",
+            "Claude is not authenticated. Run `claude auth login` and try again.",
           );
         }).pipe(
           Effect.provide(


### PR DESCRIPTION
## What Changed

- Fall back to `claude auth status` when the Claude Agent SDK initialization probe is unavailable.
- Preserve explicit logged-out detection and existing version advisories in the fallback path.
- Add regression coverage for authenticated third-party/Bedrock sessions and logged-out sessions.

## Why

The SDK initialization probe supplies optional account and slash-command metadata, but its failure was also being treated as an authentication failure. That put otherwise working OAuth/Max and third-party Claude installations into the non-selectable “Limited” state.

The CLI auth status is an independent, authoritative fallback, so a missing initialization result no longer disables an authenticated provider.

Fixes #2653.

## Validation

- `vp test apps/server/src/provider/Layers/ProviderRegistry.test.ts`
- `vp check`
- `vp run typecheck`

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] No UI changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude auth probe fallback to parse `claude auth status` CLI output
> - Previously, `ClaudeProvider.checkClaudeProviderStatus` returned a generic warning with unknown auth when capabilities were unavailable. Now it runs `claude auth status` as a fallback and parses the result.
> - Adds `parseClaudeAuthStatusFromOutput` in [ClaudeProvider.ts](https://github.com/pingdotgg/t3code/pull/3559/files#diff-e02234c11270ac47a7034404a1d2c663a776f6f2847a6361aae778bc850a34d3) to normalize CLI stdout/stderr/exit-code into `ready/authenticated`, `error/unauthenticated`, or `warning/unknown` states with context-specific messages.
> - Auth probe is bounded by `AUTH_PROBE_TIMEOUT_MS`; timeouts produce a warning with an explicit timeout message rather than a generic failure.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b1a7386.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Claude provider selectability is determined from auth probes; incorrect parsing could mislabel working sessions as limited, but scope is limited to status checking with new regression tests.
> 
> **Overview**
> When the Claude Agent SDK initialization probe does not return capabilities, **provider status no longer treats that as an auth failure**. `checkClaudeProviderStatus` now runs **`claude auth status`** (with `AUTH_PROBE_TIMEOUT_MS`) and maps the result to ready/authenticated, error/unauthenticated, or warning/unknown.
> 
> Adds **`parseClaudeAuthStatusFromOutput`** to interpret CLI stdout/stderr (unknown command, login prompts, JSON via `extractAuthBoolean`, exit code). Timeouts get an explicit timeout message instead of a generic warning.
> 
> Tests cover **authenticated third-party/Bedrock** JSON and **logged-out** CLI responses when capabilities are unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1a7386972f78d0a49df1fab4a8abc3a30f1c0fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->