### PR TITLE
Prevent Add Project sheet from collapsing on relayout

### DIFF
--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -112,7 +112,12 @@ function AddProjectShell(props: { readonly children: ReactNode }) {
   const insets = useSafeAreaInsets();
 
   return (
-    <View className="flex-1 bg-sheet">
+    // collapsable={false} is load-bearing: if this wrapper is flattened, the
+    // ScrollView lands directly under RNSSafeAreaView and RNS's formSheet
+    // scroll-view frame correction mistakes this full-height wrapper for a
+    // "header" sibling, coercing the ScrollView to zero height (blank sheet
+    // as soon as the sheet re-lays-out, e.g. when the keyboard opens).
+    <View collapsable={false} className="flex-1 bg-sheet">
       <ScrollView
         keyboardShouldPersistTaps="handled"
         contentInsetAdjustmentBehavior="automatic"


### PR DESCRIPTION
## Summary
- Prevent the Add Project sheet wrapper from being flattened by React Native layout optimization.
- Fix a formSheet relayout bug where the ScrollView could be measured at zero height, producing a blank sheet when the keyboard opens.
- Add `collapsable={false}` to keep the wrapper in the native view hierarchy and preserve the intended scroll frame.

## Testing
- Not run (change is limited to a small mobile layout fix).
- Not run: `vp check`
- Not run: `vp run typecheck`
- Not run: `vp run lint:mobile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-prop layout fix on the Add Project sheet with no auth, data, or API changes; same pattern already used on other mobile sheet screens.
> 
> **Overview**
> Fixes the **Add Project** form sheet going blank when the keyboard opens or the sheet re-lays out.
> 
> The `AddProjectShell` root `View` now sets **`collapsable={false}`** so React Native does not flatten it out of the native hierarchy. Without that wrapper, the `ScrollView` sits directly under the safe-area view and react-native-screens’ formSheet scroll framing can treat the full-height parent as a header sibling and measure the scroll area at **zero height**. An inline comment documents this behavior for future edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59cab34dcb38d31ae5c3028e336eaa716c0f3fcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent `AddProjectShell` wrapper View from collapsing during relayout
> Sets `collapsable={false}` on the wrapper `<View>` in [AddProjectScreen.tsx](https://github.com/pingdotgg/t3code/pull/3759/files#diff-8d2af7e60f72647a590cd07374db01b9c44b29ebe1f0b9f3ba264e1c38d08bb2) so React Native always renders it as a native view. Without this, the wrapper could be flattened during relayout, breaking the `ScrollView`'s position in the native hierarchy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59cab34.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->