### PR TITLE
fix(mobile): keep new-thread targets stable during search

### DIFF
--- a/apps/mobile/src/features/home/homeThreadList.test.ts
+++ b/apps/mobile/src/features/home/homeThreadList.test.ts
@@ -743,4 +743,48 @@ describe("buildHomeThreadGroups", () => {
     expect(groups[0]?.newThreadTarget?.environmentId).toBe(desktopEnv);
     expect(groups[0]?.newThreadTarget?.id).toBe(desktopProject.id);
   });
+
+  it("keeps the quick new-thread target when search hides the newest thread", () => {
+    const laptopProject = makeProject({
+      environmentId: EnvironmentId.make("environment-laptop"),
+      id: ProjectId.make("project-laptop"),
+      title: "t3code",
+      repositoryIdentity: {
+        canonicalKey: "github.com/pingdotgg/t3code",
+        locator: {
+          source: "git-remote",
+          remoteName: "origin",
+          remoteUrl: "git@github.com:pingdotgg/t3code.git",
+        },
+      },
+    });
+    const desktopProject = makeProject({
+      ...laptopProject,
+      environmentId: EnvironmentId.make("environment-desktop"),
+      id: ProjectId.make("project-desktop"),
+    });
+    const laptopThread = makeThread({
+      environmentId: laptopProject.environmentId,
+      id: ThreadId.make("thread-laptop"),
+      projectId: laptopProject.id,
+      title: "Older laptop thread",
+      updatedAt: "2026-06-27T00:00:00.000Z",
+    });
+    const desktopThread = makeThread({
+      environmentId: desktopProject.environmentId,
+      id: ThreadId.make("thread-desktop"),
+      projectId: desktopProject.id,
+      title: "Newest desktop thread",
+      updatedAt: "2026-06-28T00:00:00.000Z",
+    });
+    const projects = [laptopProject, desktopProject];
+    const threads = [laptopThread, desktopThread];
+
+    const groups = buildGroups(projects, threads);
+    const searchGroups = buildGroups(projects, threads, { searchQuery: "laptop" });
+
+    expect(groups[0]?.newThreadTarget).toEqual(desktopProject);
+    expect(searchGroups[0]?.threads).toEqual([laptopThread]);
+    expect(searchGroups[0]?.newThreadTarget).toEqual(desktopProject);
+  });
 });

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -216,12 +216,15 @@ export function buildHomeThreadGroups(input: {
         : sortedThreads;
 
     // Sorted newest-first, so the first thread whose project is a group member
-    // marks the machine the user last worked on.
-    const lastActiveProject = Arr.findFirst(sortedThreads, (thread) =>
-      group.projects.some(
-        (project) =>
-          project.environmentId === thread.environmentId && project.id === thread.projectId,
-      ),
+    // marks the machine the user last worked on. Derived from the FULL history
+    // (not the search-filtered subset) so the target is stable across queries.
+    const lastActiveProject = Arr.findFirst(
+      sortThreads(group.threads, input.threadSortOrder),
+      (thread) =>
+        group.projects.some(
+          (project) =>
+            project.environmentId === thread.environmentId && project.id === thread.projectId,
+        ),
     ).pipe(
       Option.flatMap((thread) =>
         Arr.findFirst(

--- a/apps/mobile/src/features/home/homeThreadList.ts
+++ b/apps/mobile/src/features/home/homeThreadList.ts
@@ -327,7 +327,12 @@ export function buildHomeThreadGroups(input: {
       continue;
     }
 
-    const sortedThreads = sortThreads(matchingThreads, input.threadSortOrder);
+    const sortedGroupThreads = sortThreads(group.threads, input.threadSortOrder);
+    const matchingThreadSet = groupMatches ? null : new Set(matchingThreads);
+    const sortedThreads =
+      matchingThreadSet === null
+        ? sortedGroupThreads
+        : sortedGroupThreads.filter((thread) => matchingThreadSet.has(thread));
     // An active search should reach the full history, so the recency window
     // only trims the default (no-query) view.
     const recentThreads =
@@ -335,9 +340,9 @@ export function buildHomeThreadGroups(input: {
         ? selectRecentThreads(sortedThreads, input.threadSortOrder, now)
         : sortedThreads;
 
-    // A stale project id still resolves to the canonical member with the same
-    // environment/path, so quick creation follows the machine with the newest activity.
-    const lastActiveProject = Arr.head(sortedThreads).pipe(
+    // Use the full history so search does not change the target machine.
+    // Resolve stale project IDs to the canonical member at the same environment/path.
+    const lastActiveProject = Arr.head(sortedGroupThreads).pipe(
       Option.flatMap((thread) =>
         Arr.findFirst(
           input.projects,


### PR DESCRIPTION
Search can change which machine receives a quick new thread in a grouped mobile project.

Choose the target from the group's full history. Skip groups with no search matches, then sort each remaining group once and select matching threads for display. Keep the current canonical-project lookup and pending-project behavior.

## Checks

- 25 focused tests passed. The new search case fails on main without this fix.
- Targeted lint and formatting passed.
- Mobile package typecheck passed.

Original author and co-author credit is unchanged.

Updated with GPT-5.6 Sol in Codex.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to home thread grouping and display filtering; no auth, data, or API surface changes.
> 
> **Overview**
> **Fixes quick new-thread routing on the mobile home list when a search query hides the most recently active thread** in a grouped repository (e.g. laptop vs desktop).
> 
> `buildHomeThreadGroups` now sorts the group’s **full** thread history once, uses that ordering to pick `newThreadTarget` (still resolving stale project IDs to the canonical member), and only filters that sorted list for **display** when search is active. Search no longer shrinks the recency basis for which machine gets a new thread.
> 
> A regression test covers the case where search matches only the older laptop thread but the target must remain the desktop project with the newest activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1191747622209a5773735257cd4a95db153454b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `buildHomeThreadGroups` to keep new-thread target stable during search
> - `buildHomeThreadGroups` now sorts all group threads and picks the quick new-thread target from the full history, then filters for search display. Previously, search-matching threads drove both sorting and target selection, so hiding the newest thread changed the target.
> - Adds a regression test in [homeThreadList.test.ts](https://github.com/pingdotgg/t3code/pull/3693/files#diff-8393240ed7de0526d6a5daf03806bae67888fd5c27dbb047fdec401f66887a85) covering two projects where search hides the newer thread.
> - Behavioral Change: search results still show only matching threads, but the quick new-thread target now always reflects the newest thread in the group regardless of the active search query.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1191747.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->