### PR TITLE
feat(settings): add archived thread bulk actions

### DIFF
--- a/apps/web/src/components/settings/SettingsPanels.logic.test.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.test.ts
@@ -1,12 +1,17 @@
 import {
   DEFAULT_SERVER_SETTINGS,
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceId,
+  ThreadId,
   type ProviderInstanceConfig,
 } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 import {
+  archivedThreadSelectionKey,
+  buildArchivedThreadSelectionKeys,
   buildProviderInstanceUpdatePatch,
+  pruneArchivedThreadSelection,
   formatDiagnosticsDescription,
 } from "./SettingsPanels.logic";
 
@@ -100,5 +105,64 @@ describe("buildProviderInstanceUpdatePatch", () => {
 
     expect(patch.providerInstances?.[instanceId]).toEqual(nextInstance);
     expect(patch.providers).toBeUndefined();
+  });
+});
+
+describe("archived thread selection helpers", () => {
+  it("scopes selection keys by environment and thread", () => {
+    const threadId = ThreadId.make("thread-1");
+
+    expect(
+      archivedThreadSelectionKey({
+        environmentId: EnvironmentId.make("environment-a"),
+        threadId,
+      }),
+    ).toBe("environment-a:thread-1");
+    expect(
+      archivedThreadSelectionKey({
+        environmentId: EnvironmentId.make("environment-b"),
+        threadId,
+      }),
+    ).toBe("environment-b:thread-1");
+  });
+
+  it("keeps duplicate thread ids distinct across environments", () => {
+    const threadId = ThreadId.make("thread-1");
+    const selected = new Set([
+      archivedThreadSelectionKey({
+        environmentId: EnvironmentId.make("environment-a"),
+        threadId,
+      }),
+      archivedThreadSelectionKey({
+        environmentId: EnvironmentId.make("environment-b"),
+        threadId,
+      }),
+    ]);
+
+    expect(selected.size).toBe(2);
+  });
+
+  it("builds select-all keys from scoped archived threads", () => {
+    expect(
+      buildArchivedThreadSelectionKeys([
+        {
+          environmentId: EnvironmentId.make("environment-a"),
+          threadId: ThreadId.make("thread-1"),
+        },
+        {
+          environmentId: EnvironmentId.make("environment-b"),
+          threadId: ThreadId.make("thread-1"),
+        },
+      ]),
+    ).toEqual(["environment-a:thread-1", "environment-b:thread-1"]);
+  });
+
+  it("prunes selections that are no longer present in archived snapshots", () => {
+    const selected = new Set(["environment-a:thread-1", "environment-a:thread-2"]);
+    const available = new Set(["environment-a:thread-2", "environment-b:thread-1"]);
+
+    expect([...pruneArchivedThreadSelection(selected, available)]).toEqual([
+      "environment-a:thread-2",
+    ]);
   });
 });

--- a/apps/web/src/components/settings/SettingsPanels.logic.ts
+++ b/apps/web/src/components/settings/SettingsPanels.logic.ts
@@ -1,11 +1,42 @@
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import type {
+  EnvironmentId,
   ProviderDriverKind,
   ProviderInstanceConfig,
   ProviderInstanceId,
   ServerSettings,
+  ThreadId,
   UnifiedSettings,
 } from "@t3tools/contracts";
 import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+
+export type ArchivedThreadSelectionItem = {
+  readonly environmentId: EnvironmentId;
+  readonly threadId: ThreadId;
+};
+
+export function archivedThreadSelectionKey(input: ArchivedThreadSelectionItem): string {
+  return scopedThreadKey(scopeThreadRef(input.environmentId, input.threadId));
+}
+
+export function buildArchivedThreadSelectionKeys(
+  threads: ReadonlyArray<ArchivedThreadSelectionItem>,
+): ReadonlyArray<string> {
+  return threads.map(archivedThreadSelectionKey);
+}
+
+export function pruneArchivedThreadSelection(
+  selectedKeys: ReadonlySet<string>,
+  availableKeys: ReadonlySet<string>,
+): Set<string> {
+  const next = new Set<string>();
+  for (const key of selectedKeys) {
+    if (availableKeys.has(key)) {
+      next.add(key);
+    }
+  }
+  return next;
+}
 
 function collapseOtelSignalsUrl(input: {
   readonly tracesUrl: string;

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1,6 +1,13 @@
-import { ArchiveIcon, ArchiveX, LoaderIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
+import {
+  ArchiveIcon,
+  ArchiveX,
+  LoaderIcon,
+  PlusIcon,
+  RefreshCwIcon,
+  Trash2Icon,
+} from "lucide-react";
 import { Link } from "@tanstack/react-router";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAtomValue } from "@effect/atom-react";
 import {
   defaultInstanceIdForDriver,
@@ -11,7 +18,7 @@ import {
   type ProviderInstanceId,
   type ScopedThreadRef,
 } from "@t3tools/contracts";
-import { scopeThreadRef } from "@t3tools/client-runtime/environment";
+import { scopedThreadKey, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
 import {
   isAtomCommandInterrupted,
@@ -37,7 +44,11 @@ import { TraitsPicker } from "../chat/TraitsPicker";
 import { isElectron } from "../../env";
 import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
 import { useTheme } from "../../hooks/useTheme";
-import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
+import {
+  useClientSettings,
+  usePrimarySettings,
+  useUpdatePrimarySettings,
+} from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -59,7 +70,17 @@ import { usePrimaryEnvironment } from "../../state/environments";
 import { useProjects } from "../../state/entities";
 import { useArchivedThreadSnapshots } from "../../lib/archivedThreadsState";
 import { formatRelativeTime, formatRelativeTimeLabel } from "../../timestampFormat";
+import {
+  AlertDialog,
+  AlertDialogClose,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogPopup,
+  AlertDialogTitle,
+} from "../ui/alert-dialog";
 import { Button } from "../ui/button";
+import { Checkbox } from "../ui/checkbox";
 import { DraftInput } from "../ui/draft-input";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Switch } from "../ui/switch";
@@ -76,8 +97,10 @@ import {
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
+  buildArchivedThreadSelectionKeys,
   buildProviderInstanceUpdatePatch,
   formatDiagnosticsDescription,
+  pruneArchivedThreadSelection,
 } from "./SettingsPanels.logic";
 import {
   SettingResetButton,
@@ -1422,7 +1445,13 @@ export function ProviderSettingsPanel() {
 
 export function ArchivedThreadsPanel() {
   const projects = useProjects();
-  const { unarchiveThread, confirmAndDeleteThread } = useThreadActions();
+  const confirmThreadDelete = useClientSettings((settings) => settings.confirmThreadDelete);
+  const { unarchiveThread, confirmAndDeleteThread, deleteThread } = useThreadActions();
+  const [selectedArchivedThreadKeys, setSelectedArchivedThreadKeys] = useState(
+    () => new Set<string>(),
+  );
+  const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
+  const [bulkActionPending, setBulkActionPending] = useState<"delete" | "unarchive" | null>(null);
   const environmentIds = useMemo(
     () => [...new Set(projects.map((project) => project.environmentId))],
     [projects],
@@ -1483,6 +1512,167 @@ export function ArchivedThreadsPanel() {
     }
     return groups;
   }, [archivedSnapshots]);
+
+  const archivedThreadEntries = useMemo(
+    () =>
+      archivedGroups.flatMap(({ threads: projectThreads }) =>
+        projectThreads.map((thread) => {
+          const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+          return {
+            key: scopedThreadKey(threadRef),
+            threadRef,
+          };
+        }),
+      ),
+    [archivedGroups],
+  );
+
+  const archivedThreadSelectionKeys = useMemo(
+    () =>
+      buildArchivedThreadSelectionKeys(
+        archivedThreadEntries.map((entry) => ({
+          environmentId: entry.threadRef.environmentId,
+          threadId: entry.threadRef.threadId,
+        })),
+      ),
+    [archivedThreadEntries],
+  );
+  const archivedThreadSelectionKeySet = useMemo(
+    () => new Set(archivedThreadSelectionKeys),
+    [archivedThreadSelectionKeys],
+  );
+  const archivedThreadSelectionKeySignature = archivedThreadSelectionKeys.join("\0");
+
+  useEffect(() => {
+    setSelectedArchivedThreadKeys((previous) => {
+      const next = pruneArchivedThreadSelection(previous, archivedThreadSelectionKeySet);
+      if (next.size === previous.size && [...next].every((key) => previous.has(key))) {
+        return previous;
+      }
+      return next;
+    });
+  }, [archivedThreadSelectionKeySet, archivedThreadSelectionKeySignature]);
+
+  const selectedArchivedThreadEntries = useMemo(
+    () => archivedThreadEntries.filter((entry) => selectedArchivedThreadKeys.has(entry.key)),
+    [archivedThreadEntries, selectedArchivedThreadKeys],
+  );
+  const selectedArchivedThreadCount = selectedArchivedThreadEntries.length;
+  const isArchiveBulkActionPending = bulkActionPending !== null;
+  const allArchivedThreadsSelected =
+    archivedThreadEntries.length > 0 &&
+    selectedArchivedThreadCount === archivedThreadEntries.length;
+  const someArchivedThreadsSelected =
+    selectedArchivedThreadCount > 0 && !allArchivedThreadsSelected;
+
+  const clearSelectedArchivedThreads = useCallback(() => {
+    setSelectedArchivedThreadKeys(new Set());
+  }, []);
+
+  const toggleArchivedThreadSelection = useCallback((threadKey: string, checked: boolean) => {
+    setSelectedArchivedThreadKeys((previous) => {
+      const next = new Set(previous);
+      if (checked) {
+        next.add(threadKey);
+      } else {
+        next.delete(threadKey);
+      }
+      return next;
+    });
+  }, []);
+
+  const executeBulkUnarchiveArchivedThreads = useCallback(async () => {
+    if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
+    const totalCount = selectedArchivedThreadEntries.length;
+    let failedCount = 0;
+    let lastErrorMessage = "An error occurred.";
+    setBulkActionPending("unarchive");
+    try {
+      for (const entry of selectedArchivedThreadEntries) {
+        const result = await unarchiveThread(entry.threadRef);
+        if (result._tag === "Failure") {
+          if (!isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            failedCount += 1;
+            lastErrorMessage = error instanceof Error ? error.message : "An error occurred.";
+          }
+        }
+      }
+      clearSelectedArchivedThreads();
+      refreshArchivedThreads();
+      if (failedCount > 0) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: `Failed to unarchive ${failedCount} of ${totalCount} threads`,
+            description: lastErrorMessage,
+          }),
+        );
+      }
+    } finally {
+      setBulkActionPending(null);
+    }
+  }, [
+    bulkActionPending,
+    clearSelectedArchivedThreads,
+    refreshArchivedThreads,
+    selectedArchivedThreadEntries,
+    unarchiveThread,
+  ]);
+
+  const executeBulkDeleteArchivedThreads = useCallback(async () => {
+    if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
+    const totalCount = selectedArchivedThreadEntries.length;
+    const deletedThreadKeys = new Set(selectedArchivedThreadEntries.map((entry) => entry.key));
+    let failedCount = 0;
+    let lastErrorMessage = "An error occurred.";
+    setBulkActionPending("delete");
+    try {
+      for (const entry of selectedArchivedThreadEntries) {
+        const result = await deleteThread(entry.threadRef, { deletedThreadKeys });
+        if (result._tag === "Failure") {
+          if (!isAtomCommandInterrupted(result)) {
+            const error = squashAtomCommandFailure(result);
+            failedCount += 1;
+            lastErrorMessage = error instanceof Error ? error.message : "An error occurred.";
+          }
+        }
+      }
+      clearSelectedArchivedThreads();
+      refreshArchivedThreads();
+      if (failedCount > 0) {
+        toastManager.add(
+          stackedThreadToast({
+            type: "error",
+            title: `Failed to delete ${failedCount} of ${totalCount} threads`,
+            description: lastErrorMessage,
+          }),
+        );
+      }
+    } finally {
+      setBulkActionPending(null);
+    }
+  }, [
+    bulkActionPending,
+    clearSelectedArchivedThreads,
+    deleteThread,
+    refreshArchivedThreads,
+    selectedArchivedThreadEntries,
+  ]);
+
+  const requestBulkDeleteArchivedThreads = useCallback(() => {
+    if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
+    if (confirmThreadDelete) {
+      setBulkDeleteDialogOpen(true);
+      return;
+    }
+    void executeBulkDeleteArchivedThreads();
+  }, [
+    bulkActionPending,
+    confirmThreadDelete,
+    executeBulkDeleteArchivedThreads,
+    selectedArchivedThreadEntries.length,
+  ]);
 
   const handleArchivedThreadContextMenu = useCallback(
     async (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
@@ -1559,85 +1749,179 @@ export function ArchivedThreadsPanel() {
           />
         </SettingsSection>
       ) : (
-        archivedGroups.map(({ project, threads: projectThreads }) => (
-          <SettingsSection
-            key={project.id}
-            title={project.name}
-            icon={<ProjectFavicon environmentId={project.environmentId} cwd={project.cwd} />}
-          >
-            {projectThreads.map((thread) => (
-              <SettingsRow
-                key={thread.id}
-                onContextMenu={(event) => {
-                  event.preventDefault();
-                  void (async () => {
-                    const result = await settlePromise(() =>
-                      handleArchivedThreadContextMenu(
-                        scopeThreadRef(thread.environmentId, thread.id),
-                        {
-                          x: event.clientX,
-                          y: event.clientY,
-                        },
-                      ),
+        <div className="flex flex-col gap-3">
+          <div className="flex h-10 items-center justify-between gap-3 border-b border-border/60 px-4 sm:px-5">
+            <div className="flex min-w-0 items-center">
+              <label className="inline-flex cursor-pointer items-center gap-2">
+                <Checkbox
+                  checked={allArchivedThreadsSelected}
+                  indeterminate={someArchivedThreadsSelected}
+                  disabled={isArchiveBulkActionPending}
+                  aria-label="Select all archived threads"
+                  onCheckedChange={(checked) => {
+                    setSelectedArchivedThreadKeys(
+                      checked === true ? new Set(archivedThreadSelectionKeys) : new Set(),
                     );
-                    if (result._tag === "Failure") {
-                      const error = squashAtomCommandFailure(result);
-                      toastManager.add(
-                        stackedThreadToast({
-                          type: "error",
-                          title: "Archived thread action failed",
-                          description:
-                            error instanceof Error ? error.message : "An error occurred.",
-                        }),
-                      );
-                    }
-                  })();
-                }}
-                title={thread.title}
-                description={
-                  <>
-                    Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}
-                    {" \u00b7 Created "}
-                    {formatRelativeTimeLabel(thread.createdAt)}
-                  </>
-                }
-                control={
+                  }}
+                />
+                <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-foreground/50">
+                  Select all
+                </span>
+              </label>
+            </div>
+            <div className="flex shrink-0 items-center justify-end gap-2">
+              {selectedArchivedThreadCount > 0 ? (
+                <>
                   <Button
                     type="button"
-                    variant="outline"
                     size="sm"
+                    variant="destructive"
                     className="h-7 shrink-0 cursor-pointer gap-1.5 px-2.5"
-                    onClick={() => {
-                      void (async () => {
-                        const result = await unarchiveThread(
-                          scopeThreadRef(thread.environmentId, thread.id),
-                        );
-                        if (result._tag === "Success") {
-                          refreshArchivedThreads();
-                          return;
-                        }
-                        if (!isAtomCommandInterrupted(result)) {
-                          const error = squashAtomCommandFailure(result);
-                          toastManager.add(
-                            stackedThreadToast({
-                              type: "error",
-                              title: "Failed to unarchive thread",
-                              description:
-                                error instanceof Error ? error.message : "An error occurred.",
-                            }),
-                          );
-                        }
-                      })();
-                    }}
+                    disabled={isArchiveBulkActionPending}
+                    onClick={requestBulkDeleteArchivedThreads}
+                  >
+                    <Trash2Icon className="size-3.5" />
+                    <span>Delete ({selectedArchivedThreadCount})</span>
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="h-7 shrink-0 cursor-pointer gap-1.5 px-2.5"
+                    disabled={isArchiveBulkActionPending}
+                    onClick={() => void executeBulkUnarchiveArchivedThreads()}
                   >
                     <ArchiveX className="size-3.5" />
-                    <span>Unarchive</span>
+                    <span>Unarchive ({selectedArchivedThreadCount})</span>
                   </Button>
-                }
-              />
+                </>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-8">
+            {archivedGroups.map(({ project, threads: projectThreads }) => (
+              <SettingsSection
+                key={`${project.environmentId}:${project.id}`}
+                title={project.name}
+                icon={<ProjectFavicon environmentId={project.environmentId} cwd={project.cwd} />}
+              >
+                {projectThreads.map((thread) => {
+                  const threadRef = scopeThreadRef(thread.environmentId, thread.id);
+                  const threadKey = scopedThreadKey(threadRef);
+                  return (
+                    <SettingsRow
+                      key={threadKey}
+                      onContextMenu={(event) => {
+                        event.preventDefault();
+                        void (async () => {
+                          const result = await settlePromise(() =>
+                            handleArchivedThreadContextMenu(threadRef, {
+                              x: event.clientX,
+                              y: event.clientY,
+                            }),
+                          );
+                          if (result._tag === "Failure") {
+                            const error = squashAtomCommandFailure(result);
+                            toastManager.add(
+                              stackedThreadToast({
+                                type: "error",
+                                title: "Archived thread action failed",
+                                description:
+                                  error instanceof Error ? error.message : "An error occurred.",
+                              }),
+                            );
+                          }
+                        })();
+                      }}
+                      title={
+                        <label className="inline-flex min-w-0 cursor-pointer items-center gap-2">
+                          <Checkbox
+                            checked={selectedArchivedThreadKeys.has(threadKey)}
+                            disabled={isArchiveBulkActionPending}
+                            aria-label={`Select ${thread.title}`}
+                            onCheckedChange={(checked) =>
+                              toggleArchivedThreadSelection(threadKey, checked === true)
+                            }
+                          />
+                          <span className="truncate">{thread.title}</span>
+                        </label>
+                      }
+                      description={
+                        <>
+                          Archived {formatRelativeTimeLabel(thread.archivedAt ?? thread.createdAt)}
+                          {" \u00b7 Created "}
+                          {formatRelativeTimeLabel(thread.createdAt)}
+                        </>
+                      }
+                      control={
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="h-7 shrink-0 cursor-pointer gap-1.5 px-2.5"
+                          disabled={isArchiveBulkActionPending}
+                          onClick={() => {
+                            void (async () => {
+                              const result = await unarchiveThread(threadRef);
+                              if (result._tag === "Success") {
+                                refreshArchivedThreads();
+                                return;
+                              }
+                              if (!isAtomCommandInterrupted(result)) {
+                                const error = squashAtomCommandFailure(result);
+                                toastManager.add(
+                                  stackedThreadToast({
+                                    type: "error",
+                                    title: "Failed to unarchive thread",
+                                    description:
+                                      error instanceof Error ? error.message : "An error occurred.",
+                                  }),
+                                );
+                              }
+                            })();
+                          }}
+                        >
+                          <ArchiveX className="size-3.5" />
+                          <span>Unarchive</span>
+                        </Button>
+                      }
+                    />
+                  );
+                })}
+              </SettingsSection>
             ))}
-          </SettingsSection>
-        ))
+          </div>
+
+          <AlertDialog open={bulkDeleteDialogOpen} onOpenChange={setBulkDeleteDialogOpen}>
+            <AlertDialogPopup>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  Delete {selectedArchivedThreadCount} archived thread
+                  {selectedArchivedThreadCount === 1 ? "" : "s"}?
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  This permanently clears conversation history for the selected archived threads.
+                  This cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+                <Button
+                  variant="destructive"
+                  disabled={isArchiveBulkActionPending}
+                  onClick={() => {
+                    void executeBulkDeleteArchivedThreads().finally(() =>
+                      setBulkDeleteDialogOpen(false),
+                    );
+                  }}
+                >
+                  Delete threads
+                </Button>
+              </AlertDialogFooter>
+            </AlertDialogPopup>
+          </AlertDialog>
+        </div>
       )}
     </SettingsPageContainer>
   );

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -44,11 +44,7 @@ import { TraitsPicker } from "../chat/TraitsPicker";
 import { isElectron } from "../../env";
 import { buildHostedChannelSelectionUrl, type HostedAppChannel } from "../../hostedPairing";
 import { useTheme } from "../../hooks/useTheme";
-import {
-  useClientSettings,
-  usePrimarySettings,
-  useUpdatePrimarySettings,
-} from "../../hooks/useSettings";
+import { usePrimarySettings, useUpdatePrimarySettings } from "../../hooks/useSettings";
 import { useThreadActions } from "../../hooks/useThreadActions";
 import { useDesktopUpdateState } from "../../state/desktopUpdate";
 import {
@@ -1445,12 +1441,12 @@ export function ProviderSettingsPanel() {
 
 export function ArchivedThreadsPanel() {
   const projects = useProjects();
-  const confirmThreadDelete = useClientSettings((settings) => settings.confirmThreadDelete);
   const { unarchiveThread, confirmAndDeleteThread, deleteThread } = useThreadActions();
   const [selectedArchivedThreadKeys, setSelectedArchivedThreadKeys] = useState(
     () => new Set<string>(),
   );
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
+  const [bulkUnarchiveDialogOpen, setBulkUnarchiveDialogOpen] = useState(false);
   const [bulkActionPending, setBulkActionPending] = useState<"delete" | "unarchive" | null>(null);
   const environmentIds = useMemo(
     () => [...new Set(projects.map((project) => project.environmentId))],
@@ -1662,17 +1658,13 @@ export function ArchivedThreadsPanel() {
 
   const requestBulkDeleteArchivedThreads = useCallback(() => {
     if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
-    if (confirmThreadDelete) {
-      setBulkDeleteDialogOpen(true);
-      return;
-    }
-    void executeBulkDeleteArchivedThreads();
-  }, [
-    bulkActionPending,
-    confirmThreadDelete,
-    executeBulkDeleteArchivedThreads,
-    selectedArchivedThreadEntries.length,
-  ]);
+    setBulkDeleteDialogOpen(true);
+  }, [bulkActionPending, selectedArchivedThreadEntries.length]);
+
+  const requestBulkUnarchiveArchivedThreads = useCallback(() => {
+    if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
+    setBulkUnarchiveDialogOpen(true);
+  }, [bulkActionPending, selectedArchivedThreadEntries.length]);
 
   const handleArchivedThreadContextMenu = useCallback(
     async (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
@@ -1789,7 +1781,7 @@ export function ArchivedThreadsPanel() {
                     variant="outline"
                     className="h-7 shrink-0 cursor-pointer gap-1.5 px-2.5"
                     disabled={isArchiveBulkActionPending}
-                    onClick={() => void executeBulkUnarchiveArchivedThreads()}
+                    onClick={requestBulkUnarchiveArchivedThreads}
                   >
                     <ArchiveX className="size-3.5" />
                     <span>Unarchive ({selectedArchivedThreadCount})</span>
@@ -1917,6 +1909,34 @@ export function ArchivedThreadsPanel() {
                   }}
                 >
                   Delete threads
+                </Button>
+              </AlertDialogFooter>
+            </AlertDialogPopup>
+          </AlertDialog>
+
+          <AlertDialog open={bulkUnarchiveDialogOpen} onOpenChange={setBulkUnarchiveDialogOpen}>
+            <AlertDialogPopup>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  Unarchive {selectedArchivedThreadCount} archived thread
+                  {selectedArchivedThreadCount === 1 ? "" : "s"}?
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  This restores the selected archived threads to their project thread lists.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogClose render={<Button variant="outline" />}>Cancel</AlertDialogClose>
+                <Button
+                  variant="default"
+                  disabled={isArchiveBulkActionPending}
+                  onClick={() => {
+                    void executeBulkUnarchiveArchivedThreads().finally(() =>
+                      setBulkUnarchiveDialogOpen(false),
+                    );
+                  }}
+                >
+                  Unarchive threads
                 </Button>
               </AlertDialogFooter>
             </AlertDialogPopup>

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1448,6 +1448,7 @@ export function ArchivedThreadsPanel() {
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
   const [bulkUnarchiveDialogOpen, setBulkUnarchiveDialogOpen] = useState(false);
   const [bulkActionPending, setBulkActionPending] = useState<"delete" | "unarchive" | null>(null);
+  const bulkActionPendingRef = useRef<"delete" | "unarchive" | null>(null);
   const environmentIds = useMemo(
     () => [...new Set(projects.map((project) => project.environmentId))],
     [projects],
@@ -1578,10 +1579,13 @@ export function ArchivedThreadsPanel() {
   }, []);
 
   const executeBulkUnarchiveArchivedThreads = useCallback(async () => {
-    if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
+    if (selectedArchivedThreadEntries.length === 0 || bulkActionPendingRef.current !== null) {
+      return;
+    }
     const totalCount = selectedArchivedThreadEntries.length;
     let failedCount = 0;
     let lastErrorMessage = "An error occurred.";
+    bulkActionPendingRef.current = "unarchive";
     setBulkActionPending("unarchive");
     try {
       for (const entry of selectedArchivedThreadEntries) {
@@ -1606,10 +1610,10 @@ export function ArchivedThreadsPanel() {
         );
       }
     } finally {
+      bulkActionPendingRef.current = null;
       setBulkActionPending(null);
     }
   }, [
-    bulkActionPending,
     clearSelectedArchivedThreads,
     refreshArchivedThreads,
     selectedArchivedThreadEntries,
@@ -1617,11 +1621,14 @@ export function ArchivedThreadsPanel() {
   ]);
 
   const executeBulkDeleteArchivedThreads = useCallback(async () => {
-    if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
+    if (selectedArchivedThreadEntries.length === 0 || bulkActionPendingRef.current !== null) {
+      return;
+    }
     const totalCount = selectedArchivedThreadEntries.length;
     const deletedThreadKeys = new Set(selectedArchivedThreadEntries.map((entry) => entry.key));
     let failedCount = 0;
     let lastErrorMessage = "An error occurred.";
+    bulkActionPendingRef.current = "delete";
     setBulkActionPending("delete");
     try {
       for (const entry of selectedArchivedThreadEntries) {
@@ -1646,10 +1653,10 @@ export function ArchivedThreadsPanel() {
         );
       }
     } finally {
+      bulkActionPendingRef.current = null;
       setBulkActionPending(null);
     }
   }, [
-    bulkActionPending,
     clearSelectedArchivedThreads,
     deleteThread,
     refreshArchivedThreads,
@@ -1657,14 +1664,14 @@ export function ArchivedThreadsPanel() {
   ]);
 
   const requestBulkDeleteArchivedThreads = useCallback(() => {
-    if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
+    if (selectedArchivedThreadEntries.length === 0 || bulkActionPendingRef.current !== null) return;
     setBulkDeleteDialogOpen(true);
-  }, [bulkActionPending, selectedArchivedThreadEntries.length]);
+  }, [selectedArchivedThreadEntries.length]);
 
   const requestBulkUnarchiveArchivedThreads = useCallback(() => {
-    if (selectedArchivedThreadEntries.length === 0 || bulkActionPending !== null) return;
+    if (selectedArchivedThreadEntries.length === 0 || bulkActionPendingRef.current !== null) return;
     setBulkUnarchiveDialogOpen(true);
-  }, [bulkActionPending, selectedArchivedThreadEntries.length]);
+  }, [selectedArchivedThreadEntries.length]);
 
   const handleArchivedThreadContextMenu = useCallback(
     async (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -1566,6 +1566,10 @@ export function ArchivedThreadsPanel() {
     setSelectedArchivedThreadKeys(new Set());
   }, []);
 
+  const retainSelectedArchivedThreadKeys = useCallback((threadKeys: ReadonlySet<string>) => {
+    setSelectedArchivedThreadKeys(new Set(threadKeys));
+  }, []);
+
   const toggleArchivedThreadSelection = useCallback((threadKey: string, checked: boolean) => {
     setSelectedArchivedThreadKeys((previous) => {
       const next = new Set(previous);
@@ -1583,6 +1587,7 @@ export function ArchivedThreadsPanel() {
       return;
     }
     const totalCount = selectedArchivedThreadEntries.length;
+    const unsuccessfulThreadKeys = new Set<string>();
     let failedCount = 0;
     let lastErrorMessage = "An error occurred.";
     bulkActionPendingRef.current = "unarchive";
@@ -1591,6 +1596,7 @@ export function ArchivedThreadsPanel() {
       for (const entry of selectedArchivedThreadEntries) {
         const result = await unarchiveThread(entry.threadRef);
         if (result._tag === "Failure") {
+          unsuccessfulThreadKeys.add(entry.key);
           if (!isAtomCommandInterrupted(result)) {
             const error = squashAtomCommandFailure(result);
             failedCount += 1;
@@ -1598,7 +1604,11 @@ export function ArchivedThreadsPanel() {
           }
         }
       }
-      clearSelectedArchivedThreads();
+      if (unsuccessfulThreadKeys.size === 0) {
+        clearSelectedArchivedThreads();
+      } else {
+        retainSelectedArchivedThreadKeys(unsuccessfulThreadKeys);
+      }
       refreshArchivedThreads();
       if (failedCount > 0) {
         toastManager.add(
@@ -1615,6 +1625,7 @@ export function ArchivedThreadsPanel() {
     }
   }, [
     clearSelectedArchivedThreads,
+    retainSelectedArchivedThreadKeys,
     refreshArchivedThreads,
     selectedArchivedThreadEntries,
     unarchiveThread,
@@ -1626,14 +1637,19 @@ export function ArchivedThreadsPanel() {
     }
     const totalCount = selectedArchivedThreadEntries.length;
     const deletedThreadKeys = new Set(selectedArchivedThreadEntries.map((entry) => entry.key));
+    const unsuccessfulThreadKeys = new Set<string>();
     let failedCount = 0;
     let lastErrorMessage = "An error occurred.";
     bulkActionPendingRef.current = "delete";
     setBulkActionPending("delete");
     try {
       for (const entry of selectedArchivedThreadEntries) {
-        const result = await deleteThread(entry.threadRef, { deletedThreadKeys });
+        const result = await deleteThread(entry.threadRef, {
+          deletedThreadKeys,
+          ignorePostDeleteCleanupFailure: true,
+        });
         if (result._tag === "Failure") {
+          unsuccessfulThreadKeys.add(entry.key);
           if (!isAtomCommandInterrupted(result)) {
             const error = squashAtomCommandFailure(result);
             failedCount += 1;
@@ -1641,7 +1657,11 @@ export function ArchivedThreadsPanel() {
           }
         }
       }
-      clearSelectedArchivedThreads();
+      if (unsuccessfulThreadKeys.size === 0) {
+        clearSelectedArchivedThreads();
+      } else {
+        retainSelectedArchivedThreadKeys(unsuccessfulThreadKeys);
+      }
       refreshArchivedThreads();
       if (failedCount > 0) {
         toastManager.add(
@@ -1659,6 +1679,7 @@ export function ArchivedThreadsPanel() {
   }, [
     clearSelectedArchivedThreads,
     deleteThread,
+    retainSelectedArchivedThreadKeys,
     refreshArchivedThreads,
     selectedArchivedThreadEntries,
   ]);

--- a/apps/web/src/hooks/useThreadActions.ts
+++ b/apps/web/src/hooks/useThreadActions.ts
@@ -148,7 +148,13 @@ export function useThreadActions() {
   );
 
   const deleteThread = useCallback(
-    async (target: ScopedThreadRef, opts: { deletedThreadKeys?: ReadonlySet<string> } = {}) => {
+    async (
+      target: ScopedThreadRef,
+      opts: {
+        deletedThreadKeys?: ReadonlySet<string>;
+        ignorePostDeleteCleanupFailure?: boolean;
+      } = {},
+    ) => {
       const resolved = resolveThreadTarget(target);
       if (!resolved) {
         // Thread not in main store (e.g. archived thread) — dispatch delete directly.
@@ -325,6 +331,9 @@ export function useThreadActions() {
             description: `Could not remove ${displayWorktreePath ?? orphanedWorktreePath}. ${message}`,
           }),
         );
+        if (opts.ignorePostDeleteCleanupFailure) {
+          return deleteResult;
+        }
         return cleanupFailure;
       }
       return deleteResult;


### PR DESCRIPTION
## What Changed

- **Settings → Archive:** Added multi-select support for archived threads using environment-scoped thread keys, so duplicate thread IDs across connected environments remain distinct.
- **Bulk actions:** Added bulk delete and bulk unarchive for selected archived threads. Delete reuses the existing scoped `deletedThreadKeys` behavior so batch deletion stays aligned with the sidebar flow.
- **UI:** Added a slim inline control strip above archived thread groups: a left-aligned "Select all" checkbox anchored to the row checkbox column, with Delete / Unarchive buttons appearing on the right only when one or more threads are selected.
- **Reliability:** Bulk delete and unarchive aggregate per-thread failures into a single summary toast instead of stacking one toast per failed thread.
- **Tests:** Added scoped archive selection helper tests covering duplicate thread IDs across environments, select-all key generation, and stale-selection pruning.

## Why

Adds bulk select, unarchive, and delete for archived threads — the panel previously only supported acting on one thread at a time. Built on the app's per-environment archive model (snapshots load per environment, actions route through scoped refs), with destructive actions kept predictable.

## UI Changes

## Old UI

<img width="609" height="202" alt="image" src="https://github.com/user-attachments/assets/b5ca7b6c-f53b-4c77-92e0-9bc27c5e71f5" />

## New UI

<img width="1083" height="399" alt="image" src="https://github.com/user-attachments/assets/db8402ef-babf-45bf-a5e2-b3b6e13e551b" />
<img width="767" height="451" alt="image" src="https://github.com/user-attachments/assets/c9d56331-2e61-4958-b941-24a3ac882804" />


  **Video**

https://github.com/user-attachments/assets/13e7c76f-d415-40a8-946a-a70ad6c6807e

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [x] I included a video for animation/interaction changes


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bulk select, delete, and unarchive actions to the archived threads settings panel
> - Adds checkboxes to each row in `ArchivedThreadsPanel` with a select-all header checkbox, enabling bulk delete and bulk unarchive via confirmation dialogs.
> - Selection keys are scoped per environment using `scopedThreadKey`/`scopeThreadRef`; a `useEffect` prunes selected keys when the snapshot changes so stale selections are not retained.
> - After a bulk action, selection is reduced to keys of threads that failed, allowing retry without re-selecting.
> - Extends `deleteThread` in [`useThreadActions.ts`](https://github.com/pingdotgg/t3code/pull/3614/files#diff-7d3463056176ee1e173c0ae885b4305a70a7cc854fee7040d9b9a5a28dfbda50) with an `ignorePostDeleteCleanupFailure` flag that suppresses worktree cleanup errors and returns the delete result instead.
> - All per-row and bulk controls are disabled while a bulk action is in flight.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fec911a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk permanent delete of conversation history is user-facing and irreversible; batch delete reuses existing scoped delete paths with a new flag to tolerate post-delete worktree cleanup failures.
> 
> **Overview**
> **Archived Threads** in Settings now supports **multi-select** with environment-scoped keys (`environmentId:threadId`), so the same thread ID in different connected environments stays distinct.
> 
> A **Select all** strip and per-row checkboxes drive **bulk Delete** and **Unarchive** when anything is selected. Destructive actions use **AlertDialog** confirmations; controls disable while a bulk run is in progress. Selection is **pruned** when the archived list changes, and partial failures surface as **one aggregated error toast** instead of per-thread toasts.
> 
> Bulk delete calls `deleteThread` with shared `deletedThreadKeys` (aligned with sidebar batch behavior) and **`ignorePostDeleteCleanupFailure`** so worktree cleanup issues do not fail the whole batch. New helpers in `SettingsPanels.logic` (`archivedThreadSelectionKey`, `buildArchivedThreadSelectionKeys`, `pruneArchivedThreadSelection`) are covered by unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec911a2a6d1a619d1db6e8e5799ccb1d93ac125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->