### PR TITLE
fix(chat): unwrap raw JSON provider error payloads into readable messages

### DIFF
--- a/apps/server/src/provider/Layers/CodexAdapter.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.ts
@@ -38,6 +38,7 @@ import * as CodexErrors from "effect-codex-app-server/errors";
 import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import { getModelSelectionStringOptionValue } from "@t3tools/shared/model";
+import { extractProviderErrorMessage } from "@t3tools/shared/providerError";
 import { getCodexServiceTierOptionValue } from "../../codexModelOptions.ts";
 import * as McpProviderSession from "../../mcp/McpProviderSession.ts";
 
@@ -764,7 +765,8 @@ function mapToRuntimeEvents(
     if (!payload) {
       return [];
     }
-    const errorMessage = trimText(payload.turn.error?.message);
+    const rawErrorMessage = trimText(payload.turn.error?.message);
+    const errorMessage = rawErrorMessage ? extractProviderErrorMessage(rawErrorMessage) : undefined;
     return [
       {
         ...runtimeEventBase(event, canonicalThreadId),
@@ -1241,7 +1243,9 @@ function mapToRuntimeEvents(
 
   if (event.method === "error") {
     const payload = readPayload(EffectCodexSchema.V2ErrorNotification, event.payload);
-    const message = payload?.error.message ?? event.message ?? "Provider runtime error";
+    const message = extractProviderErrorMessage(
+      payload?.error.message ?? event.message ?? "Provider runtime error",
+    );
     const willRetry = payload?.willRetry === true;
     return [
       {

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -18,6 +18,7 @@ import {
 } from "@t3tools/contracts";
 import { resolveSpawnCommand } from "@t3tools/shared/shell";
 import { normalizeModelSlug } from "@t3tools/shared/model";
+import { extractProviderErrorMessage } from "@t3tools/shared/providerError";
 import * as Crypto from "effect/Crypto";
 import * as DateTime from "effect/DateTime";
 import * as Deferred from "effect/Deferred";
@@ -921,7 +922,7 @@ export const makeCodexSessionRuntime = (
           }
           const lastError =
             payload.turn.status === "failed" && "error" in payload.turn && payload.turn.error
-              ? payload.turn.error.message
+              ? extractProviderErrorMessage(payload.turn.error.message)
               : undefined;
           return updateSession(sessionRef, {
             status: payload.turn.status === "failed" ? "error" : "ready",
@@ -939,7 +940,7 @@ export const makeCodexSessionRuntime = (
           if (providerThreadId && payloadThreadId && payloadThreadId !== providerThreadId) {
             return Effect.void;
           }
-          const errorMessage = payload.error.message;
+          const errorMessage = extractProviderErrorMessage(payload.error.message);
           const willRetry = payload.willRetry;
           return updateSession(sessionRef, {
             status: willRetry ? "running" : "error",

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { extractProviderErrorMessage } from "@t3tools/shared/providerError";
 import { Alert, AlertAction, AlertDescription } from "../ui/alert";
 import { Button } from "../ui/button";
 import { CircleAlertIcon, XIcon } from "lucide-react";
@@ -12,16 +13,19 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
   onDismiss?: () => void;
 }) {
   if (!error) return null;
+  // errors persisted before the server started unwrapping provider payloads
+  // can still be raw JSON, so unwrap here too
+  const message = extractProviderErrorMessage(error);
   return (
     <div className="pt-3 mx-auto max-w-3xl">
       <Alert variant="error">
         <CircleAlertIcon />
         <Tooltip>
-          <TooltipTrigger render={<AlertDescription className="line-clamp-3" />}>
-            {error}
+          <TooltipTrigger render={<AlertDescription className="line-clamp-3 break-words" />}>
+            {message}
           </TooltipTrigger>
-          <TooltipPopup side="top" className="max-w-96 whitespace-pre-wrap">
-            {error}
+          <TooltipPopup side="top" className="max-w-96 whitespace-pre-wrap break-words">
+            {message}
           </TooltipPopup>
         </Tooltip>
         {onDismiss && (

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -182,6 +182,10 @@
     "./httpReadiness": {
       "types": "./src/httpReadiness.ts",
       "import": "./src/httpReadiness.ts"
+    },
+    "./providerError": {
+      "types": "./src/providerError.ts",
+      "import": "./src/providerError.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/providerError.test.ts
+++ b/packages/shared/src/providerError.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { extractProviderErrorMessage } from "./providerError.ts";
+
+describe("extractProviderErrorMessage", () => {
+  it("returns plain messages unchanged", () => {
+    expect(extractProviderErrorMessage("Something went wrong")).toBe("Something went wrong");
+  });
+
+  it("extracts the nested message from a codex/upstream error body", () => {
+    const raw =
+      '{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The \'gpt-5.3-codex\' model is not supported when using Codex with a ChatGPT account."}}';
+    expect(extractProviderErrorMessage(raw)).toBe(
+      "The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.",
+    );
+  });
+
+  it("extracts a top-level message field", () => {
+    expect(extractProviderErrorMessage('{"message":"rate limited","code":429}')).toBe(
+      "rate limited",
+    );
+  });
+
+  it("unwraps double-encoded payloads", () => {
+    const inner = '{"error":{"message":"quota exceeded"}}';
+    const outer = JSON.stringify({ message: inner });
+    expect(extractProviderErrorMessage(outer)).toBe("quota exceeded");
+  });
+
+  it("returns invalid JSON unchanged", () => {
+    expect(extractProviderErrorMessage('{"type":"error", broken')).toBe('{"type":"error", broken');
+  });
+
+  it("returns JSON without a usable message unchanged", () => {
+    expect(extractProviderErrorMessage('{"status":500}')).toBe('{"status":500}');
+  });
+
+  it("ignores empty or whitespace-only message fields", () => {
+    expect(extractProviderErrorMessage('{"message":"  ","error":{"message":"real cause"}}')).toBe(
+      "real cause",
+    );
+  });
+
+  it("does not touch non-object JSON", () => {
+    expect(extractProviderErrorMessage('"just a string"')).toBe('"just a string"');
+    expect(extractProviderErrorMessage("[1,2,3]")).toBe("[1,2,3]");
+  });
+});

--- a/packages/shared/src/providerError.ts
+++ b/packages/shared/src/providerError.ts
@@ -1,0 +1,36 @@
+function readMessage(value: unknown): string | undefined {
+  if (typeof value !== "object" || value === null) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (typeof record.message === "string" && record.message.trim().length > 0) {
+    return record.message.trim();
+  }
+  // upstream errors often nest the useful part, e.g. {"type":"error","status":400,"error":{"message":...}}
+  return readMessage(record.error);
+}
+
+/**
+ * Providers sometimes surface the raw upstream error body as the error
+ * message string (e.g. `{"type":"error","status":400,"error":{"type":
+ * "invalid_request_error","message":"..."}}`). Pull out the human readable
+ * message when that happens; otherwise return the input unchanged.
+ */
+export function extractProviderErrorMessage(message: string): string {
+  const trimmed = message.trim();
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) {
+    return message;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return message;
+  }
+  const extracted = readMessage(parsed);
+  if (extracted === undefined || extracted === trimmed) {
+    return message;
+  }
+  // handles double-encoded payloads; the inequality check above guarantees progress
+  return extractProviderErrorMessage(extracted);
+}


### PR DESCRIPTION
Fixes #3747

## What

Model/provider errors were rendered in the chat UI as the raw upstream JSON body, e.g.

```
{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}}
```

and since that string is one long unbreakable token, it also overflowed/clipped the error banner.

## Why it happens

Codex fills the `error.message` / `turn.error.message` notification fields with the stringified upstream response body, and t3code passes that string through verbatim into `session.lastError` and `runtime.error` events. `ThreadErrorBanner` then renders it as-is with `line-clamp-3` but no word-breaking, so the unwrappable token can't clamp and overflows instead.

## Changes

- **`packages/shared/providerError.ts`** (new): `extractProviderErrorMessage()` — if an error string parses as JSON with a `message` (or nested `error.message`) field, return that; otherwise return the input unchanged. Handles double-encoded payloads. Shared module per the maintainability guidance in AGENTS.md, since both server and web need it. 8 unit tests included.
- **`apps/server` (CodexSessionRuntime, CodexAdapter)**: apply it at the four places codex error text becomes `session.lastError` / `turn.completed.errorMessage` / `runtime.error.message`.
- **`apps/web` (ThreadErrorBanner)**: unwrap defensively too (covers `lastError` values persisted before this fix, and any other adapter with the same habit), and add `break-words` to the banner + tooltip so a long unbreakable string wraps and clamps properly instead of clipping.

Raw payload details are unaffected for debugging — the `runtime.error` event still carries the original payload in `detail`.

## Before / after

With the payload above, the banner previously showed the full raw JSON (clipped); it now shows:

> The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account.

## Checks

- `vp check` ✅
- `vp run typecheck` ✅ (all 15 packages)
- `packages/shared` + codex adapter/runtime test suites pass; the only failures in `packages/shared` (`logging.test.ts`, `relayClient.test.ts`) also fail on a clean checkout of `main` on this machine (Windows env-specific) and are untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized display and message normalization for Codex errors; no auth or persistence schema changes, and debugging payloads remain in event detail.
> 
> **Overview**
> Codex often forwards **stringified upstream error JSON** as the user-visible message, which showed up as one long token in the chat error banner and overflowed `line-clamp-3`.
> 
> This PR adds **`extractProviderErrorMessage`** in `@t3tools/shared/providerError` (with unit tests) to pull a human-readable `message` or nested `error.message` from JSON-shaped strings, including double-encoded payloads, and leaves plain text unchanged.
> 
> **Server:** Codex **`CodexAdapter`** and **`CodexSessionRuntime`** apply the helper when setting `turn.completed.errorMessage`, `runtime.error` / warning messages, and `session.lastError` from turn failures and provider `error` notifications. **`runtime.error` still keeps the raw payload in `detail`.**
> 
> **Web:** **`ThreadErrorBanner`** unwraps errors again for values stored before the server change, and adds **`break-words`** on the banner and tooltip so long strings wrap and clamp correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8118eeb2ffef4494118ea37a565d4f17056cae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unwrap raw JSON provider error payloads into readable messages in chat
> - Adds `extractProviderErrorMessage` in [providerError.ts](https://github.com/pingdotgg/t3code/pull/3830/files#diff-e070373acb2fd8072aee08ceddc6e9502b58c2e916200687d30aeb81bf3d90e5) that parses JSON error bodies from providers, extracts a human-readable message string, and recursively unwraps double-encoded payloads, returning the original input unchanged for non-JSON or unrecognized formats.
> - Applies `extractProviderErrorMessage` in [CodexAdapter.ts](https://github.com/pingdotgg/t3code/pull/3830/files#diff-f37bcac225467446dcf6198df38d357c15304b19eebacbdcdea70047f507707d) and [CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/3830/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) so `turn/completed` and `error` runtime events carry unwrapped messages.
> - Updates [ThreadErrorBanner.tsx](https://github.com/pingdotgg/t3code/pull/3830/files#diff-3fa9e223d4ae557ff232900844d971974d42e09f07a6d6e005538eab923867f0) to unwrap previously persisted raw JSON errors at render time and adds `break-words` to prevent long-token overflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d8118e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->