### PR TITLE
fix(mobile): restore header blur and reliable swipe-back on new iOS versions

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -8,7 +8,7 @@ import {
 import { usePathname } from "expo-router";
 import Stack from "expo-router/stack";
 import { useCallback } from "react";
-import { StatusBar, useColorScheme } from "react-native";
+import { Platform, StatusBar, useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -26,6 +26,7 @@ import {
   useClerkSettingsSheetDetent,
 } from "../features/cloud/ClerkSettingsSheetDetent";
 import { useAgentNotificationNavigation } from "../features/agent-awareness/notificationNavigation";
+import { useHeaderBlurEffect } from "../lib/useHeaderBlurEffect";
 import { useThemeColor } from "../lib/useThemeColor";
 
 function AppNavigator() {
@@ -45,7 +46,9 @@ function AppNavigatorContent() {
   const { collapse, isExpanded } = useClerkSettingsSheetDetent();
   const colorScheme = useColorScheme();
   const statusBarBg = useThemeColor("--color-status-bar");
+  const screenColor = useThemeColor("--color-screen");
   const sheetStyle = useResolveClassNames("bg-sheet");
+  const headerBlurEffect = useHeaderBlurEffect();
   useAgentNotificationNavigation();
   useThreadOutboxDrain();
 
@@ -96,12 +99,10 @@ function AppNavigatorContent() {
         <Stack.Screen
           name="index"
           options={{
-            contentStyle: { backgroundColor: "transparent" },
+            contentStyle: { backgroundColor: String(screenColor) },
             headerShown: true,
             headerTransparent: true,
-            // Recent iOS betas no longer draw an implicit blur behind
-            // transparent navigation bars, so request one explicitly.
-            headerBlurEffect: "systemChromeMaterial",
+            headerBlurEffect,
             headerShadowVisible: false,
           }}
         />
@@ -115,8 +116,11 @@ function AppNavigatorContent() {
         <Stack.Screen
           name="threads/[environmentId]/[threadId]"
           options={{
-            animation: "slide_from_right",
-            contentStyle: { backgroundColor: "transparent" },
+            // iOS keeps the default push animation: forcing slide_from_right
+            // switches react-native-screens to its custom swipe animator,
+            // which leaves a black void behind the screen during swipe-back.
+            animation: Platform.OS === "ios" ? "default" : "slide_from_right",
+            contentStyle: { backgroundColor: String(screenColor) },
             gestureEnabled: true,
             fullScreenGestureEnabled: true,
             headerShown: false,

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -8,7 +8,7 @@ import {
 import { usePathname } from "expo-router";
 import Stack from "expo-router/stack";
 import { useCallback } from "react";
-import { Platform, StatusBar, useColorScheme } from "react-native";
+import { StatusBar, useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
@@ -26,6 +26,7 @@ import {
   useClerkSettingsSheetDetent,
 } from "../features/cloud/ClerkSettingsSheetDetent";
 import { useAgentNotificationNavigation } from "../features/agent-awareness/notificationNavigation";
+import { pushScreenAnimation } from "../lib/pushScreenAnimation";
 import { useHeaderBlurEffect } from "../lib/useHeaderBlurEffect";
 import { useThemeColor } from "../lib/useThemeColor";
 
@@ -99,7 +100,7 @@ function AppNavigatorContent() {
         <Stack.Screen
           name="index"
           options={{
-            contentStyle: { backgroundColor: String(screenColor) },
+            contentStyle: { backgroundColor: screenColor },
             headerShown: true,
             headerTransparent: true,
             headerBlurEffect,
@@ -116,11 +117,8 @@ function AppNavigatorContent() {
         <Stack.Screen
           name="threads/[environmentId]/[threadId]"
           options={{
-            // iOS keeps the default push animation: forcing slide_from_right
-            // switches react-native-screens to its custom swipe animator,
-            // which leaves a black void behind the screen during swipe-back.
-            animation: Platform.OS === "ios" ? "default" : "slide_from_right",
-            contentStyle: { backgroundColor: String(screenColor) },
+            animation: pushScreenAnimation,
+            contentStyle: { backgroundColor: screenColor },
             gestureEnabled: true,
             fullScreenGestureEnabled: true,
             headerShown: false,

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -99,6 +99,9 @@ function AppNavigatorContent() {
             contentStyle: { backgroundColor: "transparent" },
             headerShown: true,
             headerTransparent: true,
+            // Recent iOS betas no longer draw an implicit blur behind
+            // transparent navigation bars, so request one explicitly.
+            headerBlurEffect: "systemChromeMaterial",
             headerShadowVisible: false,
           }}
         />
@@ -115,6 +118,7 @@ function AppNavigatorContent() {
             animation: "slide_from_right",
             contentStyle: { backgroundColor: "transparent" },
             gestureEnabled: true,
+            fullScreenGestureEnabled: true,
             headerShown: false,
           }}
         />

--- a/apps/mobile/src/app/connections/_layout.tsx
+++ b/apps/mobile/src/app/connections/_layout.tsx
@@ -1,5 +1,6 @@
 import Stack from "expo-router/stack";
 import { useResolveClassNames } from "uniwind";
+import { pushScreenAnimation } from "../../lib/pushScreenAnimation";
 import { useThemeColor } from "../../lib/useThemeColor";
 
 export const unstable_settings = {
@@ -23,7 +24,7 @@ export default function ConnectionsLayout() {
       }}
     >
       <Stack.Screen name="index" options={{ animation: "none" }} />
-      <Stack.Screen name="new" options={{ animation: "slide_from_right" }} />
+      <Stack.Screen name="new" options={{ animation: pushScreenAnimation }} />
     </Stack>
   );
 }

--- a/apps/mobile/src/app/new/_layout.tsx
+++ b/apps/mobile/src/app/new/_layout.tsx
@@ -2,6 +2,7 @@ import Stack from "expo-router/stack";
 import { useResolveClassNames } from "uniwind";
 
 import { NewTaskFlowProvider } from "../../features/threads/new-task-flow-provider";
+import { pushScreenAnimation } from "../../lib/pushScreenAnimation";
 import { useThemeColor } from "../../lib/useThemeColor";
 
 export const unstable_settings = {
@@ -29,21 +30,21 @@ export default function NewTaskLayout() {
         <Stack.Screen name="index" options={{ animation: "none", title: "Choose project" }} />
         <Stack.Screen
           name="add-project/index"
-          options={{ animation: "slide_from_right", title: "New project" }}
+          options={{ animation: pushScreenAnimation, title: "New project" }}
         />
         <Stack.Screen
           name="add-project/repository"
-          options={{ animation: "slide_from_right", title: "Repository" }}
+          options={{ animation: pushScreenAnimation, title: "Repository" }}
         />
         <Stack.Screen
           name="add-project/destination"
-          options={{ animation: "slide_from_right", title: "Clone destination" }}
+          options={{ animation: pushScreenAnimation, title: "Clone destination" }}
         />
         <Stack.Screen
           name="add-project/local"
-          options={{ animation: "slide_from_right", title: "Local folder" }}
+          options={{ animation: pushScreenAnimation, title: "Local folder" }}
         />
-        <Stack.Screen name="draft" options={{ animation: "slide_from_right", title: "New task" }} />
+        <Stack.Screen name="draft" options={{ animation: pushScreenAnimation, title: "New task" }} />
       </Stack>
     </NewTaskFlowProvider>
   );

--- a/apps/mobile/src/app/new/_layout.tsx
+++ b/apps/mobile/src/app/new/_layout.tsx
@@ -44,7 +44,10 @@ export default function NewTaskLayout() {
           name="add-project/local"
           options={{ animation: pushScreenAnimation, title: "Local folder" }}
         />
-        <Stack.Screen name="draft" options={{ animation: pushScreenAnimation, title: "New task" }} />
+        <Stack.Screen
+          name="draft"
+          options={{ animation: pushScreenAnimation, title: "New task" }}
+        />
       </Stack>
     </NewTaskFlowProvider>
   );

--- a/apps/mobile/src/app/settings/_layout.tsx
+++ b/apps/mobile/src/app/settings/_layout.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import { useResolveClassNames } from "uniwind";
 
 import { useClerkSettingsSheetDetent } from "../../features/cloud/ClerkSettingsSheetDetent";
+import { pushScreenAnimation } from "../../lib/pushScreenAnimation";
 import { useThemeColor } from "../../lib/useThemeColor";
 
 export const unstable_settings = {
@@ -37,25 +38,25 @@ export default function SettingsLayout() {
       <Stack.Screen name="index" options={{ animation: "none", title: "Settings" }} />
       <Stack.Screen
         name="environments"
-        options={{ animation: "slide_from_right", title: "Environments" }}
+        options={{ animation: pushScreenAnimation, title: "Environments" }}
       />
       <Stack.Screen
         name="environment-new"
-        options={{ animation: "slide_from_right", title: "Add Environment" }}
+        options={{ animation: pushScreenAnimation, title: "Add Environment" }}
       />
       <Stack.Screen
         name="waitlist"
-        options={{ animation: "slide_from_right", title: "Join the waitlist" }}
+        options={{ animation: pushScreenAnimation, title: "Join the waitlist" }}
       />
       <Stack.Screen
         name="archive"
         listeners={{ transitionEnd: handleExpandedRouteTransitionEnd }}
-        options={{ animation: "slide_from_right", title: "Archived Threads" }}
+        options={{ animation: pushScreenAnimation, title: "Archived Threads" }}
       />
       <Stack.Screen
         name="auth"
         listeners={{ transitionEnd: handleExpandedRouteTransitionEnd }}
-        options={{ animation: "slide_from_right", title: "Sign in" }}
+        options={{ animation: pushScreenAnimation, title: "Sign in" }}
       />
     </Stack>
   );

--- a/apps/mobile/src/app/threads/[environmentId]/[threadId]/_layout.tsx
+++ b/apps/mobile/src/app/threads/[environmentId]/[threadId]/_layout.tsx
@@ -1,8 +1,16 @@
 import Stack from "expo-router/stack";
-import { StyleSheet } from "react-native";
+import { Platform, StyleSheet } from "react-native";
 import { useResolveClassNames } from "uniwind";
 
+import { useHeaderBlurEffect } from "../../../../lib/useHeaderBlurEffect";
+
+// iOS keeps the default push animation: forcing slide_from_right switches
+// react-native-screens to its custom swipe animator, which paints a black
+// void behind the outgoing screen during interactive swipe-back.
+const pushAnimation = Platform.OS === "ios" ? ("default" as const) : ("slide_from_right" as const);
+
 export default function ThreadLayout() {
+  const headerBlurEffect = useHeaderBlurEffect();
   const sheetStyle = StyleSheet.flatten(useResolveClassNames("bg-sheet"));
   const headerBg = {
     backgroundColor: (sheetStyle as { backgroundColor?: string })?.backgroundColor,
@@ -16,9 +24,7 @@ export default function ThreadLayout() {
           contentStyle: { backgroundColor: "transparent" },
           headerShown: true,
           headerTransparent: true,
-          // Recent iOS betas no longer draw an implicit blur behind
-          // transparent navigation bars, so request one explicitly.
-          headerBlurEffect: "systemChromeMaterial",
+          headerBlurEffect,
           headerShadowVisible: false,
           headerTitle: "",
         }}
@@ -48,7 +54,7 @@ export default function ThreadLayout() {
       <Stack.Screen
         name="review"
         options={{
-          animation: "slide_from_right",
+          animation: pushAnimation,
           contentStyle: sheetStyle,
           fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
@@ -62,7 +68,7 @@ export default function ThreadLayout() {
       <Stack.Screen
         name="files/index"
         options={{
-          animation: "slide_from_right",
+          animation: pushAnimation,
           contentStyle: sheetStyle,
           fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
@@ -76,7 +82,7 @@ export default function ThreadLayout() {
       <Stack.Screen
         name="files/[...path]"
         options={{
-          animation: "slide_from_right",
+          animation: pushAnimation,
           contentStyle: sheetStyle,
           fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
@@ -101,7 +107,7 @@ export default function ThreadLayout() {
       <Stack.Screen
         name="terminal"
         options={{
-          animation: "slide_from_right",
+          animation: pushAnimation,
           contentStyle: { backgroundColor: "#050505" },
           headerBackButtonDisplayMode: "minimal",
           headerShown: true,

--- a/apps/mobile/src/app/threads/[environmentId]/[threadId]/_layout.tsx
+++ b/apps/mobile/src/app/threads/[environmentId]/[threadId]/_layout.tsx
@@ -1,13 +1,9 @@
 import Stack from "expo-router/stack";
-import { Platform, StyleSheet } from "react-native";
+import { StyleSheet } from "react-native";
 import { useResolveClassNames } from "uniwind";
 
+import { pushScreenAnimation } from "../../../../lib/pushScreenAnimation";
 import { useHeaderBlurEffect } from "../../../../lib/useHeaderBlurEffect";
-
-// iOS keeps the default push animation: forcing slide_from_right switches
-// react-native-screens to its custom swipe animator, which paints a black
-// void behind the outgoing screen during interactive swipe-back.
-const pushAnimation = Platform.OS === "ios" ? ("default" as const) : ("slide_from_right" as const);
 
 export default function ThreadLayout() {
   const headerBlurEffect = useHeaderBlurEffect();
@@ -54,7 +50,7 @@ export default function ThreadLayout() {
       <Stack.Screen
         name="review"
         options={{
-          animation: pushAnimation,
+          animation: pushScreenAnimation,
           contentStyle: sheetStyle,
           fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
@@ -68,7 +64,7 @@ export default function ThreadLayout() {
       <Stack.Screen
         name="files/index"
         options={{
-          animation: pushAnimation,
+          animation: pushScreenAnimation,
           contentStyle: sheetStyle,
           fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
@@ -82,7 +78,7 @@ export default function ThreadLayout() {
       <Stack.Screen
         name="files/[...path]"
         options={{
-          animation: pushAnimation,
+          animation: pushScreenAnimation,
           contentStyle: sheetStyle,
           fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
@@ -107,8 +103,11 @@ export default function ThreadLayout() {
       <Stack.Screen
         name="terminal"
         options={{
-          animation: pushAnimation,
+          animation: pushScreenAnimation,
           contentStyle: { backgroundColor: "#050505" },
+          // No fullScreenGestureEnabled here: the terminal consumes
+          // horizontal pans (readline editing, mouse reporting), so
+          // back-swipe stays confined to the screen edge.
           headerBackButtonDisplayMode: "minimal",
           headerShown: true,
           headerShadowVisible: false,

--- a/apps/mobile/src/app/threads/[environmentId]/[threadId]/_layout.tsx
+++ b/apps/mobile/src/app/threads/[environmentId]/[threadId]/_layout.tsx
@@ -16,6 +16,9 @@ export default function ThreadLayout() {
           contentStyle: { backgroundColor: "transparent" },
           headerShown: true,
           headerTransparent: true,
+          // Recent iOS betas no longer draw an implicit blur behind
+          // transparent navigation bars, so request one explicitly.
+          headerBlurEffect: "systemChromeMaterial",
           headerShadowVisible: false,
           headerTitle: "",
         }}
@@ -47,6 +50,7 @@ export default function ThreadLayout() {
         options={{
           animation: "slide_from_right",
           contentStyle: sheetStyle,
+          fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
           headerShown: true,
           headerTitle: "Files changed",
@@ -60,6 +64,7 @@ export default function ThreadLayout() {
         options={{
           animation: "slide_from_right",
           contentStyle: sheetStyle,
+          fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
           headerShown: true,
           headerTitle: "Files",
@@ -73,6 +78,7 @@ export default function ThreadLayout() {
         options={{
           animation: "slide_from_right",
           contentStyle: sheetStyle,
+          fullScreenGestureEnabled: true,
           headerBackButtonDisplayMode: "minimal",
           headerShown: true,
           headerTitle: "File",

--- a/apps/mobile/src/app/threads/[environmentId]/[threadId]/git/_layout.tsx
+++ b/apps/mobile/src/app/threads/[environmentId]/[threadId]/git/_layout.tsx
@@ -2,6 +2,8 @@ import Stack from "expo-router/stack";
 import { StyleSheet } from "react-native";
 import { useResolveClassNames } from "uniwind";
 
+import { pushScreenAnimation } from "../../../../../lib/pushScreenAnimation";
+
 export const unstable_settings = {
   anchor: "index",
 };
@@ -23,7 +25,7 @@ export default function GitSheetLayout() {
       <Stack.Screen
         name="commit"
         options={{
-          animation: "slide_from_right",
+          animation: pushScreenAnimation,
           headerShown: true,
           headerTitle: "Commit changes",
           headerBackTitle: "",
@@ -34,7 +36,7 @@ export default function GitSheetLayout() {
       <Stack.Screen
         name="branches"
         options={{
-          animation: "slide_from_right",
+          animation: pushScreenAnimation,
           headerShown: true,
           headerTitle: "Branches & worktrees",
           headerBackTitle: "",
@@ -45,7 +47,7 @@ export default function GitSheetLayout() {
       <Stack.Screen
         name="review"
         options={{
-          animation: "slide_from_right",
+          animation: pushScreenAnimation,
           headerShown: true,
           headerTitle: "Review changes",
           headerBackTitle: "",

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -19,6 +19,7 @@ import { cn } from "../../lib/cn";
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
 import { buildThreadFilesNavigation } from "../../lib/routes";
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
+import { useHeaderBlurEffect } from "../../lib/useHeaderBlurEffect";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useThreadSelection } from "../../state/use-thread-selection";
 import { useSelectedThreadWorktree } from "../../state/use-selected-thread-worktree";
@@ -444,6 +445,7 @@ function FilesToolbarBottomFade() {
 
 export function ThreadFilesTreeScreen() {
   const router = useRouter();
+  const headerBlurEffect = useHeaderBlurEffect();
   const [searchQuery, setSearchQuery] = useState("");
   const { cwd, environmentId, projectName, selectedThread, threadId } = useThreadFilesWorkspace();
   const entriesQuery = useEnvironmentQuery(
@@ -481,6 +483,7 @@ export function ThreadFilesTreeScreen() {
           title: "Files",
           headerShown: true,
           headerTransparent: true,
+          headerBlurEffect,
           headerStyle: { backgroundColor: "transparent" },
           headerShadowVisible: false,
           headerTitle: () => <FilesHeaderTitle projectName={projectName} />,

--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -11,6 +11,7 @@ import {
 import { Stack } from "expo-router";
 import { Text as RNText, View } from "react-native";
 
+import { useHeaderBlurEffect } from "../../lib/useHeaderBlurEffect";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import type { HomeProjectSortOrder } from "./homeThreadList";
@@ -72,6 +73,7 @@ export function HomeHeader(props: {
   readonly onOpenSettings: () => void;
   readonly onStartNewTask: () => void;
 }) {
+  const headerBlurEffect = useHeaderBlurEffect();
   const iconColor = useThemeColor("--color-icon");
   const mutedColor = useThemeColor("--color-foreground-muted");
   const subtleColor = useThemeColor("--color-subtle");
@@ -88,9 +90,7 @@ export function HomeHeader(props: {
           headerShown: true,
           headerTransparent: true,
           headerStyle: { backgroundColor: "transparent" },
-          // Recent iOS betas no longer draw an implicit blur behind
-          // transparent navigation bars, so request one explicitly.
-          headerBlurEffect: "systemChromeMaterial",
+          headerBlurEffect,
           headerShadowVisible: false,
           headerTintColor: iconColor,
           headerTitle: "",

--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -88,6 +88,9 @@ export function HomeHeader(props: {
           headerShown: true,
           headerTransparent: true,
           headerStyle: { backgroundColor: "transparent" },
+          // Recent iOS betas no longer draw an implicit blur behind
+          // transparent navigation bars, so request one explicitly.
+          headerBlurEffect: "systemChromeMaterial",
           headerShadowVisible: false,
           headerTintColor: iconColor,
           headerTitle: "",

--- a/apps/mobile/src/features/review/ReviewSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewSheet.tsx
@@ -19,6 +19,7 @@ import { AppText as Text } from "../../components/AppText";
 import { environmentCatalog } from "../../connection/catalog";
 import { useEnvironmentPresentation } from "../../state/presentation";
 import { useAtomCommand } from "../../state/use-atom-command";
+import { useHeaderBlurEffect } from "../../lib/useHeaderBlurEffect";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThreadDraftForThread } from "../../state/use-thread-composer-state";
@@ -113,6 +114,7 @@ function ReviewSelectionActionBar(props: {
 export function ReviewSheet() {
   const insets = useSafeAreaInsets();
   const colorScheme = useColorScheme();
+  const headerBlurEffect = useHeaderBlurEffect();
   const headerForeground = String(useThemeColor("--color-foreground"));
   const headerMuted = String(useThemeColor("--color-foreground-muted"));
   const headerIcon = String(useThemeColor("--color-icon"));
@@ -241,6 +243,7 @@ export function ReviewSheet() {
       <Stack.Screen
         options={{
           headerTransparent: true,
+          headerBlurEffect,
           headerShadowVisible: false,
           headerTintColor: headerIcon,
           headerStyle: {

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -253,7 +253,11 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
     () =>
       Gesture.Pan()
         .enabled(!isSplitLayout)
-        .hitSlop({ left: 0, width: 40 })
+        // Confine the drawer pan to the top-left corner where it completes
+        // (see the `event.y` check below). Covering the full left edge stole
+        // the touch from the native swipe-back gesture, leaving back
+        // navigation dead below the header.
+        .hitSlop({ left: 0, width: 40, top: 0, height: drawerGestureThreshold })
         .activeOffsetX([10, 999])
         .failOffsetY([-24, 24])
         .onEnd((event) => {

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -5,6 +5,7 @@ import { EnvironmentId, type ProjectScript } from "@t3tools/contracts";
 import { projectScriptCwd, projectScriptRuntimeEnv } from "@t3tools/shared/projectScripts";
 import { Pressable, ScrollView, Text as RNText, View } from "react-native";
 import { useWorkspaceState } from "../../state/workspace";
+import { useHeaderBlurEffect } from "../../lib/useHeaderBlurEffect";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useEnvironmentQuery } from "../../state/query";
 import { dismissGitActionResult, useGitActionProgress } from "../../state/use-vcs-action-state";
@@ -104,6 +105,7 @@ export function ThreadRouteScreen() {
   const iconColor = String(useThemeColor("--color-icon"));
   const foregroundColor = String(useThemeColor("--color-foreground"));
   const secondaryFg = String(useThemeColor("--color-foreground-secondary"));
+  const headerBlurEffect = useHeaderBlurEffect();
 
   /* ─── Git status for native header trigger ───────────────────────── */
   const gitStatus = useEnvironmentQuery(
@@ -326,9 +328,7 @@ export function ThreadRouteScreen() {
           headerShown: true,
           headerTransparent: true,
           headerStyle: { backgroundColor: "transparent" },
-          // Recent iOS betas no longer draw an implicit blur behind
-          // transparent navigation bars, so request one explicitly.
-          headerBlurEffect: "systemChromeMaterial",
+          headerBlurEffect,
           headerShadowVisible: false,
           headerTintColor: iconColor,
           headerBackTitle: "",

--- a/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadRouteScreen.tsx
@@ -326,6 +326,9 @@ export function ThreadRouteScreen() {
           headerShown: true,
           headerTransparent: true,
           headerStyle: { backgroundColor: "transparent" },
+          // Recent iOS betas no longer draw an implicit blur behind
+          // transparent navigation bars, so request one explicitly.
+          headerBlurEffect: "systemChromeMaterial",
           headerShadowVisible: false,
           headerTintColor: iconColor,
           headerBackTitle: "",

--- a/apps/mobile/src/lib/pushScreenAnimation.ts
+++ b/apps/mobile/src/lib/pushScreenAnimation.ts
@@ -1,0 +1,12 @@
+import { Platform } from "react-native";
+
+/**
+ * Stack animation for pushed (non-sheet) screens.
+ *
+ * iOS keeps the default push animation: forcing `slide_from_right` switches
+ * react-native-screens to its custom swipe animator, which paints a black
+ * void behind the outgoing screen during interactive swipe-back. The native
+ * default is visually the same slide with proper parallax over the previous
+ * screen. Android has no interactive pop, so it keeps `slide_from_right`.
+ */
+export const pushScreenAnimation = Platform.OS === "ios" ? "default" : "slide_from_right";

--- a/apps/mobile/src/lib/useHeaderBlurEffect.ts
+++ b/apps/mobile/src/lib/useHeaderBlurEffect.ts
@@ -1,0 +1,15 @@
+import { useColorScheme } from "react-native";
+
+/**
+ * Blur effect for transparent navigation headers.
+ *
+ * Recent iOS betas stopped drawing the implicit material behind transparent
+ * navigation bars, and the trait-adaptive `systemChromeMaterial` resolves to
+ * its light variant there even while the app renders in dark mode — so pick
+ * the light/dark variant explicitly from the app color scheme.
+ */
+export function useHeaderBlurEffect() {
+  return useColorScheme() === "dark"
+    ? ("systemChromeMaterialDark" as const)
+    : ("systemChromeMaterialLight" as const);
+}


### PR DESCRIPTION
## What Changed

Two iOS regressions that show up on recent iOS releases (reproduced on an iPhone 17 Pro Max running the current iOS beta), plus review follow-ups:

**1. Transparent headers lost their blur material.**
Every transparent header (`headerTransparent: true`) relied on iOS drawing its implicit material behind the navigation bar. Recent iOS betas stopped doing that, so white header titles sat over raw scrolling content. And the trait-adaptive `systemChromeMaterial` resolves to its *light* variant there even while the app renders dark — a washed-out white glass over dark content.

Fix: a shared `useHeaderBlurEffect()` hook picks `systemChromeMaterialDark`/`Light` explicitly from the app color scheme (`useColorScheme`, the same signal uniwind's CSS variables follow). Applied to every transparent header: home, thread detail, thread index layout, review sheet, and files tree.

**2. Swipe-back showed a black void and was hard to trigger.**
- `animation: "slide_from_right"` switches react-native-screens from the native UIKit push transition to its custom animator, which does not composite the previous screen underneath during interactive swipe-back → black void. iOS now uses the default push animation (visually the same slide, with proper parallax); Android keeps `slide_from_right`. The choice lives in one shared `pushScreenAnimation` constant used by all six stacks that push screens.
- Screen content backgrounds went from `transparent` to the themed screen color so nothing can show through during transitions.
- The thread-detail drawer-open pan gesture claimed a 40pt strip down the **entire left edge**, swallowing the native swipe-back gesture below the header (its completion check only ever fired in the top 80pt anyway). Its hit area now matches the top-left corner where it completes.
- `fullScreenGestureEnabled: true` on the thread, review, and files screens so back-swipe works from anywhere, not just the left edge. Deliberately **not** applied to the terminal screen (it consumes horizontal pans) — commented inline.

## Why

On current iOS betas the mobile app's headers render with no material at all (white text clashing with content), and back navigation frequently doesn't respond unless grabbed at the very top of the left edge. Both verified fixed on-device.

## UI Changes

- Transparent headers now show a dark (or light, matching theme) chrome material blur.
- Swipe-back no longer reveals a black void behind the outgoing screen; the previous screen shows underneath with standard parallax.
- Back-swipe works from anywhere on thread/review/files screens.

Tested on a physical iPhone 17 Pro Max on the current iOS beta (Release build, dark mode): header material renders, swipe-back works mid-screen, no void.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes — verified on-device; can attach captures if wanted
- [ ] I included a video for animation/interaction changes — n/a, restores standard native push/pop behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/3647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore header blur and reliable swipe-back gestures on iOS in the mobile app
> - Adds [`useHeaderBlurEffect`](https://github.com/pingdotgg/t3code/pull/3647/files#diff-15cb05a751ab637ce63d08566356dd8a5909301de14c89077262bd44c560551c) hook that returns a blur material string matching the current color scheme, applied to headers across home, thread, review, and files screens.
> - Adds [`pushScreenAnimation`](https://github.com/pingdotgg/t3code/pull/3647/files#diff-fd078809d842cc1381e0191e76239e6ba0606715df912f08a199d2cb439079e6) constant that selects `default` on iOS and `slide_from_right` on Android, replacing hardcoded values across all stack navigators.
> - Enables `fullScreenGestureEnabled` on thread, review, and file screens so the system edge-swipe gesture works along the full left edge.
> - Constrains the drawer pan gesture hit area in [`ThreadDetailScreen`](https://github.com/pingdotgg/t3code/pull/3647/files#diff-4a36307d6c720c14cd36832a71a74b980215a01d29282c4f03d82889219d2fae) to the top-left region so it no longer hijacks the system back-swipe below the header.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 67aedfc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->