### PR TITLE
feat(source-control): detect outdated GitHub CLI instead of "Not authenticated"

### DIFF
--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -381,3 +381,33 @@ it("reports unauthenticated when GitHub JSON has accounts but none are valid", (
     },
   );
 });
+
+it("reports an outdated CLI when gh rejects the --json flag", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth({
+    stdout: "",
+    stderr: "unknown flag: --json\n\nUsage:  gh auth status [flags]",
+    exitCode: ChildProcessSpawner.ExitCode(1),
+    version: Option.some("gh version 2.74.2 (2025-06-18)"),
+    platform: "darwin",
+  });
+
+  assert.deepStrictEqual(
+    { status: auth.status, detail: auth.detail },
+    { status: "outdated", detail: Option.some("brew upgrade gh") },
+  );
+});
+
+it("detects an outdated gh by version and suggests the platform upgrade command", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth({
+    stdout: "",
+    stderr: "",
+    exitCode: ChildProcessSpawner.ExitCode(1),
+    version: Option.some("gh version 2.40.0 (2023-11-01)"),
+    platform: "win32",
+  });
+
+  assert.deepStrictEqual(
+    { status: auth.status, detail: auth.detail },
+    { status: "outdated", detail: Option.some("winget upgrade --id GitHub.cli") },
+  );
+});

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -411,3 +411,18 @@ it("detects an outdated gh by version and suggests the platform upgrade command"
     { status: "outdated", detail: Option.some("winget upgrade --id GitHub.cli") },
   );
 });
+
+it("omits the upgrade command on platforms without a known package manager", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth({
+    stdout: "",
+    stderr: "unknown flag: --json",
+    exitCode: ChildProcessSpawner.ExitCode(1),
+    version: Option.some("gh version 2.74.2 (2025-06-18)"),
+    platform: "freebsd",
+  });
+
+  assert.deepStrictEqual(
+    { status: auth.status, detail: auth.detail },
+    { status: "outdated", detail: Option.none() },
+  );
+});

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
+import { compareSemverVersions } from "@t3tools/shared/semver";
 import {
   SourceControlProviderError,
   type ChangeRequest,
@@ -42,6 +43,44 @@ function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeReq
   };
 }
 
+/**
+ * Minimum `gh` version that supports `gh auth status --json`, which the server
+ * relies on to read authentication state. Shipped in gh v2.81.0 (cli/cli#11544).
+ */
+const GITHUB_CLI_MIN_VERSION = "2.81.0";
+
+function parseGitHubCliVersion(version: Option.Option<string> | undefined): string | null {
+  const raw = version === undefined ? undefined : Option.getOrUndefined(version);
+  if (raw === undefined) return null;
+  const match = raw.match(/\bversion\s+(\d+\.\d+\.\d+)/iu) ?? raw.match(/(\d+\.\d+\.\d+)/u);
+  return match?.[1] ?? null;
+}
+
+/**
+ * True when the failed auth probe is explained by an outdated `gh` rather than a
+ * missing login. The definitive signal is gh rejecting `--json`; the parsed
+ * version is a fallback should the flag surface differently in future releases.
+ */
+function isOutdatedGitHubCli(input: SourceControlAuthProbeInput): boolean {
+  if (/unknown flag:\s*--json/iu.test(`${input.stdout}\n${input.stderr}`)) {
+    return true;
+  }
+  const version = parseGitHubCliVersion(input.version);
+  return version !== null && compareSemverVersions(version, GITHUB_CLI_MIN_VERSION) < 0;
+}
+
+function gitHubCliUpgradeCommand(platform: NodeJS.Platform | undefined): string {
+  switch (platform) {
+    case "darwin":
+      return "brew upgrade gh";
+    case "win32":
+      return "winget upgrade --id GitHub.cli";
+    default:
+      // Debian/Ubuntu default. Detecting the actual package manager is a follow-up.
+      return "sudo apt update && sudo apt install gh";
+  }
+}
+
 function parseGitHubAuth(input: SourceControlAuthProbeInput) {
   const output = combinedAuthOutput(input);
   const authStatus = parseGitHubAuthStatus(input.stdout);
@@ -53,6 +92,16 @@ function parseGitHubAuth(input: SourceControlAuthProbeInput) {
       status: "authenticated",
       account: authenticatedAccount.account,
       host,
+    });
+  }
+
+  // A `gh` too old for `auth status --json` can't be parsed here, so the probe
+  // looks like a sign-out even when the user is authenticated. Surface it as an
+  // outdated CLI, with the platform-appropriate upgrade command in `detail`.
+  if (!authStatus.parsed && isOutdatedGitHubCli(input)) {
+    return providerAuth({
+      status: "outdated",
+      detail: gitHubCliUpgradeCommand(input.platform),
     });
   }
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -69,15 +69,19 @@ function isOutdatedGitHubCli(input: SourceControlAuthProbeInput): boolean {
   return version !== null && compareSemverVersions(version, GITHUB_CLI_MIN_VERSION) < 0;
 }
 
-function gitHubCliUpgradeCommand(platform: NodeJS.Platform | undefined): string {
+function gitHubCliUpgradeCommand(platform: NodeJS.Platform | undefined): string | null {
   switch (platform) {
     case "darwin":
       return "brew upgrade gh";
     case "win32":
       return "winget upgrade --id GitHub.cli";
-    default:
+    case "linux":
       // Debian/Ubuntu default. Detecting the actual package manager is a follow-up.
       return "sudo apt update && sudo apt install gh";
+    default:
+      // BSDs, illumos, AIX, etc.: no safe single command. Return null so we show
+      // the generic "update it" guidance instead of a command that can't run.
+      return null;
   }
 }
 
@@ -101,7 +105,7 @@ function parseGitHubAuth(input: SourceControlAuthProbeInput) {
   if (!authStatus.parsed && isOutdatedGitHubCli(input)) {
     return providerAuth({
       status: "outdated",
-      detail: gitHubCliUpgradeCommand(input.platform),
+      detail: gitHubCliUpgradeCommand(input.platform) ?? undefined,
     });
   }
 

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -4,6 +4,7 @@ import type {
   SourceControlProviderInfo,
   SourceControlProviderKind,
 } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 
@@ -14,6 +15,10 @@ export interface SourceControlAuthProbeInput {
   readonly stdout: string;
   readonly stderr: string;
   readonly exitCode: VcsProcess.VcsProcessOutput["exitCode"];
+  /** First line of the CLI `--version` probe, when it was available. */
+  readonly version?: Option.Option<string>;
+  /** Host platform, so `parseAuth` can suggest an OS-appropriate upgrade command. */
+  readonly platform?: NodeJS.Platform;
 }
 
 export interface SourceControlUnknownRemoteRefinementInput {
@@ -249,12 +254,20 @@ export function probeSourceControlProvider(input: {
           appendTruncationMarker: true,
         })
         .pipe(
-          Effect.map(
-            (result) =>
-              ({
+          Effect.flatMap((result) =>
+            Effect.gen(function* () {
+              const platform = yield* HostProcessPlatform;
+              return {
                 ...item,
-                auth: spec.parseAuth(result),
-              }) satisfies SourceControlProviderDiscoveryItem,
+                auth: spec.parseAuth({
+                  stdout: result.stdout,
+                  stderr: result.stderr,
+                  exitCode: result.exitCode,
+                  version: item.version,
+                  platform,
+                }),
+              } satisfies SourceControlProviderDiscoveryItem;
+            }),
           ),
           Effect.catch((cause) =>
             Effect.succeed({

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -312,6 +312,13 @@ function buildAddProjectRemoteSourceReadiness(
       readiness[source] = { ready: false, hint: provider.installHint };
       continue;
     }
+    if (provider.auth.status === "outdated") {
+      readiness[source] = {
+        ready: false,
+        hint: `${provider.label} CLI is outdated and can't confirm sign-in. Open Settings -> Source Control to update it.`,
+      };
+      continue;
+    }
     if (provider.auth.status === "unauthenticated") {
       readiness[source] = {
         ready: false,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -225,6 +225,12 @@ function getPublishProviderReadiness(input: {
   if (discovered.status !== "available") {
     return { ready: false, hint: discovered.installHint };
   }
+  if (discovered.auth.status === "outdated") {
+    return {
+      ready: false,
+      hint: `${discovered.label} CLI is outdated and can't confirm sign-in. Open Settings -> Source Control to update it.`,
+    };
+  }
   if (discovered.auth.status === "unauthenticated") {
     return {
       ready: false,

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -202,9 +202,9 @@ function itemSummary({
     if (auth.status === "outdated") {
       return (
         <span>
-          Your <code className="rounded bg-muted px-1 py-px text-[11px]">{item.executable}</code> CLI
-          is too old for {item.label} sign-in to be detected here — you may already be authenticated.
-          Update it on the server host, then Rescan.
+          Your <code className="rounded bg-muted px-1 py-px text-[11px]">{item.executable}</code>{" "}
+          CLI is too old for {item.label} sign-in to be detected here — you may already be
+          authenticated. Update it on the server host, then Rescan.
         </span>
       );
     }
@@ -253,6 +253,38 @@ function CliVersion({
   );
 }
 
+/**
+ * Copy helper that works outside secure contexts / embedded webviews, where
+ * `navigator.clipboard` is undefined. Falls back to a hidden-textarea +
+ * `execCommand("copy")`. Returns whether the copy succeeded.
+ */
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the execCommand fallback below.
+    }
+  }
+  if (typeof document === "undefined") return false;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(textarea);
+  return ok;
+}
+
 function UpgradeCommandLine({ command }: { readonly command: string }) {
   const [copied, setCopied] = useState(false);
   return (
@@ -264,7 +296,8 @@ function UpgradeCommandLine({ command }: { readonly command: string }) {
         variant="ghost"
         className="h-6 shrink-0 gap-1 px-1.5 text-xs text-primary hover:text-primary"
         onClick={() => {
-          void navigator.clipboard.writeText(command).then(() => {
+          void copyTextToClipboard(command).then((ok) => {
+            if (!ok) return;
             setCopied(true);
             window.setTimeout(() => setCopied(false), 1500);
           });

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -1,4 +1,10 @@
-import { ChevronDownIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  CopyIcon,
+  GitPullRequestIcon,
+  RefreshCwIcon,
+} from "lucide-react";
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
 import { useState, type ReactNode } from "react";
@@ -105,6 +111,9 @@ function authPresentation(auth: SourceControlProviderAuth): {
   if (auth.status === "unauthenticated") {
     return { label: "Not authenticated", badge: "warning" };
   }
+  if (auth.status === "outdated") {
+    return { label: "Outdated CLI", badge: "warning" };
+  }
   return { label: "Status unknown", badge: null };
 }
 
@@ -190,6 +199,16 @@ function itemSummary({
       return <span>Available. {item.installHint}</span>;
     }
 
+    if (auth.status === "outdated") {
+      return (
+        <span>
+          Your <code className="rounded bg-muted px-1 py-px text-[11px]">{item.executable}</code> CLI
+          is too old for {item.label} sign-in to be detected here — you may already be authenticated.
+          Update it on the server host, then Rescan.
+        </span>
+      );
+    }
+
     if (auth.status === "unauthenticated") {
       return (
         <span>
@@ -207,6 +226,56 @@ function itemSummary({
   }
 
   return <span>Available</span>;
+}
+
+function CliVersion({
+  version,
+  outdated,
+}: {
+  readonly version: string;
+  readonly outdated: boolean;
+}) {
+  if (!outdated) {
+    return <code className="text-xs text-muted-foreground">{version}</code>;
+  }
+  const match = version.match(/\d+\.\d+\.\d+/);
+  if (!match) {
+    return <code className="text-xs font-semibold text-destructive-foreground">{version}</code>;
+  }
+  const number = match[0];
+  const start = version.indexOf(number);
+  return (
+    <code className="text-xs text-muted-foreground">
+      {version.slice(0, start)}
+      <span className="font-semibold text-destructive-foreground">{number}</span>
+      {version.slice(start + number.length)}
+    </code>
+  );
+}
+
+function UpgradeCommandLine({ command }: { readonly command: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="mt-1.5 flex items-center gap-2 rounded-md border border-border bg-muted/60 px-2.5 py-1.5">
+      <span className="select-none font-mono text-xs text-muted-foreground">$</span>
+      <code className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">{command}</code>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-6 shrink-0 gap-1 px-1.5 text-xs text-primary hover:text-primary"
+        onClick={() => {
+          void navigator.clipboard.writeText(command).then(() => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1500);
+          });
+        }}
+        aria-label="Copy upgrade command"
+      >
+        {copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}
+        {copied ? "Copied" : "Copy"}
+      </Button>
+    </div>
+  );
 }
 
 function DiscoveryItemRow({
@@ -241,7 +310,9 @@ function DiscoveryItemRow({
               <span className="truncate text-[13px] font-semibold tracking-[-0.01em] text-foreground">
                 {item.label}
               </span>
-              {version ? <code className="text-xs text-muted-foreground">{version}</code> : null}
+              {version ? (
+                <CliVersion version={version} outdated={auth?.status === "outdated"} />
+              ) : null}
               {isVcsNotReady(item) ? (
                 <Badge variant="warning" size="sm">
                   Coming Soon
@@ -256,6 +327,9 @@ function DiscoveryItemRow({
             <p className="flex min-w-0 flex-wrap items-center gap-x-1 text-xs text-muted-foreground/80">
               {itemSummary({ item, auth, authAccount })}
             </p>
+            {auth?.status === "outdated" && optionLabel(auth.detail) ? (
+              <UpgradeCommandLine command={optionLabel(auth.detail) as string} />
+            ) : null}
           </div>
           <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
             {hasDetails ? (

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -151,6 +151,13 @@ export function buildAddProjectRemoteSourceReadiness(
       readiness[source] = { ready: false, hint: provider.installHint };
       continue;
     }
+    if (provider.auth.status === "outdated") {
+      readiness[source] = {
+        ready: false,
+        hint: `${provider.label} CLI is outdated and can't confirm sign-in. Open Source Control settings to update it.`,
+      };
+      continue;
+    }
     if (provider.auth.status === "unauthenticated") {
       readiness[source] = {
         ready: false,

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -109,6 +109,11 @@ export type SourceControlDiscoveryStatus = typeof SourceControlDiscoveryStatus.T
 export const SourceControlProviderAuthStatus = Schema.Literals([
   "authenticated",
   "unauthenticated",
+  // The provider CLI is installed but too old to report auth status in the
+  // format the server needs (e.g. `gh` predating `auth status --json`). The
+  // user may well be signed in — we just can't read it. `detail` carries the
+  // platform-appropriate upgrade command.
+  "outdated",
   "unknown",
 ]);
 export type SourceControlProviderAuthStatus = typeof SourceControlProviderAuthStatus.Type;


### PR DESCRIPTION
# feat(source-control): detect outdated GitHub CLI instead of "Not authenticated"

> Draft — opening for early feedback. Fixes #3806.

## Problem
When the server's `gh` predates `gh auth status --json` (gh **v2.81.0**, cli/cli#11544), the auth probe fails with `unknown flag: --json` and the Source Control row shows a misleading **"Not authenticated"** even though the user is signed in. `gh auth login` never clears it.

## What this does
Adds an `outdated` source-control auth status and surfaces it clearly instead of faking a sign-out.

**Contracts** — `packages/contracts/src/sourceControl.ts`
- New `outdated` literal on `SourceControlProviderAuthStatus`.

**Server**
- `SourceControlProviderDiscovery.ts`: thread the CLI `--version` output and host `platform` (via the existing ambient `HostProcessPlatform` reference) into `parseAuth` as optional fields — no change to `probeSourceControlProvider`'s public signature, and existing `parseAuth` callers/tests keep compiling.
- `GitHubSourceControlProvider.ts`: classify the `unknown flag: --json` / sub-`2.81.0` case as `outdated`, and put an OS-appropriate upgrade command in `auth.detail` (`brew upgrade gh` / `winget upgrade --id GitHub.cli` / `sudo apt … gh`). Version compare reuses `@t3tools/shared/semver`.

**Web** — `apps/web/src/components/settings/SourceControlSettings.tsx`
- Version **number** rendered red, an **"Outdated CLI"** badge, and a copyable upgrade command line, for `auth.status === "outdated"`.

## Screenshot

<!-- 📎 DRAG t3code-mockup.png HERE (before vs. after mockup) -->


## Testing
- Added unit tests in `GitHubSourceControlProvider.test.ts` for both detection paths: the `--json` flag rejection, and the version-gate fallback (with per-platform command assertions).
- **Draft caveat:** I couldn't run the repo toolchain in my environment — please let CI run `pnpm typecheck` + tests. I followed existing patterns (ambient `HostProcessPlatform` usage, Effect `.gen` in the probe pipe) but haven't compiled locally.

## Deliberately out of scope (separate follow-up PR, if you want it)
- **Package-manager-aware** upgrade command — detect brew vs. apt/dnf/pacman vs. winget/scoop/choco/MSI, rather than one default per OS. This is the part that needs a product/design call (how much probing is worth the DX), so I kept it out of this minimal fix.
- **One-click "run upgrade in a terminal at repo root"** — the terminal RPC is `ScopedThreadRef`/project-scoped, and the Settings page only has an `environmentId`, so wiring a run button there is a larger cross-cutting change.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect outdated GitHub CLI and surface platform-specific upgrade command in source control settings
> - Adds an `'outdated'` auth status to the source control contract, returned when `gh` is too old (below v2.81.0) or rejects the `--json` flag, instead of treating the state as unauthenticated.
> - Adds `isOutdatedGitHubCli`, `parseGitHubCliVersion`, and `gitHubCliUpgradeCommand` helpers in [`GitHubSourceControlProvider.ts`](https://github.com/pingdotgg/t3code/pull/3808/files#diff-e0f205b78b622887367441bbfc3eb4e71dfcda583b3e98e45ad9a7c72f8002bc) to detect the outdated condition and map the host platform to a specific upgrade command (`brew`, `winget`, or `apt`).
> - Passes CLI version and host platform through [`SourceControlProviderDiscovery.ts`](https://github.com/pingdotgg/t3code/pull/3808/files#diff-7088228dcd4bc662e8316e8ab1fea8209a6943dda31a104daacc2fec81e084be) to `parseAuth` so providers can produce the new status.
> - Renders a warning badge, highlighted version number, and a copyable upgrade command in [`SourceControlSettings.tsx`](https://github.com/pingdotgg/t3code/pull/3808/files#diff-9f2e55c161725a6350a5fe7b23c2b7ada03b60855000614a443c6253ad64b625) when auth status is `'outdated'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized c529532. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->