### PR TITLE
Fix Expo widget asset wiring order

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -155,6 +155,12 @@ const config: ExpoConfig = {
       },
     ],
     "./plugins/withIosCocoaPodsUuidCache.cjs",
+    // Must be listed BEFORE expo-widgets: same-type mods run last-registered-
+    // first, so registering earlier makes this plugin's mods run AFTER
+    // expo-widgets' — its dangerous mod wipes ios/ExpoWidgetsTarget/ (which
+    // would delete the asset catalog) and its xcodeproj mod creates the widget
+    // target (which must exist before the compile phase can be attached).
+    "./plugins/withWidgetLogoAsset.cjs",
     [
       "expo-widgets",
       {
@@ -174,9 +180,6 @@ const config: ExpoConfig = {
         ],
       },
     ],
-    // Must run after expo-widgets so the widget target exists when it wires in
-    // the branded logo asset catalog.
-    "./plugins/withWidgetLogoAsset.cjs",
     "./plugins/withIosSceneLifecycle.cjs",
     "./plugins/withAndroidCleartextTraffic.cjs",
   ],

--- a/apps/mobile/plugins/lib/addWidgetAssetCatalog.cjs
+++ b/apps/mobile/plugins/lib/addWidgetAssetCatalog.cjs
@@ -9,8 +9,10 @@
 // drops the compiled Assets.car into the extension bundle. Marked
 // alwaysOutOfDate so the build system always runs it.
 //
-// Idempotent across re-runs. Returns true when it added the phase, false when it
-// was already present or the target was not found.
+// Idempotent across re-runs. Returns true when it added the phase, false when
+// it was already present. Throws when the target does not exist — that means
+// this ran before expo-widgets created the target (plugin ordering bug) and
+// silently skipping would ship a widget without its assets.
 
 const PHASE_NAME = "Compile Widget Assets";
 
@@ -20,8 +22,8 @@ const ACTOOL_SCRIPT = [
   "set -e",
   'CATALOG="${SRCROOT}/ExpoWidgetsTarget/Assets.xcassets"',
   'if [ ! -d "$CATALOG" ]; then',
-  '  echo "warning: widget asset catalog not found at $CATALOG"',
-  "  exit 0",
+  '  echo "error: widget asset catalog not found at $CATALOG (expo-widgets wiped it? check plugin ordering in app.config.ts)"',
+  "  exit 1",
   "fi",
   'DEST="${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}"',
   'mkdir -p "$DEST"',
@@ -51,7 +53,13 @@ function findByName(map, name) {
 function addWidgetAssetCatalog(proj, opts) {
   const objects = proj.hash.project.objects;
   const target = findByName(objects.PBXNativeTarget, opts.targetName);
-  if (!target) return false;
+  if (!target) {
+    throw new Error(
+      `addWidgetAssetCatalog: target "${opts.targetName}" not found — ` +
+        "withWidgetLogoAsset must be registered before expo-widgets so its " +
+        "xcodeproj mod runs after the widget target is created.",
+    );
+  }
 
   const phases = target.value.buildPhases || [];
   const existing = objects.PBXShellScriptBuildPhase || {};

--- a/apps/mobile/plugins/withWidgetLogoAsset.cjs
+++ b/apps/mobile/plugins/withWidgetLogoAsset.cjs
@@ -5,9 +5,15 @@
 // expo-widgets generates ExpoWidgetsTarget without a Resources build phase and
 // has no asset support, so this plugin (a) writes an SVG template image set into
 // the generated widget asset catalog and (b) wires that catalog into the widget
-// target with a dedicated Resources build phase. Both steps are idempotent and
-// survive `expo prebuild --clean`. Must be listed AFTER "expo-widgets" in the
-// plugins array so the widget target exists when this runs.
+// target with an actool build phase.
+//
+// ORDERING: must be listed BEFORE "expo-widgets" in the plugins array. Expo
+// chains same-type mods so the last-registered runs FIRST; registering this
+// plugin earlier makes its mods run AFTER expo-widgets' mods. That matters
+// twice: expo-widgets' dangerous mod rmSync's ios/ExpoWidgetsTarget/ (deleting
+// any catalog written before it), and its xcodeproj mod is what creates the
+// widget target. Listed after expo-widgets, both steps silently no-op on a
+// fresh prebuild — which is how prod build 8 shipped without the logo.
 
 const path = require("path");
 const fs = require("fs");

--- a/apps/mobile/scripts/wire-widget-asset-catalog.cjs
+++ b/apps/mobile/scripts/wire-widget-asset-catalog.cjs
@@ -26,5 +26,5 @@ if (added) {
   fs.writeFileSync(pbxprojPath, proj.writeSync());
   console.log("Added widget asset-compile phase to ExpoWidgetsTarget.");
 } else {
-  console.log("No change: phase already present or target not found.");
+  console.log("No change: phase already present.");
 }


### PR DESCRIPTION
## Summary
- Reordered the mobile Expo plugins so `withWidgetLogoAsset` registers before `expo-widgets`, ensuring its Xcode mods run after the widget target is created.
- Made widget asset wiring fail loudly when the target is missing instead of silently skipping, which prevents shipping a widget without its logo assets.
- Updated the widget asset-catalog script and plugin comments to reflect the new ordering and failure behavior.

## Testing
- Not run (PR description only).
- Existing project checks should still be run before merge: `vp check` and `vp run typecheck`.
- For mobile changes, also run `vp run lint:mobile`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only mobile iOS prebuild/plugin wiring, but incorrect ordering or a thrown error could block releases until fixed; the fix directly affects widget extension assets in production builds.
> 
> **Overview**
> Fixes iOS widget branding by **reordering Expo config plugins** so `withWidgetLogoAsset` is registered **before** `expo-widgets`. Same-type mods run last-registered-first, so this makes the logo plugin run **after** `expo-widgets` creates `ExpoWidgetsTarget` and after its dangerous mod clears `ios/ExpoWidgetsTarget/`—the previous order caused a fresh prebuild to no-op and ship widgets without the T3 mark (prod build 8).
> 
> **Fails loudly instead of silently skipping:** `addWidgetAssetCatalog` now **throws** if the widget Xcode target is missing, and the `actool` shell phase **errors** if `Assets.xcassets` is absent. Comments and the one-off `wire-widget-asset-catalog` script message were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ae30007cf250499ab8f996802c354254af4ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Expo widget asset wiring by registering `withWidgetLogoAsset` before `expo-widgets`
> - Reorders plugins in [app.config.ts](https://github.com/pingdotgg/t3code/pull/3763/files#diff-290065ad5da22af2aa0a274a6657359bd050ba8ad4e36b97765dac7c98f90bab) so `withWidgetLogoAsset` is listed before `expo-widgets`, ensuring its mods run after `expo-widgets`' mods (same-type mods execute in reverse registration order). This prevents `expo-widgets` from wiping the asset catalog and ensures the widget target exists before asset wiring.
> - Changes `addWidgetAssetCatalog` in [addWidgetAssetCatalog.cjs](https://github.com/pingdotgg/t3code/pull/3763/files#diff-ca24c393c6e1118258568ae4a29afd4d932b2ab0cfd1f95ef47cb4ed1ae6c9fe) to throw an error when the PBXNativeTarget is missing instead of silently returning `false`, causing prebuild to fail fast on misconfiguration.
> - The Xcode shell-script build phase now exits with code 1 (error) instead of 0 (warning) when the widget asset catalog is missing at build time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89ae300.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->