### PR TITLE
[codex] Label max and ultra reasoning

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -56,6 +56,8 @@ const REASONING_EFFORT_LABELS: Readonly<Record<string, string>> = {
   medium: "Medium",
   high: "High",
   xhigh: "Extra High",
+  max: "Max",
+  ultra: "Ultra",
 };
 
 const DEFAULT_SERVICE_TIER_ID = "default";


### PR DESCRIPTION
## Summary

Codex now advertises `max` and `ultra` as reasoning effort values, but the provider label map did not recognize them. As a result, the reasoning picker exposed the raw lowercase identifiers rather than labels consistent with the existing options.

This change maps `max` to **Max** and `ultra` to **Ultra**, so both options display cleanly in the model configuration UI.

## Validation

- `vp run --filter t3 test`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only label mapping in the Codex provider with no auth, persistence, or generation logic changes.
> 
> **Overview**
> Codex can now return **`max`** and **`ultra`** in `supportedReasoningEfforts`, but the provider’s `REASONING_EFFORT_LABELS` map did not include them, so the reasoning picker showed raw ids instead of human-readable text.
> 
> This adds **`max` → Max** and **`ultra` → Ultra** in `CodexProvider.ts`, matching the existing pattern for `none` through `xhigh`. Labels flow through `reasoningEffortLabel` into model capability options for the configuration UI only; behavior and API values are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc5f1f38a9d0e0b4cd4f6993e98d34958358833. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'max' and 'ultra' labels to `REASONING_EFFORT_LABELS` in CodexProvider
> Adds two missing entries to the `REASONING_EFFORT_LABELS` record in [CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/3824/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53), mapping `'max'` → `'Max'` and `'ultra'` → `'Ultra'`. Previously, lookups for these keys returned `undefined`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized dbc5f1f. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->