### PR TITLE
fix: delegate OpenCode session titles to provider

### DIFF
--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -54,6 +54,7 @@ const runtimeMock = {
   state: {
     startCalls: [] as string[],
     sessionCreateUrls: [] as string[],
+    sessionCreateInputs: [] as Array<Record<string, unknown>>,
     authHeaders: [] as Array<string | null>,
     abortCalls: [] as string[],
     closeCalls: [] as string[],
@@ -67,6 +68,7 @@ const runtimeMock = {
   reset() {
     this.state.startCalls.length = 0;
     this.state.sessionCreateUrls.length = 0;
+    this.state.sessionCreateInputs.length = 0;
     this.state.authHeaders.length = 0;
     this.state.abortCalls.length = 0;
     this.state.closeCalls.length = 0;
@@ -122,8 +124,9 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
   createOpenCodeSdkClient: ({ baseUrl, serverPassword }) =>
     ({
       session: {
-        create: async () => {
+        create: async (input: Record<string, unknown>) => {
           runtimeMock.state.sessionCreateUrls.push(baseUrl);
+          runtimeMock.state.sessionCreateInputs.push(input);
           runtimeMock.state.authHeaders.push(
             serverPassword ? `Basic ${btoa(`opencode:${serverPassword}`)}` : null,
           );
@@ -729,6 +732,48 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
       const completed = events.at(-1);
       if (completed?.type === "item.completed") {
         NodeAssert.equal(completed.payload.detail, "A BBonus");
+      }
+    }),
+  );
+
+  it.effect("lets OpenCode own session title generation and emits title metadata updates", () =>
+    Effect.gen(function* () {
+      const adapter = yield* OpenCodeAdapter;
+      const threadId = asThreadId("thread-opencode-title-sync");
+      runtimeMock.state.subscribedEvents = [
+        {
+          type: "session.updated",
+          properties: {
+            sessionID: "http://127.0.0.1:9999/session",
+            info: {
+              id: "http://127.0.0.1:9999/session",
+              title: "Investigate OpenCode title sync",
+            },
+          },
+        },
+      ];
+
+      const eventsFiber = yield* adapter.streamEvents.pipe(
+        Stream.filter((event) => event.threadId === threadId),
+        Stream.take(3),
+        Stream.runCollect,
+        Effect.forkChild,
+      );
+
+      yield* adapter.startSession({
+        provider: ProviderDriverKind.make("opencode"),
+        threadId,
+        runtimeMode: "full-access",
+      });
+
+      const events = Array.from(yield* Fiber.join(eventsFiber).pipe(Effect.timeout("1 second")));
+      NodeAssert.equal(runtimeMock.state.sessionCreateInputs.length, 1);
+      NodeAssert.equal("title" in (runtimeMock.state.sessionCreateInputs[0] ?? {}), false);
+
+      const metadataUpdated = events.find((event) => event.type === "thread.metadata.updated");
+      NodeAssert.ok(metadataUpdated);
+      if (metadataUpdated.type === "thread.metadata.updated") {
+        NodeAssert.equal(metadataUpdated.payload.name, "Investigate OpenCode title sync");
       }
     }),
   );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -744,7 +744,6 @@ it.layer(OpenCodeAdapterTestLayer)("OpenCodeAdapterLive", (it) => {
         {
           type: "session.updated",
           properties: {
-            sessionID: "http://127.0.0.1:9999/session",
             info: {
               id: "http://127.0.0.1:9999/session",
               title: "Investigate OpenCode title sync",

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -65,6 +65,29 @@ type OpenCodeSubscribedEvent =
     ? TEvent
     : never;
 
+function trimText(value: string | undefined | null): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function openCodeEventSessionId(event: OpenCodeSubscribedEvent): string | undefined {
+  const properties = "properties" in event ? event.properties : undefined;
+  if (!properties || typeof properties !== "object") {
+    return undefined;
+  }
+
+  const sessionID = (properties as { readonly sessionID?: unknown }).sessionID;
+  return typeof sessionID === "string" ? sessionID : undefined;
+}
+
+function openCodeEventSessionTitle(event: OpenCodeSubscribedEvent): string | undefined {
+  if (event.type !== "session.updated") {
+    return undefined;
+  }
+
+  return trimText(event.properties.info.title);
+}
+
 interface OpenCodeSessionContext {
   session: ProviderSession;
   readonly client: OpencodeClient;
@@ -646,8 +669,7 @@ export function makeOpenCodeAdapter(
       context: OpenCodeSessionContext,
       event: OpenCodeSubscribedEvent,
     ) {
-      const payloadSessionId =
-        "properties" in event ? (event.properties as { sessionID?: unknown }).sessionID : undefined;
+      const payloadSessionId = openCodeEventSessionId(event);
       if (payloadSessionId !== context.openCodeSessionId) {
         return;
       }
@@ -666,6 +688,26 @@ export function makeOpenCodeAdapter(
       });
 
       switch (event.type) {
+        case "session.updated": {
+          const title = openCodeEventSessionTitle(event);
+          if (title) {
+            yield* emit({
+              ...(yield* buildEventBase({
+                threadId: context.session.threadId,
+                raw: event,
+              })),
+              type: "thread.metadata.updated",
+              payload: {
+                name: title,
+                metadata: {
+                  sessionID: context.openCodeSessionId,
+                },
+              },
+            });
+          }
+          break;
+        }
+
         case "message.updated": {
           context.messageRoleById.set(event.properties.info.id, event.properties.info.role);
           if (event.properties.info.role === "assistant") {
@@ -1072,7 +1114,6 @@ export function makeOpenCodeAdapter(
               }
               const openCodeSession = yield* runOpenCodeSdk("session.create", () =>
                 client.session.create({
-                  title: `T3 Code ${input.threadId}`,
                   permission: buildOpenCodePermissionRules(input.runtimeMode),
                 }),
               );

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -76,13 +76,14 @@ function openCodeEventSessionId(event: OpenCodeSubscribedEvent): string | undefi
     return undefined;
   }
 
-  const info = (properties as { readonly info?: { readonly id?: unknown } }).info;
-  const sessionIDFromInfo = info && typeof info.id === "string" ? info.id : undefined;
-  if (sessionIDFromInfo) {
-    return sessionIDFromInfo;
-  }
   const sessionID = (properties as { readonly sessionID?: unknown }).sessionID;
-  return typeof sessionID === "string" ? sessionID : undefined;
+  const sessionIDFromProperties = typeof sessionID === "string" ? sessionID : undefined;
+  if (sessionIDFromProperties) {
+    return sessionIDFromProperties;
+  }
+
+  const info = (properties as { readonly info?: { readonly id?: unknown } }).info;
+  return info && typeof info.id === "string" ? info.id : undefined;
 }
 
 function openCodeEventSessionTitle(event: OpenCodeSubscribedEvent): string | undefined {

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -76,6 +76,11 @@ function openCodeEventSessionId(event: OpenCodeSubscribedEvent): string | undefi
     return undefined;
   }
 
+  const info = (properties as { readonly info?: { readonly id?: unknown } }).info;
+  const sessionIDFromInfo = info && typeof info.id === "string" ? info.id : undefined;
+  if (sessionIDFromInfo) {
+    return sessionIDFromInfo;
+  }
   const sessionID = (properties as { readonly sessionID?: unknown }).sessionID;
   return typeof sessionID === "string" ? sessionID : undefined;
 }


### PR DESCRIPTION


<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

- Stop sending a generated title when creating OpenCode sessions
- Emit thread metadata updates from OpenCode session title events
- Cover the title sync flow in adapter tests

This means that when a thread in opencode is created it created without a title, opencode generates the title and this is recieved by t3code

## Why

Native opencode never recived the t3code title. This made it a bit disorientating when switching between t3code and the native app

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized OpenCode adapter behavior around display titles and event mapping; no auth, persistence, or security-sensitive paths change.
> 
> **Overview**
> OpenCode sessions are no longer created with a T3-generated `title` on `session.create`; only permission rules are sent so **OpenCode owns title generation**, matching the native app.
> 
> When OpenCode emits **`session.updated`** with a non-empty title, the adapter now maps that to **`thread.metadata.updated`** (`payload.name` plus `metadata.sessionID`). Session filtering for subscribed events also resolves the session id from either `properties.sessionID` or `properties.info.id` (needed for `session.updated`).
> 
> Adapter tests assert create payloads omit `title` and that title events surface as thread metadata updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bee25b2ece9eeb03a832fbdb7aeafb9ce031f3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Delegate session title generation to OpenCode provider
> - Removes the `title` field from the `session.create` payload so OpenCode owns title generation instead of the caller.
> - Adds a `session.updated` event handler in `makeOpenCodeAdapter` that extracts the title from the event and emits a `thread.metadata.updated` runtime event.
> - Adds `openCodeEventSessionId` to also accept session IDs from `properties.info.id`, in addition to `properties.sessionID`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bee25b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->