### PR TITLE
Show compact PR number badges in mobile thread rows

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -517,7 +517,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
         ) : null}
         {pr !== null ? (
           <View
-            accessibilityLabel={`${pr.label} pull request ${pr.state}`}
+            accessibilityLabel={pr.accessibilityLabel}
             className="flex-row items-center gap-0.5"
           >
             <PullRequestIcon

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -6,8 +6,9 @@ import type {
 import type { MenuAction } from "@react-native-menu/menu";
 import { SymbolView } from "expo-symbols";
 import { memo, useCallback, useMemo, type ComponentProps } from "react";
-import { Pressable, useWindowDimensions, View } from "react-native";
+import { Pressable, useColorScheme, useWindowDimensions, View } from "react-native";
 import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
+import Svg, { Circle, Path } from "react-native-svg";
 
 import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
@@ -16,7 +17,7 @@ import { cn } from "../../lib/cn";
 import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
-import { useThreadPr } from "../../state/use-thread-pr";
+import { useThreadPr, type ThreadPr } from "../../state/use-thread-pr";
 import type { HomeGroupDisplayAction } from "../home/homeListItems";
 import { ThreadSwipeable } from "../home/thread-swipe-actions";
 import { resolveThreadStatus } from "./threadPresentation";
@@ -32,6 +33,41 @@ export type ThreadListVariant = "compact" | "sidebar";
 /** Left inset that aligns compact secondary rows with the title column. */
 export const THREAD_LIST_COMPACT_INSET = 20;
 const SIDEBAR_ROW_RADIUS = 12;
+
+function pullRequestTintColor(
+  state: ThreadPr["state"],
+  colorScheme: ReturnType<typeof useColorScheme>,
+) {
+  const dark = colorScheme === "dark";
+  switch (state) {
+    case "open":
+      return dark ? "#34d399" : "#059669";
+    case "merged":
+      return dark ? "#a78bfa" : "#7c3aed";
+    case "closed":
+      return dark ? "#a1a1aa" : "#71717a";
+  }
+}
+
+function PullRequestIcon(props: { readonly size: number; readonly color: string }) {
+  return (
+    <Svg
+      width={props.size}
+      height={props.size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={props.color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <Circle cx={18} cy={18} r={3} />
+      <Circle cx={6} cy={6} r={3} />
+      <Path d="M13 6h3a2 2 0 0 1 2 2v7" />
+      <Path d="M6 9v12" />
+    </Svg>
+  );
+}
 
 /* ─── Project group header ───────────────────────────────────────────── */
 
@@ -394,6 +430,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   >["simultaneousWithExternalGesture"];
 }) {
   const { width: windowWidth } = useWindowDimensions();
+  const colorScheme = useColorScheme();
   const compact = props.variant === "compact";
   const selected = props.selected === true;
   // Recycling-safe: resets when the list container is reused for another
@@ -479,13 +516,22 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
           </>
         ) : null}
         {pr !== null ? (
-          <Text
-            className={`${compact ? "text-sm" : "text-xs"} font-t3-medium ${
-              selected ? "text-white" : pr.textClassName
-            }`}
+          <View
+            accessibilityLabel={`${pr.label} pull request ${pr.state}`}
+            className="flex-row items-center gap-0.5"
           >
-            {pr.label}
-          </Text>
+            <PullRequestIcon
+              size={compact ? 13 : 11}
+              color={selected ? "#ffffff" : pullRequestTintColor(pr.state, colorScheme)}
+            />
+            <Text
+              className={`${compact ? "text-sm" : "text-xs"} font-t3-medium ${
+                selected ? "text-white" : pr.textClassName
+              }`}
+            >
+              {pr.label}
+            </Text>
+          </View>
         ) : null}
       </View>
     ) : null;

--- a/apps/mobile/src/state/thread-pr-presentation.ts
+++ b/apps/mobile/src/state/thread-pr-presentation.ts
@@ -1,0 +1,28 @@
+import type { VcsStatusResult } from "@t3tools/contracts";
+
+export type ThreadPr = NonNullable<VcsStatusResult["pr"]>;
+
+export interface ThreadPrPresentation {
+  readonly number: number;
+  readonly state: ThreadPr["state"];
+  readonly url: string;
+  /** Compact desktop-style label, e.g. "#3774". */
+  readonly label: string;
+  readonly textClassName: string;
+}
+
+const PR_STATE_TEXT_CLASS: Record<ThreadPr["state"], string> = {
+  open: "text-emerald-600 dark:text-emerald-400",
+  merged: "text-violet-600 dark:text-violet-400",
+  closed: "text-zinc-500 dark:text-zinc-400",
+};
+
+export function presentThreadPr(pr: ThreadPr): ThreadPrPresentation {
+  return {
+    number: pr.number,
+    state: pr.state,
+    url: pr.url,
+    label: `#${pr.number}`,
+    textClassName: PR_STATE_TEXT_CLASS[pr.state],
+  };
+}

--- a/apps/mobile/src/state/thread-pr-presentation.ts
+++ b/apps/mobile/src/state/thread-pr-presentation.ts
@@ -1,4 +1,5 @@
 import type { VcsStatusResult } from "@t3tools/contracts";
+import { resolveChangeRequestPresentation } from "@t3tools/shared/sourceControl";
 
 export type ThreadPr = NonNullable<VcsStatusResult["pr"]>;
 
@@ -8,6 +9,8 @@ export interface ThreadPrPresentation {
   readonly url: string;
   /** Compact desktop-style label, e.g. "#3774". */
   readonly label: string;
+  /** Full, provider-aware label for assistive technologies. */
+  readonly accessibilityLabel: string;
   readonly textClassName: string;
 }
 
@@ -17,12 +20,17 @@ const PR_STATE_TEXT_CLASS: Record<ThreadPr["state"], string> = {
   closed: "text-zinc-500 dark:text-zinc-400",
 };
 
-export function presentThreadPr(pr: ThreadPr): ThreadPrPresentation {
+export function presentThreadPr(
+  pr: ThreadPr,
+  provider: VcsStatusResult["sourceControlProvider"] | null | undefined,
+): ThreadPrPresentation {
+  const presentation = resolveChangeRequestPresentation(provider);
   return {
     number: pr.number,
     state: pr.state,
     url: pr.url,
     label: `#${pr.number}`,
+    accessibilityLabel: `#${pr.number} ${presentation.longName} ${pr.state}`,
     textClassName: PR_STATE_TEXT_CLASS[pr.state],
   };
 }

--- a/apps/mobile/src/state/use-thread-pr.test.ts
+++ b/apps/mobile/src/state/use-thread-pr.test.ts
@@ -14,9 +14,23 @@ const pullRequest: NonNullable<VcsStatusResult["pr"]> = {
 
 describe("presentThreadPr", () => {
   it("uses the compact desktop-style pull request number label", () => {
-    expect(presentThreadPr(pullRequest)).toMatchObject({
+    expect(presentThreadPr(pullRequest, undefined)).toMatchObject({
       label: "#3774",
+      accessibilityLabel: "#3774 pull request merged",
       textClassName: "text-violet-600 dark:text-violet-400",
+    });
+  });
+
+  it("uses merge-request terminology for GitLab", () => {
+    expect(
+      presentThreadPr(pullRequest, {
+        kind: "gitlab",
+        name: "GitLab",
+        baseUrl: "https://gitlab.com",
+      }),
+    ).toMatchObject({
+      label: "#3774",
+      accessibilityLabel: "#3774 merge request merged",
     });
   });
 });

--- a/apps/mobile/src/state/use-thread-pr.test.ts
+++ b/apps/mobile/src/state/use-thread-pr.test.ts
@@ -1,0 +1,22 @@
+import type { VcsStatusResult } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { presentThreadPr } from "./thread-pr-presentation";
+
+const pullRequest: NonNullable<VcsStatusResult["pr"]> = {
+  number: 3774,
+  title: "Desktop-style pull request indicator",
+  url: "https://github.com/t3tools/t3code/pull/3774",
+  baseRef: "main",
+  headRef: "codex/desktop-style-pr-indicator",
+  state: "merged",
+};
+
+describe("presentThreadPr", () => {
+  it("uses the compact desktop-style pull request number label", () => {
+    expect(presentThreadPr(pullRequest)).toMatchObject({
+      label: "#3774",
+      textClassName: "text-violet-600 dark:text-violet-400",
+    });
+  });
+});

--- a/apps/mobile/src/state/use-thread-pr.ts
+++ b/apps/mobile/src/state/use-thread-pr.ts
@@ -37,5 +37,5 @@ export function useThreadPr(
   if (!status.pr) {
     return null;
   }
-  return presentThreadPr(status.pr);
+  return presentThreadPr(status.pr, status.sourceControlProvider);
 }

--- a/apps/mobile/src/state/use-thread-pr.ts
+++ b/apps/mobile/src/state/use-thread-pr.ts
@@ -1,40 +1,14 @@
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
-import type { VcsStatusResult } from "@t3tools/contracts";
-import { resolveChangeRequestPresentation } from "@t3tools/shared/sourceControl";
 
 import { useEnvironmentQuery } from "./query";
+import { presentThreadPr, type ThreadPrPresentation } from "./thread-pr-presentation";
 import { vcsEnvironment } from "./vcs";
 
-export type ThreadPr = NonNullable<VcsStatusResult["pr"]>;
-
-export interface ThreadPrPresentation {
-  readonly number: number;
-  readonly state: ThreadPr["state"];
-  readonly url: string;
-  /** Compact chip label, e.g. "PR open" / "MR merged". */
-  readonly label: string;
-  readonly textClassName: string;
-}
-
-const PR_STATE_TEXT_CLASS: Record<ThreadPr["state"], string> = {
-  open: "text-emerald-600 dark:text-emerald-400",
-  merged: "text-violet-600 dark:text-violet-400",
-  closed: "text-zinc-500 dark:text-zinc-400",
-};
-
-export function presentThreadPr(
-  pr: ThreadPr,
-  provider: VcsStatusResult["sourceControlProvider"] | null | undefined,
-): ThreadPrPresentation {
-  const shortName = resolveChangeRequestPresentation(provider).shortName;
-  return {
-    number: pr.number,
-    state: pr.state,
-    url: pr.url,
-    label: `${shortName} ${pr.state}`,
-    textClassName: PR_STATE_TEXT_CLASS[pr.state],
-  };
-}
+export {
+  presentThreadPr,
+  type ThreadPr,
+  type ThreadPrPresentation,
+} from "./thread-pr-presentation";
 
 /**
  * Live PR status for a thread's branch. Subscriptions are deduplicated per
@@ -63,5 +37,5 @@ export function useThreadPr(
   if (!status.pr) {
     return null;
   }
-  return presentThreadPr(status.pr, status.sourceControlProvider);
+  return presentThreadPr(status.pr);
 }


### PR DESCRIPTION
## Summary
- Add a shared mobile PR presentation helper that formats pull requests as compact `#number` labels.
- Update mobile thread rows to display a PR icon plus number with state-aware colors.
- Add coverage for compact PR label formatting.

## Testing
- `vp check`
- `vp run typecheck`
- `vp test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only mobile list presentation with no auth, data, or API changes; behavior change is limited to how PR text appears on screen.
> 
> **Overview**
> Mobile thread list rows now show pull requests like desktop: a **PR icon** plus **`#<number>`** instead of provider-style text such as `PR merged`.
> 
> `presentThreadPr` moves into **`thread-pr-presentation.ts`**. Visible labels are always `#number`; **accessibility** still uses provider terms (e.g. merge request on GitLab). State-based **Tailwind text classes** are unchanged.
> 
> **`ThreadListRow`** adds an SVG `PullRequestIcon`, **`pullRequestTintColor`** for open/merged/closed in light and dark mode, and wraps the badge in a row with **`accessibilityLabel`**. The icon is white when the sidebar row is selected; size follows compact vs sidebar layout.
> 
> Tests cover the new label format and GitLab accessibility wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ecb46e726d01bffebf21bf6b349fdfc282a54ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show compact PR number badges with state-tinted SVG icons in mobile thread list rows
> - Adds a `PullRequestIcon` SVG component and a `pullRequestTintColor` utility that maps PR state (`open`/`merged`/`closed`) and light/dark color scheme to a hex tint color.
> - Replaces the previous provider/state chip label in thread rows with a compact `#<number>` badge that prepends the new icon, tinted by state and theme (white when selected).
> - Extracts PR presentation logic into a new [thread-pr-presentation.ts](https://github.com/pingdotgg/t3code/pull/3827/files#diff-befc8c3b6d8c70a55eaf17f748347c0e6796e91fda062e99ccd9da596395c595) module and re-exports from [use-thread-pr.ts](https://github.com/pingdotgg/t3code/pull/3827/files#diff-7dd25e0529316f8e52e729651acdbdce620dd5dd5ea76017bf5bf192b5168fc3).
> - Adds an `accessibilityLabel` field to PR badges combining number, provider-specific terminology ("pull request" vs "merge request"), and state.
> - Behavioral Change: `presentThreadPr` now returns `#<number>` as the label instead of the previous provider/state chip text; any consumer relying on the old label format will see different output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ecb46e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->