### PR TITLE
Make the thread composer read as elevated liquid glass

### DIFF
--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -117,32 +117,46 @@ function ComposerSurface(props: {
   readonly style: ViewStyle;
   readonly isDarkMode: boolean;
 }) {
+  // Drop shadow lives on a wrapper: `overflow: "hidden"` on the surface itself
+  // (needed to clip content to the pill shape) would clip the shadow on iOS.
+  const shadowStyle: ViewStyle = {
+    borderRadius: props.style.borderRadius,
+    shadowColor: "#000000",
+    shadowOpacity: props.isDarkMode ? 0.35 : 0.12,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 10,
+  };
+
   if (isLiquidGlassSupported) {
     return (
-      <LiquidGlassView
-        effect="clear"
-        interactive
-        tintColor={props.isDarkMode ? "rgba(44,44,46,0.5)" : "rgba(255,255,255,0.45)"}
-        colorScheme={props.isDarkMode ? "dark" : "light"}
-        style={props.style}
-      >
-        {props.children}
-      </LiquidGlassView>
+      <View style={shadowStyle}>
+        <LiquidGlassView
+          effect="regular"
+          interactive
+          colorScheme={props.isDarkMode ? "dark" : "light"}
+          style={props.style}
+        >
+          {props.children}
+        </LiquidGlassView>
+      </View>
     );
   }
 
   return (
-    <View
-      style={[
-        props.style,
-        {
-          backgroundColor: props.isDarkMode ? "rgba(44,44,46,0.96)" : "rgba(255,255,255,0.96)",
-          borderWidth: 1,
-          borderColor: props.isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)",
-        },
-      ]}
-    >
-      {props.children}
+    <View style={shadowStyle}>
+      <View
+        style={[
+          props.style,
+          {
+            backgroundColor: props.isDarkMode ? "rgba(44,44,46,0.96)" : "rgba(255,255,255,0.96)",
+            borderWidth: 1,
+            borderColor: props.isDarkMode ? "rgba(255,255,255,0.08)" : "rgba(0,0,0,0.06)",
+          },
+        ]}
+      >
+        {props.children}
+      </View>
     </View>
   );
 }
@@ -661,8 +675,8 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         paddingTop: isExpanded ? 8 : 6,
         paddingBottom: (props.bottomInset ?? 0) + (isExpanded ? 8 : 6),
         experimental_backgroundImage: isDarkMode
-          ? "linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.85) 40%, rgba(0,0,0,0.95) 100%)"
-          : "linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.85) 40%, rgba(255,255,255,0.95) 100%)",
+          ? "linear-gradient(to bottom, rgba(0,0,0,0) 0%, rgba(0,0,0,0.6) 55%, rgba(0,0,0,0.9) 100%)"
+          : "linear-gradient(to bottom, rgba(255,255,255,0) 0%, rgba(255,255,255,0.6) 55%, rgba(255,255,255,0.9) 100%)",
       }}
     >
       <View


### PR DESCRIPTION
## Summary

The glass composer had the glass effect but blended into the background instead of floating above it like the native search bar. Three fixes in `ThreadComposer.tsx`:

- **`effect="clear"` → `effect="regular"`** — the native search bar uses the *regular* liquid glass material (built-in rim highlight, adaptive shading, system shadow). `clear` is the flat variant meant for glass over media; over a white feed it disappears.
- **Dropped the ~50% tint** — regular glass supplies its own milky base; the heavy tint on top flattened it. Untinted regular matches the system search-bar recipe.
- **Added a drop shadow** (0.12 light / 0.35 dark, radius 14, y-offset 6; `elevation: 10` for Android/fallback). Lives on a wrapper view since `overflow: "hidden"` on the surface would clip it on iOS. The opaque fallback path gets the same shadow.
- **Softened the backdrop gradient** (`0.85 @ 40% → 0.95` down to `0.6 @ 55% → 0.9`) so feed content stays faintly visible under the pill — previously the glass sat on near-opaque white with nothing to refract.

## Testing

- [ ] Collapsed pill + expanded card, light and dark mode, on an iOS 26 device (liquid glass path)
- [ ] Fallback path (non-glass devices / Android) still renders opaque surface with shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only styling in the mobile thread composer; no messaging, auth, or data-path changes.
> 
> **Overview**
> Updates **`ComposerSurface`** in `ThreadComposer.tsx` so the composer reads as floating above the feed instead of blending in.
> 
> On the liquid-glass path, **`LiquidGlassView`** switches from **`effect="clear"`** to **`effect="regular"`** and drops **`tintColor`**, relying on the system material. Both glass and opaque fallbacks are wrapped in an outer **`View`** that carries a theme-aware drop shadow (and **`elevation`** on Android), so clipping from **`overflow: "hidden"`** on the pill/card does not eat the shadow on iOS.
> 
> The composer chrome backdrop gradient is softened (mid stop **40% → 55%**, opacities **0.85/0.95 → 0.6/0.9**) in light and dark mode so more feed shows through under the pill.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 053d14a458c11d7fec63d8eb2ceec60ace85782d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render thread composer with elevated liquid glass effect and drop shadow
> - Updates `ComposerSurface` in [ThreadComposer.tsx](https://github.com/pingdotgg/t3code/pull/3668/files#diff-4c62d895b68dd46f4d2858321c8942fde0d3ddd37c5e4253cba04c18c21a6024) to wrap the surface in a shadow container (radius 14, offset {0,6}, elevation 10) on all platforms.
> - Switches the `LiquidGlassView` effect from `"clear"` to `"regular"` and removes the `tintColor` prop on supported iOS devices.
> - Reduces opacity of the background gradient behind the composer (mid-stop moves from 40%→55%, mid opacity 0.85→0.6, end opacity 0.95→0.9) in both light and dark modes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 053d14a.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->