### PR TITLE
Clear VCS presentation state on finish

### DIFF
--- a/packages/client-runtime/src/state/vcsAction.test.ts
+++ b/packages/client-runtime/src/state/vcsAction.test.ts
@@ -155,6 +155,46 @@ describe("vcsActionState", () => {
     });
   });
 
+  it("clears running presentation state once the action finishes", () => {
+    const initial = beginVcsActionState({
+      operation: "run_change_request",
+      label: "Running source control action",
+      actionId,
+    });
+    const pushing = applyVcsActionProgressEvent(
+      initial,
+      progress({
+        actionId,
+        action,
+        cwd,
+        kind: "phase_started",
+        phase: "push",
+        label: "Pushing...",
+      }),
+    );
+    const finished = applyVcsActionProgressEvent(
+      pushing,
+      progress({
+        actionId,
+        action,
+        cwd,
+        kind: "action_finished",
+        result,
+      }),
+    );
+
+    expect(finished).toMatchObject({
+      isRunning: false,
+      operation: "run_change_request",
+      actionId,
+      action,
+      currentLabel: null,
+      currentPhaseLabel: null,
+      lastOutputLine: null,
+      error: null,
+    });
+  });
+
   it("retains a terminal action error for presentation", () => {
     const initial = beginVcsActionState({
       operation: "run_change_request",

--- a/packages/client-runtime/src/state/vcsAction.ts
+++ b/packages/client-runtime/src/state/vcsAction.ts
@@ -386,12 +386,10 @@ export function applyVcsActionProgressEvent(
       };
     case "action_finished":
       return {
-        ...current,
-        isRunning: false,
+        ...EMPTY_VCS_ACTION_STATE,
         actionId: event.actionId,
         action: event.action,
         operation: "run_change_request",
-        error: null,
       };
     case "action_failed":
       return {


### PR DESCRIPTION
## Summary
- Clear client-side VCS action presentation state when an action finishes, instead of carrying forward stale labels and output.
- Add coverage for the finished-state reset behavior in `packages/client-runtime`.
- Reduce the mobile widget asset pipeline to a single splash asset and tighten widget activity display to the top 3 rows.
- Update mobile plugin wiring so the widget asset catalog is attached after `expo-widgets` creates the target.

## Testing
- Added/updated unit tests in `packages/client-runtime/src/state/vcsAction.test.ts`.
- Updated relay tests for the new 3-row agent activity cap.
- Not run: `vp check`.
- Not run: `vp run typecheck`.
- Not run: `vp test`.
- Not run: `vp run lint:mobile`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized client-side state reducer change with new unit coverage; no auth, network, or persistence impact.
> 
> **Overview**
> **VCS action UI state** no longer keeps phase labels, hook output, or other in-progress fields after a stacked Git action completes successfully.
> 
> On `action_finished`, `applyVcsActionProgressEvent` now resets from `EMPTY_VCS_ACTION_STATE` (like `action_failed`) and only keeps `actionId`, `action`, and `operation`, instead of spreading the prior `current` state with `isRunning: false`. A unit test asserts labels and `lastOutputLine` are cleared while the completed action identity remains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f6d2911c33680935f00537f07ec5b580bcd331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clear transient presentation state when a VCS action finishes
> In the `applyVcsActionProgressEvent` reducer, the `action_finished` case now spreads `EMPTY_VCS_ACTION_STATE` instead of current state, preserving only `actionId`, `action`, and `operation`. This clears transient fields like `currentLabel`, `currentPhaseLabel`, `hookName`, and `lastOutputLine` that previously persisted after an action completed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01f6d29.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->