### PR TITLE
[codex] Fix preview automation edge cases

### DIFF
--- a/apps/desktop/src/preview/Manager.test.ts
+++ b/apps/desktop/src/preview/Manager.test.ts
@@ -1,4 +1,5 @@
 import { it as effectIt } from "@effect/vitest";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
@@ -91,6 +92,7 @@ const layer = PreviewManager.layer.pipe(
   Layer.provideMerge(environmentLayer),
   Layer.provideMerge(fileSystemLayer),
   Layer.provideMerge(Path.layer),
+  Layer.provideMerge(Layer.succeed(HostProcessPlatform, "linux")),
 );
 const encodePreviewManagerError = Schema.encodeSync(PreviewManager.PreviewManagerError);
 

--- a/apps/desktop/src/preview/Manager.ts
+++ b/apps/desktop/src/preview/Manager.ts
@@ -25,6 +25,7 @@ import type {
   PreviewAutomationTypeInput,
   PreviewAutomationWaitForInput,
 } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { normalizePreviewUrl } from "@t3tools/shared/preview";
 import {
   type BrowserWindow,
@@ -379,6 +380,7 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
   artifactDirectory: string,
 ) {
   const fileSystem = yield* FileSystem.FileSystem;
+  const hostPlatform = yield* HostProcessPlatform;
   const path = yield* Path.Path;
   const parentScope = yield* Scope.Scope;
   const context = yield* Effect.context<never>();
@@ -2226,7 +2228,9 @@ const makeNativeOperations = Effect.fn("PreviewManager.makeOperations")(function
     sendCleanup: SendCommand,
   ) {
     yield* prepareAutomationInput(send, false);
-    const keySequence = makePreviewAutomationKeySequence(input);
+    const keySequence = makePreviewAutomationKeySequence(input, {
+      isMac: hostPlatform === "darwin",
+    });
     const previouslyFocused = yield* attempt(
       { operation: "automationPress.getFocusedWebContents", tabId, webContentsId: wc.id },
       () => webContents.getFocusedWebContents(),

--- a/apps/desktop/src/preview/PreviewKeyboard.test.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.test.ts
@@ -42,7 +42,9 @@ describe("preview keyboard packets", () => {
   });
 
   it("suppresses text and uses raw key-down for shortcuts", () => {
-    expect(makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }).keyDown).toEqual({
+    expect(
+      makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }, { isMac: true }).keyDown,
+    ).toEqual({
       type: "rawKeyDown",
       key: "a",
       code: "KeyA",
@@ -50,7 +52,18 @@ describe("preview keyboard packets", () => {
       windowsVirtualKeyCode: 65,
       location: 0,
       isKeypad: false,
+      commands: ["selectAll"],
     });
+  });
+
+  it("maps common macOS editing shortcuts without changing other platforms", () => {
+    expect(
+      makePreviewAutomationKeySequence({ key: "z", modifiers: ["Shift", "Meta"] }, { isMac: true })
+        .keyDown.commands,
+    ).toEqual(["redo"]);
+    expect(
+      makePreviewAutomationKeySequence({ key: "a", modifiers: ["Meta"] }).keyDown,
+    ).not.toHaveProperty("commands");
   });
 
   it("resolves shifted printable keys to their browser values", () => {

--- a/apps/desktop/src/preview/PreviewKeyboard.ts
+++ b/apps/desktop/src/preview/PreviewKeyboard.ts
@@ -20,6 +20,7 @@ export interface PreviewAutomationKeyEvent {
   readonly isKeypad: boolean;
   readonly text?: string;
   readonly unmodifiedText?: string;
+  readonly commands?: ReadonlyArray<string>;
 }
 
 export interface PreviewAutomationKeySequence {
@@ -79,6 +80,42 @@ const PRINTABLE_KEYS: ReadonlyArray<KeyDefinition> = [
   { code: "Slash", key: "/", shiftedKey: "?", keyCode: 191 },
 ];
 
+/**
+ * Chromium does not infer macOS editing commands from synthetic Meta chords.
+ * Keep the common browser editing/navigation shortcuts explicit so dispatched
+ * key events behave like their physical-key equivalents.
+ */
+const MAC_EDITING_COMMANDS: Readonly<Record<string, string>> = {
+  "Meta+Backspace": "deleteToBeginningOfLine",
+  "Meta+ArrowUp": "moveToBeginningOfDocument",
+  "Meta+ArrowDown": "moveToEndOfDocument",
+  "Meta+ArrowLeft": "moveToLeftEndOfLine",
+  "Meta+ArrowRight": "moveToRightEndOfLine",
+  "Shift+Meta+ArrowUp": "moveToBeginningOfDocumentAndModifySelection",
+  "Shift+Meta+ArrowDown": "moveToEndOfDocumentAndModifySelection",
+  "Shift+Meta+ArrowLeft": "moveToLeftEndOfLineAndModifySelection",
+  "Shift+Meta+ArrowRight": "moveToRightEndOfLineAndModifySelection",
+  "Meta+KeyA": "selectAll",
+  "Meta+KeyC": "copy",
+  "Meta+KeyX": "cut",
+  "Meta+KeyV": "paste",
+  "Meta+KeyZ": "undo",
+  "Shift+Meta+KeyZ": "redo",
+};
+const SHORTCUT_MODIFIER_ORDER = ["Shift", "Control", "Alt", "Meta"] as const;
+
+const macEditingCommands = (
+  code: string,
+  modifiers: PreviewAutomationPressInput["modifiers"],
+): ReadonlyArray<string> => {
+  const shortcut = [
+    ...SHORTCUT_MODIFIER_ORDER.filter((modifier) => modifiers?.includes(modifier)),
+    code,
+  ].join("+");
+  const command = MAC_EDITING_COMMANDS[shortcut];
+  return command ? [command] : [];
+};
+
 const modifierMask = (modifiers: PreviewAutomationPressInput["modifiers"]): number =>
   (modifiers ?? []).reduce((value, modifier) => {
     switch (modifier) {
@@ -136,12 +173,14 @@ function resolveKeyDefinition(input: PreviewAutomationPressInput): KeyDefinition
  */
 export function makePreviewAutomationKeySequence(
   input: PreviewAutomationPressInput,
+  options?: { readonly isMac?: boolean },
 ): PreviewAutomationKeySequence {
   const definition = resolveKeyDefinition(input);
   const modifiers = modifierMask(input.modifiers);
   const suppressText = input.modifiers?.some((modifier) => modifier !== "Shift") ?? false;
   const text = suppressText ? "" : (definition.text ?? "");
   const location = definition.location ?? 0;
+  const commands = options?.isMac ? macEditingCommands(definition.code, input.modifiers) : [];
   const shared = {
     key: definition.key,
     code: definition.code,
@@ -156,6 +195,7 @@ export function makePreviewAutomationKeySequence(
       type: text ? "keyDown" : "rawKeyDown",
       ...shared,
       ...(text ? { text, unmodifiedText: text } : {}),
+      ...(commands.length > 0 ? { commands } : {}),
     },
     keyUp: { type: "keyUp", ...shared },
     signal: { kind: "key", key: definition.key, code: definition.code },

--- a/apps/web/src/components/preview/PreviewAutomationHosts.tsx
+++ b/apps/web/src/components/preview/PreviewAutomationHosts.tsx
@@ -51,6 +51,7 @@ import {
   PreviewAutomationTargetUnavailableError,
   PreviewAutomationViewportTimeoutError,
 } from "./previewAutomationErrors";
+import { previewAutomationOpenNeedsOverlay } from "./previewAutomationOpenReadiness";
 import { createPreviewAutomationRequestConsumerAtom } from "./previewAutomationRequestConsumer";
 import { createPreviewAutomationClientId } from "./previewAutomationClientId";
 import {
@@ -333,6 +334,9 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
             const input = request.input as PreviewAutomationOpenInput;
             let activeTabId =
               (input.reuseExistingTab ?? true) ? (state.snapshot?.tabId ?? null) : null;
+            let activeSnapshot = activeTabId
+              ? (state.sessions[activeTabId] ?? state.snapshot ?? undefined)
+              : undefined;
             const reusedExistingTab = activeTabId !== null;
             tabId = activeTabId;
             if (!activeTabId) {
@@ -349,17 +353,20 @@ function PreviewAutomationHost(props: { readonly environmentId: EnvironmentId })
               const snapshot = result.value;
               applyPreviewServerSnapshot(threadRef, snapshot);
               activeTabId = snapshot.tabId;
+              activeSnapshot = snapshot;
               tabId = activeTabId;
             }
             if (input.show ?? true) {
               useRightPanelStore.getState().openBrowser(threadRef, activeTabId);
             }
-            await waitForDesktopOverlay(
-              threadRef,
-              request.requestId,
-              activeTabId,
-              request.timeoutMs,
-            );
+            if (activeSnapshot && previewAutomationOpenNeedsOverlay(input, activeSnapshot)) {
+              await waitForDesktopOverlay(
+                threadRef,
+                request.requestId,
+                activeTabId,
+                request.timeoutMs,
+              );
+            }
             if (reusedExistingTab && input.url && previewBridge) {
               const resolution = resolveBrowserNavigationTarget(environmentId, {
                 kind: "url",

--- a/apps/web/src/components/preview/previewAutomationOpenReadiness.test.ts
+++ b/apps/web/src/components/preview/previewAutomationOpenReadiness.test.ts
@@ -1,0 +1,46 @@
+import type { PreviewAutomationOpenInput, PreviewSessionSnapshot } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { previewAutomationOpenNeedsOverlay } from "./previewAutomationOpenReadiness";
+
+const snapshot = (navStatus: PreviewSessionSnapshot["navStatus"]): PreviewSessionSnapshot => ({
+  threadId: "thread-1",
+  tabId: "tab-1",
+  navStatus,
+  canGoBack: false,
+  canGoForward: false,
+  updatedAt: "2026-06-26T00:00:00.000Z",
+});
+
+describe("preview automation open readiness", () => {
+  it("does not wait for a desktop overlay when opening an empty tab", () => {
+    expect(
+      previewAutomationOpenNeedsOverlay(
+        {} as PreviewAutomationOpenInput,
+        snapshot({ _tag: "Idle" }),
+      ),
+    ).toBe(false);
+  });
+
+  it("waits when an empty tab is immediately given a URL", () => {
+    expect(
+      previewAutomationOpenNeedsOverlay(
+        { url: "https://example.com" } as PreviewAutomationOpenInput,
+        snapshot({ _tag: "Idle" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("waits for existing tabs that already have rendered content", () => {
+    expect(
+      previewAutomationOpenNeedsOverlay(
+        {} as PreviewAutomationOpenInput,
+        snapshot({
+          _tag: "Success",
+          url: "https://example.com/",
+          title: "Example",
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/components/preview/previewAutomationOpenReadiness.ts
+++ b/apps/web/src/components/preview/previewAutomationOpenReadiness.ts
@@ -1,0 +1,8 @@
+import type { PreviewAutomationOpenInput, PreviewSessionSnapshot } from "@t3tools/contracts";
+
+export function previewAutomationOpenNeedsOverlay(
+  input: PreviewAutomationOpenInput,
+  snapshot: PreviewSessionSnapshot,
+): boolean {
+  return input.url !== undefined || snapshot.navStatus._tag !== "Idle";
+}


### PR DESCRIPTION
## Why

This is a focused follow-up to #3548 based on the final installed-build smoke test.

Two small automation edge cases remained:

- On macOS, `preview_press` delivered trusted `Meta+A` keyboard events, but Chromium did not perform the native Select All editing action. Agents could emit the chord while the focused field remained unchanged.
- Opening a preview without an initial URL created the intended idle tab, but the request still waited for a desktop webview readiness condition. Because an empty tab has no navigation to become ready, `preview_open` could time out even though the tab had been created successfully.

## Root cause

Chromium's debugger input API does not infer macOS editing commands from synthetic Meta chords. Those commands must be attached explicitly to the key-down packet.

The preview automation host also treated every open operation as if it needed navigated guest content. URL-less idle sessions only need the tab and panel state; requiring the rendered overlay made their completion depend on unrelated webview initialization.

## How

- Add the common macOS editing and navigation command mappings to preview keyboard packets, gated by the injected host platform. This covers Select All, copy/cut/paste, undo/redo, document and line navigation, selection variants, and delete-to-line-start.
- Keep non-macOS key packets unchanged.
- Skip the desktop-overlay wait only when `preview_open` is opening or reusing an idle tab without a URL. Opens with a URL and tabs with existing content retain the existing readiness wait.
- Add focused packet, manager-layer, and open-readiness regression coverage.

## Validation

- `vp test apps/desktop/src/preview/PreviewKeyboard.test.ts apps/desktop/src/preview/Manager.test.ts apps/web/src/components/preview/previewAutomationOpenReadiness.test.ts` — 27 tests passed
- `vp check` — passed
- `vp run typecheck` — all 15 packages passed


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix preview automation edge cases for macOS key events and overlay wait conditions
> - Adds a `commands` field to `PreviewAutomationKeyEvent` and populates it with Chromium editing commands when running on macOS hosts, so Meta-chord shortcuts (e.g. Cmd+C) are handled correctly in the preview.
> - Reads the host OS platform from Effect context in [`Manager.ts`](https://github.com/pingdotgg/t3code/pull/3561/files#diff-089eb443c0884e11dbe412c68c0a1b7b22e3f1d0b8672c79facba02399e3dc53) and passes `isMac` to `makePreviewAutomationKeySequence` so platform-specific key sequences are generated correctly.
> - Introduces `previewAutomationOpenNeedsOverlay` in [`previewAutomationOpenReadiness.ts`](https://github.com/pingdotgg/t3code/pull/3561/files#diff-b04a64ead65541fa783290ae40b0163777923b59996322546f1857a0eff229e1) to conditionally skip waiting for the desktop overlay when opening a preview into an empty tab with no URL.
> - Behavioral Change: automation `open` no longer unconditionally waits for the desktop overlay; it waits only when a URL is provided or the tab already has rendered content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ba8c96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted preview automation behavior with regression tests; no auth, data, or broad API surface changes.
> 
> **Overview**
> Fixes two preview automation edge cases: **macOS Meta shortcuts** not performing native editing actions, and **`preview_open` timing out** on URL-less idle tabs.
> 
> On **darwin**, `makePreviewAutomationKeySequence` now attaches Chromium CDP `commands` (select all, copy/cut/paste, undo/redo, line/document navigation, etc.) to synthetic Meta chords; `PreviewManager` reads `HostProcessPlatform` and passes `isMac` into key dispatch. Non-macOS packets are unchanged.
> 
> For **`open`**, the web automation host only waits for the desktop webview overlay when `previewAutomationOpenNeedsOverlay` says so—i.e. when a URL is provided or the session is not idle. Reusing or creating an empty idle tab no longer blocks on overlay readiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ba8c962f0f2bfab2f58008aa3ac1853d80bb848. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->