### PR TITLE
feat: persist and restore main window size and position

### DIFF
--- a/apps/desktop/src/app/DesktopEnvironment.ts
+++ b/apps/desktop/src/app/DesktopEnvironment.ts
@@ -47,6 +47,7 @@ export class DesktopEnvironment extends Context.Service<
     readonly clientSettingsPath: string;
     readonly savedEnvironmentRegistryPath: string;
     readonly serverSettingsPath: string;
+    readonly windowStatePath: string;
     readonly logDir: string;
     readonly browserArtifactsDir: string;
     readonly rootDir: string;
@@ -178,6 +179,7 @@ const make = Effect.fn("desktop.environment.make")(function* (
     clientSettingsPath: path.join(stateDir, "client-settings.json"),
     savedEnvironmentRegistryPath: path.join(stateDir, "saved-environments.json"),
     serverSettingsPath: path.join(stateDir, "settings.json"),
+    windowStatePath: path.join(stateDir, "window-state.json"),
     logDir: path.join(stateDir, "logs"),
     browserArtifactsDir: path.join(stateDir, "browser-artifacts"),
     rootDir,

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -50,6 +50,7 @@ import * as DesktopUpdates from "./updates/DesktopUpdates.ts";
 import * as BrowserSession from "./preview/BrowserSession.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as DesktopWindow from "./window/DesktopWindow.ts";
+import * as DesktopWindowState from "./window/DesktopWindowState.ts";
 import * as DesktopWslBackend from "./wsl/DesktopWslBackend.ts";
 import * as DesktopWslEnvironment from "./wsl/DesktopWslEnvironment.ts";
 
@@ -124,6 +125,7 @@ const desktopFoundationLayer = Layer.mergeAll(
   DesktopConnectionCatalogStore.layer.pipe(Layer.provideMerge(DesktopSavedEnvironments.layer)),
   DesktopAssets.layer,
   DesktopObservability.layer,
+  DesktopWindowState.layer,
 ).pipe(Layer.provideMerge(desktopEnvironmentLayer));
 
 const desktopSshLayer = desktopSshEnvironmentLayer.pipe(

--- a/apps/desktop/src/window/DesktopWindow.test.ts
+++ b/apps/desktop/src/window/DesktopWindow.test.ts
@@ -18,6 +18,9 @@ vi.mock("electron", async (importOriginal) => ({
       setUserAgent: vi.fn(),
     })),
   },
+  screen: {
+    getAllDisplays: vi.fn(() => []),
+  },
 }));
 
 import * as DesktopAssets from "../app/DesktopAssets.ts";
@@ -31,6 +34,7 @@ import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import { MENU_ACTION_CHANNEL } from "../ipc/channels.ts";
 import * as DesktopServerExposure from "../backend/DesktopServerExposure.ts";
 import * as DesktopWindow from "./DesktopWindow.ts";
+import * as DesktopWindowState from "./DesktopWindowState.ts";
 import * as PreviewManager from "../preview/Manager.ts";
 
 const environmentInput = {
@@ -65,10 +69,14 @@ function makeFakeBrowserWindow() {
   const window = {
     close: vi.fn(),
     focus: vi.fn(),
+    getNormalBounds: vi.fn(() => ({ x: 0, y: 0, width: 1100, height: 780 })),
     isDestroyed: vi.fn(() => false),
+    isFullScreen: vi.fn(() => false),
+    isMaximized: vi.fn(() => false),
     isMinimized: vi.fn(() => false),
     isVisible: vi.fn(() => true),
     loadURL: vi.fn(() => Promise.resolve()),
+    maximize: vi.fn(),
     on: vi.fn(),
     once: vi.fn(),
     restore: vi.fn(),
@@ -127,6 +135,11 @@ const electronThemeLayer = Layer.succeed(ElectronTheme.ElectronTheme, {
   onUpdated: () => Effect.void,
 } satisfies ElectronTheme.ElectronTheme["Service"]);
 
+const desktopWindowStateLayer = Layer.succeed(DesktopWindowState.DesktopWindowState, {
+  load: Effect.succeed(Option.none<DesktopWindowState.WindowState>()),
+  save: () => Effect.void,
+} satisfies DesktopWindowState.DesktopWindowState["Service"]);
+
 const desktopEnvironmentLayer = DesktopEnvironment.layer(environmentInput).pipe(
   Layer.provide(
     Layer.mergeAll(
@@ -171,6 +184,7 @@ function makeTestLayer(input: {
         desktopAssetsLayer,
         desktopEnvironmentLayer,
         desktopServerExposureLayer,
+        desktopWindowStateLayer,
         DesktopState.layer,
         electronMenuLayer,
         Layer.succeed(ElectronShell.ElectronShell, {
@@ -268,6 +282,7 @@ const makeSplashScenario = (createOutcomes: readonly (Electron.BrowserWindow | n
           desktopAssetsLayer,
           desktopEnvironmentLayer,
           desktopServerExposureLayer,
+          desktopWindowStateLayer,
           electronMenuLayer,
           Layer.succeed(ElectronShell.ElectronShell, {
             openExternal: () => Effect.succeed(true),

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -6,6 +6,7 @@ import * as Option from "effect/Option";
 import * as Ref from "effect/Ref";
 
 import type * as Electron from "electron";
+import { screen } from "electron";
 
 import * as DesktopAssets from "../app/DesktopAssets.ts";
 import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
@@ -17,7 +18,12 @@ import * as ElectronTheme from "../electron/ElectronTheme.ts";
 import * as ElectronWindow from "../electron/ElectronWindow.ts";
 import { MENU_ACTION_CHANNEL } from "../ipc/channels.ts";
 import * as PreviewManager from "../preview/Manager.ts";
+import * as DesktopWindowState from "./DesktopWindowState.ts";
 
+const DEFAULT_WINDOW_SIZE = { width: 1100, height: 780 } as const;
+// Resize/move fire continuously while dragging; coalesce persistence so we write
+// once the gesture settles instead of on every pixel.
+const WINDOW_STATE_SAVE_DEBOUNCE_MS = 400;
 const TITLEBAR_HEIGHT = 40;
 const TITLEBAR_COLOR = "#01000000"; // #00000000 does not work correctly on Linux
 const TITLEBAR_LIGHT_SYMBOL_COLOR = "#1f2937";
@@ -45,6 +51,7 @@ type DesktopWindowRuntimeServices =
   | ElectronShell.ElectronShell
   | ElectronTheme.ElectronTheme
   | ElectronWindow.ElectronWindow
+  | DesktopWindowState.DesktopWindowState
   | PreviewManager.PreviewManager;
 
 export type DesktopWindowError =
@@ -201,6 +208,7 @@ export const make = Effect.gen(function* () {
   const electronShell = yield* ElectronShell.ElectronShell;
   const electronTheme = yield* ElectronTheme.ElectronTheme;
   const electronWindow = yield* ElectronWindow.ElectronWindow;
+  const windowState = yield* DesktopWindowState.DesktopWindowState;
   const previewManager = yield* PreviewManager.PreviewManager;
   // Window-side latch for the primary backend's readiness. Set by
   // handleBackendReady (driven by the pool's onReady callback), cleared
@@ -250,9 +258,14 @@ export const make = Effect.gen(function* () {
     const iconPaths = yield* assets.iconPaths;
     const iconOption = getIconOption(iconPaths, environment.platform);
     const shouldUseDarkColors = yield* electronTheme.shouldUseDarkColors;
+    const savedWindowState = yield* windowState.load;
+    const initialWindowBounds = DesktopWindowState.resolveInitialWindowBounds(
+      savedWindowState,
+      screen.getAllDisplays().map((display) => display.workArea),
+      DEFAULT_WINDOW_SIZE,
+    );
     const window = yield* electronWindow.create({
-      width: 1100,
-      height: 780,
+      ...initialWindowBounds.bounds,
       minWidth: 840,
       minHeight: 620,
       show: false,
@@ -274,6 +287,66 @@ export const make = Effect.gen(function* () {
     if (environment.platform === "darwin") {
       window.setAutoHideCursor(false);
     }
+
+    if (initialWindowBounds.maximize) {
+      window.maximize();
+    }
+
+    // Persist geometry so the next launch restores it. Saves are debounced via a
+    // restartable fiber (mirroring the development-load retry below) while the
+    // user drags/resizes, and flushed on close; a failed write is logged and
+    // otherwise ignored since it only costs the remembered size, nothing more.
+    let windowStateSaveFiber: Fiber.Fiber<void, never> | undefined;
+    const persistWindowState = () => {
+      if (window.isDestroyed() || window.isMinimized() || window.isFullScreen()) {
+        return;
+      }
+      const normalBounds = window.getNormalBounds();
+      runFork(
+        windowState
+          .save({
+            x: normalBounds.x,
+            y: normalBounds.y,
+            width: normalBounds.width,
+            height: normalBounds.height,
+            maximized: window.isMaximized(),
+          })
+          .pipe(
+            Effect.catch((error) =>
+              logWindowWarning("failed to persist window state", { path: error.path }),
+            ),
+          ),
+      );
+    };
+    const cancelScheduledWindowStateSave = () => {
+      if (windowStateSaveFiber === undefined) {
+        return;
+      }
+      const saveFiber = windowStateSaveFiber;
+      windowStateSaveFiber = undefined;
+      runFork(Fiber.interrupt(saveFiber));
+    };
+    const scheduleWindowStateSave = () => {
+      cancelScheduledWindowStateSave();
+      windowStateSaveFiber = runFork(
+        Effect.sleep(WINDOW_STATE_SAVE_DEBOUNCE_MS).pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              windowStateSaveFiber = undefined;
+              persistWindowState();
+            }),
+          ),
+        ),
+      );
+    };
+    window.on("resize", scheduleWindowStateSave);
+    window.on("move", scheduleWindowStateSave);
+    window.on("maximize", scheduleWindowStateSave);
+    window.on("unmaximize", scheduleWindowStateSave);
+    window.on("close", () => {
+      cancelScheduledWindowStateSave();
+      persistWindowState();
+    });
 
     yield* previewManager.setMainWindow(window);
     window.webContents.on("will-attach-webview", (event, webPreferences, params) => {

--- a/apps/desktop/src/window/DesktopWindowState.test.ts
+++ b/apps/desktop/src/window/DesktopWindowState.test.ts
@@ -1,0 +1,49 @@
+import { assert, describe, it } from "@effect/vitest";
+import * as Option from "effect/Option";
+
+import * as DesktopWindowState from "./DesktopWindowState.ts";
+
+const DEFAULTS = { width: 1100, height: 780 } as const;
+const DISPLAYS = [{ x: 0, y: 0, width: 1920, height: 1080 }] as const;
+
+describe("resolveInitialWindowBounds", () => {
+  it("falls back to defaults when there is no saved state", () => {
+    assert.deepStrictEqual(
+      DesktopWindowState.resolveInitialWindowBounds(Option.none(), DISPLAYS, DEFAULTS),
+      { bounds: { width: 1100, height: 780 }, maximize: false },
+    );
+  });
+
+  it("restores a saved position that is visible on a display", () => {
+    assert.deepStrictEqual(
+      DesktopWindowState.resolveInitialWindowBounds(
+        Option.some({ x: 100, y: 120, width: 800, height: 600, maximized: true }),
+        DISPLAYS,
+        DEFAULTS,
+      ),
+      { bounds: { x: 100, y: 120, width: 800, height: 600 }, maximize: true },
+    );
+  });
+
+  it("drops an off-screen position but keeps the size and maximized flag", () => {
+    assert.deepStrictEqual(
+      DesktopWindowState.resolveInitialWindowBounds(
+        Option.some({ x: 5000, y: 5000, width: 800, height: 600, maximized: true }),
+        DISPLAYS,
+        DEFAULTS,
+      ),
+      { bounds: { width: 800, height: 600 }, maximize: true },
+    );
+  });
+
+  it("uses size only when the saved state has no position", () => {
+    assert.deepStrictEqual(
+      DesktopWindowState.resolveInitialWindowBounds(
+        Option.some({ width: 800, height: 600 }),
+        DISPLAYS,
+        DEFAULTS,
+      ),
+      { bounds: { width: 800, height: 600 }, maximize: false },
+    );
+  });
+});

--- a/apps/desktop/src/window/DesktopWindowState.ts
+++ b/apps/desktop/src/window/DesktopWindowState.ts
@@ -1,0 +1,130 @@
+import { fromLenientJson } from "@t3tools/shared/schemaJson";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+
+import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
+
+// Persisted geometry of the main window. `width`/`height` are the un-maximized
+// ("normal") content bounds; `maximized` restores the maximized state on top of
+// them. `x`/`y` are optional so a document written before we tracked position
+// (or one whose position is off-screen on load) still restores the size.
+const WindowStateDocument = Schema.Struct({
+  x: Schema.optionalKey(Schema.Number),
+  y: Schema.optionalKey(Schema.Number),
+  width: Schema.Number,
+  height: Schema.Number,
+  maximized: Schema.optionalKey(Schema.Boolean),
+});
+
+export type WindowState = typeof WindowStateDocument.Type;
+
+const WindowStateJson = fromLenientJson(WindowStateDocument);
+const decodeWindowStateJson = Schema.decodeEffect(WindowStateJson);
+const encodeWindowStateJson = Schema.encodeEffect(WindowStateJson);
+
+export class DesktopWindowStateWriteError extends Schema.TaggedErrorClass<DesktopWindowStateWriteError>()(
+  "DesktopWindowStateWriteError",
+  {
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    return `Failed to persist desktop window state at ${this.path}.`;
+  }
+}
+
+export interface WindowRect {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface InitialWindowBounds {
+  // Spread straight into BrowserWindow options. `x`/`y` are dropped when the
+  // saved position lands outside every display so the window can't open
+  // off-screen (e.g. after an external monitor is unplugged).
+  readonly bounds: { x?: number; y?: number; width: number; height: number };
+  readonly maximize: boolean;
+}
+
+const isUsableSize = (state: WindowState): boolean =>
+  Number.isFinite(state.width) &&
+  state.width > 0 &&
+  Number.isFinite(state.height) &&
+  state.height > 0;
+
+const rectsIntersect = (a: WindowRect, b: WindowRect): boolean =>
+  a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+
+// Pure so it can be unit-tested without Electron. `displays` are the work areas
+// of the connected screens; pass `screen.getAllDisplays().map((d) => d.workArea)`.
+export function resolveInitialWindowBounds(
+  saved: Option.Option<WindowState>,
+  displays: readonly WindowRect[],
+  defaults: { readonly width: number; readonly height: number },
+): InitialWindowBounds {
+  if (Option.isNone(saved)) {
+    return { bounds: { ...defaults }, maximize: false };
+  }
+
+  const state = saved.value;
+  const size = { width: state.width, height: state.height };
+  const maximize = state.maximized === true;
+
+  if (state.x === undefined || state.y === undefined) {
+    return { bounds: size, maximize };
+  }
+
+  const rect: WindowRect = { x: state.x, y: state.y, width: state.width, height: state.height };
+  const onScreen = displays.some((display) => rectsIntersect(display, rect));
+  return onScreen ? { bounds: rect, maximize } : { bounds: size, maximize };
+}
+
+export class DesktopWindowState extends Context.Service<
+  DesktopWindowState,
+  {
+    readonly load: Effect.Effect<Option.Option<WindowState>>;
+    readonly save: (state: WindowState) => Effect.Effect<void, DesktopWindowStateWriteError>;
+  }
+>()("@t3tools/desktop/window/DesktopWindowState") {}
+
+export const make = Effect.gen(function* () {
+  const environment = yield* DesktopEnvironment.DesktopEnvironment;
+  const fileSystem = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+
+  const load = fileSystem.readFileString(environment.windowStatePath).pipe(
+    Effect.flatMap(decodeWindowStateJson),
+    Effect.map((state) => (isUsableSize(state) ? Option.some(state) : Option.none<WindowState>())),
+    // Missing file, unreadable file, or a malformed document all fall back to
+    // "no saved state" so a first launch (or a corrupt file) opens at defaults.
+    Effect.orElseSucceed(() => Option.none<WindowState>()),
+    Effect.withSpan("desktop.windowState.load"),
+  );
+
+  const save = (state: WindowState) =>
+    encodeWindowStateJson(state).pipe(
+      Effect.flatMap((encoded) =>
+        fileSystem
+          .makeDirectory(path.dirname(environment.windowStatePath), { recursive: true })
+          .pipe(
+            Effect.andThen(fileSystem.writeFileString(environment.windowStatePath, `${encoded}\n`)),
+          ),
+      ),
+      Effect.mapError(
+        (cause) => new DesktopWindowStateWriteError({ path: environment.windowStatePath, cause }),
+      ),
+      Effect.withSpan("desktop.windowState.save"),
+    );
+
+  return DesktopWindowState.of({ load, save });
+});
+
+export const layer = Layer.effect(DesktopWindowState, make);


### PR DESCRIPTION
## What

The main window now remembers its **size, position, and maximized state** across launches. Before this, it always reopened at the hardcoded `1100×780` in `DesktopWindow.ts`, throwing away whatever size/position you left it at.

## How

- New `DesktopWindowState` service (`apps/desktop/src/window/DesktopWindowState.ts`) persists geometry to `window-state.json` in the existing state dir, following the `DesktopAppSettings` idiom (effect `FileSystem` + `Schema`, falls back to defaults on a missing/corrupt file).
- `DesktopWindow` loads the saved geometry before creating the window, then writes it back on `resize` / `move` / `maximize` / `unmaximize` / `close`. Writes are debounced with a restartable fiber (same pattern as the existing dev-load retry in that file) so dragging/resizing doesn't thrash the disk.
- Saved positions are validated against the connected displays' work areas: an off-screen position (e.g. after unplugging an external monitor) falls back to size-only so the window can't open where you can't see it.

## Scope / notes

- Behavior-only change; no visual UI change.
- Persists normal bounds + maximized flag; fullscreen is intentionally not persisted (restores to normal/maximized instead).
- A failed write is logged and otherwise ignored — worst case is the window opens at the last-known or default size.

## Testing

- `pnpm --filter @t3tools/desktop typecheck` — clean
- `vp check` — clean
- Desktop test suite: **339 passed**, including a new `DesktopWindowState.test.ts` (off-screen / maximized / size-only cases) and updated `DesktopWindow.test.ts` doubles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local UX and JSON persistence in userdata only; corrupt/missing files fall back to defaults with no security or backend impact.
> 
> **Overview**
> The desktop main window **remembers size, position, and maximized state** across launches instead of always opening at fixed `1100×780`.
> 
> A new **`DesktopWindowState`** service reads/writes `window-state.json` in the state directory (same Effect + Schema pattern as other desktop settings). **`DesktopWindow`** loads saved geometry before `BrowserWindow` creation, applies **maximize** when saved, and persists on resize/move/maximize/unmaximize/close with **400ms debounced** writes. Off-screen saved positions are dropped using display **work areas** (e.g. unplugged monitor) while keeping size and maximized flag. Fullscreen is not persisted; writes failures are logged only.
> 
> Wiring adds `windowStatePath` to **`DesktopEnvironment`**, registers the layer in **`main.ts`**, and extends tests (`DesktopWindowState.test.ts`, updated **`DesktopWindow.test`** mocks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd5a7ba8c3ff9e6322cf048f52c288ac14a3d873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist and restore main window size, position, and maximized state
> - Adds a new `DesktopWindowState` service in [`DesktopWindowState.ts`](https://github.com/pingdotgg/t3code/pull/3673/files#diff-93ab793de58e685de779afb1a28de5f6fd6ca1283c131310912db70044ab7d30) that reads/writes window geometry to `window-state.json` in the app state directory.
> - On window creation, loads saved bounds and maximized state; uses `resolveInitialWindowBounds` to constrain the window to visible displays, falling back to defaults if off-screen or no saved state exists.
> - Persists window geometry (size, position, maximized) on resize, move, maximize, and unmaximize with debouncing, plus a final save on close.
> - Behavioral Change: the desktop window now opens at its last-used size and position instead of always using the default size.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cd5a7ba. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->