### PR TITLE
fix(mobile): enlarge new-task composer text to 17pt

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -457,7 +457,7 @@ export function NewTaskDraftScreen(props: {
             onPasteImages={(uris) => void handleNativePasteImages(uris)}
             placeholder={`Describe a coding task in ${selectedProject.title}`}
             style={{ flex: 1, minHeight: 0 }}
-            textStyle={MOBILE_TYPOGRAPHY.composer}
+            textStyle={MOBILE_TYPOGRAPHY.headline}
           />
         </View>
 


### PR DESCRIPTION
## What Changed

On the mobile new-task draft screen (`NewTaskDraftScreen`, route `/new/draft`), the task-description input now renders text at **17pt** instead of **14pt**.

- `apps/mobile/src/features/threads/NewTaskDraftScreen.tsx`: `textStyle={MOBILE_TYPOGRAPHY.composer}` → `textStyle={MOBILE_TYPOGRAPHY.headline}` (one line).

`headline` is an existing token in `lib/typography.ts` (`{ fontSize: 17, lineHeight: 22 }`), so no new values are introduced. The native iOS composer derives both its typed-text and placeholder font size from this `textStyle`, so both grow.

## Why

14pt felt too small for a full-screen, primary "describe a coding task" input. 17pt is the iOS-standard body text size and is noticeably more comfortable to read and type in, while still reusing the shared typography scale.

The change is intentionally scoped to the new-task screen only. The in-thread `ThreadComposer` keeps its 14pt size — it lives in a compact collapsible pill where the smaller size is deliberate.

## UI Changes

This changes the font size of typed text + placeholder on the new-task composer (14pt → 17pt). I wasn't able to attach real iOS-simulator before/after screenshots from my environment (the change is on a native composer that requires a full build). Maintainers/reviewers running the app will see the new-task input text render one size larger; happy to add captures if a simulator build is available.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — see note above (couldn't capture native iOS simulator output here)
- [ ] I included a video for animation/interaction changes — n/a, no motion/interaction change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-screen typography token swap with no logic, API, or data changes.
> 
> **Overview**
> On the mobile **new-task draft** screen, the primary task description `ComposerEditor` now uses **`MOBILE_TYPOGRAPHY.headline`** (17pt / 22 line height) instead of **`composer`** (14pt / 20). Typed text and the placeholder both scale up because the native composer reads font size from `textStyle`.
> 
> **In-thread** `ThreadComposer` is unchanged and still uses the compact **composer** token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 455b95ffb2812ae1bbafcf28fc0d1c95b616fc10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enlarge new-task composer text to 17pt on mobile
> Changes the text style in [NewTaskDraftScreen.tsx](https://github.com/pingdotgg/t3code/pull/3605/files#diff-3229a7fbe268616b0e0d87fc45bb21f28684e0dd853067f0cd6840e6caa1f3a2) from `MOBILE_TYPOGRAPHY.composer` to `MOBILE_TYPOGRAPHY.headline`, increasing the prompt input font size to 17pt.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 455b95f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->