### PR TITLE
fix(orchestrator): Claude plan-mode plan proposals + real provider error causes

### DIFF
--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
@@ -209,6 +209,21 @@ describe("ClaudeAdapterV2 runtime query policy", () => {
       installPermissionCallback: false,
     });
   });
+
+  it("installs the permission callback in plan mode so ExitPlanMode can propose plans", () => {
+    const queryPolicy = claudeRuntimeQueryPolicyForRuntimePolicy(
+      ProviderAdapterV2RuntimePolicy.make({
+        runtimeMode: "full-access",
+        interactionMode: "plan",
+        cwd: "/workspace",
+      }),
+    );
+
+    assert.deepEqual(queryPolicy, {
+      permissionMode: "plan",
+      installPermissionCallback: true,
+    });
+  });
 });
 
 describe("ClaudeAdapterV2 native protocol logging", () => {

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -276,16 +276,23 @@ export class ClaudeAgentSdkQueryRunnerError extends Schema.TaggedErrorClass<Clau
   },
 ) {
   override get message(): string {
-    const detail =
-      this.cause instanceof Error
-        ? this.cause.message
-        : typeof this.cause === "string"
-          ? this.cause
-          : null;
-    return detail === null || detail.trim().length === 0
-      ? `Claude Agent SDK query failed (${this.method}).`
-      : `Claude Agent SDK query failed (${this.method}): ${detail}`;
+    return `Claude Agent SDK query failed (${this.method}).`;
   }
+}
+
+/**
+ * Provider-failure payloads render the failure's own message, so the runner
+ * wrapper would mask the actionable SDK error (missing binary, resume
+ * rejection, spawn failure). Surface the underlying error to the existing
+ * redaction/bounding pipeline in makeProviderFailure; the wrapper stays the
+ * failure for anything that is not a real Error.
+ */
+const isClaudeAgentSdkQueryRunnerError = Schema.is(ClaudeAgentSdkQueryRunnerError);
+
+function claudeProviderFailureCause(failure: unknown): unknown {
+  return isClaudeAgentSdkQueryRunnerError(failure) && failure.cause instanceof Error
+    ? failure.cause
+    : failure;
 }
 
 export interface ClaudeAgentSdkQueryRunnerShape {
@@ -2744,7 +2751,10 @@ export function makeClaudeAdapterV2(
               ? {}
               : {
                   failure: makeProviderFailure({
-                    cause: cause === undefined ? undefined : Cause.squash(cause),
+                    cause:
+                      cause === undefined
+                        ? undefined
+                        : claudeProviderFailureCause(Cause.squash(cause)),
                     class: "transport_error",
                   }),
                 }),

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -1864,6 +1864,18 @@ export function makeClaudeAdapterV2(
         });
         const events = yield* Queue.unbounded<ProviderAdapterV2Event>();
         const activeTurn = yield* Ref.make<ActiveClaudeTurnContext | null>(null);
+        /**
+         * Async native tasks (Task tool with isAsync) usually complete after
+         * their parent turn has finalized and activeTurn is null. Their turn
+         * contexts are retained here, keyed by native task id, so the late
+         * task_notification can still resolve the subagent under the original
+         * run — which RunExecutionService keeps draining until every child
+         * subagent is terminal. Entries are removed when the notification
+         * arrives.
+         */
+        const pendingAsyncTaskContexts = yield* Ref.make(
+          new Map<string, ActiveClaudeTurnContext>(),
+        );
         const interruptedTurns = yield* Ref.make(new Set<OrchestrationV2ProviderTurn["id"]>());
         const steeredTurns = yield* Ref.make(new Set<OrchestrationV2ProviderTurn["id"]>());
         const queryContext = yield* Ref.make<ClaudeLiveQueryContext | null>(null);
@@ -2681,6 +2693,16 @@ export function makeClaudeAdapterV2(
             ],
             { concurrency: 1 },
           );
+          yield* Ref.update(pendingAsyncTaskContexts, (current) => {
+            let updated: Map<string, ActiveClaudeTurnContext> | null = null;
+            for (const [taskId, subagent] of input.context.subagentsByTaskId) {
+              if (subagent.task.status === "running") {
+                updated ??= new Map(current);
+                updated.set(taskId, input.context);
+              }
+            }
+            return updated ?? current;
+          });
           yield* Ref.update(activeTurn, (current) =>
             current?.providerTurnId === input.context.providerTurnId ? null : current,
           );
@@ -2784,6 +2806,42 @@ export function makeClaudeAdapterV2(
           }
 
           const message = input.message;
+          if (message.type === "system" && message.subtype === "task_notification") {
+            // Async task completions typically land after the parent turn has
+            // finalized (activeTurn is null) or while an unrelated turn is
+            // active; resolve them against the retained owning context so the
+            // subagent terminalizes under its original run.
+            const active = yield* Ref.get(activeTurn);
+            const retired = (yield* Ref.get(pendingAsyncTaskContexts)).get(message.task_id);
+            const taskContext =
+              active !== null && active.subagentsByTaskId.has(message.task_id)
+                ? active
+                : (retired ?? active);
+            if (taskContext !== null && !taskContext.ignoredTaskIds.has(message.task_id)) {
+              yield* updateClaudeSubagentNode({
+                context: taskContext,
+                taskId: message.task_id,
+                ...(message.tool_use_id === undefined ? {} : { toolUseId: message.tool_use_id }),
+                result: message.summary,
+                status:
+                  message.status === "completed"
+                    ? "completed"
+                    : message.status === "stopped"
+                      ? "cancelled"
+                      : "failed",
+              });
+            }
+            yield* Ref.update(pendingAsyncTaskContexts, (current) => {
+              if (!current.has(message.task_id)) {
+                return current;
+              }
+              const updated = new Map(current);
+              updated.delete(message.task_id);
+              return updated;
+            });
+            return;
+          }
+
           const context = yield* Ref.get(activeTurn);
           if (context === null) {
             return;
@@ -2817,23 +2875,6 @@ export function makeClaudeAdapterV2(
                 ...(message.tool_use_id === undefined ? {} : { toolUseId: message.tool_use_id }),
                 progress,
                 status: "running",
-              });
-            }
-          }
-
-          if (message.type === "system" && message.subtype === "task_notification") {
-            if (!context.ignoredTaskIds.has(message.task_id)) {
-              yield* updateClaudeSubagentNode({
-                context,
-                taskId: message.task_id,
-                ...(message.tool_use_id === undefined ? {} : { toolUseId: message.tool_use_id }),
-                result: message.summary,
-                status:
-                  message.status === "completed"
-                    ? "completed"
-                    : message.status === "stopped"
-                      ? "cancelled"
-                      : "failed",
               });
             }
           }

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -25,6 +25,7 @@ import {
   type ModelSelection,
   type OrchestrationV2ConversationMessage,
   type OrchestrationV2ExecutionNode,
+  type OrchestrationV2PlanArtifact,
   type OrchestrationV2ProviderCapabilities,
   type OrchestrationV2ProviderFailure,
   type OrchestrationV2ProviderSession,
@@ -166,7 +167,7 @@ export const ClaudeProviderCapabilitiesV2 = {
   planning: {
     emitsPlanUpdated: false,
     emitsTodoList: false,
-    emitsProposedPlan: false,
+    emitsProposedPlan: true,
     supportsStructuredQuestions: false,
     planDeltasHaveItemIds: false,
   },
@@ -1146,11 +1147,14 @@ export function claudeRuntimeQueryPolicyForRuntimePolicy(
       : undefined;
 
   if (permissionMode === "plan") {
+    // The permission callback must be installed in plan mode: without it the
+    // SDK has no way to raise ExitPlanMode, so the model can never propose a
+    // plan and the plan interaction mode dead-ends in prose.
     return {
       permissionMode,
       ...(readOnlyTools === undefined ? {} : { tools: readOnlyTools }),
       ...(allowedTools === undefined ? {} : { allowedTools }),
-      installPermissionCallback: false,
+      installPermissionCallback: true,
     };
   }
 
@@ -1169,9 +1173,6 @@ export function claudeRuntimeQueryPolicyForRuntimePolicy(
 }
 
 function shouldInstallClaudePermissionCallback(policy: ClaudeRuntimeQueryPolicy): boolean {
-  if (policy.permissionMode === "plan") {
-    return false;
-  }
   return policy.installPermissionCallback;
 }
 
@@ -2934,6 +2935,92 @@ export function makeClaudeAdapterV2(
           }
         });
 
+        const emitProposedPlanArtifacts = Effect.fnUntraced(function* (input: {
+          readonly context: ActiveClaudeTurnContext;
+          readonly nativeItemId: string;
+          readonly markdown: string;
+        }) {
+          const now = yield* DateTime.now;
+          const nativeItemId = `plan:${input.nativeItemId}`;
+          const planId = yield* idAllocator.allocate.plan({
+            threadId: input.context.input.threadId,
+            ...(input.context.input.runId === null ? {} : { runId: input.context.input.runId }),
+            driver: CLAUDE_PROVIDER,
+          });
+          const ordinal = yield* resolveItemOrdinal(input.context, nativeItemId);
+          const nodeId = idAllocator.derive.nodeFromProviderItem({
+            driver: CLAUDE_PROVIDER,
+            nativeItemId,
+          });
+          const nativeItemRef = {
+            driver: CLAUDE_PROVIDER,
+            nativeId: input.nativeItemId,
+            strength: "strong" as const,
+          };
+          const plan: OrchestrationV2PlanArtifact = {
+            id: planId,
+            threadId: input.context.input.threadId,
+            runId: input.context.input.runId,
+            nodeId,
+            kind: "proposed_plan",
+            status: "active",
+            markdown: input.markdown,
+          };
+          yield* emitProviderEvent({
+            type: "node.updated",
+            driver: CLAUDE_PROVIDER,
+            node: {
+              id: nodeId,
+              threadId: input.context.input.threadId,
+              runId: input.context.input.runId,
+              parentNodeId: input.context.input.rootNodeId,
+              rootNodeId: input.context.input.rootNodeId,
+              kind: "plan",
+              status: "completed",
+              countsForRun: false,
+              providerThreadId: input.context.input.providerThread.id,
+              providerTurnId: input.context.providerTurnId,
+              nativeItemRef,
+              runtimeRequestId: null,
+              checkpointScopeId: null,
+              startedAt: now,
+              completedAt: now,
+            },
+          });
+          yield* emitProviderEvent({
+            type: "plan.updated",
+            driver: CLAUDE_PROVIDER,
+            plan,
+          });
+          yield* emitProviderEvent({
+            type: "turn_item.updated",
+            driver: CLAUDE_PROVIDER,
+            turnItem: {
+              id: idAllocator.derive.turnItemFromProviderItem({
+                driver: CLAUDE_PROVIDER,
+                nativeItemId,
+              }),
+              threadId: input.context.input.threadId,
+              runId: input.context.input.runId,
+              nodeId,
+              providerThreadId: input.context.input.providerThread.id,
+              providerTurnId: input.context.providerTurnId,
+              nativeItemRef,
+              parentItemId: null,
+              ordinal,
+              status: "completed",
+              title: null,
+              startedAt: now,
+              completedAt: now,
+              updatedAt: now,
+              type: "proposed_plan",
+              planId,
+              markdown: input.markdown,
+              streaming: false,
+            },
+          });
+        });
+
         const canUseToolEffect = Effect.fn("ClaudeAdapterV2.canUseTool")(function* (
           toolName: Parameters<CanUseTool>[0],
           toolInput: Parameters<CanUseTool>[1],
@@ -2944,6 +3031,25 @@ export function makeClaudeAdapterV2(
             return {
               behavior: "deny",
               message: "Claude V2 adapter has no active turn for this tool request.",
+              toolUseID: callbackOptions.toolUseID,
+            } satisfies PermissionResult;
+          }
+
+          if (toolName === "ExitPlanMode" || toolName === "exit_plan_mode") {
+            // Plan proposals are approved through the app's plan card, not the
+            // SDK permission flow: capture the plan as a v2 artifact so the
+            // thread flips to Plan Ready, and keep the session in plan mode.
+            const planMarkdown = toolInput["plan"];
+            yield* emitProposedPlanArtifacts({
+              context,
+              nativeItemId: callbackOptions.toolUseID,
+              markdown: typeof planMarkdown === "string" ? planMarkdown : "",
+            });
+            return {
+              behavior: "deny",
+              message:
+                "The proposed plan has been shared with the user for review in the app. " +
+                "End the turn now; do not start implementing until the user approves the plan.",
               toolUseID: callbackOptions.toolUseID,
             } satisfies PermissionResult;
           }

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -1810,6 +1810,9 @@ interface ClaudeLiveQueryContext {
   readonly queryPolicyKey: string;
   readonly selectionKey: string;
   readonly closed: Deferred.Deferred<void, never>;
+  readonly openedWithResumeSessionAt: boolean;
+  /** True once any SDK message arrived on this query. */
+  receivedSdkMessage: boolean;
 }
 
 interface ActiveClaudeToolCall {
@@ -1876,6 +1879,14 @@ export function makeClaudeAdapterV2(
         const pendingAsyncTaskContexts = yield* Ref.make(
           new Map<string, ActiveClaudeTurnContext>(),
         );
+        /**
+         * Native threads whose next open must skip the resumeSessionAt pin.
+         * A dirty shutdown can record a conversation head that the killed
+         * claude process never flushed to its transcript; resuming at that
+         * head fails the first query. Entries are one-shot: consumed by the
+         * next openQuery and re-added if the unpinned open fails again.
+         */
+        const suppressResumeSessionAt = yield* Ref.make(new Set<string>());
         const interruptedTurns = yield* Ref.make(new Set<OrchestrationV2ProviderTurn["id"]>());
         const steeredTurns = yield* Ref.make(new Set<OrchestrationV2ProviderTurn["id"]>());
         const queryContext = yield* Ref.make<ClaudeLiveQueryContext | null>(null);
@@ -2759,6 +2770,24 @@ export function makeClaudeAdapterV2(
         const finalizeActiveTurnAfterQueryExit = Effect.fnUntraced(function* (
           cause?: Cause.Cause<ClaudeAgentSdkQueryRunnerError>,
         ) {
+          if (cause !== undefined) {
+            const failedQuery = yield* Ref.get(queryContext);
+            if (
+              failedQuery !== null &&
+              failedQuery.openedWithResumeSessionAt &&
+              !failedQuery.receivedSdkMessage
+            ) {
+              yield* Ref.update(suppressResumeSessionAt, (current) => {
+                const updated = new Set(current);
+                updated.add(failedQuery.nativeThreadId);
+                return updated;
+              });
+              yield* Effect.logWarning("orchestration-v2.claude-resume-pin-suppressed", {
+                providerSessionId: input.providerSessionId,
+                nativeThreadId: failedQuery.nativeThreadId,
+              });
+            }
+          }
           const context = yield* Ref.get(activeTurn);
           if (context === null) {
             return;
@@ -2804,6 +2833,7 @@ export function makeClaudeAdapterV2(
           if (liveQuery?.query !== input.query) {
             return;
           }
+          liveQuery.receivedSdkMessage = true;
 
           const message = input.message;
           if (message.type === "system" && message.subtype === "task_notification") {
@@ -3226,7 +3256,17 @@ export function makeClaudeAdapterV2(
             updated.add(nativeThreadId);
             return [false, updated];
           });
-          const shouldResume = resumeSessionAt !== undefined || openedWithResume;
+          const pinSuppressed = yield* Ref.modify(suppressResumeSessionAt, (current) => {
+            if (!current.has(nativeThreadId)) {
+              return [false, current] as const;
+            }
+            const updated = new Set(current);
+            updated.delete(nativeThreadId);
+            return [true, updated] as const;
+          });
+          const effectiveResumeSessionAt = pinSuppressed ? undefined : resumeSessionAt;
+          const shouldResume =
+            effectiveResumeSessionAt !== undefined || openedWithResume || pinSuppressed;
           const querySession = yield* queryRunner.open({
             threadId: turnInput.threadId,
             providerSessionId: input.providerSessionId,
@@ -3234,7 +3274,9 @@ export function makeClaudeAdapterV2(
               modelSelection: turnInput.modelSelection,
               nativeThreadId,
               resume: shouldResume,
-              ...(resumeSessionAt === undefined ? {} : { resumeSessionAt }),
+              ...(effectiveResumeSessionAt === undefined
+                ? {}
+                : { resumeSessionAt: effectiveResumeSessionAt }),
               cwd: turnInput.runtimePolicy.cwd,
               settings: adapterOptions.settings,
               environment: adapterOptions.environment,
@@ -3254,6 +3296,8 @@ export function makeClaudeAdapterV2(
             queryPolicyKey,
             selectionKey: compiledSelection.queryIdentity,
             closed,
+            openedWithResumeSessionAt: effectiveResumeSessionAt !== undefined,
+            receivedSdkMessage: false,
           };
           yield* Ref.set(queryContext, context);
           yield* querySession.messages.pipe(

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -275,7 +275,15 @@ export class ClaudeAgentSdkQueryRunnerError extends Schema.TaggedErrorClass<Clau
   },
 ) {
   override get message(): string {
-    return "Claude Agent SDK query failed.";
+    const detail =
+      this.cause instanceof Error
+        ? this.cause.message
+        : typeof this.cause === "string"
+          ? this.cause
+          : null;
+    return detail === null || detail.trim().length === 0
+      ? `Claude Agent SDK query failed (${this.method}).`
+      : `Claude Agent SDK query failed (${this.method}): ${detail}`;
   }
 }
 
@@ -2750,7 +2758,7 @@ export function makeClaudeAdapterV2(
               providerSessionId: input.providerSessionId,
               providerThreadId: context.input.providerThread.id,
               providerTurnId: context.providerTurnId,
-              cause,
+              cause: Cause.pretty(cause),
             });
           }
         });

--- a/apps/server/src/orchestration-v2/RunExecutionService.test.ts
+++ b/apps/server/src/orchestration-v2/RunExecutionService.test.ts
@@ -32,7 +32,7 @@ import { CheckpointServiceV2 } from "./CheckpointService.ts";
 import { EventSinkV2 } from "./EventSink.ts";
 import { layer as idAllocatorLayer } from "./IdAllocator.ts";
 import type { ProviderAdapterV2Event, ProviderAdapterV2SessionRuntime } from "./ProviderAdapter.ts";
-import { ProviderEventIngestorV2 } from "./ProviderEventIngestor.ts";
+import { ProviderEventIngestorV2, ProviderEventNormalizeError } from "./ProviderEventIngestor.ts";
 import {
   finalProviderThreadStatus,
   layer as runExecutionServiceLayer,
@@ -457,5 +457,169 @@ it.effect("keeps ingesting owned child events after the root turn terminalizes",
     );
     assert.isTrue(Option.isSome(observed), "child message was not ingested after root terminal");
     assert.deepEqual(yield* Ref.get(order), ["root-finalized", "child-message"]);
+  }),
+);
+
+it.effect("drops a poison event whose ingestion fails and keeps ingesting later events", () =>
+  Effect.gen(function* () {
+    const threadId = ThreadId.make("thread:run-execution-poison");
+    const runId = RunId.make("run:run-execution-poison");
+    const attemptId = RunAttemptId.make("attempt:run-execution-poison");
+    const providerInstanceId = ProviderInstanceId.make("codex");
+    const providerSessionId = ProviderSessionId.make("session:run-execution-poison");
+    const providerThreadId = ProviderThreadId.make("provider-thread:run-execution-poison");
+    const rootProviderTurnId = ProviderTurnId.make("provider-turn:run-execution-poison");
+    const rootNodeId = NodeId.make("node:run-execution-poison");
+    const poisonMessageId = MessageId.make("message:run-execution-poison:poison");
+    const goodMessageId = MessageId.make("message:run-execution-poison:good");
+    const goodMessageIngested = yield* Deferred.make<void>();
+    const rootFinalized = yield* Deferred.make<void>();
+    const order = yield* Ref.make<ReadonlyArray<string>>([]);
+    const testLayer = runExecutionServiceLayer.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          Layer.mock(CheckpointServiceV2)({ captureBaseline: () => Effect.void }),
+          Layer.mock(EventSinkV2)({
+            write: () => Effect.succeed([]),
+            writeWithEffects: (input) =>
+              Effect.gen(function* () {
+                if (
+                  input.events.some(
+                    (event) => event.type === "run.updated" && event.runId === runId,
+                  )
+                ) {
+                  yield* Ref.update(order, (current) => [...current, "root-finalized"]);
+                  yield* Deferred.succeed(rootFinalized, undefined).pipe(Effect.ignore);
+                }
+                return [];
+              }),
+            writeIfRunCurrent: () => Effect.succeed({ committed: true, storedEvents: [] }),
+          }),
+          idAllocatorLayer,
+          Layer.mock(ProviderEventIngestorV2)({
+            ingestNormalized: (input) =>
+              Effect.gen(function* () {
+                if (
+                  input.event.type === "message.updated" &&
+                  input.event.message.id === poisonMessageId
+                ) {
+                  return yield* new ProviderEventNormalizeError({
+                    providerSessionId,
+                    threadId,
+                    providerEvent: input.event,
+                  });
+                }
+                if (
+                  input.event.type === "message.updated" &&
+                  input.event.message.id === goodMessageId
+                ) {
+                  yield* Ref.update(order, (current) => [...current, "good-message"]);
+                  yield* Deferred.succeed(goodMessageIngested, undefined).pipe(Effect.ignore);
+                }
+                return [];
+              }),
+          }),
+          ServerSettingsService.layerTest(),
+        ),
+      ),
+    );
+    const events: ReadonlyArray<ProviderAdapterV2Event> = [
+      {
+        type: "message.updated",
+        driver,
+        message: {
+          id: poisonMessageId,
+          threadId,
+          runId,
+          nodeId: rootNodeId,
+          role: "assistant",
+          text: "poison",
+          streaming: false,
+        },
+      } as ProviderAdapterV2Event,
+      {
+        type: "message.updated",
+        driver,
+        message: {
+          id: goodMessageId,
+          threadId,
+          runId,
+          nodeId: rootNodeId,
+          role: "assistant",
+          text: "good",
+          streaming: false,
+        },
+      } as ProviderAdapterV2Event,
+      {
+        type: "turn.terminal",
+        driver,
+        providerThreadId,
+        providerTurnId: rootProviderTurnId,
+        runOrdinal: 1,
+        status: "completed",
+        failure: null,
+        threadDisposition: "reusable",
+      },
+    ];
+
+    yield* Effect.gen(function* () {
+      const runExecution = yield* RunExecutionServiceV2;
+      yield* runExecution.startRootRun({
+        commandId: CommandId.make("command:run-execution-poison"),
+        appThread: { id: threadId } as OrchestrationV2AppThread,
+        providerSessionId,
+        session: {
+          events: Stream.fromIterable(events),
+          startTurn: () => Effect.void,
+        } as unknown as ProviderAdapterV2SessionRuntime,
+        run: {
+          id: runId,
+          threadId,
+          ordinal: 1,
+          providerInstanceId,
+        } as OrchestrationV2Run,
+        rootNode: { id: rootNodeId } as OrchestrationV2ExecutionNode,
+        checkpointScope: {
+          id: CheckpointScopeId.make("checkpoint-scope:run-execution-poison"),
+        } as OrchestrationV2CheckpointScope,
+        providerThread: {
+          id: providerThreadId,
+          driver,
+        } as OrchestrationV2ProviderThread,
+        attempt: {
+          id: attemptId,
+          providerTurnId: rootProviderTurnId,
+        } as OrchestrationV2RunAttempt,
+        attemptId,
+        providerTurnOrdinal: 1,
+        message: {
+          messageId: MessageId.make("message:run-execution-poison:user"),
+          text: "Survive a poison event.",
+          attachments: [],
+          createdBy: "user",
+          creationSource: "web",
+        },
+        modelSelection: { instanceId: providerInstanceId, model: "gpt-5.4" },
+        runtimePolicy: {
+          runtimeMode: "full-access",
+          interactionMode: "default",
+          cwd: process.cwd(),
+          approvalPolicy: "never",
+          sandboxPolicy: {
+            type: "readOnly",
+            access: { type: "fullAccess" },
+            networkAccess: false,
+          },
+        },
+      });
+    }).pipe(Effect.provide(testLayer));
+
+    const observed = yield* Deferred.await(goodMessageIngested).pipe(
+      Effect.timeoutOption("2 seconds"),
+    );
+    assert.isTrue(Option.isSome(observed), "good event was not ingested after the poison event");
+    const finalized = yield* Deferred.await(rootFinalized).pipe(Effect.timeoutOption("2 seconds"));
+    assert.isTrue(finalized._tag === "Some", "root run was not finalized after the poison event");
+    assert.deepEqual(yield* Ref.get(order), ["good-message", "root-finalized"]);
   }),
 );

--- a/apps/server/src/orchestration-v2/RunExecutionService.ts
+++ b/apps/server/src/orchestration-v2/RunExecutionService.ts
@@ -700,7 +700,7 @@ export const layer: Layer.Layer<
                 Effect.flatMap((finalized) =>
                   Effect.logWarning("orchestration V2 provider event ingestion failed", {
                     runId: input.run.id,
-                    cause,
+                    cause: Cause.pretty(cause),
                   }).pipe(
                     Effect.andThen(
                       finalized
@@ -773,7 +773,7 @@ export const layer: Layer.Layer<
               Effect.catchCause((cause) =>
                 Effect.logError("orchestration V2 provider turn start failed", {
                   runId: input.run.id,
-                  cause,
+                  cause: Cause.pretty(cause),
                 }).pipe(
                   Effect.andThen(Fiber.interrupt(providerEventFiber)),
                   Effect.andThen(Ref.get(latestProviderThread)),

--- a/apps/server/src/orchestration-v2/RunExecutionService.ts
+++ b/apps/server/src/orchestration-v2/RunExecutionService.ts
@@ -681,7 +681,26 @@ export const layer: Layer.Layer<
                   yield* finalizeRootRun(event);
                 }
                 yield* trackChildLifecycle(event);
-              }),
+              }).pipe(
+                // A single unmappable event (e.g. a late subagent notification
+                // that references an already-finalized run) must not tear down
+                // ingestion for the whole session: dropping it keeps the
+                // pipeline alive for every later event. Root turn.terminal
+                // failures still escalate so the fallback finalization in the
+                // outer catch keeps running.
+                Effect.catchCause((eventCause) =>
+                  event.type === "turn.terminal"
+                    ? Effect.failCause(eventCause)
+                    : Effect.logWarning(
+                        "orchestration V2 provider event dropped after ingestion failure",
+                        {
+                          runId: input.run.id,
+                          eventType: event.type,
+                          cause: Cause.pretty(eventCause),
+                        },
+                      ),
+                ),
+              ),
             ),
             Stream.takeUntilEffect(() => shouldStopProviderEventIngestion),
             Stream.runDrain,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14507,19 +14507,19 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(rolldown@1.1.3)
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)':
+  '@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
+      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)':
+  '@vitest/browser@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
@@ -14528,7 +14528,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -20136,8 +20136,8 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.136.0
       '@oxlint/plugins': 1.68.0
-      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)
-      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)
+      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))
+      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
       '@vitest/pretty-format': 4.1.9
@@ -20150,7 +20150,7 @@ snapshots:
       oxlint: 1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@24.12.4)(bufferutil@4.1.0)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(utf-8-validate@6.0.6)(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.1
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.1
@@ -20196,7 +20196,7 @@ snapshots:
     optionalDependencies:
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'
 
-  vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)):
+  vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
@@ -20220,7 +20220,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
-      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)
+      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14507,19 +14507,19 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(rolldown@1.1.3)
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
+      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))':
+  '@vitest/browser@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
@@ -14528,7 +14528,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
@@ -20136,8 +20136,8 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.136.0
       '@oxlint/plugins': 1.68.0
-      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))
-      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))
+      '@vitest/browser': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)
+      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
       '@vitest/pretty-format': 4.1.9
@@ -20150,7 +20150,7 @@ snapshots:
       oxlint: 1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@types/node@24.12.4)(bufferutil@4.1.0)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(utf-8-validate@6.0.6)(yaml@2.9.0))
       oxlint-tsgolint: 0.23.0
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'
-      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
+      vitest: 4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.2.1
       '@voidzero-dev/vite-plus-darwin-x64': 0.2.1
@@ -20196,7 +20196,7 @@ snapshots:
     optionalDependencies:
       vite: '@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)'
 
-  vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9))(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)):
+  vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))
@@ -20220,7 +20220,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
-      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9(@types/node@24.12.4)(@vitest/browser-preview@4.1.9)(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3)))
+      '@vitest/browser-preview': 4.1.9(@voidzero-dev/vite-plus-core@0.2.1(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(bufferutil@4.1.0)(msw@2.12.11(@types/node@24.12.4)(typescript@6.0.3))(utf-8-validate@6.0.6)(vitest@4.1.9)
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
## What Changed

Five focused bug fixes for the Claude adapter / run execution in the v2 orchestrator (this PR's branch):

1. **Surface real causes in Claude provider failures** — `ClaudeAgentSdkQueryRunnerError.message` was a fixed string (`"Claude Agent SDK query failed."`), so every provider-error card showed that and nothing else, and the run-path logs printed `cause: [Object]`. The error message now appends the failing SDK method and the underlying defect message, and the three warn/error logs on the run path render `Cause.pretty` output.
2. **Let Claude plan mode propose approvable plans** — plan-mode sessions were launched with `installPermissionCallback: false`, so the SDK never exposed `ExitPlanMode` and plan mode could only ever end in prose: no plan artifact, no "Plan Ready" state, no approve/implement flow (`orchestration_v2_projection_plans` stayed empty). The callback is now installed in plan mode, and `canUseTool` intercepts `ExitPlanMode`: it emits the proposed plan as v2 node/plan/turn-item artifacts (`status: "active"`, which flips `hasActionableProposedPlan`) and denies the tool call with guidance to end the turn, so the session stays in plan mode until the user approves from the app. `emitsProposedPlan` capability flipped to `true`, regression test added for the plan-mode query policy.

3. **Drop poison provider events instead of killing ingestion** — one event failing `ingestNormalized` (e.g. a late async-subagent notification referencing a finalized run) tore down the whole `Stream.tap` pipeline, leaving the session's event routing dead and the next run wedged at `starting` until a server restart. Failed non-terminal events are now logged and dropped; root `turn.terminal` failures still escalate to the existing fallback finalization. Regression test included.
4. **Resolve async subagent completions after turn finalization** — the SDK's `system/task_notification` for an async Task usually arrives after the parent turn finalized (`activeTurn === null`), so it was silently dropped: the subagent projection stayed `running` forever and `RunExecutionService` kept waiting on a child that could never terminalize. Turn contexts with still-running tasks are now retained (keyed by native task id) and late notifications resolve against the owning context, emitting the subagent/node/turn-item updates under the original run.
5. **Skip a stale resume pin after a dirty-shutdown query failure** — resuming pins `resumeSessionAt` to the recorded conversation head; after a dirty shutdown that head may never have been flushed to the native transcript, so the first query failed and only an unexplained manual retry recovered. A pinned query that dies before producing any SDK message now marks the native thread so the next open resumes unpinned (one-shot).

The `ClaudeAgentSdkQueryRunnerError` message is derived from structural fields only (per the Effect service conventions); the underlying SDK error reaches the provider-failure card via `makeProviderFailure`'s existing redaction/bounding pipeline instead.

Known follow-up (not in this PR): a stop/cancel affordance for runs stuck in `queued/preparing/starting`.

## Why

Found while testing this PR end-to-end with the Claude provider:

- Every failure — missing cwd, SDK spawn failure, broken session resume — rendered as the same opaque card (`transport_error · "Claude Agent SDK query failed." · code: null`), and the logs gave nothing more. `makeProviderFailure` already extracts `Error#message`; the information was being discarded at the error-class layer.
- Plan mode on `claudeAgent` was a dead-end: the model itself reports it has no `ExitPlanMode` tool, writes its plan as chat prose, and the plan interaction mode can never hand off to the build flow. With this fix the full loop works: plan request → plan card + "Plan Ready" pill → Implement → build run executes the plan.

Both verified live against a scratch project (screenshots below); full server suite passes (1199 tests).

## UI Changes

No component changes — both fixes are server-side, but they change what the existing UI displays.

**Provider error card** (same failure class — a project whose workspace folder was deleted). Before: the bare one-liner with `code: null`. After: the card names the failing SDK method and the real cause.

| Before | After |
| --- | --- |
| <img alt="before: bare provider error card" src="https://github.com/user-attachments/assets/a424683c-edcc-4abf-b6cb-44e2ad4f9ed6" /> | <img alt="after: provider error card with method and real cause" src="https://github.com/user-attachments/assets/1cb3f84c-2aba-4d93-9c81-9d40f610b4ba" /> |

**Plan mode.** Before: the plan exists only as chat prose — no plan card, no Plan Ready, nothing to approve — and the model states it has no `ExitPlanMode` tool. After: a proposed-plan card is emitted, the thread flips to "Plan Ready", and Implement kicks off the build run that executes the plan (card + pill mid-flow state in the collapsed section below).

| Before | After |
| --- | --- |
| <img alt="before: plan as prose, no ExitPlanMode tool" src="https://github.com/user-attachments/assets/911330ba-eea5-4b39-ab46-944b0aad4666" /> | <img alt="after: plan implemented via the plan flow with changed files" src="https://github.com/user-attachments/assets/c4649c35-2403-4730-a044-352731146369" /> |

<details>
<summary>Extra: the proposed-plan card + "Plan Ready" pill + Implement button state (mid-flow)</summary>

<img width="834" height="772" alt="plan card with Plan Ready pill and Implement button" src="https://github.com/user-attachments/assets/6594661e-18ac-45c9-ac7c-7351b5641006" />


</details>

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core orchestration behavior (event ingestion, Claude session resume, plan/subagent lifecycle) in the v2 run path; mistakes could wedge runs or mis-route subagent/plan state, though failures are mostly isolated with logging and tests.
> 
> **Overview**
> Hardens the **Claude v2 adapter** and **run execution** path with five targeted fixes.
> 
> **Plan mode** now installs the SDK permission callback in plan mode and handles `ExitPlanMode` by emitting proposed-plan node/plan/turn-item artifacts (then denying the tool so review stays in-app). Capability `emitsProposedPlan` is set to true.
> 
> **Provider failures** unwrap `ClaudeAgentSdkQueryRunnerError` to the underlying `Error` for `makeProviderFailure`, and run-path logs use `Cause.pretty` instead of opaque cause objects.
> 
> **Async subagents** retain turn context for running tasks after parent finalization so late `task_notification` messages still terminalize subagents on the original run.
> 
> **Resume** skips a stale `resumeSessionAt` pin when a pinned query fails before any SDK message (one-shot per native thread).
> 
> **Run ingestion** logs and drops non-terminal events that fail normalization instead of killing the stream; root `turn.terminal` failures still escalate. Regression tests cover plan-mode query policy and poison-event handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeb5f9554f115768454469690ebbcd2915d2cc37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Claude plan-mode plan proposals and provider error cause unwrapping
> - Sets `emitsProposedPlan` to `true` in `ClaudeProviderCapabilitiesV2` and installs the permission callback in plan mode so the adapter can intercept `ExitPlanMode` tool calls, emit a `proposed_plan` artifact, and keep the session in plan mode.
> - Introduces `claudeProviderFailureCause` to unwrap the underlying `Error` from `ClaudeAgentSdkQueryRunnerError`, so provider failure logs now report the real SDK error cause rather than the wrapper.
> - Retains `ActiveClaudeTurnContext` for async tasks after a turn finalizes so `system.task_notification` messages received late are still resolved correctly.
> - Drops non-terminal provider events that fail ingestion normalization in `RunExecutionService` (logging a warning) while still aborting on root `turn.terminal` failures.
> - If a query opened with `resumeSessionAt` fails before any SDK message arrives, the next open for that native thread suppresses the resume pin and logs a warning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eeb5f95.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->