### PR TITLE
Group threads by worktree

### DIFF
--- a/apps/desktop/src/settings/DesktopClientSettings.test.ts
+++ b/apps/desktop/src/settings/DesktopClientSettings.test.ts
@@ -26,6 +26,7 @@ const clientSettings: ClientSettings = {
   },
   sidebarProjectSortOrder: "manual",
   sidebarThreadSortOrder: "created_at",
+  sidebarThreadGroupingMode: "separate",
   sidebarThreadPreviewCount: 6,
   timestampFormat: "24-hour",
   wordWrap: true,

--- a/apps/server/src/git/GitWorkflowService.ts
+++ b/apps/server/src/git/GitWorkflowService.ts
@@ -75,7 +75,7 @@ export class GitWorkflowService extends Context.Service<
       readonly fallbackRemoteName: string;
     }) => Effect.Effect<
       { readonly commitSha: string; readonly remoteRefName: string },
-      GitCommandError
+      GitCommandError | GitVcsDriver.RemoteTrackingRefNotFoundError
     >;
     readonly removeWorktree: (
       input: VcsRemoveWorktreeInput,

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6929,9 +6929,10 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       );
       const missingRemoteBranch = new GitCommandError({
         operation: "GitVcsDriver.resolveRemoteTrackingCommit",
-        command: "git rev-parse --verify refs/remotes/origin/t3code/local-only",
+        command: "git show-ref --verify --quiet refs/remotes/origin/t3code/local-only",
         cwd: "/tmp/project",
-        detail: "remote branch does not exist",
+        detail: GitVcsDriver.REMOTE_TRACKING_REF_NOT_FOUND_DETAIL,
+        exitCode: 1,
       });
 
       yield* buildAppUnderTest({
@@ -7018,6 +7019,79 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
         dispatchedCommands.map((command) => command.type),
         ["thread.create", "thread.meta.update", "thread.turn.start"],
       );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
+  it.effect("propagates unexpected remote base resolution failures", () =>
+    Effect.gen(function* () {
+      const createWorktree = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
+          Effect.succeed({
+            worktree: {
+              refName: "t3code/bootstrap-unexpected-failure",
+              path: "/tmp/bootstrap-unexpected-failure",
+            },
+          }),
+      );
+      const unexpectedFailure = new GitCommandError({
+        operation: "GitVcsDriver.resolveRemoteTrackingCommit",
+        command: "git show-ref --verify --quiet refs/remotes/origin/main",
+        cwd: "/tmp/project",
+        detail: "Git remote tracking ref lookup failed.",
+        exitCode: 128,
+      });
+
+      yield* buildAppUnderTest({
+        layers: {
+          gitVcsDriver: {
+            fetchRemote: () => Effect.void,
+            resolveRemoteTrackingCommit: () => Effect.fail(unexpectedFailure),
+            createWorktree,
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const failed = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.turn.start",
+            commandId: CommandId.make("cmd-bootstrap-unexpected-failure"),
+            threadId: ThreadId.make("thread-bootstrap-unexpected-failure"),
+            message: {
+              messageId: MessageId.make("msg-bootstrap-unexpected-failure"),
+              role: "user",
+              text: "hello",
+              attachments: [],
+            },
+            modelSelection: defaultModelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            bootstrap: {
+              createThread: {
+                projectId: defaultProjectId,
+                title: "Bootstrap Unexpected Failure",
+                modelSelection: defaultModelSelection,
+                runtimeMode: "full-access",
+                interactionMode: "default",
+                branch: "main",
+                worktreePath: null,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+              prepareWorktree: {
+                projectCwd: "/tmp/project",
+                baseBranch: "main",
+                branch: "t3code/bootstrap-unexpected-failure",
+                startFromOrigin: true,
+              },
+            },
+            createdAt: "2026-01-01T00:00:00.000Z",
+          }),
+        ),
+      ).pipe(Effect.match({ onFailure: () => true, onSuccess: () => false }));
+
+      assertTrue(failed);
+      assert.equal(createWorktree.mock.calls.length, 0);
     }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6927,12 +6927,9 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
             },
           }),
       );
-      const missingRemoteBranch = new GitCommandError({
-        operation: "GitVcsDriver.resolveRemoteTrackingCommit",
-        command: "git show-ref --verify --quiet refs/remotes/origin/t3code/local-only",
+      const missingRemoteBranch = new GitVcsDriver.RemoteTrackingRefNotFoundError({
         cwd: "/tmp/project",
-        detail: GitVcsDriver.REMOTE_TRACKING_REF_NOT_FOUND_DETAIL,
-        exitCode: 1,
+        remoteRefName: "origin/t3code/local-only",
       });
 
       yield* buildAppUnderTest({

--- a/apps/server/src/server.test.ts
+++ b/apps/server/src/server.test.ts
@@ -6915,6 +6915,112 @@ it.layer(NodeServices.layer)("server router seam", (it) => {
       }).pipe(Effect.provide(NodeHttpServer.layerTest)),
   );
 
+  it.effect("falls back to a local base when the branch is not available on origin", () =>
+    Effect.gen(function* () {
+      const dispatchedCommands: Array<OrchestrationCommand> = [];
+      const createWorktree = vi.fn(
+        (_: Parameters<GitVcsDriver.GitVcsDriver["Service"]["createWorktree"]>[0]) =>
+          Effect.succeed({
+            worktree: {
+              refName: "t3code/bootstrap-local-base",
+              path: "/tmp/bootstrap-local-base",
+            },
+          }),
+      );
+      const missingRemoteBranch = new GitCommandError({
+        operation: "GitVcsDriver.resolveRemoteTrackingCommit",
+        command: "git rev-parse --verify refs/remotes/origin/t3code/local-only",
+        cwd: "/tmp/project",
+        detail: "remote branch does not exist",
+      });
+
+      yield* buildAppUnderTest({
+        layers: {
+          gitVcsDriver: {
+            fetchRemote: () => Effect.void,
+            resolveRemoteTrackingCommit: () => Effect.fail(missingRemoteBranch),
+            createWorktree,
+          },
+          vcsStatusBroadcaster: {
+            refreshStatus: () =>
+              Effect.succeed({
+                isRepo: true,
+                hasPrimaryRemote: true,
+                isDefaultRef: false,
+                refName: "t3code/bootstrap-local-base",
+                hasWorkingTreeChanges: false,
+                workingTree: { files: [], insertions: 0, deletions: 0 },
+                hasUpstream: false,
+                aheadCount: 0,
+                behindCount: 0,
+                pr: null,
+              }),
+          },
+          orchestrationEngine: {
+            dispatch: (command) =>
+              Effect.sync(() => {
+                dispatchedCommands.push(command);
+                return { sequence: dispatchedCommands.length };
+              }),
+            readEvents: () => Stream.empty,
+          },
+        },
+      });
+
+      const wsUrl = yield* getWsServerUrl("/ws");
+      const response = yield* Effect.scoped(
+        withWsRpcClient(wsUrl, (client) =>
+          client[ORCHESTRATION_WS_METHODS.dispatchCommand]({
+            type: "thread.turn.start",
+            commandId: CommandId.make("cmd-bootstrap-local-base"),
+            threadId: ThreadId.make("thread-bootstrap-local-base"),
+            message: {
+              messageId: MessageId.make("msg-bootstrap-local-base"),
+              role: "user",
+              text: "hello",
+              attachments: [],
+            },
+            modelSelection: defaultModelSelection,
+            runtimeMode: "full-access",
+            interactionMode: "default",
+            bootstrap: {
+              createThread: {
+                projectId: defaultProjectId,
+                title: "Bootstrap Local Base",
+                modelSelection: defaultModelSelection,
+                runtimeMode: "full-access",
+                interactionMode: "default",
+                branch: "t3code/local-only",
+                worktreePath: null,
+                createdAt: "2026-01-01T00:00:00.000Z",
+              },
+              prepareWorktree: {
+                projectCwd: "/tmp/project",
+                baseBranch: "t3code/local-only",
+                branch: "t3code/bootstrap-local-base",
+                startFromOrigin: true,
+              },
+            },
+            createdAt: "2026-01-01T00:00:00.000Z",
+          }),
+        ),
+      );
+
+      assert.equal(response.sequence, 3);
+      assert.deepEqual(createWorktree.mock.calls[0]?.[0], {
+        cwd: "/tmp/project",
+        refName: "t3code/local-only",
+        newRefName: "t3code/bootstrap-local-base",
+        baseRefName: "t3code/local-only",
+        path: null,
+      });
+      assert.deepEqual(
+        dispatchedCommands.map((command) => command.type),
+        ["thread.create", "thread.meta.update", "thread.turn.start"],
+      );
+    }).pipe(Effect.provide(NodeHttpServer.layerTest)),
+  );
+
   it.effect("records setup-script failures without aborting bootstrap turn start", () =>
     Effect.gen(function* () {
       const dispatchedCommands: Array<OrchestrationCommand> = [];

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -177,6 +177,12 @@ export interface GitResolveRemoteTrackingCommitResult {
   remoteRefName: string;
 }
 
+export const REMOTE_TRACKING_REF_NOT_FOUND_DETAIL = "Remote tracking ref does not exist.";
+
+export function isRemoteTrackingRefNotFound(error: GitCommandError): boolean {
+  return error.detail === REMOTE_TRACKING_REF_NOT_FOUND_DETAIL;
+}
+
 export interface GitSetBranchUpstreamInput {
   cwd: string;
   branch: string;

--- a/apps/server/src/vcs/GitVcsDriver.ts
+++ b/apps/server/src/vcs/GitVcsDriver.ts
@@ -7,6 +7,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import * as Path from "effect/Path";
+import * as Schema from "effect/Schema";
 import { ChildProcessSpawner } from "effect/unstable/process";
 
 import {
@@ -177,11 +178,19 @@ export interface GitResolveRemoteTrackingCommitResult {
   remoteRefName: string;
 }
 
-export const REMOTE_TRACKING_REF_NOT_FOUND_DETAIL = "Remote tracking ref does not exist.";
-
-export function isRemoteTrackingRefNotFound(error: GitCommandError): boolean {
-  return error.detail === REMOTE_TRACKING_REF_NOT_FOUND_DETAIL;
+export class RemoteTrackingRefNotFoundError extends Schema.TaggedErrorClass<RemoteTrackingRefNotFoundError>()(
+  "RemoteTrackingRefNotFoundError",
+  {
+    cwd: Schema.String,
+    remoteRefName: Schema.String,
+  },
+) {
+  override get message(): string {
+    return `Remote tracking ref '${this.remoteRefName}' does not exist (${this.cwd}).`;
+  }
 }
+
+export const isRemoteTrackingRefNotFound = Schema.is(RemoteTrackingRefNotFoundError);
 
 export interface GitSetBranchUpstreamInput {
   cwd: string;
@@ -246,7 +255,10 @@ export class GitVcsDriver extends Context.Service<
     readonly fetchRemote: (input: GitFetchRemoteInput) => Effect.Effect<void, GitCommandError>;
     readonly resolveRemoteTrackingCommit: (
       input: GitResolveRemoteTrackingCommitInput,
-    ) => Effect.Effect<GitResolveRemoteTrackingCommitResult, GitCommandError>;
+    ) => Effect.Effect<
+      GitResolveRemoteTrackingCommitResult,
+      GitCommandError | RemoteTrackingRefNotFoundError
+    >;
     readonly fetchRemoteBranch: (
       input: GitFetchRemoteBranchInput,
     ) => Effect.Effect<void, GitCommandError>;

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -769,8 +769,10 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
             fallbackRemoteName: "origin",
           })
           .pipe(Effect.flip);
-        assert.equal(missingRemoteRef.detail, GitVcsDriver.REMOTE_TRACKING_REF_NOT_FOUND_DETAIL);
-        assert.equal(missingRemoteRef.exitCode, 1);
+        assert.equal(GitVcsDriver.isRemoteTrackingRefNotFound(missingRemoteRef), true);
+        if (GitVcsDriver.isRemoteTrackingRefNotFound(missingRemoteRef)) {
+          assert.equal(missingRemoteRef.remoteRefName, "origin/missing-remote-ref");
+        }
 
         const pathService = yield* Path.Path;
         const worktreePath = pathService.join(

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -601,6 +601,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         const cwd = yield* makeTmpDir();
         yield* initRepoWithCommit(cwd);
         const driver = yield* GitVcsDriver.GitVcsDriver;
+        const fileSystem = yield* FileSystem.FileSystem;
 
         yield* driver.createRef({ cwd, refName: "feature/original" });
         const switchRef = yield* driver.switchRef({ cwd, refName: "feature/original" });
@@ -615,6 +616,10 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.equal(yield* git(cwd, ["branch", "--show-current"]), "feature/renamed");
 
         const refs = yield* driver.listRefs({ cwd });
+        assert.equal(
+          refs.mainCheckoutPath ? yield* fileSystem.realPath(refs.mainCheckoutPath) : null,
+          yield* fileSystem.realPath(cwd),
+        );
         assert.equal(
           refs.refs.find((refName) => refName.name === "feature/renamed")?.current,
           true,

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -762,6 +762,16 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.deepEqual(explicitlyResolvedBase, resolvedBase);
         assert.equal(yield* git(cwd, ["rev-parse", initialBranch]), beforeFetch);
 
+        const missingRemoteRef = yield* driver
+          .resolveRemoteTrackingCommit({
+            cwd,
+            refName: "missing-remote-ref",
+            fallbackRemoteName: "origin",
+          })
+          .pipe(Effect.flip);
+        assert.equal(missingRemoteRef.detail, GitVcsDriver.REMOTE_TRACKING_REF_NOT_FOUND_DETAIL);
+        assert.equal(missingRemoteRef.exitCode, 1);
+
         const pathService = yield* Path.Path;
         const worktreePath = pathService.join(
           yield* makeTmpDir("git-fetched-worktrees-"),

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2353,16 +2353,19 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         { allowNonZeroExit: true },
       );
       if (result.exitCode !== 0) {
+        if (result.exitCode === 1) {
+          return yield* new GitVcsDriver.RemoteTrackingRefNotFoundError({
+            cwd: input.cwd,
+            remoteRefName,
+          });
+        }
         return yield* new GitCommandError({
           ...gitCommandContext({
             operation: "GitVcsDriver.resolveRemoteTrackingCommit",
             cwd: input.cwd,
             args,
           }),
-          detail:
-            result.exitCode === 1
-              ? GitVcsDriver.REMOTE_TRACKING_REF_NOT_FOUND_DETAIL
-              : "Git remote tracking ref lookup failed.",
+          detail: "Git remote tracking ref lookup failed.",
           ...(result.exitCode === null ? {} : { exitCode: result.exitCode }),
           stdoutLength: result.stdout.length,
           stderrLength: result.stderr.length,

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2158,8 +2158,10 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           : null;
 
       const worktreeMap = new Map<string, string>();
+      let mainCheckoutPath: string | null = null;
       if (worktreeList.exitCode === 0) {
         let currentPath: string | null = null;
+        let sawMainCheckout = false;
         for (const line of worktreeList.stdout.split("\n")) {
           if (line.startsWith("worktree ")) {
             const candidatePath = line.slice("worktree ".length);
@@ -2168,6 +2170,10 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
               Effect.orElseSucceed(() => false),
             );
             currentPath = exists ? candidatePath : null;
+            if (!sawMainCheckout) {
+              mainCheckoutPath = currentPath;
+              sawMainCheckout = true;
+            }
           } else if (line.startsWith("branch refs/heads/") && currentPath) {
             worktreeMap.set(line.slice("branch refs/heads/".length), currentPath);
           } else if (line === "") {
@@ -2178,6 +2184,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
 
       const localBranches = Arr.filterMap(localBranchResult.stdout.split("\n"), (line) => {
         const refName = parseBranchLine(line);
+        const worktreePath = refName === null ? null : (worktreeMap.get(refName.name) ?? null);
         return refName === null
           ? Result.failVoid
           : Result.succeed({
@@ -2185,7 +2192,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
               current: refName.current,
               isRemote: false,
               isDefault: refName.name === defaultBranch,
-              worktreePath: worktreeMap.get(refName.name) ?? null,
+              worktreePath,
             });
       }).toSorted((a, b) => {
         const aPriority = a.current ? 0 : a.isDefault ? 1 : 2;
@@ -2251,6 +2258,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
         refs: [...refs.refs],
         isRepo: true,
         hasPrimaryRemote: remoteNames.includes("origin"),
+        mainCheckoutPath,
         nextCursor: refs.nextCursor,
         totalCount: refs.totalCount,
       };

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2344,10 +2344,35 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       );
       const remoteRefName =
         parsedRemoteRef?.remoteRef ?? `${input.fallbackRemoteName}/${input.refName}`;
+      const remoteRef = `refs/remotes/${remoteRefName}`;
+      const args = ["show-ref", "--verify", "--quiet", remoteRef];
+      const result = yield* executeGit(
+        "GitVcsDriver.resolveRemoteTrackingCommit",
+        input.cwd,
+        args,
+        { allowNonZeroExit: true },
+      );
+      if (result.exitCode !== 0) {
+        return yield* new GitCommandError({
+          ...gitCommandContext({
+            operation: "GitVcsDriver.resolveRemoteTrackingCommit",
+            cwd: input.cwd,
+            args,
+          }),
+          detail:
+            result.exitCode === 1
+              ? GitVcsDriver.REMOTE_TRACKING_REF_NOT_FOUND_DETAIL
+              : "Git remote tracking ref lookup failed.",
+          ...(result.exitCode === null ? {} : { exitCode: result.exitCode }),
+          stdoutLength: result.stdout.length,
+          stderrLength: result.stderr.length,
+        });
+      }
       const commitSha = yield* runGitStdout("GitVcsDriver.resolveRemoteTrackingCommit", input.cwd, [
-        "rev-parse",
+        "show-ref",
         "--verify",
-        `refs/remotes/${remoteRefName}^{commit}`,
+        "--hash=40",
+        remoteRef,
       ]).pipe(Effect.map((stdout) => stdout.trim()));
 
       return { commitSha, remoteRefName };

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1007,19 +1007,16 @@ const makeWsRpcLayer = (
                     fallbackRemoteName: "origin",
                   })
                   .pipe(
-                    Effect.matchEffect({
-                      onFailure: (error) =>
-                        GitVcsDriver.isRemoteTrackingRefNotFound(error)
-                          ? Effect.logWarning(
-                              "Remote tracking branch was unavailable; using the local worktree base",
-                              {
-                                cwd: prepareWorktree.projectCwd,
-                                baseBranch: prepareWorktree.baseBranch,
-                                detail: error.message,
-                              },
-                            ).pipe(Effect.as(null))
-                          : Effect.fail(error),
-                      onSuccess: (resolved) => Effect.succeed(resolved),
+                    Effect.catchTags({
+                      RemoteTrackingRefNotFoundError: (error) =>
+                        Effect.logWarning(
+                          "Remote tracking branch was unavailable; using the local worktree base",
+                          {
+                            cwd: prepareWorktree.projectCwd,
+                            baseBranch: prepareWorktree.baseBranch,
+                            detail: error.message,
+                          },
+                        ).pipe(Effect.as(null)),
                     }),
                   );
                 if (resolvedRemoteBase) {

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -1009,14 +1009,16 @@ const makeWsRpcLayer = (
                   .pipe(
                     Effect.matchEffect({
                       onFailure: (error) =>
-                        Effect.logWarning(
-                          "Remote tracking branch was unavailable; using the local worktree base",
-                          {
-                            cwd: prepareWorktree.projectCwd,
-                            baseBranch: prepareWorktree.baseBranch,
-                            detail: error.message,
-                          },
-                        ).pipe(Effect.as(null)),
+                        GitVcsDriver.isRemoteTrackingRefNotFound(error)
+                          ? Effect.logWarning(
+                              "Remote tracking branch was unavailable; using the local worktree base",
+                              {
+                                cwd: prepareWorktree.projectCwd,
+                                baseBranch: prepareWorktree.baseBranch,
+                                detail: error.message,
+                              },
+                            ).pipe(Effect.as(null))
+                          : Effect.fail(error),
                       onSuccess: (resolved) => Effect.succeed(resolved),
                     }),
                   );

--- a/apps/server/src/ws.ts
+++ b/apps/server/src/ws.ts
@@ -993,24 +993,42 @@ const makeWsRpcLayer = (
             }
 
             if (bootstrap?.prepareWorktree) {
-              let worktreeBaseRef = bootstrap.prepareWorktree.baseBranch;
-              if (bootstrap.prepareWorktree.startFromOrigin) {
+              const prepareWorktree = bootstrap.prepareWorktree;
+              let worktreeBaseRef = prepareWorktree.baseBranch;
+              if (prepareWorktree.startFromOrigin) {
                 yield* gitWorkflow.fetchRemote({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
+                  cwd: prepareWorktree.projectCwd,
                   remoteName: "origin",
                 });
-                const resolvedRemoteBase = yield* gitWorkflow.resolveRemoteTrackingCommit({
-                  cwd: bootstrap.prepareWorktree.projectCwd,
-                  refName: bootstrap.prepareWorktree.baseBranch,
-                  fallbackRemoteName: "origin",
-                });
-                worktreeBaseRef = resolvedRemoteBase.commitSha;
+                const resolvedRemoteBase = yield* gitWorkflow
+                  .resolveRemoteTrackingCommit({
+                    cwd: prepareWorktree.projectCwd,
+                    refName: prepareWorktree.baseBranch,
+                    fallbackRemoteName: "origin",
+                  })
+                  .pipe(
+                    Effect.matchEffect({
+                      onFailure: (error) =>
+                        Effect.logWarning(
+                          "Remote tracking branch was unavailable; using the local worktree base",
+                          {
+                            cwd: prepareWorktree.projectCwd,
+                            baseBranch: prepareWorktree.baseBranch,
+                            detail: error.message,
+                          },
+                        ).pipe(Effect.as(null)),
+                      onSuccess: (resolved) => Effect.succeed(resolved),
+                    }),
+                  );
+                if (resolvedRemoteBase) {
+                  worktreeBaseRef = resolvedRemoteBase.commitSha;
+                }
               }
               const worktree = yield* gitWorkflow.createWorktree({
-                cwd: bootstrap.prepareWorktree.projectCwd,
+                cwd: prepareWorktree.projectCwd,
                 refName: worktreeBaseRef,
-                newRefName: bootstrap.prepareWorktree.branch,
-                baseRefName: bootstrap.prepareWorktree.baseBranch,
+                newRefName: prepareWorktree.branch,
+                baseRefName: prepareWorktree.baseBranch,
                 path: null,
               });
               targetWorktreePath = worktree.worktree.path;

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -12,6 +12,7 @@ import {
   resolveWorkspaceSelection,
   resolveBranchToolbarValue,
   shouldIncludeBranchPickerItem,
+  withActiveWorkspaceFallback,
 } from "./BranchToolbar.logic";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
@@ -202,6 +203,45 @@ describe("resolveWorkspaceSelection", () => {
       selectedExistingWorktree: projectCheckout,
       value: `existing:${projectCheckout.path}`,
       label: "t3code/current",
+    });
+  });
+
+  it("normalizes workspace paths when resolving the active selection", () => {
+    expect(
+      resolveWorkspaceSelection({
+        effectiveEnvMode: "local",
+        activeWorktreePath: "C:\\repo\\worktrees\\current\\",
+        mainCheckout,
+        existingWorktrees: [{ ...projectCheckout, path: "C:/repo/worktrees/current" }],
+      }),
+    ).toMatchObject({
+      label: "t3code/current",
+      value: "existing:C:/repo/worktrees/current",
+    });
+  });
+});
+
+describe("withActiveWorkspaceFallback", () => {
+  it("keeps an active worktree visible while refs are unavailable", () => {
+    expect(
+      withActiveWorkspaceFallback(
+        { mainCheckout: null, existingWorktrees: [] },
+        {
+          activeWorktreePath: "/repo/.t3/worktrees/current",
+          activeBranch: "feature/current",
+          projectWorkspaceRoot: "/repo/.t3/worktrees/current",
+        },
+      ),
+    ).toEqual({
+      mainCheckout: null,
+      existingWorktrees: [
+        {
+          branch: "feature/current",
+          label: "feature/current",
+          path: "/repo/.t3/worktrees/current",
+          isProjectCheckout: true,
+        },
+      ],
     });
   });
 });

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -9,6 +9,7 @@ import {
   resolveDraftEnvModeAfterBranchChange,
   resolveEffectiveEnvMode,
   resolveEnvModeLabel,
+  resolveMainCheckoutTarget,
   resolveWorkspaceSelection,
   resolveBranchToolbarValue,
   shouldIncludeBranchPickerItem,
@@ -242,6 +243,47 @@ describe("withActiveWorkspaceFallback", () => {
           isProjectCheckout: true,
         },
       ],
+    });
+  });
+});
+
+describe("resolveMainCheckoutTarget", () => {
+  it("uses the branch currently checked out in the main project checkout", () => {
+    const refs: VcsRef[] = [
+      {
+        name: "feature/current",
+        current: true,
+        isDefault: false,
+        worktreePath: "/repo",
+      },
+      { name: "main", current: false, isDefault: true, worktreePath: null },
+    ];
+
+    expect(resolveMainCheckoutTarget(refs, "/repo", "/repo")).toEqual({
+      branch: "feature/current",
+      path: null,
+    });
+  });
+
+  it("returns the external main checkout for a registered linked worktree", () => {
+    const refs: VcsRef[] = [
+      {
+        name: "feature/linked",
+        current: true,
+        isDefault: false,
+        worktreePath: "/repo/worktrees/linked",
+      },
+      {
+        name: "feature/main-checkout",
+        current: false,
+        isDefault: false,
+        worktreePath: "/repo",
+      },
+    ];
+
+    expect(resolveMainCheckoutTarget(refs, "/repo/worktrees/linked", "/repo")).toEqual({
+      branch: "feature/main-checkout",
+      path: "/repo",
     });
   });
 });

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -220,6 +220,20 @@ describe("resolveWorkspaceSelection", () => {
       value: "existing:C:/repo/worktrees/current",
     });
   });
+
+  it("treats Windows drive-letter paths as case-insensitive", () => {
+    expect(
+      resolveWorkspaceSelection({
+        effectiveEnvMode: "local",
+        activeWorktreePath: "C:/Repo/worktrees/current",
+        mainCheckout: { ...mainCheckout, path: "c:/repo" },
+        existingWorktrees: [{ ...projectCheckout, path: "c:/repo/worktrees/current" }],
+      }),
+    ).toMatchObject({
+      label: "t3code/current",
+      value: "existing:c:/repo/worktrees/current",
+    });
+  });
 });
 
 describe("withActiveWorkspaceFallback", () => {

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -3,19 +3,183 @@ import { describe, expect, it } from "vite-plus/test";
 import {
   dedupeRemoteBranchesWithLocalMatches,
   deriveLocalBranchNameFromRemoteRef,
+  deriveWorkspaceOptions,
   resolveEnvironmentOptionLabel,
   resolveBranchSelectionTarget,
-  resolveCurrentWorkspaceLabel,
   resolveDraftEnvModeAfterBranchChange,
   resolveEffectiveEnvMode,
   resolveEnvModeLabel,
+  resolveWorkspaceSelection,
   resolveBranchToolbarValue,
-  resolveLockedWorkspaceLabel,
   shouldIncludeBranchPickerItem,
 } from "./BranchToolbar.logic";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
 const remoteEnvironmentId = EnvironmentId.make("environment-remote");
+
+describe("deriveWorkspaceOptions", () => {
+  it("combines the default branch with the local main checkout", () => {
+    const refs: VcsRef[] = [
+      {
+        name: "main",
+        current: true,
+        isDefault: true,
+        worktreePath: "/repo",
+      },
+      {
+        name: "feature/one",
+        current: false,
+        isDefault: false,
+        worktreePath: "/repo/.t3/worktrees/one",
+      },
+      {
+        name: "feature/one-alias",
+        current: false,
+        isDefault: false,
+        worktreePath: "/repo/.t3/worktrees/one",
+      },
+    ];
+
+    expect(deriveWorkspaceOptions(refs, "/repo")).toEqual({
+      mainCheckout: null,
+      existingWorktrees: [
+        {
+          branch: "feature/one",
+          label: "feature/one",
+          path: "/repo/.t3/worktrees/one",
+          isProjectCheckout: false,
+        },
+      ],
+    });
+  });
+
+  it("promotes a separate default-branch worktree to the main checkout option", () => {
+    const refs: VcsRef[] = [
+      {
+        name: "feature/current",
+        current: true,
+        isDefault: false,
+        worktreePath: "/repo/.t3/worktrees/current",
+      },
+      {
+        name: "main",
+        current: false,
+        isDefault: true,
+        worktreePath: "/repo",
+      },
+      {
+        name: "feature/other",
+        current: false,
+        isDefault: false,
+        worktreePath: "/repo/.t3/worktrees/other",
+      },
+    ];
+
+    expect(deriveWorkspaceOptions(refs, "/repo/.t3/worktrees/current")).toEqual({
+      mainCheckout: {
+        branch: "main",
+        label: "main",
+        path: "/repo",
+        isProjectCheckout: false,
+      },
+      existingWorktrees: [
+        {
+          branch: "feature/current",
+          label: "feature/current",
+          path: "/repo/.t3/worktrees/current",
+          isProjectCheckout: true,
+        },
+        {
+          branch: "feature/other",
+          label: "feature/other",
+          path: "/repo/.t3/worktrees/other",
+          isProjectCheckout: false,
+        },
+      ],
+    });
+  });
+
+  it("does not duplicate the project checkout when its current branch is not the default", () => {
+    const refs: VcsRef[] = [
+      {
+        name: "feature/current",
+        current: true,
+        isDefault: false,
+        worktreePath: "/repo",
+      },
+      {
+        name: "main",
+        current: false,
+        isDefault: true,
+        worktreePath: null,
+      },
+      {
+        name: "feature/other",
+        current: false,
+        isDefault: false,
+        worktreePath: "/repo/.t3/worktrees/other",
+      },
+    ];
+
+    expect(deriveWorkspaceOptions(refs, "/repo")).toEqual({
+      mainCheckout: null,
+      existingWorktrees: [
+        {
+          branch: "feature/other",
+          label: "feature/other",
+          path: "/repo/.t3/worktrees/other",
+          isProjectCheckout: false,
+        },
+      ],
+    });
+  });
+});
+
+describe("resolveWorkspaceSelection", () => {
+  const projectCheckout = {
+    branch: "t3code/current",
+    label: "t3code/current",
+    path: "/repo/worktrees/current",
+    isProjectCheckout: true,
+  };
+  const mainCheckout = {
+    branch: "main",
+    label: "main",
+    path: "/repo",
+    isProjectCheckout: false,
+  };
+
+  it("keeps New worktree selected when the registered project is a linked worktree", () => {
+    expect(
+      resolveWorkspaceSelection({
+        effectiveEnvMode: "worktree",
+        activeWorktreePath: null,
+        mainCheckout,
+        existingWorktrees: [projectCheckout],
+      }),
+    ).toMatchObject({
+      isMainCheckout: false,
+      selectedExistingWorktree: undefined,
+      value: "worktree",
+      label: "New worktree",
+    });
+  });
+
+  it("selects the registered project checkout only in local mode", () => {
+    expect(
+      resolveWorkspaceSelection({
+        effectiveEnvMode: "local",
+        activeWorktreePath: null,
+        mainCheckout,
+        existingWorktrees: [projectCheckout],
+      }),
+    ).toMatchObject({
+      selectedExistingWorktree: projectCheckout,
+      value: `existing:${projectCheckout.path}`,
+      label: "t3code/current",
+    });
+  });
+});
 
 describe("resolveDraftEnvModeAfterBranchChange", () => {
   it("switches to local mode when returning from an existing worktree to the main worktree", () => {
@@ -143,28 +307,8 @@ describe("resolveEffectiveEnvMode", () => {
 
 describe("resolveEnvModeLabel", () => {
   it("uses explicit workspace labels", () => {
-    expect(resolveEnvModeLabel("local")).toBe("Current checkout");
+    expect(resolveEnvModeLabel("local")).toBe("Main checkout");
     expect(resolveEnvModeLabel("worktree")).toBe("New worktree");
-  });
-});
-
-describe("resolveCurrentWorkspaceLabel", () => {
-  it("describes the main repo checkout when no worktree path is active", () => {
-    expect(resolveCurrentWorkspaceLabel(null)).toBe("Current checkout");
-  });
-
-  it("describes the active checkout as a worktree when one is attached", () => {
-    expect(resolveCurrentWorkspaceLabel("/repo/.t3/worktrees/feature-a")).toBe("Current worktree");
-  });
-});
-
-describe("resolveLockedWorkspaceLabel", () => {
-  it("uses a shorter label for the main repo checkout", () => {
-    expect(resolveLockedWorkspaceLabel(null)).toBe("Local checkout");
-  });
-
-  it("uses a shorter label for an attached worktree", () => {
-    expect(resolveLockedWorkspaceLabel("/repo/.t3/worktrees/feature-a")).toBe("Worktree");
   });
 });
 

--- a/apps/web/src/components/BranchToolbar.logic.test.ts
+++ b/apps/web/src/components/BranchToolbar.logic.test.ts
@@ -75,7 +75,7 @@ describe("deriveWorkspaceOptions", () => {
       },
     ];
 
-    expect(deriveWorkspaceOptions(refs, "/repo/.t3/worktrees/current")).toEqual({
+    expect(deriveWorkspaceOptions(refs, "/repo/.t3/worktrees/current", "/repo")).toEqual({
       mainCheckout: {
         branch: "main",
         label: "main",
@@ -96,6 +96,31 @@ describe("deriveWorkspaceOptions", () => {
           isProjectCheckout: false,
         },
       ],
+    });
+  });
+
+  it("uses checkout metadata when the default branch is not checked out", () => {
+    const refs: VcsRef[] = [
+      {
+        name: "feature/current",
+        current: true,
+        isDefault: false,
+        worktreePath: "/repo/.t3/worktrees/current",
+      },
+      {
+        name: "feature/main-checkout",
+        current: false,
+        isDefault: false,
+        worktreePath: "/repo",
+      },
+      { name: "main", current: false, isDefault: true, worktreePath: null },
+    ];
+
+    expect(deriveWorkspaceOptions(refs, "/repo/.t3/worktrees/current", "/repo")).toMatchObject({
+      mainCheckout: {
+        branch: "feature/main-checkout",
+        path: "/repo",
+      },
     });
   });
 

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -27,6 +27,14 @@ export interface WorkspaceOptions {
   readonly existingWorktrees: readonly ExistingWorktreeOption[];
 }
 
+export function normalizeWorkspacePath(path: string): string {
+  return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+function workspacePathsEqual(left: string, right: string): boolean {
+  return normalizeWorkspacePath(left) === normalizeWorkspacePath(right);
+}
+
 export function resolveWorkspaceSelection(input: {
   readonly effectiveEnvMode: EnvMode;
   readonly activeWorktreePath: string | null;
@@ -40,10 +48,10 @@ export function resolveWorkspaceSelection(input: {
 } {
   const { effectiveEnvMode, activeWorktreePath, mainCheckout, existingWorktrees } = input;
   const isMainCheckout = activeWorktreePath
-    ? mainCheckout?.path === activeWorktreePath
+    ? mainCheckout !== null && workspacePathsEqual(mainCheckout.path, activeWorktreePath)
     : effectiveEnvMode === "local" && mainCheckout === null;
   const selectedExistingWorktree = activeWorktreePath
-    ? existingWorktrees.find((worktree) => worktree.path === activeWorktreePath)
+    ? existingWorktrees.find((worktree) => workspacePathsEqual(worktree.path, activeWorktreePath))
     : effectiveEnvMode === "local"
       ? existingWorktrees.find((worktree) => worktree.isProjectCheckout)
       : undefined;
@@ -68,12 +76,13 @@ export function resolveWorkspaceSelection(input: {
 export function deriveWorkspaceOptions(
   refs: readonly VcsRef[],
   projectWorkspaceRoot: string,
+  mainCheckoutPath?: string | null,
 ): WorkspaceOptions {
-  const normalizedProjectRoot = projectWorkspaceRoot.replaceAll("\\", "/").replace(/\/+$/, "");
+  const normalizedProjectRoot = normalizeWorkspacePath(projectWorkspaceRoot);
   const worktreeOptions = refs.flatMap((ref): ExistingWorktreeOption[] => {
     const worktreePath = ref.worktreePath?.trim();
     if (!worktreePath) return [];
-    const normalizedPath = worktreePath.replaceAll("\\", "/").replace(/\/+$/, "");
+    const normalizedPath = normalizeWorkspacePath(worktreePath);
     return [
       {
         branch: ref.name,
@@ -83,21 +92,37 @@ export function deriveWorkspaceOptions(
       },
     ];
   });
-  const externalDefaultRef = refs.find(
-    (ref) =>
-      ref.isDefault &&
-      ref.worktreePath !== null &&
-      ref.worktreePath.replaceAll("\\", "/").replace(/\/+$/, "") !== normalizedProjectRoot,
-  );
-  const mainCheckout = externalDefaultRef
-    ? (worktreeOptions.find((option) => option.path === externalDefaultRef.worktreePath) ?? null)
-    : null;
-  const seenPaths = new Set(
-    mainCheckout ? [mainCheckout.path.replaceAll("\\", "/").replace(/\/+$/, "")] : [],
-  );
+  const explicitMainCheckoutPath = mainCheckoutPath?.trim() || null;
+  const mainCheckoutRef = explicitMainCheckoutPath
+    ? refs.find(
+        (ref) =>
+          ref.worktreePath !== null &&
+          workspacePathsEqual(ref.worktreePath, explicitMainCheckoutPath),
+      )
+    : refs.find(
+        (ref) =>
+          ref.isDefault &&
+          ref.worktreePath !== null &&
+          normalizeWorkspacePath(ref.worktreePath) !== normalizedProjectRoot,
+      );
+  const resolvedMainCheckoutPath =
+    explicitMainCheckoutPath ?? mainCheckoutRef?.worktreePath ?? null;
+  const mainCheckout =
+    resolvedMainCheckoutPath !== null &&
+    normalizeWorkspacePath(resolvedMainCheckoutPath) !== normalizedProjectRoot
+      ? (worktreeOptions.find((option) =>
+          workspacePathsEqual(option.path, resolvedMainCheckoutPath),
+        ) ?? {
+          branch: mainCheckoutRef?.name ?? "HEAD",
+          label: mainCheckoutRef?.name ?? "Main checkout",
+          path: resolvedMainCheckoutPath,
+          isProjectCheckout: false,
+        })
+      : null;
+  const seenPaths = new Set(mainCheckout ? [normalizeWorkspacePath(mainCheckout.path)] : []);
   const existingWorktrees = worktreeOptions.filter((option) => {
     if (mainCheckout === null && option.isProjectCheckout) return false;
-    const normalizedPath = option.path.replaceAll("\\", "/").replace(/\/+$/, "");
+    const normalizedPath = normalizeWorkspacePath(option.path);
     if (seenPaths.has(normalizedPath)) return false;
     seenPaths.add(normalizedPath);
     return true;

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -130,6 +130,35 @@ export function deriveWorkspaceOptions(
   return { mainCheckout, existingWorktrees };
 }
 
+export function withActiveWorkspaceFallback(
+  options: WorkspaceOptions,
+  input: {
+    readonly activeWorktreePath: string | null;
+    readonly activeBranch: string | null;
+    readonly projectWorkspaceRoot: string;
+  },
+): WorkspaceOptions {
+  const activePath = input.activeWorktreePath?.trim();
+  if (
+    !activePath ||
+    (options.mainCheckout !== null && workspacePathsEqual(options.mainCheckout.path, activePath)) ||
+    options.existingWorktrees.some((worktree) => workspacePathsEqual(worktree.path, activePath))
+  ) {
+    return options;
+  }
+
+  const fallback: ExistingWorktreeOption = {
+    branch: input.activeBranch?.trim() || "Current worktree",
+    path: activePath,
+    label:
+      input.activeBranch?.trim() ||
+      normalizeWorkspacePath(activePath).split("/").at(-1) ||
+      "Current worktree",
+    isProjectCheckout: workspacePathsEqual(activePath, input.projectWorkspaceRoot),
+  };
+  return { ...options, existingWorktrees: [...options.existingWorktrees, fallback] };
+}
+
 const GENERIC_LOCAL_ENVIRONMENT_LABELS = new Set(["local", "local environment"]);
 
 function normalizeDisplayLabel(value: string | null | undefined): string | null {

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -31,8 +31,19 @@ export function normalizeWorkspacePath(path: string): string {
   return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
 }
 
-function workspacePathsEqual(left: string, right: string): boolean {
-  return normalizeWorkspacePath(left) === normalizeWorkspacePath(right);
+function looksLikeWindowsPath(path: string): boolean {
+  return /^[a-zA-Z]:\//.test(path);
+}
+
+function workspacePathKey(path: string): string {
+  const normalized = normalizeWorkspacePath(path);
+  // Paths may come from a remote Windows environment even when the UI runs on
+  // another OS, so detect Windows paths by shape rather than process.platform.
+  return looksLikeWindowsPath(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+export function workspacePathsEqual(left: string, right: string): boolean {
+  return workspacePathKey(left) === workspacePathKey(right);
 }
 
 export function resolveWorkspaceSelection(input: {
@@ -78,17 +89,15 @@ export function deriveWorkspaceOptions(
   projectWorkspaceRoot: string,
   mainCheckoutPath?: string | null,
 ): WorkspaceOptions {
-  const normalizedProjectRoot = normalizeWorkspacePath(projectWorkspaceRoot);
   const worktreeOptions = refs.flatMap((ref): ExistingWorktreeOption[] => {
     const worktreePath = ref.worktreePath?.trim();
     if (!worktreePath) return [];
-    const normalizedPath = normalizeWorkspacePath(worktreePath);
     return [
       {
         branch: ref.name,
         path: worktreePath,
         label: ref.name,
-        isProjectCheckout: normalizedPath === normalizedProjectRoot,
+        isProjectCheckout: workspacePathsEqual(worktreePath, projectWorkspaceRoot),
       },
     ];
   });
@@ -103,13 +112,13 @@ export function deriveWorkspaceOptions(
         (ref) =>
           ref.isDefault &&
           ref.worktreePath !== null &&
-          normalizeWorkspacePath(ref.worktreePath) !== normalizedProjectRoot,
+          !workspacePathsEqual(ref.worktreePath, projectWorkspaceRoot),
       );
   const resolvedMainCheckoutPath =
     explicitMainCheckoutPath ?? mainCheckoutRef?.worktreePath ?? null;
   const mainCheckout =
     resolvedMainCheckoutPath !== null &&
-    normalizeWorkspacePath(resolvedMainCheckoutPath) !== normalizedProjectRoot
+    !workspacePathsEqual(resolvedMainCheckoutPath, projectWorkspaceRoot)
       ? (worktreeOptions.find((option) =>
           workspacePathsEqual(option.path, resolvedMainCheckoutPath),
         ) ?? {
@@ -119,12 +128,12 @@ export function deriveWorkspaceOptions(
           isProjectCheckout: false,
         })
       : null;
-  const seenPaths = new Set(mainCheckout ? [normalizeWorkspacePath(mainCheckout.path)] : []);
+  const seenPaths = new Set(mainCheckout ? [workspacePathKey(mainCheckout.path)] : []);
   const existingWorktrees = worktreeOptions.filter((option) => {
     if (mainCheckout === null && option.isProjectCheckout) return false;
-    const normalizedPath = normalizeWorkspacePath(option.path);
-    if (seenPaths.has(normalizedPath)) return false;
-    seenPaths.add(normalizedPath);
+    const pathKey = workspacePathKey(option.path);
+    if (seenPaths.has(pathKey)) return false;
+    seenPaths.add(pathKey);
     return true;
   });
   return { mainCheckout, existingWorktrees };

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -130,6 +130,28 @@ export function deriveWorkspaceOptions(
   return { mainCheckout, existingWorktrees };
 }
 
+export function resolveMainCheckoutTarget(
+  refs: readonly VcsRef[],
+  projectWorkspaceRoot: string,
+  mainCheckoutPath?: string | null,
+): { readonly branch: string; readonly path: string | null } | null {
+  const options = deriveWorkspaceOptions(refs, projectWorkspaceRoot, mainCheckoutPath);
+  if (options.mainCheckout) {
+    return { branch: options.mainCheckout.branch, path: options.mainCheckout.path };
+  }
+
+  const projectCheckoutRef = refs.find(
+    (ref) =>
+      !ref.isRemote &&
+      ref.worktreePath !== null &&
+      workspacePathsEqual(ref.worktreePath, projectWorkspaceRoot),
+  );
+  const currentRef = refs.find((ref) => !ref.isRemote && ref.current);
+  const defaultRef = refs.find((ref) => !ref.isRemote && ref.isDefault);
+  const branch = projectCheckoutRef?.name ?? currentRef?.name ?? defaultRef?.name;
+  return branch ? { branch, path: null } : null;
+}
+
 export function withActiveWorkspaceFallback(
   options: WorkspaceOptions,
   input: {

--- a/apps/web/src/components/BranchToolbar.logic.ts
+++ b/apps/web/src/components/BranchToolbar.logic.ts
@@ -15,6 +15,96 @@ export interface EnvironmentOption {
 export const EnvMode = Schema.Literals(["local", "worktree"]);
 export type EnvMode = typeof EnvMode.Type;
 
+export interface ExistingWorktreeOption {
+  readonly branch: string;
+  readonly path: string;
+  readonly label: string;
+  readonly isProjectCheckout: boolean;
+}
+
+export interface WorkspaceOptions {
+  readonly mainCheckout: ExistingWorktreeOption | null;
+  readonly existingWorktrees: readonly ExistingWorktreeOption[];
+}
+
+export function resolveWorkspaceSelection(input: {
+  readonly effectiveEnvMode: EnvMode;
+  readonly activeWorktreePath: string | null;
+  readonly mainCheckout: ExistingWorktreeOption | null;
+  readonly existingWorktrees: readonly ExistingWorktreeOption[];
+}): {
+  readonly isMainCheckout: boolean;
+  readonly selectedExistingWorktree: ExistingWorktreeOption | undefined;
+  readonly value: string;
+  readonly label: string;
+} {
+  const { effectiveEnvMode, activeWorktreePath, mainCheckout, existingWorktrees } = input;
+  const isMainCheckout = activeWorktreePath
+    ? mainCheckout?.path === activeWorktreePath
+    : effectiveEnvMode === "local" && mainCheckout === null;
+  const selectedExistingWorktree = activeWorktreePath
+    ? existingWorktrees.find((worktree) => worktree.path === activeWorktreePath)
+    : effectiveEnvMode === "local"
+      ? existingWorktrees.find((worktree) => worktree.isProjectCheckout)
+      : undefined;
+  const value = isMainCheckout
+    ? mainCheckout
+      ? `main:${mainCheckout.path}`
+      : "local"
+    : selectedExistingWorktree
+      ? `existing:${selectedExistingWorktree.path}`
+      : effectiveEnvMode;
+  const label = isMainCheckout
+    ? "Main checkout"
+    : selectedExistingWorktree
+      ? selectedExistingWorktree.label
+      : effectiveEnvMode === "worktree"
+        ? resolveEnvModeLabel("worktree")
+        : "Main checkout";
+
+  return { isMainCheckout, selectedExistingWorktree, value, label };
+}
+
+export function deriveWorkspaceOptions(
+  refs: readonly VcsRef[],
+  projectWorkspaceRoot: string,
+): WorkspaceOptions {
+  const normalizedProjectRoot = projectWorkspaceRoot.replaceAll("\\", "/").replace(/\/+$/, "");
+  const worktreeOptions = refs.flatMap((ref): ExistingWorktreeOption[] => {
+    const worktreePath = ref.worktreePath?.trim();
+    if (!worktreePath) return [];
+    const normalizedPath = worktreePath.replaceAll("\\", "/").replace(/\/+$/, "");
+    return [
+      {
+        branch: ref.name,
+        path: worktreePath,
+        label: ref.name,
+        isProjectCheckout: normalizedPath === normalizedProjectRoot,
+      },
+    ];
+  });
+  const externalDefaultRef = refs.find(
+    (ref) =>
+      ref.isDefault &&
+      ref.worktreePath !== null &&
+      ref.worktreePath.replaceAll("\\", "/").replace(/\/+$/, "") !== normalizedProjectRoot,
+  );
+  const mainCheckout = externalDefaultRef
+    ? (worktreeOptions.find((option) => option.path === externalDefaultRef.worktreePath) ?? null)
+    : null;
+  const seenPaths = new Set(
+    mainCheckout ? [mainCheckout.path.replaceAll("\\", "/").replace(/\/+$/, "")] : [],
+  );
+  const existingWorktrees = worktreeOptions.filter((option) => {
+    if (mainCheckout === null && option.isProjectCheckout) return false;
+    const normalizedPath = option.path.replaceAll("\\", "/").replace(/\/+$/, "");
+    if (seenPaths.has(normalizedPath)) return false;
+    seenPaths.add(normalizedPath);
+    return true;
+  });
+  return { mainCheckout, existingWorktrees };
+}
+
 const GENERIC_LOCAL_ENVIRONMENT_LABELS = new Set(["local", "local environment"]);
 
 function normalizeDisplayLabel(value: string | null | undefined): string | null {
@@ -43,15 +133,7 @@ export function resolveEnvironmentOptionLabel(input: {
 }
 
 export function resolveEnvModeLabel(mode: EnvMode): string {
-  return mode === "worktree" ? "New worktree" : "Current checkout";
-}
-
-export function resolveCurrentWorkspaceLabel(activeWorktreePath: string | null): string {
-  return activeWorktreePath ? "Current worktree" : resolveEnvModeLabel("local");
-}
-
-export function resolveLockedWorkspaceLabel(activeWorktreePath: string | null): string {
-  return activeWorktreePath ? "Worktree" : "Local checkout";
+  return mode === "worktree" ? "New worktree" : "Main checkout";
 }
 
 export function resolveEffectiveEnvMode(input: {

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -187,11 +187,7 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
                 (item) => `existing:${item.path}` === value,
               );
               if (existingWorktree) {
-                if (existingWorktree.isProjectCheckout) {
-                  onEnvModeChange("local");
-                } else {
-                  onExistingWorktreeChange(existingWorktree);
-                }
+                onExistingWorktreeChange(existingWorktree);
                 return;
               }
               onEnvModeChange(value as EnvMode);

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -21,6 +21,7 @@ import {
   resolveEnvModeLabel,
   resolveEffectiveEnvMode,
   resolveWorkspaceSelection,
+  withActiveWorkspaceFallback,
 } from "./BranchToolbar.logic";
 import { BranchToolbarBranchSelector } from "./BranchToolbarBranchSelector";
 import { BranchToolbarEnvironmentSelector } from "./BranchToolbarEnvironmentSelector";
@@ -279,17 +280,23 @@ export const BranchToolbar = memo(function BranchToolbar({
     environmentId,
     cwd: activeProject?.workspaceRoot ?? null,
   });
-  const workspaceOptions = useMemo(
-    () =>
-      activeProject
-        ? deriveWorkspaceOptions(
-            branchState.data?.refs ?? [],
-            activeProject.workspaceRoot,
-            branchState.data?.mainCheckoutPath,
-          )
-        : { mainCheckout: null, existingWorktrees: [] },
-    [activeProject, branchState.data],
-  );
+  const activeBranch =
+    activeThreadBranchOverride ?? serverThread?.branch ?? draftThread?.branch ?? null;
+  const workspaceOptions = useMemo(() => {
+    if (!activeProject) return { mainCheckout: null, existingWorktrees: [] };
+    const options = deriveWorkspaceOptions(
+      branchState.data?.refs ?? [],
+      activeProject.workspaceRoot,
+      branchState.data?.mainCheckoutPath,
+    );
+    return branchState.data
+      ? options
+      : withActiveWorkspaceFallback(options, {
+          activeWorktreePath,
+          activeBranch,
+          projectWorkspaceRoot: activeProject.workspaceRoot,
+        });
+  }, [activeBranch, activeProject, activeWorktreePath, branchState.data]);
 
   const showEnvironmentPicker = Boolean(
     availableEnvironments && availableEnvironments.length > 1 && onEnvironmentChange,

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -265,10 +265,9 @@ export const BranchToolbar = memo(function BranchToolbar({
       : null;
   const activeProject = useProject(activeProjectRef);
   const hasActiveThread = serverThread !== null || draftThread !== null;
+  const persistedWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
   const activeWorktreePath =
-    activeWorktreePathOverride !== undefined
-      ? activeWorktreePathOverride
-      : (serverThread?.worktreePath ?? draftThread?.worktreePath ?? null);
+    activeWorktreePathOverride !== undefined ? activeWorktreePathOverride : persistedWorktreePath;
   const effectiveEnvMode =
     effectiveEnvModeOverride ??
     resolveEffectiveEnvMode({
@@ -276,7 +275,7 @@ export const BranchToolbar = memo(function BranchToolbar({
       hasServerThread: serverThread !== null,
       draftThreadEnvMode: draftThread?.envMode,
     });
-  const envModeLocked = envLocked || (serverThread !== null && activeWorktreePath !== null);
+  const envModeLocked = envLocked || (serverThread !== null && persistedWorktreePath !== null);
   const branchState = useBranches({
     environmentId,
     cwd: activeProject?.workspaceRoot ?? null,

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -285,13 +285,13 @@ export const BranchToolbar = memo(function BranchToolbar({
       activeProject.workspaceRoot,
       branchState.data?.mainCheckoutPath,
     );
-    return branchState.data
-      ? options
-      : withActiveWorkspaceFallback(options, {
-          activeWorktreePath,
-          activeBranch,
-          projectWorkspaceRoot: activeProject.workspaceRoot,
-        });
+    // Always apply the fallback so a partial first page of refs that omits the
+    // active worktree still keeps that checkout selectable in the picker.
+    return withActiveWorkspaceFallback(options, {
+      activeWorktreePath,
+      activeBranch,
+      projectWorkspaceRoot: activeProject.workspaceRoot,
+    });
   }, [activeBranch, activeProject, activeWorktreePath, branchState.data]);
 
   const showEnvironmentPicker = Boolean(

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -47,6 +47,7 @@ interface BranchToolbarProps {
   onEnvModeChange: (mode: EnvMode) => void;
   onExistingWorktreeChange: (worktree: ExistingWorktreeOption) => void;
   effectiveEnvModeOverride?: EnvMode;
+  activeWorktreePathOverride?: string | null;
   activeThreadBranchOverride?: string | null;
   onActiveThreadBranchOverrideChange?: (branch: string | null) => void;
   startFromOrigin: boolean;
@@ -238,6 +239,7 @@ export const BranchToolbar = memo(function BranchToolbar({
   onEnvModeChange,
   onExistingWorktreeChange,
   effectiveEnvModeOverride,
+  activeWorktreePathOverride,
   activeThreadBranchOverride,
   onActiveThreadBranchOverrideChange,
   startFromOrigin,
@@ -263,7 +265,10 @@ export const BranchToolbar = memo(function BranchToolbar({
       : null;
   const activeProject = useProject(activeProjectRef);
   const hasActiveThread = serverThread !== null || draftThread !== null;
-  const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
+  const activeWorktreePath =
+    activeWorktreePathOverride !== undefined
+      ? activeWorktreePathOverride
+      : (serverThread?.worktreePath ?? draftThread?.worktreePath ?? null);
   const effectiveEnvMode =
     effectiveEnvModeOverride ??
     resolveEffectiveEnvMode({

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -354,6 +354,7 @@ export const BranchToolbar = memo(function BranchToolbar({
         {...(draftId ? { draftId } : {})}
         envLocked={envLocked}
         {...(effectiveEnvModeOverride ? { effectiveEnvModeOverride } : {})}
+        {...(activeWorktreePathOverride !== undefined ? { activeWorktreePathOverride } : {})}
         {...(activeThreadBranchOverride !== undefined ? { activeThreadBranchOverride } : {})}
         {...(onActiveThreadBranchOverrideChange ? { onActiveThreadBranchOverrideChange } : {})}
         startFromOrigin={startFromOrigin}

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -38,7 +38,7 @@ import {
   MenuTrigger,
 } from "./ui/menu";
 import { Separator } from "./ui/separator";
-import { useBranches } from "../state/queries";
+import { useAllBranches } from "../state/queries";
 
 interface BranchToolbarProps {
   environmentId: EnvironmentId;
@@ -276,7 +276,7 @@ export const BranchToolbar = memo(function BranchToolbar({
       draftThreadEnvMode: draftThread?.envMode,
     });
   const envModeLocked = envLocked || (serverThread !== null && persistedWorktreePath !== null);
-  const branchState = useBranches({
+  const branchState = useAllBranches({
     environmentId,
     cwd: activeProject?.workspaceRoot ?? null,
   });

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -282,9 +282,13 @@ export const BranchToolbar = memo(function BranchToolbar({
   const workspaceOptions = useMemo(
     () =>
       activeProject
-        ? deriveWorkspaceOptions(branchState.data?.refs ?? [], activeProject.workspaceRoot)
+        ? deriveWorkspaceOptions(
+            branchState.data?.refs ?? [],
+            activeProject.workspaceRoot,
+            branchState.data?.mainCheckoutPath,
+          )
         : { mainCheckout: null, existingWorktrees: [] },
-    [activeProject, branchState.data?.refs],
+    [activeProject, branchState.data],
   );
 
   const showEnvironmentPicker = Boolean(

--- a/apps/web/src/components/BranchToolbar.tsx
+++ b/apps/web/src/components/BranchToolbar.tsx
@@ -16,10 +16,11 @@ import { useIsMobile } from "../hooks/useMediaQuery";
 import {
   type EnvMode,
   type EnvironmentOption,
-  resolveCurrentWorkspaceLabel,
+  type ExistingWorktreeOption,
+  deriveWorkspaceOptions,
   resolveEnvModeLabel,
   resolveEffectiveEnvMode,
-  resolveLockedWorkspaceLabel,
+  resolveWorkspaceSelection,
 } from "./BranchToolbar.logic";
 import { BranchToolbarBranchSelector } from "./BranchToolbarBranchSelector";
 import { BranchToolbarEnvironmentSelector } from "./BranchToolbarEnvironmentSelector";
@@ -36,12 +37,14 @@ import {
   MenuTrigger,
 } from "./ui/menu";
 import { Separator } from "./ui/separator";
+import { useBranches } from "../state/queries";
 
 interface BranchToolbarProps {
   environmentId: EnvironmentId;
   threadId: ThreadId;
   draftId?: DraftId;
   onEnvModeChange: (mode: EnvMode) => void;
+  onExistingWorktreeChange: (worktree: ExistingWorktreeOption) => void;
   effectiveEnvModeOverride?: EnvMode;
   activeThreadBranchOverride?: string | null;
   onActiveThreadBranchOverrideChange?: (branch: string | null) => void;
@@ -64,6 +67,9 @@ interface MobileRunContextSelectorProps {
   effectiveEnvMode: EnvMode;
   activeWorktreePath: string | null;
   onEnvModeChange: (mode: EnvMode) => void;
+  existingWorktrees: readonly ExistingWorktreeOption[];
+  mainCheckout: ExistingWorktreeOption | null;
+  onExistingWorktreeChange: (worktree: ExistingWorktreeOption) => void;
 }
 
 const MobileRunContextSelector = memo(function MobileRunContextSelector({
@@ -76,22 +82,30 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
   effectiveEnvMode,
   activeWorktreePath,
   onEnvModeChange,
+  existingWorktrees,
+  mainCheckout,
+  onExistingWorktreeChange,
 }: MobileRunContextSelectorProps) {
   const activeEnvironment = useMemo(
     () => availableEnvironments?.find((env) => env.environmentId === environmentId) ?? null,
     [availableEnvironments, environmentId],
   );
-  const WorkspaceIcon =
-    effectiveEnvMode === "worktree"
-      ? FolderGit2Icon
-      : activeWorktreePath
-        ? FolderGitIcon
-        : FolderIcon;
-  const workspaceLabel = envModeLocked
-    ? resolveLockedWorkspaceLabel(activeWorktreePath)
-    : effectiveEnvMode === "worktree"
-      ? resolveEnvModeLabel("worktree")
-      : resolveCurrentWorkspaceLabel(activeWorktreePath);
+  const {
+    isMainCheckout,
+    selectedExistingWorktree,
+    value: workspaceValue,
+    label: workspaceLabel,
+  } = resolveWorkspaceSelection({
+    effectiveEnvMode,
+    activeWorktreePath,
+    mainCheckout,
+    existingWorktrees,
+  });
+  const WorkspaceIcon = isMainCheckout
+    ? FolderIcon
+    : selectedExistingWorktree
+      ? FolderGitIcon
+      : FolderGit2Icon;
   const isLocked = envLocked || envModeLocked;
   const EnvironmentIcon = activeEnvironment?.isPrimary ? MonitorIcon : CloudIcon;
   const icon = showEnvironmentPicker ? (
@@ -162,19 +176,37 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
         <MenuGroup>
           <MenuGroupLabel>Workspace</MenuGroupLabel>
           <MenuRadioGroup
-            value={effectiveEnvMode}
-            onValueChange={(value) => onEnvModeChange(value as EnvMode)}
+            value={workspaceValue}
+            onValueChange={(value) => {
+              if (mainCheckout && value === `main:${mainCheckout.path}`) {
+                onExistingWorktreeChange(mainCheckout);
+                return;
+              }
+              const existingWorktree = existingWorktrees.find(
+                (item) => `existing:${item.path}` === value,
+              );
+              if (existingWorktree) {
+                if (existingWorktree.isProjectCheckout) {
+                  onEnvModeChange("local");
+                } else {
+                  onExistingWorktreeChange(existingWorktree);
+                }
+                return;
+              }
+              onEnvModeChange(value as EnvMode);
+            }}
           >
-            <MenuRadioItem disabled={envModeLocked} value="local">
+            <MenuRadioItem
+              disabled={envModeLocked}
+              value={mainCheckout ? `main:${mainCheckout.path}` : "local"}
+            >
               <span className="flex min-w-0 items-center gap-1.5">
                 {activeWorktreePath ? (
                   <FolderGitIcon className="size-3" />
                 ) : (
                   <FolderIcon className="size-3" />
                 )}
-                <span className="min-w-0 truncate">
-                  {resolveCurrentWorkspaceLabel(activeWorktreePath)}
-                </span>
+                <span className="min-w-0 truncate">Main checkout</span>
               </span>
             </MenuRadioItem>
             <MenuRadioItem disabled={envModeLocked} value="worktree">
@@ -183,6 +215,18 @@ const MobileRunContextSelector = memo(function MobileRunContextSelector({
                 <span className="min-w-0 truncate">{resolveEnvModeLabel("worktree")}</span>
               </span>
             </MenuRadioItem>
+            {existingWorktrees.map((worktree) => (
+              <MenuRadioItem
+                key={worktree.path}
+                disabled={envModeLocked}
+                value={`existing:${worktree.path}`}
+              >
+                <span className="flex min-w-0 items-center gap-1.5">
+                  <FolderGitIcon className="size-3" />
+                  <span className="min-w-0 truncate">{worktree.label}</span>
+                </span>
+              </MenuRadioItem>
+            ))}
           </MenuRadioGroup>
         </MenuGroup>
       </MenuPopup>
@@ -195,6 +239,7 @@ export const BranchToolbar = memo(function BranchToolbar({
   threadId,
   draftId,
   onEnvModeChange,
+  onExistingWorktreeChange,
   effectiveEnvModeOverride,
   activeThreadBranchOverride,
   onActiveThreadBranchOverrideChange,
@@ -230,6 +275,17 @@ export const BranchToolbar = memo(function BranchToolbar({
       draftThreadEnvMode: draftThread?.envMode,
     });
   const envModeLocked = envLocked || (serverThread !== null && activeWorktreePath !== null);
+  const branchState = useBranches({
+    environmentId,
+    cwd: activeProject?.workspaceRoot ?? null,
+  });
+  const workspaceOptions = useMemo(
+    () =>
+      activeProject
+        ? deriveWorkspaceOptions(branchState.data?.refs ?? [], activeProject.workspaceRoot)
+        : { mainCheckout: null, existingWorktrees: [] },
+    [activeProject, branchState.data?.refs],
+  );
 
   const showEnvironmentPicker = Boolean(
     availableEnvironments && availableEnvironments.length > 1 && onEnvironmentChange,
@@ -251,6 +307,9 @@ export const BranchToolbar = memo(function BranchToolbar({
           effectiveEnvMode={effectiveEnvMode}
           activeWorktreePath={activeWorktreePath}
           onEnvModeChange={onEnvModeChange}
+          existingWorktrees={workspaceOptions.existingWorktrees}
+          mainCheckout={workspaceOptions.mainCheckout}
+          onExistingWorktreeChange={onExistingWorktreeChange}
         />
       ) : (
         <div className="flex min-w-0 shrink-0 items-center gap-1">
@@ -270,6 +329,9 @@ export const BranchToolbar = memo(function BranchToolbar({
             effectiveEnvMode={effectiveEnvMode}
             activeWorktreePath={activeWorktreePath}
             onEnvModeChange={onEnvModeChange}
+            existingWorktrees={workspaceOptions.existingWorktrees}
+            mainCheckout={workspaceOptions.mainCheckout}
+            onExistingWorktreeChange={onExistingWorktreeChange}
           />
         </div>
       )}

--- a/apps/web/src/components/BranchToolbarBranchSelector.tsx
+++ b/apps/web/src/components/BranchToolbarBranchSelector.tsx
@@ -65,6 +65,7 @@ interface BranchToolbarBranchSelectorProps {
   draftId?: DraftId;
   envLocked: boolean;
   effectiveEnvModeOverride?: "local" | "worktree";
+  activeWorktreePathOverride?: string | null;
   activeThreadBranchOverride?: string | null;
   onActiveThreadBranchOverrideChange?: (refName: string | null) => void;
   startFromOrigin: boolean;
@@ -99,6 +100,7 @@ export function BranchToolbarBranchSelector({
   draftId,
   envLocked,
   effectiveEnvModeOverride,
+  activeWorktreePathOverride,
   activeThreadBranchOverride,
   onActiveThreadBranchOverrideChange,
   startFromOrigin,
@@ -144,7 +146,10 @@ export function BranchToolbarBranchSelector({
     activeThreadBranchOverride !== undefined
       ? activeThreadBranchOverride
       : (serverThread?.branch ?? draftThread?.branch ?? null);
-  const activeWorktreePath = serverThread?.worktreePath ?? draftThread?.worktreePath ?? null;
+  const activeWorktreePath =
+    activeWorktreePathOverride !== undefined
+      ? activeWorktreePathOverride
+      : (serverThread?.worktreePath ?? draftThread?.worktreePath ?? null);
   const activeProjectCwd = activeProject?.workspaceRoot ?? null;
   const branchCwd = activeWorktreePath ?? activeProjectCwd;
   const hasServerThread = serverThread !== null;

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -92,11 +92,7 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
           (worktree) => `existing:${worktree.path}` === value,
         );
         if (existingWorktree) {
-          if (existingWorktree.isProjectCheckout) {
-            onEnvModeChange("local");
-          } else {
-            onExistingWorktreeChange(existingWorktree);
-          }
+          onExistingWorktreeChange(existingWorktree);
           return;
         }
         onEnvModeChange(value as EnvMode);

--- a/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
+++ b/apps/web/src/components/BranchToolbarEnvModeSelector.tsx
@@ -2,9 +2,9 @@ import { FolderGit2Icon, FolderGitIcon, FolderIcon } from "lucide-react";
 import { memo, useMemo } from "react";
 
 import {
-  resolveCurrentWorkspaceLabel,
   resolveEnvModeLabel,
-  resolveLockedWorkspaceLabel,
+  resolveWorkspaceSelection,
+  type ExistingWorktreeOption,
   type EnvMode,
 } from "./BranchToolbar.logic";
 import {
@@ -14,7 +14,6 @@ import {
   SelectItem,
   SelectPopup,
   SelectTrigger,
-  SelectValue,
 } from "./ui/select";
 
 interface BranchToolbarEnvModeSelectorProps {
@@ -22,6 +21,9 @@ interface BranchToolbarEnvModeSelectorProps {
   effectiveEnvMode: EnvMode;
   activeWorktreePath: string | null;
   onEnvModeChange: (mode: EnvMode) => void;
+  existingWorktrees: readonly ExistingWorktreeOption[];
+  mainCheckout: ExistingWorktreeOption | null;
+  onExistingWorktreeChange: (worktree: ExistingWorktreeOption) => void;
 }
 
 export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSelector({
@@ -29,27 +31,48 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
   effectiveEnvMode,
   activeWorktreePath,
   onEnvModeChange,
+  existingWorktrees,
+  mainCheckout,
+  onExistingWorktreeChange,
 }: BranchToolbarEnvModeSelectorProps) {
+  const {
+    isMainCheckout,
+    selectedExistingWorktree,
+    value: selectValue,
+    label: selectedWorkspaceLabel,
+  } = resolveWorkspaceSelection({
+    effectiveEnvMode,
+    activeWorktreePath,
+    mainCheckout,
+    existingWorktrees,
+  });
   const envModeItems = useMemo(
     () => [
-      { value: "local", label: resolveCurrentWorkspaceLabel(activeWorktreePath) },
+      {
+        value: mainCheckout ? `main:${mainCheckout.path}` : "local",
+        label: "Main checkout",
+      },
       { value: "worktree", label: resolveEnvModeLabel("worktree") },
+      ...existingWorktrees.map((worktree) => ({
+        value: `existing:${worktree.path}`,
+        label: worktree.label,
+      })),
     ],
-    [activeWorktreePath],
+    [existingWorktrees, mainCheckout],
   );
 
   if (envLocked) {
     return (
       <span className="inline-flex items-center gap-1 border border-transparent px-[calc(--spacing(3)-1px)] text-sm font-medium text-muted-foreground/70 sm:text-xs">
-        {activeWorktreePath ? (
+        {selectedExistingWorktree ? (
           <>
             <FolderGitIcon className="size-3" />
-            {resolveLockedWorkspaceLabel(activeWorktreePath)}
+            {selectedExistingWorktree.label}
           </>
         ) : (
           <>
             <FolderIcon className="size-3" />
-            {resolveLockedWorkspaceLabel(activeWorktreePath)}
+            Main checkout
           </>
         )}
       </span>
@@ -59,31 +82,50 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
   return (
     <Select
       modal={false}
-      value={effectiveEnvMode}
-      onValueChange={(value) => onEnvModeChange(value as EnvMode)}
+      value={selectValue}
+      onValueChange={(value) => {
+        if (mainCheckout && value === `main:${mainCheckout.path}`) {
+          onExistingWorktreeChange(mainCheckout);
+          return;
+        }
+        const existingWorktree = existingWorktrees.find(
+          (worktree) => `existing:${worktree.path}` === value,
+        );
+        if (existingWorktree) {
+          if (existingWorktree.isProjectCheckout) {
+            onEnvModeChange("local");
+          } else {
+            onExistingWorktreeChange(existingWorktree);
+          }
+          return;
+        }
+        onEnvModeChange(value as EnvMode);
+      }}
       items={envModeItems}
     >
       <SelectTrigger variant="ghost" size="xs" className="font-medium" aria-label="Workspace">
-        {effectiveEnvMode === "worktree" ? (
+        {isMainCheckout ? (
+          <FolderIcon className="size-3" />
+        ) : effectiveEnvMode === "worktree" ? (
           <FolderGit2Icon className="size-3" />
         ) : activeWorktreePath ? (
           <FolderGitIcon className="size-3" />
         ) : (
           <FolderIcon className="size-3" />
         )}
-        <SelectValue />
+        <span className="min-w-0 flex-1 truncate">{selectedWorkspaceLabel}</span>
       </SelectTrigger>
       <SelectPopup>
         <SelectGroup>
           <SelectGroupLabel>Workspace</SelectGroupLabel>
-          <SelectItem value="local">
+          <SelectItem value={mainCheckout ? `main:${mainCheckout.path}` : "local"}>
             <span className="inline-flex items-center gap-1.5">
-              {activeWorktreePath ? (
+              {mainCheckout ? (
                 <FolderGitIcon className="size-3" />
               ) : (
                 <FolderIcon className="size-3" />
               )}
-              {resolveCurrentWorkspaceLabel(activeWorktreePath)}
+              Main checkout
             </span>
           </SelectItem>
           <SelectItem value="worktree">
@@ -93,6 +135,19 @@ export const BranchToolbarEnvModeSelector = memo(function BranchToolbarEnvModeSe
             </span>
           </SelectItem>
         </SelectGroup>
+        {existingWorktrees.length > 0 ? (
+          <SelectGroup>
+            <SelectGroupLabel>Existing worktrees</SelectGroupLabel>
+            {existingWorktrees.map((worktree) => (
+              <SelectItem key={worktree.path} value={`existing:${worktree.path}`}>
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <FolderGitIcon className="size-3 shrink-0" />
+                  <span className="truncate">{worktree.label}</span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        ) : null}
       </SelectPopup>
     </Select>
   );

--- a/apps/web/src/components/ChatView.logic.test.ts
+++ b/apps/web/src/components/ChatView.logic.test.ts
@@ -20,6 +20,7 @@ import {
   hasServerAcknowledgedLocalDispatch,
   reconcileMountedTerminalThreadIds,
   reconcileRetainedMountedThreadIds,
+  resolveEffectiveServerThreadWorktreePath,
   resolveSendEnvMode,
   shouldWriteThreadErrorToCurrentServerThread,
 } from "./ChatView.logic";
@@ -258,6 +259,28 @@ describe("resolveSendEnvMode", () => {
   it("keeps worktree mode only for git repositories", () => {
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: true })).toBe("worktree");
     expect(resolveSendEnvMode({ requestedEnvMode: "worktree", isGitRepo: false })).toBe("local");
+  });
+});
+
+describe("resolveEffectiveServerThreadWorktreePath", () => {
+  it("uses a pending existing-worktree selection before metadata round-trips", () => {
+    expect(
+      resolveEffectiveServerThreadWorktreePath({
+        canOverride: true,
+        persistedWorktreePath: null,
+        pendingWorktreePath: "/repo/worktrees/selected",
+      }),
+    ).toBe("/repo/worktrees/selected");
+  });
+
+  it("uses persisted metadata once overrides are locked", () => {
+    expect(
+      resolveEffectiveServerThreadWorktreePath({
+        canOverride: false,
+        persistedWorktreePath: "/repo/worktrees/persisted",
+        pendingWorktreePath: "/repo/worktrees/stale",
+      }),
+    ).toBe("/repo/worktrees/persisted");
   });
 });
 

--- a/apps/web/src/components/ChatView.logic.ts
+++ b/apps/web/src/components/ChatView.logic.ts
@@ -193,6 +193,16 @@ export function resolveSendEnvMode(input: {
   return input.isGitRepo ? input.requestedEnvMode : "local";
 }
 
+export function resolveEffectiveServerThreadWorktreePath(input: {
+  readonly canOverride: boolean;
+  readonly persistedWorktreePath: string | null;
+  readonly pendingWorktreePath: string | null | undefined;
+}): string | null {
+  return input.canOverride && input.pendingWorktreePath !== undefined
+    ? input.pendingWorktreePath
+    : input.persistedWorktreePath;
+}
+
 export function cloneComposerImageForRetry(
   image: ComposerImageAttachment,
 ): ComposerImageAttachment {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -241,6 +241,7 @@ import {
   deriveLockedProvider,
   readFileAsDataUrl,
   reconcileMountedTerminalThreadIds,
+  resolveEffectiveServerThreadWorktreePath,
   resolveSendEnvMode,
   revokeBlobPreviewUrl,
   revokeUserMessagePreviewUrls,
@@ -1237,6 +1238,9 @@ function ChatViewContent(props: ChatViewProps) {
   const [pendingServerThreadEnvMode, setPendingServerThreadEnvMode] =
     useState<DraftThreadEnvMode | null>(null);
   const [pendingServerThreadBranch, setPendingServerThreadBranch] = useState<string | null>();
+  const [pendingServerThreadWorktreePath, setPendingServerThreadWorktreePath] = useState<
+    string | null
+  >();
   const [
     pendingServerThreadStartFromOriginByThreadId,
     setPendingServerThreadStartFromOriginByThreadId,
@@ -3710,12 +3714,7 @@ function ChatViewContent(props: ChatViewProps) {
     setExpandedImage(null);
   }, []);
 
-  const activeWorktreePath = activeThread?.worktreePath ?? null;
-  const derivedEnvMode: DraftThreadEnvMode = resolveEffectiveEnvMode({
-    activeWorktreePath,
-    hasServerThread: isServerThread,
-    draftThreadEnvMode: isLocalDraftThread ? draftThread?.envMode : undefined,
-  });
+  const persistedWorktreePath = activeThread?.worktreePath ?? null;
   const canOverrideServerThreadEnvMode = Boolean(
     isServerThread &&
     activeThread &&
@@ -3723,6 +3722,16 @@ function ChatViewContent(props: ChatViewProps) {
     activeThread.worktreePath === null &&
     !envLocked,
   );
+  const activeWorktreePath = resolveEffectiveServerThreadWorktreePath({
+    canOverride: canOverrideServerThreadEnvMode,
+    persistedWorktreePath,
+    pendingWorktreePath: pendingServerThreadWorktreePath,
+  });
+  const derivedEnvMode: DraftThreadEnvMode = resolveEffectiveEnvMode({
+    activeWorktreePath,
+    hasServerThread: isServerThread,
+    draftThreadEnvMode: isLocalDraftThread ? draftThread?.envMode : undefined,
+  });
   const envMode: DraftThreadEnvMode = canOverrideServerThreadEnvMode
     ? (pendingServerThreadEnvMode ?? draftThread?.envMode ?? derivedEnvMode)
     : derivedEnvMode;
@@ -3744,6 +3753,7 @@ function ChatViewContent(props: ChatViewProps) {
   useEffect(() => {
     setPendingServerThreadEnvMode(null);
     setPendingServerThreadBranch(undefined);
+    setPendingServerThreadWorktreePath(undefined);
   }, [activeThread?.id]);
 
   useEffect(() => {
@@ -3752,6 +3762,7 @@ function ChatViewContent(props: ChatViewProps) {
     }
     setPendingServerThreadEnvMode(null);
     setPendingServerThreadBranch(undefined);
+    setPendingServerThreadWorktreePath(undefined);
   }, [canOverrideServerThreadEnvMode]);
 
   useEffect(() => {
@@ -4124,14 +4135,14 @@ function ChatViewContent(props: ChatViewProps) {
     const threadIdForSend = activeThread.id;
     const isFirstMessage = !isServerThread || activeThread.messages.length === 0;
     const baseBranchForWorktree =
-      isFirstMessage && sendEnvMode === "worktree" && !activeThread.worktreePath
+      isFirstMessage && sendEnvMode === "worktree" && !activeWorktreePath
         ? activeThreadBranch
         : null;
 
     // In worktree mode, require an explicit base branch so we don't silently
     // fall back to local execution when branch selection is missing.
     const shouldCreateWorktree =
-      isFirstMessage && sendEnvMode === "worktree" && !activeThread.worktreePath;
+      isFirstMessage && sendEnvMode === "worktree" && !activeWorktreePath;
     if (shouldCreateWorktree && !activeThreadBranch) {
       setThreadError(threadIdForSend, "Select a base branch before sending in New worktree mode.");
       return;
@@ -4316,7 +4327,7 @@ function ChatViewContent(props: ChatViewProps) {
                       runtimeMode,
                       interactionMode,
                       branch: activeThreadBranch,
-                      worktreePath: activeThread.worktreePath,
+                      worktreePath: activeWorktreePath,
                       createdAt: activeThread.createdAt,
                     },
                   }
@@ -5015,6 +5026,7 @@ function ChatViewContent(props: ChatViewProps) {
     (mode: DraftThreadEnvMode) => {
       if (canOverrideServerThreadEnvMode) {
         setPendingServerThreadEnvMode(mode);
+        setPendingServerThreadWorktreePath(null);
         scheduleComposerFocus();
         return;
       }
@@ -5051,6 +5063,7 @@ function ChatViewContent(props: ChatViewProps) {
       if (canOverrideServerThreadEnvMode && activeThread) {
         setPendingServerThreadEnvMode("worktree");
         setPendingServerThreadBranch(worktree.branch);
+        setPendingServerThreadWorktreePath(worktree.path);
         void updateThreadMetadata({
           environmentId: activeThread.environmentId,
           input: {

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -211,7 +211,7 @@ import { ChatHeader } from "./chat/ChatHeader";
 import { PanelLayoutControls, RightPanelMaximizeControl } from "./chat/PanelLayoutControls";
 import { type ExpandedImagePreview } from "./chat/ExpandedImagePreview";
 import { NoActiveThreadState } from "./NoActiveThreadState";
-import { resolveEffectiveEnvMode } from "./BranchToolbar.logic";
+import { resolveEffectiveEnvMode, type ExistingWorktreeOption } from "./BranchToolbar.logic";
 import { ProviderStatusBanner } from "./chat/ProviderStatusBanner";
 import { ThreadErrorBanner } from "./chat/ThreadErrorBanner";
 import { ComposerBannerStack, type ComposerBannerStackItem } from "./chat/ComposerBannerStack";
@@ -5025,7 +5025,11 @@ function ChatViewContent(props: ChatViewProps) {
             envMode: mode,
             newWorktreesStartFromOrigin: settings.newWorktreesStartFromOrigin,
           }),
-          ...(mode === "worktree" && draftThread?.worktreePath ? { worktreePath: null } : {}),
+          ...(draftThread?.worktreePath
+            ? mode === "local"
+              ? { branch: null, worktreePath: null }
+              : { worktreePath: null }
+            : {}),
         });
       }
       scheduleComposerFocus();
@@ -5039,6 +5043,43 @@ function ChatViewContent(props: ChatViewProps) {
       setPendingServerThreadEnvMode,
       scheduleComposerFocus,
       setDraftThreadContext,
+    ],
+  );
+
+  const onExistingWorktreeChange = useCallback(
+    (worktree: ExistingWorktreeOption) => {
+      if (canOverrideServerThreadEnvMode && activeThread) {
+        setPendingServerThreadEnvMode("worktree");
+        setPendingServerThreadBranch(worktree.branch);
+        void updateThreadMetadata({
+          environmentId: activeThread.environmentId,
+          input: {
+            threadId: activeThread.id,
+            branch: worktree.branch,
+            worktreePath: worktree.path,
+          },
+        });
+        scheduleComposerFocus();
+        return;
+      }
+      if (isLocalDraftThread) {
+        setDraftThreadContext(composerDraftTarget, {
+          branch: worktree.branch,
+          worktreePath: worktree.path,
+          envMode: "worktree",
+          startFromOrigin: false,
+        });
+      }
+      scheduleComposerFocus();
+    },
+    [
+      activeThread,
+      canOverrideServerThreadEnvMode,
+      composerDraftTarget,
+      isLocalDraftThread,
+      scheduleComposerFocus,
+      setDraftThreadContext,
+      updateThreadMetadata,
     ],
   );
 
@@ -5459,6 +5500,7 @@ function ChatViewContent(props: ChatViewProps) {
                               threadId={activeThread.id}
                               {...(routeKind === "draft" && draftId ? { draftId } : {})}
                               onEnvModeChange={onEnvModeChange}
+                              onExistingWorktreeChange={onExistingWorktreeChange}
                               startFromOrigin={startFromOrigin}
                               onStartFromOriginChange={onStartFromOriginChange}
                               {...(canOverrideServerThreadEnvMode

--- a/apps/web/src/components/ChatView.tsx
+++ b/apps/web/src/components/ChatView.tsx
@@ -5517,10 +5517,9 @@ function ChatViewContent(props: ChatViewProps) {
                               startFromOrigin={startFromOrigin}
                               onStartFromOriginChange={onStartFromOriginChange}
                               {...(canOverrideServerThreadEnvMode
-                                ? { effectiveEnvModeOverride: envMode }
-                                : {})}
-                              {...(canOverrideServerThreadEnvMode
                                 ? {
+                                    effectiveEnvModeOverride: envMode,
+                                    activeWorktreePathOverride: activeWorktreePath,
                                     activeThreadBranchOverride: activeThreadBranch,
                                     onActiveThreadBranchOverrideChange:
                                       setPendingServerThreadBranch,

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -478,6 +478,7 @@ function OpenCommandPaletteDialog(props: {
     defaultThreadEnvMode,
     handleNewThread,
     resolveDefaultMainCheckout,
+    resolveNewThreadDefaults,
   } = useHandleNewThread();
   const projects = useProjects();
   const threads = useThreadShells();
@@ -701,6 +702,7 @@ function OpenCommandPaletteDialog(props: {
               defaultNewWorktreesStartFromOrigin,
               handleNewThread,
               resolveDefaultMainCheckout,
+              resolveNewThreadDefaults,
             },
             scopeProjectRef(project.environmentId, project.id),
           );
@@ -715,6 +717,7 @@ function OpenCommandPaletteDialog(props: {
       handleNewThread,
       projects,
       resolveDefaultMainCheckout,
+      resolveNewThreadDefaults,
     ],
   );
 
@@ -1017,6 +1020,7 @@ function OpenCommandPaletteDialog(props: {
             defaultNewWorktreesStartFromOrigin,
             handleNewThread,
             resolveDefaultMainCheckout,
+            resolveNewThreadDefaults,
           });
         },
       });

--- a/apps/web/src/components/CommandPalette.tsx
+++ b/apps/web/src/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useAtomValue } from "@effect/atom-react";
 import { scopeProjectRef, scopeThreadRef } from "@t3tools/client-runtime/environment";
 import {
   isAtomCommandInterrupted,
@@ -11,12 +12,12 @@ import {
   type DesktopWslState,
   type EnvironmentId,
   type FilesystemBrowseResult,
+  PRIMARY_LOCAL_ENVIRONMENT_ID,
   type ProjectId,
   ProviderInstanceId,
   type SourceControlDiscoveryResult,
   type SourceControlProviderKind,
   type SourceControlRepositoryInfo,
-  PRIMARY_LOCAL_ENVIRONMENT_ID,
 } from "@t3tools/contracts";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import * as Option from "effect/Option";
@@ -33,6 +34,8 @@ import {
   SquarePenIcon,
 } from "lucide-react";
 import {
+  type KeyboardEvent,
+  type ReactNode,
   useCallback,
   useDeferredValue,
   useEffect,
@@ -41,28 +44,17 @@ import {
   useReducer,
   useRef,
   useState,
-  type KeyboardEvent,
-  type ReactNode,
 } from "react";
-import { useAtomValue } from "@effect/atom-react";
 import { OpenAddProjectCommandPaletteProvider } from "../commandPaletteContext";
-import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
+import { ComposerHandleContext, useComposerHandleContext } from "../composerHandleContext";
+import { desktopLocalBackendId, isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
 import { useClientSettings } from "../hooks/useSettings";
-import { readLocalApi } from "../localApi";
-import { desktopLocalBackendId } from "../connection/desktopLocal";
-import { filesystemEnvironment } from "../state/filesystem";
-import { projectEnvironment } from "../state/projects";
-import { useEnvironmentQuery } from "../state/query";
-import { sourceControlEnvironment } from "../state/sourceControl";
-import { useAtomCommand } from "../state/use-atom-command";
-import { useAtomQueryRunner } from "../state/use-atom-query-runner";
-import { useEnvironments, usePrimaryEnvironment } from "../state/environments";
-import { useProjects, useThreadShells } from "../state/entities";
+import { resolveShortcutCommand } from "../keybindings";
 import {
-  startNewThreadInProjectFromContext,
   startNewThreadFromContext,
+  startNewThreadInProjectFromContext,
 } from "../lib/chatThreadActions";
 import {
   appendBrowsePathSegment,
@@ -82,6 +74,16 @@ import {
 import { isTerminalFocused } from "../lib/terminalFocus";
 import { getLatestThreadForProject } from "../lib/threadSort";
 import { cn, isMacPlatform, isWindowsPlatform, newProjectId } from "../lib/utils";
+import { readLocalApi } from "../localApi";
+import { useProjects, useThreadShells } from "../state/entities";
+import { useEnvironments, usePrimaryEnvironment } from "../state/environments";
+import { filesystemEnvironment } from "../state/filesystem";
+import { projectEnvironment } from "../state/projects";
+import { useEnvironmentQuery } from "../state/query";
+import { primaryServerKeybindingsAtom } from "../state/server";
+import { sourceControlEnvironment } from "../state/sourceControl";
+import { useAtomCommand } from "../state/use-atom-command";
+import { useAtomQueryRunner } from "../state/use-atom-query-runner";
 import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { buildThreadRouteParams, resolveThreadRouteTarget } from "../threadRoutes";
 import {
@@ -90,6 +92,7 @@ import {
   resolveProjectPickerTarget,
   resolveWslProjectSelection,
 } from "../wslPaths";
+import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
 import {
   ADDON_ICON_CLASS,
   buildBrowseGroups,
@@ -106,13 +109,12 @@ import {
   ITEM_ICON_CLASS,
   RECENT_THREAD_LIMIT,
 } from "./CommandPalette.logic";
-import { resolveEnvironmentOptionLabel } from "./BranchToolbar.logic";
 import { CommandPaletteResults } from "./CommandPaletteResults";
+import type { ChatComposerHandle } from "./chat/ChatComposer";
 import { AzureDevOpsIcon, BitbucketIcon, GitHubIcon, GitLabIcon } from "./Icons";
 import { ProjectFavicon } from "./ProjectFavicon";
 import { ThreadRowLeadingStatus, ThreadRowTrailingStatus } from "./ThreadStatusIndicators";
-import { primaryServerKeybindingsAtom } from "../state/server";
-import { resolveShortcutCommand } from "../keybindings";
+import { Button } from "./ui/button";
 import {
   Command,
   CommandDialog,
@@ -121,12 +123,9 @@ import {
   CommandInput,
   CommandPanel,
 } from "./ui/command";
-import { Button } from "./ui/button";
 import { Kbd, KbdGroup } from "./ui/kbd";
 import { stackedThreadToast, toastManager } from "./ui/toast";
 import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
-import { ComposerHandleContext, useComposerHandleContext } from "../composerHandleContext";
-import type { ChatComposerHandle } from "./chat/ChatComposer";
 
 const EMPTY_BROWSE_ENTRIES: FilesystemBrowseResult["entries"] = [];
 
@@ -471,8 +470,15 @@ function OpenCommandPaletteDialog(props: {
   const { environments } = useEnvironments();
   const desktopLocalBootstraps = useDesktopLocalBootstraps();
   const primaryEnvironment = usePrimaryEnvironment();
-  const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread } =
-    useHandleNewThread();
+  const {
+    activeDraftThread,
+    activeThread,
+    defaultProjectRef,
+    defaultNewWorktreesStartFromOrigin,
+    defaultThreadEnvMode,
+    handleNewThread,
+    resolveDefaultMainCheckout,
+  } = useHandleNewThread();
   const projects = useProjects();
   const threads = useThreadShells();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
@@ -624,7 +630,12 @@ function OpenCommandPaletteDialog(props: {
   const isBrowsePending = browseQuery.isPending;
   const browseEntries = browseResult?.entries ?? EMPTY_BROWSE_ENTRIES;
   const { filteredEntries: filteredBrowseEntries, exactEntry: exactBrowseEntry } = useMemo(
-    () => filterBrowseEntries({ browseEntries, browseFilterQuery, highlightedItemValue }),
+    () =>
+      filterBrowseEntries({
+        browseEntries,
+        browseFilterQuery,
+        highlightedItemValue,
+      }),
     [browseEntries, browseFilterQuery, highlightedItemValue],
   );
 
@@ -686,13 +697,25 @@ function OpenCommandPaletteDialog(props: {
               activeDraftThread,
               activeThread: activeThread ?? undefined,
               defaultProjectRef,
+              defaultThreadEnvMode,
+              defaultNewWorktreesStartFromOrigin,
               handleNewThread,
+              resolveDefaultMainCheckout,
             },
             scopeProjectRef(project.environmentId, project.id),
           );
         },
       }),
-    [activeDraftThread, activeThread, defaultProjectRef, handleNewThread, projects],
+    [
+      activeDraftThread,
+      activeThread,
+      defaultNewWorktreesStartFromOrigin,
+      defaultProjectRef,
+      defaultThreadEnvMode,
+      handleNewThread,
+      projects,
+      resolveDefaultMainCheckout,
+    ],
   );
 
   const allThreadItems = useMemo(
@@ -875,7 +898,13 @@ function OpenCommandPaletteDialog(props: {
         });
       }
 
-      return [{ value: `sources:${environmentId}`, label: "Sources", items: sourceItems }];
+      return [
+        {
+          value: `sources:${environmentId}`,
+          label: "Sources",
+          items: sourceItems,
+        },
+      ];
     },
     [openSourceControlSettings, startAddProjectBrowse, startAddProjectClone],
   );
@@ -984,7 +1013,10 @@ function OpenCommandPaletteDialog(props: {
             activeDraftThread,
             activeThread: activeThread ?? undefined,
             defaultProjectRef,
+            defaultThreadEnvMode,
+            defaultNewWorktreesStartFromOrigin,
             handleNewThread,
+            resolveDefaultMainCheckout,
           });
         },
       });
@@ -1614,7 +1646,13 @@ function OpenCommandPaletteDialog(props: {
               (candidate) => candidate.httpBaseUrl === environment.displayUrl,
             );
             const runningDistro = bootstrap?.runningDistro ?? null;
-            return [{ environmentId: environment.environmentId, backendId, runningDistro }];
+            return [
+              {
+                environmentId: environment.environmentId,
+                backendId,
+                runningDistro,
+              },
+            ];
           }),
           primaryEnvironmentId,
           desktopWslState ?? null,
@@ -1822,9 +1860,13 @@ function OpenCommandPaletteDialog(props: {
                       : "Enter a repository path and press Enter to look it up.",
                 }
               : addProjectCloneFlow?.step === "confirm"
-                ? { emptyStateMessage: "Choose a destination path and press Enter to clone." }
+                ? {
+                    emptyStateMessage: "Choose a destination path and press Enter to clone.",
+                  }
                 : relativePathNeedsActiveProject
-                  ? { emptyStateMessage: "Relative paths require an active project." }
+                  ? {
+                      emptyStateMessage: "Relative paths require an active project.",
+                    }
                   : willCreateProjectPath
                     ? {
                         emptyStateMessage:

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -231,7 +231,7 @@ describe("groupSidebarThreadsByWorktree", () => {
           projectId: "two",
           projectCheckoutPath: "/repo-two",
           projectCheckoutLabel: "feature/two",
-          mainCheckoutPath: "/main-two",
+          mainCheckoutPath: null,
         },
       ],
     );

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -26,6 +26,7 @@ import {
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  orderSidebarThreadsByWorktree,
   resolveAdjacentThreadId,
   resolveProjectStatusIndicator,
   resolveSidebarNewThreadEnvMode,
@@ -248,6 +249,26 @@ describe("groupSidebarThreadsByWorktree", () => {
         threads: [memberTwoImplicit, memberTwoExplicit],
       },
     ]);
+  });
+});
+
+describe("orderSidebarThreadsByWorktree", () => {
+  it("matches the visual grouped-row order for interleaved worktrees", () => {
+    const first = {
+      environmentId: "local",
+      projectId: "project",
+      branch: "feature/one",
+      worktreePath: "/repo/one",
+    };
+    const second = {
+      environmentId: "local",
+      projectId: "project",
+      branch: "feature/two",
+      worktreePath: "/repo/two",
+    };
+    const third = { ...first, branch: "feature/one-again" };
+
+    expect(orderSidebarThreadsByWorktree([first, second, third])).toEqual([first, third, second]);
   });
 });
 

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -170,13 +170,18 @@ describe("groupSidebarThreadsByWorktree", () => {
     };
 
     expect(
-      groupSidebarThreadsByWorktree([linkedCheckoutThread, mainCheckoutThread], {
-        environmentId: "local",
-        projectId: "project",
-        projectCheckoutPath: "/repo/.t3/worktrees/group-threads-worktrees",
-        projectCheckoutLabel: "t3code/group-threads-worktrees",
-        mainCheckoutPath: "/repo",
-      }),
+      groupSidebarThreadsByWorktree(
+        [linkedCheckoutThread, mainCheckoutThread],
+        [
+          {
+            environmentId: "local",
+            projectId: "project",
+            projectCheckoutPath: "/repo/.t3/worktrees/group-threads-worktrees",
+            projectCheckoutLabel: "t3code/group-threads-worktrees",
+            mainCheckoutPath: "/repo",
+          },
+        ],
+      ),
     ).toEqual([
       {
         key: "local:worktree:/repo/.t3/worktrees/group-threads-worktrees",
@@ -187,6 +192,60 @@ describe("groupSidebarThreadsByWorktree", () => {
         key: "local:worktree:/repo",
         label: "Main checkout",
         threads: [mainCheckoutThread],
+      },
+    ]);
+  });
+
+  it("reconciles each logical-project member with its own checkout", () => {
+    const memberOneImplicit = {
+      environmentId: "local",
+      projectId: "one",
+      branch: "feature/one",
+      worktreePath: null,
+    };
+    const memberTwoImplicit = {
+      environmentId: "local",
+      projectId: "two",
+      branch: "feature/two",
+      worktreePath: null,
+    };
+    const memberTwoExplicit = {
+      environmentId: "local",
+      projectId: "two",
+      branch: "feature/two",
+      worktreePath: "/repo-two",
+    };
+
+    const groups = groupSidebarThreadsByWorktree(
+      [memberOneImplicit, memberTwoImplicit, memberTwoExplicit],
+      [
+        {
+          environmentId: "local",
+          projectId: "one",
+          projectCheckoutPath: "/repo-one",
+          projectCheckoutLabel: "feature/one",
+          mainCheckoutPath: "/repo-one",
+        },
+        {
+          environmentId: "local",
+          projectId: "two",
+          projectCheckoutPath: "/repo-two",
+          projectCheckoutLabel: "feature/two",
+          mainCheckoutPath: "/main-two",
+        },
+      ],
+    );
+
+    expect(groups).toEqual([
+      {
+        key: "local:worktree:/repo-one",
+        label: "Main checkout",
+        threads: [memberOneImplicit],
+      },
+      {
+        key: "local:worktree:/repo-two",
+        label: "feature/two",
+        threads: [memberTwoImplicit, memberTwoExplicit],
       },
     ]);
   });

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -250,6 +250,40 @@ describe("groupSidebarThreadsByWorktree", () => {
       },
     ]);
   });
+
+  it("groups Windows workspace paths case-insensitively", () => {
+    const implicitThread = {
+      environmentId: "windows",
+      projectId: "project",
+      branch: "main",
+      worktreePath: null,
+    };
+    const explicitThread = {
+      ...implicitThread,
+      worktreePath: "c:\\repo\\worktree",
+    };
+
+    expect(
+      groupSidebarThreadsByWorktree(
+        [implicitThread, explicitThread],
+        [
+          {
+            environmentId: "windows",
+            projectId: "project",
+            projectCheckoutPath: "C:\\Repo\\Worktree",
+            projectCheckoutLabel: "main",
+            mainCheckoutPath: "C:\\REPO\\WORKTREE",
+          },
+        ],
+      ),
+    ).toEqual([
+      {
+        key: "windows:worktree:c:/repo/worktree",
+        label: "Main checkout",
+        threads: [implicitThread, explicitThread],
+      },
+    ]);
+  });
 });
 
 describe("orderSidebarThreadsByWorktree", () => {

--- a/apps/web/src/components/Sidebar.logic.test.ts
+++ b/apps/web/src/components/Sidebar.logic.test.ts
@@ -1,20 +1,33 @@
+import {
+  EnvironmentId,
+  type OrchestrationLatestTurn,
+  ProjectId,
+  ProviderInstanceId,
+  ThreadId,
+} from "@t3tools/contracts";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import {
+  DEFAULT_INTERACTION_MODE,
+  DEFAULT_RUNTIME_MODE,
+  type Project,
+  type Thread,
+} from "../types";
 import {
   archiveSelectedThreadEntries,
   buildMultiSelectThreadContextMenuItems,
   createThreadJumpHintVisibilityController,
+  getFallbackThreadIdAfterDelete,
+  getProjectSortTimestamp,
   getSidebarThreadIdsToPrewarm,
   getVisibleSidebarThreadIds,
-  resolveAdjacentThreadId,
-  getFallbackThreadIdAfterDelete,
   getVisibleThreadsForProject,
-  getProjectSortTimestamp,
+  groupSidebarThreadsByWorktree,
   hasUnseenCompletion,
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  resolveAdjacentThreadId,
   resolveProjectStatusIndicator,
-  resolveSidebarNewThreadSeedContext,
   resolveSidebarNewThreadEnvMode,
   resolveSidebarStageBadgeLabel,
   resolveThreadRowClassName,
@@ -24,19 +37,6 @@ import {
   sortScopedProjectsForSidebar,
   THREAD_JUMP_HINT_SHOW_DELAY_MS,
 } from "./Sidebar.logic";
-import {
-  EnvironmentId,
-  OrchestrationLatestTurn,
-  ProjectId,
-  ProviderInstanceId,
-  ThreadId,
-} from "@t3tools/contracts";
-import {
-  DEFAULT_INTERACTION_MODE,
-  DEFAULT_RUNTIME_MODE,
-  type Project,
-  type Thread,
-} from "../types";
 
 const localEnvironmentId = EnvironmentId.make("environment-local");
 
@@ -104,6 +104,91 @@ describe("buildMultiSelectThreadContextMenuItems", () => {
     expect(
       buildMultiSelectThreadContextMenuItems({ count: 2, hasRunningThread: true }),
     ).toContainEqual({ id: "archive", label: "Archive (2)", disabled: true });
+  });
+});
+
+describe("groupSidebarThreadsByWorktree", () => {
+  it("groups threads sharing a worktree and labels the group with its branch", () => {
+    const threads = [
+      {
+        environmentId: "local",
+        projectId: "project",
+        branch: "feature/shared",
+        worktreePath: "/repo/.t3/worktrees/shared",
+        id: "one",
+      },
+      {
+        environmentId: "local",
+        projectId: "project",
+        branch: "feature/shared",
+        worktreePath: "/repo/.t3/worktrees/shared",
+        id: "two",
+      },
+    ];
+
+    expect(groupSidebarThreadsByWorktree(threads)).toEqual([
+      {
+        key: "local:worktree:/repo/.t3/worktrees/shared",
+        label: "feature/shared",
+        threads,
+      },
+    ]);
+  });
+
+  it("keeps main checkouts from different projects in separate groups", () => {
+    const groups = groupSidebarThreadsByWorktree([
+      {
+        environmentId: "local",
+        projectId: "one",
+        branch: "main",
+        worktreePath: null,
+      },
+      {
+        environmentId: "local",
+        projectId: "two",
+        branch: "main",
+        worktreePath: null,
+      },
+    ]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((group) => group.label)).toEqual(["main", "main"]);
+  });
+
+  it("distinguishes a registered linked worktree from the actual main checkout", () => {
+    const linkedCheckoutThread = {
+      environmentId: "local",
+      projectId: "project",
+      branch: "t3code/group-threads-worktrees",
+      worktreePath: null,
+    };
+    const mainCheckoutThread = {
+      environmentId: "local",
+      projectId: "project",
+      branch: "main",
+      worktreePath: "/repo",
+    };
+
+    expect(
+      groupSidebarThreadsByWorktree([linkedCheckoutThread, mainCheckoutThread], {
+        environmentId: "local",
+        projectId: "project",
+        projectCheckoutPath: "/repo/.t3/worktrees/group-threads-worktrees",
+        projectCheckoutLabel: "t3code/group-threads-worktrees",
+        mainCheckoutPath: "/repo",
+      }),
+    ).toEqual([
+      {
+        key: "local:worktree:/repo/.t3/worktrees/group-threads-worktrees",
+        label: "t3code/group-threads-worktrees",
+        threads: [linkedCheckoutThread],
+      },
+      {
+        key: "local:worktree:/repo",
+        label: "Main checkout",
+        threads: [mainCheckoutThread],
+      },
+    ]);
   });
 });
 
@@ -327,93 +412,6 @@ describe("resolveSidebarNewThreadEnvMode", () => {
         defaultEnvMode: "worktree",
       }),
     ).toBe("local");
-  });
-});
-
-describe("resolveSidebarNewThreadSeedContext", () => {
-  it("prefers the default worktree mode over active thread context", () => {
-    expect(
-      resolveSidebarNewThreadSeedContext({
-        projectId: "project-1",
-        defaultEnvMode: "worktree",
-        activeThread: {
-          projectId: "project-1",
-          branch: "feature/existing",
-          worktreePath: "/repo/.t3/worktrees/existing",
-        },
-        activeDraftThread: {
-          projectId: "project-1",
-          branch: "feature/draft",
-          worktreePath: "/repo/.t3/worktrees/draft",
-          envMode: "worktree",
-          startFromOrigin: true,
-        },
-      }),
-    ).toEqual({
-      envMode: "worktree",
-    });
-  });
-
-  it("inherits the active server thread context when creating a new thread in the same project", () => {
-    expect(
-      resolveSidebarNewThreadSeedContext({
-        projectId: "project-1",
-        defaultEnvMode: "local",
-        activeThread: {
-          projectId: "project-1",
-          branch: "effect-atom",
-          worktreePath: null,
-        },
-        activeDraftThread: null,
-      }),
-    ).toEqual({
-      branch: "effect-atom",
-      worktreePath: null,
-      envMode: "local",
-    });
-  });
-
-  it("prefers the active draft thread context when it matches the target project", () => {
-    expect(
-      resolveSidebarNewThreadSeedContext({
-        projectId: "project-1",
-        defaultEnvMode: "local",
-        activeThread: {
-          projectId: "project-1",
-          branch: "effect-atom",
-          worktreePath: null,
-        },
-        activeDraftThread: {
-          projectId: "project-1",
-          branch: "feature/new-draft",
-          worktreePath: "/repo/worktree",
-          envMode: "worktree",
-          startFromOrigin: true,
-        },
-      }),
-    ).toEqual({
-      branch: "feature/new-draft",
-      worktreePath: "/repo/worktree",
-      envMode: "worktree",
-      startFromOrigin: true,
-    });
-  });
-
-  it("falls back to the default env mode when there is no matching active thread context", () => {
-    expect(
-      resolveSidebarNewThreadSeedContext({
-        projectId: "project-2",
-        defaultEnvMode: "worktree",
-        activeThread: {
-          projectId: "project-1",
-          branch: "effect-atom",
-          worktreePath: null,
-        },
-        activeDraftThread: null,
-      }),
-    ).toEqual({
-      envMode: "worktree",
-    });
   });
 });
 
@@ -739,7 +737,10 @@ describe("resolveThreadStatusPill", () => {
 
 describe("resolveThreadRowClassName", () => {
   it("uses the darker selected palette when a thread is both selected and active", () => {
-    const className = resolveThreadRowClassName({ isActive: true, isSelected: true });
+    const className = resolveThreadRowClassName({
+      isActive: true,
+      isSelected: true,
+    });
     expect(className).toContain("bg-primary/22");
     expect(className).toContain("hover:bg-primary/26");
     expect(className).toContain("dark:bg-primary/30");
@@ -747,7 +748,10 @@ describe("resolveThreadRowClassName", () => {
   });
 
   it("uses selected hover colors for selected threads", () => {
-    const className = resolveThreadRowClassName({ isActive: false, isSelected: true });
+    const className = resolveThreadRowClassName({
+      isActive: false,
+      isSelected: true,
+    });
     expect(className).toContain("bg-primary/15");
     expect(className).toContain("hover:bg-primary/19");
     expect(className).toContain("dark:bg-primary/22");
@@ -755,7 +759,10 @@ describe("resolveThreadRowClassName", () => {
   });
 
   it("keeps the accent palette for active-only threads", () => {
-    const className = resolveThreadRowClassName({ isActive: true, isSelected: false });
+    const className = resolveThreadRowClassName({
+      isActive: true,
+      isSelected: false,
+    });
     expect(className).toContain("bg-accent/85");
     expect(className).toContain("hover:bg-accent");
   });

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -93,6 +93,22 @@ export function groupSidebarThreadsByWorktree<
 
   return [...groups].map(([key, group]) => ({ key, ...group }));
 }
+
+export function orderSidebarThreadsByWorktree<
+  TThread extends {
+    readonly environmentId: string;
+    readonly projectId: string;
+    readonly branch: string | null;
+    readonly worktreePath: string | null;
+  },
+>(
+  threads: readonly TThread[],
+  workspaceIdentities: readonly SidebarWorkspaceIdentity[] = [],
+): TThread[] {
+  return groupSidebarThreadsByWorktree(threads, workspaceIdentities).flatMap(
+    (group) => group.threads,
+  );
+}
 type SidebarProject = {
   id: string;
   title: string;

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -30,7 +30,7 @@ export interface SidebarWorkspaceIdentity {
   readonly projectId: string;
   readonly projectCheckoutPath: string;
   readonly projectCheckoutLabel: string | null;
-  readonly mainCheckoutPath: string;
+  readonly mainCheckoutPath: string | null;
 }
 
 function normalizeWorkspacePath(path: string): string {
@@ -67,6 +67,7 @@ export function groupSidebarThreadsByWorktree<
     const normalizedEffectivePath = effectivePath ? normalizeWorkspacePath(effectivePath) : null;
     const isMainCheckout =
       matchesWorkspaceIdentity &&
+      workspaceIdentity.mainCheckoutPath !== null &&
       normalizedEffectivePath === normalizeWorkspacePath(workspaceIdentity.mainCheckoutPath);
     const key = normalizedEffectivePath
       ? `${thread.environmentId}:worktree:${normalizedEffectivePath}`

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -51,14 +51,16 @@ export function groupSidebarThreadsByWorktree<
   },
 >(
   threads: readonly TThread[],
-  workspaceIdentity?: SidebarWorkspaceIdentity | null,
+  workspaceIdentities: readonly SidebarWorkspaceIdentity[] = [],
 ): SidebarWorktreeThreadGroup<TThread>[] {
   const groups = new Map<string, { label: string; threads: TThread[] }>();
 
   for (const thread of threads) {
-    const matchesWorkspaceIdentity =
-      workspaceIdentity?.environmentId === thread.environmentId &&
-      workspaceIdentity.projectId === thread.projectId;
+    const workspaceIdentity = workspaceIdentities.find(
+      (identity) =>
+        identity.environmentId === thread.environmentId && identity.projectId === thread.projectId,
+    );
+    const matchesWorkspaceIdentity = workspaceIdentity !== undefined;
     const worktreePath = thread.worktreePath?.trim() || null;
     const effectivePath =
       worktreePath ?? (matchesWorkspaceIdentity ? workspaceIdentity.projectCheckoutPath : null);

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -1,16 +1,16 @@
-import * as React from "react";
 import type { ContextMenuItem } from "@t3tools/contracts";
 import type { SidebarProjectSortOrder, SidebarThreadSortOrder } from "@t3tools/contracts/settings";
+import * as React from "react";
+import { resolveServerBackedAppStageLabel } from "../branding.logic";
 import {
   getThreadSortTimestamp,
   sortThreads,
-  toSortableTimestamp,
   type ThreadSortInput,
+  toSortableTimestamp,
 } from "../lib/threadSort";
-import type { SidebarThreadSummary, Thread } from "../types";
 import { cn } from "../lib/utils";
 import { isLatestTurnSettled } from "../session-logic";
-import { resolveServerBackedAppStageLabel } from "../branding.logic";
+import type { SidebarThreadSummary, Thread } from "../types";
 
 export const THREAD_SELECTION_SAFE_SELECTOR = "[data-thread-item], [data-thread-selection-safe]";
 export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
@@ -18,6 +18,78 @@ export const THREAD_JUMP_HINT_SHOW_DELAY_MS = 100;
 // nearby thread usually reuses an already-hot subscription.
 export const SIDEBAR_THREAD_PREWARM_LIMIT = 10;
 export type SidebarNewThreadEnvMode = "local" | "worktree";
+
+export interface SidebarWorktreeThreadGroup<TThread> {
+  readonly key: string;
+  readonly label: string;
+  readonly threads: readonly TThread[];
+}
+
+export interface SidebarWorkspaceIdentity {
+  readonly environmentId: string;
+  readonly projectId: string;
+  readonly projectCheckoutPath: string;
+  readonly projectCheckoutLabel: string | null;
+  readonly mainCheckoutPath: string;
+}
+
+function normalizeWorkspacePath(path: string): string {
+  return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+function worktreeDisplayName(path: string): string {
+  const normalized = path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+  return normalized.split("/").at(-1) || path;
+}
+
+export function groupSidebarThreadsByWorktree<
+  TThread extends {
+    readonly environmentId: string;
+    readonly projectId: string;
+    readonly branch: string | null;
+    readonly worktreePath: string | null;
+  },
+>(
+  threads: readonly TThread[],
+  workspaceIdentity?: SidebarWorkspaceIdentity | null,
+): SidebarWorktreeThreadGroup<TThread>[] {
+  const groups = new Map<string, { label: string; threads: TThread[] }>();
+
+  for (const thread of threads) {
+    const matchesWorkspaceIdentity =
+      workspaceIdentity?.environmentId === thread.environmentId &&
+      workspaceIdentity.projectId === thread.projectId;
+    const worktreePath = thread.worktreePath?.trim() || null;
+    const effectivePath =
+      worktreePath ?? (matchesWorkspaceIdentity ? workspaceIdentity.projectCheckoutPath : null);
+    const normalizedEffectivePath = effectivePath ? normalizeWorkspacePath(effectivePath) : null;
+    const isMainCheckout =
+      matchesWorkspaceIdentity &&
+      normalizedEffectivePath === normalizeWorkspacePath(workspaceIdentity.mainCheckoutPath);
+    const key = normalizedEffectivePath
+      ? `${thread.environmentId}:worktree:${normalizedEffectivePath}`
+      : `${thread.environmentId}:project:${thread.projectId}:checkout`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.threads.push(thread);
+      continue;
+    }
+    groups.set(key, {
+      label: isMainCheckout
+        ? "Main checkout"
+        : worktreePath
+          ? thread.branch?.trim() || worktreeDisplayName(worktreePath)
+          : matchesWorkspaceIdentity
+            ? (workspaceIdentity.projectCheckoutLabel ??
+              thread.branch?.trim() ??
+              "Project checkout")
+            : thread.branch?.trim() || "Project checkout",
+      threads: [thread],
+    });
+  }
+
+  return [...groups].map(([key, group]) => ({ key, ...group }));
+}
 type SidebarProject = {
   id: string;
   title: string;
@@ -242,55 +314,6 @@ export function resolveSidebarNewThreadEnvMode(input: {
   defaultEnvMode: SidebarNewThreadEnvMode;
 }): SidebarNewThreadEnvMode {
   return input.requestedEnvMode ?? input.defaultEnvMode;
-}
-
-export function resolveSidebarNewThreadSeedContext(input: {
-  projectId: string;
-  defaultEnvMode: SidebarNewThreadEnvMode;
-  activeThread?: {
-    projectId: string;
-    branch: string | null;
-    worktreePath: string | null;
-  } | null;
-  activeDraftThread?: {
-    projectId: string;
-    branch: string | null;
-    worktreePath: string | null;
-    envMode: SidebarNewThreadEnvMode;
-    startFromOrigin: boolean;
-  } | null;
-}): {
-  branch?: string | null;
-  worktreePath?: string | null;
-  envMode: SidebarNewThreadEnvMode;
-  startFromOrigin?: boolean;
-} {
-  if (input.defaultEnvMode === "worktree") {
-    return {
-      envMode: "worktree",
-    };
-  }
-
-  if (input.activeDraftThread?.projectId === input.projectId) {
-    return {
-      branch: input.activeDraftThread.branch,
-      worktreePath: input.activeDraftThread.worktreePath,
-      envMode: input.activeDraftThread.envMode,
-      startFromOrigin: input.activeDraftThread.startFromOrigin,
-    };
-  }
-
-  if (input.activeThread?.projectId === input.projectId) {
-    return {
-      branch: input.activeThread.branch,
-      worktreePath: input.activeThread.worktreePath,
-      envMode: input.activeThread.worktreePath ? "worktree" : "local",
-    };
-  }
-
-  return {
-    envMode: input.defaultEnvMode,
-  };
 }
 
 export function orderItemsByPreferredIds<TItem, TId>(input: {

--- a/apps/web/src/components/Sidebar.logic.ts
+++ b/apps/web/src/components/Sidebar.logic.ts
@@ -34,7 +34,10 @@ export interface SidebarWorkspaceIdentity {
 }
 
 function normalizeWorkspacePath(path: string): string {
-  return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+  const normalized = path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+  return /^[A-Za-z]:\//.test(normalized) || normalized.startsWith("//")
+    ? normalized.toLowerCase()
+    : normalized;
 }
 
 function worktreeDisplayName(path: string): string {

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -153,6 +153,7 @@ import {
   isContextMenuPointerDown,
   isTrailingDoubleClick,
   orderItemsByPreferredIds,
+  orderSidebarThreadsByWorktree,
   resolveAdjacentThreadId,
   resolveProjectStatusIndicator,
   resolveSidebarStageBadgeLabel,
@@ -1332,6 +1333,17 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     }
     return counts;
   }, [memberProjectByScopedKey, project.memberProjects, projectThreads]);
+  const fallbackWorkspaceIdentities = useMemo(
+    () =>
+      project.memberProjects.map((member) => ({
+        environmentId: member.environmentId,
+        projectId: member.id,
+        projectCheckoutPath: member.workspaceRoot,
+        projectCheckoutLabel: null,
+        mainCheckoutPath: null,
+      })),
+    [project.memberProjects],
+  );
 
   const { projectStatus, visibleProjectThreads, orderedProjectThreadKeys } = useMemo(() => {
     const lastVisitedAtByThreadKey = new Map(
@@ -1358,14 +1370,24 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     const projectStatus = resolveProjectStatusIndicator(
       visibleProjectThreads.map((thread) => resolveProjectThreadStatus(thread)),
     );
+    const orderedVisibleProjectThreads =
+      threadGroupingMode === "worktree"
+        ? orderSidebarThreadsByWorktree(visibleProjectThreads, fallbackWorkspaceIdentities)
+        : visibleProjectThreads;
     return {
-      orderedProjectThreadKeys: visibleProjectThreads.map((thread) =>
+      orderedProjectThreadKeys: orderedVisibleProjectThreads.map((thread) =>
         scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
       ),
       projectStatus,
       visibleProjectThreads,
     };
-  }, [projectThreads, threadLastVisitedAts, threadSortOrder]);
+  }, [
+    fallbackWorkspaceIdentities,
+    projectThreads,
+    threadGroupingMode,
+    threadLastVisitedAts,
+    threadSortOrder,
+  ]);
   const pinnedCollapsedThread = useMemo(() => {
     const activeThreadKey = activeRouteThreadKey ?? undefined;
     if (!activeThreadKey || projectExpanded) {
@@ -3602,7 +3624,20 @@ export default function Sidebar() {
             ? projectThreads
             : projectThreads.slice(0, sidebarThreadPreviewCount);
         const renderedThreads = pinnedCollapsedThread ? [pinnedCollapsedThread] : previewThreads;
-        return renderedThreads.map((thread) =>
+        const orderedRenderedThreads =
+          sidebarThreadGroupingMode === "worktree"
+            ? orderSidebarThreadsByWorktree(
+                renderedThreads,
+                project.memberProjects.map((member) => ({
+                  environmentId: member.environmentId,
+                  projectId: member.id,
+                  projectCheckoutPath: member.workspaceRoot,
+                  projectCheckoutLabel: null,
+                  mainCheckoutPath: null,
+                })),
+              )
+            : renderedThreads;
+        return orderedRenderedThreads.map((thread) =>
           scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id)),
         );
       }),
@@ -3612,6 +3647,7 @@ export default function Sidebar() {
       expandedThreadListsByProject,
       projectExpandedById,
       routeThreadKey,
+      sidebarThreadGroupingMode,
       sortedProjects,
       threadsByProjectKey,
     ],

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1017,29 +1017,26 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
   const workspaceRefResults = useAtomValue(workspaceRefsAtom);
   const workspaceIdentities = useMemo(
     () =>
-      workspaceRefResults.flatMap(({ member, result }) => {
+      workspaceRefResults.map(({ member, result }) => {
         const data = Option.getOrNull(AsyncResult.value(result));
-        if (!data) return [];
-        const options = deriveWorkspaceOptions(
-          data.refs,
-          member.workspaceRoot,
-          data.mainCheckoutPath,
-        );
+        const options = data
+          ? deriveWorkspaceOptions(data.refs, member.workspaceRoot, data.mainCheckoutPath)
+          : null;
         const normalizedProjectCwd = member.workspaceRoot.replaceAll("\\", "/").replace(/\/+$/, "");
         const projectCheckoutRef = data?.refs.find(
           (ref) =>
             ref.worktreePath?.replaceAll("\\", "/").replace(/\/+$/, "") === normalizedProjectCwd,
         );
-        return [
-          {
-            environmentId: member.environmentId,
-            projectId: member.id,
-            projectCheckoutPath: member.workspaceRoot,
-            projectCheckoutLabel: projectCheckoutRef?.name ?? null,
-            mainCheckoutPath:
-              data.mainCheckoutPath ?? options.mainCheckout?.path ?? member.workspaceRoot,
-          },
-        ];
+        return {
+          environmentId: member.environmentId,
+          projectId: member.id,
+          projectCheckoutPath: member.workspaceRoot,
+          projectCheckoutLabel: projectCheckoutRef?.name ?? null,
+          mainCheckoutPath:
+            data?.mainCheckoutPath ??
+            options?.mainCheckout?.path ??
+            (data ? member.workspaceRoot : null),
+        };
       }),
     [workspaceRefResults],
   );

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -3231,6 +3231,7 @@ export default function Sidebar() {
     defaultThreadEnvMode,
     handleNewThread: handleNewThreadRaw,
     resolveDefaultMainCheckout,
+    resolveNewThreadDefaults,
   } = useHandleNewThread();
   const handleNewThread = useCallback(
     (projectRef: ScopedProjectRef) =>
@@ -3243,6 +3244,7 @@ export default function Sidebar() {
           defaultThreadEnvMode,
           handleNewThread: handleNewThreadRaw,
           resolveDefaultMainCheckout,
+          resolveNewThreadDefaults,
         },
         projectRef,
       ),
@@ -3251,6 +3253,7 @@ export default function Sidebar() {
       defaultThreadEnvMode,
       handleNewThreadRaw,
       resolveDefaultMainCheckout,
+      resolveNewThreadDefaults,
     ],
   );
   const { archiveThread, deleteThread } = useThreadActions();

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1,4 +1,52 @@
 import {
+  type CollisionDetection,
+  closestCorners,
+  DndContext,
+  type DragCancelEvent,
+  type DragEndEvent,
+  type DragStartEvent,
+  PointerSensor,
+  pointerWithin,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
+import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { useAtomValue } from "@effect/atom-react";
+import { autoAnimate } from "@formkit/auto-animate";
+import {
+  parseScopedThreadKey,
+  scopedProjectKey,
+  scopedThreadKey,
+  scopeProjectRef,
+  scopeThreadRef,
+} from "@t3tools/client-runtime/environment";
+import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
+import {
+  isAtomCommandInterrupted,
+  settlePromise,
+  squashAtomCommandFailure,
+} from "@t3tools/client-runtime/state/runtime";
+import type {
+  ContextMenuItem,
+  ProjectId,
+  ResolvedKeybindingsConfig,
+  ScopedProjectRef,
+  ScopedThreadRef,
+  SidebarProjectGroupingMode,
+  SidebarThreadGroupingMode,
+  ThreadId,
+} from "@t3tools/contracts";
+import {
+  MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
+  MIN_SIDEBAR_THREAD_PREVIEW_COUNT,
+  type SidebarProjectSortOrder,
+  type SidebarThreadPreviewCount,
+  type SidebarThreadSortOrder,
+} from "@t3tools/contracts/settings";
+import { Link, useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
+import {
   ArchiveIcon,
   ArrowUpDownIcon,
   ChevronRightIcon,
@@ -13,90 +61,20 @@ import {
   TerminalIcon,
   TriangleAlertIcon,
 } from "lucide-react";
-import {
-  ChangeRequestStatusIcon,
-  prStatusIndicator,
-  resolveThreadPr,
-  terminalStatusFromRunningIds,
-  ThreadStatusLabel,
-  ThreadWorktreeIndicator,
-} from "./ThreadStatusIndicators";
-import { ProjectFavicon } from "./ProjectFavicon";
-import { useAtomValue } from "@effect/atom-react";
-import { autoAnimate } from "@formkit/auto-animate";
-import React, { useCallback, useEffect, memo, useMemo, useRef, useState } from "react";
+import type React from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import {
-  DndContext,
-  type DragCancelEvent,
-  type CollisionDetection,
-  PointerSensor,
-  type DragStartEvent,
-  closestCorners,
-  pointerWithin,
-  useSensor,
-  useSensors,
-  type DragEndEvent,
-} from "@dnd-kit/core";
-import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { restrictToFirstScrollableAncestor, restrictToVerticalAxis } from "@dnd-kit/modifiers";
-import { CSS } from "@dnd-kit/utilities";
-import {
-  type ContextMenuItem,
-  DEFAULT_SERVER_SETTINGS,
-  ProjectId,
-  type ScopedThreadRef,
-  type ResolvedKeybindingsConfig,
-  type SidebarProjectGroupingMode,
-  ThreadId,
-} from "@t3tools/contracts";
-import {
-  parseScopedThreadKey,
-  scopedProjectKey,
-  scopedThreadKey,
-  scopeProjectRef,
-  scopeThreadRef,
-} from "@t3tools/client-runtime/environment";
-import { safeErrorLogAttributes } from "@t3tools/client-runtime/errors";
-import {
-  isAtomCommandInterrupted,
-  settlePromise,
-  squashAtomCommandFailure,
-} from "@t3tools/client-runtime/state/runtime";
-import { Link, useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
-import {
-  MAX_SIDEBAR_THREAD_PREVIEW_COUNT,
-  MIN_SIDEBAR_THREAD_PREVIEW_COUNT,
-  type SidebarProjectSortOrder,
-  type SidebarThreadPreviewCount,
-  type SidebarThreadSortOrder,
-} from "@t3tools/contracts/settings";
+import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
+import { useIsMobile } from "~/hooks/useMediaQuery";
+import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
+import { APP_STAGE_LABEL } from "../branding";
+import { useOpenAddProjectCommandPalette } from "../commandPaletteContext";
+import { useComposerDraftStore } from "../composerDraftStore";
 import { isDesktopLocalConnectionTarget } from "../connection/desktopLocal";
 import { useDesktopLocalBootstraps } from "../connection/useDesktopLocalBootstraps";
 import { isElectron } from "../env";
-import { APP_STAGE_LABEL } from "../branding";
-import { useOpenPrLink } from "../lib/openPullRequestLink";
-import { isTerminalFocused } from "../lib/terminalFocus";
-import { cn, isMacPlatform } from "../lib/utils";
-import {
-  readThreadShell,
-  useProject,
-  useProjects,
-  useServerConfigs,
-  useThreadShells,
-  useThreadShellsForProjectRefs,
-} from "../state/entities";
-import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
-import { useThreadRunningTerminalIds } from "../state/terminalSessions";
-import { useThreadDiscoveredPorts } from "../portDiscoveryState";
-import { openDiscoveredPort } from "./preview/openDiscoveredPort";
-import { useAtomCommand } from "../state/use-atom-command";
-import { previewEnvironment } from "../state/preview";
-import {
-  legacyProjectCwdPreferenceKey,
-  resolveProjectExpanded,
-  useUiStateStore,
-} from "../uiStateStore";
+import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { useThreadActions } from "../hooks/useThreadActions";
 import {
   resolveShortcutCommand,
   shortcutLabelForCommand,
@@ -105,29 +83,55 @@ import {
   threadJumpIndexFromCommand,
   threadTraversalDirectionFromCommand,
 } from "../keybindings";
-import { isModelPickerOpen } from "../modelPickerVisibility";
-import { useShortcutModifierState } from "../shortcutModifierState";
+import { useOpenPrLink } from "../lib/openPullRequestLink";
+import { startNewThreadInProjectFromContext } from "../lib/chatThreadActions";
+import { isTerminalFocused } from "../lib/terminalFocus";
+import { sortThreads } from "../lib/threadSort";
+import { cn, isMacPlatform } from "../lib/utils";
 import { readLocalApi } from "../localApi";
-import { useComposerDraftStore } from "../composerDraftStore";
-import { useNewThreadHandler } from "../hooks/useHandleNewThread";
+import {
+  derivePhysicalProjectKey,
+  deriveProjectGroupingOverrideKey,
+  getProjectOrderKey,
+  selectProjectGroupingSettings,
+} from "../logicalProject";
+import { isModelPickerOpen } from "../modelPickerVisibility";
+import { useThreadDiscoveredPorts } from "../portDiscoveryState";
+import { useShortcutModifierState } from "../shortcutModifierState";
+import {
+  buildPhysicalToLogicalProjectKeyMap,
+  buildSidebarProjectSnapshots,
+  type SidebarProjectGroupMember,
+  type SidebarProjectSnapshot,
+} from "../sidebarProjectGrouping";
 import { useDesktopUpdateState } from "../state/desktopUpdate";
-
-import { useThreadActions } from "../hooks/useThreadActions";
+import {
+  readThreadShell,
+  useProject,
+  useProjects,
+  useThreadShells,
+  useThreadShellsForProjectRefs,
+} from "../state/entities";
+import { useEnvironment, useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
+import { previewEnvironment } from "../state/preview";
 import { projectEnvironment } from "../state/projects";
 import { useEnvironmentQuery } from "../state/query";
+import { primaryServerConfigAtom, primaryServerKeybindingsAtom } from "../state/server";
+import { useThreadRunningTerminalIds } from "../state/terminalSessions";
 import { threadEnvironment, useEnvironmentThread } from "../state/threads";
+import { useAtomCommand } from "../state/use-atom-command";
 import { vcsEnvironment } from "../state/vcs";
-import { useEnvironment, useEnvironments, usePrimaryEnvironmentId } from "../state/environments";
-import {
-  buildThreadRouteParams,
-  resolveThreadRouteRef,
-  resolveThreadRouteTarget,
-} from "../threadRoutes";
-import { stackedThreadToast, toastManager } from "./ui/toast";
+import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
+import { buildThreadRouteParams, resolveThreadRouteRef } from "../threadRoutes";
+import { useThreadSelectionStore } from "../threadSelectionStore";
 import { formatRelativeTimeLabel } from "../timestampFormat";
-import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
-import { SidebarStageBackdrop, resolveSidebarStageBackdropVariant } from "./SidebarStageBackdrop";
-import { Kbd } from "./ui/kbd";
+import type { SidebarThreadSummary } from "../types";
+import {
+  legacyProjectCwdPreferenceKey,
+  resolveProjectExpanded,
+  useUiStateStore,
+} from "../uiStateStore";
+import { deriveWorkspaceOptions } from "./BranchToolbar.logic";
 import {
   getArm64IntelBuildWarningDescription,
   getDesktopUpdateActionError,
@@ -137,8 +141,41 @@ import {
   shouldShowArm64IntelBuildWarning,
   shouldToastDesktopUpdateActionResult,
 } from "./desktopUpdate.logic";
+import { ProjectFavicon } from "./ProjectFavicon";
+import { openDiscoveredPort } from "./preview/openDiscoveredPort";
+import {
+  getSidebarThreadIdsToPrewarm,
+  groupSidebarThreadsByWorktree,
+  archiveSelectedThreadEntries,
+  buildMultiSelectThreadContextMenuItems,
+  isContextMenuPointerDown,
+  isTrailingDoubleClick,
+  orderItemsByPreferredIds,
+  resolveAdjacentThreadId,
+  resolveProjectStatusIndicator,
+  resolveSidebarStageBadgeLabel,
+  resolveThreadRowClassName,
+  resolveThreadStatusPill,
+  shouldClearThreadSelectionOnMouseDown,
+  sortProjectsForSidebar,
+  type ThreadStatusPill,
+  useThreadJumpHintVisibility,
+} from "./Sidebar.logic";
+import { SettingsSidebarNav } from "./settings/SettingsSidebarNav";
+import { SidebarProviderUpdatePill } from "./sidebar/SidebarProviderUpdatePill";
+import { SidebarStageBackdrop, resolveSidebarStageBackdropVariant } from "./SidebarStageBackdrop";
+import { SidebarUpdatePill } from "./sidebar/SidebarUpdatePill";
+import {
+  ChangeRequestStatusIcon,
+  prStatusIndicator,
+  resolveThreadPr,
+  ThreadStatusLabel,
+  ThreadWorktreeIndicator,
+  terminalStatusFromRunningIds,
+} from "./ThreadStatusIndicators";
 import { Alert, AlertAction, AlertDescription, AlertTitle } from "./ui/alert";
 import { Button } from "./ui/button";
+import { CommandDialogTrigger } from "./ui/command";
 import {
   Dialog,
   DialogDescription,
@@ -149,6 +186,7 @@ import {
   DialogTitle,
 } from "./ui/dialog";
 import { Input } from "./ui/input";
+import { Kbd } from "./ui/kbd";
 import {
   Menu,
   MenuGroup,
@@ -166,7 +204,6 @@ import {
   NumberFieldInput,
 } from "./ui/number-field";
 import { Select, SelectItem, SelectPopup, SelectTrigger, SelectValue } from "./ui/select";
-import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
 import {
   SidebarContent,
   SidebarFooter,
@@ -182,48 +219,9 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "./ui/sidebar";
-import { useThreadSelectionStore } from "../threadSelectionStore";
-import { useOpenAddProjectCommandPalette } from "../commandPaletteContext";
-import {
-  archiveSelectedThreadEntries,
-  buildMultiSelectThreadContextMenuItems,
-  getSidebarThreadIdsToPrewarm,
-  resolveAdjacentThreadId,
-  isContextMenuPointerDown,
-  isTrailingDoubleClick,
-  resolveProjectStatusIndicator,
-  resolveSidebarNewThreadSeedContext,
-  resolveSidebarNewThreadEnvMode,
-  resolveSidebarStageBadgeLabel,
-  resolveThreadRowClassName,
-  resolveThreadStatusPill,
-  orderItemsByPreferredIds,
-  shouldClearThreadSelectionOnMouseDown,
-  sortProjectsForSidebar,
-  useThreadJumpHintVisibility,
-  ThreadStatusPill,
-} from "./Sidebar.logic";
-import { sortThreads } from "../lib/threadSort";
-import { SidebarUpdatePill } from "./sidebar/SidebarUpdatePill";
-import { useCopyToClipboard } from "~/hooks/useCopyToClipboard";
-import { useIsMobile } from "~/hooks/useMediaQuery";
-import { CommandDialogTrigger } from "./ui/command";
-import { useClientSettings, useUpdateClientSettings } from "~/hooks/useSettings";
-import { primaryServerConfigAtom, primaryServerKeybindingsAtom } from "../state/server";
-import {
-  derivePhysicalProjectKey,
-  deriveProjectGroupingOverrideKey,
-  getProjectOrderKey,
-  selectProjectGroupingSettings,
-} from "../logicalProject";
-import type { SidebarThreadSummary } from "../types";
-import {
-  buildPhysicalToLogicalProjectKeyMap,
-  buildSidebarProjectSnapshots,
-  type SidebarProjectGroupMember,
-  type SidebarProjectSnapshot,
-} from "../sidebarProjectGrouping";
-import { SidebarProviderUpdatePill } from "./sidebar/SidebarProviderUpdatePill";
+import { stackedThreadToast, toastManager } from "./ui/toast";
+import { Tooltip, TooltipPopup, TooltipTrigger } from "./ui/tooltip";
+
 const SIDEBAR_SORT_LABELS: Record<SidebarProjectSortOrder, string> = {
   updated_at: "Last user message",
   created_at: "Created at",
@@ -241,6 +239,10 @@ const EMPTY_THREAD_JUMP_LABELS = new Map<string, string>();
 const PROJECT_GROUPING_MODE_LABELS: Record<SidebarProjectGroupingMode, string> = {
   repository: "Group by repository",
   repository_path: "Group by repository path",
+  separate: "Keep separate",
+};
+const THREAD_GROUPING_MODE_LABELS: Record<SidebarThreadGroupingMode, string> = {
+  worktree: "Group by worktree",
   separate: "Keep separate",
 };
 const SIDEBAR_ICON_ACTION_BUTTON_CLASS =
@@ -443,7 +445,11 @@ export const SidebarThreadRow = memo(function SidebarThreadRow(props: SidebarThr
       event.stopPropagation();
       navigateToThread(threadRef);
       void (async () => {
-        const result = await openDiscoveredPort({ threadRef, port, openPreview });
+        const result = await openDiscoveredPort({
+          threadRef,
+          port,
+          openPreview,
+        });
         if (result._tag === "Success" || isAtomCommandInterrupted(result)) {
           return;
         }
@@ -897,6 +903,7 @@ interface SidebarProjectThreadListProps {
   hiddenThreadStatus: ThreadStatusPill | null;
   orderedProjectThreadKeys: readonly string[];
   renderedThreads: readonly SidebarThreadSummary[];
+  threadGroupingMode: SidebarThreadGroupingMode;
   showEmptyThreadState: boolean;
   shouldShowThreadPanel: boolean;
   isThreadListExpanded: boolean;
@@ -948,6 +955,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     hiddenThreadStatus,
     orderedProjectThreadKeys,
     renderedThreads,
+    threadGroupingMode,
     showEmptyThreadState,
     shouldShowThreadPanel,
     isThreadListExpanded,
@@ -979,6 +987,68 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
   } = props;
   const showMoreButtonRender = useMemo(() => <button type="button" />, []);
   const showLessButtonRender = useMemo(() => <button type="button" />, []);
+  const workspaceEnvironmentId = renderedThreads[0]?.environmentId ?? null;
+  const workspaceProjectId = renderedThreads[0]?.projectId ?? null;
+  const workspaceRefs = useEnvironmentQuery(
+    workspaceEnvironmentId
+      ? vcsEnvironment.listRefs({
+          environmentId: workspaceEnvironmentId,
+          input: { cwd: projectCwd, limit: 100 },
+        })
+      : null,
+  );
+  const workspaceIdentity = useMemo(() => {
+    if (!workspaceEnvironmentId || !workspaceProjectId || !workspaceRefs.data) return null;
+    const options = deriveWorkspaceOptions(workspaceRefs.data.refs, projectCwd);
+    const normalizedProjectCwd = projectCwd.replaceAll("\\", "/").replace(/\/+$/, "");
+    const projectCheckoutRef = workspaceRefs.data.refs.find(
+      (ref) => ref.worktreePath?.replaceAll("\\", "/").replace(/\/+$/, "") === normalizedProjectCwd,
+    );
+    return {
+      environmentId: workspaceEnvironmentId,
+      projectId: workspaceProjectId,
+      projectCheckoutPath: projectCwd,
+      projectCheckoutLabel: projectCheckoutRef?.name ?? null,
+      mainCheckoutPath: options.mainCheckout?.path ?? projectCwd,
+    };
+  }, [projectCwd, workspaceEnvironmentId, workspaceProjectId, workspaceRefs.data]);
+  const renderedThreadGroups = useMemo(
+    () => groupSidebarThreadsByWorktree(renderedThreads, workspaceIdentity),
+    [renderedThreads, workspaceIdentity],
+  );
+
+  const renderThread = (thread: SidebarThreadSummary) => {
+    const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
+    return (
+      <SidebarThreadRow
+        key={threadKey}
+        thread={thread}
+        projectCwd={projectCwd}
+        orderedProjectThreadKeys={orderedProjectThreadKeys}
+        isActive={activeRouteThreadKey === threadKey}
+        jumpLabel={threadJumpLabelByKey.get(threadKey) ?? null}
+        appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}
+        renamingThreadKey={renamingThreadKey}
+        renamingTitle={renamingTitle}
+        setRenamingTitle={setRenamingTitle}
+        startThreadRename={startThreadRename}
+        renamingInputRef={renamingInputRef}
+        renamingCommittedRef={renamingCommittedRef}
+        confirmingArchiveThreadKey={confirmingArchiveThreadKey}
+        setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
+        confirmArchiveButtonRefs={confirmArchiveButtonRefs}
+        handleThreadClick={handleThreadClick}
+        navigateToThread={navigateToThread}
+        handleMultiSelectContextMenu={handleMultiSelectContextMenu}
+        handleThreadContextMenu={handleThreadContextMenu}
+        clearSelection={clearSelection}
+        commitRename={commitRename}
+        cancelRename={cancelRename}
+        attemptArchiveThread={attemptArchiveThread}
+        openPrLink={openPrLink}
+      />
+    );
+  };
 
   return (
     <SidebarMenuSub
@@ -995,39 +1065,22 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
           </div>
         </SidebarMenuSubItem>
       ) : null}
-      {shouldShowThreadPanel &&
-        renderedThreads.map((thread) => {
-          const threadKey = scopedThreadKey(scopeThreadRef(thread.environmentId, thread.id));
-          return (
-            <SidebarThreadRow
-              key={threadKey}
-              thread={thread}
-              projectCwd={projectCwd}
-              orderedProjectThreadKeys={orderedProjectThreadKeys}
-              isActive={activeRouteThreadKey === threadKey}
-              jumpLabel={threadJumpLabelByKey.get(threadKey) ?? null}
-              appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}
-              renamingThreadKey={renamingThreadKey}
-              renamingTitle={renamingTitle}
-              setRenamingTitle={setRenamingTitle}
-              startThreadRename={startThreadRename}
-              renamingInputRef={renamingInputRef}
-              renamingCommittedRef={renamingCommittedRef}
-              confirmingArchiveThreadKey={confirmingArchiveThreadKey}
-              setConfirmingArchiveThreadKey={setConfirmingArchiveThreadKey}
-              confirmArchiveButtonRefs={confirmArchiveButtonRefs}
-              handleThreadClick={handleThreadClick}
-              navigateToThread={navigateToThread}
-              handleMultiSelectContextMenu={handleMultiSelectContextMenu}
-              handleThreadContextMenu={handleThreadContextMenu}
-              clearSelection={clearSelection}
-              commitRename={commitRename}
-              cancelRename={cancelRename}
-              attemptArchiveThread={attemptArchiveThread}
-              openPrLink={openPrLink}
-            />
-          );
-        })}
+      {shouldShowThreadPanel && threadGroupingMode === "separate"
+        ? renderedThreads.map(renderThread)
+        : null}
+      {shouldShowThreadPanel && threadGroupingMode === "worktree"
+        ? renderedThreadGroups.flatMap((group) => [
+            <SidebarMenuSubItem key={`${group.key}:label`} className="w-full">
+              <div className="flex h-5 w-full items-center gap-1.5 px-2 pt-0.5 text-[10px] font-medium text-muted-foreground/55">
+                <span className="truncate">{group.label}</span>
+                <span className="shrink-0 tabular-nums text-muted-foreground/35">
+                  {group.threads.length}
+                </span>
+              </div>
+            </SidebarMenuSubItem>,
+            ...group.threads.map(renderThread),
+          ])
+        : null}
 
       {projectExpanded && hasOverflowingThreads && !isThreadListExpanded && (
         <SidebarMenuSubItem className="w-full">
@@ -1071,7 +1124,7 @@ interface SidebarProjectItemProps {
   isThreadListExpanded: boolean;
   activeRouteThreadKey: string | null;
   newThreadShortcutLabel: string | null;
-  handleNewThread: ReturnType<typeof useNewThreadHandler>;
+  handleNewThread: (projectRef: ScopedProjectRef) => Promise<void>;
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   threadJumpLabelByKey: ReadonlyMap<string, string>;
@@ -1114,7 +1167,6 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
     (settings) => settings.confirmThreadArchive,
   );
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
-  const serverConfigs = useServerConfigs();
   const deleteProject = useAtomCommand(projectEnvironment.delete, {
     reportFailure: false,
   });
@@ -1127,6 +1179,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
   const updateSettings = useUpdateClientSettings();
   const sidebarThreadPreviewCount = useClientSettings<SidebarThreadPreviewCount>(
     (settings) => settings.sidebarThreadPreviewCount,
+  );
+  const threadGroupingMode = useClientSettings<SidebarThreadGroupingMode>(
+    (settings) => settings.sidebarThreadGroupingMode,
   );
   const router = useRouter();
   const { isMobile, setOpenMobile } = useSidebar();
@@ -1618,7 +1673,9 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
                 openProjectGroupingDialog(member);
                 return;
               case "copy-path":
-                copyPathToClipboard(member.workspaceRoot, { path: member.workspaceRoot });
+                copyPathToClipboard(member.workspaceRoot, {
+                  path: member.workspaceRoot,
+                });
                 return;
               case "delete":
                 return handleRemoveProject(member);
@@ -1886,61 +1943,12 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
 
   const createThreadForProjectMember = useCallback(
     (member: SidebarProjectGroupMember) => {
-      const currentRouteParams =
-        router.state.matches[router.state.matches.length - 1]?.params ?? {};
-      const currentRouteTarget = resolveThreadRouteTarget(currentRouteParams);
-      const currentActiveThread =
-        currentRouteTarget?.kind === "server"
-          ? readThreadShell(currentRouteTarget.threadRef)
-          : null;
-      const draftStore = useComposerDraftStore.getState();
-      const currentActiveDraftThread =
-        currentRouteTarget?.kind === "server"
-          ? (draftStore.getDraftThread(currentRouteTarget.threadRef) ?? null)
-          : currentRouteTarget?.kind === "draft"
-            ? (draftStore.getDraftSession(currentRouteTarget.draftId) ?? null)
-            : null;
-      const seedContext = resolveSidebarNewThreadSeedContext({
-        projectId: member.id,
-        defaultEnvMode: resolveSidebarNewThreadEnvMode({
-          defaultEnvMode:
-            serverConfigs.get(member.environmentId)?.settings.defaultThreadEnvMode ??
-            DEFAULT_SERVER_SETTINGS.defaultThreadEnvMode,
-        }),
-        activeThread:
-          currentActiveThread && currentActiveThread.projectId === member.id
-            ? {
-                projectId: currentActiveThread.projectId,
-                branch: currentActiveThread.branch,
-                worktreePath: currentActiveThread.worktreePath,
-              }
-            : null,
-        activeDraftThread:
-          currentActiveDraftThread && currentActiveDraftThread.projectId === member.id
-            ? {
-                projectId: currentActiveDraftThread.projectId,
-                branch: currentActiveDraftThread.branch,
-                worktreePath: currentActiveDraftThread.worktreePath,
-                envMode: currentActiveDraftThread.envMode,
-                startFromOrigin: currentActiveDraftThread.startFromOrigin,
-              }
-            : null,
-      });
       if (isMobile) {
         setOpenMobile(false);
       }
       void (async () => {
         const result = await settlePromise(() =>
-          handleNewThread(scopeProjectRef(member.environmentId, member.id), {
-            ...(seedContext.branch !== undefined ? { branch: seedContext.branch } : {}),
-            ...(seedContext.worktreePath !== undefined
-              ? { worktreePath: seedContext.worktreePath }
-              : {}),
-            envMode: seedContext.envMode,
-            ...(seedContext.startFromOrigin !== undefined
-              ? { startFromOrigin: seedContext.startFromOrigin }
-              : {}),
-          }),
+          handleNewThread(scopeProjectRef(member.environmentId, member.id)),
         );
         if (result._tag === "Failure") {
           const error = squashAtomCommandFailure(result);
@@ -1954,7 +1962,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         }
       })();
     },
-    [handleNewThread, isMobile, router, serverConfigs, setOpenMobile],
+    [handleNewThread, isMobile, setOpenMobile],
   );
 
   const handleCreateThreadClick = useCallback(
@@ -2362,6 +2370,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         hiddenThreadStatus={hiddenThreadStatus}
         orderedProjectThreadKeys={orderedProjectThreadKeys}
         renderedThreads={renderedThreads}
+        threadGroupingMode={threadGroupingMode}
         showEmptyThreadState={showEmptyThreadState}
         shouldShowThreadPanel={shouldShowThreadPanel}
         isThreadListExpanded={isThreadListExpanded}
@@ -2605,19 +2614,23 @@ function ProjectSortMenu({
   projectSortOrder,
   threadSortOrder,
   projectGroupingMode,
+  threadGroupingMode,
   threadPreviewCount,
   onProjectSortOrderChange,
   onThreadSortOrderChange,
   onProjectGroupingModeChange,
+  onThreadGroupingModeChange,
   onThreadPreviewCountChange,
 }: {
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
   projectGroupingMode: SidebarProjectGroupingMode;
+  threadGroupingMode: SidebarThreadGroupingMode;
   threadPreviewCount: SidebarThreadPreviewCount;
   onProjectSortOrderChange: (sortOrder: SidebarProjectSortOrder) => void;
   onThreadSortOrderChange: (sortOrder: SidebarThreadSortOrder) => void;
   onProjectGroupingModeChange: (mode: SidebarProjectGroupingMode) => void;
+  onThreadGroupingModeChange: (mode: SidebarThreadGroupingMode) => void;
   onThreadPreviewCountChange: (count: SidebarThreadPreviewCount) => void;
 }) {
   const handleThreadPreviewCountChange = useCallback(
@@ -2737,6 +2750,29 @@ function ProjectSortMenu({
             {(
               Object.entries(PROJECT_GROUPING_MODE_LABELS) as Array<
                 [SidebarProjectGroupingMode, string]
+              >
+            ).map(([value, label]) => (
+              <MenuRadioItem key={value} value={value} className="min-h-7 py-1 sm:text-xs">
+                {label}
+              </MenuRadioItem>
+            ))}
+          </MenuRadioGroup>
+        </MenuGroup>
+        <MenuGroup>
+          <div className="px-2 pt-2 pb-1 font-medium text-muted-foreground sm:text-xs">
+            Group threads
+          </div>
+          <MenuRadioGroup
+            value={threadGroupingMode}
+            onValueChange={(value) => {
+              if (value === "worktree" || value === "separate") {
+                onThreadGroupingModeChange(value);
+              }
+            }}
+          >
+            {(
+              Object.entries(THREAD_GROUPING_MODE_LABELS) as Array<
+                [SidebarThreadGroupingMode, string]
               >
             ).map(([value, label]) => (
               <MenuRadioItem key={value} value={value} className="min-h-7 py-1 sm:text-xs">
@@ -2902,6 +2938,7 @@ interface SidebarProjectsContentProps {
   projectSortOrder: SidebarProjectSortOrder;
   threadSortOrder: SidebarThreadSortOrder;
   projectGroupingMode: SidebarProjectGroupingMode;
+  threadGroupingMode: SidebarThreadGroupingMode;
   threadPreviewCount: SidebarThreadPreviewCount;
   updateSettings: ReturnType<typeof useUpdateClientSettings>;
   openAddProject: () => void;
@@ -2911,7 +2948,7 @@ interface SidebarProjectsContentProps {
   handleProjectDragStart: (event: DragStartEvent) => void;
   handleProjectDragEnd: (event: DragEndEvent) => void;
   handleProjectDragCancel: (event: DragCancelEvent) => void;
-  handleNewThread: ReturnType<typeof useNewThreadHandler>;
+  handleNewThread: (projectRef: ScopedProjectRef) => Promise<void>;
   archiveThread: ReturnType<typeof useThreadActions>["archiveThread"];
   deleteThread: ReturnType<typeof useThreadActions>["deleteThread"];
   sortedProjects: readonly SidebarProjectSnapshot[];
@@ -2943,6 +2980,7 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
     projectSortOrder,
     threadSortOrder,
     projectGroupingMode,
+    threadGroupingMode,
     threadPreviewCount,
     updateSettings,
     openAddProject,
@@ -2987,6 +3025,12 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
   const handleProjectGroupingModeChange = useCallback(
     (groupingMode: SidebarProjectGroupingMode) => {
       updateSettings({ sidebarProjectGroupingMode: groupingMode });
+    },
+    [updateSettings],
+  );
+  const handleThreadGroupingModeChange = useCallback(
+    (groupingMode: SidebarThreadGroupingMode) => {
+      updateSettings({ sidebarThreadGroupingMode: groupingMode });
     },
     [updateSettings],
   );
@@ -3056,10 +3100,12 @@ const SidebarProjectsContent = memo(function SidebarProjectsContent(
               projectSortOrder={projectSortOrder}
               threadSortOrder={threadSortOrder}
               projectGroupingMode={projectGroupingMode}
+              threadGroupingMode={threadGroupingMode}
               threadPreviewCount={threadPreviewCount}
               onProjectSortOrderChange={handleProjectSortOrderChange}
               onThreadSortOrderChange={handleThreadSortOrderChange}
               onProjectGroupingModeChange={handleProjectGroupingModeChange}
+              onThreadGroupingModeChange={handleThreadGroupingModeChange}
               onThreadPreviewCountChange={handleThreadPreviewCountChange}
             />
             <Tooltip>
@@ -3176,10 +3222,37 @@ export default function Sidebar() {
   const sidebarThreadSortOrder = useClientSettings((s) => s.sidebarThreadSortOrder);
   const sidebarProjectSortOrder = useClientSettings((s) => s.sidebarProjectSortOrder);
   const sidebarProjectGroupingMode = useClientSettings((s) => s.sidebarProjectGroupingMode);
+  const sidebarThreadGroupingMode = useClientSettings((s) => s.sidebarThreadGroupingMode);
   const projectGroupingSettings = useClientSettings(selectProjectGroupingSettings);
   const sidebarThreadPreviewCount = useClientSettings((s) => s.sidebarThreadPreviewCount);
   const updateSettings = useUpdateClientSettings();
-  const handleNewThread = useNewThreadHandler();
+  const {
+    defaultNewWorktreesStartFromOrigin,
+    defaultThreadEnvMode,
+    handleNewThread: handleNewThreadRaw,
+    resolveDefaultMainCheckout,
+  } = useHandleNewThread();
+  const handleNewThread = useCallback(
+    (projectRef: ScopedProjectRef) =>
+      startNewThreadInProjectFromContext(
+        {
+          activeDraftThread: null,
+          activeThread: undefined,
+          defaultProjectRef: null,
+          defaultNewWorktreesStartFromOrigin,
+          defaultThreadEnvMode,
+          handleNewThread: handleNewThreadRaw,
+          resolveDefaultMainCheckout,
+        },
+        projectRef,
+      ),
+    [
+      defaultNewWorktreesStartFromOrigin,
+      defaultThreadEnvMode,
+      handleNewThreadRaw,
+      resolveDefaultMainCheckout,
+    ],
+  );
   const { archiveThread, deleteThread } = useThreadActions();
   const { isMobile, setOpenMobile } = useSidebar();
   const routeThreadRef = useParams({
@@ -3776,6 +3849,7 @@ export default function Sidebar() {
             projectSortOrder={sidebarProjectSortOrder}
             threadSortOrder={sidebarThreadSortOrder}
             projectGroupingMode={sidebarProjectGroupingMode}
+            threadGroupingMode={sidebarThreadGroupingMode}
             threadPreviewCount={sidebarThreadPreviewCount}
             updateSettings={updateSettings}
             openAddProject={openAddProjectCommandPalette}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -46,6 +46,8 @@ import {
   type SidebarThreadSortOrder,
 } from "@t3tools/contracts/settings";
 import { Link, useLocation, useNavigate, useParams, useRouter } from "@tanstack/react-router";
+import * as Option from "effect/Option";
+import { AsyncResult, Atom } from "effect/unstable/reactivity";
 import {
   ArchiveIcon,
   ArrowUpDownIcon,
@@ -908,6 +910,7 @@ interface SidebarProjectThreadListProps {
   shouldShowThreadPanel: boolean;
   isThreadListExpanded: boolean;
   projectCwd: string;
+  projectMembers: readonly SidebarProjectGroupMember[];
   activeRouteThreadKey: string | null;
   threadJumpLabelByKey: ReadonlyMap<string, string>;
   appSettingsConfirmThreadArchive: boolean;
@@ -960,6 +963,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
     shouldShowThreadPanel,
     isThreadListExpanded,
     projectCwd,
+    projectMembers,
     activeRouteThreadKey,
     threadJumpLabelByKey,
     appSettingsConfirmThreadArchive,
@@ -987,34 +991,61 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
   } = props;
   const showMoreButtonRender = useMemo(() => <button type="button" />, []);
   const showLessButtonRender = useMemo(() => <button type="button" />, []);
-  const workspaceEnvironmentId = renderedThreads[0]?.environmentId ?? null;
-  const workspaceProjectId = renderedThreads[0]?.projectId ?? null;
-  const workspaceRefs = useEnvironmentQuery(
-    workspaceEnvironmentId
-      ? vcsEnvironment.listRefs({
-          environmentId: workspaceEnvironmentId,
-          input: { cwd: projectCwd, limit: 100 },
-        })
-      : null,
+  const workspaceRefTargets = useMemo(
+    () =>
+      threadGroupingMode === "worktree"
+        ? projectMembers.map((member) => ({
+            member,
+            atom: vcsEnvironment.listRefs({
+              environmentId: member.environmentId,
+              input: { cwd: member.workspaceRoot, limit: 100 },
+            }),
+          }))
+        : [],
+    [projectMembers, threadGroupingMode],
   );
-  const workspaceIdentity = useMemo(() => {
-    if (!workspaceEnvironmentId || !workspaceProjectId || !workspaceRefs.data) return null;
-    const options = deriveWorkspaceOptions(workspaceRefs.data.refs, projectCwd);
-    const normalizedProjectCwd = projectCwd.replaceAll("\\", "/").replace(/\/+$/, "");
-    const projectCheckoutRef = workspaceRefs.data.refs.find(
-      (ref) => ref.worktreePath?.replaceAll("\\", "/").replace(/\/+$/, "") === normalizedProjectCwd,
-    );
-    return {
-      environmentId: workspaceEnvironmentId,
-      projectId: workspaceProjectId,
-      projectCheckoutPath: projectCwd,
-      projectCheckoutLabel: projectCheckoutRef?.name ?? null,
-      mainCheckoutPath: options.mainCheckout?.path ?? projectCwd,
-    };
-  }, [projectCwd, workspaceEnvironmentId, workspaceProjectId, workspaceRefs.data]);
+  const workspaceRefsAtom = useMemo(
+    () =>
+      Atom.make((get) =>
+        workspaceRefTargets.map((target) => ({
+          member: target.member,
+          result: get(target.atom),
+        })),
+      ).pipe(Atom.withLabel(`sidebar:workspace-refs:${projectKey}`)),
+    [projectKey, workspaceRefTargets],
+  );
+  const workspaceRefResults = useAtomValue(workspaceRefsAtom);
+  const workspaceIdentities = useMemo(
+    () =>
+      workspaceRefResults.flatMap(({ member, result }) => {
+        const data = Option.getOrNull(AsyncResult.value(result));
+        if (!data) return [];
+        const options = deriveWorkspaceOptions(
+          data.refs,
+          member.workspaceRoot,
+          data.mainCheckoutPath,
+        );
+        const normalizedProjectCwd = member.workspaceRoot.replaceAll("\\", "/").replace(/\/+$/, "");
+        const projectCheckoutRef = data?.refs.find(
+          (ref) =>
+            ref.worktreePath?.replaceAll("\\", "/").replace(/\/+$/, "") === normalizedProjectCwd,
+        );
+        return [
+          {
+            environmentId: member.environmentId,
+            projectId: member.id,
+            projectCheckoutPath: member.workspaceRoot,
+            projectCheckoutLabel: projectCheckoutRef?.name ?? null,
+            mainCheckoutPath:
+              data.mainCheckoutPath ?? options.mainCheckout?.path ?? member.workspaceRoot,
+          },
+        ];
+      }),
+    [workspaceRefResults],
+  );
   const renderedThreadGroups = useMemo(
-    () => groupSidebarThreadsByWorktree(renderedThreads, workspaceIdentity),
-    [renderedThreads, workspaceIdentity],
+    () => groupSidebarThreadsByWorktree(renderedThreads, workspaceIdentities),
+    [renderedThreads, workspaceIdentities],
   );
 
   const renderThread = (thread: SidebarThreadSummary) => {
@@ -2375,6 +2406,7 @@ const SidebarProjectItem = memo(function SidebarProjectItem(props: SidebarProjec
         shouldShowThreadPanel={shouldShowThreadPanel}
         isThreadListExpanded={isThreadListExpanded}
         projectCwd={project.workspaceRoot}
+        projectMembers={project.memberProjects}
         activeRouteThreadKey={activeRouteThreadKey}
         threadJumpLabelByKey={threadJumpLabelByKey}
         appSettingsConfirmThreadArchive={appSettingsConfirmThreadArchive}

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -994,7 +994,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
   const showLessButtonRender = useMemo(() => <button type="button" />, []);
   const workspaceRefTargets = useMemo(
     () =>
-      threadGroupingMode === "worktree"
+      threadGroupingMode === "worktree" && shouldShowThreadPanel
         ? projectMembers.map((member) => ({
             member,
             atom: vcsEnvironment.listRefs({
@@ -1003,7 +1003,7 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
             }),
           }))
         : [],
-    [projectMembers, threadGroupingMode],
+    [projectMembers, shouldShowThreadPanel, threadGroupingMode],
   );
   const workspaceRefsAtom = useMemo(
     () =>

--- a/apps/web/src/components/Sidebar.tsx
+++ b/apps/web/src/components/Sidebar.tsx
@@ -1033,10 +1033,10 @@ const SidebarProjectThreadList = memo(function SidebarProjectThreadList(
           projectId: member.id,
           projectCheckoutPath: member.workspaceRoot,
           projectCheckoutLabel: projectCheckoutRef?.name ?? null,
-          mainCheckoutPath:
-            data?.mainCheckoutPath ??
-            options?.mainCheckout?.path ??
-            (data ? member.workspaceRoot : null),
+          // Only use an explicit main checkout path. Falling back to the
+          // project workspace root mislabels linked-checkout projects as
+          // "Main checkout" when refs load without a separate main path.
+          mainCheckoutPath: data?.mainCheckoutPath ?? options?.mainCheckout?.path ?? null,
         };
       }),
     [workspaceRefResults],

--- a/apps/web/src/components/settings/SettingsPanels.tsx
+++ b/apps/web/src/components/settings/SettingsPanels.tsx
@@ -761,12 +761,12 @@ export function GeneralSettingsPanel() {
             >
               <SelectTrigger className="w-full sm:w-44" aria-label="Default thread mode">
                 <SelectValue>
-                  {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local"}
+                  {settings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Main checkout"}
                 </SelectValue>
               </SelectTrigger>
               <SelectPopup align="end" alignItemWithTrigger={false}>
                 <SelectItem hideIndicator value="local">
-                  Local
+                  Main checkout
                 </SelectItem>
                 <SelectItem hideIndicator value="worktree">
                   New worktree

--- a/apps/web/src/hooks/useHandleNewThread.logic.test.ts
+++ b/apps/web/src/hooks/useHandleNewThread.logic.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import { resolveProjectMainCheckout } from "./useHandleNewThread.logic";
+
+describe("resolveProjectMainCheckout", () => {
+  it("uses loaded active-project refs without issuing another lookup", async () => {
+    const loadRefs = vi.fn(async () => null);
+
+    await expect(
+      resolveProjectMainCheckout({
+        isActiveProject: true,
+        activeRefsLoaded: true,
+        activeProjectMainCheckout: { branch: "main", path: "/repo" },
+        projectWorkspaceRoot: "/repo/worktree",
+        loadRefs,
+      }),
+    ).resolves.toEqual({ branch: "main", path: "/repo" });
+    expect(loadRefs).not.toHaveBeenCalled();
+  });
+
+  it("waits for ref discovery when active-project refs are still loading", async () => {
+    const loadRefs = vi.fn(async () => ({
+      refs: [
+        {
+          name: "feature/current",
+          current: true,
+          isDefault: false,
+          worktreePath: "/repo",
+        },
+      ],
+      mainCheckoutPath: "/repo",
+    }));
+
+    await expect(
+      resolveProjectMainCheckout({
+        isActiveProject: true,
+        activeRefsLoaded: false,
+        activeProjectMainCheckout: undefined,
+        projectWorkspaceRoot: "/repo",
+        loadRefs,
+      }),
+    ).resolves.toEqual({ branch: "feature/current", path: null });
+    expect(loadRefs).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/hooks/useHandleNewThread.logic.test.ts
+++ b/apps/web/src/hooks/useHandleNewThread.logic.test.ts
@@ -42,4 +42,16 @@ describe("resolveProjectMainCheckout", () => {
     ).resolves.toEqual({ branch: "feature/current", path: null });
     expect(loadRefs).toHaveBeenCalledOnce();
   });
+
+  it("does not reuse another project's checkout when ref discovery fails", async () => {
+    await expect(
+      resolveProjectMainCheckout({
+        isActiveProject: false,
+        activeRefsLoaded: true,
+        activeProjectMainCheckout: { branch: "feature/active", path: "/active" },
+        projectWorkspaceRoot: "/target",
+        loadRefs: async () => null,
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/web/src/hooks/useHandleNewThread.logic.ts
+++ b/apps/web/src/hooks/useHandleNewThread.logic.ts
@@ -24,7 +24,7 @@ export async function resolveProjectMainCheckout(input: {
   }
 
   const snapshot = await input.loadRefs();
-  if (snapshot === null) return input.activeProjectMainCheckout ?? undefined;
+  if (snapshot === null) return undefined;
   const options = deriveWorkspaceOptions(
     snapshot.refs,
     input.projectWorkspaceRoot,

--- a/apps/web/src/hooks/useHandleNewThread.logic.ts
+++ b/apps/web/src/hooks/useHandleNewThread.logic.ts
@@ -1,6 +1,6 @@
 import type { VcsRef } from "@t3tools/contracts";
 
-import { deriveWorkspaceOptions } from "../components/BranchToolbar.logic";
+import { resolveMainCheckoutTarget } from "../components/BranchToolbar.logic";
 
 interface MainCheckoutTarget {
   readonly branch: string;
@@ -25,12 +25,11 @@ export async function resolveProjectMainCheckout(input: {
 
   const snapshot = await input.loadRefs();
   if (snapshot === null) return undefined;
-  const options = deriveWorkspaceOptions(
-    snapshot.refs,
-    input.projectWorkspaceRoot,
-    snapshot.mainCheckoutPath,
+  return (
+    resolveMainCheckoutTarget(
+      snapshot.refs,
+      input.projectWorkspaceRoot,
+      snapshot.mainCheckoutPath,
+    ) ?? undefined
   );
-  if (options.mainCheckout) return options.mainCheckout;
-  const defaultRef = snapshot.refs.find((ref) => !ref.isRemote && ref.isDefault);
-  return defaultRef ? { branch: defaultRef.name, path: null } : undefined;
 }

--- a/apps/web/src/hooks/useHandleNewThread.logic.ts
+++ b/apps/web/src/hooks/useHandleNewThread.logic.ts
@@ -2,14 +2,14 @@ import type { VcsRef } from "@t3tools/contracts";
 
 import { resolveMainCheckoutTarget } from "../components/BranchToolbar.logic";
 
-interface MainCheckoutTarget {
+export interface MainCheckoutTarget {
   readonly branch: string;
   readonly path: string | null;
 }
 
 interface RefSnapshot {
   readonly refs: readonly VcsRef[];
-  readonly mainCheckoutPath?: string | null;
+  readonly mainCheckoutPath?: string | null | undefined;
 }
 
 export async function resolveProjectMainCheckout(input: {

--- a/apps/web/src/hooks/useHandleNewThread.logic.ts
+++ b/apps/web/src/hooks/useHandleNewThread.logic.ts
@@ -1,0 +1,36 @@
+import type { VcsRef } from "@t3tools/contracts";
+
+import { deriveWorkspaceOptions } from "../components/BranchToolbar.logic";
+
+interface MainCheckoutTarget {
+  readonly branch: string;
+  readonly path: string | null;
+}
+
+interface RefSnapshot {
+  readonly refs: readonly VcsRef[];
+  readonly mainCheckoutPath?: string | null;
+}
+
+export async function resolveProjectMainCheckout(input: {
+  readonly isActiveProject: boolean;
+  readonly activeRefsLoaded: boolean;
+  readonly activeProjectMainCheckout: MainCheckoutTarget | null | undefined;
+  readonly projectWorkspaceRoot: string;
+  readonly loadRefs: () => Promise<RefSnapshot | null>;
+}): Promise<MainCheckoutTarget | undefined> {
+  if (input.isActiveProject && input.activeRefsLoaded) {
+    return input.activeProjectMainCheckout ?? undefined;
+  }
+
+  const snapshot = await input.loadRefs();
+  if (snapshot === null) return input.activeProjectMainCheckout ?? undefined;
+  const options = deriveWorkspaceOptions(
+    snapshot.refs,
+    input.projectWorkspaceRoot,
+    snapshot.mainCheckoutPath,
+  );
+  if (options.mainCheckout) return options.mainCheckout;
+  const defaultRef = snapshot.refs.find((ref) => !ref.isRemote && ref.isDefault);
+  return defaultRef ? { branch: defaultRef.name, path: null } : undefined;
+}

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -317,6 +317,7 @@ export function useHandleNewThread() {
     defaultNewWorktreesStartFromOrigin: defaultProjectSettings.newWorktreesStartFromOrigin,
     handleNewThread,
     resolveDefaultMainCheckout,
+    resolveNewThreadDefaults,
     routeThreadRef,
   };
 }

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -32,6 +32,7 @@ import { vcsEnvironment } from "../state/vcs";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { useClientSettings } from "./useSettings";
+import { resolveProjectMainCheckout } from "./useHandleNewThread.logic";
 
 export function useNewThreadHandler() {
   const projects = useProjects();
@@ -267,27 +268,31 @@ export function useHandleNewThread() {
       );
       if (!project) return undefined;
 
-      if (
+      const isActiveProject =
         newThreadProjectRef !== null &&
         projectRef.environmentId === newThreadProjectRef.environmentId &&
-        projectRef.projectId === newThreadProjectRef.projectId
-      ) {
-        return activeProjectMainCheckout;
-      }
-
-      const result = await listRefs({
-        environmentId: projectRef.environmentId,
-        input: { cwd: project.workspaceRoot, limit: 100 },
+        projectRef.projectId === newThreadProjectRef.projectId;
+      return resolveProjectMainCheckout({
+        isActiveProject,
+        activeRefsLoaded: activeProjectBranches.data !== null,
+        activeProjectMainCheckout,
+        projectWorkspaceRoot: project.workspaceRoot,
+        loadRefs: async () => {
+          const result = await listRefs({
+            environmentId: projectRef.environmentId,
+            input: { cwd: project.workspaceRoot, limit: 100 },
+          });
+          return result._tag === "Failure" ? null : result.value;
+        },
       });
-      if (result._tag === "Failure") return activeProjectMainCheckout;
-
-      const workspaceOptions = deriveWorkspaceOptions(result.value.refs, project.workspaceRoot);
-      if (workspaceOptions.mainCheckout) return workspaceOptions.mainCheckout;
-
-      const defaultRef = result.value.refs.find((ref) => !ref.isRemote && ref.isDefault);
-      return defaultRef ? { branch: defaultRef.name, path: null } : undefined;
     },
-    [activeProjectMainCheckout, listRefs, newThreadProjectRef, projects],
+    [
+      activeProjectBranches.data,
+      activeProjectMainCheckout,
+      listRefs,
+      newThreadProjectRef,
+      projects,
+    ],
   );
   const defaultProjectSettings = useMemo(() => {
     if (newThreadProjectRef === null) {

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -10,21 +10,25 @@ import {
 } from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
+import { deriveWorkspaceOptions } from "../components/BranchToolbar.logic";
+import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
 import {
-  markPromotedDraftThreadByRef,
   type DraftThreadEnvMode,
   type DraftThreadState,
+  markPromotedDraftThreadByRef,
   useComposerDraftStore,
 } from "../composerDraftStore";
+import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
 import { newDraftId, newThreadId } from "../lib/utils";
-import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
 import {
   deriveLogicalProjectKeyFromSettings,
   getProjectOrderKey,
   selectProjectGroupingSettings,
 } from "../logicalProject";
 import { readThreadShell, useProjects, useServerConfigs, useThread } from "../state/entities";
-import { resolveNewDraftStartFromOrigin } from "../lib/chatThreadActions";
+import { useBranches } from "../state/queries";
+import { useAtomQueryRunner } from "../state/use-atom-query-runner";
+import { vcsEnvironment } from "../state/vcs";
 import { resolveThreadRouteTarget } from "../threadRoutes";
 import { legacyProjectCwdPreferenceKey, useUiStateStore } from "../uiStateStore";
 import { useClientSettings } from "./useSettings";
@@ -207,6 +211,10 @@ export function useHandleNewThread() {
       : null,
   );
   const projects = useProjects();
+  const serverConfigs = useServerConfigs();
+  const listRefs = useAtomQueryRunner(vcsEnvironment.listRefs, {
+    reportFailure: false,
+  });
   const orderedProjects = useMemo(() => {
     return orderItemsByPreferredIds({
       items: projects,
@@ -219,14 +227,85 @@ export function useHandleNewThread() {
     });
   }, [projectOrder, projects]);
   const handleNewThread = useNewThreadHandler();
+  const defaultProjectRef = orderedProjects[0]
+    ? scopeProjectRef(orderedProjects[0].environmentId, orderedProjects[0].id)
+    : null;
+  const newThreadProjectRef = activeThread
+    ? scopeProjectRef(activeThread.environmentId, activeThread.projectId)
+    : activeDraftThread
+      ? scopeProjectRef(activeDraftThread.environmentId, activeDraftThread.projectId)
+      : defaultProjectRef;
+  const newThreadProject = newThreadProjectRef
+    ? projects.find(
+        (project) =>
+          project.environmentId === newThreadProjectRef.environmentId &&
+          project.id === newThreadProjectRef.projectId,
+      )
+    : undefined;
+  const activeProjectBranches = useBranches({
+    environmentId: newThreadProject?.environmentId ?? null,
+    cwd: newThreadProject?.workspaceRoot ?? null,
+  });
+  const activeProjectMainCheckout = useMemo(() => {
+    if (!newThreadProject || !activeProjectBranches.data) return undefined;
+    const workspaceOptions = deriveWorkspaceOptions(
+      activeProjectBranches.data.refs,
+      newThreadProject.workspaceRoot,
+    );
+    if (workspaceOptions.mainCheckout) return workspaceOptions.mainCheckout;
+    const defaultRef = activeProjectBranches.data.refs.find(
+      (ref) => !ref.isRemote && ref.isDefault,
+    );
+    return defaultRef ? { branch: defaultRef.name, path: null } : undefined;
+  }, [activeProjectBranches.data, newThreadProject]);
+  const resolveDefaultMainCheckout = useCallback(
+    async (projectRef: ScopedProjectRef) => {
+      const project = projects.find(
+        (candidate) =>
+          candidate.environmentId === projectRef.environmentId &&
+          candidate.id === projectRef.projectId,
+      );
+      if (!project) return undefined;
+
+      if (
+        newThreadProjectRef !== null &&
+        projectRef.environmentId === newThreadProjectRef.environmentId &&
+        projectRef.projectId === newThreadProjectRef.projectId
+      ) {
+        return activeProjectMainCheckout;
+      }
+
+      const result = await listRefs({
+        environmentId: projectRef.environmentId,
+        input: { cwd: project.workspaceRoot, limit: 100 },
+      });
+      if (result._tag === "Failure") return activeProjectMainCheckout;
+
+      const workspaceOptions = deriveWorkspaceOptions(result.value.refs, project.workspaceRoot);
+      if (workspaceOptions.mainCheckout) return workspaceOptions.mainCheckout;
+
+      const defaultRef = result.value.refs.find((ref) => !ref.isRemote && ref.isDefault);
+      return defaultRef ? { branch: defaultRef.name, path: null } : undefined;
+    },
+    [activeProjectMainCheckout, listRefs, newThreadProjectRef, projects],
+  );
+  const defaultProjectSettings = useMemo(() => {
+    if (newThreadProjectRef === null) {
+      return DEFAULT_SERVER_SETTINGS;
+    }
+    return (
+      serverConfigs.get(newThreadProjectRef.environmentId)?.settings ?? DEFAULT_SERVER_SETTINGS
+    );
+  }, [newThreadProjectRef, serverConfigs]);
 
   return {
     activeDraftThread,
     activeThread,
-    defaultProjectRef: orderedProjects[0]
-      ? scopeProjectRef(orderedProjects[0].environmentId, orderedProjects[0].id)
-      : null,
+    defaultProjectRef,
+    defaultThreadEnvMode: defaultProjectSettings.defaultThreadEnvMode,
+    defaultNewWorktreesStartFromOrigin: defaultProjectSettings.newWorktreesStartFromOrigin,
     handleNewThread,
+    resolveDefaultMainCheckout,
     routeThreadRef,
   };
 }

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -297,6 +297,17 @@ export function useHandleNewThread() {
       serverConfigs.get(newThreadProjectRef.environmentId)?.settings ?? DEFAULT_SERVER_SETTINGS
     );
   }, [newThreadProjectRef, serverConfigs]);
+  const resolveNewThreadDefaults = useCallback(
+    (projectRef: ScopedProjectRef) => {
+      const settings =
+        serverConfigs.get(projectRef.environmentId)?.settings ?? DEFAULT_SERVER_SETTINGS;
+      return {
+        envMode: settings.defaultThreadEnvMode,
+        newWorktreesStartFromOrigin: settings.newWorktreesStartFromOrigin,
+      };
+    },
+    [serverConfigs],
+  );
 
   return {
     activeDraftThread,

--- a/apps/web/src/hooks/useHandleNewThread.ts
+++ b/apps/web/src/hooks/useHandleNewThread.ts
@@ -10,7 +10,7 @@ import {
 } from "@t3tools/contracts";
 import { useParams, useRouter } from "@tanstack/react-router";
 import { useCallback, useMemo } from "react";
-import { deriveWorkspaceOptions } from "../components/BranchToolbar.logic";
+import { resolveMainCheckoutTarget } from "../components/BranchToolbar.logic";
 import { orderItemsByPreferredIds } from "../components/Sidebar.logic";
 import {
   type DraftThreadEnvMode,
@@ -249,15 +249,11 @@ export function useHandleNewThread() {
   });
   const activeProjectMainCheckout = useMemo(() => {
     if (!newThreadProject || !activeProjectBranches.data) return undefined;
-    const workspaceOptions = deriveWorkspaceOptions(
+    return resolveMainCheckoutTarget(
       activeProjectBranches.data.refs,
       newThreadProject.workspaceRoot,
+      activeProjectBranches.data.mainCheckoutPath,
     );
-    if (workspaceOptions.mainCheckout) return workspaceOptions.mainCheckout;
-    const defaultRef = activeProjectBranches.data.refs.find(
-      (ref) => !ref.isRemote && ref.isDefault,
-    );
-    return defaultRef ? { branch: defaultRef.name, path: null } : undefined;
   }, [activeProjectBranches.data, newThreadProject]);
   const resolveDefaultMainCheckout = useCallback(
     async (projectRef: ScopedProjectRef) => {

--- a/apps/web/src/keybindings.test.ts
+++ b/apps/web/src/keybindings.test.ts
@@ -119,6 +119,16 @@ const DEFAULT_BINDINGS = compile([
     whenAst: whenNot(whenIdentifier("terminalFocus")),
   },
   {
+    shortcut: modShortcut("n"),
+    command: "chat.new",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
+    shortcut: modShortcut("t"),
+    command: "chat.newSameWorktree",
+    whenAst: whenNot(whenIdentifier("terminalFocus")),
+  },
+  {
     shortcut: modShortcut("m", { shiftKey: true }),
     command: "modelPicker.toggle",
     whenAst: whenNot(whenIdentifier("terminalFocus")),
@@ -459,6 +469,12 @@ describe("model picker navigation helpers", () => {
 
 describe("chat/editor shortcuts", () => {
   it("matches chat.new shortcut", () => {
+    assert.isTrue(
+      isChatNewShortcut(event({ key: "n", metaKey: true }), DEFAULT_BINDINGS, {
+        platform: "MacIntel",
+        context: { terminalFocus: false },
+      }),
+    );
     assert.isTrue(
       isChatNewShortcut(event({ key: "o", metaKey: true, shiftKey: true }), DEFAULT_BINDINGS, {
         platform: "MacIntel",

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -159,6 +159,34 @@ describe("chatThreadActions", () => {
     });
   });
 
+  it("resolves thread defaults for the target project", async () => {
+    const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
+    const targetProjectRef = scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID);
+    const resolveNewThreadDefaults = vi.fn(() => ({
+      envMode: "worktree" as const,
+      newWorktreesStartFromOrigin: true,
+    }));
+
+    await startNewThreadFromContext(
+      createContext({
+        defaultProjectRef: targetProjectRef,
+        defaultThreadEnvMode: "local",
+        defaultNewWorktreesStartFromOrigin: false,
+        resolveNewThreadDefaults,
+        resolveDefaultMainCheckout: async () => ({ branch: "main", path: "/repo/main" }),
+        handleNewThread,
+      }),
+    );
+
+    expect(resolveNewThreadDefaults).toHaveBeenCalledWith(targetProjectRef);
+    expect(handleNewThread).toHaveBeenCalledWith(targetProjectRef, {
+      branch: "main",
+      worktreePath: null,
+      envMode: "worktree",
+      startFromOrigin: true,
+    });
+  });
+
   it("still starts an ordinary new thread when main-checkout discovery is unavailable", async () => {
     const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
 

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -214,6 +214,34 @@ describe("chatThreadActions", () => {
     });
   });
 
+  it("still starts an ordinary new thread when main-checkout discovery never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
+      const didStart = startNewThreadFromContext(
+        createContext({
+          defaultProjectRef: scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID),
+          defaultThreadEnvMode: "worktree",
+          defaultNewWorktreesStartFromOrigin: true,
+          resolveDefaultMainCheckout: () => new Promise(() => {}),
+          handleNewThread,
+        }),
+      );
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      await expect(didStart).resolves.toBe(true);
+      expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+        branch: null,
+        worktreePath: null,
+        envMode: "worktree",
+        startFromOrigin: true,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not inherit an active worktree for ordinary new threads", async () => {
     const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
 

--- a/apps/web/src/lib/chatThreadActions.test.ts
+++ b/apps/web/src/lib/chatThreadActions.test.ts
@@ -2,11 +2,12 @@ import { scopeProjectRef } from "@t3tools/client-runtime/environment";
 import { EnvironmentId, ProjectId } from "@t3tools/contracts";
 import { describe, expect, it, vi } from "vite-plus/test";
 import {
-  resolveThreadActionProjectRef,
+  type ChatThreadActionContext,
   resolveNewDraftStartFromOrigin,
+  resolveThreadActionProjectRef,
   startNewLocalThreadFromContext,
   startNewThreadFromContext,
-  type ChatThreadActionContext,
+  startNewThreadInSameWorktreeFromContext,
 } from "./chatThreadActions";
 
 const ENVIRONMENT_ID = EnvironmentId.make("environment-1");
@@ -69,7 +70,7 @@ describe("chatThreadActions", () => {
   it("starts a contextual new thread from the active draft thread", async () => {
     const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
 
-    const didStart = await startNewThreadFromContext(
+    const didStart = await startNewThreadInSameWorktreeFromContext(
       createContext({
         activeDraftThread: {
           environmentId: ENVIRONMENT_ID,
@@ -95,7 +96,7 @@ describe("chatThreadActions", () => {
   it("preserves an explicitly disabled origin base in contextual thread options", async () => {
     const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
 
-    await startNewThreadFromContext(
+    await startNewThreadInSameWorktreeFromContext(
       createContext({
         activeDraftThread: {
           environmentId: ENVIRONMENT_ID,
@@ -117,7 +118,7 @@ describe("chatThreadActions", () => {
     });
   });
 
-  it("delegates the target environment defaults to the new-thread handler", async () => {
+  it("starts ordinary new threads in the local checkout", async () => {
     const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
 
     const didStart = await startNewLocalThreadFromContext(
@@ -128,7 +129,122 @@ describe("chatThreadActions", () => {
     );
 
     expect(didStart).toBe(true);
-    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID));
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+      branch: null,
+      worktreePath: null,
+      envMode: "local",
+      startFromOrigin: false,
+    });
+  });
+
+  it("starts ordinary new threads using configured default thread mode", async () => {
+    const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
+
+    const didStart = await startNewThreadFromContext(
+      createContext({
+        defaultProjectRef: scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID),
+        defaultThreadEnvMode: "worktree",
+        defaultNewWorktreesStartFromOrigin: true,
+        resolveDefaultMainCheckout: async () => ({ branch: "main", path: "/repo/main" }),
+        handleNewThread,
+      }),
+    );
+
+    expect(didStart).toBe(true);
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+      branch: "main",
+      worktreePath: null,
+      envMode: "worktree",
+      startFromOrigin: true,
+    });
+  });
+
+  it("still starts an ordinary new thread when main-checkout discovery is unavailable", async () => {
+    const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
+
+    const didStart = await startNewThreadFromContext(
+      createContext({
+        activeThread: {
+          environmentId: ENVIRONMENT_ID,
+          projectId: PROJECT_ID,
+          branch: "feature/refactor",
+          worktreePath: "/tmp/worktree",
+        },
+        defaultThreadEnvMode: "worktree",
+        defaultNewWorktreesStartFromOrigin: true,
+        resolveDefaultMainCheckout: async () => undefined,
+        handleNewThread,
+      }),
+    );
+
+    expect(didStart).toBe(true);
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+      branch: null,
+      worktreePath: null,
+      envMode: "worktree",
+      startFromOrigin: true,
+    });
+  });
+
+  it("does not inherit an active worktree for ordinary new threads", async () => {
+    const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
+
+    await startNewThreadFromContext(
+      createContext({
+        activeThread: {
+          environmentId: ENVIRONMENT_ID,
+          projectId: PROJECT_ID,
+          branch: "feature/refactor",
+          worktreePath: "/tmp/worktree",
+        },
+        defaultThreadEnvMode: "local",
+        defaultNewWorktreesStartFromOrigin: false,
+        defaultMainCheckout: {
+          branch: "main",
+          path: "/tmp/main-checkout",
+        },
+        handleNewThread,
+      }),
+    );
+
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+      branch: "main",
+      worktreePath: "/tmp/main-checkout",
+      envMode: "local",
+      startFromOrigin: false,
+    });
+  });
+
+  it("waits for the main checkout resolver before creating a local thread", async () => {
+    const handleNewThread = vi.fn<ChatThreadActionContext["handleNewThread"]>(async () => {});
+    const resolveDefaultMainCheckout = vi.fn(async () => ({
+      branch: "main",
+      path: "/repo/main",
+    }));
+
+    await startNewThreadFromContext(
+      createContext({
+        activeThread: {
+          environmentId: ENVIRONMENT_ID,
+          projectId: PROJECT_ID,
+          branch: "t3code/group-threads-worktrees",
+          worktreePath: null,
+        },
+        defaultThreadEnvMode: "local",
+        resolveDefaultMainCheckout,
+        handleNewThread,
+      }),
+    );
+
+    expect(resolveDefaultMainCheckout).toHaveBeenCalledWith(
+      scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID),
+    );
+    expect(handleNewThread).toHaveBeenCalledWith(scopeProjectRef(ENVIRONMENT_ID, PROJECT_ID), {
+      branch: "main",
+      worktreePath: "/repo/main",
+      envMode: "local",
+      startFromOrigin: false,
+    });
   });
 
   it("does not start a thread when there is no project context", async () => {

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -26,6 +26,11 @@ type NewThreadHandler = (
 
 type NewThreadOptions = NonNullable<Parameters<NewThreadHandler>[1]>;
 
+interface NewThreadDefaults {
+  readonly envMode: DraftThreadEnvMode;
+  readonly newWorktreesStartFromOrigin: boolean;
+}
+
 export interface ChatThreadActionContext {
   readonly activeDraftThread: DraftThreadContextLike | null;
   readonly activeThread: ThreadContextLike | undefined;
@@ -33,6 +38,9 @@ export interface ChatThreadActionContext {
   readonly handleNewThread: NewThreadHandler;
   readonly defaultThreadEnvMode?: DraftThreadEnvMode;
   readonly defaultNewWorktreesStartFromOrigin?: boolean;
+  readonly resolveNewThreadDefaults?: (
+    projectRef: ScopedProjectRef,
+  ) => NewThreadDefaults | Promise<NewThreadDefaults>;
   readonly defaultMainCheckout?: {
     readonly branch: string;
     readonly path: string | null;
@@ -40,6 +48,24 @@ export interface ChatThreadActionContext {
   readonly resolveDefaultMainCheckout?: (
     projectRef: ScopedProjectRef,
   ) => Promise<{ readonly branch: string; readonly path: string | null } | null | undefined>;
+}
+
+async function resolveThreadDefaults(
+  context: ChatThreadActionContext,
+  projectRef: ScopedProjectRef,
+): Promise<NewThreadDefaults | null> {
+  if (context.resolveNewThreadDefaults) {
+    try {
+      return await context.resolveNewThreadDefaults(projectRef);
+    } catch {
+      // Fall through to the captured defaults so thread creation remains available.
+    }
+  }
+  if (context.defaultThreadEnvMode === undefined) return null;
+  return {
+    envMode: context.defaultThreadEnvMode,
+    newWorktreesStartFromOrigin: context.defaultNewWorktreesStartFromOrigin ?? false,
+  };
 }
 
 async function resolveMainCheckout(
@@ -101,12 +127,13 @@ export async function startNewThreadInProjectFromContext(
   context: ChatThreadActionContext,
   projectRef: ScopedProjectRef,
 ): Promise<void> {
-  if (context.defaultThreadEnvMode === undefined) {
+  const defaults = await resolveThreadDefaults(context, projectRef);
+  if (defaults === null) {
     await context.handleNewThread(projectRef);
     return;
   }
 
-  const threadEnvMode: DraftThreadEnvMode = context.defaultThreadEnvMode;
+  const threadEnvMode = defaults.envMode;
   const mainCheckout = await resolveMainCheckout(context, projectRef);
   await context.handleNewThread(projectRef, {
     branch: mainCheckout?.branch ?? null,
@@ -114,7 +141,7 @@ export async function startNewThreadInProjectFromContext(
     envMode: threadEnvMode,
     startFromOrigin: resolveNewDraftStartFromOrigin({
       envMode: threadEnvMode,
-      newWorktreesStartFromOrigin: context.defaultNewWorktreesStartFromOrigin ?? false,
+      newWorktreesStartFromOrigin: defaults.newWorktreesStartFromOrigin,
     }),
   });
 }

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -14,17 +14,15 @@ interface DraftThreadContextLike extends ThreadContextLike {
   startFromOrigin: boolean;
 }
 
-interface NewThreadHandler {
-  (
-    projectRef: ScopedProjectRef,
-    options?: {
-      branch?: string | null;
-      worktreePath?: string | null;
-      envMode?: DraftThreadEnvMode;
-      startFromOrigin?: boolean;
-    },
-  ): Promise<void>;
-}
+type NewThreadHandler = (
+  projectRef: ScopedProjectRef,
+  options?: {
+    branch?: string | null;
+    worktreePath?: string | null;
+    envMode?: DraftThreadEnvMode;
+    startFromOrigin?: boolean;
+  },
+) => Promise<void>;
 
 type NewThreadOptions = NonNullable<Parameters<NewThreadHandler>[1]>;
 
@@ -33,6 +31,34 @@ export interface ChatThreadActionContext {
   readonly activeThread: ThreadContextLike | undefined;
   readonly defaultProjectRef: ScopedProjectRef | null;
   readonly handleNewThread: NewThreadHandler;
+  readonly defaultThreadEnvMode?: DraftThreadEnvMode;
+  readonly defaultNewWorktreesStartFromOrigin?: boolean;
+  readonly defaultMainCheckout?: {
+    readonly branch: string;
+    readonly path: string | null;
+  } | null;
+  readonly resolveDefaultMainCheckout?: (
+    projectRef: ScopedProjectRef,
+  ) => Promise<{ readonly branch: string; readonly path: string | null } | null | undefined>;
+}
+
+async function resolveMainCheckout(
+  context: ChatThreadActionContext,
+  projectRef: ScopedProjectRef,
+): Promise<{
+  readonly branch: string;
+  readonly path: string | null;
+} | null> {
+  if (!context.resolveDefaultMainCheckout) {
+    return context.defaultMainCheckout ?? null;
+  }
+  try {
+    return (
+      (await context.resolveDefaultMainCheckout(projectRef)) ?? context.defaultMainCheckout ?? null
+    );
+  } catch {
+    return context.defaultMainCheckout ?? null;
+  }
 }
 
 export function resolveNewDraftStartFromOrigin(input: {
@@ -75,7 +101,22 @@ export async function startNewThreadInProjectFromContext(
   context: ChatThreadActionContext,
   projectRef: ScopedProjectRef,
 ): Promise<void> {
-  await context.handleNewThread(projectRef, buildContextualThreadOptions(context));
+  if (context.defaultThreadEnvMode === undefined) {
+    await context.handleNewThread(projectRef);
+    return;
+  }
+
+  const threadEnvMode: DraftThreadEnvMode = context.defaultThreadEnvMode;
+  const mainCheckout = await resolveMainCheckout(context, projectRef);
+  await context.handleNewThread(projectRef, {
+    branch: mainCheckout?.branch ?? null,
+    worktreePath: threadEnvMode === "local" ? (mainCheckout?.path ?? null) : null,
+    envMode: threadEnvMode,
+    startFromOrigin: resolveNewDraftStartFromOrigin({
+      envMode: threadEnvMode,
+      newWorktreesStartFromOrigin: context.defaultNewWorktreesStartFromOrigin ?? false,
+    }),
+  });
 }
 
 export async function startNewThreadFromContext(
@@ -90,6 +131,18 @@ export async function startNewThreadFromContext(
   return true;
 }
 
+export async function startNewThreadInSameWorktreeFromContext(
+  context: ChatThreadActionContext,
+): Promise<boolean> {
+  const projectRef = resolveThreadActionProjectRef(context);
+  if (!projectRef) {
+    return false;
+  }
+
+  await context.handleNewThread(projectRef, buildContextualThreadOptions(context));
+  return true;
+}
+
 export async function startNewLocalThreadFromContext(
   context: ChatThreadActionContext,
 ): Promise<boolean> {
@@ -98,6 +151,13 @@ export async function startNewLocalThreadFromContext(
     return false;
   }
 
-  await context.handleNewThread(projectRef);
+  const mainCheckout = await resolveMainCheckout(context, projectRef);
+
+  await context.handleNewThread(projectRef, {
+    branch: mainCheckout?.branch ?? null,
+    worktreePath: mainCheckout?.path ?? null,
+    envMode: "local",
+    startFromOrigin: false,
+  });
   return true;
 }

--- a/apps/web/src/lib/chatThreadActions.ts
+++ b/apps/web/src/lib/chatThreadActions.ts
@@ -31,6 +31,8 @@ interface NewThreadDefaults {
   readonly newWorktreesStartFromOrigin: boolean;
 }
 
+const MAIN_CHECKOUT_RESOLUTION_TIMEOUT_MS = 500;
+
 export interface ChatThreadActionContext {
   readonly activeDraftThread: DraftThreadContextLike | null;
   readonly activeThread: ThreadContextLike | undefined;
@@ -78,12 +80,24 @@ async function resolveMainCheckout(
   if (!context.resolveDefaultMainCheckout) {
     return context.defaultMainCheckout ?? null;
   }
+  let timeout: number | undefined;
   try {
     return (
-      (await context.resolveDefaultMainCheckout(projectRef)) ?? context.defaultMainCheckout ?? null
+      (await Promise.race([
+        context.resolveDefaultMainCheckout(projectRef),
+        new Promise<undefined>((resolve) => {
+          timeout = setTimeout(resolve, MAIN_CHECKOUT_RESOLUTION_TIMEOUT_MS);
+        }),
+      ])) ??
+      context.defaultMainCheckout ??
+      null
     );
   } catch {
     return context.defaultMainCheckout ?? null;
+  } finally {
+    if (timeout !== undefined) {
+      clearTimeout(timeout);
+    }
   }
 }
 

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -30,6 +30,7 @@ function ChatRouteGlobalShortcuts() {
     defaultThreadEnvMode,
     handleNewThread,
     resolveDefaultMainCheckout,
+    resolveNewThreadDefaults,
     routeThreadRef,
   } = useHandleNewThread();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
@@ -79,6 +80,7 @@ function ChatRouteGlobalShortcuts() {
           defaultNewWorktreesStartFromOrigin,
           handleNewThread,
           resolveDefaultMainCheckout,
+          resolveNewThreadDefaults,
         });
         return;
       }
@@ -94,6 +96,7 @@ function ChatRouteGlobalShortcuts() {
           defaultNewWorktreesStartFromOrigin,
           handleNewThread,
           resolveDefaultMainCheckout,
+          resolveNewThreadDefaults,
         });
         return;
       }
@@ -109,6 +112,7 @@ function ChatRouteGlobalShortcuts() {
           defaultNewWorktreesStartFromOrigin,
           handleNewThread,
           resolveDefaultMainCheckout,
+          resolveNewThreadDefaults,
         });
         return;
       }
@@ -169,6 +173,7 @@ function ChatRouteGlobalShortcuts() {
     clearSelection,
     handleNewThread,
     resolveDefaultMainCheckout,
+    resolveNewThreadDefaults,
     keybindings,
     defaultProjectRef,
     previewOpen,

--- a/apps/web/src/routes/_chat.tsx
+++ b/apps/web/src/routes/_chat.tsx
@@ -1,29 +1,37 @@
-import { Outlet, createFileRoute, redirect } from "@tanstack/react-router";
 import { useAtomValue } from "@effect/atom-react";
+import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
 import { useEffect } from "react";
-
+import { stackedThreadToast, toastManager } from "~/components/ui/toast";
+import { primaryServerKeybindingsAtom } from "~/state/server";
 import { isCommandPaletteOpen } from "../commandPaletteContext";
 import { dispatchPreviewAction } from "../components/preview/previewActionBus";
 import { useHandleNewThread } from "../hooks/useHandleNewThread";
+import { resolveShortcutCommand } from "../keybindings";
 import {
   startNewLocalThreadFromContext,
   startNewThreadFromContext,
+  startNewThreadInSameWorktreeFromContext,
 } from "../lib/chatThreadActions";
 import { isPreviewFocused } from "../lib/previewFocus";
 import { isTerminalFocused } from "../lib/terminalFocus";
-import { resolveShortcutCommand } from "../keybindings";
-import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { isPreviewSupportedInRuntime } from "../previewStateStore";
 import { selectActiveRightPanel, useRightPanelStore } from "../rightPanelStore";
+import { selectThreadTerminalUiState, useTerminalUiStateStore } from "../terminalUiStateStore";
 import { useThreadSelectionStore } from "../threadSelectionStore";
-import { stackedThreadToast, toastManager } from "~/components/ui/toast";
-import { primaryServerKeybindingsAtom } from "~/state/server";
 
 function ChatRouteGlobalShortcuts() {
   const clearSelection = useThreadSelectionStore((state) => state.clearSelection);
   const selectedThreadKeysSize = useThreadSelectionStore((state) => state.selectedThreadKeys.size);
-  const { activeDraftThread, activeThread, defaultProjectRef, handleNewThread, routeThreadRef } =
-    useHandleNewThread();
+  const {
+    activeDraftThread,
+    activeThread,
+    defaultProjectRef,
+    defaultNewWorktreesStartFromOrigin,
+    defaultThreadEnvMode,
+    handleNewThread,
+    resolveDefaultMainCheckout,
+    routeThreadRef,
+  } = useHandleNewThread();
   const keybindings = useAtomValue(primaryServerKeybindingsAtom);
   const terminalOpen = useTerminalUiStateStore((state) =>
     routeThreadRef
@@ -67,7 +75,10 @@ function ChatRouteGlobalShortcuts() {
           activeDraftThread,
           activeThread: activeThread ?? undefined,
           defaultProjectRef,
+          defaultThreadEnvMode,
+          defaultNewWorktreesStartFromOrigin,
           handleNewThread,
+          resolveDefaultMainCheckout,
         });
         return;
       }
@@ -79,7 +90,25 @@ function ChatRouteGlobalShortcuts() {
           activeDraftThread,
           activeThread: activeThread ?? undefined,
           defaultProjectRef,
+          defaultThreadEnvMode,
+          defaultNewWorktreesStartFromOrigin,
           handleNewThread,
+          resolveDefaultMainCheckout,
+        });
+        return;
+      }
+
+      if (command === "chat.newSameWorktree") {
+        event.preventDefault();
+        event.stopPropagation();
+        void startNewThreadInSameWorktreeFromContext({
+          activeDraftThread,
+          activeThread: activeThread ?? undefined,
+          defaultProjectRef,
+          defaultThreadEnvMode,
+          defaultNewWorktreesStartFromOrigin,
+          handleNewThread,
+          resolveDefaultMainCheckout,
         });
         return;
       }
@@ -135,8 +164,11 @@ function ChatRouteGlobalShortcuts() {
   }, [
     activeDraftThread,
     activeThread,
+    defaultNewWorktreesStartFromOrigin,
+    defaultThreadEnvMode,
     clearSelection,
     handleNewThread,
+    resolveDefaultMainCheckout,
     keybindings,
     defaultProjectRef,
     previewOpen,

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -198,9 +198,9 @@ export function useAllBranches(target: VcsRefTarget) {
       return;
     }
     if (state.error !== null) {
-      const retry = window.setTimeout(state.loadNext, 1_000);
+      const retry = window.setInterval(state.loadNext, 1_000);
       return () => {
-        window.clearTimeout(retry);
+        window.clearInterval(retry);
       };
     }
     if (nextCursor !== null && nextCursor !== undefined) {

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -194,17 +194,18 @@ export function useAllBranches(target: VcsRefTarget) {
   const nextCursor = state.data?.nextCursor;
 
   useEffect(() => {
-    if (state.isPending || nextCursor === null || nextCursor === undefined) {
+    if (state.isPending) {
       return;
     }
-    if (state.error === null) {
+    if (state.error !== null) {
+      const retry = window.setTimeout(state.loadNext, 1_000);
+      return () => {
+        window.clearTimeout(retry);
+      };
+    }
+    if (nextCursor !== null && nextCursor !== undefined) {
       state.loadNext();
-      return;
     }
-    const retry = window.setTimeout(state.loadNext, 1_000);
-    return () => {
-      window.clearTimeout(retry);
-    };
   }, [nextCursor, state.error, state.isPending, state.loadNext]);
 
   return state;

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -154,6 +154,7 @@ export function usePaginatedBranches(target: VcsRefTarget) {
             : "Failed to load refs.";
         })()
       : null;
+  const failedPage = pageAtoms[results.findIndex((result) => result._tag === "Failure")] ?? null;
   const refresh = useCallback(() => {
     const firstPage = pageAtoms[0];
     setPagination({ targetKey, cursors: INITIAL_BRANCH_CURSORS });
@@ -162,6 +163,10 @@ export function usePaginatedBranches(target: VcsRefTarget) {
     }
   }, [pageAtoms, targetKey]);
   const loadNext = useCallback(() => {
+    if (failedPage !== null) {
+      appAtomRegistry.refresh(failedPage);
+      return;
+    }
     if (targetKey === null || data?.nextCursor === null || data?.nextCursor === undefined) {
       return;
     }
@@ -172,7 +177,7 @@ export function usePaginatedBranches(target: VcsRefTarget) {
         ? { targetKey, cursors: currentCursors }
         : { targetKey, cursors: [...currentCursors, data.nextCursor!] };
     });
-  }, [data?.nextCursor, targetKey]);
+  }, [data?.nextCursor, failedPage, targetKey]);
 
   return {
     data,
@@ -189,10 +194,18 @@ export function useAllBranches(target: VcsRefTarget) {
   const nextCursor = state.data?.nextCursor;
 
   useEffect(() => {
-    if (!state.isPending && nextCursor !== null && nextCursor !== undefined) {
-      state.loadNext();
+    if (state.isPending || nextCursor === null || nextCursor === undefined) {
+      return;
     }
-  }, [nextCursor, state.isPending, state.loadNext]);
+    if (state.error === null) {
+      state.loadNext();
+      return;
+    }
+    const retry = window.setTimeout(state.loadNext, 1_000);
+    return () => {
+      window.clearTimeout(retry);
+    };
+  }, [nextCursor, state.error, state.isPending, state.loadNext]);
 
   return state;
 }

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -184,6 +184,19 @@ export function usePaginatedBranches(target: VcsRefTarget) {
   };
 }
 
+export function useAllBranches(target: VcsRefTarget) {
+  const state = usePaginatedBranches(target);
+  const nextCursor = state.data?.nextCursor;
+
+  useEffect(() => {
+    if (!state.isPending && nextCursor !== null && nextCursor !== undefined) {
+      state.loadNext();
+    }
+  }, [nextCursor, state.isPending, state.loadNext]);
+
+  return state;
+}
+
 export function useComposerPathSearch(target: ComposerPathSearchTarget) {
   const normalizedTarget = useMemo(
     () => ({

--- a/apps/web/src/state/queries.ts
+++ b/apps/web/src/state/queries.ts
@@ -138,6 +138,9 @@ export function usePaginatedBranches(target: VcsRefTarget) {
           refs: [...refs.values()],
           isRepo: first.isRepo,
           hasPrimaryRemote: first.hasPrimaryRemote,
+          ...(first.mainCheckoutPath !== undefined
+            ? { mainCheckoutPath: first.mainCheckoutPath }
+            : {}),
           nextCursor: last.nextCursor,
           totalCount: Math.max(...values.map((value) => value.totalCount)),
         };

--- a/docs/user/keybindings.md
+++ b/docs/user/keybindings.md
@@ -31,6 +31,7 @@ See the full schema for more details: [`packages/contracts/src/keybindings.ts`](
   { "key": "mod+0", "command": "preview.resetZoom", "when": "previewFocus" },
   { "key": "mod+k", "command": "commandPalette.toggle", "when": "!terminalFocus" },
   { "key": "mod+n", "command": "chat.new", "when": "!terminalFocus" },
+  { "key": "mod+t", "command": "chat.newSameWorktree", "when": "!terminalFocus" },
   { "key": "mod+shift+o", "command": "chat.new", "when": "!terminalFocus" },
   { "key": "mod+shift+n", "command": "chat.newLocal", "when": "!terminalFocus" },
   { "key": "mod+o", "command": "editor.openFavorite" }
@@ -64,8 +65,9 @@ Invalid rules are ignored. Invalid config files are ignored. Warnings are logged
 - `preview.zoomOut`: zoom the preview viewport out one step (in focused preview context by default)
 - `preview.resetZoom`: reset the preview zoom to 100% (in focused preview context by default)
 - `commandPalette.toggle`: open or close the global command palette
-- `chat.new`: create a new chat thread preserving the active thread's branch/worktree state
-- `chat.newLocal`: create a new chat thread for the active project in a new environment (local/worktree determined by app settings (default `local`))
+- `chat.new`: create a new chat thread using the configured default workspace mode
+- `chat.newSameWorktree`: create a new chat thread in the active thread's checkout/worktree
+- `chat.newLocal`: create a new chat thread in the active project's main checkout
 - `editor.openFavorite`: open current project/worktree in the last-used editor
 - `script.{id}.run`: run a project script by id (for example `script.test.run`)
 

--- a/packages/contracts/src/git.ts
+++ b/packages/contracts/src/git.ts
@@ -256,6 +256,7 @@ export const VcsListRefsResult = Schema.Struct({
   refs: Schema.Array(VcsRef),
   isRepo: Schema.Boolean,
   hasPrimaryRemote: Schema.Boolean,
+  mainCheckoutPath: Schema.optional(TrimmedNonEmptyStringSchema.pipe(Schema.NullOr)),
   nextCursor: NonNegativeInt.pipe(Schema.NullOr),
   totalCount: NonNegativeInt,
 });

--- a/packages/contracts/src/keybindings.test.ts
+++ b/packages/contracts/src/keybindings.test.ts
@@ -65,6 +65,12 @@ it.effect("parses keybinding rules", () =>
     });
     assert.strictEqual(parsedLocal.command, "chat.newLocal");
 
+    const parsedSameWorktree = yield* decode(KeybindingRule, {
+      key: "mod+t",
+      command: "chat.newSameWorktree",
+    });
+    assert.strictEqual(parsedSameWorktree.command, "chat.newSameWorktree");
+
     const parsedModelPickerToggle = yield* decode(KeybindingRule, {
       key: "mod+shift+m",
       command: "modelPicker.toggle",

--- a/packages/contracts/src/keybindings.ts
+++ b/packages/contracts/src/keybindings.ts
@@ -65,6 +65,7 @@ const STATIC_KEYBINDING_COMMANDS = [
   "commandPalette.toggle",
   "chat.new",
   "chat.newLocal",
+  "chat.newSameWorktree",
   "editor.openFavorite",
   ...MODEL_PICKER_KEYBINDING_COMMANDS,
   ...THREAD_KEYBINDING_COMMANDS,

--- a/packages/contracts/src/settings.test.ts
+++ b/packages/contracts/src/settings.test.ts
@@ -31,6 +31,18 @@ describe("ClientSettings word wrap", () => {
   });
 });
 
+describe("ClientSettings sidebar thread grouping", () => {
+  it("groups threads by worktree by default", () => {
+    expect(decodeClientSettings({}).sidebarThreadGroupingMode).toBe("worktree");
+  });
+
+  it("preserves the legacy separate-thread presentation when selected", () => {
+    expect(
+      decodeClientSettings({ sidebarThreadGroupingMode: "separate" }).sidebarThreadGroupingMode,
+    ).toBe("separate");
+  });
+});
+
 describe("ServerSettings.providerInstances (slice-2 invariant)", () => {
   it("defaults to an empty record so legacy configs without the key still decode", () => {
     expect(DEFAULT_SERVER_SETTINGS.providerInstances).toEqual({});

--- a/packages/contracts/src/settings.ts
+++ b/packages/contracts/src/settings.ts
@@ -21,6 +21,10 @@ export const SidebarThreadSortOrder = Schema.Literals(["updated_at", "created_at
 export type SidebarThreadSortOrder = typeof SidebarThreadSortOrder.Type;
 export const DEFAULT_SIDEBAR_THREAD_SORT_ORDER: SidebarThreadSortOrder = "updated_at";
 
+export const SidebarThreadGroupingMode = Schema.Literals(["worktree", "separate"]);
+export type SidebarThreadGroupingMode = typeof SidebarThreadGroupingMode.Type;
+export const DEFAULT_SIDEBAR_THREAD_GROUPING_MODE: SidebarThreadGroupingMode = "worktree";
+
 export const SidebarProjectGroupingMode = Schema.Literals([
   "repository",
   "repository_path",
@@ -84,6 +88,9 @@ export const ClientSettingsSchema = Schema.Struct({
   ),
   sidebarThreadSortOrder: SidebarThreadSortOrder.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_SORT_ORDER)),
+  ),
+  sidebarThreadGroupingMode: SidebarThreadGroupingMode.pipe(
+    Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_GROUPING_MODE)),
   ),
   sidebarThreadPreviewCount: SidebarThreadPreviewCount.pipe(
     Schema.withDecodingDefault(Effect.succeed(DEFAULT_SIDEBAR_THREAD_PREVIEW_COUNT)),
@@ -573,6 +580,7 @@ export const ClientSettingsPatch = Schema.Struct({
   ),
   sidebarProjectSortOrder: Schema.optionalKey(SidebarProjectSortOrder),
   sidebarThreadSortOrder: Schema.optionalKey(SidebarThreadSortOrder),
+  sidebarThreadGroupingMode: Schema.optionalKey(SidebarThreadGroupingMode),
   sidebarThreadPreviewCount: Schema.optionalKey(SidebarThreadPreviewCount),
   timestampFormat: Schema.optionalKey(TimestampFormat),
   wordWrap: Schema.optionalKey(Schema.Boolean),

--- a/packages/shared/src/keybindings.ts
+++ b/packages/shared/src/keybindings.ts
@@ -36,6 +36,7 @@ export const DEFAULT_KEYBINDINGS: ReadonlyArray<KeybindingRule> = [
   { key: "mod+0", command: "preview.resetZoom", when: "previewFocus" },
   { key: "mod+k", command: "commandPalette.toggle", when: "!terminalFocus" },
   { key: "mod+n", command: "chat.new", when: "!terminalFocus" },
+  { key: "mod+t", command: "chat.newSameWorktree", when: "!terminalFocus" },
   { key: "mod+shift+o", command: "chat.new", when: "!terminalFocus" },
   { key: "mod+shift+n", command: "chat.newLocal", when: "!terminalFocus" },
   { key: "mod+shift+m", command: "modelPicker.toggle", when: "!terminalFocus" },


### PR DESCRIPTION
Solves https://github.com/pingdotgg/t3code/issues/3697

## Reasoning/Justification

https://cap.so/s/dvaz19nmrwjh2ja

## Verification

https://github.com/user-attachments/assets/c8b25fc0-5e12-4c75-9847-dc5695809ea6

## Summary

- add a **Group threads** setting with **Group by worktree** as the default and **Keep separate** for the previous behavior
- add workspace-aware thread creation with **Main checkout**, **New worktree**, and existing-worktree choices
- make Cmd+N follow the configured default and add Cmd+T for creating a thread in the active worktree
- group sidebar threads under their checkout/worktree and keep labels consistent across the picker and sidebar
- fall back to a local base when a branch has no remote-tracking commit

## Why

Thread creation previously conflated the registered project checkout, the true main checkout, and the active worktree. That made new drafts inherit whichever worktree happened to be active, produced misleading picker selections, and could make Cmd+N silently do nothing while resolving the main checkout.

The new flow resolves the primary checkout from Git worktree/ref data, keeps Cmd+N and Cmd+T semantics separate, and ensures checkout discovery failures cannot swallow thread creation.

## User impact

Users can keep related threads grouped by worktree, deliberately create a thread in an existing worktree, and rely on Cmd+N to honor the configured Main checkout/New worktree default. Cmd+T always retains the active worktree.

## Validation

- `vp check`
- `vp run typecheck`
- focused web tests: 83 passed
- desktop dev-app smoke testing for grouping, workspace selection, worktree creation, and provider submission


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Group sidebar threads by worktree with a new `chat.newSameWorktree` shortcut
> - Adds a `sidebarThreadGroupingMode` client setting (default `'worktree'`) that groups sidebar threads under labeled worktree sections with counts; a 'Keep separate' option restores the flat list.
> - Introduces `groupSidebarThreadsByWorktree` and `orderSidebarThreadsByWorktree` utilities in [Sidebar.logic.ts](https://github.com/pingdotgg/t3code/pull/3898/files#diff-529ae8997a33774d7ec3514d7abdb655942eaa993f71e6ec6728c892285d251a) with Windows path case-insensitivity and 'Main checkout' label detection.
> - Adds a `deriveWorkspaceOptions` / `resolveWorkspaceSelection` system in [BranchToolbar.logic.ts](https://github.com/pingdotgg/t3code/pull/3898/files#diff-22eaeeb6cc7f6e680a66d29924a8aa6c56a51450578462389a4b649102ea655f) to expose concrete selectable worktrees (main checkout + existing) in the env-mode selector and mobile selector.
> - `listRefs` now returns `mainCheckoutPath` (first worktree from `git worktree list`); `resolveRemoteTrackingCommit` returns a typed `RemoteTrackingRefNotFoundError` instead of crashing, and the server falls back to the local base branch on that error.
> - Adds a `mod+t` → `chat.newSameWorktree` keybinding and updates `chat.newLocal` / `chat.new` to pass resolved main-checkout defaults (branch, path, envMode) when creating threads.
> - Renames the 'Local' label to 'Main checkout' across the branch toolbar, settings panel, and env-mode selector.
> - Behavioral Change: new threads created via `chat.new` now inherit envMode and worktree from per-project resolved defaults rather than always opening with no options.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ca6eab8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches thread bootstrap worktree creation, Git remote-ref resolution, and widespread composer/sidebar workspace state; incorrect checkout selection could run agents in the wrong tree, though behavior is heavily tested.
> 
> **Overview**
> Introduces **sidebar thread grouping by worktree** (default) with a **Keep separate** setting, plus labeled group headers driven by VCS ref/`mainCheckoutPath` data.
> 
> The **branch toolbar workspace UI** is reworked: users pick **Main checkout**, **New worktree**, or **existing worktrees** (with path-normalized selection and a fallback when refs are incomplete). **Local** mode is relabeled **Main checkout** in settings and pickers.
> 
> **New-thread shortcuts** are split: **Cmd+N** uses per-project default env mode and resolves the main checkout (with a timeout so creation still proceeds); **Cmd+T** (`chat.newSameWorktree`) keeps the active thread’s branch/worktree. Sidebar/command-palette creation goes through the same centralized handlers instead of `resolveSidebarNewThreadSeedContext`.
> 
> On the server, **`listRefs` exposes `mainCheckoutPath`**, remote base resolution returns **`RemoteTrackingRefNotFoundError`** when the tracking ref is absent, and bootstrap **falls back to the local base branch** instead of failing when **start from origin** cannot resolve `origin/<branch>`.
> 
> **Chat** tracks pending worktree path overrides before first send so existing-worktree picks apply to bootstrap metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6eab886d1b0d24f3f3ed42e140b6e0cd30b9ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->