### PR TITLE
Add Claude Code auto permission mode as a 4th runtime mode

### DIFF
--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -204,7 +204,7 @@ export function NewTaskDraftScreen(props: {
         subactions: [
           { id: "options:runtime:approval-required", title: "Approve actions" },
           { id: "options:runtime:auto-accept-edits", title: "Auto-accept edits" },
-          ...(flow.selectedModelOption?.providerDriver === "claudeAgent"
+          ...(flow.selectedModelOption?.supportsAutoRuntimeMode
             ? [{ id: "options:runtime:auto", title: "Auto" }]
             : []),
           { id: "options:runtime:full-access", title: "Full access" },
@@ -237,7 +237,7 @@ export function NewTaskDraftScreen(props: {
     [
       flow.interactionMode,
       flow.runtimeMode,
-      flow.selectedModelOption?.providerDriver,
+      flow.selectedModelOption?.supportsAutoRuntimeMode,
       providerOptionDescriptors,
     ],
   );

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -198,10 +198,15 @@ export function NewTaskDraftScreen(props: {
             ? "Approve actions"
             : flow.runtimeMode === "auto-accept-edits"
               ? "Auto-accept edits"
-              : "Full access",
+              : flow.runtimeMode === "auto"
+                ? "Auto"
+                : "Full access",
         subactions: [
           { id: "options:runtime:approval-required", title: "Approve actions" },
           { id: "options:runtime:auto-accept-edits", title: "Auto-accept edits" },
+          ...(flow.selectedModelOption?.providerDriver === "claudeAgent"
+            ? [{ id: "options:runtime:auto", title: "Auto" }]
+            : []),
           { id: "options:runtime:full-access", title: "Full access" },
         ].map((option) => {
           const value = option.id.replace("options:runtime:", "");
@@ -229,7 +234,12 @@ export function NewTaskDraftScreen(props: {
         }),
       },
     ],
-    [flow.interactionMode, flow.runtimeMode, providerOptionDescriptors],
+    [
+      flow.interactionMode,
+      flow.runtimeMode,
+      flow.selectedModelOption?.providerDriver,
+      providerOptionDescriptors,
+    ],
   );
 
   const workspaceMenuActions = useMemo(() => {

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -552,10 +552,15 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
             ? "Approve actions"
             : currentRuntimeMode === "auto-accept-edits"
               ? "Auto-accept edits"
-              : "Full access",
+              : currentRuntimeMode === "auto"
+                ? "Auto"
+                : "Full access",
         subactions: [
           { id: "options:runtime:approval-required", title: "Approve actions" },
           { id: "options:runtime:auto-accept-edits", title: "Auto-accept edits" },
+          ...(currentModelOption?.providerDriver === "claudeAgent"
+            ? [{ id: "options:runtime:auto", title: "Auto" }]
+            : []),
           { id: "options:runtime:full-access", title: "Full access" },
         ].map((option) => {
           const value = option.id.replace("options:runtime:", "");
@@ -583,7 +588,12 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         }),
       },
     ],
-    [currentInteractionMode, currentRuntimeMode, providerOptionDescriptors],
+    [
+      currentInteractionMode,
+      currentModelOption?.providerDriver,
+      currentRuntimeMode,
+      providerOptionDescriptors,
+    ],
   );
 
   // ── Menu handlers ────────────────────────────────────────

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -558,7 +558,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         subactions: [
           { id: "options:runtime:approval-required", title: "Approve actions" },
           { id: "options:runtime:auto-accept-edits", title: "Auto-accept edits" },
-          ...(currentModelOption?.providerDriver === "claudeAgent"
+          ...(currentModelOption?.supportsAutoRuntimeMode
             ? [{ id: "options:runtime:auto", title: "Auto" }]
             : []),
           { id: "options:runtime:full-access", title: "Full access" },
@@ -590,7 +590,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
     ],
     [
       currentInteractionMode,
-      currentModelOption?.providerDriver,
+      currentModelOption?.supportsAutoRuntimeMode,
       currentRuntimeMode,
       providerOptionDescriptors,
     ],

--- a/apps/mobile/src/lib/modelOptions.ts
+++ b/apps/mobile/src/lib/modelOptions.ts
@@ -15,6 +15,7 @@ export type ModelOption = {
   readonly providerKey: string;
   readonly providerLabel: string;
   readonly providerDriver: string;
+  readonly supportsAutoRuntimeMode: boolean;
   readonly capabilities: ModelCapabilities | null;
   readonly selection: ModelSelection;
 };
@@ -78,6 +79,7 @@ export function buildModelOptions(
         providerKey: provider.instanceId,
         providerLabel,
         providerDriver: provider.driver,
+        supportsAutoRuntimeMode: provider.supportsAutoRuntimeMode ?? false,
         capabilities: model.capabilities,
         selection: normalizeSelectionOptions(
           {
@@ -107,6 +109,7 @@ export function buildModelOptions(
         providerKey: fallbackModelSelection.instanceId,
         providerLabel,
         providerDriver: fallbackModelSelection.instanceId,
+        supportsAutoRuntimeMode: false,
         capabilities: null,
         selection: fallbackModelSelection,
       });

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3431,6 +3431,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
       const effectiveEffort = getEffectiveClaudeAgentEffort(effort, modelSelection?.model);
       const runtimeModeToPermission: Record<string, PermissionMode> = {
         "auto-accept-edits": "acceptEdits",
+        auto: "auto",
         "full-access": "bypassPermissions",
       };
       const permissionMode = runtimeModeToPermission[input.runtimeMode];

--- a/apps/server/src/provider/Layers/ClaudeProvider.ts
+++ b/apps/server/src/provider/Layers/ClaudeProvider.ts
@@ -47,6 +47,7 @@ const PROVIDER = ProviderDriverKind.make("claudeAgent");
 const CLAUDE_PRESENTATION = {
   displayName: "Claude",
   showInteractionModeToggle: true,
+  supportsAutoRuntimeMode: true,
 } as const;
 const MINIMUM_CLAUDE_FABLE_5_VERSION = "2.1.169";
 const MINIMUM_CLAUDE_OPUS_4_8_VERSION = "2.1.154";

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -273,6 +273,7 @@ function runtimeModeToThreadConfig(input: RuntimeMode): {
         sandbox: "read-only",
       };
     case "auto-accept-edits":
+    case "auto":
       return {
         approvalPolicy: "on-request",
         sandbox: "workspace-write",
@@ -311,6 +312,7 @@ function runtimeModeToTurnSandboxPolicy(
         type: "readOnly",
       };
     case "auto-accept-edits":
+    case "auto":
       return {
         type: "workspaceWrite",
       };

--- a/apps/server/src/provider/providerSnapshot.ts
+++ b/apps/server/src/provider/providerSnapshot.ts
@@ -57,6 +57,7 @@ export interface ServerProviderPresentation {
   readonly badgeLabel?: string;
   readonly showInteractionModeToggle?: boolean;
   readonly requiresNewThreadForModelChange?: boolean;
+  readonly supportsAutoRuntimeMode?: boolean;
 }
 
 export type ServerProviderDraft = Omit<ServerProvider, "instanceId" | "driver">;
@@ -233,6 +234,9 @@ export function buildServerProvider(input: {
       : {}),
     ...(typeof input.presentation.requiresNewThreadForModelChange === "boolean"
       ? { requiresNewThreadForModelChange: input.presentation.requiresNewThreadForModelChange }
+      : {}),
+    ...(typeof input.presentation.supportsAutoRuntimeMode === "boolean"
+      ? { supportsAutoRuntimeMode: input.presentation.supportsAutoRuntimeMode }
       : {}),
     enabled: input.enabled,
     installed: input.probe.installed,

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -101,10 +101,15 @@ import {
   LockIcon,
   LockOpenIcon,
   PenLineIcon,
+  SparklesIcon,
   XIcon,
 } from "lucide-react";
 import { proposedPlanTitle } from "../../proposedPlan";
-import { getProviderDisplayName, getProviderInteractionModeToggle } from "../../providerModels";
+import {
+  getProviderAutoRuntimeModeSupport,
+  getProviderDisplayName,
+  getProviderInteractionModeToggle,
+} from "../../providerModels";
 import {
   applyProviderInstanceSettings,
   deriveProviderInstanceEntries,
@@ -141,6 +146,11 @@ const runtimeModeConfig: Record<
     label: "Auto-accept edits",
     description: "Auto-approve edits, ask before other actions.",
     icon: PenLineIcon,
+  },
+  auto: {
+    label: "Auto",
+    description: "Run without prompts; a safety classifier reviews actions in the background.",
+    icon: SparklesIcon,
   },
   "full-access": {
     label: "Full access",
@@ -194,6 +204,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
   showInteractionModeToggle: boolean;
   interactionMode: ProviderInteractionMode;
   runtimeMode: RuntimeMode;
+  runtimeModeOptions: ReadonlyArray<RuntimeMode>;
   showPlanToggle: boolean;
   planSidebarLabel: string;
   planSidebarOpen: boolean;
@@ -269,7 +280,7 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
             <SelectValue>{runtimeModeOption.label}</SelectValue>
           </TooltipTrigger>
           <SelectPopup alignItemWithTrigger={false}>
-            {runtimeModeOptions.map((mode) => {
+            {props.runtimeModeOptions.map((mode) => {
               const option = runtimeModeConfig[mode];
               const OptionIcon = option.icon;
               return (
@@ -817,8 +828,16 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
         providerStatuses,
         selectedProvider,
       ),
+      supportsAutoRuntimeMode: getProviderAutoRuntimeModeSupport(providerStatuses, selectedProvider),
     }),
     [providerStatuses, selectedProvider],
+  );
+  const runtimeModeOptionsForProvider = useMemo(
+    () =>
+      composerProviderControls.supportsAutoRuntimeMode
+        ? runtimeModeOptions
+        : runtimeModeOptions.filter((mode) => mode !== "auto"),
+    [composerProviderControls.supportsAutoRuntimeMode],
   );
   const selectedModelSelection = useMemo<ModelSelection>(
     () => createModelSelection(selectedInstanceId, selectedModel, selectedModelOptionsForDispatch),
@@ -2500,6 +2519,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     planSidebarLabel={planSidebarLabel}
                     planSidebarOpen={planSidebarOpen}
                     runtimeMode={runtimeMode}
+                    runtimeModeOptions={runtimeModeOptionsForProvider}
                     showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
                     traitsMenuContent={providerTraitsMenuContent}
                     onToggleInteractionMode={toggleInteractionMode}
@@ -2518,6 +2538,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                       showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
                       interactionMode={interactionMode}
                       runtimeMode={runtimeMode}
+                      runtimeModeOptions={runtimeModeOptionsForProvider}
                       showPlanToggle={showPlanSidebarToggle}
                       planSidebarLabel={planSidebarLabel}
                       planSidebarOpen={planSidebarOpen}

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -12,12 +12,20 @@ import {
   MenuTrigger,
 } from "../ui/menu";
 
+const RUNTIME_MODE_LABELS: Record<RuntimeMode, string> = {
+  "approval-required": "Supervised",
+  "auto-accept-edits": "Auto-accept edits",
+  auto: "Auto",
+  "full-access": "Full access",
+};
+
 export const CompactComposerControlsMenu = memo(function CompactComposerControlsMenu(props: {
   activePlan: boolean;
   interactionMode: ProviderInteractionMode;
   planSidebarLabel: string;
   planSidebarOpen: boolean;
   runtimeMode: RuntimeMode;
+  runtimeModeOptions: ReadonlyArray<RuntimeMode>;
   showInteractionModeToggle: boolean;
   traitsMenuContent?: ReactNode;
   onToggleInteractionMode: () => void;
@@ -69,9 +77,11 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
             props.onRuntimeModeChange(value as RuntimeMode);
           }}
         >
-          <MenuRadioItem value="approval-required">Supervised</MenuRadioItem>
-          <MenuRadioItem value="auto-accept-edits">Auto-accept edits</MenuRadioItem>
-          <MenuRadioItem value="full-access">Full access</MenuRadioItem>
+          {props.runtimeModeOptions.map((mode) => (
+            <MenuRadioItem key={mode} value={mode}>
+              {RUNTIME_MODE_LABELS[mode]}
+            </MenuRadioItem>
+          ))}
         </MenuRadioGroup>
         {props.activePlan ? (
           <>

--- a/apps/web/src/providerModels.ts
+++ b/apps/web/src/providerModels.ts
@@ -53,6 +53,13 @@ export function getProviderInteractionModeToggle(
   return getProviderSnapshot(providers, provider)?.showInteractionModeToggle ?? true;
 }
 
+export function getProviderAutoRuntimeModeSupport(
+  providers: ReadonlyArray<ServerProvider>,
+  provider: ProviderDriverKind,
+): boolean {
+  return getProviderSnapshot(providers, provider)?.supportsAutoRuntimeMode ?? false;
+}
+
 export function isProviderEnabled(
   providers: ReadonlyArray<ServerProvider>,
   provider: ProviderDriverKind,

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -117,6 +117,7 @@ export type ModelSelection = typeof ModelSelection.Type;
 export const RuntimeMode = Schema.Literals([
   "approval-required",
   "auto-accept-edits",
+  "auto",
   "full-access",
 ]);
 export type RuntimeMode = typeof RuntimeMode.Type;

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -166,6 +166,7 @@ export const ServerProvider = Schema.Struct({
   continuation: Schema.optional(ServerProviderContinuation),
   showInteractionModeToggle: Schema.optional(Schema.Boolean),
   requiresNewThreadForModelChange: Schema.optional(Schema.Boolean),
+  supportsAutoRuntimeMode: Schema.optional(Schema.Boolean),
   enabled: Schema.Boolean,
   installed: Schema.Boolean,
   version: Schema.NullOr(TrimmedNonEmptyString),


### PR DESCRIPTION
## What Changed

Adds Claude Code's `auto` permission mode as a fourth runtime mode option, alongside the existing Supervised / Auto-accept edits / Full access modes.

- `RuntimeMode` contract gains an `"auto"` value.
- `ClaudeAdapter` maps it to the Agent SDK's native `permissionMode: "auto"`, and never sets `allowDangerouslySkipPermissions` for it (that flag stays scoped to `bypassPermissions` only).
- A new `supportsAutoRuntimeMode` provider capability flag gates the option so it only shows up for the Claude provider. Codex defensively maps an incoming `"auto"` to its existing `workspace-write` policy instead of falling through to full sandbox bypass.
- Surfaced in the web composer's runtime mode dropdown/menu and in the mobile runtime option list.

## Why

Claude Code's TypeScript Agent SDK supports six `PermissionMode` values (`default | acceptEdits | bypassPermissions | plan | dontAsk | auto`), but only two of those were reachable from this app's runtime mode selector. `auto` mode runs tool calls through a background safety classifier rather than skipping permission checks outright, so it's meaningfully different from `bypassPermissions`: it does not require `allowDangerouslySkipPermissions`. **That matters for orgs whose managed Claude Code settings disable `bypassPermissions`/`--dangerously-skip-permissions` but still allow `auto` mode — those users currently have no way to reduce prompt fatigue in this app beyond `acceptEdits`.**

## UI Changes

New "Auto" option in the runtime mode selector (web composer dropdown + compact menu), visible only when the active provider is Claude.

<img width="887" height="390" alt="Screenshot 2026-06-30 at 9 02 27 PM" src="https://github.com/user-attachments/assets/f600c7a1-0772-48a4-9d09-1877ada13b6b" />

## Checklist

- [x] This PR is small and focused (11 files, +77/-9)
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'auto' as a fourth runtime mode for Claude Code permission handling
> - Adds `'auto'` to the `RuntimeMode` contract schema and wires it through the server, mobile, and web layers.
> - The Claude provider advertises `supportsAutoRuntimeMode: true`; UI components (web composer, compact menu, mobile thread composer) conditionally show the 'Auto' option only when the selected provider/model supports it.
> - On the server, `'auto'` maps to `permissionMode: 'auto'` in the Claude adapter and to `on-request` approval policy with `workspace-write` sandbox in the Codex session runtime (same behavior as `'auto-accept-edits'`).
> - Behavioral Change: selecting 'Auto' mode in the Claude provider now sends `permissionMode: 'auto'` to the Claude API rather than rejecting it as an unknown mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45eddfd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes permission/runtime semantics for agent sessions; impact is mostly gated to Claude UI, but Codex still accepts `auto` at the API layer with a conservative sandbox mapping.
> 
> **Overview**
> Introduces a fourth runtime mode, **`auto`**, for Claude Code’s background safety-classifier permission path (distinct from full **`bypassPermissions`**).
> 
> **Contracts & server:** `RuntimeMode` and provider snapshots gain **`supportsAutoRuntimeMode`**. Claude declares it; **`ClaudeAdapter`** maps **`auto`** → SDK **`permissionMode: "auto"`**. Codex treats an incoming **`auto`** like **`auto-accept-edits`** (workspace-write / on-request) so it never falls through to full-access sandbox.
> 
> **Clients:** Web **`ChatComposer`** / compact menu and mobile new-task / thread composers add an **Auto** runtime choice only when the selected model’s provider supports it; mobile **`ModelOption`** carries the flag from server config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45eddfd23d7ffa1ecf691a4e85dbd226268a7966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->