### PR TITLE
fix(web): remove glass chrome strip below chat composer

### DIFF
--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5350,16 +5350,8 @@ function ChatViewContent(props: ChatViewProps) {
             <div
               ref={setComposerOverlayElement}
               data-chat-composer-overlay="true"
-              className="pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 sm:pt-2"
+              className="pointer-events-none absolute inset-x-0 bottom-0 z-20 pt-1.5 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] sm:pt-2 sm:pb-[calc(env(safe-area-inset-bottom)+1rem)]"
             >
-              <div
-                aria-hidden="true"
-                className="chat-composer-horizontal-inset pointer-events-none absolute inset-x-0 top-1.5 bottom-0 z-0 sm:top-2"
-              >
-                <div className="chat-content-lane relative h-full overflow-clip rounded-t-[20px]">
-                  <div className="chat-composer-shared-blur absolute -inset-8" />
-                </div>
-              </div>
               <div className="chat-composer-horizontal-inset">
                 <div className="pointer-events-auto relative z-10 isolate">
                   {isServerThread && activeThread ? (
@@ -5445,7 +5437,6 @@ function ChatViewContent(props: ChatViewProps) {
                   </div>
                 </div>
               </div>
-              <div className="chat-composer-horizontal-inset chat-composer-lower-chrome relative z-10 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] sm:pb-[calc(env(safe-area-inset-bottom)+1rem)]" />
             </div>
 
             {pullRequestDialogState ? (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -177,12 +177,8 @@
     );
   }
 
-  .floating-glass-surface,
-  .chat-composer-lower-chrome {
-    background: color-mix(in srgb, var(--card) 20%, transparent);
-  }
-
   .floating-glass-surface {
+    background: color-mix(in srgb, var(--card) 20%, transparent);
     box-shadow:
       0 18px 48px -20px rgb(0 0 0 / 28%),
       0 4px 14px -7px rgb(0 0 0 / 22%);
@@ -190,26 +186,11 @@
     backdrop-filter: blur(16px);
   }
 
-  .chat-composer-shared-blur {
-    -webkit-backdrop-filter: blur(16px);
-    backdrop-filter: blur(16px);
-  }
-
-  .dark .floating-glass-surface,
-  .dark .chat-composer-lower-chrome {
-    background: color-mix(in srgb, var(--card) 45%, transparent);
-  }
-
   .dark .floating-glass-surface {
+    background: color-mix(in srgb, var(--card) 45%, transparent);
     box-shadow:
       0 18px 48px -20px rgb(0 0 0 / 60%),
       0 4px 14px -7px rgb(0 0 0 / 40%);
-  }
-
-  .chat-composer-lower-chrome {
-    margin-top: -1px;
-    margin-inline-end: var(--app-scrollbar-width);
-    padding-top: 1px;
   }
 
   @media (min-width: 40rem) {
@@ -227,8 +208,7 @@
   }
 
   @supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
-    .floating-glass-surface,
-    .chat-composer-lower-chrome {
+    .floating-glass-surface {
       background: var(--card);
     }
   }


### PR DESCRIPTION
## What Changed

Removed the glass chrome strip that rendered below the chat composer: the empty `chat-composer-lower-chrome` div and the `chat-composer-shared-blur` backdrop layer, plus their now-dead CSS rules. The composer overlay keeps the same bottom spacing via its own padding, and the composer's `floating-glass-surface` is unchanged.

## Why

The strip appeared as a second glass box leaking out under the input, instead of the composer floating on its own. Deleting the two decorative elements and folding their shared background values into the surviving `.floating-glass-surface` selectors fixes it with a net −29 line diff and no behavior change to the input itself.

## UI Changes

| Before | After |
|--------|------|
| <img width="803" height="525" alt="image" src="https://github.com/user-attachments/assets/2603bd59-e42a-4ac1-8c01-d6fdf4077a80" /> | <img width="400" height="128" alt="image" src="https://github.com/user-attachments/assets/57734dee-e586-48c3-bdee-9e690871df2a" /> |


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes (n/a — no motion changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/layout-only chat composer chrome cleanup with no logic or API changes; minor risk of bottom spacing differences on devices with safe-area insets.
> 
> **Overview**
> Fixes a **second glass panel** appearing under the chat input by removing the decorative backdrop layer (`chat-composer-shared-blur`) and the empty **`chat-composer-lower-chrome`** spacer from `ChatView`.
> 
> Bottom **safe-area padding** now lives on the composer overlay wrapper instead of the removed lower chrome, so timeline inset / `composerOverlayHeight` behavior should stay aligned. **`floating-glass-surface`** on `ChatComposer` is unchanged; related CSS is trimmed so glass styles apply only to that class (no shared rules with the deleted chrome).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a342fb5fa9a03d08e226ff1a2663db58b21e3b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove glass chrome strip below chat composer
> Removes the lower chrome divider and shared blur wrapper elements from the chat composer in [ChatView.tsx](https://github.com/pingdotgg/t3code/pull/3706/files#diff-4b49e092ccd43be0f0de24abe85ba522e09f04288a5d84253b0263e1a389400e). Safe-area bottom padding is now applied directly on the composer overlay wrapper. Corresponding CSS classes `chat-composer-lower-chrome` and `chat-composer-shared-blur` are deleted from [index.css](https://github.com/pingdotgg/t3code/pull/3706/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd), with glass styling consolidated onto `.floating-glass-surface` only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4a342fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->