### PR TITLE
Add local voice mode (whisper.cpp STT + Kokoro TTS) with an orb view

### DIFF
--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -79,7 +79,7 @@ export function resolveDevRedirectUrl(devUrl: URL, requestUrl: URL): string {
   return redirectUrl.toString();
 }
 
-const authenticateRawRouteWithScope = (
+export const authenticateRawRouteWithScope = (
   scope: typeof AuthOrchestrationReadScope | typeof AuthOrchestrationOperateScope,
 ) =>
   Effect.gen(function* () {

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -86,6 +86,8 @@ import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/provid
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as ServerSettings from "./serverSettings.ts";
+import { SpeechToText } from "./speech/SpeechToText.ts";
+import { TextToSpeech } from "./speech/TextToSpeech.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
@@ -559,10 +561,18 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provide(
-        Layer.mock(ExternalLauncher.ExternalLauncher)({
-          resolveAvailableEditors: () => Effect.succeed([]),
-          ...options?.layers?.externalLauncher,
-        }),
+        Layer.mergeAll(
+          Layer.mock(ExternalLauncher.ExternalLauncher)({
+            resolveAvailableEditors: () => Effect.succeed([]),
+            ...options?.layers?.externalLauncher,
+          }),
+          Layer.mock(SpeechToText)({
+            transcribe: () => Effect.succeed({ text: "" }),
+          }),
+          Layer.mock(TextToSpeech)({
+            synthesize: () => Effect.succeed({ wavBytes: new Uint8Array() }),
+          }),
+        ),
       ),
       Layer.provide(
         Layer.mock(ProcessDiagnostics.ProcessDiagnostics)({

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -14,6 +14,9 @@ import {
 } from "./http.ts";
 import { fixPath } from "./os-jank.ts";
 import { websocketRpcRouteLayer } from "./ws.ts";
+import { sttRouteLayer, ttsRouteLayer } from "./speech/speechRoutes.ts";
+import * as SpeechToText from "./speech/SpeechToText.ts";
+import * as TextToSpeech from "./speech/TextToSpeech.ts";
 import * as ExternalLauncher from "./process/externalLauncher.ts";
 import { layerConfig as SqlitePersistenceLayerLive } from "./persistence/Layers/Sqlite.ts";
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
@@ -239,6 +242,14 @@ const CheckpointingLayerLive = Layer.empty.pipe(
 
 const PortScannerLayerLive = PortScanner.layer.pipe(Layer.provide(ProcessRunner.layer));
 
+// Local voice mode: whisper.cpp (STT) + Kokoro (TTS). Provides `ProcessRunner`
+// internally; its remaining requirements (ServerSettingsService plus the
+// platform FileSystem/Path/ChildProcessSpawner) are satisfied where this layer
+// is merged into the runtime dependency graph below.
+const SpeechLayerLive = Layer.mergeAll(SpeechToText.layer, TextToSpeech.layer).pipe(
+  Layer.provide(ProcessRunner.layer),
+);
+
 const TerminalLayerLive = TerminalManager.layer.pipe(
   Layer.provide(PtyAdapterLive),
   Layer.provide(PortScannerLayerLive),
@@ -312,7 +323,10 @@ const RuntimeCoreDependenciesLive = ReactorLayerLive.pipe(
   // the rewritten registry reads snapshots off the instance registry and
   // no longer transitively provides it. Exposing it at the runtime level
   // keeps a single Live for all opencode consumers.
-  Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
+  // SpeechLayerLive is merged here (before ServerSettings) so its settings
+  // output flows into the speech services — later `provideMerge` entries feed
+  // earlier ones. Bundled with OpenCodeRuntime to stay within pipe's arg limit.
+  Layer.provideMerge(Layer.mergeAll(OpenCodeRuntime.OpenCodeRuntimeLive, SpeechLayerLive)),
   Layer.provideMerge(ServerSettings.layer.pipe(Layer.provide(ServerSecretStore.layer))),
   Layer.provideMerge(WorkspaceLayerLive),
   Layer.provideMerge(ProjectFaviconResolverLayerLive),
@@ -356,6 +370,8 @@ export const makeRoutesLayer = Layer.mergeAll(
     assetRouteLayer,
     staticAndDevRouteLayer,
     websocketRpcRouteLayer,
+    sttRouteLayer,
+    ttsRouteLayer,
   ),
   McpHttpServer.layer.pipe(Layer.provide(McpSessionRegistry.layer)),
 ).pipe(Layer.provide(PreviewAutomationBroker.layer), Layer.provide(browserApiCorsLayer));

--- a/apps/server/src/speech/SpeechToText.ts
+++ b/apps/server/src/speech/SpeechToText.ts
@@ -1,0 +1,163 @@
+/**
+ * SpeechToText - local speech-to-text via whisper.cpp.
+ *
+ * Spawns the whisper.cpp `whisper-cli` (a.k.a. `main`) binary through
+ * `ProcessRunner`, transcribing a single 16 kHz mono WAV utterance. Binary and
+ * model paths come from the persisted server settings (`speech.*`), with
+ * `T3_WHISPER_BIN` / `T3_WHISPER_MODEL` env fallbacks. The feature is OFF by
+ * default; handlers fail with a typed `SpeechToTextError` when disabled or when
+ * the model path is missing.
+ *
+ * @module SpeechToText
+ */
+import { SpeechToTextError } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import { ProcessRunner } from "../processRunner.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
+
+export interface SpeechToTextInput {
+  readonly wavBytes: Uint8Array;
+  readonly language?: string | undefined;
+}
+
+export interface SpeechToTextOutput {
+  readonly text: string;
+}
+
+export class SpeechToText extends Context.Service<
+  SpeechToText,
+  {
+    readonly transcribe: (
+      input: SpeechToTextInput,
+    ) => Effect.Effect<SpeechToTextOutput, SpeechToTextError>;
+  }
+>()("t3/speech/SpeechToText") {}
+
+const resolveConfigValue = (value: string | undefined, envKey: string): string => {
+  const trimmed = value?.trim();
+  if (trimmed) return trimmed;
+  const fromEnv = process.env[envKey]?.trim();
+  return fromEnv ?? "";
+};
+
+export const make = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const processRunner = yield* ProcessRunner;
+  const settingsService = yield* ServerSettingsService;
+
+  const transcribe: SpeechToText["Service"]["transcribe"] = (input) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const settings = yield* settingsService.getSettings.pipe(
+          Effect.mapError(
+            (cause) =>
+              new SpeechToTextError({
+                reason: "not-configured",
+                detail: "Failed to read server settings.",
+                cause,
+              }),
+          ),
+        );
+        const speech = settings.speech;
+        if (!speech.sttEnabled) {
+          return yield* Effect.fail(
+            new SpeechToTextError({
+              reason: "not-configured",
+              detail: "Speech-to-text is disabled in settings.",
+            }),
+          );
+        }
+
+        const binary = resolveConfigValue(speech.whisperBinaryPath, "T3_WHISPER_BIN") || "whisper-cli";
+        const model = resolveConfigValue(speech.whisperModelPath, "T3_WHISPER_MODEL");
+        if (!model) {
+          return yield* Effect.fail(
+            new SpeechToTextError({
+              reason: "model-missing",
+              detail: "No whisper.cpp model path configured.",
+            }),
+          );
+        }
+
+        const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-stt-" }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new SpeechToTextError({
+                reason: "process-failed",
+                detail: "Failed to create temp directory.",
+                cause,
+              }),
+          ),
+        );
+        const wavPath = path.join(dir, "input.wav");
+        const outBase = path.join(dir, "out");
+
+        yield* fs.writeFile(wavPath, input.wavBytes).pipe(
+          Effect.mapError(
+            (cause) =>
+              new SpeechToTextError({
+                reason: "process-failed",
+                detail: "Failed to write temp WAV.",
+                cause,
+              }),
+          ),
+        );
+
+        const language = input.language?.trim();
+        const args = [
+          "-m",
+          model,
+          "-f",
+          wavPath,
+          "-otxt",
+          "-nt",
+          "-of",
+          outBase,
+          ...(language ? ["-l", language] : []),
+        ];
+
+        const result = yield* processRunner
+          .run({
+            command: binary,
+            args,
+            timeout: "120 seconds",
+            maxOutputBytes: 4 * 1024 * 1024,
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new SpeechToTextError({
+                  reason: cause._tag === "ProcessSpawnError" ? "binary-missing" : "process-failed",
+                  detail: `whisper-cli failed to run ('${binary}').`,
+                  cause,
+                }),
+            ),
+          );
+
+        if (result.code !== 0) {
+          return yield* Effect.fail(
+            new SpeechToTextError({
+              reason: "process-failed",
+              detail: `whisper-cli exited with code ${result.code}: ${result.stderr.slice(0, 500)}`,
+            }),
+          );
+        }
+
+        const transcript = yield* fs
+          .readFileString(`${outBase}.txt`)
+          .pipe(Effect.orElseSucceed(() => result.stdout));
+
+        return { text: transcript.trim() };
+      }),
+    );
+
+  return SpeechToText.of({ transcribe });
+});
+
+export const layer = Layer.effect(SpeechToText, make);

--- a/apps/server/src/speech/TextToSpeech.ts
+++ b/apps/server/src/speech/TextToSpeech.ts
@@ -1,0 +1,171 @@
+/**
+ * TextToSpeech - local text-to-speech via Kokoro.
+ *
+ * Kokoro ships no native binary, so this spawns a small adapter command
+ * (configured as `speech.kokoroCommand`, e.g. `python kokoro_adapter.py`)
+ * through `ProcessRunner`. The adapter reads the text to speak on stdin and
+ * writes a WAV file to the `--out <path>` argument we pass it. We read those
+ * bytes back with `FileSystem.readFile` (binary-safe) rather than piping WAV
+ * through stdout, because `ProcessRunner` decodes stdout as UTF-8.
+ *
+ * OFF by default; fails with a typed `TextToSpeechError` when disabled or when
+ * no adapter command is configured.
+ *
+ * @module TextToSpeech
+ */
+import { TextToSpeechError } from "@t3tools/contracts";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+import { ProcessRunner } from "../processRunner.ts";
+import { ServerSettingsService } from "../serverSettings.ts";
+
+export interface TextToSpeechInput {
+  readonly text: string;
+  readonly voice?: string | undefined;
+  readonly speed?: number | undefined;
+}
+
+export interface TextToSpeechOutput {
+  readonly wavBytes: Uint8Array;
+}
+
+export class TextToSpeech extends Context.Service<
+  TextToSpeech,
+  {
+    readonly synthesize: (
+      input: TextToSpeechInput,
+    ) => Effect.Effect<TextToSpeechOutput, TextToSpeechError>;
+  }
+>()("t3/speech/TextToSpeech") {}
+
+const resolveConfigValue = (value: string | undefined, envKey: string): string => {
+  const trimmed = value?.trim();
+  if (trimmed) return trimmed;
+  const fromEnv = process.env[envKey]?.trim();
+  return fromEnv ?? "";
+};
+
+/** Split a configured command string into an executable and leading args. */
+const splitCommand = (command: string): { readonly executable: string; readonly preArgs: string[] } => {
+  const parts = command.trim().split(/\s+/).filter((part) => part.length > 0);
+  const [executable, ...preArgs] = parts;
+  return { executable: executable ?? "", preArgs };
+};
+
+export const make = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const processRunner = yield* ProcessRunner;
+  const settingsService = yield* ServerSettingsService;
+
+  const synthesize: TextToSpeech["Service"]["synthesize"] = (input) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const settings = yield* settingsService.getSettings.pipe(
+          Effect.mapError(
+            (cause) =>
+              new TextToSpeechError({
+                reason: "not-configured",
+                detail: "Failed to read server settings.",
+                cause,
+              }),
+          ),
+        );
+        const speech = settings.speech;
+        if (!speech.ttsEnabled) {
+          return yield* Effect.fail(
+            new TextToSpeechError({
+              reason: "not-configured",
+              detail: "Text-to-speech is disabled in settings.",
+            }),
+          );
+        }
+
+        const command = resolveConfigValue(speech.kokoroCommand, "T3_KOKORO_CMD");
+        if (!command) {
+          return yield* Effect.fail(
+            new TextToSpeechError({
+              reason: "binary-missing",
+              detail: "No Kokoro command configured.",
+            }),
+          );
+        }
+
+        const model = resolveConfigValue(speech.kokoroModelPath, "T3_KOKORO_MODEL");
+        const voice =
+          input.voice?.trim() || resolveConfigValue(speech.kokoroVoice, "T3_KOKORO_VOICE") || "af_heart";
+
+        const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3-tts-" }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new TextToSpeechError({
+                reason: "process-failed",
+                detail: "Failed to create temp directory.",
+                cause,
+              }),
+          ),
+        );
+        const outPath = path.join(dir, "out.wav");
+
+        const { executable, preArgs } = splitCommand(command);
+        const args = [
+          ...preArgs,
+          "--out",
+          outPath,
+          "--voice",
+          voice,
+          ...(model ? ["--model", model] : []),
+          ...(input.speed !== undefined ? ["--speed", String(input.speed)] : []),
+        ];
+
+        const result = yield* processRunner
+          .run({
+            command: executable,
+            args,
+            stdin: input.text,
+            timeout: "120 seconds",
+            maxOutputBytes: 4 * 1024 * 1024,
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new TextToSpeechError({
+                  reason: cause._tag === "ProcessSpawnError" ? "binary-missing" : "process-failed",
+                  detail: `Kokoro adapter failed to run ('${executable}').`,
+                  cause,
+                }),
+            ),
+          );
+
+        if (result.code !== 0) {
+          return yield* Effect.fail(
+            new TextToSpeechError({
+              reason: "process-failed",
+              detail: `Kokoro adapter exited with code ${result.code}: ${result.stderr.slice(0, 500)}`,
+            }),
+          );
+        }
+
+        const wavBytes = yield* fs.readFile(outPath).pipe(
+          Effect.mapError(
+            (cause) =>
+              new TextToSpeechError({
+                reason: "decode-failed",
+                detail: "Kokoro adapter did not produce a WAV file.",
+                cause,
+              }),
+          ),
+        );
+
+        return { wavBytes };
+      }),
+    );
+
+  return TextToSpeech.of({ synthesize });
+});
+
+export const layer = Layer.effect(TextToSpeech, make);

--- a/apps/server/src/speech/speechRoutes.ts
+++ b/apps/server/src/speech/speechRoutes.ts
@@ -1,0 +1,119 @@
+/**
+ * Raw HTTP routes for local voice mode.
+ *
+ * Audio is bulk binary, so it travels over dedicated authenticated HTTP routes
+ * rather than the JSON-encoded RPC Socket:
+ *   - `POST /api/stt/transcribe` — raw `audio/wav` body in, JSON transcript out.
+ *   - `POST /api/tts/synthesize` — JSON `{ text, voice?, speed? }` in, `audio/wav` out.
+ *
+ * Both are gated with `authenticateRawRouteWithScope(AuthOrchestrationOperateScope)`
+ * (Operate — they spawn processes), mirroring `otlpTracesProxyRouteLayer`.
+ *
+ * @module speechRoutes
+ */
+import { AuthOrchestrationOperateScope, TextToSpeechRequest } from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import {
+  HttpRouter,
+  HttpServerRequest,
+  HttpServerResponse,
+  HttpServerRespondable,
+} from "effect/unstable/http";
+
+import { authenticateRawRouteWithScope } from "../http.ts";
+import { SpeechToText } from "./SpeechToText.ts";
+import { TextToSpeech } from "./TextToSpeech.ts";
+
+const STT_PATH = "/api/stt/transcribe";
+const TTS_PATH = "/api/tts/synthesize";
+
+const decodeTtsRequest = Schema.decodeUnknownEffect(TextToSpeechRequest);
+
+const speechErrorStatus = (reason: string): number => {
+  switch (reason) {
+    case "not-configured":
+    case "binary-missing":
+    case "model-missing":
+      return 503;
+    case "decode-failed":
+      return 502;
+    default:
+      return 500;
+  }
+};
+
+const authErrorHandlers = {
+  EnvironmentAuthInvalidError: HttpServerRespondable.toResponse,
+  EnvironmentInternalError: HttpServerRespondable.toResponse,
+  EnvironmentScopeRequiredError: HttpServerRespondable.toResponse,
+} as const;
+
+export const sttRouteLayer = HttpRouter.add(
+  "POST",
+  STT_PATH,
+  Effect.gen(function* () {
+    yield* authenticateRawRouteWithScope(AuthOrchestrationOperateScope);
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const speechToText = yield* SpeechToText;
+
+    const url = HttpServerRequest.toURL(request);
+    const language = Option.isSome(url)
+      ? (url.value.searchParams.get("language") ?? undefined)
+      : undefined;
+
+    const body = yield* request.arrayBuffer.pipe(
+      Effect.orElseSucceed(() => new ArrayBuffer(0)),
+    );
+    const wavBytes = new Uint8Array(body);
+    if (wavBytes.byteLength === 0) {
+      return HttpServerResponse.text("Empty audio body.", { status: 400 });
+    }
+
+    return yield* speechToText.transcribe({ wavBytes, language }).pipe(
+      Effect.map((result) => HttpServerResponse.jsonUnsafe(result, { status: 200 })),
+      Effect.catchTag("SpeechToTextError", (error) =>
+        Effect.succeed(
+          HttpServerResponse.jsonUnsafe(
+            { error: error.reason, detail: error.detail ?? null },
+            { status: speechErrorStatus(error.reason) },
+          ),
+        ),
+      ),
+    );
+  }).pipe(Effect.catchTags(authErrorHandlers)),
+);
+
+export const ttsRouteLayer = HttpRouter.add(
+  "POST",
+  TTS_PATH,
+  Effect.gen(function* () {
+    yield* authenticateRawRouteWithScope(AuthOrchestrationOperateScope);
+    const request = yield* HttpServerRequest.HttpServerRequest;
+    const textToSpeech = yield* TextToSpeech;
+
+    const json = yield* request.json.pipe(Effect.orElseSucceed(() => null));
+    const decoded = yield* decodeTtsRequest(json).pipe(Effect.option);
+    if (Option.isNone(decoded)) {
+      return HttpServerResponse.text("Invalid request body.", { status: 400 });
+    }
+
+    return yield* textToSpeech.synthesize(decoded.value).pipe(
+      Effect.map((result) =>
+        HttpServerResponse.uint8Array(result.wavBytes, {
+          status: 200,
+          contentType: "audio/wav",
+        }),
+      ),
+      Effect.catchTag("TextToSpeechError", (error) =>
+        Effect.succeed(
+          HttpServerResponse.jsonUnsafe(
+            { error: error.reason, detail: error.detail ?? null },
+            { status: speechErrorStatus(error.reason) },
+          ),
+        ),
+      ),
+    );
+  }).pipe(Effect.catchTags(authErrorHandlers)),
+);

--- a/apps/web/public/voice-worklet.js
+++ b/apps/web/public/voice-worklet.js
@@ -1,0 +1,56 @@
+/**
+ * Voice capture AudioWorklet.
+ *
+ * Downsamples the mic input to 16 kHz mono and posts Int16 PCM frames to the
+ * main thread, along with a per-frame RMS level used for a lightweight,
+ * dependency-free voice-activity (silence) detector. whisper.cpp wants 16 kHz
+ * mono PCM, so producing it here avoids any server-side resampling.
+ */
+class VoiceCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.targetRate = 16000;
+    // `sampleRate` is a global available inside the worklet scope.
+    this.ratio = sampleRate / this.targetRate;
+    this.carry = 0;
+  }
+
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) {
+      return true;
+    }
+    const channel = input[0];
+    if (!channel || channel.length === 0) {
+      return true;
+    }
+
+    // Simple linear-interpolation downsampler from `sampleRate` to 16 kHz.
+    const outLength = Math.floor((channel.length - this.carry) / this.ratio) + 1;
+    const out = new Int16Array(Math.max(0, outLength));
+    let outIndex = 0;
+    let sumSquares = 0;
+    let position = this.carry;
+    while (position < channel.length && outIndex < out.length) {
+      const index = Math.floor(position);
+      const frac = position - index;
+      const sample = channel[index] * (1 - frac) + (channel[index + 1] ?? channel[index]) * frac;
+      const clamped = Math.max(-1, Math.min(1, sample));
+      out[outIndex] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+      sumSquares += clamped * clamped;
+      outIndex += 1;
+      position += this.ratio;
+    }
+    this.carry = position - channel.length;
+
+    if (outIndex > 0) {
+      const rms = Math.sqrt(sumSquares / outIndex);
+      const frame = out.subarray(0, outIndex);
+      this.port.postMessage({ pcm: frame, rms }, [frame.buffer]);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor("voice-capture-processor", VoiceCaptureProcessor);

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -91,6 +91,7 @@ import { Separator } from "../ui/separator";
 import { Button } from "../ui/button";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "../ui/tooltip";
+import { ComposerVoiceButton } from "../voice/ComposerVoiceButton";
 import { toastManager } from "../ui/toast";
 import {
   BotIcon,
@@ -323,6 +324,8 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
           </Tooltip>
         </>
       ) : null}
+
+      <ComposerVoiceButton />
     </>
   );
 });

--- a/apps/web/src/components/voice/ComposerVoiceButton.tsx
+++ b/apps/web/src/components/voice/ComposerVoiceButton.tsx
@@ -1,0 +1,43 @@
+import { useAtomValue } from "@effect/atom-react";
+import { MicIcon } from "lucide-react";
+
+import { Button } from "~/components/ui/button";
+import { Separator } from "~/components/ui/separator";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "~/components/ui/tooltip";
+import { primaryServerSettingsAtom } from "~/state/server";
+import { useVoiceStore } from "~/voice/useVoiceStore";
+
+/**
+ * Composer footer button that opens Voice Mode. Hidden unless local
+ * speech-to-text is enabled in server settings.
+ */
+export function ComposerVoiceButton() {
+  const settings = useAtomValue(primaryServerSettingsAtom);
+  const open = useVoiceStore((state) => state.open);
+
+  if (!settings.speech.sttEnabled) return null;
+
+  return (
+    <>
+      <Separator orientation="vertical" className="mx-0.5 hidden h-4 sm:block" />
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="ghost"
+              className="shrink-0 whitespace-nowrap px-2 text-muted-foreground/70 hover:text-foreground/80 sm:px-3"
+              size="sm"
+              type="button"
+              onClick={open}
+              aria-label="Voice mode"
+            />
+          }
+        >
+          <MicIcon />
+          <span className="sr-only sm:not-sr-only">Voice</span>
+        </TooltipTrigger>
+        <TooltipPopup side="top">Voice mode</TooltipPopup>
+      </Tooltip>
+    </>
+  );
+}

--- a/apps/web/src/components/voice/VoiceModeControls.tsx
+++ b/apps/web/src/components/voice/VoiceModeControls.tsx
@@ -1,0 +1,68 @@
+import { MicIcon, Volume2Icon, VolumeXIcon, XIcon } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+import { Button } from "~/components/ui/button";
+import type { VoiceSubmitMode } from "~/voice/useVoiceStore";
+import type { VoiceOrbState } from "./VoiceOrb";
+
+interface VoiceModeControlsProps {
+  readonly mode: VoiceSubmitMode;
+  readonly muted: boolean;
+  readonly status: VoiceOrbState;
+  readonly onPushStart: () => void;
+  readonly onPushEnd: () => void;
+  readonly onToggleMode: () => void;
+  readonly onToggleMute: () => void;
+  readonly onClose: () => void;
+}
+
+export function VoiceModeControls({
+  mode,
+  muted,
+  status,
+  onPushStart,
+  onPushEnd,
+  onToggleMode,
+  onToggleMute,
+  onClose,
+}: VoiceModeControlsProps) {
+  const isPushToTalk = mode === "push-to-talk";
+
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <button
+        type="button"
+        aria-label={isPushToTalk ? "Hold to talk" : "Listening"}
+        className={cn(
+          "flex size-20 items-center justify-center rounded-full border-2 transition-colors",
+          status === "listening"
+            ? "border-emerald-400 bg-emerald-500/20 text-emerald-200"
+            : "border-white/30 bg-white/10 text-white",
+          isPushToTalk ? "cursor-pointer active:scale-95" : "cursor-default",
+        )}
+        onPointerDown={isPushToTalk ? onPushStart : undefined}
+        onPointerUp={isPushToTalk ? onPushEnd : undefined}
+        onPointerLeave={isPushToTalk ? onPushEnd : undefined}
+      >
+        <MicIcon className="size-8" />
+      </button>
+
+      <div className="flex items-center gap-3">
+        <Button variant="outline" size="sm" onClick={onToggleMode}>
+          {isPushToTalk ? "Push to talk" : "Auto (silence)"}
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          aria-label={muted ? "Unmute voice" : "Mute voice"}
+          onClick={onToggleMute}
+        >
+          {muted ? <VolumeXIcon className="size-4" /> : <Volume2Icon className="size-4" />}
+        </Button>
+        <Button variant="outline" size="icon" aria-label="Close voice mode" onClick={onClose}>
+          <XIcon className="size-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/voice/VoiceModeView.tsx
+++ b/apps/web/src/components/voice/VoiceModeView.tsx
@@ -1,0 +1,64 @@
+import { useVoiceSession } from "~/voice/useVoiceSession";
+import { useVoiceStore } from "~/voice/useVoiceStore";
+
+import { VoiceModeControls } from "./VoiceModeControls";
+import { VoiceOrb } from "./VoiceOrb";
+
+const STATUS_LABEL: Record<string, string> = {
+  idle: "Starting…",
+  listening: "Listening…",
+  thinking: "Thinking…",
+  speaking: "Speaking…",
+};
+
+/**
+ * Full-screen, ChatGPT-style Voice Mode overlay: an audio-reactive orb, a live
+ * status line, the current transcript, and the mic / mode / mute / close
+ * controls. Rendered via a portal from the chat layout, gated on `isOpen`.
+ */
+export function VoiceModeView() {
+  const isOpen = useVoiceStore((state) => state.isOpen);
+  const status = useVoiceStore((state) => state.status);
+  const level = useVoiceStore((state) => state.level);
+  const muted = useVoiceStore((state) => state.muted);
+  const mode = useVoiceStore((state) => state.mode);
+  const transcript = useVoiceStore((state) => state.transcript);
+  const error = useVoiceStore((state) => state.error);
+  const close = useVoiceStore((state) => state.close);
+  const toggleMuted = useVoiceStore((state) => state.toggleMuted);
+  const setMode = useVoiceStore((state) => state.setMode);
+
+  // The session hook is only meaningful while open; it early-returns internally
+  // when closed, but we still must call it unconditionally (hook rules).
+  const { startPushToTalk, endPushToTalk } = useVoiceSession();
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center gap-10 bg-background/80 backdrop-blur-xl">
+      <div className="flex flex-col items-center gap-3">
+        <VoiceOrb level={level} state={status} size={260} />
+        <p className="text-lg font-medium text-foreground/90">
+          {STATUS_LABEL[status] ?? "Voice mode"}
+        </p>
+      </div>
+
+      {transcript ? (
+        <p className="max-w-xl px-6 text-center text-sm text-muted-foreground">“{transcript}”</p>
+      ) : null}
+
+      {error ? <p className="max-w-xl px-6 text-center text-sm text-destructive">{error}</p> : null}
+
+      <VoiceModeControls
+        mode={mode}
+        muted={muted}
+        status={status}
+        onPushStart={startPushToTalk}
+        onPushEnd={endPushToTalk}
+        onToggleMode={() => setMode(mode === "push-to-talk" ? "auto-silence" : "push-to-talk")}
+        onToggleMute={toggleMuted}
+        onClose={close}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/voice/VoiceOrb.tsx
+++ b/apps/web/src/components/voice/VoiceOrb.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef } from "react";
+
+import { cn } from "~/lib/utils";
+
+export type VoiceOrbState = "idle" | "listening" | "thinking" | "speaking";
+
+interface VoiceOrbProps {
+  /** Current audio amplitude, 0..1 — drives the pulse. */
+  readonly level: number;
+  readonly state: VoiceOrbState;
+  readonly className?: string;
+  readonly size?: number;
+}
+
+const STATE_COLORS: Record<VoiceOrbState, readonly [string, string]> = {
+  // [inner, outer] gradient stops.
+  idle: ["#6366f1", "#3b82f6"],
+  listening: ["#22c55e", "#14b8a6"],
+  thinking: ["#f59e0b", "#ec4899"],
+  speaking: ["#3b82f6", "#8b5cf6"],
+};
+
+/**
+ * A ChatGPT-voice-mode-style animated orb rendered on a canvas. It breathes on
+ * its own and pulses with the live audio `level`; color and motion follow the
+ * conversation `state`. Uses `requestAnimationFrame` and stops when unmounted.
+ */
+export function VoiceOrb({ level, state, className, size = 240 }: VoiceOrbProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  // Latest inputs, read inside the animation loop without re-subscribing.
+  const levelRef = useRef(level);
+  const stateRef = useRef(state);
+  levelRef.current = level;
+  stateRef.current = state;
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    canvas.width = size * dpr;
+    canvas.height = size * dpr;
+    ctx.scale(dpr, dpr);
+
+    const center = size / 2;
+    const baseRadius = size * 0.28;
+    let raf = 0;
+    let start = 0;
+    let displayLevel = 0;
+
+    const draw = (time: number) => {
+      if (start === 0) start = time;
+      const elapsed = (time - start) / 1000;
+
+      // Smooth the amplitude so the orb doesn't jitter.
+      displayLevel += (levelRef.current - displayLevel) * 0.15;
+      const breathe = 0.5 + 0.5 * Math.sin(elapsed * 1.6);
+      const [inner, outer] = STATE_COLORS[stateRef.current];
+      const pulse = baseRadius * (1 + displayLevel * 0.6 + breathe * 0.06);
+
+      ctx.clearRect(0, 0, size, size);
+
+      // Outer glow.
+      const glow = ctx.createRadialGradient(center, center, pulse * 0.2, center, center, pulse * 1.9);
+      glow.addColorStop(0, `${outer}55`);
+      glow.addColorStop(1, "#00000000");
+      ctx.fillStyle = glow;
+      ctx.beginPath();
+      ctx.arc(center, center, pulse * 1.9, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Core orb.
+      const core = ctx.createRadialGradient(
+        center - pulse * 0.3,
+        center - pulse * 0.3,
+        pulse * 0.1,
+        center,
+        center,
+        pulse,
+      );
+      core.addColorStop(0, inner);
+      core.addColorStop(1, outer);
+      ctx.fillStyle = core;
+      ctx.beginPath();
+      ctx.arc(center, center, pulse, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Rotating highlight ring for a bit of life.
+      ctx.strokeStyle = "#ffffff33";
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      const ringR = pulse * 1.12;
+      const sweep = 1.2 + displayLevel * 2;
+      ctx.arc(center, center, ringR, elapsed * 1.5, elapsed * 1.5 + sweep);
+      ctx.stroke();
+
+      raf = requestAnimationFrame(draw);
+    };
+
+    raf = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(raf);
+  }, [size]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className={cn("select-none", className)}
+      style={{ width: size, height: size }}
+      aria-hidden
+    />
+  );
+}

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -17,6 +17,7 @@ import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { stackedThreadToast, toastManager } from "~/components/ui/toast";
+import { VoiceModeView } from "~/components/voice/VoiceModeView";
 import { primaryServerKeybindingsAtom } from "~/state/server";
 
 function ChatRouteGlobalShortcuts() {
@@ -153,6 +154,7 @@ function ChatRouteLayout() {
     <>
       <ChatRouteGlobalShortcuts />
       <Outlet />
+      <VoiceModeView />
     </>
   );
 }

--- a/apps/web/src/voice/audioCapture.ts
+++ b/apps/web/src/voice/audioCapture.ts
@@ -1,0 +1,209 @@
+/**
+ * Microphone capture for voice mode.
+ *
+ * Captures mic audio, downsamples to 16 kHz mono Int16 PCM in an AudioWorklet
+ * (see `public/voice-worklet.js`), and exposes:
+ *   - a smoothed amplitude level for the animated orb,
+ *   - a lightweight energy-based voice-activity detector that fires
+ *     `onUtteranceEnd` with an encoded 16 kHz mono WAV when the speaker pauses,
+ *   - manual `finishUtterance()` for push-to-talk.
+ *
+ * Kept framework-agnostic (no React) so it can be unit-reasoned in isolation.
+ */
+
+const TARGET_SAMPLE_RATE = 16000;
+
+export interface VoiceCaptureCallbacks {
+  /** Smoothed 0..1 input level, emitted continuously for the orb. */
+  readonly onLevel?: (level: number) => void;
+  /** Fired when speech is detected to have started (VAD). */
+  readonly onSpeechStart?: () => void;
+  /** Fired with a complete utterance WAV (VAD silence or manual finish). */
+  readonly onUtteranceEnd?: (wav: Uint8Array) => void;
+  readonly onError?: (error: unknown) => void;
+}
+
+export interface VoiceCaptureOptions {
+  /** RMS threshold above which audio counts as speech. */
+  readonly speechThreshold?: number;
+  /** Silence (ms) after speech before an utterance is considered complete. */
+  readonly silenceHangoverMs?: number;
+  /** Minimum utterance length (ms) to bother transcribing. */
+  readonly minUtteranceMs?: number;
+  /** When false, VAD does not auto-finish; caller drives finishUtterance(). */
+  readonly autoEndOnSilence?: boolean;
+}
+
+interface WorkletMessage {
+  readonly pcm: Int16Array;
+  readonly rms: number;
+}
+
+function encodeWavFromPcm(chunks: Int16Array[], sampleRate: number): Uint8Array {
+  let totalSamples = 0;
+  for (const chunk of chunks) totalSamples += chunk.length;
+  const dataBytes = totalSamples * 2;
+  const buffer = new ArrayBuffer(44 + dataBytes);
+  const view = new DataView(buffer);
+
+  const writeString = (offset: number, value: string) => {
+    for (let i = 0; i < value.length; i += 1) view.setUint8(offset + i, value.charCodeAt(i));
+  };
+
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataBytes, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true); // PCM chunk size
+  view.setUint16(20, 1, true); // PCM format
+  view.setUint16(22, 1, true); // mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true); // byte rate
+  view.setUint16(32, 2, true); // block align
+  view.setUint16(34, 16, true); // bits per sample
+  writeString(36, "data");
+  view.setUint32(40, dataBytes, true);
+
+  let offset = 44;
+  for (const chunk of chunks) {
+    for (let i = 0; i < chunk.length; i += 1) {
+      view.setInt16(offset, chunk[i]!, true);
+      offset += 2;
+    }
+  }
+  return new Uint8Array(buffer);
+}
+
+export class VoiceCaptureController {
+  private context: AudioContext | undefined;
+  private stream: MediaStream | undefined;
+  private node: AudioWorkletNode | undefined;
+  private source: MediaStreamAudioSourceNode | undefined;
+
+  private readonly callbacks: VoiceCaptureCallbacks;
+  private readonly speechThreshold: number;
+  private readonly silenceHangoverMs: number;
+  private readonly minUtteranceMs: number;
+  private autoEndOnSilence: boolean;
+
+  private chunks: Int16Array[] = [];
+  private speaking = false;
+  private forced = false;
+  private smoothedLevel = 0;
+  private lastVoiceAt = 0;
+  private utteranceStartAt = 0;
+
+  constructor(callbacks: VoiceCaptureCallbacks, options?: VoiceCaptureOptions) {
+    this.callbacks = callbacks;
+    this.speechThreshold = options?.speechThreshold ?? 0.02;
+    this.silenceHangoverMs = options?.silenceHangoverMs ?? 900;
+    this.minUtteranceMs = options?.minUtteranceMs ?? 350;
+    this.autoEndOnSilence = options?.autoEndOnSilence ?? false;
+  }
+
+  get level(): number {
+    return this.smoothedLevel;
+  }
+
+  setAutoEndOnSilence(value: boolean): void {
+    this.autoEndOnSilence = value;
+  }
+
+  async start(): Promise<void> {
+    try {
+      this.stream = await navigator.mediaDevices.getUserMedia({
+        audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+      });
+      const context = new AudioContext();
+      this.context = context;
+      await context.audioWorklet.addModule("/voice-worklet.js");
+      this.source = context.createMediaStreamSource(this.stream);
+      this.node = new AudioWorkletNode(context, "voice-capture-processor");
+      this.node.port.onmessage = (event: MessageEvent<WorkletMessage>) => {
+        this.handleFrame(event.data);
+      };
+      this.source.connect(this.node);
+      // Keep the worklet pulling by connecting to a muted destination.
+      const silentGain = context.createGain();
+      silentGain.gain.value = 0;
+      this.node.connect(silentGain).connect(context.destination);
+    } catch (error) {
+      this.callbacks.onError?.(error);
+      throw error;
+    }
+  }
+
+  private now(): number {
+    return this.context ? this.context.currentTime * 1000 : 0;
+  }
+
+  private handleFrame(message: WorkletMessage): void {
+    const { pcm, rms } = message;
+    this.smoothedLevel = this.smoothedLevel * 0.8 + Math.min(1, rms * 8) * 0.2;
+    this.callbacks.onLevel?.(this.smoothedLevel);
+
+    const isVoice = this.forced || rms >= this.speechThreshold;
+    const now = this.now();
+
+    if (isVoice) {
+      if (!this.speaking) {
+        this.speaking = true;
+        this.utteranceStartAt = now;
+        this.chunks = [];
+        this.callbacks.onSpeechStart?.();
+      }
+      this.lastVoiceAt = now;
+    }
+
+    if (this.speaking) {
+      // Copy the frame — the transferred buffer is reused by the worklet.
+      this.chunks.push(new Int16Array(pcm));
+      if (
+        this.autoEndOnSilence &&
+        !isVoice &&
+        now - this.lastVoiceAt >= this.silenceHangoverMs
+      ) {
+        this.finishUtterance();
+      }
+    }
+  }
+
+  /** Start capturing everything until finishUtterance() (push-to-talk press). */
+  beginForcedUtterance(): void {
+    this.forced = true;
+    this.speaking = true;
+    this.utteranceStartAt = this.now();
+    this.chunks = [];
+    this.callbacks.onSpeechStart?.();
+  }
+
+  /** Manually complete the current utterance (push-to-talk release). */
+  finishUtterance(): void {
+    this.forced = false;
+    if (!this.speaking && this.chunks.length === 0) return;
+    const durationMs = this.now() - this.utteranceStartAt;
+    const chunks = this.chunks;
+    this.chunks = [];
+    this.speaking = false;
+    if (chunks.length === 0 || durationMs < this.minUtteranceMs) return;
+    const wav = encodeWavFromPcm(chunks, TARGET_SAMPLE_RATE);
+    this.callbacks.onUtteranceEnd?.(wav);
+  }
+
+  async stop(): Promise<void> {
+    this.node?.port.close();
+    this.node?.disconnect();
+    this.source?.disconnect();
+    for (const track of this.stream?.getTracks() ?? []) track.stop();
+    if (this.context && this.context.state !== "closed") {
+      await this.context.close().catch(() => undefined);
+    }
+    this.node = undefined;
+    this.source = undefined;
+    this.stream = undefined;
+    this.context = undefined;
+    this.chunks = [];
+    this.speaking = false;
+    this.smoothedLevel = 0;
+  }
+}

--- a/apps/web/src/voice/sttClient.ts
+++ b/apps/web/src/voice/sttClient.ts
@@ -1,0 +1,22 @@
+import type { SpeechToTextResult } from "@t3tools/contracts";
+
+import { voiceFetch } from "./voiceHttp";
+
+/** POST a 16 kHz mono WAV utterance and get back its transcript. */
+export async function transcribeAudio(
+  wav: Uint8Array,
+  options?: { readonly language?: string },
+): Promise<SpeechToTextResult> {
+  const query = options?.language ? `?language=${encodeURIComponent(options.language)}` : "";
+  const response = await voiceFetch(`/api/stt/transcribe${query}`, {
+    method: "POST",
+    headers: { "content-type": "audio/wav" },
+    // Uint8Array is a valid fetch body at runtime; the DOM BodyInit type is
+    // over-strict about the backing ArrayBufferLike.
+    body: wav as unknown as BodyInit,
+  });
+  if (!response.ok) {
+    throw new Error(`Transcription failed (${response.status}).`);
+  }
+  return (await response.json()) as SpeechToTextResult;
+}

--- a/apps/web/src/voice/ttsClient.ts
+++ b/apps/web/src/voice/ttsClient.ts
@@ -1,0 +1,22 @@
+import { voiceFetch } from "./voiceHttp";
+
+/** POST one speakable text unit and get back WAV audio bytes. */
+export async function synthesizeSpeech(
+  text: string,
+  options?: { readonly voice?: string; readonly speed?: number; readonly signal?: AbortSignal },
+): Promise<ArrayBuffer> {
+  const response = await voiceFetch("/api/tts/synthesize", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      text,
+      ...(options?.voice ? { voice: options.voice } : {}),
+      ...(options?.speed !== undefined ? { speed: options.speed } : {}),
+    }),
+    ...(options?.signal ? { signal: options.signal } : {}),
+  });
+  if (!response.ok) {
+    throw new Error(`Speech synthesis failed (${response.status}).`);
+  }
+  return await response.arrayBuffer();
+}

--- a/apps/web/src/voice/ttsPlayback.ts
+++ b/apps/web/src/voice/ttsPlayback.ts
@@ -1,0 +1,171 @@
+/**
+ * Ordered text-to-speech playback queue.
+ *
+ * Sentence units are enqueued by monotonic index and synthesized concurrently,
+ * but always PLAYED in index order (early-arriving later units wait). While a
+ * unit plays, an AnalyserNode feeds a smoothed amplitude to `onLevel` so the
+ * orb reacts to the voice. `stop()` aborts in-flight synthesis and playback —
+ * used for mute and barge-in.
+ */
+import { synthesizeSpeech } from "./ttsClient";
+
+export interface TtsPlaybackCallbacks {
+  readonly onLevel?: (level: number) => void;
+  readonly onPlayingChange?: (playing: boolean) => void;
+  readonly onError?: (error: unknown) => void;
+  readonly getVoice?: () => string | undefined;
+}
+
+interface PendingUnit {
+  readonly promise: Promise<ArrayBuffer | null>;
+  readonly abort: AbortController;
+}
+
+export class TtsPlaybackController {
+  private context: AudioContext | undefined;
+  private analyser: AnalyserNode | undefined;
+  private currentSource: AudioBufferSourceNode | undefined;
+  private levelRaf = 0;
+
+  private readonly units = new Map<number, PendingUnit>();
+  private playCursor = 0;
+  private enqueueCursor = 0;
+  private pumping = false;
+  private stopped = false;
+
+  constructor(private readonly callbacks: TtsPlaybackCallbacks) {}
+
+  /** Next index to assign — lets callers enqueue in stream order. */
+  nextIndex(): number {
+    const index = this.enqueueCursor;
+    this.enqueueCursor += 1;
+    return index;
+  }
+
+  enqueue(index: number, text: string): void {
+    if (this.stopped) return;
+    const abort = new AbortController();
+    const promise = synthesizeSpeech(text, {
+      ...(this.callbacks.getVoice?.() ? { voice: this.callbacks.getVoice()! } : {}),
+      signal: abort.signal,
+    })
+      .catch((error) => {
+        if (!abort.signal.aborted) this.callbacks.onError?.(error);
+        return null;
+      });
+    this.units.set(index, { promise, abort });
+    void this.pump();
+  }
+
+  private ensureContext(): AudioContext {
+    if (!this.context) {
+      this.context = new AudioContext();
+      this.analyser = this.context.createAnalyser();
+      this.analyser.fftSize = 256;
+      this.analyser.connect(this.context.destination);
+    }
+    return this.context;
+  }
+
+  private async pump(): Promise<void> {
+    if (this.pumping) return;
+    this.pumping = true;
+    try {
+      while (!this.stopped) {
+        const unit = this.units.get(this.playCursor);
+        if (!unit) break;
+        const bytes = await unit.promise;
+        this.units.delete(this.playCursor);
+        this.playCursor += 1;
+        if (this.stopped || !bytes || bytes.byteLength === 0) continue;
+        await this.playBuffer(bytes);
+      }
+    } finally {
+      this.pumping = false;
+    }
+  }
+
+  private async playBuffer(bytes: ArrayBuffer): Promise<void> {
+    const context = this.ensureContext();
+    let audioBuffer: AudioBuffer;
+    try {
+      audioBuffer = await context.decodeAudioData(bytes.slice(0));
+    } catch (error) {
+      this.callbacks.onError?.(error);
+      return;
+    }
+    if (this.stopped) return;
+
+    const source = context.createBufferSource();
+    source.buffer = audioBuffer;
+    if (this.analyser) source.connect(this.analyser);
+    this.currentSource = source;
+    this.callbacks.onPlayingChange?.(true);
+    this.startLevelLoop();
+
+    await new Promise<void>((resolve) => {
+      source.onended = () => resolve();
+      source.start();
+    });
+
+    this.currentSource = undefined;
+    if (this.units.size === 0 || this.stopped) {
+      this.stopLevelLoop();
+      this.callbacks.onPlayingChange?.(false);
+    }
+  }
+
+  private startLevelLoop(): void {
+    if (!this.analyser || this.levelRaf) return;
+    const data = new Uint8Array(this.analyser.frequencyBinCount);
+    const tick = () => {
+      if (!this.analyser) return;
+      this.analyser.getByteTimeDomainData(data);
+      let sum = 0;
+      for (let i = 0; i < data.length; i += 1) {
+        const v = (data[i]! - 128) / 128;
+        sum += v * v;
+      }
+      const rms = Math.sqrt(sum / data.length);
+      this.callbacks.onLevel?.(Math.min(1, rms * 3));
+      this.levelRaf = requestAnimationFrame(tick);
+    };
+    this.levelRaf = requestAnimationFrame(tick);
+  }
+
+  private stopLevelLoop(): void {
+    if (this.levelRaf) cancelAnimationFrame(this.levelRaf);
+    this.levelRaf = 0;
+    this.callbacks.onLevel?.(0);
+  }
+
+  /** Abort all synthesis + playback and reset (mute / barge-in / close). */
+  stop(): void {
+    this.stopped = true;
+    for (const unit of this.units.values()) unit.abort.abort();
+    this.units.clear();
+    if (this.currentSource) {
+      try {
+        this.currentSource.onended = null;
+        this.currentSource.stop();
+      } catch {
+        // already stopped
+      }
+      this.currentSource = undefined;
+    }
+    this.stopLevelLoop();
+    this.callbacks.onPlayingChange?.(false);
+    this.playCursor = 0;
+    this.enqueueCursor = 0;
+    this.stopped = false;
+  }
+
+  async dispose(): Promise<void> {
+    this.stop();
+    if (this.context && this.context.state !== "closed") {
+      await this.context.close().catch(() => undefined);
+    }
+    this.context = undefined;
+    this.analyser = undefined;
+  }
+}

--- a/apps/web/src/voice/useVoiceSession.ts
+++ b/apps/web/src/voice/useVoiceSession.ts
@@ -1,0 +1,233 @@
+/**
+ * Voice session orchestrator.
+ *
+ * Wires the microphone capture, whisper.cpp transcription, prompt submission,
+ * and Kokoro TTS playback together for the Voice Mode overlay. Owns the capture
+ * and playback controllers, drives the orb via the voice store, handles the
+ * three submit triggers (push-to-talk, silence VAD, codeword), and speaks the
+ * streaming assistant reply while it prints — skipping code.
+ */
+import { useAtomValue } from "@effect/atom-react";
+import { useParams } from "@tanstack/react-router";
+import {
+  detectSendPromptCodeword,
+  markdownToSpeakable,
+  segmentSpeakable,
+} from "@t3tools/shared/speakableText";
+import { useCallback, useEffect, useRef } from "react";
+
+import { DEFAULT_INTERACTION_MODE, DEFAULT_RUNTIME_MODE } from "~/types";
+import { newMessageId } from "~/lib/utils";
+import { useThreadMessages, useThreadSession } from "~/state/entities";
+import { primaryServerSettingsAtom } from "~/state/server";
+import { threadEnvironment } from "~/state/threads";
+import { useAtomCommand } from "~/state/use-atom-command";
+import { resolveThreadRouteTarget } from "~/threadRoutes";
+
+import { VoiceCaptureController } from "./audioCapture";
+import { TtsPlaybackController } from "./ttsPlayback";
+import { transcribeAudio } from "./sttClient";
+import { useVoiceStore } from "./useVoiceStore";
+
+export interface VoiceSessionHandlers {
+  readonly startPushToTalk: () => void;
+  readonly endPushToTalk: () => void;
+}
+
+export function useVoiceSession(): VoiceSessionHandlers {
+  const isOpen = useVoiceStore((state) => state.isOpen);
+  const mode = useVoiceStore((state) => state.mode);
+  const muted = useVoiceStore((state) => state.muted);
+
+  const settings = useAtomValue(primaryServerSettingsAtom);
+  const speech = settings.speech;
+
+  const routeTarget = useParams({
+    strict: false,
+    select: (params) => resolveThreadRouteTarget(params),
+  });
+  const threadRef = routeTarget?.kind === "server" ? routeTarget.threadRef : null;
+  const session = useThreadSession(threadRef);
+  const messages = useThreadMessages(threadRef);
+  const startTurn = useAtomCommand(threadEnvironment.startTurn, { reportFailure: false });
+
+  const captureRef = useRef<VoiceCaptureController | null>(null);
+  const playbackRef = useRef<TtsPlaybackController | null>(null);
+
+  // Latest values read inside stable callbacks.
+  const speechRef = useRef(speech);
+  speechRef.current = speech;
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  const threadRefRef = useRef(threadRef);
+  threadRefRef.current = threadRef;
+  const sessionRef = useRef(session);
+  sessionRef.current = session;
+  const startTurnRef = useRef(startTurn);
+  startTurnRef.current = startTurn;
+
+  const submitPrompt = useCallback(async (text: string) => {
+    const ref = threadRefRef.current;
+    const trimmed = text.trim();
+    if (!ref || trimmed.length === 0) return;
+    useVoiceStore.getState().setStatus("thinking");
+    await startTurnRef.current({
+      environmentId: ref.environmentId,
+      input: {
+        threadId: ref.threadId,
+        message: {
+          messageId: newMessageId(),
+          role: "user",
+          text: trimmed,
+          attachments: [],
+        },
+        runtimeMode: sessionRef.current?.runtimeMode ?? DEFAULT_RUNTIME_MODE,
+        interactionMode: DEFAULT_INTERACTION_MODE,
+      },
+    });
+  }, []);
+
+  const handleUtterance = useCallback(
+    async (wav: Uint8Array) => {
+      const store = useVoiceStore.getState();
+      store.setStatus("thinking");
+      try {
+        const { text } = await transcribeAudio(wav);
+        const trimmed = text.trim();
+        if (trimmed.length === 0) {
+          store.setStatus("listening");
+          return;
+        }
+        const codeword = speechRef.current.sendPromptCodeword || "send prompt";
+        const { matched, strippedText } = detectSendPromptCodeword(trimmed, codeword);
+        if (matched || modeRef.current === "auto-silence") {
+          const toSend = matched ? strippedText : trimmed;
+          store.setTranscript(toSend);
+          await submitPrompt(toSend);
+        } else {
+          store.setTranscript(trimmed);
+          store.setStatus("listening");
+        }
+      } catch (error) {
+        store.setError(error instanceof Error ? error.message : String(error));
+        store.setStatus("listening");
+      }
+    },
+    [submitPrompt],
+  );
+
+  // Capture + playback lifecycle, tied to the overlay being open.
+  useEffect(() => {
+    if (!isOpen) return;
+    const store = useVoiceStore.getState();
+
+    const capture = new VoiceCaptureController(
+      {
+        onLevel: (level) => {
+          if (useVoiceStore.getState().status !== "speaking") {
+            useVoiceStore.getState().setLevel(level);
+          }
+        },
+        onSpeechStart: () => {
+          // Barge-in: stop speaking as soon as the user talks.
+          playbackRef.current?.stop();
+          if (useVoiceStore.getState().status !== "thinking") {
+            useVoiceStore.getState().setStatus("listening");
+          }
+        },
+        onUtteranceEnd: (wav) => {
+          void handleUtterance(wav);
+        },
+        onError: (error) =>
+          useVoiceStore.getState().setError(error instanceof Error ? error.message : String(error)),
+      },
+      { autoEndOnSilence: modeRef.current === "auto-silence" },
+    );
+    captureRef.current = capture;
+
+    const playback = new TtsPlaybackController({
+      onLevel: (level) => useVoiceStore.getState().setLevel(level),
+      onPlayingChange: (playing) =>
+        useVoiceStore.getState().setStatus(playing ? "speaking" : "listening"),
+      getVoice: () => speechRef.current.kokoroVoice || undefined,
+    });
+    playbackRef.current = playback;
+
+    store.setStatus("idle");
+    void capture
+      .start()
+      .then(() => useVoiceStore.getState().setStatus("listening"))
+      .catch(() => undefined);
+
+    return () => {
+      void capture.stop();
+      void playback.dispose();
+      captureRef.current = null;
+      playbackRef.current = null;
+    };
+  }, [isOpen, handleUtterance]);
+
+  useEffect(() => {
+    captureRef.current?.setAutoEndOnSilence(mode === "auto-silence");
+  }, [mode]);
+
+  useEffect(() => {
+    if (muted) playbackRef.current?.stop();
+  }, [muted]);
+
+  // Speak the streaming assistant reply while it prints, skipping code. Tracks
+  // how many complete sentences have been spoken per assistant message.
+  const spokenRef = useRef<{ messageId: string | null; spokenCount: number; done: boolean }>({
+    messageId: null,
+    spokenCount: 0,
+    done: false,
+  });
+
+  useEffect(() => {
+    if (!isOpen || !speechRef.current.ttsEnabled || useVoiceStore.getState().muted) return;
+    const playback = playbackRef.current;
+    if (!playback) return;
+
+    let assistant: (typeof messages)[number] | undefined;
+    for (let i = messages.length - 1; i >= 0; i -= 1) {
+      if (messages[i]!.role === "assistant") {
+        assistant = messages[i];
+        break;
+      }
+    }
+    if (!assistant) return;
+
+    const tracker = spokenRef.current;
+    if (assistant.id !== tracker.messageId) {
+      tracker.messageId = assistant.id;
+      tracker.spokenCount = 0;
+      tracker.done = false;
+    }
+    if (tracker.done) return;
+
+    const spoken = markdownToSpeakable(assistant.text);
+    const { units, remainder } = segmentSpeakable(spoken);
+    for (let i = tracker.spokenCount; i < units.length; i += 1) {
+      playback.enqueue(playback.nextIndex(), units[i]!);
+    }
+    tracker.spokenCount = units.length;
+
+    if (!assistant.streaming) {
+      const tail = remainder.trim();
+      if (tail.length > 0) playback.enqueue(playback.nextIndex(), tail);
+      tracker.done = true;
+    }
+  }, [messages, isOpen]);
+
+  const startPushToTalk = useCallback(() => {
+    playbackRef.current?.stop();
+    captureRef.current?.beginForcedUtterance();
+    useVoiceStore.getState().setStatus("listening");
+  }, []);
+
+  const endPushToTalk = useCallback(() => {
+    captureRef.current?.finishUtterance();
+  }, []);
+
+  return { startPushToTalk, endPushToTalk };
+}

--- a/apps/web/src/voice/useVoiceStore.ts
+++ b/apps/web/src/voice/useVoiceStore.ts
@@ -1,0 +1,52 @@
+import { create } from "zustand";
+
+import type { VoiceOrbState } from "~/components/voice/VoiceOrb";
+
+export type VoiceSubmitMode = "push-to-talk" | "auto-silence";
+
+interface VoiceStoreState {
+  /** Whether the full-screen voice overlay is open. */
+  isOpen: boolean;
+  /** How an utterance is submitted while listening. */
+  mode: VoiceSubmitMode;
+  /** Visual/logical state driving the orb. */
+  status: VoiceOrbState;
+  /** Smoothed 0..1 audio level for the orb. */
+  level: number;
+  /** When true, TTS playback is silenced. */
+  muted: boolean;
+  /** Latest transcript text shown in the overlay. */
+  transcript: string;
+  /** Last error message, if any. */
+  error: string | null;
+
+  open: () => void;
+  close: () => void;
+  setMode: (mode: VoiceSubmitMode) => void;
+  setStatus: (status: VoiceOrbState) => void;
+  setLevel: (level: number) => void;
+  toggleMuted: () => void;
+  setMuted: (muted: boolean) => void;
+  setTranscript: (transcript: string) => void;
+  setError: (error: string | null) => void;
+}
+
+export const useVoiceStore = create<VoiceStoreState>((set) => ({
+  isOpen: false,
+  mode: "push-to-talk",
+  status: "idle",
+  level: 0,
+  muted: false,
+  transcript: "",
+  error: null,
+
+  open: () => set({ isOpen: true, status: "idle", error: null }),
+  close: () => set({ isOpen: false, status: "idle", level: 0, transcript: "" }),
+  setMode: (mode) => set({ mode }),
+  setStatus: (status) => set({ status }),
+  setLevel: (level) => set({ level }),
+  toggleMuted: () => set((state) => ({ muted: !state.muted })),
+  setMuted: (muted) => set({ muted }),
+  setTranscript: (transcript) => set({ transcript }),
+  setError: (error) => set({ error }),
+}));

--- a/apps/web/src/voice/voiceHttp.ts
+++ b/apps/web/src/voice/voiceHttp.ts
@@ -1,0 +1,32 @@
+/**
+ * Authenticated fetch to the primary environment for the voice routes.
+ *
+ * Mirrors `environments/primary/httpLayer.ts`: a same-origin browser sends the
+ * session cookie (`credentials: "include"`); anything else (desktop bridge,
+ * remote) attaches the desktop primary bearer token.
+ */
+import { readDesktopPrimaryBearerToken } from "../environments/primary/desktopAuth";
+import { resolvePrimaryEnvironmentHttpUrl } from "../environments/primary/target";
+
+function isSameOriginBrowserPrimary(): boolean {
+  if (
+    typeof window === "undefined" ||
+    window.desktopBridge !== undefined ||
+    window.nativeApi !== undefined ||
+    !window.location.origin.startsWith("http")
+  ) {
+    return false;
+  }
+  return new URL(resolvePrimaryEnvironmentHttpUrl("/")).origin === window.location.origin;
+}
+
+export async function voiceFetch(path: string, init: RequestInit): Promise<Response> {
+  const url = resolvePrimaryEnvironmentHttpUrl(path);
+  if (isSameOriginBrowserPrimary()) {
+    return fetch(url, { ...init, credentials: "include" });
+  }
+  const token = await readDesktopPrimaryBearerToken();
+  const headers = new Headers(init.headers);
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return fetch(url, { ...init, headers, credentials: "omit" });
+}

--- a/docs/integrations/local-voice.md
+++ b/docs/integrations/local-voice.md
@@ -1,0 +1,120 @@
+# Local Voice Mode (whisper.cpp + Kokoro)
+
+T3 Code can run a fully local, hands-free voice loop: speak a prompt, have it
+transcribed on-device with [whisper.cpp](https://github.com/ggerganov/whisper.cpp),
+sent to the agent, and have the reply spoken back with
+[Kokoro TTS](https://github.com/hexgrad/kokoro) — in parallel with the text
+printing. Anything that looks like code (fenced blocks, inline snippets, URLs,
+file paths) is stripped before it is read aloud.
+
+The feature is **off by default** and only appears once you enable it and point
+it at the required binaries/models. No large artifacts are bundled.
+
+## What you get
+
+- A **Voice Mode** overlay (mic button in the composer footer) with an animated,
+  audio-reactive orb — like ChatGPT's voice mode.
+- Three ways to submit a spoken prompt:
+  - **Push-to-talk** — hold the mic button, release to submit.
+  - **Silence detection** — pause and it submits automatically (auto mode).
+  - **Codeword** — say "send prompt" (configurable) at the end of your sentence.
+- Barge-in: start talking and the spoken reply stops immediately.
+
+## 1. Install whisper.cpp
+
+```bash
+git clone https://github.com/ggerganov/whisper.cpp
+cd whisper.cpp
+cmake -B build && cmake --build build --config Release
+# Download a model (base.en is a good default):
+./models/download-ggml-model.sh base.en
+```
+
+This produces the `whisper-cli` binary (in `build/bin/`) and a model at
+`models/ggml-base.en.bin`.
+
+## 2. Install Kokoro + an adapter
+
+Kokoro has no CLI, so T3 Code invokes a small adapter that reads the text to
+speak on **stdin** and writes a WAV to the `--out <path>` argument. Install the
+runtime:
+
+```bash
+pip install kokoro-onnx soundfile
+# download kokoro-v1.0.onnx and voices-v1.0.bin from the kokoro-onnx releases
+```
+
+Save this adapter as `kokoro_adapter.py`:
+
+```python
+import argparse, sys, soundfile as sf
+from kokoro_onnx import Kokoro
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--out", required=True)
+parser.add_argument("--voice", default="af_heart")
+parser.add_argument("--model", default="kokoro-v1.0.onnx")
+parser.add_argument("--voices", default="voices-v1.0.bin")
+parser.add_argument("--speed", type=float, default=1.0)
+args = parser.parse_args()
+
+text = sys.stdin.read()
+kokoro = Kokoro(args.model, args.voices)
+samples, sample_rate = kokoro.create(text, voice=args.voice, speed=args.speed)
+sf.write(args.out, samples, sample_rate)
+```
+
+(The adapter contract is only: read text on stdin, honor `--out`/`--voice`/
+`--model`/`--speed`, write a WAV. Swap in any TTS you like.)
+
+## 3. Configure T3 Code
+
+Set the paths either in `settings.json` (in your T3 Code state directory) under
+the `speech` group, or via environment variables. Settings take precedence.
+
+```jsonc
+{
+  "speech": {
+    "sttEnabled": true,
+    "ttsEnabled": true,
+    "whisperBinaryPath": "/path/to/whisper.cpp/build/bin/whisper-cli",
+    "whisperModelPath": "/path/to/whisper.cpp/models/ggml-base.en.bin",
+    "kokoroCommand": "python /path/to/kokoro_adapter.py",
+    "kokoroModelPath": "/path/to/kokoro-v1.0.onnx",
+    "kokoroVoice": "af_heart",
+    "sendPromptCodeword": "send prompt",
+    "submitMode": "push-to-talk"
+  }
+}
+```
+
+Environment variable fallbacks (used when a setting is blank):
+
+| Variable            | Purpose                                   |
+| ------------------- | ----------------------------------------- |
+| `T3_WHISPER_BIN`    | Path to `whisper-cli`                     |
+| `T3_WHISPER_MODEL`  | Path to the ggml whisper model            |
+| `T3_KOKORO_CMD`     | Kokoro adapter command                    |
+| `T3_KOKORO_MODEL`   | Kokoro model path (passed as `--model`)   |
+| `T3_KOKORO_VOICE`   | Default Kokoro voice                      |
+
+## 4. Use it
+
+1. Restart the server so it picks up the settings.
+2. Open a thread — a **mic button** appears in the composer footer (only when
+   `sttEnabled` is true).
+3. Click it to enter Voice Mode. Speak, then release (push-to-talk), pause
+   (auto mode), or say the codeword to submit.
+4. The reply prints and is spoken at the same time; code is skipped. Use the
+   mute or close buttons any time; starting to talk interrupts playback.
+
+## How it works
+
+- Audio is captured in the browser, downsampled to 16 kHz mono, and posted to
+  `POST /api/stt/transcribe` (authenticated). The server runs whisper.cpp via
+  the shared `ProcessRunner`.
+- The reply's streamed text is cleaned with `@t3tools/shared/speakableText`
+  (drops code/URLs/paths), split into sentences, and each sentence is sent to
+  `POST /api/tts/synthesize`, which runs the Kokoro adapter and returns WAV.
+- Both routes require the orchestration "operate" scope and fail with a typed
+  "not-configured" error when disabled or unconfigured — the UI stays hidden.

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -14,6 +14,7 @@ export * from "./model.ts";
 export * from "./keybindings.ts";
 export * from "./server.ts";
 export * from "./settings.ts";
+export * from "./speech.ts";
 export * from "./git.ts";
 export * from "./vcs.ts";
 export * from "./sourceControl.ts";

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -361,6 +361,107 @@ export const ObservabilitySettings = Schema.Struct({
 });
 export type ObservabilitySettings = typeof ObservabilitySettings.Type;
 
+// ── Local voice (speech-to-text + text-to-speech) ──────────────
+
+export const VoiceSubmitMode = Schema.Literals(["push-to-talk", "auto-silence"]);
+export type VoiceSubmitMode = typeof VoiceSubmitMode.Type;
+export const DEFAULT_VOICE_SUBMIT_MODE: VoiceSubmitMode = "push-to-talk";
+export const DEFAULT_SEND_PROMPT_CODEWORD = "send prompt";
+export const DEFAULT_KOKORO_VOICE = "af_heart";
+
+/**
+ * Local, self-hosted voice mode. Speech-to-text runs whisper.cpp and
+ * text-to-speech runs Kokoro, both as native processes on the server. The
+ * feature is OFF by default and only surfaces in the UI once enabled AND the
+ * required binary/model paths are set. Modeled on the provider binary-path
+ * settings above so it validates and renders through the same form machinery.
+ */
+export const SpeechSettings = makeProviderSettingsSchema(
+  {
+    sttEnabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({
+        title: "Enable speech-to-text",
+        description: "Transcribe microphone audio locally with whisper.cpp.",
+        providerSettingsForm: { control: "switch" },
+      }),
+    ),
+    ttsEnabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({
+        title: "Enable text-to-speech",
+        description: "Speak assistant replies aloud locally with Kokoro.",
+        providerSettingsForm: { control: "switch" },
+      }),
+    ),
+    whisperBinaryPath: makeBinaryPathSetting("whisper-cli").pipe(
+      Schema.annotateKey({
+        title: "whisper.cpp binary path",
+        description: "Path to the whisper.cpp `whisper-cli` (or `main`) binary.",
+        providerSettingsForm: { placeholder: "whisper-cli", clearWhenEmpty: "omit" },
+      }),
+    ),
+    whisperModelPath: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "whisper.cpp model path",
+        description: "Path to a ggml whisper model (e.g. ggml-base.en.bin).",
+        providerSettingsForm: { placeholder: "/path/to/ggml-base.en.bin", clearWhenEmpty: "omit" },
+      }),
+    ),
+    kokoroCommand: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Kokoro command",
+        description:
+          "Command (or adapter script path) that reads text on stdin and writes a WAV to the output path argument.",
+        providerSettingsForm: { placeholder: "python /path/to/kokoro_adapter.py", clearWhenEmpty: "omit" },
+      }),
+    ),
+    kokoroModelPath: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Kokoro model path",
+        description: "Optional path to the Kokoro model/voices file passed to the adapter.",
+        providerSettingsForm: { placeholder: "/path/to/kokoro.onnx", clearWhenEmpty: "omit" },
+      }),
+    ),
+    kokoroVoice: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed(DEFAULT_KOKORO_VOICE)),
+      Schema.annotateKey({
+        title: "Kokoro voice",
+        description: "Default Kokoro voice name.",
+        providerSettingsForm: { placeholder: DEFAULT_KOKORO_VOICE, clearWhenEmpty: "omit" },
+      }),
+    ),
+    sendPromptCodeword: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed(DEFAULT_SEND_PROMPT_CODEWORD)),
+      Schema.annotateKey({
+        title: "Send-prompt codeword",
+        description: "Say this phrase to submit the current transcript.",
+        providerSettingsForm: { placeholder: DEFAULT_SEND_PROMPT_CODEWORD, clearWhenEmpty: "omit" },
+      }),
+    ),
+    submitMode: VoiceSubmitMode.pipe(
+      Schema.withDecodingDefault(Effect.succeed(DEFAULT_VOICE_SUBMIT_MODE)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: [
+      "sttEnabled",
+      "ttsEnabled",
+      "whisperBinaryPath",
+      "whisperModelPath",
+      "kokoroCommand",
+      "kokoroModelPath",
+      "kokoroVoice",
+      "sendPromptCodeword",
+    ],
+  },
+);
+export type SpeechSettings = typeof SpeechSettings.Type;
+
 export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 
 export const ServerSettings = Schema.Struct({
@@ -409,6 +510,7 @@ export const ServerSettings = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed({})),
   ),
   observability: ObservabilitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  speech: SpeechSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
 });
 export type ServerSettings = typeof ServerSettings.Type;
 
@@ -514,6 +616,19 @@ export const ServerSettingsPatch = Schema.Struct({
     Schema.Struct({
       otlpTracesUrl: Schema.optionalKey(TrimmedString),
       otlpMetricsUrl: Schema.optionalKey(TrimmedString),
+    }),
+  ),
+  speech: Schema.optionalKey(
+    Schema.Struct({
+      sttEnabled: Schema.optionalKey(Schema.Boolean),
+      ttsEnabled: Schema.optionalKey(Schema.Boolean),
+      whisperBinaryPath: Schema.optionalKey(TrimmedString),
+      whisperModelPath: Schema.optionalKey(TrimmedString),
+      kokoroCommand: Schema.optionalKey(TrimmedString),
+      kokoroModelPath: Schema.optionalKey(TrimmedString),
+      kokoroVoice: Schema.optionalKey(TrimmedString),
+      sendPromptCodeword: Schema.optionalKey(TrimmedString),
+      submitMode: Schema.optionalKey(VoiceSubmitMode),
     }),
   ),
   providers: Schema.optionalKey(

--- a/packages/contracts/src/speech.ts
+++ b/packages/contracts/src/speech.ts
@@ -1,0 +1,66 @@
+import * as Schema from "effect/Schema";
+
+import { NonNegativeInt, TrimmedNonEmptyString } from "./baseSchemas.ts";
+
+// ── Speech-to-text ─────────────────────────────────────────────
+
+/**
+ * Result returned by the `POST /api/stt/transcribe` route. The request body
+ * is raw `audio/wav` bytes (a single 16 kHz mono utterance), so there is no
+ * JSON request schema — only this response shape.
+ */
+export const SpeechToTextResult = Schema.Struct({
+  text: Schema.String,
+  durationMs: Schema.optional(NonNegativeInt),
+});
+export type SpeechToTextResult = typeof SpeechToTextResult.Type;
+
+// ── Text-to-speech ─────────────────────────────────────────────
+
+/**
+ * Request body for `POST /api/tts/synthesize`. One sentence-sized speakable
+ * unit per request; the response body is raw `audio/wav` bytes.
+ */
+export const TextToSpeechRequest = Schema.Struct({
+  text: TrimmedNonEmptyString,
+  voice: Schema.optional(TrimmedNonEmptyString),
+  speed: Schema.optional(Schema.Number),
+});
+export type TextToSpeechRequest = typeof TextToSpeechRequest.Type;
+
+// ── Errors ─────────────────────────────────────────────────────
+
+export const SpeechFailureReason = Schema.Literals([
+  "not-configured",
+  "binary-missing",
+  "model-missing",
+  "decode-failed",
+  "process-failed",
+]);
+export type SpeechFailureReason = typeof SpeechFailureReason.Type;
+
+export class SpeechToTextError extends Schema.TaggedErrorClass<SpeechToTextError>()(
+  "SpeechToTextError",
+  {
+    reason: SpeechFailureReason,
+    detail: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Speech-to-text failed (${this.reason})${this.detail ? `: ${this.detail}` : ""}`;
+  }
+}
+
+export class TextToSpeechError extends Schema.TaggedErrorClass<TextToSpeechError>()(
+  "TextToSpeechError",
+  {
+    reason: SpeechFailureReason,
+    detail: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  override get message(): string {
+    return `Text-to-speech failed (${this.reason})${this.detail ? `: ${this.detail}` : ""}`;
+  }
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -182,6 +182,10 @@
     "./httpReadiness": {
       "types": "./src/httpReadiness.ts",
       "import": "./src/httpReadiness.ts"
+    },
+    "./speakableText": {
+      "types": "./src/speakableText.ts",
+      "import": "./src/speakableText.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/speakableText.test.ts
+++ b/packages/shared/src/speakableText.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  detectSendPromptCodeword,
+  markdownToSpeakable,
+  segmentSpeakable,
+} from "./speakableText.ts";
+
+describe("markdownToSpeakable", () => {
+  it("drops fenced code blocks", () => {
+    const md = "Here is the fix:\n\n```ts\nconst x = 1;\n```\n\nAll done.";
+    const spoken = markdownToSpeakable(md);
+    expect(spoken).not.toContain("const x");
+    expect(spoken).toContain("Here is the fix");
+    expect(spoken).toContain("All done.");
+  });
+
+  it("drops an unterminated (still streaming) fence", () => {
+    const md = "Try this:\n```js\nconsole.log('partial";
+    const spoken = markdownToSpeakable(md);
+    expect(spoken).toBe("Try this:");
+  });
+
+  it("drops inline code", () => {
+    const spoken = markdownToSpeakable("Call the `useVoiceStore` hook now.");
+    expect(spoken).not.toContain("useVoiceStore");
+    expect(spoken).toContain("Call the");
+    expect(spoken).toContain("hook now.");
+  });
+
+  it("keeps link text and drops the url", () => {
+    const spoken = markdownToSpeakable("See [the docs](https://example.com/x) for more.");
+    expect(spoken).toContain("the docs");
+    expect(spoken).not.toContain("example.com");
+  });
+
+  it("drops bare urls", () => {
+    const spoken = markdownToSpeakable("Open https://example.com/foo now.");
+    expect(spoken).not.toContain("example.com");
+    expect(spoken).toContain("Open");
+  });
+
+  it("drops file paths", () => {
+    const spoken = markdownToSpeakable("Edit src/index.ts and package.json please.");
+    expect(spoken).not.toContain("src/index.ts");
+    expect(spoken).not.toContain("package.json");
+    expect(spoken).toContain("Edit");
+    expect(spoken).toContain("please.");
+  });
+
+  it("strips markdown emphasis and headings but keeps words", () => {
+    const spoken = markdownToSpeakable("# Title\n\nThis is **bold** and _italic_ text.");
+    expect(spoken).toContain("Title");
+    expect(spoken).toContain("bold");
+    expect(spoken).toContain("italic");
+    expect(spoken).not.toContain("**");
+    expect(spoken).not.toContain("#");
+  });
+
+  it("does not treat sentence-final words as file paths", () => {
+    const spoken = markdownToSpeakable("We are done.");
+    expect(spoken).toBe("We are done.");
+  });
+});
+
+describe("segmentSpeakable", () => {
+  it("splits complete sentences and keeps the remainder", () => {
+    const { units, remainder } = segmentSpeakable("Hello there. How are you? I am fine and");
+    expect(units).toEqual(["Hello there.", "How are you?"]);
+    expect(remainder).toBe("I am fine and");
+  });
+
+  it("returns no units when there is no sentence boundary yet", () => {
+    const { units, remainder } = segmentSpeakable("still typing a sentence");
+    expect(units).toEqual([]);
+    expect(remainder).toBe("still typing a sentence");
+  });
+
+  it("handles ellipsis and trailing quotes", () => {
+    const { units, remainder } = segmentSpeakable('She said "wait." Then left.');
+    expect(units).toEqual(['She said "wait."', "Then left."]);
+    expect(remainder).toBe("");
+  });
+});
+
+describe("detectSendPromptCodeword", () => {
+  it("matches a trailing codeword and strips it", () => {
+    const result = detectSendPromptCodeword("refactor the parser send prompt", "send prompt");
+    expect(result.matched).toBe(true);
+    expect(result.strippedText).toBe("refactor the parser");
+  });
+
+  it("is punctuation and case insensitive", () => {
+    const result = detectSendPromptCodeword("Fix the bug, Send Prompt.", "send prompt");
+    expect(result.matched).toBe(true);
+    expect(result.strippedText).toBe("Fix the bug");
+  });
+
+  it("does not match the codeword mid-sentence", () => {
+    const result = detectSendPromptCodeword("send prompt to the server when ready", "send prompt");
+    expect(result.matched).toBe(false);
+    expect(result.strippedText).toBe("send prompt to the server when ready");
+  });
+
+  it("matches when the transcript is only the codeword", () => {
+    const result = detectSendPromptCodeword("send prompt", "send prompt");
+    expect(result.matched).toBe(true);
+    expect(result.strippedText).toBe("");
+  });
+
+  it("never matches an empty phrase", () => {
+    const result = detectSendPromptCodeword("anything at all", "");
+    expect(result.matched).toBe(false);
+  });
+});

--- a/packages/shared/src/speakableText.ts
+++ b/packages/shared/src/speakableText.ts
@@ -1,0 +1,156 @@
+/**
+ * Turn assistant markdown into text that is worth reading aloud, and split it
+ * into sentence-sized units for streaming text-to-speech.
+ *
+ * This is intentionally dependency-free (no markdown AST): it runs in the
+ * browser TTS pipeline on every streamed delta, so it must be cheap and pure.
+ * The goal is not perfect markdown parsing — it is to remove everything that
+ * sounds like noise when spoken: fenced code blocks, inline code, URLs, image
+ * syntax, and file-path-looking tokens, while keeping ordinary prose (and the
+ * visible text of links).
+ */
+
+const FENCED_CODE_BLOCK = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
+// An unterminated fence (still-streaming code block): drop from the fence on.
+const UNTERMINATED_FENCE = /(?:```|~~~)[\s\S]*$/;
+const INLINE_CODE = /`[^`\n]*`/g;
+const IMAGE = /!\[[^\]]*\]\([^)]*\)/g;
+// [text](url) -> text
+const LINK = /\[([^\]]*)\]\((?:[^)]*)\)/g;
+// [text][ref] -> text
+const REFERENCE_LINK = /\[([^\]]*)\]\[[^\]]*\]/g;
+const HTML_TAG = /<\/?[a-zA-Z][^>]*>/g;
+const BARE_URL = /\b(?:https?|ftp|file):\/\/\S+/gi;
+const MARKDOWN_HEADING = /^\s{0,3}#{1,6}\s+/gm;
+const BLOCKQUOTE = /^\s{0,3}>\s?/gm;
+const LIST_MARKER = /^\s{0,3}(?:[-*+]|\d+[.)])\s+/gm;
+const TABLE_ROW = /^\s*\|.*\|\s*$/gm;
+const THEMATIC_BREAK = /^\s{0,3}(?:[-*_]\s?){3,}$/gm;
+// Emphasis / strong / strikethrough markers (keep the inner words).
+const EMPHASIS_MARKERS = /(\*\*|\*|__|_|~~)/g;
+// Path-like tokens: a slash-separated path, or a bare `name.ext[:line]`.
+const PATH_LIKE =
+  /(?:\.{0,2}\/[\w.\-/]+)|(?:\b[\w.\-]+\/[\w.\-/]+)|(?:\b[\w.\-]+\.[a-zA-Z]{1,6}(?::\d+(?::\d+)?)?\b)/g;
+
+const SENTENCE_BOUNDARY = /[.!?…](?:["')\]]+)?(?=\s|$)/;
+
+/** File extensions common enough that "name.ext" should be treated as a path. */
+const COMMON_FILE_EXTENSIONS = new Set([
+  "ts", "tsx", "js", "jsx", "mjs", "cjs", "json", "md", "mdx", "css", "scss",
+  "html", "htm", "py", "rs", "go", "java", "kt", "rb", "php", "c", "h", "cpp",
+  "cc", "hpp", "cs", "sh", "bash", "zsh", "yml", "yaml", "toml", "ini", "env",
+  "lock", "sql", "xml", "svg", "png", "jpg", "jpeg", "gif", "wasm", "txt", "sh",
+]);
+
+function stripPathLike(text: string): string {
+  return text.replace(PATH_LIKE, (match) => {
+    // Keep tokens that are plainly prose ending in a sentence-final period,
+    // e.g. "done." — only drop tokens whose extension looks like a real file.
+    if (match.includes("/")) return " ";
+    const dot = match.lastIndexOf(".");
+    if (dot === -1) return match;
+    const ext = match.slice(dot + 1).split(":")[0]?.toLowerCase() ?? "";
+    return COMMON_FILE_EXTENSIONS.has(ext) ? " " : match;
+  });
+}
+
+/**
+ * Remove everything that should not be spoken and return clean prose. Safe to
+ * call on a partial (still-streaming) markdown buffer.
+ */
+export function markdownToSpeakable(markdown: string): string {
+  let text = markdown;
+  text = text.replace(FENCED_CODE_BLOCK, " ");
+  text = text.replace(UNTERMINATED_FENCE, " ");
+  text = text.replace(IMAGE, " ");
+  text = text.replace(REFERENCE_LINK, "$1");
+  text = text.replace(LINK, "$1");
+  text = text.replace(INLINE_CODE, " ");
+  text = text.replace(HTML_TAG, " ");
+  text = text.replace(BARE_URL, " ");
+  text = text.replace(TABLE_ROW, " ");
+  text = text.replace(THEMATIC_BREAK, " ");
+  text = text.replace(MARKDOWN_HEADING, "");
+  text = text.replace(BLOCKQUOTE, "");
+  text = text.replace(LIST_MARKER, "");
+  text = stripPathLike(text);
+  text = text.replace(EMPHASIS_MARKERS, "");
+  // Collapse whitespace (including the gaps left by removals).
+  text = text.replace(/[ \t]+/g, " ").replace(/\s*\n\s*/g, "\n").trim();
+  return text;
+}
+
+export interface SegmentResult {
+  /** Complete, speakable sentences ready to synthesize. */
+  readonly units: string[];
+  /** Trailing incomplete sentence to carry into the next call. */
+  readonly remainder: string;
+}
+
+/**
+ * Split cleaned text into sentence units, keeping any trailing incomplete
+ * sentence as `remainder`. Feed the remainder back in (prepended) on the next
+ * streamed chunk so sentences are never spoken half-formed or twice.
+ */
+export function segmentSpeakable(text: string): SegmentResult {
+  const units: string[] = [];
+  let rest = text;
+
+  while (rest.length > 0) {
+    const match = SENTENCE_BOUNDARY.exec(rest);
+    if (!match) break;
+    const end = match.index + match[0].length;
+    const sentence = rest.slice(0, end).trim();
+    if (sentence.length > 0) units.push(sentence);
+    rest = rest.slice(end);
+  }
+
+  return { units, remainder: rest.trim() };
+}
+
+export interface CodewordResult {
+  readonly matched: boolean;
+  /** Transcript with a trailing codeword removed (trimmed). */
+  readonly strippedText: string;
+}
+
+function normalizeForCodeword(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Detect a trailing "send prompt"-style codeword in a transcript. Matching is
+ * case/punctuation/whitespace-insensitive and only fires when the phrase is at
+ * the END of the transcript (so "send prompt" mid-sentence doesn't submit).
+ */
+export function detectSendPromptCodeword(
+  transcript: string,
+  phrase: string,
+): CodewordResult {
+  const normalizedPhrase = normalizeForCodeword(phrase);
+  if (normalizedPhrase.length === 0) {
+    return { matched: false, strippedText: transcript.trim() };
+  }
+
+  const normalized = normalizeForCodeword(transcript);
+  if (normalized !== normalizedPhrase && !normalized.endsWith(` ${normalizedPhrase}`)) {
+    return { matched: false, strippedText: transcript.trim() };
+  }
+
+  // Strip the trailing phrase from the ORIGINAL text (word-preserving), by
+  // walking back the same number of normalized words.
+  const phraseWordCount = normalizedPhrase.split(" ").length;
+  const originalWords = transcript.trim().split(/\s+/);
+  const kept = originalWords.slice(0, Math.max(0, originalWords.length - phraseWordCount));
+  const strippedText = kept
+    .join(" ")
+    // Drop a dangling separator left before the codeword (", send prompt").
+    .replace(/[\s,;:.\-–—]+$/u, "")
+    .trim();
+
+  return { matched: true, strippedText };
+}


### PR DESCRIPTION
Adds a hands-free, fully local voice loop presented as a ChatGPT-style full-screen Voice Mode overlay with an audio-reactive animated orb.

Server:
- SpeechToText / TextToSpeech Effect services running whisper.cpp and a Kokoro adapter via the shared ProcessRunner (temp-file WAV I/O).
- Raw authenticated HTTP routes POST /api/stt/transcribe (WAV in, JSON out) and POST /api/tts/synthesize (text in, audio/wav out), gated on the orchestration operate scope.
- New `speech` settings group (OFF by default) with whisper/Kokoro paths, voice, codeword, and submit mode; env fallbacks (T3_WHISPER_*/T3_KOKORO_*).

Shared:
- speakableText util (markdownToSpeakable / segmentSpeakable / detectSendPromptCodeword) that strips code, URLs, and file paths before synthesis and splits prose into speakable sentences (+ 16 unit tests).

Web:
- VoiceModeView overlay + audio-reactive canvas VoiceOrb, mounted from the chat layout; composer mic button gated on sttEnabled.
- Mic capture (16 kHz mono AudioWorklet + energy VAD), ordered TTS playback queue with barge-in, and a session orchestrator wiring capture -> STT -> submit -> streaming reply -> TTS.
- Three submit triggers: push-to-talk, silence auto-submit, and codeword.

Docs: docs/integrations/local-voice.md setup guide.


Claude-Session: https://claude.ai/code/session_01CAJD7nDKj9qdCvB4HxaXSW

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated routes spawn external processes from user-configured paths; misconfiguration or hostile binaries could affect the host, though the feature is opt-in and scope-gated.
> 
> **Overview**
> Adds **fully local Voice Mode**: speak prompts, transcribe on the server, submit to the agent, and hear replies read aloud—gated by new **`speech`** server settings (off by default) and a composer mic when STT is enabled.
> 
> **Server** wires `SpeechToText` / `TextToSpeech` through `ProcessRunner` (whisper.cpp CLI + Kokoro adapter), exposes authenticated **`POST /api/stt/transcribe`** and **`POST /api/tts/synthesize`** (operate scope), and exports **`authenticateRawRouteWithScope`** for those routes.
> 
> **Web** adds a full-screen overlay (orb, push-to-talk / silence / codeword submit, barge-in), 16 kHz capture via AudioWorklet + VAD, and ordered TTS playback while the assistant streams.
> 
> **Shared** adds **`speakableText`** to strip code/URLs/paths and segment sentences before synthesis, plus contracts for speech settings and errors. Setup is documented in **`docs/integrations/local-voice.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ea92f9070289e0ffac977021d569ea8945098d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add local voice mode with whisper.cpp STT and Kokoro TTS via an orb overlay
> - Adds server-side `POST /api/stt/transcribe` and `POST /api/tts/synthesize` routes backed by [SpeechToText.ts](https://github.com/pingdotgg/t3code/pull/3630/files#diff-c50eda64ea1d721c38351556e189a97d113213e2f36c9791d11f9cdcd883e61b) (whisper.cpp) and [TextToSpeech.ts](https://github.com/pingdotgg/t3code/pull/3630/files#diff-3e01d79d4ca86baf6ef87e532ef4acaff91ad0af3223e095b294818837829c7c) (Kokoro adapter), configured via new `speech` fields in `ServerSettings`.
> - Adds client-side mic capture in [audioCapture.ts](https://github.com/pingdotgg/t3code/pull/3630/files#diff-4b1c9204861eb2dc49ef6c28e102956c8aa5b92bdd76637f7103bdac3cafe94f) with energy-based VAD, push-to-talk support, and WAV encoding at 16 kHz mono.
> - Orchestrates the full voice loop (capture → STT → submit → stream reply → TTS playback) in [useVoiceSession.ts](https://github.com/pingdotgg/t3code/pull/3630/files#diff-341cf15ca4f85c3b14edd6132086113cf09414e55734d3a0a7d70a9bbaf25936), including barge-in and codeword-triggered submission.
> - Renders a full-screen animated orb overlay ([VoiceModeView.tsx](https://github.com/pingdotgg/t3code/pull/3630/files#diff-3f846f39ced64af8b600dac7fc1d9e750fb99087abf08eadb1a628a21002a704), [VoiceOrb.tsx](https://github.com/pingdotgg/t3code/pull/3630/files#diff-5e4033c52ba85016daa2737893e7c4f957c7e9bf52ec07ad1a09ce3cc0d4c6af)) in the chat layout, opened via a mic button that appears only when STT is enabled.
> - Adds [speakableText.ts](https://github.com/pingdotgg/t3code/pull/3630/files#diff-c34a0b365deb3a494dabba3887c3e8807701988bfa56136b0ad60fabb13a2cdb) utilities to strip markdown for TTS and segment streaming text into sentence units for incremental playback.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a8ea92f. 24 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->