### PR TITLE
Open terminal in right panel with Cmd+J

### DIFF
--- a/apps/server/src/keybindings.test.ts
+++ b/apps/server/src/keybindings.test.ts
@@ -200,6 +200,7 @@ it.layer(NodeServices.layer)("keybindings", (it) => {
       assert.equal(defaultsByCommand.get("modelPicker.toggle"), "mod+shift+m");
       assert.equal(defaultsByCommand.get("sidebar.toggle"), "mod+b");
       assert.equal(defaultsByCommand.get("rightPanel.toggle"), "mod+alt+b");
+      assert.equal(defaultsByCommand.get("terminal.focus"), "mod+t");
       assert.equal(defaultsByCommand.get("terminal.splitVertical"), "mod+shift+d");
       assert.equal(defaultsByCommand.get("modelPicker.jump.1"), "mod+1");
       assert.equal(defaultsByCommand.get("modelPicker.jump.9"), "mod+9");

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2929,6 +2929,39 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [activeThreadRef, diffOpen, dismissPlanSidebarForCurrentTurn, onDiffPanelOpen, planSidebarOpen],
   );
+  // Returns false when the right panel is closed so terminal.toggle falls back to the drawer.
+  const toggleTerminalInRightPanel = useCallback(() => {
+    if (!activeThreadRef) return false;
+    const store = useRightPanelStore.getState();
+    const panelState = selectThreadRightPanelState(store.byThreadKey, activeThreadRef);
+    if (!panelState.isOpen) return false;
+    const activeSurface = panelState.surfaces.find(
+      (surface) => surface.id === panelState.activeSurfaceId,
+    );
+    if (activeSurface?.kind === "terminal") {
+      setMaximizedRightPanelThreadKey(null);
+      store.close(activeThreadRef);
+      return true;
+    }
+    const terminalSurface = panelState.surfaces.find((surface) => surface.kind === "terminal");
+    if (terminalSurface) {
+      activateRightPanelSurface(terminalSurface);
+      return true;
+    }
+    if (!activeThreadId || !activeProject) return false;
+    if (activeSurface?.kind === "plan") {
+      dismissPlanSidebarForCurrentTurn();
+    }
+    addTerminalSurface();
+    return true;
+  }, [
+    activeProject,
+    activeThreadId,
+    activeThreadRef,
+    activateRightPanelSurface,
+    addTerminalSurface,
+    dismissPlanSidebarForCurrentTurn,
+  ]);
   const toggleRightPanel = useCallback(() => {
     if (!activeThreadRef) return;
     if (rightPanelOpen) {
@@ -3725,7 +3758,9 @@ function ChatViewContent(props: ChatViewProps) {
       if (command === "terminal.toggle") {
         event.preventDefault();
         event.stopPropagation();
-        toggleTerminalVisibility();
+        if (terminalFocusOwner === "drawer" || !toggleTerminalInRightPanel()) {
+          toggleTerminalVisibility();
+        }
         return;
       }
 
@@ -3838,6 +3873,7 @@ function ChatViewContent(props: ChatViewProps) {
     keybindings,
     onToggleDiff,
     toggleRightPanel,
+    toggleTerminalInRightPanel,
     toggleThreadPanel,
     toggleTerminalVisibility,
     composerRef,

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -2929,31 +2929,39 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [activeThreadRef, diffOpen, dismissPlanSidebarForCurrentTurn, onDiffPanelOpen, planSidebarOpen],
   );
-  // Returns false when the right panel is closed so terminal.toggle falls back to the drawer.
-  const toggleTerminalInRightPanel = useCallback(() => {
-    if (!activeThreadRef) return false;
+  const focusTerminal = useCallback(() => {
+    if (!activeThreadRef) return;
+    const terminalFocusOwner = getTerminalFocusOwner();
+    if (terminalFocusOwner !== null) return;
+
     const store = useRightPanelStore.getState();
     const panelState = selectThreadRightPanelState(store.byThreadKey, activeThreadRef);
-    if (!panelState.isOpen) return false;
-    const activeSurface = panelState.surfaces.find(
-      (surface) => surface.id === panelState.activeSurfaceId,
-    );
-    if (activeSurface?.kind === "terminal") {
-      setMaximizedRightPanelThreadKey(null);
-      store.close(activeThreadRef);
-      return true;
+    if (panelState.isOpen) {
+      const activeSurface = panelState.surfaces.find(
+        (surface) => surface.id === panelState.activeSurfaceId,
+      );
+      if (activeSurface?.kind === "terminal") {
+        setTerminalFocusRequestId((value) => value + 1);
+        return;
+      }
+      const terminalSurface = panelState.surfaces.find((surface) => surface.kind === "terminal");
+      if (terminalSurface) {
+        activateRightPanelSurface(terminalSurface);
+        return;
+      }
+      if (!activeThreadId || !activeProject) return;
+      if (activeSurface?.kind === "plan") {
+        dismissPlanSidebarForCurrentTurn();
+      }
+      addTerminalSurface();
+      return;
     }
-    const terminalSurface = panelState.surfaces.find((surface) => surface.kind === "terminal");
-    if (terminalSurface) {
-      activateRightPanelSurface(terminalSurface);
-      return true;
+
+    if (terminalUiState.terminalOpen) {
+      setTerminalFocusRequestId((value) => value + 1);
+      return;
     }
-    if (!activeThreadId || !activeProject) return false;
-    if (activeSurface?.kind === "plan") {
-      dismissPlanSidebarForCurrentTurn();
-    }
-    addTerminalSurface();
-    return true;
+    toggleTerminalVisibility();
   }, [
     activeProject,
     activeThreadId,
@@ -2961,6 +2969,8 @@ function ChatViewContent(props: ChatViewProps) {
     activateRightPanelSurface,
     addTerminalSurface,
     dismissPlanSidebarForCurrentTurn,
+    terminalUiState.terminalOpen,
+    toggleTerminalVisibility,
   ]);
   const toggleRightPanel = useCallback(() => {
     if (!activeThreadRef) return;
@@ -3755,12 +3765,17 @@ function ChatViewContent(props: ChatViewProps) {
       });
       if (!command) return;
 
+      if (command === "terminal.focus") {
+        event.preventDefault();
+        event.stopPropagation();
+        focusTerminal();
+        return;
+      }
+
       if (command === "terminal.toggle") {
         event.preventDefault();
         event.stopPropagation();
-        if (terminalFocusOwner === "drawer" || !toggleTerminalInRightPanel()) {
-          toggleTerminalVisibility();
-        }
+        toggleTerminalVisibility();
         return;
       }
 
@@ -3870,10 +3885,10 @@ function ChatViewContent(props: ChatViewProps) {
     runProjectScript,
     splitTerminal,
     splitPanelTerminal,
+    focusTerminal,
     keybindings,
     onToggleDiff,
     toggleRightPanel,
-    toggleTerminalInRightPanel,
     toggleThreadPanel,
     toggleTerminalVisibility,
     composerRef,

--- a/apps/web/src/components/ThreadTerminalDrawer.tsx
+++ b/apps/web/src/components/ThreadTerminalDrawer.tsx
@@ -46,6 +46,7 @@ import {
   isDiffToggleShortcut,
   isTerminalClearShortcut,
   isTerminalCloseShortcut,
+  isTerminalFocusShortcut,
   isTerminalNewShortcut,
   isTerminalSplitShortcut,
   isTerminalSplitVerticalShortcut,
@@ -500,6 +501,7 @@ export function TerminalViewport({
       const currentKeybindings = keybindingsRef.current;
       const options = { context: { terminalFocus: true, terminalOpen: true } };
       if (
+        isTerminalFocusShortcut(event, currentKeybindings, options) ||
         isTerminalToggleShortcut(event, currentKeybindings, options) ||
         isTerminalSplitShortcut(event, currentKeybindings, options) ||
         isTerminalSplitVerticalShortcut(event, currentKeybindings, options) ||

--- a/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
+++ b/apps/web/src/components/settings/KeybindingsSettings.logic.test.ts
@@ -122,6 +122,7 @@ describe("KeybindingsSettings.logic", () => {
 
   it("formats static and project script command labels", () => {
     expect(commandLabel("commandPalette.toggle")).toBe("Command Palette: Toggle");
+    expect(commandLabel("terminal.focus")).toBe("Terminal: Focus");
     expect(commandLabel("script.setup-db.run")).toBe("Run Script: Setup Db");
   });
 
@@ -150,7 +151,12 @@ describe("KeybindingsSettings.logic", () => {
     ] satisfies ResolvedKeybindingsConfig);
 
     expect(options).toEqual(
-      expect.arrayContaining(["chat.new", "threadPanel.toggle", "script.setup-db.run"]),
+      expect.arrayContaining([
+        "chat.new",
+        "terminal.focus",
+        "threadPanel.toggle",
+        "script.setup-db.run",
+      ]),
     );
   });
 

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -16,6 +16,7 @@ import {
   isOpenFavoriteEditorShortcut,
   isTerminalClearShortcut,
   isTerminalCloseShortcut,
+  isTerminalFocusShortcut,
   isTerminalNewShortcut,
   isTerminalSplitShortcut,
   isTerminalSplitVerticalShortcut,
@@ -87,6 +88,7 @@ function compile(bindings: TestBinding[]): ResolvedKeybindingsConfig {
 const DEFAULT_BINDINGS = compile([
   { shortcut: modShortcut("b"), command: "sidebar.toggle" },
   { shortcut: modShortcut("j"), command: "terminal.toggle" },
+  { shortcut: modShortcut("t"), command: "terminal.focus" },
   { shortcut: modShortcut("b", { altKey: true }), command: "rightPanel.toggle" },
   {
     shortcut: modShortcut("d"),
@@ -147,6 +149,24 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenIdentifier("modelPickerOpen"),
   },
 ]);
+
+describe("isTerminalFocusShortcut", () => {
+  it("matches Cmd+T on macOS", () => {
+    assert.isTrue(
+      isTerminalFocusShortcut(event({ key: "t", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+      }),
+    );
+  });
+
+  it("matches Ctrl+T on non-macOS", () => {
+    assert.isTrue(
+      isTerminalFocusShortcut(event({ key: "t", ctrlKey: true }), DEFAULT_BINDINGS, {
+        platform: "Win32",
+      }),
+    );
+  });
+});
 
 describe("isTerminalToggleShortcut", () => {
   it("matches Cmd+J on macOS", () => {

--- a/apps/web/src/keybindings.ts
+++ b/apps/web/src/keybindings.ts
@@ -347,6 +347,14 @@ export function shouldShowModelPickerJumpHintsForModifiers(
   return false;
 }
 
+export function isTerminalFocusShortcut(
+  event: ShortcutEventLike,
+  keybindings: ResolvedKeybindingsConfig,
+  options?: ShortcutMatchOptions,
+): boolean {
+  return matchesCommandShortcut(event, keybindings, "terminal.focus", options);
+}
+
 export function isTerminalToggleShortcut(
   event: ShortcutEventLike,
   keybindings: ResolvedKeybindingsConfig,

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -20,6 +20,7 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
 ```json
 [
   { "key": "mod+j", "command": "terminal.toggle" },
+  { "key": "mod+t", "command": "terminal.focus" },
   { "key": "mod+d", "command": "terminal.split", "when": "terminalFocus" },
   { "key": "mod+n", "command": "terminal.new", "when": "terminalFocus" },
   { "key": "mod+w", "command": "terminal.close", "when": "terminalFocus" },
@@ -53,6 +54,7 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 
 ### Available Commands
 
+- `terminal.focus`: open or focus a terminal without toggling it closed; targets the right panel when it is open, otherwise the drawer
 - `terminal.toggle`: open/close terminal drawer
 - `terminal.split`: split terminal (in focused terminal context by default)
 - `terminal.new`: create new terminal (in focused terminal context by default)

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -29,6 +29,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsed.command, "terminal.toggle");
 
+    const parsedTerminalFocus = yield* decode(KeybindingRule, {
+      key: "mod+t",
+      command: "terminal.focus",
+    });
+    assert.strictEqual(parsedTerminalFocus.command, "terminal.focus");
+
     const parsedSidebarToggle = yield* decode(KeybindingRule, {
       key: "mod+b",
       command: "sidebar.toggle",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -49,6 +49,7 @@ export type ModelPickerKeybindingCommand = (typeof MODEL_PICKER_KEYBINDING_COMMA
 
 export const BUILT_IN_KEYBINDING_COMMANDS = [
   "sidebar.toggle",
+  "terminal.focus",
   "terminal.toggle",
   "terminal.split",
   "terminal.splitVertical",

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -21,6 +21,7 @@ type WhenToken =
 export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+b", command: "sidebar.toggle" },
   { key: "mod+j", command: "terminal.toggle" },
+  { key: "mod+t", command: "terminal.focus" },
   { key: "mod+alt+b", command: "rightPanel.toggle" },
   { key: "mod+d", command: "terminal.split", when: "terminalFocus" },
   { key: "mod+shift+d", command: "terminal.splitVertical", when: "terminalFocus" },


### PR DESCRIPTION
## Summary
- Route Cmd+J to the right panel when it is already open.
- Reuse an existing right-panel terminal tab when available, otherwise create one.
- Keep the bottom terminal drawer behavior unchanged when the right panel is closed.

## Test Plan
- vp run typecheck
- vp check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/3627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only keyboard shortcut and focus routing; `terminal.toggle` behavior is unchanged.
> 
> **Overview**
> Adds a new **`terminal.focus`** command bound to **`mod+t`** by default, distinct from **`terminal.toggle`** (`mod+j`).
> 
> **`focusTerminal`** in `ChatView` opens or focuses a terminal without closing it: when the right panel is open it activates an existing terminal tab or creates one (dismissing an active plan surface if needed); when the panel is closed it focuses the drawer terminal or opens it via the existing toggle path. The shortcut is ignored if another terminal already owns focus.
> 
> Embedded terminals delegate **`mod+t`** to the global handler (same pattern as other terminal shortcuts). Contracts, shared defaults, docs, and settings labels/tests are updated for the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e93f1d8f2bcfc8a5e29829ac9ea985380afb0c68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Open terminal in right panel with Cmd+J shortcut
> - Adds `toggleTerminalInRightPanel` in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/3627/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e) to manage terminal surfaces scoped to the right panel: activates an existing terminal surface, creates one if none exists, or closes the right panel if the terminal is already active.
> - The `terminal.toggle` shortcut now tries the right panel first; it falls back to the drawer terminal only when the terminal focus owner is the drawer or the right panel is closed.
> - Behavioral Change: Cmd+J now opens/closes the right-panel terminal by default rather than always toggling the drawer terminal.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #3627 opened
>
> - Implemented new `terminal.focus` command handling in ChatViewContent component [e93f1d8]
> - Added `terminal.focus` to built-in keybinding commands and default keybindings [e93f1d8]
> - Updated terminal viewport to allow `terminal.focus` shortcut to bubble up [e93f1d8]
> - Added `isTerminalFocusShortcut` utility function [e93f1d8]
> - Added test coverage for `terminal.focus` command [e93f1d8]
> - Updated keybindings documentation [e93f1d8]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28f6d22.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->