### PR TITLE
fix(cursor): default binary path to cursor-agent

### DIFF
--- a/apps/server/scripts/cursor-acp-model-mismatch-probe.ts
+++ b/apps/server/scripts/cursor-acp-model-mismatch-probe.ts
@@ -62,7 +62,7 @@ const promptText = NodeProcess.argv[4] ?? "helo";
 const targetReasoning = NodeProcess.env.CURSOR_REASONING ?? "";
 const targetContext = NodeProcess.env.CURSOR_CONTEXT ?? "";
 const targetFast = NodeProcess.env.CURSOR_FAST ?? "";
-const agentBin = NodeProcess.env.CURSOR_AGENT_BIN ?? "agent";
+const agentBin = NodeProcess.env.CURSOR_AGENT_BIN ?? "cursor-agent";
 const promptWaitMs = Number(NodeProcess.env.CURSOR_PROMPT_WAIT_MS ?? "4000");
 const requestTimeoutMs = Number(NodeProcess.env.CURSOR_REQUEST_TIMEOUT_MS ?? "20000");
 

--- a/apps/server/src/provider/Drivers/CursorDriver.ts
+++ b/apps/server/src/provider/Drivers/CursorDriver.ts
@@ -1,5 +1,5 @@
 /**
- * CursorDriver — `ProviderDriver` for the Cursor Agent (`agent`) runtime.
+ * CursorDriver — `ProviderDriver` for the Cursor Agent (`cursor-agent`) runtime.
  *
  * Cursor exposes an ACP-based CLI. Model catalog and capability refreshes
  * happen during the managed provider status check via Cursor's
@@ -58,7 +58,7 @@ const UPDATE = makeStaticProviderMaintenanceResolver(
   makeProviderMaintenanceCapabilities({
     provider: DRIVER_KIND,
     packageName: null,
-    updateExecutable: "agent",
+    updateExecutable: "cursor-agent",
     updateArgs: ["update"],
     updateLockKey: "cursor-agent",
   }),

--- a/apps/server/src/provider/Layers/CursorProvider.test.ts
+++ b/apps/server/src/provider/Layers/CursorProvider.test.ts
@@ -294,7 +294,7 @@ const parameterizedClaudeModelOptionConfigOptions = [
 
 const baseCursorSettings: CursorSettings = {
   enabled: true,
-  binaryPath: "agent",
+  binaryPath: "cursor-agent",
   apiEndpoint: "",
   customModels: [],
 };

--- a/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
+++ b/apps/server/src/provider/Layers/ProviderInstanceRegistryLive.test.ts
@@ -76,7 +76,7 @@ const makeClaudeConfig = (overrides: Partial<ClaudeSettings>): ClaudeSettings =>
 
 const makeCursorConfig = (overrides: Partial<CursorSettings>): CursorSettings => ({
   enabled: false,
-  binaryPath: "agent",
+  binaryPath: "cursor-agent",
   apiEndpoint: "",
   customModels: [],
   ...overrides,

--- a/apps/server/src/provider/Layers/ProviderRegistry.test.ts
+++ b/apps/server/src/provider/Layers/ProviderRegistry.test.ts
@@ -1396,7 +1396,7 @@ it.layer(Layer.mergeAll(NodeServices.layer, ServerSettingsModule.layerTest(), Te
               Layer.provideMerge(OpenCodeRuntime.OpenCodeRuntimeLive),
               Layer.provideMerge(
                 mockCommandSpawnerLayer((command, args) => {
-                  if (command === "agent") {
+                  if (command === "cursor-agent") {
                     cursorSpawned = true;
                   }
                   const joined = args.join(" ");

--- a/apps/server/src/provider/acp/CursorAcpCliProbe.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpCliProbe.test.ts
@@ -1,5 +1,5 @@
 /**
- * Optional integration check against a real `agent acp` install.
+ * Optional integration check against a real `cursor-agent acp` install.
  * Enable with: T3_CURSOR_ACP_PROBE=1 bun run test --filter CursorAcpCliProbe
  */
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -12,7 +12,7 @@ import type * as EffectAcpSchema from "effect-acp/schema";
 import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 
 describe.runIf(process.env.T3_CURSOR_ACP_PROBE === "1")("Cursor ACP CLI probe", () => {
-  it.effect("initialize and authenticate against real agent acp", () =>
+  it.effect("initialize and authenticate against real cursor-agent acp", () =>
     Effect.gen(function* () {
       const runtime = yield* AcpSessionRuntime.AcpSessionRuntime;
       const started = yield* runtime.start();
@@ -21,7 +21,7 @@ describe.runIf(process.env.T3_CURSOR_ACP_PROBE === "1")("Cursor ACP CLI probe", 
       Effect.provide(
         AcpSessionRuntime.layer({
           spawn: {
-            command: "agent",
+            command: "cursor-agent",
             args: ["acp"],
             cwd: process.cwd(),
           },
@@ -77,7 +77,7 @@ describe.runIf(process.env.T3_CURSOR_ACP_PROBE === "1")("Cursor ACP CLI probe", 
         AcpSessionRuntime.layer({
           authMethodId: "cursor_login",
           spawn: {
-            command: "agent",
+            command: "cursor-agent",
             args: ["acp"],
             cwd: process.cwd(),
           },
@@ -133,7 +133,7 @@ describe.runIf(process.env.T3_CURSOR_ACP_PROBE === "1")("Cursor ACP CLI probe", 
         AcpSessionRuntime.layer({
           authMethodId: "cursor_login",
           spawn: {
-            command: "agent",
+            command: "cursor-agent",
             args: ["acp"],
             cwd: process.cwd(),
           },

--- a/apps/server/src/provider/acp/CursorAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.test.ts
@@ -53,7 +53,7 @@ const parameterizedGpt54ConfigOptions: ReadonlyArray<EffectAcpSchema.SessionConf
 describe("buildCursorAcpSpawnInput", () => {
   it("builds the default Cursor ACP command", () => {
     expect(buildCursorAcpSpawnInput(undefined, "/tmp/project")).toEqual({
-      command: "agent",
+      command: "cursor-agent",
       args: ["acp"],
       cwd: "/tmp/project",
     });

--- a/apps/server/src/provider/acp/CursorAcpSupport.ts
+++ b/apps/server/src/provider/acp/CursorAcpSupport.ts
@@ -35,7 +35,7 @@ export function buildCursorAcpSpawnInput(
   environment?: NodeJS.ProcessEnv,
 ): AcpSessionRuntime.AcpSpawnInput {
   return {
-    command: cursorSettings?.binaryPath || "agent",
+    command: cursorSettings?.binaryPath || "cursor-agent",
     args: [
       ...(cursorSettings?.apiEndpoint ? (["-e", cursorSettings.apiEndpoint] as const) : []),
       "acp",

--- a/apps/server/src/provider/providerMaintenanceRunner.test.ts
+++ b/apps/server/src/provider/providerMaintenanceRunner.test.ts
@@ -48,7 +48,7 @@ function lifecycleFor(provider: ProviderDriverKind): ProviderMaintenanceCapabili
     return makeProviderMaintenanceCapabilities({
       provider,
       packageName: null,
-      updateExecutable: "agent",
+      updateExecutable: "cursor-agent",
       updateArgs: ["update"],
       updateLockKey: "cursor-agent",
     });
@@ -226,7 +226,7 @@ describe("providerMaintenanceRunner", () => {
       const result = yield* updater.updateProvider(CURSOR_DRIVER);
       assert.deepStrictEqual(calls, [
         {
-          command: "agent",
+          command: "cursor-agent",
           args: ["update"],
         },
       ]);

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -252,11 +252,11 @@ export const CursorSettings = makeProviderSettingsSchema(
       Schema.withDecodingDefault(Effect.succeed(false)),
       Schema.annotateKey({ providerSettingsForm: { hidden: true } }),
     ),
-    binaryPath: makeBinaryPathSetting("agent").pipe(
+    binaryPath: makeBinaryPathSetting("cursor-agent").pipe(
       Schema.annotateKey({
         title: "Binary path",
         description: "Path to the Cursor agent binary.",
-        providerSettingsForm: { placeholder: "agent", clearWhenEmpty: "omit" },
+        providerSettingsForm: { placeholder: "cursor-agent", clearWhenEmpty: "omit" },
       }),
     ),
     apiEndpoint: TrimmedString.pipe(


### PR DESCRIPTION
## Summary

- Switch the Cursor provider default binary from `agent` to `cursor-agent` across settings schema, ACP spawn, driver update command, and probe script.
- Update related tests to match the new default.

The previous default of `agent` collides with Grok CLI's `grok agent` subcommand when both are on PATH. `cursor-agent` matches the Cursor README (`cursor-agent login`) and the effect-acp example client.

Users who explicitly set `binaryPath: "agent"` are unchanged. Only the default is affected. Existing installs that already persisted the old default may need a server restart or "reset to default" in Cursor provider settings to pick up `cursor-agent`.

## Test plan

- [x] `vp check` and `vp run typecheck` pass
- [x] Cursor provider tests updated and passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong-binary defaults can break Cursor until settings are refreshed, but the change is narrowly scoped to defaults and avoids PATH clashes with Grok’s `agent` subcommand.
> 
> **Overview**
> **Default Cursor CLI is now `cursor-agent` instead of `agent`.** That applies to decoded `CursorSettings.binaryPath` (and the settings UI placeholder), ACP spawn when no path is set (`CursorAcpSupport`), provider self-update (`CursorDriver` maintenance), and the ACP probe script’s `CURSOR_AGENT_BIN` fallback.
> 
> **Tests and mocks** that assumed the old default were updated to expect `cursor-agent` (including registry spawn tracking when Cursor is disabled).
> 
> Explicit `binaryPath: "agent"` (or any custom path) is unchanged; only unset/empty defaults pick up `cursor-agent`. Installs that already persisted the old default may need a restart or reset to default in Cursor settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7a11065cc3be8d59a452d9e7fb7e7f1903cb08b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix default binary path from `agent` to `cursor-agent` in Cursor provider
> Updates all references to the Cursor agent binary name from `agent` to `cursor-agent` across runtime code, settings defaults, and tests. Affected areas include `CursorAcpSupport.buildCursorAcpSpawnInput`, `CursorDriver` maintenance capability, `CursorSettings.binaryPath` schema default, and the ACP model mismatch probe script. Behavioral Change: any deployment relying on the previous default binary name `agent` will now invoke `cursor-agent` instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a7a1106.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->