### PR TITLE
fix(mobile): align Android terminal for 16KB pages

### DIFF
--- a/apps/mobile/modules/t3-terminal/android/src/main/cpp/CMakeLists.txt
+++ b/apps/mobile/modules/t3-terminal/android/src/main/cpp/CMakeLists.txt
@@ -16,4 +16,8 @@ target_include_directories(
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../../../../Vendor/libghostty-vt/include"
 )
 
+target_link_options(
+  t3terminal PRIVATE "-Wl,-z,common-page-size=16384" "-Wl,-z,max-page-size=16384"
+)
+
 target_link_libraries(t3terminal PRIVATE ghostty-vt log)

--- a/apps/mobile/modules/t3-terminal/scripts/libghostty-android-patches/0002-align-android-libvt-to-16kb-pages.patch
+++ b/apps/mobile/modules/t3-terminal/scripts/libghostty-android-patches/0002-align-android-libvt-to-16kb-pages.patch
@@ -1,0 +1,11 @@
+diff --git a/src/build/GhosttyLibVt.zig b/src/build/GhosttyLibVt.zig
+--- a/src/build/GhosttyLibVt.zig
++++ b/src/build/GhosttyLibVt.zig
+@@ -236,6 +236,7 @@ fn initLib(
+     if (lib.rootModuleTarget().abi.isAndroid()) {
+         // Support 16kb page sizes, required for Android 15+.
++        lib.link_z_common_page_size = 16384; // 16kb
+         lib.link_z_max_page_size = 16384; // 16kb
+ 
+         try @import("android_ndk").addPaths(b, lib);
+     }


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

Small change to make the app run on Android 17, in a Pixel 9 Pro device. This also fixes this comment left by one of the AI reviewers: https://github.com/pingdotgg/t3code/pull/3579#discussion_r3485506038

## Why

I was hitting this dialog when opening the app. This change fixed the issue.

| Before | After |
|--------|--------|
| <img width="320" alt="telegram-cloud-photo-size-4-5911104069072261009-y" src="https://github.com/user-attachments/assets/8485be1c-23e0-4728-b5a7-1486165076f2" /> | <img width="320" alt="telegram-cloud-photo-size-4-5913355868885945911-y" src="https://github.com/user-attachments/assets/e03a88c9-720f-478b-a20c-60a4d9639580" /> |


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time linker flags only; no app logic, auth, or data-path changes.
> 
> **Overview**
> Fixes Android startup failures on **16 KB page-size** devices (e.g. Pixel 9 / Android 15+) by aligning native terminal libraries with the same linker page-size settings.
> 
> The **`t3terminal`** JNI shared library build now passes **`-Wl,-z,common-page-size=16384`** and **`-Wl,-z,max-page-size=16384`** in `CMakeLists.txt`. A **Ghostty `libghostty-vt`** Android build patch adds **`link_z_common_page_size = 16384`** alongside the existing max page size so rebuilt VT binaries match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 243c6643db868852bea652687bcd429387ceba35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align Android terminal native library linker flags for 16KB page sizes
> Adds `-Wl,-z,common-page-size=16384` alongside the existing `-Wl,-z,max-page-size=16384` in both [CMakeLists.txt](https://github.com/pingdotgg/t3code/pull/3595/files#diff-3b0c301524354b3fa0899acf87d6fd21a54b98b24fca47a66fdf7d86bcc49faa) and the [libghostty patch](https://github.com/pingdotgg/t3code/pull/3595/files#diff-9f56e8f45f96a9dd082b866a080aa1e7b7f1d23f87d7ff5ff06447746654971f). Previously only the max page size was set to 16KB; without also setting the common page size, alignment requirements for 16KB-page Android devices were not fully met.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 243c664.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->