### PR TITLE
Fix worktree removal timing out on large install trees

### DIFF
--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1489,6 +1489,51 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
       }),
     );
 
+    it.effect("allows worktree removal to run longer than the default command timeout", () =>
+      Effect.gen(function* () {
+        const delegate = yield* ChildProcessSpawner.ChildProcessSpawner;
+        const removalStarted = yield* Deferred.make<void>();
+        const delayedRemovalSpawner = ChildProcessSpawner.make((command) =>
+          Effect.gen(function* () {
+            if (
+              ChildProcess.isStandardCommand(command) &&
+              command.args[0] === "worktree" &&
+              command.args[1] === "remove"
+            ) {
+              yield* Deferred.succeed(removalStarted, undefined);
+              yield* Effect.sleep("31 seconds");
+            }
+            return yield* delegate.spawn(command);
+          }),
+        );
+        const driver = yield* makeGitVcsDriverCore().pipe(
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, delayedRemovalSpawner),
+          Effect.provide(ServerConfigLayer),
+        );
+        const cwd = yield* makeTmpDir();
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        const fileSystem = yield* FileSystem.FileSystem;
+        const pathService = yield* Path.Path;
+        const worktreePath = pathService.join(yield* makeTmpDir("git-worktrees-"), "slow-removal");
+
+        yield* driver.createWorktree({
+          cwd,
+          path: worktreePath,
+          refName: initialBranch,
+          newRefName: "feature/slow-removal",
+        });
+
+        const removal = yield* driver
+          .removeWorktree({ cwd, path: worktreePath, force: true })
+          .pipe(Effect.forkChild({ startImmediately: true }));
+        yield* Deferred.await(removalStarted);
+        yield* TestClock.adjust("31 seconds");
+        yield* Fiber.join(removal);
+
+        assert.equal(yield* fileSystem.exists(worktreePath), false);
+      }),
+    );
+
     it.effect("removes the same worktree path twice without failing", () =>
       Effect.gen(function* () {
         const cwd = yield* makeTmpDir();

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -27,7 +27,7 @@ const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
   prefix: "t3-git-vcs-driver-test-",
 });
 const TestLayer = GitVcsDriver.layer.pipe(
-  Layer.provide(ServerConfigLayer),
+  Layer.provideMerge(ServerConfigLayer),
   Layer.provideMerge(NodeServices.layer),
 );
 
@@ -1406,6 +1406,64 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
 
         yield* driver.removeWorktree({ cwd, path: worktreePath, force: true });
         const fileSystem = yield* FileSystem.FileSystem;
+        assert.equal(yield* fileSystem.exists(worktreePath), false);
+      }),
+    );
+
+    it.effect("retries transient filesystem failures while force-removing a worktree", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        const { initialBranch } = yield* initRepoWithCommit(cwd);
+        const pathService = yield* Path.Path;
+        const worktreePath = pathService.join(
+          yield* makeTmpDir("git-worktrees-"),
+          "feature-worktree",
+        );
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        yield* driver.createWorktree({
+          cwd,
+          path: worktreePath,
+          refName: initialBranch,
+          newRefName: "feature/worktree-retry",
+        });
+
+        const fileSystem = yield* FileSystem.FileSystem;
+        const serverConfig = yield* ServerConfig;
+        const firstRemoveAttempt = yield* Deferred.make<void>();
+        let removeAttempts = 0;
+        const transientFailure = PlatformError.systemError({
+          _tag: "Unknown",
+          module: "FileSystem",
+          method: "remove",
+          pathOrDescriptor: worktreePath,
+          description: "Directory not empty",
+        });
+        const flakyFileSystem = FileSystem.FileSystem.of({
+          ...fileSystem,
+          remove: (target, options) =>
+            Effect.suspend(() => {
+              if (target === worktreePath && removeAttempts++ === 0) {
+                return Deferred.succeed(firstRemoveAttempt, undefined).pipe(
+                  Effect.andThen(Effect.fail(transientFailure)),
+                );
+              }
+              return fileSystem.remove(target, options);
+            }),
+        });
+        const retryingDriver = yield* GitVcsDriver.make.pipe(
+          Effect.provideService(FileSystem.FileSystem, flakyFileSystem),
+          Effect.provideService(ServerConfig, serverConfig),
+        );
+
+        const removalFiber = yield* retryingDriver
+          .removeWorktree({ cwd, path: worktreePath, force: true })
+          .pipe(Effect.forkScoped);
+        yield* Deferred.await(firstRemoveAttempt);
+        yield* TestClock.adjust("100 millis");
+        yield* Fiber.join(removalFiber);
+
+        assert.equal(removeAttempts, 2);
         assert.equal(yield* fileSystem.exists(worktreePath), false);
       }),
     );

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -16,7 +16,11 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process";
 
 import { GitCommandError, type ReviewDiffFileContentsInput } from "@t3tools/contracts";
 import { ServerConfig } from "../config.ts";
-import { makeGitVcsDriverCore, splitNullSeparatedGitStdoutPaths } from "./GitVcsDriverCore.ts";
+import {
+  makeGitVcsDriverCore,
+  parsePorcelainWorktreePaths,
+  splitNullSeparatedGitStdoutPaths,
+} from "./GitVcsDriverCore.ts";
 import * as GitVcsDriver from "./GitVcsDriver.ts";
 
 const ServerConfigLayer = ServerConfig.layerTest(process.cwd(), {
@@ -756,6 +760,48 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         });
         assert.notProperty(error, "cause");
         assert.notInclude(error.detail, "Git command failed in");
+      }),
+    );
+
+    it.effect("does not filesystem-delete a path that is not a registered worktree", () =>
+      Effect.gen(function* () {
+        const cwd = yield* makeTmpDir();
+        yield* initRepoWithCommit(cwd);
+        const pathService = yield* Path.Path;
+        const fileSystem = yield* FileSystem.FileSystem;
+        const decoyPath = pathService.join(cwd, "not-a-worktree");
+        yield* fileSystem.makeDirectory(decoyPath, { recursive: true });
+        yield* writeTextFile(decoyPath, "keep.txt", "keep\n");
+        const driver = yield* GitVcsDriver.GitVcsDriver;
+
+        const error = yield* driver
+          .removeWorktree({ cwd, path: decoyPath, force: true })
+          .pipe(Effect.flip);
+
+        assert.equal(error._tag, "GitCommandError");
+        assert.equal(yield* fileSystem.exists(pathService.join(decoyPath, "keep.txt")), true);
+      }),
+    );
+  });
+
+  describe("porcelain worktree parsing", () => {
+    it.effect("parses worktree paths from porcelain output", () =>
+      Effect.sync(() => {
+        assert.deepStrictEqual(
+          parsePorcelainWorktreePaths(
+            [
+              "worktree /repo",
+              "HEAD abc",
+              "branch refs/heads/main",
+              "",
+              "worktree /repo-feature",
+              "HEAD def",
+              "branch refs/heads/feature",
+              "",
+            ].join("\n"),
+          ),
+          ["/repo", "/repo-feature"],
+        );
       }),
     );
   });

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -1358,7 +1358,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
         assert.equal(created.worktree.refName, "feature/worktree");
         assert.equal(yield* git(worktreePath, ["branch", "--show-current"]), "feature/worktree");
 
-        yield* driver.removeWorktree({ cwd, path: worktreePath });
+        yield* driver.removeWorktree({ cwd, path: worktreePath, force: true });
         const fileSystem = yield* FileSystem.FileSystem;
         assert.equal(yield* fileSystem.exists(worktreePath), false);
       }),

--- a/apps/server/src/vcs/GitVcsDriverCore.test.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.test.ts
@@ -785,7 +785,7 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
   });
 
   describe("porcelain worktree parsing", () => {
-    it.effect("parses worktree paths from porcelain output", () =>
+    it.effect("preserves unusual paths from NUL-delimited porcelain output", () =>
       Effect.sync(() => {
         assert.deepStrictEqual(
           parsePorcelainWorktreePaths(
@@ -794,13 +794,13 @@ it.layer(TestLayer)("GitVcsDriver core integration", (it) => {
               "HEAD abc",
               "branch refs/heads/main",
               "",
-              "worktree /repo-feature",
+              "worktree /repo with spaces\nand-newline ",
               "HEAD def",
               "branch refs/heads/feature",
               "",
-            ].join("\n"),
+            ].join("\0"),
           ),
-          ["/repo", "/repo-feature"],
+          ["/repo", "/repo with spaces\nand-newline "],
         );
       }),
     );

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -43,6 +43,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 // take well beyond the default 30s (e.g. a 375k-file repo takes ~40s on an idle
 // machine). Give it generous headroom while still bounding a genuinely hung git.
 const WORKTREE_ADD_TIMEOUT_MS = 300_000;
+const WORKTREE_REMOVE_TIMEOUT_MS = Duration.toMillis(Duration.minutes(5));
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
 const PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES = 49_000;
@@ -3078,7 +3079,13 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       "GitVcsDriver.removeWorktree",
       input.cwd,
       args,
-      { timeoutMs: 15_000, allowNonZeroExit: true },
+      {
+        // Removing dependency-heavy worktrees is filesystem-bound and can take
+        // minutes, especially on Windows. Keep it bounded without interrupting
+        // git midway through cleanup.
+        timeoutMs: WORKTREE_REMOVE_TIMEOUT_MS,
+        allowNonZeroExit: true,
+      },
     );
     if (result.exitCode === 0) {
       return;

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -13,6 +13,7 @@ import * as Path from "effect/Path";
 import * as PlatformError from "effect/PlatformError";
 import * as Ref from "effect/Ref";
 import * as Result from "effect/Result";
+import * as Schedule from "effect/Schedule";
 import * as Schema from "effect/Schema";
 import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
@@ -44,6 +45,9 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 // routinely exceeds short command timeouts on developer machines.
 const REMOVE_WORKTREE_DIRECTORY_TIMEOUT_MS = 5 * 60_000;
 const REMOVE_WORKTREE_GIT_TIMEOUT_MS = 60_000;
+const REMOVE_WORKTREE_DIRECTORY_RETRY_SCHEDULE = Schedule.spaced("100 millis").pipe(
+  Schedule.take(50),
+);
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
 const PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES = 49_000;
@@ -3026,6 +3030,13 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
             .pipe(Effect.orElseSucceed(() => false));
           if (exists) {
             yield* fileSystem.remove(input.path, { recursive: true, force: true }).pipe(
+              Effect.retry({
+                schedule: REMOVE_WORKTREE_DIRECTORY_RETRY_SCHEDULE,
+                while: (cause) =>
+                  cause.reason._tag === "Busy" ||
+                  cause.reason._tag === "WouldBlock" ||
+                  cause.reason._tag === "Unknown",
+              }),
               Effect.mapError(
                 (cause) =>
                   new GitCommandError({

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -39,6 +39,11 @@ import {
 import { ServerConfig } from "../config.ts";
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+// Worktrees routinely contain multi-GB install artifacts from setup scripts
+// (node_modules, .repos, etc). Deleting those via `git worktree remove` alone
+// routinely exceeds short command timeouts on developer machines.
+const REMOVE_WORKTREE_DIRECTORY_TIMEOUT_MS = 5 * 60_000;
+const REMOVE_WORKTREE_GIT_TIMEOUT_MS = 60_000;
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";
 const PREPARED_COMMIT_PATCH_MAX_OUTPUT_BYTES = 49_000;
@@ -2964,8 +2969,47 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       args.push("--force");
     }
     args.push(input.path);
+    const commandContext = gitCommandContext({
+      operation: "GitVcsDriver.removeWorktree",
+      cwd: input.cwd,
+      args,
+    });
+
+    // When forcing, wipe the working tree via the filesystem first so git only
+    // has to clean up worktree registration metadata. That keeps the git step
+    // fast even for multi-GB trees and avoids interrupting `git worktree remove`
+    // mid-delete after a short timeout.
+    if (input.force) {
+      const exists = yield* fileSystem.exists(input.path).pipe(Effect.orElseSucceed(() => false));
+      if (exists) {
+        yield* fileSystem.remove(input.path, { recursive: true, force: true }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new GitCommandError({
+                ...commandContext,
+                detail: "Failed to delete worktree directory.",
+                cause,
+              }),
+          ),
+          Effect.timeoutOption(REMOVE_WORKTREE_DIRECTORY_TIMEOUT_MS),
+          Effect.flatMap((result) =>
+            Option.match(result, {
+              onNone: () =>
+                Effect.fail(
+                  new GitCommandError({
+                    ...commandContext,
+                    detail: "Timed out deleting worktree directory.",
+                  }),
+                ),
+              onSome: () => Effect.void,
+            }),
+          ),
+        );
+      }
+    }
+
     yield* executeGit("GitVcsDriver.removeWorktree", input.cwd, args, {
-      timeoutMs: 15_000,
+      timeoutMs: REMOVE_WORKTREE_GIT_TIMEOUT_MS,
       fallbackErrorDetail: "git worktree remove failed",
     });
   });

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -2996,6 +2996,9 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     // Only do this after confirming the path is a registered *linked* worktree.
     // Otherwise a mistyped/non-worktree path would be recursively deleted before
     // `git worktree remove` could reject it.
+    //
+    // Listing is best-effort: timeout/failure here skips the filesystem
+    // pre-delete and still falls through to `git worktree remove`.
     if (input.force) {
       const worktreeList = yield* executeGit(
         "GitVcsDriver.removeWorktree.list",
@@ -3006,8 +3009,8 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
           allowNonZeroExit: true,
           fallbackErrorDetail: "git worktree list failed",
         },
-      );
-      if (worktreeList.exitCode === 0) {
+      ).pipe(Effect.orElseSucceed(() => null));
+      if (worktreeList !== null && worktreeList.exitCode === 0) {
         const registeredPaths = parsePorcelainWorktreePaths(worktreeList.stdout);
         const canonicalize = (value: string) =>
           fileSystem.realPath(value).pipe(Effect.orElseSucceed(() => path.resolve(value)));

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -296,9 +296,9 @@ export function splitNullSeparatedGitStdoutPaths(
 
 export function parsePorcelainWorktreePaths(stdout: string): string[] {
   const paths: string[] = [];
-  for (const line of stdout.split("\n")) {
-    if (line.startsWith("worktree ")) {
-      const worktreePath = line.slice("worktree ".length).trim();
+  for (const field of stdout.split("\0")) {
+    if (field.startsWith("worktree ")) {
+      const worktreePath = field.slice("worktree ".length);
       if (worktreePath.length > 0) {
         paths.push(worktreePath);
       }
@@ -3007,7 +3007,7 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
       const worktreeList = yield* executeGit(
         "GitVcsDriver.removeWorktree.list",
         input.cwd,
-        ["worktree", "list", "--porcelain"],
+        ["worktree", "list", "--porcelain", "-z"],
         {
           timeoutMs: 5_000,
           allowNonZeroExit: true,

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -290,6 +290,19 @@ export function splitNullSeparatedGitStdoutPaths(
   return splitNullSeparatedPaths(result.stdout, result.stdoutTruncated);
 }
 
+export function parsePorcelainWorktreePaths(stdout: string): string[] {
+  const paths: string[] = [];
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      const worktreePath = line.slice("worktree ".length).trim();
+      if (worktreePath.length > 0) {
+        paths.push(worktreePath);
+      }
+    }
+  }
+  return paths;
+}
+
 function sanitizeRemoteName(value: string): string {
   const sanitized = value
     .trim()
@@ -2979,32 +2992,61 @@ export const makeGitVcsDriverCore = Effect.fn("makeGitVcsDriverCore")(function* 
     // has to clean up worktree registration metadata. That keeps the git step
     // fast even for multi-GB trees and avoids interrupting `git worktree remove`
     // mid-delete after a short timeout.
+    //
+    // Only do this after confirming the path is a registered *linked* worktree.
+    // Otherwise a mistyped/non-worktree path would be recursively deleted before
+    // `git worktree remove` could reject it.
     if (input.force) {
-      const exists = yield* fileSystem.exists(input.path).pipe(Effect.orElseSucceed(() => false));
-      if (exists) {
-        yield* fileSystem.remove(input.path, { recursive: true, force: true }).pipe(
-          Effect.mapError(
-            (cause) =>
-              new GitCommandError({
-                ...commandContext,
-                detail: "Failed to delete worktree directory.",
-                cause,
-              }),
-          ),
-          Effect.timeoutOption(REMOVE_WORKTREE_DIRECTORY_TIMEOUT_MS),
-          Effect.flatMap((result) =>
-            Option.match(result, {
-              onNone: () =>
-                Effect.fail(
+      const worktreeList = yield* executeGit(
+        "GitVcsDriver.removeWorktree.list",
+        input.cwd,
+        ["worktree", "list", "--porcelain"],
+        {
+          timeoutMs: 5_000,
+          allowNonZeroExit: true,
+          fallbackErrorDetail: "git worktree list failed",
+        },
+      );
+      if (worktreeList.exitCode === 0) {
+        const registeredPaths = parsePorcelainWorktreePaths(worktreeList.stdout);
+        const canonicalize = (value: string) =>
+          fileSystem.realPath(value).pipe(Effect.orElseSucceed(() => path.resolve(value)));
+        const [canonicalTarget, ...canonicalRegistered] = yield* Effect.all(
+          [canonicalize(input.path), ...registeredPaths.map(canonicalize)],
+          { concurrency: "unbounded" },
+        );
+        // Porcelain lists the main working tree first; never filesystem-delete it.
+        const linkedWorktreePaths = new Set(canonicalRegistered.slice(1));
+        if (linkedWorktreePaths.has(canonicalTarget)) {
+          const exists = yield* fileSystem
+            .exists(input.path)
+            .pipe(Effect.orElseSucceed(() => false));
+          if (exists) {
+            yield* fileSystem.remove(input.path, { recursive: true, force: true }).pipe(
+              Effect.mapError(
+                (cause) =>
                   new GitCommandError({
                     ...commandContext,
-                    detail: "Timed out deleting worktree directory.",
+                    detail: "Failed to delete worktree directory.",
+                    cause,
                   }),
-                ),
-              onSome: () => Effect.void,
-            }),
-          ),
-        );
+              ),
+              Effect.timeoutOption(REMOVE_WORKTREE_DIRECTORY_TIMEOUT_MS),
+              Effect.flatMap((result) =>
+                Option.match(result, {
+                  onNone: () =>
+                    Effect.fail(
+                      new GitCommandError({
+                        ...commandContext,
+                        detail: "Timed out deleting worktree directory.",
+                      }),
+                    ),
+                  onSome: () => Effect.void,
+                }),
+              ),
+            );
+          }
+        }
       }
     }
 

--- a/apps/server/src/vcs/GitVcsDriverCore.ts
+++ b/apps/server/src/vcs/GitVcsDriverCore.ts
@@ -46,7 +46,7 @@ const DEFAULT_TIMEOUT_MS = 30_000;
 const REMOVE_WORKTREE_DIRECTORY_TIMEOUT_MS = 5 * 60_000;
 const REMOVE_WORKTREE_GIT_TIMEOUT_MS = 60_000;
 const REMOVE_WORKTREE_DIRECTORY_RETRY_SCHEDULE = Schedule.spaced("100 millis").pipe(
-  Schedule.take(50),
+  Schedule.while(({ attempt }) => attempt <= 50),
 );
 const DEFAULT_MAX_OUTPUT_BYTES = 1_000_000;
 const OUTPUT_TRUNCATED_MARKER = "\n\n[truncated]";


### PR DESCRIPTION
## Summary

Solves https://github.com/pingdotgg/t3code/issues/3593

- Give `git worktree remove` a bounded five-minute cleanup window for dependency-heavy worktrees.
- Keep path validation, lock handling, removal, and registration cleanup inside Git instead of pre-deleting directories through the filesystem.
- Preserve the current already-removed worktree behavior from `main`.
- Add an integration regression test that carries a forced removal past the previous timeout.

## Test plan

- [x] `pnpm exec vp test run apps/server/src/vcs/GitVcsDriverCore.test.ts` (58 passed)
- [x] Focused formatting and lint checks
- [x] `pnpm --filter t3 typecheck`
- [x] `git diff --check`

Updated with Codex (gpt-5.6-sol) in the Codex harness.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix 'removeWorktree' timeout to 5 minutes for large install trees
> Updates [GitVcsDriverCore.ts](https://github.com/pingdotgg/t3code/pull/3902/files#diff-1c3e2b9763c6526006485633fb677c83dc54cc1ea5563a1e51aab707c35854d8) to use a new 5-minute `WORKTREE_REMOVE_TIMEOUT_MS` constant instead of the default 15-second timeout for `git worktree remove`. Adds an integration test in [GitVcsDriverCore.test.ts](https://github.com/pingdotgg/t3code/pull/3902/files#diff-ac30488287dac9aa8d4cb819c508d77d2e47267d4aae35819e6fa24b86312c26) that verifies the removal can run longer than the default command timeout without failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4410854.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Git subprocess timeout for worktree teardown; longer waits on stuck removals but no auth or data-model impact.
> 
> **Overview**
> Fixes premature failures when tearing down worktrees that contain large dependency trees (e.g. `node_modules`), where `git worktree remove` can exceed the previous **15 second** limit.
> 
> **`removeWorktree`** now uses a dedicated **`WORKTREE_REMOVE_TIMEOUT_MS`** (five minutes), aligned with the existing generous timeout for `worktree add`. Comments note the change is meant to stay bounded while avoiding killing Git mid-cleanup on slow filesystems (especially Windows). Idempotent “already gone” handling is unchanged.
> 
> Adds an integration test that wraps `git worktree remove` in a **31s** delay and asserts removal still completes—mirroring the existing “push longer than default timeout” pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44108547699fb4ae5405adde500c27e7fe40cc8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->