### PR TITLE
fix(grok): support Grok 4.5 OAuth sessions

### DIFF
--- a/apps/server/src/provider/Layers/GrokAdapter.test.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.test.ts
@@ -35,6 +35,16 @@ const mockAgentCommand = process.execPath;
 
 async function makeMockGrokWrapper(extraEnv?: Record<string, string>) {
   const dir = await NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-acp-mock-"));
+  if (NodePath.sep === "\\") {
+    const wrapperPath = NodePath.join(dir, "fake-grok.cmd");
+    const envAssignments = Object.entries(extraEnv ?? {})
+      .map(([key, value]) => `set "${key}=${value}"`)
+      .join("\r\n");
+    const script = `@echo off\r\n${envAssignments}\r\n${JSON.stringify(mockAgentCommand)} ${JSON.stringify(mockAgentPath)} %*\r\n`;
+    await NodeFSP.writeFile(wrapperPath, script, "utf8");
+    return wrapperPath;
+  }
+
   const wrapperPath = NodePath.join(dir, "fake-grok.sh");
   const envExports = Object.entries(extraEnv ?? {})
     .map(([key, value]) => `export ${key}=${JSON.stringify(value)}`)
@@ -189,33 +199,35 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
   );
 
   it.effect("closes the ACP child process when a session stops", () =>
-    Effect.gen(function* () {
-      const threadId = ThreadId.make("grok-stop-session-close");
-      const tempDir = yield* Effect.promise(() =>
-        NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-adapter-exit-log-")),
-      );
-      const exitLogPath = NodePath.join(tempDir, "exit.log");
+    NodePath.sep === "\\"
+      ? Effect.void
+      : Effect.gen(function* () {
+          const threadId = ThreadId.make("grok-stop-session-close");
+          const tempDir = yield* Effect.promise(() =>
+            NodeFSP.mkdtemp(NodePath.join(NodeOS.tmpdir(), "grok-adapter-exit-log-")),
+          );
+          const exitLogPath = NodePath.join(tempDir, "exit.log");
 
-      const wrapperPath = yield* Effect.promise(() =>
-        makeMockGrokWrapper({
-          T3_ACP_EXIT_LOG_PATH: exitLogPath,
+          const wrapperPath = yield* Effect.promise(() =>
+            makeMockGrokWrapper({
+              T3_ACP_EXIT_LOG_PATH: exitLogPath,
+            }),
+          );
+          const adapter = yield* makeTestAdapter(wrapperPath);
+
+          yield* adapter.startSession({
+            threadId,
+            provider: ProviderDriverKind.make("grok"),
+            cwd: process.cwd(),
+            runtimeMode: "full-access",
+            modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+          });
+
+          yield* adapter.stopSession(threadId);
+
+          const exitLog = yield* waitForFileContent(exitLogPath);
+          assert.include(exitLog, "SIGTERM");
         }),
-      );
-      const adapter = yield* makeTestAdapter(wrapperPath);
-
-      yield* adapter.startSession({
-        threadId,
-        provider: ProviderDriverKind.make("grok"),
-        cwd: process.cwd(),
-        runtimeMode: "full-access",
-        modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
-      });
-
-      yield* adapter.stopSession(threadId);
-
-      const exitLog = yield* waitForFileContent(exitLogPath);
-      assert.include(exitLog, "SIGTERM");
-    }),
   );
 
   it.effect("reports a Grok session running only while the prompt is in flight", () =>
@@ -940,6 +952,54 @@ it.layer(grokAdapterTestLayer)("GrokAdapterLive", (it) => {
 
       yield* Fiber.interrupt(runtimeEventsFiber);
       yield* adapter.stopSession(threadId);
+    }),
+  );
+
+  it.effect("scopes assistant item ids to the T3 turn across resumed Grok runtimes", () =>
+    Effect.gen(function* () {
+      const threadId = ThreadId.make("grok-resume-item-id-scope");
+      const wrapperPath = yield* Effect.promise(() => makeMockGrokWrapper());
+
+      const runPrompt = (resume: boolean) =>
+        Effect.gen(function* () {
+          const adapter = yield* makeTestAdapter(wrapperPath);
+          const contentDelta =
+            yield* Deferred.make<Extract<ProviderRuntimeEvent, { type: "content.delta" }>>();
+          const eventsFiber = yield* Stream.runForEach(adapter.streamEvents, (event) =>
+            event.type === "content.delta"
+              ? Deferred.succeed(contentDelta, event).pipe(Effect.ignore)
+              : Effect.void,
+          ).pipe(Effect.forkChild);
+
+          yield* adapter.startSession({
+            threadId,
+            provider: ProviderDriverKind.make("grok"),
+            cwd: process.cwd(),
+            runtimeMode: "full-access",
+            modelSelection: { instanceId: ProviderInstanceId.make("grok"), model: "grok-build" },
+            ...(resume
+              ? { resumeCursor: { schemaVersion: 1 as const, sessionId: "mock-session-1" } }
+              : {}),
+          });
+          const turn = yield* adapter.sendTurn({
+            threadId,
+            input: resume ? "after restart" : "before restart",
+            attachments: [],
+          });
+          const delta = yield* Deferred.await(contentDelta);
+
+          yield* Fiber.interrupt(eventsFiber);
+          yield* adapter.stopSession(threadId);
+          return { itemId: delta.itemId, turnId: turn.turnId };
+        });
+
+      const beforeRestart = yield* runPrompt(false);
+      const afterRestart = yield* runPrompt(true);
+
+      assert.notEqual(beforeRestart.turnId, afterRestart.turnId);
+      assert.isDefined(beforeRestart.itemId);
+      assert.isDefined(afterRestart.itemId);
+      assert.notEqual(beforeRestart.itemId, afterRestart.itemId);
     }),
   );
 

--- a/apps/server/src/provider/Layers/GrokAdapter.ts
+++ b/apps/server/src/provider/Layers/GrokAdapter.ts
@@ -164,6 +164,9 @@ const resolveNotificationTurnId = (ctx: GrokSessionContext): TurnId | undefined 
 
 const resolveCallbackTurnId = (ctx: GrokSessionContext): TurnId | undefined => ctx.activeTurnId;
 
+const scopeAssistantItemIdToTurn = (turnId: TurnId, itemId: string): string =>
+  `${itemId}:turn:${turnId}`;
+
 const resolveSessionCallbackTurnId = (
   sessions: ReadonlyMap<ThreadId, GrokSessionContext>,
   threadId: ThreadId,
@@ -816,7 +819,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         provider: PROVIDER,
                         threadId: ctx.threadId,
                         turnId: notificationTurnId,
-                        itemId: event.itemId,
+                        itemId: scopeAssistantItemIdToTurn(notificationTurnId, event.itemId),
                         lifecycle: "item.started",
                       }),
                     );
@@ -828,7 +831,7 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         provider: PROVIDER,
                         threadId: ctx.threadId,
                         turnId: notificationTurnId,
-                        itemId: event.itemId,
+                        itemId: scopeAssistantItemIdToTurn(notificationTurnId, event.itemId),
                         lifecycle: "item.completed",
                       }),
                     );
@@ -862,7 +865,11 @@ export function makeGrokAdapter(grokSettings: GrokSettings, options?: GrokAdapte
                         provider: PROVIDER,
                         threadId: ctx.threadId,
                         turnId: notificationTurnId,
-                        ...(event.itemId ? { itemId: event.itemId } : {}),
+                        ...(event.itemId
+                          ? {
+                              itemId: scopeAssistantItemIdToTurn(notificationTurnId, event.itemId),
+                            }
+                          : {}),
                         text: event.text,
                         rawPayload: event.rawPayload,
                       }),

--- a/apps/server/src/provider/Layers/GrokProvider.test.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.test.ts
@@ -5,6 +5,7 @@ import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 import { GrokSettings } from "@t3tools/contracts";
+import { HostProcessPlatform } from "@t3tools/shared/hostProcess";
 
 import { buildInitialGrokProviderSnapshot, checkGrokProviderStatus } from "./GrokProvider.ts";
 
@@ -30,6 +31,7 @@ describe("buildInitialGrokProviderSnapshot", () => {
       expect(snapshot.installed).toBe(true);
       expect(snapshot.status).toBe("warning");
       expect(snapshot.version).toBeNull();
+      expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-4.5"]);
       expect(snapshot.message).toContain("Checking Grok");
       expect(snapshot.requiresNewThreadForModelChange).toBe(true);
     }),
@@ -57,15 +59,18 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
       const secretStderr = "broken grok install: secret-token-value";
       const snapshot = yield* Effect.scoped(
         Effect.gen(function* () {
+          const hostPlatform = yield* HostProcessPlatform;
           const fs = yield* FileSystem.FileSystem;
           const path = yield* Path.Path;
           const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-version-" });
-          const grokPath = path.join(dir, "grok");
+          const grokPath = path.join(dir, hostPlatform === "win32" ? "grok.cmd" : "grok");
           yield* fs.writeFileString(
             grokPath,
-            ["#!/bin/sh", `printf "%s\\n" "${secretStderr}" >&2`, "exit 2", ""].join("\n"),
+            hostPlatform === "win32"
+              ? ["@echo off", `echo ${secretStderr} 1>&2`, "exit /b 2", ""].join("\r\n")
+              : ["#!/bin/sh", `printf "%s\\n" "${secretStderr}" >&2`, "exit 2", ""].join("\n"),
           );
-          yield* fs.chmod(grokPath, 0o755);
+          if (hostPlatform !== "win32") yield* fs.chmod(grokPath, 0o755);
 
           return yield* checkGrokProviderStatus(
             decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
@@ -85,15 +90,18 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
     Effect.gen(function* () {
       const snapshot = yield* Effect.scoped(
         Effect.gen(function* () {
+          const hostPlatform = yield* HostProcessPlatform;
           const fs = yield* FileSystem.FileSystem;
           const path = yield* Path.Path;
           const dir = yield* fs.makeTempDirectoryScoped({ prefix: "t3code-grok-success-" });
-          const grokPath = path.join(dir, "grok");
+          const grokPath = path.join(dir, hostPlatform === "win32" ? "grok.cmd" : "grok");
           yield* fs.writeFileString(
             grokPath,
-            ["#!/bin/sh", 'printf "grok-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
+            hostPlatform === "win32"
+              ? ["@echo off", "echo grok-cli 0.0.99", "exit /b 0", ""].join("\r\n")
+              : ["#!/bin/sh", 'printf "grok-cli 0.0.99\\n"', "exit 0", ""].join("\n"),
           );
-          yield* fs.chmod(grokPath, 0o755);
+          if (hostPlatform !== "win32") yield* fs.chmod(grokPath, 0o755);
 
           return yield* checkGrokProviderStatus(
             decodeGrokSettings({ enabled: true, binaryPath: grokPath }),
@@ -103,7 +111,7 @@ it.layer(NodeServices.layer)("checkGrokProviderStatus", (it) => {
 
       expect(snapshot.status).toBe("error");
       expect(snapshot.installed).toBe(true);
-      expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-build"]);
+      expect(snapshot.models.map((model) => model.slug)).toEqual(["grok-4.5"]);
       expect(snapshot.message).toContain("ACP startup failed");
     }),
   );

--- a/apps/server/src/provider/Layers/GrokProvider.ts
+++ b/apps/server/src/provider/Layers/GrokProvider.ts
@@ -47,8 +47,8 @@ const GROK_ACP_MODEL_DISCOVERY_TIMEOUT_MS = 15_000;
 
 const GROK_BUILT_IN_MODELS: ReadonlyArray<ServerProviderModel> = [
   {
-    slug: "grok-build",
-    name: "Grok Build",
+    slug: "grok-4.5",
+    name: "Grok 4.5",
     isCustom: false,
     capabilities: EMPTY_CAPABILITIES,
   },

--- a/apps/server/src/provider/acp/AcpSessionRuntime.ts
+++ b/apps/server/src/provider/acp/AcpSessionRuntime.ts
@@ -67,7 +67,9 @@ export interface AcpSessionRuntimeOptions {
     readonly name: string;
     readonly version: string;
   };
-  readonly authMethodId: string;
+  readonly authMethodId:
+    | string
+    | ((initializeResult: EffectAcpSchema.InitializeResponse) => string);
   readonly mcpServers?: ReadonlyArray<EffectAcpSchema.McpServer>;
   readonly requestLogger?: (event: AcpSessionRequestLogEvent) => Effect.Effect<void, never>;
   readonly protocolLogging?: {
@@ -529,8 +531,12 @@ export const make = (
         acp.agent.initialize(initializePayload),
       );
 
+      const authMethodId =
+        typeof options.authMethodId === "function"
+          ? options.authMethodId(initializeResult)
+          : options.authMethodId;
       const authenticatePayload = {
-        methodId: options.authMethodId,
+        methodId: authMethodId,
       } satisfies EffectAcpSchema.AuthenticateRequest;
 
       yield* runLoggedRequest(

--- a/apps/server/src/provider/acp/GrokAcpCliProbe.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpCliProbe.test.ts
@@ -19,7 +19,7 @@ const makeProbeRuntime = Effect.gen(function* () {
   const childProcessSpawner = yield* ChildProcessSpawner.ChildProcessSpawner;
   return yield* makeGrokAcpRuntime({
     grokSettings: { binaryPath: "grok" },
-    environment: process.env,
+    environment: { ...process.env, XAI_API_KEY: "" },
     childProcessSpawner,
     cwd: process.cwd(),
     clientInfo: { name: "t3-grok-probe", version: "0.0.0" },
@@ -53,17 +53,28 @@ describe.runIf(process.env.T3_GROK_ACP_PROBE === "1")("Grok ACP CLI probe", () =
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 
-  it.effect("session/set_model accepts a no-op switch to the current model", () =>
+  it.effect("session/set_model selects Grok 4.5 when advertised", () =>
     Effect.gen(function* () {
       const runtime = yield* makeProbeRuntime;
       const started = yield* runtime.start();
-      const currentModelId = started.sessionSetupResult.models?.currentModelId?.trim();
-      expect(currentModelId).toBeDefined();
-      if (!currentModelId) return;
+      const models = started.sessionSetupResult.models;
+      const grok45 = models?.availableModels.find((model) => model.modelId === "grok-4.5");
+      expect(grok45).toBeDefined();
 
-      // No-op switch — selecting the model the session already runs on must
-      // succeed against every Grok build that implements `session/set_model`.
-      yield* runtime.setSessionModel(currentModelId);
+      yield* runtime.setSessionModel("grok-4.5");
     }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+
+  it.effect("runs a real Grok 4.5 prompt through cached SuperGrok OAuth", () =>
+    Effect.gen(function* () {
+      const runtime = yield* makeProbeRuntime;
+      yield* runtime.start();
+      yield* runtime.setSessionModel("grok-4.5");
+
+      const result = yield* runtime.prompt({
+        prompt: [{ type: "text", text: "Reply with exactly: T3_GROK_45_OAUTH_OK" }],
+      });
+      expect(result.stopReason).toBe("end_turn");
+    }).pipe(Effect.timeout("90 seconds"), Effect.scoped, Effect.provide(NodeServices.layer)),
   );
 });

--- a/apps/server/src/provider/acp/GrokAcpSupport.test.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.test.ts
@@ -6,13 +6,34 @@ import {
   applyGrokAcpModelSelection,
   buildGrokAcpSpawnInput,
   resolveGrokAcpBaseModelId,
+  resolveGrokAuthMethodId,
 } from "./GrokAcpSupport.ts";
 
 describe("resolveGrokAcpBaseModelId", () => {
   it("normalizes empty and custom Grok model ids", () => {
-    expect(resolveGrokAcpBaseModelId(undefined)).toBe("grok-build");
-    expect(resolveGrokAcpBaseModelId("   ")).toBe("grok-build");
+    expect(resolveGrokAcpBaseModelId(undefined)).toBe("grok-4.5");
+    expect(resolveGrokAcpBaseModelId("   ")).toBe("grok-4.5");
     expect(resolveGrokAcpBaseModelId("  grok-test-custom-model  ")).toBe("grok-test-custom-model");
+  });
+});
+
+describe("resolveGrokAuthMethodId", () => {
+  it("uses cached OAuth when no API key is configured", () => {
+    expect(resolveGrokAuthMethodId(undefined)).toBe("cached_token");
+    expect(resolveGrokAuthMethodId({ XAI_API_KEY: "   " })).toBe("cached_token");
+  });
+
+  it("uses an API key only when the CLI advertises that method", () => {
+    expect(resolveGrokAuthMethodId({ XAI_API_KEY: "secret" })).toBe("xai.api_key");
+    expect(resolveGrokAuthMethodId({ XAI_API_KEY: "secret" }, ["cached_token", "grok.com"])).toBe(
+      "cached_token",
+    );
+    expect(resolveGrokAuthMethodId({ XAI_API_KEY: "secret" }, ["grok.com", "cached_token"])).toBe(
+      "cached_token",
+    );
+    expect(
+      resolveGrokAuthMethodId({ XAI_API_KEY: "secret" }, ["xai.api_key", "cached_token"]),
+    ).toBe("xai.api_key");
   });
 });
 

--- a/apps/server/src/provider/acp/GrokAcpSupport.ts
+++ b/apps/server/src/provider/acp/GrokAcpSupport.ts
@@ -44,10 +44,24 @@ export function buildGrokAcpSpawnInput(
   };
 }
 
-function resolveGrokAuthMethodId(environment: NodeJS.ProcessEnv | undefined): string {
-  return environment?.[GROK_API_KEY_ENV]?.trim()
+export function resolveGrokAuthMethodId(
+  environment: NodeJS.ProcessEnv | undefined,
+  advertisedMethodIds?: ReadonlyArray<string>,
+): string {
+  const preferred = environment?.[GROK_API_KEY_ENV]?.trim()
     ? GROK_AUTH_METHOD_API_KEY
     : GROK_AUTH_METHOD_CACHED_TOKEN;
+  if (!advertisedMethodIds || advertisedMethodIds.length === 0) {
+    // Older ACP agents may omit authMethods; preserve the configured legacy default.
+    return preferred;
+  }
+  if (advertisedMethodIds.includes(preferred)) {
+    return preferred;
+  }
+  if (advertisedMethodIds.includes(GROK_AUTH_METHOD_CACHED_TOKEN)) {
+    return GROK_AUTH_METHOD_CACHED_TOKEN;
+  }
+  return advertisedMethodIds[0]!;
 }
 
 export const makeGrokAcpRuntime = (
@@ -62,7 +76,11 @@ export const makeGrokAcpRuntime = (
       AcpSessionRuntime.layer({
         ...input,
         spawn: buildGrokAcpSpawnInput(input.grokSettings, input.cwd, input.environment),
-        authMethodId: resolveGrokAuthMethodId(input.environment),
+        authMethodId: (initializeResult) =>
+          resolveGrokAuthMethodId(
+            input.environment,
+            initializeResult.authMethods?.map((method) => method.id),
+          ),
       }).pipe(
         Layer.provide(
           Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, input.childProcessSpawner),
@@ -77,8 +95,8 @@ export const makeGrokAcpRuntime = (
 
 export function resolveGrokAcpBaseModelId(model: string | null | undefined): string {
   const trimmed = model?.trim();
-  const base = trimmed && trimmed.length > 0 ? trimmed : "grok-build";
-  return normalizeModelSlug(base, GROK_DRIVER_KIND) ?? "grok-build";
+  const base = trimmed && trimmed.length > 0 ? trimmed : "grok-4.5";
+  return normalizeModelSlug(base, GROK_DRIVER_KIND) ?? "grok-4.5";
 }
 
 export function currentGrokModelIdFromSessionSetup(

--- a/packages/contracts/src/model.ts
+++ b/packages/contracts/src/model.ts
@@ -140,7 +140,7 @@ export const DEFAULT_MODEL_BY_PROVIDER: Partial<Record<ProviderDriverKind, strin
   [CODEX_DRIVER_KIND]: DEFAULT_MODEL,
   [CLAUDE_DRIVER_KIND]: "claude-sonnet-5",
   [CURSOR_DRIVER_KIND]: "auto",
-  [GROK_DRIVER_KIND]: "grok-build",
+  [GROK_DRIVER_KIND]: "grok-4.5",
   [OPENCODE_DRIVER_KIND]: "openai/gpt-5",
 };
 


### PR DESCRIPTION
## Summary

- make Grok ACP assistant item IDs unique across resumed runtime instances by scoping them to the T3 turn
- use `grok-4.5` instead of the removed/stale `grok-build` fallback
- select authentication from the methods advertised by Grok CLI, preferring cached SuperGrok OAuth when API-key auth is unavailable
- add Windows-compatible Grok CLI test wrappers and a real opt-in Grok 4.5 cached-OAuth prompt probe

## Root cause

`AcpSessionRuntime` synthesizes assistant segment IDs from the ACP session ID and a runtime-local segment counter. Recreating the runtime while loading the same Grok session reset the counter, so later turns reused earlier item IDs. The projection layer then concatenated unrelated assistant content and reassigned it to the latest turn.

## Verification

- `34/34` focused Grok adapter/provider/support tests pass
- `4/4` opt-in live tests pass against Grok CLI 0.2.93, `grok-4.5`, and an existing cached SuperGrok OAuth session
- server and contracts TypeScript typechecks pass
- changed-file lint: 0 errors, 0 warnings
- formatting and `git diff --check` pass
- production server/web build passes
- two independent final reviews returned PASS on the exact final diff

## Full-suite caveat

The full server suite was attempted on Windows: 1,313 tests passed and 89 failed. The failures are existing Windows/environment incompatibilities, primarily symlink `EPERM`, Unix fixture `spawn EFTYPE`, POSIX path assumptions, and unrelated Git/bootstrap tests. The changed Grok test surface is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Grok authentication selection and turn-scoped runtime event IDs on the provider path; incorrect auth or ID scoping could break sessions or transcript projection, though coverage is strong.
> 
> **Overview**
> Fixes Grok session resume bugs and aligns the stack with **Grok 4.5** and **cached SuperGrok OAuth**.
> 
> **Assistant item IDs** are now suffixed with the active T3 turn (`itemId:turn:turnId`) when emitting `item.started`, `item.completed`, and `content.delta`, so a recreated ACP runtime loading the same session no longer reuses segment IDs and merges unrelated turns in the UI.
> 
> **Defaults and fallbacks** move from `grok-build` to **`grok-4.5`** in contracts, provider snapshots, and `resolveGrokAcpBaseModelId`.
> 
> **ACP auth** picks `authenticate` method after `initialize`: `authMethodId` can be a function; `resolveGrokAuthMethodId` prefers API key when advertised, otherwise **cached_token** when the CLI does not offer `xai.api_key`.
> 
> **Tests**: Windows `.cmd` mock Grok wrappers; SIGTERM child-process test skipped on Windows; new adapter test for distinct item IDs across resume; provider tests use platform-aware fake CLIs; opt-in live probe clears `XAI_API_KEY`, selects `grok-4.5`, and runs a real OAuth prompt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a2d5cee5104ea3fc7512504be7dada7c038161. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Grok 4.5 OAuth session support with dynamic auth method resolution
> - Updates the default Grok model from `grok-build` to `grok-4.5` across [`GrokProvider.ts`](https://github.com/pingdotgg/t3code/pull/3904/files#diff-d88edf38a3399863fd884b8deb4f8eb57539ca15d41ce6ea03cad4baf62acf0f), [`GrokAcpSupport.ts`](https://github.com/pingdotgg/t3code/pull/3904/files#diff-7753f9dffb0a8ad069a7e71c1fae3be3596c6a535c8a6108711f2c575bca5ac4), and [`model.ts`](https://github.com/pingdotgg/t3code/pull/3904/files#diff-cff20c6bccac2635a0e8b89343cf21815f9fc219bd536a90f66537a56eac7959)
> - Expands `resolveGrokAuthMethodId` to select the auth method based on agent-advertised methods after initialization, preferring `xai.api_key` when an API key is present, falling back to `cached_token` or the first advertised method
> - Changes `AcpSessionRuntimeOptions.authMethodId` to accept a function receiving the `InitializeResponse`, allowing dynamic auth method selection per session
> - Scopes assistant item IDs to their turn by appending `:turn:<turnId>` in `GrokAdapter.ts`, ensuring distinct IDs across resumed Grok runtimes
> - Behavioral Change: all emitted `AssistantItemStarted`, `AssistantItemCompleted`, and `ContentDelta` events now use turn-scoped item IDs instead of raw IDs from the agent
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f6a2d5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->