### PR TITLE
fix(server): copy ignored .env files into new worktrees

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -595,6 +595,66 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.equal(yield* fileSystem.exists(worktreePath), false);
       }),
     );
+
+    it.effect(
+      "copies ignored env files into a new worktree without descending into ignored dirs",
+      () =>
+        Effect.gen(function* () {
+          const fileSystem = yield* FileSystem.FileSystem;
+          const pathService = yield* Path.Path;
+          const driver = yield* GitVcsDriver.GitVcsDriver;
+
+          const cwd = yield* makeTmpDir();
+          yield* driver.initRepo({ cwd });
+          yield* git(cwd, ["config", "user.email", "test@test.com"]);
+          yield* git(cwd, ["config", "user.name", "Test"]);
+          // Tracked files: `.gitignore` plus a nested file so `apps/web` is a
+          // tracked directory that git will recurse into.
+          yield* writeTextFile(cwd, ".gitignore", "node_modules/\n.env\n.env.*\n");
+          yield* writeTextFile(cwd, "apps/web/index.ts", "export const x = 1;\n");
+          yield* git(cwd, ["add", "."]);
+          yield* git(cwd, ["commit", "-m", "initial commit"]);
+          const initialBranch = yield* git(cwd, ["branch", "--show-current"]);
+
+          // Ignored (untracked) env files at several levels, including one buried
+          // inside an ignored directory that must NOT be copied.
+          yield* writeTextFile(cwd, ".env", "ROOT=1\n");
+          yield* writeTextFile(cwd, ".env.local", "ROOT_LOCAL=1\n");
+          yield* writeTextFile(cwd, "apps/web/.env.local", "WEB_LOCAL=1\n");
+          yield* writeTextFile(cwd, "node_modules/pkg/.env", "NODE_MODULES=1\n");
+
+          const worktreePath = pathService.join(
+            yield* makeTmpDir("git-worktrees-"),
+            "env-worktree",
+          );
+          yield* driver.createWorktree({
+            cwd,
+            path: worktreePath,
+            refName: initialBranch,
+            newRefName: "feature/env-worktree",
+          });
+
+          assert.equal(
+            yield* fileSystem.readFileString(pathService.join(worktreePath, ".env")),
+            "ROOT=1\n",
+          );
+          assert.equal(
+            yield* fileSystem.readFileString(pathService.join(worktreePath, ".env.local")),
+            "ROOT_LOCAL=1\n",
+          );
+          assert.equal(
+            yield* fileSystem.readFileString(pathService.join(worktreePath, "apps/web/.env.local")),
+            "WEB_LOCAL=1\n",
+          );
+          // The `.env` under the ignored `node_modules/` directory is not copied.
+          assert.equal(
+            yield* fileSystem.exists(pathService.join(worktreePath, "node_modules/pkg/.env")),
+            false,
+          );
+
+          yield* driver.removeWorktree({ cwd, path: worktreePath });
+        }),
+    );
   });
 
   describe("commit context", () => {

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -47,6 +47,19 @@ const RANGE_DIFF_PATCH_MAX_OUTPUT_BYTES = 59_000;
 const REVIEW_DIFF_PATCH_MAX_OUTPUT_BYTES = 120_000;
 const REVIEW_UNTRACKED_DIFF_MAX_OUTPUT_BYTES = 80_000;
 const WORKSPACE_FILES_MAX_OUTPUT_BYTES = 120_000;
+// `.env` files are conventionally git-ignored, so `git worktree add` never
+// carries them into a freshly created worktree. Copy them from the source
+// working tree so dev servers and framework tooling (e.g. Next.js / AuthKit)
+// read the same environment they do in the primary checkout. The `--directory`
+// flag collapses ignored directories such as `node_modules/` into a single
+// entry, so `.env` files buried inside them are neither matched nor descended
+// into; only ignored env files that live in tracked directories are copied.
+const WORKTREE_ENV_FILE_PATHSPECS = [
+  ":(glob).env",
+  ":(glob).env.*",
+  ":(glob)**/.env",
+  ":(glob)**/.env.*",
+] as const;
 const STATUS_UPSTREAM_REFRESH_INTERVAL = Duration.seconds(15);
 const STATUS_UPSTREAM_REFRESH_TIMEOUT = Duration.seconds(5);
 
@@ -2242,6 +2255,59 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     },
   );
 
+  const copyIgnoredEnvFilesToWorktree = Effect.fn("copyIgnoredEnvFilesToWorktree")(function* (
+    sourceCwd: string,
+    worktreePath: string,
+  ) {
+    const listResult = yield* executeGit(
+      "GitVcsDriver.createWorktree.listEnvFiles",
+      sourceCwd,
+      [
+        "ls-files",
+        "-z",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "--directory",
+        "--",
+        ...WORKTREE_ENV_FILE_PATHSPECS,
+      ],
+      {
+        maxOutputBytes: WORKSPACE_FILES_MAX_OUTPUT_BYTES,
+        fallbackErrorDetail: "git ls-files for worktree env files failed",
+      },
+    );
+    // `--directory` reports fully-ignored directories with a trailing slash;
+    // drop those so we only copy regular files.
+    const relativePaths = splitNullSeparatedGitStdoutPaths(listResult).filter(
+      (relativePath) => relativePath.length > 0 && !relativePath.endsWith("/"),
+    );
+
+    yield* Effect.forEach(
+      relativePaths,
+      (relativePath) =>
+        Effect.gen(function* () {
+          const destination = path.join(worktreePath, relativePath);
+          // Never clobber a file that the checkout already produced.
+          if (yield* fileSystem.exists(destination)) {
+            return;
+          }
+          const contents = yield* fileSystem.readFile(path.join(sourceCwd, relativePath));
+          yield* fileSystem.makeDirectory(path.dirname(destination), { recursive: true });
+          yield* fileSystem.writeFile(destination, contents);
+        }).pipe(
+          // Copy each file independently so one failure never skips the rest.
+          Effect.catchCause((cause) =>
+            Effect.logWarning(
+              "GitVcsDriver.createWorktree failed to copy an env file into the new worktree.",
+              { relativePath, worktreePath, cause },
+            ),
+          ),
+        ),
+      { concurrency: 4, discard: true },
+    );
+  });
+
   const createWorktree: GitVcsDriver.GitVcsDriver["Service"]["createWorktree"] = Effect.fn(
     "createWorktree",
   )(function* (input) {
@@ -2270,6 +2336,17 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         baseBranch,
       ]);
     }
+
+    // Best-effort: copying env files must never fail worktree creation, or the
+    // whole thread would be lost over a missing `.env`.
+    yield* copyIgnoredEnvFilesToWorktree(input.cwd, worktreePath).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning(
+          "GitVcsDriver.createWorktree failed to copy ignored env files into the new worktree.",
+          { cwd: input.cwd, worktreePath, cause },
+        ),
+      ),
+    );
 
     return {
       worktree: {


### PR DESCRIPTION
## Problem

Git worktrees don't carry over untracked / git-ignored files. Because a project's `.env` / `.env.local` are conventionally git-ignored, they exist only in the **primary checkout** — so when a dev/preview server is started inside a t3code-created worktree, those env vars are missing.

Concretely, a Next.js + WorkOS AuthKit app crashes on first request from a worktree:

```
Runtime Error
You must provide a redirect URI in the AuthKit middleware or in the environment variables.
  src/middleware.ts (283:26) @ middleware
  > const response = await authkit(request);
```

…because `NEXT_PUBLIC_WORKOS_REDIRECT_URI` lives in the git-ignored `.env.local`, which `git worktree add` never copies. The same class of failure hits any project that reads secrets/config from a git-ignored `.env` file (database URLs, API keys, etc.).

## Fix

After `git worktree add` succeeds in `GitVcsDriverCore.createWorktree`, copy git-ignored `.env`-family files from the source working tree into the new worktree, preserving relative paths.

Enumeration uses:

```
git ls-files -z --others --ignored --exclude-standard --directory \
  -- ':(glob).env' ':(glob).env.*' ':(glob)**/.env' ':(glob)**/.env.*'
```

- **`--directory`** collapses a fully-ignored directory (e.g. `node_modules/`) into a single entry, so `.env` files buried inside ignored directories are neither matched nor descended into. Only ignored env files that live in **tracked** directories (root, `apps/*`, `packages/*`, …) are copied — monorepos are handled.
- Existing files in the worktree are **never clobbered** (`fileSystem.exists` guard).
- Copying is **best-effort and per-file resilient**: an individual copy failure is logged and skipped, and the whole step is wrapped so it can never fail worktree creation (losing a `.env` should never lose the thread).

This runs in the single `createWorktree` seam, so every worktree-creating flow (new local thread, PR thread, mobile) benefits.

## Test

Adds a `GitVcsDriverCore.test.ts` case that seeds ignored `.env`, `.env.local`, `apps/web/.env.local`, and `node_modules/pkg/.env`, then asserts the first three are copied into the worktree with their contents and the `node_modules` one is **not**.

## Verification

- `tsgo --noEmit` (apps/server): clean
- `vitest run src/vcs/GitVcsDriverCore.test.ts`: 25/25 passed
- `vp lint` on the changed files: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change reads and duplicates local secret-bearing env files on disk; failures are swallowed so worktrees may still lack env without surfacing an error.
> 
> **Overview**
> **New worktrees** now get git-ignored `.env` / `.env.*` files copied from the primary checkout after `git worktree add`, so dev servers in worktrees see the same local env as the main tree.
> 
> Enumeration uses `git ls-files` with glob pathspecs and `--directory`, so env files under fully ignored dirs (e.g. `node_modules/`) are skipped; nested paths under tracked dirs (e.g. `apps/web/.env.local`) are included. Copies are **best-effort** (per-file and whole-step failures are logged only), **never overwrite** existing worktree files, and **cannot fail** worktree creation.
> 
> An integration test asserts root, nested, and monorepo env files copy correctly while `node_modules/pkg/.env` does not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 287f0c8878ef8f3f0f8abd2d67d81823a2bf3006. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Copy ignored .env files from source worktree into newly created worktrees
> - Adds `copyIgnoredEnvFilesToWorktree` in [`GitVcsDriverCore.ts`](https://github.com/pingdotgg/t3code/pull/3887/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) that uses `git ls-files --others --ignored --exclude-standard --directory` to find ignored `.env` and `.env.*` files in the source working tree, then copies them into the new worktree.
> - Skips entries ending with `/` (fully ignored directories like `node_modules/`) to avoid copying env files nested inside ignored dirs.
> - Copying is best-effort: individual file failures log a warning without aborting worktree creation, and existing destination files are not overwritten.
> - Adds an integration test covering presence of `.env`/`.env.local` in tracked dirs and absence of `.env` files inside ignored dirs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 287f0c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->