### PR TITLE
feat(web): start a thread in an existing worktree

### DIFF
--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -2,6 +2,7 @@ import { EnvironmentId, type VcsRef } from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 import {
   dedupeRemoteBranchesWithLocalMatches,
+  deriveExistingWorktreeOptions,
   deriveLocalBranchNameFromRemoteRef,
   resolveEnvironmentOptionLabel,
   resolveBranchSelectionTarget,
@@ -16,6 +17,52 @@ import {
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
 const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+
+describe("deriveExistingWorktreeOptions", () => {
+  const ref = (
+    name: string,
+    worktreePath: string | null,
+  ): Pick<VcsRef, "name" | "worktreePath"> => ({
+    name,
+    worktreePath,
+  });
+
+  it("lists worktrees from refs, excluding main checkout and the current worktree", () => {
+    const options = deriveExistingWorktreeOptions({
+      refs: [
+        ref("main", "/repo"), // main checkout — excluded
+        ref("feature/current", "/home/.t3/worktrees/repo/t3code-current"), // active — excluded
+        ref("t3code/aaa", "/home/.t3/worktrees/repo/t3code-aaa"),
+        ref("fix/bbb", "/home/.t3/worktrees/repo/t3code-bbb"),
+        ref("origin/remote-only", null), // no worktree — excluded
+      ],
+      activeProjectCwd: "/repo",
+      activeWorktreePath: "/home/.t3/worktrees/repo/t3code-current",
+    });
+    expect(options).toEqual([
+      {
+        branch: "t3code/aaa",
+        worktreePath: "/home/.t3/worktrees/repo/t3code-aaa",
+        folderName: "t3code-aaa",
+      },
+      {
+        branch: "fix/bbb",
+        worktreePath: "/home/.t3/worktrees/repo/t3code-bbb",
+        folderName: "t3code-bbb",
+      },
+    ]);
+  });
+
+  it("dedupes by worktree path and returns empty when none qualify", () => {
+    expect(
+      deriveExistingWorktreeOptions({
+        refs: [ref("main", "/repo"), ref("HEAD", "/repo")],
+        activeProjectCwd: "/repo",
+        activeWorktreePath: null,
+      }),
+    ).toEqual([]);
+  });
+});
 
 describe("resolveDraftEnvModeAfterBranchChange", () => {
   it("switches to local mode when returning from an existing worktree to the main worktree", () => {

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -200,8 +200,10 @@ describe("resolveCurrentWorkspaceLabel", () => {
     expect(resolveCurrentWorkspaceLabel(null)).toBe("Current checkout");
   });
 
-  it("describes the active checkout as a worktree when one is attached", () => {
-    expect(resolveCurrentWorkspaceLabel("/repo/.t3/worktrees/feature-a")).toBe("Current worktree");
+  it("names the active worktree by its folder when one is attached", () => {
+    expect(resolveCurrentWorkspaceLabel("/repo/.t3/worktrees/feature-a")).toBe(
+      "Current worktree · feature-a",
+    );
   });
 });
 
@@ -210,8 +212,10 @@ describe("resolveLockedWorkspaceLabel", () => {
     expect(resolveLockedWorkspaceLabel(null)).toBe("Local checkout");
   });
 
-  it("uses a shorter label for an attached worktree", () => {
-    expect(resolveLockedWorkspaceLabel("/repo/.t3/worktrees/feature-a")).toBe("Worktree");
+  it("names the attached worktree by its folder", () => {
+    expect(resolveLockedWorkspaceLabel("/repo/.t3/worktrees/feature-a")).toBe(
+      "Worktree · feature-a",
+    );
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -62,6 +62,26 @@ describe("deriveExistingWorktreeOptions", () => {
       }),
     ).toEqual([]);
   });
+
+  it("excludes and dedupes on a canonical path spelling (separators / trailing slash)", () => {
+    const options = deriveExistingWorktreeOptions({
+      refs: [
+        ref("main", "/repo/"), // main checkout, trailing slash — still excluded
+        ref("feature/current", "C:\\wt\\current"), // active, backslashes — still excluded
+        ref("t3code/aaa", "/home/wt/t3code-aaa"),
+        ref("t3code/aaa-dupe", "/home/wt/t3code-aaa/"), // same dir, trailing slash — deduped
+      ],
+      activeProjectCwd: "/repo",
+      activeWorktreePath: "C:/wt/current",
+    });
+    expect(options).toEqual([
+      {
+        branch: "t3code/aaa",
+        worktreePath: "/home/wt/t3code-aaa",
+        folderName: "t3code-aaa",
+      },
+    ]);
+  });
 });
 
 describe("resolveDraftEnvModeAfterBranchChange", () => {

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -1,6 +1,6 @@
 import type { EnvironmentId, VcsRef, ProjectId } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
-import { formatWorktreePathForDisplay } from "../worktreeCleanup";
+import { canonicalizeWorktreePath, formatWorktreePathForDisplay } from "../worktreeCleanup";
 export {
   dedupeRemoteBranchesWithLocalMatches,
   deriveLocalBranchNameFromRemoteRef,
@@ -36,14 +36,21 @@ export function deriveExistingWorktreeOptions(input: {
   activeWorktreePath: string | null;
 }): ExistingWorktreeOption[] {
   const { refs, activeProjectCwd, activeWorktreePath } = input;
+  // Compare on a canonical form (separators/trailing slash normalized) so a
+  // worktree spelled differently by `git worktree list` and client state is
+  // still excluded/deduped instead of leaking into the list.
+  const canonicalProjectCwd = canonicalizeWorktreePath(activeProjectCwd);
+  const canonicalActiveWorktree = canonicalizeWorktreePath(activeWorktreePath);
   const byPath = new Map<string, ExistingWorktreeOption>();
   for (const ref of refs) {
     const worktreePath = ref.worktreePath;
     if (!worktreePath) continue;
-    if (worktreePath === activeProjectCwd) continue;
-    if (worktreePath === activeWorktreePath) continue;
-    if (byPath.has(worktreePath)) continue;
-    byPath.set(worktreePath, {
+    const canonical = canonicalizeWorktreePath(worktreePath);
+    if (!canonical) continue;
+    if (canonical === canonicalProjectCwd) continue;
+    if (canonical === canonicalActiveWorktree) continue;
+    if (byPath.has(canonical)) continue;
+    byPath.set(canonical, {
       branch: ref.name,
       worktreePath,
       folderName: formatWorktreePathForDisplay(worktreePath),

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -94,11 +94,13 @@ export function resolveEnvModeLabel(mode: EnvMode): string {
 }
 
 export function resolveCurrentWorkspaceLabel(activeWorktreePath: string | null): string {
-  return activeWorktreePath ? "Current worktree" : resolveEnvModeLabel("local");
+  if (!activeWorktreePath) return resolveEnvModeLabel("local");
+  return `Current worktree · ${formatWorktreePathForDisplay(activeWorktreePath)}`;
 }
 
 export function resolveLockedWorkspaceLabel(activeWorktreePath: string | null): string {
-  return activeWorktreePath ? "Worktree" : "Local checkout";
+  if (!activeWorktreePath) return "Local checkout";
+  return `Worktree · ${formatWorktreePathForDisplay(activeWorktreePath)}`;
 }
 
 export function resolveEffectiveEnvMode(input: {

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -1,9 +1,56 @@
 import type { EnvironmentId, VcsRef, ProjectId } from "@t3tools/contracts";
 import * as Schema from "effect/Schema";
+import { formatWorktreePathForDisplay } from "../worktreeCleanup";
 export {
   dedupeRemoteBranchesWithLocalMatches,
   deriveLocalBranchNameFromRemoteRef,
 } from "@t3tools/shared/git";
+
+/**
+ * An existing git worktree that a thread can be started in. Derived from the
+ * branch ref list (each ref carries its `worktreePath` from `git worktree
+ * list`), so it surfaces worktrees created by t3code AND by other tools
+ * (JetBrains/git/etc.) as long as the worktree has a checked-out branch.
+ */
+/** Prefix used to encode an existing-worktree choice as a Select/Menu value. */
+export const EXISTING_WORKTREE_VALUE_PREFIX = "existing-worktree:";
+
+export interface ExistingWorktreeOption {
+  /** The branch checked out in the worktree (used to bind the thread). */
+  branch: string;
+  /** Absolute worktree path (used as the thread's cwd). */
+  worktreePath: string;
+  /** Short label — the worktree's folder name (e.g. `t3code-4e609bb8`). */
+  folderName: string;
+}
+
+/**
+ * Collect the existing worktrees a thread could be started in, from the branch
+ * refs. Excludes the project's main checkout and the currently-active worktree
+ * (those are already covered by the "Current checkout" option). Deduped by
+ * worktree path and sorted by folder name.
+ */
+export function deriveExistingWorktreeOptions(input: {
+  refs: ReadonlyArray<Pick<VcsRef, "name" | "worktreePath">>;
+  activeProjectCwd: string | null;
+  activeWorktreePath: string | null;
+}): ExistingWorktreeOption[] {
+  const { refs, activeProjectCwd, activeWorktreePath } = input;
+  const byPath = new Map<string, ExistingWorktreeOption>();
+  for (const ref of refs) {
+    const worktreePath = ref.worktreePath;
+    if (!worktreePath) continue;
+    if (worktreePath === activeProjectCwd) continue;
+    if (worktreePath === activeWorktreePath) continue;
+    if (byPath.has(worktreePath)) continue;
+    byPath.set(worktreePath, {
+      branch: ref.name,
+      worktreePath,
+      folderName: formatWorktreePathForDisplay(worktreePath),
+    });
+  }
+  return [...byPath.values()].sort((a, b) => a.folderName.localeCompare(b.folderName));
+}
 
 export interface EnvironmentOption {
   environmentId: EnvironmentId;

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -418,6 +418,9 @@ export const BranchToolbar = memo(function BranchToolbar({
         {...(activeThreadWorktreePathOverride !== undefined
           ? { activeWorktreePathOverride: activeThreadWorktreePathOverride }
           : {})}
+        {...(onActiveThreadWorktreePathOverrideChange
+          ? { onActiveWorktreePathOverrideChange: onActiveThreadWorktreePathOverrideChange }
+          : {})}
         startFromOrigin={startFromOrigin}
         onStartFromOriginChange={onStartFromOriginChange}
         {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -51,6 +51,8 @@ interface BranchToolbarProps {
   effectiveEnvModeOverride?: EnvMode;
   activeThreadBranchOverride?: string | null;
   onActiveThreadBranchOverrideChange?: (branch: string | null) => void;
+  activeThreadWorktreePathOverride?: string | null;
+  onActiveThreadWorktreePathOverrideChange?: (worktreePath: string | null) => void;
   startFromOrigin: boolean;
   onStartFromOriginChange: (startFromOrigin: boolean) => void;
   envLocked: boolean;
@@ -233,6 +235,8 @@ export const BranchToolbar = memo(function BranchToolbar({
   effectiveEnvModeOverride,
   activeThreadBranchOverride,
   onActiveThreadBranchOverrideChange,
+  activeThreadWorktreePathOverride,
+  onActiveThreadWorktreePathOverrideChange,
   startFromOrigin,
   onStartFromOriginChange,
   envLocked,
@@ -256,7 +260,12 @@ export const BranchToolbar = memo(function BranchToolbar({
       : null;
   const activeProject = useProject(activeProjectRef);
   const hasActiveThread = serverThread !== null || draftThread !== null;
-  const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
+  // Reflect an optimistic "existing worktree" pick immediately so the env-mode
+  // lock, labels and the branch picker's cwd don't lag the metadata round-trip.
+  const activeWorktreePath =
+    activeThreadWorktreePathOverride !== undefined
+      ? activeThreadWorktreePathOverride
+      : (serverThread?.worktreePath ?? draftThread?.worktreePath ?? null);
   const effectiveEnvMode =
     effectiveEnvModeOverride ??
     resolveEffectiveEnvMode({
@@ -304,10 +313,14 @@ export const BranchToolbar = memo(function BranchToolbar({
         void stopThreadSession({ environmentId, input: { threadId: mutationThreadId } });
       }
       if (serverThread !== null) {
-        // Set the env-mode override optimistically so a send that races the
-        // async metadata round-trip already runs in the chosen worktree
-        // instead of the thread's prior (local) mode.
+        // Set the env-mode, branch and worktree-path overrides optimistically
+        // so a send that races the async metadata round-trip already runs in
+        // the chosen worktree instead of the thread's prior (local) mode. The
+        // worktree-path override is what stops that raced send from spawning a
+        // brand-new worktree and keeps the branch picker pointed at the chosen
+        // worktree until the metadata update lands.
         onEnvModeChange("worktree");
+        onActiveThreadWorktreePathOverrideChange?.(option.worktreePath);
         void updateThreadMetadata({
           environmentId,
           input: {
@@ -337,6 +350,7 @@ export const BranchToolbar = memo(function BranchToolbar({
       stopThreadSession,
       updateThreadMetadata,
       onActiveThreadBranchOverrideChange,
+      onActiveThreadWorktreePathOverrideChange,
       onEnvModeChange,
       setDraftThreadContext,
       draftId,
@@ -401,6 +415,9 @@ export const BranchToolbar = memo(function BranchToolbar({
         {...(effectiveEnvModeOverride ? { effectiveEnvModeOverride } : {})}
         {...(activeThreadBranchOverride !== undefined ? { activeThreadBranchOverride } : {})}
         {...(onActiveThreadBranchOverrideChange ? { onActiveThreadBranchOverrideChange } : {})}
+        {...(activeThreadWorktreePathOverride !== undefined
+          ? { activeWorktreePathOverride: activeThreadWorktreePathOverride }
+          : {})}
         startFromOrigin={startFromOrigin}
         onStartFromOriginChange={onStartFromOriginChange}
         {...(onCheckoutPullRequestRequest ? { onCheckoutPullRequestRequest } : {})}

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -304,6 +304,10 @@ export const BranchToolbar = memo(function BranchToolbar({
         void stopThreadSession({ environmentId, input: { threadId: mutationThreadId } });
       }
       if (serverThread !== null) {
+        // Set the env-mode override optimistically so a send that races the
+        // async metadata round-trip already runs in the chosen worktree
+        // instead of the thread's prior (local) mode.
+        onEnvModeChange("worktree");
         void updateThreadMetadata({
           environmentId,
           input: {
@@ -333,6 +337,7 @@ export const BranchToolbar = memo(function BranchToolbar({
       stopThreadSession,
       updateThreadMetadata,
       onActiveThreadBranchOverrideChange,
+      onEnvModeChange,
       setDraftThreadContext,
       draftId,
       threadRef,

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -8,14 +8,20 @@ import {
   FolderIcon,
   MonitorIcon,
 } from "lucide-react";
-import { memo, useMemo } from "react";
+import { memo, useCallback, useMemo } from "react";
 
 import { useComposerDraftStore, type DraftId } from "../composerDraftStore";
 import { useProject, useThread } from "../state/entities";
+import { useBranches } from "../state/queries";
+import { threadEnvironment } from "../state/threads";
+import { useAtomCommand } from "../state/use-atom-command";
 import { useIsMobile } from "../hooks/useMediaQuery";
 import {
+  deriveExistingWorktreeOptions,
   type EnvMode,
   type EnvironmentOption,
+  EXISTING_WORKTREE_VALUE_PREFIX,
+  type ExistingWorktreeOption,
   resolveCurrentWorkspaceLabel,
   resolveEnvModeLabel,
   resolveEffectiveEnvMode,
@@ -64,6 +70,8 @@ interface MobileRunContextSelectorProps {
   effectiveEnvMode: EnvMode;
   activeWorktreePath: string | null;
   onEnvModeChange: (mode: EnvMode) => void;
+  existingWorktrees: readonly ExistingWorktreeOption[];
+  onSelectExistingWorktree: (option: ExistingWorktreeOption) => void;
 }
 
 const MobileRunContextSelector = memo(function MobileRunContextSelector({
@@ -76,6 +84,8 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
   effectiveEnvMode,
   activeWorktreePath,
   onEnvModeChange,
+  existingWorktrees,
+  onSelectExistingWorktree,
 }: MobileRunContextSelectorProps) {
   const activeEnvironment = useMemo(
     () => availableEnvironments?.find((env) => env.environmentId === environmentId) ?? null,
@@ -163,7 +173,17 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
           <MenuGroupLabel>Workspace</MenuGroupLabel>
           <MenuRadioGroup
             value={effectiveEnvMode}
-            onValueChange={(value) => onEnvModeChange(value as EnvMode)}
+            onValueChange={(value) => {
+              if (value.startsWith(EXISTING_WORKTREE_VALUE_PREFIX)) {
+                const worktreePath = value.slice(EXISTING_WORKTREE_VALUE_PREFIX.length);
+                const option = existingWorktrees.find(
+                  (entry) => entry.worktreePath === worktreePath,
+                );
+                if (option) onSelectExistingWorktree(option);
+                return;
+              }
+              onEnvModeChange(value as EnvMode);
+            }}
           >
             <MenuRadioItem disabled={envModeLocked} value="local">
               <span className="flex min-w-0 items-center gap-1.5">
@@ -183,6 +203,21 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
                 <span className="min-w-0 truncate">{resolveEnvModeLabel("worktree")}</span>
               </span>
             </MenuRadioItem>
+            {existingWorktrees.map((option) => (
+              <MenuRadioItem
+                key={option.worktreePath}
+                disabled={envModeLocked}
+                value={`${EXISTING_WORKTREE_VALUE_PREFIX}${option.worktreePath}`}
+              >
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <FolderGitIcon className="size-3 shrink-0" />
+                  <span className="min-w-0 truncate">{option.branch}</span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground/45">
+                    {option.folderName}
+                  </span>
+                </span>
+              </MenuRadioItem>
+            ))}
           </MenuRadioGroup>
         </MenuGroup>
       </MenuPopup>
@@ -231,6 +266,80 @@ export const BranchToolbar = memo(function BranchToolbar({
     });
   const envModeLocked = envLocked || (serverThread !== null && activeWorktreePath !== null);
 
+  // Existing worktrees a fresh thread can be started in. Sourced from the
+  // branch refs (each ref carries its `worktreePath` from `git worktree list`,
+  // so t3code- and externally-created worktrees both appear). Only fetched
+  // while the workspace selector is interactive.
+  const activeProjectCwd = activeProject?.workspaceRoot ?? null;
+  const worktreeRefsQuery = useBranches({
+    environmentId,
+    cwd: envModeLocked ? null : activeProjectCwd,
+  });
+  const existingWorktrees = useMemo(
+    () =>
+      deriveExistingWorktreeOptions({
+        refs: worktreeRefsQuery.data?.refs ?? [],
+        activeProjectCwd,
+        activeWorktreePath,
+      }),
+    [worktreeRefsQuery.data?.refs, activeProjectCwd, activeWorktreePath],
+  );
+
+  const setDraftThreadContext = useComposerDraftStore((store) => store.setDraftThreadContext);
+  const updateThreadMetadata = useAtomCommand(
+    threadEnvironment.updateMetadata,
+    "thread metadata update",
+  );
+  const stopThreadSession = useAtomCommand(threadEnvironment.stopSession, "thread session stop");
+
+  // Bind the thread (draft or server) to an existing worktree. Mirrors the
+  // branch selector's `setThreadBranch` reuse path: no git op runs — the
+  // server just adopts the provided worktree path as the thread's cwd.
+  const onSelectExistingWorktree = useCallback(
+    (option: ExistingWorktreeOption) => {
+      if (!activeProject) return;
+      const mutationThreadId = serverThread?.id ?? (draftThread ? threadId : undefined);
+      if (!mutationThreadId) return;
+      if (serverThread?.session && option.worktreePath !== activeWorktreePath) {
+        void stopThreadSession({ environmentId, input: { threadId: mutationThreadId } });
+      }
+      if (serverThread !== null) {
+        void updateThreadMetadata({
+          environmentId,
+          input: {
+            threadId: mutationThreadId,
+            branch: option.branch,
+            worktreePath: option.worktreePath,
+          },
+        });
+        onActiveThreadBranchOverrideChange?.(option.branch);
+      } else {
+        setDraftThreadContext(draftId ?? threadRef, {
+          branch: option.branch,
+          worktreePath: option.worktreePath,
+          envMode: "worktree",
+          projectRef: scopeProjectRef(environmentId, activeProject.id),
+        });
+      }
+      onComposerFocusRequest?.();
+    },
+    [
+      activeProject,
+      serverThread,
+      draftThread,
+      threadId,
+      activeWorktreePath,
+      environmentId,
+      stopThreadSession,
+      updateThreadMetadata,
+      onActiveThreadBranchOverrideChange,
+      setDraftThreadContext,
+      draftId,
+      threadRef,
+      onComposerFocusRequest,
+    ],
+  );
+
   const showEnvironmentPicker = Boolean(
     availableEnvironments && availableEnvironments.length > 1 && onEnvironmentChange,
   );
@@ -251,6 +360,8 @@ export const BranchToolbar = memo(function BranchToolbar({
           effectiveEnvMode={effectiveEnvMode}
           activeWorktreePath={activeWorktreePath}
           onEnvModeChange={onEnvModeChange}
+          existingWorktrees={existingWorktrees}
+          onSelectExistingWorktree={onSelectExistingWorktree}
         />
       ) : (
         <div className="flex min-w-0 shrink-0 items-center gap-1">
@@ -270,6 +381,8 @@ export const BranchToolbar = memo(function BranchToolbar({
             effectiveEnvMode={effectiveEnvMode}
             activeWorktreePath={activeWorktreePath}
             onEnvModeChange={onEnvModeChange}
+            existingWorktrees={existingWorktrees}
+            onSelectExistingWorktree={onSelectExistingWorktree}
           />
         </div>
       )}

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -68,6 +68,7 @@ interface BranchToolbarBranchSelectorProps {
   activeThreadBranchOverride?: string | null;
   onActiveThreadBranchOverrideChange?: (refName: string | null) => void;
   activeWorktreePathOverride?: string | null;
+  onActiveWorktreePathOverrideChange?: (worktreePath: string | null) => void;
   startFromOrigin: boolean;
   onStartFromOriginChange: (startFromOrigin: boolean) => void;
   onCheckoutPullRequestRequest?: (reference: string) => void;
@@ -103,6 +104,7 @@ export function BranchToolbarBranchSelector({
   activeThreadBranchOverride,
   onActiveThreadBranchOverrideChange,
   activeWorktreePathOverride,
+  onActiveWorktreePathOverrideChange,
   startFromOrigin,
   onStartFromOriginChange,
   onCheckoutPullRequestRequest,
@@ -188,6 +190,11 @@ export function BranchToolbarBranchSelector({
       }
       if (hasServerThread) {
         onActiveThreadBranchOverrideChange?.(branch);
+        // Keep the parent's optimistic worktree-path override in step with the
+        // branch action; otherwise picking a branch that retargets the main
+        // checkout (worktreePath === null) leaves a stale override pinning
+        // branchCwd and the next send to the previously-picked worktree.
+        onActiveWorktreePathOverrideChange?.(worktreePath);
         return;
       }
       const nextDraftEnvMode = resolveDraftEnvModeAfterBranchChange({
@@ -209,6 +216,7 @@ export function BranchToolbarBranchSelector({
       activeWorktreePath,
       hasServerThread,
       onActiveThreadBranchOverrideChange,
+      onActiveWorktreePathOverrideChange,
       setDraftThreadContext,
       draftId,
       threadRef,

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -67,6 +67,7 @@ interface BranchToolbarBranchSelectorProps {
   effectiveEnvModeOverride?: "local" | "worktree";
   activeThreadBranchOverride?: string | null;
   onActiveThreadBranchOverrideChange?: (refName: string | null) => void;
+  activeWorktreePathOverride?: string | null;
   startFromOrigin: boolean;
   onStartFromOriginChange: (startFromOrigin: boolean) => void;
   onCheckoutPullRequestRequest?: (reference: string) => void;
@@ -101,6 +102,7 @@ export function BranchToolbarBranchSelector({
   effectiveEnvModeOverride,
   activeThreadBranchOverride,
   onActiveThreadBranchOverrideChange,
+  activeWorktreePathOverride,
   startFromOrigin,
   onStartFromOriginChange,
   onCheckoutPullRequestRequest,
@@ -144,7 +146,13 @@ export function BranchToolbarBranchSelector({
     activeThreadBranchOverride !== undefined
       ? activeThreadBranchOverride
       : (serverThread?.branch ?? draftThread?.branch ?? null);
-  const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
+  // An optimistic "existing worktree" pick must steer branch git ops to the
+  // chosen worktree immediately; otherwise `branchCwd` falls back to the main
+  // checkout until the metadata round-trip lands.
+  const activeWorktreePath =
+    activeWorktreePathOverride !== undefined
+      ? activeWorktreePathOverride
+      : (serverThread?.worktreePath ?? draftThread?.worktreePath ?? null);
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const branchCwd = activeWorktreePath ?? activeProjectCwd;
   const hasServerThread = serverThread !== null;

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -2,6 +2,8 @@ import { FolderGit2Icon, FolderGitIcon, FolderIcon } from "lucide-react";
 import { memo, useMemo } from "react";
 
 import {
+  EXISTING_WORKTREE_VALUE_PREFIX,
+  type ExistingWorktreeOption,
   resolveCurrentWorkspaceLabel,
   resolveEnvModeLabel,
   resolveLockedWorkspaceLabel,
@@ -22,6 +24,8 @@ interface BranchToolbarEnvModeSelectorProps {
   effectiveEnvMode: EnvMode;
   activeWorktreePath: string | null;
   onEnvModeChange: (mode: EnvMode) => void;
+  existingWorktrees: readonly ExistingWorktreeOption[];
+  onSelectExistingWorktree: (option: ExistingWorktreeOption) => void;
 }
 
 export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSelector({
@@ -29,14 +33,31 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
   effectiveEnvMode,
   activeWorktreePath,
   onEnvModeChange,
+  existingWorktrees,
+  onSelectExistingWorktree,
 }: BranchToolbarEnvModeSelectorProps) {
   const envModeItems = useMemo(
     () => [
       { value: "local", label: resolveCurrentWorkspaceLabel(activeWorktreePath) },
       { value: "worktree", label: resolveEnvModeLabel("worktree") },
+      ...existingWorktrees.map((option) => ({
+        value: `${EXISTING_WORKTREE_VALUE_PREFIX}${option.worktreePath}`,
+        label: option.branch,
+      })),
     ],
-    [activeWorktreePath],
+    [activeWorktreePath, existingWorktrees],
   );
+
+  const handleValueChange = (value: string | null) => {
+    if (value === null) return;
+    if (value.startsWith(EXISTING_WORKTREE_VALUE_PREFIX)) {
+      const worktreePath = value.slice(EXISTING_WORKTREE_VALUE_PREFIX.length);
+      const option = existingWorktrees.find((entry) => entry.worktreePath === worktreePath);
+      if (option) onSelectExistingWorktree(option);
+      return;
+    }
+    onEnvModeChange(value as EnvMode);
+  };
 
   if (envLocked) {
     return (
@@ -60,7 +81,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
     <Select
       modal={false}
       value={effectiveEnvMode}
-      onValueChange={(value) => onEnvModeChange(value as EnvMode)}
+      onValueChange={handleValueChange}
       items={envModeItems}
     >
       <SelectTrigger variant="ghost" size="xs" className="font-medium" aria-label="Workspace">
@@ -93,6 +114,25 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
             </span>
           </SelectItem>
         </SelectGroup>
+        {existingWorktrees.length > 0 ? (
+          <SelectGroup>
+            <SelectGroupLabel>Existing worktrees</SelectGroupLabel>
+            {existingWorktrees.map((option) => (
+              <SelectItem
+                key={option.worktreePath}
+                value={`${EXISTING_WORKTREE_VALUE_PREFIX}${option.worktreePath}`}
+              >
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <FolderGitIcon className="size-3 shrink-0" />
+                  <span className="min-w-0 truncate">{option.branch}</span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground/45">
+                    {option.folderName}
+                  </span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        ) : null}
       </SelectPopup>
     </Select>
   );

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -4119,13 +4119,23 @@ function ChatViewContent(props: ChatViewProps) {
     );
 
     let failure: AtomCommandResult<unknown, unknown> | null = null;
-    // Auto-title from first message
+    // Auto-title from first message. When an existing worktree was picked but
+    // its metadata update may still be in flight (optimistic override present
+    // while the thread's own worktreePath is still null), persist the branch +
+    // worktree path in this same *awaited* round-trip so the server binds the
+    // chosen worktree before startThreadTurn runs, instead of racing the
+    // fire-and-forget update and starting the turn with a null path.
+    const pendingWorktreeSync =
+      isFirstMessage && !activeThread.worktreePath && effectiveActiveWorktreePath
+        ? { branch: activeThreadBranch, worktreePath: effectiveActiveWorktreePath }
+        : {};
     if (isFirstMessage && isServerThread) {
       const titleResult = await updateThreadMetadata({
         environmentId,
         input: {
           threadId: threadIdForSend,
           title,
+          ...pendingWorktreeSync,
         },
       });
       if (titleResult._tag === "Failure") {
@@ -4862,6 +4872,11 @@ function ChatViewContent(props: ChatViewProps) {
     (mode: DraftThreadEnvMode) => {
       if (canOverrideServerThreadEnvMode) {
         setPendingServerThreadEnvMode(mode);
+        // Drop any optimistic existing-worktree pick: switching to Current
+        // checkout or New worktree abandons it. onSelectExistingWorktree calls
+        // onEnvModeChange("worktree") and then immediately re-sets the path
+        // override, so an actual existing-worktree pick is preserved.
+        setPendingServerThreadWorktreePath(undefined);
         scheduleComposerFocus();
         return;
       }
@@ -4884,6 +4899,7 @@ function ChatViewContent(props: ChatViewProps) {
       isLocalDraftThread,
       settings.newWorktreesStartFromOrigin,
       setPendingServerThreadEnvMode,
+      setPendingServerThreadWorktreePath,
       scheduleComposerFocus,
       setDraftThreadContext,
     ],

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -1139,6 +1139,14 @@ function ChatViewContent(props: ChatViewProps) {
   const [pendingServerThreadEnvMode, setPendingServerThreadEnvMode] =
     useState<DraftThreadEnvMode | null>(null);
   const [pendingServerThreadBranch, setPendingServerThreadBranch] = useState<string | null>();
+  // Optimistic worktree path for a fresh server thread that just picked an
+  // existing worktree, mirroring `pendingServerThreadBranch`. It closes the
+  // window before `updateThreadMetadata` resolves: without it a racing first
+  // send sees `worktreePath === null` and spawns a brand-new worktree, and the
+  // branch picker runs git in the main checkout instead of the chosen worktree.
+  const [pendingServerThreadWorktreePath, setPendingServerThreadWorktreePath] = useState<
+    string | null
+  >();
   const [
     pendingServerThreadStartFromOriginByThreadId,
     setPendingServerThreadStartFromOriginByThreadId,
@@ -3582,6 +3590,14 @@ function ChatViewContent(props: ChatViewProps) {
     canOverrideServerThreadEnvMode && pendingServerThreadBranch !== undefined
       ? pendingServerThreadBranch
       : (activeThread?.branch ?? null);
+  // Worktree path the thread will actually run in, reflecting an optimistic
+  // "existing worktree" pick before the metadata round-trip lands. Once the
+  // server persists the path, `canOverrideServerThreadEnvMode` flips false and
+  // this falls back to the real thread state.
+  const effectiveActiveWorktreePath =
+    canOverrideServerThreadEnvMode && pendingServerThreadWorktreePath !== undefined
+      ? pendingServerThreadWorktreePath
+      : (activeThread?.worktreePath ?? null);
   const startFromOrigin = isLocalDraftThread
     ? (draftThread?.startFromOrigin ?? false)
     : canOverrideServerThreadEnvMode
@@ -3596,6 +3612,7 @@ function ChatViewContent(props: ChatViewProps) {
   useEffect(() => {
     setPendingServerThreadEnvMode(null);
     setPendingServerThreadBranch(undefined);
+    setPendingServerThreadWorktreePath(undefined);
   }, [activeThread?.id]);
 
   useEffect(() => {
@@ -3604,6 +3621,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     setPendingServerThreadEnvMode(null);
     setPendingServerThreadBranch(undefined);
+    setPendingServerThreadWorktreePath(undefined);
   }, [canOverrideServerThreadEnvMode]);
 
   useEffect(() => {
@@ -3966,15 +3984,18 @@ function ChatViewContent(props: ChatViewProps) {
     if (!activeProject) return;
     const threadIdForSend = activeThread.id;
     const isFirstMessage = !isServerThread || activeThread.messages.length === 0;
+    // Respect an optimistically-picked existing worktree: if one is pending we
+    // must not spawn a fresh worktree while its metadata update is in flight.
+    const worktreePathForSend = effectiveActiveWorktreePath;
     const baseBranchForWorktree =
-      isFirstMessage && sendEnvMode === "worktree" && !activeThread.worktreePath
+      isFirstMessage && sendEnvMode === "worktree" && !worktreePathForSend
         ? activeThreadBranch
         : null;
 
     // In worktree mode, require an explicit base branch so we don't silently
     // fall back to local execution when branch selection is missing.
     const shouldCreateWorktree =
-      isFirstMessage && sendEnvMode === "worktree" && !activeThread.worktreePath;
+      isFirstMessage && sendEnvMode === "worktree" && !worktreePathForSend;
     if (shouldCreateWorktree && !activeThreadBranch) {
       setThreadError(threadIdForSend, "Select a base branch before sending in New worktree mode.");
       return;
@@ -4726,6 +4747,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeProject,
     activeProposedPlan,
     activeThreadBranch,
+    effectiveActiveWorktreePath,
     activeThread,
     beginLocalDispatch,
     activeEnvironmentUnavailable,
@@ -5239,6 +5261,9 @@ function ChatViewContent(props: ChatViewProps) {
                         ? {
                             activeThreadBranchOverride: activeThreadBranch,
                             onActiveThreadBranchOverrideChange: setPendingServerThreadBranch,
+                            activeThreadWorktreePathOverride: effectiveActiveWorktreePath,
+                            onActiveThreadWorktreePathOverrideChange:
+                              setPendingServerThreadWorktreePath,
                           }
                         : {})}
                       envLocked={envLocked}

--- a/apps/web/src/worktreeCleanup.ts
+++ b/apps/web/src/worktreeCleanup.ts
@@ -32,6 +32,20 @@ export function getOrphanedWorktreePathForThread(
   return isShared ? null : targetWorktreePath;
 }
 
+/**
+ * Canonicalize an absolute worktree path for equality comparison: trim, unify
+ * separators to `/`, and strip trailing slashes. `git worktree list` and client
+ * state can spell the same directory differently (backslashes, trailing slash);
+ * comparing raw strings would then wrongly treat them as distinct.
+ */
+export function canonicalizeWorktreePath(path: string | null | undefined): string | null {
+  const trimmed = path?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return trimmed.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
 export function formatWorktreePathForDisplay(worktreePath: string): string {
   const trimmed = worktreePath.trim();
   if (!trimmed) {


### PR DESCRIPTION
Closes #3796.

## What changed

Adds an **"Existing worktrees"** group to the workspace selector so a thread can be started directly in a worktree that already exists (t3code-created *or* one made by JetBrains / `git worktree add`), instead of only "Current checkout" / "New worktree".

- `deriveExistingWorktreeOptions` builds the list from the branch refs — each ref already carries `worktreePath` from `git worktree list` (`vcs.listRefs`) — excluding the main checkout and the current worktree, deduped by path.
- Selecting one binds the thread to it: draft via `setDraftThreadContext`, server thread via `updateThreadMetadata` (stopping a running session first). No git op runs — the server adopts the existing worktree path as the thread cwd, mirroring the branch selector's existing `reuseExistingWorktree` path.
- Added to both the desktop workspace `Select` and the mobile radio menu.
- The active-worktree label now includes the folder name (`Current worktree · <name>`) so you can tell which worktree a thread is in.

## Why

Worktrees could be created but not reattached to when starting a thread. This makes it practical to start a clean conversation while continuing to operate on a previous worktree.

## Notes

- **Web-only**; no server/contract changes (reuses `vcs.listRefs` + existing acceptance of a pre-existing `worktreePath` on thread create).
- Rebased on current `main`; refiles the idea from #1094 (closed for staleness, invited to resubmit).
- +263 lines, incl. unit tests for `deriveExistingWorktreeOptions` and the label helpers.
- Known limits: worktrees whose branch isn't in the first 100 refs, and detached-HEAD worktrees, aren't listed.

## Before

<img width="329" height="124" alt="pr3798-worktree-BEFORE-dropdown" src="https://github.com/user-attachments/assets/0485983c-06de-4848-8531-9386b63cecec" />

## After

<img width="329" height="184" alt="pr3798-worktree-AFTER-dropdown" src="https://github.com/user-attachments/assets/00433ebe-85fc-4f49-bcb8-084e1d21dece" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread cwd binding, session stop, and first-send worktree creation races in the composer; mistakes could run turns in the wrong directory or spawn duplicate worktrees, though behavior reuses existing metadata adoption paths with no server changes.
> 
> **Overview**
> Adds an **Existing worktrees** section to the workspace picker (desktop select and mobile menu) so threads can bind to worktrees already on disk—not only **Current checkout** or **New worktree**.
> 
> `deriveExistingWorktreeOptions` builds that list from branch refs’ `worktreePath` (from `git worktree list`), excluding the main checkout and active worktree, with `canonicalizeWorktreePath` for dedupe/exclusion across path spellings. Picking one sets branch + `worktreePath` via draft context or `updateThreadMetadata` (stopping a live session when needed), without creating a new worktree.
> 
> **Optimistic state** in `ChatView`, `BranchToolbar`, and the branch selector keeps labels, `branchCwd`, and first-send logic aligned before metadata lands: pending worktree path overrides avoid spawning a new worktree on a racing first message, and the first send can **await** metadata that includes the chosen path. Workspace labels now show the folder name (e.g. `Current worktree · feature-a`).
> 
> Unit tests cover `deriveExistingWorktreeOptions` and updated label helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78862d454efdbe149fd99b9a067306ac218ce9a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add existing worktree selection to the branch toolbar for starting threads
> - Adds an 'Existing worktrees' group to both the desktop ([BranchToolbarEnvModeSelector.tsx](https://github.com/pingdotgg/t3code/pull/3798/files#diff-f6e603d70ca6bba6f4bb6ec0c74ab245223570c8a33c292fb1d25529770f3f67)) and mobile ([BranchToolbar.tsx](https://github.com/pingdotgg/t3code/pull/3798/files#diff-698af5019ef8a26d8e1653085b9e61762e35f389e79e62d402760255625b0a10)) workspace selectors, listing worktrees derived from `VcsRef.worktreePath` (excluding the main checkout and active worktree).
> - Selecting an existing worktree optimistically updates env mode, workspace label, and branch picker context without waiting for server confirmation.
> - On first message send, the chosen worktree path is passed directly so no new worktree is created; for server threads, branch and worktreePath are persisted before the turn starts via `updateThreadMetadata`.
> - Adds `canonicalizeWorktreePath` in [worktreeCleanup.ts](https://github.com/pingdotgg/t3code/pull/3798/files#diff-f109f3305e8100c828913663ece3ea01fc79d6f70c0d3e367129387a6e647213) to normalize paths (backslashes, trailing slashes) for deduplication and exclusion comparisons.
> - Risk: optimistic state in `ChatViewContent` and `BranchToolbar` must be cleared correctly on thread change and mode switches; mismatches could cause a send to target the wrong worktree.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78862d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->