### PR TITLE
fix(ssh): select a satisfying node when the login-shell node fails the engine range

### DIFF
--- a/packages/ssh/src/tunnel.ts
+++ b/packages/ssh/src/tunnel.ts
@@ -336,8 +336,12 @@ remote_node_satisfies_engine() {
 NODE
 }
 
+remote_node_ready() {
+  command -v node >/dev/null 2>&1 && remote_node_satisfies_engine >/dev/null 2>&1
+}
+
 ensure_remote_node_path() {
-  if command -v node >/dev/null 2>&1 && remote_node_satisfies_engine >/dev/null 2>&1; then
+  if remote_node_ready; then
     return 0
   fi
 
@@ -363,7 +367,7 @@ ensure_remote_node_path() {
 
   prepend_path_if_dir "$HOME/.local/share/mise/shims"
   prepend_path_if_dir "$HOME/.mise/shims"
-  if ! command -v node >/dev/null 2>&1 && command -v mise >/dev/null 2>&1; then
+  if ! remote_node_ready && command -v mise >/dev/null 2>&1; then
     eval "$(mise activate sh)" >/dev/null 2>&1 || true
   fi
 
@@ -373,14 +377,14 @@ ensure_remote_node_path() {
   export FNM_DIR
   prepend_path_if_dir "$FNM_DIR"
   prepend_path_if_dir "$HOME/.fnm"
-  if ! command -v node >/dev/null 2>&1 && command -v fnm >/dev/null 2>&1; then
+  if ! remote_node_ready && command -v fnm >/dev/null 2>&1; then
     eval "$(fnm env --shell bash)" >/dev/null 2>&1 || true
     fnm use --silent-if-unchanged >/dev/null 2>&1 || fnm use default >/dev/null 2>&1 || true
   fi
 
   prepend_path_if_dir "$HOME/.nodenv/bin"
   prepend_path_if_dir "$HOME/.nodenv/shims"
-  if ! command -v node >/dev/null 2>&1 && command -v nodenv >/dev/null 2>&1; then
+  if ! remote_node_ready && command -v nodenv >/dev/null 2>&1; then
     eval "$(nodenv init -)" >/dev/null 2>&1 || true
   fi
 
@@ -392,21 +396,22 @@ ensure_remote_node_path() {
   if [ -s "$NVM_DIR/nvm.sh" ]; then
     # shellcheck disable=SC1090
     . "$NVM_DIR/nvm.sh"
-    if ! command -v node >/dev/null 2>&1 && command -v nvm >/dev/null 2>&1; then
+    if ! remote_node_ready && command -v nvm >/dev/null 2>&1; then
       nvm use --silent default >/dev/null 2>&1 || nvm use --silent node >/dev/null 2>&1 || nvm use --silent --lts >/dev/null 2>&1 || true
     fi
   fi
 
-  if ! command -v node >/dev/null 2>&1 && [ -d "$NVM_DIR/versions/node" ]; then
+  if ! remote_node_ready && [ -d "$NVM_DIR/versions/node" ]; then
     for T3_NODE_BIN in "$NVM_DIR"/versions/node/*/bin; do
       if [ -x "$T3_NODE_BIN/node" ]; then
         PATH="$T3_NODE_BIN:$PATH"
         export PATH
+        remote_node_ready && break
       fi
     done
   fi
 
-  command -v node >/dev/null 2>&1 && remote_node_satisfies_engine
+  remote_node_ready
 }
 `;
 


### PR DESCRIPTION
## What

`ensure_remote_node_path` (in `REMOTE_NODE_ENV_SCRIPT`) only fell back to version managers (`mise`/`fnm`/`nodenv`/`nvm`, and the nvm version scan) when there was **no `node` on `PATH` at all** (`! command -v node`). When a login shell already exposes a `node` that **fails the engine range** — e.g. an `nvm default` below the minimum, or a system `/usr/bin/node` — every fallback was skipped and the unsatisfying node was exec'd anyway (`… || true`).

This gates the fallbacks on a combined **"node present *and* satisfies engine"** check (`remote_node_ready`), so a satisfying node that's already installed via a version manager actually gets selected. The nvm version scan also stops at the first satisfying version instead of relying on glob ordering.

## Why

On Windows+WSL this made the desktop backend launch under an unsupported node: e.g. the nvm `default` was `22.12.0` while a satisfying `22.21.1` was installed but not selected. Because the server bundle gates startup on `import.meta.main` (added in Node **22.16**), it then loaded its module graph and **exited `0` silently** without binding — and the desktop respawned it forever, showing **"Connecting to WSL…"** with no diagnostic.

Full trace and repro in #3709. (That issue also notes a second, separate hardening idea: have `bin.ts` fail *loudly* on an unsupported node instead of exiting silently — kept out of this PR to stay focused.)

## Scope / risk

- Single function; **behavior-preserving** for the "satisfying node already on PATH" and "no node at all" cases. Only the "unsatisfying node present" case changes.
- No new deps, no interface changes. Existing `packages/ssh/src/tunnel.test.ts` assertions (`ensure_remote_node_path()`, `if ! ensure_remote_node_path; then`, `remote_node_satisfies_engine()`) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single embedded shell function in SSH remote bootstrap; behavior only changes when an unsatisfying node is already on PATH, with no API or dependency changes.
> 
> **Overview**
> **Remote SSH Node selection** now treats “node on PATH” and “node satisfies the engine range” as one gate via a new `remote_node_ready` helper in the embedded `REMOTE_NODE_ENV_SCRIPT`.
> 
> Previously, `ensure_remote_node_path` only ran **mise/fnm/nodenv/nvm** fallbacks when `node` was missing entirely. If the login shell already had a `node` that **failed** the semver check (e.g. nvm `default` below minimum while a newer install existed), fallbacks were skipped and the bad binary was used—leading to silent exit and stuck “Connecting to WSL…” on Windows+WSL.
> 
> Fallback activation is now **`! remote_node_ready`** at each step. The nvm version-directory scan **stops at the first PATH prefix** where `remote_node_ready` succeeds instead of depending on glob order. Behavior is unchanged when no node exists or when the current `node` already satisfies the range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27be28c55e67be5f8cfe076a5bc469246113618b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SSH tunnel node selection when the login-shell node fails the engine range
> - Adds a `remote_node_ready` helper in [tunnel.ts](https://github.com/pingdotgg/t3code/pull/3710/files#diff-7338be65675ab0699d0c8c6426e54f3421747885231f9bbb0ace4ec129cb2072) that checks both node presence and engine compatibility in one place.
> - `ensure_remote_node_path` now continues activating version managers (mise, fnm, nodenv, nvm) even when a node binary exists but doesn't satisfy the engine requirement, instead of short-circuiting on presence alone.
> - The NVM versions loop now breaks as soon as a satisfying version is found rather than iterating all candidates.
> - Behavioral Change: SSH sessions that previously used an incompatible node binary will now attempt to resolve a compatible one via available version managers.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 27be28c. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->