### PR TITLE
Use codex update for standalone installs

### DIFF
--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -74,7 +74,7 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@anthropic-ai/claude-code",
   homebrewFormula: "claude-code",
   nativeUpdate: {
-    executable: "claude",
+    defaultExecutable: "claude",
     args: ["update"],
     lockKey: "claude-native",
     isCommandPath: isClaudeNativeCommandPath,

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -74,7 +74,6 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@anthropic-ai/claude-code",
   homebrewFormula: "claude-code",
   nativeUpdate: {
-    defaultExecutable: "claude",
     args: ["update"],
     lockKey: "claude-native",
     isCommandPath: isClaudeNativeCommandPath,

--- a/apps/server/src/provider/Drivers/CodexDriver.test.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "@effect/vitest";
+
+import {
+  deriveCodexStandaloneUpdateEnvironment,
+  isCodexStandaloneCommandPath,
+} from "./CodexDriver.ts";
+
+describe("isCodexStandaloneCommandPath", () => {
+  it("matches current-symlink standalone layouts", () => {
+    expect(
+      isCodexStandaloneCommandPath("/home/u/.codex/packages/standalone/current/bin/codex"),
+    ).toBe(true);
+    expect(isCodexStandaloneCommandPath("/home/u/.codex/packages/standalone/current/codex")).toBe(
+      true,
+    );
+  });
+
+  it("matches the versioned release binary the current symlink resolves to", () => {
+    expect(
+      isCodexStandaloneCommandPath(
+        "/home/u/.codex/packages/standalone/releases/0.111.0-x86_64-unknown-linux-musl/codex",
+      ),
+    ).toBe(true);
+    expect(
+      isCodexStandaloneCommandPath(
+        "C:\\Users\\u\\.codex\\packages\\standalone\\releases\\0.111.0-x86_64-pc-windows-msvc\\codex.EXE",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects paths outside a standalone install", () => {
+    expect(isCodexStandaloneCommandPath("/home/u/.local/bin/codex")).toBe(false);
+    expect(isCodexStandaloneCommandPath("/usr/lib/node_modules/@openai/codex/bin/codex.js")).toBe(
+      false,
+    );
+    expect(
+      isCodexStandaloneCommandPath("/home/u/monorepo/packages/standalone/node_modules/.bin/codex"),
+    ).toBe(false);
+    expect(
+      isCodexStandaloneCommandPath(
+        "/home/u/.codex/packages/standalone/releases/0.111.0/notes/codex.txt",
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("deriveCodexStandaloneUpdateEnvironment", () => {
+  it("pins CODEX_HOME to the install root of the matched binary", () => {
+    expect(
+      deriveCodexStandaloneUpdateEnvironment(
+        "/home/julius/codex-home/packages/standalone/current/codex",
+      ),
+    ).toEqual({ CODEX_HOME: "/home/julius/codex-home" });
+    expect(
+      deriveCodexStandaloneUpdateEnvironment(
+        "/home/u/.codex/packages/standalone/releases/0.111.0-x86_64-unknown-linux-musl/codex",
+      ),
+    ).toEqual({ CODEX_HOME: "/home/u/.codex" });
+    expect(
+      deriveCodexStandaloneUpdateEnvironment(
+        "C:\\Users\\u\\.codex\\packages\\standalone\\releases\\1.0.0\\codex.exe",
+      ),
+    ).toEqual({ CODEX_HOME: "C:\\Users\\u\\.codex" });
+  });
+
+  it("returns null when no install root precedes the standalone segment", () => {
+    expect(deriveCodexStandaloneUpdateEnvironment("/packages/standalone/current/codex")).toBeNull();
+  });
+});

--- a/apps/server/src/provider/Drivers/CodexDriver.test.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "@effect/vitest";
 import {
   deriveCodexStandaloneUpdateEnvironment,
   isCodexStandaloneCommandPath,
+  resolveCodexProviderMaintenanceCapabilities,
 } from "./CodexDriver.ts";
 
 describe("isCodexStandaloneCommandPath", () => {
@@ -65,5 +66,82 @@ describe("deriveCodexStandaloneUpdateEnvironment", () => {
 
   it("returns null when no install root precedes the standalone segment", () => {
     expect(deriveCodexStandaloneUpdateEnvironment("/packages/standalone/current/codex")).toBeNull();
+  });
+});
+
+describe("resolveCodexProviderMaintenanceCapabilities", () => {
+  it.each([
+    {
+      label: "bare command",
+      binaryPath: "codex",
+      resolvedCommandPath: "/home/u/.local/bin/codex",
+      expectedExecutable: "/home/u/.local/bin/codex",
+    },
+    {
+      label: "current alias",
+      binaryPath: "/home/u/.codex/packages/standalone/current/codex",
+      resolvedCommandPath: "/home/u/.codex/packages/standalone/current/codex",
+      expectedExecutable: "/home/u/.codex/packages/standalone/current/codex",
+    },
+    {
+      label: "visible alias",
+      binaryPath: "/usr/local/bin/codex",
+      resolvedCommandPath: "/usr/local/bin/codex",
+      expectedExecutable: "/usr/local/bin/codex",
+    },
+  ])("allows native updates for a $label with a versioned release realpath", (testCase) => {
+    expect(
+      resolveCodexProviderMaintenanceCapabilities({
+        binaryPath: testCase.binaryPath,
+        platform: "linux",
+        resolvedCommandPath: testCase.resolvedCommandPath,
+        realCommandPath:
+          "/home/u/.codex/packages/standalone/releases/0.111.0-x86_64-unknown-linux-musl/codex",
+      }),
+    ).toEqual({
+      provider: "codex",
+      packageName: "@openai/codex",
+      update: {
+        command: `CODEX_HOME=/home/u/.codex ${testCase.expectedExecutable} update`,
+        executable: testCase.expectedExecutable,
+        args: ["update"],
+        lockKey: "codex-native",
+        env: { CODEX_HOME: "/home/u/.codex" },
+      },
+    });
+  });
+
+  it.each([
+    "/home/u/.codex/packages/standalone/releases/0.111.0-x86_64-unknown-linux-musl/codex",
+    "/home/u/.codex/packages/standalone/releases/0.111.0-x86_64-unknown-linux-musl/bin/codex",
+  ])("disables one-click updates for an explicitly configured release path: %s", (binaryPath) => {
+    expect(
+      resolveCodexProviderMaintenanceCapabilities({
+        binaryPath,
+        resolvedCommandPath: binaryPath,
+        realCommandPath: binaryPath,
+      }),
+    ).toEqual({
+      provider: "codex",
+      packageName: "@openai/codex",
+      update: null,
+    });
+  });
+
+  it("disables one-click updates when a bare command resolves directly to a release", () => {
+    const releasePath =
+      "/home/u/.codex/packages/standalone/releases/0.111.0-x86_64-unknown-linux-musl/codex";
+
+    expect(
+      resolveCodexProviderMaintenanceCapabilities({
+        binaryPath: "codex",
+        resolvedCommandPath: releasePath,
+        realCommandPath: releasePath,
+      }),
+    ).toEqual({
+      provider: "codex",
+      packageName: "@openai/codex",
+      update: null,
+    });
   });
 });

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -45,6 +45,7 @@ import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment
 import {
   enrichProviderSnapshotWithVersionAdvisory,
   makePackageManagedProviderMaintenanceResolver,
+  normalizeCommandPath,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
@@ -61,11 +62,25 @@ const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("codex");
 const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
+
+function isCodexStandaloneCommandPath(commandPath: string): boolean {
+  const normalized = normalizeCommandPath(commandPath);
+  return (
+    normalized.includes("/.codex/packages/standalone/") &&
+    (normalized.endsWith("/bin/codex") || normalized.endsWith("/bin/codex.exe"))
+  );
+}
+
 const UPDATE = makePackageManagedProviderMaintenanceResolver({
   provider: DRIVER_KIND,
   npmPackageName: "@openai/codex",
   homebrewFormula: "codex",
-  nativeUpdate: null,
+  nativeUpdate: {
+    executable: "codex",
+    args: ["update"],
+    lockKey: "codex-native",
+    isCommandPath: isCodexStandaloneCommandPath,
+  },
 });
 
 /**

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -63,15 +63,36 @@ const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 const DRIVER_KIND = ProviderDriverKind.make("codex");
 const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
 
-function isCodexStandaloneCommandPath(commandPath: string): boolean {
+// The standalone installer's `current` entry is a symlink into `releases/`,
+// so the realpath of an on-PATH codex is the versioned binary — which sits
+// directly in the release dir, without a `bin/` segment.
+const CODEX_STANDALONE_RELEASE_BINARY_PATTERN =
+  /\/packages\/standalone\/releases\/[^/]+\/codex(?:\.exe)?$/;
+const CODEX_STANDALONE_ROOT_SEGMENT_PATTERN = /\/packages\/standalone\//i;
+
+export function isCodexStandaloneCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
   return (
     normalized.includes("/packages/standalone/") &&
     (normalized.endsWith("/bin/codex") ||
       normalized.endsWith("/bin/codex.exe") ||
       normalized.endsWith("/packages/standalone/current/codex") ||
-      normalized.endsWith("/packages/standalone/current/codex.exe"))
+      normalized.endsWith("/packages/standalone/current/codex.exe") ||
+      CODEX_STANDALONE_RELEASE_BINARY_PATTERN.test(normalized))
   );
+}
+
+export function deriveCodexStandaloneUpdateEnvironment(
+  commandPath: string,
+): Readonly<Record<string, string>> | null {
+  // `codex update` locates the standalone install via $CODEX_HOME, and the
+  // maintenance runner spawns with the server's own environment — pin
+  // CODEX_HOME to the install root the matched binary actually lives in.
+  const match = CODEX_STANDALONE_ROOT_SEGMENT_PATTERN.exec(commandPath.replaceAll("\\", "/"));
+  if (!match || match.index === 0) {
+    return null;
+  }
+  return { CODEX_HOME: commandPath.slice(0, match.index) };
 }
 
 const UPDATE = makePackageManagedProviderMaintenanceResolver({
@@ -83,6 +104,7 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
     args: ["update"],
     lockKey: "codex-native",
     isCommandPath: isCodexStandaloneCommandPath,
+    deriveEnv: deriveCodexStandaloneUpdateEnvironment,
   },
 });
 

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -79,7 +79,7 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@openai/codex",
   homebrewFormula: "codex",
   nativeUpdate: {
-    executable: "codex",
+    defaultExecutable: "codex",
     args: ["update"],
     lockKey: "codex-native",
     isCommandPath: isCodexStandaloneCommandPath,

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -67,7 +67,10 @@ function isCodexStandaloneCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
   return (
     normalized.includes("/packages/standalone/") &&
-    (normalized.endsWith("/bin/codex") || normalized.endsWith("/bin/codex.exe"))
+    (normalized.endsWith("/bin/codex") ||
+      normalized.endsWith("/bin/codex.exe") ||
+      normalized.endsWith("/packages/standalone/current/codex") ||
+      normalized.endsWith("/packages/standalone/current/codex.exe"))
   );
 }
 

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -44,8 +44,11 @@ import type { ServerProviderDraft } from "../providerSnapshot.ts";
 import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
 import {
   enrichProviderSnapshotWithVersionAdvisory,
+  makeManualOnlyProviderMaintenanceCapabilities,
   makePackageManagedProviderMaintenanceResolver,
   normalizeCommandPath,
+  type ProviderMaintenanceCapabilityResolutionOptions,
+  type ProviderMaintenanceCapabilitiesResolver,
   resolveProviderMaintenanceCapabilitiesEffect,
 } from "../providerMaintenance.ts";
 import {
@@ -67,8 +70,9 @@ const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
 // so the realpath of an on-PATH codex is the versioned binary — which sits
 // directly in the release dir, without a `bin/` segment.
 const CODEX_STANDALONE_RELEASE_BINARY_PATTERN =
-  /\/packages\/standalone\/releases\/[^/]+\/codex(?:\.exe)?$/;
+  /\/packages\/standalone\/releases\/[^/]+\/(?:bin\/)?codex(?:\.exe)?$/;
 const CODEX_STANDALONE_ROOT_SEGMENT_PATTERN = /\/packages\/standalone\//i;
+const CODEX_NPM_PACKAGE_NAME = "@openai/codex";
 
 export function isCodexStandaloneCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
@@ -95,18 +99,45 @@ export function deriveCodexStandaloneUpdateEnvironment(
   return { CODEX_HOME: commandPath.slice(0, match.index) };
 }
 
-const UPDATE = makePackageManagedProviderMaintenanceResolver({
+const PACKAGE_MANAGED_UPDATE = makePackageManagedProviderMaintenanceResolver({
   provider: DRIVER_KIND,
-  npmPackageName: "@openai/codex",
+  npmPackageName: CODEX_NPM_PACKAGE_NAME,
   homebrewFormula: "codex",
   nativeUpdate: {
-    defaultExecutable: "codex",
     args: ["update"],
     lockKey: "codex-native",
     isCommandPath: isCodexStandaloneCommandPath,
     deriveEnv: deriveCodexStandaloneUpdateEnvironment,
   },
 });
+
+export function resolveCodexProviderMaintenanceCapabilities(
+  options?: ProviderMaintenanceCapabilityResolutionOptions,
+) {
+  const binaryPath = options?.binaryPath?.trim();
+  const resolvedCommandPath = options?.resolvedCommandPath?.trim() ?? binaryPath;
+
+  // A command that resolves directly to a release path stays pinned after
+  // `codex update`: the installer adds a sibling release and repoints
+  // `current`, but it does not replace that path. Keep matching release
+  // *realpaths* below so movable aliases still get native updates; only the
+  // path the provider will continue invoking makes this manual-only.
+  if (
+    resolvedCommandPath &&
+    CODEX_STANDALONE_RELEASE_BINARY_PATTERN.test(normalizeCommandPath(resolvedCommandPath))
+  ) {
+    return makeManualOnlyProviderMaintenanceCapabilities({
+      provider: DRIVER_KIND,
+      packageName: CODEX_NPM_PACKAGE_NAME,
+    });
+  }
+
+  return PACKAGE_MANAGED_UPDATE.resolve(options);
+}
+
+const UPDATE = {
+  resolve: resolveCodexProviderMaintenanceCapabilities,
+} satisfies ProviderMaintenanceCapabilitiesResolver;
 
 /**
  * Services the driver needs to materialize an instance. Surfaced as the

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -66,7 +66,7 @@ const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
 function isCodexStandaloneCommandPath(commandPath: string): boolean {
   const normalized = normalizeCommandPath(commandPath);
   return (
-    normalized.includes("/.codex/packages/standalone/") &&
+    normalized.includes("/packages/standalone/") &&
     (normalized.endsWith("/bin/codex") || normalized.endsWith("/bin/codex.exe"))
   );
 }

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -70,7 +70,7 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "opencode-ai",
   homebrewFormula: "anomalyco/tap/opencode",
   nativeUpdate: {
-    executable: "opencode",
+    defaultExecutable: "opencode",
     args: ["upgrade"],
     lockKey: "opencode-native",
     isCommandPath: isOpenCodeNativeCommandPath,

--- a/apps/server/src/provider/Drivers/OpenCodeDriver.ts
+++ b/apps/server/src/provider/Drivers/OpenCodeDriver.ts
@@ -70,7 +70,6 @@ const UPDATE = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "opencode-ai",
   homebrewFormula: "anomalyco/tap/opencode",
   nativeUpdate: {
-    defaultExecutable: "opencode",
     args: ["upgrade"],
     lockKey: "opencode-native",
     isCommandPath: isOpenCodeNativeCommandPath,

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -135,7 +135,7 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
           displayName: "Codex (work)",
           enabled: false,
           config: makeCodexConfig({
-            binaryPath: "/home/julius/.codex/packages/standalone/current/bin/codex",
+            binaryPath: "/home/julius/codex-home/packages/standalone/current/bin/codex",
             homePath: "/home/julius/.codex",
             customModels: ["work-preview"],
           }),
@@ -183,8 +183,8 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       expect(work!.snapshot.maintenanceCapabilities).toMatchObject({
         packageName: "@openai/codex",
         update: {
-          command: "codex update",
-          executable: "codex",
+          command: "/home/julius/codex-home/packages/standalone/current/bin/codex update",
+          executable: "/home/julius/codex-home/packages/standalone/current/bin/codex",
           args: ["update"],
           lockKey: "codex-native",
         },

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -183,7 +183,8 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       expect(work!.snapshot.maintenanceCapabilities).toMatchObject({
         packageName: "@openai/codex",
         update: {
-          command: "/home/julius/codex-home/packages/standalone/current/codex update",
+          command:
+            "CODEX_HOME=/home/julius/codex-home /home/julius/codex-home/packages/standalone/current/codex update",
           executable: "/home/julius/codex-home/packages/standalone/current/codex",
           args: ["update"],
           lockKey: "codex-native",

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -183,10 +183,11 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       expect(work!.snapshot.maintenanceCapabilities).toMatchObject({
         packageName: "@openai/codex",
         update: {
-          command: "codex update",
+          command: "/home/julius/codex-home/packages/standalone/current/codex update",
           executable: "/home/julius/codex-home/packages/standalone/current/codex",
           args: ["update"],
           lockKey: "codex-native",
+          env: { CODEX_HOME: "/home/julius/codex-home" },
         },
       });
 

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -183,7 +183,7 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       expect(work!.snapshot.maintenanceCapabilities).toMatchObject({
         packageName: "@openai/codex",
         update: {
-          command: "/home/julius/codex-home/packages/standalone/current/codex update",
+          command: "codex update",
           executable: "/home/julius/codex-home/packages/standalone/current/codex",
           args: ["update"],
           lockKey: "codex-native",

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -135,7 +135,7 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
           displayName: "Codex (work)",
           enabled: false,
           config: makeCodexConfig({
-            binaryPath: "/opt/codex-work/bin/codex",
+            binaryPath: "/home/julius/.codex/packages/standalone/current/bin/codex",
             homePath: "/home/julius/.codex",
             customModels: ["work-preview"],
           }),
@@ -180,6 +180,15 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       expect(workSnapshot.driver).toBe(codexDriverKind);
       expect(workSnapshot.enabled).toBe(false);
       expect(workSnapshot.continuation?.groupKey).toBe("codex:home:/home/julius/.codex");
+      expect(work!.snapshot.maintenanceCapabilities).toMatchObject({
+        packageName: "@openai/codex",
+        update: {
+          command: "codex update",
+          executable: "codex",
+          args: ["update"],
+          lockKey: "codex-native",
+        },
+      });
 
       // Nothing goes to the unavailable bucket — both drivers are registered.
       const unavailable = yield* registry.listUnavailable;

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -135,7 +135,7 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
           displayName: "Codex (work)",
           enabled: false,
           config: makeCodexConfig({
-            binaryPath: "/home/julius/codex-home/packages/standalone/current/bin/codex",
+            binaryPath: "/home/julius/codex-home/packages/standalone/current/codex",
             homePath: "/home/julius/.codex",
             customModels: ["work-preview"],
           }),
@@ -183,8 +183,8 @@ describe("ProviderInstanceRegistryLive — multi-instance codex slice", () => {
       expect(work!.snapshot.maintenanceCapabilities).toMatchObject({
         packageName: "@openai/codex",
         update: {
-          command: "/home/julius/codex-home/packages/standalone/current/bin/codex update",
-          executable: "/home/julius/codex-home/packages/standalone/current/bin/codex",
+          command: "/home/julius/codex-home/packages/standalone/current/codex update",
+          executable: "/home/julius/codex-home/packages/standalone/current/codex",
           args: ["update"],
           lockKey: "codex-native",
         },

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -48,6 +48,18 @@ const nativePackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
     isCommandPath: isNativeTestCommandPath("/.local/bin/native-package-tool"),
   },
 });
+const envPackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
+  provider: driver("envPackageTool"),
+  npmPackageName: "@example/env-package-tool",
+  homebrewFormula: "env-package-tool",
+  nativeUpdate: {
+    defaultExecutable: "env-package-tool",
+    args: ["update"],
+    lockKey: "env-package-tool-native",
+    isCommandPath: isNativeTestCommandPath("/.env-package-tool/bin/env-package-tool"),
+    deriveEnv: (commandPath) => ({ TOOL_HOME: commandPath }),
+  },
+});
 const scopedPackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
   provider: driver("scopedPackageTool"),
   npmPackageName: "@example/scoped-package-tool",
@@ -437,13 +449,37 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       provider: driver("nativePackageTool"),
       packageName: "@example/native-package-tool",
       update: {
-        command: "native-package-tool update",
+        command: "/custom/.local/bin/native-package-tool update",
 
         executable: "/custom/.local/bin/native-package-tool",
 
         args: ["update"],
 
         lockKey: "native-package-tool-native",
+      },
+    });
+  });
+
+  it("derives the native update environment from the matched command path", () => {
+    expect(
+      envPackageToolUpdate.resolve({
+        binaryPath: "env-package-tool",
+        resolvedCommandPath: "/home/u/.local/bin/env-package-tool",
+        realCommandPath: "/home/u/.env-package-tool/bin/env-package-tool",
+      }),
+    ).toEqual({
+      provider: driver("envPackageTool"),
+      packageName: "@example/env-package-tool",
+      update: {
+        command: "env-package-tool update",
+
+        executable: "env-package-tool",
+
+        args: ["update"],
+
+        lockKey: "env-package-tool-native",
+
+        env: { TOOL_HOME: "/home/u/.env-package-tool/bin/env-package-tool" },
       },
     });
   });

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -42,7 +42,6 @@ const nativePackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@example/native-package-tool",
   homebrewFormula: "native-package-tool",
   nativeUpdate: {
-    defaultExecutable: "native-package-tool",
     args: ["update"],
     lockKey: "native-package-tool-native",
     isCommandPath: isNativeTestCommandPath("/.local/bin/native-package-tool"),
@@ -53,7 +52,6 @@ const envPackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@example/env-package-tool",
   homebrewFormula: "env-package-tool",
   nativeUpdate: {
-    defaultExecutable: "env-package-tool",
     args: ["update"],
     lockKey: "env-package-tool-native",
     isCommandPath: isNativeTestCommandPath("/.env-package-tool/bin/env-package-tool"),
@@ -65,7 +63,6 @@ const scopedPackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@example/scoped-package-tool",
   homebrewFormula: "example/tap/scoped-package-tool",
   nativeUpdate: {
-    defaultExecutable: "scoped-package-tool",
     args: ["upgrade"],
     lockKey: "scoped-package-tool-native",
     isCommandPath: isNativeTestCommandPath("/.scoped-package-tool/bin/scoped-package-tool"),
@@ -368,9 +365,9 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("nativePackageTool"),
           packageName: "@example/native-package-tool",
           update: {
-            command: "native-package-tool update",
+            command: `${nativePackageToolPath} update`,
 
-            executable: "native-package-tool",
+            executable: nativePackageToolPath,
 
             args: ["update"],
 
@@ -405,9 +402,9 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
           provider: driver("scopedPackageTool"),
           packageName: "@example/scoped-package-tool",
           update: {
-            command: "scoped-package-tool upgrade",
+            command: `${scopedPackageToolPath} upgrade`,
 
-            executable: "scoped-package-tool",
+            executable: scopedPackageToolPath,
 
             args: ["upgrade"],
 
@@ -464,6 +461,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     expect(
       envPackageToolUpdate.resolve({
         binaryPath: "env-package-tool",
+        platform: "linux",
         resolvedCommandPath: "/home/u/.local/bin/env-package-tool",
         realCommandPath: "/home/u/.env-package-tool/bin/env-package-tool",
       }),
@@ -471,9 +469,10 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       provider: driver("envPackageTool"),
       packageName: "@example/env-package-tool",
       update: {
-        command: "env-package-tool update",
+        command:
+          "TOOL_HOME=/home/u/.env-package-tool/bin/env-package-tool /home/u/.local/bin/env-package-tool update",
 
-        executable: "env-package-tool",
+        executable: "/home/u/.local/bin/env-package-tool",
 
         args: ["update"],
 
@@ -482,6 +481,54 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
         env: { TOOL_HOME: "/home/u/.env-package-tool/bin/env-package-tool" },
       },
     });
+  });
+
+  it("shell-escapes native manual update commands and includes their environment", () => {
+    expect(
+      makeProviderMaintenanceCapabilities({
+        provider: driver("nativePackageTool"),
+        packageName: "@example/native-package-tool",
+        updateExecutable: "/home/user/Native Tool/bin/native-package-tool",
+        updateArgs: ["update", "channel; echo injected"],
+        updateLockKey: "native-package-tool-native",
+        updateEnv: { TOOL_HOME: "/home/user/It's Native Tool" },
+        platform: "linux",
+      }).update?.command,
+    ).toBe(
+      "TOOL_HOME='/home/user/It'\\''s Native Tool' '/home/user/Native Tool/bin/native-package-tool' update 'channel; echo injected'",
+    );
+  });
+
+  it("formats native manual update commands for PowerShell on Windows", () => {
+    expect(
+      makeProviderMaintenanceCapabilities({
+        provider: driver("nativePackageTool"),
+        packageName: "@example/native-package-tool",
+        updateExecutable: "C:\\Program Files\\Native Tool\\native-package-tool.exe",
+        updateArgs: ["update", "release candidate"],
+        updateLockKey: "native-package-tool-native",
+        updateEnv: {
+          TOOL_HOME: "C:\\Users\\O'Brien\\Native Tool",
+          UPDATE_CHANNEL: "stable",
+        },
+        platform: "win32",
+      }).update?.command,
+    ).toBe(
+      "$env:TOOL_HOME = 'C:\\Users\\O''Brien\\Native Tool'; $env:UPDATE_CHANNEL = 'stable'; & 'C:\\Program Files\\Native Tool\\native-package-tool.exe' update 'release candidate'",
+    );
+  });
+
+  it("keeps existing package-manager commands copyable in PowerShell", () => {
+    expect(
+      makeProviderMaintenanceCapabilities({
+        provider: driver("packageTool"),
+        packageName: "@example/package-tool",
+        updateExecutable: "npm",
+        updateArgs: ["install", "-g", "@example/package-tool@latest"],
+        updateLockKey: "npm-global",
+        platform: "win32",
+      }).update?.command,
+    ).toBe("npm install -g @example/package-tool@latest");
   });
 
   it("switches scoped-package-tool to Homebrew updates when the binary resolves through Homebrew", () => {

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -42,7 +42,7 @@ const nativePackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@example/native-package-tool",
   homebrewFormula: "native-package-tool",
   nativeUpdate: {
-    executable: "native-package-tool",
+    defaultExecutable: "native-package-tool",
     args: ["update"],
     lockKey: "native-package-tool-native",
     isCommandPath: isNativeTestCommandPath("/.local/bin/native-package-tool"),
@@ -53,7 +53,7 @@ const scopedPackageToolUpdate = makePackageManagedProviderMaintenanceResolver({
   npmPackageName: "@example/scoped-package-tool",
   homebrewFormula: "example/tap/scoped-package-tool",
   nativeUpdate: {
-    executable: "scoped-package-tool",
+    defaultExecutable: "scoped-package-tool",
     args: ["upgrade"],
     lockKey: "scoped-package-tool-native",
     isCommandPath: isNativeTestCommandPath("/.scoped-package-tool/bin/scoped-package-tool"),

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -428,6 +428,26 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
     });
   });
 
+  it("uses explicit native binary paths as the native update executable", () => {
+    expect(
+      nativePackageToolUpdate.resolve({
+        binaryPath: "/custom/.local/bin/native-package-tool",
+      }),
+    ).toEqual({
+      provider: driver("nativePackageTool"),
+      packageName: "@example/native-package-tool",
+      update: {
+        command: "/custom/.local/bin/native-package-tool update",
+
+        executable: "/custom/.local/bin/native-package-tool",
+
+        args: ["update"],
+
+        lockKey: "native-package-tool-native",
+      },
+    });
+  });
+
   it("switches scoped-package-tool to Homebrew updates when the binary resolves through Homebrew", () => {
     expect(
       scopedPackageToolUpdate.resolve({

--- a/apps/server/src/provider/providerMaintenance.test.ts
+++ b/apps/server/src/provider/providerMaintenance.test.ts
@@ -437,7 +437,7 @@ it.layer(NodeServices.layer)("providerMaintenance", (it) => {
       provider: driver("nativePackageTool"),
       packageName: "@example/native-package-tool",
       update: {
-        command: "/custom/.local/bin/native-package-tool update",
+        command: "native-package-tool update",
 
         executable: "/custom/.local/bin/native-package-tool",
 

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -199,6 +199,9 @@ function makeHomebrewProviderMaintenanceCapabilities(
 
 function makeNativeProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
+  options?: {
+    readonly updateExecutable?: string;
+  },
 ): ProviderMaintenanceCapabilities | null {
   if (!definition.nativeUpdate) {
     return null;
@@ -207,7 +210,7 @@ function makeNativeProviderMaintenanceCapabilities(
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: definition.npmPackageName,
-    updateExecutable: definition.nativeUpdate.executable,
+    updateExecutable: options?.updateExecutable ?? definition.nativeUpdate.executable,
     updateArgs: definition.nativeUpdate.args,
     updateLockKey: definition.nativeUpdate.lockKey,
   });
@@ -287,8 +290,11 @@ export function resolvePackageManagedProviderMaintenance(
       commandPaths.some((commandPath) => nativeUpdate.isCommandPath(commandPath))
     ) {
       return (
-        makeNativeProviderMaintenanceCapabilities(definition) ??
-        makeNpmGlobalProviderMaintenanceCapabilities(definition)
+        makeNativeProviderMaintenanceCapabilities(definition, {
+          updateExecutable: hasPathSeparator(binaryPath)
+            ? resolvedCommandPath
+            : nativeUpdate.executable,
+        }) ?? makeNpmGlobalProviderMaintenanceCapabilities(definition)
       );
     }
     if (commandPaths.some(isVitePlusGlobalCommandPath)) {

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -3,6 +3,7 @@ import {
   type ServerProvider,
   type ServerProviderVersionAdvisory,
 } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import { compareSemverVersions } from "@t3tools/shared/semver";
 import { resolveCommandPath } from "@t3tools/shared/shell";
 import * as Config from "effect/Config";
@@ -13,6 +14,8 @@ import * as FileSystem from "effect/FileSystem";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
+
+import { makeProviderMaintenanceManualCommand } from "./providerMaintenanceCommand.ts";
 
 const LATEST_VERSION_CACHE_TTL_MS = 60 * 60 * 1_000;
 const LATEST_VERSION_TIMEOUT_MS = 4_000;
@@ -44,7 +47,7 @@ export interface ProviderMaintenanceCapabilities {
 }
 
 export interface ProviderMaintenanceCommandAction {
-  readonly command: string;
+  readonly command: string | null;
   readonly executable: string;
   readonly args: ReadonlyArray<string>;
   readonly lockKey: string;
@@ -54,6 +57,7 @@ export interface ProviderMaintenanceCommandAction {
 export interface ProviderMaintenanceCapabilityResolutionOptions {
   readonly binaryPath?: string | null;
   readonly env?: NodeJS.ProcessEnv;
+  readonly platform?: NodeJS.Platform;
   readonly resolvedCommandPath?: string | null;
   readonly realCommandPath?: string | null;
 }
@@ -69,7 +73,6 @@ export interface PackageManagedProviderMaintenanceDefinition {
   readonly npmPackageName: string;
   readonly homebrewFormula: string | null;
   readonly nativeUpdate: {
-    readonly defaultExecutable: string;
     readonly args: ReadonlyArray<string>;
     readonly lockKey: string;
     readonly isCommandPath: (commandPath: string) => boolean;
@@ -109,12 +112,18 @@ export function makeProviderMaintenanceCapabilities(input: {
   readonly updateArgs: ReadonlyArray<string>;
   readonly updateLockKey: string | null;
   readonly updateEnv?: Readonly<Record<string, string>> | null;
+  readonly platform?: NodeJS.Platform;
 }): ProviderMaintenanceCapabilities {
   const update =
     input.updateExecutable === null || input.updateLockKey === null
       ? null
       : {
-          command: [input.updateExecutable, ...input.updateArgs].join(" "),
+          command: makeProviderMaintenanceManualCommand({
+            executable: input.updateExecutable,
+            args: input.updateArgs,
+            ...(input.updateEnv !== undefined ? { env: input.updateEnv } : {}),
+            ...(input.platform !== undefined ? { platform: input.platform } : {}),
+          }),
           executable: input.updateExecutable,
           args: input.updateArgs,
           lockKey: input.updateLockKey,
@@ -229,6 +238,7 @@ function makeNativeProviderMaintenanceCapabilities(
   options: {
     readonly updateExecutable: string;
     readonly updateEnv: Readonly<Record<string, string>> | null;
+    readonly platform?: NodeJS.Platform;
   },
 ): ProviderMaintenanceCapabilities {
   return makeProviderMaintenanceCapabilities({
@@ -238,6 +248,7 @@ function makeNativeProviderMaintenanceCapabilities(
     updateArgs: nativeUpdate.args,
     updateLockKey: nativeUpdate.lockKey,
     updateEnv: options.updateEnv,
+    ...(options.platform !== undefined ? { platform: options.platform } : {}),
   });
 }
 
@@ -316,10 +327,13 @@ export function resolvePackageManagedProviderMaintenance(
       );
       if (nativeCommandPath !== undefined) {
         return makeNativeProviderMaintenanceCapabilities(definition, nativeUpdate, {
-          updateExecutable: hasPathSeparator(binaryPath)
-            ? resolvedCommandPath
-            : nativeUpdate.defaultExecutable,
+          // Capability detection may use an instance-specific PATH that is not
+          // present in the long-lived server process. Pin the executable we
+          // actually resolved so the later update spawn cannot select a
+          // different installation (or fail with ENOENT).
+          updateExecutable: resolvedCommandPath,
           updateEnv: nativeUpdate.deriveEnv?.(nativeCommandPath) ?? null,
+          ...(options?.platform !== undefined ? { platform: options.platform } : {}),
         });
       }
     }
@@ -381,9 +395,11 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
   resolver: ProviderMaintenanceCapabilitiesResolver,
   options?: Omit<ProviderMaintenanceCapabilityResolutionOptions, "realCommandPath">,
 ) {
+  const platform = options?.platform ?? (yield* HostProcessPlatform);
+  const resolutionOptions = { ...options, platform };
   const binaryPath = nonEmptyString(options?.binaryPath);
   if (!binaryPath) {
-    return resolver.resolve(options);
+    return resolver.resolve(resolutionOptions);
   }
 
   const env = options?.env ?? (yield* readCommandLookupEnv);
@@ -392,7 +408,7 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
       Effect.catchTag("CommandResolutionError", () => Effect.succeed(null)),
     )) ?? (hasPathSeparator(binaryPath) ? binaryPath : null);
   if (!resolvedCommandPath) {
-    return resolver.resolve(options);
+    return resolver.resolve(resolutionOptions);
   }
 
   const fileSystem = yield* FileSystem.FileSystem;
@@ -400,7 +416,7 @@ export const resolveProviderMaintenanceCapabilitiesEffect = Effect.fn(
     .realPath(resolvedCommandPath)
     .pipe(Effect.orElseSucceed(() => resolvedCommandPath));
   return resolver.resolve({
-    ...options,
+    ...resolutionOptions,
     env,
     resolvedCommandPath,
     realCommandPath,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -118,6 +118,10 @@ export function makeProviderMaintenanceCapabilities(input: {
   };
 }
 
+function makeProviderMaintenanceUpdateActionKey(update: ProviderMaintenanceCommandAction): string {
+  return [update.lockKey, update.executable, ...update.args].join(" ");
+}
+
 export function makeManualOnlyProviderMaintenanceCapabilities(input: {
   readonly provider: ProviderDriverKind;
   readonly packageName: string | null;
@@ -424,6 +428,9 @@ export function createProviderVersionAdvisory(input: {
     currentVersion: input.currentVersion,
     latestVersion,
     updateCommand: capabilities.update?.command ?? null,
+    ...(capabilities.update
+      ? { updateActionKey: makeProviderMaintenanceUpdateActionKey(capabilities.update) }
+      : {}),
     canUpdate: capabilities.update !== null,
     checkedAt: input.checkedAt ?? null,
     message: advisory.message,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -48,6 +48,7 @@ export interface ProviderMaintenanceCommandAction {
   readonly executable: string;
   readonly args: ReadonlyArray<string>;
   readonly lockKey: string;
+  readonly env?: Readonly<Record<string, string>>;
 }
 
 export interface ProviderMaintenanceCapabilityResolutionOptions {
@@ -72,6 +73,13 @@ export interface PackageManagedProviderMaintenanceDefinition {
     readonly args: ReadonlyArray<string>;
     readonly lockKey: string;
     readonly isCommandPath: (commandPath: string) => boolean;
+    /**
+     * Extra environment for the update spawn, derived from the command path
+     * that matched `isCommandPath`. The maintenance runner spawns with the
+     * server's own environment, so anything the updater needs beyond that
+     * (e.g. the install root of the matched binary) must be supplied here.
+     */
+    readonly deriveEnv?: (commandPath: string) => Readonly<Record<string, string>> | null;
   } | null;
 }
 
@@ -97,19 +105,20 @@ function nonEmptyString(value: unknown): string | null {
 export function makeProviderMaintenanceCapabilities(input: {
   readonly provider: ProviderDriverKind;
   readonly packageName: string | null;
-  readonly updateCommand?: string | null;
   readonly updateExecutable: string | null;
   readonly updateArgs: ReadonlyArray<string>;
   readonly updateLockKey: string | null;
+  readonly updateEnv?: Readonly<Record<string, string>> | null;
 }): ProviderMaintenanceCapabilities {
   const update =
     input.updateExecutable === null || input.updateLockKey === null
       ? null
       : {
-          command: input.updateCommand ?? [input.updateExecutable, ...input.updateArgs].join(" "),
+          command: [input.updateExecutable, ...input.updateArgs].join(" "),
           executable: input.updateExecutable,
           args: input.updateArgs,
           lockKey: input.updateLockKey,
+          ...(input.updateEnv ? { env: input.updateEnv } : {}),
         };
   return {
     provider: input.provider,
@@ -119,7 +128,19 @@ export function makeProviderMaintenanceCapabilities(input: {
 }
 
 function makeProviderMaintenanceUpdateActionKey(update: ProviderMaintenanceCommandAction): string {
-  return [update.lockKey, update.executable, ...update.args].join(" ");
+  // Opaque identity for "do these instances run the same update action?" —
+  // JSON keeps path/arg/env boundaries unambiguous where a plain join would
+  // alias (executables are user-controlled paths that may contain spaces).
+  return JSON.stringify([
+    update.lockKey,
+    update.executable,
+    update.args,
+    update.env
+      ? Object.entries(update.env).toSorted(([left], [right]) =>
+          left < right ? -1 : left > right ? 1 : 0,
+        )
+      : null,
+  ]);
 }
 
 export function makeManualOnlyProviderMaintenanceCapabilities(input: {
@@ -204,22 +225,19 @@ function makeHomebrewProviderMaintenanceCapabilities(
 
 function makeNativeProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
-  options?: {
-    readonly updateCommand?: string;
-    readonly updateExecutable?: string;
+  nativeUpdate: NonNullable<PackageManagedProviderMaintenanceDefinition["nativeUpdate"]>,
+  options: {
+    readonly updateExecutable: string;
+    readonly updateEnv: Readonly<Record<string, string>> | null;
   },
-): ProviderMaintenanceCapabilities | null {
-  if (!definition.nativeUpdate) {
-    return null;
-  }
-
+): ProviderMaintenanceCapabilities {
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: definition.npmPackageName,
-    updateCommand: options?.updateCommand ?? null,
-    updateExecutable: options?.updateExecutable ?? definition.nativeUpdate.defaultExecutable,
-    updateArgs: definition.nativeUpdate.args,
-    updateLockKey: definition.nativeUpdate.lockKey,
+    updateExecutable: options.updateExecutable,
+    updateArgs: nativeUpdate.args,
+    updateLockKey: nativeUpdate.lockKey,
+    updateEnv: options.updateEnv,
   });
 }
 
@@ -292,18 +310,18 @@ export function resolvePackageManagedProviderMaintenance(
     ];
 
     const nativeUpdate = definition.nativeUpdate;
-    if (
-      nativeUpdate &&
-      commandPaths.some((commandPath) => nativeUpdate.isCommandPath(commandPath))
-    ) {
-      return (
-        makeNativeProviderMaintenanceCapabilities(definition, {
-          updateCommand: [nativeUpdate.defaultExecutable, ...nativeUpdate.args].join(" "),
+    if (nativeUpdate) {
+      const nativeCommandPath = commandPaths.find((commandPath) =>
+        nativeUpdate.isCommandPath(commandPath),
+      );
+      if (nativeCommandPath !== undefined) {
+        return makeNativeProviderMaintenanceCapabilities(definition, nativeUpdate, {
           updateExecutable: hasPathSeparator(binaryPath)
             ? resolvedCommandPath
             : nativeUpdate.defaultExecutable,
-        }) ?? makeNpmGlobalProviderMaintenanceCapabilities(definition)
-      );
+          updateEnv: nativeUpdate.deriveEnv?.(nativeCommandPath) ?? null,
+        });
+      }
     }
     if (commandPaths.some(isVitePlusGlobalCommandPath)) {
       return makeVitePlusGlobalProviderMaintenanceCapabilities(definition);

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -97,6 +97,7 @@ function nonEmptyString(value: unknown): string | null {
 export function makeProviderMaintenanceCapabilities(input: {
   readonly provider: ProviderDriverKind;
   readonly packageName: string | null;
+  readonly updateCommand?: string | null;
   readonly updateExecutable: string | null;
   readonly updateArgs: ReadonlyArray<string>;
   readonly updateLockKey: string | null;
@@ -105,7 +106,7 @@ export function makeProviderMaintenanceCapabilities(input: {
     input.updateExecutable === null || input.updateLockKey === null
       ? null
       : {
-          command: [input.updateExecutable, ...input.updateArgs].join(" "),
+          command: input.updateCommand ?? [input.updateExecutable, ...input.updateArgs].join(" "),
           executable: input.updateExecutable,
           args: input.updateArgs,
           lockKey: input.updateLockKey,
@@ -200,6 +201,7 @@ function makeHomebrewProviderMaintenanceCapabilities(
 function makeNativeProviderMaintenanceCapabilities(
   definition: PackageManagedProviderMaintenanceDefinition,
   options?: {
+    readonly updateCommand?: string;
     readonly updateExecutable?: string;
   },
 ): ProviderMaintenanceCapabilities | null {
@@ -210,6 +212,7 @@ function makeNativeProviderMaintenanceCapabilities(
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: definition.npmPackageName,
+    updateCommand: options?.updateCommand ?? null,
     updateExecutable: options?.updateExecutable ?? definition.nativeUpdate.defaultExecutable,
     updateArgs: definition.nativeUpdate.args,
     updateLockKey: definition.nativeUpdate.lockKey,
@@ -291,6 +294,7 @@ export function resolvePackageManagedProviderMaintenance(
     ) {
       return (
         makeNativeProviderMaintenanceCapabilities(definition, {
+          updateCommand: [nativeUpdate.defaultExecutable, ...nativeUpdate.args].join(" "),
           updateExecutable: hasPathSeparator(binaryPath)
             ? resolvedCommandPath
             : nativeUpdate.defaultExecutable,

--- a/apps/server/src/provider/providerMaintenance.ts
+++ b/apps/server/src/provider/providerMaintenance.ts
@@ -68,7 +68,7 @@ export interface PackageManagedProviderMaintenanceDefinition {
   readonly npmPackageName: string;
   readonly homebrewFormula: string | null;
   readonly nativeUpdate: {
-    readonly executable: string;
+    readonly defaultExecutable: string;
     readonly args: ReadonlyArray<string>;
     readonly lockKey: string;
     readonly isCommandPath: (commandPath: string) => boolean;
@@ -210,7 +210,7 @@ function makeNativeProviderMaintenanceCapabilities(
   return makeProviderMaintenanceCapabilities({
     provider: definition.provider,
     packageName: definition.npmPackageName,
-    updateExecutable: options?.updateExecutable ?? definition.nativeUpdate.executable,
+    updateExecutable: options?.updateExecutable ?? definition.nativeUpdate.defaultExecutable,
     updateArgs: definition.nativeUpdate.args,
     updateLockKey: definition.nativeUpdate.lockKey,
   });
@@ -293,7 +293,7 @@ export function resolvePackageManagedProviderMaintenance(
         makeNativeProviderMaintenanceCapabilities(definition, {
           updateExecutable: hasPathSeparator(binaryPath)
             ? resolvedCommandPath
-            : nativeUpdate.executable,
+            : nativeUpdate.defaultExecutable,
         }) ?? makeNpmGlobalProviderMaintenanceCapabilities(definition)
       );
     }

--- a/apps/server/src/provider/providerMaintenanceCommand.ts
+++ b/apps/server/src/provider/providerMaintenanceCommand.ts
@@ -1,0 +1,108 @@
+const POSIX_SHELL_SAFE_WORD_PATTERN = /^[A-Za-z0-9_@%+=:,./-]+$/;
+const POWERSHELL_SAFE_WORD_PATTERN = /^[A-Za-z0-9_@%+=:,./\\-]+$/;
+const SHELL_ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function containsNullByte(value: string): boolean {
+  return value.includes("\0");
+}
+
+function quotePosixShellWord(value: string): string | null {
+  if (containsNullByte(value)) {
+    return null;
+  }
+  if (value.length > 0 && POSIX_SHELL_SAFE_WORD_PATTERN.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+function quotePowerShellStringLiteral(value: string): string | null {
+  if (containsNullByte(value)) {
+    return null;
+  }
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function quotePowerShellWord(value: string): string | null {
+  if (containsNullByte(value)) {
+    return null;
+  }
+  if (value.length > 0 && POWERSHELL_SAFE_WORD_PATTERN.test(value)) {
+    return value;
+  }
+  return quotePowerShellStringLiteral(value);
+}
+
+/**
+ * Render the structured maintenance action for the host's interactive shell.
+ * Returns null instead of publishing a command that would lose environment,
+ * argument boundaries, or executable-path quoting.
+ */
+export function makeProviderMaintenanceManualCommand(input: {
+  readonly executable: string;
+  readonly args: ReadonlyArray<string>;
+  readonly env?: Readonly<Record<string, string>> | null;
+  readonly platform?: NodeJS.Platform;
+}): string | null {
+  const envEntries = Object.entries(input.env ?? {}).toSorted(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+  if (envEntries.some(([name]) => !SHELL_ENV_NAME_PATTERN.test(name))) {
+    return null;
+  }
+
+  // Module-level static capabilities do not have an Effect runtime from
+  // which to read the host platform. Preserve the existing portable command
+  // form for simple words, but do not guess a shell when quoting or
+  // environment assignment syntax would be platform-specific.
+  if (input.platform === undefined) {
+    const words = [input.executable, ...input.args];
+    return envEntries.length === 0 &&
+      words.every(
+        (word) =>
+          !containsNullByte(word) && word.length > 0 && POSIX_SHELL_SAFE_WORD_PATTERN.test(word),
+      )
+      ? words.join(" ")
+      : null;
+  }
+
+  if (input.platform === "win32") {
+    const executable = quotePowerShellWord(input.executable);
+    const args = input.args.map(quotePowerShellWord);
+    const env = envEntries.map(([name, value]) => {
+      // Assignment RHS is parsed in PowerShell's expression mode rather than
+      // native-command argument mode, so even path-looking values must be
+      // explicit string literals.
+      const quotedValue = quotePowerShellStringLiteral(value);
+      return quotedValue === null ? null : `$env:${name} = ${quotedValue}`;
+    });
+    if (
+      executable === null ||
+      args.some((arg) => arg === null) ||
+      env.some((item) => item === null)
+    ) {
+      return null;
+    }
+
+    const invocation = [
+      POWERSHELL_SAFE_WORD_PATTERN.test(input.executable) ? executable : `& ${executable}`,
+      ...args,
+    ].join(" ");
+    return [...env, invocation].join("; ");
+  }
+
+  const executable = quotePosixShellWord(input.executable);
+  const args = input.args.map(quotePosixShellWord);
+  const env = envEntries.map(([name, value]) => {
+    const quotedValue = quotePosixShellWord(value);
+    return quotedValue === null ? null : `${name}=${quotedValue}`;
+  });
+  if (
+    executable === null ||
+    args.some((arg) => arg === null) ||
+    env.some((item) => item === null)
+  ) {
+    return null;
+  }
+  return [...env, executable, ...args].join(" ");
+}

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -666,6 +666,72 @@ describe("providerMaintenanceRunner", () => {
       ),
   );
 
+  it.effect("spawns native updates with the action's derived environment", () => {
+    const captured: Array<{
+      readonly command: string;
+      readonly args: ReadonlyArray<string>;
+      readonly env: Record<string, string | undefined> | undefined;
+      readonly extendEnv: boolean | undefined;
+    }> = [];
+    return Effect.gen(function* () {
+      const { registry } = yield* makeRegistry(baseProvider);
+      const runner = yield* makeTestRunner({
+        ...registry,
+        getProviderMaintenanceCapabilitiesForInstance: () =>
+          Effect.succeed(
+            makeProviderMaintenanceCapabilities({
+              provider: CODEX_DRIVER,
+              packageName: "@openai/codex",
+              updateExecutable: "/home/u/codex-home/packages/standalone/current/codex",
+              updateArgs: ["update"],
+              updateLockKey: "codex-native",
+              updateEnv: { CODEX_HOME: "/home/u/codex-home" },
+            }),
+          ),
+      });
+
+      const result = yield* runner.updateProvider(CODEX_DRIVER);
+
+      assert.strictEqual(captured.length, 1);
+      const call = captured[0];
+      assert.ok(call, "expected the spawner to be invoked once");
+      assert.strictEqual(call.command, "/home/u/codex-home/packages/standalone/current/codex");
+      assert.deepStrictEqual(call.args, ["update"]);
+      // The derived env extends the server env rather than replacing it, so
+      // PATH and friends stay intact for the updater.
+      assert.deepStrictEqual(call.env, { CODEX_HOME: "/home/u/codex-home" });
+      assert.strictEqual(call.extendEnv, true);
+      assert.strictEqual(result.providers[0]?.updateState?.status, "succeeded");
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          NonWindowsPlatform,
+          latestVersionHttpClient("0.0.0"),
+          Layer.succeed(
+            ChildProcessSpawner.ChildProcessSpawner,
+            ChildProcessSpawner.make((command) => {
+              const childProcess = command as unknown as {
+                readonly command: string;
+                readonly args: ReadonlyArray<string>;
+                readonly options: {
+                  readonly env?: Record<string, string | undefined> | undefined;
+                  readonly extendEnv?: boolean | undefined;
+                };
+              };
+              captured.push({
+                command: childProcess.command,
+                args: childProcess.args,
+                env: childProcess.options.env,
+                extendEnv: childProcess.options.extendEnv,
+              });
+              return Effect.succeed(mockHandle({ stdout: "updated" }));
+            }),
+          ),
+        ),
+      ),
+    );
+  });
+
   it.effect("resolves npm to a .cmd shim and routes through the shell on win32", () => {
     const captured: Array<{
       readonly command: string;

--- a/apps/server/src/provider/providerMaintenanceRunner.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.ts
@@ -73,6 +73,7 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
     readonly spawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
     readonly command: string;
     readonly args: ReadonlyArray<string>;
+    readonly env?: Readonly<Record<string, string>>;
   }) {
     const collectCommandResult = Effect.fn("ProviderMaintenanceRunner.collectCommandResult")(
       function* () {
@@ -83,7 +84,12 @@ const runProviderMaintenanceCommandWithSpawner = Effect.fn("ProviderMaintenanceR
         // shell. On Linux/macOS (incl. the WSL backend) this is a no-op.
         const resolved = yield* resolveSpawnCommand(input.command, input.args);
         const child = yield* input.spawner
-          .spawn(ChildProcess.make(resolved.command, resolved.args, { shell: resolved.shell }))
+          .spawn(
+            ChildProcess.make(resolved.command, resolved.args, {
+              shell: resolved.shell,
+              ...(input.env ? { env: input.env, extendEnv: true } : {}),
+            }),
+          )
           .pipe(
             Effect.mapError(
               (cause) =>
@@ -201,11 +207,16 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
   const providerRegistry = yield* ProviderRegistry;
   const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   const httpClient = yield* HttpClient.HttpClient;
-  const runMaintenanceCommand = (command: string, args: ReadonlyArray<string>) =>
+  const runMaintenanceCommand = (
+    command: string,
+    args: ReadonlyArray<string>,
+    env?: Readonly<Record<string, string>>,
+  ) =>
     runProviderMaintenanceCommandWithSpawner({
       spawner,
       command,
       args,
+      ...(env ? { env } : {}),
     });
   const commandCoordinator = yield* makeProviderMaintenanceCommandCoordinator({
     makeAlreadyRunningError: () =>
@@ -339,7 +350,7 @@ export const make = Effect.fn("ProviderMaintenanceRunner.make")(function* () {
               }),
             );
 
-            const result = yield* runMaintenanceCommand(update.executable, update.args);
+            const result = yield* runMaintenanceCommand(update.executable, update.args, update.env);
             const finishedAt = yield* nowIso;
             if (result.timedOut || result.exitCode !== 0) {
               return yield* finish(

--- a/apps/web/src/components/ProviderUpdateEnvironmentRows.test.tsx
+++ b/apps/web/src/components/ProviderUpdateEnvironmentRows.test.tsx
@@ -6,6 +6,7 @@ import {
   ProviderInstanceId,
   type ServerProvider,
 } from "@t3tools/contracts";
+import * as Cause from "effect/Cause";
 import { AsyncResult } from "effect/unstable/reactivity";
 
 import type {
@@ -367,9 +368,11 @@ describe("ProviderUpdateEnvironmentRows", () => {
 
   it.each(["connecting", "disconnected", "error"] as const)(
     "keeps an empty interacted host open while an environment is %s",
-    (connectionState) => {
+    async (connectionState) => {
       const onEmpty = vi.fn();
-      renderRow();
+      testState.updateProvider.mockResolvedValue(AsyncResult.failure(Cause.interrupt()));
+      renderRow().props.onUpdate();
+      await flushPromises();
       testState.isAnySettling = connectionState === "connecting";
       testState.groups = testState.groups.map((group) => ({
         ...group,
@@ -389,28 +392,38 @@ describe("ProviderUpdateEnvironmentRows", () => {
     },
   );
 
-  it("ignores an unrelated disconnected environment when closing an empty host", () => {
+  it("ignores an unattempted disconnected candidate when closing an empty host", async () => {
     const onEmpty = vi.fn();
-    renderRow();
+    const attemptedGroup = testState.groups[0]!;
+    const unattemptedCandidate = {
+      ...provider(),
+      instanceId: ProviderInstanceId.make("codex-other-wsl"),
+    } as ProviderUpdateCandidate;
     testState.groups = [
+      attemptedGroup,
       {
-        ...testState.groups[0]!,
-        candidates: [],
-        oneClickCandidates: [],
-        runnableCandidates: [],
-        providers: [],
-      },
-      {
-        ...testState.groups[0]!,
+        ...attemptedGroup,
         environmentId: "env-unrelated" as EnvironmentId,
         label: "Other WSL",
-        connectionState: "disconnected",
-        candidates: [],
-        oneClickCandidates: [],
-        runnableCandidates: [],
-        providers: [],
+        candidates: [unattemptedCandidate],
+        oneClickCandidates: [unattemptedCandidate],
+        runnableCandidates: [unattemptedCandidate],
+        providers: [unattemptedCandidate],
       },
     ];
+    testState.updateProvider.mockResolvedValue(AsyncResult.failure(Cause.interrupt()));
+
+    renderRow().props.onUpdate();
+    await flushPromises();
+
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      connectionState: group.environmentId === environmentId ? "ready" : "disconnected",
+      candidates: [],
+      oneClickCandidates: [],
+      runnableCandidates: [],
+      providers: group.environmentId === environmentId ? [provider("succeeded")] : [],
+    }));
 
     hooks.beginRender();
     const output = ProviderUpdateEnvironmentRows({ onEmpty });

--- a/apps/web/src/components/ProviderUpdateEnvironmentRows.test.tsx
+++ b/apps/web/src/components/ProviderUpdateEnvironmentRows.test.tsx
@@ -16,6 +16,7 @@ import type {
 
 const testState = vi.hoisted(() => ({
   groups: [] as LocalEnvironmentUpdateGroup[],
+  isAnySettling: false,
   updateProvider: vi.fn(),
 }));
 
@@ -40,6 +41,10 @@ const hooks = vi.hoisted(() => {
     useMemo<T>(factory: () => T): T {
       nextIndex();
       return factory();
+    },
+    useEffect(effect: () => void | (() => void)): void {
+      nextIndex();
+      effect();
     },
     useMemoCache(size: number): unknown[] {
       const index = nextIndex();
@@ -76,6 +81,7 @@ vi.mock("react", async (importOriginal) => {
   return {
     ...actual,
     useCallback: hooks.useCallback,
+    useEffect: hooks.useEffect,
     useMemo: hooks.useMemo,
     useRef: hooks.useRef,
     useState: hooks.useState,
@@ -97,7 +103,7 @@ vi.mock("~/state/use-atom-command", () => ({
 vi.mock("./ProviderUpdateLaunchNotification.environments", () => ({
   useLocalEnvironmentUpdateGroups: () => ({
     groups: testState.groups,
-    isAnySettling: false,
+    isAnySettling: testState.isAnySettling,
   }),
 }));
 
@@ -154,6 +160,7 @@ function deferred<T>() {
 
 type RowElement = ReactElement<{
   readonly status: ProviderUpdateRowStatus;
+  readonly canUpdate: boolean;
   readonly onUpdate: () => void;
 }>;
 
@@ -176,6 +183,7 @@ describe("ProviderUpdateEnvironmentRows", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     hooks.reset();
+    testState.isAnySettling = false;
     testState.updateProvider.mockReset();
     const candidate = provider() as ProviderUpdateCandidate;
     testState.groups = [
@@ -183,8 +191,11 @@ describe("ProviderUpdateEnvironmentRows", () => {
         environmentId,
         label: "WSL",
         isPrimary: false,
+        connectionState: "ready",
         isSettling: false,
         candidates: [candidate],
+        oneClickCandidates: [candidate],
+        runnableCandidates: [candidate],
         providers: [candidate],
       },
     ];
@@ -192,6 +203,242 @@ describe("ProviderUpdateEnvironmentRows", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+  });
+
+  it("does not expose or dispatch an update for settings-only candidates", () => {
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      oneClickCandidates: [],
+      runnableCandidates: [],
+    }));
+
+    const row = renderRow();
+
+    expect(row.props.canUpdate).toBe(false);
+    row.props.onUpdate();
+    expect(testState.updateProvider).not.toHaveBeenCalled();
+  });
+
+  it("does not mark unattempted settings-only candidates as updated", async () => {
+    const runnable = testState.groups[0]!.candidates[0]!;
+    const settingsOnly = {
+      ...provider(),
+      instanceId: ProviderInstanceId.make("claude-wsl"),
+      driver: ProviderDriverKind.make("claudeAgent"),
+      versionAdvisory: {
+        ...provider().versionAdvisory!,
+        updateCommand: null,
+        canUpdate: false,
+      },
+    } as ProviderUpdateCandidate;
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      candidates: [runnable, settingsOnly],
+      oneClickCandidates: [runnable],
+      runnableCandidates: [runnable],
+      providers: [runnable, settingsOnly],
+    }));
+    testState.updateProvider.mockResolvedValue(
+      AsyncResult.success({ providers: [provider("succeeded")] }),
+    );
+
+    renderRow().props.onUpdate();
+    await flushPromises();
+
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      candidates: [settingsOnly],
+      oneClickCandidates: [],
+      runnableCandidates: [],
+      providers: [settingsOnly],
+    }));
+    const row = renderRow();
+
+    expect(row.props.status.kind).toBe("idle");
+    expect(row.props.canUpdate).toBe(false);
+  });
+
+  it("shows sibling progress without allowing an idle representative to be redispatched", () => {
+    const candidate = provider() as ProviderUpdateCandidate;
+    const activeSibling = {
+      ...provider(),
+      instanceId: ProviderInstanceId.make("codex-work"),
+      updateState: {
+        status: "running" as const,
+        startedAt: "2099-01-01T00:00:00.000Z",
+        finishedAt: null,
+        message: "Updating provider.",
+        output: null,
+      },
+    } as ProviderUpdateCandidate;
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      candidates: [candidate],
+      oneClickCandidates: [candidate],
+      runnableCandidates: [],
+      providers: [candidate, activeSibling],
+    }));
+
+    const row = renderRow();
+
+    expect(row.props.status.kind).toBe("loading");
+    expect(row.props.canUpdate).toBe(false);
+  });
+
+  it("does not let a sibling's success hide an outdated runnable target", () => {
+    const candidate = provider() as ProviderUpdateCandidate;
+    const successfulSibling = {
+      ...provider("succeeded"),
+      instanceId: ProviderInstanceId.make("codex-work"),
+      updateState: {
+        status: "succeeded" as const,
+        startedAt: "2099-01-01T00:00:00.000Z",
+        finishedAt: "2099-01-01T00:00:01.000Z",
+        message: "Provider updated.",
+        output: null,
+      },
+    };
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      candidates: [candidate],
+      oneClickCandidates: [candidate],
+      runnableCandidates: [candidate],
+      providers: [successfulSibling, candidate],
+    }));
+
+    const row = renderRow();
+
+    expect(row.props.status.kind).toBe("idle");
+    expect(row.props.canUpdate).toBe(true);
+  });
+
+  it("hides a transport error after its attempted target is no longer offered", async () => {
+    const runnable = testState.groups[0]!.candidates[0]!;
+    const settingsOnly = {
+      ...provider(),
+      instanceId: ProviderInstanceId.make("claude-wsl"),
+      driver: ProviderDriverKind.make("claudeAgent"),
+      versionAdvisory: {
+        ...provider().versionAdvisory!,
+        updateCommand: null,
+        canUpdate: false,
+      },
+    } as ProviderUpdateCandidate;
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      candidates: [runnable, settingsOnly],
+      oneClickCandidates: [runnable],
+      runnableCandidates: [runnable],
+      providers: [runnable, settingsOnly],
+    }));
+    testState.updateProvider.mockRejectedValue(new Error("WebSocket closed"));
+
+    renderRow().props.onUpdate();
+    await flushPromises();
+    expect(renderRow().props.status).toMatchObject({ kind: "failed", text: "WebSocket closed" });
+
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      candidates: [settingsOnly],
+      oneClickCandidates: [],
+      runnableCandidates: [],
+      providers: [settingsOnly],
+    }));
+
+    expect(renderRow().props.status.kind).toBe("idle");
+  });
+
+  it("notifies the host when no row remains to render", () => {
+    const onEmpty = vi.fn();
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      candidates: [],
+      oneClickCandidates: [],
+      runnableCandidates: [],
+      providers: [],
+    }));
+
+    hooks.beginRender();
+    const output = ProviderUpdateEnvironmentRows({ onEmpty });
+
+    expect(output).toBeNull();
+    expect(onEmpty).toHaveBeenCalledOnce();
+  });
+
+  it.each(["connecting", "disconnected", "error"] as const)(
+    "keeps an empty interacted host open while an environment is %s",
+    (connectionState) => {
+      const onEmpty = vi.fn();
+      renderRow();
+      testState.isAnySettling = connectionState === "connecting";
+      testState.groups = testState.groups.map((group) => ({
+        ...group,
+        connectionState,
+        isSettling: connectionState === "connecting",
+        candidates: [],
+        oneClickCandidates: [],
+        runnableCandidates: [],
+        providers: [],
+      }));
+
+      hooks.beginRender();
+      const output = ProviderUpdateEnvironmentRows({ onEmpty });
+
+      expect(output).toBeNull();
+      expect(onEmpty).not.toHaveBeenCalled();
+    },
+  );
+
+  it("ignores an unrelated disconnected environment when closing an empty host", () => {
+    const onEmpty = vi.fn();
+    renderRow();
+    testState.groups = [
+      {
+        ...testState.groups[0]!,
+        candidates: [],
+        oneClickCandidates: [],
+        runnableCandidates: [],
+        providers: [],
+      },
+      {
+        ...testState.groups[0]!,
+        environmentId: "env-unrelated" as EnvironmentId,
+        label: "Other WSL",
+        connectionState: "disconnected",
+        candidates: [],
+        oneClickCandidates: [],
+        runnableCandidates: [],
+        providers: [],
+      },
+    ];
+
+    hooks.beginRender();
+    const output = ProviderUpdateEnvironmentRows({ onEmpty });
+
+    expect(output).toBeNull();
+    expect(onEmpty).toHaveBeenCalledOnce();
+  });
+
+  it("clears a lost-response error once a ready snapshot confirms the target is current", async () => {
+    const onEmpty = vi.fn();
+    testState.updateProvider.mockRejectedValue(new Error("WebSocket closed"));
+
+    renderRow().props.onUpdate();
+    await flushPromises();
+    expect(renderRow().props.status.kind).toBe("failed");
+
+    testState.groups = testState.groups.map((group) => ({
+      ...group,
+      candidates: [],
+      oneClickCandidates: [],
+      runnableCandidates: [],
+      providers: [provider("succeeded")],
+    }));
+    hooks.beginRender();
+    const output = ProviderUpdateEnvironmentRows({ onEmpty });
+
+    expect(output).toBeNull();
+    expect(onEmpty).toHaveBeenCalledOnce();
   });
 
   it("keeps a successor pending when an expired request resolves late, then shows its success", async () => {

--- a/apps/web/src/components/ProviderUpdateEnvironmentRows.tsx
+++ b/apps/web/src/components/ProviderUpdateEnvironmentRows.tsx
@@ -223,7 +223,11 @@ export function ProviderUpdateEnvironmentRows({
   const [resultByEnvironment, setResultByEnvironment] = useState<
     ReadonlyMap<EnvironmentId, EnvironmentUpdateResult>
   >(() => new Map());
-  const relevantEnvironmentIdsRef = useRef<Set<EnvironmentId>>(new Set());
+  // Remember only environments where this mounted prompt actually accepted an
+  // update attempt. If an interrupted request loses its row while that backend
+  // reconnects, this keeps the prompt alive until its snapshot is authoritative
+  // again without letting an unrelated offline candidate strand the prompt.
+  const attemptedEnvironmentIdsRef = useRef<Set<EnvironmentId>>(new Set());
 
   const clearPending = useCallback((environmentId: EnvironmentId) => {
     setPendingEnvironments((previous) => {
@@ -246,6 +250,7 @@ export function ProviderUpdateEnvironmentRows({
         return;
       }
       inFlightEnvironmentsRef.current.add(environmentId);
+      attemptedEnvironmentIdsRef.current.add(environmentId);
       const requestVersion = (requestVersionRef.current.get(environmentId) ?? 0) + 1;
       requestVersionRef.current.set(environmentId, requestVersion);
       const isCurrentRequest = () =>
@@ -457,27 +462,14 @@ export function ProviderUpdateEnvironmentRows({
     .filter(({ group, status }) => group.candidates.length > 0 || status.kind !== "idle");
 
   useEffect(() => {
-    for (const group of groups) {
-      if (
-        group.candidates.length > 0 ||
-        pendingEnvironments.has(group.environmentId) ||
-        errorByEnvironment.has(group.environmentId) ||
-        resultByEnvironment.has(group.environmentId)
-      ) {
-        relevantEnvironmentIdsRef.current.add(group.environmentId);
-      }
-    }
-  }, [errorByEnvironment, groups, pendingEnvironments, resultByEnvironment]);
-
-  useEffect(() => {
     // Empty provider snapshots from connecting, disconnected, or failed
     // backends are not authoritative. Keep an interacted toast mounted until
     // every backend that contributed an update or attempt is ready; unrelated
     // offline environments must not strand an otherwise-empty toast.
-    const relevantGroups = groups.filter((group) =>
-      relevantEnvironmentIdsRef.current.has(group.environmentId),
+    const attemptedGroups = groups.filter((group) =>
+      attemptedEnvironmentIdsRef.current.has(group.environmentId),
     );
-    if (rows.length === 0 && relevantGroups.every((group) => group.connectionState === "ready")) {
+    if (rows.length === 0 && attemptedGroups.every((group) => group.connectionState === "ready")) {
       onEmpty?.();
     }
   }, [groups, onEmpty, rows.length]);

--- a/apps/web/src/components/ProviderUpdateEnvironmentRows.tsx
+++ b/apps/web/src/components/ProviderUpdateEnvironmentRows.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon } from "lucide-react";
-import { type ReactNode, useCallback, useMemo, useRef, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { EnvironmentId, ServerProvider } from "@t3tools/contracts";
 import {
   isAtomCommandInterrupted,
@@ -16,10 +16,12 @@ import {
   firstRejectedProviderUpdateMessage,
   getProviderUpdateProgressToastView,
   getProviderUpdateSidebarPillView,
+  isProviderUpdateActive,
   isTerminalProviderUpdatePhase,
   resolveEnvironmentUpdateRowStatus,
   type LocalEnvironmentUpdateGroup,
   type LocalProviderUpdateOutcome,
+  type ProviderUpdateCandidate,
   type ProviderUpdateRowStatus,
   type ProviderUpdateRowStatusKind,
   type ProviderUpdateToastView,
@@ -31,6 +33,25 @@ type ProviderUpdateCommandResult = AtomCommandResult<
   { readonly providers: ReadonlyArray<ServerProvider> },
   unknown
 >;
+
+interface EnvironmentUpdateResult {
+  readonly view: ProviderUpdateToastView;
+  readonly attemptedCandidateKeys: ReadonlySet<string>;
+}
+
+interface EnvironmentUpdateError {
+  readonly message: string;
+  readonly attemptedCandidateKeys: ReadonlySet<string>;
+}
+
+function providerUpdateResultKey(candidate: ProviderUpdateCandidate): string {
+  const advisory = candidate.versionAdvisory;
+  return JSON.stringify([
+    candidate.driver,
+    advisory.latestVersion,
+    advisory.updateActionKey ?? advisory.updateCommand,
+  ]);
+}
 
 /**
  * Map one targeted instance's update command result into the settled-outcome
@@ -109,10 +130,12 @@ function rowToneClass(kind: ProviderUpdateRowStatusKind): string {
 function EnvironmentUpdateRow({
   group,
   status,
+  canUpdate,
   onUpdate,
 }: {
   readonly group: LocalEnvironmentUpdateGroup;
   readonly status: ProviderUpdateRowStatus;
+  readonly canUpdate: boolean;
   readonly onUpdate: () => void;
 }) {
   let trailing: ReactNode;
@@ -125,18 +148,18 @@ function EnvironmentUpdateRow({
       break;
     case "failed":
     case "unchanged":
-      trailing = (
+      trailing = canUpdate ? (
         <Button size="xs" variant="outline" onClick={onUpdate}>
           Retry
         </Button>
-      );
+      ) : null;
       break;
     default:
-      trailing = (
+      trailing = canUpdate ? (
         <Button size="xs" onClick={onUpdate}>
           Update
         </Button>
-      );
+      ) : null;
       break;
   }
 
@@ -153,14 +176,17 @@ function EnvironmentUpdateRow({
 
 /**
  * The launch popover's body when WSL is present: one row per local environment
- * (Windows + WSL), each with its own "update all" trigger that targets only
- * that environment's backend.
+ * (Windows + WSL). Each row targets only its own backend and exposes an update
+ * trigger only for candidates whose actions can be safely dispatched.
  */
 export function ProviderUpdateEnvironmentRows({
   onInteract,
+  onEmpty,
 }: {
   /** Called the first time the user triggers an update, so the host can stop refreshing the prompt. */
   readonly onInteract?: () => void;
+  /** Called once no update, progress, or result row remains for the host toast to display. */
+  readonly onEmpty?: () => void;
 }) {
   const { groups } = useLocalEnvironmentUpdateGroups();
   const updateProvider = useAtomCommand(serverEnvironment.updateProvider, {
@@ -191,12 +217,13 @@ export function ProviderUpdateEnvironmentRows({
   const [pendingEnvironments, setPendingEnvironments] = useState<ReadonlySet<EnvironmentId>>(
     () => new Set(),
   );
-  const [errorByEnvironment, setErrorByEnvironment] = useState<ReadonlyMap<EnvironmentId, string>>(
-    () => new Map(),
-  );
-  const [resultByEnvironment, setResultByEnvironment] = useState<
-    ReadonlyMap<EnvironmentId, ProviderUpdateToastView>
+  const [errorByEnvironment, setErrorByEnvironment] = useState<
+    ReadonlyMap<EnvironmentId, EnvironmentUpdateError>
   >(() => new Map());
+  const [resultByEnvironment, setResultByEnvironment] = useState<
+    ReadonlyMap<EnvironmentId, EnvironmentUpdateResult>
+  >(() => new Map());
+  const relevantEnvironmentIdsRef = useRef<Set<EnvironmentId>>(new Set());
 
   const clearPending = useCallback((environmentId: EnvironmentId) => {
     setPendingEnvironments((previous) => {
@@ -212,7 +239,7 @@ export function ProviderUpdateEnvironmentRows({
   const handleUpdate = useCallback(
     async (environmentId: EnvironmentId) => {
       const group = groupByEnvironment.get(environmentId);
-      if (!group || group.candidates.length === 0) {
+      if (!group || group.runnableCandidates.length === 0) {
         return;
       }
       if (inFlightEnvironmentsRef.current.has(environmentId)) {
@@ -224,8 +251,9 @@ export function ProviderUpdateEnvironmentRows({
       const isCurrentRequest = () =>
         requestVersionRef.current.get(environmentId) === requestVersion;
       onInteract?.();
-      const providerCount = group.candidates.length;
-      const targets = group.candidates.map((candidate) => ({
+      const providerCount = group.runnableCandidates.length;
+      const attemptedCandidateKeys = new Set(group.runnableCandidates.map(providerUpdateResultKey));
+      const targets = group.runnableCandidates.map((candidate) => ({
         driver: candidate.driver,
         instanceId: candidate.instanceId,
       }));
@@ -261,7 +289,10 @@ export function ProviderUpdateEnvironmentRows({
         inFlightEnvironmentsRef.current.delete(environmentId);
         clearPending(environmentId);
         setErrorByEnvironment((previous) =>
-          new Map(previous).set(environmentId, "Update timed out — try again."),
+          new Map(previous).set(environmentId, {
+            message: "Update timed out — try again.",
+            attemptedCandidateKeys,
+          }),
         );
       }, PENDING_EXPIRY_MS);
       try {
@@ -306,17 +337,20 @@ export function ProviderUpdateEnvironmentRows({
         });
         if (results.length === 0) {
           setErrorByEnvironment((previous) =>
-            new Map(previous).set(
-              environmentId,
-              "This environment isn’t connected — try again once it reconnects.",
-            ),
+            new Map(previous).set(environmentId, {
+              message: "This environment isn’t connected — try again once it reconnects.",
+              attemptedCandidateKeys,
+            }),
           );
           return;
         }
         const rejectedMessage = firstRejectedProviderUpdateMessage(results);
         if (rejectedMessage) {
           setErrorByEnvironment((previous) =>
-            new Map(previous).set(environmentId, rejectedMessage),
+            new Map(previous).set(environmentId, {
+              message: rejectedMessage,
+              attemptedCandidateKeys,
+            }),
           );
           return;
         }
@@ -334,15 +368,17 @@ export function ProviderUpdateEnvironmentRows({
         // the live per-environment provider state (pill) plus the pending expiry
         // drive the row, so it self-heals to whatever the backend actually did.
         if (isTerminalProviderUpdatePhase(view.phase)) {
-          setResultByEnvironment((previous) => new Map(previous).set(environmentId, view));
+          setResultByEnvironment((previous) =>
+            new Map(previous).set(environmentId, { view, attemptedCandidateKeys }),
+          );
         }
       } catch (error) {
         if (isCurrentRequest()) {
           setErrorByEnvironment((previous) =>
-            new Map(previous).set(
-              environmentId,
-              error instanceof Error ? error.message : "Provider update failed.",
-            ),
+            new Map(previous).set(environmentId, {
+              message: error instanceof Error ? error.message : "Provider update failed.",
+              attemptedCandidateKeys,
+            }),
           );
         }
       } finally {
@@ -359,24 +395,92 @@ export function ProviderUpdateEnvironmentRows({
   );
 
   const rows = groups
-    .map((group) => ({
-      group,
-      status: resolveEnvironmentUpdateRowStatus({
+    .map((group) => {
+      const storedResult = resultByEnvironment.get(group.environmentId);
+      const storedError = errorByEnvironment.get(group.environmentId);
+      const hasAttemptedCandidate =
+        storedResult !== undefined &&
+        group.candidates.some((candidate) =>
+          storedResult.attemptedCandidateKeys.has(providerUpdateResultKey(candidate)),
+        );
+      const hasUnattemptedCandidate =
+        storedResult !== undefined &&
+        group.candidates.some(
+          (candidate) =>
+            !storedResult.attemptedCandidateKeys.has(providerUpdateResultKey(candidate)),
+        );
+      const oneClickCandidateKeys = new Set(group.oneClickCandidates.map(providerUpdateResultKey));
+      const hasSettingsOnlyCandidate = group.candidates.some(
+        (candidate) => !oneClickCandidateKeys.has(providerUpdateResultKey(candidate)),
+      );
+      const pillProviders = group.oneClickCandidates.map(
+        (candidate) =>
+          group.providers.find(
+            (provider) => provider.driver === candidate.driver && isProviderUpdateActive(provider),
+          ) ?? candidate,
+      );
+      const pill = getProviderUpdateSidebarPillView(pillProviders, {
+        visibleAfterIso: visibleAfterIsoRef.current,
+      });
+      const hasErrorTarget =
+        storedError !== undefined &&
+        group.candidates.some((candidate) =>
+          storedError.attemptedCandidateKeys.has(providerUpdateResultKey(candidate)),
+        );
+      const visibleError =
+        storedError !== undefined && group.connectionState === "ready" && !hasErrorTarget
+          ? undefined
+          : storedError?.message;
+      const visibleResult =
+        (group.candidates.length > 0 && storedResult !== undefined && !hasAttemptedCandidate) ||
+        (storedResult?.view.phase === "succeeded" && hasUnattemptedCandidate)
+          ? undefined
+          : storedResult?.view;
+      const visiblePill = pill?.tone === "success" && hasSettingsOnlyCandidate ? null : pill;
+
+      return {
         group,
-        error: errorByEnvironment.get(group.environmentId),
-        result: resultByEnvironment.get(group.environmentId),
-        // Derive the live pill from the candidates this row is actually
-        // tracking, not every provider in the environment. Otherwise an
-        // unrelated provider's recent success (or one candidate succeeding while
-        // another was interrupted) makes the pill report success and hides the
-        // Update action for candidates that are still outdated.
-        pill: getProviderUpdateSidebarPillView(group.candidates, {
-          visibleAfterIso: visibleAfterIsoRef.current,
+        status: resolveEnvironmentUpdateRowStatus({
+          group,
+          error: visibleError,
+          result: visibleResult,
+          // Derive the live pill from the candidates this row is actually
+          // tracking, not every provider in the environment. Otherwise an
+          // unrelated provider's recent success (or one candidate succeeding while
+          // another was interrupted) makes the pill report success and hides the
+          // Update action for candidates that are still outdated.
+          pill: visiblePill,
+          isPending: pendingEnvironments.has(group.environmentId),
         }),
-        isPending: pendingEnvironments.has(group.environmentId),
-      }),
-    }))
+      };
+    })
     .filter(({ group, status }) => group.candidates.length > 0 || status.kind !== "idle");
+
+  useEffect(() => {
+    for (const group of groups) {
+      if (
+        group.candidates.length > 0 ||
+        pendingEnvironments.has(group.environmentId) ||
+        errorByEnvironment.has(group.environmentId) ||
+        resultByEnvironment.has(group.environmentId)
+      ) {
+        relevantEnvironmentIdsRef.current.add(group.environmentId);
+      }
+    }
+  }, [errorByEnvironment, groups, pendingEnvironments, resultByEnvironment]);
+
+  useEffect(() => {
+    // Empty provider snapshots from connecting, disconnected, or failed
+    // backends are not authoritative. Keep an interacted toast mounted until
+    // every backend that contributed an update or attempt is ready; unrelated
+    // offline environments must not strand an otherwise-empty toast.
+    const relevantGroups = groups.filter((group) =>
+      relevantEnvironmentIdsRef.current.has(group.environmentId),
+    );
+    if (rows.length === 0 && relevantGroups.every((group) => group.connectionState === "ready")) {
+      onEmpty?.();
+    }
+  }, [groups, onEmpty, rows.length]);
 
   if (rows.length === 0) {
     return null;
@@ -389,6 +493,7 @@ export function ProviderUpdateEnvironmentRows({
           key={group.environmentId}
           group={group}
           status={status}
+          canUpdate={group.runnableCandidates.length > 0}
           onUpdate={() => handleUpdate(group.environmentId)}
         />
       ))}

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -54,6 +54,7 @@ function provider(input: {
   readonly latestVersion?: string | null;
   readonly canUpdate?: boolean;
   readonly updateCommand?: string | null;
+  readonly updateActionKey?: string;
   readonly updateState?: ServerProvider["updateState"];
   readonly advisoryStatus?: NonNullable<ServerProvider["versionAdvisory"]>["status"];
 }): ServerProvider {
@@ -74,6 +75,7 @@ function provider(input: {
       currentVersion: input.version ?? "1.0.0",
       latestVersion: "latestVersion" in input ? input.latestVersion : "1.1.0",
       updateCommand: "updateCommand" in input ? input.updateCommand : "npm install -g provider",
+      ...("updateActionKey" in input ? { updateActionKey: input.updateActionKey } : {}),
       canUpdate: input.canUpdate ?? true,
       checkedAt,
       message: "Update available.",
@@ -141,6 +143,31 @@ describe("provider update launch notification logic", () => {
           latestVersion: "2.1.123",
           canUpdate: true,
           updateCommand: "bun add -g @anthropic-ai/claude-code@latest",
+        }),
+      ]),
+    ).toBe(false);
+  });
+
+  it("disables one-click updates when provider instances share a command but run different actions", () => {
+    const candidate = updateCandidate({
+      driver: driver("codex"),
+      instanceId: instanceId("codex_personal"),
+      latestVersion: "0.143.0",
+      updateCommand: "codex update",
+      updateActionKey: "codex-native /home/me/.codex/packages/standalone/current/bin/codex update",
+    });
+
+    expect(
+      canOneClickUpdateProviderCandidate(candidate, [
+        candidate,
+        provider({
+          driver: driver("codex"),
+          instanceId: instanceId("codex_work"),
+          latestVersion: "0.143.0",
+          canUpdate: true,
+          updateCommand: "codex update",
+          updateActionKey:
+            "codex-native /home/me/work-codex/packages/standalone/current/bin/codex update",
         }),
       ]),
     ).toBe(false);

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.test.ts
@@ -227,6 +227,27 @@ describe("provider update launch notification logic", () => {
     expect(canOneClickUpdateProviderCandidate(candidate, [candidate])).toBe(false);
   });
 
+  it("blocks a shared driver action while a sibling instance is already updating", () => {
+    const candidate = updateCandidate({
+      driver: driver("codex"),
+      instanceId: instanceId("codex"),
+    });
+    const activeSibling = provider({
+      driver: driver("codex"),
+      instanceId: instanceId("codex_work"),
+      updateState: {
+        status: "running",
+        startedAt: checkedAt,
+        finishedAt: null,
+        message: "Updating provider.",
+        output: null,
+      },
+    });
+
+    expect(hasOneClickUpdateProviderCandidate(candidate, [candidate, activeSibling])).toBe(true);
+    expect(canOneClickUpdateProviderCandidate(candidate, [candidate, activeSibling])).toBe(false);
+  });
+
   it("builds a notification key from provider latest versions", () => {
     const codex = updateCandidate({
       driver: driver("codex"),
@@ -554,6 +575,29 @@ describe("provider update launch notification logic", () => {
       tone: "loading",
       title: "Updating Codex",
       description: "Codex update in progress.",
+    });
+  });
+
+  it("shows a non-default instance's active update ahead of an idle default instance", () => {
+    const view = getProviderUpdateSidebarPillView([
+      provider({ driver: driver("codex"), instanceId: instanceId("codex") }),
+      provider({
+        driver: driver("codex"),
+        instanceId: instanceId("codex_work"),
+        updateState: {
+          status: "running",
+          startedAt: checkedAt,
+          finishedAt: null,
+          message: "Updating provider.",
+          output: null,
+        },
+      }),
+    ]);
+
+    expect(view).toMatchObject({
+      key: "loading:codex:running",
+      tone: "loading",
+      title: "Updating Codex",
     });
   });
 
@@ -887,7 +931,7 @@ describe("provider update launch notification logic", () => {
       providers: input.providers,
     });
 
-    it("groups each environment's outdated one-click candidates", () => {
+    it("groups each environment's outdated candidates and safe one-click targets", () => {
       const result = buildLocalEnvironmentUpdateGroups([
         environment({
           environmentId: "env-windows",
@@ -905,6 +949,97 @@ describe("provider update launch notification logic", () => {
       expect(result.isAnySettling).toBe(false);
       expect(result.groups.map((group) => group.label)).toEqual(["Windows", "WSL"]);
       expect(result.groups.every((group) => group.candidates.length === 1)).toBe(true);
+      expect(result.groups.every((group) => group.oneClickCandidates.length === 1)).toBe(true);
+      expect(result.groups.every((group) => group.runnableCandidates.length === 1)).toBe(true);
+    });
+
+    it("keeps settings-only updates visible without creating a runnable target", () => {
+      const { groups } = buildLocalEnvironmentUpdateGroups([
+        environment({
+          environmentId: "env-wsl",
+          label: "WSL",
+          providers: [
+            provider({
+              driver: driver("codex"),
+              instanceId: instanceId("codex_personal"),
+              latestVersion: "0.143.0",
+              updateCommand: "codex update",
+              updateActionKey:
+                "codex-native /home/me/.codex/packages/standalone/current/bin/codex update",
+            }),
+            provider({
+              driver: driver("codex"),
+              instanceId: instanceId("codex_work"),
+              latestVersion: "0.143.0",
+              updateCommand: "codex update",
+              updateActionKey:
+                "codex-native /home/me/work-codex/packages/standalone/current/bin/codex update",
+            }),
+          ],
+        }),
+      ]);
+
+      expect(groups[0]?.candidates).toHaveLength(1);
+      expect(groups[0]?.oneClickCandidates).toEqual([]);
+      expect(groups[0]?.runnableCandidates).toEqual([]);
+      expect(environmentGroupsWithUpdates(groups).map((group) => group.environmentId)).toEqual([
+        "env-wsl",
+      ]);
+      expect(localEnvironmentUpdateNotificationKey(groups)).toBe("env-wsl=codex:0.143.0");
+    });
+
+    it("keeps active update targets available for live progress but not redispatch", () => {
+      const active = provider({
+        driver: driver("codex"),
+        instanceId: instanceId("codex_wsl"),
+        updateState: {
+          status: "running",
+          startedAt: checkedAt,
+          finishedAt: null,
+          message: "Updating provider.",
+          output: null,
+        },
+      });
+      const { groups } = buildLocalEnvironmentUpdateGroups([
+        environment({
+          environmentId: "env-wsl",
+          label: "WSL",
+          providers: [active],
+        }),
+      ]);
+
+      expect(groups[0]?.candidates).toHaveLength(1);
+      expect(groups[0]?.oneClickCandidates).toHaveLength(1);
+      expect(groups[0]?.runnableCandidates).toEqual([]);
+    });
+
+    it("does not expose an idle representative while a same-driver sibling is active", () => {
+      const idleDefault = provider({
+        driver: driver("codex"),
+        instanceId: instanceId("codex"),
+      });
+      const activeSibling = provider({
+        driver: driver("codex"),
+        instanceId: instanceId("codex_work"),
+        updateState: {
+          status: "running",
+          startedAt: checkedAt,
+          finishedAt: null,
+          message: "Updating provider.",
+          output: null,
+        },
+      });
+      const { groups } = buildLocalEnvironmentUpdateGroups([
+        environment({
+          environmentId: "env-wsl",
+          label: "WSL",
+          providers: [idleDefault, activeSibling],
+        }),
+      ]);
+
+      expect(groups[0]?.candidates).toHaveLength(1);
+      expect(groups[0]?.oneClickCandidates).toHaveLength(1);
+      expect(groups[0]?.runnableCandidates).toEqual([]);
     });
 
     it("flags settling while a secondary backend is still connecting", () => {
@@ -1040,8 +1175,11 @@ describe("provider update launch notification logic", () => {
       environmentId: "env-wsl" as EnvironmentId,
       label: "WSL",
       isPrimary: false,
+      connectionState: "ready",
       isSettling: false,
       candidates: [updateCandidate({ driver: driver("codex"), latestVersion: "1.1.0" })],
+      oneClickCandidates: [updateCandidate({ driver: driver("codex"), latestVersion: "1.1.0" })],
+      runnableCandidates: [updateCandidate({ driver: driver("codex"), latestVersion: "1.1.0" })],
       providers: [],
     };
     const runningResult: ProviderUpdateToastView = {

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -165,7 +165,7 @@ export function hasOneClickUpdateProviderCandidate(
     return false;
   }
 
-  const updateCommands = new Set<string>();
+  const updateActionKeys = new Set<string>();
   for (const provider of driverProviders) {
     if (!isProviderUpdateCandidate(provider)) {
       continue;
@@ -174,10 +174,10 @@ export function hasOneClickUpdateProviderCandidate(
     if (!advisory || advisory.canUpdate !== true || advisory.updateCommand === null) {
       return false;
     }
-    updateCommands.add(advisory.updateCommand);
+    updateActionKeys.add(advisory.updateActionKey ?? advisory.updateCommand);
   }
 
-  return updateCommands.size === 1;
+  return updateActionKeys.size === 1;
 }
 
 export function canOneClickUpdateProviderCandidate(

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.logic.ts
@@ -185,7 +185,9 @@ export function canOneClickUpdateProviderCandidate(
   providers: ReadonlyArray<ServerProvider>,
 ): boolean {
   return (
-    !isProviderUpdateActive(candidate) && hasOneClickUpdateProviderCandidate(candidate, providers)
+    !providers.some(
+      (provider) => provider.driver === candidate.driver && isProviderUpdateActive(provider),
+    ) && hasOneClickUpdateProviderCandidate(candidate, providers)
   );
 }
 
@@ -409,8 +411,12 @@ export function getProviderUpdateSidebarPillView(
   providers: ReadonlyArray<ServerProvider>,
   options?: ProviderUpdateSidebarPillOptions,
 ): ProviderUpdateSidebarPillView | null {
+  // Check activity before choosing one representative instance per driver. A
+  // shared driver update may be running on a non-default instance while the
+  // default instance remains idle; preferring the default first would hide the
+  // live update and allow the same driver action to be queued again.
+  const activeProviders = dedupeProvidersByDriver(providers.filter(isProviderUpdateActive));
   const dedupedProviders = dedupeProvidersByDriver(providers);
-  const activeProviders = dedupedProviders.filter(isProviderUpdateActive);
   if (activeProviders.length > 0) {
     const activeProvider = activeProviders[0]!;
     const activeProviderName =
@@ -709,39 +715,55 @@ export interface LocalEnvironmentUpdateGroup {
   readonly environmentId: EnvironmentId;
   readonly label: string;
   readonly isPrimary: boolean;
+  /** Whether this backend's provider snapshot is authoritative right now. */
+  readonly connectionState: EnvironmentUpdateConnectionState;
   /** True while this environment's backend is still connecting (e.g. WSL booting). */
   readonly isSettling: boolean;
-  /** Outdated, one-click-updatable providers in this environment. */
+  /** Outdated driver candidates, including settings-only updates. */
   readonly candidates: ProviderUpdateCandidate[];
+  /** Outdated providers whose update actions can be safely grouped. */
+  readonly oneClickCandidates: ProviderUpdateCandidate[];
+  /** Group-safe providers that are not already queued or running. */
+  readonly runnableCandidates: ProviderUpdateCandidate[];
   /** Full provider list for this environment, used to derive live update progress. */
   readonly providers: ReadonlyArray<ServerProvider>;
 }
 
 /**
- * Build one update group per local environment, pairing each environment's
- * outdated one-click candidates with its own provider list, and report whether
- * any environment is still settling (so the caller can defer the popover).
+ * Build one update group per local environment, retaining each outdated driver
+ * candidate for notification while separately identifying the candidates that
+ * are safe to update with one click. Also report whether any environment is
+ * still settling (so the caller can defer the popover).
  */
 export function buildLocalEnvironmentUpdateGroups(
   environments: ReadonlyArray<LocalEnvironmentProvidersInput>,
 ): { groups: LocalEnvironmentUpdateGroup[]; isAnySettling: boolean } {
-  const groups = environments.map((environment) => ({
-    environmentId: environment.environmentId,
-    label: environment.label,
-    isPrimary: environment.isPrimary,
-    isSettling: environment.connectionState === "connecting",
-    candidates: collectProviderUpdateCandidates(environment.providers).filter((candidate) =>
-      canOneClickUpdateProviderCandidate(candidate, environment.providers),
-    ),
-    providers: environment.providers,
-  }));
+  const groups = environments.map((environment) => {
+    const candidates = collectProviderUpdateCandidates(environment.providers);
+    const oneClickCandidates = candidates.filter((candidate) =>
+      hasOneClickUpdateProviderCandidate(candidate, environment.providers),
+    );
+    return {
+      environmentId: environment.environmentId,
+      label: environment.label,
+      isPrimary: environment.isPrimary,
+      connectionState: environment.connectionState,
+      isSettling: environment.connectionState === "connecting",
+      candidates,
+      oneClickCandidates,
+      runnableCandidates: oneClickCandidates.filter((candidate) =>
+        canOneClickUpdateProviderCandidate(candidate, environment.providers),
+      ),
+      providers: environment.providers,
+    };
+  });
   const isAnySettling = environments.some(
     (environment) => environment.connectionState === "connecting",
   );
   return { groups, isAnySettling };
 }
 
-/** Groups that actually have a one-click update available, in display order (primary first). */
+/** Groups that have an update available, including settings-only updates. */
 export function environmentGroupsWithUpdates(
   groups: ReadonlyArray<LocalEnvironmentUpdateGroup>,
 ): LocalEnvironmentUpdateGroup[] {

--- a/apps/web/src/components/ProviderUpdateLaunchNotification.tsx
+++ b/apps/web/src/components/ProviderUpdateLaunchNotification.tsx
@@ -94,6 +94,11 @@ function ProviderUpdateEnvironmentsNotification() {
     () => collectProviderUpdateCandidates(updateGroups.flatMap((group) => group.candidates)),
     [updateGroups],
   );
+  const runnableCandidateUnion = useMemo(
+    () =>
+      collectProviderUpdateCandidates(updateGroups.flatMap((group) => group.runnableCandidates)),
+    [updateGroups],
+  );
 
   // Defer while any local backend is still connecting, up to the grace period.
   const [settleGraceElapsed, setSettleGraceElapsed] = useState(false);
@@ -115,6 +120,14 @@ function ProviderUpdateEnvironmentsNotification() {
     }
     void navigate({ to: "/settings/providers" });
   }, [navigate]);
+
+  const closeEmptyPrompt = useCallback(() => {
+    const active = activeToastRef.current;
+    if (active !== null) {
+      toastManager.close(active.toastId);
+      activeToastRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     // Whether a fresh prompt can actually be shown for the current update set.
@@ -162,13 +175,14 @@ function ProviderUpdateEnvironmentsNotification() {
         type: "warning",
         title: getProviderUpdateInitialToastView({
           updateProviders: candidateUnion,
-          oneClickProviders: candidateUnion,
+          oneClickProviders: runnableCandidateUnion,
         }).title,
         description: (
           <ProviderUpdateEnvironmentRows
             onInteract={() => {
               hasInteractedRef.current = true;
             }}
+            onEmpty={closeEmptyPrompt}
           />
         ),
         timeout: 0,
@@ -189,9 +203,11 @@ function ProviderUpdateEnvironmentsNotification() {
     notificationKey,
     isGated,
     candidateUnion,
+    runnableCandidateUnion,
     dismissedNotificationKeys,
     dismissNotificationKey,
     openProviderSettings,
+    closeEmptyPrompt,
   ]);
 
   return null;

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -128,6 +128,7 @@ export const ServerProviderVersionAdvisory = Schema.Struct({
   currentVersion: Schema.NullOr(TrimmedNonEmptyString),
   latestVersion: Schema.NullOr(TrimmedNonEmptyString),
   updateCommand: Schema.NullOr(TrimmedNonEmptyString),
+  updateActionKey: Schema.optionalKey(TrimmedNonEmptyString),
   canUpdate: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   checkedAt: Schema.NullOr(IsoDateTime),
   message: Schema.NullOr(TrimmedNonEmptyString),


### PR DESCRIPTION
## Summary

Standalone Codex installs update via `codex update` instead of npm global installs.

- Detects the installer's real layout — `packages/standalone/releases/<version>/codex`, which the `current` and `~/.local/bin/codex` symlinks resolve to — plus `current/codex`, `current/bin/codex`, and custom `CODEX_HOME` roots.
- Spawns the update with `CODEX_HOME` pinned to the matched install root, since `codex update` locates its install via `$CODEX_HOME` and the maintenance runner spawns with the server env.
- `updateCommand` mirrors the spawned action (full path for explicitly configured binaries), so the copyable manual command targets the selected install.
- `updateActionKey` (JSON-encoded lockKey/executable/args/env) gates one-click grouping to instances that run the same update action.

Package-manager installs (npm/pnpm/bun/Vite Plus/Homebrew) keep their existing update paths.

Known limitation: instances reaching the same install through different spellings (bare name vs explicit path) don't group for one-click; each still updates individually.

## UI Changes

No visual changes.

## Validation

- Server provider tests, web update-notification tests, contracts tests
- Server/web/contracts typecheck; format and lint on touched files

## Checklist

- [x] Small and focused
- [x] Explained what changed and why
- [x] No visual UI changes
- [x] No animation or interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider update spawning (env, resolved executables) and advisory/UI grouping logic; incorrect path or env handling could update the wrong install or mislead one-click grouping, though behavior is heavily covered by new tests.
> 
> **Overview**
> Adds **native `codex update`** for standalone Codex installs: detects `packages/standalone` layouts (including symlinked `current` and versioned release binaries), pins **`CODEX_HOME`** on the spawned update, and disables one-click updates when the configured binary is a **pinned release path** that `codex update` would not replace.
> 
> Refactors **provider maintenance** so native updates use the **resolved binary path** (drops static `executable` on Claude/OpenCode/Codex), supports optional **`deriveEnv`** on update actions, passes **`env`** through the maintenance runner spawn, and builds **copyable manual commands** via shell-safe quoting (POSIX / PowerShell) instead of naive joins. Version advisories gain optional **`updateActionKey`** so the UI can tell apart actions that share the same command string.
> 
> **Update notification UI** splits outdated providers into visible **`candidates`**, group-safe **`oneClickCandidates`**, and dispatchable **`runnableCandidates`**; blocks one-click while a same-driver sibling is active; prefers active instances in the sidebar pill; and tightens row/toast lifecycle (no update for settings-only rows, **`onEmpty`** when nothing remains, stale errors cleared when targets disappear).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6adf5ad40546953800eaf2b0a537944db07991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add native one-click update support for Codex standalone installs
> - Adds `isCodexStandaloneCommandPath` and `deriveCodexStandaloneUpdateEnvironment` to [CodexDriver.ts](https://github.com/pingdotgg/t3code/pull/3626/files#diff-c705233bf69322a30e4a04be3428cd51dc6fa014d5a03b852da94c6ab9b6ae35) to detect standalone installs and derive `CODEX_HOME` for update commands; pinned release binary paths are excluded from one-click eligibility.
> - Refactors `resolvePackageManagedProviderMaintenance` in [providerMaintenance.ts](https://github.com/pingdotgg/t3code/pull/3626/files#diff-e29fae218a488cafd27faaeea37f0b7c1dccd03ba4a994975736ddf89e3bde14) so the resolved command path is used as the executable and derived env vars are passed through, replacing statically configured executables.
> - Adds platform-aware shell quoting (POSIX and PowerShell) via [providerMaintenanceCommand.ts](https://github.com/pingdotgg/t3code/pull/3626/files#diff-7adbbe138e67d20cf73e20d8827f46aacf36d944c58859412cc19ba7ad2990aa); the displayed update command may now be `null` when safe rendering is not possible.
> - Extends the `ServerProviderVersionAdvisory` schema with an optional `updateActionKey` field, used by the frontend to deduplicate and gate one-click update actions across driver instances.
> - Updates `ProviderUpdateEnvironmentRows` to dispatch updates only for `runnableCandidates`, hide Update/Retry buttons when no runnable candidates exist, and close the toast via `onEmpty` when all interacted environments reach a ready state.
> - Risk: `updateCommand` in advisories may now be `null`; callers that assumed a non-null string must handle the null case.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2d6adf5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->



