### PR TITLE
fix(desktop): stop Linux context menus from activating an item on open

### DIFF
--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -43,26 +43,33 @@ if (gateContextMenuOnPointerRelease) {
   window.addEventListener("blur", () => (pointerButtonsHeld = 0));
 }
 
-function waitForPointerRelease(): Promise<void> {
+// Resolves true once every button held at request time is released (buttons
+// pressed mid-gesture don't keep the menu waiting), or false when the gesture
+// is cancelled (pointercancel / focus loss) — opening a menu then would either
+// land mid-hold (re-triggering #3698) or appear at stale coordinates the user
+// no longer expects.
+function waitForPointerRelease(): Promise<boolean> {
   return new Promise((resolve) => {
-    if (pointerButtonsHeld === 0) {
-      resolve();
+    const buttonsAtRequest = pointerButtonsHeld;
+    if (buttonsAtRequest === 0) {
+      resolve(true);
       return;
     }
-    const settle = () => {
+    const finish = (proceed: boolean) => {
       window.removeEventListener("pointerup", onPointerUp, true);
-      window.removeEventListener("pointercancel", settle, true);
-      window.removeEventListener("blur", settle);
-      resolve();
+      window.removeEventListener("pointercancel", onAbort, true);
+      window.removeEventListener("blur", onAbort);
+      resolve(proceed);
     };
     const onPointerUp = (event: PointerEvent) => {
-      if (event.buttons === 0) {
-        settle();
+      if ((event.buttons & buttonsAtRequest) === 0) {
+        finish(true);
       }
     };
+    const onAbort = () => finish(false);
     window.addEventListener("pointerup", onPointerUp, true);
-    window.addEventListener("pointercancel", settle, true);
-    window.addEventListener("blur", settle);
+    window.addEventListener("pointercancel", onAbort, true);
+    window.addEventListener("blur", onAbort);
   });
 }
 
@@ -139,8 +146,8 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   confirm: (message) => ipcRenderer.invoke(IpcChannels.CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(IpcChannels.SET_THEME_CHANNEL, theme),
   showContextMenu: async (items, position) => {
-    if (gateContextMenuOnPointerRelease) {
-      await waitForPointerRelease();
+    if (gateContextMenuOnPointerRelease && !(await waitForPointerRelease())) {
+      return null;
     }
     return ipcRenderer.invoke(IpcChannels.CONTEXT_MENU_CHANNEL, {
       items,

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -27,6 +27,45 @@ function unwrapEnsureSshEnvironmentResult(result: unknown) {
   return result as Awaited<ReturnType<DesktopBridge["ensureSshEnvironment"]>>;
 }
 
+// On Linux, Chromium fires `contextmenu` on right-button PRESS (Windows fires it
+// on release). Popping the native menu while the button is still held makes the
+// menu grab the pointer, and the subsequent release "clicks" whatever item sits
+// under the cursor — a random item activates the instant the menu opens (#3698).
+// Track pointer-button state and delay opening the menu until the press that
+// triggered it has been released, matching the Windows semantics.
+// oxlint-disable-next-line t3code/no-global-process-runtime -- Preload script has no Effect runtime.
+const gateContextMenuOnPointerRelease = process.platform === "linux";
+let pointerButtonsHeld = 0;
+if (gateContextMenuOnPointerRelease) {
+  window.addEventListener("pointerdown", (event) => (pointerButtonsHeld = event.buttons), true);
+  window.addEventListener("pointerup", (event) => (pointerButtonsHeld = event.buttons), true);
+  window.addEventListener("pointercancel", () => (pointerButtonsHeld = 0), true);
+  window.addEventListener("blur", () => (pointerButtonsHeld = 0));
+}
+
+function waitForPointerRelease(): Promise<void> {
+  return new Promise((resolve) => {
+    if (pointerButtonsHeld === 0) {
+      resolve();
+      return;
+    }
+    const settle = () => {
+      window.removeEventListener("pointerup", onPointerUp, true);
+      window.removeEventListener("pointercancel", settle, true);
+      window.removeEventListener("blur", settle);
+      resolve();
+    };
+    const onPointerUp = (event: PointerEvent) => {
+      if (event.buttons === 0) {
+        settle();
+      }
+    };
+    window.addEventListener("pointerup", onPointerUp, true);
+    window.addEventListener("pointercancel", settle, true);
+    window.addEventListener("blur", settle);
+  });
+}
+
 contextBridge.exposeInMainWorld("desktopBridge", {
   getAppBranding: () => {
     const result = ipcRenderer.sendSync(IpcChannels.GET_APP_BRANDING_CHANNEL);
@@ -99,11 +138,15 @@ contextBridge.exposeInMainWorld("desktopBridge", {
   pickFolder: (options) => ipcRenderer.invoke(IpcChannels.PICK_FOLDER_CHANNEL, options),
   confirm: (message) => ipcRenderer.invoke(IpcChannels.CONFIRM_CHANNEL, message),
   setTheme: (theme) => ipcRenderer.invoke(IpcChannels.SET_THEME_CHANNEL, theme),
-  showContextMenu: (items, position) =>
-    ipcRenderer.invoke(IpcChannels.CONTEXT_MENU_CHANNEL, {
+  showContextMenu: async (items, position) => {
+    if (gateContextMenuOnPointerRelease) {
+      await waitForPointerRelease();
+    }
+    return ipcRenderer.invoke(IpcChannels.CONTEXT_MENU_CHANNEL, {
       items,
       ...(position === undefined ? {} : { position }),
-    }),
+    });
+  },
   openExternal: (url: string) => ipcRenderer.invoke(IpcChannels.OPEN_EXTERNAL_CHANNEL, url),
   onMenuAction: (listener) => {
     const wrappedListener = (_event: Electron.IpcRendererEvent, action: unknown) => {


### PR DESCRIPTION
Fixes #3698

## What

On Linux, right-clicking a project/thread in the sidebar makes the context menu flash open and instantly close, with a random menu item activated as if clicked (regression of #285 — still present in v0.0.28 despite the #3025 fix).

## Why it happens

Two facts combine:

1. **The desktop app never runs the code #3025 fixed.** `localApi.ts` routes context menus through `window.desktopBridge.showContextMenu` → IPC → the native Electron menu (`ElectronMenu.ts`) whenever the bridge exists — which on desktop is always. The `canDismissFromPointer` guard added by #3025 lives in `contextMenuFallback.ts`, the browser-only fallback, so it could never fix the desktop bug.
2. **On Linux, Chromium fires `contextmenu` on right-button *press*** (Windows fires it on *release*). So the native menu pops up — positioned directly under the cursor — while the button is still physically held. The menu takes the pointer grab, and the tail of the same right-click gesture (the button release) lands on whatever item happens to sit under the cursor and activates it. This also explains the reported workaround: holding the right button and dragging *away* before releasing means the release lands outside the menu.

## Change

In the desktop preload, `desktopBridge.showContextMenu` now waits (Linux only) for the pointer buttons to be released before invoking the context-menu IPC — i.e. the menu opens on release, exactly matching the Windows event semantics that don't exhibit the bug. Button state is tracked with capture-phase pointer listeners; `pointercancel` and window `blur` settle the wait so it can't hang. Menus opened with no button held (keyboard, normal-click "…" buttons — where `click` fires after release) are unaffected, as are Windows and macOS entirely.

The `process.platform` check uses the repo's established `oxlint-disable` pattern for standalone non-Effect scripts (same as `apps/desktop/scripts/*`).

## Verification

- `vp check` and `vp run typecheck` pass.
- I don't have a Linux desktop environment to hand, so this is verified by analysis rather than by reproducing on Ubuntu — the event-order reasoning above matches the reporter's symptoms and workaround exactly, but a maintainer with a Linux box may want to sanity-check before merging. Happy to adjust if testing surfaces anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Linux preload pointer gating around context-menu IPC; other platforms and no-button menu paths are unchanged.
> 
> **Overview**
> Fixes **#3698**: on Linux, native context menus opened while the right button was still down, so the release could activate a random item under the cursor.
> 
> **`desktopBridge.showContextMenu`** in the desktop preload is now **async** and, **on Linux only**, waits for pointer buttons to clear before calling the context-menu IPC. Global capture-phase listeners track `pointerButtonsHeld`; **`waitForPointerRelease`** proceeds immediately when no buttons are held (keyboard / “…” menus), waits for release of the buttons that were down at request time, or returns **`null`** on **`pointercancel`** / window **`blur`** so the menu does not open mid-gesture or at stale coordinates. **Windows and macOS** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d82d5685a9cb68f7fccb3497135cdfe629b12d78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Linux context menus activating an item on open by waiting for pointer release
> On Linux, right-clicking to open a context menu could immediately trigger an item because the menu appeared while the pointer button was still held. This fix delays the `desktopBridge.showContextMenu` IPC call until all held pointer buttons are released. If the gesture is cancelled or the window loses focus before release, the menu is not opened and the method returns `null`. Other platforms are unaffected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d82d568.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->