### PR TITLE
Fix desktop native optional dependency packaging

### DIFF
--- a/scripts/build-desktop-artifact.test.ts
+++ b/scripts/build-desktop-artifact.test.ts
@@ -33,6 +33,7 @@ import {
   resolveGitHubPublishConfig,
   resolveMockUpdateServerPort,
   resolveMockUpdateServerUrl,
+  resolvePackageManagerUserAgent,
   stageLinuxIconSize,
   STAGE_INSTALL_ARGS,
 } from "./build-desktop-artifact.ts";
@@ -208,6 +209,13 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         cpu: ["x64"],
       },
     });
+    assert.deepStrictEqual(createStageWorkspaceConfig({ platform: "linux", arch: "x64" }), {
+      supportedArchitectures: {
+        os: ["linux"],
+        cpu: ["x64"],
+        libc: ["glibc"],
+      },
+    });
     // Windows artifacts also bundle the same-architecture WSL (Linux, glibc) backend, so the
     // staged install must fetch its native optional deps (e.g. ffi-rs) too.
     assert.deepStrictEqual(createStageWorkspaceConfig({ platform: "win", arch: "x64" }), {
@@ -253,6 +261,7 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
         supportedArchitectures: {
           os: ["linux"],
           cpu: ["x64"],
+          libc: ["glibc"],
         },
         allowBuilds: {
           electron: true,
@@ -527,6 +536,12 @@ it.layer(NodeServices.layer)("build-desktop-artifact", (it) => {
   it("falls back to the default mock update port when the configured port is blank", () => {
     assert.equal(resolveMockUpdateServerUrl(undefined), "http://localhost:3000");
     assert.equal(resolveMockUpdateServerUrl(4123), "http://localhost:4123");
+  });
+
+  it("derives the electron-builder package manager user agent from packageManager", () => {
+    assert.equal(resolvePackageManagerUserAgent("pnpm@11.10.0"), "pnpm/11.10.0");
+    assert.equal(resolvePackageManagerUserAgent(" yarn@4.9.2 "), "yarn/4.9.2");
+    assert.equal(resolvePackageManagerUserAgent("pnpm"), "pnpm");
   });
 
   it.effect("normalizes mock update server ports from env-style strings", () =>

--- a/scripts/build-desktop-artifact.ts
+++ b/scripts/build-desktop-artifact.ts
@@ -890,22 +890,27 @@ export function createStageWorkspaceConfig(input: {
   const { platform, arch, allowBuilds, patchedDependencies, overrides } = input;
   const hostOs = platform === "mac" ? "darwin" : platform === "win" ? "win32" : "linux";
   const hostCpu = arch === "universal" ? ["arm64", "x64"] : [arch];
-  // Windows artifacts also bundle the same-architecture WSL Linux backend, which loads
-  // Linux-native optional deps at runtime (e.g. @yuuang/ffi-rs-linux-x64-gnu).
-  // Pull the Linux (glibc) variants in addition to the host platform's so
-  // they ship in the asar; without them the WSL backend crash-loops on require
-  // ("Cannot find module '@yuuang/ffi-rs-linux-x64-gnu'").
+  // Linux AppImages and Windows WSL backends both execute a Linux/glibc Node
+  // process that loads Linux-native optional deps at runtime (e.g.
+  // @yuuang/ffi-rs-linux-x64-gnu). Keep libc explicit so pnpm includes those
+  // optional packages in the staged production install.
   const supportedArchitectures =
-    platform === "win"
+    platform === "linux"
       ? {
-          os: Array.from(new Set([hostOs, "linux"])),
+          os: [hostOs],
           cpu: hostCpu,
           libc: ["glibc"],
         }
-      : {
-          os: [hostOs],
-          cpu: hostCpu,
-        };
+      : platform === "win"
+        ? {
+            os: Array.from(new Set([hostOs, "linux"])),
+            cpu: hostCpu,
+            libc: ["glibc"],
+          }
+        : {
+            os: [hostOs],
+            cpu: hostCpu,
+          };
 
   return {
     supportedArchitectures,
@@ -1337,6 +1342,19 @@ export function resolveDesktopBuildIconAssets(version: string): DesktopBuildIcon
 
 export function resolveMockUpdateServerUrl(mockUpdateServerPort: number | undefined): string {
   return `http://localhost:${mockUpdateServerPort ?? 3000}`;
+}
+
+// Electron Builder detects pnpm from npm_config_user_agent, whose value uses
+// user-agent syntax (pnpm/11.10.0) rather than packageManager syntax
+// (pnpm@11.10.0).
+export function resolvePackageManagerUserAgent(packageManager: string): string {
+  const trimmed = packageManager.trim();
+  const versionSeparator = trimmed.lastIndexOf("@");
+  if (versionSeparator <= 0 || versionSeparator === trimmed.length - 1) {
+    return trimmed;
+  }
+
+  return `${trimmed.slice(0, versionSeparator)}/${trimmed.slice(versionSeparator + 1)}`;
 }
 
 export function resolveDesktopProductName(version: string): string {
@@ -1799,6 +1817,7 @@ const buildDesktopArtifact = Effect.fn("buildDesktopArtifact")(function* (
   const buildEnv: NodeJS.ProcessEnv = {
     ...process.env,
   };
+  buildEnv.npm_config_user_agent = resolvePackageManagerUserAgent(rootPackageJson.packageManager);
   for (const [key, value] of Object.entries(buildEnv)) {
     if (value === "") {
       delete buildEnv[key];


### PR DESCRIPTION
## Summary

Fixes desktop packaging regressions where nightly Linux and Windows builds could ship `ffi-rs` without the platform-native optional `@yuuang/ffi-rs-*` binding required at runtime.

Covered issues:

- Fixes #3812
- Fixes #3807
- Fixes #3804

## Problem

Recent nightly desktop builds started failing during backend startup because the packaged app included `ffi-rs`, but did not include the native optional dependency that `ffi-rs` loads for the current platform.

On Linux AppImage builds, the backend crashed with:

```text
Cannot find module '@yuuang/ffi-rs-linux-x64-gnu'
```

On Windows builds, affected users saw the app never render a window. The server child process was crash-looping with:

```text
Cannot find module '@yuuang/ffi-rs-win32-x64-msvc'
```

Both failures happen before the desktop backend can become ready, so the UI either shows a generic Electron process error or never opens.

## Root Cause

There were two related packaging gaps.

### Linux AppImage

The staged production `pnpm-workspace.yaml` declared the target `os` and `cpu`, but did not declare `libc`.

Packages such as `@yuuang/ffi-rs-linux-x64-gnu` are optional dependencies with:

```json
{
  "os": ["linux"],
  "cpu": ["x64"],
  "libc": ["glibc"]
}
```

Without `libc: ["glibc"]`, pnpm could skip that optional native package during the staged production install, leaving `ffi-rs` present but unable to resolve its Linux binding.

### Windows

The Windows stage already requested the right target architectures, including Windows and Linux/glibc for WSL. However, Electron Builder was detecting the staged app as an npm project when collecting `node_modules`.

Because the staged install uses pnpm, npm-style collection can miss optional dependency subtrees from the pnpm layout. That caused the Windows artifact to omit packages like:

```text
@yuuang/ffi-rs-win32-x64-msvc
```

The fix explicitly passes a pnpm user agent to Electron Builder so it uses the pnpm collector for the staged app.

## Changes

- Add `libc: ["glibc"]` to Linux desktop staging architecture metadata.
- Keep Windows staging behavior for host Windows plus Linux/glibc WSL backend.
- Add `resolvePackageManagerUserAgent()` to convert `packageManager` syntax:

```text
pnpm@11.10.0
```

into npm user-agent syntax:

```text
pnpm/11.10.0
```

- Set `buildEnv.npm_config_user_agent` before invoking Electron Builder.
- Add tests for Linux staging architecture metadata and packageManager-to-user-agent conversion.

## Validation

Commands run:

```bash
vp test run scripts/build-desktop-artifact.test.ts
vp check
vp run typecheck
```

Local artifacts generated for verification:

```bash
node scripts/build-desktop-artifact.ts --platform linux --target AppImage --arch x64 --build-version 0.0.29-nightly.20260708.999 --output-dir release-test

node scripts/build-desktop-artifact.ts --platform win --target nsis --arch x64 --build-version 0.0.29-nightly.20260708.999 --output-dir release-test --skip-build
```

Artifact inspection confirmed:

- Linux AppImage includes:

```text
resources/app.asar.unpacked/node_modules/@yuuang/ffi-rs-linux-x64-gnu/ffi-rs.linux-x64-gnu.node
```

- Windows installer includes:

```text
resources/app.asar.unpacked/node_modules/@yuuang/ffi-rs-win32-x64-msvc/ffi-rs.win32-x64-msvc.node
```

Note: the local Windows installer was generated without `T3CODE_DESKTOP_WSL_PREBUILD`, so it validates the primary Windows backend packaging path and the missing `ffi-rs` binding, but not the WSL backend binary path.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop native optional dependency packaging for Linux and package manager user agent
> - Adds `libc: ["glibc"]` to `supportedArchitectures` in `createStageWorkspaceConfig` for Linux builds in [build-desktop-artifact.ts](https://github.com/pingdotgg/t3code/pull/3816/files#diff-384c39593c6da8887b4f03c00f763af0e3b689525d3555a9fe03fd05c808471d), ensuring native optional dependencies targeting glibc are included during staged production installs.
> - Introduces `resolvePackageManagerUserAgent`, which converts a `package.json` `packageManager` field (e.g. `pnpm@11.10.0`) to a user-agent string (`pnpm/11.10.0`) for use by electron-builder.
> - Sets `npm_config_user_agent` in the electron-builder environment using the derived user agent before the env-scrubbing step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6d0d98e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only desktop packaging scripts but affect runtime-critical native modules; mis-staging would still break backend startup on Linux/Windows without obvious compile-time failures.
> 
> **Overview**
> Fixes desktop builds shipping `ffi-rs` without the platform-specific `@yuuang/ffi-rs-*` optional bindings, which caused Linux AppImage and Windows backend crash-loops (`Cannot find module '@yuuang/ffi-rs-…'`).
> 
> **Linux staging:** `createStageWorkspaceConfig` now sets `libc: ["glibc"]` for Linux targets (not only Windows), so staged `pnpm install --prod` resolves glibc-scoped optional natives like `@yuuang/ffi-rs-linux-x64-gnu`.
> 
> **Electron Builder / Windows:** Adds `resolvePackageManagerUserAgent()` to map root `packageManager` (`pnpm@11.10.0`) to `npm_config_user_agent` form (`pnpm/11.10.0`), and sets that on the electron-builder env so collection uses the pnpm layout and optional Windows bindings (e.g. `@yuuang/ffi-rs-win32-x64-msvc`) are not dropped.
> 
> Tests cover Linux workspace `supportedArchitectures` (including libc in full yaml fixtures) and user-agent conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d0d98ed09eb15794b58c9dfd5fa355d199d3e7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->