### PR TITLE
fix: ThreadErrorBanner tooltip

### DIFF
--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -16,14 +16,14 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
     <div className="pt-3 mx-auto max-w-3xl">
       <Alert variant="error">
         <CircleAlertIcon />
-        <Tooltip>
-          <TooltipTrigger render={<AlertDescription className="line-clamp-3" />}>
-            {error}
-          </TooltipTrigger>
-          <TooltipPopup side="top" className="max-w-96 whitespace-pre-wrap">
-            {error}
-          </TooltipPopup>
-        </Tooltip>
+        <AlertDescription>
+          <Tooltip>
+            <TooltipTrigger render={<span className="line-clamp-3" />}>{error}</TooltipTrigger>
+            <TooltipPopup side="top" className="max-w-96 whitespace-pre-wrap">
+              {error}
+            </TooltipPopup>
+          </Tooltip>
+        </AlertDescription>
         {onDismiss && (
           <AlertAction>
             <Button variant="ghost" size="icon-xs" aria-label="Dismiss error" onClick={onDismiss}>


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed
ThreadErrorBanner was updated so the tooltip wraps only the error text (<span>), not the whole AlertDescription. 


## Why

ThreadErrorBanner UI was broken as you can see from this issue https://github.com/pingdotgg/t3code/issues/3635.

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

| Before |  After |
|---|---|
|  <img width="1188" height="158" alt="image" src="https://github.com/user-attachments/assets/8fd6e797-3410-4139-81b1-1b6951ea7963" /> |  <img width="1185" height="136" alt="image" src="https://github.com/user-attachments/assets/8f182dbc-b782-443d-b29f-2f36a2e5267b" /> |


## Checklist

- [X] This PR is small and focused
- [X] I explained what changed and why
- [X] I included before/after screenshots for any UI changes
- [X] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component UI markup fix with no auth, data, or API impact.
> 
> **Overview**
> Fixes broken **ThreadErrorBanner** layout by changing how the error tooltip is composed.
> 
> **`AlertDescription`** now wraps the full **`Tooltip`** block. The **`TooltipTrigger`** uses a **`span`** with **`line-clamp-3`** for the truncated error text instead of rendering **`AlertDescription`** as the trigger element, so the dismiss action and alert chrome stay outside the tooltip target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7773a2c9068460adcb05136443387cce0b9bbb70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tooltip structure in `ThreadErrorBanner` component
> Restructures the tooltip in [ThreadErrorBanner.tsx](https://github.com/pingdotgg/t3code/pull/3682/files#diff-3fa9e223d4ae557ff232900844d971974d42e09f07a6d6e005538eab923867f0) so that `AlertDescription` wraps the entire `Tooltip` block, rather than being used as the `TooltipTrigger` rendered element. The trigger is now a `span` with `line-clamp-3` styling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7773a2c.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->