### PR TITLE
Add profile-scoped tool access and plan goal mode

### DIFF
--- a/apps/desktop/src/backend/DesktopBackendPool.test.ts
+++ b/apps/desktop/src/backend/DesktopBackendPool.test.ts
@@ -113,9 +113,7 @@ describe("DesktopBackendPool", () => {
 
   it.effect("layerTest dies when no instances are supplied", () =>
     Effect.exit(
-      Effect.gen(function* () {
-        yield* DesktopBackendPool.DesktopBackendPool;
-      }).pipe(Effect.provide(DesktopBackendPool.layerTest([]))),
+      DesktopBackendPool.DesktopBackendPool.pipe(Effect.provide(DesktopBackendPool.layerTest([]))),
     ).pipe(Effect.map((exit) => assert.equal(exit._tag, "Failure"))),
   );
 

--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -13,13 +13,22 @@ import * as DesktopEnvironment from "../app/DesktopEnvironment.ts";
 import * as DesktopClientSettings from "./DesktopClientSettings.ts";
 
 const clientSettings: ClientSettings = {
+  activeProfileId: "default",
+  appBackgroundColor: "",
   autoOpenPlanSidebar: false,
   confirmThreadArchive: true,
   confirmThreadDelete: false,
   dismissedProviderUpdateNotificationKeys: [],
   diffIgnoreWhitespace: true,
   favorites: [],
+  globalToolAccessPolicy: { mode: "all", enabledToolKeys: [] },
+  planAndGoalReviewMode: "manual_review",
+  profiles: [{ id: "default", name: "Default" }],
+  profileToolAccessPolicies: {},
+  projectToolAccessPolicies: {},
+  projectProfileAssignments: {},
   providerModelPreferences: {},
+  providerInstanceProfileAssignments: {},
   sidebarProjectGroupingMode: "repository_path",
   sidebarProjectGroupingOverrides: {
     "environment-1:/tmp/project-a": "separate",

--- a/apps/desktop/src/wsl/DesktopWslEnvironment.ts
+++ b/apps/desktop/src/wsl/DesktopWslEnvironment.ts
@@ -811,15 +811,14 @@ export const layer = Layer.effect(
     // distro. Negative results aren't cached so a transient wsl.exe failure
     // doesn't permanently disable tilde expansion.
     const userHomeCache = new Map<string, string>();
-    const getUserHome = (distro: string | null) =>
-      Effect.gen(function* () {
-        const key = distro ?? "__default__";
-        const cached = userHomeCache.get(key);
-        if (cached !== undefined) return Option.some(cached);
-        const resolved = yield* provideSpawner(getUserHomeImpl(distro));
-        if (Option.isSome(resolved)) userHomeCache.set(key, resolved.value);
-        return resolved;
-      }).pipe(Effect.withSpan("desktop.wsl.getUserHome"));
+    const getUserHome = Effect.fn("desktop.wsl.getUserHome")(function* (distro: string | null) {
+      const key = distro ?? "__default__";
+      const cached = userHomeCache.get(key);
+      if (cached !== undefined) return Option.some(cached);
+      const resolved = yield* provideSpawner(getUserHomeImpl(distro));
+      if (Option.isSome(resolved)) userHomeCache.set(key, resolved.value);
+      return resolved;
+    });
 
     const getDistroIp = (distro: string | null) =>
       provideSpawner(getDistroIpImpl(distro)).pipe(Effect.withSpan("desktop.wsl.getDistroIp"));

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -282,10 +282,16 @@ export function NewTaskDraftScreen(props: {
       {
         id: "options-interaction",
         title: "Interaction",
-        subtitle: flow.interactionMode === "plan" ? "Plan" : "Default",
+        subtitle:
+          flow.interactionMode === "plan"
+            ? "Plan"
+            : flow.interactionMode === "plan_and_goal"
+              ? "Plan and goal"
+              : "Default",
         subactions: [
           { id: "options:interaction:default", title: "Default" },
           { id: "options:interaction:plan", title: "Plan" },
+          { id: "options:interaction:plan_and_goal", title: "Plan and goal" },
         ].map((option) => {
           const value = option.id.replace("options:interaction:", "");
           return {

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -369,6 +369,13 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
           description: "Switch to plan mode",
         },
         {
+          id: "cmd:plan-goal",
+          type: "slash-command" as const,
+          command: "plan-goal",
+          label: "/plan-goal",
+          description: "Plan first, then execute as a goal",
+        },
+        {
           id: "cmd:default",
           type: "slash-command" as const,
           command: "default",
@@ -524,7 +531,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
 
       if (
         item.type === "slash-command" &&
-        (item.command === "plan" || item.command === "default")
+        (item.command === "plan" || item.command === "plan-goal" || item.command === "default")
       ) {
         const result = replaceTextRange(
           draftMessage,
@@ -534,7 +541,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         );
         setComposerSelection({ start: result.cursor, end: result.cursor });
         onChangeDraftMessage(result.text);
-        onUpdateInteractionMode(item.command);
+        onUpdateInteractionMode(item.command === "plan-goal" ? "plan_and_goal" : item.command);
         return;
       }
 

--- a/apps/mobile/src/features/threads/threadPresentation.ts
+++ b/apps/mobile/src/features/threads/threadPresentation.ts
@@ -110,7 +110,7 @@ export function resolveThreadStatus(
   }
 
   const hasPlanReadyPrompt =
-    thread.interactionMode === "plan" &&
+    (thread.interactionMode === "plan" || thread.interactionMode === "plan_and_goal") &&
     isLatestTurnSettled(thread.latestTurn, thread.session) &&
     thread.hasActionableProposedPlan;
   if (hasPlanReadyPrompt) {

--- a/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
+++ b/apps/server/src/orchestration/Layers/ProviderCommandReactor.ts
@@ -4,6 +4,7 @@ import {
   EventId,
   type ModelSelection,
   type OrchestrationEvent,
+  type ProviderInteractionMode,
   ProviderDriverKind,
   type ProjectId,
   type OrchestrationSession,
@@ -588,7 +589,8 @@ const make = Effect.gen(function* () {
     readonly messageText: string;
     readonly attachments?: ReadonlyArray<ChatAttachment>;
     readonly modelSelection?: ModelSelection;
-    readonly interactionMode?: "default" | "plan";
+    readonly interactionMode?: ProviderInteractionMode;
+    readonly goalObjective?: string;
     readonly createdAt: string;
   }) {
     const thread = yield* resolveThread(input.threadId);
@@ -641,6 +643,7 @@ const make = Effect.gen(function* () {
       ...(normalizedAttachments.length > 0 ? { attachments: normalizedAttachments } : {}),
       ...(modelForTurn !== undefined ? { modelSelection: modelForTurn } : {}),
       ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
+      ...(input.goalObjective !== undefined ? { goalObjective: input.goalObjective } : {}),
     };
   });
 
@@ -845,6 +848,9 @@ const make = Effect.gen(function* () {
         ? { modelSelection: event.payload.modelSelection }
         : {}),
       interactionMode: event.payload.interactionMode,
+      ...(event.payload.goalObjective !== undefined
+        ? { goalObjective: event.payload.goalObjective }
+        : {}),
       createdAt: event.payload.createdAt,
     }).pipe(
       Effect.map(Option.some),

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -455,6 +455,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           runtimeMode: targetThread.runtimeMode,
           interactionMode: targetThread.interactionMode,
           ...(sourceProposedPlan !== undefined ? { sourceProposedPlan } : {}),
+          ...(command.goalObjective !== undefined ? { goalObjective: command.goalObjective } : {}),
           createdAt: command.createdAt,
         },
       };

--- a/apps/server/src/provider/Layers/ClaudeAdapter.ts
+++ b/apps/server/src/provider/Layers/ClaudeAdapter.ts
@@ -3675,7 +3675,7 @@ export const makeClaudeAdapter = Effect.fn("makeClaudeAdapter")(function* (
     // "plan" maps directly to the SDK's "plan" permission mode;
     // "default" restores the session's original permission mode.
     // When interactionMode is absent we leave the current mode unchanged.
-    if (input.interactionMode === "plan") {
+    if (input.interactionMode === "plan" || input.interactionMode === "plan_and_goal") {
       yield* Effect.tryPromise({
         try: () => context.query.setPermissionMode("plan"),
         catch: (cause) => toRequestError(input.threadId, "turn/setPermissionMode", cause),

--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -1548,6 +1548,7 @@ export const makeCodexAdapter = Effect.fn("makeCodexAdapter")(function* (
           : {}),
         ...(serviceTier ? { serviceTier } : {}),
         ...(input.interactionMode !== undefined ? { interactionMode: input.interactionMode } : {}),
+        ...(input.goalObjective !== undefined ? { goalObjective: input.goalObjective } : {}),
         ...(codexAttachments.length > 0 ? { attachments: codexAttachments } : {}),
       })
       .pipe(Effect.mapError((cause) => mapCodexRuntimeError(input.threadId, "turn/start", cause)));

--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -248,6 +248,16 @@ function parseCodexSkillsListResponse(
     if (shortDescription) {
       parsedSkill.shortDescription = shortDescription;
     }
+    if (skill.dependencies?.tools && skill.dependencies.tools.length > 0) {
+      parsedSkill.toolDependencies = skill.dependencies.tools.map((tool) => ({
+        type: tool.type,
+        value: tool.value,
+        ...(tool.command !== undefined ? { command: tool.command } : {}),
+        ...(tool.description !== undefined ? { description: tool.description } : {}),
+        ...(tool.transport !== undefined ? { transport: tool.transport } : {}),
+        ...(tool.url !== undefined ? { url: tool.url } : {}),
+      }));
+    }
 
     return parsedSkill;
   });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.test.ts
@@ -124,6 +124,25 @@ describe("buildTurnStartParams", () => {
     });
   });
 
+  it("maps plan and goal collaboration to Codex plan mode", () => {
+    const params = Effect.runSync(
+      buildTurnStartParams({
+        threadId: "provider-thread-1",
+        runtimeMode: "full-access",
+        prompt: "Make a plan",
+        model: "gpt-5.3-codex",
+        effort: "medium",
+        interactionMode: "plan_and_goal",
+      }),
+    );
+
+    NodeAssert.equal(params.collaborationMode?.mode, "plan");
+    NodeAssert.equal(
+      params.collaborationMode?.settings.developer_instructions,
+      CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
+    );
+  });
+
   it("includes default collaboration mode and image attachments", () => {
     const params = Effect.runSync(
       buildTurnStartParams({

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -119,6 +119,7 @@ export interface CodexSessionRuntimeSendTurnInput {
   readonly serviceTier?: CodexServiceTier | undefined;
   readonly effort?: EffectCodexSchema.V2TurnStartParams__ReasoningEffort | undefined;
   readonly interactionMode?: ProviderInteractionMode;
+  readonly goalObjective?: string;
 }
 
 export interface CodexThreadTurnSnapshot {
@@ -330,14 +331,16 @@ function buildCodexCollaborationMode(input: {
   if (input.interactionMode === undefined) {
     return undefined;
   }
+  const codexInteractionMode =
+    input.interactionMode === "plan_and_goal" ? "plan" : input.interactionMode;
   const model = normalizeCodexModelSlug(input.model) ?? DEFAULT_MODEL;
   return {
-    mode: input.interactionMode,
+    mode: codexInteractionMode,
     settings: {
       model,
       reasoning_effort: input.effort ?? "medium",
       developer_instructions:
-        input.interactionMode === "plan"
+        codexInteractionMode === "plan"
           ? CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS
           : CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
     },
@@ -1265,6 +1268,13 @@ export const makeCodexSessionRuntime = (
       sendTurn: (input) =>
         Effect.gen(function* () {
           const providerThreadId = yield* readProviderThreadId;
+          if (input.goalObjective?.trim()) {
+            yield* client.request("thread/goal/set", {
+              threadId: providerThreadId,
+              objective: input.goalObjective.trim(),
+              status: "active",
+            });
+          }
           if (hasConfiguredMcpServer(options.appServerArgs)) {
             yield* client.request("config/mcpServer/reload", undefined).pipe(
               Effect.catch((cause) =>

--- a/apps/server/src/provider/Layers/CursorAdapter.ts
+++ b/apps/server/src/provider/Layers/CursorAdapter.ts
@@ -224,7 +224,7 @@ function resolveRequestedModeId(input: {
     return undefined;
   }
 
-  if (input.interactionMode === "plan") {
+  if (input.interactionMode === "plan" || input.interactionMode === "plan_and_goal") {
     return findModeByAliases(modeState.availableModes, ACP_PLAN_MODE_ALIASES)?.id;
   }
 

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.ts
@@ -1215,7 +1215,11 @@ export function makeOpenCodeAdapter(
       const variant = getModelSelectionStringOptionValue(modelSelection, "variant");
 
       context.activeTurnId = turnId;
-      context.activeAgent = agent ?? (input.interactionMode === "plan" ? "plan" : undefined);
+      context.activeAgent =
+        agent ??
+        (input.interactionMode === "plan" || input.interactionMode === "plan_and_goal"
+          ? "plan"
+          : undefined);
       context.activeVariant = variant;
       yield* updateProviderSession(
         context,

--- a/apps/web/src/components/AppSidebarLayout.tsx
+++ b/apps/web/src/components/AppSidebarLayout.tsx
@@ -3,6 +3,8 @@ import { useEffect, type CSSProperties, type ReactNode } from "react";
 import { useNavigate } from "@tanstack/react-router";
 
 import { isElectron } from "../env";
+import { useClientSettings } from "../hooks/useSettings";
+import { syncBrowserChromeTheme } from "../hooks/useTheme";
 import { resolveShortcutCommand, shortcutLabelForCommand } from "../keybindings";
 import { isMacPlatform } from "../lib/utils";
 import { primaryServerKeybindingsAtom } from "../state/server";
@@ -14,6 +16,16 @@ const THREAD_SIDEBAR_WIDTH_STORAGE_KEY = "chat_thread_sidebar_width";
 const THREAD_SIDEBAR_MIN_WIDTH = 13 * 16;
 const THREAD_MAIN_CONTENT_MIN_WIDTH = 40 * 16;
 const MACOS_TRAFFIC_LIGHTS_LEFT_INSET = "90px";
+
+function normalizeCssColor(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const css = globalThis.CSS;
+  if (typeof css === "undefined" || typeof css.supports !== "function") {
+    return /^#[0-9a-f]{6}$/i.test(trimmed) ? trimmed : null;
+  }
+  return css.supports("color", trimmed) ? trimmed : null;
+}
 
 function SidebarControl() {
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
@@ -55,6 +67,7 @@ function SidebarControl() {
 
 export function AppSidebarLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  const appBackgroundColor = useClientSettings((settings) => settings.appBackgroundColor);
   const macosWindowControlsStyle =
     isElectron && isMacPlatform(navigator.platform)
       ? ({ "--workspace-controls-left": MACOS_TRAFFIC_LIGHTS_LEFT_INSET } as CSSProperties)
@@ -76,6 +89,16 @@ export function AppSidebarLayout({ children }: { children: ReactNode }) {
       unsubscribe?.();
     };
   }, [navigate]);
+
+  useEffect(() => {
+    const color = normalizeCssColor(appBackgroundColor);
+    if (color) {
+      document.documentElement.style.setProperty("--app-user-background", color);
+    } else {
+      document.documentElement.style.removeProperty("--app-user-background");
+    }
+    syncBrowserChromeTheme();
+  }, [appBackgroundColor]);
 
   return (
     <SidebarProvider className="h-dvh! min-h-0!" defaultOpen style={macosWindowControlsStyle}>

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -95,6 +95,7 @@ import {
 } from "../pendingUserInput";
 import { useUiStateStore } from "../uiStateStore";
 import {
+  buildPlanGoalObjective,
   buildPlanImplementationThreadTitle,
   buildPlanImplementationPrompt,
   resolvePlanFollowUpSubmission,
@@ -1046,6 +1047,7 @@ function ChatViewContent(props: ChatViewProps) {
   );
   const timestampFormat = settings.timestampFormat;
   const autoOpenPlanSidebar = settings.autoOpenPlanSidebar;
+  const planAndGoalReviewMode = settings.planAndGoalReviewMode;
   const navigate = useNavigate();
   const { resolvedTheme } = useTheme();
   // Granular store selectors — avoid subscribing to prompt changes.
@@ -1128,6 +1130,7 @@ function ChatViewContent(props: ChatViewProps) {
   // When set, the thread-change reset effect will open the sidebar instead of closing it.
   // Used by "Implement in a new thread" to carry the sidebar-open intent across navigation.
   const planSidebarOpenOnNextThreadRef = useRef(false);
+  const autoStartedPlanAndGoalIdsRef = useRef(new Set<string>());
   const [terminalFocusRequestId, setTerminalFocusRequestId] = useState(0);
   const [pullRequestDialogState, setPullRequestDialogState] =
     useState<PullRequestDialogState | null>(null);
@@ -1791,10 +1794,12 @@ function ChatViewContent(props: ChatViewProps) {
     () => deriveActivePlanState(threadActivities, activeLatestTurn?.turnId ?? undefined),
     [activeLatestTurn?.turnId, threadActivities],
   );
-  const planSidebarLabel = sidebarProposedPlan || interactionMode === "plan" ? "Plan" : "Tasks";
+  const isPlanningInteractionMode =
+    interactionMode === "plan" || interactionMode === "plan_and_goal";
+  const planSidebarLabel = sidebarProposedPlan || isPlanningInteractionMode ? "Plan" : "Tasks";
   const showPlanFollowUpPrompt =
     pendingUserInputs.length === 0 &&
-    interactionMode === "plan" &&
+    isPlanningInteractionMode &&
     latestTurnSettled &&
     hasActionableProposedPlan(activeProposedPlan);
   const activePendingApproval = pendingApprovals[0] ?? null;
@@ -2744,7 +2749,13 @@ function ChatViewContent(props: ChatViewProps) {
     ],
   );
   const toggleInteractionMode = useCallback(() => {
-    handleInteractionModeChange(interactionMode === "plan" ? "default" : "plan");
+    const nextMode =
+      interactionMode === "default"
+        ? "plan"
+        : interactionMode === "plan"
+          ? "plan_and_goal"
+          : "default";
+    handleInteractionModeChange(nextMode);
   }, [handleInteractionModeChange, interactionMode]);
   const dismissPlanSidebarForCurrentTurn = useCallback(() => {
     planSidebarDismissedForTurnRef.current =
@@ -3922,6 +3933,8 @@ function ChatViewContent(props: ChatViewProps) {
       const followUp = resolvePlanFollowUpSubmission({
         draftText: trimmed,
         planMarkdown: activeProposedPlan.planMarkdown,
+        interactionMode,
+        executionMode: interactionMode === "plan_and_goal" ? "goal" : "implement",
       });
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);
@@ -3929,6 +3942,7 @@ function ChatViewContent(props: ChatViewProps) {
       await onSubmitPlanFollowUp({
         text: followUp.text,
         interactionMode: followUp.interactionMode,
+        ...(followUp.goalObjective !== undefined ? { goalObjective: followUp.goalObjective } : {}),
       });
       return;
     }
@@ -3941,7 +3955,9 @@ function ChatViewContent(props: ChatViewProps) {
         ? parseStandaloneComposerSlashCommand(trimmed)
         : null;
     if (standaloneSlashCommand) {
-      handleInteractionModeChange(standaloneSlashCommand);
+      handleInteractionModeChange(
+        standaloneSlashCommand === "plan-goal" ? "plan_and_goal" : standaloneSlashCommand,
+      );
       promptRef.current = "";
       clearComposerDraftContent(composerDraftTarget);
       composerRef.current?.resetCursorState();
@@ -4419,9 +4435,11 @@ function ChatViewContent(props: ChatViewProps) {
     async ({
       text,
       interactionMode: nextInteractionMode,
+      goalObjective,
     }: {
       text: string;
-      interactionMode: "default" | "plan";
+      interactionMode: ProviderInteractionMode;
+      goalObjective?: string;
     }) => {
       if (
         !activeThread ||
@@ -4531,6 +4549,7 @@ function ChatViewContent(props: ChatViewProps) {
                   },
                 }
               : {}),
+            ...(goalObjective !== undefined ? { goalObjective } : {}),
             createdAt: messageCreatedAt,
           },
         });
@@ -4582,6 +4601,46 @@ function ChatViewContent(props: ChatViewProps) {
       composerRef,
     ],
   );
+
+  useEffect(() => {
+    if (
+      planAndGoalReviewMode !== "auto" ||
+      interactionMode !== "plan_and_goal" ||
+      !showPlanFollowUpPrompt ||
+      !activeThread ||
+      !activeProposedPlan ||
+      isSendBusy ||
+      isConnecting ||
+      sendInFlightRef.current
+    ) {
+      return;
+    }
+    const autoStartKey = `${activeThread.environmentId}:${activeThread.id}:${activeProposedPlan.id}`;
+    if (autoStartedPlanAndGoalIdsRef.current.has(autoStartKey)) {
+      return;
+    }
+    autoStartedPlanAndGoalIdsRef.current.add(autoStartKey);
+    const followUp = resolvePlanFollowUpSubmission({
+      draftText: "",
+      planMarkdown: activeProposedPlan.planMarkdown,
+      interactionMode,
+      executionMode: "goal",
+    });
+    void onSubmitPlanFollowUp({
+      text: followUp.text,
+      interactionMode: followUp.interactionMode,
+      ...(followUp.goalObjective !== undefined ? { goalObjective: followUp.goalObjective } : {}),
+    });
+  }, [
+    activeProposedPlan,
+    activeThread,
+    interactionMode,
+    isConnecting,
+    isSendBusy,
+    onSubmitPlanFollowUp,
+    planAndGoalReviewMode,
+    showPlanFollowUpPrompt,
+  ]);
 
   const onImplementPlanInNewThread = useCallback(async () => {
     if (
@@ -4666,6 +4725,9 @@ function ChatViewContent(props: ChatViewProps) {
             threadId: activeThread.id,
             planId: activeProposedPlan.id,
           },
+          ...(interactionMode === "plan_and_goal"
+            ? { goalObjective: buildPlanGoalObjective(planMarkdown) }
+            : {}),
           createdAt,
         },
       });
@@ -4731,6 +4793,7 @@ function ChatViewContent(props: ChatViewProps) {
     activeEnvironmentUnavailable,
     createThread,
     deleteThread,
+    interactionMode,
     isConnecting,
     isSendBusy,
     isServerThread,
@@ -5151,6 +5214,7 @@ function ChatViewContent(props: ChatViewProps) {
                       activeThreadId={activeThreadId}
                       activeThreadEnvironmentId={activeThread?.environmentId}
                       activeThread={activeThread}
+                      activeProject={activeProject ?? null}
                       isServerThread={isServerThread}
                       isLocalDraftThread={isLocalDraftThread}
                       phase={phase}

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -49,7 +49,7 @@ import { OpenAddProjectCommandPaletteProvider } from "../commandPaletteContext";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
-import { useClientSettings } from "../hooks/useSettings";
+import { useClientSettings, useUpdateClientSettings } from "../hooks/useSettings";
 import { readLocalApi } from "../localApi";
 import { desktopLocalBackendId } from "../connection/desktopLocal";
 import { filesystemEnvironment } from "../state/filesystem";
@@ -60,6 +60,13 @@ import { useAtomCommand } from "../state/use-atom-command";
 import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { useEnvironments, usePrimaryEnvironment } from "../state/environments";
 import { useProjects, useThreadShells } from "../state/entities";
+import {
+  assignProjectKeysToProfilePatch,
+  filterProjectsForActiveProfile,
+  filterThreadsForActiveProfile,
+  getActiveProfileId,
+  projectProfileKeyFromPath,
+} from "../profiles";
 import {
   startNewThreadInProjectFromContext,
   startNewThreadFromContext,
@@ -84,6 +91,7 @@ import { getLatestThreadForProject } from "../lib/threadSort";
 import { cn, isMacPlatform, isWindowsPlatform, newProjectId } from "../lib/utils";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
+import type { Project } from "../types";
 import {
   applyWslEnvironmentConfiguration,
   parseWslUncPath,
@@ -129,6 +137,16 @@ import { ComposerHandleContext, useComposerHandleContext } from "../composerHand
 import type { ChatComposerHandle } from "./chat/ChatComposer";
 
 const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
+
+function renderProjectFavicon(project: Project): ReactNode {
+  return (
+    <ProjectFavicon
+      environmentId={project.environmentId}
+      cwd={project.workspaceRoot}
+      className={ITEM_ICON_CLASS}
+    />
+  );
+}
 
 function getLocalFileManagerName(platform: string): string {
   if (isMacPlatform(platform)) {
@@ -459,6 +477,7 @@ function OpenCommandPaletteDialog(props: {
   const isActionsOnly = deferredQuery.startsWith(">");
   const [highlightedItemValue, setHighlightedItemValue] = useState<string | null>(null);
   const clientSettings = useClientSettings();
+  const updateClientSettings = useUpdateClientSettings();
   const createProject = useAtomCommand(projectEnvironment.create, {
     reportFailure: false,
   });
@@ -475,6 +494,14 @@ function OpenCommandPaletteDialog(props: {
     useHandleNewThread();
   const projects = useProjects();
   const threads = useThreadShells();
+  const visibleProjects = useMemo(
+    () => filterProjectsForActiveProfile(projects, clientSettings),
+    [clientSettings, projects],
+  );
+  const visibleThreads = useMemo(
+    () => filterThreadsForActiveProfile(threads, projects, clientSettings),
+    [clientSettings, projects, threads],
+  );
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const [viewStack, setViewStack] = useState<CommandPaletteView[]>([]);
   const currentView = viewStack.at(-1) ?? null;
@@ -586,8 +613,8 @@ function OpenCommandPaletteDialog(props: {
     [projects],
   );
   const projectTitleById = useMemo(
-    () => new Map<ProjectId, string>(projects.map((project) => [project.id, project.title])),
-    [projects],
+    () => new Map<ProjectId, string>(visibleProjects.map((project) => [project.id, project.title])),
+    [visibleProjects],
   );
 
   const activeThreadId = activeThread?.id;
@@ -629,9 +656,9 @@ function OpenCommandPaletteDialog(props: {
   );
 
   const openProjectFromSearch = useMemo(
-    () => async (project: (typeof projects)[number]) => {
+    () => async (project: (typeof visibleProjects)[number]) => {
       const latestThread = getLatestThreadForProject(
-        threads.filter((thread) => thread.environmentId === project.environmentId),
+        visibleThreads.filter((thread) => thread.environmentId === project.environmentId),
         project.id,
         clientSettings.sidebarThreadSortOrder,
       );
@@ -647,39 +674,27 @@ function OpenCommandPaletteDialog(props: {
 
       await handleNewThread(scopeProjectRef(project.environmentId, project.id));
     },
-    [handleNewThread, navigate, clientSettings.sidebarThreadSortOrder, threads],
+    [handleNewThread, navigate, clientSettings.sidebarThreadSortOrder, visibleThreads],
   );
 
   const projectSearchItems = useMemo(
     () =>
       buildProjectActionItems({
-        projects,
+        projects: visibleProjects,
         valuePrefix: "project",
-        icon: (project) => (
-          <ProjectFavicon
-            environmentId={project.environmentId}
-            cwd={project.workspaceRoot}
-            className={ITEM_ICON_CLASS}
-          />
-        ),
+        icon: renderProjectFavicon,
         runProject: openProjectFromSearch,
       }),
-    [openProjectFromSearch, projects],
+    [openProjectFromSearch, visibleProjects],
   );
 
   const projectThreadItems = useMemo(
     () =>
       buildProjectActionItems({
-        projects,
+        projects: visibleProjects,
         valuePrefix: "new-thread-in",
         shortcutCommand: "chat.new",
-        icon: (project) => (
-          <ProjectFavicon
-            environmentId={project.environmentId}
-            cwd={project.workspaceRoot}
-            className={ITEM_ICON_CLASS}
-          />
-        ),
+        icon: renderProjectFavicon,
         runProject: async (project) => {
           await startNewThreadInProjectFromContext(
             {
@@ -692,13 +707,13 @@ function OpenCommandPaletteDialog(props: {
           );
         },
       }),
-    [activeDraftThread, activeThread, defaultProjectRef, handleNewThread, projects],
+    [activeDraftThread, activeThread, defaultProjectRef, handleNewThread, visibleProjects],
   );
 
   const allThreadItems = useMemo(
     () =>
       buildThreadActionItems({
-        threads,
+        threads: visibleThreads,
         ...(activeThreadId ? { activeThreadId } : {}),
         projectTitleById,
         sortOrder: clientSettings.sidebarThreadSortOrder,
@@ -712,7 +727,13 @@ function OpenCommandPaletteDialog(props: {
           });
         },
       }),
-    [activeThreadId, clientSettings.sidebarThreadSortOrder, navigate, projectTitleById, threads],
+    [
+      activeThreadId,
+      clientSettings.sidebarThreadSortOrder,
+      navigate,
+      projectTitleById,
+      visibleThreads,
+    ],
   );
   const recentThreadItems = allThreadItems.slice(0, RECENT_THREAD_LIMIT);
 
@@ -1116,6 +1137,13 @@ function OpenCommandPaletteDialog(props: {
         cwd,
       );
       if (existing) {
+        updateClientSettings(
+          assignProjectKeysToProfilePatch(
+            clientSettings,
+            [projectProfileKeyFromPath(existing.environmentId, existing.workspaceRoot)],
+            getActiveProfileId(clientSettings),
+          ),
+        );
         const latestThread = getLatestThreadForProject(
           threads.filter((thread) => thread.environmentId === existing.environmentId),
           existing.id,
@@ -1176,6 +1204,14 @@ function OpenCommandPaletteDialog(props: {
         return;
       }
 
+      updateClientSettings(
+        assignProjectKeysToProfilePatch(
+          clientSettings,
+          [projectProfileKeyFromPath(input.environmentId, cwd)],
+          getActiveProfileId(clientSettings),
+        ),
+      );
+
       const navigationResult = await settlePromise(() =>
         handleNewThread(scopeProjectRef(input.environmentId, projectId)),
       );
@@ -1195,11 +1231,14 @@ function OpenCommandPaletteDialog(props: {
     [
       handleNewThread,
       createProject,
+      updateClientSettings,
       navigate,
       projects,
       setOpen,
+      clientSettings,
       clientSettings.sidebarThreadSortOrder,
       threads,
+      visibleThreads,
     ],
   );
 

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -400,7 +400,7 @@ export function resolveThreadStatusPill(input: {
 
   const hasPlanReadyPrompt =
     !thread.hasPendingUserInput &&
-    thread.interactionMode === "plan" &&
+    (thread.interactionMode === "plan" || thread.interactionMode === "plan_and_goal") &&
     isLatestTurnSettled(thread.latestTurn, thread.session) &&
     thread.hasActionableProposedPlan;
   if (hasPlanReadyPrompt) {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,17 +1,20 @@
 import {
   ArchiveIcon,
   ArrowUpDownIcon,
+  BotIcon,
   ChevronRightIcon,
   CloudIcon,
   ContainerIcon,
   FolderPlusIcon,
   Globe2Icon,
   LoaderIcon,
+  PlusIcon,
   SearchIcon,
   SettingsIcon,
   SquarePenIcon,
   TerminalIcon,
   TriangleAlertIcon,
+  UserRoundIcon,
 } from "lucide-react";
 import {
   ChangeRequestStatusIcon,
@@ -44,6 +47,7 @@ import { CSS } from "@dnd-kit/utilities";
 import {
   type ContextMenuItem,
   DEFAULT_SERVER_SETTINGS,
+  type AppToolAccessPolicy,
   ProjectId,
   type ScopedThreadRef,
   type ResolvedKeybindingsConfig,
@@ -83,6 +87,7 @@ import {
   useProject,
   useProjects,
   useServerConfigs,
+  useThreadActivities,
   useThreadShells,
   useThreadShellsForProjectRefs,
 } from "../state/entities";
@@ -206,7 +211,11 @@ import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
 import { useIsMobile } from "~/hooks/useMediaQuery";
 import { CommandDialogTrigger } from "./ui/command";
 import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
-import { primaryServerConfigAtom, primaryServerKeybindingsAtom } from "../state/server";
+import {
+  primaryServerConfigAtom,
+  primaryServerKeybindingsAtom,
+  primaryServerProvidersAtom,
+} from "../state/server";
 import {
   derivePhysicalProjectKey,
   deriveProjectGroupingOverrideKey,
@@ -221,6 +230,18 @@ import {
   type SidebarProjectSnapshot,
 } from "../sidebarProjectGrouping";
 import { SidebarProviderUpdatePill } from "./sidebar/SidebarProviderUpdatePill";
+import {
+  assignProjectKeysToProfilePatch,
+  createProfilePatch,
+  filterProjectsForActiveProfile,
+  filterThreadsForActiveProfile,
+  getActiveProfile,
+  getActiveProfileId,
+  getAppProfiles,
+} from "../profiles";
+import { buildToolAccessCatalog } from "../toolAccess";
+import { ToolAccessPolicyControl } from "./settings/ToolAccessPolicyControl";
+import { deriveSidebarSubchats, type SidebarSubchatStatus } from "../sidebarSubchats";
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
@@ -317,6 +338,28 @@ function buildThreadJumpLabelMap(input: {
   return mapping.size > 0 ? mapping : EMPTY_THREAD_JUMP_LABELS;
 }
 
+function subchatStatusClassName(status: SidebarSubchatStatus): string {
+  switch (status) {
+    case "completed":
+      return "bg-emerald-500";
+    case "failed":
+      return "bg-destructive";
+    case "running":
+      return "bg-sky-500 animate-pulse";
+  }
+}
+
+function subchatStatusLabel(status: SidebarSubchatStatus): string {
+  switch (status) {
+    case "completed":
+      return "Completed";
+    case "failed":
+      return "Failed";
+    case "running":
+      return "Running";
+  }
+}
+
 interface SidebarThreadRowProps {
   thread: SidebarThreadSummary;
   projectCwd: string | null;
@@ -383,6 +426,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
   } = props;
   const threadRef = scopeThreadRef(thread.environmentId, thread.id);
   const threadKey = scopedThreadKey(threadRef);
+  const threadActivities = useThreadActivities(isActive ? threadRef : null);
+  const subchats = useMemo(
+    () => (isActive ? deriveSidebarSubchats(threadActivities) : []),
+    [isActive, threadActivities],
+  );
   const lastVisitedAt = useUiStateStore((state) => state.threadLastVisitedAtById[threadKey]);
   const isSelected = useThreadSelectionStore((state) => state.selectedThreadKeys.has(threadKey));
   const runningTerminalIds = useThreadRunningTerminalIds({
@@ -881,6 +929,34 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
           </div>
         </div>
       </SidebarMenuSubButton>
+      {subchats.length > 0 ? (
+        <div
+          className="ml-5 mt-0.5 grid gap-0.5 border-l border-border/60 pl-2"
+          data-testid={`thread-subchats-${thread.id}`}
+        >
+          {subchats.slice(-4).map((subchat) => (
+            <div
+              key={subchat.id}
+              className="flex h-5 min-w-0 items-center gap-1.5 rounded-sm px-1 text-[10px] text-muted-foreground/80"
+              title={subchat.detail ?? subchat.label}
+            >
+              <BotIcon className="size-3 shrink-0 text-muted-foreground/60" aria-hidden />
+              <span
+                className={`size-1.5 shrink-0 rounded-full ${subchatStatusClassName(
+                  subchat.status,
+                )}`}
+                aria-label={subchatStatusLabel(subchat.status)}
+              />
+              <span className="min-w-0 flex-1 truncate">{subchat.label}</span>
+              {subchat.receiverThreadIds.length > 0 ? (
+                <span className="shrink-0 font-mono text-[9px] text-muted-foreground/50">
+                  {subchat.receiverThreadIds.length}
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      ) : null}
     </SidebarMenuSubItem>
   );
 });
@@ -1110,6 +1186,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   );
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const serverConfigs = useServerConfigs();
+  const providerStatuses = useAtomValue(primaryServerProvidersAtom);
+  const toolCatalog = useMemo(() => buildToolAccessCatalog(providerStatuses), [providerStatuses]);
   const deleteProject = useAtomCommand(projectEnvironment.delete, {
     reportFailure: false,
   });
@@ -1120,6 +1198,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     reportFailure: false,
   });
   const updateSettings = useUpdateClientSettings();
+  const clientSettings = useClientSettings();
+  const profiles = getAppProfiles(clientSettings);
   const sidebarThreadPreviewCount = useClientSettings<SidebarThreadPreviewCount>(
     (settings) => settings.sidebarThreadPreviewCount,
   );
@@ -1216,6 +1296,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const [projectGroupingSelection, setProjectGroupingSelection] = useState<
     SidebarProjectGroupingMode | "inherit"
   >("inherit");
+  const [projectToolAccessTarget, setProjectToolAccessTarget] =
+    useState<SidebarProjectGroupMember | null>(null);
   const renamingCommittedRef = useRef(false);
   const renamingInputRef = useRef<HTMLInputElement | null>(null);
   const confirmArchiveButtonRefs = useRef(new Map<string, HTMLButtonElement>());
@@ -1434,6 +1516,10 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     [projectGroupingSettings.sidebarProjectGroupingOverrides],
   );
 
+  const openProjectToolAccessDialog = useCallback((member: SidebarProjectGroupMember) => {
+    setProjectToolAccessTarget(member);
+  }, []);
+
   const removeProject = useCallback(
     async (member: SidebarProjectGroupMember, options: { force?: boolean } = {}) => {
       const memberProjectRef = scopeProjectRef(member.environmentId, member.id);
@@ -1596,7 +1682,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
         const actionHandlers = new Map<string, () => Promise<void> | void>();
         const makeLeaf = (
-          action: "rename" | "grouping" | "copy-path" | "delete",
+          action: "rename" | "grouping" | "tools" | "copy-path" | "delete",
           member: SidebarProjectGroupMember,
           options?: {
             destructive?: boolean;
@@ -1611,6 +1697,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                 return;
               case "grouping":
                 openProjectGroupingDialog(member);
+                return;
+              case "tools":
+                openProjectToolAccessDialog(member);
                 return;
               case "copy-path":
                 copyPathToClipboard(member.workspaceRoot, { path: member.workspaceRoot });
@@ -1628,8 +1717,29 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           };
         };
 
+        const moveToProfileItem: ContextMenuItem<string> = {
+          id: "profile:submenu",
+          label: "Move to profile...",
+          children: profiles.map((profile) => {
+            const id = `profile:${profile.id}`;
+            actionHandlers.set(id, () => {
+              updateSettings(
+                assignProjectKeysToProfilePatch(
+                  clientSettings,
+                  project.memberProjects.map((member) => member.physicalProjectKey),
+                  profile.id,
+                ),
+              );
+            });
+            return {
+              id,
+              label: profile.name,
+            };
+          }),
+        };
+
         const buildTargetedItem = (
-          action: "rename" | "grouping" | "copy-path" | "delete",
+          action: "rename" | "grouping" | "tools" | "copy-path" | "delete",
           label: string,
           options?: {
             destructive?: boolean;
@@ -1665,6 +1775,8 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           [
             buildTargetedItem("rename", "Rename"),
             buildTargetedItem("grouping", "Group into..."),
+            buildTargetedItem("tools", "Customize tools..."),
+            moveToProfileItem,
             buildTargetedItem("copy-path", "Copy Path"),
             buildTargetedItem("delete", "Remove", {
               destructive: true,
@@ -1686,11 +1798,15 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     [
       copyPathToClipboard,
       handleRemoveProject,
+      clientSettings,
       openProjectGroupingDialog,
       openProjectRenameDialog,
+      openProjectToolAccessDialog,
       project.groupedProjectCount,
       project.memberProjects,
+      profiles,
       suppressProjectClickForContextMenuRef,
+      updateSettings,
     ],
   );
 
@@ -2111,6 +2227,42 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     updateSettings,
   ]);
 
+  const closeProjectToolAccessDialog = useCallback(() => {
+    setProjectToolAccessTarget(null);
+  }, []);
+
+  const updateProjectToolAccessPolicy = useCallback(
+    (policy: AppToolAccessPolicy) => {
+      if (!projectToolAccessTarget) {
+        return;
+      }
+      updateSettings({
+        projectToolAccessPolicies: {
+          ...clientSettings.projectToolAccessPolicies,
+          [projectToolAccessTarget.physicalProjectKey]: policy,
+        },
+      });
+    },
+    [clientSettings.projectToolAccessPolicies, projectToolAccessTarget, updateSettings],
+  );
+
+  const resetProjectToolAccessPolicy = useCallback(() => {
+    if (!projectToolAccessTarget) {
+      return;
+    }
+    const nextPolicies = { ...clientSettings.projectToolAccessPolicies };
+    delete nextPolicies[projectToolAccessTarget.physicalProjectKey];
+    updateSettings({
+      projectToolAccessPolicies: nextPolicies,
+    });
+    closeProjectToolAccessDialog();
+  }, [
+    clientSettings.projectToolAccessPolicies,
+    closeProjectToolAccessDialog,
+    projectToolAccessTarget,
+    updateSettings,
+  ]);
+
   const handleThreadContextMenu = useCallback(
     async (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
       const api = readLocalApi();
@@ -2459,6 +2611,49 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           </DialogFooter>
         </DialogPopup>
       </Dialog>
+
+      <Dialog
+        open={projectToolAccessTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeProjectToolAccessDialog();
+          }
+        }}
+      >
+        <DialogPopup className="max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Project tools</DialogTitle>
+            <DialogDescription>
+              {projectToolAccessTarget
+                ? `Configured provider tools for ${projectToolAccessTarget.workspaceRoot}.`
+                : "Configured provider tools for this project."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogPanel className="space-y-4">
+            <ToolAccessPolicyControl
+              catalog={toolCatalog}
+              scope="project"
+              policy={
+                projectToolAccessTarget
+                  ? clientSettings.projectToolAccessPolicies[
+                      projectToolAccessTarget.physicalProjectKey
+                    ]
+                  : undefined
+              }
+              onChange={updateProjectToolAccessPolicy}
+            />
+          </DialogPanel>
+          <DialogFooter>
+            <Button variant="outline" onClick={closeProjectToolAccessDialog}>
+              Cancel
+            </Button>
+            <Button variant="outline" onClick={resetProjectToolAccessPolicy}>
+              Use inherited tools
+            </Button>
+            <Button onClick={closeProjectToolAccessDialog}>Done</Button>
+          </DialogFooter>
+        </DialogPopup>
+      </Dialog>
     </>
   );
 });
@@ -2801,6 +2996,60 @@ function T3Wordmark() {
   );
 }
 
+const CREATE_PROFILE_SELECT_VALUE = "__create_profile__";
+
+const SidebarProfileSwitcher = memo(function SidebarProfileSwitcher() {
+  const settings = useClientSettings();
+  const updateSettings = useUpdateClientSettings();
+  const profiles = getAppProfiles(settings);
+  const activeProfileId = getActiveProfileId(settings);
+  const activeProfile = getActiveProfile(settings);
+
+  const handleProfileChange = useCallback(
+    (value: string | null) => {
+      if (!value) {
+        return;
+      }
+      if (value === CREATE_PROFILE_SELECT_VALUE) {
+        updateSettings(createProfilePatch(settings));
+        return;
+      }
+      updateSettings({ activeProfileId: value });
+    },
+    [settings, updateSettings],
+  );
+
+  return (
+    <div className="px-1 pb-1">
+      <Select value={activeProfileId} onValueChange={handleProfileChange}>
+        <SelectTrigger
+          size="sm"
+          className="h-8 w-full justify-start gap-2 rounded-md border border-border/60 bg-sidebar-accent/30 px-2 text-left font-mono text-xs text-sidebar-foreground hover:bg-sidebar-accent"
+          aria-label="Active profile"
+        >
+          <UserRoundIcon className="size-3.5 shrink-0 text-muted-foreground" />
+          <SelectValue>
+            <span className="min-w-0 truncate">{activeProfile.name}</span>
+          </SelectValue>
+        </SelectTrigger>
+        <SelectPopup align="start" alignItemWithTrigger={false}>
+          {profiles.map((profile) => (
+            <SelectItem key={profile.id} value={profile.id}>
+              {profile.name}
+            </SelectItem>
+          ))}
+          <SelectItem value={CREATE_PROFILE_SELECT_VALUE}>
+            <span className="inline-flex items-center gap-1.5">
+              <PlusIcon className="size-3.5" />
+              New profile
+            </span>
+          </SelectItem>
+        </SelectPopup>
+      </Select>
+    </div>
+  );
+});
+
 const SidebarChromeFooter = memo(function SidebarChromeFooter() {
   const navigate = useNavigate();
   const { isMobile, setOpenMobile } = useSidebar();
@@ -2813,6 +3062,7 @@ const SidebarChromeFooter = memo(function SidebarChromeFooter() {
 
   return (
     <SidebarFooter className="p-2">
+      <SidebarProfileSwitcher />
       <SidebarProviderUpdatePill />
       <SidebarUpdatePill />
       <SidebarMenu>
@@ -3111,6 +3361,7 @@ export default function Sidebar() {
   const navigate = useNavigate();
   const pathname = useLocation({ select: (loc) => loc.pathname });
   const isOnSettings = pathname.startsWith("/settings");
+  const clientSettings = useClientSettings();
   const sidebarThreadSortOrder = useClientSettings((s) => s.sidebarThreadSortOrder);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const sidebarProjectGroupingMode = useClientSettings((s) => s.sidebarProjectGroupingMode);
@@ -3162,9 +3413,17 @@ export default function Sidebar() {
       ),
     [environments],
   );
+  const visibleProjects = useMemo(
+    () => filterProjectsForActiveProfile(projects, clientSettings),
+    [clientSettings, projects],
+  );
+  const visibleSidebarThreads = useMemo(
+    () => filterThreadsForActiveProfile(sidebarThreads, projects, clientSettings),
+    [clientSettings, projects, sidebarThreads],
+  );
   const orderedProjects = useMemo(() => {
     return orderItemsByPreferredIds({
-      items: projects,
+      items: visibleProjects,
       preferredIds: projectOrder,
       getId: getProjectOrderKey,
       getPreferenceIds: (project) => [
@@ -3172,7 +3431,7 @@ export default function Sidebar() {
         legacyProjectCwdPreferenceKey(project.workspaceRoot),
       ],
     });
-  }, [projectOrder, projects]);
+  }, [projectOrder, visibleProjects]);
 
   // Build a mapping from physical project key → logical project key for
   // cross-environment grouping.  Projects that share a repositoryIdentity
@@ -3217,12 +3476,12 @@ export default function Sidebar() {
   const sidebarThreadByKey = useMemo(
     () =>
       new Map(
-        sidebarThreads.map(
+        visibleSidebarThreads.map(
           (thread) =>
             [scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)), thread] as const,
         ),
       ),
-    [sidebarThreads],
+    [visibleSidebarThreads],
   );
   // Resolve the active route's project key to a logical key so it matches the
   // sidebar's grouped project entries.
@@ -3243,7 +3502,7 @@ export default function Sidebar() {
   // are displayed together.
   const threadsByProjectKey = useMemo(() => {
     const next = new Map<string, SidebarThreadSummary[]>();
-    for (const thread of sidebarThreads) {
+    for (const thread of visibleSidebarThreads) {
       const physicalKey =
         projectPhysicalKeyByScopedRef.get(
           scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
@@ -3257,7 +3516,7 @@ export default function Sidebar() {
       }
     }
     return next;
-  }, [sidebarThreads, physicalToLogicalKey, projectPhysicalKeyByScopedRef]);
+  }, [visibleSidebarThreads, physicalToLogicalKey, projectPhysicalKeyByScopedRef]);
   const getCurrentSidebarShortcutContext = useCallback(
     () => ({
       terminalFocus: isTerminalFocused(),
@@ -3366,8 +3625,8 @@ export default function Sidebar() {
   }, []);
 
   const visibleThreads = useMemo(
-    () => sidebarThreads.filter((thread) => thread.archivedAt === null),
-    [sidebarThreads],
+    () => visibleSidebarThreads.filter((thread) => thread.archivedAt === null),
+    [visibleSidebarThreads],
   );
   const sortedProjects = useMemo(() => {
     const sortableProjects = sidebarProjects.map((project) => ({
@@ -3739,7 +3998,7 @@ export default function Sidebar() {
             suppressProjectClickAfterDragRef={suppressProjectClickAfterDragRef}
             suppressProjectClickForContextMenuRef={suppressProjectClickForContextMenuRef}
             attachProjectListAutoAnimateRef={attachProjectListAutoAnimateRef}
-            projectsLength={projects.length}
+            projectsLength={visibleProjects.length}
           />
 
           <SidebarSeparator />

--- a/apps/web/src/components/chat/ChatComposer.tsx
+++ b/apps/web/src/components/chat/ChatComposer.tsx
@@ -97,6 +97,7 @@ import {
   CircleAlertIcon,
   ListTodoIcon,
   PencilRulerIcon,
+  TargetIcon,
   type LucideIcon,
   LockIcon,
   LockOpenIcon,
@@ -114,15 +115,17 @@ import {
 } from "../../providerInstances";
 import { type AppModelOption, getAppModelOptionsForInstance } from "../../modelSelection";
 import type { UnifiedSettings } from "@t3tools/contracts/settings";
-import type { SessionPhase, Thread } from "../../types";
+import type { Project, SessionPhase, Thread } from "../../types";
 import type { PendingUserInputDraftAnswer } from "../../pendingUserInput";
 import type { PendingApproval, PendingUserInput } from "../../session-logic";
+import { filterProviderInstancesForActiveProfile } from "../../profiles";
 import {
   deriveLatestContextWindowSnapshot,
   formatProviderDisplayName,
 } from "../../lib/contextWindow";
 import { formatProviderSkillDisplayName } from "../../providerSkillPresentation";
 import { searchProviderSkills } from "../../providerSkillSearch";
+import { buildToolAccessCatalog, filterProviderSkillsForToolAccess } from "../../toolAccess";
 import { useMediaQuery } from "../../hooks/useMediaQuery";
 import type { ReviewCommentContext } from "../../reviewCommentContext";
 
@@ -203,10 +206,37 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
 }) {
   const runtimeModeOption = runtimeModeConfig[props.runtimeMode];
   const RuntimeModeIcon = runtimeModeOption.icon;
-  const interactionModeTooltip =
-    props.interactionMode === "plan"
-      ? "Plan mode — click to return to normal build mode"
-      : "Default mode — click to enter plan mode";
+  const interactionModeConfig: Record<
+    ProviderInteractionMode,
+    {
+      readonly label: string;
+      readonly tooltip: string;
+      readonly icon: LucideIcon;
+      readonly activeClassName: string;
+    }
+  > = {
+    default: {
+      label: "Build",
+      tooltip: "Default build mode - click for plan mode",
+      icon: BotIcon,
+      activeClassName: "text-muted-foreground/70 hover:text-foreground/80",
+    },
+    plan: {
+      label: "Plan",
+      tooltip: "Plan mode - click for plan and goal mode",
+      icon: PencilRulerIcon,
+      activeClassName: "bg-blue-500/10 text-blue-400 hover:bg-blue-500/15 hover:text-blue-300",
+    },
+    plan_and_goal: {
+      label: "Goal",
+      tooltip: "Plan and goal mode - click to return to build mode",
+      icon: TargetIcon,
+      activeClassName:
+        "bg-emerald-500/10 text-emerald-400 hover:bg-emerald-500/15 hover:text-emerald-300",
+    },
+  };
+  const interactionModeOption = interactionModeConfig[props.interactionMode];
+  const InteractionModeIcon = interactionModeOption.icon;
   const planSidebarTooltip = props.planSidebarOpen
     ? `Hide ${props.planSidebarLabel.toLowerCase()} sidebar`
     : `Show ${props.planSidebarLabel.toLowerCase()} sidebar`;
@@ -221,27 +251,21 @@ const ComposerFooterModeControls = memo(function ComposerFooterModeControls(prop
               variant="ghost"
               className={cn(
                 "shrink-0 whitespace-nowrap px-2 sm:px-3",
-                props.interactionMode === "plan"
-                  ? "bg-blue-500/10 text-blue-400 hover:bg-blue-500/15 hover:text-blue-300"
-                  : "text-muted-foreground/70 hover:text-foreground/80",
+                interactionModeOption.activeClassName,
               )}
               size="sm"
               type="button"
               onClick={props.onToggleInteractionMode}
-              aria-label={interactionModeTooltip}
+              aria-label={interactionModeOption.tooltip}
             />
           }
         >
-          {props.interactionMode === "plan" ? (
-            <PencilRulerIcon className="text-current opacity-100" />
-          ) : (
-            <BotIcon />
-          )}
-          <span className="sr-only sm:not-sr-only">
-            {props.interactionMode === "plan" ? "Plan" : "Build"}
-          </span>
+          <InteractionModeIcon
+            className={props.interactionMode === "default" ? undefined : "text-current opacity-100"}
+          />
+          <span className="sr-only sm:not-sr-only">{interactionModeOption.label}</span>
         </TooltipTrigger>
-        <TooltipPopup side="top">{interactionModeTooltip}</TooltipPopup>
+        <TooltipPopup side="top">{interactionModeOption.tooltip}</TooltipPopup>
       </Tooltip>
     </>
   ) : null;
@@ -439,6 +463,7 @@ export interface ChatComposerProps {
   activeThreadId: ThreadId | null;
   activeThreadEnvironmentId: EnvironmentId | undefined;
   activeThread: Thread | undefined;
+  activeProject: Project | null;
   isServerThread: boolean;
   isLocalDraftThread: boolean;
 
@@ -550,6 +575,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
     activeThreadId,
     activeThreadEnvironmentId: _activeThreadEnvironmentId,
     activeThread,
+    activeProject,
     isServerThread: _isServerThread,
     isLocalDraftThread: _isLocalDraftThread,
     phase,
@@ -657,13 +683,12 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   // Instance-aware projection of the wire provider list. One entry per
   // configured instance (default built-in + any custom `providerInstances.*`),
   // sorted default-first per driver kind for a stable picker order.
-  const providerInstanceEntries = useMemo<ReadonlyArray<ProviderInstanceEntry>>(
-    () =>
-      sortProviderInstanceEntries(
-        applyProviderInstanceSettings(deriveProviderInstanceEntries(providerStatuses), settings),
-      ),
-    [providerStatuses, settings],
-  );
+  const providerInstanceEntries = useMemo<ReadonlyArray<ProviderInstanceEntry>>(() => {
+    const entries = sortProviderInstanceEntries(
+      applyProviderInstanceSettings(deriveProviderInstanceEntries(providerStatuses), settings),
+    );
+    return filterProviderInstancesForActiveProfile(entries, settings);
+  }, [providerStatuses, settings]);
   const selectedProviderByThreadId = composerDraft.activeProvider ?? null;
   const threadProvider =
     activeThread?.session?.providerInstanceId ??
@@ -780,6 +805,17 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
   const selectedProviderStatus = useMemo(
     () => selectedProviderEntry?.snapshot ?? null,
     [selectedProviderEntry],
+  );
+  const toolCatalog = useMemo(() => buildToolAccessCatalog(providerStatuses), [providerStatuses]);
+  const selectedProviderSkills = useMemo(
+    () =>
+      filterProviderSkillsForToolAccess({
+        provider: selectedProviderStatus,
+        catalog: toolCatalog,
+        settings,
+        project: activeProject,
+      }),
+    [activeProject, selectedProviderStatus, settings, toolCatalog],
   );
   const selectedProviderModels = useMemo<ReadonlyArray<ServerProvider["models"][number]>>(
     () => selectedProviderEntry?.models ?? [],
@@ -965,6 +1001,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           description: "Switch this thread into plan mode",
         },
         {
+          id: "slash:plan-goal",
+          type: "slash-command",
+          command: "plan-goal",
+          label: "/plan-goal",
+          description: "Plan first, then implement the accepted plan as a goal",
+        },
+        {
           id: "slash:default",
           type: "slash-command",
           command: "default",
@@ -990,22 +1033,26 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
       return searchSlashCommandItems(slashCommandItems, query);
     }
     if (composerTrigger.kind === "skill") {
-      return searchProviderSkills(selectedProviderStatus?.skills ?? [], composerTrigger.query).map(
-        (skill) => ({
-          id: `skill:${selectedProvider}:${skill.name}`,
-          type: "skill" as const,
-          provider: selectedProvider,
-          skill,
-          label: formatProviderSkillDisplayName(skill),
-          description:
-            skill.shortDescription ??
-            skill.description ??
-            (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
-        }),
-      );
+      return searchProviderSkills(selectedProviderSkills, composerTrigger.query).map((skill) => ({
+        id: `skill:${selectedProvider}:${skill.name}`,
+        type: "skill" as const,
+        provider: selectedProvider,
+        skill,
+        label: formatProviderSkillDisplayName(skill),
+        description:
+          skill.shortDescription ??
+          skill.description ??
+          (skill.scope ? `${skill.scope} skill` : "Run provider skill"),
+      }));
     }
     return [];
-  }, [composerTrigger, selectedProvider, selectedProviderStatus, workspaceEntries.entries]);
+  }, [
+    composerTrigger,
+    selectedProvider,
+    selectedProviderSkills,
+    selectedProviderStatus,
+    workspaceEntries.entries,
+  ]);
 
   const composerMenuOpen = Boolean(composerTrigger);
   const composerMenuSearchKey = composerTrigger
@@ -1584,7 +1631,13 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
           }
           return;
         }
-        void handleInteractionModeChange(item.command === "plan" ? "plan" : "default");
+        const nextInteractionMode =
+          item.command === "plan"
+            ? "plan"
+            : item.command === "plan-goal"
+              ? "plan_and_goal"
+              : "default";
+        void handleInteractionModeChange(nextInteractionMode);
         const applied = applyPromptReplacement(trigger.rangeStart, trigger.rangeEnd, "", {
           expectedText: snapshot.value.slice(trigger.rangeStart, trigger.rangeEnd),
         });
@@ -2396,7 +2449,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     ? composerTerminalContexts
                     : []
                 }
-                skills={selectedProviderStatus?.skills ?? []}
+                skills={selectedProviderSkills}
                 {...(showMobilePendingAnswerActions ? { className: "max-sm:pb-11" } : {})}
                 onRemoveTerminalContext={removeComposerTerminalContextFromDraft}
                 onChange={onPromptChange}
@@ -2502,7 +2555,7 @@ export const ChatComposer = memo(function ChatComposer(props: ChatComposerProps)
                     runtimeMode={runtimeMode}
                     showInteractionModeToggle={composerProviderControls.showInteractionModeToggle}
                     traitsMenuContent={providerTraitsMenuContent}
-                    onToggleInteractionMode={toggleInteractionMode}
+                    onInteractionModeChange={handleInteractionModeChange}
                     onTogglePlanSidebar={togglePlanSidebar}
                     onRuntimeModeChange={handleRuntimeModeChange}
                   />

--- a/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
+++ b/apps/web/src/components/chat/CompactComposerControlsMenu.tsx
@@ -20,7 +20,7 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
   runtimeMode: RuntimeMode;
   showInteractionModeToggle: boolean;
   traitsMenuContent?: ReactNode;
-  onToggleInteractionMode: () => void;
+  onInteractionModeChange: (mode: ProviderInteractionMode) => void;
   onTogglePlanSidebar: () => void;
   onRuntimeModeChange: (mode: RuntimeMode) => void;
 }) {
@@ -52,11 +52,12 @@ export const CompactComposerControlsMenu = memo(function CompactComposerControls
               value={props.interactionMode}
               onValueChange={(value) => {
                 if (!value || value === props.interactionMode) return;
-                props.onToggleInteractionMode();
+                props.onInteractionModeChange(value as ProviderInteractionMode);
               }}
             >
               <MenuRadioItem value="default">Chat</MenuRadioItem>
               <MenuRadioItem value="plan">Plan</MenuRadioItem>
+              <MenuRadioItem value="plan_and_goal">Plan and goal</MenuRadioItem>
             </MenuRadioGroup>
             <MenuDivider />
           </>

--- a/apps/web/src/components/settings/ProviderInstanceCard.tsx
+++ b/apps/web/src/components/settings/ProviderInstanceCard.tsx
@@ -550,9 +550,7 @@ export function ProviderInstanceCard({
   const titleTailNode = (
     <>
       {headerAction ? (
-        <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
-          {headerAction}
-        </span>
+        <span className="inline-flex shrink-0 items-center justify-center">{headerAction}</span>
       ) : null}
       {onDelete ? (
         <span className="inline-flex h-5 w-5 shrink-0 items-center justify-center">

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -18,7 +18,7 @@ import {
   settlePromise,
   squashAtomCommandFailure,
 } from "@t3tools/client-runtime/state/runtime";
-import { DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
+import { DEFAULT_PROFILE_ID, DEFAULT_UNIFIED_SETTINGS } from "@t3tools/contracts/settings";
 import { createModelSelection } from "@t3tools/shared/model";
 import * as Arr from "effect/Array";
 import * as Duration from "effect/Duration";
@@ -49,6 +49,15 @@ import {
   deriveProviderInstanceEntries,
   sortProviderInstanceEntries,
 } from "../../providerInstances";
+import {
+  ALL_PROFILES_PROVIDER_SCOPE,
+  assignProviderInstanceToProfilePatch,
+  getActiveProfile,
+  getAppProfiles,
+  projectProfileKeyFromPath,
+  providerScopeLabel,
+} from "../../profiles";
+import { buildToolAccessCatalog } from "../../toolAccess";
 import { ensureLocalApi, readLocalApi } from "../../localApi";
 import {
   primaryServerObservabilityAtom,
@@ -74,6 +83,7 @@ import {
   type ProviderUpdateCandidate,
 } from "../ProviderUpdateLaunchNotification.logic";
 import { ProviderInstanceCard } from "./ProviderInstanceCard";
+import { ToolAccessPolicyControl } from "./ToolAccessPolicyControl";
 import { DRIVER_OPTIONS, getDriverOption } from "./providerDriverMeta";
 import {
   buildProviderInstanceUpdatePatch,
@@ -108,6 +118,11 @@ const TIMESTAMP_FORMAT_LABELS = {
   locale: "System default",
   "12-hour": "12-hour",
   "24-hour": "24-hour",
+} as const;
+
+const PLAN_AND_GOAL_REVIEW_MODE_LABELS = {
+  manual_review: "Manual Review",
+  auto: "Auto",
 } as const;
 
 const DEFAULT_DRIVER_KIND = ProviderDriverKind.make("codex");
@@ -385,6 +400,9 @@ export function useSettingsRestore(onRestored?: () => void) {
   const changedSettingLabels = useMemo(
     () => [
       ...(theme !== "system" ? ["Theme"] : []),
+      ...(settings.appBackgroundColor !== DEFAULT_UNIFIED_SETTINGS.appBackgroundColor
+        ? ["Background"]
+        : []),
       ...(settings.timestampFormat !== DEFAULT_UNIFIED_SETTINGS.timestampFormat
         ? ["Time format"]
         : []),
@@ -421,13 +439,25 @@ export function useSettingsRestore(onRestored?: () => void) {
       ...(settings.confirmThreadDelete !== DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete
         ? ["Delete confirmation"]
         : []),
+      ...(!Equal.equals(
+        settings.globalToolAccessPolicy,
+        DEFAULT_UNIFIED_SETTINGS.globalToolAccessPolicy,
+      )
+        ? ["All chat tools"]
+        : []),
+      ...(Object.keys(settings.profileToolAccessPolicies).length > 0 ? ["Profile tools"] : []),
+      ...(Object.keys(settings.projectToolAccessPolicies).length > 0 ? ["Project tools"] : []),
       ...(isGitWritingModelDirty ? ["Git writing model"] : []),
     ],
     [
       isGitWritingModelDirty,
+      settings.appBackgroundColor,
       settings.autoOpenPlanSidebar,
       settings.confirmThreadArchive,
       settings.confirmThreadDelete,
+      settings.globalToolAccessPolicy,
+      settings.profileToolAccessPolicies,
+      settings.projectToolAccessPolicies,
       settings.addProjectBaseDirectory,
       settings.defaultThreadEnvMode,
       settings.newWorktreesStartFromOrigin,
@@ -453,6 +483,7 @@ export function useSettingsRestore(onRestored?: () => void) {
 
     setTheme("system");
     updateSettings({
+      appBackgroundColor: DEFAULT_UNIFIED_SETTINGS.appBackgroundColor,
       timestampFormat: DEFAULT_UNIFIED_SETTINGS.timestampFormat,
       wordWrap: DEFAULT_UNIFIED_SETTINGS.wordWrap,
       diffIgnoreWhitespace: DEFAULT_UNIFIED_SETTINGS.diffIgnoreWhitespace,
@@ -465,6 +496,9 @@ export function useSettingsRestore(onRestored?: () => void) {
       addProjectBaseDirectory: DEFAULT_UNIFIED_SETTINGS.addProjectBaseDirectory,
       confirmThreadArchive: DEFAULT_UNIFIED_SETTINGS.confirmThreadArchive,
       confirmThreadDelete: DEFAULT_UNIFIED_SETTINGS.confirmThreadDelete,
+      globalToolAccessPolicy: DEFAULT_UNIFIED_SETTINGS.globalToolAccessPolicy,
+      profileToolAccessPolicies: DEFAULT_UNIFIED_SETTINGS.profileToolAccessPolicies,
+      projectToolAccessPolicies: DEFAULT_UNIFIED_SETTINGS.projectToolAccessPolicies,
       textGenerationModelSelection: DEFAULT_UNIFIED_SETTINGS.textGenerationModelSelection,
     });
     onRestored?.();
@@ -482,6 +516,12 @@ export function GeneralSettingsPanel() {
   const updateSettings = useUpdatePrimarySettings();
   const observability = useAtomValue(primaryServerObservabilityAtom);
   const serverProviders = useAtomValue(primaryServerProvidersAtom);
+  const toolCatalog = useMemo(() => buildToolAccessCatalog(serverProviders), [serverProviders]);
+  const activeProfile = getActiveProfile(settings);
+  const appBackgroundColor = settings.appBackgroundColor.trim();
+  const appBackgroundColorInputValue = /^#[0-9a-f]{6}$/i.test(appBackgroundColor)
+    ? appBackgroundColor
+    : "#0b1210";
   const diagnosticsDescription = formatDiagnosticsDescription({
     localTracingEnabled: observability?.localTracingEnabled ?? false,
     otlpTracesEnabled: observability?.otlpTracesEnabled ?? false,
@@ -546,6 +586,42 @@ export function GeneralSettingsPanel() {
                 ))}
               </SelectPopup>
             </Select>
+          }
+        />
+
+        <SettingsRow
+          title="Background"
+          description="Set the app chrome background color."
+          resetAction={
+            settings.appBackgroundColor !== DEFAULT_UNIFIED_SETTINGS.appBackgroundColor ? (
+              <SettingResetButton
+                label="background color"
+                onClick={() =>
+                  updateSettings({
+                    appBackgroundColor: DEFAULT_UNIFIED_SETTINGS.appBackgroundColor,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <div className="flex items-center gap-2">
+              <input
+                type="color"
+                value={appBackgroundColorInputValue}
+                aria-label="App background color"
+                className="h-8 w-11 cursor-pointer rounded-md border border-border bg-background p-1"
+                onChange={(event) => updateSettings({ appBackgroundColor: event.target.value })}
+              />
+              <DraftInput
+                className="w-28 font-mono text-xs"
+                value={settings.appBackgroundColor}
+                onCommit={(next) => updateSettings({ appBackgroundColor: next.trim() })}
+                placeholder="Default"
+                spellCheck={false}
+                aria-label="App background color value"
+              />
+            </div>
           }
         />
 
@@ -718,6 +794,47 @@ export function GeneralSettingsPanel() {
               }
               aria-label="Open the task panel automatically"
             />
+          }
+        />
+
+        <SettingsRow
+          title="Plan and goal"
+          description="Choose whether accepted plan+goal plans wait for review or start automatically."
+          resetAction={
+            settings.planAndGoalReviewMode !== DEFAULT_UNIFIED_SETTINGS.planAndGoalReviewMode ? (
+              <SettingResetButton
+                label="plan and goal review mode"
+                onClick={() =>
+                  updateSettings({
+                    planAndGoalReviewMode: DEFAULT_UNIFIED_SETTINGS.planAndGoalReviewMode,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <Select
+              value={settings.planAndGoalReviewMode}
+              onValueChange={(value) => {
+                if (value === "manual_review" || value === "auto") {
+                  updateSettings({ planAndGoalReviewMode: value });
+                }
+              }}
+            >
+              <SelectTrigger className="w-full sm:w-44" aria-label="Plan and goal review mode">
+                <SelectValue>
+                  {PLAN_AND_GOAL_REVIEW_MODE_LABELS[settings.planAndGoalReviewMode]}
+                </SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem hideIndicator value="manual_review">
+                  {PLAN_AND_GOAL_REVIEW_MODE_LABELS.manual_review}
+                </SelectItem>
+                <SelectItem hideIndicator value="auto">
+                  {PLAN_AND_GOAL_REVIEW_MODE_LABELS.auto}
+                </SelectItem>
+              </SelectPopup>
+            </Select>
           }
         />
 
@@ -952,6 +1069,70 @@ export function GeneralSettingsPanel() {
         />
       </SettingsSection>
 
+      <SettingsSection title="Tools">
+        <SettingsRow
+          title="All chats"
+          description="Default plugins, MCPs, and skills available to every chat."
+          resetAction={
+            settings.globalToolAccessPolicy.mode !==
+              DEFAULT_UNIFIED_SETTINGS.globalToolAccessPolicy.mode ||
+            settings.globalToolAccessPolicy.enabledToolKeys.length > 0 ? (
+              <SettingResetButton
+                label="all chat tools"
+                onClick={() =>
+                  updateSettings({
+                    globalToolAccessPolicy: DEFAULT_UNIFIED_SETTINGS.globalToolAccessPolicy,
+                  })
+                }
+              />
+            ) : null
+          }
+          control={
+            <div className="w-full sm:w-[28rem]">
+              <ToolAccessPolicyControl
+                scope="global"
+                catalog={toolCatalog}
+                policy={settings.globalToolAccessPolicy}
+                onChange={(policy) => updateSettings({ globalToolAccessPolicy: policy })}
+              />
+            </div>
+          }
+        />
+        <SettingsRow
+          title={`${activeProfile.name} profile`}
+          description="Profile-level tools used unless a project has its own custom list."
+          resetAction={
+            settings.profileToolAccessPolicies[activeProfile.id] !== undefined ? (
+              <SettingResetButton
+                label="profile tools"
+                onClick={() => {
+                  const next = { ...settings.profileToolAccessPolicies };
+                  delete next[activeProfile.id];
+                  updateSettings({ profileToolAccessPolicies: next });
+                }}
+              />
+            ) : null
+          }
+          control={
+            <div className="w-full sm:w-[28rem]">
+              <ToolAccessPolicyControl
+                scope="profile"
+                catalog={toolCatalog}
+                policy={settings.profileToolAccessPolicies[activeProfile.id]}
+                onChange={(policy) =>
+                  updateSettings({
+                    profileToolAccessPolicies: {
+                      ...settings.profileToolAccessPolicies,
+                      [activeProfile.id]: policy,
+                    },
+                  })
+                }
+              />
+            </div>
+          }
+        />
+      </SettingsSection>
+
       <SettingsSection title="About">
         {isElectron || HOSTED_APP_CHANNEL ? (
           <AboutVersionSection />
@@ -1012,6 +1193,7 @@ export function ProviderSettingsPanel() {
   );
   const textGenerationModelSelection = resolveAppModelSelectionState(settings, serverProviders);
   const textGenInstanceId = textGenerationModelSelection.instanceId;
+  const profiles = getAppProfiles(settings);
   const lastCheckedAt =
     serverProviders.length > 0
       ? serverProviders.reduce(
@@ -1343,13 +1525,52 @@ export function ProviderSettingsPanel() {
             favorite.provider === row.instanceId ? Result.succeed(favorite.model) : Result.failVoid,
           );
           const resetLabel = driverOption?.label ?? String(row.driver);
-          const headerAction =
+          const assignedProfileId =
+            settings.providerInstanceProfileAssignments?.[row.instanceId] ??
+            ALL_PROFILES_PROVIDER_SCOPE;
+          const profileScopeControl = (
+            <Select
+              value={assignedProfileId}
+              onValueChange={(value) => {
+                updateSettings(
+                  assignProviderInstanceToProfilePatch(
+                    settings,
+                    row.instanceId,
+                    value === ALL_PROFILES_PROVIDER_SCOPE ? null : value,
+                  ),
+                );
+              }}
+            >
+              <SelectTrigger
+                size="xs"
+                className="h-6 min-w-0 max-w-32 border-border/70 px-2 text-[11px]"
+                aria-label={`${resetLabel} profile scope`}
+              >
+                <SelectValue>{providerScopeLabel(settings, row.instanceId)}</SelectValue>
+              </SelectTrigger>
+              <SelectPopup align="end" alignItemWithTrigger={false}>
+                <SelectItem value={ALL_PROFILES_PROVIDER_SCOPE}>All profiles</SelectItem>
+                {profiles.map((profile) => (
+                  <SelectItem key={profile.id} value={profile.id}>
+                    {profile.name}
+                  </SelectItem>
+                ))}
+              </SelectPopup>
+            </Select>
+          );
+          const resetAction =
             row.isDefault && row.isDirty ? (
               <SettingResetButton
                 label={`${resetLabel} provider settings`}
                 onClick={() => resetDefaultInstance(row.driver)}
               />
             ) : null;
+          const headerAction = (
+            <div className="flex min-w-0 items-center gap-1.5">
+              {profileScopeControl}
+              {resetAction}
+            </div>
+          );
           return (
             <ProviderInstanceCard
               key={row.instanceId}
@@ -1422,6 +1643,8 @@ export function ProviderSettingsPanel() {
 
 export function ArchivedThreadsPanel() {
   const projects = useProjects();
+  const settings = usePrimarySettings();
+  const activeProfile = getActiveProfile(settings);
   const { unarchiveThread, confirmAndDeleteThread } = useThreadActions();
   const environmentIds = useMemo(
     () => [...new Set(projects.map((project) => project.environmentId))],
@@ -1437,8 +1660,15 @@ export function ArchivedThreadsPanel() {
   const archivedGroups = useMemo(() => {
     const projectsByEnvironmentAndId = new Map(
       archivedSnapshots.flatMap(({ environmentId, snapshot }) =>
-        snapshot.projects.map(
-          (project) =>
+        snapshot.projects.flatMap((project) => {
+          const assignedProfileId =
+            settings.projectProfileAssignments[
+              projectProfileKeyFromPath(environmentId, project.workspaceRoot)
+            ] ?? DEFAULT_PROFILE_ID;
+          if (assignedProfileId !== activeProfile.id) {
+            return [];
+          }
+          return [
             [
               `${environmentId}:${project.id}`,
               {
@@ -1448,14 +1678,19 @@ export function ArchivedThreadsPanel() {
                 cwd: project.workspaceRoot,
               },
             ] as const,
-        ),
+          ];
+        }),
       ),
     );
     const threads = archivedSnapshots.flatMap(({ environmentId, snapshot }) =>
-      snapshot.threads.map((thread) => ({
-        ...thread,
-        environmentId,
-      })),
+      snapshot.threads
+        .map((thread) => ({
+          ...thread,
+          environmentId,
+        }))
+        .filter((thread) =>
+          projectsByEnvironmentAndId.has(`${thread.environmentId}:${thread.projectId}`),
+        ),
     );
 
     const archivedProjects = Array.from(projectsByEnvironmentAndId.values());
@@ -1482,7 +1717,7 @@ export function ArchivedThreadsPanel() {
       }
     }
     return groups;
-  }, [archivedSnapshots]);
+  }, [activeProfile.id, archivedSnapshots, settings.projectProfileAssignments]);
 
   const handleArchivedThreadContextMenu = useCallback(
     async (threadRef: ScopedThreadRef, position: { x: number; y: number }) => {
@@ -1548,20 +1783,20 @@ export function ArchivedThreadsPanel() {
                   ? "Loading archived threads"
                   : archiveError
                     ? "Could not load archived threads"
-                    : "No archived threads"}
+                    : `No archived threads in ${activeProfile.name}`}
               </span>
             }
             description={
               isLoadingArchive
                 ? "Checking connected environments."
-                : (archiveError ?? "Archived threads will appear here.")
+                : (archiveError ?? "Archived threads for this profile will appear here.")
             }
           />
         </SettingsSection>
       ) : (
         archivedGroups.map(({ project, threads: projectThreads }) => (
           <SettingsSection
-            key={project.id}
+            key={`${project.environmentId}:${project.id}`}
             title={project.name}
             icon={<ProjectFavicon environmentId={project.environmentId} cwd={project.cwd} />}
           >

--- a/apps/web/src/components/settings/ToolAccessPolicyControl.tsx
+++ b/apps/web/src/components/settings/ToolAccessPolicyControl.tsx
@@ -1,0 +1,170 @@
+import type { AppToolAccessPolicy } from "@t3tools/contracts";
+
+import {
+  normalizeToolAccessPolicy,
+  updateToolAccessPolicySelection,
+  type ToolAccessCatalogEntry,
+} from "../../toolAccess";
+import { Checkbox } from "../ui/checkbox";
+import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "../ui/select";
+import { Button } from "../ui/button";
+
+const KIND_LABELS = {
+  skill: "Skills",
+  plugin: "Plugins",
+  mcp: "MCPs",
+} as const;
+
+type ToolPolicyScope = "global" | "profile" | "project";
+
+function modeLabel(scope: ToolPolicyScope, mode: AppToolAccessPolicy["mode"]): string {
+  if (mode === "custom") return "Custom";
+  if (mode === "inherit") {
+    return scope === "project" ? "Use profile" : "Use global";
+  }
+  return "All tools";
+}
+
+function selectableModes(scope: ToolPolicyScope): ReadonlyArray<AppToolAccessPolicy["mode"]> {
+  return scope === "global" ? ["all", "custom"] : ["inherit", "all", "custom"];
+}
+
+export function ToolAccessPolicyControl({
+  catalog,
+  onChange,
+  policy,
+  scope,
+}: {
+  readonly catalog: ReadonlyArray<ToolAccessCatalogEntry>;
+  readonly onChange: (policy: AppToolAccessPolicy) => void;
+  readonly policy: AppToolAccessPolicy | undefined;
+  readonly scope: ToolPolicyScope;
+}) {
+  const normalized = normalizeToolAccessPolicy(policy, scope === "global" ? "all" : "inherit");
+  const selectedKeys = new Set(normalized.enabledToolKeys);
+  const enabledCatalogKeys = catalog.filter((entry) => entry.enabled).map((entry) => entry.key);
+  const customPolicyWithCurrentCatalog = (): AppToolAccessPolicy => ({
+    mode: "custom",
+    enabledToolKeys:
+      normalized.enabledToolKeys.length > 0
+        ? normalized.enabledToolKeys
+        : [...new Set(enabledCatalogKeys)].sort(),
+  });
+
+  return (
+    <div className="grid gap-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Select
+          value={normalized.mode}
+          onValueChange={(value) => {
+            if (value !== "all" && value !== "custom" && value !== "inherit") {
+              return;
+            }
+            onChange(
+              value === "custom"
+                ? customPolicyWithCurrentCatalog()
+                : { ...normalized, mode: value },
+            );
+          }}
+        >
+          <SelectTrigger className="w-40" aria-label="Tool access mode">
+            <SelectValue>{modeLabel(scope, normalized.mode)}</SelectValue>
+          </SelectTrigger>
+          <SelectPopup align="end" alignItemWithTrigger={false}>
+            {selectableModes(scope).map((mode) => (
+              <SelectItem key={mode} value={mode}>
+                {modeLabel(scope, mode)}
+              </SelectItem>
+            ))}
+          </SelectPopup>
+        </Select>
+        {normalized.mode === "custom" && catalog.length > 0 ? (
+          <>
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={() =>
+                onChange({
+                  mode: "custom",
+                  enabledToolKeys: [...new Set(enabledCatalogKeys)].sort(),
+                })
+              }
+            >
+              Select all
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="xs"
+              onClick={() => onChange({ mode: "custom", enabledToolKeys: [] })}
+            >
+              Clear
+            </Button>
+          </>
+        ) : null}
+      </div>
+
+      {normalized.mode === "custom" ? (
+        <div className="max-h-72 overflow-auto rounded-md border border-border bg-background/50">
+          {catalog.length === 0 ? (
+            <div className="px-3 py-2 text-xs text-muted-foreground">
+              No provider tools were reported yet.
+            </div>
+          ) : (
+            (["plugin", "mcp", "skill"] as const).map((kind) => {
+              const entries = catalog.filter((entry) => entry.kind === kind);
+              if (entries.length === 0) return null;
+              return (
+                <div key={kind} className="border-b border-border/60 last:border-b-0">
+                  <div className="sticky top-0 z-10 border-b border-border/60 bg-background/95 px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
+                    {KIND_LABELS[kind]}
+                  </div>
+                  <div className="divide-y divide-border/40">
+                    {entries.map((entry) => (
+                      <label
+                        key={entry.key}
+                        className="flex cursor-pointer items-start gap-2 px-3 py-2 text-xs hover:bg-accent/60"
+                      >
+                        <Checkbox
+                          checked={selectedKeys.has(entry.key)}
+                          disabled={!entry.enabled}
+                          onCheckedChange={(checked) =>
+                            onChange(
+                              updateToolAccessPolicySelection({
+                                policy: normalized,
+                                toolKey: entry.key,
+                                checked: Boolean(checked),
+                              }),
+                            )
+                          }
+                          aria-label={`Allow ${entry.label}`}
+                          className="mt-0.5"
+                        />
+                        <span className="min-w-0 flex-1">
+                          <span className="flex min-w-0 items-center gap-2">
+                            <span className="truncate font-medium text-foreground">
+                              {entry.label}
+                            </span>
+                            <span className="shrink-0 text-[10px] text-muted-foreground/70">
+                              {entry.providerLabel}
+                            </span>
+                          </span>
+                          {entry.description || entry.source ? (
+                            <span className="mt-0.5 block truncate text-muted-foreground">
+                              {[entry.description, entry.source].filter(Boolean).join(" · ")}
+                            </span>
+                          ) : null}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/composer-logic.test.ts
+++ b/apps/web/src/composer-logic.test.ts
@@ -340,6 +340,11 @@ describe("parseStandaloneComposerSlashCommand", () => {
     expect(parseStandaloneComposerSlashCommand(" /plan ")).toBe("plan");
   });
 
+  it("parses standalone /plan-goal command", () => {
+    expect(parseStandaloneComposerSlashCommand("/plan-goal")).toBe("plan-goal");
+    expect(parseStandaloneComposerSlashCommand("/plan_and_goal")).toBe("plan-goal");
+  });
+
   it("parses standalone /default command", () => {
     expect(parseStandaloneComposerSlashCommand("/default")).toBe("default");
   });

--- a/apps/web/src/composer-logic.ts
+++ b/apps/web/src/composer-logic.ts
@@ -2,7 +2,7 @@ import { splitPromptIntoComposerSegments } from "./composer-editor-mentions";
 import { INLINE_TERMINAL_CONTEXT_PLACEHOLDER } from "./lib/terminalContext";
 
 export type ComposerTriggerKind = "path" | "slash-command" | "skill";
-export type ComposerSlashCommand = "model" | "plan" | "default";
+export type ComposerSlashCommand = "model" | "plan" | "plan-goal" | "default";
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -258,12 +258,13 @@ export function detectComposerTrigger(text: string, cursorInput: number): Compos
 export function parseStandaloneComposerSlashCommand(
   text: string,
 ): Exclude<ComposerSlashCommand, "model"> | null {
-  const match = /^\/(plan|default)\s*$/i.exec(text.trim());
+  const match = /^\/(plan|plan-goal|plan_and_goal|default)\s*$/i.exec(text.trim());
   if (!match) {
     return null;
   }
   const command = match[1]?.toLowerCase();
   if (command === "plan") return "plan";
+  if (command === "plan-goal" || command === "plan_and_goal") return "plan-goal";
   return "default";
 }
 

--- a/apps/web/src/composerDraftStore.ts
+++ b/apps/web/src/composerDraftStore.ts
@@ -53,6 +53,7 @@ import { getDefaultServerModel } from "./providerModels";
 import { UnifiedSettings } from "@t3tools/contracts/settings";
 import { ReviewCommentContextSchema, type ReviewCommentContext } from "./reviewCommentContext";
 const isRuntimeMode = Schema.is(RuntimeMode);
+const isProviderInteractionMode = Schema.is(ProviderInteractionMode);
 const isProviderDriverKind = Schema.is(ProviderDriverKind);
 const isReviewCommentContext = Schema.is(ReviewCommentContextSchema);
 
@@ -1531,11 +1532,9 @@ function normalizePersistedDraftThreads(
         runtimeMode: isRuntimeMode(candidateDraftThread.runtimeMode)
           ? candidateDraftThread.runtimeMode
           : DEFAULT_RUNTIME_MODE,
-        interactionMode:
-          candidateDraftThread.interactionMode === "plan" ||
-          candidateDraftThread.interactionMode === "default"
-            ? candidateDraftThread.interactionMode
-            : DEFAULT_INTERACTION_MODE,
+        interactionMode: isProviderInteractionMode(candidateDraftThread.interactionMode)
+          ? candidateDraftThread.interactionMode
+          : DEFAULT_INTERACTION_MODE,
         branch: typeof branch === "string" ? branch : null,
         worktreePath: normalizedWorktreePath,
         envMode: normalizeDraftThreadEnvMode(candidateDraftThread.envMode, normalizedWorktreePath),
@@ -1663,10 +1662,9 @@ function normalizePersistedDraftsByThreadId(
     const runtimeMode = isRuntimeMode(draftCandidate.runtimeMode)
       ? draftCandidate.runtimeMode
       : null;
-    const interactionMode =
-      draftCandidate.interactionMode === "plan" || draftCandidate.interactionMode === "default"
-        ? draftCandidate.interactionMode
-        : null;
+    const interactionMode = isProviderInteractionMode(draftCandidate.interactionMode)
+      ? draftCandidate.interactionMode
+      : null;
     const prompt = ensureInlineTerminalContextPlaceholders(
       promptCandidate,
       terminalContexts.length,
@@ -2810,8 +2808,9 @@ const composerDraftStore = create<ComposerDraftStoreState>()(
           if (threadKey.length === 0) {
             return;
           }
-          const nextInteractionMode =
-            interactionMode === "plan" || interactionMode === "default" ? interactionMode : null;
+          const nextInteractionMode = isProviderInteractionMode(interactionMode)
+            ? interactionMode
+            : null;
           set((state) => {
             const existing = state.draftsByThreadKey[threadKey];
             if (!existing && nextInteractionMode === null) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -226,15 +226,15 @@
 
 :root {
   color-scheme: light;
-  --radius: 0.625rem;
-  --background: var(--color-white);
-  --app-chrome-background: var(--background);
+  --radius: 0.375rem;
+  --background: color-mix(in srgb, var(--color-white) 96%, var(--color-emerald-50));
+  --app-chrome-background: var(--app-user-background, var(--background));
   --foreground: var(--color-neutral-800);
   --card: var(--color-white);
   --card-foreground: var(--color-neutral-800);
   --popover: var(--color-white);
   --popover-foreground: var(--color-neutral-800);
-  --primary: oklch(0.488 0.217 264);
+  --primary: oklch(0.53 0.14 155);
   --primary-foreground: var(--color-white);
   --secondary: --alpha(var(--color-black) / 4%);
   --secondary-foreground: var(--color-neutral-800);
@@ -245,7 +245,7 @@
   --destructive: var(--color-red-500);
   --border: --alpha(var(--color-black) / 8%);
   --input: --alpha(var(--color-black) / 10%);
-  --ring: oklch(0.488 0.217 264);
+  --ring: oklch(0.53 0.14 155);
   --destructive-foreground: var(--color-red-700);
   --info: var(--color-blue-500);
   --info-foreground: var(--color-blue-700);
@@ -253,17 +253,19 @@
   --success-foreground: var(--color-emerald-700);
   --warning: var(--color-amber-500);
   --warning-foreground: var(--color-amber-700);
+  --terminal-grid-color: rgb(16 185 129 / 6%);
+  --terminal-scanline-color: rgb(15 23 42 / 4%);
 
   @variant dark {
     color-scheme: dark;
-    --background: color-mix(in srgb, var(--color-neutral-950) 95%, var(--color-white));
-    --app-chrome-background: var(--background);
+    --background: color-mix(in srgb, var(--color-neutral-950) 92%, var(--color-emerald-950));
+    --app-chrome-background: var(--app-user-background, var(--background));
     --foreground: var(--color-neutral-100);
     --card: color-mix(in srgb, var(--background) 98%, var(--color-white));
     --card-foreground: var(--color-neutral-100);
     --popover: color-mix(in srgb, var(--background) 98%, var(--color-white));
     --popover-foreground: var(--color-neutral-100);
-    --primary: oklch(0.588 0.217 264);
+    --primary: oklch(0.72 0.14 155);
     --primary-foreground: var(--color-white);
     --secondary: --alpha(var(--color-white) / 4%);
     --secondary-foreground: var(--color-neutral-100);
@@ -274,7 +276,7 @@
     --destructive: color-mix(in srgb, var(--color-red-500) 90%, var(--color-white));
     --border: --alpha(var(--color-white) / 6%);
     --input: --alpha(var(--color-white) / 8%);
-    --ring: oklch(0.588 0.217 264);
+    --ring: oklch(0.72 0.14 155);
     --destructive-foreground: var(--color-red-400);
     --info: var(--color-blue-500);
     --info-foreground: var(--color-blue-400);
@@ -282,6 +284,8 @@
     --success-foreground: var(--color-emerald-400);
     --warning: var(--color-amber-500);
     --warning-foreground: var(--color-amber-400);
+    --terminal-grid-color: rgb(52 211 153 / 7%);
+    --terminal-scanline-color: rgb(255 255 255 / 3%);
   }
 }
 
@@ -331,8 +335,30 @@ body::after {
   background-size: 256px 256px;
 }
 
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.55;
+  background-image:
+    linear-gradient(to bottom, var(--terminal-scanline-color) 1px, transparent 1px),
+    linear-gradient(to right, var(--terminal-grid-color) 1px, transparent 1px);
+  background-size:
+    100% 28px,
+    28px 100%;
+  mask-image: linear-gradient(to bottom, transparent, black 8%, black 92%, transparent);
+}
+
 pre,
 code {
+  font-family:
+    "SF Mono", "SFMono-Regular", "JetBrains Mono", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+[data-slot="sidebar-wrapper"],
+.workspace-topbar,
+.surface-subheader {
   font-family:
     "SF Mono", "SFMono-Regular", "JetBrains Mono", Consolas, "Liberation Mono", Menlo, monospace;
 }

--- a/apps/web/src/profiles.test.ts
+++ b/apps/web/src/profiles.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  DEFAULT_CLIENT_SETTINGS,
+  type ClientSettings,
+  ProviderInstanceId,
+} from "@t3tools/contracts";
+import { EnvironmentId, ProjectId, ThreadId } from "@t3tools/contracts";
+
+import {
+  assignProjectKeysToProfilePatch,
+  filterProjectsForActiveProfile,
+  filterProviderInstancesForActiveProfile,
+  filterThreadsForActiveProfile,
+  getActiveProfile,
+  projectProfileKey,
+} from "./profiles";
+import type { Project, SidebarThreadSummary } from "./types";
+import type { ProviderInstanceEntry } from "./providerInstances";
+
+const env = EnvironmentId.make("local");
+
+function project(input: { id: string; cwd: string; title?: string }): Project {
+  return {
+    environmentId: env,
+    id: ProjectId.make(input.id),
+    title: input.title ?? input.id,
+    workspaceRoot: input.cwd,
+    defaultModelSelection: null,
+    repositoryIdentity: null,
+    scripts: [],
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function thread(input: { id: string; projectId: string }): SidebarThreadSummary {
+  return {
+    environmentId: env,
+    id: ThreadId.make(input.id),
+    projectId: ProjectId.make(input.projectId),
+    title: input.id,
+    modelSelection: {
+      instanceId: ProviderInstanceId.make("codex"),
+      model: "gpt-5",
+    },
+    runtimeMode: "full-access",
+    interactionMode: "default",
+    branch: null,
+    worktreePath: null,
+    latestTurn: null,
+    session: null,
+    latestUserMessageAt: null,
+    hasPendingApprovals: false,
+    hasPendingUserInput: false,
+    hasActionableProposedPlan: false,
+    archivedAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+  };
+}
+
+function settings(patch: Partial<ClientSettings> = {}): ClientSettings {
+  return {
+    ...DEFAULT_CLIENT_SETTINGS,
+    ...patch,
+  };
+}
+
+describe("profiles", () => {
+  it("resolves the built-in default profile", () => {
+    expect(getActiveProfile(DEFAULT_CLIENT_SETTINGS)).toEqual({
+      id: "default",
+      name: "Default",
+    });
+  });
+
+  it("filters projects by active profile assignment", () => {
+    const alpha = project({ id: "alpha", cwd: "/repo/alpha" });
+    const beta = project({ id: "beta", cwd: "/repo/beta" });
+    const profileSettings = settings({
+      activeProfileId: "work",
+      profiles: [
+        { id: "default", name: "Default" },
+        { id: "work", name: "Work" },
+      ],
+      projectProfileAssignments: {
+        [projectProfileKey(beta)]: "work",
+      },
+    });
+
+    expect(filterProjectsForActiveProfile([alpha, beta], profileSettings)).toEqual([beta]);
+  });
+
+  it("defaults unassigned projects to the default profile", () => {
+    const alpha = project({ id: "alpha", cwd: "/repo/alpha" });
+    const profileSettings = settings({
+      activeProfileId: "default",
+      profiles: [
+        { id: "default", name: "Default" },
+        { id: "work", name: "Work" },
+      ],
+    });
+
+    expect(filterProjectsForActiveProfile([alpha], profileSettings)).toEqual([alpha]);
+  });
+
+  it("filters threads through their visible project", () => {
+    const alpha = project({ id: "alpha", cwd: "/repo/alpha" });
+    const beta = project({ id: "beta", cwd: "/repo/beta" });
+    const alphaThread = thread({ id: "thread-alpha", projectId: "alpha" });
+    const betaThread = thread({ id: "thread-beta", projectId: "beta" });
+    const profileSettings = settings({
+      activeProfileId: "work",
+      profiles: [
+        { id: "default", name: "Default" },
+        { id: "work", name: "Work" },
+      ],
+      projectProfileAssignments: {
+        [projectProfileKey(beta)]: "work",
+      },
+    });
+
+    expect(
+      filterThreadsForActiveProfile([alphaThread, betaThread], [alpha, beta], profileSettings),
+    ).toEqual([betaThread]);
+  });
+
+  it("keeps provider instances global until explicitly scoped", () => {
+    const codex = { instanceId: ProviderInstanceId.make("codex") } as ProviderInstanceEntry;
+    const workCodex = {
+      instanceId: ProviderInstanceId.make("codex_work"),
+    } as ProviderInstanceEntry;
+    const profileSettings = settings({
+      activeProfileId: "work",
+      profiles: [
+        { id: "default", name: "Default" },
+        { id: "work", name: "Work" },
+      ],
+      providerInstanceProfileAssignments: {
+        [ProviderInstanceId.make("codex_work")]: "work",
+      },
+    });
+
+    expect(filterProviderInstancesForActiveProfile([codex, workCodex], profileSettings)).toEqual([
+      codex,
+      workCodex,
+    ]);
+  });
+
+  it("builds project assignment patches", () => {
+    expect(
+      assignProjectKeysToProfilePatch(DEFAULT_CLIENT_SETTINGS, ["local:/repo"], "work"),
+    ).toEqual({
+      projectProfileAssignments: {
+        "local:/repo": "work",
+      },
+    });
+  });
+});

--- a/apps/web/src/profiles.ts
+++ b/apps/web/src/profiles.ts
@@ -1,0 +1,231 @@
+import { scopedProjectKey, scopeProjectRef } from "@t3tools/client-runtime/environment";
+import {
+  DEFAULT_PROFILE_ID,
+  type AppProfile,
+  type ClientSettings,
+  type ClientSettingsPatch,
+  type ProviderInstanceId,
+} from "@t3tools/contracts";
+
+import { derivePhysicalProjectKey, derivePhysicalProjectKeyFromPath } from "./logicalProject";
+import type { ProviderInstanceEntry } from "./providerInstances";
+import type { Project, SidebarThreadSummary } from "./types";
+
+export const ALL_PROFILES_PROVIDER_SCOPE = "__all_profiles__";
+
+const DEFAULT_PROFILE: AppProfile = {
+  id: DEFAULT_PROFILE_ID,
+  name: "Default",
+};
+
+function normalizeProfile(profile: AppProfile): AppProfile | null {
+  const id = profile.id.trim();
+  const name = profile.name.trim();
+  if (!id || !name) {
+    return null;
+  }
+  return {
+    id,
+    name,
+    ...(profile.accentColor?.trim() ? { accentColor: profile.accentColor.trim() } : {}),
+  };
+}
+
+export function getAppProfiles(
+  settings: Pick<ClientSettings, "profiles">,
+): ReadonlyArray<AppProfile> {
+  const byId = new Map<string, AppProfile>();
+  byId.set(DEFAULT_PROFILE.id, DEFAULT_PROFILE);
+  for (const rawProfile of settings.profiles ?? []) {
+    const profile = normalizeProfile(rawProfile);
+    if (!profile) {
+      continue;
+    }
+    byId.set(profile.id, profile);
+  }
+  return [...byId.values()];
+}
+
+export function getActiveProfileId(
+  settings: Pick<ClientSettings, "activeProfileId" | "profiles">,
+): string {
+  const profiles = getAppProfiles(settings);
+  const activeProfileId = settings.activeProfileId.trim();
+  if (profiles.some((profile) => profile.id === activeProfileId)) {
+    return activeProfileId;
+  }
+  return profiles[0]?.id ?? DEFAULT_PROFILE_ID;
+}
+
+export function getActiveProfile(
+  settings: Pick<ClientSettings, "activeProfileId" | "profiles">,
+): AppProfile {
+  const activeProfileId = getActiveProfileId(settings);
+  return (
+    getAppProfiles(settings).find((profile) => profile.id === activeProfileId) ?? DEFAULT_PROFILE
+  );
+}
+
+export function makeNextProfileName(settings: Pick<ClientSettings, "profiles">): string {
+  const existingNames = new Set(getAppProfiles(settings).map((profile) => profile.name));
+  for (let index = 2; index < 1000; index += 1) {
+    const name = `Profile ${index}`;
+    if (!existingNames.has(name)) {
+      return name;
+    }
+  }
+  return `Profile ${Date.now().toString(36)}`;
+}
+
+export function makeProfileId(name: string, existingIds: ReadonlySet<string>): string {
+  const base =
+    name
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "profile";
+  if (!existingIds.has(base)) {
+    return base;
+  }
+  for (let index = 2; index < 1000; index += 1) {
+    const candidate = `${base}-${index}`;
+    if (!existingIds.has(candidate)) {
+      return candidate;
+    }
+  }
+  return `${base}-${Date.now().toString(36)}`;
+}
+
+export function createProfilePatch(
+  settings: Pick<ClientSettings, "profiles">,
+  name = makeNextProfileName(settings),
+): ClientSettingsPatch {
+  const profiles = getAppProfiles(settings);
+  const id = makeProfileId(name, new Set(profiles.map((profile) => profile.id)));
+  const profile: AppProfile = { id, name: name.trim() || "Profile" };
+  return {
+    activeProfileId: profile.id,
+    profiles: [...profiles, profile],
+  };
+}
+
+export function projectProfileKey(
+  project: Pick<Project, "environmentId" | "workspaceRoot">,
+): string {
+  return derivePhysicalProjectKey(project);
+}
+
+export function projectProfileKeyFromPath(environmentId: string, workspaceRoot: string): string {
+  return derivePhysicalProjectKeyFromPath(environmentId, workspaceRoot);
+}
+
+function assignedProfileIdForProject(
+  settings: Pick<ClientSettings, "projectProfileAssignments">,
+  projectKey: string,
+): string {
+  return settings.projectProfileAssignments?.[projectKey] ?? DEFAULT_PROFILE_ID;
+}
+
+export function isProjectVisibleInActiveProfile(
+  project: Pick<Project, "environmentId" | "workspaceRoot">,
+  settings: Pick<ClientSettings, "activeProfileId" | "profiles" | "projectProfileAssignments">,
+): boolean {
+  return (
+    assignedProfileIdForProject(settings, projectProfileKey(project)) ===
+    getActiveProfileId(settings)
+  );
+}
+
+export function filterProjectsForActiveProfile(
+  projects: ReadonlyArray<Project>,
+  settings: Pick<ClientSettings, "activeProfileId" | "profiles" | "projectProfileAssignments">,
+): ReadonlyArray<Project> {
+  return projects.filter((project) => isProjectVisibleInActiveProfile(project, settings));
+}
+
+export function filterThreadsForActiveProfile(
+  threads: ReadonlyArray<SidebarThreadSummary>,
+  projects: ReadonlyArray<Project>,
+  settings: Pick<ClientSettings, "activeProfileId" | "profiles" | "projectProfileAssignments">,
+): ReadonlyArray<SidebarThreadSummary> {
+  const visibleProjectRefs = new Set(
+    filterProjectsForActiveProfile(projects, settings).map((project) =>
+      scopedProjectKey(scopeProjectRef(project.environmentId, project.id)),
+    ),
+  );
+  return threads.filter((thread) =>
+    visibleProjectRefs.has(
+      scopedProjectKey(scopeProjectRef(thread.environmentId, thread.projectId)),
+    ),
+  );
+}
+
+export function assignProjectKeysToProfilePatch(
+  settings: Pick<ClientSettings, "projectProfileAssignments">,
+  projectKeys: ReadonlyArray<string>,
+  profileId: string,
+): ClientSettingsPatch {
+  const nextAssignments = { ...settings.projectProfileAssignments };
+  for (const projectKey of projectKeys) {
+    nextAssignments[projectKey] = profileId;
+  }
+  return { projectProfileAssignments: nextAssignments };
+}
+
+export function assignProjectsToProfilePatch(
+  settings: Pick<ClientSettings, "projectProfileAssignments">,
+  projects: ReadonlyArray<Pick<Project, "environmentId" | "workspaceRoot">>,
+  profileId: string,
+): ClientSettingsPatch {
+  return assignProjectKeysToProfilePatch(
+    settings,
+    projects.map((project) => projectProfileKey(project)),
+    profileId,
+  );
+}
+
+export function providerScopeLabel(
+  settings: Pick<ClientSettings, "profiles" | "providerInstanceProfileAssignments">,
+  instanceId: ProviderInstanceId,
+): string {
+  const profileId = settings.providerInstanceProfileAssignments?.[instanceId];
+  if (!profileId) {
+    return "All profiles";
+  }
+  return getAppProfiles(settings).find((profile) => profile.id === profileId)?.name ?? profileId;
+}
+
+export function isProviderInstanceVisibleInActiveProfile(
+  entry: Pick<ProviderInstanceEntry, "instanceId">,
+  settings: Pick<
+    ClientSettings,
+    "activeProfileId" | "profiles" | "providerInstanceProfileAssignments"
+  >,
+): boolean {
+  const assignedProfileId = settings.providerInstanceProfileAssignments?.[entry.instanceId];
+  return !assignedProfileId || assignedProfileId === getActiveProfileId(settings);
+}
+
+export function filterProviderInstancesForActiveProfile(
+  entries: ReadonlyArray<ProviderInstanceEntry>,
+  settings: Pick<
+    ClientSettings,
+    "activeProfileId" | "profiles" | "providerInstanceProfileAssignments"
+  >,
+): ReadonlyArray<ProviderInstanceEntry> {
+  return entries.filter((entry) => isProviderInstanceVisibleInActiveProfile(entry, settings));
+}
+
+export function assignProviderInstanceToProfilePatch(
+  settings: Pick<ClientSettings, "providerInstanceProfileAssignments">,
+  instanceId: ProviderInstanceId,
+  profileId: string | null,
+): ClientSettingsPatch {
+  const nextAssignments = { ...settings.providerInstanceProfileAssignments };
+  if (profileId) {
+    nextAssignments[instanceId] = profileId;
+  } else {
+    delete nextAssignments[instanceId];
+  }
+  return { providerInstanceProfileAssignments: nextAssignments };
+}

--- a/apps/web/src/proposedPlan.test.ts
+++ b/apps/web/src/proposedPlan.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vite-plus/test";
 
 import {
   buildCollapsedProposedPlanPreviewMarkdown,
+  buildPlanGoalObjective,
   buildPlanImplementationThreadTitle,
   buildPlanImplementationPrompt,
   buildProposedPlanMarkdownFilename,
@@ -25,6 +26,12 @@ describe("buildPlanImplementationPrompt", () => {
     expect(buildPlanImplementationPrompt("## Ship it\n\n- step 1\n")).toBe(
       "PLEASE IMPLEMENT THIS PLAN:\n## Ship it\n\n- step 1",
     );
+  });
+});
+
+describe("buildPlanGoalObjective", () => {
+  it("uses the plan markdown as the goal objective", () => {
+    expect(buildPlanGoalObjective("## Ship it\n\n- step 1\n")).toBe("## Ship it\n\n- step 1");
   });
 });
 
@@ -85,6 +92,33 @@ describe("resolvePlanFollowUpSubmission", () => {
     ).toEqual({
       text: "Refine step 2 first",
       interactionMode: "plan",
+    });
+  });
+
+  it("keeps plan and goal mode when the user refines that mode's plan", () => {
+    expect(
+      resolvePlanFollowUpSubmission({
+        draftText: "Add rollback checks",
+        planMarkdown: "## Ship it\n\n- step 1\n",
+        interactionMode: "plan_and_goal",
+      }),
+    ).toEqual({
+      text: "Add rollback checks",
+      interactionMode: "plan_and_goal",
+    });
+  });
+
+  it("returns a goal objective for plan and goal implementation", () => {
+    expect(
+      resolvePlanFollowUpSubmission({
+        draftText: "   ",
+        planMarkdown: "## Ship it\n\n- step 1\n",
+        executionMode: "goal",
+      }),
+    ).toEqual({
+      text: "PLEASE IMPLEMENT THIS PLAN:\n## Ship it\n\n- step 1",
+      interactionMode: "default",
+      goalObjective: "## Ship it\n\n- step 1",
     });
   });
 });

--- a/apps/web/src/proposedPlan.ts
+++ b/apps/web/src/proposedPlan.ts
@@ -1,3 +1,5 @@
+import type { ProviderInteractionMode } from "@t3tools/contracts";
+
 export function proposedPlanTitle(planMarkdown: string): string | null {
   const heading = planMarkdown.match(/^\s{0,3}#{1,6}\s+(.+)$/m)?.[1]?.trim();
   return heading && heading.length > 0 ? heading : null;
@@ -74,20 +76,39 @@ export function buildPlanImplementationPrompt(planMarkdown: string): string {
   return `PLEASE IMPLEMENT THIS PLAN:\n${planMarkdown.trim()}`;
 }
 
-export function resolvePlanFollowUpSubmission(input: { draftText: string; planMarkdown: string }): {
+export function buildPlanGoalObjective(planMarkdown: string): string {
+  return planMarkdown.trim();
+}
+
+export function resolvePlanFollowUpSubmission(input: {
+  draftText: string;
+  planMarkdown: string;
+  interactionMode?: ProviderInteractionMode;
+  executionMode?: "implement" | "goal";
+}): {
   text: string;
-  interactionMode: "default" | "plan";
+  interactionMode: ProviderInteractionMode;
+  goalObjective?: string;
 } {
   const trimmedDraftText = input.draftText.trim();
   if (trimmedDraftText.length > 0) {
     return {
       text: trimmedDraftText,
-      interactionMode: "plan",
+      interactionMode: input.interactionMode ?? "plan",
+    };
+  }
+
+  const implementationPrompt = buildPlanImplementationPrompt(input.planMarkdown);
+  if (input.executionMode === "goal") {
+    return {
+      text: implementationPrompt,
+      interactionMode: "default",
+      goalObjective: buildPlanGoalObjective(input.planMarkdown),
     };
   }
 
   return {
-    text: buildPlanImplementationPrompt(input.planMarkdown),
+    text: implementationPrompt,
     interactionMode: "default",
   };
 }

--- a/apps/web/src/sidebarSubchats.test.ts
+++ b/apps/web/src/sidebarSubchats.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vite-plus/test";
+import { EventId, type OrchestrationThreadActivity } from "@t3tools/contracts";
+
+import { deriveSidebarSubchats } from "./sidebarSubchats";
+
+function activity(
+  patch: Omit<Partial<OrchestrationThreadActivity>, "id" | "payload"> & {
+    readonly id: string;
+    readonly payload: unknown;
+  },
+): OrchestrationThreadActivity {
+  const { id, payload, ...rest } = patch;
+  return {
+    id: EventId.make(id),
+    tone: "tool",
+    kind: "tool.completed",
+    summary: "Tool",
+    turnId: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    payload,
+    ...rest,
+  } as OrchestrationThreadActivity;
+}
+
+describe("sidebarSubchats", () => {
+  it("deduplicates Codex collab activities by receiver thread ids", () => {
+    const subchats = deriveSidebarSubchats([
+      activity({
+        id: "evt-started",
+        kind: "tool.started",
+        summary: "Tool started",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          detail: "Investigate failing checks",
+          status: "inProgress",
+          data: {
+            item: {
+              receiverThreadIds: ["thread-child"],
+            },
+          },
+        },
+      }),
+      activity({
+        id: "evt-completed",
+        kind: "tool.completed",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          detail: "Investigate failing checks",
+          data: {
+            item: {
+              receiverThreadIds: ["thread-child"],
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(subchats).toEqual([
+      {
+        id: "evt-started",
+        label: "Investigate failing checks",
+        detail: "Investigate failing checks",
+        status: "completed",
+        receiverThreadIds: ["thread-child"],
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("extracts Claude subagent labels from tool input data", () => {
+    const subchats = deriveSidebarSubchats([
+      activity({
+        id: "evt-claude",
+        kind: "tool.updated",
+        payload: {
+          itemType: "collab_agent_tool_call",
+          status: "failed",
+          data: {
+            toolName: "Task",
+            input: {
+              description: "Audit thread projection",
+              prompt: "Longer prompt not shown when a description exists",
+            },
+          },
+        },
+      }),
+    ]);
+
+    expect(
+      subchats.map(({ label, detail, status, receiverThreadIds }) => ({
+        label,
+        detail,
+        status,
+        receiverThreadIds,
+      })),
+    ).toEqual([
+      {
+        label: "Audit thread projection",
+        detail: "Audit thread projection",
+        status: "failed",
+        receiverThreadIds: [],
+      },
+    ]);
+  });
+});

--- a/apps/web/src/sidebarSubchats.ts
+++ b/apps/web/src/sidebarSubchats.ts
@@ -1,0 +1,187 @@
+import type { OrchestrationThreadActivity } from "@t3tools/contracts";
+
+export type SidebarSubchatStatus = "running" | "completed" | "failed";
+
+export interface SidebarSubchatSummary {
+  readonly id: string;
+  readonly label: string;
+  readonly detail: string | null;
+  readonly status: SidebarSubchatStatus;
+  readonly receiverThreadIds: ReadonlyArray<string>;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
+}
+
+function payloadRecord(activity: OrchestrationThreadActivity): Record<string, unknown> | null {
+  return isRecord(activity.payload) ? activity.payload : null;
+}
+
+function firstReadableLine(value: unknown): string | null {
+  const text = stringValue(value);
+  if (!text) {
+    return null;
+  }
+  const normalized = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean)
+    ?.replace(/\s+/g, " ");
+  if (!normalized) {
+    return null;
+  }
+  return normalized.length > 96 ? `${normalized.slice(0, 93)}...` : normalized;
+}
+
+function collectReceiverThreadIds(
+  value: unknown,
+  output = new Set<string>(),
+  depth = 0,
+): Set<string> {
+  if (depth > 5 || !isRecord(value)) {
+    return output;
+  }
+  for (const [key, entry] of Object.entries(value)) {
+    if (key === "receiverThreadIds" && Array.isArray(entry)) {
+      for (const candidate of entry) {
+        const threadId = stringValue(candidate);
+        if (threadId) {
+          output.add(threadId);
+        }
+      }
+      continue;
+    }
+    if (isRecord(entry)) {
+      collectReceiverThreadIds(entry, output, depth + 1);
+    } else if (Array.isArray(entry)) {
+      for (const nested of entry) {
+        collectReceiverThreadIds(nested, output, depth + 1);
+      }
+    }
+  }
+  return output;
+}
+
+function stringAtPath(value: unknown, path: ReadonlyArray<string>): string | null {
+  let current = value;
+  for (const segment of path) {
+    if (!isRecord(current)) {
+      return null;
+    }
+    current = current[segment];
+  }
+  return firstReadableLine(current);
+}
+
+function subchatLabel(
+  activity: OrchestrationThreadActivity,
+  payload: Record<string, unknown>,
+): string {
+  const data = payload.data;
+  const candidates = [
+    payload.detail,
+    stringAtPath(data, ["item", "title"]),
+    stringAtPath(data, ["item", "summary"]),
+    stringAtPath(data, ["item", "prompt"]),
+    stringAtPath(data, ["input", "description"]),
+    stringAtPath(data, ["input", "prompt"]),
+    stringAtPath(data, ["toolName"]),
+    activity.summary.replace(/\s+started$/i, ""),
+  ];
+  for (const candidate of candidates) {
+    const label = firstReadableLine(candidate);
+    if (label && label.toLowerCase() !== "tool") {
+      return label;
+    }
+  }
+  return "Subchat";
+}
+
+function subchatDetail(payload: Record<string, unknown>): string | null {
+  const data = payload.data;
+  return (
+    firstReadableLine(payload.detail) ??
+    stringAtPath(data, ["input", "description"]) ??
+    stringAtPath(data, ["input", "prompt"]) ??
+    null
+  );
+}
+
+function activityStatus(
+  activity: OrchestrationThreadActivity,
+  payload: Record<string, unknown>,
+): SidebarSubchatStatus {
+  const payloadStatus = stringValue(payload.status);
+  if (payloadStatus === "failed" || activity.tone === "error" || activity.kind.includes("failed")) {
+    return "failed";
+  }
+  if (payloadStatus === "completed" || activity.kind === "tool.completed") {
+    return "completed";
+  }
+  return "running";
+}
+
+function mergeStatus(
+  previous: SidebarSubchatStatus,
+  next: SidebarSubchatStatus,
+): SidebarSubchatStatus {
+  if (previous === "failed" || next === "failed") {
+    return "failed";
+  }
+  return next;
+}
+
+export function deriveSidebarSubchats(
+  activities: ReadonlyArray<OrchestrationThreadActivity>,
+): ReadonlyArray<SidebarSubchatSummary> {
+  const byKey = new Map<string, SidebarSubchatSummary>();
+
+  for (const activity of activities) {
+    const payload = payloadRecord(activity);
+    if (payload?.itemType !== "collab_agent_tool_call") {
+      continue;
+    }
+
+    const receiverThreadIds = [...collectReceiverThreadIds(payload.data)].sort();
+    const label = subchatLabel(activity, payload);
+    const detail = subchatDetail(payload);
+    const key =
+      receiverThreadIds.length > 0
+        ? `receiver:${receiverThreadIds.join("|")}`
+        : `label:${activity.turnId ?? "thread"}:${label}`;
+    const existing = byKey.get(key);
+    const nextStatus = activityStatus(activity, payload);
+
+    if (!existing) {
+      byKey.set(key, {
+        id: String(activity.id),
+        label,
+        detail,
+        status: nextStatus,
+        receiverThreadIds,
+        createdAt: activity.createdAt,
+        updatedAt: activity.createdAt,
+      });
+      continue;
+    }
+
+    byKey.set(key, {
+      ...existing,
+      label: existing.label === "Subchat" ? label : existing.label,
+      detail: existing.detail ?? detail,
+      status: mergeStatus(existing.status, nextStatus),
+      receiverThreadIds:
+        existing.receiverThreadIds.length > 0 ? existing.receiverThreadIds : receiverThreadIds,
+      updatedAt: activity.createdAt,
+    });
+  }
+
+  return [...byKey.values()];
+}

--- a/apps/web/src/toolAccess.test.ts
+++ b/apps/web/src/toolAccess.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  DEFAULT_CLIENT_SETTINGS,
+  ProviderInstanceId,
+  ProviderDriverKind,
+  type ClientSettings,
+  type ServerProvider,
+} from "@t3tools/contracts";
+import { EnvironmentId } from "@t3tools/contracts";
+
+import {
+  buildToolAccessCatalog,
+  filterProviderSkillsForToolAccess,
+  resolveEffectiveToolAccess,
+  toolKeyForPlugin,
+  toolKeyForSkill,
+} from "./toolAccess";
+
+const codexInstance = ProviderInstanceId.make("codex");
+const workInstance = ProviderInstanceId.make("codex_work");
+const env = EnvironmentId.make("local");
+
+function provider(input: Partial<ServerProvider> = {}): ServerProvider {
+  return {
+    instanceId: codexInstance,
+    driver: ProviderDriverKind.make("codex"),
+    enabled: true,
+    installed: true,
+    version: "1.0.0",
+    status: "ready",
+    auth: { status: "authenticated" },
+    checkedAt: "2026-01-01T00:00:00.000Z",
+    models: [],
+    slashCommands: [],
+    skills: [],
+    ...input,
+  };
+}
+
+function settings(patch: Partial<ClientSettings> = {}): ClientSettings {
+  return {
+    ...DEFAULT_CLIENT_SETTINGS,
+    ...patch,
+  };
+}
+
+describe("toolAccess", () => {
+  it("builds skill and plugin entries from provider skills", () => {
+    const catalog = buildToolAccessCatalog([
+      provider({
+        skills: [
+          {
+            name: "gh-fix-ci",
+            displayName: "Fix CI",
+            path: "/Users/julius/.codex/plugins/cache/github/skills/gh-fix-ci/SKILL.md",
+            enabled: true,
+          },
+        ],
+      }),
+    ]);
+
+    expect(catalog.map((entry) => entry.key)).toEqual([
+      toolKeyForPlugin(codexInstance, "github"),
+      toolKeyForSkill(codexInstance, "gh-fix-ci"),
+    ]);
+  });
+
+  it("uses global custom policy when neither profile nor project overrides exist", () => {
+    const allowed = resolveEffectiveToolAccess({
+      catalog: [],
+      settings: settings({
+        globalToolAccessPolicy: {
+          mode: "custom",
+          enabledToolKeys: [toolKeyForSkill(codexInstance, "imagegen")],
+        },
+      }),
+    });
+
+    expect([...(allowed ?? [])]).toEqual([toolKeyForSkill(codexInstance, "imagegen")]);
+  });
+
+  it("lets project custom policy use tools from another provider profile", () => {
+    const project = { environmentId: env, workspaceRoot: "/repo/app" };
+    const skillKey = toolKeyForSkill(workInstance, "deploy");
+    const allowed = resolveEffectiveToolAccess({
+      catalog: [],
+      project,
+      settings: settings({
+        activeProfileId: "default",
+        profiles: [
+          { id: "default", name: "Default" },
+          { id: "work", name: "Work" },
+        ],
+        profileToolAccessPolicies: {
+          default: {
+            mode: "custom",
+            enabledToolKeys: [toolKeyForSkill(codexInstance, "imagegen")],
+          },
+        },
+        projectToolAccessPolicies: {
+          "local:/repo/app": {
+            mode: "custom",
+            enabledToolKeys: [skillKey],
+          },
+        },
+      }),
+    });
+
+    expect([...(allowed ?? [])]).toEqual([skillKey]);
+  });
+
+  it("filters provider skills through plugin keys", () => {
+    const snapshot = provider({
+      skills: [
+        {
+          name: "gh-fix-ci",
+          path: "/Users/julius/.codex/plugins/cache/github/skills/gh-fix-ci/SKILL.md",
+          enabled: true,
+        },
+        {
+          name: "imagegen",
+          path: "/Users/julius/.codex/skills/imagegen/SKILL.md",
+          enabled: true,
+        },
+      ],
+    });
+
+    const filtered = filterProviderSkillsForToolAccess({
+      provider: snapshot,
+      catalog: buildToolAccessCatalog([snapshot]),
+      settings: settings({
+        globalToolAccessPolicy: {
+          mode: "custom",
+          enabledToolKeys: [toolKeyForPlugin(codexInstance, "github")],
+        },
+      }),
+    });
+
+    expect(filtered.map((skill) => skill.name)).toEqual(["gh-fix-ci"]);
+  });
+});

--- a/apps/web/src/toolAccess.ts
+++ b/apps/web/src/toolAccess.ts
@@ -1,0 +1,252 @@
+import {
+  DEFAULT_APP_TOOL_ACCESS_POLICY,
+  type AppToolAccessPolicy,
+  type ClientSettings,
+  type ProviderInstanceId,
+  type ServerProvider,
+  type ServerProviderSkill,
+} from "@t3tools/contracts";
+
+import type { Project } from "./types";
+import { getActiveProfileId, projectProfileKey } from "./profiles";
+
+export type ToolAccessKind = "skill" | "plugin" | "mcp";
+
+export interface ToolAccessCatalogEntry {
+  readonly key: string;
+  readonly kind: ToolAccessKind;
+  readonly providerInstanceId: ProviderInstanceId;
+  readonly providerLabel: string;
+  readonly name: string;
+  readonly label: string;
+  readonly description: string | null;
+  readonly source: string | null;
+  readonly enabled: boolean;
+}
+
+function providerLabel(provider: ServerProvider): string {
+  return provider.displayName ?? provider.badgeLabel ?? provider.driver;
+}
+
+export function toolKeyForSkill(instanceId: ProviderInstanceId, skillName: string): string {
+  return `skill:${instanceId}:${skillName}`;
+}
+
+export function toolKeyForPlugin(instanceId: ProviderInstanceId, pluginName: string): string {
+  return `plugin:${instanceId}:${pluginName}`;
+}
+
+export function toolKeyForMcp(instanceId: ProviderInstanceId, type: string, value: string): string {
+  return `mcp:${instanceId}:${type}:${value}`;
+}
+
+function pluginNameFromSkillPath(path: string): string | null {
+  const normalized = path.replace(/\\/g, "/");
+  const marker = "/plugins/";
+  const markerIndex = normalized.indexOf(marker);
+  if (markerIndex === -1) {
+    return null;
+  }
+
+  const afterPlugins = normalized.slice(markerIndex + marker.length);
+  const segments = afterPlugins.split("/").filter(Boolean);
+  if (segments[0] === "cache" && segments[1]) {
+    return segments[1];
+  }
+  return segments[0] ?? null;
+}
+
+function upsertEntry(
+  entriesByKey: Map<string, ToolAccessCatalogEntry>,
+  entry: ToolAccessCatalogEntry,
+): void {
+  const existing = entriesByKey.get(entry.key);
+  if (!existing) {
+    entriesByKey.set(entry.key, entry);
+    return;
+  }
+  entriesByKey.set(entry.key, {
+    ...existing,
+    enabled: existing.enabled || entry.enabled,
+    description: existing.description ?? entry.description,
+    source: existing.source ?? entry.source,
+  });
+}
+
+export function buildToolAccessCatalog(
+  providers: ReadonlyArray<ServerProvider>,
+): ReadonlyArray<ToolAccessCatalogEntry> {
+  const entriesByKey = new Map<string, ToolAccessCatalogEntry>();
+
+  for (const provider of providers) {
+    const label = providerLabel(provider);
+    for (const skill of provider.skills) {
+      upsertEntry(entriesByKey, {
+        key: toolKeyForSkill(provider.instanceId, skill.name),
+        kind: "skill",
+        providerInstanceId: provider.instanceId,
+        providerLabel: label,
+        name: skill.name,
+        label: skill.displayName ?? skill.name,
+        description: skill.shortDescription ?? skill.description ?? null,
+        source: skill.scope ?? null,
+        enabled: skill.enabled,
+      });
+
+      const pluginName = pluginNameFromSkillPath(skill.path);
+      if (pluginName) {
+        upsertEntry(entriesByKey, {
+          key: toolKeyForPlugin(provider.instanceId, pluginName),
+          kind: "plugin",
+          providerInstanceId: provider.instanceId,
+          providerLabel: label,
+          name: pluginName,
+          label: pluginName,
+          description: null,
+          source: "plugin install",
+          enabled: skill.enabled,
+        });
+      }
+
+      for (const dependency of skill.toolDependencies ?? []) {
+        upsertEntry(entriesByKey, {
+          key: toolKeyForMcp(provider.instanceId, dependency.type, dependency.value),
+          kind: "mcp",
+          providerInstanceId: provider.instanceId,
+          providerLabel: label,
+          name: dependency.value,
+          label: dependency.value,
+          description: dependency.description ?? null,
+          source: dependency.transport ?? dependency.type,
+          enabled: skill.enabled,
+        });
+      }
+    }
+  }
+
+  return [...entriesByKey.values()].sort(
+    (left, right) =>
+      left.kind.localeCompare(right.kind) ||
+      left.providerLabel.localeCompare(right.providerLabel) ||
+      left.label.localeCompare(right.label) ||
+      left.key.localeCompare(right.key),
+  );
+}
+
+export function normalizeToolAccessPolicy(
+  policy: AppToolAccessPolicy | undefined,
+  fallbackMode: AppToolAccessPolicy["mode"] = DEFAULT_APP_TOOL_ACCESS_POLICY.mode,
+): AppToolAccessPolicy {
+  if (!policy) {
+    return { ...DEFAULT_APP_TOOL_ACCESS_POLICY, mode: fallbackMode };
+  }
+  return {
+    mode: policy.mode,
+    enabledToolKeys: [...new Set(policy.enabledToolKeys.map((key) => key.trim()).filter(Boolean))],
+  };
+}
+
+export function isToolAccessPolicyCustom(policy: AppToolAccessPolicy | undefined): boolean {
+  return normalizeToolAccessPolicy(policy).mode === "custom";
+}
+
+export function resolveEffectiveToolAccess(input: {
+  readonly settings: Pick<
+    ClientSettings,
+    | "activeProfileId"
+    | "profiles"
+    | "globalToolAccessPolicy"
+    | "profileToolAccessPolicies"
+    | "projectToolAccessPolicies"
+  >;
+  readonly catalog: ReadonlyArray<ToolAccessCatalogEntry>;
+  readonly project?: Pick<Project, "environmentId" | "workspaceRoot"> | null;
+}): ReadonlySet<string> | null {
+  const projectPolicy =
+    input.project === undefined || input.project === null
+      ? undefined
+      : input.settings.projectToolAccessPolicies[projectProfileKey(input.project)];
+  const normalizedProjectPolicy = normalizeToolAccessPolicy(projectPolicy, "inherit");
+  if (normalizedProjectPolicy.mode === "custom") {
+    return new Set(normalizedProjectPolicy.enabledToolKeys);
+  }
+
+  const activeProfileId = getActiveProfileId(input.settings);
+  const profilePolicy = normalizeToolAccessPolicy(
+    input.settings.profileToolAccessPolicies[activeProfileId],
+    "inherit",
+  );
+  if (profilePolicy.mode === "custom") {
+    return new Set(profilePolicy.enabledToolKeys);
+  }
+
+  const globalPolicy = normalizeToolAccessPolicy(input.settings.globalToolAccessPolicy);
+  if (globalPolicy.mode === "custom") {
+    return new Set(globalPolicy.enabledToolKeys);
+  }
+
+  return null;
+}
+
+function skillAccessKeys(input: {
+  readonly provider: Pick<ServerProvider, "instanceId">;
+  readonly skill: ServerProviderSkill;
+}): ReadonlyArray<string> {
+  const keys = [toolKeyForSkill(input.provider.instanceId, input.skill.name)];
+  const pluginName = pluginNameFromSkillPath(input.skill.path);
+  if (pluginName) {
+    keys.push(toolKeyForPlugin(input.provider.instanceId, pluginName));
+  }
+  for (const dependency of input.skill.toolDependencies ?? []) {
+    keys.push(toolKeyForMcp(input.provider.instanceId, dependency.type, dependency.value));
+  }
+  return keys;
+}
+
+export function filterProviderSkillsForToolAccess(input: {
+  readonly provider: ServerProvider | null;
+  readonly settings: Pick<
+    ClientSettings,
+    | "activeProfileId"
+    | "profiles"
+    | "globalToolAccessPolicy"
+    | "profileToolAccessPolicies"
+    | "projectToolAccessPolicies"
+  >;
+  readonly catalog: ReadonlyArray<ToolAccessCatalogEntry>;
+  readonly project?: Pick<Project, "environmentId" | "workspaceRoot"> | null;
+}): ReadonlyArray<ServerProviderSkill> {
+  if (!input.provider) {
+    return [];
+  }
+  const allowed = resolveEffectiveToolAccess({
+    settings: input.settings,
+    catalog: input.catalog,
+    ...(input.project === undefined ? {} : { project: input.project }),
+  });
+  if (allowed === null) {
+    return input.provider.skills;
+  }
+  return input.provider.skills.filter((skill) =>
+    skillAccessKeys({ provider: input.provider!, skill }).some((key) => allowed.has(key)),
+  );
+}
+
+export function updateToolAccessPolicySelection(input: {
+  readonly policy: AppToolAccessPolicy | undefined;
+  readonly toolKey: string;
+  readonly checked: boolean;
+  readonly fallbackMode?: AppToolAccessPolicy["mode"];
+}): AppToolAccessPolicy {
+  const policy = normalizeToolAccessPolicy(input.policy, input.fallbackMode);
+  const nextKeys = new Set(policy.enabledToolKeys);
+  if (input.checked) {
+    nextKeys.add(input.toolKey);
+  } else {
+    nextKeys.delete(input.toolKey);
+  }
+  return {
+    mode: "custom",
+    enabledToolKeys: [...nextKeys].sort(),
+  };
+}

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -240,7 +240,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
           }));
           return;
         }
-        return yield* Effect.fail(failure);
+        return yield* failure;
       }
       const clerkToken = tokenResult.success;
       if ((yield* Ref.get(accountGeneration)) !== generation) {

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -121,7 +121,7 @@ export const RuntimeMode = Schema.Literals([
 ]);
 export type RuntimeMode = typeof RuntimeMode.Type;
 export const DEFAULT_RUNTIME_MODE: RuntimeMode = "full-access";
-export const ProviderInteractionMode = Schema.Literals(["default", "plan"]);
+export const ProviderInteractionMode = Schema.Literals(["default", "plan", "plan_and_goal"]);
 export type ProviderInteractionMode = typeof ProviderInteractionMode.Type;
 export const DEFAULT_PROVIDER_INTERACTION_MODE: ProviderInteractionMode = "default";
 export const ProviderRequestKind = Schema.Literals(["command", "file-read", "file-change"]);
@@ -615,6 +615,7 @@ export const ThreadTurnStartCommand = Schema.Struct({
   ),
   bootstrap: Schema.optional(ThreadTurnStartBootstrap),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
+  goalObjective: Schema.optional(TrimmedNonEmptyString),
   createdAt: IsoDateTime,
 });
 
@@ -634,6 +635,7 @@ const ClientThreadTurnStartCommand = Schema.Struct({
   interactionMode: ProviderInteractionMode,
   bootstrap: Schema.optional(ThreadTurnStartBootstrap),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
+  goalObjective: Schema.optional(TrimmedNonEmptyString),
   createdAt: IsoDateTime,
 });
 
@@ -933,6 +935,7 @@ export const ThreadTurnStartRequestedPayload = Schema.Struct({
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROVIDER_INTERACTION_MODE)),
   ),
   sourceProposedPlan: Schema.optional(SourceProposedPlanReference),
+  goalObjective: Schema.optional(TrimmedNonEmptyString),
   createdAt: IsoDateTime,
 });
 

--- a/packages/contracts/src/provider.ts
+++ b/packages/contracts/src/provider.ts
@@ -74,6 +74,9 @@ export const ProviderSendTurnInput = Schema.Struct({
   ),
   modelSelection: Schema.optional(ModelSelection),
   interactionMode: Schema.optional(ProviderInteractionMode),
+  goalObjective: Schema.optional(
+    TrimmedNonEmptyString.check(Schema.isMaxLength(PROVIDER_SEND_TURN_MAX_INPUT_CHARS)),
+  ),
 });
 export type ProviderSendTurnInput = typeof ProviderSendTurnInput.Type;
 

--- a/packages/contracts/src/server.test.ts
+++ b/packages/contracts/src/server.test.ts
@@ -27,6 +27,42 @@ describe("ServerProvider", () => {
     expect(parsed.updateState).toBeUndefined();
   });
 
+  it("decodes optional skill tool dependencies", () => {
+    const parsed = decodeServerProvider({
+      instanceId: "codex",
+      driver: "codex",
+      enabled: true,
+      installed: true,
+      version: "1.0.0",
+      status: "ready",
+      auth: {
+        status: "authenticated",
+      },
+      checkedAt: "2026-04-10T00:00:00.000Z",
+      models: [],
+      skills: [
+        {
+          name: "browser",
+          path: "/Users/julius/.codex/skills/browser/SKILL.md",
+          enabled: true,
+          toolDependencies: [
+            {
+              type: "mcp",
+              value: "browser",
+              transport: "stdio",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(parsed.skills[0]?.toolDependencies?.[0]).toMatchObject({
+      type: "mcp",
+      value: "browser",
+      transport: "stdio",
+    });
+  });
+
   it("defaults one-click update support when decoding older advisory snapshots", () => {
     const parsed = decodeServerProvider({
       instanceId: "codex",

--- a/packages/contracts/src/server.ts
+++ b/packages/contracts/src/server.ts
@@ -88,6 +88,18 @@ export const ServerProviderSkill = Schema.Struct({
   enabled: Schema.Boolean,
   displayName: Schema.optional(TrimmedNonEmptyString),
   shortDescription: Schema.optional(TrimmedNonEmptyString),
+  toolDependencies: Schema.optionalKey(
+    Schema.Array(
+      Schema.Struct({
+        type: TrimmedNonEmptyString,
+        value: TrimmedNonEmptyString,
+        command: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
+        description: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
+        transport: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
+        url: Schema.optionalKey(Schema.NullOr(TrimmedNonEmptyString)),
+      }),
+    ),
+  ),
 });
 export type ServerProviderSkill = typeof ServerProviderSkill.Type;
 

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -39,7 +39,47 @@ export const SidebarThreadPreviewCount = Schema.Int.check(
 export type SidebarThreadPreviewCount = typeof SidebarThreadPreviewCount.Type;
 export const DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT: SidebarThreadPreviewCount = 6;
 
+export const DEFAULT_PROFILE_ID = "default";
+
+export const AppProfile = Schema.Struct({
+  id: TrimmedNonEmptyString,
+  name: TrimmedNonEmptyString,
+  accentColor: Schema.optionalKey(TrimmedNonEmptyString),
+});
+export type AppProfile = typeof AppProfile.Type;
+
+export const PlanAndGoalReviewMode = Schema.Literals(["manual_review", "auto"]);
+export type PlanAndGoalReviewMode = typeof PlanAndGoalReviewMode.Type;
+export const DEFAULT_PLAN_AND_GOAL_REVIEW_MODE: PlanAndGoalReviewMode = "manual_review";
+
+export const AppToolAccessPolicyMode = Schema.Literals(["all", "custom", "inherit"]);
+export type AppToolAccessPolicyMode = typeof AppToolAccessPolicyMode.Type;
+
+export const AppToolAccessPolicy = Schema.Struct({
+  mode: AppToolAccessPolicyMode.pipe(Schema.withDecodingDefault(Effect.succeed("all" as const))),
+  enabledToolKeys: Schema.Array(TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed([])),
+  ),
+});
+export type AppToolAccessPolicy = typeof AppToolAccessPolicy.Type;
+
+export const DEFAULT_APP_TOOL_ACCESS_POLICY: AppToolAccessPolicy = {
+  mode: "all",
+  enabledToolKeys: [],
+};
+
+const DEFAULT_APP_PROFILES: ReadonlyArray<AppProfile> = [
+  {
+    id: DEFAULT_PROFILE_ID,
+    name: "Default",
+  },
+];
+
 export const ClientSettingsSchema = Schema.Struct({
+  activeProfileId: TrimmedNonEmptyString.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PROFILE_ID)),
+  ),
+  appBackgroundColor: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   autoOpenPlanSidebar: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadArchive: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(false))),
   confirmThreadDelete: Schema.Boolean.pipe(Schema.withDecodingDefault(Effect.succeed(true))),
@@ -72,6 +112,27 @@ export const ClientSettingsSchema = Schema.Struct({
       modelOrder: Schema.Array(Schema.String).pipe(Schema.withDecodingDefault(Effect.succeed([]))),
     }),
   ).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+  planAndGoalReviewMode: PlanAndGoalReviewMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_PLAN_AND_GOAL_REVIEW_MODE)),
+  ),
+  profiles: Schema.Array(AppProfile).pipe(
+    Schema.withDecodingDefault(Effect.succeed([...DEFAULT_APP_PROFILES])),
+  ),
+  projectProfileAssignments: Schema.Record(TrimmedNonEmptyString, TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
+  globalToolAccessPolicy: AppToolAccessPolicy.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_APP_TOOL_ACCESS_POLICY)),
+  ),
+  profileToolAccessPolicies: Schema.Record(TrimmedNonEmptyString, AppToolAccessPolicy).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
+  projectToolAccessPolicies: Schema.Record(TrimmedNonEmptyString, AppToolAccessPolicy).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
+  providerInstanceProfileAssignments: Schema.Record(ProviderInstanceId, TrimmedNonEmptyString).pipe(
+    Schema.withDecodingDefault(Effect.succeed({})),
+  ),
   sidebarProjectGroupingMode: SidebarProjectGroupingMode.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_PROJECT_GROUPING_MODE)),
   ),
@@ -534,6 +595,8 @@ export const ServerSettingsPatch = Schema.Struct({
 export type ServerSettingsPatch = typeof ServerSettingsPatch.Type;
 
 export const ClientSettingsPatch = Schema.Struct({
+  activeProfileId: Schema.optionalKey(TrimmedNonEmptyString),
+  appBackgroundColor: Schema.optionalKey(TrimmedString),
   autoOpenPlanSidebar: Schema.optionalKey(Schema.Boolean),
   confirmThreadArchive: Schema.optionalKey(Schema.Boolean),
   confirmThreadDelete: Schema.optionalKey(Schema.Boolean),
@@ -558,6 +621,21 @@ export const ClientSettingsPatch = Schema.Struct({
         ),
       }),
     ),
+  ),
+  planAndGoalReviewMode: Schema.optionalKey(PlanAndGoalReviewMode),
+  profiles: Schema.optionalKey(Schema.Array(AppProfile)),
+  projectProfileAssignments: Schema.optionalKey(
+    Schema.Record(TrimmedNonEmptyString, TrimmedNonEmptyString),
+  ),
+  globalToolAccessPolicy: Schema.optionalKey(AppToolAccessPolicy),
+  profileToolAccessPolicies: Schema.optionalKey(
+    Schema.Record(TrimmedNonEmptyString, AppToolAccessPolicy),
+  ),
+  projectToolAccessPolicies: Schema.optionalKey(
+    Schema.Record(TrimmedNonEmptyString, AppToolAccessPolicy),
+  ),
+  providerInstanceProfileAssignments: Schema.optionalKey(
+    Schema.Record(ProviderInstanceId, TrimmedNonEmptyString),
   ),
   sidebarProjectGroupingMode: Schema.optionalKey(SidebarProjectGroupingMode),
   sidebarProjectGroupingOverrides: Schema.optionalKey(

--- a/packages/shared/src/composerTrigger.ts
+++ b/packages/shared/src/composerTrigger.ts
@@ -1,5 +1,5 @@
 export type ComposerTriggerKind = "path" | "slash-command" | "slash-model" | "skill";
-export type ComposerSlashCommand = "model" | "plan" | "default";
+export type ComposerSlashCommand = "model" | "plan" | "plan-goal" | "default";
 
 export interface ComposerTrigger {
   kind: ComposerTriggerKind;
@@ -127,12 +127,13 @@ export function detectComposerTrigger(
 export function parseStandaloneComposerSlashCommand(
   text: string,
 ): Exclude<ComposerSlashCommand, "model"> | null {
-  const match = /^\/(plan|default)\s*$/i.exec(text.trim());
+  const match = /^\/(plan|plan-goal|plan_and_goal|default)\s*$/i.exec(text.trim());
   if (!match) {
     return null;
   }
   const command = match[1]?.toLowerCase();
   if (command === "plan") return "plan";
+  if (command === "plan-goal" || command === "plan_and_goal") return "plan-goal";
   return "default";
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,10 @@ overrides:
   '@types/node': 24.12.4
   effect: 4.0.0-beta.78
   expo-modules-jsi: 56.0.10
+  undici@>=7.0.0 <7.28.0: 7.28.0
+  undici@>=8.0.0 <8.5.0: 8.7.0
   vite: npm:@voidzero-dev/vite-plus-core@0.2.2
+  xcode>uuid: 11.1.1
   yaml: ^2.9.0
 
 packageExtensionsChecksum: sha256-FV3+2NW/9MFbunJaPsMxvO0LAzyfccoPtPiKoIXAwUU=
@@ -9665,12 +9668,12 @@ packages:
     resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
     engines: {node: '>=18.17'}
 
-  undici@7.27.1:
-    resolution: {integrity: sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.3.0:
-    resolution: {integrity: sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==}
+  undici@8.7.0:
+    resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
     engines: {node: '>=22.19.0'}
 
   unenv@2.0.0-rc.24:
@@ -9882,13 +9885,12 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@7.0.3:
-    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   validate-npm-package-name@5.0.1:
@@ -11611,7 +11613,7 @@ snapshots:
       effect: 4.0.0-beta.78(patch_hash=c502bc684210b707dfceb87d8fe6ad6843395af6e19cfc02cd65854898bde2c5)
       ioredis: 5.11.0
       mime: 4.1.0
-      undici: 8.3.0
+      undici: 8.7.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -14833,7 +14835,7 @@ snapshots:
       picomatch: 4.0.4
       react: 19.2.6
       rolldown: 1.0.1
-      undici: 7.27.1
+      undici: 7.28.0
       yaml: 2.9.0
     optionalDependencies:
       '@effect/platform-bun': 4.0.0-beta.78(bufferutil@4.1.0)(effect@4.0.0-beta.78(patch_hash=c502bc684210b707dfceb87d8fe6ad6843395af6e19cfc02cd65854898bde2c5))(utf-8-validate@6.0.6)
@@ -19996,9 +19998,9 @@ snapshots:
 
   undici@6.26.0: {}
 
-  undici@7.27.1: {}
+  undici@7.28.0: {}
 
-  undici@8.3.0: {}
+  undici@8.7.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -20180,9 +20182,9 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@14.0.0: {}
+  uuid@11.1.1: {}
 
-  uuid@7.0.3: {}
+  uuid@14.0.0: {}
 
   validate-npm-package-name@5.0.1: {}
 
@@ -20499,7 +20501,7 @@ snapshots:
   xcode@3.0.1:
     dependencies:
       simple-plist: 1.3.1
-      uuid: 7.0.3
+      uuid: 11.1.1
 
   xdg-app-paths@8.3.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ overrides:
   '@types/node': 24.12.4
   effect: 4.0.0-beta.78
   expo-modules-jsi: 56.0.10
+  form-data@>=4.0.0 <4.0.6: 4.0.6
+  path-to-regexp@>=4.0.0 <6.3.0: 6.3.0
+  undici@>=6.0.0 <6.27.0: 6.27.0
   undici@>=7.0.0 <7.28.0: 7.28.0
   undici@>=8.0.0 <8.5.0: 8.7.0
   vite: npm:@voidzero-dev/vite-plus-core@0.2.2
@@ -6865,8 +6868,8 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -8446,9 +8449,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@6.1.0:
-    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
-
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
@@ -9664,8 +9664,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.26.0:
-    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   undici@7.28.0:
@@ -14522,7 +14522,7 @@ snapshots:
 
   '@vercel/routing-utils@6.2.0':
     dependencies:
-      path-to-regexp: 6.1.0
+      path-to-regexp: 6.3.0
       path-to-regexp-updated: path-to-regexp@6.3.0
     optionalDependencies:
       ajv: 6.15.0
@@ -15932,7 +15932,7 @@ snapshots:
       builder-util: 26.15.3
       builder-util-runtime: 9.7.0
       chalk: 4.1.2
-      form-data: 4.0.5
+      form-data: 4.0.6
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
@@ -16686,7 +16686,7 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -18341,7 +18341,7 @@ snapshots:
       semver: 7.8.5
       tar: 7.5.16
       tinyglobby: 0.2.17
-      undici: 6.26.0
+      undici: 6.27.0
       which: 6.0.1
 
   node-int64@0.4.0: {}
@@ -18600,8 +18600,6 @@ snapshots:
     dependencies:
       lru-cache: 11.5.1
       minipass: 7.1.3
-
-  path-to-regexp@6.1.0: {}
 
   path-to-regexp@6.3.0: {}
 
@@ -19996,7 +19994,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.26.0: {}
+  undici@6.27.0: {}
 
   undici@7.28.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,7 +86,10 @@ overrides:
   "@types/node": "catalog:"
   effect: "catalog:"
   expo-modules-jsi: 56.0.10
+  "undici@>=7.0.0 <7.28.0": 7.28.0
+  "undici@>=8.0.0 <8.5.0": 8.7.0
   vite: "catalog:"
+  "xcode>uuid": 11.1.1
   yaml: "catalog:"
 
 packageExtensions:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,9 @@ overrides:
   "@types/node": "catalog:"
   effect: "catalog:"
   expo-modules-jsi: 56.0.10
+  "form-data@>=4.0.0 <4.0.6": 4.0.6
+  "path-to-regexp@>=4.0.0 <6.3.0": 6.3.0
+  "undici@>=6.0.0 <6.27.0": 6.27.0
   "undici@>=7.0.0 <7.28.0": 7.28.0
   "undici@>=8.0.0 <8.5.0": 8.7.0
   vite: "catalog:"


### PR DESCRIPTION
<!--
⚠️ READ BEFORE OPENING ⚠️

We are not actively accepting contributions right now.

You can still open a PR, but please do so knowing there is a high chance
we may close it without merging it, or never review it.

- Small, focused PRs are strongly preferred. Bug fixes are most likely to be merged.
- New features will most likely just annoy us.
- 1,000+ line PRs with a bunch of new features will probably get you banned from the repo.
-->

## What Changed

<!-- Describe the change clearly and keep scope tight. -->

## Why

<!-- Explain the problem being solved and why this approach is the right one. -->

## UI Changes

<!-- If this PR changes UI, include clear before/after screenshots.
     If the change involves motion or interaction, include a short video.
     Delete this section if not applicable. -->

## Checklist

- [ ] This PR is small and focused
- [ ] I explained what changed and why
- [ ] I included before/after screenshots for any UI changes
- [ ] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large cross-cutting change to orchestration, multiple provider adapters, client settings schema, and core chat UX (profiles, tool filtering, auto plan-and-goal); regressions could affect turn starts, provider behavior, or what users see per profile.
> 
> **Overview**
> Adds **work profiles** so the sidebar, command palette, composer provider list, and archived threads only show projects, threads, and provider instances tied to the active profile. Users switch profiles from the sidebar, assign projects when adding them or via context menu, and can scope provider instances to one profile or all profiles.
> 
> Introduces **tool access policies** at global, profile, and project levels (all / inherit / custom allowlists for skills, plugins, and MCP tools). Settings and a project context-menu dialog use a new `ToolAccessPolicyControl`; the composer filters `$` skills through the effective policy for the active project.
> 
> Adds **`plan_and_goal`** interaction mode (`/plan-goal`, three-way mode toggle: build → plan → goal). After a plan is accepted, follow-up can send **`goalObjective`** through orchestration to providers (Codex sets thread goal; Claude/Cursor/OpenCode treat it like plan mode for permissions). **`planAndGoalReviewMode`** can auto-submit goal execution when a plan is ready.
> 
> **Sidebar** shows deduplicated **subchat** rows from collab agent tool activities. **UI chrome** adds optional app background color and emerald/terminal styling. Contracts gain profile/tool settings, skill `toolDependencies`, and extended interaction/turn payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e27feca4150579ee665883ce5eedf031bedd332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add profile-scoped tool access, provider assignment, and plan-goal interaction mode
> - Introduces an `AppProfile` system: users can create and switch profiles from the sidebar; projects, threads, and provider instances are filtered to the active profile across the sidebar, command palette, and archived threads view.
> - Adds a `plan_and_goal` interaction mode (alongside `plan` and `default`) exposed as a `/plan-goal` slash command in all composers; triggers plan-mode on providers and optionally sets a thread goal via `thread/goal/set`.
> - Adds per-scope tool access policies (global, profile, project) with a new `ToolAccessPolicyControl` UI and `resolveEffectiveToolAccess` precedence logic; provider skills visible in the composer are filtered accordingly.
> - Extends `ClientSettings` with new fields: `activeProfileId`, `profiles`, `projectProfileAssignments`, `providerInstanceProfileAssignments`, `globalToolAccessPolicy`, `profileToolAccessPolicies`, `projectToolAccessPolicies`, `appBackgroundColor`, and `planAndGoalReviewMode`.
> - Adds an optional `goalObjective` field end-to-end: from client settings patch through orchestration contracts, provider adapters (Codex, Claude, Cursor, OpenCode), and message creation.
> - Adds a `plan_and_goal` auto-review mode that automatically submits a goal execution follow-up when a plan is ready.
> - Risk: `ClientSettings` schema gains many new required-with-defaults fields; existing persisted settings missing these fields will decode with defaults, but any custom serialization or test fixtures must be updated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e27fec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->