### PR TITLE
Serve stack-specific default project favicons

### DIFF
--- a/apps/server/src/assets/AssetAccess.test.ts
+++ b/apps/server/src/assets/AssetAccess.test.ts
@@ -11,7 +11,12 @@ import * as ServerSecretStore from "../auth/ServerSecretStore.ts";
 import * as ServerConfig from "../config.ts";
 import * as ProjectFaviconResolver from "../project/ProjectFaviconResolver.ts";
 import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
-import { ASSET_ROUTE_PREFIX, issueAssetUrl, resolveAsset } from "./AssetAccess.ts";
+import {
+  ASSET_ROUTE_PREFIX,
+  FALLBACK_PROJECT_FAVICON_SVG,
+  issueAssetUrl,
+  resolveAsset,
+} from "./AssetAccess.ts";
 
 const configLayer = ServerConfig.ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-asset-access-test-",
@@ -235,7 +240,56 @@ describe("AssetAccess", () => {
           fallbackSuffix.slice(0, fallbackSeparatorIndex),
           fallbackSuffix.slice(fallbackSeparatorIndex + 1),
         ),
-      ).toEqual({ kind: "project-favicon-fallback" });
+      ).toEqual({ kind: "project-favicon-fallback", svg: FALLBACK_PROJECT_FAVICON_SVG });
+    }).pipe(Effect.provide(testLayer)),
+  );
+
+  it.effect("serves stack-specific fallback icons for projects without a favicon", () =>
+    Effect.gen(function* () {
+      const fileSystem = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+
+      const resolveFallbackSvg = Effect.fnUntraced(function* (root: string) {
+        const result = yield* issueAssetUrl({
+          resource: { _tag: "project-favicon", cwd: root },
+        });
+        const suffix = result.relativeUrl.slice(`${ASSET_ROUTE_PREFIX}/`.length);
+        const separatorIndex = suffix.indexOf("/");
+        const resolved = yield* resolveAsset(
+          suffix.slice(0, separatorIndex),
+          suffix.slice(separatorIndex + 1),
+        );
+        expect(resolved?.kind).toBe("project-favicon-fallback");
+        return resolved?.kind === "project-favicon-fallback" ? resolved.svg : "";
+      });
+
+      const reactRoot = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-react-",
+      });
+      yield* fileSystem.writeFileString(
+        path.join(reactRoot, "package.json"),
+        '{"dependencies":{"react":"^19.0.0"}}',
+      );
+      expect(yield* resolveFallbackSvg(reactRoot)).toContain(
+        'data-fallback="project-favicon-react"',
+      );
+
+      const androidRoot = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-android-",
+      });
+      yield* fileSystem.writeFileString(path.join(androidRoot, "build.gradle"), "");
+      expect(yield* resolveFallbackSvg(androidRoot)).toContain(
+        'data-fallback="project-favicon-android"',
+      );
+
+      const plainRoot = yield* fileSystem.makeTempDirectoryScoped({
+        prefix: "t3-asset-favicon-plain-",
+      });
+      yield* fileSystem.writeFileString(
+        path.join(plainRoot, "package.json"),
+        '{"dependencies":{"express":"^5.0.0"}}',
+      );
+      expect(yield* resolveFallbackSvg(plainRoot)).toBe(FALLBACK_PROJECT_FAVICON_SVG);
     }).pipe(Effect.provide(testLayer)),
   );
 

--- a/apps/server/src/assets/AssetAccess.ts
+++ b/apps/server/src/assets/AssetAccess.ts
@@ -41,6 +41,15 @@ import * as WorkspacePaths from "../workspace/WorkspacePaths.ts";
 
 export const ASSET_ROUTE_PREFIX = "/api/assets";
 export const FALLBACK_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#6b728080" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" data-fallback="project-favicon"><path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-8l-2-2H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2Z"/></svg>`;
+const REACT_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="-11.5 -10.23174 23 20.46348" data-fallback="project-favicon-react"><circle cx="0" cy="0" r="2.05" fill="#61dafb"/><g fill="none" stroke="#61dafb" stroke-width="1"><ellipse rx="11" ry="4.2"/><ellipse rx="11" ry="4.2" transform="rotate(60)"/><ellipse rx="11" ry="4.2" transform="rotate(120)"/></g></svg>`;
+const ANDROID_PROJECT_FAVICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" data-fallback="project-favicon-android"><path fill="#3ddc84" d="M32 54h64v44c0 7.7-6.3 14-14 14H46c-7.7 0-14-6.3-14-14V54Z"/><path fill="#3ddc84" d="M39.5 48C42.8 34.2 52.2 26 64 26s21.2 8.2 24.5 22h-49Z"/><path stroke="#3ddc84" stroke-width="7" stroke-linecap="round" d="M46 24 36 8m46 16L92 8M22 62v31m84-31v31M49 112v10m30-10v10"/><circle cx="52" cy="40" r="4" fill="#173b2d"/><circle cx="76" cy="40" r="4" fill="#173b2d"/></svg>`;
+
+const ANDROID_PROJECT_MARKER_FILES = [
+  "settings.gradle",
+  "settings.gradle.kts",
+  "build.gradle",
+  "build.gradle.kts",
+];
 
 const SIGNING_SECRET_NAME = "asset-access-signing-key";
 const ASSET_TOKEN_TTL_MS = 60 * 60 * 1000;
@@ -93,7 +102,53 @@ const encodeAssetClaims = Schema.encodeSync(AssetClaimsJson);
 
 export type ResolvedAsset =
   | { readonly kind: "file"; readonly path: string }
-  | { readonly kind: "project-favicon-fallback" };
+  | { readonly kind: "project-favicon-fallback"; readonly svg: string };
+
+const PackageJsonDependenciesJson = Schema.fromJsonString(
+  Schema.Struct({
+    dependencies: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+    devDependencies: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  }),
+);
+const decodePackageJsonDependencies = Schema.decodeUnknownOption(PackageJsonDependenciesJson);
+
+function parsePackageJsonDependencyNames(contents: string): ReadonlySet<string> {
+  const parsed = Option.getOrNull(decodePackageJsonDependencies(contents));
+  return new Set([
+    ...Object.keys(parsed?.dependencies ?? {}),
+    ...Object.keys(parsed?.devDependencies ?? {}),
+  ]);
+}
+
+// Detection failures degrade to the generic fallback icon rather than failing
+// the asset request.
+const resolveProjectFaviconFallbackSvg = Effect.fn("AssetAccess.resolveProjectFaviconFallbackSvg")(
+  function* (workspaceRoot: string) {
+    const fileSystem = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+
+    const packageJsonContents = yield* fileSystem
+      .readFileString(path.join(workspaceRoot, "package.json"))
+      .pipe(Effect.orElseSucceed(() => null));
+    if (packageJsonContents !== null) {
+      const dependencyNames = parsePackageJsonDependencyNames(packageJsonContents);
+      if (dependencyNames.has("react") || dependencyNames.has("react-native")) {
+        return REACT_PROJECT_FAVICON_SVG;
+      }
+    }
+
+    for (const markerFile of ANDROID_PROJECT_MARKER_FILES) {
+      const markerExists = yield* fileSystem
+        .exists(path.join(workspaceRoot, markerFile))
+        .pipe(Effect.orElseSucceed(() => false));
+      if (markerExists) {
+        return ANDROID_PROJECT_FAVICON_SVG;
+      }
+    }
+
+    return FALLBACK_PROJECT_FAVICON_SVG;
+  },
+);
 
 function decodeClaims(encodedPayload: string): AssetClaims | null {
   try {
@@ -392,7 +447,10 @@ export const resolveAsset = Effect.fn("AssetAccess.resolveAsset")(function* (
 
   if (claims.kind === "project-favicon") {
     if (claims.relativePath === null) {
-      return { kind: "project-favicon-fallback" } satisfies ResolvedAsset;
+      return {
+        kind: "project-favicon-fallback",
+        svg: yield* resolveProjectFaviconFallbackSvg(claims.workspaceRoot),
+      } satisfies ResolvedAsset;
     }
     const faviconPath = yield* resolveCanonicalWorkspaceFileForRequest({
       workspaceRoot: claims.workspaceRoot,

--- a/apps/server/src/http.ts
+++ b/apps/server/src/http.ts
@@ -25,11 +25,7 @@ import * as HttpApiBuilder from "effect/unstable/httpapi/HttpApiBuilder";
 import { OtlpTracer } from "effect/unstable/observability";
 
 import * as ServerConfig from "./config.ts";
-import {
-  ASSET_ROUTE_PREFIX,
-  FALLBACK_PROJECT_FAVICON_SVG,
-  resolveAsset,
-} from "./assets/AssetAccess.ts";
+import { ASSET_ROUTE_PREFIX, resolveAsset } from "./assets/AssetAccess.ts";
 import * as BrowserTraceCollector from "./observability/BrowserTraceCollector.ts";
 import * as EnvironmentAuth from "./auth/EnvironmentAuth.ts";
 import { traceRelayRequest } from "./cloud/traceRelayRequest.ts";
@@ -197,7 +193,7 @@ export const assetRouteLayer = HttpRouter.add(
       return HttpServerResponse.text("Not Found", { status: 404 });
     }
     if (asset.kind === "project-favicon-fallback") {
-      return HttpServerResponse.text(FALLBACK_PROJECT_FAVICON_SVG, {
+      return HttpServerResponse.text(asset.svg, {
         status: 200,
         contentType: "image/svg+xml",
         headers: {


### PR DESCRIPTION
When a project has no favicon, the server currently serves a generic folder icon as the fallback. This PR makes that fallback smarter by detecting the project's stack: React/React Native projects (via `package.json` dependencies) get a React icon, and Gradle-based Android projects get an Android icon. Anything else — including any detection error — falls back to the existing generic icon, so behavior only changes for projects that match a known stack.

The `ResolvedAsset` fallback variant now carries the resolved SVG, and the asset route serves it directly. Detection is intentionally conservative (two well-known stacks, marker files only) so more stacks can be added incrementally if there's interest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only asset fallback logic with fail-safe defaults; no auth, signing, or data-model changes beyond carrying SVG on the fallback variant.
> 
> **Overview**
> When a project has no favicon file, the asset route no longer always returns the same generic folder SVG. **`resolveProjectFaviconFallbackSvg`** inspects the signed workspace root and picks a fallback: React or React Native (from `package.json` dependencies), else Gradle/Android marker files (`build.gradle`, `settings.gradle`, etc.), else the existing generic icon. Read/parse failures degrade to the generic icon so requests still succeed.
> 
> The **`project-favicon-fallback`** resolved asset now includes the chosen **`svg`** string; **`http.ts`** serves that payload instead of importing a single constant. Tests cover React, Android, and non-matching stacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9d03fc2c167ced53df58f285d8cd8770cb5d8f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Serve stack-specific default project favicons for React and Android workspaces
> - Adds `resolveProjectFaviconFallbackSvg` in [AssetAccess.ts](https://github.com/pingdotgg/t3code/pull/3852/files#diff-7106051c89d4fb8e7cebeee854e81bb55fdf03ec154089eb8c7499ef78ae51c1) to detect the project stack and return a matching SVG: React (via `react`/`react-native` in `package.json` dependencies) or Android (via Gradle marker files), falling back to the generic default.
> - Extends the `project-favicon-fallback` variant of `ResolvedAsset` to carry the resolved `svg` string, and updates [http.ts](https://github.com/pingdotgg/t3code/pull/3852/files#diff-55fb49cf72ecef123d8f2fa7061526dadb37cf93f8e9dd9e7f0d4f8cd4ff9f6d) to serve that SVG directly instead of a hardcoded constant.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b9d03fc. 2 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->