### PR TITLE
Expose mobile PR indicator labels to accessibility

### DIFF
--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -517,7 +517,9 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
         ) : null}
         {pr !== null ? (
           <View
+            accessible
             accessibilityLabel={pr.accessibilityLabel}
+            accessibilityRole="text"
             className="flex-row items-center gap-0.5"
           >
             <PullRequestIcon

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -517,7 +517,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
         ) : null}
         {pr !== null ? (
           <View
-            accessibilityLabel={`${pr.label} pull request ${pr.state}`}
+            accessibilityLabel={pr.accessibilityLabel}
             className="flex-row items-center gap-0.5"
           >
             <PullRequestIcon

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -450,6 +450,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   const timestamp = relativeTime(
     thread.latestUserMessageAt ?? thread.updatedAt ?? thread.createdAt,
   );
+  const threadAccessibilityLabel = pr ? `${thread.title}, ${pr.accessibilityLabel}` : thread.title;
   const subtitleParts = [props.environmentLabel, thread.branch].filter((part): part is string =>
     Boolean(part),
   );
@@ -507,12 +508,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
           </>
         ) : null}
         {pr !== null ? (
-          <View
-            accessible
-            accessibilityLabel={pr.accessibilityLabel}
-            accessibilityRole="text"
-            className="flex-row items-center gap-0.5"
-          >
+          <View className="flex-row items-center gap-0.5">
             <PullRequestIcon
               size={compact ? 13 : 11}
               color={selected ? "#ffffff" : pullRequestTintColor(pr.state, colorScheme)}
@@ -533,7 +529,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
     compact ? (
       <Pressable
         accessibilityHint="Swipe left for archive and delete actions"
-        accessibilityLabel={thread.title}
+        accessibilityLabel={threadAccessibilityLabel}
         accessibilityRole="button"
         className="bg-screen"
         onPress={() => {
@@ -579,7 +575,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
     ) : (
       <Pressable
         accessibilityHint="Opens the thread"
-        accessibilityLabel={thread.title}
+        accessibilityLabel={threadAccessibilityLabel}
         accessibilityRole="button"
         accessibilityState={{ selected }}
         onHoverIn={() => setHovered(true)}

--- a/apps/mobile/src/features/threads/thread-list-items.tsx
+++ b/apps/mobile/src/features/threads/thread-list-items.tsx
@@ -6,8 +6,9 @@ import type {
 import type { MenuAction } from "@react-native-menu/menu";
 import { SymbolView } from "expo-symbols";
 import { memo, useCallback, useMemo, type ComponentProps } from "react";
-import { Pressable, useWindowDimensions, View } from "react-native";
+import { Pressable, useColorScheme, useWindowDimensions, View } from "react-native";
 import type { SwipeableMethods } from "react-native-gesture-handler/ReanimatedSwipeable";
+import Svg, { Circle, Path } from "react-native-svg";
 
 import { AppText as Text } from "../../components/AppText";
 import { ControlPillMenu } from "../../components/ControlPill";
@@ -16,7 +17,7 @@ import { cn } from "../../lib/cn";
 import { relativeTime } from "../../lib/time";
 import { useThemeColor } from "../../lib/useThemeColor";
 import type { PendingNewTask } from "../../state/use-pending-new-tasks";
-import { useThreadPr } from "../../state/use-thread-pr";
+import { useThreadPr, type ThreadPr } from "../../state/use-thread-pr";
 import type { HomeGroupDisplayAction } from "../home/homeListItems";
 import { ThreadSwipeable } from "../home/thread-swipe-actions";
 import { resolveThreadStatus } from "./threadPresentation";
@@ -32,6 +33,41 @@ export type ThreadListVariant = "compact" | "sidebar";
 /** Left inset that aligns compact secondary rows with the title column. */
 export const THREAD_LIST_COMPACT_INSET = 20;
 const SIDEBAR_ROW_RADIUS = 12;
+
+function pullRequestTintColor(
+  state: ThreadPr["state"],
+  colorScheme: ReturnType<typeof useColorScheme>,
+) {
+  const dark = colorScheme === "dark";
+  switch (state) {
+    case "open":
+      return dark ? "#34d399" : "#059669";
+    case "merged":
+      return dark ? "#a78bfa" : "#7c3aed";
+    case "closed":
+      return dark ? "#a1a1aa" : "#71717a";
+  }
+}
+
+function PullRequestIcon(props: { readonly size: number; readonly color: string }) {
+  return (
+    <Svg
+      width={props.size}
+      height={props.size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={props.color}
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <Circle cx={18} cy={18} r={3} />
+      <Circle cx={6} cy={6} r={3} />
+      <Path d="M13 6h3a2 2 0 0 1 2 2v7" />
+      <Path d="M6 9v12" />
+    </Svg>
+  );
+}
 
 /* ─── Project group header ───────────────────────────────────────────── */
 
@@ -394,6 +430,7 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
   >["simultaneousWithExternalGesture"];
 }) {
   const { width: windowWidth } = useWindowDimensions();
+  const colorScheme = useColorScheme();
   const compact = props.variant === "compact";
   const selected = props.selected === true;
   // Recycling-safe: resets when the list container is reused for another
@@ -479,13 +516,22 @@ export const ThreadListRow = memo(function ThreadListRow(props: {
           </>
         ) : null}
         {pr !== null ? (
-          <Text
-            className={`${compact ? "text-sm" : "text-xs"} font-t3-medium ${
-              selected ? "text-white" : pr.textClassName
-            }`}
+          <View
+            accessibilityLabel={`${pr.label} pull request ${pr.state}`}
+            className="flex-row items-center gap-0.5"
           >
-            {pr.label}
-          </Text>
+            <PullRequestIcon
+              size={compact ? 13 : 11}
+              color={selected ? "#ffffff" : pullRequestTintColor(pr.state, colorScheme)}
+            />
+            <Text
+              className={`${compact ? "text-sm" : "text-xs"} font-t3-medium ${
+                selected ? "text-white" : pr.textClassName
+              }`}
+            >
+              {pr.label}
+            </Text>
+          </View>
         ) : null}
       </View>
     ) : null;

--- a/apps/mobile/src/state/thread-pr-presentation.ts
+++ b/apps/mobile/src/state/thread-pr-presentation.ts
@@ -1,0 +1,28 @@
+import type { VcsStatusResult } from "@t3tools/contracts";
+
+export type ThreadPr = NonNullable<VcsStatusResult["pr"]>;
+
+export interface ThreadPrPresentation {
+  readonly number: number;
+  readonly state: ThreadPr["state"];
+  readonly url: string;
+  /** Compact desktop-style label, e.g. "#3774". */
+  readonly label: string;
+  readonly textClassName: string;
+}
+
+const PR_STATE_TEXT_CLASS: Record<ThreadPr["state"], string> = {
+  open: "text-emerald-600 dark:text-emerald-400",
+  merged: "text-violet-600 dark:text-violet-400",
+  closed: "text-zinc-500 dark:text-zinc-400",
+};
+
+export function presentThreadPr(pr: ThreadPr): ThreadPrPresentation {
+  return {
+    number: pr.number,
+    state: pr.state,
+    url: pr.url,
+    label: `#${pr.number}`,
+    textClassName: PR_STATE_TEXT_CLASS[pr.state],
+  };
+}

--- a/apps/mobile/src/state/thread-pr-presentation.ts
+++ b/apps/mobile/src/state/thread-pr-presentation.ts
@@ -1,4 +1,5 @@
 import type { VcsStatusResult } from "@t3tools/contracts";
+import { resolveChangeRequestPresentation } from "@t3tools/shared/sourceControl";
 
 export type ThreadPr = NonNullable<VcsStatusResult["pr"]>;
 
@@ -8,6 +9,8 @@ export interface ThreadPrPresentation {
   readonly url: string;
   /** Compact desktop-style label, e.g. "#3774". */
   readonly label: string;
+  /** Full, provider-aware label for assistive technologies. */
+  readonly accessibilityLabel: string;
   readonly textClassName: string;
 }
 
@@ -17,12 +20,17 @@ const PR_STATE_TEXT_CLASS: Record<ThreadPr["state"], string> = {
   closed: "text-zinc-500 dark:text-zinc-400",
 };
 
-export function presentThreadPr(pr: ThreadPr): ThreadPrPresentation {
+export function presentThreadPr(
+  pr: ThreadPr,
+  provider: VcsStatusResult["sourceControlProvider"] | null | undefined,
+): ThreadPrPresentation {
+  const presentation = resolveChangeRequestPresentation(provider);
   return {
     number: pr.number,
     state: pr.state,
     url: pr.url,
     label: `#${pr.number}`,
+    accessibilityLabel: `#${pr.number} ${presentation.longName} ${pr.state}`,
     textClassName: PR_STATE_TEXT_CLASS[pr.state],
   };
 }

--- a/apps/mobile/src/state/use-thread-pr.test.ts
+++ b/apps/mobile/src/state/use-thread-pr.test.ts
@@ -14,9 +14,23 @@ const pullRequest: NonNullable<VcsStatusResult["pr"]> = {
 
 describe("presentThreadPr", () => {
   it("uses the compact desktop-style pull request number label", () => {
-    expect(presentThreadPr(pullRequest)).toMatchObject({
+    expect(presentThreadPr(pullRequest, undefined)).toMatchObject({
       label: "#3774",
+      accessibilityLabel: "#3774 pull request merged",
       textClassName: "text-violet-600 dark:text-violet-400",
+    });
+  });
+
+  it("uses merge-request terminology for GitLab", () => {
+    expect(
+      presentThreadPr(pullRequest, {
+        kind: "gitlab",
+        name: "GitLab",
+        baseUrl: "https://gitlab.com",
+      }),
+    ).toMatchObject({
+      label: "#3774",
+      accessibilityLabel: "#3774 merge request merged",
     });
   });
 });

--- a/apps/mobile/src/state/use-thread-pr.test.ts
+++ b/apps/mobile/src/state/use-thread-pr.test.ts
@@ -1,0 +1,22 @@
+import type { VcsStatusResult } from "@t3tools/contracts";
+import { describe, expect, it } from "vite-plus/test";
+
+import { presentThreadPr } from "./thread-pr-presentation";
+
+const pullRequest: NonNullable<VcsStatusResult["pr"]> = {
+  number: 3774,
+  title: "Desktop-style pull request indicator",
+  url: "https://github.com/t3tools/t3code/pull/3774",
+  baseRef: "main",
+  headRef: "codex/desktop-style-pr-indicator",
+  state: "merged",
+};
+
+describe("presentThreadPr", () => {
+  it("uses the compact desktop-style pull request number label", () => {
+    expect(presentThreadPr(pullRequest)).toMatchObject({
+      label: "#3774",
+      textClassName: "text-violet-600 dark:text-violet-400",
+    });
+  });
+});

--- a/apps/mobile/src/state/use-thread-pr.ts
+++ b/apps/mobile/src/state/use-thread-pr.ts
@@ -37,5 +37,5 @@ export function useThreadPr(
   if (!status.pr) {
     return null;
   }
-  return presentThreadPr(status.pr);
+  return presentThreadPr(status.pr, status.sourceControlProvider);
 }

--- a/apps/mobile/src/state/use-thread-pr.ts
+++ b/apps/mobile/src/state/use-thread-pr.ts
@@ -1,40 +1,14 @@
 import type { EnvironmentThreadShell } from "@t3tools/client-runtime/state/shell";
-import type { VcsStatusResult } from "@t3tools/contracts";
-import { resolveChangeRequestPresentation } from "@t3tools/shared/sourceControl";
 
 import { useEnvironmentQuery } from "./query";
+import { presentThreadPr, type ThreadPrPresentation } from "./thread-pr-presentation";
 import { vcsEnvironment } from "./vcs";
 
-export type ThreadPr = NonNullable<VcsStatusResult["pr"]>;
-
-export interface ThreadPrPresentation {
-  readonly number: number;
-  readonly state: ThreadPr["state"];
-  readonly url: string;
-  /** Compact chip label, e.g. "PR open" / "MR merged". */
-  readonly label: string;
-  readonly textClassName: string;
-}
-
-const PR_STATE_TEXT_CLASS: Record<ThreadPr["state"], string> = {
-  open: "text-emerald-600 dark:text-emerald-400",
-  merged: "text-violet-600 dark:text-violet-400",
-  closed: "text-zinc-500 dark:text-zinc-400",
-};
-
-export function presentThreadPr(
-  pr: ThreadPr,
-  provider: VcsStatusResult["sourceControlProvider"] | null | undefined,
-): ThreadPrPresentation {
-  const shortName = resolveChangeRequestPresentation(provider).shortName;
-  return {
-    number: pr.number,
-    state: pr.state,
-    url: pr.url,
-    label: `${shortName} ${pr.state}`,
-    textClassName: PR_STATE_TEXT_CLASS[pr.state],
-  };
-}
+export {
+  presentThreadPr,
+  type ThreadPr,
+  type ThreadPrPresentation,
+} from "./thread-pr-presentation";
 
 /**
  * Live PR status for a thread's branch. Subscriptions are deduplicated per
@@ -63,5 +37,5 @@ export function useThreadPr(
   if (!status.pr) {
     return null;
   }
-  return presentThreadPr(status.pr, status.sourceControlProvider);
+  return presentThreadPr(status.pr);
 }


### PR DESCRIPTION
## Summary
- Marks the mobile thread row PR indicator as an accessible text element.
- Uses the existing provider-aware PR accessibility label for screen readers.

## Testing
- Not run (PR content generated from provided commit and diff metadata).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and accessibility-only changes in mobile thread list presentation with updated unit tests; no auth, data, or API impact.
> 
> **Overview**
> Thread list rows now announce pull request context to screen readers by setting the row **`accessibilityLabel`** to `thread title` plus the existing provider-aware PR label (e.g. `#3774 pull request merged`), instead of only the title.
> 
> **Visual tweaks:** the branch **`SymbolView`** is removed from the subtitle row, and the on-screen PR number drops the **`#`** prefix (`3774` vs `#3774`) while **`accessibilityLabel`** still includes `#` and GitLab merge-request wording. Unused muted-color styling tied to the branch icon is cleaned up, and the PR subtitle container no longer carries its own **`accessibilityLabel`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d1129dc2743afd7f33833769f6415bad4b3f65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose PR indicator labels to accessibility in mobile thread list rows
> - The `ThreadListRow` accessible name now includes PR info (title + `pr.accessibilityLabel`) when a PR is present, instead of just the thread title.
> - The branch `SymbolView` icon preceding the subtitle text is removed from the thread list row.
> - `presentThreadPr` label is changed from `#${pr.number}` to `String(pr.number)`, dropping the leading `#` from the compact PR label. Tests are updated to match.
> - Behavioral Change: consumers of `ThreadPrPresentation.label` (e.g. displayed PR badges) will no longer show a `#` prefix on the PR number.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d0d1129.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->