### PR TITLE
fix(dev): Fix electron dev launch and add test

### DIFF
--- a/apps/desktop/scripts/electron-launcher.mjs
+++ b/apps/desktop/scripts/electron-launcher.mjs
@@ -358,10 +358,7 @@ function resolveLinuxSandboxArgs(electronBinaryPath) {
 }
 
 export function resolveElectronPath() {
-  ensureElectronRuntime();
-
-  const require = NodeModule.createRequire(import.meta.url);
-  const electronBinaryPath = require("electron");
+  const electronBinaryPath = resolveElectronBinaryPath();
 
   if (hostPlatform !== "darwin") {
     return electronBinaryPath;
@@ -378,13 +375,23 @@ export function resolveElectronLaunchCommand(args = []) {
   };
 }
 
+export function resolveElectronBinaryPath({
+  ensureRuntime = ensureElectronRuntime,
+  createRequire = NodeModule.createRequire,
+  moduleUrl = import.meta.url,
+} = {}) {
+  ensureRuntime();
+
+  const require = createRequire(moduleUrl);
+  return require("electron");
+}
+
 export function resolveDevProtocolClient() {
   if (hostPlatform !== "darwin" || !isDevelopment) {
     return null;
   }
 
-  const require = NodeModule.createRequire(import.meta.url);
-  const electronBinaryPath = require("electron");
+  const electronBinaryPath = resolveElectronBinaryPath();
   const launcherBinaryPath = buildMacLauncher(electronBinaryPath);
   return {
     appBundlePath: NodePath.resolve(launcherBinaryPath, "..", "..", ".."),

--- a/apps/desktop/scripts/electron-launcher.test.mjs
+++ b/apps/desktop/scripts/electron-launcher.test.mjs
@@ -1,6 +1,6 @@
 import { assert, describe, it } from "vite-plus/test";
 
-import { makeDevelopmentLauncherScript } from "./electron-launcher.mjs";
+import { makeDevelopmentLauncherScript, resolveElectronBinaryPath } from "./electron-launcher.mjs";
 
 describe("electron development launcher", () => {
   it("uses captured values only as fallbacks for a live runner environment", () => {
@@ -24,5 +24,25 @@ describe("electron development launcher", () => {
       script,
       "exec '/repo/node_modules/electron/Electron' --t3code-dev-root='/repo/apps/desktop' '/repo/apps/desktop/dist-electron/main.cjs' \"$@\"",
     );
+  });
+
+  it("repairs Electron before loading the package entrypoint", () => {
+    const calls = [];
+    const electronPath = resolveElectronBinaryPath({
+      ensureRuntime: () => {
+        calls.push("ensure");
+      },
+      createRequire: () => (specifier) => {
+        calls.push(`require:${specifier}`);
+        return "/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron";
+      },
+      moduleUrl: import.meta.url,
+    });
+
+    assert.equal(
+      electronPath,
+      "/repo/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron",
+    );
+    assert.deepEqual(calls, ["ensure", "require:electron"]);
   });
 });


### PR DESCRIPTION
I couldn't get electron working in dev. This fixed it.

<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/pingdotgg/t3code/pull/3662" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small refactor of desktop dev launcher scripts with a regression test; no production auth or data paths touched.
> 
> **Overview**
> Dev Electron launch was failing when the binary path was resolved without running the Electron runtime repair step first. This PR extracts **`resolveElectronBinaryPath`**, which always calls **`ensureElectronRuntime`** before **`require("electron")`**, and routes **`resolveElectronPath`** and **`resolveDevProtocolClient`** through it (the protocol client path previously skipped repair).
> 
> The helper accepts injectable **`ensureRuntime`**, **`createRequire`**, and **`moduleUrl`** for tests. A new unit test asserts repair runs before the **`electron`** package is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58c801b2cbfa353f4ca41608e7b14067b700530b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix electron dev launch by extracting `resolveElectronBinaryPath` and ensuring runtime repair runs first
> - Extracts a new `resolveElectronBinaryPath()` helper in [electron-launcher.mjs](https://github.com/pingdotgg/t3code/pull/3662/files#diff-8a117bf8144a87af3b3928053a08e442ffe3b14884df08757b77d55907d596b4) that calls `ensureElectronRuntime()` before requiring the `electron` package.
> - Updates both `resolveElectronPath` and `resolveDevProtocolClient` to use the new helper, ensuring the runtime is repaired on darwin dev paths that previously skipped this step.
> - Adds a test in [electron-launcher.test.mjs](https://github.com/pingdotgg/t3code/pull/3662/files#diff-edda2f4931abb8e6b89fee3bb966335449d93a03032307d79d91eef861587a42) verifying that `ensureRuntime` is called before the `electron` module is required.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 58c801b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->