### PR TITLE
fix(acp): drop Grok skills-reload responses that kill the protocol

### DIFF
--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -733,7 +733,13 @@ export const make = (
               ),
               Effect.ensuring(
                 Effect.gen(function* () {
-                  yield* Fiber.interrupt(promptRpcFiber).pipe(Effect.ignore);
+                  // Only interrupt a still-running RPC fiber. After a successful
+                  // join, re-interrupting is unnecessary; when the parent race
+                  // (xAI prompt_complete fallback) abandons a loser mid-flight
+                  // we still need to interrupt so the permit is released.
+                  if (promptRpcFiber.pollUnsafe() === undefined) {
+                    yield* Fiber.interrupt(promptRpcFiber).pipe(Effect.ignore);
+                  }
                   yield* Ref.set(activePromptFiberRef, Option.none());
                 }),
               ),

--- a/packages/effect-acp/src/protocol.test.ts
+++ b/packages/effect-acp/src/protocol.test.ts
@@ -3,6 +3,7 @@ import * as AcpError from "./errors.ts";
 import * as Effect from "effect/Effect";
 import * as Deferred from "effect/Deferred";
 import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
 import * as Queue from "effect/Queue";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
@@ -648,5 +649,74 @@ it.layer(NodeServices.layer)("effect-acp protocol", (it) => {
       assert.instanceOf(error, AcpError.AcpProcessExitedError);
       assert.equal(error.code, 0);
     }),
+  );
+
+  it.effect(
+    "drops unsolicited non-numeric response ids (Grok skills-reload) without terminating the protocol",
+    () =>
+      Effect.gen(function* () {
+        assert.equal(AcpProtocol.isRpcClientSafeRequestId("skills-reload"), false);
+        assert.equal(AcpProtocol.isRpcClientSafeRequestId("42"), true);
+        assert.equal(AcpProtocol.isRpcClientSafeRequestId(""), false);
+
+        const { stdio, input, output } = yield* makeInMemoryStdio();
+        const termination = yield* Deferred.make<AcpError.AcpError>();
+        const transport = yield* AcpProtocol.makeAcpPatchedProtocol({
+          stdio,
+          serverRequestMethods: new Set(),
+          onTermination: (error) => Deferred.succeed(termination, error).pipe(Effect.asVoid),
+        });
+
+        // Grok emits these during ACP startup; RpcClient would BigInt() the id and die.
+        yield* Queue.offer(
+          input,
+          encoder.encode(
+            `${encodeUnknownJsonString({
+              jsonrpc: "2.0",
+              id: "skills-reload",
+              result: { result: { reloaded: 0 } },
+            })}\n`,
+          ),
+        );
+        yield* Queue.offer(
+          input,
+          encoder.encode(
+            `${encodeUnknownJsonString({
+              jsonrpc: "2.0",
+              id: "skills-reload",
+              result: { result: { reloaded: 0 } },
+            })}\n`,
+          ),
+        );
+
+        // Protocol must still accept a normal extension request after the noise.
+        const responseFiber = yield* transport
+          .request("x/test", { hello: "world" })
+          .pipe(Effect.forkScoped);
+        const outbound = yield* Queue.take(output);
+        const decoded = JSON.parse(String(outbound)) as {
+          readonly id: string;
+          readonly method: string;
+        };
+        assert.equal(decoded.method, "x/test");
+        assert.isTrue(AcpProtocol.isRpcClientSafeRequestId(String(decoded.id)));
+
+        yield* Queue.offer(
+          input,
+          encoder.encode(
+            `${encodeUnknownJsonString({
+              jsonrpc: "2.0",
+              id: decoded.id,
+              result: { ok: true },
+            })}\n`,
+          ),
+        );
+
+        const response = yield* Fiber.join(responseFiber);
+        assert.deepEqual(response, { ok: true });
+
+        // Protocol must not have terminated from the skills-reload noise.
+        assert.isTrue(Option.isNone(yield* Deferred.poll(termination)));
+      }),
   );
 });

--- a/packages/effect-acp/src/protocol.ts
+++ b/packages/effect-acp/src/protocol.ts
@@ -77,6 +77,30 @@ const decodeElicitationComplete = Schema.decodeUnknownEffect(
 );
 const parserFactory = RpcSerialization.ndJsonRpc();
 
+/**
+ * Effect's RpcMessage.RequestId coerces wire ids with `BigInt(id)`. Agents such
+ * as Grok emit unsolicited JSON-RPC *responses* with non-numeric ids (e.g.
+ * `"skills-reload"`). Forwarding those to RpcClient dies with:
+ *   SyntaxError: Cannot convert skills-reload to a BigInt
+ * which tears down the ACP protocol mid-session.
+ *
+ * Drop orphan Exit/Chunk messages whose request ids cannot be coerced, before
+ * they reach RpcClient. Pending extension requests still match by string id.
+ *
+ * @see https://github.com/pingdotgg/t3code/issues/3666
+ */
+export function isRpcClientSafeRequestId(requestId: string): boolean {
+  if (requestId.length === 0) {
+    return false;
+  }
+  try {
+    BigInt(requestId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(function* (
   options: AcpPatchedProtocolOptions,
 ): Effect.fn.Return<AcpPatchedProtocol, never, Scope.Scope> {
@@ -342,6 +366,12 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
       Effect.flatMap((pending) => {
         const pendingRequest = pending.get(message.requestId);
         if (!pendingRequest) {
+          // Unsolicited / non-pending responses with non-numeric ids (Grok
+          // `skills-reload`) must not reach RpcClient — BigInt coercion throws
+          // and kills the protocol loop.
+          if (!isRpcClientSafeRequestId(message.requestId)) {
+            return Effect.void;
+          }
           return Queue.offer(clientQueue, message).pipe(Effect.asVoid);
         }
         if (message.exit._tag === "Success") {
@@ -381,15 +411,19 @@ export const makeAcpPatchedProtocol = Effect.fn("makeAcpPatchedProtocol")(functi
         return Ref.get(extPending).pipe(
           Effect.flatMap((pending) => {
             const pendingRequest = pending.get(message.requestId);
-            return pendingRequest
-              ? completeExtPendingFailure(
+            if (pendingRequest) {
+              return completeExtPendingFailure(
+                message.requestId,
+                AcpError.AcpRequestError.unsupportedStreamingResponse(
+                  pendingRequest.method,
                   message.requestId,
-                  AcpError.AcpRequestError.unsupportedStreamingResponse(
-                    pendingRequest.method,
-                    message.requestId,
-                  ),
-                )
-              : Queue.offer(clientQueue, message).pipe(Effect.asVoid);
+                ),
+              );
+            }
+            if (!isRpcClientSafeRequestId(message.requestId)) {
+              return Effect.void;
+            }
+            return Queue.offer(clientQueue, message).pipe(Effect.asVoid);
           }),
         );
       case "Defect":


### PR DESCRIPTION
## Summary

Grok threads in T3 can show **no assistant output** (user messages only) on Linux when the ACP protocol loop dies mid-session.

### Root cause

Grok CLI emits unsolicited JSON-RPC **responses** like:

```json
{"jsonrpc":"2.0","id":"skills-reload","result":{"result":{"reloaded":0}}}
```

Effect's `RpcMessage.RequestId` coerces wire ids with `BigInt(id)`. Non-numeric ids throw:

```
SyntaxError: Cannot convert skills-reload to a BigInt
```

That exception tears down the ACP client protocol loop. After that, turns never complete in the UI — which looks like a silent / dead Grok chat even though auth and SuperGrok are fine.

Reproduced against Grok CLI 0.2.93 + T3 Code 0.0.28. Matches [#3666](https://github.com/pingdotgg/t3code/issues/3666).

### Fix

1. **`packages/effect-acp`**: Before forwarding orphan `Exit`/`Chunk` messages to `RpcClient`, drop those whose request ids cannot be coerced to `BigInt`. Pending extension requests still match by string id as before.
2. **`AcpSessionRuntime`**: Only interrupt a prompt RPC fiber if it is still running (`pollUnsafe() === undefined`), avoiding unnecessary re-interrupt after a clean join.

### Test plan

- [x] `vp test packages/effect-acp apps/server/src/provider/acp/XAiAcpExtension.test.ts apps/server/src/provider/acp/AcpJsonRpcConnection.test.ts` (55 tests pass)
- [x] New test: protocol survives multiple `skills-reload` responses and still completes a subsequent extension request
- [ ] Manual: T3 + Grok on Linux — new thread, send `hi`, assistant reply sticks

### Notes

- This is separate from orchestrator-v2 settlement work in #3580 / #3578 (reply shows then wedges). This patch targets the **no assistant output at all** path caused by protocol death.
- Upstream CONTRIBUTING says contributions are not actively accepted; opening this because the bug is reproducible and the fix is isolated + tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core ACP wire routing and prompt fiber lifecycle; behavior change is narrow and covered by tests, but incorrect filtering could drop legitimate RpcClient traffic.
> 
> **Overview**
> Fixes **silent Grok threads** (no assistant output) when the ACP protocol loop dies after Grok emits unsolicited JSON-RPC responses with id `"skills-reload"`. Effect's RpcClient coerces ids with `BigInt()`, which throws on that string and tears down the session.
> 
> In **`effect-acp`**, adds `isRpcClientSafeRequestId` and **drops** orphan `Exit`/`Chunk` messages whose ids are not BigInt-coercible before they reach RpcClient; pending extension requests still correlate by string id. A protocol test asserts survival after multiple `skills-reload` frames and a normal extension round-trip.
> 
> In **`AcpSessionRuntime`**, prompt cleanup **only interrupts** the prompt RPC fiber when it is still running (`pollUnsafe() === undefined`), so a completed join is not re-interrupted while races (e.g. xAI `prompt_complete` fallback) can still interrupt losers to release the permit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e807573e00087a560078f85ad7dead5a0d31c9dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop unsolicited Grok `skills-reload` responses with non-numeric IDs to prevent protocol termination
> - Grok emits unsolicited JSON-RPC responses with non-numeric IDs (e.g. `skills-reload`), which cause `RpcClient` to fail on BigInt coercion and kill the protocol loop.
> - Adds `isRpcClientSafeRequestId` in [protocol.ts](https://github.com/pingdotgg/t3code/pull/3850/files#diff-c41432f9e7fbaf0a7a40c325bf318ea40df32aed6b771c8b6fa5c935e37006d2) to detect non-numeric or empty string IDs, and drops unsolicited Exit/Chunk messages with unsafe IDs instead of forwarding them to the client queue.
> - Also fixes [AcpSessionRuntime.ts](https://github.com/pingdotgg/t3code/pull/3850/files#diff-947405407dc15b91fd18625aab3132939b58753dce5a014fe17c590f2abfa5d6) to only interrupt the prompt RPC fiber after join if it is still running, avoiding redundant interrupts.
> - Behavioral Change: unsolicited messages with safe (numeric) IDs continue to be forwarded as before; only non-numeric unsolicited IDs are dropped.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e807573.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->