### PR TITLE
fix(codex): tolerate reasoning config skew during app-server startup

### DIFF
--- a/apps/server/src/provider/Layers/CodexProvider.ts
+++ b/apps/server/src/provider/Layers/CodexProvider.ts
@@ -31,6 +31,7 @@ import {
   buildServerProvider,
   type ServerProviderDraft,
 } from "../providerSnapshot.ts";
+import { buildCodexAppServerArgs } from "../codexAppServerArgs.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
 import packageJson from "../../../package.json" with { type: "json" };
 const isCodexAppServerSpawnError = Schema.is(CodexErrors.CodexAppServerSpawnError);
@@ -303,7 +304,7 @@ const probeCodexAppServerProvider = Effect.fn("probeCodexAppServerProvider")(fun
     ...input.environment,
     ...(resolvedHomePath ? { CODEX_HOME: resolvedHomePath } : {}),
   };
-  const spawnCommand = yield* resolveSpawnCommand(input.binaryPath, ["app-server"], {
+  const spawnCommand = yield* resolveSpawnCommand(input.binaryPath, buildCodexAppServerArgs(), {
     env: environment,
     extendEnv: true,
   });

--- a/apps/server/src/provider/Layers/CodexSessionRuntime.ts
+++ b/apps/server/src/provider/Layers/CodexSessionRuntime.ts
@@ -37,6 +37,7 @@ import * as EffectCodexSchema from "effect-codex-app-server/schema";
 
 import { buildCodexInitializeParams } from "./CodexProvider.ts";
 import { expandHomePath } from "../../pathExpansion.ts";
+import { buildCodexAppServerArgs } from "../codexAppServerArgs.ts";
 import {
   CODEX_DEFAULT_MODE_DEVELOPER_INSTRUCTIONS,
   CODEX_PLAN_MODE_DEVELOPER_INSTRUCTIONS,
@@ -721,7 +722,7 @@ export const makeCodexSessionRuntime = (
     const extendEnv = options.environment === undefined;
     const spawnCommand = yield* resolveSpawnCommand(
       options.binaryPath,
-      ["app-server", ...(options.appServerArgs ?? [])],
+      buildCodexAppServerArgs(options.appServerArgs),
       { env, extendEnv },
     );
     const child = yield* spawner

--- a/apps/server/src/provider/codexAppServerArgs.test.ts
+++ b/apps/server/src/provider/codexAppServerArgs.test.ts
@@ -1,0 +1,34 @@
+import { assert, it } from "@effect/vitest";
+
+import { buildCodexAppServerArgs } from "./codexAppServerArgs.ts";
+
+it("uses a portable reasoning effort when starting Codex app-server", () => {
+  assert.deepStrictEqual(buildCodexAppServerArgs(), [
+    "app-server",
+    "--config",
+    'model_reasoning_effort="medium"',
+  ]);
+});
+
+it("preserves extra app-server arguments after the compatibility default", () => {
+  assert.deepStrictEqual(
+    buildCodexAppServerArgs(["-c", "mcp_servers.t3-code.url=http://127.0.0.1:3774/mcp"]),
+    [
+      "app-server",
+      "--config",
+      'model_reasoning_effort="medium"',
+      "-c",
+      "mcp_servers.t3-code.url=http://127.0.0.1:3774/mcp",
+    ],
+  );
+});
+
+it("keeps an intentional reasoning override after the compatibility default", () => {
+  assert.deepStrictEqual(buildCodexAppServerArgs(["-c", 'model_reasoning_effort="high"']), [
+    "app-server",
+    "--config",
+    'model_reasoning_effort="medium"',
+    "-c",
+    'model_reasoning_effort="high"',
+  ]);
+});

--- a/apps/server/src/provider/codexAppServerArgs.ts
+++ b/apps/server/src/provider/codexAppServerArgs.ts
@@ -1,0 +1,17 @@
+const CODEX_APP_SERVER_BASE_REASONING_EFFORT = "medium";
+
+/**
+ * T3 Code sends the selected reasoning effort with each turn. Pin the app-server
+ * startup default to a portable value so config written by a newer Codex build
+ * cannot prevent an older configured binary from loading.
+ */
+export function buildCodexAppServerArgs(
+  extraArgs: ReadonlyArray<string> = [],
+): ReadonlyArray<string> {
+  return [
+    "app-server",
+    "--config",
+    `model_reasoning_effort="${CODEX_APP_SERVER_BASE_REASONING_EFFORT}"`,
+    ...extraArgs,
+  ];
+}


### PR DESCRIPTION
## Summary

- pin Codex app-server startup to the portable medium reasoning effort
- apply the same compatibility default to provider probing and session launches
- preserve later explicit app-server arguments, including intentional reasoning overrides
- add focused regression coverage for the generated argv

## Bug

Codex CLI 0.133.0 rejects newer `model_reasoning_effort = "ultra"` values from `~/.codex/config.toml` while T3 probes the app-server. The failed `skills/list` request makes the whole Codex provider appear unavailable.

## Verification

- `vp check` (format passes; lint passes with existing unrelated warnings)
- focused helper test: all 3 assertions pass (verified before packaging)
- `git diff --check`

The arm64 DMG build was attempted, but the package registry returned 503/connection-reset errors for uncached Expo and VS Code protocol tarballs, so no artifact was produced in this environment.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Codex app-server startup by defaulting `model_reasoning_effort` to `medium`
> - Introduces [`[buildCodexAppServerArgs](https://github.com/pingdotgg/t3code/pull/3845/files#diff-c8f0b103ab30f3ae4b12c0804aa8725a83b32f7a0e20457dbbd76f80a5a88d12)`](https://github.com/pingdotgg/t3code/pull/3845/files#diff-c8f0b103ab30f3ae4b12c0804aa8725a83b32f7a0e20457dbbd76f80a5a88d12), a utility that prepends `--config model_reasoning_effort="medium"` to the Codex app-server argument list, tolerating reasoning config skew at startup.
> - Replaces hardcoded `["app-server"]` args in both [`[CodexProvider.ts](https://github.com/pingdotgg/t3code/pull/3845/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53)`](https://github.com/pingdotgg/t3code/pull/3845/files#diff-c0fb5ae851f722b7ec74cc0b9dab393a72637319c70756f8532c0a4e73ccae53) and [`[CodexSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/3845/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c)`](https://github.com/pingdotgg/t3code/pull/3845/files#diff-e29bf409c8e737a2d4e655f7e9e7def9c78c008d98a0a23575baa5e714c4e12c) with calls to this helper.
> - Behavioral Change: all Codex app-server spawns now include an explicit `model_reasoning_effort="medium"` config entry ahead of any caller-supplied args.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 32c0347. 3 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->