### PR TITLE
Avoid recursive config watches under proot

### DIFF
--- a/apps/server/src/configDirectoryWatch.ts
+++ b/apps/server/src/configDirectoryWatch.ts
@@ -1,0 +1,30 @@
+import * as NodeModule from "node:module";
+
+import * as Cause from "effect/Cause";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Queue from "effect/Queue";
+import * as Stream from "effect/Stream";
+
+export function watchConfigDirectory(fs: FileSystem.FileSystem, directory: string) {
+  if (!process.env.PROOT_L2S_DIR) {
+    return fs.watch(directory);
+  }
+  const nodeFS = NodeModule.createRequire(import.meta.url)("node:fs") as typeof import("node:fs");
+
+  return Stream.callback<FileSystem.WatchEvent>((queue) =>
+    Effect.acquireRelease(
+      Effect.sync(() => {
+        const watcher = nodeFS.watch(directory, { recursive: false }, (_event, fileName) => {
+          if (fileName) {
+            Queue.offerUnsafe(queue, { _tag: "Update", path: String(fileName) });
+          }
+        });
+        watcher.on("error", (error) => Queue.failCauseUnsafe(queue, Cause.die(error)));
+        watcher.on("close", () => Queue.endUnsafe(queue));
+        return watcher;
+      }),
+      (watcher) => Effect.sync(() => watcher.close()),
+    ),
+  );
+}

--- a/apps/server/src/keybindings.ts
+++ b/apps/server/src/keybindings.ts
@@ -42,6 +42,7 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as Semaphore from "effect/Semaphore";
 import * as ServerConfig from "./config.ts";
+import { watchConfigDirectory } from "./configDirectoryWatch.ts";
 import { writeFileStringAtomically } from "./atomicWrite.ts";
 import { fromJsonStringPretty, fromLenientJson } from "@t3tools/shared/schemaJson";
 import {
@@ -585,7 +586,7 @@ const make = Effect.gen(function* () {
     // Debounce watch events so the file is fully written before we read it.
     // Editors emit multiple events per save (truncate, write, rename) and
     // `fs.watch` can fire before the content has been flushed to disk.
-    const debouncedKeybindingsEvents = fs.watch(keybindingsConfigDir).pipe(
+    const debouncedKeybindingsEvents = watchConfigDirectory(fs, keybindingsConfigDir).pipe(
       Stream.filter((event) => {
         return (
           event.path === keybindingsConfigFile ||

--- a/apps/server/src/serverSettings.ts
+++ b/apps/server/src/serverSettings.ts
@@ -45,6 +45,7 @@ import * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import { writeFileStringAtomically } from "./atomicWrite.ts";
 import * as ServerConfig from "./config.ts";
+import { watchConfigDirectory } from "./configDirectoryWatch.ts";
 import { type DeepPartial, deepMerge } from "@t3tools/shared/Struct";
 import { fromJsonStringPretty, fromLenientJson } from "@t3tools/shared/schemaJson";
 import { applyServerSettingsPatch } from "@t3tools/shared/serverSettings";
@@ -517,7 +518,7 @@ const make = Effect.gen(function* () {
     // Debounce watch events so the file is fully written before we read it.
     // Editors emit multiple events per save (truncate, write, rename) and
     // `fs.watch` can fire before the content has been flushed to disk.
-    const debouncedSettingsEvents = fs.watch(settingsDir).pipe(
+    const debouncedSettingsEvents = watchConfigDirectory(fs, settingsDir).pipe(
       Stream.filter((event) => {
         return (
           event.path === settingsFile ||


### PR DESCRIPTION
## What Changed

- Use a shared proot-specific config-directory watcher for keybindings and server settings.
- Keep the existing Effect `FileSystem.watch` behavior outside proot.
- Under proot, use non-recursive `node:fs.watch` and emit update events for changed config filenames.

## Why

Effect recursive directory watching expands into hundreds of active `fs_event` watcher handles under proot for the T3 userdata config directory. In the observed Android/proot environment, the server went from about 900 active `fs_event` handles before this change to 2 after applying the non-recursive config watcher.

These numbers are not checks per second or per minute. They are the number of live filesystem watcher handles held by the Node process. Reducing them removes avoidable native watcher and event-loop pressure for two config files that only need shallow directory watching.

This keeps live reload behavior for `keybindings.json` and `settings.json` while avoiding recursive watcher fanout when `PROOT_L2S_DIR` is present.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] I included before/after screenshots for any UI changes (not applicable; no UI changes)
- [x] I included a video for animation/interaction changes (not applicable; no UI changes)

Validation:
- `./node_modules/.bin/vp check`
- `pnpm --filter t3 typecheck`
