### PR TITLE
Archive selected threads from the context menu

### DIFF
--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import {
+  buildMultiSelectThreadContextMenuItems,
   createThreadJumpHintVisibilityController,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
@@ -36,6 +37,20 @@ import {
 } from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
+
+describe("buildMultiSelectThreadContextMenuItems", () => {
+  it("offers bulk archive with the selected count", () => {
+    expect(
+      buildMultiSelectThreadContextMenuItems({ count: 3, hasRunningThread: false }),
+    ).toContainEqual({ id: "archive", label: "Archive (3)", disabled: false });
+  });
+
+  it("disables bulk archive when a selected thread is running", () => {
+    expect(
+      buildMultiSelectThreadContextMenuItems({ count: 2, hasRunningThread: true }),
+    ).toContainEqual({ id: "archive", label: "Archive (2)", disabled: true });
+  });
+});
 
 describe("resolveSidebarStageBadgeLabel", () => {
   it("returns Nightly for nightly primary server versions", () => {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -26,6 +26,21 @@ type SidebarProject = {
 
 export type ThreadTraversalDirection = "previous" | "next";
 
+export function buildMultiSelectThreadContextMenuItems(input: {
+  count: number;
+  hasRunningThread: boolean;
+}) {
+  return [
+    { id: "mark-unread", label: `Mark unread (${input.count})` },
+    {
+      id: "archive",
+      label: `Archive (${input.count})`,
+      disabled: input.hasRunningThread,
+    },
+    { id: "delete", label: `Delete (${input.count})`, destructive: true },
+  ] as const;
+}
+
 export interface ThreadStatusPill {
   label:
     | "Working"

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -184,6 +184,7 @@ import {
 import { useThreadSelectionStore } from "../threadSelectionStore";
 import { useOpenAddProjectCommandPalette } from "../commandPaletteContext";
 import {
+  buildMultiSelectThreadContextMenuItems,
   getSidebarThreadIdsToPrewarm,
   resolveAdjacentThreadId,
   isContextMenuPointerDown,
@@ -1772,12 +1773,13 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       const threadKeys = [...useThreadSelectionStore.getState().selectedThreadKeys];
       if (threadKeys.length === 0) return;
       const count = threadKeys.length;
+      const hasRunningThread = threadKeys.some((threadKey) => {
+        const thread = sidebarThreadByKeyRef.current.get(threadKey);
+        return thread?.session?.status === "running" && thread.session.activeTurnId != null;
+      });
 
       const clicked = await api.contextMenu.show(
-        [
-          { id: "mark-unread", label: `Mark unread (${count})` },
-          { id: "delete", label: `Delete (${count})`, destructive: true },
-        ],
+        buildMultiSelectThreadContextMenuItems({ count, hasRunningThread }),
         position,
       );
 
@@ -1787,6 +1789,36 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
           markThreadUnread(threadKey, thread?.latestTurn?.completedAt);
         }
         clearSelection();
+        return;
+      }
+
+      if (clicked === "archive") {
+        if (appSettingsConfirmThreadArchive) {
+          const confirmed = await api.dialogs.confirm(
+            `Archive ${count} thread${count === 1 ? "" : "s"}?`,
+          );
+          if (!confirmed) return;
+        }
+
+        for (const threadKey of threadKeys) {
+          const thread = sidebarThreadByKeyRef.current.get(threadKey);
+          if (!thread) continue;
+          const result = await archiveThread(scopeThreadRef(thread.environmentId, thread.id));
+          if (result._tag === "Failure") {
+            if (!isAtomCommandInterrupted(result)) {
+              const error = squashAtomCommandFailure(result);
+              toastManager.add(
+                stackedThreadToast({
+                  type: "error",
+                  title: "Failed to archive threads",
+                  description: error instanceof Error ? error.message : "An error occurred.",
+                }),
+              );
+            }
+            return;
+          }
+        }
+        removeFromSelection(threadKeys);
         return;
       }
 
@@ -1826,7 +1858,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
       removeFromSelection(threadKeys);
     },
     [
+      appSettingsConfirmThreadArchive,
       appSettingsConfirmThreadDelete,
+      archiveThread,
       clearSelection,
       deleteThread,
       markThreadUnread,


### PR DESCRIPTION
Cleaning up several finished threads currently requires archiving them one at a time. Add Archive to the multi-select context menu so a group of selected threads can be archived in one action.

The action confirms once when archive confirmation is enabled. It is disabled when any selected thread has an active turn.

Tests cover the bulk Archive menu item, selected-thread count, and running-thread state.

Checks:
- `vp test apps/web/src/components/Sidebar.logic.test.ts`
- `vp check`
- `vp run typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar-only UX that reuses existing per-thread archive; main caveat is partial batch failure stopping mid-loop, same pattern as bulk delete.
> 
> **Overview**
> Adds **Archive** to the sidebar multi-select context menu so several selected threads can be archived in one action instead of one-by-one.
> 
> Menu items are built by a new `buildMultiSelectThreadContextMenuItems` helper (mark unread, archive with count, delete). **Archive** is disabled when any selected thread has an active running turn. On choose, the flow respects **archive confirmation** settings (single confirm for the batch), calls `archiveThread` for each selection, shows a toast on failure, and clears those keys from the selection on success.
> 
> Unit tests cover the archive label/count and the running-thread disabled state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e431b781d1f2e575b86f87f78d233f328b7b6180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add archive action to multi-select thread context menu in sidebar
> - Adds an 'Archive (n)' option to the multi-select thread context menu in [`Sidebar.tsx`](https://github.com/pingdotgg/t3code/pull/3894/files#diff-12c9f3c619e6ab8dda238e965323ac96e62f3084e3adfb0671b1a6459aa61ba1), alongside the existing 'Mark unread' and 'Delete' actions.
> - The archive action is disabled when any selected thread has an active running session.
> - When triggered, optionally prompts for confirmation based on `appSettingsConfirmThreadArchive`, then archives each selected thread and removes it from the selection.
> - Errors during archiving are surfaced via a stacked toast notification.
> - A new `buildMultiSelectThreadContextMenuItems` utility in [`Sidebar.logic.ts`](https://github.com/pingdotgg/t3code/pull/3894/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) centralizes menu item construction.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e431b78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->