### PR TITLE
Add VS Code tunnel editor support

### DIFF
--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -46,6 +46,22 @@ describe("ElectronShell", () => {
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 
+  it.effect("opens VS Code protocol URLs", () =>
+    Effect.gen(function* () {
+      openExternalMock.mockResolvedValue(undefined);
+
+      const electronShell = yield* ElectronShell.ElectronShell;
+      const result = yield* electronShell.openExternal(
+        "vscode://vscode-remote/tunnel+devbox/workspaces/demo",
+      );
+
+      assert.equal(result, true);
+      assert.deepEqual(openExternalMock.mock.calls, [
+        ["vscode://vscode-remote/tunnel+devbox/workspaces/demo"],
+      ]);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
   it.effect("returns false when Electron rejects openExternal", () =>
     Effect.gen(function* () {
       openExternalMock.mockRejectedValue(new Error("open failed"));

--- a/apps/desktop/src/electron/ElectronShell.test.ts
+++ b/apps/desktop/src/electron/ElectronShell.test.ts
@@ -62,6 +62,16 @@ describe("ElectronShell", () => {
     }).pipe(Effect.provide(ElectronShell.layer)),
   );
 
+  it.effect("does not open non-tunnel VS Code URLs", () =>
+    Effect.gen(function* () {
+      const electronShell = yield* ElectronShell.ElectronShell;
+      const result = yield* electronShell.openExternal("vscode://file/etc/passwd");
+
+      assert.equal(result, false);
+      assert.equal(openExternalMock.mock.calls.length, 0);
+    }).pipe(Effect.provide(ElectronShell.layer)),
+  );
+
   it.effect("returns false when Electron rejects openExternal", () =>
     Effect.gen(function* () {
       openExternalMock.mockRejectedValue(new Error("open failed"));

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -5,7 +5,7 @@ import * as Option from "effect/Option";
 
 import * as Electron from "electron";
 
-const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
+const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "vscode:"]);
 
 export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
   if (typeof rawUrl !== "string") {

--- a/apps/desktop/src/electron/ElectronShell.ts
+++ b/apps/desktop/src/electron/ElectronShell.ts
@@ -5,7 +5,15 @@ import * as Option from "effect/Option";
 
 import * as Electron from "electron";
 
-const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:", "vscode:"]);
+const SAFE_EXTERNAL_PROTOCOLS = new Set(["http:", "https:"]);
+
+function isSafeVSCodeTunnelUrl(url: URL): boolean {
+  return (
+    url.protocol === "vscode:" &&
+    url.hostname === "vscode-remote" &&
+    url.pathname.startsWith("/tunnel+")
+  );
+}
 
 export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
   if (typeof rawUrl !== "string") {
@@ -14,7 +22,9 @@ export function parseSafeExternalUrl(rawUrl: unknown): Option.Option<string> {
 
   try {
     const url = new URL(rawUrl);
-    return SAFE_EXTERNAL_PROTOCOLS.has(url.protocol) ? Option.some(url.href) : Option.none();
+    return SAFE_EXTERNAL_PROTOCOLS.has(url.protocol) || isSafeVSCodeTunnelUrl(url)
+      ? Option.some(url.href)
+      : Option.none();
   } catch {
     return Option.none();
   }

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -86,6 +86,7 @@ import { makeManualOnlyProviderMaintenanceCapabilities } from "./provider/provid
 import * as ServerLifecycleEvents from "./serverLifecycleEvents.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
 import * as ServerSettings from "./serverSettings.ts";
+import * as VSCodeTunnel from "./vscodeTunnel.ts";
 import * as TerminalManager from "./terminal/Manager.ts";
 import * as PreviewManager from "./preview/Manager.ts";
 import * as PortScanner from "./preview/PortScanner.ts";
@@ -549,14 +550,29 @@ const buildAppUnderTest = (options?: {
         }),
       ),
       Layer.provide(
-        Layer.mock(ServerSettings.ServerSettingsService)({
-          start: Effect.void,
-          ready: Effect.void,
-          getSettings: Effect.succeed(DEFAULT_SERVER_SETTINGS),
-          updateSettings: () => Effect.succeed(DEFAULT_SERVER_SETTINGS),
-          streamChanges: Stream.empty,
-          ...options?.layers?.serverSettings,
-        }),
+        Layer.mergeAll(
+          Layer.mock(ServerSettings.ServerSettingsService)({
+            start: Effect.void,
+            ready: Effect.void,
+            getSettings: Effect.succeed(DEFAULT_SERVER_SETTINGS),
+            updateSettings: () => Effect.succeed(DEFAULT_SERVER_SETTINGS),
+            streamChanges: Stream.empty,
+            ...options?.layers?.serverSettings,
+          }),
+          Layer.mock(VSCodeTunnel.VSCodeTunnelMonitor)({
+            getSnapshot: () =>
+              Effect.succeed({
+                tunnel: null,
+                status: {
+                  checked: false,
+                  connected: false,
+                  machineName: null,
+                  serviceInstalled: null,
+                },
+              }),
+            streamChanges: Stream.empty,
+          }),
+        ),
       ),
       Layer.provide(
         Layer.mock(ExternalLauncher.ExternalLauncher)({
@@ -4225,6 +4241,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         keybindings: [],
         issues: [],
       } as const;
+      const keybindingChanges = yield* PubSub.unbounded<typeof changeEvent>();
 
       yield* buildAppUnderTest({
         config: {
@@ -4233,11 +4250,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         },
         layers: {
           keybindings: {
-            loadConfigState: Effect.succeed({
-              keybindings: [],
-              issues: [],
-            }),
-            streamChanges: Stream.succeed(changeEvent),
+            loadConfigState: PubSub.publish(keybindingChanges, changeEvent).pipe(
+              Effect.as({
+                keybindings: [],
+                issues: [],
+              }),
+            ),
+            streamChanges: Stream.fromPubSub(keybindingChanges),
           },
           providerRegistry: {
             getProviders: Effect.succeed(providers),
@@ -4298,6 +4317,7 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
           skills: [],
         },
       ] as const;
+      const providerChanges = yield* PubSub.unbounded<typeof nextProviders>();
 
       yield* buildAppUnderTest({
         layers: {
@@ -4309,8 +4329,8 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             streamChanges: Stream.empty,
           },
           providerRegistry: {
-            getProviders: Effect.succeed([]),
-            streamChanges: Stream.succeed(nextProviders),
+            getProviders: PubSub.publish(providerChanges, nextProviders).pipe(Effect.as([])),
+            streamChanges: Stream.fromPubSub(providerChanges).pipe(Stream.take(1)),
           },
         },
       });

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -4248,7 +4248,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       const wsUrl = yield* getWsServerUrl("/ws");
       const events = yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>
-          client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.take(2), Stream.runCollect),
+          client[WS_METHODS.subscribeServerConfig]({}).pipe(
+            Stream.filter(
+              (event) => event.type === "snapshot" || event.type === "keybindingsUpdated",
+            ),
+            Stream.take(2),
+            Stream.runCollect,
+          ),
         ),
       );
 
@@ -4312,7 +4318,13 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       const wsUrl = yield* getWsServerUrl("/ws");
       const events = yield* Effect.scoped(
         withWsRpcClient(wsUrl, (client) =>
-          client[WS_METHODS.subscribeServerConfig]({}).pipe(Stream.take(2), Stream.runCollect),
+          client[WS_METHODS.subscribeServerConfig]({}).pipe(
+            Stream.filter(
+              (event) => event.type === "snapshot" || event.type === "providerStatuses",
+            ),
+            Stream.take(2),
+            Stream.runCollect,
+          ),
         ),
       );
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -43,6 +43,7 @@ import * as ProcessRunner from "./processRunner.ts";
 import * as GitManager from "./git/GitManager.ts";
 import * as Keybindings from "./keybindings.ts";
 import * as ServerRuntimeStartup from "./serverRuntimeStartup.ts";
+import * as VSCodeTunnel from "./vscodeTunnel.ts";
 import { OrchestrationReactorLive } from "./orchestration/Layers/OrchestrationReactor.ts";
 import { RuntimeReceiptBusLive } from "./orchestration/Layers/RuntimeReceiptBus.ts";
 import { ProviderRuntimeIngestionLive } from "./orchestration/Layers/ProviderRuntimeIngestion.ts";
@@ -339,9 +340,10 @@ const RuntimeDependenciesLive = RuntimeCoreDependenciesLive.pipe(
   Layer.provide(NetService.layer),
 );
 
-const RuntimeServicesLive = ServerRuntimeStartup.layer.pipe(
-  Layer.provideMerge(RuntimeDependenciesLive),
-);
+const RuntimeServicesLive = Layer.mergeAll(
+  ServerRuntimeStartup.layer,
+  VSCodeTunnel.monitorLayer.pipe(Layer.provide(ProcessRunner.layer)),
+).pipe(Layer.provideMerge(RuntimeDependenciesLive));
 
 export const makeRoutesLayer = Layer.mergeAll(
   Layer.mergeAll(

--- a/apps/server/src/vscodeTunnel.test.ts
+++ b/apps/server/src/vscodeTunnel.test.ts
@@ -4,6 +4,7 @@ import * as Layer from "effect/Layer";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 
 import * as ProcessRunner from "./processRunner.ts";
+import * as ServerSettings from "./serverSettings.ts";
 import * as VSCodeTunnel from "./vscodeTunnel.ts";
 
 describe("vscode tunnel status resolution", () => {
@@ -37,6 +38,69 @@ describe("vscode tunnel status resolution", () => {
       ),
     ),
   );
+
+  it.effect("ignores stray quotes before the status JSON", () =>
+    Effect.gen(function* () {
+      const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({
+        enabled: true,
+      });
+
+      expect(resolved.status.connected).toBe(true);
+      expect(resolved.tunnel).toEqual({ machineName: "devbox" });
+    }).pipe(
+      Effect.provide(
+        Layer.succeed(ProcessRunner.ProcessRunner, {
+          run: () =>
+            Effect.succeed({
+              stdout: [
+                'warning: unexpected " in configuration',
+                '{"tunnel":{"name":"devbox","tunnel":"connected"},"service_installed":true}',
+              ].join("\n"),
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("shares cached tunnel status across snapshot readers", () => {
+    let runCount = 0;
+    const monitorLayer = VSCodeTunnel.monitorLayer.pipe(
+      Layer.provide(ServerSettings.layerTest({ enableVSCodeRemoteTunnels: true })),
+      Layer.provide(
+        Layer.succeed(ProcessRunner.ProcessRunner, {
+          run: () =>
+            Effect.sync(() => {
+              runCount += 1;
+              return {
+                stdout:
+                  '{"tunnel":{"name":"devbox","tunnel":"connected"},"service_installed":true}',
+                stderr: "",
+                code: ChildProcessSpawner.ExitCode(0),
+                timedOut: false,
+                stdoutTruncated: false,
+                stderrTruncated: false,
+              };
+            }),
+        }),
+      ),
+    );
+
+    return Effect.gen(function* () {
+      const monitor = yield* VSCodeTunnel.VSCodeTunnelMonitor;
+      const snapshots = yield* Effect.all(
+        [monitor.getSnapshot({ enabled: true }), monitor.getSnapshot({ enabled: true })],
+        { concurrency: "unbounded" },
+      );
+
+      expect(runCount).toBe(1);
+      expect(snapshots[0]).toEqual(snapshots[1]);
+    }).pipe(Effect.provide(monitorLayer));
+  });
 
   it.effect("parses connected status when JSON is pretty-printed", () =>
     Effect.gen(function* () {

--- a/apps/server/src/vscodeTunnel.test.ts
+++ b/apps/server/src/vscodeTunnel.test.ts
@@ -38,6 +38,44 @@ describe("vscode tunnel status resolution", () => {
     ),
   );
 
+  it.effect("parses connected status when JSON is pretty-printed", () =>
+    Effect.gen(function* () {
+      const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({
+        enabled: true,
+      });
+
+      expect(resolved.status.checked).toBe(true);
+      expect(resolved.status.connected).toBe(true);
+      expect(resolved.status.machineName).toBe("devbox");
+      expect(resolved.status.serviceInstalled).toBe(true);
+      expect(resolved.tunnel).toEqual({ machineName: "devbox" });
+    }).pipe(
+      Effect.provide(
+        Layer.succeed(ProcessRunner.ProcessRunner, {
+          run: () =>
+            Effect.succeed({
+              stdout: [
+                "Some informational output...",
+                "{",
+                '  "tunnel": {',
+                '    "name": "devbox",',
+                '    "tunnel": "connected"',
+                "  },",
+                '  "service_installed": true',
+                "}",
+                "Trailing output line",
+              ].join("\n"),
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  );
+
   it.effect("returns unavailable status when no JSON object is present", () =>
     Effect.gen(function* () {
       const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({

--- a/apps/server/src/vscodeTunnel.test.ts
+++ b/apps/server/src/vscodeTunnel.test.ts
@@ -76,6 +76,67 @@ describe("vscode tunnel status resolution", () => {
     ),
   );
 
+  it.effect("accepts tunnel:null and preserves service status", () =>
+    Effect.gen(function* () {
+      const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({
+        enabled: true,
+      });
+
+      expect(resolved.tunnel).toBeNull();
+      expect(resolved.status).toEqual({
+        checked: true,
+        connected: false,
+        machineName: null,
+        serviceInstalled: true,
+      });
+    }).pipe(
+      Effect.provide(
+        Layer.succeed(ProcessRunner.ProcessRunner, {
+          run: () =>
+            Effect.succeed({
+              stdout: '{"tunnel":null,"service_installed":true}',
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("skips unrelated JSON and parses the status payload", () =>
+    Effect.gen(function* () {
+      const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({
+        enabled: true,
+      });
+
+      expect(resolved.status.checked).toBe(true);
+      expect(resolved.status.connected).toBe(true);
+      expect(resolved.status.machineName).toBe("devbox");
+      expect(resolved.status.serviceInstalled).toBe(true);
+      expect(resolved.tunnel).toEqual({ machineName: "devbox" });
+    }).pipe(
+      Effect.provide(
+        Layer.succeed(ProcessRunner.ProcessRunner, {
+          run: () =>
+            Effect.succeed({
+              stdout: [
+                '{"log":"starting"}',
+                '{"tunnel":{"name":"devbox","tunnel":"connected"},"service_installed":true}',
+              ].join("\n"),
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  );
+
   it.effect("returns unavailable status when no JSON object is present", () =>
     Effect.gen(function* () {
       const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({

--- a/apps/server/src/vscodeTunnel.test.ts
+++ b/apps/server/src/vscodeTunnel.test.ts
@@ -137,6 +137,37 @@ describe("vscode tunnel status resolution", () => {
     ),
   );
 
+  it.effect("parses status JSON even when stray closing braces precede the payload", () =>
+    Effect.gen(function* () {
+      const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({
+        enabled: true,
+      });
+
+      expect(resolved.status.checked).toBe(true);
+      expect(resolved.status.connected).toBe(true);
+      expect(resolved.status.machineName).toBe("devbox");
+      expect(resolved.status.serviceInstalled).toBe(true);
+      expect(resolved.tunnel).toEqual({ machineName: "devbox" });
+    }).pipe(
+      Effect.provide(
+        Layer.succeed(ProcessRunner.ProcessRunner, {
+          run: () =>
+            Effect.succeed({
+              stdout: [
+                "noise } }",
+                '{"tunnel":{"name":"devbox","tunnel":"connected"},"service_installed":true}',
+              ].join("\n"),
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  );
+
   it.effect("returns unavailable status when no JSON object is present", () =>
     Effect.gen(function* () {
       const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({

--- a/apps/server/src/vscodeTunnel.test.ts
+++ b/apps/server/src/vscodeTunnel.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+import * as ProcessRunner from "./processRunner.ts";
+import * as VSCodeTunnel from "./vscodeTunnel.ts";
+
+describe("vscode tunnel status resolution", () => {
+  it.effect("parses connected status when JSON is preceded by non-JSON output", () =>
+    Effect.gen(function* () {
+      const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({
+        enabled: true,
+      });
+
+      expect(resolved.status.checked).toBe(true);
+      expect(resolved.status.connected).toBe(true);
+      expect(resolved.status.machineName).toBe("devbox");
+      expect(resolved.status.serviceInstalled).toBe(true);
+      expect(resolved.tunnel).toEqual({ machineName: "devbox" });
+    }).pipe(
+      Effect.provide(
+        Layer.succeed(ProcessRunner.ProcessRunner, {
+          run: () =>
+            Effect.succeed({
+              stdout: [
+                "Some informational output...",
+                '{"tunnel":{"name":"devbox","tunnel":"connected"},"service_installed":true}',
+              ].join("\n"),
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  );
+
+  it.effect("returns unavailable status when no JSON object is present", () =>
+    Effect.gen(function* () {
+      const resolved = yield* VSCodeTunnel.resolveVSCodeTunnel({
+        enabled: true,
+      });
+
+      expect(resolved.tunnel).toBeNull();
+      expect(resolved.status).toEqual({
+        checked: true,
+        connected: false,
+        machineName: null,
+        serviceInstalled: null,
+      });
+    }).pipe(
+      Effect.provide(
+        Layer.succeed(ProcessRunner.ProcessRunner, {
+          run: () =>
+            Effect.succeed({
+              stdout: "status unavailable",
+              stderr: "",
+              code: ChildProcessSpawner.ExitCode(0),
+              timedOut: false,
+              stdoutTruncated: false,
+              stderrTruncated: false,
+            }),
+        }),
+      ),
+    ),
+  );
+});

--- a/apps/server/src/vscodeTunnel.ts
+++ b/apps/server/src/vscodeTunnel.ts
@@ -24,12 +24,53 @@ const decodeVSCodeTunnelStatusJson = Schema.decodeUnknownOption(
 
 function extractVSCodeTunnelStatusJson(stdout: string): string {
   const trimmed = stdout.trim();
-  const jsonLine =
-    trimmed
-      .split(/\r?\n/)
-      .find((line) => line.trim().startsWith("{"))
-      ?.trim() ?? "";
-  return jsonLine || trimmed;
+  const start = trimmed.indexOf("{");
+  if (start < 0) {
+    return trimmed;
+  }
+
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = start; index < trimmed.length; index += 1) {
+    const char = trimmed[index];
+    if (char === undefined) break;
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === "\\") {
+        escaped = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inString = true;
+      continue;
+    }
+
+    if (char === "{") {
+      depth += 1;
+      continue;
+    }
+
+    if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        return trimmed.slice(start, index + 1);
+      }
+    }
+  }
+
+  return trimmed.slice(start);
 }
 
 const UNCHECKED_STATUS: ServerVSCodeTunnelStatus = {

--- a/apps/server/src/vscodeTunnel.ts
+++ b/apps/server/src/vscodeTunnel.ts
@@ -1,12 +1,20 @@
 import { type ServerVSCodeTunnel, type ServerVSCodeTunnelStatus } from "@t3tools/contracts";
+import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
+import * as Ref from "effect/Ref";
+import * as Semaphore from "effect/Semaphore";
 import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
 
 import * as ProcessRunner from "./processRunner.ts";
+import * as ServerSettings from "./serverSettings.ts";
 
 const VSCODE_TUNNEL_STATUS_TIMEOUT = Duration.millis(1_500);
+const VSCODE_TUNNEL_REFRESH_INTERVAL = Duration.minutes(1);
 
 const VSCodeTunnelStatusJson = Schema.Struct({
   tunnel: Schema.optional(
@@ -51,7 +59,7 @@ function extractVSCodeTunnelStatusJson(stdout: string): string {
       continue;
     }
 
-    if (char === '"') {
+    if (char === '"' && depth > 0) {
       inString = true;
       continue;
     }
@@ -181,3 +189,91 @@ export const resolveVSCodeTunnel = Effect.fn("vscodeTunnel.resolve")(function* (
     status,
   } satisfies ResolvedVSCodeTunnel;
 });
+
+interface CachedVSCodeTunnel {
+  readonly enabled: boolean;
+  readonly resolved: ResolvedVSCodeTunnel;
+}
+
+export interface VSCodeTunnelMonitorShape {
+  readonly getSnapshot: (input: {
+    readonly enabled: boolean;
+  }) => Effect.Effect<ResolvedVSCodeTunnel>;
+  readonly streamChanges: Stream.Stream<ResolvedVSCodeTunnel>;
+}
+
+export class VSCodeTunnelMonitor extends Context.Service<
+  VSCodeTunnelMonitor,
+  VSCodeTunnelMonitorShape
+>()("t3/vscodeTunnel/VSCodeTunnelMonitor") {}
+
+const makeVSCodeTunnelMonitor = Effect.gen(function* () {
+  const processRunner = yield* ProcessRunner.ProcessRunner;
+  const serverSettings = yield* ServerSettings.ServerSettingsService;
+  const cachedRef = yield* Ref.make<CachedVSCodeTunnel | null>(null);
+  const changesPubSub = yield* PubSub.unbounded<ResolvedVSCodeTunnel>();
+  const refreshSemaphore = yield* Semaphore.make(1);
+
+  const refresh = Effect.fn("VSCodeTunnelMonitor.refresh")(function* (input: {
+    readonly enabled: boolean;
+    readonly force: boolean;
+  }) {
+    return yield* refreshSemaphore.withPermits(1)(
+      Effect.gen(function* () {
+        const cached = yield* Ref.get(cachedRef);
+        if (!input.force && cached?.enabled === input.enabled) {
+          return cached.resolved;
+        }
+
+        const resolved = yield* resolveVSCodeTunnel({ enabled: input.enabled }).pipe(
+          Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+        );
+        yield* Ref.set(cachedRef, { enabled: input.enabled, resolved });
+        yield* PubSub.publish(changesPubSub, resolved);
+        return resolved;
+      }),
+    );
+  });
+
+  const refreshFromCurrentSettings = (force: boolean) =>
+    serverSettings.getSettings.pipe(
+      Effect.flatMap((settings) =>
+        refresh({
+          enabled: settings.enableVSCodeRemoteTunnels,
+          force,
+        }),
+      ),
+      Effect.asVoid,
+      Effect.catchCause((cause) =>
+        Effect.logWarning("failed to refresh VS Code tunnel status", { cause }),
+      ),
+    );
+
+  const settingsRefreshes = serverSettings.streamChanges.pipe(
+    Stream.mapEffect((settings) =>
+      refresh({
+        enabled: settings.enableVSCodeRemoteTunnels,
+        force: false,
+      }),
+    ),
+  );
+  const periodicRefreshes = Stream.tick(VSCODE_TUNNEL_REFRESH_INTERVAL).pipe(
+    Stream.mapEffect(() => refreshFromCurrentSettings(true)),
+  );
+
+  yield* settingsRefreshes.pipe(
+    Stream.merge(periodicRefreshes),
+    Stream.runDrain,
+    Effect.ignoreCause({ log: true }),
+    Effect.forkScoped({ startImmediately: true }),
+  );
+
+  return VSCodeTunnelMonitor.of({
+    getSnapshot: ({ enabled }) => refresh({ enabled, force: false }),
+    get streamChanges() {
+      return Stream.fromPubSub(changesPubSub);
+    },
+  });
+});
+
+export const monitorLayer = Layer.effect(VSCodeTunnelMonitor, makeVSCodeTunnelMonitor);

--- a/apps/server/src/vscodeTunnel.ts
+++ b/apps/server/src/vscodeTunnel.ts
@@ -22,6 +22,16 @@ const decodeVSCodeTunnelStatusJson = Schema.decodeUnknownOption(
   Schema.fromJsonString(VSCodeTunnelStatusJson),
 );
 
+function extractVSCodeTunnelStatusJson(stdout: string): string {
+  const trimmed = stdout.trim();
+  const jsonLine =
+    trimmed
+      .split(/\r?\n/)
+      .find((line) => line.trim().startsWith("{"))
+      ?.trim() ?? "";
+  return jsonLine || trimmed;
+}
+
 const UNCHECKED_STATUS: ServerVSCodeTunnelStatus = {
   checked: false,
   connected: false,
@@ -77,7 +87,7 @@ export const resolveVSCodeTunnel = Effect.fn("vscodeTunnel.resolve")(function* (
     } satisfies ResolvedVSCodeTunnel;
   }
 
-  const decoded = decodeVSCodeTunnelStatusJson(output.stdout.trim());
+  const decoded = decodeVSCodeTunnelStatusJson(extractVSCodeTunnelStatusJson(output.stdout));
   if (Option.isNone(decoded)) {
     return {
       tunnel: null,

--- a/apps/server/src/vscodeTunnel.ts
+++ b/apps/server/src/vscodeTunnel.ts
@@ -65,6 +65,9 @@ function extractVSCodeTunnelStatusJson(stdout: string): string {
     }
 
     if (char === "}") {
+      if (depth === 0) {
+        continue;
+      }
       depth -= 1;
       if (depth === 0 && start >= 0) {
         candidates.push(trimmed.slice(start, index + 1));
@@ -89,7 +92,7 @@ function extractVSCodeTunnelStatusJson(stdout: string): string {
     }
   }
 
-  return candidates[0] ?? trimmed;
+  return "";
 }
 
 const UNCHECKED_STATUS: ServerVSCodeTunnelStatus = {

--- a/apps/server/src/vscodeTunnel.ts
+++ b/apps/server/src/vscodeTunnel.ts
@@ -10,10 +10,12 @@ const VSCODE_TUNNEL_STATUS_TIMEOUT = Duration.millis(1_500);
 
 const VSCodeTunnelStatusJson = Schema.Struct({
   tunnel: Schema.optional(
-    Schema.Struct({
-      name: Schema.optional(Schema.String),
-      tunnel: Schema.optional(Schema.String),
-    }),
+    Schema.NullOr(
+      Schema.Struct({
+        name: Schema.optional(Schema.String),
+        tunnel: Schema.optional(Schema.String),
+      }),
+    ),
   ),
   service_installed: Schema.optional(Schema.Boolean),
 });
@@ -24,16 +26,13 @@ const decodeVSCodeTunnelStatusJson = Schema.decodeUnknownOption(
 
 function extractVSCodeTunnelStatusJson(stdout: string): string {
   const trimmed = stdout.trim();
-  const start = trimmed.indexOf("{");
-  if (start < 0) {
-    return trimmed;
-  }
-
+  let start = -1;
   let depth = 0;
   let inString = false;
   let escaped = false;
+  const candidates: Array<string> = [];
 
-  for (let index = start; index < trimmed.length; index += 1) {
+  for (let index = 0; index < trimmed.length; index += 1) {
     const char = trimmed[index];
     if (char === undefined) break;
 
@@ -58,19 +57,39 @@ function extractVSCodeTunnelStatusJson(stdout: string): string {
     }
 
     if (char === "{") {
+      if (depth === 0) {
+        start = index;
+      }
       depth += 1;
       continue;
     }
 
     if (char === "}") {
       depth -= 1;
-      if (depth === 0) {
-        return trimmed.slice(start, index + 1);
+      if (depth === 0 && start >= 0) {
+        candidates.push(trimmed.slice(start, index + 1));
+        start = -1;
       }
     }
   }
 
-  return trimmed.slice(start);
+  for (const candidate of candidates) {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        (Object.prototype.hasOwnProperty.call(parsed, "tunnel") ||
+          Object.prototype.hasOwnProperty.call(parsed, "service_installed"))
+      ) {
+        return candidate;
+      }
+    } catch {
+      // Ignore invalid JSON fragments and continue scanning.
+    }
+  }
+
+  return candidates[0] ?? trimmed;
 }
 
 const UNCHECKED_STATUS: ServerVSCodeTunnelStatus = {

--- a/apps/server/src/vscodeTunnel.ts
+++ b/apps/server/src/vscodeTunnel.ts
@@ -1,0 +1,111 @@
+import { type ServerVSCodeTunnel, type ServerVSCodeTunnelStatus } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+
+import { ProcessRunner } from "./processRunner.ts";
+
+const VSCODE_TUNNEL_STATUS_TIMEOUT = Duration.millis(1_500);
+
+const VSCodeTunnelStatusJson = Schema.Struct({
+  tunnel: Schema.optional(
+    Schema.Struct({
+      name: Schema.optional(Schema.String),
+      tunnel: Schema.optional(Schema.String),
+    }),
+  ),
+  service_installed: Schema.optional(Schema.Boolean),
+});
+
+const decodeVSCodeTunnelStatusJson = Schema.decodeUnknownOption(
+  Schema.fromJsonString(VSCodeTunnelStatusJson),
+);
+
+const UNCHECKED_STATUS: ServerVSCodeTunnelStatus = {
+  checked: false,
+  connected: false,
+  machineName: null,
+  serviceInstalled: null,
+};
+
+const CHECKED_UNAVAILABLE_STATUS: ServerVSCodeTunnelStatus = {
+  checked: true,
+  connected: false,
+  machineName: null,
+  serviceInstalled: null,
+};
+
+export interface ResolvedVSCodeTunnel {
+  readonly tunnel: ServerVSCodeTunnel | null;
+  readonly status: ServerVSCodeTunnelStatus;
+}
+
+export const resolveVSCodeTunnel = Effect.fn("vscodeTunnel.resolve")(function* (input: {
+  readonly enabled: boolean;
+  readonly networkAccessEnabled: boolean;
+}) {
+  if (!input.enabled || !input.networkAccessEnabled) {
+    return {
+      tunnel: null,
+      status: UNCHECKED_STATUS,
+    } satisfies ResolvedVSCodeTunnel;
+  }
+
+  const runner = yield* ProcessRunner;
+  const result = yield* runner
+    .run({
+      command: "code",
+      args: ["tunnel", "status"],
+      timeout: VSCODE_TUNNEL_STATUS_TIMEOUT,
+      maxOutputBytes: 16 * 1024,
+      outputMode: "truncate",
+      timeoutBehavior: "timedOutResult",
+    })
+    .pipe(Effect.option);
+
+  if (Option.isNone(result)) {
+    return {
+      tunnel: null,
+      status: CHECKED_UNAVAILABLE_STATUS,
+    } satisfies ResolvedVSCodeTunnel;
+  }
+  const output = result.value;
+  if (output.timedOut || output.code !== 0) {
+    return {
+      tunnel: null,
+      status: CHECKED_UNAVAILABLE_STATUS,
+    } satisfies ResolvedVSCodeTunnel;
+  }
+
+  const decoded = decodeVSCodeTunnelStatusJson(output.stdout.trim());
+  if (Option.isNone(decoded)) {
+    return {
+      tunnel: null,
+      status: CHECKED_UNAVAILABLE_STATUS,
+    } satisfies ResolvedVSCodeTunnel;
+  }
+  const tunnel = decoded.value.tunnel;
+  const machineName = tunnel?.name?.trim() ?? "";
+  const connected = Boolean(machineName) && tunnel?.tunnel?.toLowerCase() === "connected";
+  const status: ServerVSCodeTunnelStatus = {
+    checked: true,
+    connected,
+    machineName: machineName || null,
+    serviceInstalled: decoded.value.service_installed ?? null,
+  };
+
+  if (!connected) {
+    return {
+      tunnel: null,
+      status,
+    } satisfies ResolvedVSCodeTunnel;
+  }
+
+  return {
+    tunnel: {
+      machineName,
+    },
+    status,
+  } satisfies ResolvedVSCodeTunnel;
+});

--- a/apps/server/src/vscodeTunnel.ts
+++ b/apps/server/src/vscodeTunnel.ts
@@ -4,7 +4,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 
-import { ProcessRunner } from "./processRunner.ts";
+import * as ProcessRunner from "./processRunner.ts";
 
 const VSCODE_TUNNEL_STATUS_TIMEOUT = Duration.millis(1_500);
 
@@ -43,16 +43,15 @@ export interface ResolvedVSCodeTunnel {
 
 export const resolveVSCodeTunnel = Effect.fn("vscodeTunnel.resolve")(function* (input: {
   readonly enabled: boolean;
-  readonly networkAccessEnabled: boolean;
 }) {
-  if (!input.enabled || !input.networkAccessEnabled) {
+  if (!input.enabled) {
     return {
       tunnel: null,
       status: UNCHECKED_STATUS,
     } satisfies ResolvedVSCodeTunnel;
   }
 
-  const runner = yield* ProcessRunner;
+  const runner = yield* ProcessRunner.ProcessRunner;
   const result = yield* runner
     .run({
       command: "code",

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1817,11 +1817,20 @@ const makeWsRpcLayer = (
                     },
                   })),
                 );
-              const vscodeTunnelSettingsUpdates: Stream.Stream<ServerConfigStreamEvent> =
-                serverSettings.streamChanges.pipe(
+              const vscodeTunnelSettingsUpdates: Stream.Stream<ServerConfigStreamEvent> = (() => {
+                let previousTunnelEnabled: boolean | undefined;
+                return serverSettings.streamChanges.pipe(
                   Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
+                  Stream.filter((settings) => {
+                    const changed =
+                      previousTunnelEnabled === undefined ||
+                      previousTunnelEnabled !== settings.enableVSCodeRemoteTunnels;
+                    previousTunnelEnabled = settings.enableVSCodeRemoteTunnels;
+                    return changed;
+                  }),
                   Stream.mapEffect(toVSCodeTunnelUpdateEvent),
                 );
+              })();
               const vscodeTunnelPeriodicUpdates: Stream.Stream<ServerConfigStreamEvent> =
                 Stream.tick(VSCODE_TUNNEL_REFRESH_INTERVAL).pipe(
                   Stream.mapEffect(() =>

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -5,6 +5,7 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as PubSub from "effect/PubSub";
 import * as Queue from "effect/Queue";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
@@ -120,8 +121,6 @@ import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
-const VSCODE_TUNNEL_REFRESH_INTERVAL = Duration.minutes(1);
-
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
 }
@@ -394,6 +393,8 @@ function toAuthAccessStreamEvent(
 const makeWsRpcLayer = (
   currentSession: EnvironmentAuth.AuthenticatedSession,
   previewAutomationBroker: PreviewAutomationBroker.PreviewAutomationBroker["Service"],
+  serverConfigUpdates: PubSub.PubSub<ServerConfigStreamEvent>,
+  vscodeTunnelMonitor: VSCodeTunnel.VSCodeTunnelMonitor["Service"],
 ) =>
   WsRpcGroup.toLayer(
     Effect.gen(function* () {
@@ -910,11 +911,6 @@ const makeWsRpcLayer = (
           );
       };
 
-      const resolveVSCodeTunnelForSettings = (settings: { enableVSCodeRemoteTunnels: boolean }) =>
-        VSCodeTunnel.resolveVSCodeTunnel({
-          enabled: settings.enableVSCodeRemoteTunnels,
-        });
-
       const loadServerConfig = Effect.gen(function* () {
         const keybindingsConfig = yield* keybindings.loadConfigState;
         const providers = yield* providerRegistry.getProviders;
@@ -923,7 +919,9 @@ const makeWsRpcLayer = (
         );
         const environment = yield* serverEnvironment.getDescriptor;
         const auth = yield* serverAuth.getDescriptor();
-        const vscodeTunnel = yield* resolveVSCodeTunnelForSettings(settings);
+        const vscodeTunnel = yield* vscodeTunnelMonitor.getSnapshot({
+          enabled: settings.enableVSCodeRemoteTunnels,
+        });
 
         return {
           environment,
@@ -1773,105 +1771,11 @@ const makeWsRpcLayer = (
           observeRpcStreamEffect(
             WS_METHODS.subscribeServerConfig,
             Effect.gen(function* () {
-              const processRunner = yield* ProcessRunner.ProcessRunner;
-              const keybindingsUpdates: Stream.Stream<ServerConfigStreamEvent> =
-                keybindings.streamChanges.pipe(
-                  Stream.map((event) => ({
-                    version: 1 as const,
-                    type: "keybindingsUpdated" as const,
-                    payload: {
-                      keybindings: event.keybindings,
-                      issues: event.issues,
-                    },
-                  })),
-                );
-              const providerStatuses: Stream.Stream<ServerConfigStreamEvent> =
-                providerRegistry.streamChanges.pipe(
-                  Stream.map((providers) => ({
-                    version: 1 as const,
-                    type: "providerStatuses" as const,
-                    payload: { providers },
-                  })),
-                  Stream.debounce(Duration.millis(PROVIDER_STATUS_DEBOUNCE_MS)),
-                );
-              const settingsUpdates: Stream.Stream<ServerConfigStreamEvent> =
-                serverSettings.streamChanges.pipe(
-                  Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
-                  Stream.map((settings) => ({
-                    version: 1 as const,
-                    type: "settingsUpdated" as const,
-                    payload: { settings },
-                  })),
-                );
-              const toVSCodeTunnelUpdateEvent = (settings: {
-                readonly enableVSCodeRemoteTunnels: boolean;
-              }) =>
-                resolveVSCodeTunnelForSettings(settings).pipe(
-                  Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
-                  Effect.map((vscodeTunnel) => ({
-                    version: 1 as const,
-                    type: "vscodeTunnelUpdated" as const,
-                    payload: {
-                      vscodeTunnel: vscodeTunnel.tunnel,
-                      vscodeTunnelStatus: vscodeTunnel.status,
-                    },
-                  })),
-                );
-              const vscodeTunnelSettingsUpdates: Stream.Stream<ServerConfigStreamEvent> = (() => {
-                let previousTunnelEnabled: boolean | undefined;
-                return serverSettings.streamChanges.pipe(
-                  Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
-                  Stream.filter((settings) => {
-                    const changed =
-                      previousTunnelEnabled === undefined ||
-                      previousTunnelEnabled !== settings.enableVSCodeRemoteTunnels;
-                    previousTunnelEnabled = settings.enableVSCodeRemoteTunnels;
-                    return changed;
-                  }),
-                  Stream.mapEffect(toVSCodeTunnelUpdateEvent),
-                );
-              })();
-              const vscodeTunnelPeriodicUpdates: Stream.Stream<ServerConfigStreamEvent> =
-                Stream.tick(VSCODE_TUNNEL_REFRESH_INTERVAL).pipe(
-                  Stream.mapEffect(() =>
-                    serverSettings.getSettings.pipe(
-                      Effect.map((settings) =>
-                        ServerSettings.redactServerSettingsForClient(settings),
-                      ),
-                      Effect.flatMap(toVSCodeTunnelUpdateEvent),
-                      Effect.catchCause((cause) =>
-                        Effect.logWarning("failed to refresh VS Code tunnel settings", {
-                          cause,
-                        }).pipe(
-                          Effect.as({
-                            version: 1 as const,
-                            type: "vscodeTunnelUpdated" as const,
-                            payload: {
-                              vscodeTunnel: null,
-                              vscodeTunnelStatus: {
-                                checked: true,
-                                connected: false,
-                                machineName: null,
-                                serviceInstalled: null,
-                              },
-                            },
-                          }),
-                        ),
-                      ),
-                    ),
-                  ),
-                );
+              const liveUpdates = yield* PubSub.subscribe(serverConfigUpdates);
 
               yield* providerRegistry
                 .refresh()
                 .pipe(Effect.ignoreCause({ log: true }), Effect.forkScoped);
-
-              const liveUpdates: Stream.Stream<ServerConfigStreamEvent> = keybindingsUpdates.pipe(
-                Stream.merge(providerStatuses),
-                Stream.merge(settingsUpdates),
-                Stream.merge(vscodeTunnelSettingsUpdates),
-                Stream.merge(vscodeTunnelPeriodicUpdates),
-              );
 
               return Stream.concat(
                 Stream.make({
@@ -1879,7 +1783,7 @@ const makeWsRpcLayer = (
                   type: "snapshot" as const,
                   config: yield* loadServerConfig,
                 }),
-                liveUpdates,
+                Stream.fromSubscription(liveUpdates),
               );
             }),
             { "rpc.aggregate": "server" },
@@ -1938,6 +1842,62 @@ const makeWsRpcLayer = (
 export const websocketRpcRouteLayer = Layer.unwrap(
   Effect.gen(function* () {
     const previewAutomationBroker = yield* PreviewAutomationBroker.PreviewAutomationBroker;
+    const keybindings = yield* Keybindings.Keybindings;
+    const providerRegistry = yield* ProviderRegistry.ProviderRegistry;
+    const serverSettings = yield* ServerSettings.ServerSettingsService;
+    const vscodeTunnelMonitor = yield* VSCodeTunnel.VSCodeTunnelMonitor;
+    const serverConfigUpdates = yield* PubSub.unbounded<ServerConfigStreamEvent>();
+
+    const keybindingsUpdates: Stream.Stream<ServerConfigStreamEvent> =
+      keybindings.streamChanges.pipe(
+        Stream.map((event) => ({
+          version: 1 as const,
+          type: "keybindingsUpdated" as const,
+          payload: {
+            keybindings: event.keybindings,
+            issues: event.issues,
+          },
+        })),
+      );
+    const providerStatuses: Stream.Stream<ServerConfigStreamEvent> =
+      providerRegistry.streamChanges.pipe(
+        Stream.map((providers) => ({
+          version: 1 as const,
+          type: "providerStatuses" as const,
+          payload: { providers },
+        })),
+        Stream.debounce(Duration.millis(PROVIDER_STATUS_DEBOUNCE_MS)),
+      );
+    const settingsUpdates: Stream.Stream<ServerConfigStreamEvent> =
+      serverSettings.streamChanges.pipe(
+        Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
+        Stream.map((settings) => ({
+          version: 1 as const,
+          type: "settingsUpdated" as const,
+          payload: { settings },
+        })),
+      );
+    const vscodeTunnelUpdates: Stream.Stream<ServerConfigStreamEvent> =
+      vscodeTunnelMonitor.streamChanges.pipe(
+        Stream.map((vscodeTunnel) => ({
+          version: 1 as const,
+          type: "vscodeTunnelUpdated" as const,
+          payload: {
+            vscodeTunnel: vscodeTunnel.tunnel,
+            vscodeTunnelStatus: vscodeTunnel.status,
+          },
+        })),
+      );
+
+    yield* keybindingsUpdates.pipe(
+      Stream.merge(providerStatuses),
+      Stream.merge(settingsUpdates),
+      Stream.merge(vscodeTunnelUpdates),
+      Stream.runForEach((event) => PubSub.publish(serverConfigUpdates, event)),
+      Effect.ignoreCause({ log: true }),
+      Effect.forkScoped({ startImmediately: true }),
+    );
+
     return HttpRouter.add(
       "GET",
       "/ws",
@@ -1957,7 +1917,12 @@ export const websocketRpcRouteLayer = Layer.unwrap(
           disableTracing: true,
         }).pipe(
           Effect.provide(
-            makeWsRpcLayer(session, previewAutomationBroker).pipe(
+            makeWsRpcLayer(
+              session,
+              previewAutomationBroker,
+              serverConfigUpdates,
+              vscodeTunnelMonitor,
+            ).pipe(
               Layer.provideMerge(RpcSerialization.layerJson),
               Layer.provideMerge(ProcessRunner.layer),
               Layer.provide(ProviderMaintenanceRunner.layer),

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -116,7 +116,6 @@ import * as VcsProcess from "./vcs/VcsProcess.ts";
 import * as PairingGrantStore from "./auth/PairingGrantStore.ts";
 import * as SessionStore from "./auth/SessionStore.ts";
 import { failEnvironmentAuthInvalid, failEnvironmentInternal } from "./auth/http.ts";
-import { isLoopbackHost, isWildcardHost } from "./startupAccess.ts";
 import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 
@@ -911,14 +910,9 @@ const makeWsRpcLayer = (
           );
       };
 
-      const networkAccessEnabled =
-        config.tailscaleServeEnabled ||
-        (config.host !== undefined &&
-          (isWildcardHost(config.host) || !isLoopbackHost(config.host)));
       const resolveVSCodeTunnelForSettings = (settings: { enableVSCodeRemoteTunnels: boolean }) =>
         VSCodeTunnel.resolveVSCodeTunnel({
           enabled: settings.enableVSCodeRemoteTunnels,
-          networkAccessEnabled,
         });
 
       const loadServerConfig = Effect.gen(function* () {

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -116,6 +116,7 @@ import * as VcsProcess from "./vcs/VcsProcess.ts";
 import * as PairingGrantStore from "./auth/PairingGrantStore.ts";
 import * as SessionStore from "./auth/SessionStore.ts";
 import { failEnvironmentAuthInvalid, failEnvironmentInternal } from "./auth/http.ts";
+import { isLoopbackHost, isWildcardHost } from "./startupAccess.ts";
 import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 
@@ -910,7 +911,10 @@ const makeWsRpcLayer = (
           );
       };
 
-      const networkAccessEnabled = config.host !== undefined || config.tailscaleServeEnabled;
+      const networkAccessEnabled =
+        config.tailscaleServeEnabled ||
+        (config.host !== undefined &&
+          (isWildcardHost(config.host) || !isLoopbackHost(config.host)));
       const resolveVSCodeTunnelForSettings = (settings: { enableVSCodeRemoteTunnels: boolean }) =>
         VSCodeTunnel.resolveVSCodeTunnel({
           enabled: settings.enableVSCodeRemoteTunnels,
@@ -1831,13 +1835,20 @@ const makeWsRpcLayer = (
                       Effect.map((settings) =>
                         ServerSettings.redactServerSettingsForClient(settings),
                       ),
+                      Effect.flatMap(toVSCodeTunnelUpdateEvent),
+                      Effect.map((event) => Option.some(event)),
                       Effect.catchCause((cause) =>
                         Effect.logWarning("failed to refresh VS Code tunnel settings", {
                           cause,
-                        }).pipe(Effect.as({ enableVSCodeRemoteTunnels: false })),
+                        }).pipe(Effect.as(Option.none<ServerConfigStreamEvent>())),
                       ),
-                      Effect.flatMap(toVSCodeTunnelUpdateEvent),
                     ),
+                  ),
+                  Stream.flatMap((event) =>
+                    Option.match(event, {
+                      onNone: () => Stream.empty,
+                      onSome: (resolvedEvent) => Stream.make(resolvedEvent),
+                    }),
                   ),
                 );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1830,19 +1830,26 @@ const makeWsRpcLayer = (
                         ServerSettings.redactServerSettingsForClient(settings),
                       ),
                       Effect.flatMap(toVSCodeTunnelUpdateEvent),
-                      Effect.map((event) => Option.some(event)),
                       Effect.catchCause((cause) =>
                         Effect.logWarning("failed to refresh VS Code tunnel settings", {
                           cause,
-                        }).pipe(Effect.as(Option.none<ServerConfigStreamEvent>())),
+                        }).pipe(
+                          Effect.as({
+                            version: 1 as const,
+                            type: "vscodeTunnelUpdated" as const,
+                            payload: {
+                              vscodeTunnel: null,
+                              vscodeTunnelStatus: {
+                                checked: true,
+                                connected: false,
+                                machineName: null,
+                                serviceInstalled: null,
+                              },
+                            },
+                          }),
+                        ),
                       ),
                     ),
-                  ),
-                  Stream.flatMap((event) =>
-                    Option.match(event, {
-                      onNone: () => Stream.empty,
-                      onSome: (resolvedEvent) => Stream.make(resolvedEvent),
-                    }),
                   ),
                 );
 

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -39,6 +39,7 @@ import {
   type ProjectEntriesFailure,
   type ProjectFileFailure,
   type ProjectFileOperation,
+  type ServerConfigStreamEvent,
   ProjectListEntriesError,
   ProjectReadFileError,
   ProjectSearchEntriesError,
@@ -95,10 +96,12 @@ import * as ReviewService from "./review/ReviewService.ts";
 import * as ProjectSetupScriptRunner from "./project/ProjectSetupScriptRunner.ts";
 import * as RepositoryIdentityResolver from "./project/RepositoryIdentityResolver.ts";
 import * as ServerEnvironment from "./environment/ServerEnvironment.ts";
+import * as VSCodeTunnel from "./vscodeTunnel.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import * as ProcessDiagnostics from "./diagnostics/ProcessDiagnostics.ts";
 import * as ProcessResourceMonitor from "./diagnostics/ProcessResourceMonitor.ts";
 import * as TraceDiagnostics from "./diagnostics/TraceDiagnostics.ts";
+import * as ProcessRunner from "./processRunner.ts";
 import * as SourceControlDiscovery from "./sourceControl/SourceControlDiscovery.ts";
 import * as SourceControlRepositoryService from "./sourceControl/SourceControlRepositoryService.ts";
 import * as AzureDevOpsCli from "./sourceControl/AzureDevOpsCli.ts";
@@ -117,6 +120,7 @@ import * as RelayClient from "@t3tools/shared/relayClient";
 const isOrchestrationDispatchCommandError = Schema.is(OrchestrationDispatchCommandError);
 
 const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+const VSCODE_TUNNEL_REFRESH_INTERVAL = Duration.minutes(1);
 
 function unexpectedCompatibilityError(error: never): never {
   throw new Error(`Unhandled compatibility error: ${String(error)}`);
@@ -906,6 +910,13 @@ const makeWsRpcLayer = (
           );
       };
 
+      const networkAccessEnabled = config.host !== undefined || config.tailscaleServeEnabled;
+      const resolveVSCodeTunnelForSettings = (settings: { enableVSCodeRemoteTunnels: boolean }) =>
+        VSCodeTunnel.resolveVSCodeTunnel({
+          enabled: settings.enableVSCodeRemoteTunnels,
+          networkAccessEnabled,
+        });
+
       const loadServerConfig = Effect.gen(function* () {
         const keybindingsConfig = yield* keybindings.loadConfigState;
         const providers = yield* providerRegistry.getProviders;
@@ -914,6 +925,7 @@ const makeWsRpcLayer = (
         );
         const environment = yield* serverEnvironment.getDescriptor;
         const auth = yield* serverAuth.getDescriptor();
+        const vscodeTunnel = yield* resolveVSCodeTunnelForSettings(settings);
 
         return {
           environment,
@@ -924,6 +936,8 @@ const makeWsRpcLayer = (
           issues: keybindingsConfig.issues,
           providers,
           availableEditors: yield* externalLauncher.resolveAvailableEditors(),
+          vscodeTunnel: vscodeTunnel.tunnel,
+          vscodeTunnelStatus: vscodeTunnel.status,
           observability: {
             logsDirectoryPath: config.logsDir,
             localTracingEnabled: true,
@@ -1761,40 +1775,81 @@ const makeWsRpcLayer = (
           observeRpcStreamEffect(
             WS_METHODS.subscribeServerConfig,
             Effect.gen(function* () {
-              const keybindingsUpdates = keybindings.streamChanges.pipe(
-                Stream.map((event) => ({
-                  version: 1 as const,
-                  type: "keybindingsUpdated" as const,
-                  payload: {
-                    keybindings: event.keybindings,
-                    issues: event.issues,
-                  },
-                })),
-              );
-              const providerStatuses = providerRegistry.streamChanges.pipe(
-                Stream.map((providers) => ({
-                  version: 1 as const,
-                  type: "providerStatuses" as const,
-                  payload: { providers },
-                })),
-                Stream.debounce(Duration.millis(PROVIDER_STATUS_DEBOUNCE_MS)),
-              );
-              const settingsUpdates = serverSettings.streamChanges.pipe(
-                Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
-                Stream.map((settings) => ({
-                  version: 1 as const,
-                  type: "settingsUpdated" as const,
-                  payload: { settings },
-                })),
-              );
+              const processRunner = yield* ProcessRunner.ProcessRunner;
+              const keybindingsUpdates: Stream.Stream<ServerConfigStreamEvent> =
+                keybindings.streamChanges.pipe(
+                  Stream.map((event) => ({
+                    version: 1 as const,
+                    type: "keybindingsUpdated" as const,
+                    payload: {
+                      keybindings: event.keybindings,
+                      issues: event.issues,
+                    },
+                  })),
+                );
+              const providerStatuses: Stream.Stream<ServerConfigStreamEvent> =
+                providerRegistry.streamChanges.pipe(
+                  Stream.map((providers) => ({
+                    version: 1 as const,
+                    type: "providerStatuses" as const,
+                    payload: { providers },
+                  })),
+                  Stream.debounce(Duration.millis(PROVIDER_STATUS_DEBOUNCE_MS)),
+                );
+              const settingsUpdates: Stream.Stream<ServerConfigStreamEvent> =
+                serverSettings.streamChanges.pipe(
+                  Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
+                  Stream.map((settings) => ({
+                    version: 1 as const,
+                    type: "settingsUpdated" as const,
+                    payload: { settings },
+                  })),
+                );
+              const toVSCodeTunnelUpdateEvent = (settings: {
+                readonly enableVSCodeRemoteTunnels: boolean;
+              }) =>
+                resolveVSCodeTunnelForSettings(settings).pipe(
+                  Effect.provideService(ProcessRunner.ProcessRunner, processRunner),
+                  Effect.map((vscodeTunnel) => ({
+                    version: 1 as const,
+                    type: "vscodeTunnelUpdated" as const,
+                    payload: {
+                      vscodeTunnel: vscodeTunnel.tunnel,
+                      vscodeTunnelStatus: vscodeTunnel.status,
+                    },
+                  })),
+                );
+              const vscodeTunnelSettingsUpdates: Stream.Stream<ServerConfigStreamEvent> =
+                serverSettings.streamChanges.pipe(
+                  Stream.map((settings) => ServerSettings.redactServerSettingsForClient(settings)),
+                  Stream.mapEffect(toVSCodeTunnelUpdateEvent),
+                );
+              const vscodeTunnelPeriodicUpdates: Stream.Stream<ServerConfigStreamEvent> =
+                Stream.tick(VSCODE_TUNNEL_REFRESH_INTERVAL).pipe(
+                  Stream.mapEffect(() =>
+                    serverSettings.getSettings.pipe(
+                      Effect.map((settings) =>
+                        ServerSettings.redactServerSettingsForClient(settings),
+                      ),
+                      Effect.catchCause((cause) =>
+                        Effect.logWarning("failed to refresh VS Code tunnel settings", {
+                          cause,
+                        }).pipe(Effect.as({ enableVSCodeRemoteTunnels: false })),
+                      ),
+                      Effect.flatMap(toVSCodeTunnelUpdateEvent),
+                    ),
+                  ),
+                );
 
               yield* providerRegistry
                 .refresh()
                 .pipe(Effect.ignoreCause({ log: true }), Effect.forkScoped);
 
-              const liveUpdates = Stream.merge(
-                keybindingsUpdates,
-                Stream.merge(providerStatuses, settingsUpdates),
+              const liveUpdates: Stream.Stream<ServerConfigStreamEvent> = keybindingsUpdates.pipe(
+                Stream.merge(providerStatuses),
+                Stream.merge(settingsUpdates),
+                Stream.merge(vscodeTunnelSettingsUpdates),
+                Stream.merge(vscodeTunnelPeriodicUpdates),
               );
 
               return Stream.concat(
@@ -1883,6 +1938,7 @@ export const websocketRpcRouteLayer = Layer.unwrap(
           Effect.provide(
             makeWsRpcLayer(session, previewAutomationBroker).pipe(
               Layer.provideMerge(RpcSerialization.layerJson),
+              Layer.provideMerge(ProcessRunner.layer),
               Layer.provide(ProviderMaintenanceRunner.layer),
               Layer.provide(
                 SourceControlDiscovery.layer.pipe(

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5051,7 +5051,7 @@ function ChatViewContent(props: ChatViewProps) {
               serverConfig?.settings.enableVSCodeRemoteTunnels ? serverConfig.vscodeTunnel : null
             }
             openVSCodeRemoteTunnelsInDesktop={
-              serverConfig?.settings.openVSCodeRemoteTunnelsInDesktop ?? false
+              primaryEnvironment?.serverConfig?.settings.openVSCodeRemoteTunnelsInDesktop ?? false
             }
             rightPanelOpen={rightPanelOpen}
             gitCwd={gitCwd}

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5047,6 +5047,12 @@ function ChatViewContent(props: ChatViewProps) {
             }
             keybindings={keybindings}
             availableEditors={availableEditors}
+            vscodeTunnel={
+              serverConfig?.settings.enableVSCodeRemoteTunnels ? serverConfig.vscodeTunnel : null
+            }
+            openVSCodeRemoteTunnelsInDesktop={
+              serverConfig?.settings.openVSCodeRemoteTunnelsInDesktop ?? false
+            }
             rightPanelOpen={rightPanelOpen}
             gitCwd={gitCwd}
             onRunProjectScript={runProjectScript}

--- a/apps/web/src/components/chat/ChatHeader.tsx
+++ b/apps/web/src/components/chat/ChatHeader.tsx
@@ -3,6 +3,7 @@ import {
   type EditorId,
   type ProjectScript,
   type ResolvedKeybindingsConfig,
+  type ServerVSCodeTunnel,
   type ThreadId,
 } from "@t3tools/contracts";
 import { scopeThreadRef } from "@t3tools/client-runtime/environment";
@@ -29,6 +30,8 @@ interface ChatHeaderProps {
   preferredScriptId: string | null;
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
+  vscodeTunnel: ServerVSCodeTunnel | null;
+  openVSCodeRemoteTunnelsInDesktop: boolean;
   rightPanelOpen: boolean;
   gitCwd: string | null;
   onRunProjectScript: (script: ProjectScript) => void;
@@ -63,6 +66,8 @@ export const ChatHeader = memo(function ChatHeader({
   preferredScriptId,
   keybindings,
   availableEditors,
+  vscodeTunnel,
+  openVSCodeRemoteTunnelsInDesktop,
   rightPanelOpen,
   gitCwd,
   onRunProjectScript,
@@ -76,6 +81,9 @@ export const ChatHeader = memo(function ChatHeader({
     activeThreadEnvironmentId,
     primaryEnvironmentId,
   });
+  const showTunnelPicker = Boolean(
+    !showOpenInPicker && activeProjectName && vscodeTunnel && openInCwd,
+  );
   return (
     <div className="@container/header-actions flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
       <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden sm:gap-3">
@@ -111,12 +119,14 @@ export const ChatHeader = memo(function ChatHeader({
             onDeleteScript={onDeleteProjectScript}
           />
         )}
-        {showOpenInPicker && (
+        {(showOpenInPicker || showTunnelPicker) && (
           <OpenInPicker
             environmentId={activeThreadEnvironmentId}
             keybindings={keybindings}
-            availableEditors={availableEditors}
+            availableEditors={showOpenInPicker ? availableEditors : []}
             openInCwd={openInCwd}
+            vscodeTunnel={vscodeTunnel}
+            openVSCodeRemoteTunnelsInDesktop={openVSCodeRemoteTunnelsInDesktop}
           />
         )}
         {activeProjectName && (

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -250,6 +250,7 @@ export const OpenInPicker = memo(function OpenInPicker({
     (option: PickerOption | null) => {
       if (!openInCwd || !option) return;
       if (isVSCodeTunnelOption(option)) {
+        latestEditorSelectionRef.current += 1;
         const editorSelectionVersion = latestEditorSelectionRef.current;
         const url = openVSCodeRemoteTunnelsInDesktop
           ? buildVSCodeTunnelDesktopUrl(option.vscodeTunnel.machineName, openInCwd)

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -214,7 +214,7 @@ export const OpenInPicker = memo(function OpenInPicker({
   const openInEditorMutation = useAtomCommand(shellEnvironment.openInEditor, "open in editor");
   const [preferredEditor, setPreferredEditor] = usePreferredEditor(availableEditors);
   const [preferVSCodeTunnel, setPreferVSCodeTunnel] = useState(false);
-  const latestOpenActionRef = useRef(0);
+  const latestEditorSelectionRef = useRef(0);
   const editorOptions = useMemo(
     () => resolveOptions(navigator.platform, availableEditors),
     [availableEditors],
@@ -250,8 +250,7 @@ export const OpenInPicker = memo(function OpenInPicker({
     (option: PickerOption | null) => {
       if (!openInCwd || !option) return;
       if (isVSCodeTunnelOption(option)) {
-        const actionId = latestOpenActionRef.current + 1;
-        latestOpenActionRef.current = actionId;
+        const editorSelectionVersion = latestEditorSelectionRef.current;
         const url = openVSCodeRemoteTunnelsInDesktop
           ? buildVSCodeTunnelDesktopUrl(option.vscodeTunnel.machineName, openInCwd)
           : buildVSCodeTunnelUrl(option.vscodeTunnel.machineName, openInCwd);
@@ -267,11 +266,11 @@ export const OpenInPicker = memo(function OpenInPicker({
         void localApi.shell
           .openExternal(url)
           .then(() => {
-            if (latestOpenActionRef.current !== actionId) return;
+            if (latestEditorSelectionRef.current !== editorSelectionVersion) return;
             setPreferVSCodeTunnel(true);
           })
           .catch((error) => {
-            if (latestOpenActionRef.current !== actionId) return;
+            if (latestEditorSelectionRef.current !== editorSelectionVersion) return;
             setPreferVSCodeTunnel(false);
             toastManager.add(
               stackedThreadToast({
@@ -285,7 +284,7 @@ export const OpenInPicker = memo(function OpenInPicker({
       }
 
       const editor = option.value;
-      latestOpenActionRef.current += 1;
+      latestEditorSelectionRef.current += 1;
       setPreferVSCodeTunnel(false);
       const result = openInEditorMutation({
         environmentId,

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -4,7 +4,7 @@ import {
   type ResolvedKeybindingsConfig,
   type ServerVSCodeTunnel,
 } from "@t3tools/contracts";
-import { memo, useCallback, useEffect, useMemo, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
 import { usePreferredEditor } from "../../editorPreferences";
 import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
@@ -214,6 +214,7 @@ export const OpenInPicker = memo(function OpenInPicker({
   const openInEditorMutation = useAtomCommand(shellEnvironment.openInEditor, "open in editor");
   const [preferredEditor, setPreferredEditor] = usePreferredEditor(availableEditors);
   const [preferVSCodeTunnel, setPreferVSCodeTunnel] = useState(false);
+  const latestOpenActionRef = useRef(0);
   const editorOptions = useMemo(
     () => resolveOptions(navigator.platform, availableEditors),
     [availableEditors],
@@ -249,6 +250,8 @@ export const OpenInPicker = memo(function OpenInPicker({
     (option: PickerOption | null) => {
       if (!openInCwd || !option) return;
       if (isVSCodeTunnelOption(option)) {
+        const actionId = latestOpenActionRef.current + 1;
+        latestOpenActionRef.current = actionId;
         const url = openVSCodeRemoteTunnelsInDesktop
           ? buildVSCodeTunnelDesktopUrl(option.vscodeTunnel.machineName, openInCwd)
           : buildVSCodeTunnelUrl(option.vscodeTunnel.machineName, openInCwd);
@@ -264,9 +267,11 @@ export const OpenInPicker = memo(function OpenInPicker({
         void localApi.shell
           .openExternal(url)
           .then(() => {
+            if (latestOpenActionRef.current !== actionId) return;
             setPreferVSCodeTunnel(true);
           })
           .catch((error) => {
+            if (latestOpenActionRef.current !== actionId) return;
             setPreferVSCodeTunnel(false);
             toastManager.add(
               stackedThreadToast({
@@ -280,6 +285,7 @@ export const OpenInPicker = memo(function OpenInPicker({
       }
 
       const editor = option.value;
+      latestOpenActionRef.current += 1;
       setPreferVSCodeTunnel(false);
       const result = openInEditorMutation({
         environmentId,

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -4,7 +4,7 @@ import {
   type ResolvedKeybindingsConfig,
   type ServerVSCodeTunnel,
 } from "@t3tools/contracts";
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
 import { usePreferredEditor } from "../../editorPreferences";
 import { ChevronDownIcon, FolderClosedIcon } from "lucide-react";
@@ -40,6 +40,7 @@ import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { shellEnvironment } from "~/state/shell";
 import { useAtomCommand } from "~/state/use-atom-command";
 import { readLocalApi } from "~/localApi";
+import { stackedThreadToast, toastManager } from "../ui/toast";
 
 type EditorPickerOption = { label: string; Icon: Icon; value: EditorId };
 type VSCodeTunnelPickerOption = {
@@ -171,12 +172,14 @@ const resolveOptions = (platform: string, availableEditors: ReadonlyArray<Editor
 };
 
 function encodeVSCodeTunnelPath(cwd: string): string {
-  return cwd
-    .replaceAll("\\", "/")
+  const normalized = cwd.replaceAll("\\", "/");
+  const hasLeadingSlash = normalized.startsWith("/");
+  const encodedSegments = normalized
     .split("/")
-    .filter((segment, index) => index > 0 || segment.length > 0)
+    .filter((segment) => segment.length > 0)
     .map(encodeURIComponent)
     .join("/");
+  return hasLeadingSlash ? `/${encodedSegments}` : encodedSegments;
 }
 
 function buildVSCodeTunnelUrl(machineName: string, cwd: string): string {
@@ -210,6 +213,7 @@ export const OpenInPicker = memo(function OpenInPicker({
 }) {
   const openInEditorMutation = useAtomCommand(shellEnvironment.openInEditor, "open in editor");
   const [preferredEditor, setPreferredEditor] = usePreferredEditor(availableEditors);
+  const [preferVSCodeTunnel, setPreferVSCodeTunnel] = useState(false);
   const editorOptions = useMemo(
     () => resolveOptions(navigator.platform, availableEditors),
     [availableEditors],
@@ -231,20 +235,46 @@ export const OpenInPicker = memo(function OpenInPicker({
     [editorOptions, vscodeTunnelOption],
   );
   const primaryOption =
+    (preferVSCodeTunnel ? vscodeTunnelOption : null) ??
     editorOptions.find(({ value }) => value === preferredEditor) ??
     (editorOptions.length === 0 ? vscodeTunnelOption : null);
+
+  useEffect(() => {
+    if (!vscodeTunnelOption && preferVSCodeTunnel) {
+      setPreferVSCodeTunnel(false);
+    }
+  }, [preferVSCodeTunnel, vscodeTunnelOption]);
 
   const openOption = useCallback(
     (option: PickerOption | null) => {
       if (!openInCwd || !option) return;
       if (isVSCodeTunnelOption(option)) {
+        setPreferVSCodeTunnel(true);
         const url = openVSCodeRemoteTunnelsInDesktop
           ? buildVSCodeTunnelDesktopUrl(option.vscodeTunnel.machineName, openInCwd)
           : buildVSCodeTunnelUrl(option.vscodeTunnel.machineName, openInCwd);
-        return readLocalApi()?.shell.openExternal(url);
+        const localApi = readLocalApi();
+        if (!localApi) {
+          toastManager.add({
+            type: "error",
+            title: "Link opening is unavailable.",
+          });
+          return;
+        }
+        void localApi.shell.openExternal(url).catch((error) => {
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Unable to open tunnel link",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        });
+        return;
       }
 
       const editor = option.value;
+      setPreferVSCodeTunnel(false);
       const result = openInEditorMutation({
         environmentId,
         input: {

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -1,4 +1,9 @@
-import { EditorId, type EnvironmentId, type ResolvedKeybindingsConfig } from "@t3tools/contracts";
+import {
+  EditorId,
+  type EnvironmentId,
+  type ResolvedKeybindingsConfig,
+  type ServerVSCodeTunnel,
+} from "@t3tools/contracts";
 import { memo, useCallback, useEffect, useMemo } from "react";
 import { isOpenFavoriteEditorShortcut, shortcutLabelForCommand } from "../../keybindings";
 import { usePreferredEditor } from "../../editorPreferences";
@@ -34,9 +39,23 @@ import {
 import { isMacPlatform, isWindowsPlatform } from "~/lib/utils";
 import { shellEnvironment } from "~/state/shell";
 import { useAtomCommand } from "~/state/use-atom-command";
+import { readLocalApi } from "~/localApi";
+
+type EditorPickerOption = { label: string; Icon: Icon; value: EditorId };
+type VSCodeTunnelPickerOption = {
+  label: string;
+  Icon: Icon;
+  value: "vscode-tunnel";
+  vscodeTunnel: ServerVSCodeTunnel;
+};
+type PickerOption = EditorPickerOption | VSCodeTunnelPickerOption;
+
+function isVSCodeTunnelOption(option: PickerOption): option is VSCodeTunnelPickerOption {
+  return option.value === "vscode-tunnel";
+}
 
 const resolveOptions = (platform: string, availableEditors: ReadonlyArray<EditorId>) => {
-  const baseOptions: ReadonlyArray<{ label: string; Icon: Icon; value: EditorId }> = [
+  const baseOptions: ReadonlyArray<EditorPickerOption> = [
     {
       label: "Cursor",
       Icon: CursorIcon,
@@ -151,10 +170,31 @@ const resolveOptions = (platform: string, availableEditors: ReadonlyArray<Editor
   return baseOptions.filter((option) => availableEditorSet.has(option.value));
 };
 
+function encodeVSCodeTunnelPath(cwd: string): string {
+  return cwd
+    .replaceAll("\\", "/")
+    .split("/")
+    .filter((segment, index) => index > 0 || segment.length > 0)
+    .map(encodeURIComponent)
+    .join("/");
+}
+
+function buildVSCodeTunnelUrl(machineName: string, cwd: string): string {
+  const encodedPath = encodeVSCodeTunnelPath(cwd);
+  return `https://vscode.dev/tunnel/${encodeURIComponent(machineName)}/${encodedPath}`;
+}
+
+function buildVSCodeTunnelDesktopUrl(machineName: string, cwd: string): string {
+  const encodedPath = encodeVSCodeTunnelPath(cwd);
+  return `vscode://vscode-remote/tunnel+${encodeURIComponent(machineName)}/${encodedPath}`;
+}
+
 export const OpenInPicker = memo(function OpenInPicker({
   environmentId,
   keybindings,
   availableEditors,
+  vscodeTunnel = null,
+  openVSCodeRemoteTunnelsInDesktop = false,
   openInCwd,
   compact = false,
   enableShortcut = true,
@@ -162,23 +202,49 @@ export const OpenInPicker = memo(function OpenInPicker({
   environmentId: EnvironmentId;
   keybindings: ResolvedKeybindingsConfig;
   availableEditors: ReadonlyArray<EditorId>;
+  vscodeTunnel?: ServerVSCodeTunnel | null;
+  openVSCodeRemoteTunnelsInDesktop?: boolean;
   openInCwd: string | null;
   compact?: boolean;
   enableShortcut?: boolean;
 }) {
   const openInEditorMutation = useAtomCommand(shellEnvironment.openInEditor, "open in editor");
   const [preferredEditor, setPreferredEditor] = usePreferredEditor(availableEditors);
-  const options = useMemo(
+  const editorOptions = useMemo(
     () => resolveOptions(navigator.platform, availableEditors),
     [availableEditors],
   );
-  const primaryOption = options.find(({ value }) => value === preferredEditor) ?? null;
+  const vscodeTunnelOption = useMemo<VSCodeTunnelPickerOption | null>(
+    () =>
+      vscodeTunnel && openInCwd
+        ? {
+            label: `VS Code Tunnel (${vscodeTunnel.machineName})`,
+            Icon: VisualStudioCode,
+            value: "vscode-tunnel",
+            vscodeTunnel,
+          }
+        : null,
+    [openInCwd, vscodeTunnel],
+  );
+  const options = useMemo(
+    () => (vscodeTunnelOption ? [...editorOptions, vscodeTunnelOption] : editorOptions),
+    [editorOptions, vscodeTunnelOption],
+  );
+  const primaryOption =
+    editorOptions.find(({ value }) => value === preferredEditor) ??
+    (editorOptions.length === 0 ? vscodeTunnelOption : null);
 
-  const openInEditor = useCallback(
-    (editorId: EditorId | null) => {
-      if (!openInCwd) return;
-      const editor = editorId ?? preferredEditor;
-      if (!editor) return;
+  const openOption = useCallback(
+    (option: PickerOption | null) => {
+      if (!openInCwd || !option) return;
+      if (isVSCodeTunnelOption(option)) {
+        const url = openVSCodeRemoteTunnelsInDesktop
+          ? buildVSCodeTunnelDesktopUrl(option.vscodeTunnel.machineName, openInCwd)
+          : buildVSCodeTunnelUrl(option.vscodeTunnel.machineName, openInCwd);
+        return readLocalApi()?.shell.openExternal(url);
+      }
+
+      const editor = option.value;
       const result = openInEditorMutation({
         environmentId,
         input: {
@@ -189,7 +255,13 @@ export const OpenInPicker = memo(function OpenInPicker({
       setPreferredEditor(editor);
       return result;
     },
-    [environmentId, openInCwd, openInEditorMutation, preferredEditor, setPreferredEditor],
+    [
+      environmentId,
+      openInCwd,
+      openInEditorMutation,
+      openVSCodeRemoteTunnelsInDesktop,
+      setPreferredEditor,
+    ],
   );
 
   const openFavoriteEditorShortcutLabel = useMemo(
@@ -230,8 +302,8 @@ export const OpenInPicker = memo(function OpenInPicker({
         aria-label={compact ? "Open file in preferred editor" : undefined}
         size="xs"
         variant="outline"
-        disabled={!preferredEditor || !openInCwd}
-        onClick={() => openInEditor(preferredEditor)}
+        disabled={!primaryOption || !openInCwd}
+        onClick={() => openOption(primaryOption)}
       >
         {primaryOption?.Icon && <primaryOption.Icon aria-hidden="true" className="size-3.5" />}
         <span
@@ -258,14 +330,19 @@ export const OpenInPicker = memo(function OpenInPicker({
           <ChevronDownIcon aria-hidden="true" className="size-4" />
         </MenuTrigger>
         <MenuPopup align="end">
-          {options.length === 0 && <MenuItem disabled>No installed editors found</MenuItem>}
-          {options.map(({ label, Icon, value }) => (
-            <MenuItem key={value} onClick={() => openInEditor(value)}>
-              <Icon aria-hidden="true" className="text-muted-foreground" />
-              {label}
-              {value === preferredEditor && openFavoriteEditorShortcutLabel && (
-                <MenuShortcut>{openFavoriteEditorShortcutLabel}</MenuShortcut>
-              )}
+          {options.length === 0 && <MenuItem disabled>No editors available</MenuItem>}
+          {options.map((option) => (
+            <MenuItem key={option.value} onClick={() => openOption(option)}>
+              {(() => {
+                const Icon = option.Icon;
+                return <Icon aria-hidden="true" className="text-muted-foreground" />;
+              })()}
+              {option.label}
+              {!isVSCodeTunnelOption(option) &&
+                option.value === preferredEditor &&
+                openFavoriteEditorShortcutLabel && (
+                  <MenuShortcut>{openFavoriteEditorShortcutLabel}</MenuShortcut>
+                )}
             </MenuItem>
           ))}
         </MenuPopup>

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -249,27 +249,33 @@ export const OpenInPicker = memo(function OpenInPicker({
     (option: PickerOption | null) => {
       if (!openInCwd || !option) return;
       if (isVSCodeTunnelOption(option)) {
-        setPreferVSCodeTunnel(true);
         const url = openVSCodeRemoteTunnelsInDesktop
           ? buildVSCodeTunnelDesktopUrl(option.vscodeTunnel.machineName, openInCwd)
           : buildVSCodeTunnelUrl(option.vscodeTunnel.machineName, openInCwd);
         const localApi = readLocalApi();
         if (!localApi) {
+          setPreferVSCodeTunnel(false);
           toastManager.add({
             type: "error",
             title: "Link opening is unavailable.",
           });
           return;
         }
-        void localApi.shell.openExternal(url).catch((error) => {
-          toastManager.add(
-            stackedThreadToast({
-              type: "error",
-              title: "Unable to open tunnel link",
-              description: error instanceof Error ? error.message : "An error occurred.",
-            }),
-          );
-        });
+        void localApi.shell
+          .openExternal(url)
+          .then(() => {
+            setPreferVSCodeTunnel(true);
+          })
+          .catch((error) => {
+            setPreferVSCodeTunnel(false);
+            toastManager.add(
+              stackedThreadToast({
+                type: "error",
+                title: "Unable to open tunnel link",
+                description: error instanceof Error ? error.message : "An error occurred.",
+              }),
+            );
+          });
         return;
       }
 

--- a/apps/web/src/components/chat/OpenInPicker.tsx
+++ b/apps/web/src/components/chat/OpenInPicker.tsx
@@ -274,27 +274,14 @@ export const OpenInPicker = memo(function OpenInPicker({
     const handler = (e: globalThis.KeyboardEvent) => {
       if (!isOpenFavoriteEditorShortcut(e, keybindings)) return;
       if (!openInCwd) return;
-      if (!preferredEditor) return;
+      if (!primaryOption) return;
 
       e.preventDefault();
-      void openInEditorMutation({
-        environmentId,
-        input: {
-          cwd: openInCwd,
-          editor: preferredEditor,
-        },
-      });
+      void openOption(primaryOption);
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [
-    enableShortcut,
-    environmentId,
-    keybindings,
-    openInCwd,
-    openInEditorMutation,
-    preferredEditor,
-  ]);
+  }, [enableShortcut, keybindings, openInCwd, openOption, primaryOption]);
 
   return (
     <Group aria-label="Open in editor">

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -2937,7 +2937,7 @@ export function ConnectionsSettings() {
     const statusDescription = !primarySettings.enableVSCodeRemoteTunnels
       ? "Disabled. T3 Code is not checking code tunnel status."
       : !status.checked
-        ? "Not checked because network access is not enabled for this environment."
+        ? "Tunnel status has not been checked yet."
         : status.connected
           ? `Connected${status.machineName ? ` as ${status.machineName}` : ""}.`
           : "No connected VS Code tunnel was detected.";

--- a/apps/web/src/components/settings/ConnectionsSettings.tsx
+++ b/apps/web/src/components/settings/ConnectionsSettings.tsx
@@ -94,6 +94,7 @@ import {
 import { Textarea } from "../ui/textarea";
 import { getPairingTokenFromUrl, setPairingTokenOnUrl } from "../../pairingUrl";
 import { readHostedPairingRequest } from "../../hostedPairing";
+import { useUpdatePrimarySettings } from "../../hooks/useSettings";
 import {
   createServerPairingCredential,
   revokeOtherServerClientSessions,
@@ -1698,6 +1699,7 @@ export function ConnectionsSettings() {
   });
   const removeEnvironment = useAtomCommand(environmentCatalog.remove, { reportFailure: false });
   const retryEnvironment = useAtomCommand(environmentCatalog.retryNow, { reportFailure: false });
+  const updateSettings = useUpdatePrimarySettings();
   const primaryEnvironmentId = primaryEnvironment?.environmentId ?? null;
   const primarySessionState = usePrimarySessionState();
   const currentSessionScopes = desktopBridge
@@ -1816,6 +1818,7 @@ export function ConnectionsSettings() {
     DesktopServerExposureState["mode"] | null
   >(null);
   const primaryServerConfig = primaryEnvironment?.serverConfig ?? null;
+  const primarySettings = primaryServerConfig?.settings ?? null;
   const primaryVersionMismatch = resolveServerConfigVersionMismatch(primaryServerConfig);
   const [isAdvertisedEndpointListExpanded, setIsAdvertisedEndpointListExpanded] = useState(false);
   const defaultAdvertisedEndpointKey = useUiStateStore(
@@ -2928,6 +2931,73 @@ export function ConnectionsSettings() {
       control={renderNetworkAccessToggle()}
     />
   );
+  const renderVSCodeTunnelRow = () => {
+    if (!primarySettings || !primaryServerConfig) return null;
+    const status = primaryServerConfig.vscodeTunnelStatus;
+    const statusDescription = !primarySettings.enableVSCodeRemoteTunnels
+      ? "Disabled. T3 Code is not checking code tunnel status."
+      : !status.checked
+        ? "Not checked because network access is not enabled for this environment."
+        : status.connected
+          ? `Connected${status.machineName ? ` as ${status.machineName}` : ""}.`
+          : "No connected VS Code tunnel was detected.";
+    const serviceStatus =
+      status.serviceInstalled === null
+        ? "Service unknown"
+        : status.serviceInstalled
+          ? "Service installed"
+          : "Service not installed";
+
+    return (
+      <SettingsRow
+        title="VS Code remote tunnels"
+        description="Offer a browser-based VS Code shortcut when this environment has a connected remote tunnel."
+        status={
+          <span className="inline-flex flex-wrap items-center gap-x-2 gap-y-1">
+            <span className="block">{statusDescription}</span>
+            <span className="text-border" aria-hidden="true">
+              |
+            </span>
+            <span className="block">{status.checked ? serviceStatus : "Status not checked"}</span>
+          </span>
+        }
+        control={
+          <Switch
+            checked={primarySettings.enableVSCodeRemoteTunnels}
+            onCheckedChange={(checked) =>
+              updateSettings({ enableVSCodeRemoteTunnels: Boolean(checked) })
+            }
+            aria-label="Enable VS Code remote tunnels"
+          />
+        }
+      />
+    );
+  };
+  const renderVSCodeTunnelOpenTargetRow = () => {
+    if (!primarySettings?.enableVSCodeRemoteTunnels) return null;
+    return (
+      <SettingsRow
+        title="Open tunnels in VS Code Desktop"
+        description="Use the local VS Code app for tunnel shortcuts instead of opening vscode.dev in the browser."
+        status={
+          <span className="block">
+            {primarySettings.openVSCodeRemoteTunnelsInDesktop
+              ? "Tunnel shortcuts will use the vscode:// desktop link."
+              : "Tunnel shortcuts open the web UI."}
+          </span>
+        }
+        control={
+          <Switch
+            checked={primarySettings.openVSCodeRemoteTunnelsInDesktop}
+            onCheckedChange={(checked) =>
+              updateSettings({ openVSCodeRemoteTunnelsInDesktop: Boolean(checked) })
+            }
+            aria-label="Open VS Code tunnels in VS Code Desktop"
+          />
+        }
+      />
+    );
+  };
   const renderDisabledNetworkAccessRow = () => (
     <SettingsRow
       title="Network access"
@@ -2980,6 +3050,8 @@ export function ConnectionsSettings() {
               <>
                 {renderNetworkAccessRow()}
                 {renderEndpointRows("endpoint-rail")}
+                {renderVSCodeTunnelRow()}
+                {renderVSCodeTunnelOpenTargetRow()}
                 {renderTailscaleRow()}
                 {renderWslRow()}
                 <CloudLinkRow canManageRelay={canManageRelay} />

--- a/packages/client-runtime/src/rpc/session.test.ts
+++ b/packages/client-runtime/src/rpc/session.test.ts
@@ -123,6 +123,13 @@ const SERVER_CONFIG: ServerConfigType = {
   issues: [],
   providers: [],
   availableEditors: [],
+  vscodeTunnel: null,
+  vscodeTunnelStatus: {
+    checked: false,
+    connected: false,
+    machineName: null,
+    serviceInstalled: null,
+  },
   observability: {
     logsDirectoryPath: "/tmp/logs",
     localTracingEnabled: false,

--- a/packages/client-runtime/src/state/server.test.ts
+++ b/packages/client-runtime/src/state/server.test.ts
@@ -36,6 +36,13 @@ const CONFIG = {
   observability: null,
   providers: [],
   settings: {},
+  vscodeTunnel: null,
+  vscodeTunnelStatus: {
+    checked: false,
+    connected: false,
+    machineName: null,
+    serviceInstalled: null,
+  },
 } as unknown as ServerConfig;
 
 const snapshotEvent = (config: ServerConfig): ServerConfigStreamEvent => ({
@@ -78,6 +85,38 @@ describe("server state projection", () => {
     const result = Option.getOrThrow(projected);
     expect(result.config.settings).toBe(settings);
     expect(result.latestEvent.type).toBe("settingsUpdated");
+  });
+
+  it("applies VS Code tunnel updates to the projected snapshot", () => {
+    const snapshot = applyServerConfigProjection(Option.none(), {
+      version: 1,
+      type: "snapshot",
+      config: CONFIG,
+    });
+    const projected = applyServerConfigProjection(snapshot, {
+      version: 1,
+      type: "vscodeTunnelUpdated",
+      payload: {
+        vscodeTunnel: { machineName: "mac" },
+        vscodeTunnelStatus: {
+          checked: true,
+          connected: true,
+          machineName: "mac",
+          serviceInstalled: true,
+        },
+      },
+    });
+
+    const result = Option.getOrThrow(projected);
+    expect(result.source).toBe("live");
+    expect(result.config.vscodeTunnel).toEqual({ machineName: "mac" });
+    expect(result.config.vscodeTunnelStatus).toEqual({
+      checked: true,
+      connected: true,
+      machineName: "mac",
+      serviceInstalled: true,
+    });
+    expect(result.latestEvent.type).toBe("vscodeTunnelUpdated");
   });
 
   it("retains welcome when a ready event follows in the same stream chunk", () => {

--- a/packages/client-runtime/src/state/server.ts
+++ b/packages/client-runtime/src/state/server.ts
@@ -72,6 +72,16 @@ export function applyServerConfigProjection(
         latestEvent: event,
         source: "live",
       }));
+    case "vscodeTunnelUpdated":
+      return Option.map(current, (projection) => ({
+        config: {
+          ...projection.config,
+          vscodeTunnel: event.payload.vscodeTunnel,
+          vscodeTunnelStatus: event.payload.vscodeTunnelStatus,
+        },
+        latestEvent: event,
+        source: "live",
+      }));
   }
 }
 

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -406,6 +406,26 @@ export const ServerSignalProcessResult = Schema.Struct({
 });
 export type ServerSignalProcessResult = typeof ServerSignalProcessResult.Type;
 
+export const ServerVSCodeTunnel = Schema.Struct({
+  machineName: TrimmedNonEmptyString,
+});
+export type ServerVSCodeTunnel = typeof ServerVSCodeTunnel.Type;
+
+export const ServerVSCodeTunnelStatus = Schema.Struct({
+  checked: Schema.Boolean,
+  connected: Schema.Boolean,
+  machineName: Schema.NullOr(TrimmedNonEmptyString),
+  serviceInstalled: Schema.NullOr(Schema.Boolean),
+});
+export type ServerVSCodeTunnelStatus = typeof ServerVSCodeTunnelStatus.Type;
+
+const DEFAULT_SERVER_VSCODE_TUNNEL_STATUS: ServerVSCodeTunnelStatus = {
+  checked: false,
+  connected: false,
+  machineName: null,
+  serviceInstalled: null,
+};
+
 export const ServerConfig = Schema.Struct({
   environment: ExecutionEnvironmentDescriptor,
   auth: ServerAuthDescriptor,
@@ -415,6 +435,12 @@ export const ServerConfig = Schema.Struct({
   issues: ServerConfigIssues,
   providers: ServerProviders,
   availableEditors: Schema.Array(EditorId),
+  vscodeTunnel: Schema.NullOr(ServerVSCodeTunnel).pipe(
+    Schema.withDecodingDefault(Effect.succeed(null)),
+  ),
+  vscodeTunnelStatus: ServerVSCodeTunnelStatus.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SERVER_VSCODE_TUNNEL_STATUS)),
+  ),
   observability: ServerObservability,
   settings: ServerSettings,
 });
@@ -470,6 +496,13 @@ export const ServerConfigSettingsUpdatedPayload = Schema.Struct({
 });
 export type ServerConfigSettingsUpdatedPayload = typeof ServerConfigSettingsUpdatedPayload.Type;
 
+export const ServerConfigVSCodeTunnelUpdatedPayload = Schema.Struct({
+  vscodeTunnel: Schema.NullOr(ServerVSCodeTunnel),
+  vscodeTunnelStatus: ServerVSCodeTunnelStatus,
+});
+export type ServerConfigVSCodeTunnelUpdatedPayload =
+  typeof ServerConfigVSCodeTunnelUpdatedPayload.Type;
+
 export const ServerConfigStreamSnapshotEvent = Schema.Struct({
   version: Schema.Literal(1),
   type: Schema.Literal("snapshot"),
@@ -501,11 +534,20 @@ export const ServerConfigStreamSettingsUpdatedEvent = Schema.Struct({
 export type ServerConfigStreamSettingsUpdatedEvent =
   typeof ServerConfigStreamSettingsUpdatedEvent.Type;
 
+export const ServerConfigStreamVSCodeTunnelUpdatedEvent = Schema.Struct({
+  version: Schema.Literal(1),
+  type: Schema.Literal("vscodeTunnelUpdated"),
+  payload: ServerConfigVSCodeTunnelUpdatedPayload,
+});
+export type ServerConfigStreamVSCodeTunnelUpdatedEvent =
+  typeof ServerConfigStreamVSCodeTunnelUpdatedEvent.Type;
+
 export const ServerConfigStreamEvent = Schema.Union([
   ServerConfigStreamSnapshotEvent,
   ServerConfigStreamKeybindingsUpdatedEvent,
   ServerConfigStreamProviderStatusesEvent,
   ServerConfigStreamSettingsUpdatedEvent,
+  ServerConfigStreamVSCodeTunnelUpdatedEvent,
 ]);
 export type ServerConfigStreamEvent = typeof ServerConfigStreamEvent.Type;
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -366,6 +366,10 @@ export const DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL = Duration.seconds(30);
 export const ServerSettings = Schema.Struct({
   enableAssistantStreaming: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   enableProviderUpdateChecks: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  enableVSCodeRemoteTunnels: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
+  openVSCodeRemoteTunnelsInDesktop: Schema.Boolean.pipe(
+    Schema.withDecodingDefault(Effect.succeed(false)),
+  ),
   automaticGitFetchInterval: Schema.DurationFromMillis.pipe(
     Schema.withDecodingDefault(
       Effect.succeed(Duration.toMillis(DEFAULT_AUTOMATIC_GIT_FETCH_INTERVAL)),
@@ -505,6 +509,8 @@ export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
   enableProviderUpdateChecks: Schema.optionalKey(Schema.Boolean),
+  enableVSCodeRemoteTunnels: Schema.optionalKey(Schema.Boolean),
+  openVSCodeRemoteTunnelsInDesktop: Schema.optionalKey(Schema.Boolean),
   automaticGitFetchInterval: Schema.optionalKey(Schema.DurationFromMillis),
   defaultThreadEnvMode: Schema.optionalKey(ThreadEnvMode),
   newWorktreesStartFromOrigin: Schema.optionalKey(Schema.Boolean),


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

Support for VSCode tunnels was added. VSCode tunnels allows a user to access a remote VSCode instance over the internet. This makes it possible to use T3Code on a remote machine and open a VSCode window like the code was local.

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

To make remote workflows easier for VSCode users

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

Editor dropdown:
<img width="1043" height="139" alt="image" src="https://github.com/user-attachments/assets/53effa3e-b8d7-4111-87a6-7fe20ac46890" />
Settings:
<img width="793" height="372" alt="image" src="https://github.com/user-attachments/assets/0eaa2364-3013-4119-a3aa-35ede1772e12" />


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces subprocess execution and external URL opening with tightened allowlists; server config stream shape and WS wiring change, but scope is feature-flagged via settings defaults.
> 
> **Overview**
> Adds **VS Code remote tunnel** support end-to-end: the server can detect an active `code tunnel`, expose it on the server config WebSocket stream, and the chat **Open** control can launch the workspace in vscode.dev or the desktop app.
> 
> **Server & contracts:** New `vscodeTunnel` / `vscodeTunnelStatus` on `ServerConfig`, settings `enableVSCodeRemoteTunnels` and `openVSCodeRemoteTunnelsInDesktop`, and a `vscodeTunnelUpdated` stream event. A `VSCodeTunnelMonitor` runs `code tunnel status` (with robust JSON extraction), caches results, refreshes on settings changes and on a 1-minute tick, and feeds a centralized PubSub fan-in for `subscribeServerConfig` (replacing per-handler merges for keybindings/providers/settings).
> 
> **Desktop & web:** Electron `openExternal` now allows only `vscode://vscode-remote/tunnel+...` URLs (not arbitrary `vscode:` links). **OpenInPicker** gains a tunnel menu entry and primary action when no cross-environment editor picker is shown; links use `shell.openExternal`. **Connections** settings show tunnel status and the two toggles.
> 
> **Tests:** Coverage for URL allowlisting, tunnel JSON parsing, monitor caching, client config projection, and server WS subscription behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 941fe4c188be87c8e299b86b1ab442033dc08369. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add VS Code remote tunnel editor support to the server config stream and UI
> - Adds a `VSCodeTunnelMonitor` service ([vscodeTunnel.ts](https://github.com/pingdotgg/t3code/pull/3721/files#diff-6d9da79ef29bbdc9bce583c28eb40591e5d83fde26bb4568de028cf91cf94e0a)) that periodically runs `code tunnel status`, parses the output, and publishes updates via a PubSub stream
> - Extends the server config WebSocket stream with a new `vscodeTunnelUpdated` event type and includes `vscodeTunnel`/`vscodeTunnelStatus` fields in the config snapshot
> - Adds an `OpenInPicker` option in the chat header to open the current path via a VS Code remote tunnel (web `vscode.dev` URL or desktop `vscode://` URL based on settings)
> - Adds two settings in `ConnectionsSettings`: toggle tunnel monitoring (`enableVSCodeRemoteTunnels`) and choose desktop vs. browser target (`openVSCodeRemoteTunnelsInDesktop`)
> - Extends `parseSafeExternalUrl` in [ElectronShell.ts](https://github.com/pingdotgg/t3code/pull/3721/files#diff-0b7636a4a3ddf8fc7846cb5dbd4e2bdbb2c8b6946910d46f069493c0f389a4dc) to allow `vscode://vscode-remote/tunnel+*` URLs through the external link safety check
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 941fe4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->