### PR TITLE
Prevent Grok ACP prompt-completion timeouts

### DIFF
--- a/apps/server/scripts/acp-mock-agent.ts
+++ b/apps/server/scripts/acp-mock-agent.ts
@@ -20,6 +20,8 @@ const emitGenericToolPlaceholders = process.env.T3_ACP_EMIT_GENERIC_TOOL_PLACEHO
 const emitAskQuestion = process.env.T3_ACP_EMIT_ASK_QUESTION === "1";
 const emitXAiAskUserQuestion = process.env.T3_ACP_EMIT_XAI_ASK_USER_QUESTION === "1";
 const emitXAiPromptCompleteThenHang = process.env.T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG === "1";
+const xAiPromptCompleteMethod =
+  process.env.T3_ACP_XAI_PROMPT_COMPLETE_METHOD ?? "_x.ai/session/prompt_complete";
 const emitForeignSessionUpdates = process.env.T3_ACP_EMIT_FOREIGN_SESSION_UPDATES === "1";
 const hangPromptForever = process.env.T3_ACP_HANG_PROMPT_FOREVER === "1";
 const hangFirstPromptForever = process.env.T3_ACP_HANG_FIRST_PROMPT_FOREVER === "1";
@@ -477,14 +479,14 @@ const program = Effect.gen(function* () {
 
       if (emitStaleXAiPromptCompleteBeforeSecondHang && promptCount === 2) {
         const currentPromptId = promptIdFromRequestMeta(request) ?? "mock-current-xai-prompt-2";
-        writeJsonRpcNotification("_x.ai/session/prompt_complete", {
+        writeJsonRpcNotification(xAiPromptCompleteMethod, {
           sessionId: requestedSessionId,
           promptId: "mock-stale-xai-prompt-1",
           stopReason: "end_turn",
           agentResult: null,
         });
 
-        writeJsonRpcNotification("_x.ai/session/prompt_complete", {
+        writeJsonRpcNotification(xAiPromptCompleteMethod, {
           sessionId: requestedSessionId,
           promptId: currentPromptId,
           stopReason: "end_turn",
@@ -502,13 +504,13 @@ const program = Effect.gen(function* () {
       if (emitOverlappingXAiPromptCompleteOutOfOrder && promptCount === 2) {
         const secondPromptId = promptIdFromRequestMeta(request);
         if (overlappingFirstPromptId !== undefined && secondPromptId !== undefined) {
-          writeJsonRpcNotification("_x.ai/session/prompt_complete", {
+          writeJsonRpcNotification(xAiPromptCompleteMethod, {
             sessionId: requestedSessionId,
             promptId: secondPromptId,
             stopReason: "end_turn",
             agentResult: null,
           });
-          writeJsonRpcNotification("_x.ai/session/prompt_complete", {
+          writeJsonRpcNotification(xAiPromptCompleteMethod, {
             sessionId: requestedSessionId,
             promptId: overlappingFirstPromptId,
             stopReason: "end_turn",
@@ -541,7 +543,7 @@ const program = Effect.gen(function* () {
           });
         }
 
-        writeJsonRpcNotification("_x.ai/session/prompt_complete", {
+        writeJsonRpcNotification(xAiPromptCompleteMethod, {
           sessionId: requestedSessionId,
           promptId: promptIdFromRequestMeta(request) ?? "mock-xai-prompt-1",
           ...(omitXAiPromptCompleteStopReason ? {} : { stopReason: "end_turn" }),

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -3,6 +3,7 @@ import * as NodePath from "node:path";
 import * as NodeURL from "node:url";
 
 import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as Deferred from "effect/Deferred";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
@@ -20,7 +21,10 @@ import * as AcpSessionRuntime from "./AcpSessionRuntime.ts";
 const __dirname = NodePath.dirname(NodeURL.fileURLToPath(import.meta.url));
 const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.ts");
 
-const makePromptCompletionRuntime = (env: NodeJS.ProcessEnv) =>
+const makePromptCompletionRuntime = (
+  env: NodeJS.ProcessEnv,
+  overrides: Partial<Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "cancel">> = {},
+) =>
   Effect.gen(function* () {
     const runtime = yield* AcpSessionRuntime.make({
       spawn: {
@@ -32,7 +36,7 @@ const makePromptCompletionRuntime = (env: NodeJS.ProcessEnv) =>
       clientInfo: { name: "t3-test", version: "0.0.0" },
       authMethodId: "test",
     });
-    return yield* makeXAiPromptCompletionRuntime(runtime);
+    return yield* makeXAiPromptCompletionRuntime({ ...runtime, ...overrides });
   });
 
 const decodeXAiAskUserQuestionRequest = Schema.decodeUnknownSync(XAiAskUserQuestionRequest);
@@ -312,6 +316,35 @@ describe("XAiAcpExtension", () => {
       });
 
       expect(promptResult.stopReason).toBe("end_turn");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("returns the xAI fallback without waiting for cancellation", () =>
+    Effect.gen(function* () {
+      const cancelStarted = yield* Deferred.make<void>();
+      const cancelGate = yield* Deferred.make<void>();
+      const runtime = yield* makePromptCompletionRuntime(
+        {
+          T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
+        },
+        {
+          cancel: Effect.gen(function* () {
+            yield* Deferred.succeed(cancelStarted, undefined);
+            yield* Deferred.await(cancelGate);
+          }),
+        },
+      );
+      yield* runtime.start();
+
+      const promptResult = yield* runtime
+        .prompt({
+          prompt: [{ type: "text", text: "hi" }],
+        })
+        .pipe(Effect.timeout("500 millis"));
+
+      expect(promptResult.stopReason).toBe("end_turn");
+      yield* Deferred.await(cancelStarted).pipe(Effect.timeout("500 millis"));
+      yield* Deferred.succeed(cancelGate, undefined);
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -6,6 +6,7 @@ import * as NodeServices from "@effect/platform-node/NodeServices";
 import * as Deferred from "effect/Deferred";
 import { it } from "@effect/vitest";
 import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
 import * as Schema from "effect/Schema";
 import { describe, expect } from "vite-plus/test";
 
@@ -23,7 +24,9 @@ const mockAgentPath = NodePath.join(__dirname, "../../../scripts/acp-mock-agent.
 
 const makePromptCompletionRuntime = (
   env: NodeJS.ProcessEnv,
-  overrides: Partial<Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "cancel">> = {},
+  overrides: Partial<
+    Pick<AcpSessionRuntime.AcpSessionRuntime["Service"], "cancel" | "prompt">
+  > = {},
 ) =>
   Effect.gen(function* () {
     const runtime = yield* AcpSessionRuntime.make({
@@ -345,6 +348,44 @@ describe("XAiAcpExtension", () => {
       expect(promptResult.stopReason).toBe("end_turn");
       yield* Deferred.await(cancelStarted).pipe(Effect.timeout("500 millis"));
       yield* Deferred.succeed(cancelGate, undefined);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("does not cancel twice after an explicit cancellation", () =>
+    Effect.gen(function* () {
+      const promptStarted = yield* Deferred.make<void>();
+      const promptGate = yield* Deferred.make<void>();
+      let cancelCalls = 0;
+      const runtime = yield* makeXAiPromptCompletionRuntime({
+        handleExtNotification: () => Effect.void,
+        start: () =>
+          Effect.succeed({
+            sessionId: "mock-session-1",
+          } as AcpSessionRuntime.AcpSessionRuntimeStartResult),
+        prompt: () =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(promptStarted, undefined);
+            yield* Deferred.await(promptGate);
+          }),
+        cancel: Effect.sync(() => {
+          cancelCalls += 1;
+        }),
+      } as unknown as AcpSessionRuntime.AcpSessionRuntime["Service"]);
+      yield* runtime.start();
+
+      const promptFiber = yield* runtime
+        .prompt({
+          prompt: [{ type: "text", text: "hi" }],
+        })
+        .pipe(Effect.forkScoped);
+      yield* Deferred.await(promptStarted).pipe(Effect.timeout("500 millis"));
+
+      yield* runtime.cancel.pipe(Effect.timeout("500 millis"));
+      const promptResult = yield* Fiber.join(promptFiber).pipe(Effect.timeout("500 millis"));
+
+      expect(promptResult.stopReason).toBe("cancelled");
+      yield* Effect.yieldNow;
+      expect(cancelCalls).toBe(1);
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 

--- a/apps/server/src/provider/acp/XAiAcpExtension.test.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.test.ts
@@ -299,6 +299,22 @@ describe("XAiAcpExtension", () => {
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
+  it.effect("accepts the public xAI prompt-complete notification name", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makePromptCompletionRuntime({
+        T3_ACP_EMIT_XAI_PROMPT_COMPLETE_THEN_HANG: "1",
+        T3_ACP_XAI_PROMPT_COMPLETE_METHOD: "x.ai/session/prompt_complete",
+      });
+      yield* runtime.start();
+
+      const promptResult = yield* runtime.prompt({
+        prompt: [{ type: "text", text: "hi" }],
+      });
+
+      expect(promptResult.stopReason).toBe("end_turn");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
   it.effect("ignores stale xAI completion from an already settled prompt", () =>
     Effect.gen(function* () {
       const runtime = yield* makePromptCompletionRuntime({

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -24,6 +24,7 @@ interface PendingXAiPromptCompletion {
 
 const completedXAiPromptIdLimit = 128;
 const xAiStopReasonMissingMetaKey = "xAiStopReasonMissing";
+const xAiPromptCompletionCancelTimeout = "5 seconds";
 
 const XAiAskUserQuestionOption = Schema.Struct({
   label: Schema.String,
@@ -259,7 +260,16 @@ export const makeXAiPromptCompletionRuntime = Effect.fn("makeXAiPromptCompletion
           ).pipe(
             Effect.tap(() =>
               Ref.get(fallbackWon).pipe(
-                Effect.flatMap((won) => (won ? runtime.cancel.pipe(Effect.ignore) : Effect.void)),
+                Effect.flatMap((won) =>
+                  won
+                    ? runtime.cancel.pipe(
+                        Effect.timeout(xAiPromptCompletionCancelTimeout),
+                        Effect.ignore,
+                        Effect.forkDetach,
+                        Effect.asVoid,
+                      )
+                    : Effect.void,
+                ),
               ),
             ),
             Effect.tap((response) =>

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -211,15 +211,17 @@ export const makeXAiPromptCompletionRuntime = Effect.fn("makeXAiPromptCompletion
       return `t3-xai-prompt-${nextPromptFallbackId}`;
     });
 
-    yield* runtime.handleExtNotification(
-      "_x.ai/session/prompt_complete",
-      XAiPromptCompleteNotification,
-      (notification) =>
-        resolveXAiPromptCompletionFallback({
-          pendingRef,
-          completedPromptIdsRef,
-          notification,
-        }),
+    yield* Effect.forEach(
+      ["x.ai/session/prompt_complete", "_x.ai/session/prompt_complete"] as const,
+      (method) =>
+        runtime.handleExtNotification(method, XAiPromptCompleteNotification, (notification) =>
+          resolveXAiPromptCompletionFallback({
+            pendingRef,
+            completedPromptIdsRef,
+            notification,
+          }),
+        ),
+      { discard: true },
     );
 
     return {
@@ -249,11 +251,17 @@ export const makeXAiPromptCompletionRuntime = Effect.fn("makeXAiPromptCompletion
               requestId: fallback.promptId,
             },
           } satisfies Omit<EffectAcpSchema.PromptRequest, "sessionId">;
+          const fallbackWon = yield* Ref.make(false);
 
           return yield* Effect.raceFirst(
             runtime.prompt(requestPayload),
-            Deferred.await(fallback.deferred),
+            Deferred.await(fallback.deferred).pipe(Effect.tap(() => Ref.set(fallbackWon, true))),
           ).pipe(
+            Effect.tap(() =>
+              Ref.get(fallbackWon).pipe(
+                Effect.flatMap((won) => (won ? runtime.cancel.pipe(Effect.ignore) : Effect.void)),
+              ),
+            ),
             Effect.tap((response) =>
               rememberCompletedXAiPromptId(completedPromptIdsRef, response, fallback.promptId),
             ),

--- a/apps/server/src/provider/acp/XAiAcpExtension.ts
+++ b/apps/server/src/provider/acp/XAiAcpExtension.ts
@@ -206,6 +206,7 @@ export const makeXAiPromptCompletionRuntime = Effect.fn("makeXAiPromptCompletion
     const activeSessionIdRef = yield* Ref.make<string | undefined>(undefined);
     const pendingRef = yield* Ref.make<ReadonlyArray<PendingXAiPromptCompletion>>([]);
     const completedPromptIdsRef = yield* Ref.make<ReadonlyArray<string>>([]);
+    const explicitlyCancelledPromptIdsRef = yield* Ref.make<ReadonlyArray<string>>([]);
     let nextPromptFallbackId = 0;
     const allocatePromptFallbackId = Effect.sync(() => {
       nextPromptFallbackId += 1;
@@ -259,18 +260,33 @@ export const makeXAiPromptCompletionRuntime = Effect.fn("makeXAiPromptCompletion
             Deferred.await(fallback.deferred).pipe(Effect.tap(() => Ref.set(fallbackWon, true))),
           ).pipe(
             Effect.tap(() =>
-              Ref.get(fallbackWon).pipe(
-                Effect.flatMap((won) =>
-                  won
-                    ? runtime.cancel.pipe(
-                        Effect.timeout(xAiPromptCompletionCancelTimeout),
-                        Effect.ignore,
-                        Effect.forkDetach,
-                        Effect.asVoid,
-                      )
-                    : Effect.void,
-                ),
-              ),
+              Effect.gen(function* () {
+                const won = yield* Ref.get(fallbackWon);
+                if (!won) {
+                  return;
+                }
+                const explicitlyCancelled = yield* Ref.modify(
+                  explicitlyCancelledPromptIdsRef,
+                  (promptIds) => {
+                    const wasCancelled = promptIds.includes(fallback.promptId);
+                    return [
+                      wasCancelled,
+                      wasCancelled
+                        ? promptIds.filter((promptId) => promptId !== fallback.promptId)
+                        : promptIds,
+                    ] as const;
+                  },
+                );
+                if (explicitlyCancelled) {
+                  return;
+                }
+                yield* runtime.cancel.pipe(
+                  Effect.timeout(xAiPromptCompletionCancelTimeout),
+                  Effect.ignore,
+                  Effect.forkDetach,
+                  Effect.asVoid,
+                );
+              }),
             ),
             Effect.tap((response) =>
               rememberCompletedXAiPromptId(completedPromptIdsRef, response, fallback.promptId),
@@ -282,9 +298,11 @@ export const makeXAiPromptCompletionRuntime = Effect.fn("makeXAiPromptCompletion
         Effect.flatMap((sessionId) =>
           sessionId === undefined
             ? runtime.cancel
-            : abortPendingPromptCompletions(pendingRef, sessionId).pipe(
-                Effect.andThen(runtime.cancel),
-              ),
+            : abortPendingPromptCompletions(
+                pendingRef,
+                explicitlyCancelledPromptIdsRef,
+                sessionId,
+              ).pipe(Effect.andThen(runtime.cancel)),
         ),
       ),
     } satisfies AcpSessionRuntime.AcpSessionRuntime["Service"];
@@ -310,6 +328,7 @@ const unregisterXAiPromptCompletionFallback = (
 
 const abortPendingPromptCompletions = (
   pendingRef: Ref.Ref<ReadonlyArray<PendingXAiPromptCompletion>>,
+  explicitlyCancelledPromptIdsRef: Ref.Ref<ReadonlyArray<string>>,
   sessionId: string,
 ) =>
   Ref.modify(pendingRef, (pending) => {
@@ -324,20 +343,26 @@ const abortPendingPromptCompletions = (
       return [Effect.void, pending] as const;
     }
     return [
-      Effect.forEach(
-        toAbort,
-        (entry) =>
-          Deferred.succeed(
-            entry.deferred,
-            promptResponseFromXAi({
-              sessionId: entry.sessionId,
-              promptId: entry.promptId,
-              stopReason: "cancelled",
-              agentResult: null,
-            }),
-          ),
-        { concurrency: "unbounded" },
-      ).pipe(Effect.asVoid),
+      Effect.gen(function* () {
+        yield* Ref.update(explicitlyCancelledPromptIdsRef, (promptIds) => [
+          ...promptIds,
+          ...toAbort.map((entry) => entry.promptId),
+        ]);
+        yield* Effect.forEach(
+          toAbort,
+          (entry) =>
+            Deferred.succeed(
+              entry.deferred,
+              promptResponseFromXAi({
+                sessionId: entry.sessionId,
+                promptId: entry.promptId,
+                stopReason: "cancelled",
+                agentResult: null,
+              }),
+            ),
+          { concurrency: "unbounded" },
+        );
+      }),
       remaining,
     ] as const;
   }).pipe(Effect.flatten);


### PR DESCRIPTION
## Summary

This PR makes Grok ACP prompt completion more reliable when Grok has finished a turn but the standard ACP `session/prompt` RPC remains open.

That mismatch can leave T3 waiting on a prompt that is already complete, making the turn appear stuck until a timeout. This change treats Grok's xAI `prompt_complete` notification as the completion signal, returns the completed turn without waiting for cancellation cleanup, and asks the provider to release the still-open prompt.

## What changes

- Accepts both xAI notification spellings:
  - `x.ai/session/prompt_complete`
  - `_x.ai/session/prompt_complete`
- When the xAI completion fallback wins over a hanging `session/prompt`, sends `session/cancel` to clear the provider-side prompt.
- Runs cancellation cleanup asynchronously with a 5-second bound, so a slow or stuck cancellation cannot hold up the completed turn.
- Tracks prompts cancelled through the normal explicit-stop path to avoid sending a second cancellation for the same prompt.
- Adds mock-agent coverage for the public notification spelling, non-blocking cleanup, and explicit-cancel behavior.

## Why this improves stability

Before this change, Grok could report that a turn was complete while T3 still had a live standard prompt request. The UI could finish rendering the response, but the provider could remain busy and later operations could wait for the stale prompt or hit timeout behavior.

After this change, the xAI completion signal can settle the turn immediately while cleanup runs independently. The goal is to keep the session usable after completion and prevent an already-finished Grok turn from timing out because the standard ACP request never closed.

## Scope

This is focused lifecycle hardening. It does not change Grok authentication, MCP configuration, model selection, or the existing stale-completion filtering.

## Validation

- `vp test run XAiAcpExtension`
- `vp run typecheck`
- `vp check`

The repository check reports only existing lint warnings outside this change.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden Grok ACP prompt completion handling for fallback and duplicate cancellation
> - Registers handlers for both `x.ai/session/prompt_complete` and `_x.ai/session/prompt_complete` in [`XAiAcpExtension.ts`](https://github.com/pingdotgg/t3code/pull/3839/files#diff-facfffc25c57123d8d9a118e55dc2c9856d28b4ed93f1c10cc9dbf6f6f5c360a) so either notification name resolves the prompt.
> - When the fallback wins the prompt race, asynchronously cancels the underlying runtime with a 5-second timeout, without blocking the caller.
> - Tracks explicitly cancelled prompts via `explicitlyCancelledPromptIdsRef` to avoid issuing a redundant cancel after an explicit cancellation already occurred.
> - Makes the prompt_complete method name configurable in the mock agent via `T3_ACP_XAI_PROMPT_COMPLETE_METHOD` for testing both notification variants.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b6dd19.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grok prompt lifecycle and cancellation timing around in-flight ACP RPCs; mistakes could leave hung prompts or double-cancel, but scope is limited to the xAI extension wrapper and mock tests.
> 
> **Overview**
> **Grok ACP** now treats both `x.ai/session/prompt_complete` and `_x.ai/session/prompt_complete` as valid completion notifications, so turns can finish when xAI uses the public method name.
> 
> When the xAI notification wins the race while standard `session/prompt` is still pending, the wrapper **returns the fallback immediately** and issues a **detached `session/cancel`** (5s timeout, errors ignored) so the provider does not keep a live prompt after the UI shows a completed turn. User-initiated cancel records prompt IDs so that cleanup **does not call cancel again**.
> 
> The **ACP mock agent** reads `T3_ACP_XAI_PROMPT_COMPLETE_METHOD` for the notification method (default unchanged). Tests cover the public spelling, non-blocking fallback return, and single cancel on explicit cancellation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6dd19f469949882d547f07dd763cd5a7f8d4cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->