### PR TITLE
feat: allow switching provider/model mid-conversation

### DIFF
--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.test.ts
@@ -1461,7 +1461,7 @@ describe("ProviderCommandReactor", () => {
     expect(thread?.session?.runtimeMode).toBe("full-access");
   });
 
-  it("rejects provider changes after a thread is already bound to a session provider", async () => {
+  it("hands off a thread to a different provider driver mid-conversation", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -1487,6 +1487,18 @@ describe("ProviderCommandReactor", () => {
 
     await Effect.runPromise(
       harness.engine.dispatch({
+        type: "thread.message.assistant.delta",
+        commandId: CommandId.make("cmd-assistant-provider-switch-1"),
+        threadId: ThreadId.make("thread-1"),
+        messageId: asMessageId("assistant-message-provider-switch-1"),
+        delta: "codex reply before handoff",
+        turnId: asTurnId("turn-1"),
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
         type: "thread.turn.start",
         commandId: CommandId.make("cmd-turn-start-provider-switch-2"),
         threadId: ThreadId.make("thread-1"),
@@ -1506,34 +1518,47 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await harness.readModel();
-      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 2);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 2);
+    await harness.drain();
 
-    expect(harness.startSession.mock.calls.length).toBe(1);
-    expect(harness.sendTurn.mock.calls.length).toBe(1);
-    expect(harness.stopSession.mock.calls.length).toBe(0);
+    // Fresh session on the new driver, without the old driver's resume cursor.
+    expect(harness.startSession.mock.calls[1]?.[1]).toMatchObject({
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+    });
+    expect(harness.startSession.mock.calls[1]?.[1]).not.toHaveProperty("resumeCursor");
+
+    // Prior conversation is replayed as a transcript prelude on the next turn.
+    const handoffTurn = harness.sendTurn.mock.calls[1]?.[0] as { input?: string };
+    expect(handoffTurn.input).toContain("[Conversation handoff]");
+    expect(handoffTurn.input).toContain("first");
+    expect(handoffTurn.input).toContain("codex reply before handoff");
+    expect(handoffTurn.input?.endsWith("second")).toBe(true);
 
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-    expect(thread?.session?.threadId).toBe("thread-1");
-    expect(thread?.session?.providerName).toBe("codex");
-    expect(thread?.session?.runtimeMode).toBe("approval-required");
+    expect(thread?.session?.providerName).toBe("claudeAgent");
+    expect(thread?.modelSelection).toEqual({
+      instanceId: ProviderInstanceId.make("claudeAgent"),
+      model: "claude-opus-4-6",
+    });
     expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
-      },
+      thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toBe(false);
+    // A model-change notice is appended so the UI can render an inline marker.
+    const modelChangeActivity = thread?.activities.find(
+      (activity) => activity.kind === "thread.model-changed",
+    );
+    expect(modelChangeActivity).toBeDefined();
+    expect(modelChangeActivity?.tone).toBe("info");
+    expect(modelChangeActivity?.payload).toMatchObject({
+      toInstanceId: "claudeAgent",
+      toModel: "claude-opus-4-6",
+      isHandoff: true,
     });
   });
 
-  it("rejects cross-driver provider changes after the existing thread session has stopped", async () => {
+  it("hands off to a different driver after the existing thread session has stopped", async () => {
     const harness = await createHarness();
     const now = "2026-01-01T00:00:00.000Z";
 
@@ -1552,6 +1577,17 @@ describe("ProviderCommandReactor", () => {
           lastError: null,
           updatedAt: now,
         },
+        createdAt: now,
+      }),
+    );
+
+    await Effect.runPromise(
+      harness.engine.dispatch({
+        type: "thread.message.assistant.delta",
+        commandId: CommandId.make("cmd-assistant-stopped-provider-switch"),
+        threadId: ThreadId.make("thread-1"),
+        messageId: asMessageId("assistant-message-stopped-provider-switch"),
+        delta: "reply from the stopped codex session",
         createdAt: now,
       }),
     );
@@ -1577,26 +1613,28 @@ describe("ProviderCommandReactor", () => {
       }),
     );
 
-    await waitFor(async () => {
-      const readModel = await harness.readModel();
-      const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-      return (
-        thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed") ??
-        false
-      );
-    });
+    await waitFor(() => harness.startSession.mock.calls.length === 1);
+    await waitFor(() => harness.sendTurn.mock.calls.length === 1);
+    await harness.drain();
 
-    expect(harness.startSession.mock.calls.length).toBe(0);
-    expect(harness.sendTurn.mock.calls.length).toBe(0);
+    expect(harness.startSession.mock.calls[0]?.[1]).toMatchObject({
+      providerInstanceId: ProviderInstanceId.make("claudeAgent"),
+    });
+    const handoffTurn = harness.sendTurn.mock.calls[0]?.[0] as { input?: string };
+    expect(handoffTurn.input).toContain("[Conversation handoff]");
+    expect(handoffTurn.input).toContain("reply from the stopped codex session");
+    expect(handoffTurn.input?.endsWith("continue with claude")).toBe(true);
+
     const readModel = await harness.readModel();
     const thread = readModel.threads.find((entry) => entry.id === ThreadId.make("thread-1"));
-    expect(
-      thread?.activities.find((activity) => activity.kind === "provider.turn.start.failed"),
-    ).toMatchObject({
-      payload: {
-        detail: expect.stringContaining("cannot switch to 'claudeAgent'"),
-      },
+    expect(thread?.session?.providerName).toBe("claudeAgent");
+    expect(thread?.modelSelection).toEqual({
+      instanceId: ProviderInstanceId.make("claudeAgent"),
+      model: "claude-opus-4-6",
     });
+    expect(
+      thread?.activities.some((activity) => activity.kind === "provider.turn.start.failed"),
+    ).toBe(false);
   });
 
   it("reacts to thread.turn.interrupt-requested by calling provider interrupt", async () => {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -4,6 +4,7 @@ import {
   EventId,
   type ModelSelection,
   type OrchestrationEvent,
+  PROVIDER_SEND_TURN_MAX_INPUT_CHARS,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -26,6 +27,10 @@ import * as Stream from "effect/Stream";
 import { makeDrainableWorker } from "@t3tools/shared/DrainableWorker";
 
 import { resolveThreadWorkspaceCwd } from "../../checkpointing/Utils.ts";
+import {
+  HANDOFF_TRANSCRIPT_MAX_CHARS,
+  renderProviderHandoffPrelude,
+} from "../providerHandoffTranscript.ts";
 import { increment, orchestrationEventsProcessedTotal } from "../../observability/Metrics.ts";
 import { ProviderAdapterRequestError } from "../../provider/Errors.ts";
 import type { ProviderServiceError } from "../../provider/Errors.ts";
@@ -428,7 +433,21 @@ const make = Effect.gen(function* () {
       });
     }
     const preferredProvider: ProviderDriverKind = desiredDriverKind;
-    if (thread.session !== null) {
+    // A provider handoff moves the thread to an instance whose resume state is
+    // incompatible with the current one (different driver, or same driver with
+    // a different continuation key). The old session cannot be resumed; the
+    // thread gets a fresh session on the new provider and the caller replays
+    // prior context as a transcript prelude on the next turn.
+    const isProviderHandoff =
+      requestedModelSelection !== undefined &&
+      requestedModelSelection.instanceId !== currentInstanceId &&
+      (currentInfo.driverKind !== desiredInfo.driverKind ||
+        currentInfo.continuationIdentity.continuationKey !==
+          desiredInfo.continuationIdentity.continuationKey);
+    if (thread.session !== null && !isProviderHandoff) {
+      // `requiresNewThreadForModelChange` only constrains model changes within
+      // a provider's own resumable thread. A handoff starts a fresh provider
+      // thread, so the flag does not apply there.
       yield* rejectStartedThreadModelChangeIfRequired({
         threadId,
         currentModelSelection:
@@ -442,29 +461,60 @@ const make = Effect.gen(function* () {
         requestedModelSelection,
       });
     }
-    if (
+    const hasPriorAssistantContext = thread.messages.some(
+      (message) => message.role === "assistant" && message.text.trim().length > 0,
+    );
+    const handedOff = isProviderHandoff && hasPriorAssistantContext;
+    const persistHandoffModelSelection = Effect.gen(function* () {
+      if (!isProviderHandoff) {
+        return;
+      }
+      yield* orchestrationEngine.dispatch({
+        type: "thread.meta.update",
+        commandId: yield* serverCommandId("provider-handoff-model-selection"),
+        threadId,
+        modelSelection: desiredModelSelection,
+      });
+    });
+    // Surface a Codex-style inline notice whenever the user changes the model
+    // or provider on a thread that has already started. `currentModel` reads
+    // the live session first and falls back to the thread's stored selection
+    // (e.g. after a restart drops the live session).
+    const currentModel = activeSession?.model ?? thread.modelSelection.model;
+    const modelSelectionChangedForStartedThread =
       thread.session !== null &&
       requestedModelSelection !== undefined &&
-      requestedModelSelection.instanceId !== currentInstanceId
-    ) {
-      if (currentInfo.driverKind !== desiredInfo.driverKind) {
-        return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
-          method: "thread.turn.start",
-          detail: `Thread '${threadId}' is bound to driver '${currentInfo.driverKind}' and cannot switch to '${desiredInfo.driverKind}'.`,
-        });
+      (desiredInstanceId !== currentInstanceId || desiredModelSelection.model !== currentModel);
+    const appendModelChangedNotice = Effect.gen(function* () {
+      if (!modelSelectionChangedForStartedThread) {
+        return;
       }
-      if (
-        currentInfo.continuationIdentity.continuationKey !==
-        desiredInfo.continuationIdentity.continuationKey
-      ) {
-        return yield* new ProviderAdapterRequestError({
-          provider: preferredProvider,
-          method: "thread.turn.start",
-          detail: `Thread '${threadId}' cannot switch from instance '${currentInstanceId}' to '${desiredInstanceId}' because their provider resume state is incompatible.`,
-        });
-      }
-    }
+      const eventId = yield* serverEventId();
+      const commandId = yield* serverCommandId("thread-model-changed-notice");
+      yield* orchestrationEngine.dispatch({
+        type: "thread.activity.append",
+        commandId,
+        threadId,
+        activity: {
+          id: eventId,
+          tone: "info",
+          kind: "thread.model-changed",
+          summary: `Switched model to ${desiredModelSelection.model}`,
+          payload: {
+            fromInstanceId: String(currentInstanceId),
+            fromModel: currentModel,
+            fromDriverKind: currentInfo.driverKind,
+            toInstanceId: String(desiredInstanceId),
+            toModel: desiredModelSelection.model,
+            toDriverKind: desiredInfo.driverKind,
+            isHandoff: isProviderHandoff,
+          },
+          turnId: null,
+          createdAt,
+        },
+        createdAt,
+      });
+    });
     const project = yield* resolveProject(thread.projectId);
     const effectiveCwd = resolveThreadWorkspaceCwd({
       thread,
@@ -511,6 +561,11 @@ const make = Effect.gen(function* () {
         });
       });
 
+    // Emitted once per turn before the session is (re)started so the notice
+    // renders regardless of which path handles the change — an in-session
+    // model swap (no restart), a session restart, or a cross-provider handoff.
+    yield* appendModelChangedNotice;
+
     const existingSessionThreadId =
       thread.session && thread.session.status !== "stopped" && activeSession ? thread.id : null;
     if (existingSessionThreadId) {
@@ -538,12 +593,15 @@ const make = Effect.gen(function* () {
         !shouldRestartForModelChange &&
         !shouldRestartForModelSelectionChange
       ) {
-        return existingSessionThreadId;
+        return { sessionThreadId: existingSessionThreadId, handedOff: false };
       }
 
-      const resumeCursor = shouldRestartForModelChange
-        ? undefined
-        : (activeSession?.resumeCursor ?? undefined);
+      // A handoff must not carry the old provider's resume cursor: it is
+      // meaningless (or harmful) to the new driver.
+      const resumeCursor =
+        shouldRestartForModelChange || isProviderHandoff
+          ? undefined
+          : (activeSession?.resumeCursor ?? undefined);
       yield* Effect.logInfo("provider command reactor restarting provider session", {
         threadId,
         existingSessionThreadId,
@@ -575,16 +633,19 @@ const make = Effect.gen(function* () {
         cwd: restartedSession.cwd,
       });
       yield* bindSessionToThread(restartedSession);
-      return restartedSession.threadId;
+      yield* persistHandoffModelSelection;
+      return { sessionThreadId: restartedSession.threadId, handedOff };
     }
 
     const startedSession = yield* startProviderSession(undefined);
     yield* bindSessionToThread(startedSession);
-    return startedSession.threadId;
+    yield* persistHandoffModelSelection;
+    return { sessionThreadId: startedSession.threadId, handedOff };
   });
 
   const buildSendTurnRequestForThread = Effect.fnUntraced(function* (input: {
     readonly threadId: ThreadId;
+    readonly messageId?: string;
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
     readonly modelSelection?: ModelSelection;
@@ -597,7 +658,7 @@ const make = Effect.gen(function* () {
         new Error(`Thread '${input.threadId}' was not found in read model.`),
       );
     }
-    yield* ensureSessionForThread(
+    const ensuredSession = yield* ensureSessionForThread(
       input.threadId,
       input.createdAt,
       input.modelSelection !== undefined ? { modelSelection: input.modelSelection } : {},
@@ -606,6 +667,20 @@ const make = Effect.gen(function* () {
       threadModelSelections.set(input.threadId, input.modelSelection);
     }
     const normalizedInput = toNonEmptyProviderInput(input.messageText);
+    const handoffPrelude = ensuredSession.handedOff
+      ? renderProviderHandoffPrelude({
+          messages: thread.messages,
+          activities: thread.activities,
+          ...(input.messageId !== undefined ? { excludeMessageId: input.messageId } : {}),
+          maxChars: Math.min(
+            HANDOFF_TRANSCRIPT_MAX_CHARS,
+            PROVIDER_SEND_TURN_MAX_INPUT_CHARS - (normalizedInput?.length ?? 0) - 1_000,
+          ),
+        })
+      : undefined;
+    const inputWithHandoffPrelude = handoffPrelude
+      ? [handoffPrelude, normalizedInput].filter(Boolean).join("\n\n")
+      : normalizedInput;
     const normalizedAttachments = input.attachments ?? [];
     const activeSession = yield* providerService
       .listSessions()
@@ -637,7 +712,7 @@ const make = Effect.gen(function* () {
 
     return {
       threadId: input.threadId,
-      ...(normalizedInput ? { input: normalizedInput } : {}),
+      ...(inputWithHandoffPrelude ? { input: inputWithHandoffPrelude } : {}),
       ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
       ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
       ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
@@ -839,6 +914,7 @@ const make = Effect.gen(function* () {
 
     const sendTurnRequest = yield* buildSendTurnRequestForThread({
       threadId: event.payload.threadId,
+      messageId: event.payload.messageId,
       messageText: message.text,
       ...(message.attachments !== undefined ? { attachments: message.attachments } : {}),
       ...(event.payload.modelSelection !== undefined

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -395,7 +395,12 @@ const make = Effect.gen(function* () {
       activeSession !== undefined &&
       activeSession.providerInstanceId !== undefined
         ? activeSession.providerInstanceId
-        : thread.modelSelection.instanceId;
+        : // Prefer the last-bound session's provider over the thread's stored
+          // modelSelection: the selection may already have been advanced to the
+          // new provider (e.g. persisted before the turn, or after a prior
+          // handoff) while the thread physically last ran on the old one. Using
+          // the session keeps cross-provider handoff detectable after a restart.
+          (thread.session?.providerInstanceId ?? thread.modelSelection.instanceId);
     const desiredModelSelection = requestedModelSelection ?? thread.modelSelection;
     const desiredInstanceId = desiredModelSelection.instanceId;
     const currentInfo = yield* providerService.getInstanceInfo(currentInstanceId).pipe(
@@ -461,10 +466,11 @@ const make = Effect.gen(function* () {
         requestedModelSelection,
       });
     }
-    const hasPriorAssistantContext = thread.messages.some(
-      (message) => message.role === "assistant" && message.text.trim().length > 0,
-    );
-    const handedOff = isProviderHandoff && hasPriorAssistantContext;
+    // Replay prior context on any provider handoff. The renderer itself
+    // returns `undefined` when there is genuinely nothing to hand off, so we
+    // must not gate on an assistant message specifically — a thread with only
+    // user messages and/or tool activity still has context worth carrying.
+    const handedOff = isProviderHandoff;
     const persistHandoffModelSelection = Effect.gen(function* () {
       if (!isProviderHandoff) {
         return;
@@ -561,11 +567,10 @@ const make = Effect.gen(function* () {
         });
       });
 
-    // Emitted once per turn before the session is (re)started so the notice
-    // renders regardless of which path handles the change — an in-session
-    // model swap (no restart), a session restart, or a cross-provider handoff.
-    yield* appendModelChangedNotice;
-
+    // The model-changed notice is emitted only *after* a session is confirmed
+    // alive on each success path below (in-session no-op, restart, or fresh
+    // start). Emitting it up front would leave a "switched" notice behind if
+    // the (re)start then failed.
     const existingSessionThreadId =
       thread.session && thread.session.status !== "stopped" && activeSession ? thread.id : null;
     if (existingSessionThreadId) {
@@ -593,6 +598,9 @@ const make = Effect.gen(function* () {
         !shouldRestartForModelChange &&
         !shouldRestartForModelSelectionChange
       ) {
+        // In-session model change (no restart) — the live session already
+        // reflects it, so the notice is safe to record here.
+        yield* appendModelChangedNotice;
         return { sessionThreadId: existingSessionThreadId, handedOff: false };
       }
 
@@ -634,12 +642,14 @@ const make = Effect.gen(function* () {
       });
       yield* bindSessionToThread(restartedSession);
       yield* persistHandoffModelSelection;
+      yield* appendModelChangedNotice;
       return { sessionThreadId: restartedSession.threadId, handedOff };
     }
 
     const startedSession = yield* startProviderSession(undefined);
     yield* bindSessionToThread(startedSession);
     yield* persistHandoffModelSelection;
+    yield* appendModelChangedNotice;
     return { sessionThreadId: startedSession.threadId, handedOff };
   });
 

--- a/apps/server/src/orchestration/providerHandoffTranscript.test.ts
+++ b/apps/server/src/orchestration/providerHandoffTranscript.test.ts
@@ -1,0 +1,270 @@
+import {
+  EventId,
+  MessageId,
+  type OrchestrationMessage,
+  type OrchestrationThreadActivity,
+  TurnId,
+} from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { renderProviderHandoffPrelude } from "./providerHandoffTranscript.ts";
+
+const NOW = "2026-01-01T00:00:00.000Z";
+
+function message(
+  id: string,
+  role: OrchestrationMessage["role"],
+  text: string,
+  createdAt: string = NOW,
+): OrchestrationMessage {
+  return {
+    id: MessageId.make(id),
+    role,
+    text,
+    turnId: TurnId.make("turn-1"),
+    streaming: false,
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function activity(overrides: {
+  id: string;
+  kind: string;
+  summary: string;
+  createdAt: string;
+  tone?: OrchestrationThreadActivity["tone"];
+  payload?: Record<string, unknown>;
+}): OrchestrationThreadActivity {
+  return {
+    id: EventId.make(overrides.id),
+    tone: overrides.tone ?? "tool",
+    kind: overrides.kind,
+    summary: overrides.summary,
+    payload: overrides.payload ?? {},
+    turnId: TurnId.make("turn-1"),
+    createdAt: overrides.createdAt,
+  };
+}
+
+describe("renderProviderHandoffPrelude", () => {
+  it("renders user and assistant messages in order with role labels", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [
+        message("m1", "user", "hello"),
+        message("m2", "assistant", "hi there"),
+        message("m3", "user", "do the thing"),
+      ],
+    });
+    expect(prelude).toBeDefined();
+    expect(prelude).toContain("[Conversation handoff]");
+    expect(prelude).toContain("User:\nhello");
+    expect(prelude).toContain("Assistant:\nhi there");
+    expect(prelude?.indexOf("hello")).toBeLessThan(prelude!.indexOf("hi there"));
+    expect(prelude).not.toContain("[Older history omitted for length]");
+  });
+
+  it("excludes the in-flight message and skips system/empty messages", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [
+        message("m1", "user", "hello"),
+        message("m2", "assistant", "hi there"),
+        message("m3", "system", "internal note"),
+        message("m4", "assistant", "   "),
+        message("m5", "user", "current message"),
+      ],
+      excludeMessageId: "m5",
+    });
+    expect(prelude).toContain("hello");
+    expect(prelude).toContain("hi there");
+    expect(prelude).not.toContain("internal note");
+    expect(prelude).not.toContain("current message");
+  });
+
+  it("returns undefined when there is nothing to hand off", () => {
+    expect(renderProviderHandoffPrelude({ messages: [] })).toBeUndefined();
+    expect(
+      renderProviderHandoffPrelude({
+        messages: [message("m1", "user", "only message")],
+        excludeMessageId: "m1",
+      }),
+    ).toBeUndefined();
+    expect(
+      renderProviderHandoffPrelude({
+        messages: [message("m1", "user", "hello")],
+        maxChars: 0,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps the most recent messages and flags truncation when over budget", () => {
+    const messages = Array.from({ length: 50 }, (_, index) =>
+      message(
+        `m${index}`,
+        index % 2 === 0 ? "user" : "assistant",
+        `message ${index} ${"x".repeat(200)}`,
+      ),
+    );
+    const prelude = renderProviderHandoffPrelude({ messages, maxChars: 2_000 });
+    expect(prelude).toBeDefined();
+    expect(prelude!.length).toBeLessThanOrEqual(2_000);
+    expect(prelude).toContain("[Older history omitted for length]");
+    expect(prelude).toContain("message 49");
+    expect(prelude).not.toContain("message 0 ");
+  });
+
+  it("carries a shell command, its exit code, and its output as a structured line", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [
+        message("m1", "user", "what is HEAD?", "2026-01-01T00:00:00.000Z"),
+        message("m2", "assistant", "let me check", "2026-01-01T00:00:03.000Z"),
+      ],
+      activities: [
+        // Real Codex shape: the command is in `detail`; the output and exit
+        // code live in the raw provider item under `data.item`.
+        activity({
+          id: "a1",
+          kind: "tool.completed",
+          summary: "Ran command",
+          createdAt: "2026-01-01T00:00:02.000Z",
+          payload: {
+            itemType: "command_execution",
+            detail: "git rev-parse HEAD",
+            data: {
+              item: {
+                id: "item-1",
+                command: "git rev-parse HEAD",
+                exitCode: 0,
+                aggregatedOutput: "6e42231cb1da130069cbc694f9da4a185067a81f",
+              },
+            },
+          },
+        }),
+      ],
+    });
+    expect(prelude).toBeDefined();
+    // Command shown under the "$" tag, with exit code and raw output.
+    expect(prelude).toContain("[$] git rev-parse HEAD (exit 0)");
+    expect(prelude).toContain("6e42231cb1da130069cbc694f9da4a185067a81f");
+    // Ordered by timestamp: user message, then the tool line, then assistant.
+    expect(prelude!.indexOf("what is HEAD")).toBeLessThan(prelude!.indexOf("[$] git rev-parse"));
+    expect(prelude!.indexOf("[$] git rev-parse")).toBeLessThan(prelude!.indexOf("let me check"));
+  });
+
+  it("renders file edits with their touched paths under an 'edit' tag", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [message("m1", "user", "refactor it", "2026-01-01T00:00:00.000Z")],
+      activities: [
+        activity({
+          id: "a1",
+          kind: "tool.completed",
+          summary: "Edited files",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          payload: {
+            itemType: "file_change",
+            title: "Apply patch",
+            data: {
+              item: {
+                id: "edit-1",
+                changes: [{ path: "src/foo.ts" }, { path: "src/bar.ts" }],
+              },
+            },
+          },
+        }),
+      ],
+    });
+    expect(prelude).toContain("[edit] src/foo.ts, src/bar.ts");
+  });
+
+  it("flags a failed command with its non-zero exit code", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [message("m1", "user", "run tests", "2026-01-01T00:00:00.000Z")],
+      activities: [
+        activity({
+          id: "a1",
+          kind: "tool.completed",
+          summary: "Ran command",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          payload: {
+            itemType: "command_execution",
+            detail: "npm test <exited with exit code 1>",
+            data: { item: { id: "cmd-1", command: "npm test", aggregatedOutput: "1 failing" } },
+          },
+        }),
+      ],
+    });
+    expect(prelude).toContain("[$] npm test (exit 1)");
+    expect(prelude).toContain("1 failing");
+  });
+
+  it("labels an MCP tool call under the 'mcp' tag", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [],
+      activities: [
+        activity({
+          id: "a1",
+          kind: "tool.completed",
+          summary: "MCP call",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          payload: {
+            itemType: "mcp_tool_call",
+            title: "lottie.create",
+            data: { item: { id: "mcp-1", aggregatedOutput: "created animation" } },
+          },
+        }),
+      ],
+    });
+    expect(prelude).toContain("[mcp] lottie.create");
+    expect(prelude).toContain("created animation");
+  });
+
+  it("keeps only the richest line per tool call and truncates long output", () => {
+    const longOutput = "y".repeat(5_000);
+    const prelude = renderProviderHandoffPrelude({
+      messages: [message("m1", "user", "run it", "2026-01-01T00:00:00.000Z")],
+      activities: [
+        activity({
+          id: "a1",
+          kind: "tool.updated",
+          summary: "Running",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          payload: {
+            itemType: "command_execution",
+            data: { item: { id: "call-1", command: "big-cmd" } },
+          },
+        }),
+        activity({
+          id: "a2",
+          kind: "tool.completed",
+          summary: "Ran command",
+          createdAt: "2026-01-01T00:00:02.000Z",
+          payload: {
+            itemType: "command_execution",
+            data: { item: { id: "call-1", command: "big-cmd", aggregatedOutput: longOutput } },
+          },
+        }),
+      ],
+    });
+    expect(prelude).toBeDefined();
+    // Single deduped tool line for call-1, with output truncated.
+    expect(prelude!.match(/\[\$\] big-cmd/g)?.length).toBe(1);
+    expect(prelude).toContain("[truncated]");
+    expect(prelude!.length).toBeLessThan(2_000);
+  });
+
+  it("still renders a tool trail when there are no textual messages", () => {
+    const prelude = renderProviderHandoffPrelude({
+      messages: [],
+      activities: [
+        activity({
+          id: "a1",
+          kind: "tool.completed",
+          summary: "Edited file",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          payload: { title: "Edit src/app.ts" },
+        }),
+      ],
+    });
+    expect(prelude).toContain("[tool] Edit src/app.ts");
+  });
+});

--- a/apps/server/src/orchestration/providerHandoffTranscript.test.ts
+++ b/apps/server/src/orchestration/providerHandoffTranscript.test.ts
@@ -252,6 +252,46 @@ describe("renderProviderHandoffPrelude", () => {
     expect(prelude!.length).toBeLessThan(2_000);
   });
 
+  it("prefers the terminal completed event even when an in-progress update is longer", () => {
+    // A verbose `tool.updated` (streaming partial output, no exit code) must not
+    // shadow the shorter but authoritative `tool.completed` line that carries
+    // the real exit code and final output.
+    const verboseStreaming = "z".repeat(400);
+    const prelude = renderProviderHandoffPrelude({
+      messages: [message("m1", "user", "run it", "2026-01-01T00:00:00.000Z")],
+      activities: [
+        activity({
+          id: "a1",
+          kind: "tool.updated",
+          summary: "Running",
+          createdAt: "2026-01-01T00:00:01.000Z",
+          payload: {
+            itemType: "command_execution",
+            data: { item: { id: "call-1", command: "flaky", aggregatedOutput: verboseStreaming } },
+          },
+        }),
+        activity({
+          id: "a2",
+          kind: "tool.completed",
+          summary: "Ran command",
+          createdAt: "2026-01-01T00:00:02.000Z",
+          payload: {
+            itemType: "command_execution",
+            data: {
+              item: { id: "call-1", command: "flaky", exitCode: 129, aggregatedOutput: "boom" },
+            },
+          },
+        }),
+      ],
+    });
+    expect(prelude).toBeDefined();
+    // Exactly one line for call-1, sourced from the completed event.
+    expect(prelude!.match(/\[\$\] flaky/g)?.length).toBe(1);
+    expect(prelude).toContain("[$] flaky (exit 129)");
+    expect(prelude).toContain("boom");
+    expect(prelude).not.toContain(verboseStreaming);
+  });
+
   it("still renders a tool trail when there are no textual messages", () => {
     const prelude = renderProviderHandoffPrelude({
       messages: [],

--- a/apps/server/src/orchestration/providerHandoffTranscript.ts
+++ b/apps/server/src/orchestration/providerHandoffTranscript.ts
@@ -1,0 +1,366 @@
+/**
+ * providerHandoffTranscript - Renders a thread's neutral message log into a
+ * plain-text prelude for provider handoffs.
+ *
+ * When a thread switches to a provider whose resume state is incompatible with
+ * the previous one (different driver or continuation key), the new provider
+ * session starts with no context: conversation history lives in each
+ * provider's own session state, not in anything the next provider can resume.
+ * This prelude is prepended to the first turn sent to the new provider so it
+ * can pick the conversation up from the orchestration layer's own record.
+ *
+ * The prelude interleaves the user/assistant messages with a compact trail of
+ * the tool activity (commands run, files changed, MCP/skill calls and their
+ * output) so the new provider inherits the actual work done, not just the
+ * previous assistant's prose summary of it.
+ *
+ * @module providerHandoffTranscript
+ */
+import type { OrchestrationMessage, OrchestrationThreadActivity } from "@t3tools/contracts";
+
+export const HANDOFF_TRANSCRIPT_MAX_CHARS = 80_000;
+const TOOL_OUTPUT_MAX_CHARS = 600;
+const TOOL_SUBJECT_MAX_CHARS = 300;
+const MAX_CHANGED_FILES = 12;
+
+const HANDOFF_HEADER = [
+  "[Conversation handoff]",
+  "You are taking over an existing conversation that was previously handled by a different AI assistant.",
+  'The transcript below is the conversation so far. "User:" lines are from the user; "Assistant:" lines were written by the previous assistant.',
+  'Lines in [brackets] are the tools the previous assistant invoked — shell commands ("$"), file edits ("edit"), file reads ("read"), MCP/skill/other tool calls — with their exit status and output. Treat them as a log of work already performed.',
+  "--- transcript start ---",
+].join("\n");
+
+const HANDOFF_FOOTER = [
+  "--- transcript end ---",
+  "Continue this conversation naturally from where it left off. The workspace already reflects any changes above. Do not introduce yourself again and do not mention this handoff unless the user asks about it.",
+].join("\n");
+
+const TRUNCATION_NOTICE = "[Older history omitted for length]";
+const ENTRY_SEPARATOR = "\n\n";
+
+interface TranscriptEntry {
+  readonly createdAt: string;
+  readonly text: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}… [truncated]` : value;
+}
+
+/**
+ * A tool call surfaces as several activities (started → updated → completed).
+ * This key groups them so only the richest single line survives per call.
+ */
+function toolCallGroupKey(activity: OrchestrationThreadActivity, payload: Record<string, unknown>) {
+  const item = asRecord(asRecord(payload.data)?.item);
+  return (
+    asNonEmptyString(payload.toolCallId) ??
+    asNonEmptyString(payload.callId) ??
+    asNonEmptyString(payload.id) ??
+    asNonEmptyString(item?.id) ??
+    activity.id
+  );
+}
+
+function isToolTrailActivity(activity: OrchestrationThreadActivity): boolean {
+  return (
+    activity.kind === "tool.updated" ||
+    activity.kind === "tool.completed" ||
+    activity.kind === "task.completed"
+  );
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function toolItem(payload: Record<string, unknown>): Record<string, unknown> | null {
+  return asRecord(asRecord(payload.data)?.item);
+}
+
+function toolItemType(payload: Record<string, unknown>): string | null {
+  return asNonEmptyString(payload.itemType) ?? asNonEmptyString(toolItem(payload)?.type);
+}
+
+/** Strip a trailing `<exited with exit code N>` marker that some providers append. */
+function stripExitMarker(value: string | null): { text: string | null; exitCode: number | null } {
+  if (!value) {
+    return { text: null, exitCode: null };
+  }
+  const match = /^([\s\S]*?)(?:\s*<exited with exit code (\d+)>)\s*$/i.exec(value.trim());
+  if (!match) {
+    return { text: value.trim() || null, exitCode: null };
+  }
+  return {
+    text: match[1]!.trim() || null,
+    exitCode: Number.parseInt(match[2]!, 10),
+  };
+}
+
+function toolCommand(payload: Record<string, unknown>): string | null {
+  const item = toolItem(payload);
+  const input = asRecord(item?.input);
+  const detail = stripExitMarker(asNonEmptyString(payload.detail));
+  return (
+    asNonEmptyString(item?.command) ??
+    asNonEmptyString(input?.command) ??
+    (toolItemType(payload) === "command_execution" ? detail.text : null)
+  );
+}
+
+function toolExitCode(payload: Record<string, unknown>): number | null {
+  return (
+    asFiniteNumber(toolItem(payload)?.exitCode) ??
+    stripExitMarker(asNonEmptyString(payload.detail)).exitCode
+  );
+}
+
+function pushFile(target: string[], seen: Set<string>, value: unknown): void {
+  const normalized = asNonEmptyString(value);
+  if (normalized && !seen.has(normalized)) {
+    seen.add(normalized);
+    target.push(normalized);
+  }
+}
+
+/** Walk the raw provider item collecting touched file paths (bounded). */
+function collectFiles(value: unknown, target: string[], seen: Set<string>, depth: number): void {
+  if (depth > 4 || target.length >= MAX_CHANGED_FILES) {
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      collectFiles(entry, target, seen, depth + 1);
+      if (target.length >= MAX_CHANGED_FILES) return;
+    }
+    return;
+  }
+  const record = asRecord(value);
+  if (!record) {
+    return;
+  }
+  pushFile(target, seen, record.path);
+  pushFile(target, seen, record.filePath);
+  pushFile(target, seen, record.relativePath);
+  pushFile(target, seen, record.newPath);
+  pushFile(target, seen, record.oldPath);
+  for (const key of ["item", "result", "input", "changes", "files", "edits", "patches"]) {
+    if (key in record) {
+      collectFiles(record[key], target, seen, depth + 1);
+      if (target.length >= MAX_CHANGED_FILES) return;
+    }
+  }
+}
+
+function toolChangedFiles(payload: Record<string, unknown>): string[] {
+  const files: string[] = [];
+  collectFiles(asRecord(payload.data), files, new Set<string>(), 0);
+  return files;
+}
+
+function toolStatus(payload: Record<string, unknown>): string | null {
+  return asNonEmptyString(payload.status) ?? asNonEmptyString(toolItem(payload)?.status);
+}
+
+/** Best-effort extraction of a tool's *output* (as opposed to its invocation). */
+function toolOutput(payload: Record<string, unknown>, command: string | null): string | null {
+  const data = asRecord(payload.data);
+  const item = toolItem(payload);
+  const rawOutput = asRecord(data?.rawOutput);
+  const detailText = stripExitMarker(asNonEmptyString(payload.detail)).text;
+  const candidates = [
+    item?.aggregatedOutput,
+    data?.aggregatedOutput,
+    rawOutput?.content,
+    rawOutput?.stdout,
+    item?.output,
+    data?.output,
+    item?.stdout,
+    data?.stdout,
+    // `detail` doubles as output only when it isn't just the command label.
+    detailText && detailText !== command ? detailText : null,
+  ];
+  for (const candidate of candidates) {
+    const text = asNonEmptyString(candidate);
+    if (text) {
+      return truncate(text, TOOL_OUTPUT_MAX_CHARS);
+    }
+  }
+  const totalFiles = asFiniteNumber(rawOutput?.totalFiles);
+  if (totalFiles !== null) {
+    return `${totalFiles} file${totalFiles === 1 ? "" : "s"}${rawOutput?.truncated === true ? "+" : ""}`;
+  }
+  return null;
+}
+
+/**
+ * Map a tool activity to a short `tag` (how the timeline categorises it) and a
+ * `subject` (what it acted on: a command, file list, or tool name).
+ */
+function describeTool(
+  activity: OrchestrationThreadActivity,
+  payload: Record<string, unknown>,
+): { tag: string; subject: string } | null {
+  const itemType = toolItemType(payload);
+  const command = toolCommand(payload);
+  const files = toolChangedFiles(payload);
+  const fileList = files.length > 0 ? files.join(", ") : null;
+  const title = asNonEmptyString(payload.title) ?? asNonEmptyString(activity.summary);
+
+  if (activity.kind === "task.completed") {
+    return title ? { tag: "task", subject: title } : null;
+  }
+
+  let tag: string;
+  let subject: string | null;
+  switch (itemType) {
+    case "command_execution":
+      tag = "$";
+      subject = command ?? title;
+      break;
+    case "file_change":
+      tag = "edit";
+      subject = fileList ?? title;
+      break;
+    case "mcp_tool_call":
+      tag = "mcp";
+      subject = title ?? command;
+      break;
+    case "web_search":
+      tag = "search";
+      subject = title ?? command;
+      break;
+    case "image_view":
+      tag = "view";
+      subject = fileList ?? title;
+      break;
+    case "dynamic_tool_call":
+    case "collab_agent_tool_call":
+      tag = "tool";
+      subject = title ?? command ?? fileList;
+      break;
+    default:
+      tag = "tool";
+      subject = command ?? fileList ?? title;
+      break;
+  }
+  return subject ? { tag, subject: truncate(subject, TOOL_SUBJECT_MAX_CHARS) } : null;
+}
+
+function buildToolTrailLine(activity: OrchestrationThreadActivity): string | null {
+  const payload = asRecord(activity.payload) ?? {};
+  const described = describeTool(activity, payload);
+  if (!described) {
+    return null;
+  }
+  const command = toolCommand(payload);
+  const exitCode = toolExitCode(payload);
+  const status = toolStatus(payload)?.toLowerCase();
+  const statusSuffix =
+    exitCode !== null
+      ? ` (exit ${exitCode})`
+      : status === "failed" || status === "error" || status === "declined"
+        ? ` (${status})`
+        : "";
+  const output = toolOutput(payload, command);
+  return `[${described.tag}] ${described.subject}${statusSuffix}${output ? `\n→ ${output}` : ""}`;
+}
+
+function collectToolTrailEntries(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): TranscriptEntry[] {
+  // Keep the single most detailed line per tool call so the terminal state
+  // (which carries the output) wins over its earlier lifecycle events.
+  const byGroup = new Map<string, TranscriptEntry>();
+  for (const activity of activities) {
+    if (!isToolTrailActivity(activity)) {
+      continue;
+    }
+    const line = buildToolTrailLine(activity);
+    if (!line) {
+      continue;
+    }
+    const key = toolCallGroupKey(activity, asRecord(activity.payload) ?? {});
+    const existing = byGroup.get(key);
+    if (!existing || line.length > existing.text.length) {
+      byGroup.set(key, { createdAt: activity.createdAt, text: line });
+    }
+  }
+  return Array.from(byGroup.values());
+}
+
+/**
+ * Render the prior conversation (messages + tool trail) as a handoff prelude,
+ * keeping the most recent entries that fit within `maxChars`. Returns
+ * `undefined` when there is nothing worth handing off.
+ */
+export function renderProviderHandoffPrelude(input: {
+  readonly messages: ReadonlyArray<OrchestrationMessage>;
+  readonly activities?: ReadonlyArray<OrchestrationThreadActivity>;
+  readonly excludeMessageId?: string;
+  readonly maxChars?: number;
+}): string | undefined {
+  const maxChars = input.maxChars ?? HANDOFF_TRANSCRIPT_MAX_CHARS;
+  const messageEntries: TranscriptEntry[] = input.messages
+    .filter((message) => message.id !== input.excludeMessageId)
+    .filter((message) => message.role === "user" || message.role === "assistant")
+    .map((message) => ({
+      createdAt: message.createdAt,
+      text: `${message.role === "user" ? "User" : "Assistant"}:\n${message.text.trim()}`,
+      hasText: message.text.trim().length > 0,
+    }))
+    .filter((entry) => entry.hasText)
+    .map(({ createdAt, text }) => ({ createdAt, text }));
+
+  const toolEntries = collectToolTrailEntries(input.activities ?? []);
+  if (messageEntries.length === 0 && toolEntries.length === 0) {
+    return undefined;
+  }
+
+  // A tool line shares its turn's timestamp with the surrounding messages;
+  // ties keep insertion order, which is close enough to causal order.
+  const entries = [...messageEntries, ...toolEntries]
+    .toSorted((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .map((entry) => entry.text);
+
+  const frameCost =
+    HANDOFF_HEADER.length +
+    HANDOFF_FOOTER.length +
+    TRUNCATION_NOTICE.length +
+    ENTRY_SEPARATOR.length * 3;
+  const entryBudget = maxChars - frameCost;
+  if (entryBudget <= 0) {
+    return undefined;
+  }
+
+  const kept: string[] = [];
+  let used = 0;
+  for (let index = entries.length - 1; index >= 0; index--) {
+    const entry = entries[index]!;
+    const cost = entry.length + ENTRY_SEPARATOR.length;
+    if (used + cost > entryBudget) {
+      break;
+    }
+    kept.unshift(entry);
+    used += cost;
+  }
+  if (kept.length === 0) {
+    return undefined;
+  }
+
+  const truncated = kept.length < entries.length;
+  return [HANDOFF_HEADER, ...(truncated ? [TRUNCATION_NOTICE] : []), ...kept, HANDOFF_FOOTER].join(
+    ENTRY_SEPARATOR,
+  );
+}

--- a/apps/server/src/orchestration/providerHandoffTranscript.ts
+++ b/apps/server/src/orchestration/providerHandoffTranscript.ts
@@ -63,11 +63,13 @@ function truncate(value: string, max: number): string {
  * This key groups them so only the richest single line survives per call.
  */
 function toolCallGroupKey(activity: OrchestrationThreadActivity, payload: Record<string, unknown>) {
-  const item = asRecord(asRecord(payload.data)?.item);
+  const data = asRecord(payload.data);
+  const item = asRecord(data?.item);
   return (
     asNonEmptyString(payload.toolCallId) ??
     asNonEmptyString(payload.callId) ??
     asNonEmptyString(payload.id) ??
+    asNonEmptyString(data?.toolCallId) ??
     asNonEmptyString(item?.id) ??
     activity.id
   );
@@ -120,8 +122,10 @@ function toolCommand(payload: Record<string, unknown>): string | null {
 }
 
 function toolExitCode(payload: Record<string, unknown>): number | null {
+  const rawOutput = asRecord(asRecord(payload.data)?.rawOutput);
   return (
     asFiniteNumber(toolItem(payload)?.exitCode) ??
+    asFiniteNumber(rawOutput?.exitCode) ??
     stripExitMarker(asNonEmptyString(payload.detail)).exitCode
   );
 }
@@ -188,6 +192,11 @@ function toolOutput(payload: Record<string, unknown>, command: string | null): s
     data?.output,
     item?.stdout,
     data?.stdout,
+    // stderr matters most for failed commands, whose diagnostics often land
+    // only there — otherwise a non-zero exit would carry no error text.
+    rawOutput?.stderr,
+    item?.stderr,
+    data?.stderr,
     // `detail` doubles as output only when it isn't just the command label.
     detailText && detailText !== command ? detailText : null,
   ];

--- a/apps/server/src/orchestration/providerHandoffTranscript.ts
+++ b/apps/server/src/orchestration/providerHandoffTranscript.ts
@@ -83,6 +83,16 @@ function isToolTrailActivity(activity: OrchestrationThreadActivity): boolean {
   );
 }
 
+/**
+ * A tool call's terminal lifecycle event (`tool.completed` / `task.completed`)
+ * carries the real exit code and output; an in-progress `tool.updated` does not.
+ * When collapsing a group we prefer the terminal event so a verbose partial
+ * update can't shadow the shorter-but-authoritative final result.
+ */
+function isTerminalToolActivity(activity: OrchestrationThreadActivity): boolean {
+  return activity.kind === "tool.completed" || activity.kind === "task.completed";
+}
+
 function asFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
@@ -289,9 +299,12 @@ function buildToolTrailLine(activity: OrchestrationThreadActivity): string | nul
 function collectToolTrailEntries(
   activities: ReadonlyArray<OrchestrationThreadActivity>,
 ): TranscriptEntry[] {
-  // Keep the single most detailed line per tool call so the terminal state
-  // (which carries the output) wins over its earlier lifecycle events.
-  const byGroup = new Map<string, TranscriptEntry>();
+  // Keep one line per tool call. A terminal event (tool.completed /
+  // task.completed) carries the authoritative exit code and output, so it
+  // always wins over a non-terminal tool.updated — even a verbose in-progress
+  // update that happens to be longer. Ties (same terminality) fall back to the
+  // most detailed (longest) line.
+  const byGroup = new Map<string, { entry: TranscriptEntry; terminal: boolean }>();
   for (const activity of activities) {
     if (!isToolTrailActivity(activity)) {
       continue;
@@ -301,12 +314,17 @@ function collectToolTrailEntries(
       continue;
     }
     const key = toolCallGroupKey(activity, asRecord(activity.payload) ?? {});
+    const terminal = isTerminalToolActivity(activity);
     const existing = byGroup.get(key);
-    if (!existing || line.length > existing.text.length) {
-      byGroup.set(key, { createdAt: activity.createdAt, text: line });
+    const shouldReplace =
+      !existing ||
+      (terminal && !existing.terminal) ||
+      (terminal === existing.terminal && line.length > existing.entry.text.length);
+    if (shouldReplace) {
+      byGroup.set(key, { entry: { createdAt: activity.createdAt, text: line }, terminal });
     }
   }
-  return Array.from(byGroup.values());
+  return Array.from(byGroup.values()).map((value) => value.entry);
 }
 
 /**

--- a/apps/server/src/provider/Layers/ProviderService.test.ts
+++ b/apps/server/src/provider/Layers/ProviderService.test.ts
@@ -1049,35 +1049,42 @@ routing.layer("ProviderServiceLive routing", (it) => {
     }),
   );
 
-  it.effect("dies when an active session conflicts with its persisted binding", () =>
-    Effect.gen(function* () {
-      const provider = yield* ProviderService.ProviderService;
-      const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
-      const threadId = asThreadId("thread-binding-mismatch");
+  it.effect(
+    "lists a session as-is when it conflicts with its persisted binding (handoff in flight)",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* ProviderService.ProviderService;
+        const directory = yield* ProviderSessionDirectory.ProviderSessionDirectory;
+        const threadId = asThreadId("thread-binding-mismatch");
 
-      yield* provider.startSession(threadId, {
-        provider: ProviderDriverKind.make("codex"),
-        providerInstanceId: codexInstanceId,
-        threadId,
-        cwd: "/tmp/project-binding-mismatch",
-        runtimeMode: "full-access",
-      });
-      yield* directory.upsert({
-        threadId,
-        provider: ProviderDriverKind.make("claudeAgent"),
-        providerInstanceId: claudeAgentInstanceId,
-        runtimeMode: "full-access",
-      });
+        yield* provider.startSession(threadId, {
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          threadId,
+          cwd: "/tmp/project-binding-mismatch",
+          runtimeMode: "full-access",
+        });
+        yield* directory.upsert({
+          threadId,
+          provider: ProviderDriverKind.make("claudeAgent"),
+          providerInstanceId: claudeAgentInstanceId,
+          runtimeMode: "full-access",
+        });
 
-      const exit = yield* Effect.exit(provider.listSessions());
-      assert.equal(Exit.hasDies(exit), true);
-      yield* directory.upsert({
-        threadId,
-        provider: ProviderDriverKind.make("codex"),
-        providerInstanceId: codexInstanceId,
-        runtimeMode: "full-access",
-      });
-    }),
+        // The binding no longer describes this session (expected transiently
+        // during a provider handoff): the live session is surfaced without
+        // binding overrides instead of crashing.
+        const sessions = yield* provider.listSessions();
+        const mismatched = sessions.find((session) => session.threadId === threadId);
+        assert.equal(mismatched?.provider, "codex");
+        assert.equal(mismatched?.providerInstanceId, codexInstanceId);
+        yield* directory.upsert({
+          threadId,
+          provider: ProviderDriverKind.make("codex"),
+          providerInstanceId: codexInstanceId,
+          runtimeMode: "full-access",
+        });
+      }),
   );
 
   it.effect("stops stale sessions in other providers after a successful replacement start", () =>

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -929,44 +929,53 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         }
       }
 
-      const sessions: ProviderSession[] = [];
+      // Dedupe by threadId. During a cross-instance handoff two live sessions
+      // can briefly coexist for one thread (the new one starts before the
+      // stale one is stopped). The persisted binding names the authoritative
+      // instance, so a session that matches it always wins; a mismatched
+      // (stale) session is only kept if nothing authoritative is present. This
+      // guarantees at most one session per threadId for downstream `.find()`.
+      const resultByThreadId = new Map<
+        ThreadId,
+        { readonly session: ProviderSession; readonly bindingMatched: boolean }
+      >();
       for (const session of activeSessions) {
         const binding = bindingsByThreadId.get(session.threadId);
+        const existing = resultByThreadId.get(session.threadId);
         if (!binding) {
-          sessions.push(session);
+          if (!existing) {
+            resultByThreadId.set(session.threadId, { session, bindingMatched: false });
+          }
           continue;
         }
 
-        const overrides: {
-          resumeCursor?: ProviderSession["resumeCursor"];
-          runtimeMode?: ProviderSession["runtimeMode"];
-          providerInstanceId?: ProviderSession["providerInstanceId"];
-        } = {};
-        overrides.providerInstanceId = dieOnMissingBindingInstanceId(
+        const bindingInstanceId = dieOnMissingBindingInstanceId(
           "ProviderService.listSessions",
           binding,
         );
-        if (
-          binding.provider !== session.provider ||
-          overrides.providerInstanceId !== session.providerInstanceId
-        ) {
-          // The persisted binding does not describe this session. This is
-          // expected transiently while a thread hands off to a different
-          // provider instance (the new session starts before the binding is
-          // rewritten and stale sessions are stopped). Surface the live
-          // session as-is instead of applying the mismatched binding.
-          sessions.push(session);
-          continue;
+        const matchesBinding =
+          binding.provider === session.provider && bindingInstanceId === session.providerInstanceId;
+        if (matchesBinding) {
+          const overrides: {
+            resumeCursor?: ProviderSession["resumeCursor"];
+            runtimeMode?: ProviderSession["runtimeMode"];
+            providerInstanceId?: ProviderSession["providerInstanceId"];
+          } = { providerInstanceId: bindingInstanceId };
+          if (session.resumeCursor === undefined && binding.resumeCursor !== undefined) {
+            overrides.resumeCursor = binding.resumeCursor;
+          }
+          if (binding.runtimeMode !== undefined) {
+            overrides.runtimeMode = binding.runtimeMode;
+          }
+          resultByThreadId.set(session.threadId, {
+            session: Object.assign({}, session, overrides),
+            bindingMatched: true,
+          });
+        } else if (!existing || !existing.bindingMatched) {
+          resultByThreadId.set(session.threadId, { session, bindingMatched: false });
         }
-        if (session.resumeCursor === undefined && binding.resumeCursor !== undefined) {
-          overrides.resumeCursor = binding.resumeCursor;
-        }
-        if (binding.runtimeMode !== undefined) {
-          overrides.runtimeMode = binding.runtimeMode;
-        }
-        sessions.push(Object.assign({}, session, overrides));
       }
-      return sessions;
+      return [...resultByThreadId.values()].map((entry) => entry.session);
     },
   );
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -616,7 +616,18 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           threadId,
           currentInstanceId: resolvedInstanceId,
         });
-        yield* upsertSessionBinding(sessionWithInstance, threadId, {
+        // When the thread moves to a different provider instance, the
+        // previously persisted resume cursor belongs to the old driver and
+        // must not survive the rebind (directory.upsert would otherwise keep
+        // it), or a later recovery would feed it to the wrong adapter.
+        const bindingInstanceChanged =
+          persistedBinding !== undefined &&
+          persistedBinding.providerInstanceId !== resolvedInstanceId;
+        const sessionForBinding =
+          bindingInstanceChanged && sessionWithInstance.resumeCursor === undefined
+            ? { ...sessionWithInstance, resumeCursor: null }
+            : sessionWithInstance;
+        yield* upsertSessionBinding(sessionForBinding, threadId, {
           modelSelection: input.modelSelection,
         });
         yield* analytics.record("provider.session.started", {
@@ -935,19 +946,17 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
           "ProviderService.listSessions",
           binding,
         );
-        if (binding.provider !== session.provider) {
-          return yield* Effect.die(
-            new Error(
-              `ProviderService.listSessions: thread '${session.threadId}' is active on provider '${session.provider}' but persisted binding names provider '${binding.provider}'.`,
-            ),
-          );
-        }
-        if (overrides.providerInstanceId !== session.providerInstanceId) {
-          return yield* Effect.die(
-            new Error(
-              `ProviderService.listSessions: thread '${session.threadId}' is active on provider instance '${session.providerInstanceId}' but persisted binding names '${overrides.providerInstanceId}'.`,
-            ),
-          );
+        if (
+          binding.provider !== session.provider ||
+          overrides.providerInstanceId !== session.providerInstanceId
+        ) {
+          // The persisted binding does not describe this session. This is
+          // expected transiently while a thread hands off to a different
+          // provider instance (the new session starts before the binding is
+          // rewritten and stale sessions are stopped). Surface the live
+          // session as-is instead of applying the mismatched binding.
+          sessions.push(session);
+          continue;
         }
         if (session.resumeCursor === undefined && binding.resumeCursor !== undefined) {
           overrides.resumeCursor = binding.resumeCursor;

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -1,4 +1,11 @@
-import { EnvironmentId, ProjectId, ProviderInstanceId, ThreadId, TurnId } from "@t3tools/contracts";
+import {
+  EnvironmentId,
+  ProjectId,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
 import { describe, expect, it } from "vite-plus/test";
 
 import type { Thread } from "../types";
@@ -261,6 +268,60 @@ describe("getStartedThreadModelChangeBlockReason", () => {
       description:
         "This provider does not allow switching models after a conversation has started.",
     });
+  });
+
+  it("blocks a cross-instance switch the server treats as in-session (same driver + continuation)", () => {
+    // Two grok instances sharing a driver and continuation group: the server
+    // handles this as an in-session model change, not a handoff, and rejects it
+    // for a requiresNewThreadForModelChange provider — so the picker must block.
+    const sharedContinuationProviders = [
+      {
+        instanceId: ProviderInstanceId.make("grok_a"),
+        driver: ProviderDriverKind.make("grok"),
+        continuation: { groupKey: "grok:shared" },
+        requiresNewThreadForModelChange: true,
+      },
+      {
+        instanceId: ProviderInstanceId.make("grok_b"),
+        driver: ProviderDriverKind.make("grok"),
+        continuation: { groupKey: "grok:shared" },
+        requiresNewThreadForModelChange: true,
+      },
+    ];
+    expect(
+      getStartedThreadModelChangeBlockReason({
+        providers: sharedContinuationProviders,
+        hasStartedSession: true,
+        currentModelSelection: {
+          instanceId: ProviderInstanceId.make("grok_a"),
+          model: "grok-build",
+        },
+        nextModelSelection: { instanceId: ProviderInstanceId.make("grok_b"), model: "grok-other" },
+      }),
+    ).toEqual({
+      title: "Start a new chat to change models",
+      description:
+        "This provider does not allow switching models after a conversation has started.",
+    });
+  });
+
+  it("allows a cross-instance switch to a different driver (true handoff)", () => {
+    const crossDriverProviders = [
+      { instanceId: ProviderInstanceId.make("codex"), driver: ProviderDriverKind.make("codex") },
+      {
+        instanceId: ProviderInstanceId.make("grok"),
+        driver: ProviderDriverKind.make("grok"),
+        requiresNewThreadForModelChange: true,
+      },
+    ];
+    expect(
+      getStartedThreadModelChangeBlockReason({
+        providers: crossDriverProviders,
+        hasStartedSession: true,
+        currentModelSelection: { instanceId: ProviderInstanceId.make("codex"), model: "gpt-5.4" },
+        nextModelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -225,7 +225,7 @@ describe("getStartedThreadModelChangeBlockReason", () => {
     ).toBeNull();
   });
 
-  it("blocks started-session model changes when either provider requires a new thread", () => {
+  it("allows cross-instance switches on started sessions (provider handoff)", () => {
     expect(
       getStartedThreadModelChangeBlockReason({
         providers,
@@ -237,6 +237,23 @@ describe("getStartedThreadModelChangeBlockReason", () => {
         nextModelSelection: {
           instanceId: ProviderInstanceId.make("grok"),
           model: "grok-build",
+        },
+      }),
+    ).toBeNull();
+  });
+
+  it("blocks started-session model changes on providers that require a new thread", () => {
+    expect(
+      getStartedThreadModelChangeBlockReason({
+        providers,
+        hasStartedSession: true,
+        currentModelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-build",
+        },
+        nextModelSelection: {
+          instanceId: ProviderInstanceId.make("grok"),
+          model: "grok-other",
         },
       }),
     ).toEqual({

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -270,7 +270,10 @@ export function threadHasStarted(thread: Thread | null | undefined): boolean {
 // a handoff and starts a fresh provider session with the prior conversation
 // replayed as context.
 export function getStartedThreadModelChangeBlockReason(input: {
-  providers: ReadonlyArray<Pick<ServerProvider, "instanceId" | "requiresNewThreadForModelChange">>;
+  providers: ReadonlyArray<
+    Pick<ServerProvider, "instanceId" | "requiresNewThreadForModelChange"> &
+      Partial<Pick<ServerProvider, "driver" | "continuation">>
+  >;
   hasStartedSession: boolean;
   currentModelSelection: ModelSelection;
   currentProviderInstanceId?: ModelSelection["instanceId"] | null | undefined;
@@ -283,18 +286,35 @@ export function getStartedThreadModelChangeBlockReason(input: {
     ...input.currentModelSelection,
     instanceId: input.currentProviderInstanceId ?? input.currentModelSelection.instanceId,
   };
-  if (currentModelSelection.instanceId !== input.nextModelSelection.instanceId) {
-    // Cross-instance selection is a provider handoff, not an in-thread model
-    // change; the server starts a fresh provider session for it.
-    return null;
-  }
-  if (currentModelSelection.model === input.nextModelSelection.model) {
-    return null;
-  }
   const currentProvider = input.providers.find(
     (snapshot) => snapshot.instanceId === currentModelSelection.instanceId,
   );
-  if (currentProvider?.requiresNewThreadForModelChange !== true) {
+  const nextProvider = input.providers.find(
+    (snapshot) => snapshot.instanceId === input.nextModelSelection.instanceId,
+  );
+
+  if (currentModelSelection.instanceId !== input.nextModelSelection.instanceId) {
+    // Cross-instance: the server treats this as a fresh-session handoff — and
+    // does not apply `requiresNewThreadForModelChange` — UNLESS the two
+    // instances share a driver and continuation group (i.e. the same resumable
+    // provider thread), in which case it is really an in-session model change.
+    const sameDriver =
+      currentProvider?.driver !== undefined && currentProvider.driver === nextProvider?.driver;
+    const currentKey = currentProvider?.continuation?.groupKey ?? null;
+    const nextKey = nextProvider?.continuation?.groupKey ?? null;
+    const sameContinuation = currentKey !== null && currentKey === nextKey;
+    if (!sameDriver || !sameContinuation) {
+      return null;
+    }
+    // Falls through to the in-session block check below.
+  } else if (currentModelSelection.model === input.nextModelSelection.model) {
+    return null;
+  }
+
+  if (
+    currentProvider?.requiresNewThreadForModelChange !== true &&
+    nextProvider?.requiresNewThreadForModelChange !== true
+  ) {
     return null;
   }
   return {

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -1,9 +1,7 @@
 import {
   type EnvironmentId,
-  isProviderDriverKind,
   ProjectId,
   type ModelSelection,
-  type ProviderDriverKind,
   type ServerProvider,
   type ScopedThreadRef,
   type ThreadId,
@@ -266,41 +264,11 @@ export function threadHasStarted(thread: Thread | null | undefined): boolean {
   );
 }
 
-// `threadProvider` is the open branded driver kind carried by the session.
-// Unknown driver kinds degrade to `null` (i.e. "unlocked"), which is the safe
-// rollback / fork behavior — the routing layer is the right place to surface
-// "driver not installed" errors, not the lock state.
-//
-// `selectedProvider` takes the same open-string shape because the composer
-// now tracks the picker selection as a `ProviderInstanceId` (e.g.
-// `codex_personal`). Custom instance ids that don't directly match a
-// registered driver resolve to `null` here, which matches the existing
-// "unknown driver -> unlocked" semantics. Callers that want the lock to track
-// a custom instance's underlying driver kind should resolve the instance id
-// upstream and pass the correlated kind.
-export function deriveLockedProvider(input: {
-  thread: Thread | null | undefined;
-  selectedProvider: string | null;
-  threadProvider: string | null;
-}): ProviderDriverKind | null {
-  if (!threadHasStarted(input.thread)) {
-    return null;
-  }
-  const sessionProvider = input.thread?.session?.providerName ?? null;
-  if (sessionProvider && isProviderDriverKind(sessionProvider)) {
-    return sessionProvider;
-  }
-  const narrowedThreadProvider =
-    input.threadProvider && isProviderDriverKind(input.threadProvider)
-      ? input.threadProvider
-      : null;
-  const narrowedSelectedProvider =
-    input.selectedProvider && isProviderDriverKind(input.selectedProvider)
-      ? input.selectedProvider
-      : null;
-  return narrowedThreadProvider ?? narrowedSelectedProvider ?? null;
-}
-
+// Blocks in-thread model changes for providers that cannot resume their own
+// thread with a different model (`requiresNewThreadForModelChange`). Selecting
+// a *different* provider instance is never blocked: the server treats that as
+// a handoff and starts a fresh provider session with the prior conversation
+// replayed as context.
 export function getStartedThreadModelChangeBlockReason(input: {
   providers: ReadonlyArray<Pick<ServerProvider, "instanceId" | "requiresNewThreadForModelChange">>;
   hasStartedSession: boolean;
@@ -315,22 +283,18 @@ export function getStartedThreadModelChangeBlockReason(input: {
     ...input.currentModelSelection,
     instanceId: input.currentProviderInstanceId ?? input.currentModelSelection.instanceId,
   };
-  if (
-    currentModelSelection.instanceId === input.nextModelSelection.instanceId &&
-    currentModelSelection.model === input.nextModelSelection.model
-  ) {
+  if (currentModelSelection.instanceId !== input.nextModelSelection.instanceId) {
+    // Cross-instance selection is a provider handoff, not an in-thread model
+    // change; the server starts a fresh provider session for it.
+    return null;
+  }
+  if (currentModelSelection.model === input.nextModelSelection.model) {
     return null;
   }
   const currentProvider = input.providers.find(
     (snapshot) => snapshot.instanceId === currentModelSelection.instanceId,
   );
-  const nextProvider = input.providers.find(
-    (snapshot) => snapshot.instanceId === input.nextModelSelection.instanceId,
-  );
-  if (
-    currentProvider?.requiresNewThreadForModelChange !== true &&
-    nextProvider?.requiresNewThreadForModelChange !== true
-  ) {
+  if (currentProvider?.requiresNewThreadForModelChange !== true) {
     return null;
   }
   return {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -76,6 +76,7 @@ import {
   derivePendingUserInputs,
   derivePhase,
   deriveTimelineEntries,
+  deriveModelChangeNotices,
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
   findSidebarProposedPlan,
@@ -151,7 +152,7 @@ import {
 import { newDraftId, newMessageId, newThreadId } from "~/lib/utils";
 import { getProviderModelCapabilities, resolveSelectableProvider } from "../providerModels";
 import { useEnvironmentSettings } from "../hooks/useSettings";
-import { resolveAppModelSelectionForInstance } from "../modelSelection";
+import { resolveAppModelSelectionForInstance, resolveModelDisplayName } from "../modelSelection";
 import { getTerminalFocusOwner } from "../lib/terminalFocus";
 import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import {
@@ -227,7 +228,6 @@ import {
   type LocalDispatchSnapshot,
   PullRequestDialogState,
   cloneComposerImageForRetry,
-  deriveLockedProvider,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
   resolveSendEnvMode,
@@ -1623,11 +1623,6 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread?.modelSelection.instanceId ??
     activeProject?.defaultModelSelection?.instanceId ??
     null;
-  const lockedProvider = deriveLockedProvider({
-    thread: activeThread,
-    selectedProvider: selectedProviderByThreadId,
-    threadProvider,
-  });
   // Once a thread selects an environment, never substitute the primary
   // environment's config while the selected environment is still loading.
   const serverConfig = activeThread
@@ -1723,7 +1718,7 @@ function ChatViewContent(props: ChatViewProps) {
     providerStatuses,
     selectedProviderByThreadId ?? threadProvider ?? ProviderDriverKind.make("codex"),
   );
-  const selectedProvider: ProviderDriverKind = lockedProvider ?? unlockedSelectedProvider;
+  const selectedProvider: ProviderDriverKind = unlockedSelectedProvider;
   const phase = derivePhase(activeThread?.session ?? null);
   const threadActivities = activeThread?.activities ?? EMPTY_ACTIVITIES;
   const workLogEntries = useMemo(() => deriveWorkLogEntries(threadActivities), [threadActivities]);
@@ -2058,10 +2053,36 @@ function ChatViewContent(props: ChatViewProps) {
     }
     return [...serverMessagesWithPreviewHandoff, ...pendingMessages];
   }, [attachmentPreviewHandoffByMessageId, displayServerMessages, optimisticUserMessages]);
+  const modelChangeNotices = useMemo(() => {
+    return deriveModelChangeNotices(threadActivities).map((notice) => {
+      const toLabel = resolveModelDisplayName(
+        providerStatuses,
+        notice.toInstanceId,
+        notice.toModel,
+      );
+      const fromLabel = resolveModelDisplayName(
+        providerStatuses,
+        notice.fromInstanceId,
+        notice.fromModel,
+      );
+      const summary =
+        fromLabel && toLabel && fromLabel !== toLabel
+          ? `Switched from ${fromLabel} to ${toLabel}`
+          : toLabel
+            ? `Switched to ${toLabel}`
+            : notice.summary;
+      return { ...notice, summary, toModel: toLabel || notice.toModel };
+    });
+  }, [threadActivities, providerStatuses]);
   const timelineEntries = useMemo(
     () =>
-      deriveTimelineEntries(timelineMessages, activeThread?.proposedPlans ?? [], workLogEntries),
-    [activeThread?.proposedPlans, timelineMessages, workLogEntries],
+      deriveTimelineEntries(
+        timelineMessages,
+        activeThread?.proposedPlans ?? [],
+        workLogEntries,
+        modelChangeNotices,
+      ),
+    [activeThread?.proposedPlans, timelineMessages, workLogEntries, modelChangeNotices],
   );
   const { turnDiffSummaries, inferredCheckpointTurnCountByTurnId } =
     useTurnDiffSummaries(activeThread);
@@ -4763,32 +4784,6 @@ function ChatViewContent(props: ChatViewProps) {
   const onProviderModelSelect = useCallback(
     (instanceId: ProviderInstanceId, model: string) => {
       if (!activeThread) return;
-      // Look up the configured instance so model normalization and custom
-      // model lookup stay scoped to that exact instance. Unknown instance ids
-      // are rejected by returning early; the server remains authoritative too.
-      const entry = providerStatuses.find((snapshot) => snapshot.instanceId === instanceId);
-      const resolvedDriverKind = entry?.driver ?? null;
-      if (
-        lockedProvider !== null &&
-        resolvedDriverKind !== null &&
-        resolvedDriverKind !== lockedProvider
-      ) {
-        scheduleComposerFocus();
-        return;
-      }
-      if (lockedProvider !== null && activeThread.session?.providerInstanceId) {
-        const currentEntry = providerStatuses.find(
-          (snapshot) => snapshot.instanceId === activeThread.session?.providerInstanceId,
-        );
-        if (
-          currentEntry?.continuation?.groupKey &&
-          entry?.continuation?.groupKey &&
-          currentEntry.continuation.groupKey !== entry.continuation.groupKey
-        ) {
-          scheduleComposerFocus();
-          return;
-        }
-      }
       const resolvedModel = resolveAppModelSelectionForInstance(
         instanceId,
         settings,
@@ -4828,7 +4823,6 @@ function ChatViewContent(props: ChatViewProps) {
     },
     [
       activeThread,
-      lockedProvider,
       scheduleComposerFocus,
       setComposerDraftModelSelection,
       setStickyComposerModelSelection,
@@ -5175,7 +5169,7 @@ function ChatViewContent(props: ChatViewProps) {
                       planSidebarOpen={planSidebarOpen}
                       runtimeMode={runtimeMode}
                       interactionMode={interactionMode}
-                      lockedProvider={lockedProvider}
+                      lockedProvider={null}
                       providerStatuses={providerStatuses as ServerProvider[]}
                       activeProjectDefaultModelSelection={activeProject?.defaultModelSelection}
                       activeThreadModelSelection={activeThread?.modelSelection}

--- a/apps/web/src/components/chat/MessagesTimeline.logic.ts
+++ b/apps/web/src/components/chat/MessagesTimeline.logic.ts
@@ -3,6 +3,7 @@ import {
   formatDuration,
   workEntryIndicatesToolNeutralStatus,
   workLogEntryIsToolLike,
+  type ModelChangeNotice,
   type TimelineEntry,
   type WorkLogEntry,
 } from "../../session-logic";
@@ -135,6 +136,12 @@ export type MessagesTimelineRow =
       id: string;
       createdAt: string;
       proposedPlan: ProposedPlan;
+    }
+  | {
+      kind: "notice";
+      id: string;
+      createdAt: string;
+      notice: ModelChangeNotice;
     }
   | { kind: "working"; id: string; createdAt: string | null };
 
@@ -488,6 +495,16 @@ export function deriveMessagesTimelineRows(input: {
       continue;
     }
 
+    if (timelineEntry.kind === "notice") {
+      nextRows.push({
+        kind: "notice",
+        id: timelineEntry.id,
+        createdAt: timelineEntry.createdAt,
+        notice: timelineEntry.notice,
+      });
+      continue;
+    }
+
     const assistantTurnStillInProgress =
       timelineEntry.message.role === "assistant" &&
       unsettledTurnId !== null &&
@@ -570,6 +587,9 @@ function isRowUnchanged(a: MessagesTimelineRow, b: MessagesTimelineRow): boolean
 
     case "proposed-plan":
       return a.proposedPlan === (b as typeof a).proposedPlan;
+
+    case "notice":
+      return a.notice === (b as typeof a).notice;
 
     case "work":
       return Equal.equals(a.groupedEntries, (b as typeof a).groupedEntries);

--- a/apps/web/src/components/chat/MessagesTimeline.tsx
+++ b/apps/web/src/components/chat/MessagesTimeline.tsx
@@ -40,6 +40,7 @@ import {
 } from "../../lib/diffRendering";
 import ChatMarkdown from "../ChatMarkdown";
 import {
+  ArrowRightLeftIcon,
   BotIcon,
   CheckIcon,
   ChevronDownIcon,
@@ -820,6 +821,7 @@ const TimelineRowContent = memo(function TimelineRowContent({ row }: { row: Time
         <AssistantTimelineRow row={row} />
       ) : null}
       {row.kind === "proposed-plan" ? <ProposedPlanTimelineRow row={row} /> : null}
+      {row.kind === "notice" ? <NoticeTimelineRow row={row} /> : null}
       {row.kind === "working" ? <WorkingTimelineRow row={row} /> : null}
     </div>
   );
@@ -1046,6 +1048,17 @@ function ProposedPlanTimelineRow({
         cwd={ctx.markdownCwd}
         workspaceRoot={ctx.workspaceRoot}
       />
+    </div>
+  );
+}
+
+function NoticeTimelineRow({ row }: { row: Extract<TimelineRow, { kind: "notice" }> }) {
+  return (
+    <div className="flex items-center justify-center py-1">
+      <div className="flex items-center gap-1.5 rounded-full border border-border/60 bg-secondary/40 px-3 py-1 text-muted-foreground text-xs">
+        <ArrowRightLeftIcon className="size-3 shrink-0" />
+        <span>{row.notice.summary}</span>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/modelSelection.ts
+++ b/apps/web/src/modelSelection.ts
@@ -236,6 +236,29 @@ export function resolveAppModelSelection(
   );
 }
 
+/**
+ * Resolve a human-friendly model label for a slug, preferring the provider
+ * instance it belongs to. Falls back to a slug match across all providers,
+ * then to the raw slug when the model is not in the catalog.
+ */
+export function resolveModelDisplayName(
+  providers: ReadonlyArray<ServerProvider>,
+  instanceId: string | null | undefined,
+  slug: string | null | undefined,
+): string {
+  if (!slug) return "";
+  if (instanceId) {
+    const provider = providers.find((candidate) => candidate.instanceId === instanceId);
+    const model = provider?.models.find((entry) => entry.slug === slug);
+    if (model) return model.name;
+  }
+  for (const provider of providers) {
+    const model = provider.models.find((entry) => entry.slug === slug);
+    if (model) return model.name;
+  }
+  return slug;
+}
+
 export function resolveAppModelSelectionForInstance(
   instanceId: ProviderInstanceId,
   settings: UnifiedSettings,

--- a/apps/web/src/session-logic.test.ts
+++ b/apps/web/src/session-logic.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   deriveActiveWorkStartedAt,
   deriveActivePlanState,
+  deriveModelChangeNotices,
   derivePendingApprovals,
   derivePendingUserInputs,
   deriveTimelineEntries,
@@ -47,6 +48,85 @@ function makeActivity(overrides: {
     ...(overrides.sequence !== undefined ? { sequence: overrides.sequence } : {}),
   };
 }
+
+describe("deriveModelChangeNotices", () => {
+  it("extracts model-change notices and excludes them from work-log entries", () => {
+    const activities: OrchestrationThreadActivity[] = [
+      makeActivity({
+        id: "model-changed-1",
+        createdAt: "2026-02-23T00:00:05.000Z",
+        kind: "thread.model-changed",
+        summary: "Switched model to claude-sonnet-4-6",
+        tone: "info",
+        payload: {
+          fromInstanceId: "codex",
+          fromModel: "gpt-5.4",
+          toInstanceId: "claudeAgent",
+          toModel: "claude-sonnet-4-6",
+          isHandoff: true,
+        },
+      }),
+      makeActivity({ id: "tool-1", kind: "tool.completed", summary: "Ran a tool", tone: "tool" }),
+    ];
+
+    const notices = deriveModelChangeNotices(activities);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatchObject({
+      id: "model-changed-1",
+      fromInstanceId: "codex",
+      fromModel: "gpt-5.4",
+      toInstanceId: "claudeAgent",
+      toModel: "claude-sonnet-4-6",
+      isHandoff: true,
+      summary: "Switched model to claude-sonnet-4-6",
+    });
+
+    // The notice must not also surface as a tool-like work-log entry.
+    const workEntries = deriveWorkLogEntries(activities);
+    expect(workEntries.some((entry) => entry.id === "model-changed-1")).toBe(false);
+  });
+
+  it("merges notices into the timeline in chronological order", () => {
+    const notices = deriveModelChangeNotices([
+      makeActivity({
+        id: "model-changed-2",
+        createdAt: "2026-02-23T00:00:02.000Z",
+        kind: "thread.model-changed",
+        summary: "Switched to Claude Sonnet 4.6",
+        tone: "info",
+        payload: { toInstanceId: "claudeAgent", toModel: "claude-sonnet-4-6", isHandoff: false },
+      }),
+    ]);
+    const entries = deriveTimelineEntries([], [], [], notices);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ kind: "notice", id: "model-changed-2" });
+  });
+
+  it("orders a notice above the user message that shares its timestamp", () => {
+    const sharedTimestamp = "2026-02-23T00:00:02.000Z";
+    const userMessage = {
+      id: MessageId.make("user-msg"),
+      role: "user" as const,
+      text: "continue on the new model",
+      turnId: null,
+      streaming: false,
+      createdAt: sharedTimestamp,
+      updatedAt: sharedTimestamp,
+    };
+    const notices = deriveModelChangeNotices([
+      makeActivity({
+        id: "model-changed-3",
+        createdAt: sharedTimestamp,
+        kind: "thread.model-changed",
+        summary: "Switched to GPT-5.4",
+        tone: "info",
+        payload: { toInstanceId: "codex", toModel: "gpt-5.4", isHandoff: true },
+      }),
+    ]);
+    const entries = deriveTimelineEntries([userMessage], [], [], notices);
+    expect(entries.map((entry) => entry.kind)).toEqual(["notice", "message"]);
+  });
+});
 
 describe("derivePendingApprovals", () => {
   it("tracks open approvals and removes resolved ones", () => {

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -119,6 +119,17 @@ export interface LatestProposedPlanState {
   implementationThreadId: ThreadId | null;
 }
 
+export interface ModelChangeNotice {
+  id: string;
+  createdAt: string;
+  fromInstanceId: string | null;
+  fromModel: string | null;
+  toInstanceId: string | null;
+  toModel: string | null;
+  isHandoff: boolean;
+  summary: string;
+}
+
 export type TimelineEntry =
   | {
       id: string;
@@ -137,6 +148,12 @@ export type TimelineEntry =
       kind: "work";
       createdAt: string;
       entry: WorkLogEntry;
+    }
+  | {
+      id: string;
+      kind: "notice";
+      createdAt: string;
+      notice: ModelChangeNotice;
     };
 
 export function workLogEntryIsToolLike(entry: WorkLogEntry): boolean {
@@ -633,6 +650,9 @@ export function deriveWorkLogEntries(
     if (activity.kind === "tool.started") continue;
     if (activity.kind === "task.started") continue;
     if (activity.kind === "context-window.updated") continue;
+    // Model-change notices render as their own inline timeline row, not as a
+    // tool-like work entry. See deriveModelChangeNotices.
+    if (activity.kind === "thread.model-changed") continue;
     if (activity.summary === "Checkpoint captured") continue;
     if (isPlanBoundaryToolActivity(activity)) continue;
     entries.push(toDerivedWorkLogEntry(activity));
@@ -1337,10 +1357,42 @@ function compareActivityLifecycleRank(kind: string): number {
   return 1;
 }
 
+/**
+ * Extract Codex-style "model/provider changed" notices from the thread's
+ * activity log. These are appended by the server whenever the user swaps the
+ * model or provider on a started thread (see ProviderCommandReactor).
+ */
+export function deriveModelChangeNotices(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ModelChangeNotice[] {
+  const notices: ModelChangeNotice[] = [];
+  for (const activity of activities) {
+    if (activity.kind !== "thread.model-changed") continue;
+    const payload =
+      activity.payload && typeof activity.payload === "object" && !Array.isArray(activity.payload)
+        ? (activity.payload as Record<string, unknown>)
+        : {};
+    const asString = (value: unknown): string | null =>
+      typeof value === "string" && value.length > 0 ? value : null;
+    notices.push({
+      id: activity.id,
+      createdAt: activity.createdAt,
+      fromInstanceId: asString(payload.fromInstanceId),
+      fromModel: asString(payload.fromModel),
+      toInstanceId: asString(payload.toInstanceId),
+      toModel: asString(payload.toModel),
+      isHandoff: payload.isHandoff === true,
+      summary: activity.summary,
+    });
+  }
+  return notices;
+}
+
 export function deriveTimelineEntries(
   messages: ReadonlyArray<ChatMessage>,
   proposedPlans: ReadonlyArray<ProposedPlan>,
   workEntries: ReadonlyArray<WorkLogEntry>,
+  notices: ReadonlyArray<ModelChangeNotice> = [],
 ): TimelineEntry[] {
   const messageRows: TimelineEntry[] = messages.map((message) => ({
     id: message.id,
@@ -1360,9 +1412,22 @@ export function deriveTimelineEntries(
     createdAt: entry.createdAt,
     entry,
   }));
-  return [...messageRows, ...proposedPlanRows, ...workRows].toSorted((a, b) =>
-    a.createdAt.localeCompare(b.createdAt),
-  );
+  const noticeRows: TimelineEntry[] = notices.map((notice) => ({
+    id: notice.id,
+    kind: "notice",
+    createdAt: notice.createdAt,
+    notice,
+  }));
+  return [...messageRows, ...proposedPlanRows, ...workRows, ...noticeRows].toSorted((a, b) => {
+    const byTime = a.createdAt.localeCompare(b.createdAt);
+    if (byTime !== 0) return byTime;
+    // A model-change notice shares its timestamp with the user message that
+    // triggered the switch; render the notice just above that message so it
+    // reads as a boundary ("switched to X" then the message sent to X).
+    const aNotice = a.kind === "notice" ? 0 : 1;
+    const bNotice = b.kind === "notice" ? 0 : 1;
+    return aNotice - bNotice;
+  });
 }
 
 export function inferCheckpointTurnCountByTurnId(


### PR DESCRIPTION
Closes #3797.

> **Heads up on scope:** this is a large change (~1.1k lines) and overlaps the in-flight orchestrator-v2 work. I'm opening it for visibility per the linked issue and CONTRIBUTING's "issues first" — happy to close, split, or defer if it's not wanted as-is.

## What changed

Allows switching provider/model mid-conversation, **without resuming the old provider's session** (which #2365 found doesn't work across providers).

- On a cross-provider switch, `ensureSessionForThread` starts a **fresh** session on the target provider (dropping the old resume cursor) and persists the new `modelSelection`, instead of rejecting the switch.
- `providerHandoffTranscript` renders the prior conversation — user/assistant messages **plus a structured tool/command trail** (commands, file edits, MCP/skill calls, exit codes, output) — and prepends it to the first turn on the new provider, so it inherits the actual work, not just prose.
- An inline "Switched from X to Y" activity is rendered as a timeline notice above the triggering message.
- The picker is unlocked on started threads; the in-thread block is kept only for providers that require a new thread for a model change.

## Why this differs from prior attempts

- #2365 (closed not-planned): cross-provider *continuation* was disabled because the old session couldn't be resumed. This never resumes it — it replays a transcript into a fresh session.
- #1911: similar goal (handoff summary), but session compaction/continuation; this uses transcript replay instead.

## Notes

- Adds **no DB migrations**.
- Same-driver model switches are unchanged; this only adds the cross-driver handoff path.
- Verified end-to-end: a cross-provider switch carries context, including command output and non-zero exit codes the previous assistant never narrated.
- Tradeoff: the new provider sees a rendered transcript, not native tool-call state, so per-turn rollback/checkpointing doesn't span the switch boundary.

## Before / after

<img width="764" height="180" alt="pr3799-provider-AFTER-switched-notice" src="https://github.com/user-attachments/assets/57631a55-5359-4769-892e-ceca5e06694b" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core turn-start/session binding and provider input shaping in orchestration; incorrect handoff detection or transcript handling could mis-route turns or leak stale resume state, though behavior is heavily covered by new tests.
> 
> **Overview**
> **Mid-conversation provider/model switches** are allowed when the target instance uses a different driver or continuation key. The server no longer rejects those turns; it starts a **fresh provider session** (no old `resumeCursor`), persists the new `modelSelection`, and prepends a **`[Conversation handoff]`** transcript to the first turn on the new provider via new `renderProviderHandoffPrelude` (messages plus deduped tool/command/MCP trail, size-capped).
> 
> `ProviderCommandReactor` detects handoffs, skips in-session model-change rules for them, appends **`thread.model-changed`** activities after a successful (re)start, and resolves “current” instance from the bound session when needed. **`ProviderService`** tolerates transient binding mismatches during handoff and dedupes overlapping live sessions per thread.
> 
> The **web UI** unlocks the model picker on started threads, only blocks same-driver/same-continuation switches for `requiresNewThreadForModelChange` providers, and shows **inline “Switched from X to Y”** timeline notices from those activities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 853c8d5e306ad1cd7489197ca025599ae0eb2448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Allow switching provider/model mid-conversation with transcript handoff
> - When a user switches to a provider with a different driver or continuation group, the orchestrator starts a fresh session on the new provider instead of rejecting the change, prepending a `[Conversation handoff]` transcript prelude to the next turn so the new provider has prior context.
> - A `thread.model-changed` activity is appended to the thread on handoff; the UI renders this as a pill-styled notice row in the conversation timeline via a new `NoticeTimelineRow` component.
> - `listSessions` in `ProviderService` no longer dies on provider/instance binding mismatches; it returns at most one session per thread, preferring the authoritative binding match.
> - The `getStartedThreadModelChangeBlockReason` logic is relaxed so cross-instance switches are allowed unless both instances share the same driver and continuation group.
> - Resume cursors are cleared when rebinding to a different provider instance to prevent stale cursor reuse across drivers.
> - Risk: the handoff prelude is capped at 80,000 chars and will silently omit older history when truncated, which may cause the new provider to miss earlier context.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 853c8d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->