### PR TITLE
fix(ci): stabilize flaky tests — live-clock polling, GitManager timeouts, web test budget

### DIFF
--- a/.cursor/rules/cursor-cloud.mdc
+++ b/.cursor/rules/cursor-cloud.mdc
@@ -68,5 +68,9 @@ Gradle auto-downloads any additional pinned SDK packages on demand.
 
 ## Known flaky tests (unrelated to setup)
 
-- `apps/server/src/git/GitManager.test.ts` (cross-repo PR metadata, can time out at 12s).
-- `apps/server/src/provider/Layers/ProviderRegistry.test.ts` (codex binaryPath re-probe ordering).
+Previously flaky suites (`GitManager` cross-repo PR timeouts, `ProviderRegistry` codex binaryPath
+re-probe, `CursorAdapter` interrupt/cancel log polling) were fixed by removing tight per-test
+timeout overrides and polling on the live clock via `apps/server/src/provider/testUtils/pollUntil.ts`.
+If a test needs to wait for out-of-process work (child processes, real spawns, file appends from
+another process) under `it.effect`'s `TestClock`, use `pollUntil` — `Effect.yieldNow` loops and
+`TestClock.adjust` provide no wall-clock time and will flake on loaded CI hosts.

--- a/apps/server/src/git/GitManager.test.ts
+++ b/apps/server/src/git/GitManager.test.ts
@@ -1008,73 +1008,70 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
       }),
   );
 
-  it.effect(
-    "status detects cross-repo PRs from the upstream remote URL owner",
-    () =>
-      Effect.gen(function* () {
-        const repoDir = yield* makeTempDir("t3code-git-manager-");
-        yield* initRepo(repoDir);
-        const forkDir = yield* createBareRemote();
-        yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
-        yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
-        NodeFS.writeFileSync(NodePath.join(repoDir, "fork-pr.txt"), "fork pr\n");
-        yield* runGit(repoDir, ["add", "fork-pr.txt"]);
-        yield* runGit(repoDir, ["commit", "-m", "Fork PR branch"]);
-        yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
-        yield* runGit(repoDir, ["checkout", "-b", "t3code/pr-488/statemachine"]);
-        yield* runGit(repoDir, ["branch", "--set-upstream-to", "fork-seed/statemachine"]);
-        yield* configureVisibleRemoteUrlWithLocalRewrite(
-          repoDir,
-          "fork-seed",
-          "git@github.com:jasonLaster/codething-mvp.git",
-          forkDir,
-        );
+  it.effect("status detects cross-repo PRs from the upstream remote URL owner", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      const forkDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
+      yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
+      NodeFS.writeFileSync(NodePath.join(repoDir, "fork-pr.txt"), "fork pr\n");
+      yield* runGit(repoDir, ["add", "fork-pr.txt"]);
+      yield* runGit(repoDir, ["commit", "-m", "Fork PR branch"]);
+      yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
+      yield* runGit(repoDir, ["checkout", "-b", "t3code/pr-488/statemachine"]);
+      yield* runGit(repoDir, ["branch", "--set-upstream-to", "fork-seed/statemachine"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "fork-seed",
+        "git@github.com:jasonLaster/codething-mvp.git",
+        forkDir,
+      );
 
-        const { manager, ghCalls } = yield* makeManager({
-          ghScenario: {
-            prListSequence: [
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              JSON.stringify([]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              JSON.stringify([]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              JSON.stringify([
-                {
-                  number: 488,
-                  title: "Rebase this PR on latest main",
-                  url: "https://github.com/pingdotgg/codething-mvp/pull/488",
-                  baseRefName: "main",
-                  headRefName: "statemachine",
-                  state: "OPEN",
-                  updatedAt: "2026-03-10T07:00:00Z",
-                  isCrossRepository: true,
-                  headRepository: {
-                    nameWithOwner: "jasonLaster/codething-mvp",
-                  },
-                  headRepositoryOwner: {
-                    login: "jasonLaster",
-                  },
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 488,
+                title: "Rebase this PR on latest main",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/488",
+                baseRefName: "main",
+                headRefName: "statemachine",
+                state: "OPEN",
+                updatedAt: "2026-03-10T07:00:00Z",
+                isCrossRepository: true,
+                headRepository: {
+                  nameWithOwner: "jasonLaster/codething-mvp",
                 },
-              ]),
-            ],
-          },
-        });
+                headRepositoryOwner: {
+                  login: "jasonLaster",
+                },
+              },
+            ]),
+          ],
+        },
+      });
 
-        const status = yield* manager.status({ cwd: repoDir });
-        expect(status.refName).toBe("t3code/pr-488/statemachine");
-        expect(status.pr).toEqual({
-          number: 488,
-          title: "Rebase this PR on latest main",
-          url: "https://github.com/pingdotgg/codething-mvp/pull/488",
-          baseRef: "main",
-          headRef: "statemachine",
-          state: "open",
-        });
-        expect(ghCalls).toContain(
-          "pr list --head jasonLaster:statemachine --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
-        );
-      }),
-    20_000,
+      const status = yield* manager.status({ cwd: repoDir });
+      expect(status.refName).toBe("t3code/pr-488/statemachine");
+      expect(status.pr).toEqual({
+        number: 488,
+        title: "Rebase this PR on latest main",
+        url: "https://github.com/pingdotgg/codething-mvp/pull/488",
+        baseRef: "main",
+        headRef: "statemachine",
+        state: "open",
+      });
+      expect(ghCalls).toContain(
+        "pr list --head jasonLaster:statemachine --state all --limit 20 --json number,title,url,baseRefName,headRefName,state,mergedAt,updatedAt,isCrossRepository,headRepository,headRepositoryOwner",
+      );
+    }),
   );
 
   it.effect(
@@ -1190,7 +1187,6 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           ),
         ).toBe(false);
       }),
-    20_000,
   );
 
   it.effect("status returns merged PR state when latest PR was merged", () =>
@@ -1884,65 +1880,62 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
     }),
   );
 
-  it.effect(
-    "returns existing cross-repo PR metadata using the fork owner selector",
-    () =>
-      Effect.gen(function* () {
-        const repoDir = yield* makeTempDir("t3code-git-manager-");
-        yield* initRepo(repoDir);
-        yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
-        const forkDir = yield* createBareRemote();
-        yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
-        yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
-        yield* configureVisibleRemoteUrlWithLocalRewrite(
-          repoDir,
-          "fork-seed",
-          "git@github.com:octocat/codething-mvp.git",
-          forkDir,
-        );
+  it.effect("returns existing cross-repo PR metadata using the fork owner selector", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
+      const forkDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
+      yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "fork-seed",
+        "git@github.com:octocat/codething-mvp.git",
+        forkDir,
+      );
 
-        const { manager, ghCalls } = yield* makeManager({
-          ghScenario: {
-            prListSequence: [
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              JSON.stringify([]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              JSON.stringify([
-                {
-                  number: 142,
-                  title: "Existing fork PR",
-                  url: "https://github.com/pingdotgg/codething-mvp/pull/142",
-                  baseRefName: "main",
-                  headRefName: "statemachine",
-                  state: "OPEN",
-                  isCrossRepository: true,
-                  headRepository: {
-                    nameWithOwner: "octocat/codething-mvp",
-                  },
-                  headRepositoryOwner: {
-                    login: "octocat",
-                  },
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListSequence: [
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            JSON.stringify([
+              {
+                number: 142,
+                title: "Existing fork PR",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/142",
+                baseRefName: "main",
+                headRefName: "statemachine",
+                state: "OPEN",
+                isCrossRepository: true,
+                headRepository: {
+                  nameWithOwner: "octocat/codething-mvp",
                 },
-              ]),
-            ],
-          },
-        });
+                headRepositoryOwner: {
+                  login: "octocat",
+                },
+              },
+            ]),
+          ],
+        },
+      });
 
-        const result = yield* runStackedAction(manager, {
-          cwd: repoDir,
-          action: "commit_push_pr",
-        });
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit_push_pr",
+      });
 
-        expect(result.pr.status).toBe("opened_existing");
-        expect(result.pr.number).toBe(142);
-        expect(
-          ghCalls.some((call) =>
-            call.includes("pr list --head octocat:statemachine --state open --limit 1"),
-          ),
-        ).toBe(true);
-        expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
-      }),
-    12_000,
+      expect(result.pr.status).toBe("opened_existing");
+      expect(result.pr.number).toBe(142);
+      expect(
+        ghCalls.some((call) =>
+          call.includes("pr list --head octocat:statemachine --state open --limit 1"),
+        ),
+      ).toBe(true);
+      expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
+    }),
   );
 
   it.effect(
@@ -2042,149 +2035,142 @@ it.layer(GitManagerTestLayer)("GitManager", (it) => {
           false,
         );
       }),
-    20_000,
   );
 
-  it.effect(
-    "prefers owner-qualified selectors before bare branch names for cross-repo PRs",
-    () =>
-      Effect.gen(function* () {
-        const repoDir = yield* makeTempDir("t3code-git-manager-");
-        yield* initRepo(repoDir);
-        yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
-        const forkDir = yield* createBareRemote();
-        yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
-        yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
-        yield* runGit(repoDir, ["checkout", "-b", "t3code/pr-142/statemachine"]);
-        yield* runGit(repoDir, ["branch", "--set-upstream-to", "fork-seed/statemachine"]);
-        yield* configureVisibleRemoteUrlWithLocalRewrite(
-          repoDir,
-          "fork-seed",
-          "git@github.com:octocat/codething-mvp.git",
-          forkDir,
-        );
+  it.effect("prefers owner-qualified selectors before bare branch names for cross-repo PRs", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
+      const forkDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
+      yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
+      yield* runGit(repoDir, ["checkout", "-b", "t3code/pr-142/statemachine"]);
+      yield* runGit(repoDir, ["branch", "--set-upstream-to", "fork-seed/statemachine"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "fork-seed",
+        "git@github.com:octocat/codething-mvp.git",
+        forkDir,
+      );
 
-        const { manager, ghCalls } = yield* makeManager({
-          ghScenario: {
-            prListByHeadSelector: {
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              "t3code/pr-142/statemachine": JSON.stringify([]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              statemachine: JSON.stringify([
-                {
-                  number: 41,
-                  title: "Unrelated same-repo PR",
-                  url: "https://github.com/pingdotgg/codething-mvp/pull/41",
-                  baseRefName: "main",
-                  headRefName: "statemachine",
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListByHeadSelector: {
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "t3code/pr-142/statemachine": JSON.stringify([]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            statemachine: JSON.stringify([
+              {
+                number: 41,
+                title: "Unrelated same-repo PR",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/41",
+                baseRefName: "main",
+                headRefName: "statemachine",
+              },
+            ]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "octocat:statemachine": JSON.stringify([
+              {
+                number: 142,
+                title: "Existing fork PR",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/142",
+                baseRefName: "main",
+                headRefName: "statemachine",
+                state: "OPEN",
+                isCrossRepository: true,
+                headRepository: {
+                  nameWithOwner: "octocat/codething-mvp",
                 },
-              ]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              "octocat:statemachine": JSON.stringify([
-                {
-                  number: 142,
-                  title: "Existing fork PR",
-                  url: "https://github.com/pingdotgg/codething-mvp/pull/142",
-                  baseRefName: "main",
-                  headRefName: "statemachine",
-                  state: "OPEN",
-                  isCrossRepository: true,
-                  headRepository: {
-                    nameWithOwner: "octocat/codething-mvp",
-                  },
-                  headRepositoryOwner: {
-                    login: "octocat",
-                  },
+                headRepositoryOwner: {
+                  login: "octocat",
                 },
-              ]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              "fork-seed:statemachine": JSON.stringify([]),
-            },
+              },
+            ]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "fork-seed:statemachine": JSON.stringify([]),
           },
-        });
+        },
+      });
 
-        const result = yield* runStackedAction(manager, {
-          cwd: repoDir,
-          action: "commit_push_pr",
-        });
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit_push_pr",
+      });
 
-        expect(result.pr.status).toBe("opened_existing");
-        expect(result.pr.number).toBe(142);
+      expect(result.pr.status).toBe("opened_existing");
+      expect(result.pr.number).toBe(142);
 
-        const ownerSelectorCallIndex = ghCalls.findIndex((call) =>
-          call.includes("pr list --head octocat:statemachine --state open --limit 1"),
-        );
-        expect(ownerSelectorCallIndex).toBeGreaterThanOrEqual(0);
-        expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
-      }),
-    12_000,
+      const ownerSelectorCallIndex = ghCalls.findIndex((call) =>
+        call.includes("pr list --head octocat:statemachine --state open --limit 1"),
+      );
+      expect(ownerSelectorCallIndex).toBeGreaterThanOrEqual(0);
+      expect(ghCalls.some((call) => call.startsWith("pr create "))).toBe(false);
+    }),
   );
 
-  it.effect(
-    "stops probing head selectors after finding an existing PR",
-    () =>
-      Effect.gen(function* () {
-        const repoDir = yield* makeTempDir("t3code-git-manager-");
-        yield* initRepo(repoDir);
-        yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
-        const forkDir = yield* createBareRemote();
-        yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
-        yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
-        yield* runGit(repoDir, ["checkout", "-b", "t3code/pr-142/statemachine"]);
-        yield* runGit(repoDir, ["branch", "--set-upstream-to", "fork-seed/statemachine"]);
-        yield* configureVisibleRemoteUrlWithLocalRewrite(
-          repoDir,
-          "fork-seed",
-          "git@github.com:octocat/codething-mvp.git",
-          forkDir,
-        );
+  it.effect("stops probing head selectors after finding an existing PR", () =>
+    Effect.gen(function* () {
+      const repoDir = yield* makeTempDir("t3code-git-manager-");
+      yield* initRepo(repoDir);
+      yield* runGit(repoDir, ["checkout", "-b", "statemachine"]);
+      const forkDir = yield* createBareRemote();
+      yield* runGit(repoDir, ["remote", "add", "fork-seed", forkDir]);
+      yield* runGit(repoDir, ["push", "-u", "fork-seed", "statemachine"]);
+      yield* runGit(repoDir, ["checkout", "-b", "t3code/pr-142/statemachine"]);
+      yield* runGit(repoDir, ["branch", "--set-upstream-to", "fork-seed/statemachine"]);
+      yield* configureVisibleRemoteUrlWithLocalRewrite(
+        repoDir,
+        "fork-seed",
+        "git@github.com:octocat/codething-mvp.git",
+        forkDir,
+      );
 
-        const { manager, ghCalls } = yield* makeManager({
-          ghScenario: {
-            prListByHeadSelector: {
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              "octocat:statemachine": JSON.stringify([
-                {
-                  number: 142,
-                  title: "Existing fork PR",
-                  url: "https://github.com/pingdotgg/codething-mvp/pull/142",
-                  baseRefName: "main",
-                  headRefName: "statemachine",
-                  state: "OPEN",
-                  isCrossRepository: true,
-                  headRepository: {
-                    nameWithOwner: "octocat/codething-mvp",
-                  },
-                  headRepositoryOwner: {
-                    login: "octocat",
-                  },
+      const { manager, ghCalls } = yield* makeManager({
+        ghScenario: {
+          prListByHeadSelector: {
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "octocat:statemachine": JSON.stringify([
+              {
+                number: 142,
+                title: "Existing fork PR",
+                url: "https://github.com/pingdotgg/codething-mvp/pull/142",
+                baseRefName: "main",
+                headRefName: "statemachine",
+                state: "OPEN",
+                isCrossRepository: true,
+                headRepository: {
+                  nameWithOwner: "octocat/codething-mvp",
                 },
-              ]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              "fork-seed:statemachine": JSON.stringify([]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              "t3code/pr-142/statemachine": JSON.stringify([]),
-              // @effect-diagnostics-next-line preferSchemaOverJson:off
-              statemachine: JSON.stringify([]),
-            },
+                headRepositoryOwner: {
+                  login: "octocat",
+                },
+              },
+            ]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "fork-seed:statemachine": JSON.stringify([]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            "t3code/pr-142/statemachine": JSON.stringify([]),
+            // @effect-diagnostics-next-line preferSchemaOverJson:off
+            statemachine: JSON.stringify([]),
           },
-        });
+        },
+      });
 
-        const result = yield* runStackedAction(manager, {
-          cwd: repoDir,
-          action: "commit_push_pr",
-        });
+      const result = yield* runStackedAction(manager, {
+        cwd: repoDir,
+        action: "commit_push_pr",
+      });
 
-        expect(result.pr.status).toBe("opened_existing");
-        expect(result.pr.number).toBe(142);
+      expect(result.pr.status).toBe("opened_existing");
+      expect(result.pr.number).toBe(142);
 
-        const openLookupCalls = ghCalls.filter((call) => call.includes("--state open --limit 1"));
-        expect(openLookupCalls).toHaveLength(1);
-        expect(openLookupCalls[0]).toContain(
-          "pr list --head octocat:statemachine --state open --limit 1",
-        );
-      }),
-    12_000,
+      const openLookupCalls = ghCalls.filter((call) => call.includes("--state open --limit 1"));
+      expect(openLookupCalls).toHaveLength(1);
+      expect(openLookupCalls[0]).toContain(
+        "pr list --head octocat:statemachine --state open --limit 1",
+      );
+    }),
   );
 
   it.effect("creates PR when one does not already exist", () =>

--- a/apps/server/src/provider/Layers/CursorAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.test.ts
@@ -28,6 +28,7 @@ import {
 import { ServerConfig } from "../../config.ts";
 import { ServerSettingsService } from "../../serverSettings.ts";
 import type { CursorAdapterShape } from "../Services/CursorAdapter.ts";
+import { pollUntil } from "../testUtils/pollUntil.ts";
 import { makeCursorAdapter } from "./CursorAdapter.ts";
 const decodeCursorSettings = Schema.decodeSync(CursorSettings);
 
@@ -97,36 +98,34 @@ async function readJsonLines(filePath: string) {
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0)
-    .map((line) => JSON.parse(line) as Record<string, unknown>);
+    .flatMap((line) => {
+      // The mock agent appends lines from a separate process, so a poll may
+      // observe a partially written trailing line. Skip it; the next poll
+      // sees the complete line.
+      try {
+        return [JSON.parse(line) as Record<string, unknown>];
+      } catch {
+        return [];
+      }
+    });
 }
 
-async function waitForFileContent(filePath: string, attempts = 40) {
-  for (let attempt = 0; attempt < attempts; attempt += 1) {
-    try {
-      const raw = await NodeFSP.readFile(filePath, "utf8");
-      if (raw.trim().length > 0) {
-        return raw;
-      }
-    } catch {}
-    await Effect.runPromise(Effect.yieldNow);
-  }
-  throw new Error(`Timed out waiting for file content at ${filePath}`);
+function waitForFileContent(filePath: string) {
+  return pollUntil({
+    poll: Effect.promise(() => NodeFSP.readFile(filePath, "utf8").catch(() => "")),
+    until: (raw) => raw.trim().length > 0,
+    description: `file content at ${filePath}`,
+  });
 }
 
 function waitForJsonLogMatch(
   filePath: string,
   predicate: (entry: Record<string, unknown>) => boolean,
-  attempts = 40,
 ) {
-  return Effect.gen(function* () {
-    for (let attempt = 0; attempt < attempts; attempt += 1) {
-      const requests = yield* Effect.promise(() => readJsonLines(filePath));
-      if (requests.some(predicate)) {
-        return requests;
-      }
-      yield* Effect.yieldNow;
-    }
-    return yield* Effect.promise(() => readJsonLines(filePath));
+  return pollUntil({
+    poll: Effect.promise(() => readJsonLines(filePath)),
+    until: (entries) => entries.some(predicate),
+    description: `a matching json log entry in ${filePath}`,
   });
 }
 
@@ -353,7 +352,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
 
       yield* adapter.stopSession(threadId);
 
-      const exitLog = yield* Effect.promise(() => waitForFileContent(exitLogPath));
+      const exitLog = yield* waitForFileContent(exitLogPath);
       assert.include(exitLog, "SIGTERM");
     }),
   );
@@ -405,7 +404,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
 
         yield* adapter.stopSession(threadId);
 
-        const exitLog = yield* Effect.promise(() => waitForFileContent(exitLogPath));
+        const exitLog = yield* waitForFileContent(exitLogPath);
         assert.equal(exitLog.match(/SIGTERM/g)?.length ?? 0, 2);
       }),
   );
@@ -516,7 +515,7 @@ cursorAdapterTestLayer("CursorAdapterLive", (it) => {
           modelSelection,
         });
 
-        yield* Effect.promise(() => waitForFileContent(requestLogPath));
+        yield* waitForFileContent(requestLogPath);
 
         const requestsAfterStart = yield* Effect.promise(() => readJsonLines(requestLogPath));
         const configIdsAfterStart = requestsAfterStart.flatMap((entry) =>

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -49,6 +49,7 @@ import type { ProviderInstance } from "../ProviderDriver.ts";
 import * as ProviderInstanceRegistry from "../Services/ProviderInstanceRegistry.ts";
 import * as ProviderRegistry from "../Services/ProviderRegistry.ts";
 import { makeManualOnlyProviderMaintenanceCapabilities } from "../providerMaintenance.ts";
+import { pollUntil } from "../testUtils/pollUntil.ts";
 const decodeServerSettings = Schema.decodeSync(ServerSettings);
 const encodeServerSettings = Schema.encodeSync(ServerSettings);
 const encodedDefaultServerSettings = encodeServerSettings(DEFAULT_SERVER_SETTINGS);
@@ -1132,17 +1133,15 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
 
           yield* Effect.gen(function* () {
             const registry = yield* ProviderRegistry.ProviderRegistry;
-            let providers = yield* registry.getProviders;
-            for (
-              let attempts = 0;
-              attempts < 50 &&
-              providers.find((provider) => provider.instanceId === "codex_personal")?.status !==
-                "error";
-              attempts += 1
-            ) {
-              yield* Effect.yieldNow;
-              providers = yield* registry.getProviders;
-            }
+            // The probe spawns a real child process, so its ENOENT arrives on
+            // the live event loop — poll with real wall-clock pauses.
+            const providers = yield* pollUntil({
+              poll: registry.getProviders,
+              until: (current) =>
+                current.find((provider) => provider.instanceId === "codex_personal")?.status ===
+                "error",
+              description: "the codex_personal probe error snapshot to reach the aggregator",
+            });
             const codexPersonal = providers.find(
               (provider) => provider.instanceId === "codex_personal",
             );
@@ -1228,19 +1227,15 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
             const registry = yield* ProviderRegistry.ProviderRegistry;
             // Boot-time probe: the default codex instance is enabled with
             // `firstMissing`, so the real spawner yields ENOENT and the
-            // snapshot should be `status: "error"`.
-            let initialProviders = yield* registry.getProviders;
-            for (
-              let attempts = 0;
-              attempts < 50 &&
-              initialProviders.find((provider) => provider.instanceId === "codex")?.status !==
-                "error";
-              attempts += 1
-            ) {
-              yield* TestClock.adjust("10 millis");
-              yield* Effect.yieldNow;
-              initialProviders = yield* registry.getProviders;
-            }
+            // snapshot should be `status: "error"`. The spawn error arrives
+            // on the live event loop, so poll with real wall-clock pauses
+            // while still nudging the virtual clock for any test timers.
+            const initialProviders = yield* pollUntil({
+              poll: TestClock.adjust("10 millis").pipe(Effect.andThen(registry.getProviders)),
+              until: (providers) =>
+                providers.find((provider) => provider.instanceId === "codex")?.status === "error",
+              description: "the boot-time codex probe to fail against the first missing binary",
+            });
             const initialCodex = initialProviders.find(
               (provider) => provider.instanceId === "codex",
             );
@@ -1264,22 +1259,21 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
 
             // Poll until the injected process boundary observes the new
             // executable. This verifies the public settings-to-probe behavior
-            // without depending on timestamps assigned by TestClock.
-            const refreshed = yield* Effect.gen(function* () {
-              for (let attempts = 0; attempts < 60; attempts += 1) {
-                const providers = yield* registry.getProviders;
+            // without depending on timestamps assigned by TestClock. The
+            // settings stream, reconcile, and re-probe all hop through real
+            // fibers and a real child-process spawn, so give them wall-clock
+            // time between attempts.
+            const refreshed = yield* pollUntil({
+              poll: TestClock.adjust("50 millis").pipe(Effect.andThen(registry.getProviders)),
+              until: (providers) => {
                 const codex = providers.find((provider) => provider.instanceId === "codex");
-                if (
+                return (
                   codex !== undefined &&
                   codex.status === "error" &&
                   spawnedCommands.includes(secondMissing)
-                ) {
-                  return providers;
-                }
-                yield* TestClock.adjust("50 millis");
-                yield* Effect.yieldNow;
-              }
-              return yield* registry.getProviders;
+                );
+              },
+              description: "the codex re-probe against the second missing binary",
             });
 
             const reprobedCodex = refreshed.find((provider) => provider.instanceId === "codex");

--- a/apps/server/src/provider/testUtils/pollUntil.ts
+++ b/apps/server/src/provider/testUtils/pollUntil.ts
@@ -1,0 +1,69 @@
+import * as Clock from "effect/Clock";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+
+const describeValue = (value: unknown) => {
+  try {
+    const text = JSON.stringify(value);
+    if (text === undefined) {
+      return String(value);
+    }
+    return text.length > 2_000 ? `${text.slice(0, 2_000)}…` : text;
+  } catch {
+    return String(value);
+  }
+};
+
+export interface PollUntilOptions<A, E, R> {
+  /** Effect run on each attempt; its latest result is checked with `until`. */
+  readonly poll: Effect.Effect<A, E, R>;
+  /** Predicate on the polled value that ends the wait. */
+  readonly until: (value: A) => boolean;
+  /** Human-readable description of what is being waited for, used in the timeout error. */
+  readonly description: string;
+  /** Wall-clock budget for the whole wait. Defaults to 10 seconds. */
+  readonly timeout?: Duration.Input;
+  /** Wall-clock pause between attempts. Defaults to 25 millis. */
+  readonly interval?: Duration.Input;
+}
+
+/**
+ * Repeatedly runs `poll` until `until` matches, sleeping on the live clock
+ * between attempts.
+ *
+ * Tests running under `@effect/vitest`'s `it.effect` / `it.layer` are on the
+ * `TestClock`, where `Effect.sleep` only advances via `TestClock.adjust` and
+ * `Effect.yieldNow` yields no wall-clock time at all. Polling loops built from
+ * those primitives give out-of-process work — mock agent child processes,
+ * real `ChildProcessSpawner` probes, libuv I/O callbacks — essentially zero
+ * real time to complete, which makes them flaky on loaded CI hosts. Sleeping
+ * via `TestClock.withLive` lets the event loop and child processes make
+ * progress while the rest of the test stays on the virtual clock.
+ *
+ * Dies with a descriptive error (including the last polled value) when the
+ * budget is exhausted, so a timeout fails loudly instead of letting a later
+ * assertion fail on stale data.
+ */
+export const pollUntil = <A, E, R>(options: PollUntilOptions<A, E, R>) =>
+  Effect.gen(function* () {
+    const timeoutMillis = Duration.toMillis(options.timeout ?? "10 seconds");
+    const interval = options.interval ?? "25 millis";
+    const startedAt = yield* TestClock.withLive(Clock.currentTimeMillis);
+    for (;;) {
+      const value = yield* options.poll;
+      if (options.until(value)) {
+        return value;
+      }
+      const now = yield* TestClock.withLive(Clock.currentTimeMillis);
+      if (now - startedAt >= timeoutMillis) {
+        return yield* Effect.die(
+          new Error(
+            `Timed out after ${timeoutMillis}ms waiting for ${options.description}. ` +
+              `Last polled value: ${describeValue(value)}`,
+          ),
+        );
+      }
+      yield* TestClock.withLive(Effect.sleep(interval));
+    }
+  });

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -58,9 +58,11 @@ const unitTestProject = {
     include: ["src/**/*.test.{ts,tsx}"],
     // The web runtime suite exercises auth bootstrap, saved environments,
     // and websocket subscription lifecycles. Under the full monorepo test
-    // run, those async tests can exceed Vitest's default 5s budget.
-    hookTimeout: 15_000,
-    testTimeout: 15_000,
+    // run every package's suite competes for the same CI cores, so even
+    // import/transform of heavy components (e.g. MessagesTimeline) has blown
+    // a 15s budget. Match the root config's 60s budget.
+    hookTimeout: 60_000,
+    testTimeout: 60_000,
   },
 } satisfies TestProjectInlineConfiguration;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audited the last ~50 failed CI runs and fixed the recurring cross-branch flakes (as opposed to genuine PR-branch failures):

- **`CursorAdapter.test.ts` — "cancels pending ACP approvals…"** (7+ CI failures across unrelated branches). The test polled the mock agent's request log with bare `Effect.yieldNow` loops, which yield **zero wall-clock time** under `it.effect`'s `TestClock`. The mock agent is a separate OS process, so its `session/cancel` log append routinely landed after the ~40 microtask hops and the assertion read stale data. A standalone repro of the old helper missed a write arriving just 5ms late, 3/3 times.
- **`ProviderRegistry.test.ts` — "re-probes when settings change the codex binaryPath"** (documented known flake). Same mechanism: the re-probe spawns a real child process whose ENOENT arrives on the live event loop, but the poll loop only did `TestClock.adjust` + `yieldNow`.
- **`GitManager.test.ts` — cross-repo PR tests timing out at 12s** (documented known flake). Six tests carried 12s/20s per-test timeouts left over from when the suite default was Vitest's 5s. The server suite now sets a 120s budget precisely because these git-subprocess-heavy tests crawl on loaded CI hosts — the stale overrides only *shrank* the budget. Removed them.
- **`MessagesTimeline.test.tsx` — "anchors a sent attachment message…"** timed out at exactly the web suite's 15s budget under a full-monorepo parallel test run. Raised `apps/web` test/hook timeouts to match the root config's 60s.

## Fix

New shared helper `apps/server/src/provider/testUtils/pollUntil.ts`: polls an effect until a predicate matches, sleeping on the **live clock** via `TestClock.withLive` between attempts (so child processes and libuv make progress while the test stays on the virtual clock), and dies loudly with the last polled value on timeout instead of silently returning stale data. Both flaky server test files now use it for every cross-process wait. `readJsonLines` also tolerates a partially written trailing line while the child is mid-append.

Updated `.cursor/rules/cursor-cloud.mdc` known-flaky notes to describe the fixes and point future polling waits at `pollUntil`.

## Testing

- ✅ `vp run typecheck`
- ✅ `vp check --fix` (formatter-clean, 0 errors)
- ✅ `vp run test` in `apps/server` — full suite, 160 files / 1397 tests passed
- ✅ `vp test src/components/chat/MessagesTimeline.test.tsx` in `apps/web`
- ✅ Stress test: previously flaky `CursorAdapter` cancel test ran 8×, and `ProviderRegistry` re-probe test 5×, under 6 concurrent CPU busy-loops on a 4-core VM — all passed
- ✅ Standalone repro confirmed the old `waitForJsonLogMatch` misses a 5ms-late cross-process write (3/3 runs), validating the root cause
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-64e3e569-df80-4cdf-b71c-1a67c81d316d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-64e3e569-df80-4cdf-b71c-1a67c81d316d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix flaky CI tests by replacing manual polling loops with live-clock `pollUntil` utility
> - Adds [`pollUntil`](https://github.com/pingdotgg/t3code/pull/3778/files#diff-d7798dbabc3ace75977da14fbf332586b118a2eca769070d2c5d9ffd03c11d96), a reusable test utility that polls an Effect on the live clock (default 10s timeout, 25ms interval) until a predicate matches, using `TestClock.withLive` to avoid interference with `it.effect`'s test clock.
> - Updates [`CursorAdapter.test.ts`](https://github.com/pingdotgg/t3code/pull/3778/files#diff-34f25d7565d468e4410e8949e082c6176c8fa9c8949b5074c05098c1c61e13c0) and [`ProviderRegistry.test.ts`](https://github.com/pingdotgg/t3code/pull/3778/files#diff-28b6372c54d8310c6909678b338ea3a67f48ea13b57386544bfe5ffdfa742b6f) to replace manual `Effect.yieldNow` loops with `pollUntil`, fixing races on out-of-process child process and file I/O timing.
> - Fixes partial JSON line errors in `readJsonLines` by silently skipping lines that fail to parse, handling mid-write appends from separate processes.
> - Removes explicit per-test timeout overrides in [`GitManager.test.ts`](https://github.com/pingdotgg/t3code/pull/3778/files#diff-913ade748b9dbddd4912c2fd2d736a754c232ed342415f121860f38508455eb1), deferring to the framework default.
> - Increases Vitest `hookTimeout` and `testTimeout` from 15s to 60s in [`apps/web/vite.config.ts`](https://github.com/pingdotgg/t3code/pull/3778/files#diff-eea049695b0188b525a44f51269fe670485ed3e355f8cede185cafedec24d786) to align with root config budget under CI contention.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c660f28. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->