### PR TITLE
fix(auth): keep MCP sessions authorized past token expiry

### DIFF
--- a/apps/server/src/mcp/McpSessionRegistry.test.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.test.ts
@@ -88,3 +88,45 @@ it.effect("expires credentials after inactivity", () =>
     expect(yield* registry.resolve(token)).toBeUndefined();
   }),
 );
+
+it.effect("expires a never-used credential once it hits the maximum lifetime", () =>
+  Effect.gen(function* () {
+    let timestamp = 1_000;
+    const registry = yield* makeRegistry(() => timestamp);
+    const issued = yield* registry.issue({
+      threadId: ThreadId.make("thread-3"),
+      providerInstanceId: ProviderInstanceId.make("claude"),
+    });
+    const token = issued.config.authorizationHeader.replace(/^Bearer\s+/, "");
+    // Stay within the idle window but past the maximum lifetime.
+    timestamp += 1_001;
+    expect(yield* registry.resolve(token)).toBeUndefined();
+  }),
+);
+
+it.effect(
+  "transparently renews a credential's expiry on every use, so an actively-used session outlives the maximum lifetime",
+  () =>
+    Effect.gen(function* () {
+      let timestamp = 1_000;
+      const registry = yield* makeRegistry(() => timestamp);
+      const threadId = ThreadId.make("thread-4");
+      const issued = yield* registry.issue({
+        threadId,
+        providerInstanceId: ProviderInstanceId.make("claude"),
+      });
+      const token = issued.config.authorizationHeader.replace(/^Bearer\s+/, "");
+
+      // Repeatedly use the credential at an interval shorter than both the
+      // idle timeout and the maximum lifetime, well past the point where the
+      // original mint-time expiry (issuedAt + maximumLifetimeMs = 2_000)
+      // would have killed it without renewal.
+      for (let i = 0; i < 20; i++) {
+        timestamp += 90;
+        const resolved = yield* registry.resolve(token);
+        expect(resolved?.threadId).toBe(threadId);
+      }
+
+      expect(timestamp).toBeGreaterThan(issued.expiresAt);
+    }),
+);

--- a/apps/server/src/mcp/McpSessionRegistry.ts
+++ b/apps/server/src/mcp/McpSessionRegistry.ts
@@ -53,7 +53,23 @@ export interface McpSessionRegistryOptions {
 }
 
 const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60 * 1_000;
-const DEFAULT_MAXIMUM_LIFETIME_MS = 8 * 60 * 60 * 1_000;
+// This bounds how long an MCP bearer credential stays valid *without any use*
+// past its mint time before `resolve` refreshes it (see below) — it is not a
+// hard cap on session length. Agent sessions routinely run far longer than a
+// single workday (multi-hour coding sessions, overnight/scheduled runs), and
+// the credential is minted once at provider-session start and handed to the
+// agent process as a static header, so there is no way for the agent to pick
+// up a rotated token later. A short absolute cap therefore silently kills the
+// MCP connection out from under an otherwise-healthy session (observed
+// 2026-07-03: "t3-code requires re-authorization (token expired)" mid-session).
+// The credential is already tightly scoped (random 256-bit token, single
+// thread + provider instance, held only in memory, and explicitly revoked on
+// session stop/error/environment shutdown — see `revokeThread`/`revokeAll`),
+// so a long backstop here doesn't meaningfully widen exposure; it's paired
+// with `resolve` sliding the expiry forward on every authenticated use so
+// active sessions never approach the cap, and the existing idle timeout still
+// reclaims credentials for threads that truly go quiet.
+const DEFAULT_MAXIMUM_LIFETIME_MS = 30 * 24 * 60 * 60 * 1_000;
 
 const bytesToHex = (bytes: Uint8Array): string =>
   Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
@@ -147,8 +163,17 @@ const makeWithOptions = Effect.fn("McpSessionRegistry.make")(function* (
         const record = current.get(tokenHash);
         if (!record) return [undefined, { records: current }] as const;
         const next = new Map(current);
-        next.set(tokenHash, { ...record, lastUsedAt: timestamp });
-        return [record.scope, { records: next }] as const;
+        // Transparently re-issue: every authenticated use of a still-valid
+        // credential pushes its absolute expiry forward, so a session that
+        // keeps calling MCP tools never runs into the maximum-lifetime cap
+        // above. Only sessions that stop using MCP entirely fall back to
+        // that cap (or the idle timeout, whichever is hit first).
+        const renewedScope: McpInvocationContext.McpInvocationScope = {
+          ...record.scope,
+          expiresAt: Math.max(record.scope.expiresAt, timestamp + maximumLifetimeMs),
+        };
+        next.set(tokenHash, { ...record, scope: renewedScope, lastUsedAt: timestamp });
+        return [renewedScope, { records: next }] as const;
       });
     },
   );


### PR DESCRIPTION
## Diagnosis

The desktop app's MCP server ("t3-code") authenticates agent-session traffic through `McpSessionRegistry` (`apps/server/src/mcp/McpSessionRegistry.ts`). A per-thread bearer credential is minted **once**, at provider-session start (`ProviderService.prepareMcpSession`, called from `startSession`/`recoverSessionForThread` in `apps/server/src/provider/Layers/ProviderService.ts:217-224,400,593`), and handed to the agent process as a **static** config value — e.g. `mcp_servers.t3-code` with a bearer header/env var baked in at process launch (`apps/server/src/provider/Layers/ClaudeAdapter.ts:3468-3475`, `apps/server/src/provider/Layers/CodexAdapter.ts:1405-1415`).

That credential previously carried a hard **8 hour** absolute cap (`DEFAULT_MAXIMUM_LIFETIME_MS = 8 * 60 * 60 * 1_000` in `McpSessionRegistry.ts`), counted from mint time, with **no refresh mechanism whatsoever** — `resolve()` only bumped `lastUsedAt` for the separate 30-minute idle timeout, never the absolute `expiresAt`. Since the token is a static header the running agent process can't rotate on its own, any session that outlived 8 hours (a normal outcome for long coding sessions, overnight work, or scheduled/background runs) would have its MCP calls start failing with 401 out from under an otherwise-healthy session — surfacing to the user as "t3-code requires re-authorization (token expired)" (2026-07-03, ~09:16 UTC), fixable only by a manual re-authorization.

## Fix

`apps/server/src/mcp/McpSessionRegistry.ts`:
- `resolve()` now transparently re-issues the credential's expiry on every authenticated use — it slides `expiresAt` forward to `now + maximumLifetimeMs` (never backward) instead of leaving it fixed at mint time. A session that keeps calling MCP tools never approaches the cap; the existing 30-minute idle timeout still reclaims credentials for threads that genuinely go quiet.
- Bumped `DEFAULT_MAXIMUM_LIFETIME_MS` from 8h to 30 days (matching `SessionStore`'s browser-session TTL) as a backstop for sessions that don't happen to call MCP tools often. This is safe to widen because the credential is already tightly scoped — random 256-bit token, single thread + provider instance, in-memory only, explicitly revoked on session stop/error/environment shutdown (`revokeThread`/`revokeAll`) — so the absolute cap wasn't providing much security value beyond what revocation + idle timeout already do; it was just killing healthy long sessions.

No changes to the provider adapters, auth session/pairing stores, or DPoP/HTTP auth layers — this is scoped entirely to the MCP credential registry.

## Tests

`apps/server/src/mcp/McpSessionRegistry.test.ts` — added:
- a never-used credential still expires once it passes the maximum lifetime (regression guard for the cap itself)
- a credential that's resolved repeatedly at short intervals survives well past what its original mint-time expiry would have been (the actual fix)

`cd apps/server && vp test run src/auth src/mcp` — 13 files / 79 tests passed.
`vp run --filter t3 typecheck` — passed (exit 0).

## Caveats

- This fixes the "still-actively-used session dies anyway" and "long-idle-but-legitimate session dies anyway" cases via sliding-window renewal + a much longer backstop cap. It does not add true OAuth-style token refresh/rotation to the MCP credential — the token itself never changes for the life of a thread's provider session, it's the same static bearer the agent process was launched with, just kept valid longer. That's consistent with how the credential is delivered today (static header at process spawn) and avoids touching the provider adapters.
- If an environment/server process restarts, all in-memory `McpSessionRegistry` records are lost as before (`revokeAll` on shutdown) — that's pre-existing behavior and orthogonal to this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP bearer credential lifetime and renewal in an auth path; scope is limited to in-memory registry behavior with existing idle timeout and revocation unchanged.
> 
> **Overview**
> Fixes mid-session **t3-code** MCP 401s by changing how bearer credentials age in `McpSessionRegistry`.
> 
> **`resolve`** now **slides `expiresAt` forward** on each successful auth (`max(existing, now + maximumLifetimeMs)`) while still updating `lastUsedAt`, so long-running agent sessions that keep calling MCP tools are no longer cut off by a fixed mint-time deadline. The **default maximum lifetime backstop** moves from **8 hours to 30 days** (documented as a cap for unused/stale credentials, not a hard session limit).
> 
> Tests add coverage for unused credentials expiring at the cap and for repeated `resolve` calls keeping a token valid past the original `expiresAt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1efa8a3894218a897d558c042a8edc1151dd47ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Renew MCP session credential expiry on each use to keep active sessions authorized
> - `McpSessionRegistry.resolve` now updates `expiresAt` to `max(previous expiresAt, now + maximumLifetimeMs)` on every successful use, so actively-used sessions are never cut off by the original expiry.
> - `DEFAULT_MAXIMUM_LIFETIME_MS` is raised from 8 hours to 30 days; this now acts as a "maximum idle lifetime" rather than an absolute cap.
> - Behavioral Change: tokens for inactive sessions still expire, but tokens for active sessions now have a rolling expiry that resets on every `resolve` call.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1efa8a3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->