### PR TITLE
feat(web): create folders from the add-project path picker

### DIFF
--- a/apps/server/src/workspace/WorkspaceEntries.test.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.test.ts
@@ -391,4 +391,54 @@ it.layer(TestLayer, { excludeTestServices: true })("WorkspaceEntries", (it) => {
       }),
     );
   });
+
+  describe("createDirectory", () => {
+    it.effect("creates a missing directory under an existing parent", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-create-dir-" });
+        const targetPath = path.join(cwd, "new-project");
+
+        const result = yield* workspaceEntries.createDirectory({
+          partialPath: targetPath,
+        });
+
+        expect(result).toEqual({ directoryPath: targetPath });
+        const stat = yield* fileSystem.stat(targetPath);
+        expect(stat.type).toBe("Directory");
+      }),
+    );
+
+    it.effect("returns the existing directory path when it already exists", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+        const path = yield* Path.Path;
+        const cwd = yield* makeTempDir({ prefix: "t3code-workspace-create-existing-" });
+        yield* writeTextFile(cwd, "existing/index.ts", "export {};\n");
+        const existingPath = path.join(cwd, "existing");
+
+        const result = yield* workspaceEntries.createDirectory({
+          partialPath: existingPath,
+        });
+
+        expect(result).toEqual({ directoryPath: existingPath });
+      }),
+    );
+
+    it.effect("rejects relative paths without cwd", () =>
+      Effect.gen(function* () {
+        const workspaceEntries = yield* WorkspaceEntries.WorkspaceEntries;
+
+        const error = yield* workspaceEntries
+          .createDirectory({
+            partialPath: "./new-dir",
+          })
+          .pipe(Effect.flip);
+
+        expect(error._tag).toBe("WorkspaceEntriesCurrentProjectRequiredError");
+      }),
+    );
+  });
 });

--- a/apps/server/src/workspace/WorkspaceEntries.ts
+++ b/apps/server/src/workspace/WorkspaceEntries.ts
@@ -12,6 +12,8 @@ import * as Schema from "effect/Schema";
 import type {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
+  FilesystemCreateDirectoryInput,
+  FilesystemCreateDirectoryResult,
   ProjectListEntriesInput,
   ProjectListEntriesResult,
   ProjectSearchEntriesInput,
@@ -63,12 +65,85 @@ export class WorkspaceEntriesReadDirectoryError extends Schema.TaggedErrorClass<
   }
 }
 
-export const WorkspaceEntriesBrowseError = Schema.Union([
+export class WorkspaceEntriesPathAlreadyExistsError extends Schema.TaggedErrorClass<WorkspaceEntriesPathAlreadyExistsError>()(
+  "WorkspaceEntriesPathAlreadyExistsError",
+  {
+    cwd: Schema.optional(Schema.String),
+    partialPath: Schema.String,
+    directoryPath: Schema.String,
+  },
+) {
+  override get message(): string {
+    const cwd = this.cwd ? ` from '${this.cwd}'` : "";
+    return `Filesystem path '${this.directoryPath}' already exists while creating '${this.partialPath}'${cwd}.`;
+  }
+}
+
+export class WorkspaceEntriesPathNotDirectoryError extends Schema.TaggedErrorClass<WorkspaceEntriesPathNotDirectoryError>()(
+  "WorkspaceEntriesPathNotDirectoryError",
+  {
+    cwd: Schema.optional(Schema.String),
+    partialPath: Schema.String,
+    directoryPath: Schema.String,
+  },
+) {
+  override get message(): string {
+    const cwd = this.cwd ? ` from '${this.cwd}'` : "";
+    return `Filesystem path '${this.directoryPath}' is not a directory while creating '${this.partialPath}'${cwd}.`;
+  }
+}
+
+export class WorkspaceEntriesParentNotFoundError extends Schema.TaggedErrorClass<WorkspaceEntriesParentNotFoundError>()(
+  "WorkspaceEntriesParentNotFoundError",
+  {
+    cwd: Schema.optional(Schema.String),
+    partialPath: Schema.String,
+    parentPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const cwd = this.cwd ? ` from '${this.cwd}'` : "";
+    return `Parent directory '${this.parentPath}' does not exist while creating '${this.partialPath}'${cwd}.`;
+  }
+}
+
+export class WorkspaceEntriesCreateDirectoryError extends Schema.TaggedErrorClass<WorkspaceEntriesCreateDirectoryError>()(
+  "WorkspaceEntriesCreateDirectoryError",
+  {
+    cwd: Schema.optional(Schema.String),
+    partialPath: Schema.String,
+    directoryPath: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {
+  override get message(): string {
+    const cwd = this.cwd ? ` from '${this.cwd}'` : "";
+    return `Failed to create directory '${this.directoryPath}' for '${this.partialPath}'${cwd}.`;
+  }
+}
+
+export const WorkspaceEntriesResolveTargetError = Schema.Union([
   WorkspaceEntriesWindowsPathUnsupportedError,
   WorkspaceEntriesCurrentProjectRequiredError,
+]);
+export type WorkspaceEntriesResolveTargetError = typeof WorkspaceEntriesResolveTargetError.Type;
+
+export const WorkspaceEntriesBrowseError = Schema.Union([
+  WorkspaceEntriesResolveTargetError,
   WorkspaceEntriesReadDirectoryError,
 ]);
 export type WorkspaceEntriesBrowseError = typeof WorkspaceEntriesBrowseError.Type;
+
+export const WorkspaceEntriesCreateDirectoryErrorUnion = Schema.Union([
+  WorkspaceEntriesResolveTargetError,
+  WorkspaceEntriesPathAlreadyExistsError,
+  WorkspaceEntriesPathNotDirectoryError,
+  WorkspaceEntriesParentNotFoundError,
+  WorkspaceEntriesCreateDirectoryError,
+]);
+export type WorkspaceEntriesCreateDirectoryErrorUnion =
+  typeof WorkspaceEntriesCreateDirectoryErrorUnion.Type;
 
 export const WorkspaceEntriesError = Schema.Union([
   WorkspacePaths.WorkspaceRootNotExistsError,
@@ -87,6 +162,9 @@ export class WorkspaceEntries extends Context.Service<
     readonly browse: (
       input: FilesystemBrowseInput,
     ) => Effect.Effect<FilesystemBrowseResult, WorkspaceEntriesBrowseError>;
+    readonly createDirectory: (
+      input: FilesystemCreateDirectoryInput,
+    ) => Effect.Effect<FilesystemCreateDirectoryResult, WorkspaceEntriesCreateDirectoryErrorUnion>;
     readonly list: (
       input: ProjectListEntriesInput,
     ) => Effect.Effect<ProjectListEntriesResult, WorkspaceEntriesError>;
@@ -110,7 +188,7 @@ function expandHomePath(input: string, path: Path.Path): string {
 const resolveBrowseTarget = Effect.fn("WorkspaceEntries.resolveBrowseTarget")(function* (
   input: FilesystemBrowseInput,
   path: Path.Path,
-): Effect.fn.Return<string, WorkspaceEntriesBrowseError> {
+): Effect.fn.Return<string, WorkspaceEntriesResolveTargetError> {
   const platform = yield* HostProcessPlatform;
   if (platform !== "win32" && isWindowsAbsolutePath(input.partialPath)) {
     return yield* new WorkspaceEntriesWindowsPathUnsupportedError({
@@ -177,6 +255,86 @@ export const make = Effect.gen(function* () {
       );
     },
   );
+
+  const createDirectory: WorkspaceEntries["Service"]["createDirectory"] = Effect.fn(
+    "WorkspaceEntries.createDirectory",
+  )(function* (input) {
+    const resolvedDirectoryPath = yield* resolveBrowseTarget(input, path);
+    const existingStat = yield* Effect.tryPromise({
+      try: () => NodeFSP.stat(resolvedDirectoryPath),
+      catch: (cause) => cause,
+    }).pipe(
+      Effect.match({
+        onFailure: () => null,
+        onSuccess: (stat) => stat,
+      }),
+    );
+
+    if (existingStat) {
+      if (existingStat.isDirectory()) {
+        return { directoryPath: resolvedDirectoryPath } as const;
+      }
+      return yield* new WorkspaceEntriesPathNotDirectoryError({
+        cwd: input.cwd,
+        partialPath: input.partialPath,
+        directoryPath: resolvedDirectoryPath,
+      });
+    }
+
+    const parentPath = path.dirname(resolvedDirectoryPath);
+    const parentStat = yield* Effect.tryPromise({
+      try: () => NodeFSP.stat(parentPath),
+      catch: (cause) => cause,
+    }).pipe(
+      Effect.matchEffect({
+        onFailure: (cause) =>
+          Effect.fail(
+            new WorkspaceEntriesParentNotFoundError({
+              cwd: input.cwd,
+              partialPath: input.partialPath,
+              parentPath,
+              cause,
+            }),
+          ),
+        onSuccess: Effect.succeed,
+      }),
+    );
+    if (!parentStat.isDirectory()) {
+      return yield* new WorkspaceEntriesPathNotDirectoryError({
+        cwd: input.cwd,
+        partialPath: input.partialPath,
+        directoryPath: parentPath,
+      });
+    }
+
+    yield* Effect.tryPromise({
+      try: () => NodeFSP.mkdir(resolvedDirectoryPath),
+      catch: (cause) => cause,
+    }).pipe(
+      Effect.catchIf(
+        (cause) => (cause as NodeJS.ErrnoException | undefined)?.code === "EEXIST",
+        () =>
+          Effect.fail(
+            new WorkspaceEntriesPathAlreadyExistsError({
+              cwd: input.cwd,
+              partialPath: input.partialPath,
+              directoryPath: resolvedDirectoryPath,
+            }),
+          ),
+      ),
+      Effect.mapError(
+        (cause) =>
+          new WorkspaceEntriesCreateDirectoryError({
+            cwd: input.cwd,
+            partialPath: input.partialPath,
+            directoryPath: resolvedDirectoryPath,
+            cause,
+          }),
+      ),
+    );
+
+    return { directoryPath: resolvedDirectoryPath } as const;
+  });
 
   const browse: WorkspaceEntries["Service"]["browse"] = Effect.fn("WorkspaceEntries.browse")(
     function* (input) {
@@ -251,7 +409,7 @@ export const make = Effect.gen(function* () {
     },
   );
 
-  return WorkspaceEntries.of({ browse, list, refresh, search });
+  return WorkspaceEntries.of({ browse, createDirectory, list, refresh, search });
 });
 
 export const layer = Layer.effect(WorkspaceEntries, make).pipe(

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -46,6 +46,8 @@ import {
   OrchestrationReplayEventsError,
   type FilesystemBrowseFailure,
   FilesystemBrowseError,
+  type FilesystemCreateDirectoryFailure,
+  FilesystemCreateDirectoryError,
   AssetWorkspaceContextNotFoundError,
   AssetWorkspaceContextResolutionError,
   EnvironmentAuthorizationError,
@@ -201,6 +203,31 @@ function filesystemBrowseFailureContext(error: WorkspaceEntries.WorkspaceEntries
   }
 }
 
+function filesystemCreateDirectoryFailureContext(
+  error: WorkspaceEntries.WorkspaceEntriesCreateDirectoryErrorUnion,
+): {
+  readonly failure: FilesystemCreateDirectoryFailure;
+  readonly directoryPath?: string;
+  readonly platform?: string;
+} {
+  switch (error._tag) {
+    case "WorkspaceEntriesWindowsPathUnsupportedError":
+      return { failure: "windows_path_unsupported", platform: error.platform };
+    case "WorkspaceEntriesCurrentProjectRequiredError":
+      return { failure: "current_project_required" };
+    case "WorkspaceEntriesPathAlreadyExistsError":
+      return { failure: "path_already_exists", directoryPath: error.directoryPath };
+    case "WorkspaceEntriesPathNotDirectoryError":
+      return { failure: "path_not_directory", directoryPath: error.directoryPath };
+    case "WorkspaceEntriesParentNotFoundError":
+      return { failure: "parent_not_found", directoryPath: error.parentPath };
+    case "WorkspaceEntriesCreateDirectoryError":
+      return { failure: "create_directory_failed", directoryPath: error.directoryPath };
+    default:
+      return unexpectedCompatibilityError(error);
+  }
+}
+
 function projectFileFailureContext(
   error:
     | WorkspaceFileSystem.WorkspaceFileSystemError
@@ -305,6 +332,7 @@ const RPC_REQUIRED_SCOPE = new Map<string, AuthEnvironmentScope>([
   [WS_METHODS.projectsWriteFile, AuthOrchestrationOperateScope],
   [WS_METHODS.shellOpenInEditor, AuthOrchestrationOperateScope],
   [WS_METHODS.filesystemBrowse, AuthOrchestrationReadScope],
+  [WS_METHODS.filesystemCreateDirectory, AuthOrchestrationOperateScope],
   [WS_METHODS.assetsCreateUrl, AuthOrchestrationReadScope],
   [WS_METHODS.subscribeVcsStatus, AuthOrchestrationReadScope],
   [WS_METHODS.vcsRefreshStatus, AuthOrchestrationReadScope],
@@ -1398,6 +1426,21 @@ const makeWsRpcLayer = (
                   new FilesystemBrowseError({
                     ...input,
                     ...filesystemBrowseFailureContext(cause),
+                    cause,
+                  }),
+              ),
+            ),
+            { "rpc.aggregate": "workspace" },
+          ),
+        [WS_METHODS.filesystemCreateDirectory]: (input) =>
+          observeRpcEffect(
+            WS_METHODS.filesystemCreateDirectory,
+            workspaceEntries.createDirectory(input).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new FilesystemCreateDirectoryError({
+                    ...input,
+                    ...filesystemCreateDirectoryFailureContext(cause),
                     cause,
                   }),
               ),

--- a/apps/web/src/components/CommandPalette.logic.test.ts
+++ b/apps/web/src/components/CommandPalette.logic.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vite-plus/test";
 import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
 import type { Thread } from "../types";
 import {
+  buildBrowseGroups,
   buildThreadActionItems,
   filterCommandPaletteGroups,
+  getBrowseCreateFolderName,
   type CommandPaletteGroup,
 } from "./CommandPalette.logic";
 
@@ -34,6 +36,61 @@ function makeThread(overrides: Partial<Thread> = {}): Thread {
     ...overrides,
   };
 }
+
+describe("getBrowseCreateFolderName", () => {
+  it("returns a folder name when the typed leaf does not match an existing entry", () => {
+    expect(
+      getBrowseCreateFolderName({
+        browseFilterQuery: "new-folder",
+        exactEntry: null,
+        browseParentPath: "/Users/luke/projects",
+        isBrowsePending: false,
+        relativePathNeedsActiveProject: false,
+      }),
+    ).toBe("new-folder");
+  });
+
+  it("returns null when an exact directory match already exists", () => {
+    expect(
+      getBrowseCreateFolderName({
+        browseFilterQuery: "projects",
+        exactEntry: { name: "projects", fullPath: "/Users/luke/projects" },
+        browseParentPath: "/Users/luke",
+        isBrowsePending: false,
+        relativePathNeedsActiveProject: false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("buildBrowseGroups", () => {
+  it("adds a create-folder action when a new folder name is available", async () => {
+    const createFolder = vi.fn(async () => undefined);
+    const groups = buildBrowseGroups({
+      browseEntries: [],
+      browseQuery: "~/projects/new-folder",
+      canBrowseUp: false,
+      upIcon: null,
+      directoryIcon: null,
+      createFolderIcon: null,
+      createFolderName: "new-folder",
+      browseUp: () => undefined,
+      browseTo: () => undefined,
+      createFolder,
+    });
+
+    const createItem = groups[0]?.items.find(
+      (item) => item.value === "browse:create-folder:new-folder",
+    );
+    expect(createItem?.kind).toBe("action");
+    if (createItem?.kind !== "action") {
+      throw new Error("Expected create-folder browse action");
+    }
+    expect(createItem.title).toBe('Create folder "new-folder"');
+    await createItem.run();
+    expect(createFolder).toHaveBeenCalledWith("new-folder");
+  });
+});
 
 describe("buildThreadActionItems", () => {
   it("orders threads by most recent activity and formats timestamps from updatedAt", () => {

--- a/apps/web/src/components/CommandPalette.logic.ts
+++ b/apps/web/src/components/CommandPalette.logic.ts
@@ -54,6 +54,32 @@ export interface CommandPaletteView {
 
 export type CommandPaletteMode = "root" | "root-browse" | "submenu" | "submenu-browse";
 
+export function getBrowseCreateFolderName(input: {
+  browseFilterQuery: string;
+  exactEntry: FilesystemBrowseEntry | null;
+  browseParentPath: string | null | undefined;
+  isBrowsePending: boolean;
+  relativePathNeedsActiveProject: boolean;
+}): string | null {
+  const folderName = input.browseFilterQuery.trim();
+  if (
+    folderName.length === 0 ||
+    input.exactEntry !== null ||
+    input.isBrowsePending ||
+    input.relativePathNeedsActiveProject ||
+    input.browseParentPath === null ||
+    input.browseParentPath === undefined ||
+    input.browseParentPath.length === 0
+  ) {
+    return null;
+  }
+  return folderName;
+}
+
+export function buildBrowseCreateFolderValue(folderName: string): string {
+  return `browse:create-folder:${folderName}`;
+}
+
 export function filterBrowseEntries(input: {
   browseEntries: ReadonlyArray<FilesystemBrowseEntry>;
   browseFilterQuery: string;
@@ -285,8 +311,11 @@ export function buildBrowseGroups(input: {
   canBrowseUp: boolean;
   upIcon: ReactNode;
   directoryIcon: ReactNode;
+  createFolderIcon?: ReactNode;
+  createFolderName?: string | null;
   browseUp: () => void;
   browseTo: (name: string) => void;
+  createFolder?: (folderName: string) => Promise<void>;
 }): CommandPaletteGroup[] {
   const items: CommandPaletteActionItem[] = [];
 
@@ -314,6 +343,20 @@ export function buildBrowseGroups(input: {
       keepOpen: true,
       run: async () => {
         input.browseTo(entry.name);
+      },
+    });
+  }
+
+  if (input.createFolderName && input.createFolder) {
+    items.push({
+      kind: "action",
+      value: buildBrowseCreateFolderValue(input.createFolderName),
+      searchTerms: [input.browseQuery, input.createFolderName, "create folder"],
+      title: `Create folder "${input.createFolderName}"`,
+      icon: input.createFolderIcon ?? input.directoryIcon,
+      keepOpen: true,
+      run: async () => {
+        await input.createFolder!(input.createFolderName!);
       },
     });
   }

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -77,6 +77,7 @@ import {
   isExplicitRelativeProjectPath,
   isFilesystemBrowseQuery,
   isUnsupportedWindowsProjectPath,
+  normalizeProjectPathForDispatch,
   resolveProjectPathForDispatch,
 } from "../lib/projectPaths";
 import { isTerminalFocused } from "../lib/terminalFocus";
@@ -101,6 +102,7 @@ import {
   type CommandPaletteView,
   filterBrowseEntries,
   filterCommandPaletteGroups,
+  getBrowseCreateFolderName,
   getCommandPaletteInputPlaceholder,
   getCommandPaletteMode,
   ITEM_ICON_CLASS,
@@ -462,6 +464,9 @@ function OpenCommandPaletteDialog(props: {
   const createProject = useAtomCommand(projectEnvironment.create, {
     reportFailure: false,
   });
+  const createDirectory = useAtomCommand(filesystemEnvironment.createDirectory, {
+    reportFailure: false,
+  });
   const lookupRepository = useAtomQueryRunner(sourceControlEnvironment.repository, {
     reportFailure: false,
   });
@@ -483,6 +488,7 @@ function OpenCommandPaletteDialog(props: {
     null,
   );
   const [isPickingProjectFolder, setIsPickingProjectFolder] = useState(false);
+  const [isCreatingBrowseFolder, setIsCreatingBrowseFolder] = useState(false);
   const [addProjectCloneFlow, setAddProjectCloneFlow] = useState<AddProjectCloneFlow | null>(null);
   const [isRemoteProjectLookingUp, setIsRemoteProjectLookingUp] = useState(false);
   const [isRemoteProjectCloning, setIsRemoteProjectCloning] = useState(false);
@@ -626,6 +632,74 @@ function OpenCommandPaletteDialog(props: {
   const { filteredEntries: filteredBrowseEntries, exactEntry: exactBrowseEntry } = useMemo(
     () => filterBrowseEntries({ browseEntries, browseFilterQuery, highlightedItemValue }),
     [browseEntries, browseFilterQuery, highlightedItemValue],
+  );
+  const browseCreateFolderName = useMemo(
+    () =>
+      getBrowseCreateFolderName({
+        browseFilterQuery,
+        exactEntry: exactBrowseEntry,
+        browseParentPath: browseResult?.parentPath,
+        isBrowsePending,
+        relativePathNeedsActiveProject,
+      }),
+    [
+      browseFilterQuery,
+      browseResult?.parentPath,
+      exactBrowseEntry,
+      isBrowsePending,
+      relativePathNeedsActiveProject,
+    ],
+  );
+
+  const handleCreateBrowseFolder = useCallback(
+    async (folderName: string) => {
+      if (!browseEnvironmentId || isCreatingBrowseFolder) {
+        return;
+      }
+
+      const partialPath = normalizeProjectPathForDispatch(
+        appendBrowsePathSegment(getBrowseDirectoryPath(query), folderName),
+      );
+      if (partialPath.length === 0) {
+        return;
+      }
+
+      setIsCreatingBrowseFolder(true);
+      const createResult = await createDirectory({
+        environmentId: browseEnvironmentId,
+        input: {
+          partialPath,
+          ...(currentProjectCwdForBrowse ? { cwd: currentProjectCwdForBrowse } : {}),
+        },
+      });
+      setIsCreatingBrowseFolder(false);
+
+      if (createResult._tag === "Failure") {
+        if (!isAtomCommandInterrupted(createResult)) {
+          const error = squashAtomCommandFailure(createResult);
+          toastManager.add(
+            stackedThreadToast({
+              type: "error",
+              title: "Failed to create folder",
+              description: error instanceof Error ? error.message : "An error occurred.",
+            }),
+          );
+        }
+        return;
+      }
+
+      const nextQuery = appendBrowsePathSegment(query, folderName);
+      setHighlightedItemValue(null);
+      setQuery(nextQuery);
+      setBrowseGeneration((generation) => generation + 1);
+    },
+    [
+      browseEnvironmentId,
+      createDirectory,
+      currentProjectCwdForBrowse,
+      isCreatingBrowseFolder,
+      query,
+    ],
   );
 
   const openProjectFromSearch = useMemo(
@@ -1384,8 +1458,11 @@ function OpenCommandPaletteDialog(props: {
     canBrowseUp,
     upIcon: <CornerLeftUpIcon className={ITEM_ICON_CLASS} />,
     directoryIcon: <FolderIcon className={ITEM_ICON_CLASS} />,
+    createFolderIcon: <FolderPlusIcon className={ITEM_ICON_CLASS} />,
+    createFolderName: browseCreateFolderName,
     browseUp,
     browseTo,
+    createFolder: handleCreateBrowseFolder,
   });
   const cloneDestinationBrowseGroups = useMemo(
     () =>
@@ -1497,9 +1574,22 @@ function OpenCommandPaletteDialog(props: {
       return;
     }
 
+    if (
+      canSubmitBrowsePath &&
+      event.key === "Enter" &&
+      event.shiftKey &&
+      browseCreateFolderName &&
+      !isPrimaryModifierPressed(event)
+    ) {
+      event.preventDefault();
+      void handleCreateBrowseFolder(browseCreateFolderName);
+      return;
+    }
+
     const shouldSubmitBrowsePath =
       canSubmitBrowsePath &&
       event.key === "Enter" &&
+      !event.shiftKey &&
       (!hasHighlightedBrowseItem || isPrimaryModifierPressed(event));
 
     if (shouldSubmitBrowsePath) {
@@ -1758,6 +1848,7 @@ function OpenCommandPaletteDialog(props: {
                     aria-label={`${submitActionLabel} (${addShortcutLabel})`}
                     disabled={
                       relativePathNeedsActiveProject ||
+                      isCreatingBrowseFolder ||
                       (isCloneDestinationStep && isRemoteProjectPending)
                     }
                     onMouseDown={(event) => {
@@ -1825,12 +1916,16 @@ function OpenCommandPaletteDialog(props: {
                 ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
                 : relativePathNeedsActiveProject
                   ? { emptyStateMessage: "Relative paths require an active project." }
-                  : willCreateProjectPath
+                  : browseCreateFolderName
                     ? {
-                        emptyStateMessage:
-                          "Press Enter to create this folder and add it as a project.",
+                        emptyStateMessage: `Press Shift+Enter to create "${browseCreateFolderName}", or Enter to ${isCloneDestinationStep ? "clone here" : "add it as a project"}.`,
                       }
-                    : {})}
+                    : willCreateProjectPath
+                      ? {
+                          emptyStateMessage:
+                            "Press Enter to create this folder and add it as a project.",
+                        }
+                      : {})}
           />
         </CommandPanel>
         <CommandFooter className="gap-3 max-sm:flex-col max-sm:items-start">
@@ -1855,6 +1950,13 @@ function OpenCommandPaletteDialog(props: {
               <KbdGroup className="items-center gap-1.5">
                 <Kbd>Enter</Kbd>
                 <span className={cn("text-muted-foreground/80")}>Select</span>
+              </KbdGroup>
+            ) : null}
+            {isBrowsing && browseCreateFolderName ? (
+              <KbdGroup className="items-center gap-1.5">
+                <Kbd>Shift</Kbd>
+                <Kbd>Enter</Kbd>
+                <span className={cn("text-muted-foreground/80")}>Create folder</span>
               </KbdGroup>
             ) : null}
             {isSubmenu ? (

--- a/packages/client-runtime/src/state/filesystem.ts
+++ b/packages/client-runtime/src/state/filesystem.ts
@@ -1,7 +1,7 @@
 import { WS_METHODS } from "@t3tools/contracts";
 import { Atom } from "effect/unstable/reactivity";
 
-import { createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
+import { createEnvironmentRpcCommand, createEnvironmentRpcQueryAtomFamily } from "./runtime.ts";
 import type { EnvironmentRegistry } from "../connection/registry.ts";
 
 export function createFilesystemEnvironmentAtoms<R, E>(
@@ -11,6 +11,10 @@ export function createFilesystemEnvironmentAtoms<R, E>(
     browse: createEnvironmentRpcQueryAtomFamily(runtime, {
       label: "environment-data:filesystem:browse",
       tag: WS_METHODS.filesystemBrowse,
+    }),
+    createDirectory: createEnvironmentRpcCommand(runtime, {
+      label: "environment-command:filesystem:create-directory",
+      tag: WS_METHODS.filesystemCreateDirectory,
     }),
   };
 }

--- a/packages/contracts/src/filesystem.test.ts
+++ b/packages/contracts/src/filesystem.test.ts
@@ -1,7 +1,7 @@
 import * as Schema from "effect/Schema";
 import { describe, expect, it } from "vite-plus/test";
 
-import { FilesystemBrowseError } from "./filesystem.ts";
+import { FilesystemBrowseError, FilesystemCreateDirectoryError } from "./filesystem.ts";
 
 describe("FilesystemBrowseError", () => {
   it("derives a stable message from browse context while retaining the cause", () => {
@@ -29,5 +29,24 @@ describe("FilesystemBrowseError", () => {
     expect(error.message).toBe("Legacy filesystem browse failure.");
     expect(error.partialPath).toBeUndefined();
     expect(error.failure).toBeUndefined();
+  });
+});
+
+describe("FilesystemCreateDirectoryError", () => {
+  it("derives a stable message from create-directory context while retaining the cause", () => {
+    const cause = new Error("sensitive filesystem detail");
+    const error = new FilesystemCreateDirectoryError({
+      cwd: "/workspace",
+      partialPath: "./src/new-dir",
+      failure: "create_directory_failed",
+      directoryPath: "/workspace/src/new-dir",
+      cause,
+    });
+
+    expect(error.message).toBe(
+      "Failed to create filesystem directory './src/new-dir' from '/workspace'.",
+    );
+    expect(error.message).not.toContain(cause.message);
+    expect(error.cause).toBe(cause);
   });
 });

--- a/packages/contracts/src/filesystem.ts
+++ b/packages/contracts/src/filesystem.ts
@@ -28,6 +28,58 @@ export const FilesystemBrowseFailure = Schema.Literals([
 ]);
 export type FilesystemBrowseFailure = typeof FilesystemBrowseFailure.Type;
 
+export const FilesystemCreateDirectoryInput = Schema.Struct({
+  partialPath: TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH)),
+  cwd: Schema.optional(TrimmedNonEmptyString.check(Schema.isMaxLength(FILESYSTEM_PATH_MAX_LENGTH))),
+});
+export type FilesystemCreateDirectoryInput = typeof FilesystemCreateDirectoryInput.Type;
+
+export const FilesystemCreateDirectoryResult = Schema.Struct({
+  directoryPath: TrimmedNonEmptyString,
+});
+export type FilesystemCreateDirectoryResult = typeof FilesystemCreateDirectoryResult.Type;
+
+export const FilesystemCreateDirectoryFailure = Schema.Literals([
+  "windows_path_unsupported",
+  "current_project_required",
+  "path_already_exists",
+  "path_not_directory",
+  "parent_not_found",
+  "create_directory_failed",
+]);
+export type FilesystemCreateDirectoryFailure = typeof FilesystemCreateDirectoryFailure.Type;
+
+export class FilesystemCreateDirectoryError extends Schema.TaggedErrorClass<FilesystemCreateDirectoryError>()(
+  "FilesystemCreateDirectoryError",
+  {
+    partialPath: Schema.optional(TrimmedNonEmptyString),
+    cwd: Schema.optional(TrimmedNonEmptyString),
+    failure: Schema.optional(FilesystemCreateDirectoryFailure),
+    directoryPath: Schema.optional(TrimmedNonEmptyString),
+    platform: Schema.optional(TrimmedNonEmptyString),
+    message: TrimmedNonEmptyString,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {
+  // @effect-diagnostics-next-line overriddenSchemaConstructor:off
+  constructor(props: {
+    readonly partialPath: string;
+    readonly cwd?: string | undefined;
+    readonly failure: FilesystemCreateDirectoryFailure;
+    readonly directoryPath?: string;
+    readonly platform?: string;
+    readonly cause?: unknown;
+  }) {
+    const cwd = props.cwd === undefined ? "" : ` from '${props.cwd}'`;
+    super({
+      ...props,
+      message:
+        decodedFilesystemBrowseErrorMessage(props) ??
+        `Failed to create filesystem directory '${props.partialPath}'${cwd}.`,
+    } as any);
+  }
+}
+
 function decodedFilesystemBrowseErrorMessage(props: object): string | undefined {
   if (!("message" in props)) return undefined;
   return typeof props.message === "string" ? props.message : undefined;

--- a/packages/contracts/src/ipc.ts
+++ b/packages/contracts/src/ipc.ts
@@ -19,7 +19,12 @@ import type {
   VcsStatusResult,
 } from "./git.ts";
 import type { ReviewDiffPreviewInput, ReviewDiffPreviewResult } from "./review.ts";
-import type { FilesystemBrowseInput, FilesystemBrowseResult } from "./filesystem.ts";
+import type {
+  FilesystemBrowseInput,
+  FilesystemBrowseResult,
+  FilesystemCreateDirectoryInput,
+  FilesystemCreateDirectoryResult,
+} from "./filesystem.ts";
 import type { AssetCreateUrlInput, AssetCreateUrlResult } from "./assets.ts";
 import type {
   ProjectListEntriesInput,
@@ -1162,6 +1167,9 @@ export interface EnvironmentApi {
   };
   filesystem: {
     browse: (input: FilesystemBrowseInput) => Promise<FilesystemBrowseResult>;
+    createDirectory: (
+      input: FilesystemCreateDirectoryInput,
+    ) => Promise<FilesystemCreateDirectoryResult>;
   };
   assets: {
     createUrl: (input: AssetCreateUrlInput) => Promise<AssetCreateUrlResult>;

--- a/packages/contracts/src/rpc.ts
+++ b/packages/contracts/src/rpc.ts
@@ -12,6 +12,9 @@ import {
   FilesystemBrowseInput,
   FilesystemBrowseResult,
   FilesystemBrowseError,
+  FilesystemCreateDirectoryInput,
+  FilesystemCreateDirectoryResult,
+  FilesystemCreateDirectoryError,
 } from "./filesystem.ts";
 import { AssetAccessError, AssetCreateUrlInput, AssetCreateUrlResult } from "./assets.ts";
 import {
@@ -159,6 +162,7 @@ export const WS_METHODS = {
 
   // Filesystem methods
   filesystemBrowse: "filesystem.browse",
+  filesystemCreateDirectory: "filesystem.createDirectory",
   assetsCreateUrl: "assets.createUrl",
 
   // VCS methods
@@ -387,6 +391,12 @@ export const WsFilesystemBrowseRpc = Rpc.make(WS_METHODS.filesystemBrowse, {
   payload: FilesystemBrowseInput,
   success: FilesystemBrowseResult,
   error: Schema.Union([FilesystemBrowseError, EnvironmentAuthorizationError]),
+});
+
+export const WsFilesystemCreateDirectoryRpc = Rpc.make(WS_METHODS.filesystemCreateDirectory, {
+  payload: FilesystemCreateDirectoryInput,
+  success: FilesystemCreateDirectoryResult,
+  error: Schema.Union([FilesystemCreateDirectoryError, EnvironmentAuthorizationError]),
 });
 
 export const WsAssetsCreateUrlRpc = Rpc.make(WS_METHODS.assetsCreateUrl, {
@@ -705,6 +715,7 @@ export const WsRpcGroup = RpcGroup.make(
   WsProjectsWriteFileRpc,
   WsShellOpenInEditorRpc,
   WsFilesystemBrowseRpc,
+  WsFilesystemCreateDirectoryRpc,
   WsAssetsCreateUrlRpc,
   WsSubscribeVcsStatusRpc,
   WsVcsPullRpc,


### PR DESCRIPTION
## Summary

Adds the ability to **create folders while browsing** in the add-project path picker, without immediately adding them as a project.

Previously, typing a non-existent path and pressing Enter always created the directory and added it as a project. There was no way to create intermediate folders and keep browsing.

## What's included

- New `filesystem.createDirectory` RPC (contracts, server, client-runtime)
- Picker shows **Create folder "name"** when the typed leaf has no exact match
- **Shift+Enter** creates the folder and navigates into it (browse only)
- **Enter** unchanged: create folder and add as project (or clone destination)
- Footer hint and empty-state copy for discoverability

## Design notes

- Directory creation is server-side via `WorkspaceEntries.createDirectory` (parent must exist; idempotent if the folder already exists)
- Uses `AuthOrchestrationOperateScope` for the new RPC
- Client-only picker UX; no orchestration/project schema changes

## Testing

- `vp check` — pass
- `vp run typecheck` — pass
- Unit tests: `filesystem.test.ts`, `WorkspaceEntries.test.ts`, `CommandPalette.logic.test.ts`
- Manual: desktop dev (`bun run dev:desktop`) — create folder via Shift+Enter, navigate in, then add project with Enter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an authenticated but operate-scoped RPC that performs real `mkdir` on the host filesystem; path rules mirror browse, but misuse or bugs could still create directories outside user intent.
> 
> **Overview**
> Introduces **`filesystem.createDirectory`** through contracts, client-runtime, `WorkspaceEntries`, and WebSocket RPC ( **`AuthOrchestrationOperateScope`** ), with typed failures mapped to client-facing errors.
> 
> The **add-project path browser** can show **Create folder "name"** when the typed leaf has no exact match; **Shift+Enter** (or the list action) creates the directory and refreshes browse into it, while **Enter** still adds the path as a project or clone destination. Footer and empty-state copy document the shortcut.
> 
> Server **`createDirectory`** reuses browse path resolution, requires an existing parent directory, is idempotent when the target is already a directory, and rejects files / missing parents / races (`EEXIST`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcccbf61546b81672ab3a5449b6d7bf23aaf846f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add folder creation to the add-project path picker in the command palette
> - Adds a `filesystem.createDirectory` RPC across contracts, server, and client, with typed input/result schemas and structured failure codes in [filesystem.ts](https://github.com/pingdotgg/t3code/pull/3723/files#diff-80a6cb4180ec3fb0a1c336a148b6ad7313a759f0abf07941a4faf3019d6bf553).
> - Implements `WorkspaceEntries.createDirectory` on the server, resolving paths, checking parent existence, and mapping `mkdir` errors to tagged error types.
> - Extends the command palette browse view to show a 'Create folder' action item (or Shift+Enter) when the query doesn't match an existing entry; on success, the palette navigates into the new folder.
> - Errors surface as toast notifications; the submit button reflects the busy state during creation.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized bcccbf6. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->