### PR TITLE
fix(web): align thread details panel controls and menus

### DIFF
--- a/apps/server/src/claudeModelOptions.test.ts
+++ b/apps/server/src/claudeModelOptions.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 
 import { ProviderInstanceId, type ModelSelection } from "@t3tools/contracts";
 

--- a/apps/server/src/orchestration-v2/ProviderSelectionTransition.test.ts
+++ b/apps/server/src/orchestration-v2/ProviderSelectionTransition.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from "@effect/vitest";
 
 import {
   type ModelSelection,

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -31,6 +31,7 @@ import { cn } from "../lib/utils";
 import {
   THREAD_DETAILS_PANEL_CHEVRON_CLASS,
   THREAD_DETAILS_PANEL_ICON_CLASS,
+  THREAD_DETAILS_PANEL_ROW_POPUP_CLASS,
   THREAD_DETAILS_PANEL_ROW_CLASS,
 } from "./chat/threadDetailsPanelStyles";
 import { parsePullRequestReference } from "../pullRequestReference";
@@ -730,7 +731,10 @@ export function BranchToolbarBranchSelector({
       <ComboboxPopup
         align={displayMode === "panel" ? "start" : "end"}
         side={displayMode === "panel" ? "bottom" : "top"}
-        className="flex w-80 flex-col"
+        className={cn(
+          "flex flex-col",
+          displayMode === "panel" ? THREAD_DETAILS_PANEL_ROW_POPUP_CLASS : "w-80",
+        )}
       >
         <div className="shrink-0 px-3 pt-2.5">
           <div className="relative -translate-y-px border-b border-border/70 pb-1.5 transition-colors focus-within:border-ring">

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -4,6 +4,7 @@ import { cn } from "../lib/utils";
 import {
   THREAD_DETAILS_PANEL_ICON_CLASS,
   THREAD_DETAILS_PANEL_LOCKED_ROW_CLASS,
+  THREAD_DETAILS_PANEL_ROW_POPUP_CLASS,
   THREAD_DETAILS_PANEL_SELECT_ROW_CLASS,
 } from "./chat/threadDetailsPanelStyles";
 
@@ -137,7 +138,14 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
         </TooltipTrigger>
         {workspacePath ? <TooltipPopup side="left">{workspacePath}</TooltipPopup> : null}
       </Tooltip>
-      <SelectPopup>
+      <SelectPopup
+        {...(displayMode === "panel"
+          ? {
+              alignItemWithTrigger: false,
+              popupClassName: THREAD_DETAILS_PANEL_ROW_POPUP_CLASS,
+            }
+          : {})}
+      >
         <SelectGroup>
           <SelectGroupLabel>Workspace</SelectGroupLabel>
           <SelectItem value="local">

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -4,7 +4,7 @@ import { cn } from "../lib/utils";
 import {
   THREAD_DETAILS_PANEL_ICON_CLASS,
   THREAD_DETAILS_PANEL_LOCKED_ROW_CLASS,
-  THREAD_DETAILS_PANEL_ROW_CLASS,
+  THREAD_DETAILS_PANEL_SELECT_ROW_CLASS,
 } from "./chat/threadDetailsPanelStyles";
 
 import {
@@ -109,7 +109,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
               size={displayMode === "panel" ? "default" : "xs"}
               className={cn(
                 "font-medium",
-                displayMode === "panel" && THREAD_DETAILS_PANEL_ROW_CLASS,
+                displayMode === "panel" && THREAD_DETAILS_PANEL_SELECT_ROW_CLASS,
               )}
               aria-label="Workspace"
             />

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -7,6 +7,7 @@ import { cn } from "../lib/utils";
 import {
   THREAD_DETAILS_PANEL_ICON_CLASS,
   THREAD_DETAILS_PANEL_LOCKED_ROW_CLASS,
+  THREAD_DETAILS_PANEL_ROW_POPUP_CLASS,
   THREAD_DETAILS_PANEL_SELECT_ROW_CLASS,
 } from "./chat/threadDetailsPanelStyles";
 import {
@@ -96,7 +97,14 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
         )}
         <SelectValue />
       </SelectTrigger>
-      <SelectPopup>
+      <SelectPopup
+        {...(displayMode === "panel"
+          ? {
+              alignItemWithTrigger: false,
+              popupClassName: THREAD_DETAILS_PANEL_ROW_POPUP_CLASS,
+            }
+          : {})}
+      >
         <SelectGroup>
           <SelectGroupLabel>Run on</SelectGroupLabel>
           {availableEnvironments.map((env) => (

--- a/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvironmentSelector.tsx
@@ -7,7 +7,7 @@ import { cn } from "../lib/utils";
 import {
   THREAD_DETAILS_PANEL_ICON_CLASS,
   THREAD_DETAILS_PANEL_LOCKED_ROW_CLASS,
-  THREAD_DETAILS_PANEL_ROW_CLASS,
+  THREAD_DETAILS_PANEL_SELECT_ROW_CLASS,
 } from "./chat/threadDetailsPanelStyles";
 import {
   Select,
@@ -79,7 +79,10 @@ export const BranchToolbarEnvironmentSelector = memo(function BranchToolbarEnvir
       <SelectTrigger
         variant="ghost"
         size={displayMode === "panel" ? "default" : "xs"}
-        className={cn("font-medium", displayMode === "panel" && THREAD_DETAILS_PANEL_ROW_CLASS)}
+        className={cn(
+          "font-medium",
+          displayMode === "panel" && THREAD_DETAILS_PANEL_SELECT_ROW_CLASS,
+        )}
         aria-label="Run on"
       >
         {activeEnvironment?.isPrimary ? (

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -91,6 +91,7 @@ import { readLocalApi } from "~/localApi";
 import {
   THREAD_DETAILS_PANEL_CHEVRON_CLASS,
   THREAD_DETAILS_PANEL_ICON_CLASS,
+  THREAD_DETAILS_PANEL_ROW_POPUP_CLASS,
   THREAD_DETAILS_PANEL_ROW_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_PRIMARY_CLASS,
@@ -989,6 +990,7 @@ export default function GitActionsControl({
 }: GitActionsControlProps) {
   const isPanel = displayMode === "panel";
   const ActionGroup = isPanel ? "div" : Group;
+  const panelAnchorRef = useRef<HTMLDivElement | null>(null);
   const updateThreadMetadata = useAtomCommand(
     threadEnvironment.updateMetadata,
     "thread branch metadata update",
@@ -1706,6 +1708,7 @@ export default function GitActionsControl({
         <ActionGroup
           role="group"
           aria-label="Git actions"
+          {...(isPanel ? { ref: panelAnchorRef } : {})}
           className={cn("shrink-0", isPanel && THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS)}
         >
           {quickActionDisabledReason ? (
@@ -1793,7 +1796,11 @@ export default function GitActionsControl({
                 className={isPanel ? THREAD_DETAILS_PANEL_CHEVRON_CLASS : "size-4"}
               />
             </MenuTrigger>
-            <MenuPopup align="end" className="w-full">
+            <MenuPopup
+              align="end"
+              {...(isPanel ? { anchor: panelAnchorRef } : {})}
+              className={isPanel ? THREAD_DETAILS_PANEL_ROW_POPUP_CLASS : "w-full"}
+            >
               {gitActionMenuItems.map((item) => {
                 const disabledReason = getMenuActionDisabledReason({
                   item,

--- a/apps/web/src/components/ProjectScriptsControl.tsx
+++ b/apps/web/src/components/ProjectScriptsControl.tsx
@@ -63,6 +63,7 @@ import { cn } from "~/lib/utils";
 import {
   THREAD_DETAILS_PANEL_CHEVRON_CLASS,
   THREAD_DETAILS_PANEL_ICON_CLASS,
+  THREAD_DETAILS_PANEL_ROW_POPUP_CLASS,
   THREAD_DETAILS_PANEL_ROW_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_PRIMARY_CLASS,
@@ -134,6 +135,7 @@ export default function ProjectScriptsControl({
 }: ProjectScriptsControlProps) {
   const isPanel = displayMode === "panel";
   const ActionGroup = isPanel ? "div" : Group;
+  const panelAnchorRef = React.useRef<HTMLDivElement | null>(null);
   const addScriptFormId = React.useId();
   const [editingScriptId, setEditingScriptId] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -267,7 +269,9 @@ export default function ProjectScriptsControl({
         <ActionGroup
           role="group"
           aria-label="Project scripts"
-          {...(isPanel ? { className: THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS } : {})}
+          {...(isPanel
+            ? { className: THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS, ref: panelAnchorRef }
+            : {})}
         >
           <Tooltip>
             <TooltipTrigger
@@ -316,7 +320,11 @@ export default function ProjectScriptsControl({
                 className={isPanel ? THREAD_DETAILS_PANEL_CHEVRON_CLASS : "size-4"}
               />
             </MenuTrigger>
-            <MenuPopup align="end">
+            <MenuPopup
+              align="end"
+              {...(isPanel ? { anchor: panelAnchorRef } : {})}
+              className={isPanel ? THREAD_DETAILS_PANEL_ROW_POPUP_CLASS : undefined}
+            >
               {scripts.map((script) => {
                 const shortcutLabel = shortcutLabelForCommand(
                   keybindings,

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -1,5 +1,5 @@
 import { EditorId, type EnvironmentId, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
-import { memo, useCallback, useMemo } from "react";
+import { memo, useCallback, useMemo, useRef } from "react";
 import { shortcutLabelForCommand } from "../../keybindings";
 import { usePreferredEditor } from "../../editorPreferences";
 import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
@@ -37,6 +37,7 @@ import { useAtomCommand } from "~/state/use-atom-command";
 import {
   THREAD_DETAILS_PANEL_CHEVRON_CLASS,
   THREAD_DETAILS_PANEL_ICON_CLASS,
+  THREAD_DETAILS_PANEL_ROW_POPUP_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_PRIMARY_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_SECONDARY_CLASS,
@@ -176,6 +177,7 @@ export const OpenInPicker = memo(function OpenInPicker({
 }) {
   const isPanel = displayMode === "panel";
   const ActionGroup = isPanel ? "div" : Group;
+  const panelAnchorRef = useRef<HTMLDivElement | null>(null);
   const openInEditorMutation = useAtomCommand(shellEnvironment.openInEditor, "open in editor");
   const [preferredEditor, setPreferredEditor] = usePreferredEditor(availableEditors);
   const options = useMemo(
@@ -212,7 +214,9 @@ export const OpenInPicker = memo(function OpenInPicker({
     <ActionGroup
       aria-label="Open in editor"
       role="group"
-      {...(isPanel ? { className: THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS } : {})}
+      {...(isPanel
+        ? { className: THREAD_DETAILS_PANEL_SPLIT_GROUP_CLASS, ref: panelAnchorRef }
+        : {})}
     >
       <Button
         aria-label={compact ? "Open file in preferred editor" : primaryLabel}
@@ -260,7 +264,11 @@ export const OpenInPicker = memo(function OpenInPicker({
             className={isPanel ? THREAD_DETAILS_PANEL_CHEVRON_CLASS : "size-4"}
           />
         </MenuTrigger>
-        <MenuPopup align="end">
+        <MenuPopup
+          align="end"
+          {...(isPanel ? { anchor: panelAnchorRef } : {})}
+          className={isPanel ? THREAD_DETAILS_PANEL_ROW_POPUP_CLASS : undefined}
+        >
           {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
           {options.map(({ label, Icon, value }) => (
             <MenuItem key={value} onClick={() => openInEditor(value)}>

--- a/apps/web/src/components/chat/ThreadRelationshipsControl.tsx
+++ b/apps/web/src/components/chat/ThreadRelationshipsControl.tsx
@@ -30,7 +30,6 @@ import { Button } from "../ui/button";
 import { Menu, MenuItem, MenuPopup, MenuTrigger } from "../ui/menu";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
 import {
-  THREAD_DETAILS_PANEL_ICON_CLASS,
   THREAD_DETAILS_PANEL_ICON_ACTION_CLASS,
   THREAD_DETAILS_PANEL_LINK_ROW_CLASS,
   THREAD_DETAILS_PANEL_LINK_SPLIT_GROUP_CLASS,
@@ -38,6 +37,8 @@ import {
   THREAD_DETAILS_PANEL_LINK_SPLIT_SECONDARY_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_SEPARATOR_CLASS,
 } from "./threadDetailsPanelStyles";
+
+const THREAD_RELATIONSHIP_ICON_CLASS = "size-4 shrink-0 text-muted-foreground";
 
 function relationshipLabel(edge: ThreadRelationshipEdge, currentThreadId: ThreadId) {
   if (edge.kind === "transfer") return "Context transfer";
@@ -221,7 +222,7 @@ export function ThreadRelationshipsPanel(props: {
             const relationshipContent = (
               <>
                 <span className="relative -mx-0.5 grid size-4 shrink-0 place-items-center">
-                  <RelationshipIcon className={THREAD_DETAILS_PANEL_ICON_CLASS} />
+                  <RelationshipIcon className={THREAD_RELATIONSHIP_ICON_CLASS} />
                   <span
                     className={cn(
                       "absolute -bottom-1 -right-1 size-2 rounded-full border-2 border-card",

--- a/apps/web/src/components/chat/ThreadRelationshipsControl.tsx
+++ b/apps/web/src/components/chat/ThreadRelationshipsControl.tsx
@@ -35,6 +35,7 @@ import {
   THREAD_DETAILS_PANEL_LINK_SPLIT_GROUP_CLASS,
   THREAD_DETAILS_PANEL_LINK_SPLIT_PRIMARY_CLASS,
   THREAD_DETAILS_PANEL_LINK_SPLIT_SECONDARY_CLASS,
+  THREAD_DETAILS_PANEL_MENU_POPUP_CLASS,
   THREAD_DETAILS_PANEL_SPLIT_SEPARATOR_CLASS,
 } from "./threadDetailsPanelStyles";
 
@@ -191,7 +192,7 @@ export function ThreadRelationshipsPanel(props: {
               >
                 <MoreHorizontalIcon className="size-3.5" />
               </MenuTrigger>
-              <MenuPopup align="end">
+              <MenuPopup align="end" className={THREAD_DETAILS_PANEL_MENU_POPUP_CLASS}>
                 <MenuItem onClick={() => void detach()}>
                   <UnplugIcon className="size-3.5" />
                   Disconnect agent session

--- a/apps/web/src/components/chat/glassPopupStyles.ts
+++ b/apps/web/src/components/chat/glassPopupStyles.ts
@@ -1,0 +1,6 @@
+export const CHAT_GLASS_POPUP_SURFACE_CLASS =
+  "floating-glass-surface !bg-[color-mix(in_srgb,var(--card)_20%,transparent)] dark:!bg-[color-mix(in_srgb,var(--card)_45%,transparent)]";
+
+export const CHAT_GLASS_ROW_POPUP_CLASS = `${CHAT_GLASS_POPUP_SURFACE_CLASS} w-(--anchor-width)`;
+
+export const CHAT_GLASS_MENU_POPUP_CLASS = `${CHAT_GLASS_POPUP_SURFACE_CLASS} min-w-60 max-w-(--available-width)`;

--- a/apps/web/src/components/chat/threadDetailsPanelStyles.ts
+++ b/apps/web/src/components/chat/threadDetailsPanelStyles.ts
@@ -19,7 +19,7 @@ const THREAD_DETAILS_PANEL_SPLIT_BUTTON_SURFACE_CLASS = `${THREAD_DETAILS_PANEL_
 
 export const THREAD_DETAILS_PANEL_ROW_CLASS = `h-9 w-full justify-start gap-2.5 rounded-lg border-transparent bg-transparent px-2.5 text-[13px] font-medium text-foreground/80 sm:h-9 sm:text-[13px] ${THREAD_DETAILS_PANEL_ROW_SURFACE_CLASS}`;
 
-export const THREAD_DETAILS_PANEL_SELECT_ROW_CLASS = `${THREAD_DETAILS_PANEL_ROW_CLASS} before:pointer-events-none before:absolute before:inset-0`;
+export const THREAD_DETAILS_PANEL_SELECT_ROW_CLASS = `${THREAD_DETAILS_PANEL_ROW_CLASS} pe-0 before:pointer-events-none before:absolute before:inset-0 [&_[data-slot=select-icon]]:-me-px [&_[data-slot=select-icon]]:relative [&_[data-slot=select-icon]]:flex [&_[data-slot=select-icon]]:h-full [&_[data-slot=select-icon]]:w-8 [&_[data-slot=select-icon]]:shrink-0 [&_[data-slot=select-icon]]:items-center [&_[data-slot=select-icon]]:justify-center [&_[data-slot=select-icon]]:before:absolute [&_[data-slot=select-icon]]:before:-left-px [&_[data-slot=select-icon]]:before:top-1/2 [&_[data-slot=select-icon]]:before:h-4 [&_[data-slot=select-icon]]:before:w-px [&_[data-slot=select-icon]]:before:-translate-y-1/2 [&_[data-slot=select-icon]]:before:bg-border/65 [&_[data-slot=select-icon]>svg]:me-0 [&_[data-slot=select-icon]>svg]:size-4 [&_[data-slot=select-icon]>svg]:text-muted-foreground [&_[data-slot=select-icon]>svg]:opacity-100`;
 
 export const THREAD_DETAILS_PANEL_LINK_ROW_CLASS = `flex h-9 min-w-0 flex-1 cursor-pointer items-center justify-start gap-2.5 rounded-lg border border-transparent bg-transparent px-2.5 text-left text-[13px] font-medium text-foreground/80 disabled:cursor-not-allowed disabled:opacity-55 sm:h-9 sm:text-[13px] ${THREAD_DETAILS_PANEL_ROW_SURFACE_CLASS}`;
 
@@ -32,7 +32,7 @@ export const THREAD_DETAILS_PANEL_LINK_SPLIT_SECONDARY_CLASS = `h-9 w-8 shrink-0
 export const THREAD_DETAILS_PANEL_LOCKED_ROW_CLASS =
   "h-9 w-full justify-start gap-2.5 rounded-lg border border-transparent px-2.5 text-[13px] font-medium text-foreground/80 sm:h-9 sm:text-[13px]";
 
-export const THREAD_DETAILS_PANEL_ICON_CLASS = "size-4 shrink-0 text-muted-foreground";
+export const THREAD_DETAILS_PANEL_ICON_CLASS = "-mx-0.5 size-4 shrink-0 text-muted-foreground";
 
 export const THREAD_DETAILS_PANEL_CHEVRON_CLASS = "size-4 shrink-0 text-muted-foreground";
 

--- a/apps/web/src/components/chat/threadDetailsPanelStyles.ts
+++ b/apps/web/src/components/chat/threadDetailsPanelStyles.ts
@@ -1,3 +1,5 @@
+import { CHAT_GLASS_MENU_POPUP_CLASS, CHAT_GLASS_ROW_POPUP_CLASS } from "./glassPopupStyles";
+
 /**
  * Visual primitives shared by controls when they are rendered in the thread details panel.
  *
@@ -45,3 +47,7 @@ export const THREAD_DETAILS_PANEL_SPLIT_PRIMARY_CLASS = `h-9 min-w-0 flex-1 just
 export const THREAD_DETAILS_PANEL_SPLIT_SECONDARY_CLASS = `h-9 w-8 rounded-s-none border-transparent bg-transparent px-0 sm:h-9 sm:w-8 ${THREAD_DETAILS_PANEL_SPLIT_BUTTON_SURFACE_CLASS}`;
 
 export const THREAD_DETAILS_PANEL_SPLIT_SEPARATOR_CLASS = "h-4 w-px shrink-0 bg-border/65";
+
+export const THREAD_DETAILS_PANEL_ROW_POPUP_CLASS = CHAT_GLASS_ROW_POPUP_CLASS;
+
+export const THREAD_DETAILS_PANEL_MENU_POPUP_CLASS = CHAT_GLASS_MENU_POPUP_CLASS;

--- a/apps/web/src/components/chat/threadDetailsPanelStyles.ts
+++ b/apps/web/src/components/chat/threadDetailsPanelStyles.ts
@@ -19,6 +19,8 @@ const THREAD_DETAILS_PANEL_SPLIT_BUTTON_SURFACE_CLASS = `${THREAD_DETAILS_PANEL_
 
 export const THREAD_DETAILS_PANEL_ROW_CLASS = `h-9 w-full justify-start gap-2.5 rounded-lg border-transparent bg-transparent px-2.5 text-[13px] font-medium text-foreground/80 sm:h-9 sm:text-[13px] ${THREAD_DETAILS_PANEL_ROW_SURFACE_CLASS}`;
 
+export const THREAD_DETAILS_PANEL_SELECT_ROW_CLASS = `${THREAD_DETAILS_PANEL_ROW_CLASS} before:pointer-events-none before:absolute before:inset-0`;
+
 export const THREAD_DETAILS_PANEL_LINK_ROW_CLASS = `flex h-9 min-w-0 flex-1 cursor-pointer items-center justify-start gap-2.5 rounded-lg border border-transparent bg-transparent px-2.5 text-left text-[13px] font-medium text-foreground/80 disabled:cursor-not-allowed disabled:opacity-55 sm:h-9 sm:text-[13px] ${THREAD_DETAILS_PANEL_ROW_SURFACE_CLASS}`;
 
 export const THREAD_DETAILS_PANEL_LINK_SPLIT_GROUP_CLASS = `group/thread-details-link flex w-full items-center rounded-lg transition-colors ${THREAD_DETAILS_PANEL_HOVER_SURFACE_CLASS}`;


### PR DESCRIPTION
## What Changed

Aligned the thread details panel controls and their dropdowns so the workspace, version control, action, and thread rows read as one coherent panel.

- Fixed selector row content offsets, chevron sizing, and shared panel icon alignment, including the project folder icon.
- Applied the shared glass popup treatment to panel dropdowns/menus and anchored them to the full row width where they open.
- Kept toolbar mode unchanged; these primitives apply only to panel rendering.
- Fixed CI by switching two server tests from direct `vitest` imports to the workspace `@effect/vitest` test harness.

## Why

The panel was mixing generic dropdown styling with panel rows, which made opened menus feel disconnected and exposed small alignment differences between select triggers, icon rows, and split action rows. Centralizing the panel-specific row and popup primitives keeps the controls visually consistent without changing the underlying behavior.

The CI failure was unrelated to the UI changes: two server tests imported `vitest` directly, but this workspace patches tests through `@effect/vitest`, so the full typecheck could not resolve that package.

## UI Changes

| Before | After |
| --- | --- |
| <img width="349" height="636" alt="image" src="https://github.com/user-attachments/assets/b81a5f94-8ed0-4879-a768-ddcf574f67f0" /> | <img width="375" height="717" alt="image" src="https://github.com/user-attachments/assets/65d0b2ba-a5ed-4324-99cd-a9378fa9d388" /> |

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] No video needed; no animation/interaction changes

