### PR TITLE
AGT-005: add Android ongoing agent notification

### DIFF
--- a/apps/mobile/src/Stack.tsx
+++ b/apps/mobile/src/Stack.tsx
@@ -16,6 +16,7 @@ import { useResolveClassNames } from "uniwind";
 import { AppText as Text } from "./components/AppText";
 import { ArchivedThreadsRouteScreen } from "./features/archive/ArchivedThreadsRouteScreen";
 import { useAgentNotificationNavigation } from "./features/agent-awareness/notificationNavigation";
+import { useOngoingAgentNotification } from "./features/agent-awareness/useOngoingAgentNotification";
 import { ClerkSettingsSheetDetentProvider } from "./features/cloud/ClerkSettingsSheetDetent";
 import { ThreadFilesTreeScreen, ThreadFileScreen } from "./features/files/ThreadFilesRouteScreen";
 import { AdaptiveWorkspaceLayout } from "./features/layout/AdaptiveWorkspaceLayout";
@@ -250,6 +251,7 @@ function RootStackLayout(props: {
   readonly state: NavigationState;
 }) {
   useAgentNotificationNavigation();
+  useOngoingAgentNotification();
   useThreadOutboxDrain();
   // Full pathname (sheets included) for keyboard-command scoping; the
   // workspace layout only reacts to the underlying non-overlay route.

--- a/apps/mobile/src/features/agent-awareness/localAgentActivityAggregate.test.ts
+++ b/apps/mobile/src/features/agent-awareness/localAgentActivityAggregate.test.ts
@@ -1,0 +1,125 @@
+import type {
+  EnvironmentProject,
+  EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/shell";
+import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { buildLocalAgentActivityAggregate } from "./localAgentActivityAggregate";
+
+function makeProject(
+  input: Partial<EnvironmentProject> & Pick<EnvironmentProject, "environmentId" | "id" | "title">,
+): EnvironmentProject {
+  return {
+    workspaceRoot: `/workspaces/${input.id}`,
+    repositoryIdentity: null,
+    defaultModelSelection: null,
+    scripts: [],
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    ...input,
+  };
+}
+
+function makeThread(
+  input: Partial<EnvironmentThreadShell> &
+    Pick<EnvironmentThreadShell, "environmentId" | "id" | "projectId" | "title">,
+): EnvironmentThreadShell {
+  return {
+    modelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+    archivedAt: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    ...input,
+  };
+}
+
+describe("buildLocalAgentActivityAggregate", () => {
+  it("returns null when no threads are actively working", () => {
+    const environmentId = EnvironmentId.make("environment-1");
+    const project = makeProject({
+      environmentId,
+      id: ProjectId.make("project-1"),
+      title: "T3 Code",
+    });
+    const aggregate = buildLocalAgentActivityAggregate({
+      projects: [project],
+      threads: [
+        makeThread({
+          environmentId,
+          id: ThreadId.make("thread-1"),
+          projectId: project.id,
+          title: "Idle thread",
+        }),
+      ],
+    });
+    expect(aggregate).toBeNull();
+  });
+
+  it("aggregates running and approval threads with newest activity first", () => {
+    const environmentId = EnvironmentId.make("environment-1");
+    const project = makeProject({
+      environmentId,
+      id: ProjectId.make("project-1"),
+      title: "T3 Code",
+    });
+    const aggregate = buildLocalAgentActivityAggregate({
+      projects: [project],
+      threads: [
+        makeThread({
+          environmentId,
+          id: ThreadId.make("thread-running"),
+          projectId: project.id,
+          title: "Running thread",
+          updatedAt: "2026-06-29T10:00:00.000Z",
+          session: {
+            threadId: ThreadId.make("thread-running"),
+            status: "running",
+            providerName: "codex",
+            runtimeMode: "full-access",
+            activeTurnId: null,
+            lastError: null,
+            updatedAt: "2026-06-29T10:00:00.000Z",
+          },
+        }),
+        makeThread({
+          environmentId,
+          id: ThreadId.make("thread-approval"),
+          projectId: project.id,
+          title: "Approval thread",
+          updatedAt: "2026-06-29T11:00:00.000Z",
+          hasPendingApprovals: true,
+        }),
+      ],
+    });
+
+    expect(aggregate).toEqual({
+      title: "T3 Code",
+      subtitle: "Agent work in progress",
+      activeCount: 2,
+      updatedAt: "2026-06-29T11:00:00.000Z",
+      activities: [
+        expect.objectContaining({
+          threadId: ThreadId.make("thread-approval"),
+          phase: "waiting_for_approval",
+          status: "Approval",
+        }),
+        expect.objectContaining({
+          threadId: ThreadId.make("thread-running"),
+          phase: "running",
+          status: "Working",
+        }),
+      ],
+    });
+  });
+});

--- a/apps/mobile/src/features/agent-awareness/localAgentActivityAggregate.ts
+++ b/apps/mobile/src/features/agent-awareness/localAgentActivityAggregate.ts
@@ -1,0 +1,87 @@
+import type {
+  EnvironmentProject,
+  EnvironmentThreadShell,
+} from "@t3tools/client-runtime/state/shell";
+import type {
+  RelayAgentActivityAggregateRow,
+  RelayAgentActivityAggregateState,
+} from "@t3tools/contracts/relay";
+import {
+  isTerminalAgentAwarenessPhase,
+  projectThreadAwareness,
+  type AgentAwarenessPhase,
+  type AgentAwarenessState,
+} from "@t3tools/shared/agentAwareness";
+
+const MAX_ACTIVITY_ROWS = 3;
+
+function statusForPhase(phase: AgentAwarenessPhase): string {
+  switch (phase) {
+    case "waiting_for_approval":
+      return "Approval";
+    case "waiting_for_input":
+      return "Input";
+    case "completed":
+      return "Done";
+    case "failed":
+      return "Failed";
+    case "starting":
+      return "Starting";
+    case "running":
+      return "Working";
+    case "stale":
+      return "Waiting";
+  }
+}
+
+function aggregateRowForState(state: AgentAwarenessState): RelayAgentActivityAggregateRow {
+  return {
+    environmentId: state.environmentId,
+    threadId: state.threadId,
+    projectTitle: state.projectTitle,
+    threadTitle: state.threadTitle,
+    modelTitle: state.modelTitle,
+    phase: state.phase,
+    status: statusForPhase(state.phase),
+    updatedAt: state.updatedAt,
+    deepLink: state.deepLink,
+  };
+}
+
+export function buildLocalAgentActivityAggregate(input: {
+  readonly projects: ReadonlyArray<EnvironmentProject>;
+  readonly threads: ReadonlyArray<EnvironmentThreadShell>;
+}): RelayAgentActivityAggregateState | null {
+  const projectsByKey = new Map(
+    input.projects.map((project) => [`${project.environmentId}:${project.id}`, project] as const),
+  );
+  const activeStates: AgentAwarenessState[] = [];
+
+  for (const thread of input.threads) {
+    const project = projectsByKey.get(`${thread.environmentId}:${thread.projectId}`);
+    if (!project) {
+      continue;
+    }
+    const awareness = projectThreadAwareness({
+      environmentId: thread.environmentId,
+      project,
+      thread,
+    });
+    if (awareness && !isTerminalAgentAwarenessPhase(awareness.phase)) {
+      activeStates.push(awareness);
+    }
+  }
+
+  if (activeStates.length === 0) {
+    return null;
+  }
+
+  activeStates.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  return {
+    title: "T3 Code",
+    subtitle: "Agent work in progress",
+    activeCount: activeStates.length,
+    updatedAt: activeStates[0]!.updatedAt,
+    activities: activeStates.slice(0, MAX_ACTIVITY_ROWS).map(aggregateRowForState),
+  };
+}

--- a/apps/mobile/src/features/agent-awareness/ongoingNotification.test.ts
+++ b/apps/mobile/src/features/agent-awareness/ongoingNotification.test.ts
@@ -1,0 +1,183 @@
+import type { RelayAgentActivityAggregateState } from "@t3tools/contracts/relay";
+import { EnvironmentId, ThreadId } from "@t3tools/contracts";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import * as Notifications from "expo-notifications";
+
+import {
+  buildOngoingAgentNotificationContent,
+  ongoingAgentNotificationTrigger,
+  ongoingNotificationBodyPassesSec032,
+  ONGOING_AGENT_NOTIFICATION_TAG,
+  shouldShowOngoingAgentNotification,
+} from "./ongoingNotificationModel";
+import {
+  resetOngoingAgentNotificationSyncForTests,
+  syncOngoingAgentNotification,
+} from "./ongoingNotificationSync";
+const platformState = vi.hoisted(() => ({
+  OS: "android" as "ios" | "android" | "web",
+}));
+
+vi.mock("react-native", () => ({
+  Platform: {
+    get OS() {
+      return platformState.OS;
+    },
+  },
+}));
+
+vi.mock("expo-notifications", () => ({
+  AndroidNotificationPriority: {
+    LOW: -1,
+  },
+  setNotificationHandler: vi.fn(),
+  scheduleNotificationAsync: vi.fn(() => Promise.resolve("t3-agent-aggregate")),
+  dismissNotificationAsync: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("./notificationChannels", () => ({
+  AGENT_NOTIFICATION_CHANNEL_IDS: {
+    running: "agent_running",
+  },
+  ensureAgentNotificationChannels: vi.fn(() => Promise.resolve()),
+}));
+
+const aggregate: RelayAgentActivityAggregateState = {
+  title: "T3 Code",
+  subtitle: "Agent work in progress",
+  activeCount: 2,
+  updatedAt: "2026-06-29T11:00:00.000Z",
+  activities: [
+    {
+      environmentId: EnvironmentId.make("environment-1"),
+      threadId: ThreadId.make("thread-approval"),
+      projectTitle: "T3 Code",
+      threadTitle: "Approval thread",
+      modelTitle: "gpt-5.4",
+      phase: "waiting_for_approval",
+      status: "Approval",
+      updatedAt: "2026-06-29T11:00:00.000Z",
+      deepLink: "/threads/environment-1/thread-approval",
+    },
+    {
+      environmentId: EnvironmentId.make("environment-1"),
+      threadId: ThreadId.make("thread-running"),
+      projectTitle: "T3 Code",
+      threadTitle: "Running thread",
+      modelTitle: "gpt-5.4",
+      phase: "running",
+      status: "Working",
+      updatedAt: "2026-06-29T10:00:00.000Z",
+      deepLink: "/threads/environment-1/thread-running",
+    },
+  ],
+};
+
+describe("ongoing notification model", () => {
+  it("shows ongoing notification only for running or approval primaries", () => {
+    expect(shouldShowOngoingAgentNotification(aggregate)).toBe(true);
+    expect(
+      shouldShowOngoingAgentNotification({
+        ...aggregate,
+        activities: [
+          {
+            ...aggregate.activities[0]!,
+            phase: "waiting_for_input",
+            status: "Input",
+          },
+        ],
+      }),
+    ).toBe(false);
+    expect(shouldShowOngoingAgentNotification(null)).toBe(false);
+  });
+
+  it("builds sticky low-priority Android content with SEC-032-safe body", () => {
+    const content = buildOngoingAgentNotificationContent(aggregate);
+    expect(content.sticky).toBe(true);
+    expect(content.sound).toBe(false);
+    expect(content.priority).toBe(-1);
+    expect(content.data).toEqual({
+      deepLink: "/threads/environment-1/thread-approval",
+      environmentId: EnvironmentId.make("environment-1"),
+      threadId: ThreadId.make("thread-approval"),
+      notificationTag: ONGOING_AGENT_NOTIFICATION_TAG,
+      phase: "waiting_for_approval",
+    });
+    expect(content.body).toContain("Approval thread");
+    expect(content.body).not.toContain("stdout");
+    expect(ongoingNotificationBodyPassesSec032(content.body ?? "")).toBe(true);
+  });
+});
+
+describe("syncOngoingAgentNotification", () => {
+  beforeEach(() => {
+    platformState.OS = "android";
+    resetOngoingAgentNotificationSyncForTests();
+    vi.mocked(Notifications.scheduleNotificationAsync).mockClear();
+    vi.mocked(Notifications.dismissNotificationAsync).mockClear();
+    vi.mocked(Notifications.setNotificationHandler).mockClear();
+  });
+
+  it("updates the same identifier in place for aggregate ticks", async () => {
+    await syncOngoingAgentNotification({
+      aggregate,
+      notificationsEnabled: true,
+    });
+    await syncOngoingAgentNotification({
+      aggregate,
+      notificationsEnabled: true,
+    });
+
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledTimes(1);
+    expect(Notifications.scheduleNotificationAsync).toHaveBeenCalledWith({
+      identifier: ONGOING_AGENT_NOTIFICATION_TAG,
+      content: expect.objectContaining({
+        sticky: true,
+      }),
+      trigger: ongoingAgentNotificationTrigger(),
+    });
+  });
+
+  it("dismisses ongoing notification when active work is no longer eligible", async () => {
+    await syncOngoingAgentNotification({
+      aggregate,
+      notificationsEnabled: true,
+    });
+    await syncOngoingAgentNotification({
+      aggregate: {
+        ...aggregate,
+        activeCount: 0,
+        activities: [],
+      },
+      notificationsEnabled: true,
+    });
+
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith(
+      ONGOING_AGENT_NOTIFICATION_TAG,
+    );
+  });
+
+  it("skips Android notification work on non-Android platforms", async () => {
+    platformState.OS = "ios";
+    await syncOngoingAgentNotification({
+      aggregate,
+      notificationsEnabled: true,
+    });
+    expect(Notifications.scheduleNotificationAsync).not.toHaveBeenCalled();
+  });
+
+  it("clears ongoing notification when notifications are disabled", async () => {
+    await syncOngoingAgentNotification({
+      aggregate,
+      notificationsEnabled: true,
+    });
+    vi.mocked(Notifications.dismissNotificationAsync).mockClear();
+    await syncOngoingAgentNotification({
+      aggregate,
+      notificationsEnabled: false,
+    });
+    expect(Notifications.dismissNotificationAsync).toHaveBeenCalledWith(
+      ONGOING_AGENT_NOTIFICATION_TAG,
+    );
+  });
+});

--- a/apps/mobile/src/features/agent-awareness/ongoingNotificationModel.ts
+++ b/apps/mobile/src/features/agent-awareness/ongoingNotificationModel.ts
@@ -1,0 +1,116 @@
+import type { RelayAgentActivityAggregateState } from "@t3tools/contracts/relay";
+import * as Notifications from "expo-notifications";
+
+import { agentPhaseAccentColor, agentPhaseStatusLabel } from "../threads/agentPhaseIndicatorModel";
+import { AGENT_NOTIFICATION_CHANNEL_IDS } from "./notificationChannels";
+
+export const ONGOING_AGENT_NOTIFICATION_TAG = "t3-agent-aggregate" as const;
+
+const MAX_SUMMARY_TEXT_LENGTH = 120;
+const MAX_STATUS_TEXT_LENGTH = 40;
+
+const FORBIDDEN_BODY_PATTERNS = [
+  /\bstdout\b/i,
+  /\bstderr\b/i,
+  /\btool[_\s-]?output\b/i,
+  /(?:^|\s)(?:\/[\w.-]+)+\/[\w.-]+\.[A-Za-z0-9]{1,8}(?:\s|$)/,
+  /(?:^|\s)[A-Za-z]:\\[\w\\.-]+\.[A-Za-z0-9]{1,8}(?:\s|$)/,
+] as const;
+
+export type OngoingAgentNotificationPhase = "running" | "waiting_for_approval";
+
+export function shouldShowOngoingAgentNotification(
+  aggregate: RelayAgentActivityAggregateState | null,
+): aggregate is RelayAgentActivityAggregateState {
+  if (!aggregate || aggregate.activeCount <= 0) {
+    return false;
+  }
+  const primary = aggregate.activities[0];
+  if (!primary) {
+    return false;
+  }
+  return primary.phase === "running" || primary.phase === "waiting_for_approval";
+}
+
+function truncateText(value: string, maxLength: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= maxLength) {
+    return trimmed;
+  }
+  return `${trimmed.slice(0, maxLength - 3).trimEnd()}...`;
+}
+
+function formatUpdatedAtLabel(updatedAt: string): string {
+  const parsed = Date.parse(updatedAt);
+  if (!Number.isFinite(parsed)) {
+    return "now";
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(parsed));
+}
+
+function formatExpandedBody(aggregate: RelayAgentActivityAggregateState): string {
+  const lines: string[] = [`${aggregate.activeCount} active`];
+  for (const row of aggregate.activities) {
+    lines.push(
+      truncateText(row.threadTitle, MAX_SUMMARY_TEXT_LENGTH),
+      `${truncateText(row.projectTitle, MAX_SUMMARY_TEXT_LENGTH)} · ${truncateText(row.modelTitle, MAX_SUMMARY_TEXT_LENGTH)} — ${truncateText(row.status, MAX_STATUS_TEXT_LENGTH)}`,
+    );
+  }
+  lines.push(`Updated ${formatUpdatedAtLabel(aggregate.updatedAt)}`);
+  return lines.join("\n");
+}
+
+export function ongoingNotificationBodyPassesSec032(body: string): boolean {
+  return !FORBIDDEN_BODY_PATTERNS.some((pattern) => pattern.test(body));
+}
+
+export function buildOngoingAgentNotificationContent(
+  aggregate: RelayAgentActivityAggregateState,
+  colorScheme: "light" | "dark" = "dark",
+): Notifications.NotificationContentInput {
+  const primary = aggregate.activities[0]!;
+  const collapsedSubtitle =
+    aggregate.activeCount === 1
+      ? truncateText(primary.status, MAX_STATUS_TEXT_LENGTH)
+      : `${aggregate.activeCount} active`;
+  const body = formatExpandedBody(aggregate);
+
+  return {
+    title: truncateText(aggregate.title, MAX_SUMMARY_TEXT_LENGTH),
+    subtitle: collapsedSubtitle,
+    body,
+    sticky: true,
+    autoDismiss: false,
+    sound: false,
+    priority: Notifications.AndroidNotificationPriority.LOW,
+    color: agentPhaseAccentColor(primary.phase, colorScheme),
+    data: {
+      deepLink: primary.deepLink,
+      environmentId: primary.environmentId,
+      threadId: primary.threadId,
+      notificationTag: ONGOING_AGENT_NOTIFICATION_TAG,
+      phase: primary.phase,
+    },
+  };
+}
+
+export function ongoingAgentNotificationSummary(aggregate: RelayAgentActivityAggregateState): {
+  readonly phase: OngoingAgentNotificationPhase;
+  readonly status: string;
+  readonly color: string;
+} {
+  const primary = aggregate.activities[0]!;
+  const phase = primary.phase as OngoingAgentNotificationPhase;
+  return {
+    phase,
+    status: agentPhaseStatusLabel(phase),
+    color: agentPhaseAccentColor(phase, "dark"),
+  };
+}
+
+export function ongoingAgentNotificationTrigger(): Notifications.NotificationTriggerInput {
+  return { channelId: AGENT_NOTIFICATION_CHANNEL_IDS.running };
+}

--- a/apps/mobile/src/features/agent-awareness/ongoingNotificationSync.ts
+++ b/apps/mobile/src/features/agent-awareness/ongoingNotificationSync.ts
@@ -1,0 +1,93 @@
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+
+import { ensureAgentNotificationChannels } from "./notificationChannels";
+import {
+  buildOngoingAgentNotificationContent,
+  ongoingAgentNotificationTrigger,
+  ONGOING_AGENT_NOTIFICATION_TAG,
+  shouldShowOngoingAgentNotification,
+} from "./ongoingNotificationModel";
+import type { RelayAgentActivityAggregateState } from "@t3tools/contracts/relay";
+
+let handlerInstalled = false;
+let lastPublishedFingerprint: string | null = null;
+let ongoingNotificationVisible = false;
+
+function installOngoingNotificationHandler(): void {
+  if (handlerInstalled || Platform.OS !== "android") {
+    return;
+  }
+  Notifications.setNotificationHandler({
+    handleNotification: async () => ({
+      shouldShowBanner: false,
+      shouldShowList: true,
+      shouldPlaySound: false,
+      shouldSetBadge: false,
+    }),
+  });
+  handlerInstalled = true;
+}
+
+function fingerprintAggregate(aggregate: RelayAgentActivityAggregateState): string {
+  return JSON.stringify({
+    activeCount: aggregate.activeCount,
+    updatedAt: aggregate.updatedAt,
+    activities: aggregate.activities.map((row) => ({
+      environmentId: row.environmentId,
+      threadId: row.threadId,
+      phase: row.phase,
+      status: row.status,
+      updatedAt: row.updatedAt,
+    })),
+  });
+}
+
+export async function clearOngoingAgentNotification(): Promise<void> {
+  if (Platform.OS !== "android" || !ongoingNotificationVisible) {
+    lastPublishedFingerprint = null;
+    return;
+  }
+
+  await Notifications.dismissNotificationAsync(ONGOING_AGENT_NOTIFICATION_TAG);
+  ongoingNotificationVisible = false;
+  lastPublishedFingerprint = null;
+}
+
+export async function syncOngoingAgentNotification(input: {
+  readonly aggregate: RelayAgentActivityAggregateState | null;
+  readonly notificationsEnabled: boolean;
+  readonly colorScheme?: "light" | "dark";
+}): Promise<void> {
+  if (Platform.OS !== "android" || !input.notificationsEnabled) {
+    await clearOngoingAgentNotification();
+    return;
+  }
+
+  installOngoingNotificationHandler();
+  await ensureAgentNotificationChannels();
+
+  if (!shouldShowOngoingAgentNotification(input.aggregate)) {
+    await clearOngoingAgentNotification();
+    return;
+  }
+
+  const fingerprint = fingerprintAggregate(input.aggregate);
+  if (fingerprint === lastPublishedFingerprint) {
+    return;
+  }
+
+  await Notifications.scheduleNotificationAsync({
+    identifier: ONGOING_AGENT_NOTIFICATION_TAG,
+    content: buildOngoingAgentNotificationContent(input.aggregate, input.colorScheme ?? "dark"),
+    trigger: ongoingAgentNotificationTrigger(),
+  });
+  ongoingNotificationVisible = true;
+  lastPublishedFingerprint = fingerprint;
+}
+
+export function resetOngoingAgentNotificationSyncForTests(): void {
+  handlerInstalled = false;
+  lastPublishedFingerprint = null;
+  ongoingNotificationVisible = false;
+}

--- a/apps/mobile/src/features/agent-awareness/useOngoingAgentNotification.ts
+++ b/apps/mobile/src/features/agent-awareness/useOngoingAgentNotification.ts
@@ -1,0 +1,49 @@
+import * as Notifications from "expo-notifications";
+import { Platform, useColorScheme } from "react-native";
+import { useEffect, useMemo } from "react";
+
+import { useProjects, useThreadShells } from "../../state/entities";
+import { buildLocalAgentActivityAggregate } from "./localAgentActivityAggregate";
+import { syncOngoingAgentNotification } from "./ongoingNotificationSync";
+
+async function readAndroidNotificationsEnabled(): Promise<boolean> {
+  if (Platform.OS !== "android") {
+    return false;
+  }
+  const permissions = await Notifications.getPermissionsAsync();
+  return permissions.status === "granted";
+}
+
+export function useOngoingAgentNotification(): void {
+  const projects = useProjects();
+  const threads = useThreadShells();
+  const colorScheme = useColorScheme() === "light" ? "light" : "dark";
+
+  const aggregate = useMemo(
+    () => buildLocalAgentActivityAggregate({ projects, threads }),
+    [projects, threads],
+  );
+
+  useEffect(() => {
+    if (Platform.OS !== "android") {
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      const notificationsEnabled = await readAndroidNotificationsEnabled();
+      if (cancelled) {
+        return;
+      }
+      await syncOngoingAgentNotification({
+        aggregate,
+        notificationsEnabled,
+        colorScheme,
+      });
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [aggregate, colorScheme]);
+}


### PR DESCRIPTION
## Summary

- Add local aggregate builder from thread shells for agent awareness state
- Show sticky ongoing notification on Android while agents are `running` or `waiting_for_approval`
- Update in place via stable `t3-agent-aggregate` identifier (UX-007)
- SEC-032-safe notification body: thread titles and phase status only, no tool output
- Phase accent colors match in-app indicator; deep-link data for tap navigation
- Wire `useOngoingAgentNotification` into app shell alongside existing notification navigation

## Testing

- `apps/mobile/src/features/agent-awareness/ongoingNotification.test.ts`
- `apps/mobile/src/features/agent-awareness/localAgentActivityAggregate.test.ts`
- `scripts/android-parity/gate.sh` (local)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches notification content and deep-link data on Android with privacy constraints (SEC-032); scope is mobile-only and gated on permissions, but incorrect body or sync logic could leak sensitive text or spam the shade.
> 
> **Overview**
> Adds an **Android-only sticky ongoing notification** while agents are **running** or **waiting for approval**, so users see in-progress work without opening the app.
> 
> A new **`buildLocalAgentActivityAggregate`** derives relay-shaped activity from local projects and thread shells via shared **`projectThreadAwareness`**, sorts non-terminal threads by recency, and caps rows at three. **`useOngoingAgentNotification`** recomputes that aggregate from entity state and drives **`syncOngoingAgentNotification`**, which schedules or dismisses a single notification with stable id **`t3-agent-aggregate`**, skips redundant updates via fingerprinting, and respects notification permission and platform (no-op off Android).
> 
> Notification content is **low-priority, silent, and sticky**, uses in-app phase accent colors, attaches **deep-link payload** for the primary activity, and restricts body text to thread titles and phase status with **SEC-032** forbidden-pattern checks (no tool output or paths). **`useOngoingAgentNotification`** is registered in **`RootStackLayout`** next to existing agent notification navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 570681e7a7b9efd4bae72d407d57bae02bc4f72d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Android ongoing agent notification and FCM push delivery to the relay
> - Adds an Android ongoing notification (`useOngoingAgentNotification`) that reflects active agent thread state via `syncOngoingAgentNotification`, using five new Android notification channels and SEC-032 compliant body filtering.
> - Introduces FCM delivery infrastructure in the relay: `FcmClient` (JWT/OAuth, push sending), `FcmDeliveryQueue` (Cloudflare queue with signed jobs), `FcmDeliveries` (queueing, de-duplication, error handling), and `MobileDeliveries` (unified iOS/Android dispatch layer).
> - Extends device registration to support Android: relay schema, contracts, and `Devices` service now handle `platform:'android'` with `androidSdkVersion`, nulled `pushToStartToken`, and forced `liveActivitiesEnabled:false`.
> - Adds a staging test endpoint `POST /v1/staging/test/agent-push` (guarded by `stagingTestSecret` and `fcmDeliveryEnabled`) for triggering FCM pushes to a specific device.
> - Adds `AgentPhaseIndicator` and `ThreadAccessoryBar` UI components to the Android thread screen, wiring agent awareness phase display and bottom/rail navigation to files, terminal, review, and git panes.
> - Risk: FCM delivery is queue-backed and gated by `RELAY_FCM_DELIVERY_ENABLED`; the flag must be explicitly set to enable live delivery — default is `false`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 570681e. 5 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->