### PR TITLE
Lead with the outcome when no agents are active in the Live Activity

### DIFF
--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -199,6 +199,45 @@ describe("AgentActivity widget layout", () => {
     ).not.toContain("widgetURL");
   });
 
+  it("leads with the outcome instead of a zero count when nothing is active", () => {
+    const layout = AgentActivity(
+      {
+        ...props,
+        subtitle: "Agent work completed",
+        activeCount: 0,
+        activities: [makeRow({ phase: "completed", status: "Done" })],
+      },
+      environment as never,
+    );
+    const banner = JSON.stringify(layout.banner);
+    expect(banner).toContain("Agent work completed");
+    expect(banner).not.toContain("0 active");
+    expect(banner).toContain("#6ee7b7"); // emerald-300 header tint
+    expect(JSON.stringify(layout.compactTrailing)).toContain("Done");
+    expect(JSON.stringify(layout.compactTrailing)).not.toContain("0 active");
+    expect(JSON.stringify(layout.expandedLeading)).toContain("Done");
+    expect(JSON.stringify(layout.minimal)).toContain("checkmark.circle.fill");
+    expect(JSON.stringify(layout.bannerSmall)).toContain("Done");
+  });
+
+  it("reads Failed when the finished work ended in failure", () => {
+    const layout = AgentActivity(
+      {
+        ...props,
+        subtitle: "Agent work failed",
+        activeCount: 0,
+        activities: [makeRow({ phase: "failed", status: "Failed" })],
+      },
+      environment as never,
+    );
+    const banner = JSON.stringify(layout.banner);
+    expect(banner).toContain("Agent work failed");
+    expect(banner).toContain("#fca5a5"); // red-300 header tint
+    expect(JSON.stringify(layout.compactTrailing)).toContain("Failed");
+    expect(JSON.stringify(layout.expandedLeading)).toContain("Failed");
+    expect(JSON.stringify(layout.minimal)).toContain("xmark.octagon.fill");
+  });
+
   it("renders up to five rows in the banner", () => {
     const layout = AgentActivity(
       {

--- a/apps/mobile/src/widgets/AgentActivity.test.ts
+++ b/apps/mobile/src/widgets/AgentActivity.test.ts
@@ -238,6 +238,31 @@ describe("AgentActivity widget layout", () => {
     expect(JSON.stringify(layout.minimal)).toContain("xmark.octagon.fill");
   });
 
+  it("lets a failure dominate mixed finished outcomes across every presentation", () => {
+    const layout = AgentActivity(
+      {
+        ...props,
+        // The server subtitle keys off the newest terminal row (completed
+        // here); the layout must still read Failed everywhere so the header
+        // text never disagrees with the tint, count slots, or minimal glyph.
+        subtitle: "Agent work completed",
+        activeCount: 0,
+        activities: [
+          makeRow({ phase: "completed", status: "Done" }),
+          makeRow({ threadId: "thread-2", phase: "failed", status: "Failed" }),
+        ],
+      },
+      environment as never,
+    );
+    const banner = JSON.stringify(layout.banner);
+    expect(banner).toContain("Agent work failed");
+    expect(banner).not.toContain("Agent work completed");
+    expect(banner).toContain("#fca5a5"); // red-300 header tint
+    expect(JSON.stringify(layout.compactTrailing)).toContain("Failed");
+    expect(JSON.stringify(layout.expandedLeading)).toContain("Failed");
+    expect(JSON.stringify(layout.minimal)).toContain("xmark.octagon.fill");
+  });
+
   it("renders up to five rows in the banner", () => {
     const layout = AgentActivity(
       {

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -123,16 +123,25 @@ export function AgentActivity(
       ? phaseTint(failedRow.phase)
       : tint;
 
+  // With nothing active the aggregate only carries recently finished work, so
+  // "0 active agents" (and a lone "0" in the expanded island) read as broken.
+  // Lead with the outcome instead: the server's subtitle ("Agent work
+  // completed" / "Agent work failed") as the header, "Done"/"Failed" in the
+  // count slots.
+  const allDone = props.activeCount === 0;
+  const doneLabel = failedRow ? "Failed" : "Done";
+
   // Header copy: "5 active agents" + (", 1 needs attention"). The banner renders
   // the two parts in-line so the attention half can carry the accent color;
   // `summary` is the short form for tight spots (expanded center, watch card).
   const agentWord = props.activeCount === 1 ? "agent" : "agents";
-  const agentsLabel = `${props.activeCount} active ${agentWord}`;
+  const agentsLabel = allDone ? props.subtitle : `${props.activeCount} active ${agentWord}`;
   const attentionSuffix =
     attentionRows.length > 0
       ? `${attentionRows.length} need${attentionRows.length === 1 ? "s" : ""} attention`
       : "";
-  const summary = attentionSuffix || `${props.activeCount} active`;
+  const activeLabel = allDone ? doneLabel : `${props.activeCount} active`;
+  const summary = attentionSuffix || activeLabel;
 
   // Any registered scheme variant routes back to this app; taps are delivered
   // to the widget's containing app, so the prod scheme is safe for all builds.
@@ -141,8 +150,6 @@ export function AgentActivity(
     deepLinkRow && deepLinkRow.deepLink.startsWith("/") && !deepLinkRow.deepLink.startsWith("//")
       ? `t3code://${deepLinkRow.deepLink.slice(1)}`
       : null;
-
-  const activeLabel = `${props.activeCount} active`;
 
   // A scannable status glyph per phase — reads faster than colored words and
   // ties the compact / expanded / banner / watch presentations together.
@@ -245,7 +252,9 @@ export function AgentActivity(
             <Text
               modifiers={[
                 font({ weight: "semibold", size: 13 }),
-                foregroundStyle(primaryForeground),
+                // The all-done header carries the outcome tint (emerald /
+                // red) the way the Done/Failed status labels do.
+                foregroundStyle(allDone ? headerTint : primaryForeground),
                 lineLimit(1),
               ]}
             >
@@ -322,16 +331,17 @@ export function AgentActivity(
       </Text>
     ),
     // The shared/minimal form is a ~22pt circle — a single signal reads there,
-    // the wordmark does not. Show the blocking phase glyph, else the mark.
+    // the wordmark does not. Show the blocking/outcome phase glyph, else the
+    // mark (all-done shows the hero row's checkmark/cross).
     minimal:
-      attentionRow || failedRow
+      (attentionRow || failedRow || allDone) && heroRow
         ? renderGlyph(phaseSymbol(heroRow.phase), 13, phaseTint(heroRow.phase))
         : renderLogo(11, tint),
     expandedLeading: (
       <HStack spacing={5} alignment="center" modifiers={[padding({ leading: 4, vertical: 4 })]}>
         {renderLogo(15, tint)}
         <Text modifiers={[font({ weight: "bold", size: 13 }), foregroundStyle(tint)]}>
-          {`${props.activeCount}`}
+          {allDone ? doneLabel : `${props.activeCount}`}
         </Text>
       </HStack>
     ),

--- a/apps/mobile/src/widgets/AgentActivity.tsx
+++ b/apps/mobile/src/widgets/AgentActivity.tsx
@@ -125,17 +125,20 @@ export function AgentActivity(
 
   // With nothing active the aggregate only carries recently finished work, so
   // "0 active agents" (and a lone "0" in the expanded island) read as broken.
-  // Lead with the outcome instead: the server's subtitle ("Agent work
-  // completed" / "Agent work failed") as the header, "Done"/"Failed" in the
-  // count slots.
+  // Lead with the outcome instead. The outcome is derived here from the rows
+  // rather than taken from the server subtitle (which keys off the newest
+  // terminal row): every presentation — header text, tint, count slots,
+  // minimal glyph — must agree, and a failure anywhere should dominate a
+  // newer success.
   const allDone = props.activeCount === 0;
   const doneLabel = failedRow ? "Failed" : "Done";
+  const outcomeLabel = failedRow ? "Agent work failed" : "Agent work completed";
 
   // Header copy: "5 active agents" + (", 1 needs attention"). The banner renders
   // the two parts in-line so the attention half can carry the accent color;
   // `summary` is the short form for tight spots (expanded center, watch card).
   const agentWord = props.activeCount === 1 ? "agent" : "agents";
-  const agentsLabel = allDone ? props.subtitle : `${props.activeCount} active ${agentWord}`;
+  const agentsLabel = allDone ? outcomeLabel : `${props.activeCount} active ${agentWord}`;
   const attentionSuffix =
     attentionRows.length > 0
       ? `${attentionRows.length} need${attentionRows.length === 1 ? "s" : ""} attention`


### PR DESCRIPTION
When everything finishes, the card holds recently completed work with `activeCount: 0`, and the layout kept rendering the count — "0 active agents" in the banner header, "0 active" in the compact Dynamic Island, and a stale lone "0" in the expanded leading slot.

Widget-layout-only change (`AgentActivity.tsx`, ships with the next app build):

- Banner header now shows the server subtitle ("Agent work completed" / "Agent work failed") in the outcome tint (emerald / red) instead of "0 active agents".
- Compact trailing, expanded leading, and the small watch/CarPlay card show "Done" (or "Failed" when a failed row is present) instead of "0 active" / "0".
- The minimal circle shows the hero row's checkmark/cross glyph instead of the wordmark.
- Active-count > 0 presentations are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Widget-only presentation logic in the mobile app with no API or auth changes; behavior when agents are still active is preserved.
> 
> **Overview**
> When **`activeCount` is 0**, the Agent Live Activity no longer shows **"0 active"** / a lone **"0"** across banner, Dynamic Island, and watch layouts. It now **leads with the finished outcome** — **"Agent work completed"** or **"Agent work failed"** in the header (with emerald/red tint), **"Done"** / **"Failed"** in compact and expanded slots, and the **checkmark or failure SF Symbol** in the minimal circle.
> 
> Outcome copy is **derived from activity rows** (any **failed** row wins over a newer success) so header text, tints, counts, and glyphs stay consistent even when the server subtitle would say "completed". **Active work (`activeCount > 0`) is unchanged.**
> 
> Tests in **`AgentActivity.test.ts`** cover all-done, all-failed, and mixed terminal rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b998d6aaf1d874e6333c2160f99a1bcf5e0b8b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lead with outcome labels and tints in the Live Activity widget when no agents are active
> - When `activeCount === 0`, the widget now shows outcome-based labels (`'Done'`/`'Failed'`) instead of `'0 active'`, and header text changes to `'Agent work completed'` or `'Agent work failed'`.
> - Header text color uses the emerald or red outcome tint, the minimal presentation shows the checkmark or failure glyph, and the expanded leading slot shows `'Done'`/`'Failed'` instead of `0`.
> - When finished work has mixed outcomes, any failure present drives all labels and tints.
> - Behavioral Change: the zero-active state now has visually distinct styling and copy; anything previously showing `'0 active'` will now show outcome-driven text.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b998d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->