### PR TITLE
Extend Done display to 15 minutes and show up to 5 Live Activity banner rows

### DIFF
--- a/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.test.ts
@@ -736,7 +736,7 @@ describe("makeAggregateState", () => {
       ...state,
       threadId: "thread-done" as RelayAgentActivityState["threadId"],
       phase: "completed",
-      updatedAt: "1970-01-01T00:50:00.000Z",
+      updatedAt: "1970-01-01T00:44:00.000Z",
     };
     const aggregate = AgentActivityPublisher.makeAggregateState({
       activeStates: [active, staleCompleted],
@@ -769,7 +769,7 @@ describe("makeAggregateState", () => {
     });
     expect(
       AgentActivityPublisher.makeAggregateState({
-        activeStates: [{ ...lingeringCompleted, updatedAt: "1970-01-01T00:50:00.000Z" }],
+        activeStates: [{ ...lingeringCompleted, updatedAt: "1970-01-01T00:44:00.000Z" }],
         terminalState: null,
         nowMs: hourMs,
       }),
@@ -789,16 +789,25 @@ describe("makeAggregateState", () => {
       updatedAt: "1970-01-01T00:59:00.000Z",
     };
     const aggregate = AgentActivityPublisher.makeAggregateState({
-      activeStates: [mkActive("a-1"), mkActive("a-2"), mkActive("a-3"), justCompleted],
+      activeStates: [
+        mkActive("a-1"),
+        mkActive("a-2"),
+        mkActive("a-3"),
+        mkActive("a-4"),
+        mkActive("a-5"),
+        justCompleted,
+      ],
       terminalState: null,
       nowMs: hourMs,
     });
 
-    expect(aggregate?.activeCount).toBe(3);
+    expect(aggregate?.activeCount).toBe(5);
     expect(aggregate?.activities).toMatchObject([
       { threadId: "a-1" },
       { threadId: "a-2" },
       { threadId: "a-3" },
+      { threadId: "a-4" },
+      { threadId: "a-5" },
     ]);
   });
 });

--- a/infra/relay/src/agentActivity/AgentActivityPublisher.ts
+++ b/infra/relay/src/agentActivity/AgentActivityPublisher.ts
@@ -13,6 +13,7 @@ import * as Option from "effect/Option";
 import {
   isExpiredAgentActivityState,
   isTerminalPhase,
+  MAX_ACTIVITY_ROWS,
   sanitizeAgentActivityAggregateState,
 } from "./agentActivityPayloads.ts";
 
@@ -228,7 +229,7 @@ function terminalAggregateState(state: RelayAgentActivityState): RelayAgentActiv
 // How long a finished thread keeps its Done/Failed row in the aggregate while
 // other agents are still active. Long enough to be seen on the lock screen,
 // short enough that the activity list stays about live work.
-export const TERMINAL_AGENT_ACTIVITY_DISPLAY_TTL_MS = 5 * 60 * 1_000;
+export const TERMINAL_AGENT_ACTIVITY_DISPLAY_TTL_MS = 15 * 60 * 1_000;
 
 function isRecentTerminalState(state: RelayAgentActivityState, nowMs: number): boolean {
   if (!isTerminalPhase(state)) {
@@ -273,7 +274,7 @@ export function makeAggregateState(input: {
       subtitle: newest.phase === "failed" ? "Agent work failed" : "Agent work completed",
       activeCount: 0,
       updatedAt: newest.updatedAt,
-      activities: recentTerminal.slice(0, 3).map(aggregateRowForState),
+      activities: recentTerminal.slice(0, MAX_ACTIVITY_ROWS).map(aggregateRowForState),
     });
   }
   // Recently finished threads ride along after the active ones (display slots
@@ -282,7 +283,10 @@ export function makeAggregateState(input: {
   const recentTerminalStates = input.activeStates
     .filter((state) => isRecentTerminalState(state, input.nowMs))
     .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-  const displayedStates = [...activeStates.slice(0, 3), ...recentTerminalStates].slice(0, 3);
+  const displayedStates = [
+    ...activeStates.slice(0, MAX_ACTIVITY_ROWS),
+    ...recentTerminalStates,
+  ].slice(0, MAX_ACTIVITY_ROWS);
   const updatedAt = [...activeStates, ...recentTerminalStates].reduce((latest, state) =>
     state.updatedAt.localeCompare(latest.updatedAt) > 0 ? state : latest,
   ).updatedAt;

--- a/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
+++ b/infra/relay/src/agentActivity/ApnsDeliveries.test.ts
@@ -373,7 +373,7 @@ describe("ApnsDeliveries", () => {
       ...aggregate,
       title: longTitle,
       subtitle: longTitle,
-      activities: [0, 1, 2, 3].map((index) =>
+      activities: [0, 1, 2, 3, 4, 5].map((index) =>
         Object.assign({}, aggregate.activities[0]!, {
           projectTitle: longTitle,
           threadTitle: longTitle,
@@ -396,7 +396,7 @@ describe("ApnsDeliveries", () => {
       const payloadAggregate = queuedJobs[0]?.payload.aggregate;
       expect(payloadAggregate?.title.length).toBeLessThanOrEqual(120);
       expect(payloadAggregate?.subtitle.length).toBeLessThanOrEqual(120);
-      expect(payloadAggregate?.activities).toHaveLength(3);
+      expect(payloadAggregate?.activities).toHaveLength(5);
       expect(payloadAggregate?.activities[0]?.projectTitle.length).toBeLessThanOrEqual(120);
       expect(payloadAggregate?.activities[0]?.status.length).toBeLessThanOrEqual(40);
       expect(payloadAggregate?.activities[0]?.deepLink).toBe("/");

--- a/infra/relay/src/agentActivity/agentActivityPayloads.ts
+++ b/infra/relay/src/agentActivity/agentActivityPayloads.ts
@@ -43,7 +43,9 @@ export function isExpiredAgentActivityState(
 const MAX_SUMMARY_TEXT_LENGTH = 120;
 const MAX_STATUS_TEXT_LENGTH = 40;
 const MAX_DEEP_LINK_LENGTH = 512;
-const MAX_ACTIVITY_ROWS = 3;
+// The Live Activity banner (lock screen / Notification Center) renders up to
+// five rows; the expanded Dynamic Island shows the top three of these.
+export const MAX_ACTIVITY_ROWS = 5;
 
 function truncateText(value: string, maxLength: number): string {
   const trimmed = value.trim();


### PR DESCRIPTION
Follow-up to #3685, server-side only (relay deploy, no app rebuild — the banner layout already renders five rows; the server was the limiter).

- `TERMINAL_AGENT_ACTIVITY_DISPLAY_TTL_MS` 5 → 15 minutes: finished threads keep their Done/Failed row on the card longer. The 30-minute cron prune still outlives the display window.
- `MAX_ACTIVITY_ROWS` 3 → 5 (exported from `agentActivityPayloads.ts`); `makeAggregateState`'s hand-rolled `slice(0, 3)`s now use the shared constant. Active agents keep slot priority over finished ones, but "3 working + 1 done" now shows the Done row instead of crowding it out.
- The expanded Dynamic Island intentionally stays at 3 rows — its ~160pt height budget clips a fourth.
- Tests updated to the new boundaries (16-minute-old completion drops, 5-active slot priority, 5-row payload bound). Worst-case payload at 5 sanitized rows stays under the 4KB Live Activity limit; realistic payloads sit under 2.5KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Server-side relay tuning of display TTL and row limits with matching test updates; no auth or data-model changes, deploy-only for clients.
> 
> **Overview**
> Relay-only follow-up that aligns iOS Live Activity payloads with the client banner (five rows) and keeps **Done/Failed** rows visible longer.
> 
> **`TERMINAL_AGENT_ACTIVITY_DISPLAY_TTL_MS`** goes from 5 to **15 minutes**, so recently finished threads stay on the aggregate card before they drop off. **`MAX_ACTIVITY_ROWS`** is raised from 3 to **5**, exported from `agentActivityPayloads.ts`, and wired through `makeAggregateState` and sanitization instead of hard-coded `slice(0, 3)`. Active agents still fill slots first; with five slots, more in-flight work fits on the lock-screen banner without crowding out completions.
> 
> Tests are adjusted for the new TTL boundary (~16 minutes drops stale Done rows), five active rows in slot-priority cases, and APNs payload caps at five sanitized activities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 189943a2312fff629b7d4be34e14f0c823cdad41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extend Done/Failed display to 15 minutes and show up to 5 Live Activity banner rows
> - Increases `TERMINAL_AGENT_ACTIVITY_DISPLAY_TTL_MS` from 5 to 15 minutes in [`AgentActivityPublisher.ts`](https://github.com/pingdotgg/t3code/pull/3761/files#diff-bc3c00aedb9461b83b29ee4fc0612ca761c2d49a619420cbf1304ca015009b19), keeping finished threads visible longer while other agents are active.
> - Increases `MAX_ACTIVITY_ROWS` from 3 to 5 in [`agentActivityPayloads.ts`](https://github.com/pingdotgg/t3code/pull/3761/files#diff-6283ddb565acbdb5dec645fcea07e767c297834e7e9dc25366d074c602a7065f) to match the Live Activity banner's capacity (expanded Dynamic Island still shows top 3).
> - Updates `makeAggregateState` to use `MAX_ACTIVITY_ROWS` instead of hardcoded slices of 3 for both active-only and active+terminal paths.
> - Behavioral Change: aggregate payloads now include up to 5 activities instead of 3, and completed threads remain eligible for display for 15 minutes instead of 5.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 189943a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->