### PR TITLE
fix(server): Address premature provider reaping by treating provider runtime output as session activity

### DIFF
--- a/apps/server/src/persistence/ProviderSessionRuntime.ts
+++ b/apps/server/src/persistence/ProviderSessionRuntime.ts
@@ -56,6 +56,12 @@ export type GetProviderSessionRuntimeInput = typeof GetProviderSessionRuntimeInp
 export const DeleteProviderSessionRuntimeInput = Schema.Struct({ threadId: ThreadId });
 export type DeleteProviderSessionRuntimeInput = typeof DeleteProviderSessionRuntimeInput.Type;
 
+export const TouchProviderSessionRuntimeInput = Schema.Struct({
+  threadId: ThreadId,
+  lastSeenAt: IsoDateTime,
+});
+export type TouchProviderSessionRuntimeInput = typeof TouchProviderSessionRuntimeInput.Type;
+
 /**
  * ProviderSessionRuntimeRepository - Service tag for provider runtime persistence.
  */
@@ -96,6 +102,16 @@ export class ProviderSessionRuntimeRepository extends Context.Service<
      */
     readonly deleteByThreadId: (
       input: DeleteProviderSessionRuntimeInput,
+    ) => Effect.Effect<void, ProviderSessionRuntimeRepositoryError>;
+
+    /**
+     * Bump `last_seen_at` for an existing runtime row.
+     *
+     * No-op when no row matches. Cheaper than `upsert` for high-frequency
+     * activity signals because it skips the SELECT and JSON re-encoding.
+     */
+    readonly touchByThreadId: (
+      input: TouchProviderSessionRuntimeInput,
     ) => Effect.Effect<void, ProviderSessionRuntimeRepositoryError>;
   }
 >()("t3/persistence/ProviderSessionRuntime/ProviderSessionRuntimeRepository") {}
@@ -233,6 +249,16 @@ export const make = Effect.gen(function* () {
       `,
   });
 
+  const touchRuntimeByThreadId = SqlSchema.void({
+    Request: TouchProviderSessionRuntimeInput,
+    execute: ({ threadId, lastSeenAt }) =>
+      sql`
+        UPDATE provider_session_runtime
+        SET last_seen_at = ${lastSeenAt}
+        WHERE thread_id = ${threadId}
+      `,
+  });
+
   const upsert: ProviderSessionRuntimeRepository["Service"]["upsert"] = (runtime) =>
     upsertRuntimeRow(runtime).pipe(
       Effect.mapError(
@@ -308,11 +334,23 @@ export const make = Effect.gen(function* () {
       ),
     );
 
+  const touchByThreadId: ProviderSessionRuntimeRepository["Service"]["touchByThreadId"] = (input) =>
+    touchRuntimeByThreadId(input).pipe(
+      Effect.mapError(
+        toPersistenceSqlOrDecodeError(
+          "ProviderSessionRuntimeRepository.touchByThreadId:query",
+          "ProviderSessionRuntimeRepository.touchByThreadId:encodeRequest",
+          { threadId: input.threadId },
+        ),
+      ),
+    );
+
   return {
     upsert,
     getByThreadId,
     list,
     deleteByThreadId,
+    touchByThreadId,
   } satisfies ProviderSessionRuntimeRepository["Service"];
 });
 

--- a/apps/server/src/provider/Layers/CodexAdapter.test.ts
+++ b/apps/server/src/provider/Layers/CodexAdapter.test.ts
@@ -213,6 +213,7 @@ function makeScopedRuntimeFactory(options?: { readonly failConstruction?: boolea
 
 const providerSessionDirectoryTestLayer = Layer.succeed(ProviderSessionDirectory, {
   upsert: () => Effect.void,
+  touch: () => Effect.void,
   getProvider: () =>
     Effect.die(new Error("ProviderSessionDirectory.getProvider is not used in test")),
   getBinding: () => Effect.succeed(Option.none()),

--- a/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
+++ b/apps/server/src/provider/Layers/OpenCodeAdapter.test.ts
@@ -180,6 +180,7 @@ const OpenCodeRuntimeTestDouble: OpenCodeRuntimeShape = {
 
 const providerSessionDirectoryTestLayer = Layer.succeed(ProviderSessionDirectory, {
   upsert: () => Effect.void,
+  touch: () => Effect.void,
   getProvider: () =>
     Effect.die(new Error("ProviderSessionDirectory.getProvider is not used in test")),
   getBinding: () => Effect.succeed(Option.none()),

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -25,6 +25,7 @@ import {
   type ProviderSession,
 } from "@t3tools/contracts";
 import { causeErrorTag } from "@t3tools/shared/observability";
+import * as Cause from "effect/Cause";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -295,11 +296,13 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       ? Effect.void
       : directory.touch(event.threadId).pipe(
           Effect.catchCause((cause) =>
-            Effect.logDebug("provider.session.activity.touch-failed", {
-              threadId: event.threadId,
-              eventType: event.type,
-              cause,
-            }),
+            Cause.hasInterruptsOnly(cause)
+              ? Effect.interrupt
+              : Effect.logDebug("provider.session.activity.touch-failed", {
+                  threadId: event.threadId,
+                  eventType: event.type,
+                  cause,
+                }),
           ),
         );
 

--- a/apps/server/src/provider/Layers/ProviderService.ts
+++ b/apps/server/src/provider/Layers/ProviderService.ts
@@ -281,6 +281,28 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
       });
     });
 
+  // Runtime event types that must NOT count as session activity.
+  // `session.exited` means the provider process is gone — bumping `lastSeenAt`
+  // would keep the directory binding alive past the runtime that backs it,
+  // defeating the reaper. Extend this set if new event types turn out to fire
+  // after a session is effectively dead.
+  const SESSION_ACTIVITY_DENY_LIST: ReadonlySet<ProviderRuntimeEvent["type"]> = new Set([
+    "session.exited",
+  ]);
+
+  const bumpSessionActivity = (event: ProviderRuntimeEvent): Effect.Effect<void> =>
+    SESSION_ACTIVITY_DENY_LIST.has(event.type)
+      ? Effect.void
+      : directory.touch(event.threadId).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logDebug("provider.session.activity.touch-failed", {
+              threadId: event.threadId,
+              eventType: event.type,
+              cause,
+            }),
+          ),
+        );
+
   const processRuntimeEvent = (
     source: {
       readonly instanceId: ProviderInstanceId;
@@ -293,7 +315,10 @@ const makeProviderService = Effect.fn("makeProviderService")(function* (
         increment(providerRuntimeEventsTotal, {
           provider: canonicalEvent.provider,
           eventType: canonicalEvent.type,
-        }).pipe(Effect.andThen(publishRuntimeEvent(canonicalEvent))),
+        }).pipe(
+          Effect.andThen(publishRuntimeEvent(canonicalEvent)),
+          Effect.andThen(bumpSessionActivity(canonicalEvent)),
+        ),
       ),
     );
 

--- a/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Layers/ProviderSessionDirectory.ts
@@ -148,6 +148,13 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
       .pipe(Effect.mapError(toPersistenceError("ProviderSessionDirectory.upsert:upsert")));
   });
 
+  const touch: ProviderSessionDirectoryShape["touch"] = Effect.fn(function* (threadId) {
+    const now = DateTime.formatIso(yield* DateTime.now);
+    yield* repository
+      .touchByThreadId({ threadId, lastSeenAt: now })
+      .pipe(Effect.mapError(toPersistenceError("ProviderSessionDirectory.touch:touchByThreadId")));
+  });
+
   const getProvider: ProviderSessionDirectoryShape["getProvider"] = (threadId) =>
     getBinding(threadId).pipe(
       Effect.flatMap((binding) =>
@@ -184,6 +191,7 @@ const makeProviderSessionDirectory = Effect.gen(function* () {
 
   return {
     upsert,
+    touch,
     getProvider,
     getBinding,
     listThreadIds,

--- a/apps/server/src/provider/Services/ProviderSessionDirectory.ts
+++ b/apps/server/src/provider/Services/ProviderSessionDirectory.ts
@@ -45,6 +45,10 @@ export interface ProviderSessionDirectoryShape {
     binding: ProviderRuntimeBinding,
   ) => Effect.Effect<void, ProviderSessionDirectoryWriteError>;
 
+  readonly touch: (
+    threadId: ThreadId,
+  ) => Effect.Effect<void, ProviderSessionDirectoryPersistenceError>;
+
   readonly getProvider: (
     threadId: ThreadId,
   ) => Effect.Effect<ProviderDriverKind, ProviderSessionDirectoryReadError>;


### PR DESCRIPTION
## What Changed
Change activity tracking to cover provider side, not only user actions. This keeps the provider session active while (sub)agents are running.

Partially addresses #2980 & #2378..

## Why

Long running (sub)agent activity can get truncated (and lost) when the idle-session reaper kills the session due to missing user activity (see #2980 & #2378).
Rather than extending the idle-session timeout (or making it configurable), the root cause from my perspective was, that only user actions are counted as session activity, and not model (or provider outputs).
Therefore, this patch changes the session tracking to include provider actions, while ensuring that frequent events don't overwhelm the database.

## Detailed Changes described by Opus

The idle-session reaper (ProviderSessionReaper) kills sessions whose
lastSeenAt is older than the inactivity threshold (~30min). lastSeenAt was only
bumped on user-initiated actions (sendTurn, interruptTurn, binding
upserts), so a long-running turn with no fresh user input was treated as
idle and reaped mid-generation — dropping provider-side context even
though the model was actively working.

Bump lastSeenAt on every inbound runtime event in the central dispatcher
(ProviderService.processRuntimeEvent), which all provider runtimes
(Codex, Claude, OpenCode, Cursor, Grok) already flow through. Only
session.exited is excluded, so a terminated process can still be reaped.

Add ProviderSessionDirectory.touch() backed by a dedicated
touchByThreadId repository method: a single UPDATE of last_seen_at with
no preceding SELECT or JSON re-encoding, cheap enough to run per event.
Touch failures are logged at debug and swallowed so a transient DB error
never tears down the event subscription.


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Change has been running cleanly without issues for me for a couple of days

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes idle-session reaper inputs by updating `last_seen_at` on every runtime event; incorrect deny-list or touch behavior could keep dead sessions alive or add DB write load.
> 
> **Overview**
> **Provider runtime output now counts as session activity** so long-running turns are not reaped while the model is still emitting events.
> 
> Adds **`touchByThreadId`** on `ProviderSessionRuntimeRepository` (single `UPDATE` of `last_seen_at`, no full upsert) and **`ProviderSessionDirectory.touch`**. In **`ProviderService.processRuntimeEvent`**, after publishing each canonical runtime event, the service calls **`touch`** except for **`session.exited`**, which is excluded so dead sessions can still be reaped. Touch failures are logged at debug and do not break the event pipeline; interrupts propagate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd8a0a9b4a3c9a6d321596821b35008672b9c4d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix premature provider session reaping by treating runtime output events as session activity
> - Provider runtime events now trigger a `touch` on the session's `last_seen_at` timestamp, preventing the session reaper from killing active provider sessions that haven't received explicit user input.
> - Adds `touchByThreadId` to [`ProviderSessionRuntimeRepository`](https://github.com/pingdotgg/t3code/pull/3856/files#diff-c49167d140d6071e1aece96a98e7d3190e27b4f9bbcbd2ccfd8e5e0caa2c1446), issuing an `UPDATE provider_session_runtime SET last_seen_at = $1 WHERE thread_id = $2`.
> - Adds `touch(threadId)` to [`ProviderSessionDirectory`](https://github.com/pingdotgg/t3code/pull/3856/files#diff-ab92c10487184bb8cd1a1a59d84393ef1fa2b98097a9bed0a0fdcaec7c33544a), setting `last_seen_at` to the current time.
> - In [`ProviderService`](https://github.com/pingdotgg/t3code/pull/3856/files#diff-b9b9384b78856ff56cff5dd0ccb106054fb5d2d1b7500fcd30d8938ebfec5775), `processRuntimeEvent` calls `bumpSessionActivity` after publishing each event, skipping `session.exited` events; touch failures are logged at debug level unless the fiber is interrupted.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bd8a0a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session activity is now refreshed automatically when eligible provider runtime events occur.
  * Added support for updating a session’s last-seen timestamp without replacing the existing session record.

* **Bug Fixes**
  * Excluded session exit events from extending session activity.
  * Improved handling and logging of session activity update failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->