### PR TITLE
[orchestrator-v2] fix(orchestrator): Resume persisted Claude sessions after provider session recycle

### DIFF
--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts
@@ -101,13 +101,14 @@ function makeClaudeTestTurnInput(input: {
   readonly attemptId: RunAttemptId;
   readonly text: string;
   readonly attachments: ProviderAdapterV2TurnInput["message"]["attachments"];
+  readonly providerTurnOrdinal?: number;
 }): ProviderAdapterV2TurnInput {
   return {
     appThread: makeClaudeTestAppThread(input),
     threadId: input.threadId,
     runId: RunId.make(`run-${input.attemptId}`),
     runOrdinal: 1,
-    providerTurnOrdinal: 1,
+    providerTurnOrdinal: input.providerTurnOrdinal ?? 1,
     attemptId: input.attemptId,
     rootNodeId: NodeId.make(`node-${input.attemptId}`),
     providerThread: input.providerThread,
@@ -727,5 +728,89 @@ describe("ClaudeAdapterV2 native fork", () => {
         assert.equal(openedQueries[0]?.options.sessionId, undefined);
       }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
     ),
+  );
+});
+
+describe("ClaudeAdapterV2 native session identity", () => {
+  const openTurnWithOrdinal = (providerTurnOrdinal: number) =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const fileSystem = yield* FileSystem.FileSystem;
+        const idAllocator = yield* IdAllocatorV2;
+        const attachmentsDir = yield* fileSystem.makeTempDirectoryScoped({
+          prefix: "t3-claude-v2-session-identity-",
+        });
+        const openedQueries: Array<ClaudeAgentSdkQueryOpenInput> = [];
+        const adapter = makeClaudeAdapterV2({
+          instanceId: CLAUDE_DEFAULT_INSTANCE_ID,
+          settings: DEFAULT_CLAUDE_SETTINGS,
+          environment: {},
+          attachmentsDir,
+          fileSystem,
+          idAllocator,
+          queryRunner: {
+            allocateSessionId: Effect.succeed("native-session-identity"),
+            open: (input) =>
+              Effect.sync(() => {
+                openedQueries.push(input);
+                return {
+                  messages: Stream.empty,
+                  offer: () => Effect.void,
+                  setModel: () => Effect.void,
+                  interrupt: Effect.void,
+                  close: Effect.void,
+                };
+              }),
+            forkSession: () => Effect.die("unused forkSession"),
+            assertComplete: Effect.void,
+          },
+        });
+        const threadId = ThreadId.make("thread-claude-session-identity");
+        const providerSessionId = ProviderSessionId.make("provider-session-claude-identity");
+        const runtime = yield* adapter.openSession({
+          threadId,
+          providerSessionId,
+          modelSelection: CLAUDE_TEST_MODEL_SELECTION,
+          runtimePolicy: CLAUDE_TEST_RUNTIME_POLICY,
+        });
+        const providerThread = yield* runtime.ensureThread({
+          threadId,
+          modelSelection: CLAUDE_TEST_MODEL_SELECTION,
+          runtimePolicy: CLAUDE_TEST_RUNTIME_POLICY,
+        });
+        const now = yield* DateTime.now;
+        yield* runtime.startTurn(
+          makeClaudeTestTurnInput({
+            threadId,
+            providerThread,
+            now,
+            attemptId: RunAttemptId.make("run-attempt-claude-session-identity"),
+            text: "Respond with identity ok",
+            attachments: [],
+            providerTurnOrdinal,
+          }),
+        );
+        return openedQueries;
+      }).pipe(Effect.provide(Layer.merge(idAllocatorLayer, NodeServices.layer))),
+    );
+
+  it.effect("creates the native session on the first provider turn", () =>
+    Effect.gen(function* () {
+      const openedQueries = yield* openTurnWithOrdinal(1);
+      assert.equal(openedQueries.length, 1);
+      assert.equal(openedQueries[0]?.options.sessionId, "native-session-identity");
+      assert.equal(openedQueries[0]?.options.resume, undefined);
+    }),
+  );
+
+  it.effect(
+    "resumes the native session on a fresh session instance when prior provider turns exist",
+    () =>
+      Effect.gen(function* () {
+        const openedQueries = yield* openTurnWithOrdinal(2);
+        assert.equal(openedQueries.length, 1);
+        assert.equal(openedQueries[0]?.options.resume, "native-session-identity");
+        assert.equal(openedQueries[0]?.options.sessionId, undefined);
+      }),
   );
 });

--- a/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
+++ b/apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.ts
@@ -3061,7 +3061,14 @@ export function makeClaudeAdapterV2(
             updated.add(nativeThreadId);
             return [false, updated];
           });
-          const shouldResume = resumeSessionAt !== undefined || openedWithResume;
+          // openedNativeThreads is per session instance and is lost when the
+          // provider session is idle-released. A prior persisted provider turn
+          // proves the native session already exists, so the query must resume
+          // it; reopening with a fixed session id makes the CLI fail fast with
+          // "Session ID ... is already in use".
+          const hasPersistedProviderTurn = turnInput.providerTurnOrdinal > 1;
+          const shouldResume =
+            resumeSessionAt !== undefined || openedWithResume || hasPersistedProviderTurn;
           const querySession = yield* queryRunner.open({
             threadId: turnInput.threadId,
             providerSessionId: input.providerSessionId,


### PR DESCRIPTION
## Summary

Claude threads that sit idle for more than 30 minutes fail instantly on the
next message with `transport_error "Claude Agent SDK query failed."` (the CLI
reports `Session ID ... is already in use`). This PR makes the adapter resume
the persisted native session instead of trying to recreate it.

One commit on `fix/claude-session-resume`: `ClaudeAdapterV2.ts` (the fix) and
`ClaudeAdapterV2.test.ts` (two new tests). Everything else comes from the base
branch.

## Problem and Fix

| Problem and Why it Happened | Fix |
| --- | --- |
| After `ProviderSessionManager` idle-releases a provider session (30 min default), the adapter's in-memory `openedNativeThreads` set is lost. The next turn's `openQuery` therefore opens the native thread with `{sessionId}` (create semantics, `--session-id`) instead of `{resume}`, and the Claude CLI fails fast because the session id already exists on disk. | In `openQuery`, treat a persisted provider turn as proof the native session exists: `providerTurnOrdinal > 1` (computed by `ProviderTurnStartService` as max persisted turn ordinal for the provider thread plus 1) forces `{resume}` alongside the existing in-memory and rollback signals. |

Edge cases checked: run attempt retries (session created on first attempt),
steering (`steerTurn` never calls `openQuery`), `thread_start` rollback (new
provider thread id resets the ordinal to 1, so create is used for the fresh
native session), mid-thread rollback (`resumeSessionAt` already forces
resume), forks in the same session instance (covered by `openedWithResume`),
and first-run failures before CLI spawn (no turn persisted, ordinal stays 1).

## Validation

- `vp check`: pass
- `vp run typecheck`: pass
- `vp test apps/server/src/orchestration-v2/Adapters/ClaudeAdapterV2.test.ts`:
  14/14 pass, including two new tests (`ClaudeAdapterV2 native session
  identity`) asserting ordinal 1 opens with `sessionId` and ordinal 2 opens
  with `resume`
- The new resume test fails without the adapter change (verified by
  stashing the fix and rerunning)
- `OrchestratorReplayFixtures.integration.test.ts` (claude fixtures): pass

## Known limitations

- If the very first turn persists a provider turn but the CLI never created
  the native session (or the reverse: session created, persistence failed),
  the identity choice can still be wrong on retry. Both traps pre-date this
  change (the in-memory set had the same blind spots within a session
  instance); this PR keeps the fix minimal and does not add auto-retry
  identity flipping.
- A native fork creates the CLI session before any provider turn is
  persisted for the forked thread. If the process restarts between the fork
  and the forked thread's first turn, the ordinal is still 1 and `openQuery`
  sends `{sessionId}` for an existing native session. The ordinal signal
  does not engage there, so behavior is identical to before this change
  (pre-existing hole, found by review; a `forkedFrom`-based signal was
  rejected because `thread_start` rollback preserves `forkedFrom` while
  minting a fresh, uncreated native session id).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Resume persisted Claude sessions on subsequent provider turns in `ClaudeAdapterV2`
> When a provider session is recycled (idle release), the adapter previously opened a new native Claude session on the next turn instead of resuming the existing one. `openSession` now checks `providerTurnOrdinal > 1` as an additional condition to set `shouldResume`, ensuring the query opens in resume mode for any turn after the first. Tests are added to assert new-session behavior on the first provider turn and resume behavior on subsequent turns.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 97bf0d0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Claude Agent SDK queries are opened after session recycle; wrong ordinal or identity edge cases could still mis-create vs resume, but scope is limited to resume detection in the adapter.
> 
> **Overview**
> Fixes **immediate transport failures** on the next message when a Claude thread was idle long enough for the provider session to be released (~30 min). After recycle, the adapter no longer tries to **create** the native CLI session with a fixed `sessionId` (which errors with “Session ID … is already in use”); it **resumes** the on-disk session instead.
> 
> In `ClaudeAdapterV2.openQuery`, `shouldResume` now also becomes true when **`providerTurnOrdinal > 1`**, using persisted turn history as proof the native session already exists when the per-instance `openedNativeThreads` set was cleared. Tests cover first turn (`sessionId`, no `resume`) vs a later turn on a fresh session instance (`resume`, no `sessionId`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97bf0d09abdf83749a35732370fee62b17a8b8b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->