### PR TITLE
fix(mobile): compile patched native pods from source on EAS

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -120,5 +120,13 @@
   },
   "overrides": {
     "react-native-nitro-markdown": "file:deps/react-native-nitro-markdown-0.5.0.tgz"
+  },
+  "expo": {
+    "autolinking": {
+      "buildFromSource": [
+        "react-native-screens",
+        "@react-native-menu/menu"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Problem

`ios:dev` showed the iPhone Mail-style bottom search toolbar; `eas:ios:preview` never did.

EAS builds enable `EXPO_USE_PRECOMPILED_MODULES`, which links Expo's **prebuilt** `RNScreens.framework` instead of compiling `react-native-screens` from source — silently discarding every native file in `patches/react-native-screens@4.25.2.patch` (Mail-style bottom search toolbar, `headerToolbarItems`, `navigationItemStyle`, and the iOS 27 keyboard-guide fix). Local pod installs resolve the pod from source, so dev builds were unaffected.

Verified by strings-scanning a preview IPA: the prebuilt 2.3 MB `RNScreens.framework` contains zero patch symbols, while dev builds contain them all.

## Fix

Opt the natively-patched packages out via the official `expo.autolinking.buildFromSource` option:

- `react-native-screens` — the actual regression
- `@react-native-menu/menu` — defensive: not in Expo's prebuilt set today, but its patch also touches native code

## Verification

- `expo-modules-autolinking resolve` reports the `buildFromSource` configuration
- EAS preview build `eec8503f` with this change: no prebuilt `RNScreens.framework` in the IPA; patch symbols (`mailSearchToolbar`, `navigationItemStyle`) present in the compiled binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Expo autolinking config change with no app logic or auth/data impact; main effect is longer native compile time on EAS for those pods.
> 
> **Overview**
> EAS iOS preview builds were linking Expo’s **prebuilt** `RNScreens.framework`, so native changes from `patches/react-native-screens@4.25.2.patch` (Mail-style bottom search toolbar, related header APIs, keyboard-guide fix) never shipped—while local `ios:dev` builds compiled from source and looked correct.
> 
> This PR adds **`expo.autolinking.buildFromSource`** in `apps/mobile/package.json` for **`react-native-screens`** (the regression) and **`@react-native-menu/menu`** (same class of risk: patched native code). EAS should compile those pods from the repo instead of using precompiled modules, so patches apply in preview/production IPAs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ebcef05cedbf852a0dddd23b066d88f35dd3a4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Build `react-native-screens` and `@react-native-menu/menu` from source on EAS
> Adds `expo.autolinking.buildFromSource` to [apps/mobile/package.json](https://github.com/pingdotgg/t3code/pull/3667/files#diff-179bbaeea9e8295a4abee862073776f87f7dc3c78066c787b8fcdb8be71d5d83), instructing Expo autolinking to compile `react-native-screens` and `@react-native-menu/menu` from source instead of using prebuilt binaries. This is needed to apply local patches to these native pods during EAS builds.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ebcef0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->