### PR TITLE
feat(source-control): package-manager-aware `gh` upgrade command

### DIFF
--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -381,3 +381,33 @@ it("reports unauthenticated when GitHub JSON has accounts but none are valid", (
     },
   );
 });
+
+it("reports an outdated CLI when gh rejects the --json flag", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth({
+    stdout: "",
+    stderr: "unknown flag: --json\n\nUsage:  gh auth status [flags]",
+    exitCode: ChildProcessSpawner.ExitCode(1),
+    version: Option.some("gh version 2.74.2 (2025-06-18)"),
+    platform: "darwin",
+  });
+
+  assert.deepStrictEqual(
+    { status: auth.status, detail: auth.detail },
+    { status: "outdated", detail: Option.some("brew upgrade gh") },
+  );
+});
+
+it("detects an outdated gh by version and suggests the platform upgrade command", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth({
+    stdout: "",
+    stderr: "",
+    exitCode: ChildProcessSpawner.ExitCode(1),
+    version: Option.some("gh version 2.40.0 (2023-11-01)"),
+    platform: "win32",
+  });
+
+  assert.deepStrictEqual(
+    { status: auth.status, detail: auth.detail },
+    { status: "outdated", detail: Option.some("winget upgrade --id GitHub.cli") },
+  );
+});

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.test.ts
@@ -411,3 +411,18 @@ it("detects an outdated gh by version and suggests the platform upgrade command"
     { status: "outdated", detail: Option.some("winget upgrade --id GitHub.cli") },
   );
 });
+
+it("omits the upgrade command on platforms without a known package manager", () => {
+  const auth = GitHubSourceControlProvider.discovery.parseAuth({
+    stdout: "",
+    stderr: "unknown flag: --json",
+    exitCode: ChildProcessSpawner.ExitCode(1),
+    version: Option.some("gh version 2.74.2 (2025-06-18)"),
+    platform: "freebsd",
+  });
+
+  assert.deepStrictEqual(
+    { status: auth.status, detail: auth.detail },
+    { status: "outdated", detail: Option.none() },
+  );
+});

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
+import { compareSemverVersions } from "@t3tools/shared/semver";
 import {
   SourceControlProviderError,
   type ChangeRequest,
@@ -42,6 +43,44 @@ function toChangeRequest(summary: GitHubCli.GitHubPullRequestSummary): ChangeReq
   };
 }
 
+/**
+ * Minimum `gh` version that supports `gh auth status --json`, which the server
+ * relies on to read authentication state. Shipped in gh v2.81.0 (cli/cli#11544).
+ */
+const GITHUB_CLI_MIN_VERSION = "2.81.0";
+
+function parseGitHubCliVersion(version: Option.Option<string> | undefined): string | null {
+  const raw = version === undefined ? undefined : Option.getOrUndefined(version);
+  if (raw === undefined) return null;
+  const match = raw.match(/\bversion\s+(\d+\.\d+\.\d+)/iu) ?? raw.match(/(\d+\.\d+\.\d+)/u);
+  return match?.[1] ?? null;
+}
+
+/**
+ * True when the failed auth probe is explained by an outdated `gh` rather than a
+ * missing login. The definitive signal is gh rejecting `--json`; the parsed
+ * version is a fallback should the flag surface differently in future releases.
+ */
+function isOutdatedGitHubCli(input: SourceControlAuthProbeInput): boolean {
+  if (/unknown flag:\s*--json/iu.test(`${input.stdout}\n${input.stderr}`)) {
+    return true;
+  }
+  const version = parseGitHubCliVersion(input.version);
+  return version !== null && compareSemverVersions(version, GITHUB_CLI_MIN_VERSION) < 0;
+}
+
+function gitHubCliUpgradeCommand(platform: NodeJS.Platform | undefined): string {
+  switch (platform) {
+    case "darwin":
+      return "brew upgrade gh";
+    case "win32":
+      return "winget upgrade --id GitHub.cli";
+    default:
+      // Debian/Ubuntu default. Detecting the actual package manager is a follow-up.
+      return "sudo apt update && sudo apt install gh";
+  }
+}
+
 function parseGitHubAuth(input: SourceControlAuthProbeInput) {
   const output = combinedAuthOutput(input);
   const authStatus = parseGitHubAuthStatus(input.stdout);
@@ -53,6 +92,16 @@ function parseGitHubAuth(input: SourceControlAuthProbeInput) {
       status: "authenticated",
       account: authenticatedAccount.account,
       host,
+    });
+  }
+
+  // A `gh` too old for `auth status --json` can't be parsed here, so the probe
+  // looks like a sign-out even when the user is authenticated. Surface it as an
+  // outdated CLI, with the platform-appropriate upgrade command in `detail`.
+  if (!authStatus.parsed && isOutdatedGitHubCli(input)) {
+    return providerAuth({
+      status: "outdated",
+      detail: gitHubCliUpgradeCommand(input.platform),
     });
   }
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -69,15 +69,19 @@ function isOutdatedGitHubCli(input: SourceControlAuthProbeInput): boolean {
   return version !== null && compareSemverVersions(version, GITHUB_CLI_MIN_VERSION) < 0;
 }
 
-function gitHubCliUpgradeCommand(platform: NodeJS.Platform | undefined): string {
+function gitHubCliUpgradeCommand(platform: NodeJS.Platform | undefined): string | null {
   switch (platform) {
     case "darwin":
       return "brew upgrade gh";
     case "win32":
       return "winget upgrade --id GitHub.cli";
-    default:
+    case "linux":
       // Debian/Ubuntu default. Detecting the actual package manager is a follow-up.
       return "sudo apt update && sudo apt install gh";
+    default:
+      // BSDs, illumos, AIX, etc.: no safe single command. Return null so we show
+      // the generic "update it" guidance instead of a command that can't run.
+      return null;
   }
 }
 
@@ -101,7 +105,7 @@ function parseGitHubAuth(input: SourceControlAuthProbeInput) {
   if (!authStatus.parsed && isOutdatedGitHubCli(input)) {
     return providerAuth({
       status: "outdated",
-      detail: gitHubCliUpgradeCommand(input.platform),
+      detail: gitHubCliUpgradeCommand(input.platform) ?? undefined,
     });
   }
 

--- a/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
+++ b/apps/server/src/sourceControl/GitHubSourceControlProvider.ts
@@ -10,6 +10,7 @@ import {
 } from "@t3tools/contracts";
 
 import * as GitHubCli from "./GitHubCli.ts";
+import type * as VcsProcess from "../vcs/VcsProcess.ts";
 import { findAuthenticatedGitHubAccount, parseGitHubAuthStatus } from "./gitHubAuthStatus.ts";
 import { decodeGitHubPullRequestListJson } from "./gitHubPullRequests.ts";
 import * as SourceControlProvider from "./SourceControlProvider.ts";
@@ -76,13 +77,92 @@ function gitHubCliUpgradeCommand(platform: NodeJS.Platform | undefined): string 
     case "win32":
       return "winget upgrade --id GitHub.cli";
     case "linux":
-      // Debian/Ubuntu default. Detecting the actual package manager is a follow-up.
+      // Debian/Ubuntu default, used when `resolveGitHubUpgradeCommand` can't
+      // identify the actual package manager.
       return "sudo apt update && sudo apt install gh";
     default:
       // BSDs, illumos, AIX, etc.: no safe single command. Return null so we show
       // the generic "update it" guidance instead of a command that can't run.
       return null;
   }
+}
+
+function ghUpgradeProbe(
+  process: VcsProcess.VcsProcess["Service"],
+  cwd: string,
+  command: string,
+  args: ReadonlyArray<string>,
+): Effect.Effect<boolean> {
+  return process
+    .run({
+      operation: "source-control.discovery.upgrade-probe",
+      command,
+      args,
+      cwd,
+      allowNonZeroExit: true,
+      timeoutMs: 5_000,
+      maxOutputBytes: 8_000,
+      appendTruncationMarker: true,
+    })
+    .pipe(
+      Effect.map((result) => Number(result.exitCode) === 0),
+      Effect.orElseSucceed(() => false),
+    );
+}
+
+/**
+ * When `gh` is outdated, figure out which package manager installed it so we can
+ * suggest the exact upgrade command. Returns `null` when nothing matches, so the
+ * caller keeps the platform default from `gitHubCliUpgradeCommand`.
+ *
+ * These are best-effort heuristics; some managers (scoop, choco) are shims whose
+ * spawnability varies by host, so a miss simply falls back to the default.
+ */
+function resolveGitHubUpgradeCommand(input: {
+  readonly process: VcsProcess.VcsProcess["Service"];
+  readonly cwd: string;
+  readonly platform: NodeJS.Platform;
+}): Effect.Effect<string | null> {
+  const probe = (command: string, args: ReadonlyArray<string>) =>
+    ghUpgradeProbe(input.process, input.cwd, command, args);
+
+  return Effect.gen(function* () {
+    switch (input.platform) {
+      case "win32": {
+        if (yield* probe("winget", ["list", "--id", "GitHub.cli", "-e"])) {
+          return "winget upgrade --id GitHub.cli -e";
+        }
+        if (yield* probe("scoop", ["list", "gh"])) {
+          return "scoop update gh";
+        }
+        if (yield* probe("choco", ["list", "--local-only", "gh"])) {
+          return "choco upgrade gh";
+        }
+        return null;
+      }
+      case "darwin": {
+        if (yield* probe("brew", ["list", "--versions", "gh"])) {
+          return "brew upgrade gh";
+        }
+        if (yield* probe("port", ["installed", "gh"])) {
+          return "sudo port upgrade gh";
+        }
+        return null;
+      }
+      default: {
+        if (yield* probe("dpkg", ["-s", "gh"])) {
+          return "sudo apt update && sudo apt install gh";
+        }
+        if (yield* probe("rpm", ["-q", "gh"])) {
+          return "sudo dnf upgrade gh";
+        }
+        if (yield* probe("pacman", ["-Q", "github-cli"])) {
+          return "sudo pacman -S github-cli";
+        }
+        return null;
+      }
+    }
+  });
 }
 
 function parseGitHubAuth(input: SourceControlAuthProbeInput) {
@@ -143,6 +223,7 @@ export const discovery = {
   versionArgs: ["--version"],
   authArgs: ["auth", "status", "--json", "hosts"],
   parseAuth: parseGitHubAuth,
+  resolveUpgradeCommand: resolveGitHubUpgradeCommand,
   installHint:
     "Install the GitHub command-line tool (`gh`) via https://cli.github.com/ or your package manager (for example `brew install gh`).",
 } satisfies SourceControlCliDiscoverySpec;

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -39,6 +39,17 @@ export type SourceControlCliDiscoverySpec = SourceControlDiscoverySpecBase & {
   readonly versionArgs: ReadonlyArray<string>;
   readonly authArgs: ReadonlyArray<string>;
   readonly parseAuth: (input: SourceControlAuthProbeInput) => SourceControlProviderAuth;
+  /**
+   * Only consulted when `parseAuth` returns `outdated`: probe the host for how
+   * the CLI was actually installed and return the exact upgrade command (or
+   * `null` to keep `parseAuth`'s platform default). Any process error must
+   * resolve to `null` — this can never fail discovery.
+   */
+  readonly resolveUpgradeCommand?: (input: {
+    readonly process: VcsProcess.VcsProcess["Service"];
+    readonly cwd: string;
+    readonly platform: NodeJS.Platform;
+  }) => Effect.Effect<string | null>;
   readonly refineUnknownRemote?: (
     input: SourceControlUnknownRemoteRefinementInput,
   ) => SourceControlProviderInfo | null;
@@ -257,16 +268,30 @@ export function probeSourceControlProvider(input: {
           Effect.flatMap((result) =>
             Effect.gen(function* () {
               const platform = yield* HostProcessPlatform;
-              return {
-                ...item,
-                auth: spec.parseAuth({
-                  stdout: result.stdout,
-                  stderr: result.stderr,
-                  exitCode: result.exitCode,
-                  version: item.version,
-                  platform,
-                }),
-              } satisfies SourceControlProviderDiscoveryItem;
+              const auth = spec.parseAuth({
+                stdout: result.stdout,
+                stderr: result.stderr,
+                exitCode: result.exitCode,
+                version: item.version,
+                platform,
+              });
+
+              // When the CLI is outdated, let the provider probe how it was
+              // installed and refine the upgrade command. Failures fall back to
+              // the platform default already carried on `auth.detail`.
+              if (auth.status === "outdated" && spec.resolveUpgradeCommand !== undefined) {
+                const resolved = yield* spec
+                  .resolveUpgradeCommand({ process: input.process, cwd: input.cwd, platform })
+                  .pipe(Effect.orElseSucceed(() => null));
+                if (resolved !== null && resolved.trim().length > 0) {
+                  return {
+                    ...item,
+                    auth: providerAuth({ status: "outdated", detail: resolved }),
+                  } satisfies SourceControlProviderDiscoveryItem;
+                }
+              }
+
+              return { ...item, auth } satisfies SourceControlProviderDiscoveryItem;
             }),
           ),
           Effect.catch((cause) =>

--- a/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
+++ b/apps/server/src/sourceControl/SourceControlProviderDiscovery.ts
@@ -4,6 +4,7 @@ import type {
   SourceControlProviderInfo,
   SourceControlProviderKind,
 } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 
@@ -14,6 +15,10 @@ export interface SourceControlAuthProbeInput {
   readonly stdout: string;
   readonly stderr: string;
   readonly exitCode: VcsProcess.VcsProcessOutput["exitCode"];
+  /** First line of the CLI `--version` probe, when it was available. */
+  readonly version?: Option.Option<string>;
+  /** Host platform, so `parseAuth` can suggest an OS-appropriate upgrade command. */
+  readonly platform?: NodeJS.Platform;
 }
 
 export interface SourceControlUnknownRemoteRefinementInput {
@@ -249,12 +254,20 @@ export function probeSourceControlProvider(input: {
           appendTruncationMarker: true,
         })
         .pipe(
-          Effect.map(
-            (result) =>
-              ({
+          Effect.flatMap((result) =>
+            Effect.gen(function* () {
+              const platform = yield* HostProcessPlatform;
+              return {
                 ...item,
-                auth: spec.parseAuth(result),
-              }) satisfies SourceControlProviderDiscoveryItem,
+                auth: spec.parseAuth({
+                  stdout: result.stdout,
+                  stderr: result.stderr,
+                  exitCode: result.exitCode,
+                  version: item.version,
+                  platform,
+                }),
+              } satisfies SourceControlProviderDiscoveryItem;
+            }),
           ),
           Effect.catch((cause) =>
             Effect.succeed({

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -312,6 +312,13 @@ function buildAddProjectRemoteSourceReadiness(
       readiness[source] = { ready: false, hint: provider.installHint };
       continue;
     }
+    if (provider.auth.status === "outdated") {
+      readiness[source] = {
+        ready: false,
+        hint: `${provider.label} CLI is outdated and can't confirm sign-in. Open Settings -> Source Control to update it.`,
+      };
+      continue;
+    }
     if (provider.auth.status === "unauthenticated") {
       readiness[source] = {
         ready: false,

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -225,6 +225,12 @@ function getPublishProviderReadiness(input: {
   if (discovered.status !== "available") {
     return { ready: false, hint: discovered.installHint };
   }
+  if (discovered.auth.status === "outdated") {
+    return {
+      ready: false,
+      hint: `${discovered.label} CLI is outdated and can't confirm sign-in. Open Settings -> Source Control to update it.`,
+    };
+  }
   if (discovered.auth.status === "unauthenticated") {
     return {
       ready: false,

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -202,9 +202,9 @@ function itemSummary({
     if (auth.status === "outdated") {
       return (
         <span>
-          Your <code className="rounded bg-muted px-1 py-px text-[11px]">{item.executable}</code> CLI
-          is too old for {item.label} sign-in to be detected here — you may already be authenticated.
-          Update it on the server host, then Rescan.
+          Your <code className="rounded bg-muted px-1 py-px text-[11px]">{item.executable}</code>{" "}
+          CLI is too old for {item.label} sign-in to be detected here — you may already be
+          authenticated. Update it on the server host, then Rescan.
         </span>
       );
     }
@@ -253,6 +253,38 @@ function CliVersion({
   );
 }
 
+/**
+ * Copy helper that works outside secure contexts / embedded webviews, where
+ * `navigator.clipboard` is undefined. Falls back to a hidden-textarea +
+ * `execCommand("copy")`. Returns whether the copy succeeded.
+ */
+async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to the execCommand fallback below.
+    }
+  }
+  if (typeof document === "undefined") return false;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let ok = false;
+  try {
+    ok = document.execCommand("copy");
+  } catch {
+    ok = false;
+  }
+  document.body.removeChild(textarea);
+  return ok;
+}
+
 function UpgradeCommandLine({ command }: { readonly command: string }) {
   const [copied, setCopied] = useState(false);
   return (
@@ -264,7 +296,8 @@ function UpgradeCommandLine({ command }: { readonly command: string }) {
         variant="ghost"
         className="h-6 shrink-0 gap-1 px-1.5 text-xs text-primary hover:text-primary"
         onClick={() => {
-          void navigator.clipboard.writeText(command).then(() => {
+          void copyTextToClipboard(command).then((ok) => {
+            if (!ok) return;
             setCopied(true);
             window.setTimeout(() => setCopied(false), 1500);
           });

--- a/apps/web/src/components/settings/SourceControlSettings.tsx
+++ b/apps/web/src/components/settings/SourceControlSettings.tsx
@@ -1,4 +1,10 @@
-import { ChevronDownIcon, GitPullRequestIcon, RefreshCwIcon } from "lucide-react";
+import {
+  CheckIcon,
+  ChevronDownIcon,
+  CopyIcon,
+  GitPullRequestIcon,
+  RefreshCwIcon,
+} from "lucide-react";
 import * as Duration from "effect/Duration";
 import * as Option from "effect/Option";
 import { useState, type ReactNode } from "react";
@@ -105,6 +111,9 @@ function authPresentation(auth: SourceControlProviderAuth): {
   if (auth.status === "unauthenticated") {
     return { label: "Not authenticated", badge: "warning" };
   }
+  if (auth.status === "outdated") {
+    return { label: "Outdated CLI", badge: "warning" };
+  }
   return { label: "Status unknown", badge: null };
 }
 
@@ -190,6 +199,16 @@ function itemSummary({
       return <span>Available. {item.installHint}</span>;
     }
 
+    if (auth.status === "outdated") {
+      return (
+        <span>
+          Your <code className="rounded bg-muted px-1 py-px text-[11px]">{item.executable}</code> CLI
+          is too old for {item.label} sign-in to be detected here — you may already be authenticated.
+          Update it on the server host, then Rescan.
+        </span>
+      );
+    }
+
     if (auth.status === "unauthenticated") {
       return (
         <span>
@@ -207,6 +226,56 @@ function itemSummary({
   }
 
   return <span>Available</span>;
+}
+
+function CliVersion({
+  version,
+  outdated,
+}: {
+  readonly version: string;
+  readonly outdated: boolean;
+}) {
+  if (!outdated) {
+    return <code className="text-xs text-muted-foreground">{version}</code>;
+  }
+  const match = version.match(/\d+\.\d+\.\d+/);
+  if (!match) {
+    return <code className="text-xs font-semibold text-destructive-foreground">{version}</code>;
+  }
+  const number = match[0];
+  const start = version.indexOf(number);
+  return (
+    <code className="text-xs text-muted-foreground">
+      {version.slice(0, start)}
+      <span className="font-semibold text-destructive-foreground">{number}</span>
+      {version.slice(start + number.length)}
+    </code>
+  );
+}
+
+function UpgradeCommandLine({ command }: { readonly command: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="mt-1.5 flex items-center gap-2 rounded-md border border-border bg-muted/60 px-2.5 py-1.5">
+      <span className="select-none font-mono text-xs text-muted-foreground">$</span>
+      <code className="min-w-0 flex-1 truncate font-mono text-xs text-foreground">{command}</code>
+      <Button
+        size="sm"
+        variant="ghost"
+        className="h-6 shrink-0 gap-1 px-1.5 text-xs text-primary hover:text-primary"
+        onClick={() => {
+          void navigator.clipboard.writeText(command).then(() => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1500);
+          });
+        }}
+        aria-label="Copy upgrade command"
+      >
+        {copied ? <CheckIcon className="size-3.5" /> : <CopyIcon className="size-3.5" />}
+        {copied ? "Copied" : "Copy"}
+      </Button>
+    </div>
+  );
 }
 
 function DiscoveryItemRow({
@@ -241,7 +310,9 @@ function DiscoveryItemRow({
               <span className="truncate text-[13px] font-semibold tracking-[-0.01em] text-foreground">
                 {item.label}
               </span>
-              {version ? <code className="text-xs text-muted-foreground">{version}</code> : null}
+              {version ? (
+                <CliVersion version={version} outdated={auth?.status === "outdated"} />
+              ) : null}
               {isVcsNotReady(item) ? (
                 <Badge variant="warning" size="sm">
                   Coming Soon
@@ -256,6 +327,9 @@ function DiscoveryItemRow({
             <p className="flex min-w-0 flex-wrap items-center gap-x-1 text-xs text-muted-foreground/80">
               {itemSummary({ item, auth, authAccount })}
             </p>
+            {auth?.status === "outdated" && optionLabel(auth.detail) ? (
+              <UpgradeCommandLine command={optionLabel(auth.detail) as string} />
+            ) : null}
           </div>
           <div className="flex w-full shrink-0 items-center gap-2 sm:w-auto sm:justify-end">
             {hasDetails ? (

--- a/packages/client-runtime/src/operations/projects.ts
+++ b/packages/client-runtime/src/operations/projects.ts
@@ -151,6 +151,13 @@ export function buildAddProjectRemoteSourceReadiness(
       readiness[source] = { ready: false, hint: provider.installHint };
       continue;
     }
+    if (provider.auth.status === "outdated") {
+      readiness[source] = {
+        ready: false,
+        hint: `${provider.label} CLI is outdated and can't confirm sign-in. Open Source Control settings to update it.`,
+      };
+      continue;
+    }
     if (provider.auth.status === "unauthenticated") {
       readiness[source] = {
         ready: false,

--- a/packages/contracts/src/sourceControl.ts
+++ b/packages/contracts/src/sourceControl.ts
@@ -109,6 +109,11 @@ export type SourceControlDiscoveryStatus = typeof SourceControlDiscoveryStatus.T
 export const SourceControlProviderAuthStatus = Schema.Literals([
   "authenticated",
   "unauthenticated",
+  // The provider CLI is installed but too old to report auth status in the
+  // format the server needs (e.g. `gh` predating `auth status --json`). The
+  // user may well be signed in — we just can't read it. `detail` carries the
+  // platform-appropriate upgrade command.
+  "outdated",
   "unknown",
 ]);
 export type SourceControlProviderAuthStatus = typeof SourceControlProviderAuthStatus.Type;


### PR DESCRIPTION
# feat(source-control): package-manager-aware `gh` upgrade command

> **Draft — stacked on #3808.** This branch builds on the `outdated` CLI status from #3808; review that first. Until it merges, this PR's diff includes those commits. Relates to #3806.

## What this ships
Follow-up to #3808. When GitHub is flagged as an **Outdated CLI**, instead of a single per-OS default command, the server probes the host for **how `gh` was actually installed** and surfaces the exact upgrade command:

| Platform | Probed managers → command |
|---|---|
| Windows | winget → `winget upgrade --id GitHub.cli -e` · scoop → `scoop update gh` · choco → `choco upgrade gh` |
| macOS | brew → `brew upgrade gh` · macports → `sudo port upgrade gh` |
| Linux | dpkg/apt → `sudo apt … gh` · rpm/dnf → `sudo dnf upgrade gh` · pacman → `sudo pacman -S github-cli` |

Implementation:
- New optional `resolveUpgradeCommand` hook on `SourceControlCliDiscoverySpec`, run from `probeSourceControlProvider` **only when `parseAuth` reports `outdated`** (so there's zero cost on the healthy path).
- GitHub's implementation runs short, `allowNonZeroExit` presence-probes per platform; **any failure falls back** to the platform default from #3808, so it can never fail discovery.
- These are best-effort heuristics — some managers (scoop, choco) are shims whose spawnability varies, and a miss simply falls back. Refinements welcome.

<img width="1680" height="600" alt="t3code-mockup-enhancement" src="https://github.com/user-attachments/assets/dac12458-5eaa-4919-8d18-f024ffa619f4" />


## Run-in-terminal — design proposal (NOT implemented here)
The original idea was a one-click **"Run in terminal"** button on this row (dashed in the mockup). Investigating, that turns out to need an architecture decision I don't want to make unilaterally:

- The terminal drawer (`ThreadTerminalDrawer`) is mounted **only inside `ChatView`** and is keyed by a **`threadId`** (`ScopedThreadRef`). The Settings route unmounts `ChatView`, so there is no terminal to write to from Settings.
- There is **no lightweight `threadId`** — the only way to obtain one is the full `thread.create` orchestration command (requires `modelSelection`/`runtimeMode`, and creates a real, visible thread).

Two viable paths, both bigger than a button:
1. **Navigate-then-run** — resolve the environment's first project via `environmentProjects.environmentProjectRefsAtom` (→ `workspaceRoot`), reuse or create a thread, route into that chat view, then replicate the `openTerminal` + `writeTerminal` sequence (as `runProjectScript` does in `ChatView.tsx`). Downside: yanks the user out of Settings and may create a stray thread.
2. **Settings-hosted terminal** — mount a dedicated `ScopedThreadRef`-scoped terminal drawer inside the Settings screen. Cleaner UX, but a self-contained new surface.

Happy to implement whichever you prefer in a follow-up — flagging it here rather than guessing. The **Copy** button (from #3808) already covers the immediate need.

## Testing / caveats
- Existing `outdated`-detection tests from #3808 still apply. The manager-probe resolver is best-effort and gated behind the outdated path; I couldn't run the repo toolchain locally, so please let CI run `pnpm typecheck` + tests.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add package-manager-aware `gh` upgrade command to source control CLI discovery
> - Detects outdated `gh` CLI versions by checking for `unknown flag: --json` in output or by comparing against a minimum version (`2.81.0`) using semver comparison.
> - Returns a new `outdated` auth status from `parseGitHubAuth` with a platform-specific default upgrade command (`brew`, `winget`, or `apt`).
> - Probes installed package managers (winget/scoop/choco on Windows, brew/port on macOS, dpkg/rpm/pacman on Linux) to refine the upgrade command to match how `gh` was actually installed.
> - Adds a copyable upgrade command block and highlights the outdated version in the settings UI ([SourceControlSettings.tsx](https://github.com/pingdotgg/t3code/pull/3809/files#diff-9f2e55c161725a6350a5fe7b23c2b7ada03b60855000614a443c6253ad64b625)).
> - Extends the `SourceControlProviderAuthStatus` contract schema with the new `outdated` literal value.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dd14b8a. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->