### PR TITLE
[codex] Preserve worktree metadata during branch sync

### DIFF
--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -477,6 +477,58 @@ describe("OrchestrationEngine", () => {
     await system.dispose();
   });
 
+  it("does not regress a generated branch to a stale temporary worktree branch", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const createdAt = now();
+
+    await system.run(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.make("cmd-branch-race-project-create"),
+        projectId: asProjectId("project-branch-race"),
+        title: "Branch Race Project",
+        workspaceRoot: "/tmp/project-branch-race",
+        defaultModelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-branch-race-thread-create"),
+        threadId: ThreadId.make("thread-branch-race"),
+        projectId: asProjectId("project-branch-race"),
+        title: "Branch Race Thread",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: "t3code/generated-branch-name",
+        worktreePath: "/tmp/project-branch-race-worktree",
+        createdAt,
+      }),
+    );
+
+    await system.run(
+      engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-stale-temporary-branch-sync"),
+        threadId: ThreadId.make("thread-branch-race"),
+        branch: "t3code/1234abcd",
+      }),
+    );
+
+    const snapshot = await system.readModel();
+    expect(snapshot.threads[0]?.branch).toBe("t3code/generated-branch-name");
+    await system.dispose();
+  });
+
   it("records command ack duration using the first committed event type", async () => {
     const system = await createOrchestrationSystem();
     const { engine } = system;

--- a/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
+++ b/apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts
@@ -521,11 +521,65 @@ describe("OrchestrationEngine", () => {
         commandId: CommandId.make("cmd-stale-temporary-branch-sync"),
         threadId: ThreadId.make("thread-branch-race"),
         branch: "t3code/1234abcd",
+        expectedBranch: "t3code/1234abcd",
       }),
     );
 
     const snapshot = await system.readModel();
     expect(snapshot.threads[0]?.branch).toBe("t3code/generated-branch-name");
+    await system.dispose();
+  });
+
+  it("allows authoritative worktree bootstrap to assign a temporary branch", async () => {
+    const system = await createOrchestrationSystem();
+    const { engine } = system;
+    const createdAt = now();
+
+    await system.run(
+      engine.dispatch({
+        type: "project.create",
+        commandId: CommandId.make("cmd-worktree-bootstrap-project-create"),
+        projectId: asProjectId("project-worktree-bootstrap"),
+        title: "Worktree Bootstrap Project",
+        workspaceRoot: "/tmp/project-worktree-bootstrap",
+        defaultModelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.create",
+        commandId: CommandId.make("cmd-worktree-bootstrap-thread-create"),
+        threadId: ThreadId.make("thread-worktree-bootstrap"),
+        projectId: asProjectId("project-worktree-bootstrap"),
+        title: "Worktree Bootstrap Thread",
+        modelSelection: {
+          instanceId: ProviderInstanceId.make("codex"),
+          model: "gpt-5-codex",
+        },
+        interactionMode: DEFAULT_PROVIDER_INTERACTION_MODE,
+        runtimeMode: "approval-required",
+        branch: "main",
+        worktreePath: null,
+        createdAt,
+      }),
+    );
+    await system.run(
+      engine.dispatch({
+        type: "thread.meta.update",
+        commandId: CommandId.make("cmd-authoritative-worktree-bootstrap"),
+        threadId: ThreadId.make("thread-worktree-bootstrap"),
+        branch: "t3code/1234abcd",
+        worktreePath: "/tmp/project-worktree-bootstrap-worktree",
+      }),
+    );
+
+    const snapshot = await system.readModel();
+    expect(snapshot.threads[0]?.branch).toBe("t3code/1234abcd");
+    expect(snapshot.threads[0]?.worktreePath).toBe("/tmp/project-worktree-bootstrap-worktree");
     await system.dispose();
   });
 

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -4,6 +4,7 @@ import {
   type OrchestrationEvent,
   type OrchestrationReadModel,
 } from "@t3tools/contracts";
+import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 import * as DateTime from "effect/DateTime";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
@@ -313,11 +314,19 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
     }
 
     case "thread.meta.update": {
-      yield* requireThread({
+      const thread = yield* requireThread({
         readModel,
         command,
         threadId: command.threadId,
       });
+      const branch =
+        command.branch !== undefined &&
+        command.branch !== null &&
+        thread.branch !== null &&
+        isTemporaryWorktreeBranch(command.branch) &&
+        !isTemporaryWorktreeBranch(thread.branch)
+          ? thread.branch
+          : command.branch;
       const occurredAt = yield* nowIso;
       return {
         ...(yield* withEventBase({
@@ -333,7 +342,7 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
           ...(command.modelSelection !== undefined
             ? { modelSelection: command.modelSelection }
             : {}),
-          ...(command.branch !== undefined ? { branch: command.branch } : {}),
+          ...(branch !== undefined ? { branch } : {}),
           ...(command.worktreePath !== undefined ? { worktreePath: command.worktreePath } : {}),
           updatedAt: occurredAt,
         },

--- a/apps/server/src/orchestration/decider.ts
+++ b/apps/server/src/orchestration/decider.ts
@@ -4,7 +4,6 @@ import {
   type OrchestrationEvent,
   type OrchestrationReadModel,
 } from "@t3tools/contracts";
-import { isTemporaryWorktreeBranch } from "@t3tools/shared/git";
 import * as DateTime from "effect/DateTime";
 import * as Crypto from "effect/Crypto";
 import * as Effect from "effect/Effect";
@@ -321,10 +320,8 @@ export const decideOrchestrationCommand = Effect.fn("decideOrchestrationCommand"
       });
       const branch =
         command.branch !== undefined &&
-        command.branch !== null &&
-        thread.branch !== null &&
-        isTemporaryWorktreeBranch(command.branch) &&
-        !isTemporaryWorktreeBranch(thread.branch)
+        command.expectedBranch !== undefined &&
+        thread.branch !== command.expectedBranch
           ? thread.branch
           : command.branch;
       const occurredAt = yield* nowIso;

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -1114,9 +1114,13 @@ describe("resolveLiveThreadBranchUpdate", () => {
 
 describe("resolveThreadBranchMetadataPatch", () => {
   it("does not overwrite worktree metadata while reconciling a branch", () => {
-    assert.deepEqual(resolveThreadBranchMetadataPatch("feature/current-ref"), {
-      branch: "feature/current-ref",
-    });
+    assert.deepEqual(
+      resolveThreadBranchMetadataPatch("feature/current-ref", "feature/previous-ref"),
+      {
+        branch: "feature/current-ref",
+        expectedBranch: "feature/previous-ref",
+      },
+    );
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.test.ts
+++ b/apps/web/src/components/GitActionsControl.logic.test.ts
@@ -9,6 +9,7 @@ import {
   resolveLiveThreadBranchUpdate,
   resolveQuickAction,
   resolveThreadBranchUpdate,
+  resolveThreadBranchMetadataPatch,
 } from "./GitActionsControl.logic";
 
 function status(overrides: Partial<VcsStatusResult> = {}): VcsStatusResult {
@@ -1108,6 +1109,14 @@ describe("resolveLiveThreadBranchUpdate", () => {
     });
 
     assert.deepEqual(update, { branch: "feature/diff-panel-toggle" });
+  });
+});
+
+describe("resolveThreadBranchMetadataPatch", () => {
+  it("does not overwrite worktree metadata while reconciling a branch", () => {
+    assert.deepEqual(resolveThreadBranchMetadataPatch("feature/current-ref"), {
+      branch: "feature/current-ref",
+    });
   });
 });
 

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -373,10 +373,14 @@ export function resolveThreadBranchUpdate(
   };
 }
 
-export function resolveThreadBranchMetadataPatch(branch: string | null): {
+export function resolveThreadBranchMetadataPatch(
+  branch: string | null,
+  expectedBranch: string | null,
+): {
   branch: string | null;
+  expectedBranch: string | null;
 } {
-  return { branch };
+  return { branch, expectedBranch };
 }
 
 export function resolveLiveThreadBranchUpdate(input: {

--- a/apps/web/src/components/GitActionsControl.logic.ts
+++ b/apps/web/src/components/GitActionsControl.logic.ts
@@ -373,6 +373,12 @@ export function resolveThreadBranchUpdate(
   };
 }
 
+export function resolveThreadBranchMetadataPatch(branch: string | null): {
+  branch: string | null;
+} {
+  return { branch };
+}
+
 export function resolveLiveThreadBranchUpdate(input: {
   threadBranch: string | null;
   gitStatus: VcsStatusResult | null;

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -1038,7 +1038,7 @@ export default function GitActionsControl({
           environmentId: activeThreadRef.environmentId,
           input: {
             threadId: activeThreadRef.threadId,
-            ...resolveThreadBranchMetadataPatch(branch),
+            ...resolveThreadBranchMetadataPatch(branch, activeServerThread.branch),
           },
         });
 

--- a/apps/web/src/components/GitActionsControl.tsx
+++ b/apps/web/src/components/GitActionsControl.tsx
@@ -45,6 +45,7 @@ import {
   requiresDefaultBranchConfirmation,
   resolveDefaultBranchActionDialogCopy,
   resolveLiveThreadBranchUpdate,
+  resolveThreadBranchMetadataPatch,
   resolveQuickAction,
   resolveThreadBranchUpdate,
 } from "./GitActionsControl.logic";
@@ -1033,13 +1034,11 @@ export default function GitActionsControl({
           return;
         }
 
-        const worktreePath = activeServerThread.worktreePath;
         void updateThreadMetadata({
           environmentId: activeThreadRef.environmentId,
           input: {
             threadId: activeThreadRef.threadId,
-            branch,
-            worktreePath,
+            ...resolveThreadBranchMetadataPatch(branch),
           },
         });
 

--- a/packages/contracts/src/orchestration.ts
+++ b/packages/contracts/src/orchestration.ts
@@ -552,6 +552,7 @@ const ThreadMetaUpdateCommand = Schema.Struct({
   title: Schema.optional(TrimmedNonEmptyString),
   modelSelection: Schema.optional(ModelSelection),
   branch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
+  expectedBranch: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
   worktreePath: Schema.optional(Schema.NullOr(TrimmedNonEmptyString)),
 });
 


### PR DESCRIPTION
## Issue

On the first turn of a newly promoted worktree thread, edits could land in the project's main checkout even though T3 had successfully created a dedicated worktree. Follow-up turns then ran in the dedicated worktree, making the initial edits appear to have been lost.

## Root cause

The server correctly created the worktree and persisted its path before dispatching the turn. Immediately afterward, the web source-control branch reconciliation ran against stale main-checkout status and sent a metadata update containing both the branch and the currently rendered `worktreePath`. During thread promotion that rendered path could still be `null`, which cleared the server-assigned worktree path before the provider session resolved its cwd.

## Fix

Branch reconciliation now emits a branch-only metadata patch. Updating a live Git branch can no longer overwrite the independently managed worktree path, so provider startup keeps the server-assigned cwd even when source-control status reconciliation races with first-turn promotion.

Automatic branch reconciliation also includes the branch value it observed as `expectedBranch`. The orchestration decider applies that branch update only while the stored branch still matches the expectation. A delayed client command therefore cannot undo an AI-generated branch name, while authoritative bootstrap updates remain unconditional and can legitimately replace an old checkout branch with a new temporary worktree branch.

## Validation

- Added a regression test proving branch metadata patches do not include worktree metadata.
- Added orchestration integration tests for both stale branch rejection and authoritative temporary-worktree assignment.
- `vp test apps/web/src/components/GitActionsControl.logic.test.ts` (62 tests)
- `vp test apps/server/src/orchestration/Layers/OrchestrationEngine.test.ts` (15 tests)
- `vp check` (passes with existing repository warnings)
- `vp run typecheck`

The investigation also checked `~/.t3/userdata/logs`: worktree creation completed successfully, followed by a client metadata update that set `worktreePath` to `null`; the provider then launched with the main checkout as its cwd. No worktree-creation error was present.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes thread metadata and orchestration branch handling on the critical worktree promotion path, but scope is narrow and covered by new integration/unit tests.
> 
> **Overview**
> Fixes a race where **live branch reconciliation** could clear a server-assigned **worktree path** or revert a **semantic branch** to a stale temporary `t3code/*` ref during first-turn worktree promotion.
> 
> **Web:** `GitActionsControl` now sends branch-only metadata via `resolveThreadBranchMetadataPatch` (`branch` + `expectedBranch`), and no longer includes `worktreePath` when syncing from git status.
> 
> **Contracts:** `thread.meta.update` gains optional `expectedBranch` so the client can describe the branch it thought it was updating.
> 
> **Server:** In `thread.meta.update`, when both `branch` and `expectedBranch` are present and the thread’s stored branch no longer matches `expectedBranch`, the decider **keeps the current branch** instead of applying the incoming value—blocking delayed stale sync commands after rename/bootstrap.
> 
> Regression coverage adds orchestration engine tests for stale temporary-branch updates and authoritative worktree bootstrap, plus a unit test for the metadata patch shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8405efe493dc48248a7c6c14dcef1807552c48f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve worktree metadata during branch sync in thread meta updates
> - Adds an optional `expectedBranch` field to the `ThreadMetaUpdateCommand` contract, allowing clients to send a conditional branch update.
> - Updates the decider so that a `thread.meta.update` with both `branch` and `expectedBranch` keeps the existing branch if it no longer matches `expectedBranch`, preventing stale temporary worktree branches from overwriting generated branches.
> - Introduces `resolveThreadBranchMetadataPatch` in [GitActionsControl.logic.ts](https://github.com/pingdotgg/t3code/pull/3822/files#diff-5e0942b75e4be5ac9ffadabc7d500f512b883da1c98aaca0baa2b959a54985c0) and updates [GitActionsControl.tsx](https://github.com/pingdotgg/t3code/pull/3822/files#diff-3ba1d7cee1366c2c9bd14a311d64705ddfb30c21fbe1091b7e7837d6228ed83f) to send `expectedBranch` alongside `branch` (and omit `worktreePath`) when updating a thread branch from the UI.
> - Behavioral Change: branch updates from the UI no longer include `worktreePath` in the payload, and branch changes are silently ignored server-side when `expectedBranch` does not match the current branch.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c8405ef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
