### PR TITLE
Fix AL2 glibc compatibility for native startup paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,7 +289,7 @@ jobs:
             -w /workspace \
             amazonlinux:2 \
             bash -euo pipefail <<'EOF'
-          yum install -y binutils curl gcc gcc-c++ make python3 tar xz
+          yum install -y binutils curl file gcc gcc-c++ make python3 tar xz
 
           node_version="v20.19.6"
           node_dir="/opt/node-${node_version}-linux-x64-glibc-217"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,12 +254,13 @@ jobs:
 
   # node-pty publishes no Linux prebuilt and the WSL backend runs under the
   # distro's own (Linux) Node, which can't load the Windows/Electron binary. We
-  # build the Linux pty.node here, on Linux, and hand it to the Windows packaging
-  # job — the Windows artifact then ships a ready WSL backend binary with no
-  # cross-compiling and no first-launch compiler/node-gyp/network on the user's
-  # machine. node-pty is N-API, so one binary works across all WSL Node versions.
+  # build the Linux pty.node in an old-glibc container and hand it to the Windows
+  # packaging job — the Windows artifact then ships a ready WSL backend binary
+  # with no cross-compiling and no first-launch compiler/node-gyp/network on the
+  # user's machine. node-pty is N-API, so one binary works across supported WSL
+  # Node versions; building on an old glibc keeps AL2 / glibc 2.26 compatible.
   build_wsl_node_pty:
-    name: Build WSL node-pty (linux-x64)
+    name: Build WSL node-pty (linux-x64, AL2 glibc)
     needs: [preflight]
     if: ${{ !failure() && !cancelled() && needs.preflight.result == 'success' }}
     runs-on: blacksmith-8vcpu-ubuntu-2404
@@ -282,15 +283,55 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Resolve node-pty from apps/server (where it's a dependency) and build
+          docker run --rm \
+            -e GITHUB_WORKSPACE=/workspace \
+            -v "$GITHUB_WORKSPACE:/workspace" \
+            -w /workspace \
+            amazonlinux:2 \
+            bash -euo pipefail <<'EOF'
+          yum install -y binutils curl gcc gcc-c++ make python3 tar xz
+
+          node_version="v20.19.6"
+          node_dir="/opt/node-${node_version}-linux-x64-glibc-217"
+          curl -fsSL "https://unofficial-builds.nodejs.org/download/release/${node_version}/node-${node_version}-linux-x64-glibc-217.tar.xz" \
+            | tar -xJ -C /opt
+          export PATH="${node_dir}/bin:${PATH}"
+          export npm_config_python=python3
+
+          # Resolve node-pty from apps/server (where it is a dependency) and build
           # its native binary from source for Linux. node-addon-api resolves from
           # node-pty's own dependency tree, so node-gyp has everything it needs.
-          pty_pkg="$(node -e "console.log(require.resolve('node-pty/package.json', { paths: ['$GITHUB_WORKSPACE/apps/server'] }))")"
+          pty_pkg="$(node -e "console.log(require.resolve('node-pty/package.json', { paths: ['/workspace/apps/server'] }))")"
           pty_dir="$(dirname "$pty_pkg")"
           ( cd "$pty_dir" && npx --yes node-gyp rebuild )
-          mkdir -p wsl-prebuild
-          cp "$pty_dir/build/Release/pty.node" wsl-prebuild/pty.node
+
+          mkdir -p /workspace/wsl-prebuild
+          cp "$pty_dir/build/Release/pty.node" /workspace/wsl-prebuild/pty.node
+          file /workspace/wsl-prebuild/pty.node
+          EOF
+
+      - name: Verify WSL node-pty glibc compatibility
+        shell: bash
+        run: |
+          set -euo pipefail
           file wsl-prebuild/pty.node
+          objdump -T wsl-prebuild/pty.node | tee wsl-prebuild/pty.symbols.txt
+
+          max_glibc="$(
+            sed -nE 's/.*GLIBC_([0-9]+(\.[0-9]+)*).*/\1/p' wsl-prebuild/pty.symbols.txt \
+              | sort -V \
+              | tail -n1
+          )"
+          echo "Max required GLIBC version: ${max_glibc:-none}"
+          if [[ -n "$max_glibc" && "$(printf '%s\n' "$max_glibc" "2.26" | sort -V | tail -n1)" != "2.26" ]]; then
+            echo "WSL node-pty prebuild requires GLIBC_${max_glibc}, which is newer than AL2's GLIBC_2.26." >&2
+            exit 1
+          fi
+
+          if grep -q 'memfd_create' wsl-prebuild/pty.symbols.txt; then
+            echo "WSL node-pty prebuild references memfd_create; use syscall fallback or an older-glibc build." >&2
+            exit 1
+          fi
 
       - name: Upload node-pty linux-x64 prebuild
         uses: actions/upload-artifact@v7

--- a/apps/server/src/terminal/Manager.test.ts
+++ b/apps/server/src/terminal/Manager.test.ts
@@ -22,6 +22,7 @@ import * as PlatformError from "effect/PlatformError";
 import * as Path from "effect/Path";
 import * as Ref from "effect/Ref";
 import * as Schedule from "effect/Schedule";
+import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as TestClock from "effect/testing/TestClock";
 import { expect } from "vite-plus/test";
@@ -29,6 +30,8 @@ import { expect } from "vite-plus/test";
 import * as ProcessRunner from "../processRunner.ts";
 import * as TerminalManager from "./Manager.ts";
 import * as PtyAdapter from "./PtyAdapter.ts";
+
+const isPtySpawnError = Schema.is(PtyAdapter.PtySpawnError);
 
 class WaitForConditionError extends Data.TaggedError("WaitForConditionError")<{
   readonly message: string;
@@ -98,7 +101,7 @@ class FakePtyProcess implements PtyAdapter.PtyProcess {
 class FakePtyAdapter {
   readonly spawnInputs: PtyAdapter.PtySpawnInput[] = [];
   readonly processes: FakePtyProcess[] = [];
-  readonly spawnFailures: Error[] = [];
+  readonly spawnFailures: Array<Error | PtyAdapter.PtySpawnError> = [];
   private readonly mode: "sync" | "async";
   private nextPid = 9000;
 
@@ -112,6 +115,9 @@ class FakePtyAdapter {
     this.spawnInputs.push(input);
     const failure = this.spawnFailures.shift();
     if (failure) {
+      if (isPtySpawnError(failure)) {
+        return Effect.fail(failure);
+      }
       return Effect.fail(
         new PtyAdapter.PtySpawnError({
           adapter: "fake",
@@ -1257,6 +1263,25 @@ it.layer(
             .some((input) => input.shell !== "/definitely/missing-shell"),
         ).toBe(true);
       }
+    }),
+  );
+
+  it.effect("does not retry fallback shells when the PTY adapter cannot load", () =>
+    Effect.gen(function* () {
+      const { manager, ptyAdapter } = yield* createManager();
+      ptyAdapter.spawnFailures.push(
+        new PtyAdapter.PtySpawnError({
+          adapter: "node-pty",
+          shell: "/bin/zsh",
+          retryWithFallbackShell: false,
+          cause: new Error("ERR_DLOPEN_FAILED: GLIBC_2.27 not found"),
+        }),
+      );
+
+      const snapshot = yield* manager.open(openInput());
+
+      expect(snapshot.status).toBe("error");
+      expect(ptyAdapter.spawnInputs).toHaveLength(1);
     }),
   );
 

--- a/apps/server/src/terminal/Manager.ts
+++ b/apps/server/src/terminal/Manager.ts
@@ -565,6 +565,10 @@ function resolveShellCandidates(
 }
 
 function isRetryableShellSpawnError(error: PtyAdapter.PtySpawnError): boolean {
+  if (error.retryWithFallbackShell !== undefined) {
+    return error.retryWithFallbackShell;
+  }
+
   const queue: unknown[] = [error];
   const seen = new Set<unknown>();
   const messages: string[] = [];

--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -59,22 +59,37 @@ it.effect("spawns through the public adapter with the provided host references",
   }).pipe(Effect.provide(testLayer)),
 );
 
-it.effect("reports native module load failures as structured startup defects", () =>
+it.effect("reports native module load failures as structured spawn failures", () =>
   Effect.gen(function* () {
     const cause = new Error("native binding could not be loaded");
-    const exit = yield* NodePtyAdapter.make(() => Promise.reject(cause)).pipe(Effect.exit);
+    const adapter = yield* NodePtyAdapter.make(() => Promise.reject(cause));
+    const exit = yield* adapter
+      .spawn({
+        shell: "powershell.exe",
+        args: ["-NoLogo"],
+        cwd: "C:\\workspace",
+        cols: 120,
+        rows: 40,
+        env: {},
+      })
+      .pipe(Effect.exit);
 
     assert.isTrue(Exit.isFailure(exit));
     if (Exit.isFailure(exit)) {
-      assert.isTrue(Cause.hasDies(exit.cause));
       const error = Cause.squash(exit.cause);
-      assert.instanceOf(error, NodePtyAdapter.NodePtyModuleLoadError);
+      assert.instanceOf(error, PtyAdapter.PtySpawnError);
       assert.deepInclude(error, {
+        _tag: "PtySpawnError",
+        adapter: "node-pty",
+        shell: "powershell.exe",
+      });
+      assert.instanceOf(error.cause, NodePtyAdapter.NodePtyModuleLoadError);
+      assert.deepInclude(error.cause, {
         _tag: "NodePtyModuleLoadError",
         platform: "win32",
         architecture: "x64",
+        cause,
       });
-      assert.equal(error.message, "Failed to load node-pty for win32-x64.");
     }
   }).pipe(
     Effect.provide(

--- a/apps/server/src/terminal/NodePtyAdapter.test.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.test.ts
@@ -82,6 +82,7 @@ it.effect("reports native module load failures as structured spawn failures", ()
         _tag: "PtySpawnError",
         adapter: "node-pty",
         shell: "powershell.exe",
+        retryWithFallbackShell: false,
       });
       assert.instanceOf(error.cause, NodePtyAdapter.NodePtyModuleLoadError);
       assert.deepInclude(error.cause, {

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -118,15 +118,17 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
   const platform = yield* HostProcessPlatform;
   const architecture = yield* HostProcessArchitecture;
 
-  const nodePty = yield* Effect.tryPromise({
-    try: loadNodePtyModule,
-    catch: (cause) =>
-      new NodePtyModuleLoadError({
-        platform,
-        architecture,
-        cause,
-      }),
-  }).pipe(Effect.orDie);
+  const loadNodePtyModuleCached = yield* Effect.cached(
+    Effect.tryPromise({
+      try: loadNodePtyModule,
+      catch: (cause) =>
+        new NodePtyModuleLoadError({
+          platform,
+          architecture,
+          cause,
+        }),
+    }),
+  );
 
   const ensureNodePtySpawnHelperExecutableCached = yield* Effect.cached(
     ensureNodePtySpawnHelperExecutable().pipe(
@@ -140,6 +142,16 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
 
   return PtyAdapter.PtyAdapter.of({
     spawn: Effect.fn("NodePtyAdapter.spawn")(function* (input) {
+      const nodePty = yield* loadNodePtyModuleCached.pipe(
+        Effect.mapError(
+          (cause) =>
+            new PtyAdapter.PtySpawnError({
+              adapter: "node-pty",
+              shell: input.shell,
+              cause,
+            }),
+        ),
+      );
       yield* ensureNodePtySpawnHelperExecutableCached;
       const ptyProcess = yield* Effect.try({
         try: () =>

--- a/apps/server/src/terminal/NodePtyAdapter.ts
+++ b/apps/server/src/terminal/NodePtyAdapter.ts
@@ -148,6 +148,7 @@ export const make = Effect.fn("NodePtyAdapter.make")(function* (
             new PtyAdapter.PtySpawnError({
               adapter: "node-pty",
               shell: input.shell,
+              retryWithFallbackShell: false,
               cause,
             }),
         ),

--- a/apps/server/src/terminal/PtyAdapter.ts
+++ b/apps/server/src/terminal/PtyAdapter.ts
@@ -17,6 +17,7 @@ export class PtySpawnError extends Schema.TaggedErrorClass<PtySpawnError>()("Pty
   adapter: Schema.String,
   shell: Schema.optional(Schema.String),
   attemptedShells: Schema.optional(Schema.Array(Schema.String)),
+  retryWithFallbackShell: Schema.optional(Schema.Boolean),
   cause: Schema.optional(Schema.Defect()),
 }) {
   override get message(): string {

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -1,3 +1,8 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import * as NodeFSP from "node:fs/promises";
+import * as NodeOS from "node:os";
+import * as NodePath from "node:path";
+
 import type { FileFinder } from "@ff-labs/fff-node";
 import { afterEach, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
@@ -11,8 +16,17 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-it.effect("preserves unexpected FileFinder creation failures", () =>
+async function makeFallbackWorkspace() {
+  const cwd = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "t3code-search-fallback-"));
+  await NodeFSP.mkdir(NodePath.join(cwd, "src", "components"), { recursive: true });
+  await NodeFSP.writeFile(NodePath.join(cwd, "src", "components", "Composer.tsx"), "");
+  await NodeFSP.writeFile(NodePath.join(cwd, "README.md"), "");
+  return cwd;
+}
+
+it.effect("falls back when FileFinder creation throws unexpectedly", () =>
   Effect.gen(function* () {
+    const cwd = yield* Effect.promise(makeFallbackWorkspace);
     const cause = new Error("native initialization failed");
     const FileFinder = {
       create: vi.fn(() => {
@@ -20,46 +34,41 @@ it.effect("preserves unexpected FileFinder creation failures", () =>
       }),
     };
 
-    const error = yield* Effect.flip(
-      Effect.scoped(
-        WorkspaceSearchIndex.make("/workspace/project", () =>
-          Promise.resolve({
-            FileFinder: FileFinder as never,
-          }),
-        ),
+    const searchIndex = yield* Effect.scoped(
+      WorkspaceSearchIndex.make(cwd, () =>
+        Promise.resolve({
+          FileFinder: FileFinder as never,
+        }),
       ),
     );
+    const result = yield* searchIndex.search("composer", 10);
 
-    expect(error).toMatchObject({
-      _tag: "WorkspaceSearchIndexCreateFailed",
-      cwd: "/workspace/project",
-      reason: "FileFinder.create threw unexpectedly.",
-      cause,
-    });
+    expect(FileFinder.create).toHaveBeenCalledTimes(1);
+    expect(result.entries).toEqual(
+      expect.arrayContaining([{ path: "src/components/Composer.tsx", kind: "file" }]),
+    );
   }),
 );
 
-it.effect("preserves native module load failures as index creation failures", () =>
+it.effect("falls back when the native module cannot load", () =>
   Effect.gen(function* () {
+    const cwd = yield* Effect.promise(makeFallbackWorkspace);
     const cause = new Error("ERR_DLOPEN_FAILED: GLIBC_2.27 not found");
 
-    const error = yield* Effect.flip(
-      Effect.scoped(
-        WorkspaceSearchIndex.make("/workspace/project", () => Promise.reject(cause)),
-      ),
+    const searchIndex = yield* Effect.scoped(
+      WorkspaceSearchIndex.make(cwd, () => Promise.reject(cause)),
     );
+    const result = yield* searchIndex.list();
 
-    expect(error).toMatchObject({
-      _tag: "WorkspaceSearchIndexCreateFailed",
-      cwd: "/workspace/project",
-      reason: "Failed to load @ff-labs/fff-node native search module.",
-      cause,
-    });
+    expect(result.entries).toEqual(
+      expect.arrayContaining([{ path: "src/components/Composer.tsx", kind: "file" }]),
+    );
   }),
 );
 
-it.effect("keeps returned FileFinder creation diagnostics out of the cause chain", () =>
+it.effect("falls back when FileFinder returns creation diagnostics", () =>
   Effect.gen(function* () {
+    const cwd = yield* Effect.promise(makeFallbackWorkspace);
     const FileFinder = {
       create: vi.fn(() => ({
         ok: false,
@@ -67,22 +76,16 @@ it.effect("keeps returned FileFinder creation diagnostics out of the cause chain
       })),
     };
 
-    const error = yield* Effect.flip(
-      Effect.scoped(
-        WorkspaceSearchIndex.make("/workspace/project", () =>
-          Promise.resolve({
-            FileFinder: FileFinder as never,
-          }),
-        ),
+    const searchIndex = yield* Effect.scoped(
+      WorkspaceSearchIndex.make(cwd, () =>
+        Promise.resolve({
+          FileFinder: FileFinder as never,
+        }),
       ),
     );
+    const result = yield* searchIndex.search("readme", 10);
 
-    expect(error).toMatchObject({
-      _tag: "WorkspaceSearchIndexCreateFailed",
-      cwd: "/workspace/project",
-      reason: "native index rejected the directory",
-    });
-    expect(error.cause).toBeUndefined();
+    expect(result.entries).toEqual(expect.arrayContaining([{ path: "README.md", kind: "file" }]));
   }),
 );
 

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -66,6 +66,22 @@ it.effect("falls back when the native module cannot load", () =>
   }),
 );
 
+it.effect("keeps fallback search results within the requested limit", () =>
+  Effect.gen(function* () {
+    const cwd = yield* Effect.promise(makeFallbackWorkspace);
+    const searchIndex = yield* Effect.scoped(
+      WorkspaceSearchIndex.make(cwd, () =>
+        Promise.reject(new Error("ERR_DLOPEN_FAILED: GLIBC_2.27 not found")),
+      ),
+    );
+
+    const result = yield* searchIndex.search("composer", 1);
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.truncated).toBe(false);
+  }),
+);
+
 it.effect("falls back when FileFinder returns creation diagnostics", () =>
   Effect.gen(function* () {
     const cwd = yield* Effect.promise(makeFallbackWorkspace);

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -105,6 +105,35 @@ it.effect("falls back when FileFinder returns creation diagnostics", () =>
   }),
 );
 
+it.effect("destroys the native finder before falling back after scan initialization fails", () =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const cwd = yield* Effect.promise(makeFallbackWorkspace);
+      const cause = new Error("native scan failed");
+      const finder = {
+        destroy: vi.fn(),
+        isScanning: vi.fn(() => {
+          throw cause;
+        }),
+      } as unknown as FileFinder;
+      const FileFinderModule = {
+        FileFinder: {
+          create: vi.fn(() => ({ ok: true, value: finder })),
+        },
+      };
+
+      const searchIndex = yield* WorkspaceSearchIndex.make(cwd, () =>
+        Promise.resolve(FileFinderModule as never),
+      );
+
+      expect(finder.destroy).toHaveBeenCalledTimes(1);
+      expect((yield* searchIndex.search("composer", 10)).entries).toEqual(
+        expect.arrayContaining([{ path: "src/components/Composer.tsx", kind: "file" }]),
+      );
+    }),
+  ),
+);
+
 it.effect("preserves FileFinder destroy failures as structured defects", () =>
   Effect.gen(function* () {
     const cause = new Error("native destroy failed");

--- a/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.test.ts
@@ -1,4 +1,4 @@
-import { FileFinder } from "@ff-labs/fff-node";
+import type { FileFinder } from "@ff-labs/fff-node";
 import { afterEach, expect, it } from "@effect/vitest";
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
@@ -14,12 +14,20 @@ afterEach(() => {
 it.effect("preserves unexpected FileFinder creation failures", () =>
   Effect.gen(function* () {
     const cause = new Error("native initialization failed");
-    vi.spyOn(FileFinder, "create").mockImplementationOnce(() => {
-      throw cause;
-    });
+    const FileFinder = {
+      create: vi.fn(() => {
+        throw cause;
+      }),
+    };
 
     const error = yield* Effect.flip(
-      Effect.scoped(WorkspaceSearchIndex.make("/workspace/project")),
+      Effect.scoped(
+        WorkspaceSearchIndex.make("/workspace/project", () =>
+          Promise.resolve({
+            FileFinder: FileFinder as never,
+          }),
+        ),
+      ),
     );
 
     expect(error).toMatchObject({
@@ -31,15 +39,42 @@ it.effect("preserves unexpected FileFinder creation failures", () =>
   }),
 );
 
-it.effect("keeps returned FileFinder creation diagnostics out of the cause chain", () =>
+it.effect("preserves native module load failures as index creation failures", () =>
   Effect.gen(function* () {
-    vi.spyOn(FileFinder, "create").mockReturnValueOnce({
-      ok: false,
-      error: "native index rejected the directory",
-    });
+    const cause = new Error("ERR_DLOPEN_FAILED: GLIBC_2.27 not found");
 
     const error = yield* Effect.flip(
-      Effect.scoped(WorkspaceSearchIndex.make("/workspace/project")),
+      Effect.scoped(
+        WorkspaceSearchIndex.make("/workspace/project", () => Promise.reject(cause)),
+      ),
+    );
+
+    expect(error).toMatchObject({
+      _tag: "WorkspaceSearchIndexCreateFailed",
+      cwd: "/workspace/project",
+      reason: "Failed to load @ff-labs/fff-node native search module.",
+      cause,
+    });
+  }),
+);
+
+it.effect("keeps returned FileFinder creation diagnostics out of the cause chain", () =>
+  Effect.gen(function* () {
+    const FileFinder = {
+      create: vi.fn(() => ({
+        ok: false,
+        error: "native index rejected the directory",
+      })),
+    };
+
+    const error = yield* Effect.flip(
+      Effect.scoped(
+        WorkspaceSearchIndex.make("/workspace/project", () =>
+          Promise.resolve({
+            FileFinder: FileFinder as never,
+          }),
+        ),
+      ),
     );
 
     expect(error).toMatchObject({
@@ -60,11 +95,17 @@ it.effect("preserves FileFinder destroy failures as structured defects", () =>
       }),
       isScanning: vi.fn(() => false),
     } as unknown as FileFinder;
-    vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+    const FileFinderModule = {
+      FileFinder: {
+        create: vi.fn(() => ({ ok: true, value: finder })),
+      },
+    };
 
-    const exit = yield* Effect.scoped(WorkspaceSearchIndex.make("/workspace/project")).pipe(
-      Effect.exit,
-    );
+    const exit = yield* Effect.scoped(
+      WorkspaceSearchIndex.make("/workspace/project", () =>
+        Promise.resolve(FileFinderModule as never),
+      ),
+    ).pipe(Effect.exit);
 
     expect(Exit.isFailure(exit)).toBe(true);
     if (Exit.isFailure(exit)) {
@@ -95,9 +136,15 @@ it.effect("preserves search and refresh failures with operation context", () =>
           throw refreshCause;
         }),
       } as unknown as FileFinder;
-      vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+      const FileFinderModule = {
+        FileFinder: {
+          create: vi.fn(() => ({ ok: true, value: finder })),
+        },
+      };
 
-      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
+      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project", () =>
+        Promise.resolve(FileFinderModule as never),
+      );
       const query = "authorization: Bearer secret-token";
       const searchError = yield* Effect.flip(searchIndex.search(query, 3));
       const refreshError = yield* Effect.flip(searchIndex.refresh());
@@ -131,9 +178,15 @@ it.effect("keeps returned search diagnostics out of the cause chain", () =>
         mixedSearch: vi.fn(() => ({ ok: false, error: "native query rejected" })),
         scanFiles: vi.fn(() => ({ ok: false, error: "native refresh rejected" })),
       } as unknown as FileFinder;
-      vi.spyOn(FileFinder, "create").mockReturnValueOnce({ ok: true, value: finder });
+      const FileFinderModule = {
+        FileFinder: {
+          create: vi.fn(() => ({ ok: true, value: finder })),
+        },
+      };
 
-      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project");
+      const searchIndex = yield* WorkspaceSearchIndex.make("/workspace/project", () =>
+        Promise.resolve(FileFinderModule as never),
+      );
       const query = "authorization: Bearer secret-token";
       const searchError = yield* Effect.flip(searchIndex.search(query, 3));
       const refreshError = yield* Effect.flip(searchIndex.refresh());

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -1,3 +1,8 @@
+// @effect-diagnostics nodeBuiltinImport:off
+import type * as NodeFS from "node:fs";
+import * as NodeFSP from "node:fs/promises";
+import * as NodePath from "node:path";
+
 import type { FileFinder, MixedItem, MixedSearchResult } from "@ff-labs/fff-node";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -17,6 +22,7 @@ const WORKSPACE_INDEX_PAGE_SIZE = WORKSPACE_INDEX_MAX_ENTRIES + 2;
 const WORKSPACE_INDEX_SCAN_TIMEOUT = "15 seconds";
 const WORKSPACE_INDEX_IDLE_TTL = "15 minutes";
 const WORKSPACE_INDEX_SCAN_POLL_INTERVAL = "50 millis";
+const FALLBACK_EXCLUDED_DIRECTORIES = new Set([".git", ".convex", "node_modules"]);
 
 export class WorkspaceSearchIndexCreateFailed extends Schema.TaggedErrorClass<WorkspaceSearchIndexCreateFailed>()(
   "WorkspaceSearchIndexCreateFailed",
@@ -174,6 +180,163 @@ function withDirectoryAncestors(entries: ReadonlyArray<ProjectEntry>): ProjectEn
   return [...entryByPath.values()];
 }
 
+function isFuzzySubsequence(query: string, candidate: string): boolean {
+  let queryIndex = 0;
+  for (const char of candidate) {
+    if (char === query[queryIndex]) {
+      queryIndex++;
+      if (queryIndex === query.length) return true;
+    }
+  }
+  return query.length === 0;
+}
+
+function boundedEditDistance(left: string, right: string, maxDistance: number): number {
+  if (Math.abs(left.length - right.length) > maxDistance) return maxDistance + 1;
+
+  let previous = Array.from({ length: right.length + 1 }, (_, index) => index);
+  for (let leftIndex = 1; leftIndex <= left.length; leftIndex++) {
+    const current = [leftIndex];
+    let rowMin = current[0] ?? 0;
+    for (let rightIndex = 1; rightIndex <= right.length; rightIndex++) {
+      const substitutionCost = left[leftIndex - 1] === right[rightIndex - 1] ? 0 : 1;
+      const value = Math.min(
+        (previous[rightIndex] ?? 0) + 1,
+        (current[rightIndex - 1] ?? 0) + 1,
+        (previous[rightIndex - 1] ?? 0) + substitutionCost,
+      );
+      current[rightIndex] = value;
+      rowMin = Math.min(rowMin, value);
+    }
+    if (rowMin > maxDistance) return maxDistance + 1;
+    previous = current;
+  }
+  return previous[right.length] ?? maxDistance + 1;
+}
+
+function fallbackSearchScore(entry: ProjectEntry, query: string): number | null {
+  if (query.length === 0) return 0;
+
+  const path = entry.path.toLowerCase();
+  const basename = NodePath.posix.basename(path);
+  if (basename === query) return 0;
+  if (basename.startsWith(query)) return 10;
+  if (basename.includes(query)) return 20;
+  if (path.includes(query)) return 30;
+  if (isFuzzySubsequence(query, basename)) return 40;
+  if (isFuzzySubsequence(query, path)) return 50;
+
+  const maxTypoDistance = Math.min(2, Math.max(1, Math.floor(query.length / 4)));
+  if (boundedEditDistance(query, basename, maxTypoDistance) <= maxTypoDistance) return 60;
+  return null;
+}
+
+async function buildFallbackEntries(cwd: string): Promise<{
+  readonly entries: ProjectEntry[];
+  readonly truncated: boolean;
+}> {
+  const entries: ProjectEntry[] = [];
+  const directories = [""];
+
+  for (let index = 0; index < directories.length; index++) {
+    const relativeDirectory = directories[index] ?? "";
+    const absoluteDirectory = relativeDirectory ? NodePath.join(cwd, relativeDirectory) : cwd;
+    let dirents: NodeFS.Dirent[];
+    try {
+      dirents = await NodeFSP.readdir(absoluteDirectory, { withFileTypes: true });
+    } catch (cause) {
+      if (relativeDirectory === "") throw cause;
+      continue;
+    }
+
+    dirents.sort((left, right) => left.name.localeCompare(right.name));
+    for (const dirent of dirents) {
+      if (dirent.isDirectory() && FALLBACK_EXCLUDED_DIRECTORIES.has(dirent.name)) {
+        continue;
+      }
+      if (!dirent.isDirectory() && !dirent.isFile()) {
+        continue;
+      }
+
+      const relativePath = toPosixPath(
+        relativeDirectory ? NodePath.join(relativeDirectory, dirent.name) : dirent.name,
+      );
+      entries.push({
+        path: relativePath,
+        kind: dirent.isDirectory() ? "directory" : "file",
+      });
+      if (entries.length > WORKSPACE_INDEX_MAX_ENTRIES) {
+        return { entries: entries.slice(0, WORKSPACE_INDEX_MAX_ENTRIES), truncated: true };
+      }
+      if (dirent.isDirectory()) {
+        directories.push(relativePath);
+      }
+    }
+  }
+
+  return { entries, truncated: false };
+}
+
+const makeFallbackIndex = Effect.fn("WorkspaceSearchIndex.makeFallbackIndex")(function* (
+  cwd: string,
+  cause: WorkspaceSearchIndexCreateFailed | WorkspaceSearchIndexScanTimedOut,
+) {
+  yield* Effect.logWarning("Falling back to JS workspace search index", { cwd, cause });
+  let fallbackIndex = yield* Effect.tryPromise({
+    try: () => buildFallbackEntries(cwd),
+    catch: (fallbackCause) =>
+      new WorkspaceSearchIndexCreateFailed({
+        cwd,
+        reason: "Fallback workspace search index creation failed.",
+        cause: fallbackCause,
+      }),
+  });
+
+  const list: WorkspaceSearchIndex["Service"]["list"] = () =>
+    Effect.succeed({
+      entries: fallbackIndex.entries,
+      truncated: fallbackIndex.truncated,
+    });
+
+  const search: WorkspaceSearchIndex["Service"]["search"] = (query, limit) =>
+    Effect.sync(() => {
+      const normalizedQuery = query.toLowerCase();
+      const scoredEntries = fallbackIndex.entries
+        .map((entry) => ({ entry, score: fallbackSearchScore(entry, normalizedQuery) }))
+        .filter(
+          (item): item is { readonly entry: ProjectEntry; readonly score: number } =>
+            item.score !== null,
+        )
+        .sort(
+          (left, right) =>
+            left.score - right.score || left.entry.path.localeCompare(right.entry.path),
+        );
+      const entries = withDirectoryAncestors(
+        scoredEntries.slice(0, limit).map((item) => item.entry),
+      );
+      return {
+        entries,
+        truncated: fallbackIndex.truncated || scoredEntries.length > limit,
+      };
+    });
+
+  const refresh: WorkspaceSearchIndex["Service"]["refresh"] = Effect.fn(
+    "WorkspaceSearchIndex.fallbackRefresh",
+  )(function* () {
+    fallbackIndex = yield* Effect.tryPromise({
+      try: () => buildFallbackEntries(cwd),
+      catch: (refreshCause) =>
+        new WorkspaceSearchIndexRefreshFailed({
+          cwd,
+          reason: "Fallback workspace search index refresh failed.",
+          cause: refreshCause,
+        }),
+    });
+  });
+
+  return WorkspaceSearchIndex.of({ list, refresh, search });
+});
+
 const createFinder = Effect.fn("WorkspaceSearchIndex.createFinder")(function* (
   cwd: string,
   loadModule: FileFinderModuleLoader,
@@ -228,9 +391,9 @@ const waitForScan = <E>(cwd: string, finder: FileFinder, onFailure: (cause: unkn
     Effect.withSpan("WorkspaceSearchIndex.waitForScan"),
   );
 
-export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
+const makeNativeIndex = Effect.fn("WorkspaceSearchIndex.makeNativeIndex")(function* (
   cwd: string,
-  loadModule: FileFinderModuleLoader = loadFileFinderModule,
+  loadModule: FileFinderModuleLoader,
 ) {
   const finder = yield* Effect.acquireRelease(createFinder(cwd, loadModule), (finder) =>
     Effect.try({
@@ -328,6 +491,15 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
   });
 
   return WorkspaceSearchIndex.of({ list, refresh, search });
+});
+
+export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
+  cwd: string,
+  loadModule: FileFinderModuleLoader = loadFileFinderModule,
+) {
+  return yield* makeNativeIndex(cwd, loadModule).pipe(
+    Effect.catch((cause) => makeFallbackIndex(cwd, cause)),
+  );
 });
 
 /**

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -6,10 +6,12 @@ import * as NodePath from "node:path";
 import type { FileFinder, MixedItem, MixedSearchResult } from "@ff-labs/fff-node";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 import * as Layer from "effect/Layer";
 import * as LayerMap from "effect/LayerMap";
 import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
 
 import type {
   ProjectEntry,
@@ -497,9 +499,17 @@ export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
   cwd: string,
   loadModule: FileFinderModuleLoader = loadFileFinderModule,
 ) {
-  return yield* makeNativeIndex(cwd, loadModule).pipe(
-    Effect.catch((cause) => makeFallbackIndex(cwd, cause)),
+  const parentScope = yield* Scope.Scope;
+  const nativeScope = yield* Scope.fork(parentScope);
+  const nativeResult = yield* Effect.result(
+    makeNativeIndex(cwd, loadModule).pipe(Scope.provide(nativeScope)),
   );
+  if (nativeResult._tag === "Success") {
+    return nativeResult.success;
+  }
+
+  yield* Scope.close(nativeScope, Exit.fail(nativeResult.failure));
+  return yield* makeFallbackIndex(cwd, nativeResult.failure);
 });
 
 /**

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -1,4 +1,4 @@
-import { FileFinder, type MixedItem, type MixedSearchResult } from "@ff-labs/fff-node";
+import type { FileFinder, MixedItem, MixedSearchResult } from "@ff-labs/fff-node";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -89,6 +89,11 @@ export type WorkspaceSearchIndexError =
   | WorkspaceSearchIndexSearchFailed
   | WorkspaceSearchIndexRefreshFailed;
 
+type FileFinderModule = Pick<typeof import("@ff-labs/fff-node"), "FileFinder">;
+type FileFinderModuleLoader = () => Promise<FileFinderModule>;
+
+const loadFileFinderModule: FileFinderModuleLoader = () => import("@ff-labs/fff-node");
+
 export class WorkspaceSearchIndex extends Context.Service<
   WorkspaceSearchIndex,
   {
@@ -169,7 +174,19 @@ function withDirectoryAncestors(entries: ReadonlyArray<ProjectEntry>): ProjectEn
   return [...entryByPath.values()];
 }
 
-const createFinder = Effect.fn("WorkspaceSearchIndex.createFinder")(function* (cwd: string) {
+const createFinder = Effect.fn("WorkspaceSearchIndex.createFinder")(function* (
+  cwd: string,
+  loadModule: FileFinderModuleLoader,
+) {
+  const { FileFinder } = yield* Effect.tryPromise({
+    try: loadModule,
+    catch: (cause) =>
+      new WorkspaceSearchIndexCreateFailed({
+        cwd,
+        reason: "Failed to load @ff-labs/fff-node native search module.",
+        cause,
+      }),
+  });
   const result = yield* Effect.try({
     try: () =>
       FileFinder.create({
@@ -211,8 +228,11 @@ const waitForScan = <E>(cwd: string, finder: FileFinder, onFailure: (cause: unkn
     Effect.withSpan("WorkspaceSearchIndex.waitForScan"),
   );
 
-export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (cwd: string) {
-  const finder = yield* Effect.acquireRelease(createFinder(cwd), (finder) =>
+export const make = Effect.fn("WorkspaceSearchIndex.make")(function* (
+  cwd: string,
+  loadModule: FileFinderModuleLoader = loadFileFinderModule,
+) {
+  const finder = yield* Effect.acquireRelease(createFinder(cwd, loadModule), (finder) =>
     Effect.try({
       try: () => finder.destroy(),
       catch: (cause) => new WorkspaceSearchIndexDestroyFailed({ cwd, cause }),

--- a/apps/server/src/workspace/WorkspaceSearchIndex.ts
+++ b/apps/server/src/workspace/WorkspaceSearchIndex.ts
@@ -313,7 +313,7 @@ const makeFallbackIndex = Effect.fn("WorkspaceSearchIndex.makeFallbackIndex")(fu
         );
       const entries = withDirectoryAncestors(
         scoredEntries.slice(0, limit).map((item) => item.entry),
-      );
+      ).slice(0, limit);
       return {
         entries,
         truncated: fallbackIndex.truncated || scoredEntries.length > limit,

--- a/packages/client-runtime/src/relay/discovery.test.ts
+++ b/packages/client-runtime/src/relay/discovery.test.ts
@@ -16,7 +16,12 @@ import * as SubscriptionRef from "effect/SubscriptionRef";
 import * as ManagedRelay from "./managedRelay.ts";
 import * as ClientCapabilities from "../platform/capabilities.ts";
 import * as Connectivity from "../connection/connectivity.ts";
-import { ConnectionBlockedError, type NetworkStatus } from "../connection/model.ts";
+import {
+  ConnectionBlockedError,
+  type ConnectionAttemptError,
+  ConnectionTransientError,
+  type NetworkStatus,
+} from "../connection/model.ts";
 import * as ConnectionWakeups from "../connection/wakeups.ts";
 import * as RelayEnvironmentDiscovery from "./discovery.ts";
 
@@ -60,7 +65,7 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
   const listCalls = yield* Ref.make(0);
   const listFailure = yield* Ref.make<ManagedRelay.ManagedRelayClientError | null>(null);
   const secondListCall = yield* Deferred.make<void>();
-  const clerkToken = yield* Ref.make<string | null>("clerk-token");
+  const clerkToken = yield* Ref.make<string | ConnectionAttemptError | null>("clerk-token");
   const wakeups = yield* SubscriptionRef.make<{
     readonly sequence: number;
     readonly reason: "application-active" | "credentials-changed";
@@ -126,18 +131,15 @@ const makeHarness = Effect.fn("RelayDiscoveryTest.makeHarness")(function* () {
         Layer.succeed(
           ClientCapabilities.CloudSession,
           ClientCapabilities.CloudSession.of({
-            clerkToken: Ref.get(clerkToken).pipe(
-              Effect.flatMap((token) =>
-                token === null
-                  ? Effect.fail(
-                      new ConnectionBlockedError({
-                        reason: "authentication",
-                        detail: "Signed out.",
-                      }),
-                    )
-                  : Effect.succeed(token),
-              ),
-            ),
+            clerkToken: Effect.gen(function* () {
+              const token = yield* Ref.get(clerkToken);
+              if (typeof token === "string") return token;
+              if (token !== null) return yield* token;
+              return yield* new ConnectionBlockedError({
+                reason: "authentication",
+                detail: "Signed out.",
+              });
+            }),
           }),
         ),
         Layer.succeed(Connectivity.Connectivity, connectivity),
@@ -387,6 +389,26 @@ describe("RelayEnvironmentDiscovery", () => {
         expect(state.environments.size).toBe(0);
         expect(state.refreshing).toBe(false);
         expect(Option.isNone(state.error)).toBe(true);
+      }).pipe(Effect.provide(harness.layer));
+    }),
+  );
+
+  it.effect("publishes non-authentication session failures", () =>
+    Effect.gen(function* () {
+      const harness = yield* makeHarness();
+      const failure = new ConnectionTransientError({
+        reason: "network",
+        detail: "Session lookup failed.",
+      });
+      yield* Ref.set(harness.clerkToken, failure);
+
+      yield* Effect.gen(function* () {
+        const discovery = yield* RelayEnvironmentDiscovery.RelayEnvironmentDiscovery;
+        yield* discovery.refresh;
+
+        const state = yield* SubscriptionRef.get(discovery.state);
+        expect(state.refreshing).toBe(false);
+        expect(Option.getOrThrow(state.error)).toBe(failure);
       }).pipe(Effect.provide(harness.layer));
     }),
   );

--- a/packages/client-runtime/src/relay/discovery.ts
+++ b/packages/client-runtime/src/relay/discovery.ts
@@ -240,7 +240,7 @@ export const make = Effect.fn("RelayEnvironmentDiscovery.make")(function* () {
           }));
           return;
         }
-        return yield* Effect.fail(failure);
+        return yield* failure;
       }
       const clerkToken = tokenResult.success;
       if ((yield* Ref.get(accountGeneration)) !== generation) {


### PR DESCRIPTION
## Summary
- Build the Windows WSL `node-pty` prebuild inside an Amazon Linux 2 container and verify the emitted binary only depends on GLIBC 2.26-or-older symbols.
- Defer `node-pty` module loading until spawn time so startup can surface a structured `PtySpawnError` instead of failing the whole adapter during initialization.
- Add a JS fallback workspace search index when the native `@ff-labs/fff-node` module fails to load or initialize, with coverage for load failures, diagnostics, and scan behavior.
- Make relay discovery propagate failures directly through Effect instead of wrapping them again.

## Testing
- Not run.
- Added/updated unit coverage for `NodePtyAdapter` startup and spawn failure handling.
- Added/updated unit coverage for `WorkspaceSearchIndex` native failure fallback and fallback search/list behavior.
- Release workflow now checks the built `pty.node` for GLIBC symbol compatibility and rejects `memfd_create` references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release packaging for Windows/WSL, terminal spawn error paths, and workspace search behavior when native indexing fails; fallback search differs from native semantics but reduces hard failures on old glibc.
> 
> **Overview**
> Improves **WSL and older-Linux** behavior when native modules depend on newer glibc than Amazon Linux 2 (2.26).
> 
> **Release workflow:** The WSL `node-pty` prebuild is built inside an **Amazon Linux 2** Docker image with a glibc-2.17 Node tarball, then CI **fails the job** if `pty.node` needs GLIBC newer than 2.26 or references `memfd_create`.
> 
> **`NodePtyAdapter`:** `node-pty` is loaded lazily (cached) on **spawn** instead of at adapter construction, so a missing native binding surfaces as a structured **`PtySpawnError`** wrapping **`NodePtyModuleLoadError`** rather than dying during init.
> 
> **`WorkspaceSearchIndex`:** If the native `@ff-labs/fff-node` module fails to load, `FileFinder.create` throws, or scan times out, the service **logs a warning** and switches to a **JS fallback** that walks the tree (skipping `.git`, `node_modules`, `.convex`), with simple scoring for search/list/refresh. Tests inject a custom module loader to cover fallback paths.
> 
> **Relay discovery:** On non-authentication token failures, refresh now **`yield* failure`** directly instead of **`Effect.fail(failure)`**, avoiding an extra failure wrapper in the Effect chain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c9066ee78393439c90a8c253dc50785b3734dab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fallback JS search index and fix AL2 glibc compatibility for native startup paths
> - `WorkspaceSearchIndex.make` now attempts to load the native `@ff-labs/fff-node` module and, on any failure, falls back to a pure-JS in-memory index built by walking the filesystem. Previously, a failed native load would propagate as an error.
> - The fallback index in [WorkspaceSearchIndex.ts](https://github.com/pingdotgg/t3code/pull/3841/files#diff-c11793234fa6d81f052147cd8ae0b62e4e60366837e340f42279225a76704093) supports list, search (with fuzzy/edit-distance scoring), and refresh, capped at `WORKSPACE_INDEX_MAX_ENTRIES`.
> - `NodePtyAdapter` now loads `node-pty` lazily and cached; module load failures surface as `PtySpawnError` on `spawn` instead of crashing the fiber at construction time.
> - The release workflow builds `node-pty` inside an `amazonlinux:2` container using a glibc-2.17 toolchain, then verifies the binary does not reference GLIBC newer than 2.26 or `memfd_create`.
> - Behavioral Change: `NodePtyAdapter` construction no longer fails eagerly on missing native modules; errors appear at `spawn` call time instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7c9066e. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->