### PR TITLE
fix(mobile): push gating and personal-team hardening for Android PR

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -11,10 +11,15 @@ const APP_VARIANT = resolveAppVariant(repoEnv.APP_VARIANT);
 const isIosPersonalTeamBuild = repoEnv.T3CODE_IOS_PERSONAL_TEAM === "1";
 
 const personalTeamBundleIdentifier = repoEnv.T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID?.trim();
+const IOS_BUNDLE_IDENTIFIER_PATTERN = /^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)+$/;
 
-if (isIosPersonalTeamBuild && !personalTeamBundleIdentifier) {
+if (
+  isIosPersonalTeamBuild &&
+  (!personalTeamBundleIdentifier ||
+    !IOS_BUNDLE_IDENTIFIER_PATTERN.test(personalTeamBundleIdentifier))
+) {
   throw new Error(
-    "T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID is required when T3CODE_IOS_PERSONAL_TEAM=1.",
+    "T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID must be a reverse-DNS identifier such as com.example.t3code when T3CODE_IOS_PERSONAL_TEAM=1.",
   );
 }
 
@@ -191,6 +196,8 @@ const config: ExpoConfig = {
       },
     ],
     "expo-secure-store",
+    // appleSignIn must be gated here: withoutIosPersonalTeamCapabilities.cjs runs before
+    // plugins earlier in this array, so it cannot strip the entitlement Clerk would add.
     ["@clerk/expo", { theme: "./clerk-theme.json", appleSignIn: !isIosPersonalTeamBuild }],
     "expo-web-browser",
     [
@@ -242,6 +249,7 @@ const config: ExpoConfig = {
   ],
   extra: {
     appVariant: APP_VARIANT,
+    iosPersonalTeamBuild: isIosPersonalTeamBuild,
     relay: {
       url: repoEnv.T3CODE_RELAY_URL ?? null,
     },

--- a/apps/mobile/src/features/agent-awareness/capabilities.ts
+++ b/apps/mobile/src/features/agent-awareness/capabilities.ts
@@ -1,0 +1,5 @@
+import Constants from "expo-constants";
+
+export function supportsAgentAwarenessPush() {
+  return Constants.expoConfig?.extra?.iosPersonalTeamBuild !== true;
+}

--- a/apps/mobile/src/features/agent-awareness/registrationPayload.ts
+++ b/apps/mobile/src/features/agent-awareness/registrationPayload.ts
@@ -1,6 +1,7 @@
 import type { RelayDeviceRegistrationRequest } from "@t3tools/contracts/relay";
 
 import type { Preferences } from "../../lib/storage";
+import { supportsAgentAwarenessPush } from "./capabilities";
 
 // Development builds are Xcode-signed and receive sandbox APNs tokens;
 // preview and production builds are distribution-signed and use production
@@ -21,7 +22,8 @@ export function makeRelayDeviceRegistrationRequest(input: {
   readonly notificationsEnabled: boolean;
   readonly preferences: Preferences;
 }): RelayDeviceRegistrationRequest {
-  const liveActivitiesEnabled = input.preferences.liveActivitiesEnabled !== false;
+  const pushAvailable = supportsAgentAwarenessPush();
+  const liveActivitiesEnabled = pushAvailable && input.preferences.liveActivitiesEnabled !== false;
   return {
     deviceId: input.deviceId,
     label: input.label,
@@ -34,7 +36,7 @@ export function makeRelayDeviceRegistrationRequest(input: {
     ...(input.pushToStartToken ? { pushToStartToken: input.pushToStartToken } : {}),
     preferences: {
       liveActivitiesEnabled,
-      notificationsEnabled: input.notificationsEnabled,
+      notificationsEnabled: pushAvailable && input.notificationsEnabled,
       notifyOnApproval: true,
       notifyOnInput: true,
       notifyOnCompletion: true,

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.test.ts
@@ -286,6 +286,26 @@ describe("makeRelayDeviceRegistrationRequest", () => {
     expect(resolveApsEnvironment(undefined)).toBe("production");
   });
 
+  it("disables push features in Personal Team relay registrations", () => {
+    Constants.expoConfig!.extra = { iosPersonalTeamBuild: true };
+
+    expect(
+      makeRelayDeviceRegistrationRequest({
+        deviceId: "device-1",
+        label: "Julius's iPhone",
+        iosMajorVersion: 18,
+        appVersion: "1.0.0",
+        pushToken: "apns-token",
+        pushToStartToken: "push-to-start-token",
+        notificationsEnabled: true,
+        preferences: {},
+      }).preferences,
+    ).toMatchObject({
+      liveActivitiesEnabled: false,
+      notificationsEnabled: false,
+    });
+  });
+
   it("marks notification delivery disabled when APNs permission is unavailable", () => {
     expect(
       makeRelayDeviceRegistrationRequest({

--- a/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
+++ b/apps/mobile/src/features/agent-awareness/remoteRegistration.ts
@@ -30,6 +30,7 @@ import {
 } from "../../lib/storage";
 import AgentActivity, { type AgentActivityProps } from "../../widgets/AgentActivity";
 import { resolveCloudPublicConfig } from "../cloud/publicConfig";
+import { supportsAgentAwarenessPush } from "./capabilities";
 import { makeRelayDeviceRegistrationRequest, resolveApsEnvironment } from "./registrationPayload";
 
 const REMOTE_ACTIVITY_REGISTRATION_RETRY_MS = 15_000;
@@ -237,7 +238,7 @@ function iosMajorVersion(): number {
 
 function nativePushTokenRegistration(observedPushToken?: string) {
   return Effect.gen(function* () {
-    if (!canRegisterRemoteLiveActivities()) {
+    if (!canRegisterRemoteLiveActivities() || !supportsAgentAwarenessPush()) {
       return { notificationsEnabled: false, pushToken: null };
     }
     if (observedPushToken) {

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -19,6 +19,7 @@ import {
 } from "@t3tools/client-runtime/state/runtime";
 import { AndroidScreenHeader } from "../../components/AndroidScreenHeader";
 import { AppText as Text } from "../../components/AppText";
+import { supportsAgentAwarenessPush } from "../agent-awareness/capabilities";
 import { setLiveActivityUpdatesEnabled } from "../agent-awareness/liveActivityPreferences";
 import { requestAgentNotificationPermission } from "../agent-awareness/notificationPermissions";
 import {
@@ -131,6 +132,7 @@ function LocalSettingsRouteScreen() {
 }
 
 function ConfiguredSettingsRouteScreen() {
+  const agentAwarenessPushAvailable = supportsAgentAwarenessPush();
   const insets = useSafeAreaInsets();
   const navigation = useNavigation();
   const { expand: expandClerkSheet } = useClerkSettingsSheetDetent();
@@ -440,22 +442,32 @@ function ConfiguredSettingsRouteScreen() {
           <SettingsSwitchRow
             icon="bell.badge"
             label="Device Notifications"
-            disabled={notificationStatus === "checking" || notificationStatus === "unsupported"}
+            disabled={
+              !agentAwarenessPushAvailable ||
+              notificationStatus === "checking" ||
+              notificationStatus === "unsupported"
+            }
             // Only reads as on when this device is actually registered with the
             // relay; otherwise notifications cannot be delivered regardless of
             // the local iOS permission.
-            value={notificationStatus === "enabled" && deviceRegistered}
+            value={
+              agentAwarenessPushAvailable && notificationStatus === "enabled" && deviceRegistered
+            }
             onValueChange={handleDeviceNotificationsChange}
           />
           <SettingsSwitchRow
             disabled={
-              !isLoaded || liveActivityStatus === "checking" || liveActivityStatus === "linking"
+              !agentAwarenessPushAvailable ||
+              !isLoaded ||
+              liveActivityStatus === "checking" ||
+              liveActivityStatus === "linking"
             }
             icon="bolt.circle"
             label="Live Activity Updates"
             // Same gate: a saved preference is meaningless until the device
             // registration the relay needs to push updates has succeeded.
             value={
+              agentAwarenessPushAvailable &&
               (liveActivityStatus === "enabled" || liveActivityStatus === "linking") &&
               deviceRegistered
             }


### PR DESCRIPTION
PR into #3579 carrying the fixes from #3575 that its snapshot of that branch missed (it absorbed an older version of `fix/mobile-device-builds-and-android-ui`).

## What's included

**Push registration gating for Personal Team builds** (cherry-picked from #3575's `2e5b83f4c`):
- New `agent-awareness/capabilities.ts` with `supportsAgentAwarenessPush()`, driven by `extra.iosPersonalTeamBuild`
- Relay device registration payload forces `liveActivitiesEnabled`/`notificationsEnabled` off when push is unsupported (+ test)
- Settings switches for Device Notifications and Live Activity Updates disabled/forced-off on Personal Team builds

**Hardening on top:**
- `nativePushTokenRegistration` now also checks `supportsAgentAwarenessPush()`, so Personal Team builds never call `getDevicePushTokenAsync()` without the `aps-environment` entitlement (previously only the payload was gated — a build with previously-granted permission would still attempt token acquisition and could stall waiting on `didRegisterForRemoteNotifications`)
- `T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID` validated as a reverse-DNS identifier instead of just non-empty
- `extra.iosPersonalTeamBuild` exposed in the Expo config (required for the runtime gating above)
- Comment documenting that the `appleSignIn: !isIosPersonalTeamBuild` gate on the Clerk plugin is load-bearing (the `.cjs` entitlements plugin runs before plugins earlier in the array, so it can't strip Clerk's entitlement)
- Restored `react-native-keyboard-controller` **1.21.7** — main bumped it in #3545; the 1.21.6 pin here is a stale carryover that would silently downgrade it at merge

## Verification
- `tsc --noEmit` passes
- agent-awareness tests pass (28/28)
- The equivalent merged state was built as a release APK and verified running on a Pixel 10 Pro Fold

Supersedes #3575, which is now closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/3643" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate push notifications and disable notification settings for Personal Team Android builds
> - Adds a `supportsAgentAwarenessPush` utility that returns `false` when `iosPersonalTeamBuild` is set in Expo config extras, used as a single gate across the push registration flow.
> - `nativePushTokenRegistration` short-circuits without requesting permissions or an APNs token, returning `{ notificationsEnabled: false, pushToken: null }` for Personal Team builds.
> - The relay registration payload forces `liveActivitiesEnabled` and `notificationsEnabled` to `false` in Personal Team builds via `makeRelayDeviceRegistrationRequest`.
> - The Device Notifications and Live Activity Updates switches in `SettingsRouteScreen` are disabled and forced off when push is unavailable.
> - Adds bundle identifier validation in `app.config.ts` that rejects missing or non-reverse-DNS values when `T3CODE_IOS_PERSONAL_TEAM=1`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 49f5f1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted mobile build-variant gating with tests; no auth or server contract changes beyond reporting push prefs as disabled.
> 
> **Overview**
> **Personal Team iOS builds** (no `aps-environment` / push entitlements) now treat agent-awareness push as unavailable end-to-end instead of only lying in the relay payload.
> 
> `extra.iosPersonalTeamBuild` is set in Expo config from `T3CODE_IOS_PERSONAL_TEAM=1`, and **`supportsAgentAwarenessPush()`** in `capabilities.ts` is the runtime switch. **`nativePushTokenRegistration`** returns early without calling `getDevicePushTokenAsync()` or permission reads, avoiding stalls on `didRegisterForRemoteNotifications`. Relay registration via **`makeRelayDeviceRegistrationRequest`** forces `notificationsEnabled` and `liveActivitiesEnabled` off when push is unsupported. **Settings** Device Notifications and Live Activity toggles are disabled and shown off on those builds.
> 
> Build-time hardening: **`T3CODE_IOS_PERSONAL_TEAM_BUNDLE_ID`** must match a reverse-DNS pattern (not merely non-empty). A comment documents why **`appleSignIn: !isIosPersonalTeamBuild`** on `@clerk/expo` must stay—the personal-team entitlements plugin cannot strip Clerk’s Sign in with Apple entitlement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f5f1db46193e80a7ed2527b3c21f58ceee1656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->