### PR TITLE
Restore the ultrathink frame border effect

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -812,10 +812,33 @@ label:has(> select#reasoning-effort) select {
     #ec4899 90%,
     #ff6b6b 100%
   );
+  position: relative;
+  background: transparent;
+}
+
+.ultrathink-frame::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 2px;
   background-image: var(--ultrathink-spectrum);
   background-size: 220% 220%;
+  pointer-events: none;
   filter: saturate(0.82) brightness(0.92);
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
   animation: ultrathink-rainbow 10s linear infinite;
+}
+
+.ultrathink-frame > * {
+  position: relative;
 }
 
 .ultrathink-chroma {


### PR DESCRIPTION
## Summary
- Restores the `.ultrathink-frame` rainbow border as an overlay pseudo-element instead of applying the effect directly to the container background.
- Keeps the animated spectrum border visible while preserving a transparent interior and rounded corners.
- Ensures child content stays above the border layer with explicit stacking behavior.

## Testing
- Not run (no code execution requested).
- Visual check recommended in the web UI to confirm the border animation, masking, and content layering render correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only presentation change for the ultrathink composer frame; no logic, auth, or data paths touched.
> 
> **Overview**
> Restores the **ultrathink** chat composer rainbow border by moving the animated spectrum off `.ultrathink-frame` itself and onto a **`::before` overlay** with a 2px masked ring, so the interior stays transparent and corners still follow `border-radius: inherit`.
> 
> The frame container is now `position: relative` with `background: transparent`, and direct children get `position: relative` so content stacks above the non-interactive border layer (`pointer-events: none`). The existing `ultrathink-rainbow` animation and spectrum styling are unchanged; only how the border is painted differs from painting the whole box background.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cd353ab30085350d0c77bd4122a323d55785019. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore the ultrathink frame border effect using a `::before` pseudo-element
> The animated rainbow gradient on `.ultrathink-frame` was previously applied directly on the element, which caused it to obscure content. This PR moves the gradient to a `::before` pseudo-element with CSS masking (`mask` with `exclude` composite) so the effect renders only as a border, leaving the inner content visible and interactive.
> - Adds `position: relative` and `background: transparent` to `.ultrathink-frame` to support the new layering approach.
> - The `::before` overlay uses `padding: 2px` and mask compositing to create the border-only appearance.
> - Direct children of `.ultrathink-frame` get `position: relative` to ensure correct stacking above the pseudo-element overlay.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8cd353a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->