### PR TITLE
Remove update button from provider toast while updating

### DIFF
--- a/apps/web/src/components/ProviderUpdateLaunchNotification.tsx
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.tsx
@@ -66,6 +66,7 @@ function updateProviderUpdateToast(input: {
       title: input.view.title,
       description: input.view.description,
       timeout: 0,
+      actionProps: undefined,
       data: {
         hideCopyButton: true,
         ...(input.view.dismissAfterVisibleMs !== undefined


### PR DESCRIPTION
## What Changed
Fix updating provider toast to remove update button while it's updating

<!-- Describe the change clearly and keep scope tight. -->

## Why
Its already updating, so we don't need an update button

## Before

<img width="1300" height="973" alt="Screenshot 2026-06-25 at 8 49 20 PM" src="https://github.com/user-attachments/assets/17bd8afe-6b6d-44d7-ba1f-6c6860ef969c" />

## After

<img width="1212" height="892" alt="Screenshot 2026-06-25 at 8 58 01 PM" src="https://github.com/user-attachments/assets/dbe2e645-c0c9-4b30-9edc-d8d9a73cceab" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI toast update behavior change with no security or data impact.
> 
> **Overview**
> Fixes the provider update launch toast so **Update** (and related actions) do not stay visible while the toast is in **loading** or **success** states.
> 
> `updateProviderUpdateToast` now passes `actionProps: undefined` when applying those views, so a prior prompt’s action button is cleared instead of lingering during the in-flight update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f774831384383c2b2a2664549d3da83a4372003e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove the update button from provider toasts in loading or success state
> Sets `actionProps` to `undefined` in [ProviderUpdateLaunchNotification.tsx](https://github.com/pingdotgg/t3code/pull/3563/files#diff-1d243a217de778942d08f15c6120d5a194480005c811dc3d47eba9c3f441e81f) when updating a toast in the `loading` or `success` state, preventing the update button from appearing while an update is already in progress.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f774831.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->