### PR TITLE
fix(mobile): embed fonts and render project favicons reliably

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -63,6 +63,16 @@ function resolveAppVariant(value: string | undefined): AppVariant {
 
 const variant = VARIANT_CONFIG[APP_VARIANT];
 
+const dmSansFonts = {
+  regular: "@expo-google-fonts/dm-sans/400Regular/DMSans_400Regular.ttf",
+  medium: "@expo-google-fonts/dm-sans/500Medium/DMSans_500Medium.ttf",
+  bold: "@expo-google-fonts/dm-sans/700Bold/DMSans_700Bold.ttf",
+} as const;
+
+// These aliases match the fonts' PostScript names on iOS. Register the same
+// names on Android so React Native and the native composer use one set of
+// family names without waiting for runtime font loading.
+
 const config: ExpoConfig = {
   name: variant.appName,
   slug: "t3-code",
@@ -121,7 +131,30 @@ const config: ExpoConfig = {
     favicon: "./assets/favicon.png",
   },
   plugins: [
-    "expo-font",
+    [
+      "expo-font",
+      {
+        ios: {
+          fonts: [dmSansFonts.regular, dmSansFonts.medium, dmSansFonts.bold],
+        },
+        android: {
+          fonts: [
+            {
+              fontFamily: "DMSans-Regular",
+              fontDefinitions: [{ path: dmSansFonts.regular, weight: 400 }],
+            },
+            {
+              fontFamily: "DMSans-Medium",
+              fontDefinitions: [{ path: dmSansFonts.medium, weight: 500 }],
+            },
+            {
+              fontFamily: "DMSans-Bold",
+              fontDefinitions: [{ path: dmSansFonts.bold, weight: 700 }],
+            },
+          ],
+        },
+      },
+    ],
     "expo-secure-store",
     "expo-sqlite",
     ["@clerk/expo", { theme: "./clerk-theme.json" }],

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -51,6 +51,7 @@
       /* Inputs */
       --color-input: #ffffff;
       --color-input-border: rgba(0, 0, 0, 0.1);
+      --color-sidebar-search: rgba(118, 118, 128, 0.12);
       --color-placeholder: #a3a3a3;
 
       /* Icons */
@@ -144,6 +145,7 @@
       /* Inputs */
       --color-input: #141414;
       --color-input-border: rgba(255, 255, 255, 0.08);
+      --color-sidebar-search: rgba(118, 118, 128, 0.24);
       --color-placeholder: #8e8e93;
 
       /* Icons */

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -222,14 +222,14 @@
 
 /* ─── Custom utilities ──────────────────────────────────────────────── */
 @utility font-t3-medium {
-  font-family: "DMSans-Medium";
+  font-family: var(--font-medium);
 }
 
 @utility font-t3-bold {
-  font-family: "DMSans-Bold";
+  font-family: var(--font-bold);
 }
 
 @utility font-t3-extrabold {
-  font-family: "DMSans-Bold";
+  font-family: var(--font-bold);
   font-weight: 800;
 }

--- a/apps/mobile/global.css
+++ b/apps/mobile/global.css
@@ -194,9 +194,10 @@
 
 /* ─── Typography ────────────────────────────────────────────────────── */
 @theme {
-  --font-sans: "DMSans_400Regular";
-  --font-medium: "DMSans_500Medium";
-  --font-bold: "DMSans_700Bold";
+  /* Keep these native family names aligned with app.config.ts. */
+  --font-sans: "DMSans-Regular";
+  --font-medium: "DMSans-Medium";
+  --font-bold: "DMSans-Bold";
 
   /* Keep this scale aligned with src/lib/typography.ts for native style props. */
   --text-3xs: 11px;
@@ -221,14 +222,14 @@
 
 /* ─── Custom utilities ──────────────────────────────────────────────── */
 @utility font-t3-medium {
-  font-family: "DMSans_500Medium";
+  font-family: "DMSans-Medium";
 }
 
 @utility font-t3-bold {
-  font-family: "DMSans_700Bold";
+  font-family: "DMSans-Bold";
 }
 
 @utility font-t3-extrabold {
-  font-family: "DMSans_700Bold";
+  font-family: "DMSans-Bold";
   font-weight: 800;
 }

--- a/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
+++ b/apps/mobile/modules/t3-composer-editor/ios/T3ComposerEditorView.swift
@@ -300,7 +300,7 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
     skillText: "#a21caf",
     fileTint: "#737373"
   )
-  private var fontFamily = "DMSans_400Regular"
+  private var fontFamily = "DMSans-Regular"
   private var fontSize: CGFloat = 14
   private var lineHeight: CGFloat = 20
   private var contentInsetVertical: CGFloat = 0
@@ -608,7 +608,7 @@ public final class T3ComposerEditorView: ExpoView, UITextViewDelegate {
     iconImage: UIImage?,
     style: ComposerChipStyle
   ) -> UIImage {
-    let font = UIFont(name: "DMSans_500Medium", size: max(12, fontSize - 2))
+    let font = UIFont(name: "DMSans-Medium", size: max(12, fontSize - 2))
       ?? UIFont.systemFont(ofSize: max(12, fontSize - 2), weight: .medium)
     let fallbackIcon = UIImage(
       systemName: iconName,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -80,6 +80,7 @@
     "expo-font": "~56.0.7",
     "expo-glass-effect": "~56.0.4",
     "expo-haptics": "~56.0.3",
+    "expo-image": "~56.0.11",
     "expo-image-picker": "~56.0.18",
     "expo-linking": "~56.0.14",
     "expo-network": "~56.0.5",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "expo start --clear",
     "dev:client": "APP_VARIANT=development expo start --dev-client --scheme t3code-dev --clear",
-    "dev:client:preview": "eas env:exec preview 'EXPO_NO_DOTENV=1 APP_VARIANT=preview expo start --dev-client --scheme t3code-preview --clear'",
+    "dev:client:preview": "eas env:exec preview 'script -q /dev/null env EXPO_NO_DOTENV=1 APP_VARIANT=preview ./node_modules/.bin/expo start --dev-client --scheme t3code-preview --clear --lan'",
     "start": "expo start",
     "start:dev": "APP_VARIANT=development expo start",
     "start:preview": "APP_VARIANT=preview expo start",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "expo start --clear",
     "dev:client": "APP_VARIANT=development expo start --dev-client --scheme t3code-dev --clear",
-    "dev:client:preview": "eas env:exec preview 'script -q /dev/null env EXPO_NO_DOTENV=1 APP_VARIANT=preview ./node_modules/.bin/expo start --dev-client --scheme t3code-preview --clear --lan'",
+    "dev:client:preview": "eas env:exec preview 'EXPO_NO_DOTENV=1 APP_VARIANT=preview expo start --dev-client --scheme t3code-preview --clear --lan'",
     "start": "expo start",
     "start:dev": "APP_VARIANT=development expo start",
     "start:preview": "APP_VARIANT=preview expo start",

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1,4 +1,6 @@
 import * as Linking from "expo-linking";
+import * as SplashScreen from "expo-splash-screen";
+import { useEffect } from "react";
 import { StatusBar, useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
@@ -23,6 +25,10 @@ const Navigation = createStaticNavigation(RootStack);
 export default function App() {
   const colorScheme = useColorScheme();
   const statusBarBg = useThemeColor("--color-status-bar");
+
+  useEffect(() => {
+    SplashScreen.hide();
+  }, []);
 
   return (
     <RegistryContext.Provider value={appAtomRegistry}>

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -26,20 +26,33 @@ const appLinking = {
   prefixes: [Linking.createURL("/"), "t3code://", "t3code-dev://", "t3code-preview://"],
 };
 
+// Keep the native splash up until fonts resolve; without this Expo
+// auto-hides it on first render and the font gate shows a blank screen.
+SplashScreen.preventAutoHideAsync().catch(() => undefined);
+
 const Navigation = createStaticNavigation(RootStack);
 
 export default function App() {
-  const [fontsLoaded] = useFonts({
+  const [fontsLoaded, fontError] = useFonts({
     DMSans_400Regular,
     DMSans_500Medium,
     DMSans_700Bold,
   });
   const colorScheme = useColorScheme();
   const statusBarBg = useThemeColor("--color-status-bar");
+  const fontsResolved = fontsLoaded || fontError !== null;
 
   useEffect(() => {
-    if (fontsLoaded) SplashScreen.hide();
-  }, [fontsLoaded]);
+    if (fontsResolved) SplashScreen.hide();
+  }, [fontsResolved]);
+
+  // Text measured with the fallback font keeps its stale width when the
+  // custom font swaps in, clipping trailing glyphs. Hold rendering (behind
+  // the splash screen) until fonts resolve; on load failure, proceed with
+  // the system font rather than blocking the app.
+  if (!fontsResolved) {
+    return null;
+  }
 
   return (
     <RegistryContext.Provider value={appAtomRegistry}>

--- a/apps/mobile/src/App.tsx
+++ b/apps/mobile/src/App.tsx
@@ -1,11 +1,4 @@
-import {
-  DMSans_400Regular,
-  DMSans_500Medium,
-  DMSans_700Bold,
-  useFonts,
-} from "@expo-google-fonts/dm-sans";
 import * as Linking from "expo-linking";
-import * as SplashScreen from "expo-splash-screen";
 import { StatusBar, useColorScheme } from "react-native";
 import { GestureHandlerRootView } from "react-native-gesture-handler";
 import { KeyboardProvider } from "react-native-keyboard-controller";
@@ -13,7 +6,6 @@ import { SafeAreaProvider } from "react-native-safe-area-context";
 import { createStaticNavigation, DarkTheme, DefaultTheme } from "@react-navigation/native";
 
 import { RegistryContext } from "@effect/atom-react";
-import { useEffect } from "react";
 import { CloudAuthProvider } from "./features/cloud/CloudAuthProvider";
 import { AppearancePreferencesProvider } from "./features/settings/appearance/AppearancePreferencesProvider";
 import { RootStack } from "./Stack";
@@ -26,33 +18,11 @@ const appLinking = {
   prefixes: [Linking.createURL("/"), "t3code://", "t3code-dev://", "t3code-preview://"],
 };
 
-// Keep the native splash up until fonts resolve; without this Expo
-// auto-hides it on first render and the font gate shows a blank screen.
-SplashScreen.preventAutoHideAsync().catch(() => undefined);
-
 const Navigation = createStaticNavigation(RootStack);
 
 export default function App() {
-  const [fontsLoaded, fontError] = useFonts({
-    DMSans_400Regular,
-    DMSans_500Medium,
-    DMSans_700Bold,
-  });
   const colorScheme = useColorScheme();
   const statusBarBg = useThemeColor("--color-status-bar");
-  const fontsResolved = fontsLoaded || fontError !== null;
-
-  useEffect(() => {
-    if (fontsResolved) SplashScreen.hide();
-  }, [fontsResolved]);
-
-  // Text measured with the fallback font keeps its stale width when the
-  // custom font swaps in, clipping trailing glyphs. Hold rendering (behind
-  // the splash screen) until fonts resolve; on load failure, proceed with
-  // the system font rather than blocking the app.
-  if (!fontsResolved) {
-    return null;
-  }
 
   return (
     <RegistryContext.Provider value={appAtomRegistry}>

--- a/apps/mobile/src/components/AppText.tsx
+++ b/apps/mobile/src/components/AppText.tsx
@@ -17,7 +17,7 @@ export function AppText({ className, ...props }: AppTextProps) {
   return <RNText className={cn("font-sans text-foreground", className)} {...props} />;
 }
 
-export type AppTextInputProps = RNTextInputProps & {
+export type AppTextInputProps = Omit<RNTextInputProps, "placeholderTextColor"> & {
   readonly className?: string;
   readonly ref?: React.Ref<RNTextInput>;
 };
@@ -26,12 +26,7 @@ export type AppTextInputProps = RNTextInputProps & {
  * Thin wrapper around RN TextInput with default input styling.
  * Uses Uniwind className — no manual style parsing.
  */
-export function AppTextInput({
-  className,
-  placeholderTextColor,
-  ref,
-  ...props
-}: AppTextInputProps) {
+export function AppTextInput({ className, ref, ...props }: AppTextInputProps) {
   return (
     <RNTextInput
       ref={ref}
@@ -39,10 +34,7 @@ export function AppTextInput({
         "min-h-13.5 rounded-2xl border border-input-border bg-input px-3.5 py-3 font-sans text-base text-foreground",
         className,
       )}
-      placeholderTextColor={placeholderTextColor}
-      placeholderTextColorClassName={
-        placeholderTextColor === undefined ? "accent-placeholder" : undefined
-      }
+      placeholderTextColorClassName="accent-placeholder"
       {...props}
     />
   );

--- a/apps/mobile/src/components/AppText.tsx
+++ b/apps/mobile/src/components/AppText.tsx
@@ -4,7 +4,6 @@ import {
   type TextInputProps as RNTextInputProps,
   type TextProps as RNTextProps,
 } from "react-native";
-import { useThemeColor } from "../lib/useThemeColor";
 
 import { cn } from "../lib/cn";
 
@@ -33,8 +32,6 @@ export function AppTextInput({
   ref,
   ...props
 }: AppTextInputProps) {
-  const placeholderColor = useThemeColor("--color-placeholder");
-
   return (
     <RNTextInput
       ref={ref}
@@ -42,7 +39,10 @@ export function AppTextInput({
         "min-h-13.5 rounded-2xl border border-input-border bg-input px-3.5 py-3 font-sans text-base text-foreground",
         className,
       )}
-      placeholderTextColor={placeholderTextColor ?? placeholderColor}
+      placeholderTextColor={placeholderTextColor}
+      placeholderTextColorClassName={
+        placeholderTextColor === undefined ? "accent-placeholder" : undefined
+      }
       {...props}
     />
   );

--- a/apps/mobile/src/components/BrandMark.tsx
+++ b/apps/mobile/src/components/BrandMark.tsx
@@ -22,14 +22,9 @@ export function BrandMark(props: { readonly compact?: boolean; readonly stageLab
       />
       <View className="gap-1">
         <View className="flex-row items-center gap-2">
-          <Text className="text-lg font-t3-bold text-foreground" style={{ letterSpacing: -0.4 }}>
-            T3 Code
-          </Text>
+          <Text className="text-lg font-t3-bold tracking-[-0.4px] text-foreground">T3 Code</Text>
           <View className="rounded-full bg-subtle px-2 py-1">
-            <Text
-              className="text-3xs font-t3-bold uppercase text-foreground-muted"
-              style={{ letterSpacing: 1.1 }}
-            >
+            <Text className="text-3xs font-t3-bold tracking-[1.1px] uppercase text-foreground-muted">
               {stageLabel}
             </Text>
           </View>

--- a/apps/mobile/src/components/ComposerAttachmentStrip.tsx
+++ b/apps/mobile/src/components/ComposerAttachmentStrip.tsx
@@ -39,14 +39,14 @@ export function ComposerAttachmentStrip(props: ComposerAttachmentStripProps) {
       horizontal
       showsHorizontalScrollIndicator={false}
       keyboardShouldPersistTaps="always"
-      style={{ flexGrow: 0 }}
+      className="grow-0"
     >
-      <View style={{ flexDirection: "row", gap: 10 }}>
+      <View className="flex-row gap-2.5">
         {props.attachments.map((image) => (
           <View
             key={image.id}
+            className="relative"
             style={{
-              position: "relative",
               paddingTop: removeButtonGutter,
               paddingRight: removeButtonGutter,
             }}
@@ -66,16 +66,10 @@ export function ComposerAttachmentStrip(props: ComposerAttachmentStripProps) {
               />
             </Pressable>
             <Pressable
+              className="absolute h-[22px] w-[22px] items-center justify-center rounded-[11px] bg-black/55"
               style={{
-                position: "absolute",
                 top: removeButtonPlacement === "gutter" ? 0 : 4,
                 right: removeButtonPlacement === "gutter" ? 0 : 4,
-                width: 22,
-                height: 22,
-                borderRadius: 11,
-                backgroundColor: "rgba(0,0,0,0.55)",
-                alignItems: "center",
-                justifyContent: "center",
               }}
               hitSlop={6}
               onPress={() => props.onRemove(image.id)}

--- a/apps/mobile/src/components/ComposerToolbarTrigger.tsx
+++ b/apps/mobile/src/components/ComposerToolbarTrigger.tsx
@@ -31,11 +31,9 @@ export function ComposerToolbarRow(props: {
 }) {
   return (
     <View
+      className="flex-row items-center gap-1.5"
       style={[
         {
-          alignItems: "center",
-          flexDirection: "row",
-          gap: 6,
           paddingBottom: props.paddingBottom ?? 8,
           paddingHorizontal: props.paddingHorizontal ?? 6,
           paddingTop: props.paddingTop ?? 8,
@@ -89,7 +87,7 @@ export function ComposerToolbarScroller(props: {
   }, []);
 
   return (
-    <View className="min-w-0 flex-1" style={{ position: "relative" }}>
+    <View className="relative min-w-0 flex-1">
       <ScrollView
         horizontal
         keyboardShouldPersistTaps="always"

--- a/apps/mobile/src/components/GlassSafeAreaView.tsx
+++ b/apps/mobile/src/components/GlassSafeAreaView.tsx
@@ -39,22 +39,12 @@ export function GlassSafeAreaView({
         style={{ borderRadius: 0, backgroundColor: "transparent" }}
       >
         <View
-          style={{
-            flexDirection: "row",
-            alignItems: "center",
-            paddingHorizontal: 20,
-            paddingTop: headerPaddingTop,
-            paddingBottom: 16,
-            gap: 10,
-          }}
+          className="flex-row items-center gap-2.5 px-5 pb-4"
+          style={{ paddingTop: headerPaddingTop }}
         >
-          <View style={{ alignItems: "flex-start", justifyContent: "center" }}>{leftSlot}</View>
-          <View
-            style={{ flex: 1, alignItems: "center", justifyContent: "center", overflow: "hidden" }}
-          >
-            {centerSlot}
-          </View>
-          <View style={{ alignItems: "flex-end", justifyContent: "center" }}>{rightSlot}</View>
+          <View className="items-start justify-center">{leftSlot}</View>
+          <View className="flex-1 items-center justify-center overflow-hidden">{centerSlot}</View>
+          <View className="items-end justify-center">{rightSlot}</View>
         </View>
       </GlassSurface>
     </View>

--- a/apps/mobile/src/components/GlassSurface.tsx
+++ b/apps/mobile/src/components/GlassSurface.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 import { useThemeColor } from "../lib/useThemeColor";
 
-export interface GlassSurfaceProps extends ViewProps {
+export interface GlassSurfaceProps extends Omit<ViewProps, "className"> {
   readonly children: ReactNode;
   readonly glassEffectStyle?: "clear" | "regular" | "none";
   readonly tintColor?: ColorValue;

--- a/apps/mobile/src/components/ProjectFavicon.tsx
+++ b/apps/mobile/src/components/ProjectFavicon.tsx
@@ -1,6 +1,7 @@
 import { SymbolView } from "expo-symbols";
+import { Image } from "expo-image";
 import { useState } from "react";
-import { Image, View } from "react-native";
+import { View } from "react-native";
 import type { EnvironmentId } from "@t3tools/contracts";
 import { useThemeColor } from "../lib/useThemeColor";
 import { useAssetUrl } from "../state/assets";
@@ -78,7 +79,7 @@ function ProjectFaviconImage(props: {
             borderRadius: props.size * 0.16,
             ...(showImage ? {} : { position: "absolute" as const, opacity: 0 }),
           }}
-          resizeMode="contain"
+          contentFit="contain"
           onLoad={() => {
             if (props.faviconUrl) loadedFaviconUrls.add(props.faviconUrl);
             setStatus("loaded");

--- a/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
+++ b/apps/mobile/src/features/archive/ArchivedThreadsScreen.tsx
@@ -244,9 +244,8 @@ function ProjectGroupLabel(props: {
         workspaceRoot={props.project.workspaceRoot}
       />
       <Text
-        className="flex-1 text-xs font-t3-medium uppercase text-foreground-muted"
+        className="flex-1 text-xs font-t3-medium tracking-[0.5px] uppercase text-foreground-muted"
         numberOfLines={1}
-        style={{ letterSpacing: 0.5 }}
       >
         {props.project.title}
       </Text>
@@ -331,10 +330,7 @@ function ArchivedThreadRow(props: {
               >
                 {props.thread.title}
               </Text>
-              <Text
-                className="text-xs text-foreground-tertiary"
-                style={{ fontVariant: ["tabular-nums"], minWidth: 30, textAlign: "right" }}
-              >
+              <Text className="min-w-[30px] text-right text-xs tabular-nums text-foreground-tertiary">
                 {timestamp}
               </Text>
             </View>
@@ -347,9 +343,8 @@ function ArchivedThreadRow(props: {
                   type="monochrome"
                 />
                 <Text
-                  className="min-w-0 flex-1 text-2xs text-foreground-tertiary"
+                  className="min-w-0 flex-1 font-mono text-2xs text-foreground-tertiary"
                   numberOfLines={1}
-                  style={{ fontFamily: "monospace" }}
                 >
                   {subtitle.join(" · ")}
                 </Text>

--- a/apps/mobile/src/features/cloud/CloudWaitlistEnrollment.tsx
+++ b/apps/mobile/src/features/cloud/CloudWaitlistEnrollment.tsx
@@ -1,13 +1,12 @@
 import { useWaitlist } from "@clerk/expo";
-import { ActivityIndicator, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { ActivityIndicator, Pressable, Text, TextInput, View } from "react-native";
 import { useState } from "react";
 
-import { useThemeColor } from "../../lib/useThemeColor";
+import { cn } from "../../lib/cn";
 import { CloudWaitlistJoinRejectedError, joinCloudWaitlist } from "./cloudWaitlistJoin";
 
 export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }) {
   const { errors, fetchStatus, waitlist } = useWaitlist();
-  const colors = useCloudWaitlistColors();
   const [emailAddress, setEmailAddress] = useState("");
   const [requestError, setRequestError] = useState<string | null>(null);
   const isSubmitting = fetchStatus === "fetching";
@@ -34,7 +33,7 @@ export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }
 
   if (waitlist.id) {
     return (
-      <View style={styles.content}>
+      <View className="gap-[18px]">
         <Text className="text-center font-t3-bold text-xl text-foreground">
           You are on the waitlist
         </Text>
@@ -47,19 +46,22 @@ export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }
   }
 
   return (
-    <View style={styles.content}>
+    <View className="gap-[18px]">
       <Text className="font-sans text-base text-foreground-secondary">
         Enter your email and we will let you know when access is ready.
       </Text>
 
-      <View style={styles.field}>
+      <View className="gap-2">
         <Text className="font-t3-bold text-sm text-foreground-secondary">Email address</Text>
         <TextInput
           accessibilityLabel="Email address"
           autoCapitalize="none"
           autoComplete="email"
           autoCorrect={false}
-          className="font-sans text-lg text-foreground"
+          className={cn(
+            "min-h-[54px] rounded-2xl border border-input-border bg-input px-4 py-3.5 font-sans text-lg text-foreground border-continuous",
+            (fieldError || requestError) && "border-danger-foreground",
+          )}
           keyboardType="email-address"
           onChangeText={(value) => {
             setEmailAddress(value);
@@ -67,16 +69,8 @@ export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }
           }}
           onSubmitEditing={() => void joinWaitlist()}
           placeholder="Enter your email address"
-          placeholderTextColor={colors.placeholder}
+          placeholderTextColorClassName="accent-placeholder"
           returnKeyType="join"
-          style={[
-            styles.input,
-            {
-              backgroundColor: colors.input,
-              borderColor:
-                fieldError || requestError ? colors.dangerForeground : colors.inputBorder,
-            },
-          ]}
           textContentType="emailAddress"
           value={emailAddress}
         />
@@ -99,15 +93,11 @@ export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }
         }}
         disabled={isSubmitting || emailAddress.trim().length === 0}
         onPress={() => void joinWaitlist()}
-        style={[
-          styles.primaryButton,
-          {
-            backgroundColor: colors.primary,
-            opacity: isSubmitting || emailAddress.trim().length === 0 ? 0.45 : 1,
-          },
-        ]}
+        className="min-h-[54px] flex-row items-center justify-center gap-2 rounded-full bg-primary px-5 py-3 disabled:opacity-[0.45]"
       >
-        {isSubmitting ? <ActivityIndicator color={colors.primaryForeground} size="small" /> : null}
+        {isSubmitting ? (
+          <ActivityIndicator colorClassName="accent-primary-foreground" size="small" />
+        ) : null}
         <Text className="font-t3-bold text-base text-primary-foreground">
           {isSubmitting ? "Joining" : "Join the waitlist"}
         </Text>
@@ -120,7 +110,7 @@ export function CloudWaitlistEnrollment(props: { readonly onSignIn: () => void }
 
 function SignInAction(props: { readonly onPress: () => void }) {
   return (
-    <View style={styles.signInRow}>
+    <View className="flex-row items-center justify-center gap-1 pt-1">
       <Text className="font-sans text-base text-foreground-secondary">Already have access?</Text>
       <Pressable accessibilityRole="button" hitSlop={8} onPress={props.onPress}>
         <Text className="font-t3-bold text-base text-foreground">Sign in</Text>
@@ -128,48 +118,3 @@ function SignInAction(props: { readonly onPress: () => void }) {
     </View>
   );
 }
-
-function useCloudWaitlistColors() {
-  return {
-    dangerForeground: String(useThemeColor("--color-danger-foreground")),
-    input: String(useThemeColor("--color-input")),
-    inputBorder: String(useThemeColor("--color-input-border")),
-    placeholder: String(useThemeColor("--color-placeholder")),
-    primary: String(useThemeColor("--color-primary")),
-    primaryForeground: String(useThemeColor("--color-primary-foreground")),
-  };
-}
-
-const styles = StyleSheet.create({
-  content: {
-    gap: 18,
-  },
-  field: {
-    gap: 8,
-  },
-  input: {
-    borderCurve: "continuous",
-    borderRadius: 16,
-    borderWidth: 1,
-    minHeight: 54,
-    paddingHorizontal: 16,
-    paddingVertical: 14,
-  },
-  primaryButton: {
-    alignItems: "center",
-    borderRadius: 999,
-    flexDirection: "row",
-    gap: 8,
-    justifyContent: "center",
-    minHeight: 54,
-    paddingHorizontal: 20,
-    paddingVertical: 12,
-  },
-  signInRow: {
-    alignItems: "center",
-    flexDirection: "row",
-    gap: 4,
-    justifyContent: "center",
-    paddingTop: 4,
-  },
-});

--- a/apps/mobile/src/features/cloud/ConnectOnboardingRouteScreen.tsx
+++ b/apps/mobile/src/features/cloud/ConnectOnboardingRouteScreen.tsx
@@ -88,7 +88,7 @@ function ConfiguredConnectOnboardingRouteScreen() {
         alwaysBounceVertical
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
+        className="flex-1"
         contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
         contentContainerStyle={{
           gap: 16,

--- a/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
+++ b/apps/mobile/src/features/connection/CloudEnvironmentRows.tsx
@@ -297,9 +297,8 @@ function CloudEnvironmentRowShell(props: {
         {props.connectionError ? (
           <Text
             aria-hidden
-            className={cn("absolute left-0 right-0 text-xs", statusClassName)}
             onTextLayout={onMeasuredErrorTextLayout}
-            style={{ opacity: 0, zIndex: -1 }}
+            className={cn("absolute inset-x-0 -z-[1] text-xs opacity-0", statusClassName)}
           >
             {measuredErrorText}
           </Text>
@@ -321,7 +320,7 @@ function CloudEnvironmentRowShell(props: {
                 <Text
                   accessibilityHint="Copies the trace ID"
                   accessibilityRole="button"
-                  className={cn("text-xs underline", statusClassName)}
+                  className={cn("text-xs underline decoration-dotted", statusClassName)}
                   onLongPress={(event) => {
                     event.stopPropagation();
                     copyTextWithHaptic(errorTraceId, { target: "connection-trace-id" });
@@ -329,7 +328,6 @@ function CloudEnvironmentRowShell(props: {
                   onPress={(event) => {
                     event.stopPropagation();
                   }}
-                  style={{ textDecorationStyle: "dotted" }}
                 >
                   {errorTraceId}
                 </Text>

--- a/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
+++ b/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
@@ -38,7 +38,6 @@ export function ConnectionEnvironmentRow(props: {
   const [url, setUrl] = useState(props.environment.displayUrl);
 
   const mutedColor = useThemeColor("--color-icon-subtle");
-  const placeholderColor = useThemeColor("--color-placeholder");
   const primaryFg = useThemeColor("--color-primary-foreground");
   const dangerFg = useThemeColor("--color-danger-foreground");
   const statusLabel = connectionStatusLabel(props.environment);
@@ -146,7 +145,6 @@ export function ConnectionEnvironmentRow(props: {
                   autoCapitalize="words"
                   autoCorrect={false}
                   placeholder="My MacBook"
-                  placeholderTextColor={placeholderColor}
                   value={label}
                   onChangeText={setLabel}
                   className="rounded-[14px] border border-input-border bg-input px-4 py-3 text-base text-foreground"
@@ -162,7 +160,6 @@ export function ConnectionEnvironmentRow(props: {
                   autoCorrect={false}
                   keyboardType="url"
                   placeholder="192.168.1.100:8080"
-                  placeholderTextColor={placeholderColor}
                   value={url}
                   onChangeText={setUrl}
                   className="rounded-[14px] border border-input-border bg-input px-4 py-3 text-base text-foreground"

--- a/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
+++ b/apps/mobile/src/features/connection/ConnectionEnvironmentRow.tsx
@@ -98,7 +98,7 @@ export function ConnectionEnvironmentRow(props: {
                   <Text
                     accessibilityHint="Copies the trace ID"
                     accessibilityRole="button"
-                    className="underline"
+                    className="underline decoration-dotted"
                     onLongPress={(event) => {
                       event.stopPropagation();
                       copyTextWithHaptic(statusTraceId, { target: "connection-trace-id" });
@@ -106,7 +106,6 @@ export function ConnectionEnvironmentRow(props: {
                     onPress={(event) => {
                       event.stopPropagation();
                     }}
-                    style={{ textDecorationStyle: "dotted" }}
                   >
                     {statusTraceId}
                   </Text>
@@ -140,10 +139,7 @@ export function ConnectionEnvironmentRow(props: {
           ) : (
             <>
               <View className="gap-1.5">
-                <Text
-                  className="text-2xs font-t3-bold uppercase text-foreground-muted"
-                  style={{ letterSpacing: 0.8 }}
-                >
+                <Text className="text-2xs font-t3-bold tracking-[0.8px] uppercase text-foreground-muted">
                   Label
                 </Text>
                 <TextInput
@@ -158,10 +154,7 @@ export function ConnectionEnvironmentRow(props: {
               </View>
 
               <View className="gap-1.5">
-                <Text
-                  className="text-2xs font-t3-bold uppercase text-foreground-muted"
-                  style={{ letterSpacing: 0.8 }}
-                >
+                <Text className="text-2xs font-t3-bold tracking-[0.8px] uppercase text-foreground-muted">
                   URL
                 </Text>
                 <TextInput
@@ -185,10 +178,7 @@ export function ConnectionEnvironmentRow(props: {
                 onPress={handleSave}
               >
                 <SymbolView name="checkmark" size={13} tintColor={primaryFg} type="monochrome" />
-                <Text
-                  className="text-xs font-t3-bold uppercase text-primary-foreground"
-                  style={{ letterSpacing: 0.8 }}
-                >
+                <Text className="text-xs font-t3-bold tracking-[0.8px] uppercase text-primary-foreground">
                   Save
                 </Text>
               </Pressable>

--- a/apps/mobile/src/features/connection/ConnectionSheetButton.tsx
+++ b/apps/mobile/src/features/connection/ConnectionSheetButton.tsx
@@ -37,33 +37,11 @@ export function ConnectionSheetButton(props: {
 }) {
   const tone = props.tone ?? "secondary";
 
-  const primaryBg = useThemeColor("--color-primary");
   const primaryFg = useThemeColor("--color-primary-foreground");
-  const dangerBg = useThemeColor("--color-danger");
-  const dangerBorderColor = useThemeColor("--color-danger-border");
   const dangerFg = useThemeColor("--color-danger-foreground");
-  const secondaryBg = useThemeColor("--color-secondary");
   const secondaryFg = useThemeColor("--color-secondary-foreground");
-  const borderColor = useThemeColor("--color-border");
 
-  const colors =
-    tone === "primary"
-      ? {
-          backgroundColor: primaryBg,
-          borderColor: "transparent",
-          textColor: primaryFg,
-        }
-      : tone === "danger"
-        ? {
-            backgroundColor: dangerBg,
-            borderColor: dangerBorderColor,
-            textColor: dangerFg,
-          }
-        : {
-            backgroundColor: secondaryBg,
-            borderColor: borderColor,
-            textColor: secondaryFg,
-          };
+  const textColor = tone === "primary" ? primaryFg : tone === "danger" ? dangerFg : secondaryFg;
 
   const primaryShadow =
     tone === "primary"
@@ -84,28 +62,32 @@ export function ConnectionSheetButton(props: {
         props.compact
           ? "min-h-[42px] flex-row items-center justify-center gap-1.5 rounded-[14px] px-3.5 py-2.5"
           : "min-h-[48px] flex-row items-center justify-center gap-2 rounded-[16px] px-4 py-3",
+        "disabled:opacity-50",
+        tone === "primary"
+          ? "bg-primary"
+          : tone === "danger"
+            ? "border border-danger-border bg-danger"
+            : "border border-border bg-secondary",
       )}
       disabled={props.disabled}
       onPress={props.onPress}
-      style={[
-        {
-          backgroundColor: colors.backgroundColor,
-          borderWidth: tone === "primary" ? 0 : 1,
-          borderColor: colors.borderColor,
-          opacity: props.disabled ? 0.5 : 1,
-        },
-        primaryShadow,
-      ]}
+      style={primaryShadow}
     >
       <SymbolView
         name={props.icon}
         size={props.compact ? 13 : 14}
-        tintColor={colors.textColor}
+        tintColor={textColor}
         type="monochrome"
       />
       <Text
-        className="text-xs font-t3-bold uppercase"
-        style={{ color: colors.textColor, letterSpacing: 0.8 }}
+        className={cn(
+          "text-xs font-t3-bold tracking-[0.8px] uppercase",
+          tone === "primary"
+            ? "text-primary-foreground"
+            : tone === "danger"
+              ? "text-danger-foreground"
+              : "text-secondary-foreground",
+        )}
       >
         {props.label}
       </Text>

--- a/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
@@ -38,7 +38,6 @@ export function ConnectionsNewRouteScreen({
   const [scannerLocked, setScannerLocked] = useState(false);
 
   const headerIconColor = useThemeColor("--color-icon");
-  const placeholderColor = useThemeColor("--color-placeholder");
 
   const connectDisabled = isSubmitting || hostInput.trim().length === 0;
 
@@ -202,7 +201,6 @@ export function ConnectionsNewRouteScreen({
                   autoCorrect={false}
                   keyboardType="url"
                   placeholder="192.168.1.100:8080"
-                  placeholderTextColor={placeholderColor}
                   value={hostInput}
                   onChangeText={handleHostChange}
                   className="rounded-[14px] border border-input-border bg-input px-4 py-3.5 text-base text-foreground"
@@ -217,7 +215,6 @@ export function ConnectionsNewRouteScreen({
                   autoCapitalize="none"
                   autoCorrect={false}
                   placeholder="abc-123-xyz"
-                  placeholderTextColor={placeholderColor}
                   value={codeInput}
                   onChangeText={handleCodeChange}
                   className="rounded-[14px] border border-input-border bg-input px-4 py-3.5 text-base text-foreground"

--- a/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsNewRouteScreen.tsx
@@ -158,7 +158,7 @@ export function ConnectionsNewRouteScreen({
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
+        className="flex-1"
         contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
         contentContainerStyle={{
           paddingHorizontal: 20,
@@ -168,10 +168,7 @@ export function ConnectionsNewRouteScreen({
         <View collapsable={false} className="gap-5">
           {showScanner ? (
             cameraPermission?.granted ? (
-              <View
-                className="overflow-hidden rounded-[24px]"
-                style={{ borderCurve: "continuous" }}
-              >
+              <View className="overflow-hidden rounded-[24px] border-continuous">
                 <CameraView
                   barcodeScannerSettings={{ barcodeTypes: ["qr"] }}
                   onBarcodeScanned={handleQrScan}
@@ -179,10 +176,7 @@ export function ConnectionsNewRouteScreen({
                 />
               </View>
             ) : (
-              <View
-                className="items-center gap-3 rounded-[24px] bg-card px-5 py-8"
-                style={{ borderCurve: "continuous" }}
-              >
+              <View className="items-center gap-3 rounded-[24px] border-continuous bg-card px-5 py-8">
                 <Text className="text-center text-sm leading-normal text-foreground-muted">
                   Camera permission is required to scan a QR code.
                 </Text>
@@ -200,10 +194,7 @@ export function ConnectionsNewRouteScreen({
           ) : (
             <View collapsable={false} className="gap-4 rounded-[24px] bg-card p-4">
               <View collapsable={false} className="gap-1.5">
-                <Text
-                  className="text-2xs font-t3-bold uppercase text-foreground-muted"
-                  style={{ letterSpacing: 0.8 }}
-                >
+                <Text className="text-2xs font-t3-bold tracking-[0.8px] uppercase text-foreground-muted">
                   Host
                 </Text>
                 <TextInput
@@ -219,10 +210,7 @@ export function ConnectionsNewRouteScreen({
               </View>
 
               <View collapsable={false} className="gap-1.5">
-                <Text
-                  className="text-2xs font-t3-bold uppercase text-foreground-muted"
-                  style={{ letterSpacing: 0.8 }}
-                >
+                <Text className="text-2xs font-t3-bold tracking-[0.8px] uppercase text-foreground-muted">
                   Pairing code
                 </Text>
                 <TextInput

--- a/apps/mobile/src/features/connection/ConnectionsRouteScreen.tsx
+++ b/apps/mobile/src/features/connection/ConnectionsRouteScreen.tsx
@@ -42,7 +42,7 @@ export function ConnectionsRouteScreen() {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
+        className="flex-1"
         contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
         contentContainerStyle={{
           paddingHorizontal: 20,
@@ -55,10 +55,7 @@ export function ConnectionsRouteScreen() {
               <View
                 key={environment.environmentId}
                 collapsable={false}
-                style={{
-                  borderTopWidth: index === 0 ? 0 : 1,
-                }}
-                className={cn(index !== 0 && "border-border")}
+                className={cn(index !== 0 && "border-t border-border")}
               >
                 <ConnectionEnvironmentRow
                   environment={environment}

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -50,6 +50,7 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
     const renderers: CustomRenderers = {
       link: ({ href, children }) => (
         <NativeText
+          className="font-t3-medium"
           onPress={() => {
             if (href) {
               void tryOpenExternalUrl(href, "markdown-link");
@@ -57,7 +58,6 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
           }}
           style={{
             color: link,
-            fontFamily: "DMSans-Medium",
             textDecorationLine: "none",
           }}
         >

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -57,7 +57,7 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
           }}
           style={{
             color: link,
-            fontFamily: "DMSans_500Medium",
+            fontFamily: "DMSans-Medium",
             textDecorationLine: "none",
           }}
         >
@@ -86,21 +86,21 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
       styles: {
         text: {
           color: body,
-          fontFamily: "DMSans_400Regular",
+          fontFamily: "DMSans-Regular",
           fontSize: markdownFontSizes.m,
           lineHeight: markdownFontSizes.bodyLineHeight,
         },
         heading: {
           color: strong,
-          fontFamily: "DMSans_700Bold",
+          fontFamily: "DMSans-Bold",
         },
         strong: {
           color: strong,
-          fontFamily: "DMSans_700Bold",
+          fontFamily: "DMSans-Bold",
         },
         link: {
           color: link,
-          fontFamily: "DMSans_500Medium",
+          fontFamily: "DMSans-Medium",
         },
         blockquote: {
           backgroundColor: blockquoteBackground,
@@ -141,9 +141,9 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
         fontSize: nativeMarkdownTypography.fontSize,
         lineHeight: nativeMarkdownTypography.lineHeight,
         headingFontSizes: nativeMarkdownTypography.headingFontSizes,
-        fontFamily: "DMSans_400Regular",
-        headingFontFamily: "DMSans_700Bold",
-        boldFontFamily: "DMSans_700Bold",
+        fontFamily: "DMSans-Regular",
+        headingFontFamily: "DMSans-Bold",
+        boldFontFamily: "DMSans-Bold",
       },
     };
   }, [

--- a/apps/mobile/src/features/files/FileMarkdownPreview.tsx
+++ b/apps/mobile/src/features/files/FileMarkdownPreview.tsx
@@ -8,6 +8,7 @@ import {
 import { RefreshControl, ScrollView, Text as NativeText, View } from "react-native";
 
 import { tryOpenExternalUrl } from "../../lib/openExternalUrl";
+import { useFontFamily } from "../../lib/useFontFamily";
 import {
   resolveMarkdownFontSizes,
   resolveNativeMarkdownTypography,
@@ -45,6 +46,9 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
   const codeBackground = String(useThemeColor("--color-md-code-bg"));
   const codeText = String(useThemeColor("--color-md-code-text"));
   const horizontalRule = String(useThemeColor("--color-md-hr"));
+  const regularFontFamily = useFontFamily("regular");
+  const mediumFontFamily = useFontFamily("medium");
+  const boldFontFamily = useFontFamily("bold");
 
   return useMemo(() => {
     const renderers: CustomRenderers = {
@@ -86,21 +90,21 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
       styles: {
         text: {
           color: body,
-          fontFamily: "DMSans-Regular",
+          fontFamily: regularFontFamily,
           fontSize: markdownFontSizes.m,
           lineHeight: markdownFontSizes.bodyLineHeight,
         },
         heading: {
           color: strong,
-          fontFamily: "DMSans-Bold",
+          fontFamily: boldFontFamily,
         },
         strong: {
           color: strong,
-          fontFamily: "DMSans-Bold",
+          fontFamily: boldFontFamily,
         },
         link: {
           color: link,
-          fontFamily: "DMSans-Medium",
+          fontFamily: mediumFontFamily,
         },
         blockquote: {
           backgroundColor: blockquoteBackground,
@@ -141,9 +145,9 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
         fontSize: nativeMarkdownTypography.fontSize,
         lineHeight: nativeMarkdownTypography.lineHeight,
         headingFontSizes: nativeMarkdownTypography.headingFontSizes,
-        fontFamily: "DMSans-Regular",
-        headingFontFamily: "DMSans-Bold",
-        boldFontFamily: "DMSans-Bold",
+        fontFamily: regularFontFamily,
+        headingFontFamily: boldFontFamily,
+        boldFontFamily,
       },
     };
   }, [
@@ -155,8 +159,11 @@ function useMarkdownPreviewStyles(): MarkdownPreviewStyles {
     horizontalRule,
     link,
     markdownFontSizes,
+    mediumFontFamily,
     nativeMarkdownTypography,
+    regularFontFamily,
     strong,
+    boldFontFamily,
   ]);
 }
 

--- a/apps/mobile/src/features/files/FileTreeBrowser.tsx
+++ b/apps/mobile/src/features/files/FileTreeBrowser.tsx
@@ -246,7 +246,7 @@ export function FileTreeBrowser(props: {
   // flex-1 Views is ignored, which is why the tree rendered under the header with no blur.
   return (
     <FlatList
-      style={{ flex: 1 }}
+      className="flex-1"
       data={visibleNodes}
       keyExtractor={(item) => item.node.path}
       contentInsetAdjustmentBehavior={Platform.OS === "ios" ? "automatic" : "never"}

--- a/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
+++ b/apps/mobile/src/features/files/ThreadFilesRouteScreen.tsx
@@ -224,14 +224,7 @@ function FilesToolbarBottomFade() {
       pointerEvents="none"
       accessibilityElementsHidden
       importantForAccessibility="no-hide-descendants"
-      style={{
-        bottom: 0,
-        height: 112,
-        left: 0,
-        position: "absolute",
-        right: 0,
-        zIndex: 1,
-      }}
+      className="absolute inset-x-0 bottom-0 z-[1] h-28"
     >
       <Svg width="100%" height="100%">
         <Defs>

--- a/apps/mobile/src/features/home/HomeScreen.tsx
+++ b/apps/mobile/src/features/home/HomeScreen.tsx
@@ -412,7 +412,7 @@ export function HomeScreen(props: HomeScreenProps) {
       {Platform.OS === "ios" ? null : <HomeTopContentSpacer topInset={insets.top} />}
 
       {shouldShowConnectionStatus && Platform.OS === "ios" ? (
-        <View style={{ paddingBottom: 16 }}>
+        <View className="pb-4">
           <WorkspaceConnectionStatus
             state={props.catalogState}
             onPress={props.onOpenEnvironments}

--- a/apps/mobile/src/features/home/thread-swipe-actions.tsx
+++ b/apps/mobile/src/features/home/thread-swipe-actions.tsx
@@ -350,24 +350,56 @@ function SwipeActionButton(props: {
 
   return (
     <Animated.View
-      className="h-full w-[50px] items-center justify-center"
-      style={[{ zIndex: props.stretchesOnFullSwipe ? 2 : 1 }, actionStyle]}
+      style={[
+        {
+          alignItems: "center",
+          height: "100%",
+          justifyContent: "center",
+          width: ACTION_ITEM_WIDTH,
+          zIndex: props.stretchesOnFullSwipe ? 2 : 1,
+        },
+        actionStyle,
+      ]}
     >
       <Pressable
-        className="h-full w-full items-center justify-center"
         accessibilityLabel={props.accessibilityLabel}
         accessibilityRole="button"
         onPress={props.onPress}
-        style={({ pressed }) => ({ opacity: pressed ? 0.72 : 1 })}
+        style={({ pressed }) => ({
+          alignItems: "center",
+          height: "100%",
+          justifyContent: "center",
+          opacity: pressed ? 0.72 : 1,
+          width: "100%",
+        })}
       >
-        <View className="h-9 w-9">
+        <View style={{ height: ACTION_CIRCLE_SIZE, width: ACTION_CIRCLE_SIZE }}>
           <Animated.View
-            className="absolute left-0 top-0 h-9 w-9 rounded-full"
-            style={[{ backgroundColor: props.backgroundColor }, circleStyle]}
+            style={[
+              {
+                backgroundColor: props.backgroundColor,
+                borderRadius: 999,
+                height: ACTION_CIRCLE_SIZE,
+                left: 0,
+                position: "absolute",
+                top: 0,
+              },
+              circleStyle,
+            ]}
           />
           <Animated.View
-            className="absolute left-0 top-0 h-9 w-9 items-center justify-center"
-            style={iconStyle}
+            style={[
+              {
+                alignItems: "center",
+                height: ACTION_CIRCLE_SIZE,
+                justifyContent: "center",
+                left: 0,
+                position: "absolute",
+                top: 0,
+                width: ACTION_CIRCLE_SIZE,
+              },
+              iconStyle,
+            ]}
           >
             <SymbolView
               name={props.icon}
@@ -377,7 +409,7 @@ function SwipeActionButton(props: {
             />
           </Animated.View>
         </View>
-        <Animated.View className="pt-0.5" style={labelStyle}>
+        <Animated.View style={[{ paddingTop: 2 }, labelStyle]}>
           <Text className="text-3xs font-t3-medium text-foreground-muted">{props.label}</Text>
         </Animated.View>
       </Pressable>
@@ -406,7 +438,14 @@ export function ThreadSwipeActions(props: {
   );
 
   return (
-    <View className="h-full w-[100px] flex-row" style={{ backgroundColor: props.backgroundColor }}>
+    <View
+      style={{
+        backgroundColor: props.backgroundColor,
+        flexDirection: "row",
+        height: "100%",
+        width: THREAD_SWIPE_ACTIONS_WIDTH,
+      }}
+    >
       <SwipeActionButton
         accessibilityLabel={props.primaryAction.accessibilityLabel}
         backgroundColor="#007aff"

--- a/apps/mobile/src/features/home/thread-swipe-actions.tsx
+++ b/apps/mobile/src/features/home/thread-swipe-actions.tsx
@@ -350,56 +350,24 @@ function SwipeActionButton(props: {
 
   return (
     <Animated.View
-      style={[
-        {
-          alignItems: "center",
-          height: "100%",
-          justifyContent: "center",
-          width: ACTION_ITEM_WIDTH,
-          zIndex: props.stretchesOnFullSwipe ? 2 : 1,
-        },
-        actionStyle,
-      ]}
+      className="h-full w-[50px] items-center justify-center"
+      style={[{ zIndex: props.stretchesOnFullSwipe ? 2 : 1 }, actionStyle]}
     >
       <Pressable
+        className="h-full w-full items-center justify-center"
         accessibilityLabel={props.accessibilityLabel}
         accessibilityRole="button"
         onPress={props.onPress}
-        style={({ pressed }) => ({
-          alignItems: "center",
-          height: "100%",
-          justifyContent: "center",
-          opacity: pressed ? 0.72 : 1,
-          width: "100%",
-        })}
+        style={({ pressed }) => ({ opacity: pressed ? 0.72 : 1 })}
       >
-        <View style={{ height: ACTION_CIRCLE_SIZE, width: ACTION_CIRCLE_SIZE }}>
+        <View className="h-9 w-9">
           <Animated.View
-            style={[
-              {
-                backgroundColor: props.backgroundColor,
-                borderRadius: 999,
-                height: ACTION_CIRCLE_SIZE,
-                left: 0,
-                position: "absolute",
-                top: 0,
-              },
-              circleStyle,
-            ]}
+            className="absolute left-0 top-0 h-9 w-9 rounded-full"
+            style={[{ backgroundColor: props.backgroundColor }, circleStyle]}
           />
           <Animated.View
-            style={[
-              {
-                alignItems: "center",
-                height: ACTION_CIRCLE_SIZE,
-                justifyContent: "center",
-                left: 0,
-                position: "absolute",
-                top: 0,
-                width: ACTION_CIRCLE_SIZE,
-              },
-              iconStyle,
-            ]}
+            className="absolute left-0 top-0 h-9 w-9 items-center justify-center"
+            style={iconStyle}
           >
             <SymbolView
               name={props.icon}
@@ -409,7 +377,7 @@ function SwipeActionButton(props: {
             />
           </Animated.View>
         </View>
-        <Animated.View style={[{ paddingTop: 2 }, labelStyle]}>
+        <Animated.View className="pt-0.5" style={labelStyle}>
           <Text className="text-3xs font-t3-medium text-foreground-muted">{props.label}</Text>
         </Animated.View>
       </Pressable>
@@ -438,14 +406,7 @@ export function ThreadSwipeActions(props: {
   );
 
   return (
-    <View
-      style={{
-        backgroundColor: props.backgroundColor,
-        flexDirection: "row",
-        height: "100%",
-        width: THREAD_SWIPE_ACTIONS_WIDTH,
-      }}
-    >
+    <View className="h-full w-[100px] flex-row" style={{ backgroundColor: props.backgroundColor }}>
       <SwipeActionButton
         accessibilityLabel={props.primaryAction.accessibilityLabel}
         backgroundColor="#007aff"

--- a/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
+++ b/apps/mobile/src/features/layout/AdaptiveWorkspaceLayout.tsx
@@ -476,16 +476,17 @@ export function AdaptiveWorkspaceLayout(props: {
   return (
     <HomeListOptionsProvider>
       <AdaptiveWorkspaceContext.Provider value={contextValue}>
-        <View testID="adaptive-workspace-layout" style={{ flex: 1, flexDirection: "row" }}>
+        <View testID="adaptive-workspace-layout" className="flex-1 flex-row">
           {shouldRenderPrimarySidebar && layout.listPaneWidth !== null ? (
             <Animated.View
+              className="self-stretch overflow-hidden"
               accessibilityElementsHidden={!panes.primarySidebarVisible}
               collapsable={false}
               importantForAccessibility={
                 panes.primarySidebarVisible ? "auto" : "no-hide-descendants"
               }
               pointerEvents={panes.primarySidebarVisible ? "auto" : "none"}
-              style={[{ alignSelf: "stretch", overflow: "hidden" }, sidebarAnimatedStyle]}
+              style={sidebarAnimatedStyle}
             >
               <ThreadNavigationSidebar
                 width={layout.listPaneWidth}
@@ -501,7 +502,7 @@ export function AdaptiveWorkspaceLayout(props: {
               />
             </Animated.View>
           ) : null}
-          <View className="bg-screen" collapsable={false} style={{ flex: 1, overflow: "hidden" }}>
+          <View className="flex-1 overflow-hidden bg-screen" collapsable={false}>
             <View
               collapsable={false}
               style={

--- a/apps/mobile/src/features/layout/workspace-inspector-pane.tsx
+++ b/apps/mobile/src/features/layout/workspace-inspector-pane.tsx
@@ -129,13 +129,14 @@ export function WorkspaceInspectorPane(props: {
       ) : null}
       {inspectorSupported ? (
         <Animated.View
+          className="shrink-0 overflow-hidden"
           accessibilityElementsHidden={!inspectorVisible}
           collapsable={false}
           importantForAccessibility={inspectorVisible ? "auto" : "no-hide-descendants"}
           pointerEvents={inspectorVisible ? "auto" : "none"}
-          style={[{ flexShrink: 0, overflow: "hidden" }, inspectorStyle]}
+          style={inspectorStyle}
         >
-          <Animated.View style={[{ flex: 1 }, inspectorContentStyle]}>
+          <Animated.View className="flex-1" style={inspectorContentStyle}>
             {props.renderInspector?.()}
           </Animated.View>
         </Animated.View>

--- a/apps/mobile/src/features/layout/workspace-pane-divider.tsx
+++ b/apps/mobile/src/features/layout/workspace-pane-divider.tsx
@@ -69,6 +69,7 @@ export function WorkspacePaneDivider(props: WorkspacePaneDividerProps) {
   return (
     <GestureDetector gesture={resizeGesture}>
       <Pressable
+        className="relative z-[100] -mx-[22px] w-11 self-stretch cursor-pointer justify-center"
         accessibilityActions={[
           { name: "increment", label: "Make pane wider" },
           { name: "decrement", label: "Make pane narrower" },
@@ -82,7 +83,6 @@ export function WorkspacePaneDivider(props: WorkspacePaneDividerProps) {
         onAccessibilityAction={handleAccessibilityAction}
         onHoverIn={() => setHovered(true)}
         onHoverOut={() => setHovered(false)}
-        style={styles.hitTarget}
       >
         <View style={[styles.line, (hovered || dragging) && styles.activeLine]} />
       </Pressable>
@@ -91,15 +91,6 @@ export function WorkspacePaneDivider(props: WorkspacePaneDividerProps) {
 }
 
 const styles = StyleSheet.create({
-  hitTarget: {
-    alignSelf: "stretch",
-    cursor: "pointer",
-    justifyContent: "center",
-    marginHorizontal: -22,
-    position: "relative",
-    width: 44,
-    zIndex: 100,
-  },
   line: {
     alignSelf: "center",
     backgroundColor:

--- a/apps/mobile/src/features/projects/AddProjectScreen.tsx
+++ b/apps/mobile/src/features/projects/AddProjectScreen.tsx
@@ -31,6 +31,7 @@ import * as Arr from "effect/Array";
 import * as Cause from "effect/Cause";
 import * as Order from "effect/Order";
 import { AsyncResult } from "effect/unstable/reactivity";
+import { cn } from "../../lib/cn";
 
 import { useProjects, useServerConfigs } from "../../state/entities";
 import { filesystemEnvironment } from "../../state/filesystem";
@@ -99,10 +100,7 @@ function sourceFromParam(value: string | string[] | undefined): AddProjectRemote
 
 function SectionTitle(props: { readonly children: string }) {
   return (
-    <Text
-      className="px-1 text-2xs font-t3-bold uppercase text-foreground-muted"
-      style={{ letterSpacing: 0.7 }}
-    >
+    <Text className="px-1 text-2xs font-t3-bold tracking-[0.7px] uppercase text-foreground-muted">
       {props.children}
     </Text>
   );
@@ -148,19 +146,17 @@ function ListRow(props: {
   readonly right?: ReactNode;
   readonly onPress?: () => void;
 }) {
-  const borderColor = useThemeColor("--color-border-subtle");
   const chevronColor = useThemeColor("--color-chevron");
 
   return (
     <Pressable
       disabled={props.disabled}
       onPress={props.onPress}
-      className="bg-card px-3.5 py-2.5 active:opacity-70"
-      style={{
-        opacity: props.disabled ? 0.45 : 1,
-        borderTopWidth: props.isFirst ? 0 : 1,
-        borderTopColor: borderColor,
-      }}
+      className={cn(
+        "bg-card px-3.5 py-2.5 active:opacity-70",
+        !props.isFirst && "border-t border-border-subtle",
+        props.disabled && "opacity-[0.45]",
+      )}
     >
       <View className="flex-row items-center gap-3">
         <View

--- a/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewCommentComposerSheet.tsx
@@ -144,15 +144,11 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
   }
 
   return (
-    <View style={{ flex: 1 }}>
-      <KeyboardAvoidingView automaticOffset behavior="padding" style={{ flex: 1 }}>
+    <View className="flex-1">
+      <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
         <View
-          style={{
-            flex: 1,
-            paddingHorizontal: 20,
-            paddingTop: 8,
-            paddingBottom: target ? 0 : Math.max(insets.bottom, 18),
-          }}
+          className="flex-1 px-5 pt-2"
+          style={{ paddingBottom: target ? 0 : Math.max(insets.bottom, 18) }}
         >
           <View className="flex-row items-center justify-between py-2">
             <Pressable
@@ -253,8 +249,7 @@ export function ReviewCommentComposerSheet(props: ReviewCommentComposerSheetProp
                         textAlignVertical="top"
                         value={commentText}
                         onChangeText={setCommentText}
-                        className="h-full flex-1 border-0 bg-transparent px-0 py-0 font-sans text-base"
-                        style={{ flex: 1, minHeight: 0 }}
+                        className="h-full min-h-0 flex-1 border-0 bg-transparent px-0 py-0 font-sans text-base"
                       />
                     </TextInputWrapper>
                   </View>

--- a/apps/mobile/src/features/review/ReviewSheet.tsx
+++ b/apps/mobile/src/features/review/ReviewSheet.tsx
@@ -655,7 +655,7 @@ export function ReviewSheet(props: ReviewSheetProps) {
 
       <View className="flex-1 bg-sheet">
         {showConnectionNotice ? (
-          <View style={{ flex: 1, paddingTop: topContentInset }}>
+          <View className="flex-1" style={{ paddingTop: topContentInset }}>
             <EnvironmentConnectionNotice
               environmentLabel={environment.presentation?.entry.target.label ?? "Environment"}
               connection={
@@ -722,7 +722,7 @@ export function ReviewSheet(props: ReviewSheetProps) {
               bottom: Math.max(insets.bottom, 18) + 18,
             }}
             showsVerticalScrollIndicator={false}
-            style={{ flex: 1 }}
+            className="flex-1"
           >
             {listHeader}
             {!selectedSection ? (

--- a/apps/mobile/src/features/review/reviewDiffRendering.tsx
+++ b/apps/mobile/src/features/review/reviewDiffRendering.tsx
@@ -48,8 +48,8 @@ export function ReviewChangeBar(props: {
         <View>
           {Array.from({ length: Math.ceil(height / 2) }, (_, index) => (
             <View key={index}>
-              <View className="w-[5px] bg-rose-400" style={{ height: 1 }} />
-              <View style={{ height: 1 }} />
+              <View className="h-px w-[5px] bg-rose-400" />
+              <View className="h-px" />
             </View>
           ))}
         </View>

--- a/apps/mobile/src/features/settings/SettingsAppearanceRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsAppearanceRouteScreen.tsx
@@ -13,12 +13,10 @@ export function SettingsAppearanceRouteScreen() {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
+        className="flex-1"
+        contentContainerClassName="gap-6 px-5 pt-4"
         contentContainerStyle={{
-          gap: 24,
           paddingBottom: Math.max(insets.bottom, 18) + 18,
-          paddingHorizontal: 20,
-          paddingTop: 16,
         }}
       >
         <TextAppearanceSection />

--- a/apps/mobile/src/features/settings/SettingsClientStorageRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsClientStorageRouteScreen.tsx
@@ -75,13 +75,8 @@ export function SettingsClientStorageRouteScreen() {
         contentInsetAdjustmentBehavior="automatic"
         contentInset={{ bottom: Math.max(insets.bottom, 18) }}
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
-        contentContainerStyle={{
-          gap: 24,
-          paddingBottom: 18,
-          paddingHorizontal: 20,
-          paddingTop: 16,
-        }}
+        className="flex-1"
+        contentContainerClassName="gap-6 px-5 pt-4 pb-[18px]"
       >
         <SettingsSection title="Environment caches">
           {AsyncResult.isFailure(summaryResult) ? (
@@ -180,7 +175,6 @@ function CacheEnvironmentRow(props: {
   readonly onClear: () => void;
 }) {
   const iconColor = useThemeColor("--color-icon");
-  const dangerForegroundColor = useThemeColor("--color-danger-foreground");
   return (
     <View
       className={
@@ -206,11 +200,7 @@ function CacheEnvironmentRow(props: {
         onPress={props.onClear}
         className="rounded-full px-3 py-2 disabled:opacity-40"
       >
-        <Text
-          className="font-t3-medium tabular-nums text-danger-foreground"
-          numberOfLines={1}
-          style={{ color: dangerForegroundColor }}
-        >
+        <Text className="font-t3-medium tabular-nums text-danger-foreground" numberOfLines={1}>
           Clear {formatBytes(props.environment.payloadBytes)}
         </Text>
       </Pressable>

--- a/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsEnvironmentsRouteScreen.tsx
@@ -50,11 +50,10 @@ export function SettingsEnvironmentsRouteScreen() {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
+        className="flex-1"
+        contentContainerClassName="px-5 pt-4"
         contentContainerStyle={{
           paddingBottom: Math.max(insets.bottom, 18) + 18,
-          paddingHorizontal: 20,
-          paddingTop: 16,
         }}
       >
         {hasLocalEnvironments ? (
@@ -63,10 +62,7 @@ export function SettingsEnvironmentsRouteScreen() {
               <View
                 key={environment.environmentId}
                 collapsable={false}
-                style={{
-                  borderTopWidth: index === 0 ? 0 : 1,
-                }}
-                className={cn(index !== 0 && "border-border")}
+                className={cn(index !== 0 && "border-t border-border")}
               >
                 <ConnectionEnvironmentRow
                   environment={environment}

--- a/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
+++ b/apps/mobile/src/features/settings/SettingsRouteScreen.tsx
@@ -94,12 +94,10 @@ function LocalSettingsRouteScreen() {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
+        className="flex-1"
+        contentContainerClassName="gap-6 px-5 pt-4"
         contentContainerStyle={{
-          gap: 24,
           paddingBottom: Math.max(insets.bottom, 18) + 18,
-          paddingHorizontal: 20,
-          paddingTop: 16,
         }}
       >
         <SettingsSection title="Configuration">
@@ -430,12 +428,10 @@ function ConfiguredSettingsRouteScreen() {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
+        className="flex-1"
+        contentContainerClassName="gap-6 px-5 pt-4"
         contentContainerStyle={{
-          gap: 24,
           paddingBottom: Math.max(insets.bottom, 18) + 18,
-          paddingHorizontal: 20,
-          paddingTop: 16,
         }}
       >
         <View className="gap-3">

--- a/apps/mobile/src/features/settings/appearance/components/FontSizeSliderRow.tsx
+++ b/apps/mobile/src/features/settings/appearance/components/FontSizeSliderRow.tsx
@@ -136,7 +136,7 @@ export function FontSizeSliderRow(props: {
   };
 
   return (
-    <View className="gap-1 p-4" style={{ opacity: disabled ? 0.45 : 1 }}>
+    <View className={disabled ? "gap-1 p-4 opacity-[0.45]" : "gap-1 p-4"}>
       <View className="flex-row items-center gap-4">
         <SymbolView
           name={props.icon}

--- a/apps/mobile/src/features/settings/components/SettingsRow.tsx
+++ b/apps/mobile/src/features/settings/components/SettingsRow.tsx
@@ -22,8 +22,11 @@ export function SettingsRow(props: {
   const chevron = useThemeColor("--color-chevron");
   const content = (
     <View
-      className="flex-row items-center gap-4 p-4"
-      style={{ opacity: props.disabled ? 0.45 : 1 }}
+      className={
+        props.disabled
+          ? "flex-row items-center gap-4 p-4 opacity-[0.45]"
+          : "flex-row items-center gap-4 p-4"
+      }
     >
       <SymbolView name={props.icon} size={22} tintColor={icon} type="monochrome" weight="regular" />
       <Text className="shrink-0 text-lg text-foreground" numberOfLines={1}>

--- a/apps/mobile/src/features/settings/components/SettingsSection.tsx
+++ b/apps/mobile/src/features/settings/components/SettingsSection.tsx
@@ -7,10 +7,7 @@ export function SettingsSection(props: { readonly title: string; readonly childr
   return (
     <View className="gap-2">
       <Text className="px-2 text-sm font-t3-medium text-foreground-muted">{props.title}</Text>
-      <View
-        className="overflow-hidden rounded-[28px] bg-card"
-        style={{ borderCurve: "continuous" }}
-      >
+      <View className="overflow-hidden rounded-[28px] border-continuous bg-card">
         {props.children}
       </View>
     </View>

--- a/apps/mobile/src/features/settings/components/SettingsSwitchRow.tsx
+++ b/apps/mobile/src/features/settings/components/SettingsSwitchRow.tsx
@@ -20,8 +20,11 @@ export function SettingsSwitchRow(props: {
 
   return (
     <View
-      className="flex-row items-center gap-4 p-4"
-      style={{ opacity: props.disabled ? 0.45 : 1 }}
+      className={
+        props.disabled
+          ? "flex-row items-center gap-4 p-4 opacity-[0.45]"
+          : "flex-row items-center gap-4 p-4"
+      }
     >
       <SymbolView name={props.icon} size={22} tintColor={icon} type="monochrome" weight="regular" />
       <Text className="flex-1 text-lg text-foreground">{props.label}</Text>

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -165,13 +165,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
           })}
           onPress={() => props.onInput("\u0003")}
         >
-          <Text
-            className="text-2xs"
-            style={{
-              color: theme.foreground,
-              fontFamily: "DMSans-Bold",
-            }}
-          >
+          <Text className="text-2xs font-t3-bold" style={{ color: theme.foreground }}>
             Ctrl-C
           </Text>
         </Pressable>

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -169,7 +169,7 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
             className="text-2xs"
             style={{
               color: theme.foreground,
-              fontFamily: "DMSans_700Bold",
+              fontFamily: "DMSans-Bold",
             }}
           >
             Ctrl-C

--- a/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
+++ b/apps/mobile/src/features/terminal/NativeTerminalSurface.tsx
@@ -82,9 +82,9 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
 
   return (
     <View
+      className="flex-1"
       style={[
         {
-          flex: 1,
           backgroundColor: theme.background,
           borderRadius: 8,
           overflow: "hidden",
@@ -93,19 +93,18 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
       ]}
       onLayout={handleLayout}
     >
-      <View style={{ flex: 1, paddingHorizontal: 10, paddingVertical: 8 }}>
+      <View className="flex-1 px-2.5 py-2">
         <Text
-          className="text-2xs"
+          className="pb-2 text-2xs"
           style={{
             color: theme.mutedForeground,
-            paddingBottom: 8,
           }}
         >
           {statusLabel}
         </Text>
         <ScrollView
-          style={{ flex: 1 }}
-          contentContainerStyle={{ paddingBottom: 12 }}
+          className="flex-1"
+          contentContainerClassName="pb-3"
           showsVerticalScrollIndicator={false}
         >
           <Text
@@ -122,13 +121,9 @@ const FallbackTerminalSurface = memo(function FallbackTerminalSurface(props: Ter
         </ScrollView>
       </View>
       <View
+        className="flex-row items-center gap-2 border-t p-2"
         style={{
-          borderTopWidth: 1,
           borderTopColor: theme.border,
-          flexDirection: "row",
-          alignItems: "center",
-          gap: 8,
-          padding: 8,
         }}
       >
         <TextInput

--- a/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
+++ b/apps/mobile/src/features/terminal/ThreadTerminalRouteScreen.tsx
@@ -929,7 +929,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
         </NativeHeaderToolbar>
       ) : null}
 
-      <View style={{ flex: 1, backgroundColor: terminalTheme.background }}>
+      <View className="flex-1" style={{ backgroundColor: terminalTheme.background }}>
         {!isEnvironmentReady ? (
           <EnvironmentConnectionNotice
             environmentLabel={
@@ -949,7 +949,7 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
           />
         ) : (
           <>
-            <View style={{ flex: 1, paddingBottom: terminalBottomInset }}>
+            <View className="flex-1" style={{ paddingBottom: terminalBottomInset }}>
               <TerminalSurface
                 buffer={terminalSurfaceBuffer}
                 fontSize={fontSize}
@@ -968,10 +968,10 @@ export function ThreadTerminalRouteScreen(props: ThreadTerminalRouteScreenProps)
                 offset={{ closed: 0, opened: 0 }}
               >
                 <View
+                  className="border-t"
                   style={{
                     backgroundColor: terminalTheme.background,
                     borderTopColor: terminalTheme.border,
-                    borderTopWidth: 1,
                     minHeight: TERMINAL_ACCESSORY_HEIGHT,
                   }}
                 >

--- a/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
+++ b/apps/mobile/src/features/threads/ComposerCommandPopover.tsx
@@ -154,23 +154,11 @@ const CommandRow = memo(function CommandRow(props: {
       ) : iconName ? (
         <SymbolView name={iconName} size={14} tintColor={iconColor} type="monochrome" />
       ) : null}
-      <Text
-        className="text-base font-t3-medium text-foreground"
-        numberOfLines={1}
-        style={{ flexShrink: 0 }}
-      >
+      <Text className="shrink-0 text-base font-t3-medium text-foreground" numberOfLines={1}>
         {props.item.label}
       </Text>
       {props.item.description ? (
-        <Text
-          className="text-xs"
-          numberOfLines={1}
-          style={{
-            flex: 1,
-            minWidth: 0,
-            color: "#a1a1aa",
-          }}
-        >
+        <Text className="min-w-0 flex-1 text-xs text-zinc-400" numberOfLines={1}>
           {props.item.description}
         </Text>
       ) : null}
@@ -187,18 +175,15 @@ export const ComposerCommandPopover = memo(function ComposerCommandPopover(
   return (
     <PopoverSurface isDarkMode={isDarkMode}>
       {label ? (
-        <View style={{ paddingHorizontal: 14, paddingTop: 10, paddingBottom: 4 }}>
-          <Text
-            className="text-3xs font-t3-bold text-foreground-muted"
-            style={{ letterSpacing: 0.8, textTransform: "uppercase" }}
-          >
+        <View className="px-3.5 pt-2.5 pb-1">
+          <Text className="text-3xs font-t3-bold tracking-[0.8px] uppercase text-foreground-muted">
             {label}
           </Text>
         </View>
       ) : null}
       {props.items.length > 0 ? (
         <ScrollView
-          style={{ maxHeight: 180 }}
+          className="max-h-[180px]"
           keyboardShouldPersistTaps="always"
           showsVerticalScrollIndicator={false}
         >
@@ -212,7 +197,7 @@ export const ComposerCommandPopover = memo(function ComposerCommandPopover(
           ))}
         </ScrollView>
       ) : (
-        <View style={{ paddingHorizontal: 14, paddingVertical: 10 }}>
+        <View className="px-3.5 py-2.5">
           <Text className="text-xs text-foreground-tertiary">
             {emptyText(props.triggerKind, props.isLoading)}
           </Text>

--- a/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
+++ b/apps/mobile/src/features/threads/GitActionProgressOverlay.tsx
@@ -47,7 +47,8 @@ export function GitActionProgressOverlay(props: {
     <Animated.View
       entering={FadeIn.duration(200)}
       exiting={FadeOut.duration(150)}
-      style={{ top: insets.top + 48, left: 12, right: 12, position: "absolute", zIndex: 100 }}
+      className="absolute inset-x-3 z-[100]"
+      style={{ top: insets.top + 48 }}
       pointerEvents="box-none"
     >
       <Pressable onPress={handlePress}>

--- a/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskDraftScreen.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Alert, InteractionManager, View, useColorScheme } from "react-native";
 import { KeyboardAvoidingView, useKeyboardState } from "react-native-keyboard-controller";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useThemeColor } from "../../lib/useThemeColor";
 
 import { EnvironmentId } from "@t3tools/contracts";
 import {
@@ -112,7 +111,6 @@ export function NewTaskDraftScreen(props: {
     };
   }, [props.pendingTaskId, cancelEditingPendingTask]);
 
-  const borderColor = useThemeColor("--color-border");
   const headlineText = useScaledTextRole("headline");
   const sheetFadeOpaque = colorScheme === "dark" ? "rgba(14,14,14,0.98)" : "rgba(242,242,247,0.98)";
   const sheetFadeTransparent = colorScheme === "dark" ? "rgba(14,14,14,0)" : "rgba(242,242,247,0)";
@@ -600,8 +598,8 @@ export function NewTaskDraftScreen(props: {
     <View className="flex-1 bg-sheet">
       <NativeStackScreenOptions options={{ title: selectedProject.title }} />
 
-      <KeyboardAvoidingView automaticOffset behavior="padding" style={{ flex: 1 }}>
-        <View style={{ flex: 1, minHeight: 0, paddingHorizontal: 20, paddingTop: 8 }}>
+      <KeyboardAvoidingView automaticOffset behavior="padding" className="flex-1">
+        <View className="min-h-0 flex-1 px-5 pt-2">
           <ComposerEditor
             ref={promptInputRef}
             autoFocus
@@ -617,15 +615,9 @@ export function NewTaskDraftScreen(props: {
           />
         </View>
 
-        <View
-          style={{
-            borderTopWidth: 1,
-            borderTopColor: borderColor,
-            paddingBottom: controlsBottomPadding,
-          }}
-        >
+        <View className="border-t border-border" style={{ paddingBottom: controlsBottomPadding }}>
           {flow.attachments.length > 0 ? (
-            <View style={{ paddingHorizontal: 16, paddingTop: 12 }}>
+            <View className="px-4 pt-3">
               <ComposerAttachmentStrip
                 attachments={flow.attachments}
                 onRemove={flow.removeAttachment}

--- a/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
+++ b/apps/mobile/src/features/threads/NewTaskRouteScreen.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 import { ActivityIndicator, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useThemeColor } from "../../lib/useThemeColor";
+import { cn } from "../../lib/cn";
 
 import { AppText as Text } from "../../components/AppText";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
@@ -79,7 +80,6 @@ export function NewTaskRouteScreen() {
   const insets = useSafeAreaInsets();
   const chevronColor = useThemeColor("--color-chevron");
   const accentColor = useThemeColor("--color-icon-muted");
-  const borderSubtleColor = useThemeColor("--color-border-subtle");
   const repositoryGroups = useMemo(
     () => groupProjectsByRepository({ projects, threads }),
     [projects, threads],
@@ -130,7 +130,7 @@ export function NewTaskRouteScreen() {
       <ScrollView
         contentInsetAdjustmentBehavior="automatic"
         showsVerticalScrollIndicator={false}
-        style={{ flex: 1 }}
+        className="flex-1"
         contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
         contentContainerStyle={{
           paddingHorizontal: 20,
@@ -175,7 +175,6 @@ export function NewTaskRouteScreen() {
               return (
                 <Pressable
                   key={item.key}
-                  className="bg-card"
                   onPress={() =>
                     navigation.navigate("NewTaskSheet", {
                       screen: "NewTaskDraft",
@@ -186,16 +185,12 @@ export function NewTaskRouteScreen() {
                       },
                     })
                   }
-                  style={{
-                    paddingHorizontal: 16,
-                    paddingVertical: 14,
-                    borderTopWidth: isFirst ? 0 : 1,
-                    borderTopColor: borderSubtleColor,
-                    borderTopLeftRadius: isFirst ? 24 : 0,
-                    borderTopRightRadius: isFirst ? 24 : 0,
-                    borderBottomLeftRadius: isLast ? 24 : 0,
-                    borderBottomRightRadius: isLast ? 24 : 0,
-                  }}
+                  className={cn(
+                    "bg-card px-4 py-3.5",
+                    !isFirst && "border-t border-border-subtle",
+                    isFirst && "rounded-t-[24px]",
+                    isLast && "rounded-b-[24px]",
+                  )}
                 >
                   <View className="flex-row items-center justify-between gap-3">
                     <View className="h-7 w-7 items-center justify-center">

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -797,7 +797,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               textStyle={{
                 ...bodyText,
                 color: foregroundColor,
-                fontFamily: "DMSans_400Regular",
+                fontFamily: "DMSans-Regular",
               }}
             />
           </View>

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -688,9 +688,9 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
 
   return (
     <Animated.View
+      className="px-4"
       layout={COMPOSER_LAYOUT_TRANSITION}
       style={{
-        paddingHorizontal: 16,
         paddingTop: isExpanded ? 8 : 6,
         paddingBottom: (props.bottomInset ?? 0) + (isExpanded ? 8 : 6),
         experimental_backgroundImage: isDarkMode
@@ -699,21 +699,12 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
       }}
     >
       <Animated.View
-        className="w-full"
+        className="relative w-full self-center"
         layout={COMPOSER_LAYOUT_TRANSITION}
-        style={{ alignSelf: "center", maxWidth: props.contentMaxWidth, position: "relative" }}
+        style={{ maxWidth: props.contentMaxWidth }}
       >
         {composerTrigger && composerMenuItems.length > 0 ? (
-          <View
-            style={{
-              position: "absolute",
-              bottom: "100%",
-              left: 0,
-              right: 0,
-              marginBottom: 8,
-              zIndex: 10,
-            }}
-          >
+          <View className="absolute inset-x-0 bottom-full z-10 mb-2">
             <ComposerCommandPopover
               items={composerMenuItems}
               triggerKind={composerTrigger.kind}
@@ -754,9 +745,9 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
           {/* Attachment strip — inside the card, above the text input */}
           {isExpanded ? (
             <Animated.View
+              className={props.draftAttachments.length > 0 ? "pb-2.5" : undefined}
               entering={FadeIn.duration(160)}
               exiting={FadeOut.duration(120)}
-              style={{ paddingBottom: props.draftAttachments.length > 0 ? 10 : 0 }}
             >
               <ComposerAttachmentStrip
                 attachments={props.draftAttachments}
@@ -766,7 +757,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
             </Animated.View>
           ) : null}
 
-          <View style={isExpanded ? undefined : { flex: 1, minWidth: 0 }}>
+          <View className={isExpanded ? undefined : "min-w-0 flex-1"}>
             <ComposerEditor
               ref={inputRef}
               multiline
@@ -801,32 +792,18 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
             />
           </View>
           {!isExpanded && props.draftAttachments.length > 0 ? (
-            <View style={{ flexDirection: "row", gap: 4, paddingLeft: 4 }}>
+            <View className="flex-row gap-1 pl-1">
               {props.draftAttachments.slice(0, 3).map((image) => (
                 <Pressable key={image.id} onPress={() => onPressImage(image.previewUri)}>
                   <Image
                     source={{ uri: image.previewUri }}
-                    className="bg-subtle"
-                    style={{
-                      width: 30,
-                      height: 30,
-                      borderRadius: 8,
-                    }}
+                    className="size-[30px] rounded-lg bg-subtle"
                     resizeMode="cover"
                   />
                 </Pressable>
               ))}
               {props.draftAttachments.length > 3 ? (
-                <View
-                  className="bg-subtle-strong"
-                  style={{
-                    width: 30,
-                    height: 30,
-                    borderRadius: 8,
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
+                <View className="size-[30px] items-center justify-center rounded-lg bg-subtle-strong">
                   <Text className="text-foreground-muted text-2xs font-t3-bold">
                     +{props.draftAttachments.length - 3}
                   </Text>
@@ -909,7 +886,7 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
         {/* Queue count */}
         {props.queueCount > 0 ? (
           <Animated.View entering={FadeIn.duration(180)} exiting={FadeOut.duration(120)}>
-            <Text className="text-xs text-foreground-muted" style={{ paddingTop: 8 }}>
+            <Text className="pt-2 text-xs text-foreground-muted">
               {props.queueCount} queued message{props.queueCount === 1 ? "" : "s"} will send
               automatically.
             </Text>

--- a/apps/mobile/src/features/threads/ThreadComposer.tsx
+++ b/apps/mobile/src/features/threads/ThreadComposer.tsx
@@ -797,7 +797,6 @@ export const ThreadComposer = memo(function ThreadComposer(props: ThreadComposer
               textStyle={{
                 ...bodyText,
                 color: foregroundColor,
-                fontFamily: "DMSans-Regular",
               }}
             />
           </View>

--- a/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
+++ b/apps/mobile/src/features/threads/ThreadDetailScreen.tsx
@@ -193,10 +193,9 @@ const WorkingDurationPill = memo(function WorkingDurationPill(props: {
 
   return (
     <Animated.View
-      className="px-4 pb-2 pt-2"
+      className="shrink-0 px-4 pb-2 pt-2"
       entering={FadeInDown.duration(200)}
       exiting={FadeOut.duration(140)}
-      style={{ flexShrink: 0 }}
     >
       <View className="self-start rounded-full border border-neutral-200/80 bg-neutral-50/90 px-3 py-2 dark:border-white/[0.08] dark:bg-white/[0.04]">
         <View className="flex-row items-center gap-2">
@@ -390,7 +389,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
     <View className="flex-1">
       {showContent ? (
         <View
-          style={{ flex: 1 }}
+          className="flex-1"
           onTouchStart={handleFeedTouchStart}
           onTouchMove={handleFeedTouchMove}
           onTouchEnd={handleFeedTouchEnd}
@@ -419,7 +418,7 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
           />
         </View>
       ) : (
-        <View style={{ flex: 1 }} />
+        <View className="flex-1" />
       )}
 
       {/* Floating composer — sticks to keyboard via KeyboardStickyView */}
@@ -431,10 +430,11 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
           {/* No paddingTop here: the overlay's measured height becomes the
               list's bottom inset, so any padding above the pill/composer
               pushes the resting content floor up by the same amount. */}
-          <View ref={composerOverlayRef} onLayout={onComposerLayout} style={{ width: "100%" }}>
+          <View ref={composerOverlayRef} onLayout={onComposerLayout} className="w-full">
             <Animated.View
+              className="w-full self-center"
               layout={LinearTransition.duration(220)}
-              style={{ alignSelf: "center", maxWidth: contentMaxWidth, width: "100%" }}
+              style={{ maxWidth: contentMaxWidth }}
             >
               {props.activeWorkStartedAt ? (
                 <WorkingDurationPill startedAt={props.activeWorkStartedAt} />
@@ -442,10 +442,9 @@ export const ThreadDetailScreen = memo(function ThreadDetailScreen(props: Thread
 
               {props.activePendingApproval || props.activePendingUserInput ? (
                 <Animated.View
-                  className="gap-3 px-4 pb-3"
+                  className="shrink-0 gap-3 px-4 pb-3"
                   entering={FadeInDown.duration(220)}
                   exiting={FadeOut.duration(140)}
-                  style={{ flexShrink: 0 }}
                 >
                   {props.activePendingApproval ? (
                     <PendingApprovalCard

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -234,10 +234,6 @@ const markdownLinkStyles = StyleSheet.create({
   favicon: {
     borderRadius: 3,
   },
-  file: {
-    fontFamily: "DMSans-Bold",
-    fontWeight: "700",
-  },
 });
 
 const MarkdownExternalLink = memo(function MarkdownExternalLink(props: {
@@ -250,12 +246,12 @@ const MarkdownExternalLink = memo(function MarkdownExternalLink(props: {
 
   return (
     <NativeText
+      className="font-sans"
       onPress={() => {
         void Linking.openURL(props.href);
       }}
       style={{
         color: props.color,
-        fontFamily: "DMSans-Regular",
         textDecorationLine: "none",
       }}
     >
@@ -428,8 +424,9 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         if (presentation.kind === "file") {
           return (
             <NativeText
+              className="font-t3-bold"
               onPress={() => onLinkPress(href)}
-              style={[markdownLinkStyles.file, { color: inlineTextColor }]}
+              style={{ color: inlineTextColor }}
             >
               <Image
                 source={markdownFileIconSource(presentation.icon)}
@@ -488,11 +485,11 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
                 }}
               >
                 <NativeText
+                  className="font-sans"
                   style={{
                     width: ordered ? 22 : 12,
                     marginRight: 5,
                     color: inlineTextColor,
-                    fontFamily: "DMSans-Regular",
                     fontSize: markdownFontSizes.m,
                     lineHeight: markdownFontSizes.bodyLineHeight,
                     textAlign: ordered ? "right" : "center",

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -52,6 +52,7 @@ import Animated, {
   type SharedValue,
 } from "react-native-reanimated";
 import { useThemeColor } from "../../lib/useThemeColor";
+import { useFontFamily } from "../../lib/useFontFamily";
 import { copyTextWithHaptic } from "../../lib/copyTextWithHaptic";
 import {
   hasNativeSelectableMarkdownText,
@@ -310,6 +311,8 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
   );
   const colors = MARKDOWN_COLORS[colorScheme === "dark" ? "dark" : "light"];
   const inlineSkillForeground = String(useThemeColor("--color-inline-skill-foreground"));
+  const regularFontFamily = useFontFamily("regular");
+  const boldFontFamily = useFontFamily("bold");
 
   return useMemo(() => {
     const markdownBodyColor = colors.body;
@@ -361,8 +364,8 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         h6: markdownFontSizes.h6,
       },
       fontFamilies: {
-        regular: "DMSans-Regular",
-        heading: "DMSans-Bold",
+        regular: regularFontFamily,
+        heading: boldFontFamily,
         mono: "ui-monospace",
       },
       headingWeight: "700",
@@ -384,7 +387,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
       bold: {
         fontWeight: "700",
         color: markdownStrongColor,
-        fontFamily: "DMSans-Bold",
+        fontFamily: boldFontFamily,
       },
       italic: { fontStyle: "italic" },
       link: {
@@ -400,7 +403,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         marginVertical: 10,
       },
       heading: {
-        fontFamily: "DMSans-Bold",
+        fontFamily: boldFontFamily,
         color: markdownStrongColor,
         marginTop: 18,
         marginBottom: 8,
@@ -598,7 +601,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
       bold: {
         fontWeight: "700",
         color: markdownUserBodyColor,
-        fontFamily: "DMSans-Bold",
+        fontFamily: boldFontFamily,
       },
       heading: {
         ...baseStyles.heading,
@@ -652,9 +655,9 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
           fontSize: nativeMarkdownTypography.fontSize,
           lineHeight: nativeMarkdownTypography.lineHeight,
           headingFontSizes: nativeMarkdownTypography.headingFontSizes,
-          fontFamily: "DMSans-Regular",
-          headingFontFamily: "DMSans-Bold",
-          boldFontFamily: "DMSans-Bold",
+          fontFamily: regularFontFamily,
+          headingFontFamily: boldFontFamily,
+          boldFontFamily,
         },
       },
       assistant: {
@@ -683,13 +686,21 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
           fontSize: nativeMarkdownTypography.fontSize,
           lineHeight: nativeMarkdownTypography.lineHeight,
           headingFontSizes: nativeMarkdownTypography.headingFontSizes,
-          fontFamily: "DMSans-Regular",
-          headingFontFamily: "DMSans-Bold",
-          boldFontFamily: "DMSans-Bold",
+          fontFamily: regularFontFamily,
+          headingFontFamily: boldFontFamily,
+          boldFontFamily,
         },
       },
     };
-  }, [colors, inlineSkillForeground, markdownFontSizes, nativeMarkdownTypography, onLinkPress]);
+  }, [
+    boldFontFamily,
+    colors,
+    inlineSkillForeground,
+    markdownFontSizes,
+    nativeMarkdownTypography,
+    onLinkPress,
+    regularFontFamily,
+  ]);
 }
 
 function renderFeedEntry(

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -235,7 +235,7 @@ const markdownLinkStyles = StyleSheet.create({
     borderRadius: 3,
   },
   file: {
-    fontFamily: "DMSans_700Bold",
+    fontFamily: "DMSans-Bold",
     fontWeight: "700",
   },
 });
@@ -255,7 +255,7 @@ const MarkdownExternalLink = memo(function MarkdownExternalLink(props: {
       }}
       style={{
         color: props.color,
-        fontFamily: "DMSans_400Regular",
+        fontFamily: "DMSans-Regular",
         textDecorationLine: "none",
       }}
     >
@@ -365,8 +365,8 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         h6: markdownFontSizes.h6,
       },
       fontFamilies: {
-        regular: "DMSans_400Regular",
-        heading: "DMSans_700Bold",
+        regular: "DMSans-Regular",
+        heading: "DMSans-Bold",
         mono: "ui-monospace",
       },
       headingWeight: "700",
@@ -388,7 +388,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
       bold: {
         fontWeight: "700",
         color: markdownStrongColor,
-        fontFamily: "DMSans_700Bold",
+        fontFamily: "DMSans-Bold",
       },
       italic: { fontStyle: "italic" },
       link: {
@@ -404,7 +404,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         marginVertical: 10,
       },
       heading: {
-        fontFamily: "DMSans_700Bold",
+        fontFamily: "DMSans-Bold",
         color: markdownStrongColor,
         marginTop: 18,
         marginBottom: 8,
@@ -492,7 +492,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
                     width: ordered ? 22 : 12,
                     marginRight: 5,
                     color: inlineTextColor,
-                    fontFamily: "DMSans_400Regular",
+                    fontFamily: "DMSans-Regular",
                     fontSize: markdownFontSizes.m,
                     lineHeight: markdownFontSizes.bodyLineHeight,
                     textAlign: ordered ? "right" : "center",
@@ -601,7 +601,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
       bold: {
         fontWeight: "700",
         color: markdownUserBodyColor,
-        fontFamily: "DMSans_700Bold",
+        fontFamily: "DMSans-Bold",
       },
       heading: {
         ...baseStyles.heading,
@@ -655,9 +655,9 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
           fontSize: nativeMarkdownTypography.fontSize,
           lineHeight: nativeMarkdownTypography.lineHeight,
           headingFontSizes: nativeMarkdownTypography.headingFontSizes,
-          fontFamily: "DMSans_400Regular",
-          headingFontFamily: "DMSans_700Bold",
-          boldFontFamily: "DMSans_700Bold",
+          fontFamily: "DMSans-Regular",
+          headingFontFamily: "DMSans-Bold",
+          boldFontFamily: "DMSans-Bold",
         },
       },
       assistant: {
@@ -686,9 +686,9 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
           fontSize: nativeMarkdownTypography.fontSize,
           lineHeight: nativeMarkdownTypography.lineHeight,
           headingFontSizes: nativeMarkdownTypography.headingFontSizes,
-          fontFamily: "DMSans_400Regular",
-          headingFontFamily: "DMSans_700Bold",
-          boldFontFamily: "DMSans_700Bold",
+          fontFamily: "DMSans-Regular",
+          headingFontFamily: "DMSans-Bold",
+          boldFontFamily: "DMSans-Bold",
         },
       },
     };

--- a/apps/mobile/src/features/threads/ThreadFeed.tsx
+++ b/apps/mobile/src/features/threads/ThreadFeed.tsx
@@ -453,6 +453,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         const linkHref = presentation.href;
         return (
           <NativeText
+            className="underline"
             onPress={
               linkHref
                 ? () => {
@@ -460,17 +461,14 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
                   }
                 : undefined
             }
-            style={{
-              color: markdownLinkColor,
-              textDecorationLine: "underline",
-            }}
+            style={{ color: markdownLinkColor }}
           >
             {children}
           </NativeText>
         );
       },
       list: ({ node, Renderer, ordered = false, start = 1 }) => (
-        <View style={{ marginTop: 2, marginBottom: 8 }}>
+        <View className="mt-0.5 mb-2">
           {node.children?.map((child, index) => {
             const childKey = `${child.type}:${child.beg ?? "unknown"}:${child.end ?? "unknown"}`;
             if (child.type === "task_list_item") {
@@ -479,14 +477,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
               );
             }
             return (
-              <View
-                key={childKey}
-                style={{
-                  flexDirection: "row",
-                  alignItems: "flex-start",
-                  marginBottom: 3,
-                }}
-              >
+              <View className="mb-[3px] flex-row items-start" key={childKey}>
                 <NativeText
                   className="font-sans"
                   style={{
@@ -500,7 +491,7 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
                 >
                   {ordered ? `${start + index}.` : "•"}
                 </NativeText>
-                <View style={{ flex: 1, minWidth: 0 }}>
+                <View className="min-w-0 flex-1">
                   <Renderer node={child} depth={1} inListItem parentIsText={false} />
                 </View>
               </View>
@@ -512,9 +503,9 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         const value = content ?? "";
         return (
           <NativeText
+            className="font-mono"
             style={{
               color: inlineCodeTextColor,
-              fontFamily: "ui-monospace",
               fontSize: markdownFontSizes.codeBlockFontSize,
               lineHeight: markdownFontSizes.bodyLineHeight,
             }}
@@ -530,31 +521,24 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
         : {}),
       code_block: ({ content, language }) => (
         <View
+          className="my-3 overflow-hidden rounded-[10px] border"
           style={{
             backgroundColor: blockBackgroundColor,
-            borderRadius: 10,
-            borderWidth: 1,
             borderColor: markdownHrColor,
-            marginVertical: 12,
-            overflow: "hidden",
           }}
         >
           {language ? (
             <View
+              className="border-b px-3.5 py-2"
               style={{
-                borderBottomWidth: 1,
                 borderBottomColor: markdownHrColor,
-                paddingHorizontal: 14,
-                paddingVertical: 8,
               }}
             >
               <NativeText
+                className="font-mono uppercase opacity-70"
                 style={{
                   color: markdownBodyColor,
-                  fontFamily: "ui-monospace",
                   fontSize: markdownFontSizes.codeBlockFontSize,
-                  opacity: 0.7,
-                  textTransform: "uppercase",
                 }}
               >
                 {language}
@@ -565,13 +549,13 @@ function useMarkdownStyles(onLinkPress: (href: string) => void): MarkdownStyleSe
             horizontal
             showsHorizontalScrollIndicator={false}
             bounces={false}
-            contentContainerStyle={{ paddingHorizontal: 14, paddingVertical: 12 }}
+            contentContainerClassName="px-3.5 py-3"
           >
             <NativeText
               selectable
+              className="font-mono"
               style={{
                 color: blockTextColor,
-                fontFamily: "ui-monospace",
                 fontSize: markdownFontSizes.codeBlockFontSize,
                 lineHeight: markdownFontSizes.codeBlockLineHeight,
               }}
@@ -1027,11 +1011,10 @@ const ReviewCommentCard = memo(function ReviewCommentCard(props: {
 
   return (
     <View
-      className="w-full overflow-hidden rounded-[16px] border"
+      className="w-full overflow-hidden rounded-[16px] border border-continuous"
       style={{
         backgroundColor: props.colors.background,
         borderColor: props.colors.border,
-        borderCurve: "continuous",
       }}
     >
       <View
@@ -1039,8 +1022,8 @@ const ReviewCommentCard = memo(function ReviewCommentCard(props: {
         style={{ borderColor: props.colors.border }}
       >
         <View
-          className="size-6 items-center justify-center rounded-[7px]"
-          style={{ backgroundColor: props.colors.mutedBackground, borderCurve: "continuous" }}
+          className="size-6 items-center justify-center rounded-[7px] border-continuous"
+          style={{ backgroundColor: props.colors.mutedBackground }}
         >
           <SymbolView
             name="doc.text"
@@ -1093,9 +1076,9 @@ const ReviewCommentCard = memo(function ReviewCommentCard(props: {
         >
           <NativeText
             selectable
+            className="font-mono"
             style={{
               color: props.colors.text,
-              fontFamily: "ui-monospace",
               fontSize: codeSurface.fontSize,
               lineHeight: codeSurface.rowHeight,
             }}
@@ -1567,8 +1550,8 @@ export const ThreadFeed = memo(function ThreadFeed(props: ThreadFeedProps) {
 
   return (
     <>
-      <View style={{ flex: 1 }} onLayout={handleViewportLayout}>
-        <View style={{ flex: 1 }}>
+      <View className="flex-1" onLayout={handleViewportLayout}>
+        <View className="flex-1">
           <KeyboardAwareLegendList
             ref={props.listRef}
             // The empty↔filled key remounts the list when messages first

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -743,7 +743,7 @@ function ThreadNavigationSidebarPane(
             placeholder="Search"
             placeholderTextColor={placeholderColor}
             returnKeyType="search"
-            className="text-base"
+            className="text-base font-sans"
             style={[styles.searchInput, { color: foregroundColor }]}
             value={props.searchQuery}
           />
@@ -819,7 +819,6 @@ const styles = StyleSheet.create({
     height: 34,
     paddingVertical: 0,
     paddingHorizontal: 0,
-    fontFamily: "DMSans-Regular",
   },
   threadList: {
     flex: 1,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -97,8 +97,6 @@ function SidebarHeaderButtonGroup(props: {
 
 const SIDEBAR_STICKY_HEADER_HEIGHT = 106;
 const SIDEBAR_STICKY_HEADER_FADE_HEIGHT = 44;
-const IOS_SEARCH_FILL_DARK = "rgba(118, 118, 128, 0.24)";
-const IOS_SEARCH_FILL_LIGHT = "rgba(118, 118, 128, 0.12)";
 const SIDEBAR_HEADER_WASH_OPACITY = {
   dark: [0.22, 0.14, 0.04],
   light: [0.46, 0.3, 0.08],
@@ -140,15 +138,13 @@ function NativeSidebarContainer(props: ThreadNavigationSidebarProps) {
   return (
     <View
       testID="thread-navigation-sidebar"
-      style={[
-        styles.container,
-        {
-          width: props.width,
-          backgroundColor,
-          borderRightColor: borderColor,
-          borderRightWidth: StyleSheet.hairlineWidth,
-        },
-      ]}
+      className="flex-1"
+      style={{
+        width: props.width,
+        backgroundColor,
+        borderRightColor: borderColor,
+        borderRightWidth: StyleSheet.hairlineWidth,
+      }}
     >
       <SidebarNavigationShell>
         <ThreadNavigationSidebarPane {...props} nativeChrome />
@@ -338,11 +334,8 @@ function ThreadNavigationSidebarPane(
 
   const backgroundColor = useThemeColor("--color-drawer");
   const borderColor = useThemeColor("--color-border");
-  const foregroundColor = useThemeColor("--color-foreground");
   const mutedColor = useThemeColor("--color-foreground-muted");
   const placeholderColor = useThemeColor("--color-placeholder");
-  const searchBackgroundColor =
-    colorScheme === "dark" ? IOS_SEARCH_FILL_DARK : IOS_SEARCH_FILL_LIGHT;
   const headerFadeColor = String(backgroundColor);
   const headerWashOpacity = SIDEBAR_HEADER_WASH_OPACITY[colorScheme];
   const [measuredHeaderHeight, setMeasuredHeaderHeight] = useState<number | null>(null);
@@ -532,7 +525,7 @@ function ThreadNavigationSidebarPane(
     [filterIcon, filterMenu, props.onOpenSettings],
   );
   const listEmpty = (
-    <Text className="px-2 py-4 text-sm" style={{ color: mutedColor }}>
+    <Text className="px-2 py-4 text-sm text-foreground-muted">
       {catalogState.isLoadingConnections
         ? "Loading threads…"
         : props.searchQuery.trim().length > 0
@@ -566,7 +559,7 @@ function ThreadNavigationSidebarPane(
             unstable_headerRightItems: () => nativeHeaderItems,
           }}
         />
-        <View style={styles.container}>
+        <View className="flex-1">
           <SwipeableScrollGateProvider enabled={swipeEnabled}>
             <GestureDetector gesture={sidebarScrollGesture}>
               <LegendList
@@ -596,7 +589,7 @@ function ThreadNavigationSidebarPane(
                 style={styles.threadList}
                 ListHeaderComponent={
                   showsConnectionStatus ? (
-                    <View style={styles.connectionStatusNative}>
+                    <View className="px-1.5 pt-0.5 pb-2">
                       <WorkspaceConnectionStatus
                         onPress={props.onOpenEnvironmentSettings}
                         state={catalogState}
@@ -617,17 +610,15 @@ function ThreadNavigationSidebarPane(
   return (
     <View
       testID="thread-navigation-sidebar"
-      style={[
-        styles.container,
-        {
-          width: props.width,
-          backgroundColor,
-          borderRightColor: borderColor,
-          borderRightWidth: StyleSheet.hairlineWidth,
-        },
-      ]}
+      className="flex-1"
+      style={{
+        width: props.width,
+        backgroundColor,
+        borderRightColor: borderColor,
+        borderRightWidth: StyleSheet.hairlineWidth,
+      }}
     >
-      <View style={{ flex: 1, paddingBottom: insets.bottom }}>
+      <View className="flex-1" style={{ paddingBottom: insets.bottom }}>
         <SwipeableScrollGateProvider enabled={swipeEnabled}>
           <GestureDetector gesture={sidebarScrollGesture}>
             <LegendList
@@ -660,25 +651,17 @@ function ThreadNavigationSidebarPane(
       </View>
 
       <View
+        className="absolute inset-x-0 top-0 z-[4]"
         onLayout={handleStickyHeaderLayout}
         pointerEvents="box-none"
-        style={[
-          styles.stickyHeader,
-          {
-            paddingTop: insets.top,
-          },
-        ]}
+        style={{ paddingTop: insets.top }}
       >
         <View
+          className="absolute inset-x-0 top-0"
           pointerEvents="none"
           accessibilityElementsHidden
           importantForAccessibility="no-hide-descendants"
-          style={[
-            styles.stickyHeaderWash,
-            {
-              height: stickyHeaderHeight + SIDEBAR_STICKY_HEADER_FADE_HEIGHT,
-            },
-          ]}
+          style={{ height: stickyHeaderHeight + SIDEBAR_STICKY_HEADER_FADE_HEIGHT }}
         >
           <Svg width="100%" height="100%">
             <Defs>
@@ -704,12 +687,8 @@ function ThreadNavigationSidebarPane(
             <Rect width="100%" height="100%" fill="url(#sidebar-header-wash)" />
           </Svg>
         </View>
-        <View style={styles.header}>
-          <Text
-            className="flex-1 text-[34px] font-t3-bold"
-            numberOfLines={1}
-            style={{ color: foregroundColor }}
-          >
+        <View className="h-[50px] flex-row items-end gap-0.5 pr-2 pl-5">
+          <Text className="flex-1 text-[34px] font-t3-bold text-foreground" numberOfLines={1}>
             Threads
           </Text>
           <SidebarHeaderButtonGroup colorScheme={colorScheme}>
@@ -724,14 +703,7 @@ function ThreadNavigationSidebarPane(
           </SidebarHeaderButtonGroup>
         </View>
 
-        <View
-          style={[
-            styles.searchField,
-            {
-              backgroundColor: searchBackgroundColor,
-            },
-          ]}
-        >
+        <View className="mx-4 mt-[9px] h-[38px] flex-row items-center gap-1.5 rounded-xl bg-sidebar-search pr-2.5 pl-[11px]">
           <SymbolView name="magnifyingglass" size={15} tintColor={mutedColor} type="monochrome" />
           <TextInput
             ref={searchInputRef}
@@ -743,14 +715,13 @@ function ThreadNavigationSidebarPane(
             placeholder="Search"
             placeholderTextColor={placeholderColor}
             returnKeyType="search"
-            className="text-base font-sans"
-            style={[styles.searchInput, { color: foregroundColor }]}
+            className="h-[34px] flex-1 px-0 py-0 font-sans text-base text-foreground"
             value={props.searchQuery}
           />
         </View>
 
         {showsConnectionStatus ? (
-          <View style={styles.connectionStatus}>
+          <View className="px-3.5 pt-2.5">
             <WorkspaceConnectionStatus
               onPress={props.onOpenEnvironmentSettings}
               state={catalogState}
@@ -764,61 +735,11 @@ function ThreadNavigationSidebarPane(
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  stickyHeader: {
-    left: 0,
-    position: "absolute",
-    right: 0,
-    top: 0,
-    zIndex: 4,
-  },
-  stickyHeaderWash: {
-    left: 0,
-    position: "absolute",
-    right: 0,
-    top: 0,
-  },
-  header: {
-    height: 50,
-    paddingLeft: 20,
-    paddingRight: 8,
-    flexDirection: "row",
-    alignItems: "flex-end",
-    gap: 2,
-  },
   headerButtonGroup: {
     alignItems: "center",
     borderRadius: 22,
     flexDirection: "row",
     overflow: "hidden",
-  },
-  connectionStatus: {
-    paddingTop: 10,
-    paddingHorizontal: 14,
-  },
-  connectionStatusNative: {
-    paddingBottom: 8,
-    paddingHorizontal: 6,
-    paddingTop: 2,
-  },
-  searchField: {
-    height: 38,
-    marginTop: 9,
-    marginHorizontal: 16,
-    paddingLeft: 11,
-    paddingRight: 10,
-    borderRadius: 12,
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-  },
-  searchInput: {
-    flex: 1,
-    height: 34,
-    paddingVertical: 0,
-    paddingHorizontal: 0,
   },
   threadList: {
     flex: 1,

--- a/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
+++ b/apps/mobile/src/features/threads/ThreadNavigationSidebar.tsx
@@ -819,7 +819,7 @@ const styles = StyleSheet.create({
     height: 34,
     paddingVertical: 0,
     paddingHorizontal: 0,
-    fontFamily: "DMSans_400Regular",
+    fontFamily: "DMSans-Regular",
   },
   threadList: {
     flex: 1,

--- a/apps/mobile/src/features/threads/git/GitBranchesSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitBranchesSheet.tsx
@@ -3,9 +3,9 @@ import { useNavigation, type StaticScreenProps } from "@react-navigation/native"
 import { useState } from "react";
 import { Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useThemeColor } from "../../../lib/useThemeColor";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../../components/AppText";
+import { cn } from "../../../lib/cn";
 import { useEnvironmentQuery } from "../../../state/query";
 import { useThreadSelection } from "../../../state/use-thread-selection";
 import { useSelectedThreadGitActions } from "../../../state/use-selected-thread-git-actions";
@@ -26,12 +26,6 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
   const { selectedThreadCwd, selectedThreadWorktreePath } = useSelectedThreadWorktree();
   const gitState = useSelectedThreadGitState();
   const gitActions = useSelectedThreadGitActions();
-
-  const borderColor = useThemeColor("--color-border");
-  const inputBorderColor = useThemeColor("--color-input-border");
-  const inputBg = useThemeColor("--color-input");
-  const foregroundColor = useThemeColor("--color-foreground");
-  const subtleStrongColor = useThemeColor("--color-subtle-strong");
 
   const gitStatus = useEnvironmentQuery(
     selectedThread !== null && selectedThreadCwd !== null
@@ -73,23 +67,14 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
       }}
     >
       <View className="gap-2 rounded-[18px] border border-border bg-card px-4 py-4">
-        <Text
-          className="text-foreground-secondary text-2xs font-t3-bold uppercase"
-          style={{ letterSpacing: 1 }}
-        >
+        <Text className="text-foreground-secondary text-2xs font-t3-bold tracking-[1px] uppercase">
           New branch
         </Text>
         <TextInput
           value={newBranchName}
           onChangeText={setNewBranchName}
           placeholder="feature/mobile-polish"
-          className="rounded-[18px] px-3.5 py-3 font-sans text-base"
-          style={{
-            borderWidth: 1,
-            borderColor: inputBorderColor,
-            backgroundColor: inputBg,
-            color: foregroundColor,
-          }}
+          className="rounded-[18px]"
         />
         <SheetActionButton
           icon="plus"
@@ -108,35 +93,20 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
       </View>
 
       <View className="gap-2 rounded-[18px] border border-border bg-card px-4 py-4">
-        <Text
-          className="text-foreground-secondary text-2xs font-t3-bold uppercase"
-          style={{ letterSpacing: 1 }}
-        >
+        <Text className="text-foreground-secondary text-2xs font-t3-bold tracking-[1px] uppercase">
           New worktree
         </Text>
         <TextInput
           value={worktreeBaseBranch}
           onChangeText={setWorktreeBaseBranch}
           placeholder="main"
-          className="rounded-[18px] px-3.5 py-3 font-sans text-base"
-          style={{
-            borderWidth: 1,
-            borderColor: inputBorderColor,
-            backgroundColor: inputBg,
-            color: foregroundColor,
-          }}
+          className="rounded-[18px]"
         />
         <TextInput
           value={worktreeBranchName}
           onChangeText={setWorktreeBranchName}
           placeholder="feature/mobile-thread"
-          className="rounded-[18px] px-3.5 py-3 font-sans text-base"
-          style={{
-            borderWidth: 1,
-            borderColor: inputBorderColor,
-            backgroundColor: inputBg,
-            color: foregroundColor,
-          }}
+          className="rounded-[18px]"
         />
         <SheetActionButton
           icon="square.split.2x1"
@@ -158,10 +128,7 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
       </View>
 
       <View className="gap-2">
-        <Text
-          className="text-foreground-secondary text-2xs font-t3-bold uppercase"
-          style={{ letterSpacing: 1 }}
-        >
+        <Text className="text-foreground-secondary text-2xs font-t3-bold tracking-[1px] uppercase">
           Existing branches
         </Text>
         {branchesLoading ? (
@@ -185,12 +152,11 @@ export function GitBranchesSheet(_props: GitBranchesSheetProps) {
           return (
             <Pressable
               key={branch.name}
-              className="gap-1 rounded-[18px] border px-4 py-3"
+              className={cn(
+                "gap-1 rounded-[18px] border px-4 py-3 disabled:opacity-[0.45]",
+                branch.current ? "border-subtle-strong" : "border-border",
+              )}
               disabled={busy || disabled}
-              style={{
-                borderColor: branch.current ? subtleStrongColor : borderColor,
-                opacity: busy || disabled ? 0.45 : 1,
-              }}
               onPress={() => {
                 void gitActions.onCheckoutSelectedThreadBranch(branch.name).then(() => {
                   navigation.goBack();

--- a/apps/mobile/src/features/threads/git/GitCommitSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitCommitSheet.tsx
@@ -1,10 +1,10 @@
 import { useNavigation, type StaticScreenProps } from "@react-navigation/native";
 import { useCallback, useState } from "react";
-import { Pressable, ScrollView, View, useColorScheme } from "react-native";
+import { Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { useThemeColor } from "../../../lib/useThemeColor";
 
 import { AppText as Text, AppTextInput as TextInput } from "../../../components/AppText";
+import { cn } from "../../../lib/cn";
 import { useEnvironmentQuery } from "../../../state/query";
 import { useThreadSelection } from "../../../state/use-thread-selection";
 import { useSelectedThreadGitActions } from "../../../state/use-selected-thread-git-actions";
@@ -21,17 +21,10 @@ type GitCommitSheetProps = StaticScreenProps<{
 export function GitCommitSheet(_props: GitCommitSheetProps) {
   const navigation = useNavigation();
   const insets = useSafeAreaInsets();
-  const isDarkMode = useColorScheme() === "dark";
   const { selectedThread } = useThreadSelection();
   const { selectedThreadCwd } = useSelectedThreadWorktree();
   const gitState = useSelectedThreadGitState();
   const gitActions = useSelectedThreadGitActions();
-
-  const borderColor = useThemeColor("--color-border");
-  const borderSubtleColor = useThemeColor("--color-border-subtle");
-  const inputBorderColor = useThemeColor("--color-input-border");
-  const inputBg = useThemeColor("--color-input");
-  const foregroundColor = useThemeColor("--color-foreground");
 
   const gitStatus = useEnvironmentQuery(
     selectedThread !== null && selectedThreadCwd !== null
@@ -90,10 +83,7 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
           </Text>
         </View>
         {isDefaultRef ? (
-          <Text
-            className="text-xs leading-normal"
-            style={{ color: isDarkMode ? "#fbbf24" : "#b45309" }}
-          >
+          <Text className="text-xs leading-normal text-amber-700 dark:text-amber-400">
             Warning: this is the default branch.
           </Text>
         ) : null}
@@ -138,12 +128,8 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
                 <Text className="text-foreground flex-1 text-sm font-medium" numberOfLines={1}>
                   {file.path}
                 </Text>
-                <Text className="text-xs font-t3-bold" style={{ color: "#10b981" }}>
-                  +{file.insertions}
-                </Text>
-                <Text className="text-xs font-t3-bold" style={{ color: "#f43f5e" }}>
-                  -{file.deletions}
-                </Text>
+                <Text className="text-xs font-t3-bold text-emerald-500">+{file.insertions}</Text>
+                <Text className="text-xs font-t3-bold text-rose-500">-{file.deletions}</Text>
               </View>
             ))}
             {selectedFiles.length > selectedFilePreview.length ? (
@@ -159,10 +145,10 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
               return (
                 <Pressable
                   key={file.path}
-                  className="rounded-[18px] border px-4 py-3"
-                  style={{
-                    borderColor: included ? borderColor : borderSubtleColor,
-                  }}
+                  className={cn(
+                    "rounded-[18px] border px-4 py-3",
+                    included ? "border-border" : "border-border-subtle",
+                  )}
                   onPress={() => {
                     setExcludedFiles((current) => {
                       const next = new Set(current);
@@ -193,12 +179,10 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
                       ) : null}
                     </View>
                     <View className="items-end gap-1">
-                      <Text className="text-xs font-t3-bold" style={{ color: "#10b981" }}>
+                      <Text className="text-xs font-t3-bold text-emerald-500">
                         +{file.insertions}
                       </Text>
-                      <Text className="text-xs font-t3-bold" style={{ color: "#f43f5e" }}>
-                        -{file.deletions}
-                      </Text>
+                      <Text className="text-xs font-t3-bold text-rose-500">-{file.deletions}</Text>
                     </View>
                   </View>
                 </Pressable>
@@ -216,14 +200,7 @@ export function GitCommitSheet(_props: GitCommitSheetProps) {
           onChangeText={setDialogCommitMessage}
           placeholder="Leave empty to auto-generate"
           textAlignVertical="top"
-          className="min-h-[128px] rounded-[20px] px-4 py-3.5 font-sans text-base"
-          style={{
-            minHeight: 128,
-            borderWidth: 1,
-            borderColor: inputBorderColor,
-            backgroundColor: inputBg,
-            color: foregroundColor,
-          }}
+          className="min-h-[128px] rounded-[20px] px-4 py-3.5"
         />
       </View>
 

--- a/apps/mobile/src/features/threads/git/GitConfirmSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitConfirmSheet.tsx
@@ -101,13 +101,10 @@ export function GitConfirmSheet(props: GitConfirmSheetProps) {
 
   return (
     <View collapsable={false} className="flex-1 bg-sheet">
-      <View style={{ minHeight: 16, paddingTop: 8 }} />
+      <View className="min-h-4 pt-2" />
 
       <View className="items-center gap-1 px-5 pb-3 pt-4">
-        <Text
-          className="text-xs font-t3-bold uppercase text-foreground-muted"
-          style={{ letterSpacing: 1 }}
-        >
+        <Text className="text-xs font-t3-bold tracking-[1px] uppercase text-foreground-muted">
           Confirm
         </Text>
         <Text className="text-center text-3xl font-t3-bold">
@@ -118,10 +115,7 @@ export function GitConfirmSheet(props: GitConfirmSheetProps) {
         </Text>
       </View>
 
-      <View
-        className="gap-3 px-5"
-        style={{ paddingBottom: Math.max(insets.bottom, 18) + 8, paddingTop: 8 }}
-      >
+      <View className="gap-3 px-5 pt-2" style={{ paddingBottom: Math.max(insets.bottom, 18) + 8 }}>
         <SheetActionButton
           icon="arrow.right.circle"
           label={copy?.continueLabel ?? "Continue"}

--- a/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
+++ b/apps/mobile/src/features/threads/git/GitOverviewSheet.tsx
@@ -47,7 +47,6 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
   const gitActions = useSelectedThreadGitActions();
 
   const iconColor = useThemeColor("--color-icon");
-  const borderColor = useThemeColor("--color-border");
   const foregroundColor = String(useThemeColor("--color-foreground"));
   const sheetColor = String(useThemeColor("--color-sheet"));
 
@@ -205,9 +204,9 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
 
   const content = (
     <ScrollView
+      className="flex-1 bg-screen"
       contentInsetAdjustmentBehavior={Platform.OS === "ios" ? "automatic" : "never"}
       showsVerticalScrollIndicator={false}
-      style={{ flex: 1, backgroundColor: sheetColor }}
       contentInset={{ bottom: Math.max(insets.bottom, 18) + 18 }}
       contentContainerStyle={{
         paddingHorizontal: isInspector ? 12 : 20,
@@ -227,9 +226,7 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
       >
         {sheetMenuItems.map(({ item, disabledReason }, index) => (
           <View key={`${item.id}-${item.label}`}>
-            {index > 0 ? (
-              <View className="ml-12 h-px" style={{ backgroundColor: borderColor }} />
-            ) : null}
+            {index > 0 ? <View className="ml-12 h-px bg-border" /> : null}
             <SheetListRow
               icon={menuItemIconName(item.icon)}
               title={item.label}
@@ -241,7 +238,7 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
         ))}
         {behindCount > 0 ? (
           <>
-            <View className="ml-12 h-px" style={{ backgroundColor: borderColor }} />
+            <View className="ml-12 h-px bg-border" />
             <SheetListRow
               icon="arrow.down.circle"
               title="Pull latest"
@@ -251,7 +248,7 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
             />
           </>
         ) : null}
-        <View className="ml-12 h-px" style={{ backgroundColor: borderColor }} />
+        <View className="ml-12 h-px bg-border" />
         <SheetListRow
           icon="text.bubble"
           title="Review changes"
@@ -259,7 +256,7 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
           disabled={busy || !isRepo}
           onPress={() => navigation.navigate("ThreadReview", { environmentId, threadId })}
         />
-        <View className="ml-12 h-px" style={{ backgroundColor: borderColor }} />
+        <View className="ml-12 h-px bg-border" />
         <SheetListRow
           icon="point.topleft.down.curvedto.point.bottomright.up"
           title="Branches & worktrees"
@@ -365,8 +362,11 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
         }
       >
         <Pressable
-          className="absolute right-3 top-4 h-9 w-9 items-center justify-center rounded-full bg-subtle"
-          style={{ zIndex: 1, opacity: busy ? 0.45 : 1 }}
+          className={
+            busy
+              ? "absolute right-3 top-4 z-[1] h-9 w-9 items-center justify-center rounded-full bg-subtle opacity-[0.45]"
+              : "absolute right-3 top-4 z-[1] h-9 w-9 items-center justify-center rounded-full bg-subtle"
+          }
           disabled={busy}
           onPress={() => void gitActions.refreshSelectedThreadGitStatus()}
         >
@@ -378,10 +378,7 @@ export function GitOverviewSheet(props: GitOverviewSheetProps) {
             weight="medium"
           />
         </Pressable>
-        <Text
-          className="text-xs font-t3-bold uppercase text-foreground-muted"
-          style={{ letterSpacing: 1 }}
-        >
+        <Text className="text-xs font-t3-bold tracking-[1px] uppercase text-foreground-muted">
           {isInspector ? "Repository" : "Branch"}
         </Text>
         <Text className={isInspector ? "pr-10 text-xl font-t3-bold" : "text-3xl font-t3-bold"}>

--- a/apps/mobile/src/features/threads/git/gitSheetComponents.tsx
+++ b/apps/mobile/src/features/threads/git/gitSheetComponents.tsx
@@ -3,6 +3,7 @@ import type { ComponentProps } from "react";
 import { Pressable, View } from "react-native";
 import { useThemeColor } from "../../../lib/useThemeColor";
 import { AppText as Text } from "../../../components/AppText";
+import { cn } from "../../../lib/cn";
 
 /* ─── Shared sheet components ──────────────────────────────────────── */
 
@@ -13,51 +14,36 @@ export function SheetActionButton(props: {
   readonly tone?: "primary" | "secondary" | "danger";
   readonly onPress: () => void;
 }) {
-  const primaryBg = useThemeColor("--color-primary");
   const primaryFg = useThemeColor("--color-primary-foreground");
-  const dangerBg = useThemeColor("--color-danger");
-  const dangerBorder = useThemeColor("--color-danger-border");
   const dangerFg = useThemeColor("--color-danger-foreground");
-  const secondaryBg = useThemeColor("--color-secondary");
-  const secondaryBorder = useThemeColor("--color-secondary-border");
   const secondaryFg = useThemeColor("--color-secondary-foreground");
 
   const tone = props.tone ?? "secondary";
-  const colors =
-    tone === "primary"
-      ? {
-          backgroundColor: primaryBg,
-          borderColor: "transparent",
-          textColor: primaryFg,
-        }
-      : tone === "danger"
-        ? {
-            backgroundColor: dangerBg,
-            borderColor: dangerBorder,
-            textColor: dangerFg,
-          }
-        : {
-            backgroundColor: secondaryBg,
-            borderColor: secondaryBorder,
-            textColor: secondaryFg,
-          };
+  const textColor = tone === "primary" ? primaryFg : tone === "danger" ? dangerFg : secondaryFg;
 
   return (
     <Pressable
-      className="min-h-[48px] flex-1 flex-row items-center justify-center gap-2 rounded-[18px] px-4 py-3"
+      className={cn(
+        "min-h-[48px] flex-1 flex-row items-center justify-center gap-2 rounded-[18px] px-4 py-3 disabled:opacity-[0.45]",
+        tone === "primary"
+          ? "bg-primary"
+          : tone === "danger"
+            ? "border border-danger-border bg-danger"
+            : "border border-secondary-border bg-secondary",
+      )}
       disabled={props.disabled}
-      style={{
-        backgroundColor: colors.backgroundColor,
-        borderWidth: tone === "primary" ? 0 : 1,
-        borderColor: colors.borderColor,
-        opacity: props.disabled ? 0.45 : 1,
-      }}
       onPress={props.onPress}
     >
-      <SymbolView name={props.icon} size={16} tintColor={colors.textColor} type="monochrome" />
+      <SymbolView name={props.icon} size={16} tintColor={textColor} type="monochrome" />
       <Text
-        className="text-xs font-t3-bold uppercase"
-        style={{ color: colors.textColor, letterSpacing: 0.9 }}
+        className={cn(
+          "text-xs font-t3-bold tracking-[0.9px] uppercase",
+          tone === "primary"
+            ? "text-primary-foreground"
+            : tone === "danger"
+              ? "text-danger-foreground"
+              : "text-secondary-foreground",
+        )}
       >
         {props.label}
       </Text>
@@ -68,10 +54,7 @@ export function SheetActionButton(props: {
 export function MetaCard(props: { readonly label: string; readonly value: string }) {
   return (
     <View className="rounded-[18px] border border-border bg-card px-4 py-3">
-      <Text
-        className="text-foreground-muted text-2xs font-t3-bold uppercase"
-        style={{ letterSpacing: 0.9 }}
-      >
+      <Text className="text-foreground-muted text-2xs font-t3-bold tracking-[0.9px] uppercase">
         {props.label}
       </Text>
       <Text selectable className="text-foreground text-sm font-medium" numberOfLines={1}>
@@ -93,9 +76,8 @@ export function SheetListRow(props: {
 
   return (
     <Pressable
-      className="flex-row items-center gap-3 px-1 py-3"
+      className="flex-row items-center gap-3 px-1 py-3 disabled:opacity-[0.45]"
       disabled={props.disabled}
-      style={{ opacity: props.disabled ? 0.45 : 1 }}
       onPress={props.onPress}
     >
       <View className="bg-subtle h-9 w-9 items-center justify-center rounded-full">

--- a/apps/mobile/src/features/threads/sidebar-filter-button.tsx
+++ b/apps/mobile/src/features/threads/sidebar-filter-button.tsx
@@ -22,16 +22,17 @@ export function SidebarFilterButton(props: {
 
   return (
     <Pressable
+      className="h-11 w-[50px] cursor-pointer items-center justify-center rounded-[22px]"
       accessibilityLabel={props.accessibilityLabel}
       accessibilityRole="button"
       hitSlop={4}
       style={({ pressed }) => [
-        styles.button,
         props.grouped
           ? { backgroundColor: pressed ? pressedBackgroundColor : "transparent", borderWidth: 0 }
           : {
               backgroundColor: pressed ? pressedBackgroundColor : idleBackgroundColor,
               borderColor,
+              borderWidth: StyleSheet.hairlineWidth,
             },
       ]}
     >
@@ -39,17 +40,3 @@ export function SidebarFilterButton(props: {
     </Pressable>
   );
 }
-
-const styles = StyleSheet.create({
-  button: {
-    // Match the native glass UIBarButtonItem group metrics (~50pt slots,
-    // 44pt bar height, label-colored ~20pt glyphs).
-    width: 50,
-    height: 44,
-    borderRadius: 22,
-    borderWidth: StyleSheet.hairlineWidth,
-    alignItems: "center",
-    justifyContent: "center",
-    cursor: "pointer",
-  },
-});

--- a/apps/mobile/src/features/threads/sidebar-header-actions.tsx
+++ b/apps/mobile/src/features/threads/sidebar-header-actions.tsx
@@ -24,17 +24,18 @@ function FallbackHeaderButton(props: {
 
   return (
     <Pressable
+      className="h-11 w-[50px] items-center justify-center rounded-[22px]"
       accessibilityLabel={props.accessibilityLabel}
       accessibilityRole="button"
       hitSlop={4}
       onPress={props.onPress}
       style={({ pressed }) => [
-        styles.button,
         props.grouped
           ? { backgroundColor: pressed ? pressedBackgroundColor : "transparent", borderWidth: 0 }
           : {
               backgroundColor: pressed ? pressedBackgroundColor : idleBackgroundColor,
               borderColor,
+              borderWidth: StyleSheet.hairlineWidth,
             },
       ]}
     >
@@ -45,7 +46,7 @@ function FallbackHeaderButton(props: {
 
 export function SidebarHeaderActions(props: SidebarHeaderActionsProps) {
   return (
-    <View style={styles.actions}>
+    <View className="flex-row items-center gap-0.5">
       <FallbackHeaderButton
         accessibilityLabel="Open settings"
         grouped={props.grouped}
@@ -55,20 +56,3 @@ export function SidebarHeaderActions(props: SidebarHeaderActionsProps) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  actions: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 2,
-  },
-  button: {
-    // Match the native glass UIBarButtonItem group metrics.
-    width: 50,
-    height: 44,
-    borderRadius: 22,
-    borderWidth: StyleSheet.hairlineWidth,
-    alignItems: "center",
-    justifyContent: "center",
-  },
-});

--- a/apps/mobile/src/features/threads/thread-inspector-content-stack.tsx
+++ b/apps/mobile/src/features/threads/thread-inspector-content-stack.tsx
@@ -75,7 +75,7 @@ export function ThreadInspectorContentStack(props: {
   const Route = props.Route;
 
   return (
-    <View style={{ flex: 1 }}>
+    <View className="flex-1">
       <InspectorContentPane
         mounted={mountedModes.has("files") || props.mode === "files"}
         visible={props.mode === "files"}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -12,6 +12,7 @@ import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSw
 import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
 import { ProjectFavicon } from "../../components/ProjectFavicon";
+import { cn } from "../../lib/cn";
 import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
@@ -101,10 +102,9 @@ export const ThreadListGroupHeader = memo(function ThreadListGroupHeader(props: 
         <Text
           className={
             compact
-              ? "flex-shrink text-base font-t3-bold text-foreground-muted"
-              : "flex-shrink text-sm font-t3-bold text-foreground-muted"
+              ? "flex-shrink text-base font-t3-bold tracking-[0.2px] text-foreground-muted"
+              : "flex-shrink text-sm font-t3-bold tracking-[0.2px] text-foreground-muted"
           }
-          style={{ letterSpacing: 0.2 }}
           numberOfLines={1}
         >
           {props.title}
@@ -236,7 +236,6 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
   const compact = props.variant === "compact";
   const separatorColor = useThemeColor("--color-separator");
   const iconSubtleColor = useThemeColor("--color-icon-subtle");
-  const foregroundColor = useThemeColor("--color-foreground");
   const mutedColor = useThemeColor("--color-foreground-muted");
   const pressedBackgroundColor = useThemeColor("--color-subtle");
 
@@ -254,17 +253,14 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
   );
 
   const statusPill = (
-    <View
-      className="bg-zinc-500/12 dark:bg-zinc-500/16"
-      style={{ borderRadius: 99, paddingHorizontal: 6, paddingVertical: 2 }}
-    >
+    <View className="rounded-full bg-zinc-500/12 px-1.5 py-0.5 dark:bg-zinc-500/16">
       <Text className="text-3xs font-t3-bold text-zinc-600 dark:text-zinc-300">Pending</Text>
     </View>
   );
 
   const subtitleRow =
     subtitleParts.length > 0 ? (
-      <View className="flex-row items-center gap-1.5" style={{ marginTop: 1 }}>
+      <View className="mt-px flex-row items-center gap-1.5">
         <SymbolView
           name="tray.and.arrow.up"
           size={10}
@@ -272,9 +268,12 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
           type="monochrome"
         />
         <Text
-          className={compact ? "text-sm text-foreground-muted" : "text-xs"}
+          className={
+            compact
+              ? "shrink text-sm text-foreground-muted"
+              : "shrink text-xs text-foreground-muted"
+          }
           numberOfLines={1}
-          style={compact ? { flexShrink: 1 } : { flexShrink: 1, color: mutedColor }}
         >
           {subtitleParts.join(" · ")}
         </Text>
@@ -311,12 +310,7 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
             </Text>
             <View className="flex-row items-center gap-2">
               {statusPill}
-              <Text
-                className="text-base text-foreground-tertiary"
-                style={{ fontVariant: ["tabular-nums"] }}
-              >
-                {timestamp}
-              </Text>
+              <Text className="text-base tabular-nums text-foreground-tertiary">{timestamp}</Text>
               <SymbolView
                 name="chevron.right"
                 size={13}
@@ -345,22 +339,14 @@ export const PendingTaskListRow = memo(function PendingTaskListRow(props: {
         paddingVertical: 10,
       })}
     >
-      <View style={{ gap: 3 }}>
+      <View className="gap-[3px]">
         <View className="flex-row items-center justify-between gap-2">
-          <Text
-            className="flex-1 text-base font-t3-medium"
-            numberOfLines={1}
-            style={{ color: foregroundColor }}
-          >
+          <Text className="flex-1 text-base font-t3-medium text-foreground" numberOfLines={1}>
             {pendingTask.title}
           </Text>
           <View className="flex-row items-center gap-2">
             {statusPill}
-            <Text
-              className="text-xs"
-              numberOfLines={1}
-              style={{ color: mutedColor, fontVariant: ["tabular-nums"] }}
-            >
+            <Text className="text-xs tabular-nums text-foreground-muted" numberOfLines={1}>
               {timestamp}
             </Text>
           </View>
@@ -418,11 +404,9 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   const iconSubtleColor = useThemeColor("--color-icon-subtle");
   const screenColor = useThemeColor("--color-screen");
   const drawerColor = useThemeColor("--color-drawer");
-  const foregroundColor = useThemeColor("--color-foreground");
   const mutedColor = useThemeColor("--color-foreground-muted");
   const pressedBackgroundColor = useThemeColor("--color-subtle");
   const selectedBackgroundColor = useThemeColor("--color-user-bubble");
-  const selectedForegroundColor = useThemeColor("--color-user-bubble-foreground");
   const selectedMutedColor = useThemeColor("--color-user-bubble-foreground-muted");
 
   const { thread, onSelectThread, onArchiveThread, onDeleteThread } = props;
@@ -436,7 +420,6 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   );
 
   const backgroundColor = compact ? screenColor : drawerColor;
-  const effectiveForeground = selected ? selectedForegroundColor : foregroundColor;
   const effectiveMuted = selected ? selectedMutedColor : mutedColor;
   const effectivePressedBackground = selected ? "rgba(255,255,255,0.16)" : pressedBackgroundColor;
   const effectiveStatus =
@@ -464,10 +447,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   );
 
   const statusPill = effectiveStatus ? (
-    <View
-      className={effectiveStatus.pillClassName}
-      style={{ borderRadius: 99, paddingHorizontal: 6, paddingVertical: 2 }}
-    >
+    <View className={`${effectiveStatus.pillClassName} rounded-full px-1.5 py-0.5`}>
       <Text className={`text-3xs font-t3-bold ${effectiveStatus.textClassName}`}>
         {effectiveStatus.label}
       </Text>
@@ -476,7 +456,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
 
   const subtitleRow =
     subtitleParts.length > 0 || pr !== null ? (
-      <View className="flex-row items-center gap-1.5" style={{ marginTop: 1 }}>
+      <View className="mt-px flex-row items-center gap-1.5">
         {subtitleParts.length > 0 ? (
           <>
             <SymbolView
@@ -486,9 +466,13 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
               type="monochrome"
             />
             <Text
-              className={compact ? "text-sm text-foreground-muted" : "text-xs"}
+              className={cn(
+                "shrink",
+                compact ? "text-sm text-foreground-muted" : "text-xs",
+                !compact &&
+                  (selected ? "text-user-bubble-foreground-muted" : "text-foreground-muted"),
+              )}
               numberOfLines={1}
-              style={compact ? { flexShrink: 1 } : { flexShrink: 1, color: effectiveMuted }}
             >
               {subtitleParts.join(" · ")}
             </Text>
@@ -540,12 +524,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
               </Text>
               <View className="flex-row items-center gap-2">
                 {statusPill}
-                <Text
-                  className="text-base text-foreground-tertiary"
-                  style={{ fontVariant: ["tabular-nums"] }}
-                >
-                  {timestamp}
-                </Text>
+                <Text className="text-base tabular-nums text-foreground-tertiary">{timestamp}</Text>
                 <SymbolView
                   name="chevron.right"
                   size={13}
@@ -584,21 +563,25 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
           paddingVertical: 10,
         })}
       >
-        <View style={{ gap: 3 }}>
+        <View className="gap-[3px]">
           <View className="flex-row items-center justify-between gap-2">
             <Text
-              className="flex-1 text-base font-t3-medium"
+              className={cn(
+                "flex-1 text-base font-t3-medium",
+                selected ? "text-user-bubble-foreground" : "text-foreground",
+              )}
               numberOfLines={1}
-              style={{ color: effectiveForeground }}
             >
               {thread.title}
             </Text>
             <View className="flex-row items-center gap-2">
               {statusPill}
               <Text
-                className="text-xs"
+                className={cn(
+                  "text-xs tabular-nums",
+                  selected ? "text-user-bubble-foreground-muted" : "text-foreground-muted",
+                )}
                 numberOfLines={1}
-                style={{ color: effectiveMuted, fontVariant: ["tabular-nums"] }}
               >
                 {timestamp}
               </Text>

--- a/apps/mobile/src/features/threads/thread-work-log.tsx
+++ b/apps/mobile/src/features/threads/thread-work-log.tsx
@@ -206,13 +206,12 @@ export function ThreadWorkLog(props: {
                     nestedScrollEnabled
                     directionalLockEnabled
                     showsVerticalScrollIndicator
-                    style={{ maxHeight: 240 }}
+                    className="max-h-60"
                     contentContainerStyle={{ paddingRight: 8 }}
                   >
                     <Text
                       selectable
-                      className="text-2xs leading-normal text-foreground-muted"
-                      style={{ fontFamily: "ui-monospace" }}
+                      className="font-mono text-2xs leading-normal text-foreground-muted"
                     >
                       {row.fullDetail}
                     </Text>

--- a/apps/mobile/src/lib/useFontFamily.ts
+++ b/apps/mobile/src/lib/useFontFamily.ts
@@ -1,0 +1,15 @@
+import { useCSSVariable } from "uniwind";
+
+const FONT_FAMILY_VARIABLES = {
+  regular: "--font-sans",
+  medium: "--font-medium",
+  bold: "--font-bold",
+} as const;
+
+/**
+ * Resolves a font family for APIs that require a style object or native prop.
+ * Prefer Uniwind font classes when the target component accepts `className`.
+ */
+export function useFontFamily(weight: keyof typeof FONT_FAMILY_VARIABLES): string {
+  return useCSSVariable(FONT_FAMILY_VARIABLES[weight]) as string;
+}

--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -228,7 +228,7 @@ export function ComposerEditor({
       fontFamily={
         typeof resolvedTextStyle.fontFamily === "string"
           ? resolvedTextStyle.fontFamily
-          : "DMSans_400Regular"
+          : "DMSans-Regular"
       }
       fontSize={
         typeof resolvedTextStyle.fontSize === "number"

--- a/apps/mobile/src/native/T3ComposerEditor.ios.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.ios.tsx
@@ -15,6 +15,7 @@ import { Image, StyleSheet } from "react-native";
 import { markdownFileIconSource } from "@t3tools/mobile-markdown-text/file-icons";
 import { resolveMarkdownFileIcon } from "@t3tools/mobile-markdown-text/links";
 import { useThemeColor } from "../lib/useThemeColor";
+import { useFontFamily } from "../lib/useFontFamily";
 import { useScaledTextRole } from "../features/settings/appearance/useScaledTextRole";
 import {
   acknowledgeComposerNativeEvent,
@@ -117,6 +118,7 @@ export function ComposerEditor({
   const skillBorder = useThemeColor("--color-inline-skill-border");
   const skillText = useThemeColor("--color-inline-skill-foreground");
   const fileTint = useThemeColor("--color-icon-muted");
+  const fontFamily = useFontFamily("regular");
 
   useImperativeHandle(
     ref,
@@ -226,9 +228,7 @@ export function ComposerEditor({
       themeJson={themeJson}
       placeholder={props.placeholder ?? ""}
       fontFamily={
-        typeof resolvedTextStyle.fontFamily === "string"
-          ? resolvedTextStyle.fontFamily
-          : "DMSans-Regular"
+        typeof resolvedTextStyle.fontFamily === "string" ? resolvedTextStyle.fontFamily : fontFamily
       }
       fontSize={
         typeof resolvedTextStyle.fontSize === "number"

--- a/apps/mobile/src/native/T3ComposerEditor.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.tsx
@@ -3,6 +3,7 @@ import { useImperativeHandle, useRef } from "react";
 import { TextInput, type TextInput as RNTextInput } from "react-native";
 
 import { useThemeColor } from "../lib/useThemeColor";
+import { useFontFamily } from "../lib/useFontFamily";
 import { useScaledTextRole } from "../features/settings/appearance/useScaledTextRole";
 import { useNativePaste } from "../lib/useNativePaste";
 import type { ComposerEditorProps } from "./T3ComposerEditor.types";
@@ -21,6 +22,7 @@ export function ComposerEditor({
   const bodyText = useScaledTextRole("body");
   const foregroundColor = useThemeColor("--color-foreground");
   const placeholderColor = useThemeColor("--color-placeholder");
+  const fontFamily = useFontFamily("regular");
   const handlePaste = useNativePaste((uris) => onPasteImages?.(uris));
 
   useImperativeHandle(
@@ -48,7 +50,7 @@ export function ComposerEditor({
             flex: 1,
             minHeight: 0,
             color: foregroundColor,
-            fontFamily: "DMSans-Regular",
+            fontFamily,
             ...bodyText,
             paddingVertical: contentInsetVertical,
           },

--- a/apps/mobile/src/native/T3ComposerEditor.tsx
+++ b/apps/mobile/src/native/T3ComposerEditor.tsx
@@ -48,7 +48,7 @@ export function ComposerEditor({
             flex: 1,
             minHeight: 0,
             color: foregroundColor,
-            fontFamily: "DMSans_400Regular",
+            fontFamily: "DMSans-Regular",
             ...bodyText,
             paddingVertical: contentInsetVertical,
           },

--- a/apps/mobile/src/native/T3KeyboardCommands.tsx
+++ b/apps/mobile/src/native/T3KeyboardCommands.tsx
@@ -9,5 +9,5 @@ export function T3KeyboardCommands(
     readonly onCommand: (command: HardwareKeyboardCommand) => void;
   }>,
 ) {
-  return <View style={{ flex: 1 }}>{props.children}</View>;
+  return <View className="flex-1">{props.children}</View>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       expo-haptics:
         specifier: ~56.0.3
         version: 56.0.3(expo@56.0.12)
+      expo-image:
+        specifier: ~56.0.11
+        version: 56.0.11(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       expo-image-picker:
         specifier: ~56.0.18
         version: 56.0.18(expo@56.0.12)
@@ -6561,6 +6564,17 @@ packages:
     resolution: {integrity: sha512-sCjQ8M27bhGUv2vUavIE+uWdYo79b2D7Q5h9B66BSDZ+Rd8YyLVSf7vYGfIzQ7nMVoENZ6c4xo/JiDkEeQ9iTg==}
     peerDependencies:
       expo: '*'
+
+  expo-image@56.0.11:
+    resolution: {integrity: sha512-k2xwxGk14xi6zxmEGAU4rUTb1lK5qf0y0Qb8+Jaggnul0KaJJxcq9qvyDp9iyJBW35cp9isONAUnNtIiooZ/Pw==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+      react-native-web: '*'
+    peerDependenciesMeta:
+      react-native-web:
+        optional: true
 
   expo-json-utils@56.0.0:
     resolution: {integrity: sha512-lUqyv9aIGDbYTQ5Nux2FnH2/Dz0w5uJ8Pr080eS0StXi2jr5OmuMNErpzUnpfnYOU55xKotd4AHv68PfV/ludg==}
@@ -16694,6 +16708,13 @@ snapshots:
     dependencies:
       expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
       expo-image-loader: 56.0.3(expo@56.0.12)
+
+  expo-image@56.0.11(expo@56.0.12)(react-native@0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
+    dependencies:
+      expo: 56.0.12(8895228379997a2a064f9644cda56ed0)
+      react: 19.2.3
+      react-native: 0.85.3(@babel/core@7.29.7)(@react-native/metro-config@0.85.3(@babel/core@7.29.7)(bufferutil@4.1.0)(utf-8-validate@6.0.6))(@types/react@19.2.16)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
+      sf-symbols-typescript: 2.2.0
 
   expo-json-utils@56.0.0: {}
 


### PR DESCRIPTION
## Summary

Moves the shared mobile fixes out of the Android stack and onto `main`:

- Uses `expo-image` for project favicons so SVG and ICO assets returned by the favicon resolver render consistently on mobile.
- Embeds DM Sans regular, medium, and bold through the `expo-font` config plugin on iOS and Android.
- Aligns Uniwind typography tokens, explicit React Native styles, and the native iOS composer with the embedded native family names.
- Removes runtime `useFonts` loading and the root render gate, allowing providers and navigation to mount immediately.

Both `expo-image` and the embedded fonts are included in the same new native runtime. Fingerprint-based runtime versions prevent this update from reaching older binaries without those native assets. This leaves #3774 scoped to Android home branding only.

## Validation

- Generated clean iOS and Android projects with `expo prebuild`; verified iOS `UIAppFonts`/Xcode resources and Android `ReactFontManager` aliases/font resources.
- `vp check`
- `vp run typecheck`
- `vp run lint:mobile`
- React Doctor scoped to this PR: no errors.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Embed DM Sans fonts at build time and render project favicons with expo-image
> - Registers DM Sans fonts (Regular, Medium, Bold) in [app.config.ts](https://github.com/pingdotgg/t3code/pull/3823/files#diff-290065ad5da22af2aa0a274a6657359bd050ba8ad4e36b97765dac7c98f90bab) using the `expo-font` plugin with explicit family names (`DMSans-Regular`, `DMSans-Medium`, `DMSans-Bold`) and weights, replacing runtime loading via `@expo-google-fonts/dm-sans`.
> - Removes the `useFonts` call and font-loading gate from [App.tsx](https://github.com/pingdotgg/t3code/pull/3823/files#diff-e3abdca4ddbcdc4795e133268b958f77db78c542464c78af36855eead657f8a9); the splash screen now hides immediately on mount rather than waiting for font loading.
> - Updates font identifier strings across native Swift ([T3ComposerEditorView.swift](https://github.com/pingdotgg/t3code/pull/3823/files#diff-bf020ce11861c51d7a3be2ccf67632f77afe80ff4ecf76a17884c5b040c21749)) and JS composer editors to use the new family names, and introduces a `useFontFamily` hook to resolve font families from CSS variables at runtime.
> - Switches [ProjectFavicon.tsx](https://github.com/pingdotgg/t3code/pull/3823/files#diff-7e87e0cea2254a15e80b1674cae23aec30b21d987e1e5a9a130ca52fab244fa3) from `react-native` `Image` to `expo-image` with `contentFit="contain"` for more reliable favicon rendering.
> - The remainder of the PR migrates inline styles to Tailwind/NativeWind utility classes across many components; visual appearance is intended to be equivalent.
> - Risk: font identifiers change from PostScript-style names (`DMSans_400Regular`) to family names (`DMSans-Regular`); any platform code referencing the old identifiers will fail to resolve the font.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2f40ab6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requires a new native binary for embedded fonts and expo-image; splash no longer waits on font load (acceptable when fonts are in the bundle). Large UI-only diffs increase regression surface on mobile chrome and typography.
> 
> **Overview**
> **Native typography and favicons** are the main functional changes; most of the diff is a styling pass that moves inline React Native styles to Uniwind/Tailwind classes.
> 
> DM Sans is **embedded at build time** through the `expo-font` config plugin (iOS bundle + Android `fontFamily` aliases), with family names unified as `DMSans-Regular`, `DMSans-Medium`, and `DMSans-Bold` in `global.css`, the iOS composer Swift view, and a new `useFontFamily` hook for markdown and composer code paths that need `fontFamily` in style objects. **Runtime `useFonts` and the splash gate are removed** — the app mounts and hides the splash immediately.
> 
> **Project favicons** switch from `react-native` `Image` to **`expo-image`** (`contentFit`) so SVG/ICO from the resolver render reliably.
> 
> Alongside that: `--color-sidebar-search` for the sidebar search field, `AppTextInput` placeholder via `placeholderTextColorClassName`, preview dev script `--lan`, and broad refactors (git sheets, settings, connection UI, thread lists) from `StyleSheet` / `useThemeColor` inline colors to semantic Tailwind tokens (`tracking-*`, `tabular-nums`, `border-continuous`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f40ab688df66c44c7c64567d27265aee219998b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->