### PR TITLE
fix(mobile): align Android home branding with desktop

### DIFF
--- a/apps/mobile/src/components/T3Wordmark.tsx
+++ b/apps/mobile/src/components/T3Wordmark.tsx
@@ -1,0 +1,23 @@
+import type { ColorValue } from "react-native";
+import Svg, { Path } from "react-native-svg";
+
+/**
+ * The "T3" brand mark, matching the desktop sidebar's T3Wordmark SVG
+ * (apps/web Sidebar.tsx). Width derives from the viewBox aspect ratio.
+ */
+export function T3Wordmark(props: { readonly height: number; readonly color: ColorValue }) {
+  const aspectRatio = 94.3941 / 56.96;
+  return (
+    <Svg
+      accessibilityLabel="T3"
+      height={props.height}
+      width={props.height * aspectRatio}
+      viewBox="15.5309 37 94.3941 56.96"
+    >
+      <Path
+        d="M33.4509 93V47.56H15.5309V37H64.3309V47.56H46.4109V93H33.4509ZM86.7253 93.96C82.832 93.96 78.9653 93.4533 75.1253 92.44C71.2853 91.3733 68.032 89.88 65.3653 87.96L70.4053 78.04C72.5386 79.5867 75.0186 80.8133 77.8453 81.72C80.672 82.6267 83.5253 83.08 86.4053 83.08C89.6586 83.08 92.2186 82.44 94.0853 81.16C95.952 79.88 96.8853 78.12 96.8853 75.88C96.8853 73.7467 96.0586 72.0667 94.4053 70.84C92.752 69.6133 90.0853 69 86.4053 69H80.4853V60.44L96.0853 42.76L97.5253 47.4H68.1653V37H107.365V45.4L91.8453 63.08L85.2853 59.32H89.0453C95.9253 59.32 101.125 60.8667 104.645 63.96C108.165 67.0533 109.925 71.0267 109.925 75.88C109.925 79.0267 109.099 81.9867 107.445 84.76C105.792 87.48 103.259 89.6933 99.8453 91.4C96.432 93.1067 92.0586 93.96 86.7253 93.96Z"
+        fill={props.color}
+      />
+    </Svg>
+  );
+}

--- a/apps/mobile/src/features/home/HomeHeader.tsx
+++ b/apps/mobile/src/features/home/HomeHeader.tsx
@@ -13,6 +13,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { nativeHeaderScrollEdgeEffects } from "../../native/StackHeader";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { SymbolView } from "../../components/AppSymbol";
+import { T3Wordmark } from "../../components/T3Wordmark";
 import { MOBILE_TYPOGRAPHY } from "../../lib/typography";
 import { useThemeColor } from "../../lib/useThemeColor";
 import { useHardwareKeyboardCommand } from "../keyboard/hardwareKeyboardCommands";
@@ -185,15 +186,18 @@ function AndroidHomeHeader(props: HomeHeaderProps) {
         <View style={{ alignSelf: "center", gap: 12, maxWidth: 720, width: "100%" }}>
           <View style={{ alignItems: "center", flexDirection: "row", gap: 10 }}>
             <View style={{ alignItems: "center", flexDirection: "row", flex: 1, gap: 8 }}>
+              {/* Mirrors the desktop SidebarBrand: T3 mark + muted "Code". */}
+              <T3Wordmark color={iconColor} height={15} />
               <RNText
                 style={{
-                  color: iconColor,
-                  fontFamily: "DMSans_700Bold",
+                  color: mutedColor,
+                  fontFamily: "DMSans_500Medium",
                   fontSize: MOBILE_TYPOGRAPHY.title.fontSize,
                   letterSpacing: -0.5,
+                  marginLeft: -2,
                 }}
               >
-                T3 Code
+                Code
               </RNText>
               <View
                 style={{


### PR DESCRIPTION
## Summary

Narrows the Android home polish stacked on `android-dev-pr-3514` to its platform-specific scope:

- Adds a reusable T3 SVG wordmark for mobile.
- Replaces the Android home header text brand with the T3 mark and muted `Code` label used by the desktop sidebar.

The shared mobile favicon decoder and font/splash startup fixes were split into #3823, which targets `main`.

## Validation

- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`
- React Doctor scoped to this PR: no errors (one SVG path precision warning).


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align Android home header branding with desktop by adding T3 wordmark
> - Adds a new `T3Wordmark` SVG component ([T3Wordmark.tsx](https://github.com/pingdotgg/t3code/pull/3774/files#diff-24018ca5b1da56d360731b743301f1a42e44a81e1694341d748fb31ae1d235b7)) that renders the T3 brand mark at a configurable height and color.
> - Updates [AndroidHomeHeader](https://github.com/pingdotgg/t3code/pull/3774/files#diff-1ba9649b1bf1262669a23a80f40994038467f6ae019d2ce77f1bbc7e0f65e198) to display the wordmark icon followed by "Code" in muted color and medium weight, mirroring the desktop `SidebarBrand` layout.
> - Behavioral Change: The header text changes from bold "T3 Code" in icon color to "Code" in muted color with medium weight, alongside the new SVG wordmark.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1326457.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Android-only header presentation and a new static SVG component; no auth, data, or business-logic changes.
> 
> **Overview**
> Updates the **Android home header** branding to match the desktop `SidebarBrand` pattern instead of a single bold **T3 Code** label.
> 
> Adds a reusable **`T3Wordmark`** SVG component (same viewBox/path as web `Sidebar.tsx`) and renders it next to muted **Code** text using `DMSans_500Medium` and theme muted colors, with a small negative margin so the mark and label sit tight together.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1326457fd77a02f209c0943ff2a794207f0f47ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->