### PR TITLE
feat(web): add find-in-thread search with Cmd+F

### DIFF
--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -67,6 +67,7 @@ import {
 } from "../markdown-links";
 import { readLocalApi } from "../localApi";
 import { cn } from "../lib/utils";
+import { highlightHtml } from "../lib/searchHighlight";
 import { useRightPanelStore } from "../rightPanelStore";
 import { useActiveEnvironmentId } from "../state/entities";
 import { serverEnvironment } from "../state/server";
@@ -114,6 +115,7 @@ interface ChatMarkdownProps {
   className?: string;
   /** Treat single newlines as hard breaks — chat-style user input. */
   lineBreaks?: boolean;
+  searchQuery?: string;
 }
 
 const EMPTY_MARKDOWN_SKILLS: ReadonlyArray<Pick<ServerProviderSkill, "name" | "displayName">> = [];
@@ -153,10 +155,12 @@ function findTaskListMarkerOffset(markdown: string, listItemStart: number): numb
 }
 const CHAT_MARKDOWN_SANITIZE_SCHEMA = {
   ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), "mark"],
   attributes: {
     ...defaultSchema.attributes,
     "*": (defaultSchema.attributes?.["*"] ?? []).filter((attribute) => attribute !== "title"),
     code: [...(defaultSchema.attributes?.code ?? []), "dataCodeMeta"],
+    mark: ["className", "class"],
   },
   protocols: {
     ...defaultSchema.protocols,
@@ -1237,6 +1241,7 @@ function ChatMarkdown({
   skills = EMPTY_MARKDOWN_SKILLS,
   className,
   lineBreaks = false,
+  searchQuery,
 }: ChatMarkdownProps) {
   const { resolvedTheme } = useTheme();
   const createAssetUrl = useAtomQueryRunner(assetEnvironment.createUrl, {
@@ -1253,6 +1258,10 @@ function ChatMarkdown({
     serverConfig?.availableEditors ?? [],
   );
   const diffThemeName = resolveDiffThemeName(resolvedTheme);
+  const highlightedText = useMemo(
+    () => (searchQuery ? highlightHtml(text, searchQuery) : text),
+    [searchQuery, text],
+  );
   const markdownFileLinkMetaByHref = useMemo(() => {
     const metaByHref = new Map<
       string,
@@ -1328,6 +1337,9 @@ function ChatMarkdown({
   );
   const markdownComponents = useMemo<Components>(
     () => ({
+      mark({ children }) {
+        return <mark className="search-highlight">{children}</mark>;
+      },
       p({ node: _node, children, ...props }) {
         return <p {...props}>{renderSkillInlineMarkdownChildren(children, skills)}</p>;
       },
@@ -1553,7 +1565,7 @@ function ChatMarkdown({
         components={markdownComponents}
         urlTransform={markdownUrlTransform}
       >
-        {text}
+        {highlightedText}
       </ReactMarkdown>
     </div>
   );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -203,6 +203,8 @@ import { environmentShell } from "../state/shell";
 import { ChatComposer, type ChatComposerHandle } from "./chat/ChatComposer";
 import { ExpandedImageDialog } from "./chat/ExpandedImageDialog";
 import { PullRequestThreadDialog } from "./PullRequestThreadDialog";
+import { findAllMatches, type TextMatch } from "../lib/searchHighlight";
+import { FindInThread } from "./chat/FindInThread";
 import { MessagesTimeline } from "./chat/MessagesTimeline";
 import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
@@ -1110,6 +1112,9 @@ function ChatViewContent(props: ChatViewProps) {
   >({});
   const [isConnecting, _setIsConnecting] = useState(false);
   const [isRevertingCheckpoint, setIsRevertingCheckpoint] = useState(false);
+  const [findOpen, setFindOpen] = useState(false);
+  const [findQuery, setFindQuery] = useState("");
+  const [findActiveMatchIndex, setFindActiveMatchIndex] = useState(0);
   const [maximizedRightPanelThreadKey, setMaximizedRightPanelThreadKey] = useState<string | null>(
     null,
   );
@@ -2063,6 +2068,65 @@ function ChatViewContent(props: ChatViewProps) {
       deriveTimelineEntries(timelineMessages, activeThread?.proposedPlans ?? [], workLogEntries),
     [activeThread?.proposedPlans, timelineMessages, workLogEntries],
   );
+  const timelineMessagesFlat = useMemo(
+    () => timelineEntries.flatMap((entry) => (entry.kind === "message" ? [entry.message] : [])),
+    [timelineEntries],
+  );
+  const findMatches = useMemo(() => {
+    if (!findQuery || !findOpen) return [];
+    const results: Array<{ messageId: string; match: TextMatch }> = [];
+    for (const message of timelineMessagesFlat) {
+      const text = message.text ?? "";
+      const matches = findAllMatches(text, findQuery);
+      for (const match of matches) {
+        results.push({ messageId: message.id, match });
+      }
+    }
+    return results;
+  }, [findQuery, findOpen, timelineMessagesFlat]);
+  const findTotalMatches = findMatches.length;
+  const findMessageIdByMatchIndex = useMemo(
+    () => findMatches.map((match) => match.messageId),
+    [findMatches],
+  );
+  const handleFindNext = useCallback(() => {
+    if (findTotalMatches === 0) return;
+    setFindActiveMatchIndex((index) => {
+      const next = Math.min(index + 1, findTotalMatches - 1);
+      const messageId = findMessageIdByMatchIndex[next];
+      if (messageId) {
+        const element = document.querySelector(`[data-message-id="${messageId}"]`);
+        element?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+      return next;
+    });
+  }, [findTotalMatches, findMessageIdByMatchIndex]);
+  const handleFindPrevious = useCallback(() => {
+    if (findTotalMatches === 0) return;
+    setFindActiveMatchIndex((index) => {
+      const next = Math.max(index - 1, 0);
+      const messageId = findMessageIdByMatchIndex[next];
+      if (messageId) {
+        const element = document.querySelector(`[data-message-id="${messageId}"]`);
+        element?.scrollIntoView({ behavior: "smooth", block: "center" });
+      }
+      return next;
+    });
+  }, [findTotalMatches, findMessageIdByMatchIndex]);
+  const openFind = useCallback(() => {
+    setFindOpen(true);
+    setFindQuery("");
+    setFindActiveMatchIndex(0);
+  }, []);
+  const closeFind = useCallback(() => {
+    setFindOpen(false);
+    setFindQuery("");
+    setFindActiveMatchIndex(0);
+  }, []);
+  const handleFindQueryChange = useCallback((query: string) => {
+    setFindQuery(query);
+    setFindActiveMatchIndex(0);
+  }, []);
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
   const turnDiffSummaryByAssistantMessageId = useMemo(() => {
@@ -3673,6 +3737,35 @@ function ChatViewContent(props: ChatViewProps) {
 
   useEffect(() => {
     const handler = (event: globalThis.KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+
+      if (findOpen) {
+        if (event.key === "Escape" && !event.metaKey && !event.ctrlKey) {
+          event.preventDefault();
+          event.stopPropagation();
+          closeFind();
+          return;
+        }
+      }
+
+      if (
+        (event.metaKey || event.ctrlKey) &&
+        event.key.toLowerCase() === "f" &&
+        !event.shiftKey &&
+        !event.altKey
+      ) {
+        if (isCommandPaletteOpen()) return;
+        if (!activeThreadId) return;
+        event.preventDefault();
+        event.stopPropagation();
+        if (findOpen) {
+          closeFind();
+        } else {
+          openFind();
+        }
+        return;
+      }
+
       if (!activeThreadId || isCommandPaletteOpen()) {
         return;
       }
@@ -3814,6 +3907,9 @@ function ChatViewContent(props: ChatViewProps) {
     toggleRightPanel,
     toggleTerminalVisibility,
     composerRef,
+    findOpen,
+    closeFind,
+    openFind,
   ]);
 
   const onRevertToTurnCount = useCallback(
@@ -5068,6 +5164,17 @@ function ChatViewContent(props: ChatViewProps) {
           <div className="relative flex min-h-0 min-w-0 flex-1 flex-col">
             {/* Messages Wrapper */}
             <div className="relative flex min-h-0 flex-1 flex-col">
+              {findOpen ? (
+                <FindInThread
+                  query={findQuery}
+                  onQueryChange={handleFindQueryChange}
+                  matchIndex={findActiveMatchIndex}
+                  totalMatches={findTotalMatches}
+                  onNext={handleFindNext}
+                  onPrevious={handleFindPrevious}
+                  onClose={closeFind}
+                />
+              ) : null}
               {/* Messages — LegendList handles virtualization and scrolling internally */}
               <MessagesTimeline
                 key={activeThread.id}
@@ -5101,6 +5208,9 @@ function ChatViewContent(props: ChatViewProps) {
                 contentInsetEndAdjustment={composerOverlayHeight}
                 onIsAtEndChange={onIsAtEndChange}
                 onManualNavigation={cancelTimelineLiveFollowForUserNavigation}
+                findQuery={findQuery}
+                findActiveMatchIndex={findActiveMatchIndex}
+                findMatches={findMatches}
               />
 
               {/* scroll to end pill — shown when user has scrolled away from the live edge */}

--- a/apps/web/src/components/chat/FindInThread.tsx
+++ b/apps/web/src/components/chat/FindInThread.tsx
@@ -1,0 +1,160 @@
+import { useCallback, useEffect, useRef } from "react";
+import { cn } from "~/lib/utils";
+
+interface FindInThreadProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+  matchIndex: number;
+  totalMatches: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  onClose: () => void;
+}
+
+export function FindInThread({
+  query,
+  onQueryChange,
+  matchIndex,
+  totalMatches,
+  onNext,
+  onPrevious,
+  onClose,
+}: FindInThreadProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      onQueryChange(e.target.value);
+    },
+    [onQueryChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+      if (e.key === "Enter") {
+        e.preventDefault();
+        if (e.shiftKey) {
+          onPrevious();
+        } else {
+          onNext();
+        }
+        return;
+      }
+    },
+    [onClose, onNext, onPrevious],
+  );
+
+  const hasMatches = totalMatches > 0;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 border-b border-border bg-background px-3 py-1.5 text-xs sm:px-5",
+      )}
+      onPointerDown={(e) => e.stopPropagation()}
+    >
+      <svg
+        className="size-3.5 shrink-0 text-muted-foreground/60"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <path d="m21 21-4.3-4.3" />
+      </svg>
+      <input
+        ref={inputRef}
+        type="text"
+        value={query}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        placeholder="Find in thread..."
+        spellCheck={false}
+        autoComplete="off"
+        className="min-w-0 flex-1 bg-transparent text-xs text-foreground outline-none placeholder:text-muted-foreground/40"
+      />
+      {query && (
+        <span className="whitespace-nowrap tabular-nums text-muted-foreground/60">
+          {hasMatches ? `${matchIndex + 1}/${totalMatches}` : "0/0"}
+        </span>
+      )}
+      {query && (
+        <>
+          <button
+            type="button"
+            onClick={onPrevious}
+            disabled={!hasMatches}
+            className="flex size-5 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:text-foreground disabled:opacity-30"
+            title="Previous match (Shift+Enter)"
+            aria-label="Previous match"
+          >
+            <svg
+              className="size-3"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m18 15-6-6-6 6" />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            disabled={!hasMatches}
+            className="flex size-5 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:text-foreground disabled:opacity-30"
+            title="Next match (Enter)"
+            aria-label="Next match"
+          >
+            <svg
+              className="size-3"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m6 9 6 6 6-6" />
+            </svg>
+          </button>
+        </>
+      )}
+      <button
+        type="button"
+        onClick={onClose}
+        className="flex size-5 items-center justify-center rounded text-muted-foreground/50 transition-colors hover:text-foreground"
+        title="Close (Escape)"
+        aria-label="Close find"
+      >
+        <svg
+          className="size-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M18 6 6 18" />
+          <path d="m6 6 12 12" />
+        </svg>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -39,6 +39,7 @@ import {
   resolveFileDiffPath,
 } from "../../lib/diffRendering";
 import ChatMarkdown from "../ChatMarkdown";
+import { type TextMatch } from "../../lib/searchHighlight";
 import {
   BotIcon,
   CheckIcon,
@@ -134,6 +135,9 @@ interface TimelineRowSharedState {
   onOpenTurnDiff: (turnId: TurnId, filePath?: string) => void;
   onToggleTurnFold: (turnId: TurnId) => void;
   onToggleWorkGroup: (groupId: string, anchorElement?: HTMLElement) => void;
+  findQuery: string;
+  findActiveMatchIndex: number;
+  findMatches: Array<{ messageId: string; match: TextMatch }>;
 }
 
 interface TimelineRowActivityState {
@@ -179,6 +183,9 @@ interface MessagesTimelineProps {
   contentInsetEndAdjustment: number;
   onIsAtEndChange: (isAtEnd: boolean) => void;
   onManualNavigation: () => void;
+  findQuery?: string;
+  findActiveMatchIndex?: number;
+  findMatches?: Array<{ messageId: string; match: TextMatch }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +219,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
   contentInsetEndAdjustment,
   onIsAtEndChange,
   onManualNavigation,
+  findQuery = "",
+  findActiveMatchIndex = 0,
+  findMatches = [],
 }: MessagesTimelineProps) {
   const [expandedTurnIds, setExpandedTurnIds] = useState<ReadonlySet<TurnId>>(new Set());
   const [expandedWorkGroupIds, setExpandedWorkGroupIds] = useState<ReadonlySet<string>>(new Set());
@@ -421,6 +431,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onOpenTurnDiff,
       onToggleTurnFold,
       onToggleWorkGroup,
+      findQuery,
+      findActiveMatchIndex,
+      findMatches,
     }),
     [
       timestampFormat,
@@ -435,6 +448,9 @@ export const MessagesTimeline = memo(function MessagesTimeline({
       onOpenTurnDiff,
       onToggleTurnFold,
       onToggleWorkGroup,
+      findQuery,
+      findActiveMatchIndex,
+      findMatches,
     ],
   );
   const activityState = useMemo<TimelineRowActivityState>(
@@ -795,6 +811,14 @@ type TimelineWorkEntry = Extract<MessagesTimelineRow, { kind: "work" }>["grouped
 type TimelineRow = MessagesTimelineRow;
 
 const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: TimelineRow }) {
+  const ctx = use(TimelineRowCtx);
+  const messageId = row.kind === "message" ? row.message.id : null;
+  const hasActiveMatch =
+    messageId !== null &&
+    ctx.findQuery.length > 0 &&
+    ctx.findMatches.length > 0 &&
+    ctx.findMatches[ctx.findActiveMatchIndex]?.messageId === messageId;
+
   return (
     <div
       className={cn(
@@ -811,6 +835,7 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
       data-timeline-row-kind={row.kind}
       data-message-id={row.kind === "message" ? row.message.id : undefined}
       data-message-role={row.kind === "message" ? row.message.role : undefined}
+      data-search-active-match={hasActiveMatch || undefined}
     >
       {row.kind === "work" ? <WorkGroupSection groupedEntries={row.groupedEntries} /> : null}
       {row.kind === "work-toggle" ? <WorkGroupToggleTimelineRow row={row} /> : null}
@@ -987,6 +1012,7 @@ function AssistantTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "mess
           threadRef={ctx.threadRef ?? undefined}
           isStreaming={Boolean(row.message.streaming)}
           skills={ctx.skills}
+          {...(ctx.findQuery ? { searchQuery: ctx.findQuery } : {})}
         />
         <AssistantChangedFilesSection
           turnSummary={row.assistantTurnDiffSummary}
@@ -1045,6 +1071,7 @@ function ProposedPlanTimelineRow({
         threadRef={ctx.threadRef ?? undefined}
         cwd={ctx.markdownCwd}
         workspaceRoot={ctx.workspaceRoot}
+        {...(ctx.findQuery ? { searchQuery: ctx.findQuery } : {})}
       />
     </div>
   );
@@ -1462,6 +1489,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
   markdownCwd: string | undefined;
 }) {
   const ctx = use(TimelineRowCtx);
+  const searchQueryProps = ctx.findQuery ? { searchQuery: ctx.findQuery } : {};
   const renderInlineMarkdownSegment = (text: string, key: string) => {
     const leadingWhitespace = /^\s+/.exec(text)?.[0] ?? "";
     const textWithoutLeadingWhitespace = text.slice(leadingWhitespace.length);
@@ -1482,6 +1510,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
             skills={props.skills}
             className="text-foreground"
             lineBreaks
+            {...searchQueryProps}
           />
         ) : null}
         {trailingWhitespace ? <span aria-hidden="true">{trailingWhitespace}</span> : null}
@@ -1504,6 +1533,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
                   skills={props.skills}
                   className="text-foreground"
                   lineBreaks
+                  {...searchQueryProps}
                 />
               </div>
             ) : null
@@ -1592,6 +1622,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
           skills={props.skills}
           className="text-foreground"
           lineBreaks
+          {...searchQueryProps}
         />,
       );
     } else if (inlinePrefix.length === 0) {
@@ -1617,6 +1648,7 @@ const UserMessageBody = memo(function UserMessageBody(props: {
       skills={props.skills}
       className="text-foreground"
       lineBreaks
+      {...searchQueryProps}
     />
   );
 });

--- a/apps/web/src/components/chat/ProposedPlanCard.tsx
+++ b/apps/web/src/components/chat/ProposedPlanCard.tsx
@@ -39,12 +39,14 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
   threadRef,
   cwd,
   workspaceRoot,
+  searchQuery,
 }: {
   planMarkdown: string;
   environmentId: EnvironmentId;
   threadRef?: ScopedThreadRef | undefined;
   cwd: string | undefined;
   workspaceRoot: string | undefined;
+  searchQuery?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
@@ -177,6 +179,7 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
               cwd={cwd}
               threadRef={threadRef}
               isStreaming={false}
+              {...(searchQuery ? { searchQuery } : {})}
             />
           ) : (
             <ChatMarkdown
@@ -184,6 +187,7 @@ export const ProposedPlanCard = memo(function ProposedPlanCard({
               cwd={cwd}
               threadRef={threadRef}
               isStreaming={false}
+              {...(searchQuery ? { searchQuery } : {})}
             />
           )}
           {canCollapse && !expanded ? (

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -891,3 +891,30 @@ label:has(> select#reasoning-effort) select {
 .dark .model-picker-list::-webkit-scrollbar-thumb:hover {
   background: rgba(255, 255, 255, 0.15);
 }
+
+mark.search-highlight {
+  background: oklch(0.87 0.15 85);
+  color: inherit;
+  border-radius: 0.125rem;
+}
+
+.dark mark.search-highlight {
+  background: oklch(0.45 0.12 85);
+  color: inherit;
+}
+
+[data-search-active-match] mark.search-highlight {
+  background: oklch(0.78 0.18 85);
+  outline: 2px solid oklch(0.65 0.2 85);
+  outline-offset: 1px;
+}
+
+.dark [data-search-active-match] mark.search-highlight {
+  background: oklch(0.5 0.15 85);
+  outline: 2px solid oklch(0.6 0.18 85);
+  outline-offset: 1px;
+}
+
+[data-search-active-match] {
+  scroll-margin: 120px;
+}

--- a/apps/web/src/lib/searchHighlight.ts
+++ b/apps/web/src/lib/searchHighlight.ts
@@ -1,0 +1,28 @@
+export interface TextMatch {
+  start: number;
+  end: number;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function findAllMatches(text: string, query: string): TextMatch[] {
+  if (!query || !text) return [];
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  const matches: TextMatch[] = [];
+  let pos = 0;
+  while ((pos = lowerText.indexOf(lowerQuery, pos)) !== -1) {
+    matches.push({ start: pos, end: pos + lowerQuery.length });
+    pos += 1;
+  }
+  return matches;
+}
+
+/** Wraps all occurrences of `query` in `text` with `<mark>` tags. */
+export function highlightHtml(text: string, query: string): string {
+  if (!query || !text) return text;
+  const escaped = escapeRegex(query);
+  return text.replace(new RegExp(`(${escaped})`, "gi"), '<mark class="search-highlight">$1</mark>');
+}


### PR DESCRIPTION
## Summary

- Restore thread-local find (Cmd+F) in the chat view with highlighted matches
- Add next/previous navigation and scroll-to-active-match in the message timeline
- Highlight search terms in markdown-rendered assistant/user content

## Test plan

- [ ] Open a thread with several messages, press Cmd+F (Ctrl+F on non-Mac)
- [ ] Search for a term that appears in multiple messages; verify match count and highlights
- [ ] Use next/previous controls; verify active match scrolls into view
- [ ] Close find bar with Escape; verify highlights clear
- [ ] Confirm proposed plan cards and markdown code blocks highlight correctly


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add find-in-thread search triggered by Cmd+F in chat view
> - Adds a `FindInThread` UI bar that opens with Cmd/Ctrl+F and closes with Escape, with next/previous match navigation via buttons or Enter/Shift+Enter.
> - Introduces [`searchHighlight.ts`](https://github.com/pingdotgg/t3code/pull/3779/files#diff-91a745f132aa98bedfab018483529d82f52c3c88b2c378f15110414c486794fb) with `findAllMatches` and `highlightHtml` utilities for case-insensitive substring detection and `<mark>` tag injection.
> - Propagates `findQuery` and match state through `MessagesTimeline` context to highlight matches in assistant messages, user messages, and proposed plan cards via `ChatMarkdown`.
> - Extends the markdown sanitize schema in [`ChatMarkdown.tsx`](https://github.com/pingdotgg/t3code/pull/3779/files#diff-70b5bb003244414202733c39403081a84415e222927a1ef415599958115c0c05) to allow `<mark>` tags, and adds CSS in [`index.css`](https://github.com/pingdotgg/t3code/pull/3779/files#diff-70ad657a634ce55957729ff8d1c93f697cc7e3ca2a5cb5fe6b00c90d7d515fcd) to style highlighted and active matches with scroll-margin support.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 3175584. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->