### PR TITLE
Render Mosaic artifacts as native interactive UI

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -28,6 +28,7 @@
     "@effect/platform-node-shared": "catalog:",
     "@effect/sql-sqlite-bun": "catalog:",
     "@ff-labs/fff-node": "0.9.4",
+    "@mosaicjs/ai": "^0.8.0",
     "@opencode-ai/sdk": "^1.3.15",
     "@pierre/diffs": "catalog:",
     "effect": "catalog:",

--- a/apps/server/src/mcp/McpHttpServer.ts
+++ b/apps/server/src/mcp/McpHttpServer.ts
@@ -22,6 +22,8 @@ import {
   PreviewSnapshotToolkit,
   PreviewStandardToolkit,
 } from "./toolkits/preview/tools.ts";
+import { MosaicToolkitHandlersLive } from "./toolkits/mosaic/handlers.ts";
+import { MosaicToolkit } from "./toolkits/mosaic/tools.ts";
 
 const unauthorized = HttpServerResponse.jsonUnsafe(
   {
@@ -203,9 +205,14 @@ const PreviewSnapshotRegistrationLive = Layer.effectDiscard(registerPreviewSnaps
   Layer.provide(PreviewSnapshotToolkitHandlersLive),
 );
 
+const MosaicToolkitRegistrationLive = McpServer.toolkit(MosaicToolkit).pipe(
+  Layer.provide(MosaicToolkitHandlersLive),
+);
+
 export const PreviewToolkitRegistrationLive = Layer.mergeAll(
   PreviewStandardToolkitRegistrationLive,
   PreviewSnapshotRegistrationLive,
+  MosaicToolkitRegistrationLive,
 );
 
 const McpTransportLive = McpServer.layerHttp({

--- a/apps/server/src/mcp/toolkits/mosaic/handlers.ts
+++ b/apps/server/src/mcp/toolkits/mosaic/handlers.ts
@@ -1,0 +1,13 @@
+import { catBlock, lsBlocks, validateSource } from "@mosaicjs/ai";
+import * as Effect from "effect/Effect";
+
+import { MosaicToolkit } from "./tools.ts";
+
+// The Mosaic introspection handlers are pure functions over @mosaicjs/core, so
+// each tool just wraps a synchronous result in Effect.succeed - no dependencies,
+// no capability gate, no I/O.
+export const MosaicToolkitHandlersLive = MosaicToolkit.toLayer({
+  mosaic_ls: (input) => Effect.succeed(lsBlocks(input.kind)),
+  mosaic_cat: (input) => Effect.succeed(catBlock(input.block)),
+  mosaic_validate: (input) => Effect.succeed(validateSource(input.source)),
+});

--- a/apps/server/src/mcp/toolkits/mosaic/tools.test.ts
+++ b/apps/server/src/mcp/toolkits/mosaic/tools.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from "@effect/vitest";
+import { Tool } from "effect/unstable/ai";
+
+import { MosaicToolkit } from "./tools.ts";
+
+// A provider (Anthropic/OpenAI) rejects an MCP tool whose parameters are not a
+// top-level `{ type: "object" }` schema - which is exactly what an empty
+// Schema.Struct({}) produced for mosaic_ls. Pin that every Mosaic tool exports a
+// provider-compatible object schema so the tools actually load into the model.
+it("exports provider-compatible object schemas for every Mosaic tool", () => {
+  const tools = Object.values(MosaicToolkit.tools);
+  expect(tools.length).toBe(3);
+  for (const tool of tools) {
+    const schema = Tool.getJsonSchema(tool) as {
+      readonly type?: unknown;
+      readonly properties?: Readonly<Record<string, unknown>>;
+      readonly anyOf?: unknown;
+      readonly oneOf?: unknown;
+    };
+    expect(schema.type, `${tool.name} must export a top-level object schema`).toBe("object");
+    expect(schema.anyOf, `${tool.name} must not export a root anyOf`).toBeUndefined();
+    expect(schema.oneOf, `${tool.name} must not export a root oneOf`).toBeUndefined();
+    expect(
+      schema.properties,
+      `${tool.name} must expose a properties object`,
+    ).toBeTypeOf("object");
+    expect(
+      tool.description?.length ?? 0,
+      `${tool.name} should carry a useful description`,
+    ).toBeGreaterThan(40);
+  }
+});

--- a/apps/server/src/mcp/toolkits/mosaic/tools.ts
+++ b/apps/server/src/mcp/toolkits/mosaic/tools.ts
@@ -1,0 +1,52 @@
+import * as Schema from "effect/Schema";
+import { Tool, Toolkit } from "effect/unstable/ai";
+
+// Mosaic introspection tools, surfaced to the agent over T3 Code's MCP host so
+// it can learn a block's exact schema (and validate a draft) before emitting a
+// ```mosaic artifact - instead of guessing prop shapes. The tool logic lives in
+// @mosaicjs/ai; these are the read-only, side-effect-free MCP wrappers.
+
+const introspectionTool = <T extends Tool.Any>(tool: T): T =>
+  tool
+    .annotate(Tool.Readonly, true)
+    .annotate(Tool.Destructive, false)
+    .annotate(Tool.Idempotent, true) as T;
+
+export const MosaicLsTool = introspectionTool(
+  Tool.make("mosaic_ls", {
+    description:
+      "List every Mosaic block you can compose a ```mosaic artifact from, grouped by kind. Call this first when building a Mosaic artifact to see what is available. Pass kind to narrow to one group.",
+    parameters: Schema.Struct({
+      kind: Schema.optional(
+        Schema.String.annotate({
+          description: "Optional: one of layout, content, control, structure, data.",
+        }),
+      ),
+    }),
+    success: Schema.String,
+  }).annotate(Tool.Title, "List Mosaic blocks"),
+);
+
+export const MosaicCatTool = introspectionTool(
+  Tool.make("mosaic_cat", {
+    description:
+      "Show one Mosaic block's full prop schema - prop names, types, enum values, nested shapes, which are required - plus a minimal example. Call before using a block you are unsure about (DataTable, Chart, Diagram, Timeline, Tabs) so you write the exact schema instead of guessing.",
+    parameters: Schema.Struct({
+      block: Schema.String.annotate({ description: 'The block name, e.g. "DataTable".' }),
+    }),
+    success: Schema.String,
+  }).annotate(Tool.Title, "Show a Mosaic block schema"),
+);
+
+export const MosaicValidateTool = introspectionTool(
+  Tool.make("mosaic_validate", {
+    description:
+      "Compile and validate a Mosaic artifact (the mosaic-jsx inside a ```mosaic fence, or the bare source) and return every error, or confirm it is sound. Run this on your draft before emitting so mistakes are caught and fixed first.",
+    parameters: Schema.Struct({
+      source: Schema.String.annotate({ description: "The mosaic-jsx source to validate." }),
+    }),
+    success: Schema.String,
+  }).annotate(Tool.Title, "Validate a Mosaic artifact"),
+);
+
+export const MosaicToolkit = Toolkit.make(MosaicLsTool, MosaicCatTool, MosaicValidateTool);

--- a/apps/server/src/provider/Drivers/ClaudeDriver.ts
+++ b/apps/server/src/provider/Drivers/ClaudeDriver.ts
@@ -53,7 +53,12 @@ import {
   makeProviderSnapshotSettingsSource,
   type ProviderSnapshotSettings,
 } from "../providerUpdateSettings.ts";
-import { makeClaudeCapabilitiesCacheKey, makeClaudeContinuationGroupKey } from "./ClaudeHome.ts";
+import {
+  makeClaudeCapabilitiesCacheKey,
+  makeClaudeContinuationGroupKey,
+  resolveClaudeHomePath,
+} from "./ClaudeHome.ts";
+import { provisionMosaicSkill } from "../MosaicSkill.ts";
 const decodeClaudeSettings = Schema.decodeSync(ClaudeSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
@@ -128,6 +133,16 @@ export const ClaudeDriver: ProviderDriver<ClaudeSettings, ClaudeDriverEnv> = {
         instanceId,
       });
       const effectiveConfig = { ...config, enabled } satisfies ClaudeSettings;
+
+      // Deliver the Mosaic skill natively into <home>/.claude/skills, where the
+      // Claude Code SDK discovers it (settingSources includes "user"). Best
+      // effort: a skill-write failure must never keep the provider from coming
+      // up.
+      const claudeHome = yield* resolveClaudeHomePath(effectiveConfig);
+      yield* provisionMosaicSkill(path.join(claudeHome, ".claude", "skills")).pipe(
+        Effect.catch((cause) => Effect.logWarning("Failed to provision Mosaic skill.", { cause })),
+      );
+
       const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
         binaryPath: effectiveConfig.binaryPath,
         env: processEnv,

--- a/apps/server/src/provider/Drivers/CodexDriver.ts
+++ b/apps/server/src/provider/Drivers/CodexDriver.ts
@@ -57,6 +57,7 @@ import {
   materializeCodexShadowHome,
   resolveCodexHomeLayout,
 } from "./CodexHomeLayout.ts";
+import { provisionMosaicSkill } from "../MosaicSkill.ts";
 const decodeCodexSettings = Schema.decodeSync(CodexSettings);
 
 const DRIVER_KIND = ProviderDriverKind.make("codex");
@@ -139,6 +140,16 @@ export const CodexDriver: ProviderDriver<CodexSettings, CodexDriverEnv> = {
             }),
         ),
       );
+
+      // Deliver the Mosaic skill natively into the Codex home's skills dir,
+      // where Codex's `skills/list` discovers it (KNOWN_SHARED_DIRECTORIES
+      // symlinks it into the shadow home too). Best effort: a skill-write
+      // failure must never keep the provider from coming up.
+      const codexSkillsDir = (yield* Path.Path).join(homeLayout.sharedHomePath, "skills");
+      yield* provisionMosaicSkill(codexSkillsDir).pipe(
+        Effect.catch((cause) => Effect.logWarning("Failed to provision Mosaic skill.", { cause })),
+      );
+
       const effectiveConfig = {
         ...config,
         enabled,

--- a/apps/server/src/provider/MosaicSkill.ts
+++ b/apps/server/src/provider/MosaicSkill.ts
@@ -1,0 +1,260 @@
+import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
+
+import { writeFileStringAtomically } from "../atomicWrite.ts";
+
+// The Mosaic agent skill (the "with MCP" variant): written into each provider's
+// own skills directory so the agent runtime discovers it natively and
+// auto-activates from the description - no always-on prompt injection.
+// Provisioned once per provider instance (idempotent).
+//
+// This variant references T3 Code's mosaic_ls/cat/validate MCP tools and gates
+// emission on mosaic_validate; the portable format-only variant lives upstream
+// in the mosaic repo (skills/mosaic). Every code snippet in the skill compiles
+// through the real @mosaicjs parser. Keep in sync with the upstream skill and
+// the web block kit (apps/web/src/components/chat/mosaic/blocks.tsx).
+
+export const MOSAIC_SKILL_NAME = "mosaic";
+
+export const MOSAIC_SKILL_MD = `---
+name: mosaic
+description: Render the reply as a Mosaic artifact - a live, interactive interface the host app draws natively in its own design - instead of prose. Use when the answer is spatial or interactive: visualizing an architecture or flow, mocking a screen, comparing options, laying out a plan, charting data, or building an estimator or dashboard - or when the user says mosaic or asks to see an interface.
+---
+
+# Emitting Mosaic
+
+You write standard JSX from a fixed block vocabulary; the host draws every block with its own components, and interaction runs locally (a slider drives a total with no round-trip to you).
+The JSX is **data, never code**: expressions run in a bounded, pure interpreter, and events become named **intents** the host brokers.
+
+If prose reads just as well linearly, write prose.
+One artifact per reply, commentary outside the fence.
+Fence it as \` \`\`\`mosaic v=1 id=kebab-id \` and reuse the same \`id\` when regenerating so the host replaces the artifact in place.
+
+## Compose
+
+1. **Bake the state.**
+   Declare every value interaction touches in the root's \`state={{…}}\` (a literal object).
+   Everything the artifact shows lives in its props at emit time; nothing fetches or refreshes later - never a spinner.
+   Done when no expression reads a name missing from \`state\` or a \`.map\` binding.
+2. **Lay out from blocks.**
+   Nest \`Stack\` / \`Grid\` / \`Card\`; pick from the vocabulary below.
+   There is no \`<Plan>\` tag - a plan is \`Steps\` + \`Timeline\` + a \`DataTable\`.
+   Done when every tag is in the block list and every repeated shape is one \`.map\`, not copy-paste.
+   Unsure about props? \`mosaic_cat\` takes one or more blocks ("DataTable, Chart, Stack") and returns exact schemas; \`mosaic_ls\` lists every block.
+   Your client may namespace these tools (e.g. \`mcp__<server>__mosaic_cat\`); if a bare name is not found, search your tool registry for \`mosaic\` once and use the full names it returns.
+3. **Wire the interaction.**
+   \`value={path}\` / \`checked={path}\` two-way binds a control (a computed expression there is read-only).
+   \`{cond && <El/>}\` and ternaries render conditionally; \`{list.map((item) => <El key={…}/>)}\` repeats.
+   \`onClick={saveDraft({ total: seats * 16 })}\` hands the host an intent with computed args; \`onClick={toggle(open)}\` / \`onClick={set(count, count + 1)}\` mutate locally - \`set\` takes any expression, evaluated against current state at click time, so counters and calculators work.
+   Done when everything computable computes locally and every event is an intent or a local mutation.
+4. **Validate, then emit.**
+   Run \`mosaic_validate\` on the draft and fix every reported error.
+   Done when it returns VALID.
+
+## Boundaries
+
+Each of these is a compile error:
+
+- **Blocks only.** No HTML tags. The host owns the design: no \`className\`, no \`style\`, no raw colors - speak in semantic tokens (\`tone="warn"\`).
+- **Bounded expressions.** Arithmetic, comparisons, \`&& || !\`, ternary, template literals, and array methods (\`.map .filter .reduce .sort .slice .join .includes .length\`) work; the function catalog is \`abs min max round floor ceil clamp · len lower upper trim concat substr replace split join contains · formatCurrency formatNumber toFixed · map filter reduce sum count any all sort sortBy slice · has coalesce\`. No assignments, no \`new\`, no regex, no other functions. Unknown names evaluate to null.
+- **\`alt\` required** on \`Chart\` and \`Diagram\`.
+- **Host chrome stays the host's.** Modals, toasts, and navigation are requested through an intent, never drawn.
+
+## Blocks
+
+**Layout.** \`Box\` \`Stack\` \`Grid\` \`Divider\` \`Card\`
+**Content.** \`Text\` \`Heading\` \`Markdown\` \`Image\` \`Icon\` \`Link\` \`Badge\` \`Tag\` \`Avatar\` \`AvatarGroup\` \`Code\` \`Callout\`
+**Controls.** \`Button\` \`Input\` \`Select\` \`MultiSelect\` \`Autocomplete\` \`Checkbox\` \`Radio\` \`Toggle\` \`Slider\` \`DatePicker\` \`ColorPicker\` \`FilePicker\` \`Rating\` \`TagInput\` \`Field\` \`Disclosure\` \`Accordion\`
+**Structure.** \`Tabs\` \`Steps\` \`SegmentedControl\` \`Progress\` \`Empty\`
+**Media.** \`Video\` \`Audio\` \`Carousel\`
+**Data & viz.** \`DataTable\` \`List\` \`Tree\` \`Board\` \`Timeline\` \`Calendar\` \`Stat\` \`Chart\` \`VegaChart\` \`Diagram\` \`Canvas\` \`Embed\`
+
+\`mosaic_ls\` marks blocks this host adds beyond the built-ins with \`(host)\`; those exist only in this host, so recompose from primitives if you need to move an artifact elsewhere.
+
+Structure, not style.
+The format carries meaning and structure; the host owns spacing, typography, density, and chrome.
+Express structure - sections, rows, groupings - and let the host render it dense.
+There is no gap, padding, size, or weight to set: say what a thing *is*, not how big or how far apart.
+
+- \`Stack\` - \`direction="horizontal"\` for rows; \`justify="between"\` puts text left and actions right on one row; \`align\` sets the cross axis.
+- \`Card\` - \`tone\` tints it into an inset status panel (a green "handled" section).
+- \`Text\` - \`variant="label"\` is a section micro-label; \`variant="caption"\` is secondary supporting text. Inline emphasis (bold, italic) belongs to \`Markdown\`.
+- \`Button\` - \`variant\` is an intent hierarchy: \`primary\` (one per view), \`secondary\`, \`subtle\` (inline row actions), \`danger\` (destructive).
+- **Icons are Lucide** (lucide.dev), kebab-case names: \`<Icon name="wallet" />\`, or a leading icon on a block - \`<Badge icon="circle-check">…</Badge>\`, \`<Button icon="send">…</Button>\`, \`<Callout icon="sunrise">…</Callout>\`. Use real Lucide names (\`circle-check\`, \`triangle-alert\`, \`arrow-up-right\`); an unknown name renders nothing.
+
+Exact shapes for the data blocks:
+
+- \`DataTable\` - \`columns={["A","B"]}\` and \`rows={[["1","2"],["3","4"]]}\` (positional string arrays, never objects).
+- \`Chart\` - \`type\` (\`bar line area donut radar gauge scatter\`), \`data={[{ label, value }]}\`, \`alt\`.
+- \`Timeline\` - \`items={[{ date, title, description?, tone? }]}\`.
+- \`Stat\` - \`label\` + \`value\`; \`tone\` for the verdict color.
+- \`Tabs\` - \`items={["Overview","Docs"]}\` + one child panel per item.
+- Tones: \`ok warn bad primary subtle\`.
+
+## Example
+
+\`\`\`mosaic v=1 id=seat-estimator
+<Card state={{ seats: 12, annual: true }}>
+  <Field label={\`Seats: \${seats}\`}>
+    <Slider value={seats} min={1} max={200} />
+  </Field>
+  <Toggle checked={annual} label="Bill annually (save 20%)" />
+  <Stat label={annual ? "Billed today (12 mo)" : "Billed monthly"}
+        value={formatCurrency(seats * 16 * (annual ? 12 * 0.8 : 1))} />
+  {seats >= 100 && <Callout tone="warn">Above 100 seats, Enterprise usually wins.</Callout>}
+  <Button variant="primary" onClick={startCheckout({ seats: seats, total: seats * 16 * (annual ? 12 * 0.8 : 1) })}>
+    Continue to checkout
+  </Button>
+</Card>
+\`\`\`
+
+For interaction patterns (per-row selection, detail-on-click diagrams, live filters) and Chart/Diagram sizing, read [REFERENCE.md](REFERENCE.md) before composing anything beyond a simple card.
+`;
+
+export const MOSAIC_SKILL_REFERENCE_MD = `# Mosaic patterns
+
+Interaction patterns and sizing notes for [the skill](SKILL.md).
+
+## Action rows (text left, buttons right)
+
+The approval row - one line, actions right-aligned:
+
+\`\`\`jsx
+<Card state={{}}>
+  <Text variant="label" tone="subtle">Needs a quick yes</Text>
+  <Stack direction="horizontal" justify="between" align="center">
+    <Text>Pay £340 invoice to Studio Kern</Text>
+    <Stack direction="horizontal">
+      <Button>Approve</Button>
+      <Button variant="subtle">Skip</Button>
+    </Stack>
+  </Stack>
+  <Stack direction="horizontal" justify="between" align="center">
+    <Text>Send reply to Meridian's CEO</Text>
+    <Stack direction="horizontal">
+      <Button>Review</Button>
+      <Button variant="subtle">Send</Button>
+    </Stack>
+  </Stack>
+</Card>
+\`\`\`
+
+A toned card makes an inset status panel:
+
+\`\`\`jsx
+<Card tone="ok" state={{}}>
+  <Text variant="label" tone="ok">Handled while you slept</Text>
+  <Text>Sorted 38 emails, archived 22 newsletters</Text>
+  <Text>Drafted 2 replies, waiting in your outbox</Text>
+</Card>
+\`\`\`
+
+## Per-row state (selection lists, checklists)
+
+Bind through a path with the map index; fold over the same array for the summary:
+
+\`\`\`jsx
+<Stack state={{ files: [
+  { path: "src/api.ts", checked: true },
+  { path: "src/db.ts", checked: false }
+] }}>
+  {files.map((f, i) => (
+    <Stack key={f.path} direction="horizontal">
+      <Checkbox checked={files[i].checked} label={f.path} />
+    </Stack>
+  ))}
+  <Text tone="subtle">{\`\${files.filter((f) => f.checked).length} of \${files.length} selected\`}</Text>
+  <Button onClick={commit({ paths: files.filter((f) => f.checked).map((f) => f.path) })}>
+    Commit selected
+  </Button>
+</Stack>
+\`\`\`
+
+## Detail-on-click diagram
+
+\`value={selected}\` on a \`Diagram\` holds the clicked node id (null on background); a \`&&\` sibling swaps the detail panel:
+
+\`\`\`jsx
+<Stack state={{ selected: null }}>
+  <Diagram alt="Request path" value={selected} direction="down"
+    nodes={[
+      { id: "client", label: "Client", kind: "client" },
+      { id: "api", label: "API", kind: "service", badge: "p95 340ms" },
+      { id: "db", label: "Postgres", kind: "store", tone: "warn" }
+    ]}
+    edges={[
+      { from: "client", to: "api", label: "HTTPS" },
+      { from: "api", to: "db", dashed: true }
+    ]} />
+  {selected == "db" && (
+    <Card>
+      <Heading level={4}>Postgres</Heading>
+      <Text>Connection pool saturates under load; the dashed edge is the async path.</Text>
+    </Card>
+  )}
+</Stack>
+\`\`\`
+
+Ids must be unique; every \`edges[].from\`/\`to\` must name one.
+Node \`kind\`: \`service store queue client external concept code\`.
+
+## Scenario switch (no round-trip)
+
+\`\`\`jsx
+<Stack state={{ audience: "SaaS" }}>
+  <SegmentedControl value={audience} options={["SaaS", "Bank"]} />
+  {audience == "SaaS" && <Callout tone="ok">Zep wins: point-in-time recall, no graph to operate.</Callout>}
+  {audience == "Bank" && <Callout tone="warn">Neither survives an audit alone.</Callout>}
+</Stack>
+\`\`\`
+
+## Live-filtered list
+
+Map over a derived array; the source stays baked in:
+
+\`\`\`jsx
+<Stack state={{ owner: "all", tasks: [
+  { title: "Snapshot", owner: "dana" },
+  { title: "Cutover", owner: "raj" }
+] }}>
+  <Select value={owner} options={["all", "dana", "raj"]} label="Owner" />
+  {tasks.filter((t) => owner == "all" || t.owner == owner).map((t) => (
+    <Text key={t.title}>{\`\${t.title} - \${t.owner}\`}</Text>
+  ))}
+</Stack>
+\`\`\`
+
+## Layout notes
+
+- \`Stack\` - column by default; \`direction="horizontal"\` for rows; \`justify\` and \`align\` place children (structure, not spacing).
+- \`Grid\` - \`cols\` is the column count; children split it evenly.
+- Local mutations: \`set(path, expression)\` writes a computed value (\`set(count, count + 1)\`, \`set(display, display + "7")\`), \`toggle(path)\` flips a boolean; anything beyond local state crosses via an intent's args.
+
+## Chart & Diagram sizing
+
+The artifact renders in a chat column, so width is scarce.
+
+- \`Chart\` - keep to ~8 categories or fewer; use a \`DataTable\` beyond that.
+- \`Diagram\` - \`direction="right"\` only for small graphs (~5 nodes across or fewer); otherwise \`direction="down"\` so it grows vertically instead of squishing. Short node labels.
+`;
+
+/**
+ * Write the Mosaic skill (SKILL.md + REFERENCE.md) into a provider's skills
+ * directory. Atomic + idempotent, so it is safe to call on every provider
+ * create(). `skillsDir` is the provider home's skills folder - <codexHome>/
+ * skills for Codex, <claudeHome>/.claude/skills for Claude.
+ */
+export const provisionMosaicSkill = Effect.fn("provisionMosaicSkill")(function* (
+  skillsDir: string,
+) {
+  const path = yield* Path.Path;
+  const dir = path.join(skillsDir, MOSAIC_SKILL_NAME);
+  yield* writeFileStringAtomically({
+    filePath: path.join(dir, "SKILL.md"),
+    contents: MOSAIC_SKILL_MD,
+  });
+  yield* writeFileStringAtomically({
+    filePath: path.join(dir, "REFERENCE.md"),
+    contents: MOSAIC_SKILL_REFERENCE_MD,
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,8 @@
     "@formkit/auto-animate": "^0.9.0",
     "@legendapp/list": "3.2.0",
     "@lexical/react": "^0.41.0",
+    "@mosaicjs/core": "^0.8.0",
+    "@mosaicjs/react": "^0.8.0",
     "@pierre/diffs": "catalog:",
     "@pierre/trees": "1.0.0-beta.4",
     "@t3tools/client-runtime": "workspace:*",

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -40,6 +40,7 @@ import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 import { renderSkillInlineMarkdownChildren } from "./chat/SkillInlineText";
+import { extractMosaicArtifactId, MosaicArtifact } from "./chat/mosaic";
 import { CHAT_FILE_TAG_CHIP_CLASS_NAME, FileTagChipContent } from "./chat/FileTagChip";
 import { PierreEntryIcon } from "./chat/PierreEntryIcon";
 import { hasSpecificPierreIconForFileName, syntheticFileNameForLanguageId } from "../pierre-icons";
@@ -1497,6 +1498,19 @@ function ChatMarkdown({
         }
 
         const language = extractFenceLanguage(codeBlock.className);
+        if (language === "mosaic") {
+          // A ```mosaic fence is a UI artifact, not source to highlight: hand it
+          // to the Mosaic renderer, which draws it with t3code's own components.
+          // Streaming state matters: a partial fence never compiles, so the
+          // renderer waits for the final text before reporting diagnostics.
+          return (
+            <MosaicArtifact
+              source={codeBlock.code}
+              artifactId={extractMosaicArtifactId(extractPreCodeMeta(node))}
+              isStreaming={isStreaming}
+            />
+          );
+        }
         const fenceTitle = extractFenceTitle(extractPreCodeMeta(node));
         return (
           <MarkdownCodeBlock

--- a/apps/web/src/components/chat/mosaic/MosaicArtifact.test.tsx
+++ b/apps/web/src/components/chat/mosaic/MosaicArtifact.test.tsx
@@ -1,0 +1,263 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vite-plus/test";
+
+import { DEFAULT_MANIFEST, parse, validate } from "@mosaicjs/core";
+
+import { mosaicComponents } from "./blocks";
+import { MosaicArtifact } from "./MosaicArtifact";
+
+describe("MosaicArtifact", () => {
+  it("renders an artifact through t3code's own block components", () => {
+    const source = `<Card><Heading level={3}>Ship it</Heading><Text>All checks passed.</Text></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("Ship it");
+    expect(markup).toContain("All checks passed.");
+  });
+
+  it("evaluates a native expression locally at render time", () => {
+    const source = `<Stat label="Answer" value={6 * 7} />`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("42");
+  });
+
+  it("bakes initial state and evaluates template literals", () => {
+    const source = "<Card state={{ seats: 12 }}><Text>{`Seats: ${seats}`}</Text></Card>";
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("Seats: 12");
+  });
+
+  it("renders a conditional child via plain JSX &&", () => {
+    const source = `<Card state={{ seats: 120 }}>{seats >= 100 && <Callout tone="warn">Enterprise</Callout>}</Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("Enterprise");
+  });
+
+  it("renders a list via plain JSX .map", () => {
+    const source = `<Card state={{ items: [{ name: "alpha" }, { name: "beta" }] }}>{items.map((i) => <Text key={i.name}>{i.name}</Text>)}</Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("alpha");
+    expect(markup).toContain("beta");
+  });
+});
+
+describe("MosaicArtifact streaming", () => {
+  it("renders a still-streaming partial artifact progressively", () => {
+    const source = `<Card><Heading level={3}>Building</Heading><Text>partial sentence`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} isStreaming />);
+    expect(markup).toContain("Building");
+    expect(markup).toContain("partial sentence");
+  });
+
+  it("shows raw source quietly while nothing is renderable yet", () => {
+    const markup = renderToStaticMarkup(<MosaicArtifact source={"<Car"} isStreaming />);
+    expect(markup).toContain("&lt;Car");
+    expect(markup).not.toContain("Could not render");
+  });
+});
+
+describe("block rendering", () => {
+  it("renders markdown passed to <Markdown> as children (not literal ** )", () => {
+    const source = `<Markdown>**Why this is elevated** - repeated deposits.</Markdown>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("<strong>Why this is elevated</strong>");
+    expect(markup).not.toContain("**Why this is elevated**");
+  });
+
+  it("renders best-effort instead of blanking on an invalid block", () => {
+    // Chart is missing its required data - validation is advisory, so the rest
+    // of the artifact still renders and the diagnostics go to the agent.
+    const source = `<Card><Text>Still visible</Text><Chart type="bar" alt="x" /></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("Still visible");
+    expect(markup).not.toContain("Could not render");
+  });
+
+  it("does not dump raw JSON when a value is the wrong (object) shape", () => {
+    const source = `<Stat label="x" value={{ a: 1 }} />`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).not.toContain('{"a":1}');
+    expect(markup).not.toContain("&quot;a&quot;");
+  });
+});
+
+describe("layout & density (t3code's own baked defaults)", () => {
+  it("renders an action row: text left, buttons right, with a subtle inline action", () => {
+    const source = `<Card>
+  <Text variant="label" tone="subtle">Needs a quick yes</Text>
+  <Stack direction="horizontal" justify="between" align="center">
+    <Text>Pay invoice</Text>
+    <Stack direction="horizontal">
+      <Button variant="primary">Approve</Button>
+      <Button variant="subtle">Skip</Button>
+    </Stack>
+  </Stack>
+</Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("justify-between");
+    // Text variant="label" is the section micro-label: uppercase treatment.
+    expect(markup).toContain("uppercase");
+    expect(markup).toContain("Approve");
+    expect(markup).toContain("Skip");
+  });
+
+  it("renders a Card with baked compact padding and rhythm-spaced children", () => {
+    // The format carries no spacing props: the Card keeps its baked padding and
+    // spaces successive children by contextual rhythm, not one flat gap.
+    const source = `<Card><Text>First</Text><Text>Second</Text></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("p-3.5");
+    expect(markup).toContain("mt-2"); // text -> text default rhythm
+  });
+
+  it("groups adjacent cards with a modest gap, not a section break", () => {
+    const source = `<Card><Card>A</Card><Card>B</Card></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("mt-2"); // card -> card reads as one group
+  });
+
+  it("tints a toned card into an inset panel", () => {
+    const source = `<Card tone="ok"><Text>Sorted 38 emails</Text></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("bg-success/8");
+  });
+
+  it("surfaces a REMOVED_PROP diagnostic for a removed spacing prop while still rendering", () => {
+    // A removed 0.6 prop (gap) is advisory: the artifact still renders, and the
+    // validation the library feeds onDiagnostics flags it for the agent to fix.
+    const source = `<Card gap="2"><Text>Compact</Text></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("Compact");
+
+    const parsed = parse(source);
+    expect(parsed.ok).toBe(true);
+    const checked = parsed.ok ? validate(parsed.doc, DEFAULT_MANIFEST) : null;
+    expect(checked?.ok).toBe(false);
+    const diagnostics = checked && !checked.ok ? checked.errors : [];
+    expect(diagnostics.some((d) => d.code === "REMOVED_PROP" && d.prop === "gap")).toBe(true);
+  });
+});
+
+describe("contextual rhythm (spacing derives from adjacent structure)", () => {
+  // The user's morning-briefing card: a full composition the rhythm engine must
+  // give visible hierarchy - tight header cluster, section breaks before each
+  // micro-label, grouped/sectioned cards, a tight badge stack, and a callout whose
+  // body separates its button row from the message.
+  const briefing = `<Card state={{ carBooked: false, carDismissed: false }}>
+  <Stack direction="horizontal" align="center">
+    <Icon name="sunrise" />
+    <Stack>
+      <Heading level={3}>Good morning, Alex</Heading>
+      <Text variant="caption">Tuesday · 8:00am · 12°C, clear</Text>
+    </Stack>
+  </Stack>
+  <Text variant="label">On your calendar</Text>
+  <DataTable columns={["Time", "Event", "Status"]} rows={[["10:00", "Standup", "prep note ready"], ["14:30", "Client call — Meridian", "brief attached"], ["18:40", "Flight BA294", "checked in"]]} />
+  <Card tone="ok">
+    <Text variant="label">Handled while you slept</Text>
+    <Stack>
+      <Badge icon="circle-check" tone="ok">Sorted 38 emails</Badge>
+      <Badge icon="circle-check" tone="ok">Drafted 2 replies</Badge>
+    </Stack>
+  </Card>
+  <Text variant="label">Needs a quick yes</Text>
+  <Card>
+    <Stack direction="horizontal" justify="between" align="center">
+      <Stack direction="horizontal" align="center"><Icon name="wallet" /><Text>Pay £340 invoice to Studio Kern</Text></Stack>
+      <Stack direction="horizontal"><Button variant="secondary">Approve</Button><Button variant="subtle">Skip</Button></Stack>
+    </Stack>
+  </Card>
+  <Callout tone="primary" icon="lightbulb">
+    <Stack>
+      <Text>You land at 21:15 and it'll be raining. Want me to book a car?</Text>
+      <Stack direction="horizontal"><Button variant="primary">Book it</Button><Button variant="subtle">No thanks</Button></Stack>
+    </Stack>
+  </Callout>
+</Card>`;
+
+  it("renders every layer of the briefing with its hierarchy intact", () => {
+    const markup = renderToStaticMarkup(<MosaicArtifact source={briefing} />);
+    expect(markup).toContain("Good morning, Alex");
+    expect(markup).toContain("Sorted 38 emails");
+    expect(markup).toContain("Book it");
+  });
+
+  it("sits the caption tight under the heading and rides the icon on the first line", () => {
+    const source = `<Stack direction="horizontal" align="center"><Icon name="sunrise" /><Stack><Heading level={3}>Good morning, Alex</Heading><Text variant="caption">Tuesday</Text></Stack></Stack>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    // heading -> caption is a tight pair, not a full gap.
+    expect(markup).toContain("mt-0.5");
+    // Icon + multi-line block: the row tops the icon instead of centering it.
+    expect(markup).toContain("items-start");
+  });
+
+  it("breaks a section before each micro-label and ties it tight to what follows", () => {
+    const source = `<Card><Text>Intro</Text><Text variant="label">On your calendar</Text><DataTable columns={["A"]} rows={[["1"]]} /></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("mt-4"); // section break before the label
+    expect(markup).toContain("mt-1.5"); // tight tie from label to the table
+  });
+
+  it("gives a section-level gap when a card crosses into a new kind", () => {
+    const source = `<Card><DataTable columns={["A"]} rows={[["1"]]} /><Card tone="ok"><Text>Panel</Text></Card></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("mt-3"); // table -> card is a section boundary
+  });
+
+  it("separates a callout's button row from its message", () => {
+    const source = `<Callout tone="primary" icon="lightbulb"><Stack><Text>Book a car?</Text><Stack direction="horizontal"><Button variant="primary">Book it</Button></Stack></Stack></Callout>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("mt-2.5"); // text -> control row
+    expect(markup).toContain("items-start"); // icon tops the message
+  });
+});
+
+describe("icons (Lucide standard)", () => {
+  it("renders an Icon block for a valid Lucide name without crashing", () => {
+    const source = `<Card><Icon name="circle-check" tone="ok" /><Text>Done</Text></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("Done");
+    expect(markup).not.toContain("circle-check"); // the raw name is never shown as text
+  });
+
+  it("renders a leading icon on a Badge alongside its label", () => {
+    const source = `<Badge tone="warn" icon="wallet">Pay invoice</Badge>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("Pay invoice");
+    expect(markup).not.toContain("wallet");
+  });
+
+  it("ignores an unknown icon name instead of dumping it", () => {
+    const source = `<Card><Icon name="definitely-not-an-icon" /><Text>Fine</Text></Card>`;
+    const markup = renderToStaticMarkup(<MosaicArtifact source={source} />);
+    expect(markup).toContain("Fine");
+    expect(markup).not.toContain("definitely-not-an-icon");
+  });
+});
+
+describe("mosaicComponents", () => {
+  it("covers the layout, control, and data blocks a model composes from", () => {
+    for (const block of [
+      "Stack",
+      "Grid",
+      "Card",
+      "Text",
+      "Heading",
+      "Badge",
+      "Callout",
+      "Button",
+      "Slider",
+      "Toggle",
+      "Select",
+      "Checkbox",
+      "SegmentedControl",
+      "Tabs",
+      "DataTable",
+      "Stat",
+      "Chart",
+      "Timeline",
+      "Diagram",
+    ]) {
+      expect(mosaicComponents, `missing block: ${block}`).toHaveProperty(block);
+    }
+  });
+});

--- a/apps/web/src/components/chat/mosaic/MosaicArtifact.tsx
+++ b/apps/web/src/components/chat/mosaic/MosaicArtifact.tsx
@@ -1,0 +1,98 @@
+import { memo, type ReactNode, useCallback } from "react";
+
+import type { ValidationDiagnostic } from "@mosaicjs/core";
+import { Mosaic } from "@mosaicjs/react";
+
+import { useMosaicAutocorrect } from "./autocorrect";
+import { mosaicComponents } from "./blocks";
+import { useMosaicIntent } from "./intent";
+
+/** Pulls the artifact id out of fence meta: ` ```mosaic v=1 id=seat-estimator `. */
+export function extractMosaicArtifactId(meta: string | undefined): string | null {
+  const match = meta === undefined ? null : /(?:^|\s)id=([A-Za-z0-9_-]+)/.exec(meta);
+  return match?.[1] ?? null;
+}
+
+/**
+ * The readable floor: the raw Mosaic source, shown quietly (no error line) while
+ * an artifact is still streaming - a partial tree never parses - and for a final
+ * artifact that does not parse at all.
+ */
+function MosaicSource({ source }: { source: string }): ReactNode {
+  return (
+    <div className="rounded-lg border border-border bg-card p-3">
+      <pre className="overflow-auto whitespace-pre-wrap font-mono text-muted-foreground text-xs leading-relaxed">
+        {source}
+      </pre>
+    </div>
+  );
+}
+
+/** Stable <Mosaic fallback> renderer for source that does not parse. */
+const renderMosaicSource = (source: string): ReactNode => <MosaicSource source={source} />;
+
+/** Formats one validation finding the way the correction channel expects. */
+function formatDiagnostic(d: ValidationDiagnostic): string {
+  return `${d.path} <${d.type}> ${d.code}${d.prop ? ` (${d.prop})` : ""}${
+    d.fix ? ` - fix: ${d.fix}` : ""
+  }`;
+}
+
+/** Each broken artifact asks the agent for a fix at most once per session. */
+const reportedArtifacts = new Set<string>();
+
+/**
+ * Renders one `\`\`\`mosaic` artifact from an assistant reply as native,
+ * interactive UI. The library {@link Mosaic} owns parsing, the reactive loop
+ * (local `state.*`, derived `expr`, `if:show`), streaming completion, and the
+ * per-node error boundaries; every block is drawn by t3code's own
+ * {@link mosaicComponents}, so the artifact wears the app's look. Host intents
+ * flow out through {@link useMosaicIntent}.
+ *
+ * Validation is advisory: a final artifact's diagnostics are reported once
+ * through {@link useMosaicAutocorrect} for the agent to correct, never shown on
+ * screen or used to blank the render. Only genuinely unparseable source (still
+ * streaming, or truly malformed) falls back to showing its text.
+ */
+function MosaicArtifactImpl({
+  source,
+  artifactId = null,
+  isStreaming = false,
+}: {
+  source: string;
+  artifactId?: string | null;
+  isStreaming?: boolean;
+}): ReactNode {
+  const onIntent = useMosaicIntent();
+  const autocorrect = useMosaicAutocorrect();
+
+  // Hand a final artifact's validation errors to the agent once. The library
+  // fires this per distinct source; the streaming guard drops partial-prefix
+  // diagnostics, and the set guards against a remount re-reporting the same one.
+  const onDiagnostics = useCallback(
+    (diagnostics: ValidationDiagnostic[]): void => {
+      if (isStreaming || autocorrect === null || diagnostics.length === 0) return;
+      const formatted = diagnostics.map(formatDiagnostic).join("\n");
+      const key = `${artifactId ?? source} ${formatted}`;
+      if (reportedArtifacts.has(key)) return;
+      reportedArtifacts.add(key);
+      autocorrect({ artifactId, source, diagnostics: formatted });
+    },
+    [artifactId, autocorrect, isStreaming, source],
+  );
+
+  return (
+    <div className="chat-mosaic-artifact my-2 w-full min-w-0">
+      <Mosaic
+        source={source}
+        components={mosaicComponents}
+        isStreaming={isStreaming}
+        onIntent={onIntent}
+        onDiagnostics={onDiagnostics}
+        fallback={renderMosaicSource}
+      />
+    </div>
+  );
+}
+
+export const MosaicArtifact = memo(MosaicArtifactImpl);

--- a/apps/web/src/components/chat/mosaic/autocorrect.ts
+++ b/apps/web/src/components/chat/mosaic/autocorrect.ts
@@ -1,0 +1,50 @@
+import { createContext, useContext } from "react";
+
+/**
+ * What the renderer reports when a *final* (non-streaming) artifact fails to
+ * compile or validate. The diagnostics are the compiler's structured output,
+ * already formatted for a model to act on.
+ */
+export interface MosaicInvalidReport {
+  /** The fence id (` ```mosaic v=1 id=… `), when the model provided one. */
+  artifactId: string | null;
+  /** The raw mosaic-jsx source that failed. */
+  source: string;
+  /** One diagnostic per line, e.g. `14:5 INVALID_DIRECTIVE: if:show takes a string`. */
+  diagnostics: string;
+}
+
+/**
+ * The correction sink. The provider decides what "auto-correct" means - the
+ * default is nothing (broken artifacts just show their source), and ChatView
+ * overrides it with a sender that hands the diagnostics back to the agent as
+ * a follow-up turn so it can re-emit a fixed artifact.
+ */
+export type MosaicAutocorrect = (report: MosaicInvalidReport) => void;
+
+const MosaicAutocorrectContext = createContext<MosaicAutocorrect | null>(null);
+
+export const MosaicAutocorrectProvider = MosaicAutocorrectContext.Provider;
+
+export function useMosaicAutocorrect(): MosaicAutocorrect | null {
+  return useContext(MosaicAutocorrectContext);
+}
+
+/**
+ * The follow-up turn a correction sender submits. Kept here so the message
+ * wording lives next to the contract; the model sees its own diagnostics and
+ * the instruction to re-emit under the same id (so the app can treat the new
+ * artifact as the replacement).
+ */
+export function formatCorrectionPrompt(report: MosaicInvalidReport): string {
+  const identity = report.artifactId !== null ? ` (id=${report.artifactId})` : "";
+  return [
+    `Your Mosaic artifact${identity} failed to compile. Diagnostics:`,
+    "",
+    report.diagnostics,
+    "",
+    `Re-emit the corrected artifact in a \`\`\`mosaic fence${
+      report.artifactId !== null ? ` with the same id=${report.artifactId}` : ""
+    }. Fix only what the diagnostics call out; keep the content unchanged.`,
+  ].join("\n");
+}

--- a/apps/web/src/components/chat/mosaic/blocks.tsx
+++ b/apps/web/src/components/chat/mosaic/blocks.tsx
@@ -1,0 +1,1923 @@
+"use client";
+
+// The host's own block set: every Mosaic block drawn through this app's design
+// system - t3code's vendored UI kit (shadcn-style on Base UI). The artifact stays
+// data; the look is entirely ours.
+//
+// Contract (see @mosaicjs/react): each block receives
+// { node, props, children, value, setValue, events }. Stateful controls get
+// value/setValue only when the node carries bind:state; when unbound they fall
+// back to their own local state (uncontrolled defaultValue), so a mock stays a
+// live mock. Named intents leave through events.<name>().
+
+import type { BlockPropTypes, MosaicNode } from "@mosaicjs/core";
+import { defineComponents, type MosaicBlockProps } from "@mosaicjs/react";
+import { layoutDiagram } from "@mosaicjs/react";
+import { ChevronRight, CircleCheck, Info, Star, TriangleAlert, Upload, X } from "lucide-react";
+import { DynamicIcon, type IconName, iconNames } from "lucide-react/dynamic";
+import * as React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { cn } from "~/lib/utils";
+import { Alert, AlertDescription } from "../../ui/alert";
+import {
+  AutocompleteEmpty,
+  AutocompleteInput,
+  AutocompleteItem,
+  AutocompleteList,
+  AutocompletePopup,
+  Autocomplete as UIAutocomplete,
+} from "../../ui/autocomplete";
+import { Badge as UIBadge } from "../../ui/badge";
+import { Button as UIButton } from "../../ui/button";
+import { Card as UICard } from "../../ui/card";
+import { Checkbox as UICheckbox } from "../../ui/checkbox";
+import { Collapsible, CollapsiblePanel, CollapsibleTrigger } from "../../ui/collapsible";
+import {
+  Combobox,
+  ComboboxChip,
+  ComboboxChips,
+  ComboboxChipsInput,
+  ComboboxEmpty,
+  ComboboxItem,
+  ComboboxList,
+  ComboboxPopup,
+  ComboboxValue,
+} from "../../ui/combobox";
+import { Empty as UIEmpty } from "../../ui/empty";
+import { FieldLabel, Field as UIField } from "../../ui/field";
+import { Input as UIInput } from "../../ui/input";
+import { RadioGroup, Radio as UIRadio } from "../../ui/radio-group";
+import {
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+  Select as UISelect,
+} from "../../ui/select";
+import { Separator } from "../../ui/separator";
+import { Switch } from "../../ui/switch";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "../../ui/table";
+import { Textarea } from "../../ui/textarea";
+import { ToggleGroup, ToggleGroupItem } from "../../ui/toggle-group";
+
+type PV = MosaicBlockProps["props"][string];
+
+const str = (v: PV | undefined): string => {
+  if (v === undefined || v === null) return "";
+  // Objects only reach here on a schema mismatch (a cell/option that should be a
+  // scalar). Render nothing rather than dumping raw JSON into the UI; validation
+  // surfaces the real error to the model.
+  if (typeof v === "object") return "";
+  return String(v);
+};
+
+const num = (v: PV | undefined, fallback = 0): number => {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+const arr = (v: PV | undefined): PV[] => (Array.isArray(v) ? v : []);
+const strs = (v: PV | undefined): string[] => arr(v).map((x) => str(x));
+
+const ALIGN: Record<string, string> = {
+  start: "items-start",
+  center: "items-center",
+  end: "items-end",
+  baseline: "items-baseline",
+  stretch: "items-stretch",
+};
+
+const JUSTIFY: Record<string, string> = {
+  start: "justify-start",
+  center: "justify-center",
+  end: "justify-end",
+  between: "justify-between",
+};
+
+// Small muted field-label used by composite controls that cannot own a single
+// <label htmlFor>. Single-input controls associate with a real <label> instead.
+const LABEL = "font-medium text-muted-foreground text-xs";
+
+// tone -> text color (Text, Timeline dot, Stat)
+const TONE_TEXT: Record<string, string> = {
+  ok: "text-success-foreground",
+  warn: "text-warning-foreground",
+  bad: "text-destructive-foreground",
+  subtle: "text-muted-foreground",
+  primary: "text-primary",
+};
+
+// tone -> ui/badge variant (tinted background, *-foreground text)
+const BADGE_VARIANT: Record<string, "default" | "secondary" | "success" | "warning" | "error"> = {
+  ok: "success",
+  warn: "warning",
+  bad: "error",
+  primary: "default",
+  subtle: "secondary",
+};
+
+// Mosaic Button variant (an intent hierarchy) -> ui/button variant. `subtle` is
+// the inline row action, drawn with the ghost treatment.
+const BUTTON_VARIANT: Record<string, "default" | "secondary" | "destructive" | "ghost"> = {
+  primary: "default",
+  secondary: "secondary",
+  subtle: "ghost",
+  danger: "destructive",
+};
+
+// tone -> ui/alert variant + description text color
+const CALLOUT_VARIANT: Record<string, "default" | "error" | "info" | "success" | "warning"> = {
+  ok: "success",
+  warn: "warning",
+  bad: "error",
+  primary: "info",
+};
+const CALLOUT_DESC: Record<string, string> = {
+  success: "text-success-foreground",
+  warning: "text-warning-foreground",
+  error: "text-destructive-foreground",
+  info: "text-foreground",
+  default: "text-foreground",
+};
+
+// --- icons ----------------------------------------------------------------------
+// Mosaic's icon standard is Lucide (lucide.dev): every `name` / `icon` prop is a
+// Lucide icon name in kebab-case ("wallet", "circle-check", "sunrise").
+// DynamicIcon code-splits each icon, so referencing a name costs nothing until
+// it renders. A handful of common synonyms are aliased to the canonical name;
+// an unrecognized name renders nothing rather than breaking the artifact.
+
+const ICON_NAMES = new Set<string>(iconNames);
+
+const ICON_ALIAS: Record<string, string> = {
+  warning: "triangle-alert",
+  alert: "triangle-alert",
+  error: "circle-x",
+  success: "circle-check",
+  done: "check",
+  tick: "check",
+  cross: "x",
+  close: "x",
+  trash: "trash-2",
+  delete: "trash-2",
+  edit: "pencil",
+  gear: "settings",
+  idea: "lightbulb",
+  money: "wallet",
+  email: "mail",
+  time: "clock",
+  flight: "plane",
+  warn: "triangle-alert",
+};
+
+function resolveIconName(raw: string): IconName | null {
+  const kebab = raw.trim().toLowerCase().replace(/[\s_]+/g, "-");
+  const name = ICON_ALIAS[kebab] ?? kebab;
+  return ICON_NAMES.has(name) ? (name as IconName) : null;
+}
+
+/** Render a Lucide icon by name. Suspense-wrapped (DynamicIcon lazy-loads the
+ *  glyph); an unknown name renders an empty slot so layout never shifts. */
+function MosaicIcon({ name, className }: { name: string; className?: string }): React.ReactNode {
+  const resolved = resolveIconName(name);
+  if (!resolved) return null;
+  return (
+    <React.Suspense fallback={<span className={cn("inline-block size-4 shrink-0", className)} />}>
+      <DynamicIcon name={resolved} className={cn("size-4 shrink-0", className)} aria-hidden="true" />
+    </React.Suspense>
+  );
+}
+
+function Icon({ props }: MosaicBlockProps<BlockPropTypes["Icon"]>) {
+  if (!props.name) return null;
+  return <MosaicIcon name={props.name} className={cn(TONE_TEXT[props.tone ?? ""])} />;
+}
+
+// --- vertical rhythm -------------------------------------------------------------
+// Mosaic 0.7 removed every spacing prop: the host owns density. A single flat gap
+// flattens composed hierarchy, so vertical flows (Stack, Card, Callout, List) space
+// each child by what it and its predecessor ARE - spacing derives from adjacent
+// structure because the format carries none. `node.children` aligns index-for-index
+// with the rendered `children`, so the adjacent-type info is free. `flowKind`
+// classifies a node and `rhythm` turns an adjacent pair into the top-margin that
+// reads as the right break. This table is the single home of all spacing opinion.
+
+type FlowKind =
+  | "heading"
+  | "caption"
+  | "label"
+  | "text"
+  | "badge"
+  | "card"
+  | "callout"
+  | "table"
+  | "controlRow"
+  | "control"
+  | "divider"
+  | "block";
+
+const CONTROL_TYPES = new Set([
+  "Button",
+  "Input",
+  "Select",
+  "MultiSelect",
+  "Autocomplete",
+  "Checkbox",
+  "Radio",
+  "Toggle",
+  "Slider",
+  "Field",
+  "TagInput",
+  "DatePicker",
+  "ColorPicker",
+  "SegmentedControl",
+  "Rating",
+  "FilePicker",
+]);
+
+const SECTION_KINDS = new Set<FlowKind>(["card", "callout", "table"]);
+
+function isButtonRow(node: MosaicNode): boolean {
+  if (node.type !== "Stack" || node.props?.direction !== "horizontal") return false;
+  const kids = node.children ?? [];
+  return kids.length > 0 && kids.every((c) => c.type === "Button");
+}
+
+function flowKind(node: MosaicNode): FlowKind {
+  switch (node.type) {
+    case "Heading":
+      return "heading";
+    case "Text": {
+      const v = node.props?.variant;
+      return v === "caption" ? "caption" : v === "label" ? "label" : "text";
+    }
+    case "Badge":
+    case "Tag":
+      return "badge";
+    case "Card":
+      return "card";
+    case "Callout":
+      return "callout";
+    case "DataTable":
+      return "table";
+    case "Divider":
+      return "divider";
+    case "Stack":
+      return isButtonRow(node) ? "controlRow" : "block";
+    default:
+      return CONTROL_TYPES.has(node.type) ? "control" : "block";
+  }
+}
+
+/** The mt-* class that spaces `curr` under `prev` in a vertical flow. No prev (the
+ *  first child) never gets a margin. */
+function rhythm(prev: FlowKind | undefined, curr: FlowKind): string {
+  if (prev === undefined) return "";
+  if (curr === "label") return "mt-3"; // section break before a micro-label
+  if (prev === "label") return "mt-1.5"; // tight tie to what the label introduces
+  if (prev === "heading" && (curr === "caption" || curr === "text")) return "mt-0.5";
+  if (prev === "badge" && curr === "badge") return "mt-1.5"; // a tight status stack
+  if (prev === "card" && curr === "card") return "mt-2"; // grouped action rows
+  if ((SECTION_KINDS.has(prev) || SECTION_KINDS.has(curr)) && prev !== curr) return "mt-3";
+  if (prev === "text" && curr === "controlRow") return "mt-2.5"; // message, then buttons
+  return "mt-2";
+}
+
+const childKey = (child: React.ReactNode, i: number): string =>
+  React.isValidElement(child) && child.key != null ? child.key : `flow-${i}`;
+
+/** Renders a vertical flow: each child is spaced from its predecessor by rhythm().
+ *  `node.children[i]` classifies the rendered `children[i]`. */
+function Flow({
+  node,
+  children,
+  className,
+}: {
+  node: MosaicNode;
+  children: React.ReactNode[];
+  className?: string;
+}): React.ReactNode {
+  const kids = node.children ?? [];
+  let prev: FlowKind | undefined;
+  const rows = children.map((child, i) => {
+    const source = kids[i];
+    const curr = source ? flowKind(source) : "block";
+    const mt = rhythm(prev, curr);
+    prev = curr;
+    return (
+      <div key={childKey(child, i)} className={cn("min-w-0", mt)}>
+        {child}
+      </div>
+    );
+  });
+  return <div className={className}>{rows}</div>;
+}
+
+// A header cluster pairs a leading Icon with a multi-line block (a Stack that owns
+// a Heading). The icon should ride the first line, not float centered against the
+// whole block, so the row aligns to the top with a small optical drop on the icon.
+function containsHeading(node: MosaicNode): boolean {
+  return node.type === "Heading" || (node.children ?? []).some(containsHeading);
+}
+function pairsIconWithHeading(kids: MosaicNode[]): boolean {
+  return (
+    kids.some((c) => c.type === "Icon") &&
+    kids.some((c) => c.type !== "Icon" && containsHeading(c))
+  );
+}
+
+// --- layout ---------------------------------------------------------------------
+
+function Stack({ node, props, children }: MosaicBlockProps<BlockPropTypes["Stack"]>) {
+  if (props.direction !== "horizontal") {
+    return (
+      <Flow
+        node={node}
+        className={cn("flex min-w-0 flex-col", ALIGN[props.align ?? ""], JUSTIFY[props.justify ?? ""])}
+      >
+        {children}
+      </Flow>
+    );
+  }
+  const kids = node.children ?? [];
+  const allButtons = kids.length > 0 && kids.every((c) => c.type === "Button");
+  const iconLede = pairsIconWithHeading(kids);
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-row flex-wrap",
+        allButtons ? "gap-1.5" : "gap-2",
+        iconLede ? "items-start" : (ALIGN[props.align ?? ""] ?? "items-center"),
+        JUSTIFY[props.justify ?? ""],
+      )}
+    >
+      {iconLede
+        ? children.map((child, i) =>
+            kids[i]?.type === "Icon" ? (
+              <span key={childKey(child, i)} className="mt-0.5 flex shrink-0">
+                {child}
+              </span>
+            ) : (
+              child
+            ),
+          )
+        : children}
+    </div>
+  );
+}
+
+function Grid({ props, children }: MosaicBlockProps<BlockPropTypes["Grid"]>) {
+  // Children without explicit spans divide the grid equally, so a 12-col Grid
+  // with three Stats renders three real columns (never twelve thin ones).
+  const count = Math.max(React.Children.count(children), 1);
+  const cols = Math.min(count, props.cols ?? 12);
+  return (
+    <div
+      className="grid items-stretch gap-2"
+      style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Box({ children }: MosaicBlockProps) {
+  return <div className="min-w-0">{children}</div>;
+}
+
+// tone -> tinted surface (the inset status panel: a green "handled" section, an
+// amber "needs attention" strip). Untinted cards keep the default surface.
+const CARD_TONE: Record<string, string> = {
+  ok: "border-success/25 bg-success/8",
+  warn: "border-warning/25 bg-warning/8",
+  bad: "border-destructive/25 bg-destructive/8",
+  primary: "border-primary/25 bg-primary/8",
+  subtle: "border-transparent bg-muted/50",
+};
+
+function Card({ node, props, children, events }: MosaicBlockProps<BlockPropTypes["Card"]>) {
+  const clickable = Boolean(events.click);
+  return (
+    <UICard
+      className={cn(
+        // Tighter than a standalone card: an artifact is embedded in a chat
+        // message, so it reads as a compact surface, not a full page panel.
+        "rounded-xl p-3",
+        CARD_TONE[props.tone ?? ""],
+        clickable && "cursor-pointer transition-colors hover:border-ring/40",
+      )}
+      onClick={events.click}
+      onKeyUp={clickable ? (e) => e.key === "Enter" && events.click?.() : undefined}
+      tabIndex={clickable ? 0 : undefined}
+    >
+      <Flow node={node}>{children}</Flow>
+    </UICard>
+  );
+}
+
+function Divider() {
+  return <Separator />;
+}
+
+// --- content --------------------------------------------------------------------
+
+function Heading({ props, children }: MosaicBlockProps<BlockPropTypes["Heading"]>) {
+  const level = Math.min(Math.max(props.level ?? 2, 1), 6);
+  const Tag = `h${level}` as "h2";
+  const size =
+    level === 1 ? "text-xl" : level === 2 ? "text-lg" : level === 3 ? "text-base" : "text-sm";
+  return (
+    <Tag className={cn(size, "text-balance font-semibold text-foreground tracking-tight")}>
+      {children}
+    </Tag>
+  );
+}
+
+// variant is the semantic type ramp: body is prose; label is a section
+// micro-label; caption is secondary supporting text. The host owns the scale.
+const TEXT_VARIANT: Record<string, string> = {
+  label: "text-[11px] font-medium uppercase leading-snug tracking-[0.08em]",
+  caption: "text-xs text-muted-foreground leading-snug",
+};
+
+function Text({ props, children }: MosaicBlockProps<BlockPropTypes["Text"]>) {
+  return (
+    <p
+      className={cn(
+        "leading-relaxed",
+        TONE_TEXT[props.tone ?? ""] ?? "text-foreground",
+        TEXT_VARIANT[props.variant ?? "body"],
+      )}
+    >
+      {children}
+    </p>
+  );
+}
+
+function Badge({ props, children }: MosaicBlockProps<BlockPropTypes["Badge"]>) {
+  return (
+    <UIBadge variant={BADGE_VARIANT[props.tone ?? ""] ?? "secondary"} className="gap-1 rounded-full">
+      {props.icon ? <MosaicIcon name={props.icon} className="size-3" /> : null}
+      {children}
+    </UIBadge>
+  );
+}
+
+function Avatar({ props }: MosaicBlockProps) {
+  const name = str(props.name) || str(props.initials);
+  const initials = name
+    .split(/\s+/)
+    .map((w) => w[0] ?? "")
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+  return (
+    <span className="inline-flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/15 font-medium text-primary text-sm">
+      {initials}
+    </span>
+  );
+}
+
+function Callout({ node, props, children }: MosaicBlockProps<BlockPropTypes["Callout"]>) {
+  const variant = CALLOUT_VARIANT[props.tone ?? ""] ?? "default";
+  const custom = props.icon;
+  const FallbackIcon =
+    variant === "success"
+      ? CircleCheck
+      : variant === "warning" || variant === "error"
+        ? TriangleAlert
+        : Info;
+  return (
+    // [&>div]:items-start tops the icon on the first text line instead of centering
+    // it against a multi-line body (message plus a trailing button row).
+    <Alert variant={variant} className="[&>div]:items-start">
+      {custom ? <MosaicIcon name={custom} /> : <FallbackIcon />}
+      <AlertDescription className={cn("leading-relaxed", CALLOUT_DESC[variant])}>
+        <Flow node={node}>{children}</Flow>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+function Link({ props, children }: MosaicBlockProps) {
+  return (
+    <a
+      href={str(props.href)}
+      className="text-primary underline-offset-4 hover:underline"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {React.Children.count(children) > 0 ? children : str(props.href)}
+    </a>
+  );
+}
+
+// Code: a bare command / snippet block, given the app's .chat-markdown-codeblock
+// treatment (scoped under .chat-markdown).
+function Code({ props, children }: MosaicBlockProps) {
+  return (
+    <div className="chat-markdown">
+      <div className="chat-markdown-codeblock" data-wrap="true">
+        <pre>
+          <code className="font-mono text-xs">
+            {str(props.value)}
+            {children}
+          </code>
+        </pre>
+      </div>
+    </div>
+  );
+}
+
+/** Flatten rendered children back to their source text, so `<Markdown>` can
+ *  render markdown passed as children (`<Markdown>**bold**</Markdown>`), not
+ *  just via a `value` prop. */
+function nodeText(node: React.ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(nodeText).join("");
+  if (React.isValidElement(node)) {
+    return nodeText((node.props as { children?: React.ReactNode }).children);
+  }
+  return "";
+}
+
+function Markdown({ props, children }: MosaicBlockProps) {
+  const src = str(props.value) || nodeText(children);
+  return (
+    <div className="chat-markdown">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{src}</ReactMarkdown>
+    </div>
+  );
+}
+
+// --- controls ---------------------------------------------------------------------
+
+function Button({ props, children, events }: MosaicBlockProps<BlockPropTypes["Button"]>) {
+  return (
+    <UIButton
+      variant={BUTTON_VARIANT[props.variant ?? ""] ?? "secondary"}
+      size="sm"
+      onClick={events.click}
+    >
+      {props.icon ? <MosaicIcon name={props.icon} /> : null}
+      {children}
+    </UIButton>
+  );
+}
+
+function Input({ props, value, setValue }: MosaicBlockProps) {
+  const label = str(props.label);
+  const id = React.useId();
+  const current = str((value as PV) ?? props.value);
+  const placeholder = str(props.placeholder) || undefined;
+
+  if (props.multiline) {
+    // Textarea uses Base UI Field.Control, so it must live inside a Field.
+    return (
+      <UIField>
+        {label ? <FieldLabel>{label}</FieldLabel> : null}
+        <Textarea
+          placeholder={placeholder}
+          {...(setValue
+            ? { value: current, onChange: (e) => setValue(e.target.value) }
+            : { defaultValue: current })}
+        />
+      </UIField>
+    );
+  }
+
+  const input = (
+    <UIInput
+      id={id}
+      type={str(props.type) || "text"}
+      size="sm"
+      placeholder={placeholder}
+      {...(setValue
+        ? { value: current, onValueChange: (v: string) => setValue(v) }
+        : { defaultValue: current })}
+    />
+  );
+  return label ? (
+    <div className="flex min-w-0 flex-col gap-2">
+      <label htmlFor={id} className={LABEL}>
+        {label}
+      </label>
+      {input}
+    </div>
+  ) : (
+    input
+  );
+}
+
+function Select({ props, value, setValue }: MosaicBlockProps) {
+  const options = strs(props.options);
+  const label = str(props.label);
+  const current = str((value as PV) ?? props.value);
+  const el = (
+    <UISelect
+      {...(setValue
+        ? { value: current, onValueChange: (v: unknown) => setValue(str(v as PV)) }
+        : { defaultValue: current || undefined })}
+    >
+      <SelectTrigger size="sm">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectPopup>
+        {options.map((o) => (
+          <SelectItem key={o} value={o}>
+            {o}
+          </SelectItem>
+        ))}
+      </SelectPopup>
+    </UISelect>
+  );
+  return label ? (
+    <div className="flex min-w-0 flex-col gap-2">
+      <span className={LABEL}>{label}</span>
+      {el}
+    </div>
+  ) : (
+    el
+  );
+}
+
+function Checkbox({ props, value, setValue }: MosaicBlockProps) {
+  const id = React.useId();
+  const checked = Boolean(value ?? props.checked ?? props.value);
+  return (
+    <div className="flex items-start gap-2.5 text-sm leading-snug">
+      <UICheckbox
+        id={id}
+        className="mt-0.5"
+        {...(setValue
+          ? { checked, onCheckedChange: (c: boolean) => setValue(c) }
+          : { defaultChecked: Boolean(props.checked ?? props.value) })}
+      />
+      <label htmlFor={id} className="cursor-pointer">
+        {str(props.label)}
+      </label>
+    </div>
+  );
+}
+
+function Radio({ props, value, setValue }: MosaicBlockProps) {
+  const options = strs(props.options);
+  const label = str(props.label);
+  const base = React.useId();
+  const current = str((value as PV) ?? props.value);
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      {label ? <span className={LABEL}>{label}</span> : null}
+      <RadioGroup
+        className="gap-2"
+        {...(setValue
+          ? { value: current, onValueChange: (v: unknown) => setValue(str(v as PV)) }
+          : { defaultValue: current || undefined })}
+      >
+        {options.map((o, i) => {
+          const id = `${base}-${i}`;
+          return (
+            <div key={o} className="flex items-center gap-2.5 text-sm">
+              <UIRadio id={id} value={o} />
+              <label htmlFor={id} className="cursor-pointer">
+                {o}
+              </label>
+            </div>
+          );
+        })}
+      </RadioGroup>
+    </div>
+  );
+}
+
+function Toggle({ props, value, setValue }: MosaicBlockProps) {
+  const id = React.useId();
+  const on = Boolean(value ?? props.checked ?? props.value);
+  return (
+    <div className="flex items-center gap-2.5 text-sm">
+      <Switch
+        id={id}
+        {...(setValue
+          ? { checked: on, onCheckedChange: (c: boolean) => setValue(c) }
+          : { defaultChecked: Boolean(props.checked ?? props.value) })}
+      />
+      <label htmlFor={id} className="cursor-pointer">
+        {str(props.label)}
+      </label>
+    </div>
+  );
+}
+
+// t3code has no ui/slider yet, so this is a token-styled native range input.
+// accent-primary paints the track fill from the primary token.
+function Slider({ props, value, setValue }: MosaicBlockProps) {
+  const label = str(props.label);
+  const bound = Boolean(setValue);
+  const [local, setLocal] = React.useState<number>(() => num(props.value));
+  const v = bound ? num(value as PV) : local;
+  const write = (n: number) => (setValue ? setValue(n) : setLocal(n));
+  const slider = (
+    <div className="flex items-center gap-2.5">
+      <input
+        type="range"
+        min={num(props.min)}
+        max={num(props.max, 100)}
+        step={num(props.step, 1)}
+        value={v}
+        onChange={(e) => write(Number(e.target.value))}
+        className="h-1.5 w-full min-w-32 flex-1 cursor-pointer appearance-none rounded-full bg-muted accent-primary outline-none"
+      />
+      <span className="w-10 shrink-0 text-right font-mono text-muted-foreground text-xs">{v}</span>
+    </div>
+  );
+  return label ? (
+    <div className="flex min-w-0 flex-col gap-2">
+      <span className={LABEL}>{label}</span>
+      {slider}
+    </div>
+  ) : (
+    slider
+  );
+}
+
+function Field({ props, children }: MosaicBlockProps) {
+  const help = str(props.help);
+  const label = str(props.label);
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      {label ? <span className={LABEL}>{label}</span> : null}
+      {children}
+      {help ? <span className="text-muted-foreground text-xs">{help}</span> : null}
+    </div>
+  );
+}
+
+function MultiSelect({ props, value, setValue }: MosaicBlockProps) {
+  const options = strs(props.options);
+  const label = str(props.label);
+  const selected = strs((value as PV) ?? props.value);
+  const el = (
+    <Combobox
+      items={options}
+      multiple
+      {...(setValue
+        ? {
+            value: selected,
+            onValueChange: (v: unknown) =>
+              setValue((Array.isArray(v) ? v : []).map((x) => str(x as PV))),
+          }
+        : { defaultValue: selected })}
+    >
+      <ComboboxChips>
+        <ComboboxValue>
+          {(vals: unknown) =>
+            (Array.isArray(vals) ? vals : []).map((v) => (
+              <ComboboxChip key={str(v as PV)}>{str(v as PV)}</ComboboxChip>
+            ))
+          }
+        </ComboboxValue>
+        <ComboboxChipsInput placeholder={str(props.placeholder) || "Select..."} />
+      </ComboboxChips>
+      <ComboboxPopup>
+        <ComboboxEmpty>No options.</ComboboxEmpty>
+        <ComboboxList>
+          {(item: unknown) => (
+            <ComboboxItem key={str(item as PV)} value={item as string}>
+              {str(item as PV)}
+            </ComboboxItem>
+          )}
+        </ComboboxList>
+      </ComboboxPopup>
+    </Combobox>
+  );
+  return label ? (
+    <div className="flex min-w-0 flex-col gap-2">
+      <span className={LABEL}>{label}</span>
+      {el}
+    </div>
+  ) : (
+    el
+  );
+}
+
+function Autocomplete({ props, value, setValue }: MosaicBlockProps) {
+  const options = strs(props.options);
+  const label = str(props.label);
+  const current = str((value as PV) ?? props.value);
+  const el = (
+    <UIAutocomplete
+      items={options}
+      {...(setValue
+        ? { value: current, onValueChange: (v: string) => setValue(v) }
+        : { defaultValue: current })}
+    >
+      <AutocompleteInput size="sm" placeholder={str(props.placeholder) || undefined} />
+      <AutocompletePopup>
+        <AutocompleteEmpty>No matches.</AutocompleteEmpty>
+        <AutocompleteList>
+          {(item: unknown) => (
+            <AutocompleteItem key={str(item as PV)} value={item as string}>
+              {str(item as PV)}
+            </AutocompleteItem>
+          )}
+        </AutocompleteList>
+      </AutocompletePopup>
+    </UIAutocomplete>
+  );
+  return label ? (
+    <div className="flex min-w-0 flex-col gap-2">
+      <span className={LABEL}>{label}</span>
+      {el}
+    </div>
+  ) : (
+    el
+  );
+}
+
+function TagInput({ props, value, setValue }: MosaicBlockProps) {
+  const label = str(props.label);
+  const bound = Boolean(setValue);
+  const [local, setLocal] = React.useState<string[]>(() => strs(props.value));
+  const tags = bound ? strs(value as PV) : local;
+  const write = React.useCallback(
+    (next: string[]) => (setValue ? setValue(next) : setLocal(next)),
+    [setValue],
+  );
+  const [draft, setDraft] = React.useState("");
+  const commit = () => {
+    const tag = draft.trim();
+    if (tag && !tags.includes(tag)) write([...tags, tag]);
+    setDraft("");
+  };
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      {label ? <span className={LABEL}>{label}</span> : null}
+      <div className="flex min-h-9 w-full flex-wrap items-center gap-1.5 rounded-lg border border-input bg-background px-2.5 py-1.5 shadow-xs/5 transition-shadow focus-within:border-ring focus-within:ring-[3px] focus-within:ring-ring/24 dark:bg-input/32">
+        {tags.map((tag) => (
+          <UIBadge key={tag} variant="secondary" className="gap-1 pe-1">
+            {tag}
+            <button
+              type="button"
+              aria-label={`remove ${tag}`}
+              onClick={() => write(tags.filter((x) => x !== tag))}
+              className="opacity-70 transition-opacity hover:opacity-100"
+            >
+              <X className="size-3" />
+            </button>
+          </UIBadge>
+        ))}
+        <input
+          type="text"
+          value={draft}
+          placeholder={tags.length === 0 ? str(props.placeholder) || "Add..." : undefined}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === ",") {
+              e.preventDefault();
+              commit();
+            } else if (e.key === "Backspace" && draft === "" && tags.length > 0) {
+              write(tags.slice(0, -1));
+            }
+          }}
+          onBlur={commit}
+          className="min-w-20 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/72"
+        />
+      </div>
+    </div>
+  );
+}
+
+function DatePicker({ props, value, setValue }: MosaicBlockProps) {
+  const label = str(props.label);
+  const id = React.useId();
+  const current = str((value as PV) ?? props.value);
+  const input = (
+    <UIInput
+      id={id}
+      type="date"
+      size="sm"
+      className="w-fit"
+      {...(setValue
+        ? { value: current, onValueChange: (v: string) => setValue(v) }
+        : { defaultValue: current })}
+    />
+  );
+  return label ? (
+    <div className="flex min-w-0 flex-col gap-2">
+      <label htmlFor={id} className={LABEL}>
+        {label}
+      </label>
+      {input}
+    </div>
+  ) : (
+    input
+  );
+}
+
+function ColorPicker({ props, value, setValue }: MosaicBlockProps) {
+  const label = str(props.label);
+  const id = React.useId();
+  const current = str((value as PV) ?? props.value) || "#7c7cff";
+  return (
+    <div className="flex min-w-0 flex-col gap-2">
+      {label ? (
+        <label htmlFor={id} className={LABEL}>
+          {label}
+        </label>
+      ) : null}
+      <div className="flex items-center gap-2.5">
+        <input
+          id={id}
+          type="color"
+          className="size-8 cursor-pointer rounded-md border border-input bg-transparent p-0.5"
+          {...(setValue
+            ? { value: current, onChange: (e) => setValue(e.target.value) }
+            : { defaultValue: current })}
+        />
+        <code className="font-mono text-muted-foreground text-xs">{current}</code>
+      </div>
+    </div>
+  );
+}
+
+// --- structure & status ---------------------------------------------------------
+
+function SegmentedControl({ props, value, setValue }: MosaicBlockProps) {
+  const options = strs(props.options);
+  const current = str((value as PV) ?? props.value);
+  return (
+    <ToggleGroup
+      variant="outline"
+      size="sm"
+      className="w-fit"
+      {...(setValue
+        ? {
+            value: [current],
+            onValueChange: (v: unknown) => {
+              const list = Array.isArray(v) ? v : [];
+              const last = list[list.length - 1];
+              if (last !== undefined) setValue(str(last as PV));
+            },
+          }
+        : { defaultValue: current ? [current] : [] })}
+    >
+      {options.map((o) => (
+        <ToggleGroupItem key={o} value={o}>
+          {o}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  );
+}
+
+// t3code has no ui/tabs yet, so this is a token-styled pill tablist, controlled
+// via bind:state or its own local state when unbound.
+function Tabs({ props, children, value, setValue }: MosaicBlockProps) {
+  const labels = strs(props.items);
+  const active = props.active;
+  const defaultLabel =
+    typeof active === "number" ? (labels[active] ?? labels[0]) : str(active) || labels[0];
+  const panels = React.Children.toArray(children);
+  const bound = Boolean(setValue);
+  const [local, setLocal] = React.useState<string>(defaultLabel ?? "");
+  const current = bound ? str(value as PV) || (defaultLabel ?? "") : local;
+  const select = (label: string) => (setValue ? setValue(label) : setLocal(label));
+  const activeIndex = Math.max(labels.indexOf(current), 0);
+  return (
+    <div className="flex min-w-0 flex-col gap-2.5">
+      <div role="tablist" className="flex w-fit gap-1 rounded-lg bg-muted p-1">
+        {labels.map((label) => {
+          const isActive = label === current;
+          return (
+            <button
+              key={label}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => select(label)}
+              className={cn(
+                "cursor-pointer whitespace-nowrap rounded-md px-3 py-1 font-medium text-sm outline-none transition-colors",
+                isActive
+                  ? "bg-background text-foreground shadow-xs/5"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+      <div role="tabpanel">{panels[activeIndex] ?? null}</div>
+    </div>
+  );
+}
+
+// t3code has no ui/progress yet, so this is a token-styled track + fill.
+function Progress({ props }: MosaicBlockProps) {
+  const value = Math.min(Math.max(num(props.value), 0), 100);
+  const label = str(props.label);
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label ? <span className="text-muted-foreground text-xs">{label}</span> : null}
+      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full rounded-full bg-primary transition-[width]"
+          style={{ width: `${value}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Steps({ props }: MosaicBlockProps) {
+  const items = strs(props.items);
+  const current = num(props.current, -1);
+  return (
+    <ol className="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-sm">
+      {items.map((item, i) => (
+        <li key={item} className="flex items-center gap-1.5">
+          {i > 0 ? <span className="text-muted-foreground/50">→</span> : null}
+          <span
+            className={cn(
+              i === current
+                ? "font-medium text-foreground"
+                : i < current
+                  ? "text-foreground/70"
+                  : "text-muted-foreground",
+            )}
+          >
+            <span
+              className={cn(
+                "me-1.5 inline-flex size-5 items-center justify-center rounded-full text-xs",
+                i < current
+                  ? "bg-success/15 text-success-foreground"
+                  : i === current
+                    ? "bg-primary/15 text-primary"
+                    : "bg-muted text-muted-foreground",
+              )}
+            >
+              {i + 1}
+            </span>
+            {item}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function Empty({ props, children }: MosaicBlockProps) {
+  return (
+    <UIEmpty className="gap-2 rounded-lg border border-dashed p-6 text-muted-foreground text-sm">
+      {str(props.label) || (React.Children.count(children) === 0 ? "Nothing here yet." : null)}
+      {children}
+    </UIEmpty>
+  );
+}
+
+// --- data & viz -------------------------------------------------------------------
+
+function Stat({ props }: MosaicBlockProps<BlockPropTypes["Stat"]>) {
+  return (
+    <div className={cn("min-w-0", TONE_TEXT[props.tone ?? ""])}>
+      <div className="whitespace-nowrap font-[650] text-[1.125rem] leading-tight tracking-[-0.02em]">
+        {props.value}
+      </div>
+      <div className="mt-0.5 text-[11px] text-muted-foreground">{props.label}</div>
+    </div>
+  );
+}
+
+function DataTable({ props }: MosaicBlockProps) {
+  const columns = strs(props.columns);
+  const rows = arr(props.rows).map((r) => (Array.isArray(r) ? r.map((c) => str(c)) : [str(r)]));
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <Table>
+        <TableHeader>
+          <TableRow className="hover:bg-transparent">
+            {columns.map((c) => (
+              <TableHead
+                key={c}
+                className="text-[10.5px] text-muted-foreground uppercase tracking-wider"
+              >
+                {c}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row) => (
+            <TableRow key={row.join("")}>
+              {row.map((cell, ci) => (
+                <TableCell
+                  key={columns[ci] ?? cell}
+                  className="whitespace-normal align-top leading-snug"
+                >
+                  {cell}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+
+function Timeline({ props }: MosaicBlockProps) {
+  const items = arr(props.items);
+  return (
+    <ol className="flex flex-col gap-2">
+      {items.map((item) => {
+        const e = (item && typeof item === "object" && !Array.isArray(item) ? item : {}) as Record<
+          string,
+          PV
+        >;
+        const description = str(e.description);
+        return (
+          <li
+            key={`${str(e.date)}-${str(e.title)}`}
+            className="flex items-baseline gap-2.5 text-sm"
+          >
+            <span
+              className={cn("text-[0.6rem]", TONE_TEXT[str(e.tone)] ?? "text-muted-foreground/60")}
+            >
+              ●
+            </span>
+            <span className="w-14 shrink-0 font-mono text-muted-foreground text-xs">
+              {str(e.date)}
+            </span>
+            <span className="flex min-w-0 flex-col leading-snug">
+              <span>{str(e.title)}</span>
+              {description ? (
+                <span className="text-muted-foreground text-xs">{description}</span>
+              ) : null}
+            </span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function List({ node, children }: MosaicBlockProps) {
+  return (
+    <Flow node={node} className="flex min-w-0 flex-col">
+      {children}
+    </Flow>
+  );
+}
+
+function Chart({ props }: MosaicBlockProps) {
+  // Canonical data shape: [{ label, value }]. Any chart type degrades to labeled
+  // magnitude bars - a readable floor when a richer chart is not drawn.
+  const data = arr(props.data).map(rec);
+  if (data.length === 0) {
+    return <p className="text-muted-foreground text-sm">{str(props.alt)}</p>;
+  }
+  const values = data.map((d) => num(d.value));
+  const labels = data.map((d) => str(d.label));
+  const max = Math.max(...values, 1);
+  return (
+    <div role="img" aria-label={str(props.alt)} className="flex flex-col gap-1.5">
+      <div className="flex items-end gap-3 border-border border-b">
+        {values.map((v, i) => (
+          <div
+            key={labels[i]}
+            className="flex min-w-0 flex-1 flex-col justify-end gap-1.5 text-center"
+          >
+            <div className="whitespace-nowrap font-mono text-[10px] text-muted-foreground">
+              {Number.isInteger(v) ? v : v.toFixed(2)}
+            </div>
+            <div
+              className="rounded-t-sm bg-primary"
+              style={{ height: `${Math.max(Math.round((v / max) * 120), 3)}px` }}
+            />
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-3">
+        {labels.map((label) => (
+          <div
+            key={label}
+            className="min-w-0 flex-1 truncate text-center font-mono text-[10px] text-muted-foreground"
+          >
+            {label}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Diagram: declarative nodes/edges/groups. Geometry comes from @mosaicjs/react's
+// exported layoutDiagram (deterministic, dependency-free); the paint is entirely
+// this app's - token colors, ui-kit radii. Selection is the standard contract:
+// clicking a node writes its id to the bound path (setValue), the background
+// writes null, and an authored on:event select escalates through events.select
+// like any other named intent.
+
+const DIAGRAM_TONE: Record<string, string> = {
+  ok: "var(--success)",
+  warn: "var(--warning)",
+  bad: "var(--destructive)",
+  primary: "var(--primary)",
+};
+const DIAGRAM_TONE_TEXT: Record<string, string> = {
+  ok: "var(--success-foreground)",
+  warn: "var(--warning-foreground)",
+  bad: "var(--destructive-foreground)",
+  primary: "var(--primary)",
+};
+const DIAGRAM_NODE_STROKE: Record<string, string> = {
+  ok: "stroke-success/45",
+  warn: "stroke-warning/55",
+  bad: "stroke-destructive/45",
+  primary: "stroke-primary/45",
+};
+
+const mixt = (color: string, pct: number): string =>
+  `color-mix(in srgb, ${color} ${pct}%, transparent)`;
+
+const rec = (v: PV | undefined): Record<string, PV> =>
+  v !== null && v !== undefined && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, PV>)
+    : {};
+
+// A horizontal flow wider than this scales below readability in the chat
+// column, so an unspecified direction flips to vertical instead of shrinking.
+const DIAGRAM_MAX_HORIZONTAL_WIDTH = 680;
+
+function Diagram({ props, value, setValue, events }: MosaicBlockProps) {
+  const markerBase = `dg-arrow-${React.useId().replace(/[^a-zA-Z0-9_-]/g, "")}`;
+  let layout = layoutDiagram({
+    direction: props.direction,
+    nodes: props.nodes,
+    edges: props.edges,
+    groups: props.groups,
+  });
+  if (props.direction === undefined && layout.width > DIAGRAM_MAX_HORIZONTAL_WIDTH) {
+    layout = layoutDiagram({
+      direction: "down",
+      nodes: props.nodes,
+      edges: props.edges,
+      groups: props.groups,
+    });
+  }
+
+  const nodeMeta = new Map<string, Record<string, PV>>();
+  for (const n of arr(props.nodes)) {
+    const m = rec(n);
+    const id = str(m.id);
+    if (id && !nodeMeta.has(id)) nodeMeta.set(id, m);
+  }
+  const groupMeta = new Map<string, Record<string, PV>>();
+  for (const g of arr(props.groups)) groupMeta.set(str(rec(g).id), rec(g));
+  // layoutDiagram drops edges with unknown endpoints; mirror its filter so the
+  // authored metadata (tone, dashed, label) zips 1:1 with layout.edges.
+  const anchored = new Set([...layout.nodes, ...layout.groups].map((r) => r.id));
+  const edgeMeta = arr(props.edges)
+    .map(rec)
+    .filter((e) => anchored.has(str(e.from)) && anchored.has(str(e.to)));
+
+  const interactive = Boolean(setValue) || Boolean(events.select);
+  const selected = value === null || value === undefined ? null : str(value as PV);
+  const pick = (id: string) => {
+    setValue?.(id);
+    events.select?.();
+  };
+
+  // One arrowhead marker per distinct edge color, collected while edges render.
+  const markerColors: string[] = [];
+  const markerId = (color: string): string => {
+    let i = markerColors.indexOf(color);
+    if (i === -1) i = markerColors.push(color) - 1;
+    return `${markerBase}-${i}`;
+  };
+
+  const hulls = layout.groups.map((r) => {
+    const meta = groupMeta.get(r.id) ?? {};
+    const tone = DIAGRAM_TONE[str(meta.tone)];
+    return (
+      <g key={`group-${r.id}`}>
+        <rect
+          x={r.x}
+          y={r.y}
+          width={r.w}
+          height={r.h}
+          rx={12}
+          strokeDasharray="3 4"
+          style={{
+            fill: mixt(tone ?? "var(--foreground)", 3),
+            stroke: mixt(tone ?? "var(--foreground)", 14),
+          }}
+        />
+        <text
+          x={r.x + 12}
+          y={r.y + 16}
+          fontSize={9.5}
+          letterSpacing="0.08em"
+          className="fill-muted-foreground font-medium uppercase"
+          style={tone ? { fill: DIAGRAM_TONE_TEXT[str(meta.tone)] } : undefined}
+        >
+          {str(meta.label) || r.id}
+        </text>
+      </g>
+    );
+  });
+
+  const edgeEls = layout.edges.map((edge, i) => {
+    const meta = edgeMeta[i] ?? {};
+    const tone = DIAGRAM_TONE[str(meta.tone)];
+    const color = tone ? mixt(tone, 65) : mixt("var(--muted-foreground)", 50);
+    const [p0, p1, p2] = edge.points;
+    if (!p0 || !p1) return null;
+    const d = p2
+      ? `M ${p0.x} ${p0.y} Q ${p1.x} ${p1.y} ${p2.x} ${p2.y}`
+      : `M ${p0.x} ${p0.y} L ${p1.x} ${p1.y}`;
+    const mid = p2
+      ? { x: 0.25 * p0.x + 0.5 * p1.x + 0.25 * p2.x, y: 0.25 * p0.y + 0.5 * p1.y + 0.25 * p2.y }
+      : { x: (p0.x + p1.x) / 2, y: (p0.y + p1.y) / 2 };
+    const label = str(meta.label);
+    return (
+      <g key={`edge-${edge.from}-${edge.to}`}>
+        <path
+          d={d}
+          fill="none"
+          strokeWidth={1.25}
+          strokeDasharray={meta.dashed === true ? "5 4" : undefined}
+          markerEnd={`url(#${markerId(color)})`}
+          markerStart={meta.bidirectional === true ? `url(#${markerId(color)})` : undefined}
+          style={{ stroke: color }}
+        />
+        {label ? (
+          <text
+            x={mid.x}
+            y={mid.y - 5}
+            textAnchor="middle"
+            fontSize={9.5}
+            className="fill-muted-foreground font-mono"
+          >
+            {label}
+          </text>
+        ) : null}
+      </g>
+    );
+  });
+
+  const nodeEls = layout.nodes.map((r) => {
+    const meta = nodeMeta.get(r.id) ?? {};
+    const toneKey = str(meta.tone);
+    const tone = DIAGRAM_TONE[toneKey];
+    const isSelected = selected !== null && selected === r.id;
+    const label = str(meta.label) || r.id;
+    const sublabel = str(meta.sublabel);
+    const kind = str(meta.kind);
+    const badge = str(meta.badge);
+    const badgeW = Math.round(badge.length * 6.2 + 14);
+    return (
+      <g
+        key={r.id}
+        data-node-id={r.id}
+        className={interactive ? "group/node cursor-pointer" : undefined}
+        onClick={
+          interactive
+            ? (e) => {
+                e.stopPropagation();
+                pick(r.id);
+              }
+            : undefined
+        }
+      >
+        {isSelected ? (
+          <rect
+            x={r.x - 2.5}
+            y={r.y - 2.5}
+            width={r.w + 5}
+            height={r.h + 5}
+            rx={11}
+            fill="none"
+            strokeWidth={3}
+            style={{ stroke: mixt("var(--ring)", 24) }}
+          />
+        ) : null}
+        <rect
+          x={r.x}
+          y={r.y}
+          width={r.w}
+          height={r.h}
+          rx={9}
+          strokeWidth={isSelected ? 1.6 : 1}
+          className={cn(
+            isSelected ? "stroke-primary" : (DIAGRAM_NODE_STROKE[toneKey] ?? "stroke-border"),
+            interactive && !isSelected && "transition-[stroke] group-hover/node:stroke-ring/60",
+          )}
+          style={{
+            fill: tone
+              ? `color-mix(in srgb, ${tone} 9%, var(--card))`
+              : "color-mix(in srgb, var(--foreground) 4%, var(--card))",
+          }}
+        />
+        <text
+          x={r.x + 13}
+          y={r.y + (sublabel || kind ? r.h / 2 - 6 : r.h / 2)}
+          dominantBaseline="central"
+          fontSize={12}
+          className={cn("fill-foreground font-medium", kind === "code" && "font-mono")}
+        >
+          {label}
+        </text>
+        {sublabel ? (
+          <text
+            x={r.x + 13}
+            y={r.y + r.h / 2 + 9}
+            dominantBaseline="central"
+            fontSize={10}
+            className="fill-muted-foreground"
+          >
+            {sublabel}
+          </text>
+        ) : kind ? (
+          <text
+            x={r.x + 13}
+            y={r.y + r.h / 2 + 9}
+            dominantBaseline="central"
+            fontSize={8}
+            letterSpacing="0.08em"
+            className="fill-muted-foreground uppercase"
+          >
+            {kind}
+          </text>
+        ) : null}
+        {badge ? (
+          <g>
+            <rect
+              x={r.x + r.w - badgeW - 6}
+              y={r.y - 9}
+              width={badgeW}
+              height={17}
+              rx={8.5}
+              style={{
+                fill: "var(--card)",
+                stroke: tone ? mixt(tone, 45) : "var(--border)",
+              }}
+            />
+            <text
+              x={r.x + r.w - 6 - badgeW / 2}
+              y={r.y - 0.5}
+              textAnchor="middle"
+              fontSize={9}
+              className="font-mono"
+              style={{ fill: DIAGRAM_TONE_TEXT[toneKey] ?? "var(--muted-foreground)" }}
+            >
+              {badge}
+            </text>
+          </g>
+        ) : null}
+      </g>
+    );
+  });
+
+  return (
+    // Natural size inside a scroll container: a diagram slightly wider than
+    // the column pans instead of scaling its labels below readability.
+    <div className="max-w-full overflow-x-auto">
+      <svg
+        role="img"
+        aria-label={str(props.alt)}
+        width={layout.width}
+        height={layout.height}
+        viewBox={`0 0 ${layout.width} ${layout.height}`}
+        className="block"
+      >
+        <defs>
+          {markerColors.map((color, i) => (
+            <marker
+              key={color}
+              id={`${markerBase}-${i}`}
+              viewBox="0 0 10 10"
+              refX={9}
+              refY={5}
+              markerWidth={7}
+              markerHeight={7}
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" style={{ fill: color }} />
+            </marker>
+          ))}
+        </defs>
+        <rect
+          x={0}
+          y={0}
+          width={layout.width}
+          height={layout.height}
+          fill="transparent"
+          onClick={interactive && setValue ? () => setValue(null) : undefined}
+        />
+        {hulls}
+        {edgeEls}
+        {nodeEls}
+      </svg>
+    </div>
+  );
+}
+
+// --- media ----------------------------------------------------------------------
+
+/** Shared graceful surface for a block whose real render needs a source or a
+ *  dependency we deliberately keep out of the artifact renderer (a missing image,
+ *  a Vega spec, a Canvas SVG). Shows the alt so meaning never disappears. */
+function BlockPlaceholder({
+  icon,
+  label,
+  hint,
+}: {
+  icon: string;
+  label: string;
+  hint?: string;
+}): React.ReactNode {
+  return (
+    <div className="flex flex-col items-center justify-center gap-1.5 rounded-xl border border-dashed p-6 text-center text-muted-foreground">
+      <MosaicIcon name={icon} className="size-5 opacity-70" />
+      {label ? <span className="text-sm">{label}</span> : null}
+      {hint ? <span className="text-[11px] opacity-70">{hint}</span> : null}
+    </div>
+  );
+}
+
+function ImageBlock({ props }: MosaicBlockProps<BlockPropTypes["Image"]>) {
+  const src = str(props.src);
+  const alt = str(props.alt);
+  if (!src) return <BlockPlaceholder icon="image" label={alt} />;
+  // A model-authored URL rendered as data, not markup: a plain <img> keeps the
+  // artifact renderer free of any framework image pipeline.
+  return (
+    <img src={src} alt={alt} loading="lazy" className="max-h-80 w-full rounded-xl border object-contain" />
+  );
+}
+
+function VideoBlock({ props }: MosaicBlockProps<BlockPropTypes["Video"]>) {
+  const src = str(props.src);
+  const alt = str(props.alt);
+  if (!src) return <BlockPlaceholder icon="film" label={alt} />;
+  return (
+    <video src={src} controls aria-label={alt || undefined} className="max-h-96 w-full rounded-xl border">
+      <track kind="captions" />
+    </video>
+  );
+}
+
+function AudioBlock({ props }: MosaicBlockProps<BlockPropTypes["Audio"]>) {
+  const src = str(props.src);
+  const alt = str(props.alt);
+  if (!src) return <BlockPlaceholder icon="volume-2" label={alt} />;
+  return <audio src={src} controls aria-label={alt || undefined} className="w-full" />;
+}
+
+function Carousel({ children }: MosaicBlockProps) {
+  const slides = React.Children.toArray(children);
+  if (slides.length === 0) return null;
+  return (
+    <div className="-mx-1 flex snap-x snap-mandatory gap-3 overflow-x-auto px-1 pb-2">
+      {slides.map((slide, i) => (
+        <div
+          key={childKey(slide, i)}
+          className="min-w-0 shrink-0 basis-[86%] snap-start sm:basis-[46%]"
+        >
+          {slide}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// --- controls -------------------------------------------------------------------
+
+function Rating({ props, value, setValue }: MosaicBlockProps) {
+  const max = Math.min(Math.max(num(props.max, 5), 1), 10);
+  const label = str(props.label);
+  const bound = Boolean(setValue);
+  const [local, setLocal] = React.useState(0);
+  const current = bound ? num(value as PV) : local;
+  const set = (n: number) => (setValue ? setValue(n) : setLocal(n));
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label ? <span className={LABEL}>{label}</span> : null}
+      <div className="flex items-center gap-0.5">
+        {Array.from({ length: max }, (_, i) => i + 1).map((n) => (
+          <button
+            key={n}
+            type="button"
+            onClick={() => set(n)}
+            aria-label={`Rate ${n} of ${max}`}
+            className="cursor-pointer text-muted-foreground/40 transition-colors hover:text-amber-500"
+          >
+            <Star className={cn("size-5", n <= current && "fill-amber-500 text-amber-500")} />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FilePicker({ props, value, setValue }: MosaicBlockProps) {
+  const label = str(props.label);
+  const current = str(value as PV);
+  return (
+    <div className="flex flex-col gap-1.5">
+      {label ? <span className={LABEL}>{label}</span> : null}
+      <label className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed px-3 py-2 text-muted-foreground text-sm transition-colors hover:border-ring/40 hover:text-foreground">
+        <Upload className="size-4 shrink-0" />
+        <span className="truncate">{current || "Choose a file"}</span>
+        <input
+          type="file"
+          className="sr-only"
+          onChange={(e) => setValue?.(e.target.files?.[0]?.name ?? "")}
+        />
+      </label>
+    </div>
+  );
+}
+
+// --- disclosure & accordion -----------------------------------------------------
+
+function Disclosure({ node, props, children }: MosaicBlockProps) {
+  const label = str(props.label) || "Details";
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-xl border">
+      <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2 text-left font-medium text-sm">
+        <ChevronRight
+          className={cn("size-4 shrink-0 text-muted-foreground transition-transform", open && "rotate-90")}
+        />
+        {label}
+      </CollapsibleTrigger>
+      <CollapsiblePanel>
+        <div className="px-3 pb-3 ps-9">
+          <Flow node={node}>{children}</Flow>
+        </div>
+      </CollapsiblePanel>
+    </Collapsible>
+  );
+}
+
+function AccordionRow({ label, children }: { label: string; children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2.5 text-left font-medium text-sm">
+        <ChevronRight
+          className={cn("size-4 shrink-0 text-muted-foreground transition-transform", open && "rotate-90")}
+        />
+        {label}
+      </CollapsibleTrigger>
+      <CollapsiblePanel>
+        <div className="px-3 pb-3 ps-9">{children}</div>
+      </CollapsiblePanel>
+    </Collapsible>
+  );
+}
+
+function Accordion({ props, children }: MosaicBlockProps) {
+  const labels = strs(props.items);
+  const panels = React.Children.toArray(children);
+  return (
+    <div className="divide-y overflow-hidden rounded-xl border">
+      {labels.map((label, i) => (
+        <AccordionRow key={label} label={label}>
+          {panels[i] ?? null}
+        </AccordionRow>
+      ))}
+    </div>
+  );
+}
+
+// --- tree & board ---------------------------------------------------------------
+
+type TreeItem = { label: string; children?: TreeItem[] };
+
+function toTreeItems(v: PV | undefined): TreeItem[] {
+  return arr(v).map((n) => {
+    const o = (n && typeof n === "object" && !Array.isArray(n) ? n : {}) as Record<string, PV>;
+    const item: TreeItem = { label: str(o.label) };
+    if (o.children) item.children = toTreeItems(o.children);
+    return item;
+  });
+}
+
+function TreeNodes({ nodes, depth }: { nodes: TreeItem[]; depth: number }): React.ReactNode {
+  return (
+    <ul className={cn(depth > 0 && "ms-2 border-l ps-3")}>
+      {nodes.map((n) => {
+        const hasKids = (n.children?.length ?? 0) > 0;
+        return (
+          <li key={n.label} className="py-0.5">
+            <div className="flex items-center gap-1.5 text-sm">
+              <MosaicIcon
+                name={hasKids ? "folder" : "file"}
+                className="size-3.5 text-muted-foreground"
+              />
+              <span className="min-w-0 truncate">{n.label}</span>
+            </div>
+            {hasKids ? <TreeNodes nodes={n.children ?? []} depth={depth + 1} /> : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function Tree({ props }: MosaicBlockProps) {
+  return <TreeNodes nodes={toTreeItems(props.items)} depth={0} />;
+}
+
+function Board({ props }: MosaicBlockProps) {
+  const items = arr(props.items).map((it) => {
+    const o = (it && typeof it === "object" && !Array.isArray(it) ? it : {}) as Record<string, PV>;
+    return { title: str(o.title), column: str(o.column) };
+  });
+  const columns: string[] = [];
+  for (const it of items) if (!columns.includes(it.column)) columns.push(it.column);
+  return (
+    <div className="flex gap-3 overflow-x-auto pb-2">
+      {columns.map((col) => {
+        const cards = items.filter((it) => it.column === col);
+        return (
+          <div
+            key={col || "_untitled"}
+            className="flex min-w-0 shrink-0 basis-60 flex-col gap-2 rounded-xl bg-muted/50 p-2"
+          >
+            <div className="flex items-center justify-between px-1">
+              <span className={LABEL}>{col || "Untitled"}</span>
+              <span className="text-muted-foreground text-xs">{cards.length}</span>
+            </div>
+            {cards.map((card) => (
+              <div
+                key={`${col}-${card.title}`}
+                className="rounded-lg border bg-card p-2.5 text-sm shadow-xs/5"
+              >
+                {card.title}
+              </div>
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- calendar -------------------------------------------------------------------
+
+const WEEKDAYS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+function Calendar({ props }: MosaicBlockProps) {
+  const items = arr(props.items)
+    .map((it) => {
+      const o = (it && typeof it === "object" && !Array.isArray(it) ? it : {}) as Record<string, PV>;
+      return { date: str(o.date), title: str(o.title) };
+    })
+    .filter((it) => /^\d{4}-\d{2}-\d{2}/.test(it.date));
+
+  // Show the month of the earliest dated item (an artifact's data is baked in, so
+  // there is a definite month to render); fall back to the current month.
+  const earliest = items.map((it) => it.date.slice(0, 10)).sort()[0];
+  const base = earliest ? new Date(`${earliest}T00:00:00`) : new Date();
+  const year = base.getFullYear();
+  const month = base.getMonth();
+  const monthLabel = base.toLocaleDateString("en-US", { month: "long", year: "numeric" });
+  const firstWeekday = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+
+  const byDay = new Map<number, string[]>();
+  for (const it of items) {
+    const d = new Date(`${it.date.slice(0, 10)}T00:00:00`);
+    if (d.getFullYear() === year && d.getMonth() === month) {
+      const day = d.getDate();
+      byDay.set(day, [...(byDay.get(day) ?? []), it.title]);
+    }
+  }
+
+  const cells: { key: string; day: number | null }[] = [];
+  for (let i = 0; i < firstWeekday; i++) cells.push({ key: `pad-${WEEKDAYS[i]}`, day: null });
+  for (let d = 1; d <= daysInMonth; d++) cells.push({ key: `d${d}`, day: d });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="font-medium text-sm">{monthLabel}</div>
+      <div className="grid grid-cols-7 gap-1">
+        {WEEKDAYS.map((w) => (
+          <div key={w} className="pb-1 text-center text-[10px] text-muted-foreground uppercase">
+            {w}
+          </div>
+        ))}
+        {cells.map((cell) => {
+          const { day } = cell;
+          const events = day ? byDay.get(day) : undefined;
+          return (
+            <div
+              key={cell.key}
+              className={cn("min-h-14 rounded-lg border p-1", day ? "bg-card" : "border-transparent")}
+            >
+              {day ? (
+                <>
+                  <div
+                    className={cn(
+                      "text-right text-xs",
+                      events ? "font-semibold text-foreground" : "text-muted-foreground",
+                    )}
+                  >
+                    {day}
+                  </div>
+                  {events?.slice(0, 2).map((title) => (
+                    <div
+                      key={`${day}-${title}`}
+                      title={title}
+                      className="mt-0.5 truncate rounded bg-primary/12 px-1 py-0.5 text-[10px] text-primary"
+                    >
+                      {title}
+                    </div>
+                  ))}
+                  {events && events.length > 2 ? (
+                    <div className="mt-0.5 text-[10px] text-muted-foreground">+{events.length - 2}</div>
+                  ) : null}
+                </>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// --- graceful escapes -----------------------------------------------------------
+// A full Vega-Lite runtime and a sanitized-SVG pipeline are heavier than this
+// dependency-light renderer should pull in, so these two degrade to their alt -
+// on-brand, and meaning intact - rather than falling back to the reference paint.
+
+function VegaChart({ props }: MosaicBlockProps<BlockPropTypes["VegaChart"]>) {
+  return <BlockPlaceholder icon="chart-column" label={str(props.alt)} hint="Vega-Lite chart" />;
+}
+
+function Canvas({ props }: MosaicBlockProps<BlockPropTypes["Canvas"]>) {
+  return <BlockPlaceholder icon="shapes" label={str(props.alt)} hint="Canvas" />;
+}
+
+export const mosaicComponents = defineComponents({
+  Stack,
+  Grid,
+  Box,
+  Card,
+  Divider,
+  Heading,
+  Text,
+  Icon,
+  Badge,
+  Tag: Badge,
+  Avatar,
+  Callout,
+  Link,
+  Code,
+  Markdown,
+  Button,
+  Input,
+  Select,
+  MultiSelect,
+  Autocomplete,
+  Checkbox,
+  Radio,
+  Toggle,
+  Slider,
+  Field,
+  TagInput,
+  DatePicker,
+  ColorPicker,
+  SegmentedControl,
+  Tabs,
+  Progress,
+  Steps,
+  Empty,
+  Stat,
+  DataTable,
+  Timeline,
+  List,
+  Chart,
+  Diagram,
+  Image: ImageBlock,
+  Video: VideoBlock,
+  Audio: AudioBlock,
+  Carousel,
+  Rating,
+  FilePicker,
+  Disclosure,
+  Accordion,
+  Tree,
+  Board,
+  Calendar,
+  VegaChart,
+  Canvas,
+});

--- a/apps/web/src/components/chat/mosaic/index.ts
+++ b/apps/web/src/components/chat/mosaic/index.ts
@@ -1,0 +1,15 @@
+export { extractMosaicArtifactId, MosaicArtifact } from "./MosaicArtifact";
+export {
+  formatCorrectionPrompt,
+  type MosaicAutocorrect,
+  MosaicAutocorrectProvider,
+  type MosaicInvalidReport,
+  useMosaicAutocorrect,
+} from "./autocorrect";
+export {
+  defaultMosaicIntent,
+  type MosaicIntent,
+  MosaicIntentProvider,
+  useMosaicIntent,
+} from "./intent";
+export { mosaicComponents } from "./blocks";

--- a/apps/web/src/components/chat/mosaic/intent.tsx
+++ b/apps/web/src/components/chat/mosaic/intent.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext } from "react";
+
+import { toastManager } from "../../ui/toast";
+
+/**
+ * A host-intent sink. Every Mosaic `on:event` that is not a local `state.*`
+ * mutation crosses to the host as a named intent carrying already-computed
+ * args. The artifact never acts on its own - the host decides what to do.
+ */
+export type MosaicIntent = (action: string, args?: unknown) => void;
+
+/** Render intent args compactly for a toast description: `seats: 12, total: 192`. */
+function compactArgs(args: unknown): string | undefined {
+  if (args === undefined || args === null) return undefined;
+  if (typeof args !== "object" || Array.isArray(args)) return JSON.stringify(args);
+  const entries = Object.entries(args as Record<string, unknown>);
+  if (entries.length === 0) return undefined;
+  return entries.map(([key, value]) => `${key}: ${JSON.stringify(value)}`).join(", ");
+}
+
+/**
+ * Default sink: surface the intent as a toast so the click visibly does
+ * something. A surrounding {@link MosaicIntentProvider} can override this to
+ * route intents somewhere richer (e.g. back to the agent as a follow-up turn).
+ */
+export const defaultMosaicIntent: MosaicIntent = (action, args) => {
+  const description = compactArgs(args);
+  toastManager.add({
+    type: "info",
+    title: `Intent · ${action}`,
+    ...(description !== undefined ? { description } : {}),
+  });
+};
+
+const MosaicIntentContext = createContext<MosaicIntent>(defaultMosaicIntent);
+
+/** Override the intent sink for a subtree of the conversation. */
+export const MosaicIntentProvider = MosaicIntentContext.Provider;
+
+/** Read the active intent sink; falls back to {@link defaultMosaicIntent}. */
+export function useMosaicIntent(): MosaicIntent {
+  return useContext(MosaicIntentContext);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,6 +455,9 @@ importers:
       '@ff-labs/fff-node':
         specifier: 0.9.4
         version: 0.9.4(patch_hash=2b16019ce7ab61aec6478dd02f79ef468cc1d5c51e9d00764f7d2ab8167210c8)
+      '@mosaicjs/ai':
+        specifier: ^0.8.0
+        version: 0.8.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       '@opencode-ai/sdk':
         specifier: ^1.3.15
         version: 1.15.13
@@ -540,6 +543,12 @@ importers:
       '@lexical/react':
         specifier: ^0.41.0
         version: 0.41.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(yjs@13.6.31)
+      '@mosaicjs/core':
+        specifier: ^0.8.0
+        version: 0.8.0
+      '@mosaicjs/react':
+        specifier: ^0.8.0
+        version: 0.8.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@pierre/diffs':
         specifier: 'catalog:'
         version: 1.3.0-beta.5(patch_hash=7cb6da88544119adda056b2f46f43956f99326227732da0b345081e285a6c53a)(@shikijs/themes@4.3.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3084,6 +3093,29 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@mosaicjs/ai@0.8.0':
+    resolution: {integrity: sha512-DWRhi3yPH7L2Q7bfReodIBo5Oyi261HCdoNrhXsop032uOdQK86KjGa1dF2oFWqARoP2B48kH1AktwC19dDqnA==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.0.0'
+      ai: '>=6.0.0'
+      zod: '>=3.25.0'
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+      ai:
+        optional: true
+      zod:
+        optional: true
+
+  '@mosaicjs/core@0.8.0':
+    resolution: {integrity: sha512-SBRGqpPZXx/jykvqmFLIijHE3zlFMBccxO9Y7L8JXaTp0mHFVBEFl48+8e3G1EMU7tc4qaHw4eDPPVczJ9zHjQ==}
+
+  '@mosaicjs/react@0.8.0':
+    resolution: {integrity: sha512-fUojvmTWoO6Pn5mr6W6IRFPdkFmVnaVw9ZaMITqVL64wgnAVLkNAJ5jmGaXY8nzvaA8YL5vTxKolr0jPz0my9g==}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
@@ -12925,6 +12957,21 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
+
+  '@mosaicjs/ai@0.8.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@mosaicjs/core': 0.8.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
+
+  '@mosaicjs/core@0.8.0': {}
+
+  '@mosaicjs/react@0.8.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@mosaicjs/core': 0.8.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
     optional: true


### PR DESCRIPTION
## Summary

Much of what a coding agent produces is spatial, not linear - a plan with risks beside it, a diff summary, a cost breakdown across providers, an approval prompt.
Today that gets flattened into prose or a code block.
This PR teaches T3 Code to render [Mosaic](https://github.com/ruwadgroup/mosaic) artifacts: when an agent emits a ` ```mosaic ` fence in its reply, T3 Code draws it as a live, interactive interface using its own components, in its own look.

The artifact is data, never code.
A bounded, CEL-class expression language drives derived values, conditionals, and lists on the client, so a slider updates a total with no round-trip.
Anything beyond local state leaves as a named host intent that T3 Code routes through its existing command surface.
There is nothing to sandbox - no iframe, no `eval`, no live data pull.

## How it works

```
agent reply  ->  ```mosaic fence  ->  parse  ->  host block set  ->  local reactive loop  ->  named intents
             (ChatMarkdown)          (@mosaicjs)   (blocks.tsx)        (state.* / expr)        (onIntent)
```

- `ChatMarkdown` detects a ` ```mosaic ` fenced block and hands it to `<MosaicArtifact>` instead of syntax-highlighting it.
- `<MosaicArtifact>` renders through `@mosaicjs/react`'s `<Mosaic>`, which owns parsing, the reactive loop, streaming completion, and per-node error boundaries.
- Every block is drawn by T3 Code's own `mosaicComponents` (`defineComponents`), so the artifact wears the app's design.
- Host intents flow out through `useMosaicIntent`; validation diagnostics flow back to the agent once through the autocorrect channel.

## What's included

**Web (`apps/web`)**

- `components/chat/mosaic/MosaicArtifact.tsx` - the render surface: streaming-aware, `onIntent`, `onDiagnostics` (validate -> agent autocorrect), and a raw-source fallback for a partial or unparseable fence.
- `components/chat/mosaic/blocks.tsx` - the host block set: every Mosaic block drawn through T3 Code's UI kit (shadcn-on-Base-UI). Covers the full catalog (see below).
- `components/chat/mosaic/intent.tsx`, `autocorrect.ts`, `index.ts` - intent routing and the validation-to-agent loop.
- `components/ChatMarkdown.tsx` - routes ` ```mosaic ` fences to the renderer, streaming-aware.

**Server (`apps/server`)**

- `mcp/toolkits/mosaic/` - the three introspection tools (`mosaic_ls`, `mosaic_cat`, `mosaic_validate`) built on `@mosaicjs/ai`, registered in `McpHttpServer`.
- `provider/MosaicSkill.ts` - provisions the Mosaic agent skill (the MCP-aware variant) into each provider's skills directory, so the runtime discovers it natively and auto-activates from its description - no always-on prompt injection.
- `provider/Drivers/{Claude,Codex}Driver.ts` - deliver the skill (best-effort; a skill-write failure never blocks the provider from starting).

## Design and safety

- **The host owns the entire design.** Every block renders through `apps/web/src/components/ui/*` - the artifact carries semantic tokens (`tone="warn"`), never raw styles.
- **The artifact cannot execute code.** Expressions are AST-interpreted and statically bounded; the only way out is a named intent that T3 Code chooses whether to act on.
- **`Embed` is intentionally not mapped** (denied by default), consistent with the format's trust model.
- **No new runtime surface beyond `@mosaicjs/*`.** No vega, no image pipeline, no SVG injection are pulled in.

## Block coverage

The host map covers the full Mosaic catalog - layout, content, every control, structure/status, media, and data/viz (52 blocks).
This PR completes the previously-partial set by adding: `Image`, `Video`, `Audio`, `Carousel`, `Rating`, `FilePicker`, `Disclosure`, `Accordion`, `Tree`, `Board`, `Calendar`, plus graceful entries for `VegaChart` and `Canvas`.

`VegaChart` and `Canvas` degrade to their `alt` on-brand rather than rendering: a full Vega-Lite runtime and a sanitized-SVG pipeline are heavier than this renderer should pull in.
Both are noted as follow-ups.

## Embedded polish

An artifact lives inside a chat message, so the surfaces are tuned to read as compact embedded content, not standalone pages: tighter `Card` padding and radius, and a slightly tighter vertical rhythm and tab spacing.

## Testing

- `pnpm typecheck` - clean.
- `pnpm lint` - clean (no new warnings).
- Unit tests: `mcp/toolkits/mosaic/tools.test.ts`, `components/chat/mosaic/MosaicArtifact.test.tsx`.

## Dependencies

- `apps/web`: `@mosaicjs/core@^0.8.0`, `@mosaicjs/react@^0.8.0`
- `apps/server`: `@mosaicjs/ai@^0.8.0`

## Screenshots

<!-- Before / after of an agent reply rendered as a Mosaic artifact. A cross-provider cost dashboard or an approval surface reads well here. -->

## Follow-ups (not in this PR)

- `VegaChart` via a lazy-loaded Vega-Lite runtime; `Canvas` via a sanitized-SVG path.
- A custom host manifest declaring T3 Code's `components_supported` and permissions, instead of the default.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new chat rendering surface and provider filesystem writes on startup, but artifacts use bounded expression evaluation (not arbitrary code) and skill provisioning is best-effort and non-blocking.
> 
> **Overview**
> This PR wires **Mosaic** through T3 Code so agent replies can ship as live, in-app UI instead of prose or highlighted code.
> 
> **Chat rendering:** `ChatMarkdown` routes ` ```mosaic ` fences to a new **`MosaicArtifact`** path (streaming-aware, optional fence `id=`). Artifacts parse and run locally via `@mosaicjs/react`, with a large **`mosaicComponents`** map that draws the full block catalog in the app’s UI kit. Validation issues are reported once to an optional **autocorrect** channel; user actions leave as **named intents** (default: info toast).
> 
> **Agent enablement:** The MCP server registers read-only **`mosaic_ls` / `mosaic_cat` / `mosaic_validate`** tools (`@mosaicjs/ai`). On Claude and Codex instance startup, **`provisionMosaicSkill`** best-effort writes an MCP-aware Mosaic skill (`SKILL.md` + `REFERENCE.md`) into each provider’s skills directory.
> 
> **Dependencies:** `@mosaicjs/core` + `@mosaicjs/react` on web, `@mosaicjs/ai` on server (`^0.8.0`), with unit tests for tool JSON schemas and artifact rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabf4cdceaac315a0a4dccca5f2e7c24be3f6f91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Render Mosaic artifacts as native interactive UI in chat messages
> - ```` ```mosaic ```` fences in chat messages now render as interactive UI via `MosaicArtifact` instead of syntax-highlighted code, wired in [ChatMarkdown.tsx](https://github.com/pingdotgg/t3code/pull/3681/files#diff-0a03cb503a0e0d7ada585b01fb2df28e2d2e2de69e0bf4d1b4536729a65ffe04).
> - Adds a full block component library in [blocks.tsx](https://github.com/pingdotgg/t3code/pull/3681/files#diff-ec4f9a915db4ca4728758795ab75b494d0dd365f66a13f9dde9ae1c49a3f1abc) covering ~50 block types (layout, form controls, data display, media, diagrams) mapped to the app's UI kit via `@mosaicjs/react`.
> - Intents emitted by Mosaic blocks surface as info toasts by default; hosts can override the sink via `MosaicIntentProvider`.
> - Invalid final artifacts report diagnostics once per session to an autocorrect sink; while streaming, diagnostics are suppressed and best-effort rendering continues.
> - Adds MCP tools `mosaic_ls`, `mosaic_cat`, and `mosaic_validate` to the server, and provisions Mosaic skill files into Claude/Codex home directories on provider startup.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized aabf4cd. 10 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->