### PR TITLE
Fix truncated chat error alert layout

### DIFF
--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -13,17 +13,17 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
 }) {
   if (!error) return null;
   return (
-    <div className="pt-3 mx-auto max-w-3xl">
+    <div className="mx-auto w-fit max-w-3xl pt-3">
       <Alert variant="error">
         <CircleAlertIcon />
-        <Tooltip>
-          <TooltipTrigger render={<AlertDescription className="line-clamp-3" />}>
-            {error}
-          </TooltipTrigger>
-          <TooltipPopup side="top" className="max-w-96 whitespace-pre-wrap">
-            {error}
-          </TooltipPopup>
-        </Tooltip>
+        <AlertDescription>
+          <Tooltip>
+            <TooltipTrigger render={<div className="line-clamp-3" />}>{error}</TooltipTrigger>
+            <TooltipPopup side="top" className="max-w-96 whitespace-pre-wrap">
+              {error}
+            </TooltipPopup>
+          </Tooltip>
+        </AlertDescription>
         {onDismiss && (
           <AlertAction>
             <Button variant="ghost" size="icon-xs" aria-label="Dismiss error" onClick={onDismiss}>

--- a/apps/web/src/components/chat/ThreadErrorBanner.tsx
+++ b/apps/web/src/components/chat/ThreadErrorBanner.tsx
@@ -13,7 +13,7 @@ export const ThreadErrorBanner = memo(function ThreadErrorBanner({
 }) {
   if (!error) return null;
   return (
-    <div className="mx-auto w-fit max-w-3xl pt-3">
+    <div className="mx-auto w-fit max-w-[min(48rem,calc(100%-2rem))] pt-3">
       <Alert variant="error">
         <CircleAlertIcon />
         <AlertDescription>


### PR DESCRIPTION
## Verification
**BEFORE**

<img width="1200" height="700" alt="t3code-alert-before" src="https://github.com/user-attachments/assets/0278a3ce-e1b8-4301-b80c-947ba92c969d" />

**AFTER**

<img width="1200" height="700" alt="t3code-alert-w-fit-short-and-long" src="https://github.com/user-attachments/assets/10763fe5-b699-467f-965b-bbb7ec250a31" />

## Summary

- keep thread error alerts sized to their content, up to the existing `max-w-3xl` layout cap
- place tooltip-wrapped error text in the alert content slot so it receives normal flexible width

## Why

The tooltip wrapper hid `AlertDescription` from the alert's child-slot classification. The message was therefore treated like an icon and constrained to the 16px icon container, causing the alert and its text to collapse into a narrow truncated strip.

Short alerts now remain compact, while long alerts grow and wrap up to the 3xl maximum width. The existing three-line clamp and full-message tooltip remain intact.

## Validation

- `vp check`
- `vp run typecheck`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix truncated chat error alert layout in `ThreadErrorBanner`
> - Fixes the alert banner width to fit its content, capped at `min(48rem, 100%-2rem)` instead of a fixed `max-w-3xl`, preventing the banner from appearing wider than its text.
> - Restructures the tooltip trigger in [ThreadErrorBanner.tsx](https://github.com/pingdotgg/t3code/pull/3899/files#diff-3fa9e223d4ae557ff232900844d971974d42e09f07a6d6e005538eab923867f0) so `AlertDescription` wraps the tooltip rather than acting as the trigger itself, fixing the truncated layout.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b050c77.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout change in a single chat error banner component with no auth, data, or API impact.
> 
> **Overview**
> Fixes **thread error alerts** collapsing into a narrow strip by aligning markup with how `Alert` routes children into icon vs content slots.
> 
> **`AlertDescription`** now wraps the tooltip (trigger is an inner `div` with `line-clamp-3`) instead of being the tooltip trigger, so the message lands in the flexible content area instead of the 16px icon column.
> 
> The outer wrapper uses **`w-fit`** with **`max-w-[min(48rem,calc(100%-2rem))]`** so short errors stay compact and long ones grow and wrap up to the previous ~3xl cap; three-line clamp and full-text tooltip behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b050c7713a5f711f82cbeacaf5550dae6fd1c784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->