### PR TITLE
feat: reflect active project/thread in the window title

### DIFF
--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -360,9 +360,12 @@ export const make = Effect.gen(function* () {
       }
     });
 
-    window.on("page-title-updated", (event) => {
+    window.on("page-title-updated", (event, title) => {
       event.preventDefault();
-      window.setTitle(environment.displayName);
+      // Mirror the renderer's document.title (project/thread context) so external
+      // window-title scanners can see the active workspace; fall back to the app name.
+      const pageTitle = title?.trim();
+      window.setTitle(pageTitle ? pageTitle : environment.displayName);
     });
 
     let developmentLoadRetryIndex = 0;

--- a/apps/desktop/src/window/DesktopWindow.ts
+++ b/apps/desktop/src/window/DesktopWindow.ts
@@ -360,12 +360,17 @@ export const make = Effect.gen(function* () {
       }
     });
 
+    // Mirror the renderer's document.title (project/thread context) onto the native
+    // window title so external window-title scanners can see the active workspace;
+    // fall back to the app name when the renderer has no title yet.
+    const applyWorkspaceTitle = (rawTitle: string | null | undefined) => {
+      const pageTitle = rawTitle?.trim();
+      window.setTitle(pageTitle ? pageTitle : environment.displayName);
+    };
+
     window.on("page-title-updated", (event, title) => {
       event.preventDefault();
-      // Mirror the renderer's document.title (project/thread context) so external
-      // window-title scanners can see the active workspace; fall back to the app name.
-      const pageTitle = title?.trim();
-      window.setTitle(pageTitle ? pageTitle : environment.displayName);
+      applyWorkspaceTitle(title);
     });
 
     let developmentLoadRetryIndex = 0;
@@ -422,7 +427,9 @@ export const make = Effect.gen(function* () {
       }
       clearDevelopmentLoadRetry();
       developmentLoadRetryIndex = 0;
-      window.setTitle(environment.displayName);
+      // Re-apply the renderer's current document.title rather than forcing the app
+      // name, so a finished load doesn't clobber the active workspace title.
+      applyWorkspaceTitle(window.webContents.getTitle());
     });
     window.webContents.on(
       "did-fail-load",

--- a/apps/web/src/branding.logic.ts
+++ b/apps/web/src/branding.logic.ts
@@ -32,3 +32,20 @@ export function resolveServerBackedAppDisplayName(input: {
     ? input.fallbackDisplayName
     : formatAppDisplayName({ baseName: input.baseName, stageLabel });
 }
+
+/**
+ * Builds the `document.title` shown for the current workspace context so external
+ * tooling (window-title scanners, time trackers) can see the active project/thread.
+ * Falls back to the plain app name when no project/thread context is available.
+ */
+export function formatWorkspaceDocumentTitle(input: {
+  readonly appName: string;
+  readonly projectTitle: string | null | undefined;
+  readonly threadTitle: string | null | undefined;
+}): string {
+  const context = [input.projectTitle, input.threadTitle]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part));
+
+  return context.length === 0 ? input.appName : `${context.join(" – ")} — ${input.appName}`;
+}

--- a/apps/web/src/branding.test.ts
+++ b/apps/web/src/branding.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
 import {
+  formatWorkspaceDocumentTitle,
   resolveServerBackedAppDisplayName,
   resolveServerBackedAppStageLabel,
 } from "./branding.logic";
@@ -101,5 +102,47 @@ describe("branding logic", () => {
         primaryServerVersion: "0.0.28-nightly.20260616",
       }),
     ).toBe("T3 Code (Alpha)");
+  });
+});
+
+describe("workspace document title", () => {
+  it("combines the project and thread with the app name", () => {
+    expect(
+      formatWorkspaceDocumentTitle({
+        appName: "T3 Code (Alpha)",
+        projectTitle: "acme-web",
+        threadTitle: "Fix login redirect",
+      }),
+    ).toBe("acme-web – Fix login redirect — T3 Code (Alpha)");
+  });
+
+  it("includes whichever context is available", () => {
+    expect(
+      formatWorkspaceDocumentTitle({
+        appName: "T3 Code (Alpha)",
+        projectTitle: "acme-web",
+        threadTitle: null,
+      }),
+    ).toBe("acme-web — T3 Code (Alpha)");
+  });
+
+  it("falls back to the app name when no project or thread is active", () => {
+    expect(
+      formatWorkspaceDocumentTitle({
+        appName: "T3 Code (Alpha)",
+        projectTitle: null,
+        threadTitle: undefined,
+      }),
+    ).toBe("T3 Code (Alpha)");
+  });
+
+  it("ignores blank context values", () => {
+    expect(
+      formatWorkspaceDocumentTitle({
+        appName: "T3 Code (Alpha)",
+        projectTitle: "   ",
+        threadTitle: "Fix login redirect",
+      }),
+    ).toBe("Fix login redirect — T3 Code (Alpha)");
   });
 });

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -7,11 +7,12 @@ import {
   type ErrorComponentProps,
   useLocation,
   useNavigate,
+  useParams,
 } from "@tanstack/react-router";
 import { useEffect, useEffectEvent, useRef, useState } from "react";
 
 import { APP_BASE_NAME, APP_DISPLAY_NAME, APP_STAGE_LABEL } from "../branding";
-import { resolveServerBackedAppDisplayName } from "../branding.logic";
+import { formatWorkspaceDocumentTitle, resolveServerBackedAppDisplayName } from "../branding.logic";
 import { AppSidebarLayout } from "../components/AppSidebarLayout";
 import { CommandPalette } from "../components/CommandPalette";
 import { ConnectOnboardingDialog } from "../components/cloud/ConnectOnboardingDialog";
@@ -47,7 +48,14 @@ import {
   primaryServerConfigEventAtom,
   primaryServerWelcomeAtom,
 } from "../state/server";
-import { readProject, setActiveEnvironmentId, useActiveEnvironmentId } from "../state/entities";
+import {
+  readProject,
+  setActiveEnvironmentId,
+  useActiveEnvironmentId,
+  useProject,
+  useThreadShell,
+} from "../state/entities";
+import { resolveThreadRouteRef } from "../threadRoutes";
 import {
   createKeybindingsUpdateToastController,
   type KeybindingsUpdateToastController,
@@ -144,11 +152,26 @@ function RootRouteView() {
 function DocumentTitleSync() {
   const primaryServerVersion =
     useAtomValue(primaryServerConfigAtom)?.environment.serverVersion ?? null;
-  const title = resolveServerBackedAppDisplayName({
+  const appName = resolveServerBackedAppDisplayName({
     baseName: APP_BASE_NAME,
     fallbackDisplayName: APP_DISPLAY_NAME,
     fallbackStageLabel: APP_STAGE_LABEL,
     primaryServerVersion,
+  });
+
+  // Params are read non-strictly because DocumentTitleSync renders above the
+  // matched route; only thread routes expose environmentId/threadId.
+  const params = useParams({ strict: false });
+  const threadRef = resolveThreadRouteRef(params);
+  const thread = useThreadShell(threadRef);
+  const projectRef =
+    thread === null ? null : scopeProjectRef(thread.environmentId, thread.projectId);
+  const project = useProject(projectRef);
+
+  const title = formatWorkspaceDocumentTitle({
+    appName,
+    projectTitle: project?.title,
+    threadTitle: thread?.title,
   });
 
   useEffect(() => {

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -55,7 +55,8 @@ import {
   useProject,
   useThreadShell,
 } from "../state/entities";
-import { resolveThreadRouteRef } from "../threadRoutes";
+import { useComposerDraftStore } from "../composerDraftStore";
+import { resolveThreadRouteTarget } from "../threadRoutes";
 import {
   createKeybindingsUpdateToastController,
   type KeybindingsUpdateToastController,
@@ -160,12 +161,24 @@ function DocumentTitleSync() {
   });
 
   // Params are read non-strictly because DocumentTitleSync renders above the
-  // matched route; only thread routes expose environmentId/threadId.
+  // matched route; only thread/draft routes expose environmentId/threadId/draftId.
   const params = useParams({ strict: false });
-  const threadRef = resolveThreadRouteRef(params);
-  const thread = useThreadShell(threadRef);
+  const target = resolveThreadRouteTarget(params);
+
+  const thread = useThreadShell(target?.kind === "server" ? target.threadRef : null);
+  const draftId = target?.kind === "draft" ? target.draftId : null;
+  // Drafts have no thread title yet, but they still belong to a project, so the
+  // window title can reflect the active project while a new chat is being composed.
+  const draftSession = useComposerDraftStore((store) =>
+    draftId === null ? null : store.getDraftSession(draftId),
+  );
+
   const projectRef =
-    thread === null ? null : scopeProjectRef(thread.environmentId, thread.projectId);
+    thread !== null
+      ? scopeProjectRef(thread.environmentId, thread.projectId)
+      : draftSession !== null
+        ? scopeProjectRef(draftSession.environmentId, draftSession.projectId)
+        : null;
   const project = useProject(projectRef);
 
   const title = formatWorkspaceDocumentTitle({


### PR DESCRIPTION
Mirror the renderer's document.title onto the native window title so external window-title scanners and time trackers can see the active workspace. The title is formatted as "project – thread — app name", falling back to the plain app name when no project/thread context is active.

- add formatWorkspaceDocumentTitle() branding helper + unit tests
- derive document.title from the active thread/project route in DocumentTitleSync
- mirror the page title onto the Electron window via page-title-updated

## What Changed

Adds workspace context (active project + thread) to the window/document title:

- New `formatWorkspaceDocumentTitle()` helper in `branding.logic.ts` that builds `"project – thread — app name"`, includes whichever of project/thread is present, ignores blank values, and falls back to the plain app name when neither is set. Covered by unit tests.
- `DocumentTitleSync` (`__root.tsx`) now reads the active thread/project from the route (non-strict `useParams`, since it renders above the matched route) and feeds them into the helper to set `document.title`.
- On desktop, `page-title-updated` now mirrors the renderer's `document.title` onto the native window title instead of hard-coding the app name, so the OS window title reflects the active workspace.

## Why

External tooling that reads the OS window title — time trackers, window-title scanners — currently only ever sees the static app name, so it can't tell which project or thread is active. Surfacing the active workspace in the title lets that tooling attribute time/activity to the right project and thread without any new API. The renderer already knows the project/thread from the route, so the title is derived there and simply mirrored onto the native window; the pure formatting logic is isolated in `branding.logic.ts` so it's unit-testable and the fallback behavior is explicit.

## UI Changes

No in-app UI changes. The only visible effect is the window/tab title text, e.g.:

- Before: `T3 Code`
- After (thread open): `acme-web – Fix login redirect — T3 Code`
- After (no project/thread): `T3 Code` (unchanged fallback)

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (title text examples above; no visual UI beyond the window title)
- [ ] I included a video for animation/interaction changes (n/a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Title-only UX changes with no auth, data, or API surface impact; desktop title sync is a small behavioral change in window chrome.
> 
> **Overview**
> **Window and tab titles now include the active workspace** so external tools (time trackers, window scanners) can see project/thread context instead of only the static app name.
> 
> Adds `formatWorkspaceDocumentTitle()` to build titles like `project – thread — app name`, with partial context and blank-value handling; unit tests cover the formatting rules.
> 
> `DocumentTitleSync` resolves the current thread or composer draft from route params and entity state, then sets `document.title` via that helper (draft routes still show the project name).
> 
> On desktop, Electron no longer forces `environment.displayName` on `page-title-updated` and `did-finish-load`; it mirrors the renderer title with the same app-name fallback when empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 156b6e7b49e85d9beac617469bafeed504b01c09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reflect active project and thread in the desktop window title
> - Adds `formatWorkspaceDocumentTitle` in [`branding.logic.ts`](https://github.com/pingdotgg/t3code/pull/3800/files#diff-a77577502cdf9da372ba72b213b865343ec8fd9f2f232b5339202241917f3551) to build a title like `project – thread — app` from available context, falling back to the app name alone.
> - Updates `DocumentTitleSync` in [`__root.tsx`](https://github.com/pingdotgg/t3code/pull/3800/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100) to resolve the active project and thread and set `document.title` accordingly.
> - Updates [`DesktopWindow.ts`](https://github.com/pingdotgg/t3code/pull/3800/files#diff-d92229c509071d1e9d3595d187fe2f1f13c394b22e1d9d2070ed6fb99678f429) to mirror `document.title` onto the native window title via the `page-title-updated` event, falling back to the app display name when no title is set.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 156b6e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->