### PR TITLE
feat(providers): add Google Antigravity provider integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ If a tradeoff is required, choose correctness and robustness over short-term con
 
 Long term maintainability is a core priority. If you add new functionality, first check if there is shared logic that can be extracted to a separate module. Duplicate logic across multiple files is a code smell and should be avoided. Don't be afraid to change existing code. Don't take shortcuts by just adding local logic to solve a problem.
 
+## Documented Solutions
+
+`docs/solutions/` — documented solutions to past problems (bugs, best practices, workflow patterns), organized by category with YAML frontmatter (`module`, `tags`, `problem_type`). Relevant when implementing or debugging in documented areas.
+
 ## Package Roles
 
 - `apps/server`: Node.js WebSocket server. Wraps Codex app-server (JSON-RPC over stdio), serves the React web app, and manages provider sessions.

--- a/apps/server/src/provider/Drivers/AntigravityDriver.ts
+++ b/apps/server/src/provider/Drivers/AntigravityDriver.ts
@@ -1,0 +1,187 @@
+/**
+ * AntigravityDriver — `ProviderDriver` for the Antigravity Agent (`agent`) runtime.
+ *
+ * Antigravity exposes an ACP-based CLI. Model catalog and capability refreshes
+ * happen during the managed provider status check via Antigravity's
+ * `list_available_models` extension method.
+ *
+ * Text generation is supported via the ACP runtime — `makeAntigravityTextGeneration`
+ * drives `runtime.prompt` with a structured-output schema and collects the
+ * agent's `agent_message_chunk` stream into a single JSON blob.
+ *
+ * @module provider/Drivers/AntigravityDriver
+ */
+import { AntigravitySettings, ProviderDriverKind, type ServerProvider } from "@t3tools/contracts";
+import * as Duration from "effect/Duration";
+import * as Crypto from "effect/Crypto";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { ServerConfig } from "../../config.ts";
+import { ServerSettingsService } from "../../serverSettings.ts";
+import { makeAntigravityTextGeneration } from "../../textGeneration/AntigravityTextGeneration.ts";
+import { ProviderDriverError } from "../Errors.ts";
+import { makeAntigravityAdapter } from "../Layers/AntigravityAdapter.ts";
+import {
+  buildInitialAntigravityProviderSnapshot,
+  checkAntigravityProviderStatus,
+  enrichAntigravitySnapshot,
+} from "../Layers/AntigravityProvider.ts";
+import { ProviderEventLoggers } from "../Layers/ProviderEventLoggers.ts";
+import { makeManagedServerProvider } from "../makeManagedServerProvider.ts";
+import {
+  defaultProviderContinuationIdentity,
+  type ProviderDriver,
+  type ProviderInstance,
+} from "../ProviderDriver.ts";
+import type { ServerProviderDraft } from "../providerSnapshot.ts";
+import { mergeProviderInstanceEnvironment } from "../ProviderInstanceEnvironment.ts";
+import {
+  makeProviderMaintenanceCapabilities,
+  makeStaticProviderMaintenanceResolver,
+  resolveProviderMaintenanceCapabilitiesEffect,
+} from "../providerMaintenance.ts";
+import {
+  haveProviderSnapshotSettingsChanged,
+  makeProviderSnapshotSettingsSource,
+  type ProviderSnapshotSettings,
+} from "../providerUpdateSettings.ts";
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const DRIVER_KIND = ProviderDriverKind.make("antigravity");
+const SNAPSHOT_REFRESH_INTERVAL = Duration.minutes(5);
+const UPDATE = makeStaticProviderMaintenanceResolver(
+  makeProviderMaintenanceCapabilities({
+    provider: DRIVER_KIND,
+    packageName: null,
+    updateExecutable: "agy",
+    updateArgs: ["update"],
+    updateLockKey: "antigravity-agent",
+  }),
+);
+
+export type AntigravityDriverEnv =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Crypto.Crypto
+  | FileSystem.FileSystem
+  | HttpClient.HttpClient
+  | Path.Path
+  | ProviderEventLoggers
+  | ServerConfig
+  | ServerSettingsService;
+
+const withInstanceIdentity =
+  (input: {
+    readonly instanceId: ProviderInstance["instanceId"];
+    readonly displayName: string | undefined;
+    readonly accentColor: string | undefined;
+    readonly continuationGroupKey: string;
+  }) =>
+  (snapshot: ServerProviderDraft): ServerProvider => ({
+    ...snapshot,
+    instanceId: input.instanceId,
+    driver: DRIVER_KIND,
+    ...(input.displayName ? { displayName: input.displayName } : {}),
+    ...(input.accentColor ? { accentColor: input.accentColor } : {}),
+    continuation: { groupKey: input.continuationGroupKey },
+  });
+
+export const AntigravityDriver: ProviderDriver<AntigravitySettings, AntigravityDriverEnv> = {
+  driverKind: DRIVER_KIND,
+  metadata: {
+    displayName: "Antigravity",
+    supportsMultipleInstances: true,
+  },
+  configSchema: AntigravitySettings,
+  defaultConfig: (): AntigravitySettings => decodeAntigravitySettings({}),
+  create: ({ instanceId, displayName, accentColor, environment, enabled, config }) =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const httpClient = yield* HttpClient.HttpClient;
+      const serverSettings = yield* ServerSettingsService;
+      const eventLoggers = yield* ProviderEventLoggers;
+      const processEnv = mergeProviderInstanceEnvironment(environment);
+      const continuationIdentity = defaultProviderContinuationIdentity({
+        driverKind: DRIVER_KIND,
+        instanceId,
+      });
+      const stampIdentity = withInstanceIdentity({
+        instanceId,
+        displayName,
+        accentColor,
+        continuationGroupKey: continuationIdentity.continuationKey,
+      });
+      const effectiveConfig = { ...config, enabled } satisfies AntigravitySettings;
+      const maintenanceCapabilities = yield* resolveProviderMaintenanceCapabilitiesEffect(UPDATE, {
+        binaryPath: effectiveConfig.binaryPath,
+        env: processEnv,
+      });
+
+      const adapter = yield* makeAntigravityAdapter(effectiveConfig, {
+        environment: processEnv,
+        ...(eventLoggers.native ? { nativeEventLogger: eventLoggers.native } : {}),
+        instanceId,
+      });
+      const textGeneration = yield* makeAntigravityTextGeneration(effectiveConfig, processEnv);
+
+      const checkProvider = checkAntigravityProviderStatus(effectiveConfig, processEnv).pipe(
+        Effect.map(stampIdentity),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+        Effect.provideService(FileSystem.FileSystem, fileSystem),
+        Effect.provideService(Path.Path, path),
+      );
+
+      const snapshotSettings = makeProviderSnapshotSettingsSource(effectiveConfig, serverSettings);
+      const snapshot = yield* makeManagedServerProvider<
+        ProviderSnapshotSettings<AntigravitySettings>
+      >({
+        maintenanceCapabilities,
+        getSettings: snapshotSettings.getSettings,
+        streamSettings: snapshotSettings.streamSettings,
+        haveSettingsChanged: haveProviderSnapshotSettingsChanged,
+        initialSnapshot: (settings) =>
+          buildInitialAntigravityProviderSnapshot(settings.provider).pipe(
+            Effect.map(stampIdentity),
+          ),
+        checkProvider,
+        // Model catalog and capabilities come exclusively from Antigravity's
+        // list_available_models extension method during provider checks.
+        enrichSnapshot: ({ snapshot: currentSnapshot, publishSnapshot }) =>
+          enrichAntigravitySnapshot({
+            snapshot: currentSnapshot,
+            maintenanceCapabilities,
+            publishSnapshot,
+            httpClient,
+          }),
+        refreshInterval: SNAPSHOT_REFRESH_INTERVAL,
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new ProviderDriverError({
+              driver: DRIVER_KIND,
+              instanceId,
+              detail: `Failed to build Antigravity snapshot: ${cause.message ?? String(cause)}`,
+              cause,
+            }),
+        ),
+      );
+
+      return {
+        instanceId,
+        driverKind: DRIVER_KIND,
+        continuationIdentity,
+        displayName,
+        accentColor,
+        enabled,
+        snapshot,
+        adapter,
+        textGeneration,
+      } satisfies ProviderInstance;
+    }),
+};

--- a/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.test.ts
@@ -1,0 +1,123 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodePath from "node:path";
+import * as NodeOS from "node:os";
+import * as NodeFSP from "node:fs/promises";
+import * as NodeURL from "node:url";
+
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { assert, it } from "@effect/vitest";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
+import * as Stream from "effect/Stream";
+
+import {
+  ApprovalRequestId,
+  AntigravitySettings,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  ThreadId,
+  TurnId,
+  type ProviderRuntimeEvent,
+} from "@t3tools/contracts";
+
+import { ServerConfig } from "../../config.ts";
+import { makeAntigravityAdapter } from "./AntigravityAdapter.ts";
+const decodeAntigravitySettings = Schema.decodeSync(AntigravitySettings);
+
+const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
+const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.ts");
+const mockAgentCommand = process.execPath;
+
+async function makeMockAntigravityWrapper(extraEnv?: Record<string, string>) {
+  const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "antigravity-acp-mock-"));
+  const wrapperPath = NodePath.join(dir, "fake-antigravity.sh");
+  const envExports = Object.entries(extraEnv ?? {})
+    .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
+    .join("\n");
+  const script = `#!/bin/sh
+${envExports}
+exec ${JSON.stringify(mockAgentCommand)} ${JSON.stringify(mockAgentPath)} "$@"
+`;
+  await NodeFSP.writeFile(wrapperPath, script, "utf8");
+  await NodeFSP.chmod(wrapperPath, 0o755);
+  return wrapperPath;
+}
+
+const antigravityAdapterTestLayer = ServerConfig.layerTest(process.cwd(), {
+  prefix: "t3code-antigravity-adapter-test-",
+}).pipe(Layer.provideMerge(NodeServices.layer));
+
+const makeTestAdapter = (
+  binaryPath: string,
+  options?: Parameters<typeof makeAntigravityAdapter>[1],
+) => makeAntigravityAdapter(decodeAntigravitySettings({ binaryPath }), options).pipe(Effect.orDie);
+
+it.layer(antigravityAdapterTestLayer)("AntigravityAdapterLive", (it) => {
+  it.effect("starts a session and maps mock ACP prompt flow to runtime events", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("antigravity-mock-thread");
+      const wrapperPath = yield* Effect.promise(() => makeMockAntigravityWrapper());
+      const adapter = yield* makeTestAdapter(wrapperPath);
+
+      const runtimeEvents: ProviderRuntimeEvent[] = [];
+      const turnCompleted = yield* Deferred.make<void>();
+      const runtimeEventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+        Effect.sync(() => {
+          runtimeEvents.push(event);
+        }).pipe(
+          Effect.andThen(
+            event.type === "turn.completed"
+              ? Deferred.succeed(turnCompleted, undefined)
+              : Effect.void,
+          ),
+        ),
+      ).pipe(Effect.forkChild);
+
+      const session = yield* adapter.startSession({
+        threadId,
+        provider: ProviderDriverKind.make("antigravity"),
+        cwd: process.cwd(),
+        runtimeMode: "full-access",
+        modelSelection: { instanceId: ProviderInstanceId.make("antigravity"), model: "default" },
+      });
+
+      assert.equal(session.provider, "antigravity");
+      assert.equal(session.model, "default");
+      assert.deepStrictEqual(session.resumeCursor, {
+        schemaVersion: 1,
+        sessionId: "mock-session-1",
+      });
+
+      yield* adapter.sendTurn({
+        threadId,
+        input: "hello antigravity",
+        attachments: [],
+      });
+
+      yield* Deferred.await(turnCompleted);
+      yield* Fiber.interrupt(runtimeEventsFiber);
+      const types = runtimeEvents.map((e) => e.type);
+
+      assert.includeMembers(types, [
+        "session.started",
+        "session.state.changed",
+        "thread.started",
+        "turn.started",
+        "item.started",
+        "content.delta",
+        "turn.completed",
+      ] as const);
+
+      const delta = runtimeEvents.find((e) => e.type === "content.delta");
+      assert.isDefined(delta);
+      if (delta?.type === "content.delta") {
+        assert.equal(delta.payload.delta, "hello from mock");
+      }
+
+      yield* adapter.stopSession(threadId);
+    }),
+  );
+});

--- a/apps/server/src/provider/Layers/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Layers/AntigravityAdapter.ts
@@ -1,0 +1,1107 @@
+/**
+ * AntigravityAdapterLive — Antigravity CLI (`agent acp`) via ACP.
+ *
+ * @module AntigravityAdapterLive
+ */
+
+import {
+  ApprovalRequestId,
+  type AntigravitySettings,
+  type ProviderOptionSelection,
+  EventId,
+  type ProviderApprovalDecision,
+  type ProviderInteractionMode,
+  type ProviderRuntimeEvent,
+  type ProviderSession,
+  type ProviderUserInputAnswers,
+  ProviderDriverKind,
+  ProviderInstanceId,
+  RuntimeRequestId,
+  type RuntimeMode,
+  type ThreadId,
+  TurnId,
+} from "@t3tools/contracts";
+import * as DateTime from "effect/DateTime";
+import * as Crypto from "effect/Crypto";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as FileSystem from "effect/FileSystem";
+import * as Option from "effect/Option";
+import * as Path from "effect/Path";
+import * as PubSub from "effect/PubSub";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import * as Stream from "effect/Stream";
+import * as SynchronizedRef from "effect/SynchronizedRef";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import * as EffectAcpErrors from "effect-acp/errors";
+import type * as EffectAcpSchema from "effect-acp/schema";
+
+import { resolveAttachmentPath } from "../../attachmentStore.ts";
+import { ServerConfig } from "../../config.ts";
+import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
+import {
+  ProviderAdapterProcessError,
+  ProviderAdapterRequestError,
+  ProviderAdapterSessionNotFoundError,
+  ProviderAdapterValidationError,
+} from "../Errors.ts";
+import { acpPermissionOutcome, mapAcpToAdapterError } from "../acp/AcpAdapterSupport.ts";
+import type * as AcpSessionRuntime from "../acp/AcpSessionRuntime.ts";
+import {
+  makeAcpAssistantItemEvent,
+  makeAcpContentDeltaEvent,
+  makeAcpPlanUpdatedEvent,
+  makeAcpRequestOpenedEvent,
+  makeAcpRequestResolvedEvent,
+  makeAcpToolCallEvent,
+} from "../acp/AcpCoreRuntimeEvents.ts";
+import {
+  type AcpSessionMode,
+  type AcpSessionModeState,
+  parsePermissionRequest,
+} from "../acp/AcpRuntimeModel.ts";
+import { makeAcpNativeLoggerFactory } from "../acp/AcpNativeLogging.ts";
+import {
+  applyAntigravityAcpModelSelection,
+  makeAntigravityAcpRuntime,
+  resolveAntigravityAcpBaseModelId,
+} from "../acp/AntigravityAcpSupport.ts";
+import { type AntigravityAdapterShape } from "../Services/AntigravityAdapter.ts";
+import { type EventNdjsonLogger, makeEventNdjsonLogger } from "./EventNdjsonLogger.ts";
+const encodeUnknownJsonStringExit = Schema.encodeUnknownExit(Schema.UnknownFromJsonString);
+
+const PROVIDER = ProviderDriverKind.make("antigravity");
+const ANTIGRAVITY_RESUME_VERSION = 1 as const;
+const ACP_PLAN_MODE_ALIASES = ["plan", "architect"];
+const ACP_IMPLEMENT_MODE_ALIASES = ["code", "agent", "default", "chat", "implement"];
+const ACP_APPROVAL_MODE_ALIASES = ["ask"];
+
+function encodeJsonStringForDiagnostics(input: unknown): string | undefined {
+  const result = encodeUnknownJsonStringExit(input);
+  return Exit.isSuccess(result) ? result.value : undefined;
+}
+
+export interface AntigravityAdapterLiveOptions {
+  readonly environment?: NodeJS.ProcessEnv;
+  readonly nativeEventLogPath?: string;
+  readonly nativeEventLogger?: EventNdjsonLogger;
+  /**
+   * Selections are honored when `modelSelection.instanceId` matches this value.
+   * Defaults to the legacy built-in instance id (`antigravity`).
+   */
+  readonly instanceId?: ProviderInstanceId;
+  /**
+   * Optional per-session settings resolver. When provided the adapter yields
+   * this effect at the start of every session and uses the result instead of
+   * the `antigravitySettings` captured at construction.
+   *
+   * Production instances bind settings to the instance scope (the hydration
+   * layer rebuilds the adapter on config change) and leave this undefined.
+   * Test suites that mutate `ServerSettingsService` mid-flight — e.g. to
+   * swap `binaryPath` to a mock ACP wrapper — pass a resolver that reads
+   * the latest snapshot so the closure isn't stale.
+   */
+  readonly resolveSettings?: Effect.Effect<AntigravitySettings>;
+}
+
+interface PendingApproval {
+  readonly decision: Deferred.Deferred<ProviderApprovalDecision>;
+  readonly kind: string | "unknown";
+}
+
+interface PendingUserInput {
+  readonly answers: Deferred.Deferred<ProviderUserInputAnswers>;
+}
+
+interface AntigravityTurnItem {
+  readonly prompt: ReadonlyArray<EffectAcpSchema.ContentBlock>;
+  readonly result: EffectAcpSchema.PromptResponse;
+}
+
+interface AntigravitySessionContext {
+  readonly threadId: ThreadId;
+  session: ProviderSession;
+  readonly scope: Scope.Closeable;
+  readonly acp: AcpSessionRuntime.AcpSessionRuntime["Service"];
+  notificationFiber: Fiber.Fiber<void, never> | undefined;
+  readonly pendingApprovals: Map<ApprovalRequestId, PendingApproval>;
+  readonly pendingUserInputs: Map<ApprovalRequestId, PendingUserInput>;
+  readonly turns: Array<{ id: TurnId; items: Array<AntigravityTurnItem> }>;
+  lastPlanFingerprint: string | undefined;
+  activeTurnId: TurnId | undefined;
+  /** Number of sendTurn prompts currently in flight or being prepared.
+   * >0 means a turn is actively running, so a new sendTurn is a steer that
+   * continues it, and only the last remaining prompt settles the turn. */
+  promptsInFlight: number;
+  stopped: boolean;
+}
+
+function settlePendingApprovalsAsCancelled(
+  pendingApprovals: ReadonlyMap<ApprovalRequestId, PendingApproval>,
+): Effect.Effect<void> {
+  const pendingEntries = Array.from(pendingApprovals.values());
+  return Effect.forEach(
+    pendingEntries,
+    (pending) => Deferred.succeed(pending.decision, "cancel").pipe(Effect.ignore),
+    {
+      discard: true,
+    },
+  );
+}
+
+function settlePendingUserInputsAsEmptyAnswers(
+  pendingUserInputs: ReadonlyMap<ApprovalRequestId, PendingUserInput>,
+): Effect.Effect<void> {
+  const pendingEntries = Array.from(pendingUserInputs.values());
+  return Effect.forEach(
+    pendingEntries,
+    (pending) => Deferred.succeed(pending.answers, {}).pipe(Effect.ignore),
+    {
+      discard: true,
+    },
+  );
+}
+
+const AntigravityResumeSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(ANTIGRAVITY_RESUME_VERSION),
+  sessionId: Schema.String,
+});
+
+function parseAntigravityResume(raw: unknown): { sessionId: string } | undefined {
+  const result = Schema.decodeUnknownOption(AntigravityResumeSchema)(raw);
+  if (Option.isSome(result)) {
+    const sessionId = result.value.sessionId.trim();
+    if (sessionId) return { sessionId };
+  }
+  return undefined;
+}
+
+function normalizeModeSearchText(mode: AcpSessionMode): string {
+  return [mode.id, mode.name, mode.description]
+    .filter((value): value is string => typeof value === "string" && value.length > 0)
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function findModeByAliases(
+  modes: ReadonlyArray<AcpSessionMode>,
+  aliases: ReadonlyArray<string>,
+): AcpSessionMode | undefined {
+  const normalizedAliases = aliases.map((alias) => alias.toLowerCase());
+  for (const alias of normalizedAliases) {
+    const exact = modes.find((mode) => {
+      const id = mode.id.toLowerCase();
+      const name = mode.name.toLowerCase();
+      return id === alias || name === alias;
+    });
+    if (exact) {
+      return exact;
+    }
+  }
+  for (const alias of normalizedAliases) {
+    const partial = modes.find((mode) => normalizeModeSearchText(mode).includes(alias));
+    if (partial) {
+      return partial;
+    }
+  }
+  return undefined;
+}
+
+function isPlanMode(mode: AcpSessionMode): boolean {
+  return findModeByAliases([mode], ACP_PLAN_MODE_ALIASES) !== undefined;
+}
+
+function resolveRequestedModeId(input: {
+  readonly interactionMode: ProviderInteractionMode | undefined;
+  readonly runtimeMode: RuntimeMode;
+  readonly modeState: AcpSessionModeState | undefined;
+}): string | undefined {
+  const modeState = input.modeState;
+  if (!modeState) {
+    return undefined;
+  }
+
+  if (input.interactionMode === "plan") {
+    return findModeByAliases(modeState.availableModes, ACP_PLAN_MODE_ALIASES)?.id;
+  }
+
+  if (input.runtimeMode === "approval-required") {
+    return (
+      findModeByAliases(modeState.availableModes, ACP_APPROVAL_MODE_ALIASES)?.id ??
+      findModeByAliases(modeState.availableModes, ACP_IMPLEMENT_MODE_ALIASES)?.id ??
+      modeState.availableModes.find((mode) => !isPlanMode(mode))?.id ??
+      modeState.currentModeId
+    );
+  }
+
+  return (
+    findModeByAliases(modeState.availableModes, ACP_IMPLEMENT_MODE_ALIASES)?.id ??
+    findModeByAliases(modeState.availableModes, ACP_APPROVAL_MODE_ALIASES)?.id ??
+    modeState.availableModes.find((mode) => !isPlanMode(mode))?.id ??
+    modeState.currentModeId
+  );
+}
+
+function applyRequestedSessionConfiguration<E>(input: {
+  readonly runtime: AcpSessionRuntime.AcpSessionRuntime["Service"];
+  readonly runtimeMode: RuntimeMode;
+  readonly interactionMode: ProviderInteractionMode | undefined;
+  readonly modelSelection:
+    | {
+        readonly model: string;
+        readonly options?: ReadonlyArray<ProviderOptionSelection> | null | undefined;
+      }
+    | undefined;
+  readonly mapError: (context: {
+    readonly cause: import("effect-acp/errors").AcpError;
+    readonly method: "session/set_config_option" | "session/set_mode";
+  }) => E;
+}): Effect.Effect<void, E> {
+  return Effect.gen(function* () {
+    if (input.modelSelection) {
+      yield* applyAntigravityAcpModelSelection({
+        runtime: input.runtime,
+        model: input.modelSelection.model,
+        selections: input.modelSelection.options,
+        mapError: ({ cause }) =>
+          input.mapError({
+            cause,
+            method: "session/set_config_option",
+          }),
+      });
+    }
+
+    const requestedModeId = resolveRequestedModeId({
+      interactionMode: input.interactionMode,
+      runtimeMode: input.runtimeMode,
+      modeState: yield* input.runtime.getModeState,
+    });
+    if (!requestedModeId) {
+      return;
+    }
+
+    yield* input.runtime.setMode(requestedModeId).pipe(
+      Effect.mapError((cause) =>
+        input.mapError({
+          cause,
+          method: "session/set_mode",
+        }),
+      ),
+    );
+  });
+}
+
+function selectAutoApprovedPermissionOption(
+  request: EffectAcpSchema.RequestPermissionRequest,
+): string | undefined {
+  const allowAlwaysOption = request.options.find((option) => option.kind === "allow_always");
+  if (typeof allowAlwaysOption?.optionId === "string" && allowAlwaysOption.optionId.trim()) {
+    return allowAlwaysOption.optionId.trim();
+  }
+
+  const allowOnceOption = request.options.find((option) => option.kind === "allow_once");
+  if (typeof allowOnceOption?.optionId === "string" && allowOnceOption.optionId.trim()) {
+    return allowOnceOption.optionId.trim();
+  }
+
+  return undefined;
+}
+
+export function makeAntigravityAdapter(
+  antigravitySettings: AntigravitySettings,
+  options?: AntigravityAdapterLiveOptions,
+) {
+  return Effect.gen(function* () {
+    const boundInstanceId = options?.instanceId ?? ProviderInstanceId.make("antigravity");
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+    const serverConfig = yield* Effect.service(ServerConfig);
+    const crypto = yield* Crypto.Crypto;
+    const nativeEventLogger =
+      options?.nativeEventLogger ??
+      (options?.nativeEventLogPath !== undefined
+        ? yield* makeEventNdjsonLogger(options.nativeEventLogPath, {
+            stream: "native",
+          })
+        : undefined);
+    const managedNativeEventLogger =
+      options?.nativeEventLogger === undefined ? nativeEventLogger : undefined;
+    const makeAcpNativeLoggers = yield* makeAcpNativeLoggerFactory();
+
+    const sessions = new Map<ThreadId, AntigravitySessionContext>();
+    const threadLocksRef = yield* SynchronizedRef.make(new Map<string, Semaphore.Semaphore>());
+    const runtimeEventPubSub = yield* PubSub.unbounded<ProviderRuntimeEvent>();
+
+    const nowIso = Effect.map(DateTime.now, DateTime.formatIso);
+    const randomUUIDv4 = crypto.randomUUIDv4.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "crypto/randomUUIDv4",
+            detail: "Failed to generate Antigravity runtime identifier.",
+            cause,
+          }),
+      ),
+    );
+    const nextEventId = Effect.map(randomUUIDv4, (id) => EventId.make(id));
+    const makeEventStamp = () => Effect.all({ eventId: nextEventId, createdAt: nowIso });
+    const mapExtensionFailure = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      effect.pipe(
+        Effect.mapError(
+          (cause) =>
+            new EffectAcpErrors.AcpTransportError({
+              detail: "Failed to process Antigravity ACP extension event.",
+              cause,
+            }),
+        ),
+      );
+
+    const offerRuntimeEvent = (event: ProviderRuntimeEvent) =>
+      PubSub.publish(runtimeEventPubSub, event).pipe(Effect.asVoid);
+
+    const getThreadSemaphore = (threadId: string) =>
+      SynchronizedRef.modifyEffect(threadLocksRef, (current) => {
+        const existing: Option.Option<Semaphore.Semaphore> = Option.fromNullishOr(
+          current.get(threadId),
+        );
+        return Option.match(existing, {
+          onNone: () =>
+            Semaphore.make(1).pipe(
+              Effect.map((semaphore) => {
+                const next = new Map(current);
+                next.set(threadId, semaphore);
+                return [semaphore, next] as const;
+              }),
+            ),
+          onSome: (semaphore) => Effect.succeed([semaphore, current] as const),
+        });
+      });
+
+    const withThreadLock = <A, E, R>(threadId: string, effect: Effect.Effect<A, E, R>) =>
+      Effect.flatMap(getThreadSemaphore(threadId), (semaphore) => semaphore.withPermit(effect));
+
+    const logNative = (
+      threadId: ThreadId,
+      method: string,
+      payload: unknown,
+      _source: "acp.jsonrpc" | "acp.antigravity.extension",
+    ) =>
+      Effect.gen(function* () {
+        if (!nativeEventLogger) return;
+        const observedAt = yield* nowIso;
+        yield* nativeEventLogger.write(
+          {
+            observedAt,
+            event: {
+              id: yield* randomUUIDv4,
+              kind: "notification",
+              provider: PROVIDER,
+              createdAt: observedAt,
+              method,
+              threadId,
+              payload,
+            },
+          },
+          threadId,
+        );
+      });
+
+    const emitPlanUpdate = (
+      ctx: AntigravitySessionContext,
+      payload: {
+        readonly explanation?: string | null;
+        readonly plan: ReadonlyArray<{
+          readonly step: string;
+          readonly status: "pending" | "inProgress" | "completed";
+        }>;
+      },
+      rawPayload: unknown,
+      source: "acp.jsonrpc" | "acp.antigravity.extension",
+      method: string,
+    ) =>
+      Effect.gen(function* () {
+        const fingerprint = `${ctx.activeTurnId ?? "no-turn"}:${encodeJsonStringForDiagnostics(payload) ?? "[unserializable payload]"}`;
+        if (ctx.lastPlanFingerprint === fingerprint) {
+          return;
+        }
+        ctx.lastPlanFingerprint = fingerprint;
+        yield* offerRuntimeEvent(
+          makeAcpPlanUpdatedEvent({
+            stamp: yield* makeEventStamp(),
+            provider: PROVIDER,
+            threadId: ctx.threadId,
+            turnId: ctx.activeTurnId,
+            payload,
+            source,
+            method,
+            rawPayload,
+          }),
+        );
+      });
+
+    const requireSession = (
+      threadId: ThreadId,
+    ): Effect.Effect<AntigravitySessionContext, ProviderAdapterSessionNotFoundError> => {
+      const ctx = sessions.get(threadId);
+      if (!ctx || ctx.stopped) {
+        return Effect.fail(
+          new ProviderAdapterSessionNotFoundError({ provider: PROVIDER, threadId }),
+        );
+      }
+      return Effect.succeed(ctx);
+    };
+
+    const stopSessionInternal = (ctx: AntigravitySessionContext) =>
+      Effect.gen(function* () {
+        if (ctx.stopped) return;
+        ctx.stopped = true;
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        if (ctx.notificationFiber) {
+          yield* Fiber.interrupt(ctx.notificationFiber);
+        }
+        yield* Effect.ignore(Scope.close(ctx.scope, Exit.void));
+        sessions.delete(ctx.threadId);
+        yield* offerRuntimeEvent({
+          type: "session.exited",
+          ...(yield* makeEventStamp()),
+          provider: PROVIDER,
+          threadId: ctx.threadId,
+          payload: { exitKind: "graceful" },
+        });
+      });
+
+    const startSession: AntigravityAdapterShape["startSession"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          if (input.provider !== undefined && input.provider !== PROVIDER) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: `Expected provider '${PROVIDER}' but received '${input.provider}'.`,
+            });
+          }
+          if (!input.cwd?.trim()) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "startSession",
+              issue: "cwd is required and must be non-empty.",
+            });
+          }
+
+          const cwd = path.resolve(input.cwd.trim());
+          const antigravityModelSelection =
+            input.modelSelection?.instanceId === boundInstanceId ? input.modelSelection : undefined;
+          const existing = sessions.get(input.threadId);
+          if (existing && !existing.stopped) {
+            yield* stopSessionInternal(existing);
+          }
+
+          const pendingApprovals = new Map<ApprovalRequestId, PendingApproval>();
+          const pendingUserInputs = new Map<ApprovalRequestId, PendingUserInput>();
+          const sessionScope = yield* Scope.make("sequential");
+          let sessionScopeTransferred = false;
+          yield* Effect.addFinalizer(() =>
+            sessionScopeTransferred ? Effect.void : Scope.close(sessionScope, Exit.void),
+          );
+          let ctx!: AntigravitySessionContext;
+
+          const resumeSessionId = parseAntigravityResume(input.resumeCursor)?.sessionId;
+          const acpNativeLoggers = makeAcpNativeLoggers({
+            nativeEventLogger,
+            provider: PROVIDER,
+            threadId: input.threadId,
+          });
+
+          // Resolve the AntigravitySettings used to spawn the ACP child. Production
+          // leaves `options.resolveSettings` undefined so we use the value
+          // captured at adapter construction — per-instance isolation is
+          // enforced by the hydration layer rebuilding this adapter whenever
+          // its config changes. Tests set `resolveSettings` to pull the latest
+          // snapshot from `ServerSettingsService` so that mid-suite
+          // `updateSettings({ providers: { antigravity: { binaryPath } } })` calls
+          // actually take effect when the next session spawns.
+          const effectiveAntigravitySettings = options?.resolveSettings
+            ? yield* options.resolveSettings
+            : antigravitySettings;
+
+          const mcpSession = McpProviderSession.readMcpProviderSession(input.threadId);
+          const acp = yield* makeAntigravityAcpRuntime({
+            antigravitySettings: effectiveAntigravitySettings,
+            ...(options?.environment ? { environment: options.environment } : {}),
+            childProcessSpawner,
+            cwd,
+            ...(resumeSessionId ? { resumeSessionId } : {}),
+            clientInfo: { name: "t3-code", version: "0.0.0" },
+            ...(mcpSession
+              ? {
+                  mcpServers: [
+                    {
+                      type: "http" as const,
+                      name: "t3-code",
+                      url: mcpSession.endpoint,
+                      headers: [
+                        {
+                          name: "Authorization",
+                          value: mcpSession.authorizationHeader,
+                        },
+                      ],
+                    },
+                  ],
+                }
+              : {}),
+            ...acpNativeLoggers,
+          }).pipe(
+            Effect.provideService(Scope.Scope, sessionScope),
+            Effect.mapError(
+              (cause) =>
+                new ProviderAdapterProcessError({
+                  provider: PROVIDER,
+                  threadId: input.threadId,
+                  detail: cause.message,
+                  cause,
+                }),
+            ),
+          );
+          const started = yield* Effect.gen(function* () {
+            yield* acp.handleRequestPermission((params) =>
+              mapExtensionFailure(
+                Effect.gen(function* () {
+                  yield* logNative(
+                    input.threadId,
+                    "session/request_permission",
+                    params,
+                    "acp.jsonrpc",
+                  );
+                  if (input.runtimeMode === "full-access") {
+                    const autoApprovedOptionId = selectAutoApprovedPermissionOption(params);
+                    if (autoApprovedOptionId !== undefined) {
+                      return {
+                        outcome: {
+                          outcome: "selected" as const,
+                          optionId: autoApprovedOptionId,
+                        },
+                      };
+                    }
+                  }
+                  const permissionRequest = parsePermissionRequest(params);
+                  const requestId = ApprovalRequestId.make(yield* randomUUIDv4);
+                  const runtimeRequestId = RuntimeRequestId.make(requestId);
+                  const decision = yield* Deferred.make<ProviderApprovalDecision>();
+                  pendingApprovals.set(requestId, {
+                    decision,
+                    kind: permissionRequest.kind,
+                  });
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestOpenedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      detail:
+                        permissionRequest.detail ??
+                        encodeJsonStringForDiagnostics(params)?.slice(0, 2000) ??
+                        "[unserializable params]",
+                      args: params,
+                      source: "acp.jsonrpc",
+                      method: "session/request_permission",
+                      rawPayload: params,
+                    }),
+                  );
+                  const resolved = yield* Deferred.await(decision);
+                  pendingApprovals.delete(requestId);
+                  yield* offerRuntimeEvent(
+                    makeAcpRequestResolvedEvent({
+                      stamp: yield* makeEventStamp(),
+                      provider: PROVIDER,
+                      threadId: input.threadId,
+                      turnId: ctx?.activeTurnId,
+                      requestId: runtimeRequestId,
+                      permissionRequest,
+                      decision: resolved,
+                    }),
+                  );
+                  return {
+                    outcome:
+                      resolved === "cancel"
+                        ? ({ outcome: "cancelled" } as const)
+                        : {
+                            outcome: "selected" as const,
+                            optionId: acpPermissionOutcome(resolved),
+                          },
+                  };
+                }),
+              ),
+            );
+            return yield* acp.start();
+          }).pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, "session/start", error),
+            ),
+          );
+
+          yield* applyRequestedSessionConfiguration({
+            runtime: acp,
+            runtimeMode: input.runtimeMode,
+            interactionMode: undefined,
+            modelSelection: antigravityModelSelection,
+            mapError: ({ cause, method }) =>
+              mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+          });
+
+          const now = yield* nowIso;
+          const session: ProviderSession = {
+            provider: PROVIDER,
+            providerInstanceId: boundInstanceId,
+            status: "ready",
+            runtimeMode: input.runtimeMode,
+            cwd,
+            model: antigravityModelSelection?.model,
+            threadId: input.threadId,
+            resumeCursor: {
+              schemaVersion: ANTIGRAVITY_RESUME_VERSION,
+              sessionId: started.sessionId,
+            },
+            createdAt: now,
+            updatedAt: now,
+          };
+
+          ctx = {
+            threadId: input.threadId,
+            session,
+            scope: sessionScope,
+            acp,
+            notificationFiber: undefined,
+            pendingApprovals,
+            pendingUserInputs,
+            turns: [],
+            lastPlanFingerprint: undefined,
+            activeTurnId: undefined,
+            promptsInFlight: 0,
+            stopped: false,
+          };
+
+          const nf = yield* Stream.runDrain(
+            Stream.mapEffect(acp.getEvents(), (event) =>
+              Effect.gen(function* () {
+                switch (event._tag) {
+                  case "EventStreamBarrier":
+                    yield* Deferred.succeed(event.acknowledge, undefined);
+                    return;
+                  case "ModeChanged":
+                    return;
+                  case "AssistantItemStarted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.started",
+                      }),
+                    );
+                    return;
+                  case "AssistantItemCompleted":
+                    yield* offerRuntimeEvent(
+                      makeAcpAssistantItemEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        itemId: event.itemId,
+                        lifecycle: "item.completed",
+                      }),
+                    );
+                    return;
+                  case "PlanUpdated":
+                    yield* logNative(
+                      ctx.threadId,
+                      "session/update",
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                    );
+                    yield* emitPlanUpdate(
+                      ctx,
+                      event.payload,
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                      "session/update",
+                    );
+                    return;
+                  case "ToolCallUpdated":
+                    yield* logNative(
+                      ctx.threadId,
+                      "session/update",
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                    );
+                    yield* offerRuntimeEvent(
+                      makeAcpToolCallEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        toolCall: event.toolCall,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                  case "ContentDelta":
+                    yield* logNative(
+                      ctx.threadId,
+                      "session/update",
+                      event.rawPayload,
+                      "acp.jsonrpc",
+                    );
+                    yield* offerRuntimeEvent(
+                      makeAcpContentDeltaEvent({
+                        stamp: yield* makeEventStamp(),
+                        provider: PROVIDER,
+                        threadId: ctx.threadId,
+                        turnId: ctx.activeTurnId,
+                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        text: event.text,
+                        rawPayload: event.rawPayload,
+                      }),
+                    );
+                    return;
+                }
+              }),
+            ),
+          ).pipe(
+            Effect.catch((cause) =>
+              Effect.logError("Failed to process Antigravity runtime notification.", { cause }),
+            ),
+            Effect.forkIn(sessionScope),
+          );
+
+          ctx.notificationFiber = nf;
+          sessions.set(input.threadId, ctx);
+          sessionScopeTransferred = true;
+
+          yield* offerRuntimeEvent({
+            type: "session.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { resume: started.initializeResult },
+          });
+          yield* offerRuntimeEvent({
+            type: "session.state.changed",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { state: "ready", reason: "Antigravity ACP session ready" },
+          });
+          yield* offerRuntimeEvent({
+            type: "thread.started",
+            ...(yield* makeEventStamp()),
+            provider: PROVIDER,
+            threadId: input.threadId,
+            payload: { providerThreadId: started.sessionId },
+          });
+
+          return session;
+        }).pipe(Effect.scoped),
+      );
+
+    const sendTurn: AntigravityAdapterShape["sendTurn"] = (input) =>
+      withThreadLock(
+        input.threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(input.threadId);
+          // A sendTurn while a prompt is in flight is a steer: the agent folds
+          // the new prompt into the ongoing work, so the active turn id is
+          // reused instead of opening a new turn.
+          const steeringTurnId = ctx.promptsInFlight > 0 ? ctx.activeTurnId : undefined;
+          const turnId = steeringTurnId ?? TurnId.make(yield* randomUUIDv4);
+          // Count this prompt immediately so a superseded in-flight prompt
+          // resolving from here on does not settle the turn; the matching
+          // decrement is the `ensuring` below.
+          ctx.promptsInFlight += 1;
+
+          return yield* Effect.gen(function* () {
+            const turnModelSelection =
+              input.modelSelection?.instanceId === boundInstanceId
+                ? input.modelSelection
+                : undefined;
+            const model = turnModelSelection?.model ?? ctx.session.model;
+            const resolvedModel = resolveAntigravityAcpBaseModelId(model);
+            yield* applyRequestedSessionConfiguration({
+              runtime: ctx.acp,
+              runtimeMode: ctx.session.runtimeMode,
+              interactionMode: input.interactionMode,
+              modelSelection:
+                model === undefined
+                  ? undefined
+                  : {
+                      model,
+                      options: turnModelSelection?.options,
+                    },
+              mapError: ({ cause, method }) =>
+                mapAcpToAdapterError(PROVIDER, input.threadId, method, cause),
+            });
+            ctx.activeTurnId = turnId;
+            if (steeringTurnId === undefined) {
+              ctx.lastPlanFingerprint = undefined;
+            }
+            ctx.session = {
+              ...ctx.session,
+              activeTurnId: turnId,
+              updatedAt: yield* nowIso,
+            };
+
+            if (steeringTurnId === undefined) {
+              yield* offerRuntimeEvent({
+                type: "turn.started",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: { model: resolvedModel },
+              });
+            }
+
+            const promptParts: Array<EffectAcpSchema.ContentBlock> = [];
+            if (input.input?.trim()) {
+              promptParts.push({ type: "text", text: input.input.trim() });
+            }
+            if (input.attachments && input.attachments.length > 0) {
+              for (const attachment of input.attachments) {
+                const attachmentPath = resolveAttachmentPath({
+                  attachmentsDir: serverConfig.attachmentsDir,
+                  attachment,
+                });
+                if (!attachmentPath) {
+                  return yield* new ProviderAdapterRequestError({
+                    provider: PROVIDER,
+                    method: "session/prompt",
+                    detail: `Invalid attachment id '${attachment.id}'.`,
+                  });
+                }
+                const bytes = yield* fileSystem.readFile(attachmentPath).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new ProviderAdapterRequestError({
+                        provider: PROVIDER,
+                        method: "session/prompt",
+                        detail: cause.message,
+                        cause,
+                      }),
+                  ),
+                );
+                promptParts.push({
+                  type: "image",
+                  data: Buffer.from(bytes).toString("base64"),
+                  mimeType: attachment.mimeType,
+                });
+              }
+            }
+
+            if (promptParts.length === 0) {
+              return yield* new ProviderAdapterValidationError({
+                provider: PROVIDER,
+                operation: "sendTurn",
+                issue: "Turn requires non-empty text or attachments.",
+              });
+            }
+
+            const result = yield* ctx.acp
+              .prompt({
+                prompt: promptParts,
+              })
+              .pipe(
+                Effect.mapError((error) =>
+                  mapAcpToAdapterError(PROVIDER, input.threadId, "session/prompt", error),
+                ),
+              );
+
+            const turnRecord = ctx.turns.find((turn) => turn.id === turnId);
+            if (turnRecord) {
+              turnRecord.items.push({ prompt: promptParts, result });
+            } else {
+              ctx.turns.push({ id: turnId, items: [{ prompt: promptParts, result }] });
+            }
+            ctx.session = {
+              ...ctx.session,
+              activeTurnId: turnId,
+              updatedAt: yield* nowIso,
+              model: resolvedModel,
+            };
+
+            // Only the last remaining prompt settles the turn — a steer-
+            // superseded prompt resolving (usually cancelled) while another is
+            // in flight or pending must leave the merged turn running.
+            if (ctx.promptsInFlight === 1) {
+              yield* offerRuntimeEvent({
+                type: "turn.completed",
+                ...(yield* makeEventStamp()),
+                provider: PROVIDER,
+                threadId: input.threadId,
+                turnId,
+                payload: {
+                  state: result.stopReason === "cancelled" ? "cancelled" : "completed",
+                  stopReason: result.stopReason ?? null,
+                },
+              });
+            }
+
+            return {
+              threadId: input.threadId,
+              turnId,
+              resumeCursor: ctx.session.resumeCursor,
+            };
+          }).pipe(
+            Effect.ensuring(
+              Effect.sync(() => {
+                ctx.promptsInFlight = Math.max(0, ctx.promptsInFlight - 1);
+              }),
+            ),
+          );
+        }),
+      );
+
+    const interruptTurn: AntigravityAdapterShape["interruptTurn"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        yield* settlePendingApprovalsAsCancelled(ctx.pendingApprovals);
+        yield* settlePendingUserInputsAsEmptyAnswers(ctx.pendingUserInputs);
+        yield* Effect.ignore(
+          ctx.acp.cancel.pipe(
+            Effect.mapError((error) =>
+              mapAcpToAdapterError(PROVIDER, threadId, "session/cancel", error),
+            ),
+          ),
+        );
+      });
+
+    const respondToRequest: AntigravityAdapterShape["respondToRequest"] = (
+      threadId,
+      requestId,
+      decision,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingApprovals.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "session/request_permission",
+            detail: `Unknown pending approval request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.decision, decision);
+      });
+
+    const respondToUserInput: AntigravityAdapterShape["respondToUserInput"] = (
+      threadId,
+      requestId,
+      answers,
+    ) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        const pending = ctx.pendingUserInputs.get(requestId);
+        if (!pending) {
+          return yield* new ProviderAdapterRequestError({
+            provider: PROVIDER,
+            method: "antigravity/ask_question",
+            detail: `Unknown pending user-input request: ${requestId}`,
+          });
+        }
+        yield* Deferred.succeed(pending.answers, answers);
+      });
+
+    const readThread: AntigravityAdapterShape["readThread"] = (threadId) =>
+      Effect.gen(function* () {
+        const ctx = yield* requireSession(threadId);
+        return { threadId, turns: ctx.turns };
+      });
+
+    const rollbackThread: AntigravityAdapterShape["rollbackThread"] = (threadId, numTurns) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          if (ctx.promptsInFlight > 0) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "rollbackThread",
+              issue: "Cannot rollback thread while a turn is in flight.",
+            });
+          }
+          if (!Number.isInteger(numTurns) || numTurns < 1) {
+            return yield* new ProviderAdapterValidationError({
+              provider: PROVIDER,
+              operation: "rollbackThread",
+              issue: "numTurns must be an integer >= 1.",
+            });
+          }
+          const nextLength = Math.max(0, ctx.turns.length - numTurns);
+          ctx.turns.splice(nextLength);
+          return { threadId, turns: ctx.turns };
+        }),
+      );
+
+    const stopSession: AntigravityAdapterShape["stopSession"] = (threadId) =>
+      withThreadLock(
+        threadId,
+        Effect.gen(function* () {
+          const ctx = yield* requireSession(threadId);
+          yield* stopSessionInternal(ctx);
+        }),
+      );
+
+    const listSessions: AntigravityAdapterShape["listSessions"] = () =>
+      Effect.sync(() => Array.from(sessions.values(), (c) => ({ ...c.session })));
+
+    const hasSession: AntigravityAdapterShape["hasSession"] = (threadId) =>
+      Effect.sync(() => {
+        const c = sessions.get(threadId);
+        return c !== undefined && !c.stopped;
+      });
+
+    const stopAll: AntigravityAdapterShape["stopAll"] = () =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true });
+
+    yield* Effect.addFinalizer(() =>
+      Effect.forEach(sessions.values(), stopSessionInternal, { discard: true }).pipe(
+        Effect.catch((cause) =>
+          Effect.logError("Failed to emit Antigravity session shutdown event.", { cause }),
+        ),
+        Effect.tap(() => PubSub.shutdown(runtimeEventPubSub)),
+        Effect.tap(() => managedNativeEventLogger?.close() ?? Effect.void),
+      ),
+    );
+
+    const streamEvents = Stream.fromPubSub(runtimeEventPubSub);
+
+    return {
+      provider: PROVIDER,
+      capabilities: { sessionModelSwitch: "in-session" },
+      startSession,
+      sendTurn,
+      interruptTurn,
+      readThread,
+      rollbackThread,
+      respondToRequest,
+      respondToUserInput,
+      stopSession,
+      listSessions,
+      hasSession,
+      stopAll,
+      streamEvents,
+    } satisfies AntigravityAdapterShape;
+  });
+}

--- a/apps/server/src/provider/Layers/AntigravityProvider.ts
+++ b/apps/server/src/provider/Layers/AntigravityProvider.ts
@@ -1,0 +1,305 @@
+import {
+  type AntigravitySettings,
+  type ModelCapabilities,
+  ProviderDriverKind,
+  type ServerProvider,
+  type ServerProviderModel,
+} from "@t3tools/contracts";
+import { causeErrorTag } from "@t3tools/shared/observability";
+import * as DateTime from "effect/DateTime";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
+import { HttpClient } from "effect/unstable/http";
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
+import { createModelCapabilities } from "@t3tools/shared/model";
+import { resolveSpawnCommand } from "@t3tools/shared/shell";
+
+import {
+  buildServerProvider,
+  isCommandMissingCause,
+  parseGenericCliVersion,
+  providerModelsFromSettings,
+  spawnAndCollect,
+  type ServerProviderDraft,
+} from "../providerSnapshot.ts";
+import {
+  enrichProviderSnapshotWithVersionAdvisory,
+  type ProviderMaintenanceCapabilities,
+} from "../providerMaintenance.ts";
+
+const ANTIGRAVITY_PRESENTATION = {
+  displayName: "Google Antigravity",
+  badgeLabel: "Ultra",
+  showInteractionModeToggle: false,
+  requiresNewThreadForModelChange: true,
+} as const;
+
+const PROVIDER = ProviderDriverKind.make("antigravity");
+const EMPTY_CAPABILITIES: ModelCapabilities = createModelCapabilities({
+  optionDescriptors: [],
+});
+
+const VERSION_PROBE_TIMEOUT_MS = 4_000;
+const AUTH_PROBE_TIMEOUT_MS = 4_000;
+
+const ANTIGRAVITY_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
+  {
+    slug: "auto",
+    name: "Auto (Agy Default)",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "gemini-1.5-pro",
+    name: "Gemini 1.5 Pro",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+  {
+    slug: "gemini-1.5-flash",
+    name: "Gemini 1.5 Flash",
+    isCustom: false,
+    capabilities: EMPTY_CAPABILITIES,
+  },
+];
+
+export function buildInitialAntigravityProviderSnapshot(
+  settings: AntigravitySettings,
+): Effect.Effect<ServerProviderDraft> {
+  return Effect.gen(function* () {
+    const checkedAt = yield* Effect.map(DateTime.now, DateTime.formatIso);
+    const models = antigravityModelsFromSettings(settings.customModels);
+
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    return buildServerProvider({
+      presentation: ANTIGRAVITY_PRESENTATION,
+      enabled: true,
+      checkedAt,
+      models,
+      probe: {
+        installed: true,
+        version: null,
+        status: "warning",
+        auth: { status: "unknown" },
+        message: "Checking Google Antigravity CLI availability...",
+      },
+    });
+  });
+}
+
+function antigravityModelsFromSettings(
+  customModels: ReadonlyArray<string> | undefined,
+  builtInModels: ReadonlyArray<ServerProviderModel> = ANTIGRAVITY_BUILT_IN_MODELS,
+): ReadonlyArray<ServerProviderModel> {
+  return providerModelsFromSettings(
+    builtInModels,
+    PROVIDER,
+    customModels ?? [],
+    EMPTY_CAPABILITIES,
+  );
+}
+
+const runAntigravityVersionCommand = (
+  settings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const command = settings.binaryPath || "agy";
+    const spawnCommand = yield* resolveSpawnCommand(command, ["--version"], {
+      env: environment,
+    });
+    return yield* spawnAndCollect(
+      command,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env: environment,
+        shell: spawnCommand.shell,
+      }),
+    );
+  });
+
+const runAntigravityAuthStatusCommand = (
+  settings: AntigravitySettings,
+  environment: NodeJS.ProcessEnv = process.env,
+) =>
+  Effect.gen(function* () {
+    const command = settings.binaryPath || "agy";
+    const spawnCommand = yield* resolveSpawnCommand(command, ["auth", "status"], {
+      env: environment,
+    });
+    return yield* spawnAndCollect(
+      command,
+      ChildProcess.make(spawnCommand.command, spawnCommand.args, {
+        env: environment,
+        shell: spawnCommand.shell,
+      }),
+    );
+  });
+
+export const checkAntigravityProviderStatus = Effect.fn("checkAntigravityProviderStatus")(
+  function* (
+    settings: AntigravitySettings,
+    environment: NodeJS.ProcessEnv = process.env,
+  ): Effect.fn.Return<ServerProviderDraft, never, ChildProcessSpawner.ChildProcessSpawner> {
+    const checkedAt = DateTime.formatIso(yield* DateTime.now);
+    const fallbackModels = antigravityModelsFromSettings(settings.customModels);
+
+    if (!settings.enabled) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: false,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: false,
+          version: null,
+          status: "warning",
+          auth: { status: "unknown" },
+          message: "Antigravity is disabled in T3 Code settings.",
+        },
+      });
+    }
+
+    const versionResult = yield* runAntigravityVersionCommand(settings, environment).pipe(
+      Effect.timeoutOption(VERSION_PROBE_TIMEOUT_MS),
+      Effect.result,
+    );
+
+    if (Result.isFailure(versionResult)) {
+      const error = versionResult.failure;
+      yield* Effect.logWarning("Antigravity CLI health check failed.", {
+        errorTag: error._tag,
+      });
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: !isCommandMissingCause(error),
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: isCommandMissingCause(error)
+            ? "Antigravity CLI (`agy`) is not installed or not on PATH."
+            : "Failed to execute Antigravity CLI health check.",
+        },
+      });
+    }
+
+    if (Option.isNone(versionResult.success)) {
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version: null,
+          status: "error",
+          auth: { status: "unknown" },
+          message: "Antigravity CLI is installed but timed out while running `agy --version`.",
+        },
+      });
+    }
+
+    const versionOutput = versionResult.success.value;
+    const version = parseGenericCliVersion(`${versionOutput.stdout}\n${versionOutput.stderr}`);
+    if (versionOutput.code !== 0) {
+      yield* Effect.logWarning("Antigravity CLI version probe exited with a non-zero status.", {
+        exitCode: versionOutput.code,
+        stdoutLength: versionOutput.stdout.length,
+        stderrLength: versionOutput.stderr.length,
+      });
+      return buildServerProvider({
+        presentation: ANTIGRAVITY_PRESENTATION,
+        enabled: settings.enabled,
+        checkedAt,
+        models: fallbackModels,
+        probe: {
+          installed: true,
+          version,
+          status: "error",
+          auth: { status: "unknown" },
+          message: "Antigravity CLI is installed but failed to run.",
+        },
+      });
+    }
+
+    const authResult = yield* runAntigravityAuthStatusCommand(settings, environment).pipe(
+      Effect.timeoutOption(AUTH_PROBE_TIMEOUT_MS),
+      Effect.result,
+    );
+
+    let authStatus: "unknown" | "unauthenticated" | "authenticated" = "unknown";
+    let message: string | undefined = undefined;
+    let status: "ready" | "error" | "warning" = "ready";
+
+    if (Result.isSuccess(authResult) && Option.isSome(authResult.success)) {
+      const authOutput = authResult.success.value;
+      if (authOutput.code === 0 && authOutput.stdout.includes("Logged in")) {
+        authStatus = "authenticated";
+      } else {
+        authStatus = "unauthenticated";
+        status = "warning";
+        message = "You must log in to Google Antigravity. Run `agy auth login` in your terminal.";
+      }
+    } else {
+      authStatus = "unauthenticated";
+      status = "warning";
+      message = "Failed to check Antigravity auth status. Run `agy auth login` in your terminal.";
+    }
+
+    return buildServerProvider({
+      presentation: ANTIGRAVITY_PRESENTATION,
+      enabled: settings.enabled,
+      checkedAt,
+      models: fallbackModels,
+      probe: {
+        installed: true,
+        version,
+        status,
+        auth: { status: authStatus },
+        ...(message ? { message } : {}),
+      },
+    });
+  },
+);
+
+export const enrichAntigravitySnapshot = (input: {
+  readonly snapshot: ServerProvider;
+  readonly maintenanceCapabilities: ProviderMaintenanceCapabilities;
+  readonly enableProviderUpdateChecks?: boolean;
+  readonly publishSnapshot: (snapshot: ServerProvider) => Effect.Effect<void>;
+  readonly httpClient: HttpClient.HttpClient;
+}): Effect.Effect<void> => {
+  const { snapshot, publishSnapshot } = input;
+
+  return enrichProviderSnapshotWithVersionAdvisory(snapshot, input.maintenanceCapabilities, {
+    enableProviderUpdateChecks: input.enableProviderUpdateChecks,
+  }).pipe(
+    Effect.provideService(HttpClient.HttpClient, input.httpClient),
+    Effect.flatMap((enrichedSnapshot) => publishSnapshot(enrichedSnapshot)),
+    Effect.catchCause((cause) =>
+      Effect.logWarning("Antigravity version advisory enrichment failed", {
+        errorTag: causeErrorTag(cause),
+      }),
+    ),
+    Effect.asVoid,
+  );
+};

--- a/apps/server/src/provider/Services/AntigravityAdapter.ts
+++ b/apps/server/src/provider/Services/AntigravityAdapter.ts
@@ -1,0 +1,19 @@
+/**
+ * AntigravityAdapter — shape type for the Antigravity provider adapter.
+ *
+ * Historically this module exposed a `Context.Service` tag so consumers
+ * could inject the adapter through the Effect layer graph. The driver
+ * model ({@link ../Drivers/AntigravityDriver}) bundles one adapter per
+ * instance as a captured closure instead, so the tag is gone — we only
+ * retain the shape interface as a naming anchor for the driver bundle.
+ *
+ * @module AntigravityAdapter
+ */
+import type { ProviderAdapterError } from "../Errors.ts";
+import type { ProviderAdapterShape } from "./ProviderAdapter.ts";
+
+/**
+ * AntigravityAdapterShape — per-instance Antigravity adapter contract. Carries
+ * a branded driver kind as the nominal discriminant.
+ */
+export interface AntigravityAdapterShape extends ProviderAdapterShape<ProviderAdapterError> {}

--- a/apps/server/src/provider/acp/AntigravityAcpSupport.ts
+++ b/apps/server/src/provider/acp/AntigravityAcpSupport.ts
@@ -1,0 +1,107 @@
+import {
+  type AntigravitySettings,
+  type ProviderOptionSelection,
+  ProviderDriverKind,
+} from "@t3tools/contracts";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+import type * as EffectAcpErrors from "effect-acp/errors";
+import { normalizeModelSlug } from "@t3tools/shared/model";
+
+import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
+
+type AntigravityAcpRuntimeAntigravitySettings = Pick<AntigravitySettings, "binaryPath">;
+
+export interface AntigravityAcpRuntimeInput extends Omit<
+  AcpSessionRuntime.AcpSessionRuntimeOptions,
+  "authMethodId" | "clientCapabilities" | "spawn"
+> {
+  readonly childProcessSpawner: ChildProcessSpawner.ChildProcessSpawner["Service"];
+  readonly antigravitySettings: AntigravityAcpRuntimeAntigravitySettings | null | undefined;
+  readonly environment?: NodeJS.ProcessEnv;
+}
+
+export interface AntigravityAcpModelSelectionErrorContext {
+  readonly cause: EffectAcpErrors.AcpError;
+  readonly step: "set-config-option" | "set-model";
+  readonly configId?: string;
+}
+
+export function buildAntigravityAcpSpawnInput(
+  antigravitySettings: AntigravityAcpRuntimeAntigravitySettings | null | undefined,
+  cwd: string,
+  environment?: NodeJS.ProcessEnv,
+): AcpSessionRuntime.AcpSpawnInput {
+  return {
+    command: antigravitySettings?.binaryPath || "agy",
+    args: ["acp"],
+    cwd,
+    ...(environment ? { env: environment } : {}),
+  };
+}
+
+export const makeAntigravityAcpRuntime = (
+  input: AntigravityAcpRuntimeInput,
+): Effect.Effect<
+  AcpSessionRuntime.AcpSessionRuntime["Service"],
+  EffectAcpErrors.AcpError,
+  Scope.Scope
+> =>
+  Effect.gen(function* () {
+    const acpContext = yield* Layer.build(
+      AcpSessionRuntime.layer({
+        ...input,
+        spawn: buildAntigravityAcpSpawnInput(
+          input.antigravitySettings,
+          input.cwd,
+          input.environment,
+        ),
+        authMethodId: "antigravity_login",
+        clientCapabilities: {},
+      }).pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
+        ),
+      ),
+    );
+    return yield* Effect.service(AcpSessionRuntime.AcpSessionRuntime).pipe(
+      Effect.provide(acpContext),
+    );
+  });
+
+interface AntigravityAcpModelSelectionRuntime {
+  readonly getConfigOptions: AcpSessionRuntime.AcpSessionRuntime["Service"]["getConfigOptions"];
+  readonly setConfigOption: (
+    configId: string,
+    value: string | boolean,
+  ) => Effect.Effect<unknown, EffectAcpErrors.AcpError>;
+  readonly setModel: (model: string) => Effect.Effect<unknown, EffectAcpErrors.AcpError>;
+}
+
+export function applyAntigravityAcpModelSelection<E>(input: {
+  readonly runtime: AntigravityAcpModelSelectionRuntime;
+  readonly model: string | null | undefined;
+  readonly selections: ReadonlyArray<ProviderOptionSelection> | null | undefined;
+  readonly mapError: (context: AntigravityAcpModelSelectionErrorContext) => E;
+}): Effect.Effect<void, E> {
+  return Effect.gen(function* () {
+    if (input.model && input.model !== "auto") {
+      yield* input.runtime.setModel(input.model).pipe(
+        Effect.mapError((cause) =>
+          input.mapError({
+            cause,
+            step: "set-model",
+          }),
+        ),
+      );
+    }
+  });
+}
+
+export function resolveAntigravityAcpBaseModelId(model: string | null | undefined): string {
+  const trimmed = model?.trim();
+  const base = trimmed && trimmed.length > 0 ? trimmed : "gemini-1.5-flash";
+  return normalizeModelSlug(base, ProviderDriverKind.make("antigravity")) ?? "gemini-1.5-flash";
+}

--- a/apps/server/src/provider/builtInDrivers.ts
+++ b/apps/server/src/provider/builtInDrivers.ts
@@ -24,6 +24,7 @@ import { ClaudeDriver, type ClaudeDriverEnv } from "./Drivers/ClaudeDriver.ts";
 import { CodexDriver, type CodexDriverEnv } from "./Drivers/CodexDriver.ts";
 import { CursorDriver, type CursorDriverEnv } from "./Drivers/CursorDriver.ts";
 import { GrokDriver, type GrokDriverEnv } from "./Drivers/GrokDriver.ts";
+import { AntigravityDriver, type AntigravityDriverEnv } from "./Drivers/AntigravityDriver.ts";
 import { OpenCodeDriver, type OpenCodeDriverEnv } from "./Drivers/OpenCodeDriver.ts";
 import type { AnyProviderDriver } from "./ProviderDriver.ts";
 
@@ -37,6 +38,7 @@ export type BuiltInDriversEnv =
   | CodexDriverEnv
   | CursorDriverEnv
   | GrokDriverEnv
+  | AntigravityDriverEnv
   | OpenCodeDriverEnv;
 
 /**
@@ -49,5 +51,6 @@ export const BUILT_IN_DRIVERS: ReadonlyArray<AnyProviderDriver<BuiltInDriversEnv
   ClaudeDriver,
   CursorDriver,
   GrokDriver,
+  AntigravityDriver,
   OpenCodeDriver,
 ];

--- a/apps/server/src/textGeneration/AntigravityTextGeneration.ts
+++ b/apps/server/src/textGeneration/AntigravityTextGeneration.ts
@@ -1,0 +1,262 @@
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
+import * as Schema from "effect/Schema";
+import { ChildProcessSpawner } from "effect/unstable/process";
+
+import { type AntigravitySettings, type ModelSelection } from "@t3tools/contracts";
+import { sanitizeBranchFragment, sanitizeFeatureBranchName } from "@t3tools/shared/git";
+import { extractJsonObject } from "@t3tools/shared/schemaJson";
+
+import { TextGenerationError } from "@t3tools/contracts";
+import * as TextGeneration from "./TextGeneration.ts";
+import {
+  buildBranchNamePrompt,
+  buildCommitMessagePrompt,
+  buildPrContentPrompt,
+  buildThreadTitlePrompt,
+} from "./TextGenerationPrompts.ts";
+import {
+  sanitizeCommitSubject,
+  sanitizePrTitle,
+  sanitizeThreadTitle,
+} from "./TextGenerationUtils.ts";
+import {
+  applyAntigravityAcpModelSelection,
+  makeAntigravityAcpRuntime,
+} from "../provider/acp/AntigravityAcpSupport.ts";
+
+const ANTIGRAVITY_TIMEOUT_MS = 180_000;
+
+const isTextGenerationError = Schema.is(TextGenerationError);
+
+/**
+ * Build a Antigravity text-generation closure bound to a specific `AntigravitySettings`
+ * payload. See `makeCodexAdapter` for the overall per-instance rationale.
+ */
+export const makeAntigravityTextGeneration = Effect.fn("makeAntigravityTextGeneration")(function* (
+  antigravitySettings: AntigravitySettings,
+  environment?: NodeJS.ProcessEnv,
+) {
+  const commandSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
+  const resolvedEnvironment = environment ?? process.env;
+
+  const runAntigravityJson = <S extends Schema.Top>({
+    operation,
+    cwd,
+    prompt,
+    outputSchemaJson,
+    modelSelection,
+  }: {
+    operation:
+      | "generateCommitMessage"
+      | "generatePrContent"
+      | "generateBranchName"
+      | "generateThreadTitle";
+    cwd: string;
+    prompt: string;
+    outputSchemaJson: S;
+    modelSelection: ModelSelection;
+  }): Effect.Effect<S["Type"], TextGenerationError, S["DecodingServices"]> =>
+    Effect.gen(function* () {
+      const outputRef = yield* Ref.make("");
+      const runtime = yield* makeAntigravityAcpRuntime({
+        antigravitySettings,
+        environment: resolvedEnvironment,
+        childProcessSpawner: commandSpawner,
+        cwd,
+        clientInfo: { name: "t3-code-git-text", version: "0.0.0" },
+      });
+
+      yield* runtime.handleSessionUpdate((notification) => {
+        const update = notification.update;
+        if (update.sessionUpdate !== "agent_message_chunk") {
+          return Effect.void;
+        }
+        const content = update.content;
+        if (content.type !== "text") {
+          return Effect.void;
+        }
+        return Ref.update(outputRef, (current) => current + content.text);
+      });
+
+      const promptResult = yield* Effect.gen(function* () {
+        yield* runtime.start();
+        yield* Effect.ignore(runtime.setMode("ask"));
+        yield* applyAntigravityAcpModelSelection({
+          runtime,
+          model: modelSelection.model,
+          selections: modelSelection.options,
+          mapError: ({ cause, configId, step }) =>
+            new TextGenerationError({
+              operation,
+              detail:
+                step === "set-config-option"
+                  ? `Failed to set Antigravity ACP config option "${configId}" for text generation.`
+                  : "Failed to set Antigravity ACP base model for text generation.",
+              cause,
+            }),
+        });
+
+        return yield* runtime.prompt({
+          prompt: [{ type: "text", text: prompt }],
+        });
+      }).pipe(
+        Effect.timeoutOption(ANTIGRAVITY_TIMEOUT_MS),
+        Effect.flatMap(
+          Option.match({
+            onNone: () =>
+              Effect.fail(
+                new TextGenerationError({
+                  operation,
+                  detail: "Antigravity Agent request timed out.",
+                }),
+              ),
+            onSome: (value) => Effect.succeed(value),
+          }),
+        ),
+        Effect.mapError((cause) =>
+          isTextGenerationError(cause)
+            ? cause
+            : new TextGenerationError({
+                operation,
+                detail: "Antigravity ACP request failed.",
+                cause,
+              }),
+        ),
+      );
+
+      const rawResult = (yield* Ref.get(outputRef)).trim();
+      if (!rawResult) {
+        return yield* new TextGenerationError({
+          operation,
+          detail:
+            promptResult.stopReason === "cancelled"
+              ? "Antigravity ACP request was cancelled."
+              : "Antigravity Agent returned empty output.",
+        });
+      }
+
+      const decodeOutput = Schema.decodeEffect(Schema.fromJsonString(outputSchemaJson));
+      return yield* decodeOutput(extractJsonObject(rawResult)).pipe(
+        Effect.catchTags({
+          SchemaError: (cause) =>
+            Effect.fail(
+              new TextGenerationError({
+                operation,
+                detail: "Antigravity Agent returned invalid structured output.",
+                cause,
+              }),
+            ),
+        }),
+      );
+    }).pipe(
+      Effect.mapError((cause) =>
+        isTextGenerationError(cause)
+          ? cause
+          : new TextGenerationError({
+              operation,
+              detail: "Antigravity ACP text generation failed.",
+              cause,
+            }),
+      ),
+      Effect.scoped,
+    );
+
+  const generateCommitMessage: TextGeneration.TextGeneration["Service"]["generateCommitMessage"] =
+    Effect.fn("AntigravityTextGeneration.generateCommitMessage")(function* (input) {
+      const { prompt, outputSchema } = buildCommitMessagePrompt({
+        branch: input.branch,
+        stagedSummary: input.stagedSummary,
+        stagedPatch: input.stagedPatch,
+        includeBranch: input.includeBranch === true,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateCommitMessage",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        subject: sanitizeCommitSubject(generated.subject),
+        body: generated.body.trim(),
+        ...("branch" in generated && typeof generated.branch === "string"
+          ? { branch: sanitizeFeatureBranchName(generated.branch) }
+          : {}),
+      };
+    });
+
+  const generatePrContent: TextGeneration.TextGeneration["Service"]["generatePrContent"] =
+    Effect.fn("AntigravityTextGeneration.generatePrContent")(function* (input) {
+      const { prompt, outputSchema } = buildPrContentPrompt({
+        baseBranch: input.baseBranch,
+        headBranch: input.headBranch,
+        commitSummary: input.commitSummary,
+        diffSummary: input.diffSummary,
+        diffPatch: input.diffPatch,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generatePrContent",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizePrTitle(generated.title),
+        body: generated.body.trim(),
+      };
+    });
+
+  const generateBranchName: TextGeneration.TextGeneration["Service"]["generateBranchName"] =
+    Effect.fn("AntigravityTextGeneration.generateBranchName")(function* (input) {
+      const { prompt, outputSchema } = buildBranchNamePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateBranchName",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        branch: sanitizeBranchFragment(generated.branch),
+      };
+    });
+
+  const generateThreadTitle: TextGeneration.TextGeneration["Service"]["generateThreadTitle"] =
+    Effect.fn("AntigravityTextGeneration.generateThreadTitle")(function* (input) {
+      const { prompt, outputSchema } = buildThreadTitlePrompt({
+        message: input.message,
+        attachments: input.attachments,
+      });
+
+      const generated = yield* runAntigravityJson({
+        operation: "generateThreadTitle",
+        cwd: input.cwd,
+        prompt,
+        outputSchemaJson: outputSchema,
+        modelSelection: input.modelSelection,
+      });
+
+      return {
+        title: sanitizeThreadTitle(generated.title),
+      } satisfies TextGeneration.ThreadTitleGenerationResult;
+    });
+
+  return {
+    generateCommitMessage,
+    generatePrContent,
+    generateBranchName,
+    generateThreadTitle,
+  } satisfies TextGeneration.TextGeneration["Service"];
+});

--- a/apps/web/src/components/chat/providerIconUtils.ts
+++ b/apps/web/src/components/chat/providerIconUtils.ts
@@ -1,5 +1,5 @@
 import { ProviderDriverKind } from "@t3tools/contracts";
-import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, Icon, OpenAI, OpenCodeIcon, Gemini } from "../Icons";
 import { PROVIDER_OPTIONS } from "../../session-logic";
 
 export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>> = {
@@ -8,6 +8,7 @@ export const PROVIDER_ICON_BY_PROVIDER: Partial<Record<ProviderDriverKind, Icon>
   [ProviderDriverKind.make("opencode")]: OpenCodeIcon,
   [ProviderDriverKind.make("cursor")]: CursorIcon,
   [ProviderDriverKind.make("grok")]: GrokIcon,
+  [ProviderDriverKind.make("antigravity")]: Gemini,
 };
 
 function isAvailableProviderOption(option: (typeof PROVIDER_OPTIONS)[number]): option is {

--- a/apps/web/src/components/settings/providerDriverMeta.ts
+++ b/apps/web/src/components/settings/providerDriverMeta.ts
@@ -4,10 +4,11 @@ import {
   CursorSettings,
   GrokSettings,
   OpenCodeSettings,
+  AntigravitySettings,
   ProviderDriverKind,
 } from "@t3tools/contracts";
 import type * as Schema from "effect/Schema";
-import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon } from "../Icons";
+import { ClaudeAI, CursorIcon, GrokIcon, type Icon, OpenAI, OpenCodeIcon, Gemini } from "../Icons";
 
 type ProviderSettingsSchema = {
   readonly fields: Readonly<Record<string, Schema.Top>>;
@@ -60,6 +61,12 @@ export const PROVIDER_CLIENT_DEFINITIONS: readonly ProviderClientDefinition[] = 
     icon: GrokIcon,
     badgeLabel: "Early Access",
     settingsSchema: GrokSettings,
+  },
+  {
+    value: ProviderDriverKind.make("antigravity"),
+    label: "Google Antigravity",
+    icon: Gemini,
+    settingsSchema: AntigravitySettings,
   },
   {
     value: ProviderDriverKind.make("opencode"),

--- a/apps/web/src/session-logic.ts
+++ b/apps/web/src/session-logic.ts
@@ -51,6 +51,12 @@ export const PROVIDER_OPTIONS: Array<{
     available: true,
     pickerSidebarBadge: "new",
   },
+  {
+    value: ProviderDriverKind.make("antigravity"),
+    label: "Google Antigravity",
+    available: true,
+    pickerSidebarBadge: "new",
+  },
 ];
 
 export type WorkLogToolLifecycleStatus =

--- a/docs/solutions/architecture-patterns/adding-new-provider-integration.md
+++ b/docs/solutions/architecture-patterns/adding-new-provider-integration.md
@@ -1,0 +1,63 @@
+---
+title: Adding a New Provider Integration (e.g., Google Antigravity)
+date: 2026-07-08
+category: architecture-patterns
+module: provider-integration
+problem_type: architecture_pattern
+component: tooling
+severity: medium
+applies_when:
+  - "Integrating a new external AI provider, CLI tool, or Model Context Protocol (MCP) runtime"
+tags:
+  - provider-integration
+  - architecture
+  - mcp
+  - cli-adapter
+---
+
+# Adding a New Provider Integration (e.g., Google Antigravity)
+
+## Context
+
+The T3 Code application required integration with the Google Antigravity (`agy`) provider. This involved bridging the gap between the application's internal architecture (Contracts, Backend Driver & Adapter Infrastructure, Web UI) and the external `agy` CLI for authentication, model generation, and ACP (Agent Context Protocol) session orchestration. Additionally, the integration needed to handle strict concurrency requirements and thread locking constraints when orchestrating interactions between the CLI runtime and the application.
+
+## Guidance
+
+When adding a new CLI-based provider to the T3 Code architecture, follow a strict multi-layered implementation pattern:
+
+1. **Contracts & Schemas (`packages/contracts`)**:
+   - Register the provider's unique identifier using the branded type `ProviderDriverKind.make("<provider-name>")`.
+   - Define the configurable settings schema (e.g., `AntigravitySettings`).
+   - Expose the provider name in `PROVIDER_DISPLAY_NAMES`.
+
+2. **Backend Infrastructure (`apps/server`)**:
+   - **Provider**: Implement health and authentication checks (e.g., `AntigravityProvider.ts` calling `agy auth status`).
+   - **Adapter**: Implement the `AcpSessionRuntime` (e.g., `AntigravityAdapter.ts`) to orchestrate interactions between the CLI runtime and the app. Carefully orchestrate interactions and enforce strict concurrency safety/thread locking when spawning and managing the CLI process (e.g., `agy mcp`).
+   - **Text Generation**: Bridge stateless model generation calls to the CLI (e.g., `AntigravityTextGeneration.ts` via `agy --headless`).
+   - **Driver**: Hook up the components in a driver factory (e.g., `AntigravityDriver.ts`) and register it in `builtInDrivers.ts`.
+
+3. **Frontend Plumbing (`apps/web`)**:
+   - Register the provider in `PROVIDER_CLIENT_DEFINITIONS` so it appears in the Settings UI and model selectors.
+   - Add the necessary iconography in `PROVIDER_ICON_BY_PROVIDER` (e.g., inside `providerIconUtils.ts`) for chat rendering. Ensure proper model slug normalization (e.g., `resolveAntigravityAcpBaseModelId`).
+
+## Why This Matters
+
+Following this layered architecture ensures that the application remains modular, type-safe, and decoupled from the specific implementation details of the CLI tool. Correctly applying the `ProviderDriverKind` branded type prevents cross-package typecheck failures. Moreover, enforcing strict concurrency safety within the Adapter layer prevents race conditions and crashes during active ACP sessions. Failing to implement health checks in the Provider layer or mismanaging the CLI subprocesses can lead to orphaned processes, silent failures, and a degraded user experience.
+
+## When to Apply
+
+- "Integrating a new external AI provider, CLI tool, or Model Context Protocol (MCP) runtime"
+- When the provider requires maintaining a persistent session or subprocess (like ACP) alongside stateless text generation calls.
+
+## Examples
+
+**Backend Wire-up (Driver):**
+Create an `AntigravityDriver` that encapsulates the dependencies:
+
+- Connects `AntigravityProvider` for health checks.
+- Instantiates `AntigravityAdapter` for orchestrating the persistent `agy mcp` session.
+- Plugs in `AntigravityTextGeneration` for stateless `agy --headless` calls.
+  Register this driver in `apps/server/src/provider/builtInDrivers.ts`.
+
+**Contract Branding:**
+Using `ProviderDriverKind.make("antigravity")` to ensure the provider key is strictly typed across all boundaries.

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -132,6 +132,7 @@ const CLAUDE_DRIVER_KIND = ProviderDriverKind.make("claudeAgent");
 const CURSOR_DRIVER_KIND = ProviderDriverKind.make("cursor");
 const GROK_DRIVER_KIND = ProviderDriverKind.make("grok");
 const OPENCODE_DRIVER_KIND = ProviderDriverKind.make("opencode");
+const ANTIGRAVITY_DRIVER_KIND = ProviderDriverKind.make("antigravity");
 
 export const DEFAULT_MODEL = "gpt-5.4";
 export const DEFAULT_GIT_TEXT_GENERATION_MODEL = "gpt-5.4-mini";
@@ -142,6 +143,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CURSOR_DRIVER_KIND]: "auto",
   [GROK_DRIVER_KIND]: "grok-build",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ANTIGRAVITY_DRIVER_KIND]: "auto",
 };
 
 /** Per-provider text generation model defaults. */
@@ -152,6 +154,7 @@ export const DEFAULT_GIT_TEXT_GENERATION_MODEL_BY_PROVIDER: Partial<
   [CLAUDE_DRIVER_KIND]: "claude-haiku-4-5",
   [CURSOR_DRIVER_KIND]: "composer-2",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
+  [ANTIGRAVITY_DRIVER_KIND]: "auto",
 };
 
 export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
@@ -198,6 +201,7 @@ export const MODEL_SLUG_ALIASES_BY_PROVIDER: Partial<
     "opus-4.5": "claude-opus-4-5",
   },
   [OPENCODE_DRIVER_KIND]: {},
+  [ANTIGRAVITY_DRIVER_KIND]: {},
 };
 
 // ── Provider display names ────────────────────────────────────────────
@@ -208,4 +212,5 @@ export const PROVIDER_DISPLAY_NAMES: Partial<Record<ProviderDriverKind, string>>
   [CURSOR_DRIVER_KIND]: "Cursor",
   [GROK_DRIVER_KIND]: "Grok",
   [OPENCODE_DRIVER_KIND]: "OpenCode",
+  [ANTIGRAVITY_DRIVER_KIND]: "Google Antigravity",
 };

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -355,6 +355,42 @@ export const OpenCodeSettings = makeProviderSettingsSchema(
 );
 export type OpenCodeSettings = typeof OpenCodeSettings.Type;
 
+export const AntigravitySettings = makeProviderSettingsSchema(
+  {
+    enabled: Schema.Boolean.pipe(
+      Schema.withDecodingDefault(Effect.succeed(false)),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+    binaryPath: makeBinaryPathSetting("agy").pipe(
+      Schema.annotateKey({
+        title: "Binary path",
+        description: "Path to the Google Antigravity (agy) CLI.",
+        providerSettingsForm: { placeholder: "agy", clearWhenEmpty: "omit" },
+      }),
+    ),
+    modelOverride: TrimmedString.pipe(
+      Schema.withDecodingDefault(Effect.succeed("")),
+      Schema.annotateKey({
+        title: "Model override",
+        description:
+          "Optional model name to pass to agy (e.g. gemini-3.5-flash). If blank, defaults to agy's configured model.",
+        providerSettingsForm: {
+          placeholder: "Leave blank for default",
+          clearWhenEmpty: "omit",
+        },
+      }),
+    ),
+    customModels: Schema.Array(Schema.String).pipe(
+      Schema.withDecodingDefault(Effect.succeed([])),
+      Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
+    ),
+  },
+  {
+    order: ["binaryPath", "modelOverride"],
+  },
+);
+export type AntigravitySettings = typeof AntigravitySettings.Type;
+
 export const ObservabilitySettings = Schema.Struct({
   otlpTracesUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
   otlpMetricsUrl: TrimmedString.pipe(Schema.withDecodingDefault(Effect.succeed(""))),
@@ -399,6 +435,7 @@ export const ServerSettings = Schema.Struct({
     cursor: CursorSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     grok: GrokSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
     opencode: OpenCodeSettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
+    antigravity: AntigravitySettings.pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   }).pipe(Schema.withDecodingDefault(Effect.succeed({}))),
   // New driver-agnostic instance map. Keyed by `ProviderInstanceId`; values
   // are `ProviderInstanceConfig` envelopes. The driver-specific config blob
@@ -501,6 +538,13 @@ const OpenCodeSettingsPatch = Schema.Struct({
   customModels: Schema.optionalKey(Schema.Array(Schema.String)),
 });
 
+const AntigravitySettingsPatch = Schema.Struct({
+  enabled: Schema.optionalKey(Schema.Boolean),
+  binaryPath: Schema.optionalKey(TrimmedString),
+  modelOverride: Schema.optionalKey(TrimmedString),
+  customModels: Schema.optionalKey(Schema.Array(Schema.String)),
+});
+
 export const ServerSettingsPatch = Schema.Struct({
   // Server settings
   enableAssistantStreaming: Schema.optionalKey(Schema.Boolean),
@@ -523,6 +567,7 @@ export const ServerSettingsPatch = Schema.Struct({
       cursor: Schema.optionalKey(CursorSettingsPatch),
       grok: Schema.optionalKey(GrokSettingsPatch),
       opencode: Schema.optionalKey(OpenCodeSettingsPatch),
+      antigravity: Schema.optionalKey(AntigravitySettingsPatch),
     }),
   ),
   // Whole-map replacement for the new instance config. Patching individual


### PR DESCRIPTION
## Summary

Introduces the Google Antigravity (`agy`) provider integration to the T3 Code application.
This implementation builds on the standard 3-layer architecture for AI providers.

## Changes
- **Contracts**: Registered `antigravity` provider in model/settings schemas.
- **Server**: Implemented `AntigravityAdapter`, `AntigravityProvider`, `AntigravityDriver`, and `AntigravityTextGeneration`.
- **Web**: Added Gemini icon mapping, settings definitions, and routing integration.
- **Docs**: Captured the integration architecture pattern as a compound solution document under `docs/solutions/architecture-patterns/`.

## Demo
No user-facing UI changes besides the settings panel toggle, which was verified locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium: large new subprocess/ACP session path with thread locking, permission handling, and CLI health/auth probes—failures could affect session reliability or leave misconfigured installs visible as warnings rather than hard errors.
> 
> **Overview**
> Adds **Google Antigravity** (`agy`) as a first-class provider end-to-end: contracts, server driver stack, web picker/settings, and a short architecture doc.
> 
> **Contracts** register `antigravity` with `AntigravitySettings` (binary path, model override, custom models), server settings/patch shapes, and default model maps (`auto`).
> 
> **Server** wires `AntigravityDriver` into `builtInDrivers` with managed snapshots (CLI `--version` / `auth status` probes, `agy update` maintenance), an ACP adapter (`agy acp`) that maps sessions/turns/permissions/plans/tool calls to shared runtime events (including steer semantics via `promptsInFlight`), optional t3-code MCP injection, and `AntigravityTextGeneration` for structured git/thread helpers over ephemeral ACP `ask` sessions. An adapter integration test uses the existing ACP mock agent.
> 
> **Web** exposes Google Antigravity in provider pickers and settings (Gemini icon) with a “new” sidebar badge.
> 
> **Docs** add `docs/solutions/.../adding-new-provider-integration.md` and point `AGENTS.md` at `docs/solutions/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a905c9a800f6d21b26d19d3aadc8b3c29b75790b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Google Antigravity provider integration with ACP session support
> - Adds a new `antigravity` provider driver that spawns `agy acp` to run ACP sessions, streams runtime events, and handles turns with text/image attachments, steering, and cancellation.
> - Implements health checks via `agy --version` and `agy auth status` to detect CLI installation and authentication state, with periodic snapshot enrichment for update advisories.
> - Adds text generation support for commit messages, PR content, branch names, and thread titles via structured JSON decoding over ACP streams.
> - Registers Antigravity in the built-in driver registry, contracts layer (default models, display name), server settings schema, and frontend session/settings UI with the Gemini icon.
> - Defaults the base model to `gemini-1.5-flash` when no model is specified.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a905c9a. 14 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->