### PR TITLE
fix: prevent initial right-click from selecting a context menu item

### DIFF
--- a/apps/web/src/contextMenuFallback.test.ts
+++ b/apps/web/src/contextMenuFallback.test.ts
@@ -196,6 +196,23 @@ describe("showContextMenuFallback", () => {
     await expect(selectionPromise).resolves.toBe("rename");
   });
 
+  it("ignores a click from the gesture that opened the menu", async () => {
+    let enablePointerSelection: ((time: number) => void) | undefined;
+    vi.stubGlobal("requestAnimationFrame", (callback: (time: number) => void) => {
+      enablePointerSelection = callback;
+      return 0;
+    });
+
+    const selectionPromise = showContextMenuFallback([{ id: "rename", label: "Rename" }]);
+    const renameButton = findButton("Rename");
+
+    renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    enablePointerSelection?.(0);
+    renameButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    await expect(selectionPromise).resolves.toBe("rename");
+  });
+
   it("opens nested submenus and resolves the clicked leaf id", async () => {
     const selectionPromise = showContextMenuFallback([
       {

--- a/apps/web/src/contextMenuFallback.ts
+++ b/apps/web/src/contextMenuFallback.ts
@@ -272,7 +272,9 @@ export function showContextMenuFallback<T extends string>(
             button.addEventListener("mouseenter", () => {
               closeMenusFromLevel(level + 1);
             });
-            button.addEventListener("click", () => cleanup(item.id));
+            button.addEventListener("click", () => {
+              if (canDismissFromPointer) cleanup(item.id);
+            });
           }
         }
 


### PR DESCRIPTION
## What Changed

* Prevent the pointer event that opens a context menu from immediately selecting one of its items.
* Ensure pointer-based selection is only enabled after the opening interaction has completed.
* Add test coverage for delayed pointer selection to prevent this behavior from regressing.

## Why

On Linux, right-clicking a project or thread in the desktop app could cause the context menu to briefly appear and immediately close while activating a menu item.

The same pointer interaction used to open the menu was also being interpreted as a menu-item selection. This made context menus unreliable and could trigger unintended actions without a second click.

This change keeps pointer selection disabled during the initial opening interaction, while still allowing menu items to be selected normally after the required delay.

Fixes #3698

## UI Changes

### Before

Right-clicking a project or thread could immediately activate a random context-menu item and close the menu.

**Recording:**

https://github.com/user-attachments/assets/535a123f-c474-41e4-9894-8b92bfb297c3

### After

The context menu remains open after the initial right-click and waits for a separate selection from the user.

**Recording:**

https://github.com/user-attachments/assets/439a3ebf-6aaa-4644-9b53-a4d034d7fce6

## Checklist

* [x] This PR is small and focused
* [x] I explained what changed and why
* [x] I included before/after screenshots for any UI changes
* [x] I included a video for animation/interaction changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to fallback context-menu pointer handling with targeted test coverage; no auth, data, or API impact.
> 
> **Overview**
> Fixes Linux/desktop behavior where the **same pointer interaction** that opened the fallback context menu could immediately activate a leaf item and close the menu.
> 
> Leaf menu buttons now call **`cleanup` only when `canDismissFromPointer` is true**, matching the existing delay (set on the next animation frame) used for outside dismiss. Clicks during the opening gesture are ignored; a separate click still selects normally.
> 
> Adds a test that defers the rAF callback so the first click is ignored and the second resolves the item id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5fe9e04df34fb71266fb6f06ad7240be4b8a960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore the opening click gesture in the context menu fallback
> A click that occurs before the first animation frame after the menu opens no longer resolves the menu. This is done by gating leaf-item click handling on a `canDismissFromPointer` flag, which is set to `true` via `requestAnimationFrame` after the menu is rendered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5fe9e0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->