### PR TITLE
fix(grok): fail fast when Grok CLI is not authenticated

### DIFF
--- a/apps/server/src/provider/Drivers/GrokDriver.ts
+++ b/apps/server/src/provider/Drivers/GrokDriver.ts
@@ -85,6 +85,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
   create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
       const httpClient = yield* HttpClient.HttpClient;
       const serverSettings = yield* ServerSettingsService;
       const eventLoggers = yield* ProviderEventLoggers;
@@ -115,6 +117,8 @@ export const GrokDriver: ProviderDriver<GrokSettings, GrokDriverEnv> = {
       const checkProvider = checkGrokProviderStatus(effectiveConfig, processEnv).pipe(
         Effect.map(stampIdentity),
         Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
       );
 
       const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -56,7 +56,9 @@ import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
 import {
   applyGrokAcpModelSelection,
   currentGrokModelIdFromSessionSetup,
+  GROK_UNAUTHENTICATED_MESSAGE,
   makeGrokAcpRuntime,
+  probeGrokCliCredentialsWithServices,
   resolveGrokAcpBaseModelId,
 } from "../acp/GrokAcpSupport.ts";
 import {
@@ -547,6 +549,19 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           }
 
           const cwd = path.resolve(input.cwd.trim());
+          const environment = options?.environment ?? process.env;
+          const hasCredentials = yield* probeGrokCliCredentialsWithServices(
+            fileSystem,
+            path,
+            environment,
+          );
+          if (!hasCredentials) {
+            return yield* new ProviderAdapterProcessError({
+              provider: PROVIDER,
+              threadId: input.threadId,
+              detail: GROK_UNAUTHENTICATED_MESSAGE,
+            });
+          }
           const grokModelSelection =
             input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
           const existing = sessions.get(input.threadId);
@@ -572,7 +587,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
           const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
           const acp = yield* makeGrokAcpRuntime({
             grokSettings,
-            ...(options?.environment ? { environment: options.environment } : {}),
+            environment,
             childProcessSpawner,
             cwd,
             ...(resumeSessionId ? { resumeSessionId } : {}),

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -6,6 +6,7 @@ import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { GrokSettings } from "@t3tools/contracts";
 
+import { GROK_UNAUTHENTICATED_MESSAGE } from "../acp/GrokAcpSupport.ts";
 import { buildInitialGrokProviderSnapshot, checkGrokProviderStatus } from "./GrokProvider.ts";
 
 const decodeGrokSettings = Schema.decodeSync(GrokSettings);
@@ -81,6 +82,32 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
     }),
   );
 
+  it.effect("reports unauthenticated before ACP model discovery when credentials are missing", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const homeDirectory = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-unauth-" });
+      const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-cli-" });
+      const grokPath = path.join(dir, "grok");
+      yield* fs.writeFileString(
+        grokPath,
+        ["#!/bin/sh", 'printf "grok-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
+      );
+      yield* fs.chmod(grokPath, 0o755);
+
+      const snapshot = yield* checkGrokProviderStatus(
+        decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+        { HOME: homeDirectory },
+      );
+
+      expect(snapshot.status).toBe("error");
+      expect(snapshot.installed).toBe(true);
+      expect(snapshot.auth.status).toBe("unauthenticated");
+      expect(snapshot.message).toBe(GROK_UNAUTHENTICATED_MESSAGE);
+      expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-build"]);
+    }),
+  );
+
   it.effect("reports an error when ACP model discovery is unavailable", () =>
     Effect.gen(function* () {
       const snapshot = yield* Effect.scoped(
@@ -97,6 +124,7 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
 
           return yield* checkGrokProviderStatus(
             decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
+            { XAI_API_KEY: "xai-test" },
           );
         }),
       );

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -10,6 +10,8 @@ import { causeErrorTag } from "@t3tools/shared/observability";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
 import { HttpClient } from "effect/unstable/http";
@@ -29,7 +31,12 @@ import {
   enrichProviderSnapshotWithVersionAdvisory,
   type ProviderMaintenanceCapabilities,
 } from "../providerMaintenance.ts";
-import { makeGrokAcpRuntime, resolveGrokAcpBaseModelId } from "../acp/GrokAcpSupport.ts";
+import {
+  GROK_UNAUTHENTICATED_MESSAGE,
+  makeGrokAcpRuntime,
+  probeGrokCliCredentials,
+  resolveGrokAcpBaseModelId,
+} from "../acp/GrokAcpSupport.ts";
 
 const GROK_PRESENTATION = {
   displayName: "Grok",
@@ -167,7 +174,11 @@ const runGrokVersionCommand = (
 export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(function* (
   grokSettings: GrokSettings,
   environment: NodeJS.ProcessEnv = process.env,
-): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
+): Effect.fn.Return<
+  ServerProviderDraft,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner | FileSystem.FileSystem | Path.Path
+> {
   const checkedAt = DateTime.formatIso(yield* DateTime.now);
   const fallbackModels = grokModelsFromSettings(grokSettings.customModels);
 
@@ -253,6 +264,23 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
     });
   }
 
+  const hasCredentials = yield* probeGrokCliCredentials(environment);
+  if (!hasCredentials) {
+    return buildServerProvider({
+      presentation: GROK_PRESENTATION,
+      enabled: grokSettings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status: "error",
+        auth: { status: "unauthenticated" },
+        message: GROK_UNAUTHENTICATED_MESSAGE,
+      },
+    });
+  }
+
   const discoveryExit = yield* discoverGrokModelsViaAcp(grokSettings, environment).pipe(
     Effect.timeoutOption(GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS),
     Effect.exit,
@@ -289,7 +317,7 @@ export const checkGrokProviderStatus = Effect.fn("checkGrokProviderStatus")(func
         version,
         status: "error",
         auth: { status: "unknown" },
-        message: `Grok CLI is installed but ACP startup timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms.`,
+        message: `Grok CLI ACP startup timed out after ${GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS}ms. If you have not signed in, run \`grok login\` and try again.`,
       },
     });
   }

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -1,10 +1,18 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
 import * as EffectAcpErrors from "effect-acp/errors";
 
 import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
+  grokAuthJsonHasCredentials,
+  GROK_UNAUTHENTICATED_MESSAGE,
+  hasGrokApiKeyInEnvironment,
+  probeGrokCliCredentials,
+  resolveGrokAuthJsonPath,
   resolveGrokAcpBaseModelId,
 } from "./GrokAcpSupport.ts";
 
@@ -13,6 +21,55 @@ describe("resolveGrokAcpBaseModelId", () => {
     expect(resolveGrokAcpBaseModelId(undefined)).toBe("grok-build");
     expect(resolveGrokAcpBaseModelId("   ")).toBe("grok-build");
     expect(resolveGrokAcpBaseModelId("  grok-test-custom-model  ")).toBe("grok-test-custom-model");
+  });
+});
+
+describe("grok credential helpers", () => {
+  it("detects API key environment variables", () => {
+    expect(hasGrokApiKeyInEnvironment({})).toBe(false);
+    expect(hasGrokApiKeyInEnvironment({ XAI_API_KEY: "   " })).toBe(false);
+    expect(hasGrokApiKeyInEnvironment({ XAI_API_KEY: "xai-test" })).toBe(true);
+  });
+
+  it("parses cached Grok auth.json credentials", () => {
+    expect(grokAuthJsonHasCredentials("")).toBe(false);
+    expect(grokAuthJsonHasCredentials("{}")).toBe(false);
+    expect(
+      grokAuthJsonHasCredentials(
+        '{"https://auth.x.ai::example":{"refresh_token":"refresh-token"}}',
+      ),
+    ).toBe(true);
+    expect(grokAuthJsonHasCredentials('{"https://auth.x.ai::example":{"key":"api-key"}}')).toBe(
+      true,
+    );
+  });
+
+  it("resolves the default Grok auth.json path", () => {
+    expect(resolveGrokAuthJsonPath("/home/user")).toBe("/home/user/.grok/auth.json");
+  });
+
+  it.effect("probes credentials from env or auth.json", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const homeDirectory = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-auth-" });
+      const authPath = path.join(homeDirectory, ".grok", "auth.json");
+      yield* fs.makeDirectory(path.join(homeDirectory, ".grok"), { recursive: true });
+
+      expect(yield* probeGrokCliCredentials({}, homeDirectory)).toBe(false);
+
+      yield* fs.writeFileString(
+        authPath,
+        '{"https://auth.x.ai::example":{"refresh_token":"refresh-token"}}',
+      );
+      expect(yield* probeGrokCliCredentials({}, homeDirectory)).toBe(true);
+      expect(yield* probeGrokCliCredentials({ XAI_API_KEY: "xai-test" }, homeDirectory)).toBe(true);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it("documents the unauthenticated guidance message", () => {
+    expect(GROK_UNAUTHENTICATED_MESSAGE).toContain("grok login");
+    expect(GROK_UNAUTHENTICATED_MESSAGE).toContain("XAI_API_KEY");
   });
 });
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -1,7 +1,10 @@
 import { type GrokSettings, ProviderDriverKind } from "@t3tools/contracts";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 import * as Scope from "effect/Scope";
+import * as NodeOS from "node:os";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import * as EffectAcpErrors from "effect-acp/errors";
 import type * as EffectAcpSchema from "effect-acp/schema";
@@ -10,7 +13,10 @@ import { normalizeModelSlug } from "@t3tools/shared/model";
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 import { makeXAiPromptCompletionRuntime } from "./XAiAcpExtension.ts";
 
-const GROK_API_KEY_ENV = "XAI_API_KEY";
+export const GROK_API_KEY_ENV = "XAI_API_KEY";
+export const GROK_AUTH_JSON_RELATIVE_PATH = ".grok/auth.json";
+export const GROK_UNAUTHENTICATED_MESSAGE =
+  "Grok CLI is not authenticated. Run `grok login` in a terminal or set XAI_API_KEY in provider environment variables.";
 const GROK_OAUTH2_REFERRER_ENV = "GROK_OAUTH2_REFERRER";
 const T3_CODE_OAUTH_REFERRER = "t3code";
 const GROK_AUTH_METHOD_API_KEY = "xai.api_key";
@@ -45,10 +51,85 @@ export function buildGrokAcpSpawnInput(
 }
 
 function resolveGrokAuthMethodId(environment: NodeJS.ProcessEnv | undefined): string {
-  return environment?.[GROK_API_KEY_ENV]?.trim()
+  return hasGrokApiKeyInEnvironment(environment)
     ? GROK_AUTH_METHOD_API_KEY
     : GROK_AUTH_METHOD_CACHED_TOKEN;
 }
+
+export function resolveGrokAuthJsonPath(homeDirectory: string): string {
+  const normalizedHome = homeDirectory.replace(/\/$/, "");
+  return `${normalizedHome}/${GROK_AUTH_JSON_RELATIVE_PATH}`;
+}
+
+export function hasGrokApiKeyInEnvironment(environment: NodeJS.ProcessEnv | undefined): boolean {
+  const apiKey = environment?.[GROK_API_KEY_ENV]?.trim();
+  return apiKey !== undefined && apiKey.length > 0;
+}
+
+export function grokAuthJsonHasCredentials(content: string): boolean {
+  const trimmed = content.trim();
+  if (trimmed.length === 0) {
+    return false;
+  }
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return false;
+    }
+    for (const entry of Object.values(parsed as Record<string, unknown>)) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        continue;
+      }
+      const record = entry as Record<string, unknown>;
+      if (typeof record.refresh_token === "string" && record.refresh_token.trim().length > 0) {
+        return true;
+      }
+      if (typeof record.key === "string" && record.key.trim().length > 0) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function probeGrokCliCredentialsWithServices(
+  fileSystem: FileSystem.FileSystem,
+  pathService: Path.Path,
+  environment: NodeJS.ProcessEnv = process.env,
+  homeDirectory?: string,
+): Effect.Effect<boolean> {
+  return Effect.gen(function* () {
+    if (hasGrokApiKeyInEnvironment(environment)) {
+      return true;
+    }
+    const resolvedHomeDirectory =
+      homeDirectory ??
+      (environment.HOME?.trim() || environment.USERPROFILE?.trim() || NodeOS.homedir());
+    const authPath = pathService.join(resolvedHomeDirectory, GROK_AUTH_JSON_RELATIVE_PATH);
+    const exists = yield* fileSystem.exists(authPath);
+    if (!exists) {
+      return false;
+    }
+    const content = yield* fileSystem.readFileString(authPath).pipe(Effect.orElseSucceed(() => ""));
+    return grokAuthJsonHasCredentials(content);
+  }).pipe(Effect.catch(() => Effect.succeed(false)));
+}
+
+export const probeGrokCliCredentials = Effect.fn("probeGrokCliCredentials")(function* (
+  environment: NodeJS.ProcessEnv = process.env,
+  homeDirectory?: string,
+) {
+  const fileSystem = yield* FileSystem.FileSystem;
+  const pathService = yield* Path.Path;
+  return yield* probeGrokCliCredentialsWithServices(
+    fileSystem,
+    pathService,
+    environment,
+    homeDirectory,
+  );
+});
 
 export const makeGrokAcpRuntime = (
   input: GrokAcpRuntimeInput,


### PR DESCRIPTION
## Problem

When Grok is enabled in T3 Code but the user has not signed in, provider status checks and thread startup hang for **15 seconds** and then report:

> Grok CLI is installed but ACP startup timed out after 15000ms.

This is confusing because the real issue is missing authentication, not a slow or broken ACP handshake.

## Root cause

Grok ACP startup follows this sequence:

1. `grok agent stdio`
2. `initialize`
3. `authenticate` with `cached_token` (unless `XAI_API_KEY` is set)
4. `session/new`

If the user has **no** `XAI_API_KEY` and **no** cached credentials in `~/.grok/auth.json`, the `authenticate` RPC waits indefinitely for interactive OAuth. T3 Code does not implement Grok's URL elicitation / terminal auth flow, so the call never completes. After the existing 15s discovery timeout, we surface a generic timeout error.

**Workaround today:** run `grok login` in a terminal, or set `XAI_API_KEY` in provider environment variables.

## Solution

Add a lightweight **preflight credential probe** before ACP model discovery and thread startup:

- Treat `XAI_API_KEY` in the provider environment as authenticated.
- Otherwise, read `~/.grok/auth.json` and look for issuer-keyed entries containing `refresh_token` or `key` (Grok's actual auth.json shape).
- If neither is present, return immediately with `auth: { status: "unauthenticated" }` and an actionable message instead of starting ACP.

### User-facing message

```
Grok CLI is not authenticated. Run `grok login` in a terminal or set XAI_API_KEY in provider environment variables.
```

### Where the check runs

| Location | When |
|----------|------|
| `GrokProvider.checkGrokProviderStatus` | Provider enable / status refresh |
| `GrokAdapter.startSession` | Starting a Grok thread |

The timeout message for genuine ACP slowness was also updated to mention `grok login` as a possible cause.

## Out of scope (future work)

This PR does **not** wire in-app browser OAuth via ACP URL elicitation (`grok.com` login from within T3 Code). That would be a larger follow-up. This change matches the Codex pattern of guiding users to `codex login` when credentials are missing.

## Testing

- Added unit tests for credential helpers (`hasGrokApiKeyInEnvironment`, `grokAuthJsonHasCredentials`, `probeGrokCliCredentials`).
- Added provider status test: unauthenticated preflight returns `auth: unauthenticated` without hitting ACP.
- Existing ACP discovery test now passes `XAI_API_KEY` to bypass the auth gate.

```
vp test GrokAcpSupport GrokProvider
```

17 tests pass.

---

**Note:** PR #3783 was closed — it was accidentally opened against a branch that included unrelated Android parity work from fork `main`. This PR is rebased on upstream `main` and contains only the 6 Grok auth files above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Grok provider behavior with read-only credential probing; no changes to core auth or other providers.
> 
> **Overview**
> Adds a **preflight credential check** for Grok so missing auth no longer surfaces as a 15s ACP timeout.
> 
> Before ACP model discovery (`checkGrokProviderStatus`) and before starting a thread (`GrokAdapter.startSession`), the server treats **`XAI_API_KEY`** in provider env as authenticated, or reads **`~/.grok/auth.json`** for issuer entries with `refresh_token` or `key`. If neither is present, it returns immediately with **`auth: unauthenticated`** and a shared message pointing users to **`grok login`** or **`XAI_API_KEY`**.
> 
> `GrokDriver` wires **FileSystem** and **Path** into status checks. The genuine ACP timeout message now also mentions **`grok login`** as a possible cause. Unit tests cover the credential helpers and the unauthenticated provider-status path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c595058af750d7c308fea2e9a53d52a51bfb300a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fail fast with unauthenticated error in Grok provider when CLI credentials are missing
> - `checkGrokProviderStatus` in [GrokProvider.ts](https://github.com/pingdotgg/t3code/pull/3784/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f) now probes for Grok CLI credentials after detecting the CLI version; if missing, it returns an `unauthenticated` auth status with a clear message instead of attempting ACP model discovery.
> - `startSession` in [GrokAdapter.ts](https://github.com/pingdotgg/t3code/pull/3784/files#diff-1a00c5b795ace1b6633f05c6d3b900dc8d4778afd1879ebdbdf3fb41d04ed521) also fails fast with a `ProviderAdapterProcessError` when credentials are absent, before creating the ACP runtime.
> - New helpers (`probeGrokCliCredentials`, `grokAuthJsonHasCredentials`, `resolveGrokAuthJsonPath`) in [GrokAcpSupport.ts](https://github.com/pingdotgg/t3code/pull/3784/files#diff-7753f9dffb0a8ad069a7e71c1fae3be3596c6a535c8a6108711f2c575bca5ac4) check for credentials via `XAI_API_KEY` env var or `~/.grok/auth.json`.
> - The ACP startup timeout error message now includes guidance to run `grok login`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c595058.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->