### PR TITLE
fix: warm WSL before preflight in WSL-only backend mode

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -426,6 +426,8 @@ const resolveWslStartConfig = Effect.fn("desktop.backendConfiguration.resolveWsl
     : environment.appRoot;
   const wslEntryPath = environment.path.join(wslAppRoot, "apps/server/dist/bin.mjs");
 
+  yield* wslEnvironment.preWarm(input.distro);
+
   const preflight = yield* runWslPreflight({
     distro: input.distro,
     windowsEntryPath: wslEntryPath,

--- a/apps/desktop/src/backend/DesktopBackendConfiguration.ts
+++ b/apps/desktop/src/backend/DesktopBackendConfiguration.ts
@@ -426,8 +426,6 @@ const resolveWslStartConfig = Effect.fn("desktop.backendConfiguration.resolveWsl
     : environment.appRoot;
   const wslEntryPath = environment.path.join(wslAppRoot, "apps/server/dist/bin.mjs");
 
-  yield* wslEnvironment.preWarm(input.distro);
-
   const preflight = yield* runWslPreflight({
     distro: input.distro,
     windowsEntryPath: wslEntryPath,
@@ -609,6 +607,7 @@ export const make = Effect.gen(function* () {
     const backendExposure = yield* serverExposure.backendConfig;
     const persistedSettings = yield* settings.get;
     const shared = yield* sharedInputs;
+    yield* wslEnvironment.preWarm(persistedSettings.wslDistro);
     return yield* resolveWslStartConfig({
       ...shared,
       port: backendExposure.port,


### PR DESCRIPTION
## What Changed

Warm WSL before the preflight probes, so the first wsl.exe invocation doesn't pay a cold-start penalty.

## Why

preWarm was already called in the dual-backend mode but missing from the WSL-only mode. This adds it before `runWslPreflight` so both paths get the same warm-start behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line startup ordering change in desktop WSL configuration; no auth, data, or API surface changes.
> 
> **Overview**
> **WSL-only primary backend** now calls `wslEnvironment.preWarm` with the saved distro in `buildWslPrimaryConfig`, immediately before `resolveWslStartConfig` (which runs `runWslPreflight`).
> 
> That matches the dual-backend path in `DesktopWslBackend`, where pre-warm already ran before readiness checks. The goal is to avoid paying WSL’s first `wsl.exe` cold-start cost during preflight and reduce transient “WSL not ready” failures on startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf3a1c61828fbc80203b9b7f71e26720dadc4313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> <!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
> <!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Warm WSL distro before preflight in WSL-only backend mode
> In `buildWslPrimaryConfig`, calls `wslEnvironment.preWarm` with the configured distro before `resolveWslStartConfig` runs. This ensures the distro is ready before the preflight check executes in WSL-only backend mode.
> >
> <!-- Macroscope's review summary starts here -->
> >
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf3a1c6.</sup>
> <!-- Macroscope's review summary ends here -->
> >
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->