### PR TITLE
Reflow terminal on layout-driven container resizes

### DIFF
--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -200,6 +200,11 @@ interface TerminalSubprocessInspector {
   ): Effect.Effect<TerminalSubprocessInspectResult, TerminalSubprocessCheckError>;
 }
 
+// Resize can fail permanently (e.g. a Bun build without `terminal.resize`). The frontend
+// command swallows the error, so warn once per process to keep the cause visible in logs
+// without spamming on every resize.
+const resizeFailureWarned = new WeakSet<PtyAdapter.PtyProcess>();
+
 const resizePtyProcess = (
   session: TerminalSessionState,
   process: PtyAdapter.PtyProcess,
@@ -217,7 +222,20 @@ const resizePtyProcess = (
         rows,
         cause,
       }),
-  });
+  }).pipe(
+    Effect.tapError((error) =>
+      Effect.gen(function* () {
+        if (resizeFailureWarned.has(process)) return;
+        resizeFailureWarned.add(process);
+        yield* Effect.logWarning("terminal resize failed; size changes will not propagate", {
+          threadId: session.threadId,
+          terminalId: session.terminalId,
+          terminalPid: process.pid,
+          cause: error.cause,
+        });
+      }),
+    ),
+  );
 
 export interface ShellCandidate {
   shell: string;

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -794,6 +794,37 @@ export function TerminalViewport({
       window.cancelAnimationFrame(frame);
     };
   }, [drawerHeight, environmentId, resizeEpoch, terminalId, threadId]);
+
+  // CSS/flex-driven container resizes (split-pane drag, sidebar collapse) change the xterm
+  // size without firing window.resize, so resizeEpoch never advances. Observe the container
+  // directly and refit. rAF-coalesced to one fit per frame, matching the effect above.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    let frame: number | null = null;
+    const observer = new ResizeObserver(() => {
+      if (frame !== null) return;
+      frame = window.requestAnimationFrame(() => {
+        frame = null;
+        const terminal = terminalRef.current;
+        const fitAddon = fitAddonRef.current;
+        if (!terminal || !fitAddon) return;
+        const wasAtBottom = terminal.buffer.active.viewportY >= terminal.buffer.active.baseY;
+        fitTerminalSafely(fitAddon);
+        if (wasAtBottom) {
+          terminal.scrollToBottom();
+        }
+        void resizeTerminal(terminal.cols, terminal.rows);
+      });
+    });
+    observer.observe(container);
+    return () => {
+      if (frame !== null) {
+        window.cancelAnimationFrame(frame);
+      }
+      observer.disconnect();
+    };
+  }, [environmentId, terminalId, threadId]);
   return (
     <div
       ref={containerRef}


### PR DESCRIPTION
## What

The terminal only reflowed (sent `SIGWINCH` to the child process) when the **OS window** was resized. Resizing the terminal via **layout** — dragging a split-pane divider, collapsing the sidebar, dragging the editor↔terminal split — left the child process at its stale size.

## Why

`TerminalViewport`'s resize effect was gated on `window.resize` / `resizeEpoch`. Those only advance on a real `window.resize`, the drag-handle release, or a visibility toggle. A CSS/flex layout change resizes the xterm DOM node **without** firing `window.resize`, so `fitAddon.fit()` and the `terminalResize` RPC never ran → no `pty.resize()` → no `SIGWINCH`.

## Change

- **`ThreadTerminalDrawer.tsx`** — observe the xterm container with a `ResizeObserver` (rAF-coalesced to one fit per frame) that refits and sends `terminalResize` directly, instead of depending on `window.resize`. The existing window/drag/visibility path is left intact.
- **`Manager.ts`** — resize can fail permanently on a Bun build lacking `terminal.resize`, and the frontend command swallows that error. Log it **once per process** via `Effect.logWarning` at the shared `resizePtyProcess` chokepoint, so the cause is visible in logs without spamming on every resize.

No new dependencies. No lockfile changes.

## Testing

Ran a `SIGWINCH` probe in a terminal, then dragged a split divider (layout-only resize, no window resize):

```
node -e "process.on('SIGWINCH',()=>console.error('WINCH',process.stdout.columns,process.stdout.rows));setInterval(()=>{},1e9)"
```

- **Before:** no output on a layout-only resize.
- **After:** continuous `WINCH` events with the new `cols × rows` throughout the drag (cols reflow while rows stay fixed — the signature of a width-only layout resize, distinct from a window resize).

Both `apps/web` and `apps/server` typecheck.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to terminal UI reflow and non-fatal resize logging; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes terminals staying at a stale column/row count when only **layout** changes (split-pane drag, sidebar collapse, editor↔terminal split), because refit/`terminalResize` previously depended on `window.resize` and `resizeEpoch`.
> 
> **`ThreadTerminalDrawer.tsx`** adds a **`ResizeObserver`** on the xterm container, rAF-coalesced like the existing resize effect, to run `fitAddon.fit()` and **`terminalResize`** when the container size changes without a window resize event.
> 
> **`Manager.ts`** logs **`Effect.logWarning`** once per PTY process in **`resizePtyProcess`** when resize fails permanently (e.g. Bun without `terminal.resize`), since the web client swallows resize errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e879db9248153b932ffe77c570e23559669213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reflow terminal on layout-driven container resizes
> - Attaches a `ResizeObserver` in [`ThreadTerminalDrawer.tsx`](https://github.com/pingdotgg/t3code/pull/3612/files#diff-09ca7578f1aa1d1aaf5c36202aad25ecde8fb131a58b0c251fd9c03323eb5636) so the terminal refits and emits a resize to the backend when its container changes size (e.g. split-pane drag, sidebar collapse), not only on window resize.
> - Adds per-process warning deduplication in [`Manager.ts`](https://github.com/pingdotgg/t3code/pull/3612/files#diff-9b98fe5056129db24d311ed1bd8f66a72127cf90fa7529da47e0725f2813532e) using a `WeakSet`: when `process.resize` fails, a warning is logged once per process with thread, terminal, pid, and cause.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e3e879d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->